### PR TITLE
feat(amd64): fuse integer compare/eqz into if, br_if, select

### DIFF
--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -510,7 +510,15 @@ func (g *cg) memStore(r *wasm.Reader, size int) error {
 	return nil
 }
 
-func (g *cg) cmp(cond Cond, w bool) {
+// invertCond returns the condition that holds exactly when c does not. x86
+// condition codes are paired by their low bit, so flipping it negates.
+func invertCond(c Cond) Cond { return c ^ 1 }
+
+// emitCompare pops two integer operands and emits `cmp a, b`, leaving the
+// comparison result only in EFLAGS. It returns the (now dead) register that
+// held a; callers that don't want a 0/1 value should free it. The `cond`
+// passed by the consumer selects how the flags are later interpreted.
+func (g *cg) emitCompare(w bool) Reg {
 	b := g.pop()
 	a := g.pop()
 	var dst Reg
@@ -536,6 +544,11 @@ func (g *cg) cmp(cond Cond, w bool) {
 	case b.kind == vSpill:
 		g.a.AluRM(0x3B, dst, RBP, g.slotOff(b.slot), w)
 	}
+	return dst
+}
+
+func (g *cg) cmp(cond Cond, w bool) {
+	dst := g.emitCompare(w)
 	g.a.SetccReg(cond, dst) // result is i32 (0/1)
 	g.pushReg(dst)
 }
@@ -591,7 +604,9 @@ func (g *cg) intUnary(w bool, emit func(dst, src Reg, w bool)) {
 	g.pushReg(dst)
 }
 
-func (g *cg) eqz(w bool) {
+// emitEqzTest pops one operand and emits `test a, a`, leaving the result in
+// EFLAGS (CondE means a == 0). Returns the dead register that held a.
+func (g *cg) emitEqzTest(w bool) Reg {
 	a := g.pop()
 	var dst Reg
 	if a.kind == vReg {
@@ -601,6 +616,11 @@ func (g *cg) eqz(w bool) {
 		g.loadInto(dst, a)
 	}
 	g.a.TestSelf(dst, w)
+	return dst
+}
+
+func (g *cg) eqz(w bool) {
+	dst := g.emitEqzTest(w)
 	g.a.SetccReg(CondE, dst)
 	g.pushReg(dst)
 }
@@ -921,7 +941,7 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0x76:
 		g.shift(5, false)
 	case op == 0x45:
-		g.eqz(false)
+		return g.eqzFused(r, false)
 	case op == 0x67:
 		g.intUnary(false, g.a.Lzcnt) // i32.clz
 	case op == 0x68:
@@ -933,7 +953,7 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0x78:
 		g.shift(1, false) // i32.rotr
 	case i32cmp[op] != 0:
-		g.cmp(i32cmp[op], false)
+		return g.cmpFused(r, i32cmp[op], false)
 
 	case op == 0x7C:
 		g.binALU(opAdd, true)
@@ -962,7 +982,7 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0x88:
 		g.shift(5, true)
 	case op == 0x50:
-		g.eqz(true)
+		return g.eqzFused(r, true)
 	case op == 0x79:
 		g.intUnary(true, g.a.Lzcnt) // i64.clz
 	case op == 0x7A:
@@ -974,7 +994,7 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0x8A:
 		g.shift(1, true) // i64.rotr
 	case i64cmp[op] != 0:
-		g.cmp(i64cmp[op], true)
+		return g.cmpFused(r, i64cmp[op], true)
 
 	case op == 0x29: // i64.load
 		return g.memLoad(r, 8, false)

--- a/src/core/compiler/backend/amd64/fuse.go
+++ b/src/core/compiler/backend/amd64/fuse.go
@@ -1,0 +1,133 @@
+package amd64
+
+import (
+	"fmt"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// Comparison fusion.
+//
+// A WebAssembly comparison (or i32/i64.eqz) normally materializes a 0/1 value
+// with setcc. When the very next opcode consumes that boolean directly — an
+// `if`, `br_if`, or `select` — the setcc and the consumer's own test/compare
+// are both redundant: the branch can read the comparison's EFLAGS straight
+// away. This is WARP's "condense comparison" optimization (see
+// warp/docs/implementation_details/CondenseComparison.md).
+//
+// We fuse only when the consumer opcode immediately follows the comparison in
+// the bytecode. That keeps EFLAGS live for the span of a single compile step,
+// so no intervening instruction can clobber it and there is no deferred state
+// to track. Any non-adjacent use falls back to the plain setcc form, which is
+// always correct. flush() emits only moves, so it preserves the flags between
+// the compare and the branch.
+
+// cmpFused emits an integer comparison, fusing it into an immediately
+// following if / br_if / select when present; otherwise it falls back to the
+// plain setcc form (g.cmp).
+func (g *cg) cmpFused(r *wasm.Reader, cond Cond, w bool) error {
+	if next, ok := r.Peek(); ok {
+		switch next {
+		case 0x04: // if
+			_, _ = r.Byte()
+			g.freeReg(g.emitCompare(w))
+			return g.fusedIf(r, cond)
+		case 0x0D: // br_if
+			_, _ = r.Byte()
+			g.freeReg(g.emitCompare(w))
+			return g.fusedBrIf(r, cond)
+		case 0x1B: // select
+			_, _ = r.Byte()
+			g.freeReg(g.emitCompare(w))
+			g.fusedSelect(cond, false, false)
+			return nil
+		}
+	}
+	g.cmp(cond, w)
+	return nil
+}
+
+// eqzFused is cmpFused for i32/i64.eqz, whose true condition is CondE (== 0).
+func (g *cg) eqzFused(r *wasm.Reader, w bool) error {
+	if next, ok := r.Peek(); ok {
+		switch next {
+		case 0x04: // if
+			_, _ = r.Byte()
+			g.freeReg(g.emitEqzTest(w))
+			return g.fusedIf(r, CondE)
+		case 0x0D: // br_if
+			_, _ = r.Byte()
+			g.freeReg(g.emitEqzTest(w))
+			return g.fusedBrIf(r, CondE)
+		case 0x1B: // select
+			_, _ = r.Byte()
+			g.freeReg(g.emitEqzTest(w))
+			g.fusedSelect(CondE, false, false)
+			return nil
+		}
+	}
+	g.eqz(w)
+	return nil
+}
+
+// fusedIf opens an `if` frame, jumping to the else/end edge when cond is false.
+// Mirrors opBlock's reachable if-path with the condition taken from EFLAGS
+// instead of a materialized register.
+func (g *cg) fusedIf(r *wasm.Reader, cond Cond) error {
+	pN, rN, err := g.blockType(r)
+	if err != nil {
+		return err
+	}
+	f := cframe{kind: ckIf, paramN: pN, resultN: rN, branchN: rN, elseSite: -1}
+	f.height = len(g.st) - pN
+	g.flush()
+	f.elseSite = g.a.JccPlaceholder(invertCond(cond)) // skip then-edge when cond false
+	g.ctrl = append(g.ctrl, f)
+	return nil
+}
+
+// fusedBrIf takes the branch when cond is true, reading EFLAGS directly.
+// Mirrors opBr's conditional path without the test of a materialized register.
+func (g *cg) fusedBrIf(r *wasm.Reader, cond Cond) error {
+	idx, err := r.U32()
+	if err != nil {
+		return err
+	}
+	fi := len(g.ctrl) - 1 - int(idx)
+	if fi < 0 {
+		return fmt.Errorf("br label out of range")
+	}
+	f := &g.ctrl[fi]
+	a, base, d := f.branchN, f.height, len(g.st)
+	g.flush()
+	over := g.a.JccPlaceholder(invertCond(cond)) // skip the branch when cond false
+	g.moveSlots(d-a, base, a)
+	g.branchJump(f)
+	g.a.PatchRel32(over, g.a.Len())
+	return nil
+}
+
+// fusedSelect chooses a when cond is true and b otherwise, reading EFLAGS
+// directly. Mirrors selectOp without popping/testing a condition operand.
+func (g *cg) fusedSelect(cond Cond, typed, isFloat bool) {
+	b := g.pop()
+	a := g.pop()
+	if !typed {
+		isFloat = g.isFloatOperand(a) || g.isFloatOperand(b)
+	}
+	if isFloat {
+		dst := g.materializeF(a)
+		keep := g.a.JccPlaceholder(cond) // cond true -> keep a
+		src := g.materializeF(b)
+		g.a.FMov(dst, src, true)
+		g.freeFReg(src)
+		g.a.PatchRel32(keep, g.a.Len())
+		g.pushFReg(dst)
+		return
+	}
+	dst := g.materialize(a)
+	src := g.materialize(b)
+	g.a.Cmovcc(invertCond(cond), dst, src, true) // cond false -> dst = b
+	g.freeReg(src)
+	g.pushReg(dst)
+}

--- a/src/core/compiler/backend/amd64/fuse.go
+++ b/src/core/compiler/backend/amd64/fuse.go
@@ -29,15 +29,21 @@ func (g *cg) cmpFused(r *wasm.Reader, cond Cond, w bool) error {
 	if next, ok := r.Peek(); ok {
 		switch next {
 		case 0x04: // if
-			_, _ = r.Byte()
+			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
+				return err
+			}
 			g.freeReg(g.emitCompare(w))
 			return g.fusedIf(r, cond)
 		case 0x0D: // br_if
-			_, _ = r.Byte()
+			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
+				return err
+			}
 			g.freeReg(g.emitCompare(w))
 			return g.fusedBrIf(r, cond)
 		case 0x1B: // select
-			_, _ = r.Byte()
+			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
+				return err
+			}
 			g.freeReg(g.emitCompare(w))
 			g.fusedSelect(cond, false, false)
 			return nil
@@ -52,15 +58,21 @@ func (g *cg) eqzFused(r *wasm.Reader, w bool) error {
 	if next, ok := r.Peek(); ok {
 		switch next {
 		case 0x04: // if
-			_, _ = r.Byte()
+			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
+				return err
+			}
 			g.freeReg(g.emitEqzTest(w))
 			return g.fusedIf(r, CondE)
 		case 0x0D: // br_if
-			_, _ = r.Byte()
+			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
+				return err
+			}
 			g.freeReg(g.emitEqzTest(w))
 			return g.fusedBrIf(r, CondE)
 		case 0x1B: // select
-			_, _ = r.Byte()
+			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
+				return err
+			}
 			g.freeReg(g.emitEqzTest(w))
 			g.fusedSelect(CondE, false, false)
 			return nil

--- a/src/core/compiler/backend/amd64/fuse_test.go
+++ b/src/core/compiler/backend/amd64/fuse_test.go
@@ -1,0 +1,113 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFuseCorrectness exercises every fusable consumer (if, br_if, select) fed
+// by both an integer compare and eqz, checking both the true and false edges.
+func TestFuseCorrectness(t *testing.T) {
+	cases := []struct {
+		name string
+		wat  string
+		args []int32
+		want int32
+	}{
+		// compare -> if
+		{"cmp_if_true",
+			`(module (func (export "f") (param i32 i32) (result i32)
+				local.get 0 local.get 1 i32.lt_s (if (result i32) (then i32.const 10) (else i32.const 20))))`,
+			[]int32{1, 2}, 10},
+		{"cmp_if_false",
+			`(module (func (export "f") (param i32 i32) (result i32)
+				local.get 0 local.get 1 i32.lt_s (if (result i32) (then i32.const 10) (else i32.const 20))))`,
+			[]int32{2, 1}, 20},
+		// compare -> br_if (branch out of a block)
+		{"cmp_brif_taken",
+			`(module (func (export "f") (param i32) (result i32)
+				(block (result i32)
+					i32.const 99
+					local.get 0 i32.const 0 i32.eq br_if 0
+					drop i32.const 7)))`,
+			[]int32{0}, 99}, // 0==0 -> branch taken, yields 99
+		{"cmp_brif_nottaken",
+			`(module (func (export "f") (param i32) (result i32)
+				(block (result i32)
+					i32.const 99
+					local.get 0 i32.const 0 i32.eq br_if 0
+					drop i32.const 7)))`,
+			[]int32{5}, 7}, // 5==0 false -> fall through to 7
+		// compare -> select
+		{"cmp_select_true",
+			`(module (func (export "f") (param i32 i32) (result i32)
+				i32.const 111 i32.const 222 local.get 0 local.get 1 i32.gt_s select))`,
+			[]int32{9, 3}, 111}, // 9>3 -> a (111)
+		{"cmp_select_false",
+			`(module (func (export "f") (param i32 i32) (result i32)
+				i32.const 111 i32.const 222 local.get 0 local.get 1 i32.gt_s select))`,
+			[]int32{3, 9}, 222}, // 3>9 false -> b (222)
+		// eqz -> if
+		{"eqz_if_true",
+			`(module (func (export "f") (param i32) (result i32)
+				local.get 0 i32.eqz (if (result i32) (then i32.const 1) (else i32.const 0))))`,
+			[]int32{0}, 1},
+		{"eqz_if_false",
+			`(module (func (export "f") (param i32) (result i32)
+				local.get 0 i32.eqz (if (result i32) (then i32.const 1) (else i32.const 0))))`,
+			[]int32{42}, 0},
+		// regression: non-adjacent use must still work (stored, reused) -> NOT fused
+		{"cmp_stored_then_used",
+			`(module (func (export "f") (param i32 i32) (result i32) (local i32)
+				local.get 0 local.get 1 i32.lt_s local.set 2
+				local.get 2 local.get 2 i32.add))`,
+			[]int32{1, 2}, 2}, // (1<2)=1 stored; 1+1=2
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := watToModule(t, tc.wat)
+			if got := runI32(t, m, tc.args...); got != tc.want {
+				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFuseEliminatesSetcc proves the optimization fired: a compare feeding an
+// `if` must lower to `cmp` + a conditional jump with no `setcc` in between,
+// whereas the same compare whose result is stored keeps its `setcc`.
+func TestFuseEliminatesSetcc(t *testing.T) {
+	fused := watToModule(t, `(module (func (export "f") (param i32 i32) (result i32)
+		local.get 0 local.get 1 i32.lt_s (if (result i32) (then i32.const 10) (else i32.const 20))))`)
+	code, err := CompileFunction(fused, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dis := disasm(t, code); hasSetcc(dis) {
+		t.Fatalf("expected no setcc in fused compare+if; disassembly:\n%s", dis)
+	}
+
+	notFused := watToModule(t, `(module (func (export "f") (param i32 i32) (result i32) (local i32)
+		local.get 0 local.get 1 i32.lt_s local.set 2 local.get 2))`)
+	code2, err := CompileFunction(notFused, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dis2 := disasm(t, code2); !hasSetcc(dis2) {
+		t.Fatalf("expected a setcc in the non-fused store path; disassembly:\n%s", dis2)
+	}
+}
+
+// hasSetcc reports whether any setCC mnemonic appears in the disassembly.
+func hasSetcc(dis string) bool {
+	for _, line := range strings.Split(dis, "\n") {
+		for _, tok := range strings.Fields(line) {
+			if strings.HasPrefix(tok, "set") && len(tok) <= 5 { // sete, setl, setbe, ...
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/src/core/compiler/backend/amd64/fuse_test.go
+++ b/src/core/compiler/backend/amd64/fuse_test.go
@@ -104,7 +104,7 @@ func TestFuseEliminatesSetcc(t *testing.T) {
 func hasSetcc(dis string) bool {
 	for _, line := range strings.Split(dis, "\n") {
 		for _, tok := range strings.Fields(line) {
-			if strings.HasPrefix(tok, "set") && len(tok) <= 5 { // sete, setl, setbe, ...
+			if strings.HasPrefix(tok, "set") && len(tok) >= 4 && len(tok) <= 6 { // sete, setl, setbe, setnbe, ...
 				return true
 			}
 		}


### PR DESCRIPTION
Ports WARP's **condense-comparison** optimization to the amd64 backend. An integer comparison (`i32`/`i64` relops) or `i32`/`i64.eqz` normally materializes a `0`/`1` value with `setcc`, which the following `if` / `br_if` / `select` immediately re-tests. When the consumer opcode directly follows the comparison, we now emit the compare straight into the branch's condition codes and skip both the `setcc` and the consumer's redundant `test`.

This is the first of the single-pass codegen optimizations from WARP (`warp/docs/implementation_details/CondenseComparison.md`) — the start of the eventual `-O1` ladder.

- One-opcode **lookahead** at the producer: when a compare/eqz is decoded, peek the next opcode; fuse only into an immediately-following `if` (0x04), `br_if` (0x0D), or `select` (0x1B).
- Because fusion is bounded to the adjacent pair, **EFLAGS only has to survive within a single compile step**. `flush()` emits only moves, so it preserves the flags between the compare and the branch. There is no deferred/persistent flag state to track, and therefore no buried/clobbered-flags hazard.
- Any **non-adjacent** use (result stored to a local, used by arithmetic, etc.) falls back to the existing `setcc` path — always correct.
- `cmp`/`eqz` are refactored to expose flag-only emitters (`emitCompare` / `emitEqzTest`); the **non-fused path is byte-identical** to before, so existing golden/disasm tests are unaffected.
- Condition negation uses `c ^ 1` (x86 condition codes are paired by their low bit).

Float comparisons (`fcmp`) and the typed `select` (0x1C) are intentionally **out of scope** here (NaN/unordered handling and immediate parsing respectively) — left as follow-ups.