### PR TITLE
docs: add agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Direction
+
+`wago` is a low-footprint, performance-oriented WebAssembly runtime in Go. Aim
+for JIT-compiled wasm functions that run as fast as practical while still
+working well on small, low-end, memory-constrained devices.
+
+Prioritize:
+
+1. correct wasm semantics;
+2. small, predictable memory use;
+3. fast hot paths for JIT code, host calls, memory, traps, and instantiation;
+4. no-cgo operational simplicity; and
+5. auditable compiler/runtime changes.
+
+## Engineering Rules
+
+- Decode, validate, and compile wasm features completely, or reject them clearly.
+- Keep the JIT direct; add abstractions only when tests, benchmarks, or repeated
+  code prove they are needed.
+- Avoid unbounded caches, goroutine-heavy designs, and hot-path allocations
+  unless measured and justified.
+- Make performance and footprint claims with numbers.
+- Keep unsafe, mmap, stack, trap, and native-call boundaries boring and obvious.
+- Check `FEATURES.md` and `ROADMAP.md` before changing feature support or
+  priorities.
+
+## Agent Workflow
+
+- Read nearby code and tests before editing.
+- Make the smallest coherent change and add/update tests with it.
+- Run the most relevant tests; state what was not run.
+- Include benchmark or memory notes for hot-path or footprint-sensitive changes.
+- Update developer/agent docs in `docs/` when workflow, testing, benchmarking,
+  review expectations, or agent behavior changes.
+- Keep commits atomic; use `skills/commit/SKILL.md`.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,48 @@
+# Agent Workflow
+
+This project welcomes agent-assisted development, but the bar is the same as for
+hand-written changes: small diffs, measured claims, reviewed code, and clear
+ownership of correctness.
+
+## Project Direction
+
+Agents should steer `wago` toward a low-footprint, high-performance WebAssembly
+JIT runtime written in Go. Favor changes that keep the engine fast, auditable,
+and usable on small or memory-constrained machines.
+
+## Commit Discipline
+
+Use `skills/commit/SKILL.md` before preparing commits.
+
+Commits should be atomic and usually fit one of three forms:
+
+- add a red test for one missing behavior or regression;
+- make the focused tests pass;
+- combine red and green only when the behavior is too small to split usefully.
+
+Each commit should carry the documentation needed by future developers or
+agents. If the change affects workflow, tests, benchmarks, review expectations,
+or agent behavior, update a file under `docs/` in the same commit.
+
+## Measurement Expectations
+
+For hot compiler, runtime, call-boundary, memory, or JIT-generated-code changes,
+record the relevant proof:
+
+- focused Go tests or wasm fixtures for correctness;
+- benchmark results for speed-sensitive changes;
+- allocation or memory-footprint notes when memory behavior changes;
+- explicit notes when broader measurements were not run.
+
+Avoid vague performance language. Prefer concrete before/after numbers or a
+clear statement that the change is correctness-only.
+
+## Review Focus
+
+When reviewing agent-authored changes, inspect especially:
+
+- validation rules and explicit rejection of unsupported wasm features;
+- trap behavior and error paths;
+- mmap, unsafe, stack, and native-call boundaries;
+- allocations introduced in compile, instantiate, and execute hot paths;
+- documentation updates that teach future agents the new workflow.

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,0 +1,95 @@
+# Commit Skill
+
+Use this skill whenever preparing or reviewing commits for `wago`.
+
+## Goal
+
+Produce measurable, small, atomic commits that move one topic forward without
+hiding unrelated work. A good commit does one of these things:
+
+1. adds a red test that demonstrates a missing behavior or regression;
+2. makes focused tests pass with the smallest implementation change; or
+3. does both for one tightly related topic when splitting would add noise.
+
+## Commit Shape
+
+Each commit should have:
+
+- **One topic.** Keep decoder, validator, backend, runtime, CLI, docs, and
+  benchmark work separated unless the behavior is inseparable.
+- **A measurable claim.** The commit should name the test, benchmark, fixture,
+  or observable behavior that proves the change.
+- **A docs companion.** Include associated developer/agent documentation changes
+  under `docs/` when the commit changes workflow, expectations, testing,
+  benchmarking, or agent behavior.
+- **A clear boundary.** Avoid drive-by cleanup, broad formatting, unrelated
+  renames, or speculative refactors.
+
+## Red / Green Discipline
+
+Prefer this sequence:
+
+1. **Red commit:** add the smallest failing test or fixture that captures the
+   behavior. Do not include the implementation unless the red state cannot be
+   represented independently.
+2. **Green commit:** implement the smallest change that makes the focused test
+   pass while preserving existing tests.
+3. **Refine commit:** only if needed, clean up structure or performance after the
+   behavior is proven. Keep this separate and measurable.
+
+If a red and green change are combined, explain why in the commit message or PR
+notes.
+
+## Documentation Companion Rule
+
+Every commit should ask: "Did this change how future developers or agents should
+work?"
+
+If yes, update `docs/` in the same commit. Examples:
+
+- new test helper or fixture convention;
+- changed benchmark procedure or required measurement;
+- new unsafe/runtime review rule;
+- changed commit, review, or agent workflow;
+- new performance or memory-footprint expectation.
+
+If no docs update is needed, the commit message or PR notes should make that
+obvious, for example: "Docs unchanged: internal bug fix with no workflow impact."
+
+## Message Template
+
+```text
+area: imperative summary
+
+Why:
+- what behavior, regression, or measurement motivated this
+
+What:
+- the focused code/test/docs change
+
+Proof:
+- go test ./...
+- specific package test, fixture, benchmark, or measurement
+
+Docs:
+- docs/<file>.md updated
+- or: unchanged, no developer/agent workflow impact
+```
+
+Keep the subject short and specific, such as:
+
+- `wasm: reject passive data segments explicitly`
+- `amd64: add red test for i64.load8_s`
+- `runtime: reduce host-call buffer allocation`
+- `docs: record backend benchmark workflow`
+
+## Pre-Commit Checklist
+
+- [ ] The diff has one topic.
+- [ ] Tests or benchmarks prove the claim.
+- [ ] Hot-path or memory-sensitive changes include before/after numbers when
+      practical.
+- [ ] Developer/agent docs in `docs/` were updated, or the no-docs reason is
+      stated.
+- [ ] Unsupported wasm behavior is rejected explicitly.
+- [ ] No unrelated formatting, renames, or cleanup are included.


### PR DESCRIPTION
## Summary

- Add compact `AGENTS.md` project guidance for low-footprint, performance-oriented WebAssembly JIT work.
- Add a commit skill focused on small atomic, measurable commits.
- Add agent workflow docs covering measurement, review, and documentation expectations.

## Tests

Not run; documentation-only change.

Signed-off-by: jtenner <3761339+jtenner@users.noreply.github.com>