### PR TITLE
ci: drive lint/test through make, full workflow via act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,8 @@
+# Default config for `act` (https://github.com/nektos/act), used by
+# scripts/ci-local.sh to run .github/workflows/ci.yml locally in Docker.
+#
+# ubuntu-latest -> catthehacker's "medium" image: it ships sudo, apt, and the
+# tools setup-go/staticcheck/wabt installs need. act's default image is too
+# minimal for this workflow (no sudo/apt).
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+--container-architecture linux/amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,31 +31,14 @@ jobs:
           # No go.sum (stdlib-only module) -> nothing to cache; avoids a warning.
           cache: false
 
-      - name: gofmt
-        run: |
-          unformatted="$(gofmt -l .)"
-          if [ -n "$unformatted" ]; then
-            echo "::error::These files are not gofmt-ed:"
-            echo "$unformatted"
-            exit 1
-          fi
+      # `make lint` runs staticcheck when it is on PATH; install it first so CI
+      # enforces it (locally it is an optional skip). Other checks (gofmt, go
+      # generate sync, go vet) use the toolchain directly.
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@2024.1.1
 
-      - name: go generate (facade in sync)
-        run: |
-          go generate ./...
-          if ! git diff --exit-code; then
-            echo "::error::Generated files are stale. Run 'go generate ./...' and commit the result."
-            exit 1
-          fi
-
-      - name: go vet
-        run: go vet ./...
-
-      - name: staticcheck
-        uses: dominikh/staticcheck-action@v1
-        with:
-          version: "2024.1.1"
-          install-go: false
+      - name: Lint
+        run: make lint
 
   test:
     name: Build & test
@@ -73,8 +56,5 @@ jobs:
       - name: Install wabt (wat2wasm)
         run: sudo apt-get update && sudo apt-get install -y wabt
 
-      - name: Build
-        run: go build ./...
-
-      - name: Test
-        run: go test -count=1 ./...
+      - name: Build & test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+# wago task runner. Single source of truth for the dev/CI chores: the GitHub
+# Actions workflow (.github/workflows/ci.yml) calls these same targets, so
+# `make lint` / `make test` reproduce CI exactly. Run `make` to list targets.
+#
+#   make lint   gofmt + go generate sync + go vet + staticcheck   (host, no act)
+#   make test   go build + go test                                (host, no act)
+#   make ci     replay the whole workflow in Docker via act       (scripts/ci-local.sh)
+
+.DEFAULT_GOAL := help
+
+# Files written by `go generate ./...` (the genfacade output). The staleness
+# check diffs only these, so `make lint` is usable with unrelated uncommitted
+# work in the tree (CI starts clean, so it behaves identically there).
+GENERATED := wago.go
+
+# Default goal: a bare `make` sets up a fresh clone by installing the git hooks
+# (only if not already installed) before printing the target list.
+.PHONY: help
+help: hooks-ensure ## List available targets
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z0-9_-]+:.*## / {printf "  make %-8s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# Install the hooks unless core.hooksPath already points at .githooks. Silent
+# no-op when set up; the explicit `make hooks` always (re)installs.
+.PHONY: hooks-ensure
+hooks-ensure:
+	@[ "$$(git config --get core.hooksPath)" = ".githooks" ] || scripts/install-hooks.sh
+
+.PHONY: lint
+lint: lint-fmt lint-generate lint-vet lint-staticcheck ## Run all lint checks (host)
+
+.PHONY: lint-fmt
+lint-fmt:
+	@unformatted="$$(gofmt -l . | grep -vE '^(warp|tests/spec)/' || true)"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "::error::These files are not gofmt-ed:"; echo "$$unformatted"; exit 1; \
+	fi
+
+.PHONY: lint-generate
+lint-generate:
+	@go generate ./...
+	@if ! git diff --exit-code -- $(GENERATED); then \
+		echo "::error::Generated files are stale. Run 'go generate ./...' and commit the result."; \
+		exit 1; \
+	fi
+
+.PHONY: lint-vet
+lint-vet:
+	go vet ./...
+
+# staticcheck is enforced in CI (installed before `make lint`); locally it is
+# optional — skip with a hint rather than fail when it is not installed.
+.PHONY: lint-staticcheck
+lint-staticcheck:
+	@if command -v staticcheck >/dev/null 2>&1; then \
+		staticcheck ./...; \
+	else \
+		echo "make: staticcheck not found, skipping (go install honnef.co/go/tools/cmd/staticcheck@2024.1.1)"; \
+	fi
+
+.PHONY: test
+test: ## Build and run the test suite (host)
+	go build ./...
+	go test -count=1 ./...
+
+.PHONY: ci
+ci: ## Replay the full CI workflow locally in Docker (act)
+	scripts/ci-local.sh
+
+.PHONY: hooks
+hooks: ## Install the repo git hooks (.githooks)
+	scripts/install-hooks.sh

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+# Run the GitHub Actions CI workflow (.github/workflows/ci.yml) locally with
+# `act` (https://github.com/nektos/act), so you can reproduce a CI failure
+# without pushing. Runner image and arch come from .actrc at the repo root.
+#
+# Usage:
+#   scripts/ci-local.sh            # run all jobs for the pull_request event
+#   scripts/ci-local.sh lint       # run only the lint job
+#   scripts/ci-local.sh test       # run only the test job
+#   scripts/ci-local.sh test -v    # extra args after the job pass through to act
+set -eu
+
+git rev-parse --git-dir >/dev/null 2>&1 || {
+	printf '%s\n' "wago: not inside a git repository" >&2
+	exit 1
+}
+
+command -v act >/dev/null 2>&1 || {
+	printf '%s\n' "wago: 'act' not found (install: https://github.com/nektos/act)" >&2
+	exit 1
+}
+
+docker info >/dev/null 2>&1 || {
+	printf '%s\n' "wago: docker is not running; act needs a working Docker daemon" >&2
+	exit 1
+}
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+# A first positional arg that isn't a flag selects a single job (lint|test).
+job=""
+if [ "$#" -gt 0 ] && [ "${1#-}" = "$1" ]; then
+	job="$1"
+	shift
+fi
+
+set -- pull_request ${job:+-j "$job"} "$@"
+printf '%s\n' "wago: act $*"
+exec act "$@"


### PR DESCRIPTION
## What

Make is now the single source of truth for CI chores, and `.github/workflows/ci.yml` calls the same targets so local runs reproduce CI exactly.

- `make lint` — gofmt + go generate sync + go vet + staticcheck, on the host (no Docker)
- `make test` — go build + go test, on the host
- `make ci` — replay the whole workflow in Docker via [`act`](https://github.com/nektos/act) (`scripts/ci-local.sh`)
- bare `make` — prints the target list and installs the git hooks **only if not already installed**

## Details

- **Workflow refactor:** the lint/test jobs now just set up the toolchain (staticcheck for lint, wabt for test) and run `make lint` / `make test`. No behavior change vs the old inline steps.
- **`go generate` staleness check** diffs only the generated facade (`wago.go`) instead of the whole tree, so `make lint` is usable with unrelated uncommitted work. CI starts from a clean checkout, so it behaves identically there.
- **staticcheck** is enforced in CI (installed before `make lint`) and an optional skip locally (with an install hint) when not on `PATH`.
- **`.actrc`** pins the act runner image (`catthehacker/ubuntu:act-latest`) + architecture so `make ci` is reproducible.

## Verification

All run locally:
- `make lint` ✅ (host) · `make test` ✅ (host, full suite `ok`)
- `make ci` ✅ — both jobs succeed via act (lint installs staticcheck + runs `make lint`; test runs `make test`)