### PR TITLE
fix(amd64): correct NaN handling in float comparisons

### DIFF
--- a/src/core/compiler/backend/amd64/asm.go
+++ b/src/core/compiler/backend/amd64/asm.go
@@ -184,6 +184,8 @@ const (
 	CondGE Cond = 0xD
 	CondLE Cond = 0xE
 	CondG  Cond = 0xF
+	CondP  Cond = 0xA // parity (ucomis unordered: PF=1)
+	CondNP Cond = 0xB // not parity (ordered: PF=0)
 )
 
 func (a *Asm) SetccAL(c Cond) {

--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -1091,9 +1091,9 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 		g.fbin(g.a.FMax, true)
 
 	case isF32Cmp(op):
-		g.fcmp(fcmpCond[op], false)
+		g.fcmp(fcmpKinds[op], false)
 	case op >= 0x61 && op <= 0x66:
-		g.fcmp(fcmpCond[op], true)
+		g.fcmp(fcmpKinds[op], true)
 
 	case op == 0xA8: // i32.trunc_f32_s
 		g.f2iTrunc(false, false)

--- a/src/core/compiler/backend/amd64/fcmp_test.go
+++ b/src/core/compiler/backend/amd64/fcmp_test.go
@@ -2,43 +2,44 @@
 
 package amd64
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func cmpI32(t *testing.T, body string) int32 {
 	t.Helper()
 	return runI32(t, watToModule(t, `(module (func (export "f") (result i32) `+body+`))`))
 }
 
-// TestFcmpNaN: any comparison involving NaN is unordered — every ordered
-// comparison (eq/lt/gt/le/ge) is false and ne is true.
+// TestFcmpNaN exhaustively checks that any comparison involving NaN is
+// unordered — every ordered comparison (eq/lt/gt/le/ge) is false, ne is true —
+// across all six ops, both widths, with NaN on the left, right, and both sides.
 func TestFcmpNaN(t *testing.T) {
-	cases := []struct {
-		name, wat string
-		want      int32
+	ops := []struct {
+		name string
+		want int32 // result when an operand is NaN
 	}{
-		{"eq_nan", `f32.const nan f32.const 1.0 f32.eq`, 0},
-		{"ne_nan", `f32.const nan f32.const 1.0 f32.ne`, 1},
-		{"lt_nan", `f32.const nan f32.const 1.0 f32.lt`, 0},
-		{"gt_nan", `f32.const nan f32.const 1.0 f32.gt`, 0},
-		{"le_nan", `f32.const nan f32.const 1.0 f32.le`, 0},
-		{"ge_nan", `f32.const nan f32.const 1.0 f32.ge`, 0},
-		{"lt_nan_rhs", `f32.const 1.0 f32.const nan f32.lt`, 0},
-		{"gt_nan_rhs", `f32.const 1.0 f32.const nan f32.gt`, 0},
-		{"le_nan_rhs", `f32.const 1.0 f32.const nan f32.le`, 0},
-		{"eq_nan_both", `f32.const nan f32.const nan f32.eq`, 0},
-		{"ne_nan_both", `f32.const nan f32.const nan f32.ne`, 1},
-		{"f64_eq_nan", `f64.const nan f64.const 1.0 f64.eq`, 0},
-		{"f64_ne_nan", `f64.const nan f64.const 1.0 f64.ne`, 1},
-		{"f64_lt_nan", `f64.const nan f64.const 1.0 f64.lt`, 0},
-		{"f64_le_nan", `f64.const nan f64.const 1.0 f64.le`, 0},
-		{"f64_ge_nan", `f64.const nan f64.const 1.0 f64.ge`, 0},
+		{"eq", 0}, {"ne", 1}, {"lt", 0}, {"gt", 0}, {"le", 0}, {"ge", 0},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := cmpI32(t, tc.wat); got != tc.want {
-				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+	placements := []struct{ name, a, b string }{
+		{"lhs", "nan", "1.0"},
+		{"rhs", "1.0", "nan"},
+		{"both", "nan", "nan"},
+	}
+	for _, ty := range []string{"f32", "f64"} {
+		for _, op := range ops {
+			for _, p := range placements {
+				name := fmt.Sprintf("%s_%s_%s", ty, op.name, p.name)
+				wat := fmt.Sprintf("%s.const %s %s.const %s %s.%s", ty, p.a, ty, p.b, ty, op.name)
+				want := op.want
+				t.Run(name, func(t *testing.T) {
+					if got := cmpI32(t, wat); got != want {
+						t.Fatalf("%s: got %d, want %d", name, got, want)
+					}
+				})
 			}
-		})
+		}
 	}
 }
 

--- a/src/core/compiler/backend/amd64/fcmp_test.go
+++ b/src/core/compiler/backend/amd64/fcmp_test.go
@@ -1,0 +1,77 @@
+//go:build linux && amd64
+
+package amd64
+
+import "testing"
+
+func cmpI32(t *testing.T, body string) int32 {
+	t.Helper()
+	return runI32(t, watToModule(t, `(module (func (export "f") (result i32) `+body+`))`))
+}
+
+// TestFcmpNaN: any comparison involving NaN is unordered — every ordered
+// comparison (eq/lt/gt/le/ge) is false and ne is true.
+func TestFcmpNaN(t *testing.T) {
+	cases := []struct {
+		name, wat string
+		want      int32
+	}{
+		{"eq_nan", `f32.const nan f32.const 1.0 f32.eq`, 0},
+		{"ne_nan", `f32.const nan f32.const 1.0 f32.ne`, 1},
+		{"lt_nan", `f32.const nan f32.const 1.0 f32.lt`, 0},
+		{"gt_nan", `f32.const nan f32.const 1.0 f32.gt`, 0},
+		{"le_nan", `f32.const nan f32.const 1.0 f32.le`, 0},
+		{"ge_nan", `f32.const nan f32.const 1.0 f32.ge`, 0},
+		{"lt_nan_rhs", `f32.const 1.0 f32.const nan f32.lt`, 0},
+		{"gt_nan_rhs", `f32.const 1.0 f32.const nan f32.gt`, 0},
+		{"le_nan_rhs", `f32.const 1.0 f32.const nan f32.le`, 0},
+		{"eq_nan_both", `f32.const nan f32.const nan f32.eq`, 0},
+		{"ne_nan_both", `f32.const nan f32.const nan f32.ne`, 1},
+		{"f64_eq_nan", `f64.const nan f64.const 1.0 f64.eq`, 0},
+		{"f64_ne_nan", `f64.const nan f64.const 1.0 f64.ne`, 1},
+		{"f64_lt_nan", `f64.const nan f64.const 1.0 f64.lt`, 0},
+		{"f64_le_nan", `f64.const nan f64.const 1.0 f64.le`, 0},
+		{"f64_ge_nan", `f64.const nan f64.const 1.0 f64.ge`, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cmpI32(t, tc.wat); got != tc.want {
+				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFcmpOrdered: ordered comparisons must stay correct after the NaN fix.
+func TestFcmpOrdered(t *testing.T) {
+	cases := []struct {
+		name, wat string
+		want      int32
+	}{
+		{"lt_true", `f32.const 1.0 f32.const 2.0 f32.lt`, 1},
+		{"lt_false", `f32.const 2.0 f32.const 1.0 f32.lt`, 0},
+		{"lt_eq", `f32.const 1.0 f32.const 1.0 f32.lt`, 0},
+		{"le_lt", `f32.const 1.0 f32.const 2.0 f32.le`, 1},
+		{"le_eq", `f32.const 1.0 f32.const 1.0 f32.le`, 1},
+		{"le_false", `f32.const 2.0 f32.const 1.0 f32.le`, 0},
+		{"gt_true", `f32.const 2.0 f32.const 1.0 f32.gt`, 1},
+		{"gt_false", `f32.const 1.0 f32.const 2.0 f32.gt`, 0},
+		{"ge_eq", `f32.const 1.0 f32.const 1.0 f32.ge`, 1},
+		{"ge_false", `f32.const 1.0 f32.const 2.0 f32.ge`, 0},
+		{"eq_true", `f32.const 1.0 f32.const 1.0 f32.eq`, 1},
+		{"eq_false", `f32.const 1.0 f32.const 2.0 f32.eq`, 0},
+		{"ne_true", `f32.const 1.0 f32.const 2.0 f32.ne`, 1},
+		{"ne_false", `f32.const 1.0 f32.const 1.0 f32.ne`, 0},
+		{"f64_lt_true", `f64.const 1.0 f64.const 2.0 f64.lt`, 1},
+		{"f64_le_eq", `f64.const 1.0 f64.const 1.0 f64.le`, 1},
+		{"f64_gt_true", `f64.const 2.0 f64.const 1.0 f64.gt`, 1},
+		{"f64_ge_eq", `f64.const 1.0 f64.const 1.0 f64.ge`, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cmpI32(t, tc.wat); got != tc.want {
+				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/amd64/fp.go
+++ b/src/core/compiler/backend/amd64/fp.go
@@ -98,17 +98,64 @@ func (g *cg) fsign(op byte, mask64 uint64, mask32 uint32, f64 bool) {
 	g.pushFReg(x)
 }
 
-// NaN handling is conservative: unordered compares are false except ne.
-func (g *cg) fcmp(cond Cond, f64 bool) {
+// fcmpKind identifies a wasm float comparison (see fcmpKinds).
+type fcmpKind uint8
+
+const (
+	fcEq fcmpKind = iota
+	fcNe
+	fcLt
+	fcGt
+	fcLe
+	fcGe
+)
+
+// fcmp lowers a wasm float comparison NaN-correctly. ucomis sets ZF=PF=CF=1 on
+// an unordered (NaN) compare, so a single setcc is wrong for eq/ne/lt/le. We:
+//   - gt/ge: ucomis(a,b) + seta/setae — CF-based, already false when unordered.
+//   - lt/le: compare the operands reversed (b,a) and use gt/ge, which is the
+//     same NaN-safe CF-based form.
+//   - eq: setcc requires ordered AND equal -> sete AND setnp.
+//   - ne: unordered OR not-equal -> setne OR setp.
+//
+// Result: every ordered comparison is false when either operand is NaN; ne is
+// true. (WebAssembly semantics.)
+func (g *cg) fcmp(kind fcmpKind, f64 bool) {
 	b := g.pop()
 	a := g.pop()
 	xa := g.materializeF(a)
 	xb := g.materializeF(b)
-	g.a.Ucomis(xa, xb, f64) // sets CF/ZF/PF (PF=1 if unordered)
+	dst := g.allocReg()
+	switch kind {
+	case fcGt:
+		g.a.Ucomis(xa, xb, f64)
+		g.a.SetccReg(CondA, dst)
+	case fcGe:
+		g.a.Ucomis(xa, xb, f64)
+		g.a.SetccReg(CondAE, dst)
+	case fcLt: // a<b == b>a; reversed compare keeps the NaN-safe CF form
+		g.a.Ucomis(xb, xa, f64)
+		g.a.SetccReg(CondA, dst)
+	case fcLe: // a<=b == b>=a
+		g.a.Ucomis(xb, xa, f64)
+		g.a.SetccReg(CondAE, dst)
+	case fcEq: // ordered AND equal: ZF=1 and PF=0
+		g.a.Ucomis(xa, xb, f64)
+		t := g.allocReg()
+		g.a.SetccReg(CondE, dst)
+		g.a.SetccReg(CondNP, t)
+		g.a.AluRR(opAnd.rr, dst, t, false)
+		g.freeReg(t)
+	case fcNe: // unordered OR not-equal: ZF=0 or PF=1
+		g.a.Ucomis(xa, xb, f64)
+		t := g.allocReg()
+		g.a.SetccReg(CondNE, dst)
+		g.a.SetccReg(CondP, t)
+		g.a.AluRR(opOr.rr, dst, t, false)
+		g.freeReg(t)
+	}
 	g.freeFReg(xa)
 	g.freeFReg(xb)
-	dst := g.allocReg()
-	g.a.SetccReg(cond, dst)
 	g.pushReg(dst)
 }
 
@@ -205,9 +252,9 @@ func (g *cg) isFloatLocal(i int) bool {
 	return g.localFloat[i]
 }
 
-var fcmpCond = map[byte]Cond{
-	0x5B: CondE, 0x5C: CondNE, 0x5D: CondB, 0x5E: CondA, 0x5F: CondBE, 0x60: CondAE, // f32 eq ne lt gt le ge
-	0x61: CondE, 0x62: CondNE, 0x63: CondB, 0x64: CondA, 0x65: CondBE, 0x66: CondAE, // f64
+var fcmpKinds = map[byte]fcmpKind{
+	0x5B: fcEq, 0x5C: fcNe, 0x5D: fcLt, 0x5E: fcGt, 0x5F: fcLe, 0x60: fcGe, // f32 eq ne lt gt le ge
+	0x61: fcEq, 0x62: fcNe, 0x63: fcLt, 0x64: fcGt, 0x65: fcLe, 0x66: fcGe, // f64
 }
 
 func isF32Cmp(op byte) bool { return op >= 0x5B && op <= 0x60 }


### PR DESCRIPTION
## The bug

`ucomis` sets `ZF=PF=CF=1` on an unordered (NaN) compare, but `fcmp` lowered every float comparison as a single `setcc`. That's wrong for the conditions whose flags coincide with the unordered state:

| op | was | should be (NaN operand) |
|----|-----|----|
| `eq` | **1** | 0 |
| `ne` | **0** | 1 |
| `lt` | **1** | 0 |
| `le` | **1** | 0 |
| `gt` | 0 ✓ | 0 |
| `ge` | 0 ✓ | 0 |

So `f32.eq(nan, x)`, `f32.lt(nan, x)`, etc. were miscompiled — a real silent miscompile of WebAssembly semantics (every ordered comparison must be false when either operand is NaN; `ne` must be true). `gt`/`ge` were already correct (CF-based, false when unordered).

## The fix

NaN-correct lowering per comparison:
- **gt/ge** — `ucomis(a,b)` + `seta`/`setae` (CF-based, already NaN-safe)
- **lt/le** — compare operands *reversed* (`b,a`) and reuse the gt/ge form (`a<b ≡ b>a`)
- **eq** — `sete AND setnp` (ordered *and* equal)
- **ne** — `setne OR setp` (unordered *or* not-equal)

Adds `CondP`/`CondNP` and a `fcmpKind` enum so `fcmp` dispatches on the wasm comparison instead of a raw x86 condition.

## Tests

`TestFcmpNaN` checks all six comparisons with NaN on either/both sides (f32 + f64) — these **fail before this change**. `TestFcmpOrdered` regresses the ordered cases. Found while adding float-comparison constant folding (#8).

## Note

This touches `fcmp`/`fcmpCond`, which **#8 also modifies**, so #8 will need a rebase after this merges — I'll update #8's `foldFloatCmp` to the new `fcmpKind` and drop its now-unnecessary NaN bail (with the runtime correct, NaN comparisons can fold to the right value too).