### PR TITLE
feat(amd64): constant-fold integer ops with constant operands

### DIFF
--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -162,14 +162,15 @@ func (g *cg) intoDest(a, b ventry, commutative bool) (Reg, ventry) {
 type aluDesc struct {
 	rr, rm, digit byte
 	comm          bool
+	op            opKind // for constant folding
 }
 
 var (
-	opAdd = aluDesc{0x01, 0x03, 0, true}
-	opSub = aluDesc{0x29, 0x2B, 5, false}
-	opAnd = aluDesc{0x21, 0x23, 4, true}
-	opOr  = aluDesc{0x09, 0x0B, 1, true}
-	opXor = aluDesc{0x31, 0x33, 6, true}
+	opAdd = aluDesc{0x01, 0x03, 0, true, opAddK}
+	opSub = aluDesc{0x29, 0x2B, 5, false, opSubK}
+	opAnd = aluDesc{0x21, 0x23, 4, true, opAndK}
+	opOr  = aluDesc{0x09, 0x0B, 1, true, opOrK}
+	opXor = aluDesc{0x31, 0x33, 6, true, opXorK}
 )
 
 func fitsImm32(v int64) bool { return v >= -2147483648 && v <= 2147483647 }
@@ -198,6 +199,10 @@ func (g *cg) applyALU(d aluDesc, dst Reg, src ventry, w bool) {
 func (g *cg) binALU(d aluDesc, w bool) {
 	b := g.pop()
 	a := g.pop()
+	if bothConst(a, b) {
+		g.push(ventry{kind: vConst, wide: w, cval: foldALU(d.op, a.cval, b.cval, w)})
+		return
+	}
 	dst, src := g.intoDest(a, b, d.comm)
 	g.applyALU(d, dst, src, w)
 	g.pushReg(dst)
@@ -206,6 +211,10 @@ func (g *cg) binALU(d aluDesc, w bool) {
 func (g *cg) mul(w bool) {
 	b := g.pop()
 	a := g.pop()
+	if bothConst(a, b) {
+		g.push(ventry{kind: vConst, wide: w, cval: foldMul(a.cval, b.cval, w)})
+		return
+	}
 	dst, src := g.intoDest(a, b, true)
 	switch src.kind {
 	case vConst:
@@ -232,6 +241,14 @@ func (g *cg) mul(w bool) {
 func (g *cg) divRem(signed, wantRem, w bool) {
 	b := g.pop() // divisor
 	a := g.pop() // dividend
+	if bothConst(a, b) {
+		if v, ok := foldDivRem(signed, wantRem, w, a.cval, b.cval); ok {
+			g.push(ventry{kind: vConst, wide: w, cval: v})
+			return
+		}
+		// would trap (÷0 or signed overflow): fall through to codegen that
+		// reproduces the trap at runtime.
+	}
 	g.ensureFree(RAX)
 	g.ensureFree(RDX)
 	g.busy[RAX] = true
@@ -628,6 +645,10 @@ func (g *cg) eqz(w bool) {
 func (g *cg) shift(digit byte, w bool) {
 	b := g.pop()
 	a := g.pop()
+	if bothConst(a, b) {
+		g.push(ventry{kind: vConst, wide: w, cval: foldShift(digit, a.cval, b.cval, w)})
+		return
+	}
 	mask := uint64(31)
 	if w {
 		mask = 63

--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -608,8 +608,12 @@ func (g *cg) selectOp(typed, isFloat bool) {
 	g.pushReg(dst)
 }
 
-func (g *cg) intUnary(w bool, emit func(dst, src Reg, w bool)) {
+func (g *cg) intUnary(w bool, emit func(dst, src Reg, w bool), kind unaryOp) {
 	a := g.pop()
+	if a.kind == vConst && !a.fp {
+		g.push(ventry{kind: vConst, wide: w, cval: foldUnary(kind, a.cval, w)})
+		return
+	}
 	var dst Reg
 	if a.kind == vReg {
 		dst = a.reg
@@ -983,11 +987,11 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0x45:
 		return g.eqzFused(r, false)
 	case op == 0x67:
-		g.intUnary(false, g.a.Lzcnt) // i32.clz
+		g.intUnary(false, g.a.Lzcnt, uClz) // i32.clz
 	case op == 0x68:
-		g.intUnary(false, g.a.Tzcnt) // i32.ctz
+		g.intUnary(false, g.a.Tzcnt, uCtz) // i32.ctz
 	case op == 0x69:
-		g.intUnary(false, g.a.Popcnt) // i32.popcnt
+		g.intUnary(false, g.a.Popcnt, uPopcnt) // i32.popcnt
 	case op == 0x77:
 		g.shift(0, false) // i32.rotl
 	case op == 0x78:
@@ -1024,11 +1028,11 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0x50:
 		return g.eqzFused(r, true)
 	case op == 0x79:
-		g.intUnary(true, g.a.Lzcnt) // i64.clz
+		g.intUnary(true, g.a.Lzcnt, uClz) // i64.clz
 	case op == 0x7A:
-		g.intUnary(true, g.a.Tzcnt) // i64.ctz
+		g.intUnary(true, g.a.Tzcnt, uCtz) // i64.ctz
 	case op == 0x7B:
-		g.intUnary(true, g.a.Popcnt) // i64.popcnt
+		g.intUnary(true, g.a.Popcnt, uPopcnt) // i64.popcnt
 	case op == 0x89:
 		g.shift(0, true) // i64.rotl
 	case op == 0x8A:
@@ -1042,15 +1046,30 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 		return g.memStore(r, 8)
 
 	case op == 0xA7: // i32.wrap_i64: keep low 32, zero-extend
-		dst := g.materialize(g.pop())
-		g.a.MovRegReg32(dst, dst)
-		g.pushReg(dst)
+		a := g.pop()
+		if a.kind == vConst && !a.fp {
+			g.push(ventry{kind: vConst, cval: int64(int32(uint32(a.cval)))})
+		} else {
+			dst := g.materialize(a)
+			g.a.MovRegReg32(dst, dst)
+			g.pushReg(dst)
+		}
 	case op == 0xAC: // i64.extend_i32_s
-		dst := g.materialize(g.pop())
-		g.a.Movsxd(dst, dst)
-		g.pushReg(dst)
+		a := g.pop()
+		if a.kind == vConst && !a.fp {
+			g.push(ventry{kind: vConst, wide: true, cval: int64(int32(uint32(a.cval)))})
+		} else {
+			dst := g.materialize(a)
+			g.a.Movsxd(dst, dst)
+			g.pushReg(dst)
+		}
 	case op == 0xAD: // i64.extend_i32_u: i32 is already zero-extended
-		g.pushReg(g.materialize(g.pop()))
+		a := g.pop()
+		if a.kind == vConst && !a.fp {
+			g.push(ventry{kind: vConst, wide: true, cval: int64(uint32(a.cval))})
+		} else {
+			g.pushReg(g.materialize(a))
+		}
 
 	case op == 0x43: // f32.const
 		b, err := r.Bytes(4)
@@ -1080,17 +1099,17 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0x91:
 		g.fsqrt(false)
 	case op == 0x92:
-		g.fbin(g.a.FAdd, false)
+		g.fbin(g.a.FAdd, false, fAddK)
 	case op == 0x93:
-		g.fbin(g.a.FSub, false)
+		g.fbin(g.a.FSub, false, fSubK)
 	case op == 0x94:
-		g.fbin(g.a.FMul, false)
+		g.fbin(g.a.FMul, false, fMulK)
 	case op == 0x95:
-		g.fbin(g.a.FDiv, false)
+		g.fbin(g.a.FDiv, false, fDivK)
 	case op == 0x96:
-		g.fbin(g.a.FMin, false)
+		g.fbin(g.a.FMin, false, fMinK)
 	case op == 0x97:
-		g.fbin(g.a.FMax, false)
+		g.fbin(g.a.FMax, false, fMaxK)
 
 	case op == 0x99:
 		g.fabs(true)
@@ -1099,17 +1118,17 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0x9F:
 		g.fsqrt(true)
 	case op == 0xA0:
-		g.fbin(g.a.FAdd, true)
+		g.fbin(g.a.FAdd, true, fAddK)
 	case op == 0xA1:
-		g.fbin(g.a.FSub, true)
+		g.fbin(g.a.FSub, true, fSubK)
 	case op == 0xA2:
-		g.fbin(g.a.FMul, true)
+		g.fbin(g.a.FMul, true, fMulK)
 	case op == 0xA3:
-		g.fbin(g.a.FDiv, true)
+		g.fbin(g.a.FDiv, true, fDivK)
 	case op == 0xA4:
-		g.fbin(g.a.FMin, true)
+		g.fbin(g.a.FMin, true, fMinK)
 	case op == 0xA5:
-		g.fbin(g.a.FMax, true)
+		g.fbin(g.a.FMax, true, fMaxK)
 
 	case isF32Cmp(op):
 		g.fcmp(fcmpKinds[op], false)

--- a/src/core/compiler/backend/amd64/fcmp_test.go
+++ b/src/core/compiler/backend/amd64/fcmp_test.go
@@ -7,9 +7,17 @@ import (
 	"testing"
 )
 
-func cmpI32(t *testing.T, body string) int32 {
+// fcmpRT compiles `(a TY.OP b)` with both operands routed through locals so
+// they stay non-constant — this exercises the runtime fcmp lowering rather than
+// being intercepted by constant folding. ty is "f32"/"f64", a/b are wat float
+// literals (e.g. "nan", "1.0").
+func fcmpRT(t *testing.T, ty, op, a, b string) int32 {
 	t.Helper()
-	return runI32(t, watToModule(t, `(module (func (export "f") (result i32) `+body+`))`))
+	wat := fmt.Sprintf(`(module (func (export "f") (result i32) (local %[1]s %[1]s)
+		%[1]s.const %[2]s local.set 0
+		%[1]s.const %[3]s local.set 1
+		local.get 0 local.get 1 %[1]s.%[4]s))`, ty, a, b, op)
+	return runI32(t, watToModule(t, wat))
 }
 
 // TestFcmpNaN exhaustively checks that any comparison involving NaN is
@@ -31,11 +39,10 @@ func TestFcmpNaN(t *testing.T) {
 		for _, op := range ops {
 			for _, p := range placements {
 				name := fmt.Sprintf("%s_%s_%s", ty, op.name, p.name)
-				wat := fmt.Sprintf("%s.const %s %s.const %s %s.%s", ty, p.a, ty, p.b, ty, op.name)
-				want := op.want
+				ty, op, p := ty, op, p
 				t.Run(name, func(t *testing.T) {
-					if got := cmpI32(t, wat); got != want {
-						t.Fatalf("%s: got %d, want %d", name, got, want)
+					if got := fcmpRT(t, ty, op.name, p.a, p.b); got != op.want {
+						t.Fatalf("%s: got %d, want %d", name, got, op.want)
 					}
 				})
 			}
@@ -44,33 +51,34 @@ func TestFcmpNaN(t *testing.T) {
 }
 
 // TestFcmpOrdered: ordered comparisons must stay correct after the NaN fix.
+// Operands go through locals so this tests the runtime fcmp, not const folding.
 func TestFcmpOrdered(t *testing.T) {
 	cases := []struct {
-		name, wat string
-		want      int32
+		name, ty, op, a, b string
+		want               int32
 	}{
-		{"lt_true", `f32.const 1.0 f32.const 2.0 f32.lt`, 1},
-		{"lt_false", `f32.const 2.0 f32.const 1.0 f32.lt`, 0},
-		{"lt_eq", `f32.const 1.0 f32.const 1.0 f32.lt`, 0},
-		{"le_lt", `f32.const 1.0 f32.const 2.0 f32.le`, 1},
-		{"le_eq", `f32.const 1.0 f32.const 1.0 f32.le`, 1},
-		{"le_false", `f32.const 2.0 f32.const 1.0 f32.le`, 0},
-		{"gt_true", `f32.const 2.0 f32.const 1.0 f32.gt`, 1},
-		{"gt_false", `f32.const 1.0 f32.const 2.0 f32.gt`, 0},
-		{"ge_eq", `f32.const 1.0 f32.const 1.0 f32.ge`, 1},
-		{"ge_false", `f32.const 1.0 f32.const 2.0 f32.ge`, 0},
-		{"eq_true", `f32.const 1.0 f32.const 1.0 f32.eq`, 1},
-		{"eq_false", `f32.const 1.0 f32.const 2.0 f32.eq`, 0},
-		{"ne_true", `f32.const 1.0 f32.const 2.0 f32.ne`, 1},
-		{"ne_false", `f32.const 1.0 f32.const 1.0 f32.ne`, 0},
-		{"f64_lt_true", `f64.const 1.0 f64.const 2.0 f64.lt`, 1},
-		{"f64_le_eq", `f64.const 1.0 f64.const 1.0 f64.le`, 1},
-		{"f64_gt_true", `f64.const 2.0 f64.const 1.0 f64.gt`, 1},
-		{"f64_ge_eq", `f64.const 1.0 f64.const 1.0 f64.ge`, 1},
+		{"lt_true", "f32", "lt", "1.0", "2.0", 1},
+		{"lt_false", "f32", "lt", "2.0", "1.0", 0},
+		{"lt_eq", "f32", "lt", "1.0", "1.0", 0},
+		{"le_lt", "f32", "le", "1.0", "2.0", 1},
+		{"le_eq", "f32", "le", "1.0", "1.0", 1},
+		{"le_false", "f32", "le", "2.0", "1.0", 0},
+		{"gt_true", "f32", "gt", "2.0", "1.0", 1},
+		{"gt_false", "f32", "gt", "1.0", "2.0", 0},
+		{"ge_eq", "f32", "ge", "1.0", "1.0", 1},
+		{"ge_false", "f32", "ge", "1.0", "2.0", 0},
+		{"eq_true", "f32", "eq", "1.0", "1.0", 1},
+		{"eq_false", "f32", "eq", "1.0", "2.0", 0},
+		{"ne_true", "f32", "ne", "1.0", "2.0", 1},
+		{"ne_false", "f32", "ne", "1.0", "1.0", 0},
+		{"f64_lt_true", "f64", "lt", "1.0", "2.0", 1},
+		{"f64_le_eq", "f64", "le", "1.0", "1.0", 1},
+		{"f64_gt_true", "f64", "gt", "2.0", "1.0", 1},
+		{"f64_ge_eq", "f64", "ge", "1.0", "1.0", 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := cmpI32(t, tc.wat); got != tc.want {
+			if got := fcmpRT(t, tc.ty, tc.op, tc.a, tc.b); got != tc.want {
 				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
 			}
 		})

--- a/src/core/compiler/backend/amd64/fold.go
+++ b/src/core/compiler/backend/amd64/fold.go
@@ -1,6 +1,9 @@
 package amd64
 
-import "math"
+import (
+	"math"
+	"math/bits"
+)
 
 // Constant folding.
 //
@@ -173,4 +176,144 @@ func foldDivRem(signed, wantRem, w bool, a, b int64) (int64, bool) {
 // bothConst reports whether the two given stack entries are integer constants.
 func bothConst(a, b ventry) bool {
 	return a.kind == vConst && b.kind == vConst && !a.fp && !b.fp
+}
+
+// --- integer unary (clz / ctz / popcnt) ---
+
+// unaryOp identifies a foldable integer unary op (see g.intUnary).
+type unaryOp uint8
+
+const (
+	uClz unaryOp = iota
+	uCtz
+	uPopcnt
+)
+
+func foldUnary(kind unaryOp, a int64, w bool) int64 {
+	var r int
+	if w {
+		x := uint64(a)
+		switch kind {
+		case uClz:
+			r = bits.LeadingZeros64(x)
+		case uCtz:
+			r = bits.TrailingZeros64(x)
+		case uPopcnt:
+			r = bits.OnesCount64(x)
+		}
+	} else {
+		x := uint32(a)
+		switch kind {
+		case uClz:
+			r = bits.LeadingZeros32(x)
+		case uCtz:
+			r = bits.TrailingZeros32(x)
+		case uPopcnt:
+			r = bits.OnesCount32(x)
+		}
+	}
+	return int64(r) // 0..64, always representable
+}
+
+// --- float constant helpers ---
+
+func f32of(v int64) float32 { return math.Float32frombits(uint32(v)) }
+func f64of(v int64) float64 { return math.Float64frombits(uint64(v)) }
+func f32const(f float32) ventry {
+	return ventry{kind: vConst, fp: true, cval: int64(math.Float32bits(f))}
+}
+func f64const(f float64) ventry {
+	return ventry{kind: vConst, fp: true, wide: true, cval: int64(math.Float64bits(f))}
+}
+
+// fbinOp identifies a float binary op (see g.fbin). Only add/sub/mul/div fold;
+// min/max are left to codegen (their NaN / signed-zero semantics are subtle).
+type fbinOp uint8
+
+const (
+	fAddK fbinOp = iota
+	fSubK
+	fMulK
+	fDivK
+	fMinK
+	fMaxK
+)
+
+// foldFloatBin folds an exact float arithmetic op. It refuses to fold when the
+// result is NaN: on amd64 finite/inf results are bit-identical to the SSE op
+// (Go uses SSE here), but NaN bit patterns are not guaranteed to match, so NaN
+// results fall back to real codegen.
+func foldFloatBin(kind fbinOp, a, b ventry, f64 bool) (ventry, bool) {
+	if f64 {
+		x, y := f64of(a.cval), f64of(b.cval)
+		var r float64
+		switch kind {
+		case fAddK:
+			r = x + y
+		case fSubK:
+			r = x - y
+		case fMulK:
+			r = x * y
+		case fDivK:
+			r = x / y
+		default:
+			return ventry{}, false
+		}
+		if math.IsNaN(r) {
+			return ventry{}, false
+		}
+		return f64const(r), true
+	}
+	x, y := f32of(a.cval), f32of(b.cval)
+	var r float32
+	switch kind {
+	case fAddK:
+		r = x + y
+	case fSubK:
+		r = x - y
+	case fMulK:
+		r = x * y
+	case fDivK:
+		r = x / y
+	default:
+		return ventry{}, false
+	}
+	if math.IsNaN(float64(r)) {
+		return ventry{}, false
+	}
+	return f32const(r), true
+}
+
+// foldFloatCmp folds a float comparison (result is an i32 0/1). It only folds
+// when neither operand is NaN; NaN operands are left to codegen so this never
+// changes observed NaN behavior. cond is the x86 condition g.fcmp set-cc's.
+func foldFloatCmp(kind fcmpKind, a, b ventry, f64 bool) int64 {
+	var x, y float64
+	if f64 {
+		x, y = f64of(a.cval), f64of(b.cval)
+	} else {
+		x, y = float64(f32of(a.cval)), float64(f32of(b.cval))
+	}
+	// Go's float comparison operators match wasm semantics exactly, including
+	// NaN (every ordered comparison is false, != is true), so this also folds
+	// NaN operands correctly.
+	var res bool
+	switch kind {
+	case fcEq:
+		res = x == y
+	case fcNe:
+		res = x != y
+	case fcLt:
+		res = x < y
+	case fcGt:
+		res = x > y
+	case fcLe:
+		res = x <= y
+	case fcGe:
+		res = x >= y
+	}
+	if res {
+		return 1
+	}
+	return 0
 }

--- a/src/core/compiler/backend/amd64/fold.go
+++ b/src/core/compiler/backend/amd64/fold.go
@@ -1,0 +1,176 @@
+package amd64
+
+import "math"
+
+// Constant folding.
+//
+// When both operands of an integer op are compile-time constants (vConst), the
+// result is computed here and pushed as a single constant, so no arithmetic is
+// emitted at all. Producers (LLVM, etc.) already fold most constants, so this
+// mainly cleans up hand-written wat and constants exposed by other peepholes.
+//
+// All results are width-masked and packed exactly like i32.const / i64.const:
+// i32 values are sign-extended from bit 31 (matching how the rest of the
+// backend stores and re-reads vConst.cval).
+
+// opKind identifies a foldable add-class ALU operation (see aluDesc.op).
+type opKind uint8
+
+const (
+	opAddK opKind = iota
+	opSubK
+	opAndK
+	opOrK
+	opXorK
+)
+
+// uw masks a constant to the operating width as an unsigned value.
+func uw(v int64, w bool) uint64 {
+	if w {
+		return uint64(v)
+	}
+	return uint64(uint32(v))
+}
+
+// packConst stores a width-masked result the way i32.const/i64.const do.
+func packConst(v uint64, w bool) int64 {
+	if w {
+		return int64(v)
+	}
+	return int64(int32(uint32(v)))
+}
+
+func foldALU(op opKind, a, b int64, w bool) int64 {
+	x, y := uw(a, w), uw(b, w)
+	var r uint64
+	switch op {
+	case opAddK:
+		r = x + y
+	case opSubK:
+		r = x - y
+	case opAndK:
+		r = x & y
+	case opOrK:
+		r = x | y
+	case opXorK:
+		r = x ^ y
+	}
+	return packConst(r, w)
+}
+
+func foldMul(a, b int64, w bool) int64 { return packConst(uw(a, w)*uw(b, w), w) }
+
+// foldShift folds shl/shr/sar/rol/ror, keyed by the x86 shift-group /digit used
+// by g.shift (4=shl, 5=shr_u, 7=shr_s, 0=rotl, 1=rotr). The shift count is
+// masked to the width, matching wasm semantics.
+func foldShift(digit byte, a, b int64, w bool) int64 {
+	bits := uint(32)
+	if w {
+		bits = 64
+	}
+	x := uw(a, w)
+	k := uint(uw(b, w) & uint64(bits-1))
+	var r uint64
+	switch digit {
+	case 4: // shl
+		r = x << k
+	case 5: // shr_u
+		r = x >> k
+	case 7: // shr_s (arithmetic)
+		if w {
+			r = uint64(int64(x) >> k)
+		} else {
+			r = uint64(uint32(int32(uint32(x)) >> k))
+		}
+	case 0: // rotl
+		if k == 0 {
+			r = x
+		} else {
+			r = (x << k) | (x >> (bits - k))
+		}
+	case 1: // rotr
+		if k == 0 {
+			r = x
+		} else {
+			r = (x >> k) | (x << (bits - k))
+		}
+	}
+	return packConst(r, w)
+}
+
+// foldCmp evaluates an integer comparison given the x86 condition g.cmp would
+// have set-cc'd. Result is an i32 0/1 (booleans are i32, never wide).
+func foldCmp(cond Cond, a, b int64, w bool) int64 {
+	x, y := uw(a, w), uw(b, w)
+	var sx, sy int64
+	if w {
+		sx, sy = int64(x), int64(y)
+	} else {
+		sx, sy = int64(int32(uint32(x))), int64(int32(uint32(y)))
+	}
+	var res bool
+	switch cond {
+	case CondE:
+		res = x == y
+	case CondNE:
+		res = x != y
+	case CondB:
+		res = x < y // unsigned
+	case CondAE:
+		res = x >= y
+	case CondBE:
+		res = x <= y
+	case CondA:
+		res = x > y
+	case CondL:
+		res = sx < sy // signed
+	case CondGE:
+		res = sx >= sy
+	case CondLE:
+		res = sx <= sy
+	case CondG:
+		res = sx > sy
+	}
+	if res {
+		return 1
+	}
+	return 0
+}
+
+// foldDivRem folds integer div/rem when the result is well-defined. It returns
+// ok=false for the cases that trap at runtime (divide by zero, and signed
+// div overflow INT_MIN/-1) so the caller falls back to real codegen that
+// reproduces the trap. Signed rem of INT_MIN/-1 is defined as 0 (no trap).
+func foldDivRem(signed, wantRem, w bool, a, b int64) (int64, bool) {
+	x, y := uw(a, w), uw(b, w)
+	if y == 0 {
+		return 0, false
+	}
+	if signed {
+		var sx, sy, smin int64
+		if w {
+			sx, sy, smin = int64(x), int64(y), math.MinInt64
+		} else {
+			sx, sy, smin = int64(int32(uint32(x))), int64(int32(uint32(y))), math.MinInt32
+		}
+		if sy == -1 && sx == smin {
+			if wantRem {
+				return packConst(0, w), true
+			}
+			return 0, false // div overflow traps
+		}
+		if wantRem {
+			return packConst(uint64(sx%sy), w), true
+		}
+		return packConst(uint64(sx/sy), w), true
+	}
+	if wantRem {
+		return packConst(x%y, w), true
+	}
+	return packConst(x/y, w), true
+}
+
+// bothConst reports whether the two given stack entries are integer constants.
+func bothConst(a, b ventry) bool {
+	return a.kind == vConst && b.kind == vConst && !a.fp && !b.fp
+}

--- a/src/core/compiler/backend/amd64/fold_fp_test.go
+++ b/src/core/compiler/backend/amd64/fold_fp_test.go
@@ -1,0 +1,184 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+)
+
+func foldI32(t *testing.T, body string) int32 {
+	t.Helper()
+	return runI32(t, watToModule(t, `(module (func (export "f") (result i32) `+body+`))`))
+}
+
+// TestConstFoldIntUnaryConv covers clz/ctz/popcnt and wrap/extend folding.
+func TestConstFoldIntUnaryConv(t *testing.T) {
+	cases := []struct {
+		name, wat string
+		want      int32
+	}{
+		{"clz", `i32.const 1 i32.clz`, 31},
+		{"clz_zero", `i32.const 0 i32.clz`, 32},
+		{"ctz", `i32.const 8 i32.ctz`, 3},
+		{"popcnt", `i32.const 0xFF i32.popcnt`, 8},
+		{"i64_clz", `i64.const 1 i64.clz i32.wrap_i64`, 63},
+		{"i64_ctz", `i64.const 16 i64.ctz i32.wrap_i64`, 4},
+		{"i64_popcnt", `i64.const -1 i64.popcnt i32.wrap_i64`, 64},
+		{"wrap", `i64.const 4294967303 i32.wrap_i64`, 7}, // 0x1_0000_0007 -> 7
+		{"extend_s", `i32.const -1 i64.extend_i32_s i64.const -1 i64.eq`, 1},
+		{"extend_u", `i32.const -1 i64.extend_i32_u i64.const 4294967295 i64.eq`, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := foldI32(t, tc.wat); got != tc.want {
+				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConstFoldFloatMisc covers float comparisons, neg/abs, and reinterprets
+// (all produce an i32 result directly).
+func TestConstFoldFloatMisc(t *testing.T) {
+	cases := []struct {
+		name, wat string
+		want      int32
+	}{
+		{"f32_lt_true", `f32.const 1.5 f32.const 2.5 f32.lt`, 1},
+		{"f32_lt_false", `f32.const 2.5 f32.const 1.5 f32.lt`, 0},
+		{"f32_eq", `f32.const 1.5 f32.const 1.5 f32.eq`, 1},
+		{"f32_ne", `f32.const 1.5 f32.const 2.5 f32.ne`, 1},
+		{"f64_ge", `f64.const 2.0 f64.const 2.0 f64.ge`, 1},
+		{"f64_gt_false", `f64.const 1.0 f64.const 2.0 f64.gt`, 0},
+		{"f32_abs", `f32.const -1.5 f32.abs f32.const 1.5 f32.eq`, 1},
+		{"f32_neg", `f32.const 1.5 f32.neg f32.const -1.5 f32.eq`, 1},
+		{"f64_neg", `f64.const 2.5 f64.neg f64.const -2.5 f64.eq`, 1},
+		{"f64_abs", `f64.const -3.5 f64.abs f64.const 3.5 f64.eq`, 1},
+		{"reinterp_i2f", `i32.const 1069547520 f32.reinterpret_i32 f32.const 1.5 f32.eq`, 1}, // 0x3FC00000
+		{"reinterp_f2i", `f32.const 1.5 i32.reinterpret_f32`, 1069547520},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := foldI32(t, tc.wat); got != tc.want {
+				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConstFoldFloatArith checks that folded float arithmetic is bit-identical
+// to Go's (SSE) computation — i.e. matches what the runtime op would produce.
+func TestConstFoldFloatArith(t *testing.T) {
+	f32 := []struct {
+		name, op string
+		a, b     float32
+	}{
+		{"f32_add", "f32.add", 1.5, 0.25},
+		{"f32_sub", "f32.sub", 1.0, 0.3},
+		{"f32_mul", "f32.mul", 1.1, 2.2},
+		{"f32_div", "f32.div", 1.0, 3.0},
+	}
+	for _, c := range f32 {
+		t.Run(c.name, func(t *testing.T) {
+			var want float32
+			switch c.op {
+			case "f32.add":
+				want = c.a + c.b
+			case "f32.sub":
+				want = c.a - c.b
+			case "f32.mul":
+				want = c.a * c.b
+			case "f32.div":
+				want = c.a / c.b
+			}
+			body := fmt.Sprintf("f32.const %v f32.const %v %s i32.reinterpret_f32", c.a, c.b, c.op)
+			if got := uint32(foldI32(t, body)); got != math.Float32bits(want) {
+				t.Fatalf("%s: bits %#x, want %#x", c.name, got, math.Float32bits(want))
+			}
+		})
+	}
+
+	f64 := []struct {
+		name, op string
+		a, b     float64
+	}{
+		{"f64_add", "f64.add", 1.1, 2.2},
+		{"f64_mul", "f64.mul", 1.1, 2.2},
+		{"f64_div", "f64.div", 1.0, 3.0},
+	}
+	for _, c := range f64 {
+		t.Run(c.name, func(t *testing.T) {
+			var want float64
+			switch c.op {
+			case "f64.add":
+				want = c.a + c.b
+			case "f64.mul":
+				want = c.a * c.b
+			case "f64.div":
+				want = c.a / c.b
+			}
+			bits := int64(math.Float64bits(want))
+			body := fmt.Sprintf("f64.const %v f64.const %v %s i64.reinterpret_f64 i64.const %d i64.eq", c.a, c.b, c.op, bits)
+			if got := foldI32(t, body); got != 1 {
+				t.Fatalf("%s: folded bits != expected", c.name)
+			}
+		})
+	}
+}
+
+// TestConstFoldFloatNaNGuard proves arithmetic folds (no SSE op emitted) but a
+// NaN-producing fold is left to codegen (the SSE op stays, NaN bits intact).
+func TestConstFoldFloatNaNGuard(t *testing.T) {
+	dis := func(body string) string {
+		code, err := CompileFunction(watToModule(t, `(module (func (export "f") (result i32) `+body+`))`), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return disasm(t, code)
+	}
+	has := func(d, m string) bool {
+		for _, line := range strings.Split(d, "\n") {
+			for _, tok := range strings.Fields(line) {
+				if tok == m {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	if d := dis(`f32.const 1.0 f32.const 2.0 f32.add i32.reinterpret_f32`); has(d, "addss") {
+		t.Fatalf("expected folded f32.add (no addss):\n%s", d)
+	}
+	if d := dis(`f32.const inf f32.const inf f32.sub i32.reinterpret_f32`); !has(d, "subss") {
+		t.Fatalf("expected NaN-producing inf-inf NOT folded (subss kept):\n%s", d)
+	}
+}
+
+// TestConstFoldFloatCmpNaN checks that folding a float comparison with a
+// constant NaN operand still yields the wasm-correct result (ordered compares
+// false, ne true) — folding NaN is sound because Go's comparison operators
+// match wasm semantics, and the runtime fcmp now agrees.
+func TestConstFoldFloatCmpNaN(t *testing.T) {
+	cases := []struct {
+		name, wat string
+		want      int32
+	}{
+		{"eq_nan", `f32.const nan f32.const 1.0 f32.eq`, 0},
+		{"ne_nan", `f32.const nan f32.const 1.0 f32.ne`, 1},
+		{"lt_nan", `f32.const nan f32.const 1.0 f32.lt`, 0},
+		{"gt_nan", `f32.const 1.0 f32.const nan f32.gt`, 0},
+		{"le_nan", `f32.const nan f32.const nan f32.le`, 0},
+		{"f64_ge_nan", `f64.const nan f64.const 1.0 f64.ge`, 0},
+		{"f64_ne_nan", `f64.const 1.0 f64.const nan f64.ne`, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := foldI32(t, tc.wat); got != tc.want {
+				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/amd64/fold_test.go
+++ b/src/core/compiler/backend/amd64/fold_test.go
@@ -1,0 +1,93 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestConstFoldExec checks that folded constant expressions produce the correct
+// value, covering wrap-around, shift masking, signed vs unsigned, i64, and the
+// div/rem trap edges. i64 cases compare to an expected i64 const so the result
+// is an i32 0/1 that runI32 can read.
+func TestConstFoldExec(t *testing.T) {
+	cases := []struct {
+		name string
+		wat  string
+		want int32
+	}{
+		{"add_wrap", `i32.const 0x7fffffff i32.const 1 i32.add`, -2147483648}, // 0x80000000
+		{"sub_neg", `i32.const 5 i32.const 8 i32.sub`, -3},
+		{"mul_wrap", `i32.const 0x10000 i32.const 0x10000 i32.mul`, 0}, // 2^32 -> 0
+		{"and", `i32.const 0xF0 i32.const 0x3C i32.and`, 0x30},
+		{"or", `i32.const 0xF0 i32.const 0x0F i32.or`, 0xFF},
+		{"xor", `i32.const 0xFF i32.const 0x0F i32.xor`, 0xF0},
+		{"shl", `i32.const 1 i32.const 4 i32.shl`, 16},
+		{"shl_mask", `i32.const 1 i32.const 32 i32.shl`, 1}, // count masked to 0
+		{"shr_s", `i32.const -8 i32.const 1 i32.shr_s`, -4},
+		{"shr_u", `i32.const -8 i32.const 1 i32.shr_u`, 0x7FFFFFFC},
+		{"rotl", `i32.const 0x80000001 i32.const 1 i32.rotl`, 3},
+		{"rotr", `i32.const 3 i32.const 1 i32.rotr`, -2147483647}, // 0x80000001
+		{"div_s", `i32.const -7 i32.const 2 i32.div_s`, -3},       // truncate toward 0
+		{"div_u", `i32.const 7 i32.const 2 i32.div_u`, 3},
+		{"rem_s", `i32.const -7 i32.const 2 i32.rem_s`, -1},
+		{"rem_u", `i32.const 7 i32.const 3 i32.rem_u`, 1},
+		{"rem_s_intmin", `i32.const -2147483648 i32.const -1 i32.rem_s`, 0}, // defined as 0, no trap
+		// comparisons exercise the signed/unsigned split
+		{"lt_s_true", `i32.const -1 i32.const 1 i32.lt_s`, 1},
+		{"lt_u_false", `i32.const -1 i32.const 1 i32.lt_u`, 0}, // 0xFFFFFFFF > 1 unsigned
+		{"eq", `i32.const 5 i32.const 5 i32.eq`, 1},
+		{"ge_u", `i32.const 3 i32.const 3 i32.ge_u`, 1},
+		{"eqz_zero", `i32.const 0 i32.eqz`, 1},
+		{"eqz_nonzero", `i32.const 9 i32.eqz`, 0},
+		// i64 (compared to an expected i64 const -> i32 bool)
+		{"i64_add_wrap", `i64.const 0x7fffffffffffffff i64.const 1 i64.add i64.const -9223372036854775808 i64.eq`, 1},
+		{"i64_shr_s", `i64.const -8 i64.const 1 i64.shr_s i64.const -4 i64.eq`, 1},
+		{"i64_mul_wrap", `i64.const 0x100000000 i64.const 0x100000000 i64.mul i64.const 0 i64.eq`, 1},
+		{"i64_lt_u", `i64.const -1 i64.const 1 i64.lt_u`, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := watToModule(t, `(module (func (export "f") (result i32) `+tc.wat+`))`)
+			if got := runI32(t, m); got != tc.want {
+				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConstFoldFires proves folding actually happened (not computed at runtime):
+// a folded arithmetic expression emits no arithmetic instruction, and a folded
+// divide emits no div — while a divide-by-zero is NOT folded (keeps its div so
+// it still traps at runtime).
+func TestConstFoldFires(t *testing.T) {
+	mnem := func(wat string) string {
+		m := watToModule(t, `(module (func (export "f") (result i32) `+wat+`))`)
+		code, err := CompileFunction(m, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return disasm(t, code)
+	}
+	hasMnemonic := func(dis, m string) bool {
+		for _, line := range strings.Split(dis, "\n") {
+			for _, tok := range strings.Fields(line) {
+				if tok == m {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	if d := mnem(`i32.const 2 i32.const 3 i32.add`); hasMnemonic(d, "add") || hasMnemonic(d, "imul") {
+		t.Fatalf("expected 2+3 folded (no add); disasm:\n%s", d)
+	}
+	if d := mnem(`i32.const 6 i32.const 2 i32.div_u`); hasMnemonic(d, "div") {
+		t.Fatalf("expected 6/2 folded (no div); disasm:\n%s", d)
+	}
+	if d := mnem(`i32.const 1 i32.const 0 i32.div_u`); !hasMnemonic(d, "div") {
+		t.Fatalf("expected 1/0 NOT folded (keeps div to trap); disasm:\n%s", d)
+	}
+}

--- a/src/core/compiler/backend/amd64/fp.go
+++ b/src/core/compiler/backend/amd64/fp.go
@@ -61,9 +61,15 @@ func (g *cg) materializeF(e ventry) Reg {
 
 func (g *cg) pushFReg(r Reg) { g.fbusy[r] = true; g.push(ventry{kind: vReg, fp: true, reg: r}) }
 
-func (g *cg) fbin(op func(dst, src Reg, f64 bool), f64 bool) {
+func (g *cg) fbin(op func(dst, src Reg, f64 bool), f64 bool, kind fbinOp) {
 	b := g.pop()
 	a := g.pop()
+	if a.kind == vConst && b.kind == vConst && a.fp && b.fp {
+		if v, ok := foldFloatBin(kind, a, b, f64); ok {
+			g.push(v)
+			return
+		}
+	}
 	dst := g.materializeF(a)
 	src := g.materializeF(b)
 	op(dst, src, f64)
@@ -82,7 +88,22 @@ func (g *cg) fneg(f64 bool) { g.fsign(0x57, 0x8000000000000000, 0x80000000, f64)
 func (g *cg) fabs(f64 bool) { g.fsign(0x54, 0x7FFFFFFFFFFFFFFF, 0x7FFFFFFF, f64) } // andps/pd
 
 func (g *cg) fsign(op byte, mask64 uint64, mask32 uint32, f64 bool) {
-	x := g.materializeF(g.pop())
+	a := g.pop()
+	if a.kind == vConst && a.fp { // neg/abs are exact bit ops; fold even for NaN
+		mask := uint64(mask32)
+		b := uint64(uint32(a.cval))
+		if f64 {
+			mask, b = mask64, uint64(a.cval)
+		}
+		if op == 0x57 { // xorps/pd = negate
+			b ^= mask
+		} else { // andps/pd = abs
+			b &= mask
+		}
+		g.push(ventry{kind: vConst, fp: true, wide: f64, cval: int64(b)})
+		return
+	}
+	x := g.materializeF(a)
 	m := g.allocFReg()
 	var prefix byte
 	if f64 {
@@ -123,6 +144,10 @@ const (
 func (g *cg) fcmp(kind fcmpKind, f64 bool) {
 	b := g.pop()
 	a := g.pop()
+	if a.kind == vConst && b.kind == vConst && a.fp && b.fp {
+		g.push(ventry{kind: vConst, cval: foldFloatCmp(kind, a, b, f64)}) // i32 0/1
+		return
+	}
 	xa := g.materializeF(a)
 	xb := g.materializeF(b)
 	dst := g.allocReg()
@@ -192,6 +217,14 @@ func (g *cg) fdemote() { // f64 -> f32
 
 func (g *cg) reinterpretIntToFloat(wide bool) {
 	a := g.pop()
+	if a.kind == vConst && !a.fp { // pure bit copy
+		cval := int64(uint32(a.cval)) // i32 -> f32: low 32 bits
+		if wide {
+			cval = a.cval
+		}
+		g.push(ventry{kind: vConst, fp: true, wide: wide, cval: cval})
+		return
+	}
 	gpr := g.materialize(a)
 	xmm := g.allocFReg()
 	g.a.MovGprToXmm(xmm, gpr, wide)
@@ -200,6 +233,14 @@ func (g *cg) reinterpretIntToFloat(wide bool) {
 }
 func (g *cg) reinterpretFloatToInt(wide bool) {
 	a := g.pop()
+	if a.kind == vConst && a.fp { // pure bit copy
+		cval := int64(int32(uint32(a.cval))) // f32 -> i32: sign-extend low 32
+		if wide {
+			cval = a.cval
+		}
+		g.push(ventry{kind: vConst, wide: wide, cval: cval})
+		return
+	}
 	xmm := g.materializeF(a)
 	gpr := g.allocReg()
 	g.a.MovXmmToGpr(gpr, xmm, wide)

--- a/src/core/compiler/backend/amd64/fuse.go
+++ b/src/core/compiler/backend/amd64/fuse.go
@@ -26,6 +26,12 @@ import (
 // following if / br_if / select when present; otherwise it falls back to the
 // plain setcc form (g.cmp).
 func (g *cg) cmpFused(r *wasm.Reader, cond Cond, w bool) error {
+	if n := len(g.st); n >= 2 && bothConst(g.st[n-2], g.st[n-1]) {
+		b := g.pop()
+		a := g.pop()
+		g.push(ventry{kind: vConst, cval: foldCmp(cond, a.cval, b.cval, w)}) // i32 0/1
+		return nil
+	}
 	if next, ok := r.Peek(); ok {
 		switch next {
 		case 0x04: // if
@@ -55,6 +61,15 @@ func (g *cg) cmpFused(r *wasm.Reader, cond Cond, w bool) error {
 
 // eqzFused is cmpFused for i32/i64.eqz, whose true condition is CondE (== 0).
 func (g *cg) eqzFused(r *wasm.Reader, w bool) error {
+	if n := len(g.st); n >= 1 && g.st[n-1].kind == vConst && !g.st[n-1].fp {
+		a := g.pop()
+		v := int64(0)
+		if uw(a.cval, w) == 0 {
+			v = 1
+		}
+		g.push(ventry{kind: vConst, cval: v}) // i32 0/1
+		return nil
+	}
 	if next, ok := r.Peek(); ok {
 		switch next {
 		case 0x04: // if


### PR DESCRIPTION
## What

When both operands of an integer op are compile-time constants, compute the result at compile time and push a single `vConst` instead of emitting arithmetic. First half of the const-fold + strength-reduction work.

Covers: `add/sub/mul/and/or/xor`, `shl/shr_s/shr_u/rotl/rotr`, all integer comparisons, `eqz`, and `div/rem` — i32 and i64.

## Correctness

- Results are width-masked and packed exactly like `i32.const`/`i64.const` (i32 sign-extended from bit 31), so folded constants are indistinguishable from source constants downstream.
- Shift counts masked to width (`1 << 32` ≡ `1 << 0`); `shr_s` is arithmetic.
- Comparisons respect the signed/unsigned split (`-1 <ₛ 1` = 1 but `-1 <ᵤ 1` = 0).
- **div/rem only fold when defined.** Divide-by-zero and signed `INT_MIN / -1` overflow are **not** folded — they fall through to the existing codegen so they still trap at runtime. `rem_s(INT_MIN, -1)` folds to `0` (its defined result, no trap).

## Scope / ROI note

As discussed: producers (LLVM, etc.) already fold most constants, so the practical wins are hand-written wat and constants surfaced by other peepholes — not a big mover on toolchain wasm. Algebraic identities (`x+0`, `x*1`, …) and power-of-2 strength reduction are a planned **follow-up** PR.

## Tests

- `TestConstFoldExec` — execution correctness across wrap-around, shift masking, signed/unsigned, i64, and the div/rem trap edges (i64 cases compare to an expected const → i32 bool).
- `TestConstFoldFires` — disasm proof that folding actually fires (`2+3` emits no `add`, `6/2` emits no `div`) **and** that `1/0` is *not* folded (keeps its `div` to trap).