### PR TITLE
feat(amd64): implement memory.copy and memory.fill

### DIFF
--- a/src/core/compiler/backend/amd64/asm.go
+++ b/src/core/compiler/backend/amd64/asm.go
@@ -314,6 +314,13 @@ func (a *Asm) Cmp64(x, y Reg) {
 
 func (a *Asm) LeaDisp(dst, base Reg, disp int32) { a.memOp(0x8D, byte(dst), base, disp, true) }
 
+// String ops for bulk memory. In 64-bit mode these use RSI/RDI (64-bit
+// pointers) and RCX (64-bit count); rep stosb stores AL. Direction is DF.
+func (a *Asm) RepMovsb() { a.emit(0xF3, 0xA4) } // rep movs byte [RDI] <- [RSI], RCX times
+func (a *Asm) RepStosb() { a.emit(0xF3, 0xAA) } // rep stos byte [RDI] <- AL, RCX times
+func (a *Asm) Std()      { a.emit(0xFD) }       // set direction flag (decrement)
+func (a *Asm) Cld()      { a.emit(0xFC) }       // clear direction flag (increment)
+
 func (a *Asm) LoadIdx(dst, base, index Reg, size int, signed bool) {
 	w := size == 8
 	if w || dst >= 8 || index >= 8 || base >= 8 {

--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -1172,6 +1172,20 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	case op == 0xBF: // f64.reinterpret_i64
 		g.reinterpretIntToFloat(true)
 
+	case op == 0xFC: // misc (bulk memory, saturating truncation)
+		sub, err := r.U32()
+		if err != nil {
+			return err
+		}
+		switch sub {
+		case 10:
+			return g.memoryCopy(r)
+		case 11:
+			return g.memoryFill(r)
+		default:
+			return fmt.Errorf("amd64: unsupported 0xFC subopcode %d", sub)
+		}
+
 	default:
 		return &Unsupported{Op: op}
 	}

--- a/src/core/compiler/backend/amd64/memory.go
+++ b/src/core/compiler/backend/amd64/memory.go
@@ -1,0 +1,124 @@
+package amd64
+
+import "github.com/wago-org/wago/src/core/compiler/wasm"
+
+// Bulk memory ops: memory.copy (memmove) and memory.fill (memset), lowered to
+// rep movsb / rep stosb. Both bounds-check the whole range up front and trap
+// (MemOOB) before writing anything, matching wasm semantics.
+//
+// rep movs/stos require their operands in fixed registers (RDI/RSI/RCX, and AL
+// for stos). To set those up without register-assignment hazards, the three
+// i32 operands are first spilled to free frame slots and reloaded into the
+// fixed registers — the rep then dominates, so the spill is negligible. RDI and
+// RSI are never used by the value-stack allocator, so only RCX/RAX (which are)
+// need ensureFree before use.
+
+// spill3 pops the three i32 operands and stores them to three free frame slots,
+// returning the slot indices. Net stack effect is -3 (these ops push nothing).
+func (g *cg) spill3() (s0, s1, s2 int) {
+	c := g.pop()
+	b := g.pop()
+	a := g.pop()
+	base := len(g.st) // first slot above the new stack top
+	if base+3 > g.maxDepth {
+		g.maxDepth = base + 3
+	}
+	for i, e := range []ventry{a, b, c} {
+		r := g.materialize(e)
+		g.a.Store64(RBP, g.slotOff(base+i), r)
+		g.freeReg(r)
+	}
+	return base, base + 1, base + 2
+}
+
+// trapUnless emits `cmp t, mb; jbe ok; trap; ok:` — trap when t > mb (out of bounds).
+func (g *cg) trapUnlessLE(t, mb Reg) {
+	g.a.Cmp64(t, mb)
+	ok := g.a.JccPlaceholder(CondBE)
+	g.emitTrap(trapMemOOB)
+	g.a.PatchRel32(ok, g.a.Len())
+}
+
+// memoryCopy lowers memory.copy with memmove semantics (handles overlap).
+func (g *cg) memoryCopy(r *wasm.Reader) error {
+	if _, err := r.Byte(); err != nil { // dst memidx (only memory 0)
+		return err
+	}
+	if _, err := r.Byte(); err != nil { // src memidx
+		return err
+	}
+	dstS, srcS, nS := g.spill3()
+
+	g.a.Load64(RDI, RBP, g.slotOff(dstS)) // RDI = dst offset
+	g.a.Load64(RSI, RBP, g.slotOff(srcS)) // RSI = src offset
+	g.ensureFree(RCX)
+	g.a.Load64(RCX, RBP, g.slotOff(nS)) // RCX = n
+	g.busy[RCX] = true
+
+	lm := g.allocReg()
+	g.a.Load64(lm, RBP, -16) // linear memory base
+	mb := g.allocReg()
+	g.a.Load32(mb, lm, -8) // memory size in bytes
+	t := g.allocReg()
+	g.a.LeaScaled(t, RDI, RCX, 0, 0) // dst + n
+	g.trapUnlessLE(t, mb)
+	g.a.LeaScaled(t, RSI, RCX, 0, 0) // src + n
+	g.trapUnlessLE(t, mb)
+	g.freeReg(t)
+	g.freeReg(mb)
+
+	g.a.Add64(RDI, lm) // RDI = base + dst
+	g.a.Add64(RSI, lm) // RSI = base + src
+	g.freeReg(lm)
+
+	// memmove: copy forward when dst <= src, else backward, so overlapping
+	// ranges are copied as if through a temporary.
+	g.a.Cmp64(RDI, RSI)
+	fwd := g.a.JccPlaceholder(CondBE)
+	g.a.LeaScaled(RDI, RDI, RCX, 0, -1) // last dst byte
+	g.a.LeaScaled(RSI, RSI, RCX, 0, -1) // last src byte
+	g.a.Std()
+	g.a.RepMovsb()
+	g.a.Cld()
+	done := g.a.JmpPlaceholder()
+	g.a.PatchRel32(fwd, g.a.Len())
+	g.a.RepMovsb() // forward (DF=0 by ABI)
+	g.a.PatchRel32(done, g.a.Len())
+
+	g.freeReg(RCX)
+	return nil
+}
+
+// memoryFill lowers memory.fill (memset of the low byte of val).
+func (g *cg) memoryFill(r *wasm.Reader) error {
+	if _, err := r.Byte(); err != nil { // memidx
+		return err
+	}
+	dstS, valS, nS := g.spill3()
+
+	g.a.Load64(RDI, RBP, g.slotOff(dstS)) // RDI = dst offset
+	g.ensureFree(RAX)
+	g.a.Load64(RAX, RBP, g.slotOff(valS)) // AL = fill byte
+	g.busy[RAX] = true
+	g.ensureFree(RCX)
+	g.a.Load64(RCX, RBP, g.slotOff(nS)) // RCX = n
+	g.busy[RCX] = true
+
+	lm := g.allocReg()
+	g.a.Load64(lm, RBP, -16)
+	mb := g.allocReg()
+	g.a.Load32(mb, lm, -8)
+	t := g.allocReg()
+	g.a.LeaScaled(t, RDI, RCX, 0, 0) // dst + n
+	g.trapUnlessLE(t, mb)
+	g.freeReg(t)
+	g.freeReg(mb)
+
+	g.a.Add64(RDI, lm) // RDI = base + dst
+	g.freeReg(lm)
+	g.a.RepStosb() // [RDI..] = AL, RCX times (DF=0)
+
+	g.freeReg(RAX)
+	g.freeReg(RCX)
+	return nil
+}

--- a/src/core/compiler/backend/amd64/memory.go
+++ b/src/core/compiler/backend/amd64/memory.go
@@ -91,7 +91,7 @@ func (g *cg) memoryCopy(r *wasm.Reader) error {
 
 // memoryFill lowers memory.fill (memset of the low byte of val).
 func (g *cg) memoryFill(r *wasm.Reader) error {
-	if _, err := r.Byte(); err != nil { // memidx
+	if _, err := r.U32(); err != nil { // memidx
 		return err
 	}
 	dstS, valS, nS := g.spill3()

--- a/src/core/compiler/backend/amd64/memory.go
+++ b/src/core/compiler/backend/amd64/memory.go
@@ -41,10 +41,10 @@ func (g *cg) trapUnlessLE(t, mb Reg) {
 
 // memoryCopy lowers memory.copy with memmove semantics (handles overlap).
 func (g *cg) memoryCopy(r *wasm.Reader) error {
-	if _, err := r.Byte(); err != nil { // dst memidx (only memory 0)
+	if _, err := r.U32(); err != nil { // dst memidx (only memory 0)
 		return err
 	}
-	if _, err := r.Byte(); err != nil { // src memidx
+	if _, err := r.U32(); err != nil { // src memidx
 		return err
 	}
 	dstS, srcS, nS := g.spill3()

--- a/src/core/compiler/backend/amd64/memory_test.go
+++ b/src/core/compiler/backend/amd64/memory_test.go
@@ -1,0 +1,134 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/runtime"
+)
+
+// fillMod / copyMod: a function taking (dst, b, n) and performing the bulk op.
+func fillMod(t *testing.T) func(setup func([]byte), dst, val, n int32) ([]byte, error) {
+	m := watToModule(t, `(module (memory 1) (func (export "f") (param i32 i32 i32)
+		local.get 0 local.get 1 local.get 2 memory.fill))`)
+	return func(setup func([]byte), dst, val, n int32) ([]byte, error) {
+		_, mem, err := runMem(t, m, setup, dst, val, n)
+		return mem, err
+	}
+}
+
+func copyMod(t *testing.T) func(setup func([]byte), dst, src, n int32) ([]byte, error) {
+	m := watToModule(t, `(module (memory 1) (func (export "f") (param i32 i32 i32)
+		local.get 0 local.get 1 local.get 2 memory.copy))`)
+	return func(setup func([]byte), dst, src, n int32) ([]byte, error) {
+		_, mem, err := runMem(t, m, setup, dst, src, n)
+		return mem, err
+	}
+}
+
+func TestMemoryFill(t *testing.T) {
+	fill := fillMod(t)
+	mem, err := fill(nil, 10, 0xAB, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 10; i < 15; i++ {
+		if mem[i] != 0xAB {
+			t.Fatalf("mem[%d] = %#x, want 0xAB", i, mem[i])
+		}
+	}
+	if mem[9] != 0 || mem[15] != 0 {
+		t.Fatalf("fill overran: mem[9]=%#x mem[15]=%#x", mem[9], mem[15])
+	}
+
+	// only the low byte of val is used
+	mem, err = fill(nil, 0, 0x12FF, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mem[0] != 0xFF || mem[1] != 0xFF || mem[2] != 0xFF {
+		t.Fatalf("fill low-byte: %#x %#x %#x", mem[0], mem[1], mem[2])
+	}
+
+	// n == 0 is a no-op
+	mem, err = fill(nil, 20, 0x77, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mem[20] != 0 {
+		t.Fatalf("n=0 fill wrote mem[20]=%#x", mem[20])
+	}
+}
+
+func TestMemoryCopyDisjoint(t *testing.T) {
+	copyfn := copyMod(t)
+	mem, err := copyfn(func(l []byte) { copy(l, []byte{1, 2, 3, 4}) }, 100, 0, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, want := range []byte{1, 2, 3, 4} {
+		if mem[100+i] != want {
+			t.Fatalf("mem[%d] = %d, want %d", 100+i, mem[100+i], want)
+		}
+	}
+}
+
+// TestMemoryCopyOverlap verifies memmove semantics in both directions — a plain
+// forward rep movsb would corrupt the dst>src case.
+func TestMemoryCopyOverlap(t *testing.T) {
+	copyfn := copyMod(t)
+	init := func(l []byte) { copy(l, []byte{1, 2, 3, 4, 5}) }
+
+	// dst > src, overlapping: copy [0..3) -> [2..5). memmove => [1,2,1,2,3].
+	mem, err := copyfn(init, 2, 0, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := mem[:5]; got[2] != 1 || got[3] != 2 || got[4] != 3 {
+		t.Fatalf("dst>src overlap: got %v, want [1 2 1 2 3]", got)
+	}
+
+	// dst < src, overlapping: copy [2..5) -> [0..3). memmove => [3,4,5,4,5].
+	mem, err = copyfn(init, 0, 2, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := mem[:5]; got[0] != 3 || got[1] != 4 || got[2] != 5 {
+		t.Fatalf("dst<src overlap: got %v, want [3 4 5 4 5]", got)
+	}
+}
+
+func TestMemoryBulkTraps(t *testing.T) {
+	fill := fillMod(t)
+	copyfn := copyMod(t)
+	const size = 1 << 16
+
+	isOOB := func(err error) bool {
+		var te *runtime.TrapError
+		return errors.As(err, &te) && te.Code == runtime.TrapLinMemOutOfBounds
+	}
+
+	if _, err := fill(nil, size-5, 0xFF, 10); !isOOB(err) { // dst+n > size
+		t.Fatalf("fill OOB: got %v", err)
+	}
+	if _, err := copyfn(nil, size-5, 0, 10); !isOOB(err) { // dst+n > size
+		t.Fatalf("copy dst OOB: got %v", err)
+	}
+	if _, err := copyfn(nil, 0, size-5, 10); !isOOB(err) { // src+n > size
+		t.Fatalf("copy src OOB: got %v", err)
+	}
+
+	// Boundary: writing exactly up to the end is fine; one past traps.
+	if _, err := fill(nil, size-4, 0xFF, 4); err != nil {
+		t.Fatalf("fill to end should not trap: %v", err)
+	}
+	// dst == size with n == 0 is in bounds (nothing written).
+	if _, err := fill(nil, size, 0xFF, 0); err != nil {
+		t.Fatalf("fill dst==size n==0 should not trap: %v", err)
+	}
+	if _, err := fill(nil, size, 0xFF, 1); !isOOB(err) {
+		t.Fatalf("fill dst==size n==1 should trap: got %v", err)
+	}
+}


### PR DESCRIPTION
## What

`memory.copy` / `memory.fill` (the `0xFC` 10/11 ops) decoded and validated fine but **errored at codegen** (`Unsupported`) — so any module using them failed to compile. They're pervasive in real LLVM output (struct copies, buffer init, `memcpy`/`memset`). This lowers them to `rep movsb` / `rep stosb`.

- **`memory.fill`** → `rep stosb` of the low byte of `val`.
- **`memory.copy`** → **memmove**: copy forward when `dst ≤ src`, else backward (set `DF`, point at the last byte), so overlapping ranges are correct.

Both **bounds-check the whole range up front** (`dst+n`, and `src+n` for copy) against memory size and **trap `MemOOB` before writing anything** — matching wasm semantics.

## Implementation notes

- `rep` needs operands in fixed registers (`RDI`/`RSI`/`RCX`, `AL`). To set those up without register-assignment hazards, the three i32 operands are spilled to free frame slots and reloaded into the fixed regs; the `rep` dominates so the spill is negligible. `RDI`/`RSI` aren't in the value-stack scratch pool, so only `RCX`/`RAX` need `ensureFree`.
- Adds `RepMovsb`/`RepStosb`/`Std`/`Cld` assembler primitives. Forward `rep` relies on the SysV `DF=0` invariant; the backward path is the only thing that touches `DF` and restores it with `cld`.

## Tests

fill (incl. low-byte masking and `n=0` no-op), disjoint copy, **overlapping copy in both directions** (a plain forward copy would corrupt the `dst>src` case — this catches a broken memmove), and trap boundaries (`dst`/`src`+n > size traps; `dst==size` with `n=0` is in-bounds, `n=1` traps). Full suite + vet + staticcheck green.

## Follow-ups (out of scope)

`memory.init` / `data.drop` (need passive data segments) and the saturating float→int truncations (`0xFC` 0–7, also currently unimplemented).