### PR TITLE
wasm: parse and preserve name sections

### DIFF
--- a/src/core/compiler/wasm/decode.go
+++ b/src/core/compiler/wasm/decode.go
@@ -114,6 +114,9 @@ func decodeSection(m *Module, r *reader, id byte, stringRefs *[][]byte) error {
 			return err
 		}
 		if name == "name" {
+			if m.NameSec != nil {
+				return &DecodeError{Code: ErrInvalidSection, Offset: r.off()}
+			}
 			ns, err := decodeNameSec(payload)
 			if err != nil {
 				return err

--- a/src/core/compiler/wasm/decode_edges_test.go
+++ b/src/core/compiler/wasm/decode_edges_test.go
@@ -121,6 +121,40 @@ func TestDecodeNameSectionStrictness(t *testing.T) {
 	}
 }
 
+func TestDecodeDuplicateNameCustomSection(t *testing.T) {
+	payload := []byte{0x00, 0x02, 0x01, 'm'}
+	_, err := DecodeModule(module(custom("name", payload...), custom("name", payload...)))
+	var de *DecodeError
+	if !errors.As(err, &de) || de.Code != ErrInvalidSection {
+		t.Fatalf("expected duplicate name-section error, got %#v / %v", de, err)
+	}
+}
+
+func TestDecodeInvalidUTF8Name(t *testing.T) {
+	tests := []struct {
+		name string
+		mod  []byte
+	}{
+		{
+			name: "custom section name",
+			mod:  module(section(secCustom, 0x01, 0xff)),
+		},
+		{
+			name: "name subsection payload",
+			mod:  module(custom("name", 0x00, 0x02, 0x01, 0xff)),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeModule(tc.mod)
+			var de *DecodeError
+			if !errors.As(err, &de) || de.Code != ErrInvalidSection {
+				t.Fatalf("expected invalid utf-8 decode error, got %#v / %v", de, err)
+			}
+		})
+	}
+}
+
 func TestDecodeLEBBoundaries(t *testing.T) {
 	t.Run("u33 accepts upper bound", func(t *testing.T) {
 		r := newReader([]byte{0xff, 0xff, 0xff, 0xff, 0x1f})

--- a/src/core/compiler/wasm/module_helpers.go
+++ b/src/core/compiler/wasm/module_helpers.go
@@ -123,13 +123,13 @@ func (m *Module) subtypeByTypeIdx(idx TypeIdx) (*SubType, bool) {
 	if idx.Rec {
 		return nil, false
 	}
-	want := int(idx.Index)
+	want := uint64(idx.Index)
 	for gi := range m.Types {
 		rt := &m.Types[gi]
-		if want < len(rt.SubTypes) {
-			return &rt.SubTypes[want], true
+		if want < uint64(len(rt.SubTypes)) {
+			return &rt.SubTypes[int(want)], true
 		}
-		want -= len(rt.SubTypes)
+		want -= uint64(len(rt.SubTypes))
 	}
 	return nil, false
 }

--- a/src/core/compiler/wasm/more_decode_edges_test.go
+++ b/src/core/compiler/wasm/more_decode_edges_test.go
@@ -92,14 +92,58 @@ func TestMoreReferenceDecodeEdges(t *testing.T) {
 }
 
 func TestMoreNameSectionEdges(t *testing.T) {
+	name := func(s string) []byte { return append(u32(uint32(len(s))), []byte(s)...) }
+	nameMap := func(entries ...NameAssoc) []byte {
+		out := u32(uint32(len(entries)))
+		for _, e := range entries {
+			out = append(out, u32(e.Index)...)
+			out = append(out, name(e.Name)...)
+		}
+		return out
+	}
+	indirectNameMap := func(entries ...IndirectNameAssoc) []byte {
+		out := u32(uint32(len(entries)))
+		for _, e := range entries {
+			out = append(out, u32(e.Index)...)
+			out = append(out, nameMap(e.Names...)...)
+		}
+		return out
+	}
+	subsection := func(id byte, payload []byte) []byte {
+		out := []byte{id}
+		out = append(out, u32(uint32(len(payload)))...)
+		return append(out, payload...)
+	}
+
 	t.Run("malformed function name map ordering rejects module", func(t *testing.T) {
 		// custom name section: subsection 1 (function names), payload vector
 		// [(2,"b"),(1,"a")], which violates the strictly-increasing map order.
-		namePayload := []byte{0x01, 0x07, 0x02, 0x02, 0x01, 'b', 0x01, 0x01, 'a'}
+		namePayload := subsection(1, append(u32(2), append(append(u32(2), name("b")...), append(u32(1), name("a")...)...)...))
 		_, err := DecodeModule(module(custom("name", namePayload...)))
 		var de *DecodeError
 		if !errors.As(err, &de) || de.Code != ErrInvalidSection {
 			t.Fatalf("expected malformed name-section error, got %v", err)
+		}
+	})
+	t.Run("stale name indexes remain non-semantic", func(t *testing.T) {
+		namePayload := append([]byte{}, subsection(1, nameMap(NameAssoc{Index: 99, Name: "stale-func"}))...)
+		namePayload = append(namePayload, subsection(2, indirectNameMap(IndirectNameAssoc{Index: 99, Names: NameMap{{Index: 7, Name: "stale-local"}}}))...)
+		namePayload = append(namePayload, subsection(10, indirectNameMap(IndirectNameAssoc{Index: 99, Names: NameMap{{Index: 0, Name: "stale-field"}}}))...)
+		m, err := DecodeModule(module(custom("name", namePayload...)))
+		if err != nil {
+			t.Fatalf("DecodeModule: %v", err)
+		}
+		if err := ValidateModule(m); err != nil {
+			t.Fatalf("ValidateModule: %v", err)
+		}
+		if got, ok := m.NameSec.FuncName(99); !ok || got != "stale-func" {
+			t.Fatalf("FuncName(99) = %q, %v; want stale-func, true", got, ok)
+		}
+		if got, ok := m.NameSec.LocalName(99, 7); !ok || got != "stale-local" {
+			t.Fatalf("LocalName(99, 7) = %q, %v; want stale-local, true", got, ok)
+		}
+		if len(m.NameSec.FieldNames) != 1 || m.NameSec.FieldNames[0].Index != 99 || len(m.NameSec.FieldNames[0].Names) != 1 || m.NameSec.FieldNames[0].Names[0].Name != "stale-field" {
+			t.Fatalf("field names not preserved: %#v", m.NameSec.FieldNames)
 		}
 	})
 }

--- a/src/core/compiler/wasm/name_helpers.go
+++ b/src/core/compiler/wasm/name_helpers.go
@@ -1,0 +1,34 @@
+package wasm
+
+// FuncName returns the first name-section function name for a global function
+// index. Empty names are reported as present.
+func (n *NameSec) FuncName(idx uint32) (string, bool) {
+	if n == nil {
+		return "", false
+	}
+	for i := range n.FunctionNames {
+		if n.FunctionNames[i].Index == idx {
+			return n.FunctionNames[i].Name, true
+		}
+	}
+	return "", false
+}
+
+// LocalName returns the first name-section local name for localIdx in global
+// function index funcIdx. Empty names are reported as present.
+func (n *NameSec) LocalName(funcIdx, localIdx uint32) (string, bool) {
+	if n == nil {
+		return "", false
+	}
+	for i := range n.LocalNames {
+		if n.LocalNames[i].Index != funcIdx {
+			continue
+		}
+		for j := range n.LocalNames[i].Names {
+			if n.LocalNames[i].Names[j].Index == localIdx {
+				return n.LocalNames[i].Names[j].Name, true
+			}
+		}
+	}
+	return "", false
+}

--- a/src/core/compiler/wasm/reader.go
+++ b/src/core/compiler/wasm/reader.go
@@ -1,6 +1,9 @@
 package wasm
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"unicode/utf8"
+)
 
 type reader struct {
 	data []byte
@@ -101,9 +104,13 @@ func (r *reader) name() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	start := r.off()
 	b, err := r.bytes(int(n))
 	if err != nil {
 		return "", err
+	}
+	if !utf8.Valid(b) {
+		return "", &DecodeError{Code: ErrInvalidSection, Offset: start}
 	}
 	return string(b), nil
 }
@@ -115,10 +122,12 @@ func readVec[T any](r *reader, fn func(*reader) (T, error)) ([]T, error) {
 	}
 	// The declared vector length is attacker-controlled. Do not use it as a
 	// capacity hint directly: a tiny malformed payload can otherwise request a
-	// multi-gigabyte allocation before the first element read discovers EOF.
-	capHint := int(n)
-	if capHint > r.left() {
-		capHint = r.left()
+	// multi-gigabyte allocation before the first element read discovers EOF. Keep
+	// the hint in int space until n has been proven smaller, so this is safe on
+	// 32-bit Go as well as amd64.
+	capHint := r.left()
+	if uint64(n) < uint64(capHint) {
+		capHint = int(n)
 	}
 	out := make([]T, 0, capHint)
 	for i := uint32(0); i < n; i++ {

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -44,7 +44,7 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 		return nil, fmt.Errorf("compile: %w", err)
 	}
 
-	c := &Compiled{Code: cm.Code, Entry: cm.Entry, NumImports: m.ImportedFuncCount(), Exports: map[string]int{}, GlobalExports: map[string]int{}, boundsMode: cfg.boundsChecks}
+	c := &Compiled{Code: cm.Code, Entry: cm.Entry, NumImports: m.ImportedFuncCount(), Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, boundsMode: cfg.boundsChecks}
 	for i := range m.Imports {
 		im := &m.Imports[i]
 		switch im.Type.Kind {
@@ -168,6 +168,45 @@ func (c *Compiled) Signature(export string) (params, results []ValType, err erro
 		return nil, nil, err
 	}
 	return c.Funcs[li].Params, c.Funcs[li].Results, nil
+}
+
+// FuncName returns the name-section name for a global function index.
+func (c *Compiled) FuncName(funcIdx uint32) (string, bool) {
+	if c == nil || c.Names == nil {
+		return "", false
+	}
+	return c.Names.FuncName(funcIdx)
+}
+
+// LocalFuncName returns the name-section name for a locally-defined function
+// index (that is, an index into Compiled.Funcs rather than wasm's global
+// function-index space).
+func (c *Compiled) LocalFuncName(localIdx int) (string, bool) {
+	if c == nil || localIdx < 0 {
+		return "", false
+	}
+	return c.FuncName(uint32(localIdx + c.NumImports))
+}
+
+// FuncDebugName returns a stable display name for a global function index,
+// preferring the wasm name section and falling back to exports or funcN.
+func (c *Compiled) FuncDebugName(funcIdx uint32) string {
+	if name, ok := c.FuncName(funcIdx); ok && name != "" {
+		return name
+	}
+	if c != nil {
+		var exports []string
+		for name, idx := range c.Exports {
+			if idx == int(funcIdx) {
+				exports = append(exports, name)
+			}
+		}
+		if len(exports) > 0 {
+			sort.Strings(exports)
+			return exports[0]
+		}
+	}
+	return fmt.Sprintf("func%d", funcIdx)
 }
 
 func (c *Compiled) localIndex(export string) (int, error) {
@@ -328,7 +367,7 @@ func (c *Compiled) validateDeferredOffsetGlobal(kind string, seg, idx int) error
 }
 
 const wagoMagic = "WAGO"
-const wagoVersion = 7
+const wagoVersion = 8
 
 // MarshalBinary serializes the precompiled module to a ".wago" blob.
 //

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
 func marshalCompiled(c *Compiled) ([]byte, error) {
@@ -21,6 +23,7 @@ func marshalCompiled(c *Compiled) ([]byte, error) {
 		return nil, err
 	}
 	w.stringIntMap(c.Exports)
+	w.nameSec(c.Names)
 	if err := w.globalImports(c.GlobalImports); err != nil {
 		return nil, err
 	}
@@ -101,6 +104,41 @@ func (w *compiledWriter) stringIntMap(m map[string]int) {
 		w.str(k)
 		w.ivar(m[k])
 	}
+}
+func (w *compiledWriter) nameMap(m wasm.NameMap) {
+	w.uvar(uint64(len(m)))
+	for _, a := range m {
+		w.u32(a.Index)
+		w.str(a.Name)
+	}
+}
+func (w *compiledWriter) indirectNameMap(m wasm.IndirectNameMap) {
+	w.uvar(uint64(len(m)))
+	for _, a := range m {
+		w.u32(a.Index)
+		w.nameMap(a.Names)
+	}
+}
+func (w *compiledWriter) nameSec(n *wasm.NameSec) {
+	w.bool(n != nil)
+	if n == nil {
+		return
+	}
+	w.bool(n.ModuleName != nil)
+	if n.ModuleName != nil {
+		w.str(*n.ModuleName)
+	}
+	w.nameMap(n.FunctionNames)
+	w.indirectNameMap(n.LocalNames)
+	w.indirectNameMap(n.LabelNames)
+	w.nameMap(n.TypeNames)
+	w.nameMap(n.TableNames)
+	w.nameMap(n.MemoryNames)
+	w.nameMap(n.GlobalNames)
+	w.nameMap(n.ElementNames)
+	w.nameMap(n.DataNames)
+	w.indirectNameMap(n.FieldNames)
+	w.nameMap(n.TagNames)
 }
 func (w *compiledWriter) valType(t ValType) error {
 	w.u8(t.code())
@@ -200,6 +238,10 @@ func unmarshalCompiled(c *Compiled, data []byte) error {
 		return err
 	}
 	c.Exports, err = r.stringIntMap()
+	if err != nil {
+		return err
+	}
+	c.Names, err = r.nameSec()
 	if err != nil {
 		return err
 	}
@@ -397,6 +439,94 @@ func (r *compiledReader) stringIntMap() (map[string]int, error) {
 		out[k] = v
 	}
 	return out, nil
+}
+func (r *compiledReader) nameMap() (wasm.NameMap, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make(wasm.NameMap, n)
+	for i := range out {
+		out[i].Index, err = r.u32()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Name, err = r.str()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) indirectNameMap() (wasm.IndirectNameMap, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make(wasm.IndirectNameMap, n)
+	for i := range out {
+		out[i].Index, err = r.u32()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Names, err = r.nameMap()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) nameSec() (*wasm.NameSec, error) {
+	has, err := r.bool()
+	if err != nil || !has {
+		return nil, err
+	}
+	n := &wasm.NameSec{}
+	hasModule, err := r.bool()
+	if err != nil {
+		return nil, err
+	}
+	if hasModule {
+		s, err := r.str()
+		if err != nil {
+			return nil, err
+		}
+		n.ModuleName = &s
+	}
+	if n.FunctionNames, err = r.nameMap(); err != nil {
+		return nil, err
+	}
+	if n.LocalNames, err = r.indirectNameMap(); err != nil {
+		return nil, err
+	}
+	if n.LabelNames, err = r.indirectNameMap(); err != nil {
+		return nil, err
+	}
+	if n.TypeNames, err = r.nameMap(); err != nil {
+		return nil, err
+	}
+	if n.TableNames, err = r.nameMap(); err != nil {
+		return nil, err
+	}
+	if n.MemoryNames, err = r.nameMap(); err != nil {
+		return nil, err
+	}
+	if n.GlobalNames, err = r.nameMap(); err != nil {
+		return nil, err
+	}
+	if n.ElementNames, err = r.nameMap(); err != nil {
+		return nil, err
+	}
+	if n.DataNames, err = r.nameMap(); err != nil {
+		return nil, err
+	}
+	if n.FieldNames, err = r.indirectNameMap(); err != nil {
+		return nil, err
+	}
+	if n.TagNames, err = r.nameMap(); err != nil {
+		return nil, err
+	}
+	return n, nil
 }
 func (r *compiledReader) valType() (ValType, error) {
 	code, err := r.u8()

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -194,6 +194,7 @@ type Compiled struct {
 	Imports    []string       // "module.name" per imported function
 	Exports    map[string]int // exported function name -> global function index
 	NumImports int
+	Names      *wasm.NameSec // parsed debug names from the wasm name custom section
 
 	GlobalImports []GlobalImportDef // imported global entries, preceding local globals
 	Globals       []GlobalDef       // global entries in wasm global-index order

--- a/src/wago/wago_test.go
+++ b/src/wago/wago_test.go
@@ -314,6 +314,77 @@ func TestCompiledRoundtrip(t *testing.T) {
 	}
 }
 
+func TestCompiledRoundtripPreservesDebugNames(t *testing.T) {
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("imp")...)
+	importEntry = append(importEntry, 0x00) // func import
+	importEntry = append(importEntry, wasmtest.ULEB(0)...)
+	namePayload := append([]byte{}, wasmtest.NameSubsection(0, wasmtest.Name("mod"))...)
+	namePayload = append(namePayload, wasmtest.NameSubsection(1, wasmtest.NameMap(
+		wasmtest.NameAssoc{Index: 0, Name: "imported"},
+		wasmtest.NameAssoc{Index: 1, Name: ""},
+	))...)
+	namePayload = append(namePayload, wasmtest.NameSubsection(2, wasmtest.IndirectNameMap(
+		wasmtest.IndirectNameAssoc{Index: 1, Names: []wasmtest.NameAssoc{{Index: 0, Name: "local0"}}},
+	))...)
+	mod := wasmtest.Module(
+		wasmtest.Custom("name", namePayload),
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, nil),
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("z", 0, 1),
+			wasmtest.ExportEntry("a", 0, 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x2a, 0x0b}))),
+	)
+	c, err := Compile(mod)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if c.Names == nil || c.Names.ModuleName == nil || *c.Names.ModuleName != "mod" {
+		t.Fatalf("compiled names not preserved: %#v", c.Names)
+	}
+	if got, ok := c.FuncName(0); !ok || got != "imported" {
+		t.Fatalf("FuncName(0) = %q, %v; want imported, true", got, ok)
+	}
+	if got, ok := c.LocalFuncName(0); !ok || got != "" {
+		t.Fatalf("LocalFuncName(0) = %q, %v; want empty name present", got, ok)
+	}
+	if got, ok := c.Names.LocalName(1, 0); !ok || got != "local0" {
+		t.Fatalf("LocalName(1, 0) = %q, %v; want local0, true", got, ok)
+	}
+	if got := c.FuncDebugName(0); got != "imported" {
+		t.Fatalf("FuncDebugName(0) = %q, want imported", got)
+	}
+	if got := c.FuncDebugName(1); got != "a" {
+		t.Fatalf("FuncDebugName(1) = %q, want stable export fallback a", got)
+	}
+	if got := c.FuncDebugName(99); got != "func99" {
+		t.Fatalf("FuncDebugName(99) = %q, want func99", got)
+	}
+
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	loaded, err := Load(blob)
+	if err != nil {
+		t.Fatalf("Load compiled: %v", err)
+	}
+	if got, ok := loaded.FuncName(0); !ok || got != "imported" {
+		t.Fatalf("loaded FuncName(0) = %q, %v; want imported, true", got, ok)
+	}
+	if got, ok := loaded.LocalFuncName(0); !ok || got != "" {
+		t.Fatalf("loaded LocalFuncName(0) = %q, %v; want empty name present", got, ok)
+	}
+	if got := loaded.FuncDebugName(1); got != "a" {
+		t.Fatalf("loaded FuncDebugName(1) = %q, want a", got)
+	}
+}
+
 func TestCompiledOldVersionRejected(t *testing.T) {
 	old := []byte{'W', 'A', 'G', 'O', wagoVersion - 1}
 	if _, err := Load(old); err == nil {

--- a/testutil/wasmtest/builder.go
+++ b/testutil/wasmtest/builder.go
@@ -73,6 +73,49 @@ func Vec(items ...[]byte) []byte {
 
 func Name(s string) []byte { return append(ULEB(uint32(len(s))), []byte(s)...) }
 
+// NameAssoc represents one entry in a wasm name-map payload.
+type NameAssoc struct {
+	Index uint32
+	Name  string
+}
+
+// IndirectNameAssoc represents one entry in an indirect wasm name-map payload,
+// such as local names keyed by function index.
+type IndirectNameAssoc struct {
+	Index uint32
+	Names []NameAssoc
+}
+
+func NameSubsection(id byte, payload []byte) []byte {
+	out := []byte{id}
+	out = append(out, ULEB(uint32(len(payload)))...)
+	return append(out, payload...)
+}
+
+func NameMap(entries ...NameAssoc) []byte {
+	out := ULEB(uint32(len(entries)))
+	for _, e := range entries {
+		out = append(out, ULEB(e.Index)...)
+		out = append(out, Name(e.Name)...)
+	}
+	return out
+}
+
+func IndirectNameMap(entries ...IndirectNameAssoc) []byte {
+	out := ULEB(uint32(len(entries)))
+	for _, e := range entries {
+		out = append(out, ULEB(e.Index)...)
+		out = append(out, NameMap(e.Names...)...)
+	}
+	return out
+}
+
+func Custom(name string, data []byte) []byte {
+	payload := Name(name)
+	payload = append(payload, data...)
+	return Section(0, payload)
+}
+
 func FuncType(params, results []wasm.ValType) []byte {
 	out := []byte{0x60}
 	out = append(out, ULEB(uint32(len(params)))...)


### PR DESCRIPTION
## Summary
- Parse WebAssembly `name` custom sections into `wasm.Module.NameSec` while preserving raw custom sections, including the original `"name"` custom section payload.
- Preserve parsed names through `wago.Compiled` and `.wago` roundtrips, with helpers for global/local function names and stable function debug-name fallback.
- Keep name-section parsing strict for malformed structure: invalid UTF-8, bad subsection sizes, duplicate/decreasing subsection ids, malformed name maps, and duplicate/decreasing name-map indexes.
- Treat stale debug-name indexes as non-semantic: out-of-range function/type/table/memory/global/element/data/tag/local/label/field names are preserved but do not make otherwise-valid modules fail decode or compile.
- Harden attacker-controlled vector capacity hints and type-index narrowing for 32-bit safety without expanding local runs.
- Consolidate wasm/name-section test builders under `testutil/wasmtest`.

## Tests
- `go test ./...`
- `git diff --check`

## Notes
- No CLI asm-output changes are included in this branch; parsed names are exposed/preserved for API and compiled-module roundtrips.
- Docs unchanged: implementation/testing hardening only; no developer workflow change.