### PR TITLE
feat(amd64): implement saturating float->int truncations

### DIFF
--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -1178,6 +1178,22 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 			return err
 		}
 		switch sub {
+		case 0: // i32.trunc_sat_f32_s
+			g.truncSat(false, false, true)
+		case 1: // i32.trunc_sat_f32_u
+			g.truncSat(false, false, false)
+		case 2: // i32.trunc_sat_f64_s
+			g.truncSat(true, false, true)
+		case 3: // i32.trunc_sat_f64_u
+			g.truncSat(true, false, false)
+		case 4: // i64.trunc_sat_f32_s
+			g.truncSat(false, true, true)
+		case 5: // i64.trunc_sat_f32_u
+			g.truncSat(false, true, false)
+		case 6: // i64.trunc_sat_f64_s
+			g.truncSat(true, true, true)
+		case 7: // i64.trunc_sat_f64_u
+			g.truncSat(true, true, false)
 		case 10:
 			return g.memoryCopy(r)
 		case 11:

--- a/src/core/compiler/backend/amd64/truncsat.go
+++ b/src/core/compiler/backend/amd64/truncsat.go
@@ -1,0 +1,137 @@
+package amd64
+
+import "math"
+
+// Saturating float->int truncation (the 0xFC 0-7 ops: i32/i64.trunc_sat_f32/f64_s/u).
+// Unlike the trapping trunc, out-of-range and NaN inputs saturate instead of
+// trapping: NaN -> 0, values >= the high bound -> INT/UINT_MAX, values below the
+// low bound -> INT_MIN / 0.
+//
+// cvtt truncates toward zero and yields the "integer indefinite" value
+// (INT_MIN) for NaN and out-of-range inputs, which we fix up with float bound
+// comparisons.
+
+// floatBits returns the bit pattern of v in the source float width.
+func floatBits(v float64, f64 bool) uint64 {
+	if f64 {
+		return math.Float64bits(v)
+	}
+	return uint64(math.Float32bits(float32(v)))
+}
+
+// loadFConst materializes a float constant (given its bits) into a fresh XMM.
+func (g *cg) loadFConst(bits uint64, f64 bool) Reg {
+	xmm := g.allocFReg()
+	if f64 {
+		g.a.MovImm64(RSI, bits)
+		g.a.MovGprToXmm(xmm, RSI, true)
+	} else {
+		g.a.MovImm32(RSI, int32(uint32(bits)))
+		g.a.MovGprToXmm(xmm, RSI, false)
+	}
+	return xmm
+}
+
+func (g *cg) truncSat(f64src, dstWide, signed bool) {
+	x := g.materializeF(g.pop())
+	r := g.allocReg()
+	switch {
+	case signed:
+		g.truncSatSigned(x, r, f64src, dstWide)
+	case dstWide:
+		g.truncSatU64(x, r, f64src)
+	default:
+		g.truncSatU32(x, r, f64src)
+	}
+	g.freeFReg(x)
+	g.pushReg(r)
+}
+
+// truncSatSigned: cvtt is correct for in-range inputs and for x below the low
+// bound (both give INT_MIN); only NaN (-> 0) and x >= the high bound (-> MAX)
+// need fixing.
+func (g *cg) truncSatSigned(x, r Reg, f64src, dstWide bool) {
+	n := 32
+	if dstWide {
+		n = 64
+	}
+	g.a.Cvttf2si(r, x, f64src, dstWide)
+
+	g.a.Ucomis(x, x, f64src) // NaN?
+	notNaN := g.a.JccPlaceholder(CondNP)
+	g.a.XorSelf32(r) // NaN -> 0
+	toEnd := g.a.JmpPlaceholder()
+	g.a.PatchRel32(notNaN, g.a.Len())
+
+	hi := g.loadFConst(floatBits(math.Ldexp(1, n-1), f64src), f64src) // 2^(n-1)
+	g.a.Ucomis(x, hi, f64src)
+	g.freeFReg(hi)
+	below := g.a.JccPlaceholder(CondB) // x < 2^(n-1): cvtt result is correct
+	if dstWide {
+		g.a.MovImm64(r, 0x7FFFFFFFFFFFFFFF)
+	} else {
+		g.a.MovImm32(r, 0x7FFFFFFF)
+	}
+	g.a.PatchRel32(below, g.a.Len())
+	g.a.PatchRel32(toEnd, g.a.Len())
+}
+
+// truncSatU32: convert via a 64-bit signed cvtt (exact for [0, 2^32)), then
+// clamp: NaN/x<=0 -> 0, x >= 2^32 -> 0xFFFFFFFF.
+func (g *cg) truncSatU32(x, r Reg, f64src bool) {
+	g.a.Cvttf2si(r, x, f64src, true) // i64 trunc; low 32 is the u32 result in range
+
+	zero := g.loadFConst(floatBits(0, f64src), f64src)
+	g.a.Ucomis(x, zero, f64src)
+	g.freeFReg(zero)
+	pos := g.a.JccPlaceholder(CondA) // x > 0 (ordered); NaN/<=0 fall through to 0
+	g.a.XorSelf32(r)
+	toEnd := g.a.JmpPlaceholder()
+	g.a.PatchRel32(pos, g.a.Len())
+
+	hi := g.loadFConst(floatBits(math.Ldexp(1, 32), f64src), f64src) // 2^32
+	g.a.Ucomis(x, hi, f64src)
+	g.freeFReg(hi)
+	below := g.a.JccPlaceholder(CondB) // x < 2^32: cvtt result is correct
+	g.a.MovImm32(r, -1)                // 0xFFFFFFFF
+	g.a.PatchRel32(below, g.a.Len())
+	g.a.PatchRel32(toEnd, g.a.Len())
+}
+
+// truncSatU64: clamp (NaN/x<=0 -> 0, x >= 2^64 -> all ones), then convert. For
+// x >= 2^63 a signed cvtt overflows, so bias by 2^63: cvtt(x - 2^63) + 2^63.
+func (g *cg) truncSatU64(x, r Reg, f64src bool) {
+	zero := g.loadFConst(floatBits(0, f64src), f64src)
+	g.a.Ucomis(x, zero, f64src)
+	g.freeFReg(zero)
+	pos := g.a.JccPlaceholder(CondA) // x > 0; NaN/<=0 -> 0
+	g.a.XorSelf32(r)
+	end0 := g.a.JmpPlaceholder()
+	g.a.PatchRel32(pos, g.a.Len())
+
+	hi := g.loadFConst(floatBits(math.Ldexp(1, 64), f64src), f64src) // 2^64
+	g.a.Ucomis(x, hi, f64src)
+	g.freeFReg(hi)
+	inRange := g.a.JccPlaceholder(CondB)
+	g.a.MovImm64(r, 0xFFFFFFFFFFFFFFFF) // x >= 2^64 -> max
+	endMax := g.a.JmpPlaceholder()
+	g.a.PatchRel32(inRange, g.a.Len())
+
+	p63 := g.loadFConst(floatBits(math.Ldexp(1, 63), f64src), f64src) // 2^63
+	g.a.Ucomis(x, p63, f64src)
+	simple := g.a.JccPlaceholder(CondB) // x < 2^63: direct cvtt
+	g.a.FSub(x, p63, f64src)            // x -= 2^63 (x is dead afterward)
+	g.a.Cvttf2si(r, x, f64src, true)
+	t := g.allocReg()
+	g.a.MovImm64(t, 0x8000000000000000)
+	g.a.Add64(r, t) // + 2^63
+	g.freeReg(t)
+	biasEnd := g.a.JmpPlaceholder()
+	g.a.PatchRel32(simple, g.a.Len())
+	g.a.Cvttf2si(r, x, f64src, true)
+	g.a.PatchRel32(biasEnd, g.a.Len())
+	g.freeFReg(p63)
+
+	g.a.PatchRel32(endMax, g.a.Len())
+	g.a.PatchRel32(end0, g.a.Len())
+}

--- a/src/core/compiler/backend/amd64/truncsat_test.go
+++ b/src/core/compiler/backend/amd64/truncsat_test.go
@@ -1,0 +1,86 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"fmt"
+	"testing"
+)
+
+func tsI32(t *testing.T, body string) int32 {
+	t.Helper()
+	return runI32(t, watToModule(t, `(module (func (export "f") (result i32) `+body+`))`))
+}
+
+// TestTruncSatI32 covers the four i32 trunc_sat variants: in-range truncation,
+// NaN -> 0, ±inf and huge magnitudes saturating to the bounds, and (unsigned)
+// negatives saturating to 0.
+func TestTruncSatI32(t *testing.T) {
+	cases := []struct {
+		name, wat string
+		want      int32
+	}{
+		// i32.trunc_sat_f32_s
+		{"s_f32_pos", `f32.const 3.7 i32.trunc_sat_f32_s`, 3},
+		{"s_f32_neg", `f32.const -3.7 i32.trunc_sat_f32_s`, -3},
+		{"s_f32_nan", `f32.const nan i32.trunc_sat_f32_s`, 0},
+		{"s_f32_inf", `f32.const inf i32.trunc_sat_f32_s`, 2147483647},
+		{"s_f32_ninf", `f32.const -inf i32.trunc_sat_f32_s`, -2147483648},
+		{"s_f32_big", `f32.const 1e30 i32.trunc_sat_f32_s`, 2147483647},
+		{"s_f32_nbig", `f32.const -1e30 i32.trunc_sat_f32_s`, -2147483648},
+		// i32.trunc_sat_f32_u
+		{"u_f32_pos", `f32.const 3.7 i32.trunc_sat_f32_u`, 3},
+		{"u_f32_neg", `f32.const -1 i32.trunc_sat_f32_u`, 0},
+		{"u_f32_nan", `f32.const nan i32.trunc_sat_f32_u`, 0},
+		{"u_f32_inf", `f32.const inf i32.trunc_sat_f32_u`, -1},                // 0xFFFFFFFF
+		{"u_f32_hi", `f32.const 2147483648 i32.trunc_sat_f32_u`, -2147483648}, // 2^31, in range for u32
+		// i32.trunc_sat_f64_s / _u (f64 represents integers exactly)
+		{"s_f64_neg", `f64.const -3.7 i32.trunc_sat_f64_s`, -3},
+		{"s_f64_ninf", `f64.const -inf i32.trunc_sat_f64_s`, -2147483648},
+		{"u_f64_max_inrange", `f64.const 4294967295 i32.trunc_sat_f64_u`, -1}, // 2^32-1, in range
+		{"u_f64_over", `f64.const 4294967296 i32.trunc_sat_f64_u`, -1},        // 2^32 -> max
+		{"u_f64_mid", `f64.const 4000000000 i32.trunc_sat_f64_u`, -294967296}, // int32(uint32(4e9))
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tsI32(t, tc.wat); got != tc.want {
+				t.Fatalf("%s: got %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTruncSatI64 covers the four i64 variants; the result is compared against
+// an expected i64 constant so runI32 reads a 0/1.
+func TestTruncSatI64(t *testing.T) {
+	cases := []struct {
+		name, expr string
+		want       int64
+	}{
+		// i64.trunc_sat_f64_s
+		{"s_pos", `f64.const 3.7 i64.trunc_sat_f64_s`, 3},
+		{"s_neg", `f64.const -3.7 i64.trunc_sat_f64_s`, -3},
+		{"s_nan", `f64.const nan i64.trunc_sat_f64_s`, 0},
+		{"s_inf", `f64.const inf i64.trunc_sat_f64_s`, 9223372036854775807},
+		{"s_ninf", `f64.const -inf i64.trunc_sat_f64_s`, -9223372036854775808},
+		// i64.trunc_sat_f32_s
+		{"s_f32_inf", `f32.const inf i64.trunc_sat_f32_s`, 9223372036854775807},
+		// i64.trunc_sat_f64_u
+		{"u_pos", `f64.const 3.7 i64.trunc_sat_f64_u`, 3},
+		{"u_neg", `f64.const -1 i64.trunc_sat_f64_u`, 0},
+		{"u_nan", `f64.const nan i64.trunc_sat_f64_u`, 0},
+		{"u_inf", `f64.const inf i64.trunc_sat_f64_u`, -1},                                   // 0xFFFF...FFFF = uint64 max
+		{"u_p63", `f64.const 9223372036854775808 i64.trunc_sat_f64_u`, -9223372036854775808}, // 2^63 (bias path)
+		{"u_over", `f64.const 1e20 i64.trunc_sat_f64_u`, -1},                                 // >= 2^64 -> max
+		// i64.trunc_sat_f32_u, bias path
+		{"u_f32_p63", `f32.const 9223372036854775808 i64.trunc_sat_f32_u`, -9223372036854775808},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wat := fmt.Sprintf(`(module (func (export "f") (result i32) %s i64.const %d i64.eq))`, tc.expr, tc.want)
+			if got := runI32(t, watToModule(t, wat)); got != 1 {
+				t.Fatalf("%s: result != %d", tc.name, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The `trunc_sat` ops (`0xFC` 0–7: `i32`/`i64.trunc_sat_f32`/`f64_s`/`u`) validated but **errored at codegen**. They're the non-trapping float→int conversions (Rust emits them for `as` casts). Lowered with `cvtt` + float bound-checks so out-of-range/NaN inputs **saturate** instead of yielding the `cvtt` indefinite value: NaN → 0, ≥ high bound → INT/UINT_MAX, below low bound → INT_MIN / 0.

## Per-class lowering

- **signed** — `cvtt` is already correct for in-range inputs *and* for `x` below the low bound (both give INT_MIN), so only NaN (→ 0) and `x ≥ 2^(n-1)` (→ INT_MAX) need fixing.
- **unsigned i32** — convert via a 64-bit signed `cvtt` (exact on `[0, 2^32)`), then clamp `NaN`/`x≤0` → 0 and `x ≥ 2^32` → `0xFFFFFFFF`.
- **unsigned i64** — clamp `NaN`/`x≤0` → 0 and `x ≥ 2^64` → all-ones, then convert; for `x ≥ 2^63` a signed `cvtt` overflows, so bias by 2^63: `cvtt(x − 2^63) + 2^63`.

No new assembler primitives.

## Tests

All eight variants across in-range truncation, NaN, ±inf, huge magnitudes, unsigned negatives → 0, the unsigned **bias path at 2^63**, and the saturation boundaries (`2^32`/`2^64` cutovers). 30 subtests.

## ⚠️ Separate pre-existing bug spotted

The **trapping** trunc (`f2iTrunc`, ops `0xA8`–`0xB1`) just does `cvtt` with **no bounds check** — so an out-of-range or NaN input to e.g. `i32.trunc_f32_s` returns the `cvtt` indefinite value (`0x80000000`) instead of **trapping** as wasm requires. Not addressed here (out of scope); happy to fix it as a follow-up — it's a real miscompile.