### PR TITLE
ci: add coverage job with per-package reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    # Needed by the sticky PR-comment step below.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -75,10 +79,19 @@ jobs:
       - name: Install wabt (wat2wasm)
         run: sudo apt-get update && sudo apt-get install -y wabt
 
-      # `make cover` runs the suite with -coverpkg=./... and appends a
-      # per-package report to the job summary ($GITHUB_STEP_SUMMARY).
+      # `make cover` runs the suite with -coverpkg=./..., appends a per-package
+      # report to the job summary, and writes coverage-report.md for the comment.
       - name: Coverage
         run: make cover
+
+      # Post (or update) a sticky coverage comment on the PR. Skipped for fork
+      # PRs, whose GITHUB_TOKEN is read-only and cannot comment.
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: scripts/pr-coverage-comment.sh
 
       - name: Upload coverage profile
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,27 +79,28 @@ jobs:
       - name: Install wabt (wat2wasm)
         run: sudo apt-get update && sudo apt-get install -y wabt
 
-      # `make cover` runs the suite with -coverpkg=./..., appends a per-package
-      # report to the job summary, and writes coverage-report.md for the comment.
-      # On PRs, COVER_BASELINE_REF makes it also measure main (in a worktree) and
-      # add a "Δ vs main" column, so fetch main first.
-      - name: Coverage
+      # `make card` runs the coverage suite (-coverpkg=./..., appending the
+      # per-package report to the job summary) and assembles the CI info card —
+      # coverage filled in, the other sections blank placeholders for now. On PRs,
+      # COVER_BASELINE_REF measures main in a worktree for the "Δ vs main" column,
+      # so fetch main first.
+      - name: Build CI card
         env:
           COVER_BASELINE_REF: ${{ github.event_name == 'pull_request' && 'origin/main' || '' }}
         run: |
           if [ -n "$COVER_BASELINE_REF" ]; then
             git fetch --no-tags --depth=1 origin main
           fi
-          make cover
+          make card
 
-      # Post (or update) a sticky coverage comment on the PR. Skipped for fork
-      # PRs, whose GITHUB_TOKEN is read-only and cannot comment.
-      - name: Comment coverage on PR
+      # Post (or update) the sticky CI card on the PR. Skipped for fork PRs, whose
+      # GITHUB_TOKEN is read-only and cannot comment.
+      - name: Comment CI card on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: scripts/pr-coverage-comment.sh
+        run: scripts/pr-card-comment.sh
 
       - name: Upload coverage profile
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,16 @@ jobs:
 
       # `make cover` runs the suite with -coverpkg=./..., appends a per-package
       # report to the job summary, and writes coverage-report.md for the comment.
+      # On PRs, COVER_BASELINE_REF makes it also measure main (in a worktree) and
+      # add a "Δ vs main" column, so fetch main first.
       - name: Coverage
-        run: make cover
+        env:
+          COVER_BASELINE_REF: ${{ github.event_name == 'pull_request' && 'origin/main' || '' }}
+        run: |
+          if [ -n "$COVER_BASELINE_REF" ]; then
+            git fetch --no-tags --depth=1 origin main
+          fi
+          make cover
 
       # Post (or update) a sticky coverage comment on the PR. Skipped for fork
       # PRs, whose GITHUB_TOKEN is read-only and cannot comment.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,31 @@ jobs:
 
       - name: Build & test
         run: make test
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          # No go.sum (stdlib-only module) -> nothing to cache; avoids a warning.
+          cache: false
+
+      # Same wabt dependency as the test job, so the amd64 codegen tests run and
+      # count toward coverage instead of skipping.
+      - name: Install wabt (wat2wasm)
+        run: sudo apt-get update && sudo apt-get install -y wabt
+
+      # `make cover` runs the suite with -coverpkg=./... and appends a
+      # per-package report to the job summary ($GITHUB_STEP_SUMMARY).
+      - name: Coverage
+        run: make cover
+
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,16 +79,15 @@ jobs:
       - name: Install wabt (wat2wasm)
         run: sudo apt-get update && sudo apt-get install -y wabt
 
-      # `make card` runs the coverage suite (-coverpkg=./..., appending the
-      # per-package report to the job summary) and assembles the CI info card —
-      # coverage filled in, the other sections blank placeholders for now. On PRs,
-      # COVER_BASELINE_REF measures main in a worktree for the "Δ vs main" column,
+      # `make card` runs the coverage + tests producers and assembles the CI info
+      # card (benchmarks/memory are still blank placeholders). On PRs,
+      # CARD_BASELINE_REF measures main in a worktree for the "Δ vs main" columns,
       # so fetch main first.
       - name: Build CI card
         env:
-          COVER_BASELINE_REF: ${{ github.event_name == 'pull_request' && 'origin/main' || '' }}
+          CARD_BASELINE_REF: ${{ github.event_name == 'pull_request' && 'origin/main' || '' }}
         run: |
-          if [ -n "$COVER_BASELINE_REF" ]; then
+          if [ -n "$CARD_BASELINE_REF" ]; then
             git fetch --no-tags --depth=1 origin main
           fi
           make card

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ bench/corpus/vendor/
 
 # Coverage report rendered by scripts/coverage.sh for the PR comment
 coverage-report.md
+
+# CI info card artifacts (assembled by scripts/pr-card.sh)
+ci-card/
+card.md

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ bench/corpus/src/many_funcs.wat
 
 # Vendored third-party wasm binaries (fetched by corpus/fetch.sh, not committed)
 bench/corpus/vendor/
+
+# Coverage report rendered by scripts/coverage.sh for the PR comment
+coverage-report.md

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ COUNT     ?= 6
 BENCH_RUN ?= bench/.bench-run.txt
 # WARP harness for chart engine-comparison (empty skips it): WARP=auto or a path.
 WARP      ?=
+# Where `make cover` writes the coverage profile.
+COVERPROFILE ?= coverage.out
 
 # Current commit. `make bench` stamps it into the capture's first line so
 # bench-publish can refuse a capture taken at a different commit (unless FORCE=1).
@@ -78,6 +80,10 @@ lint-staticcheck:
 test: ## Build and run the test suite (host)
 	go build ./...
 	go test -count=1 ./...
+
+.PHONY: cover
+cover: ## Run tests with cross-package coverage + per-package report (COVERPROFILE=path)
+	COVERPROFILE=$(COVERPROFILE) scripts/coverage.sh
 
 .PHONY: ci
 ci: ## Replay the full CI workflow locally in Docker (act)

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,10 @@ cover: ## Run tests with cross-package coverage + per-package report (COVERPROFI
 	COVERPROFILE=$(COVERPROFILE) scripts/coverage.sh
 
 .PHONY: card
-card: ## Build the PR CI info card -> card.md (coverage filled, others blank)
+card: ## Build the PR CI info card -> card.md (coverage + tests filled)
 	@mkdir -p $(CARD_DIR)
 	COVER_REPORT=$(CARD_DIR)/coverage.md scripts/coverage.sh >/dev/null
+	TESTS_REPORT=$(CARD_DIR)/tests.md scripts/tests-card.sh >/dev/null
 	CARD_DIR=$(CARD_DIR) CARD_FILE=$(CARD_FILE) scripts/pr-card.sh
 	@cat $(CARD_FILE)
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ COUNT     ?= 6
 BENCH_RUN ?= bench/.bench-run.txt
 # WARP harness for chart engine-comparison (empty skips it): WARP=auto or a path.
 WARP      ?=
-# Where `make cover` writes the coverage profile.
+# Where `make cover` writes the coverage profile, and where `make card` collects
+# section fragments / writes the assembled PR card.
 COVERPROFILE ?= coverage.out
+CARD_DIR  ?= ci-card
+CARD_FILE ?= card.md
 
 # Current commit. `make bench` stamps it into the capture's first line so
 # bench-publish can refuse a capture taken at a different commit (unless FORCE=1).
@@ -84,6 +87,13 @@ test: ## Build and run the test suite (host)
 .PHONY: cover
 cover: ## Run tests with cross-package coverage + per-package report (COVERPROFILE=path)
 	COVERPROFILE=$(COVERPROFILE) scripts/coverage.sh
+
+.PHONY: card
+card: ## Build the PR CI info card -> card.md (coverage filled, others blank)
+	@mkdir -p $(CARD_DIR)
+	COVER_REPORT=$(CARD_DIR)/coverage.md scripts/coverage.sh >/dev/null
+	CARD_DIR=$(CARD_DIR) CARD_FILE=$(CARD_FILE) scripts/pr-card.sh
+	@cat $(CARD_FILE)
 
 .PHONY: ci
 ci: ## Replay the full CI workflow locally in Docker (act)

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -8,7 +8,6 @@ set -eu
 
 profile="${COVERPROFILE:-coverage.out}"
 report="${COVER_REPORT:-coverage-report.md}"
-marker="${COVER_MARKER:-<!-- wago-coverage -->}"
 baseline_ref="${COVER_BASELINE_REF:-}"
 tab=$(printf '\t')
 
@@ -84,39 +83,37 @@ total_delta=$(printf '%s' "$total_line" | cut -f3)
 rows=$(printf '%s\n' "$rendered" | awk -F"$tab" '$1=="ROW"' | sort -t"$tab" -k2,2n)
 n=$(printf '%s\n' "$rows" | grep -c .)
 
-# Headline: "## Coverage: 68.8%" plus a parenthetical total delta when measured.
-head="## Coverage: ${total_pct}%"
+# Emit a CI-card *section fragment*: line 1 is the summary (the collapsible's
+# visible title), the rest is the section body. The card composer (pr-card.sh)
+# wraps it in <details>. Summary: "Coverage: 68.8%" + total delta when measured.
+summary="Coverage: ${total_pct}%"
 if [ "$have_base" = 1 ]; then
 	case "$total_delta" in
-	"—" | "") head="$head (—)" ;;
-	*) head="$head ($total_delta%)" ;;
+	"—" | "") summary="$summary (—)" ;;
+	*) summary="$summary ($total_delta%)" ;;
 	esac
 fi
 
-# Compact: headline always visible, per-package table folded in <details>.
-md=$(
-	printf '%s\n%s\n\n' "$marker" "$head"
-	if [ "$have_base" = 1 ]; then
-		printf '<details><summary>per-package (%s) · Δ vs main</summary>\n\n' "$n"
+if [ "$have_base" = 1 ]; then
+	body=$(
 		printf '| Cov | Δ | Package |\n|---|---|---|\n'
 		printf '%s\n' "$rows" | while IFS="$tab" read -r _ pc d pkg; do
 			printf '| %s%% | %s | `%s` |\n' "$pc" "$d" "$pkg"
 		done
-		printf '</details>\n'
-	else
-		printf '<details><summary>per-package (%s)</summary>\n\n' "$n"
+	)
+else
+	body=$(
 		printf '| Cov | Package |\n|---|---|\n'
 		printf '%s\n' "$rows" | while IFS="$tab" read -r _ pc d pkg; do
 			printf '| %s%% | `%s` |\n' "$pc" "$pkg"
 		done
-		printf '</details>\n'
-	fi
-)
+	)
+fi
 
-printf '\n%s\nTOTAL: %s%%\n' "$head" "$total_pct"
-printf '%s\n' "$md" >"$report"
+printf '%s\n%s\n' "$summary" "$body" >"$report"
+printf '\n%s\n' "$summary" # local stdout
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-	printf '%s\n' "$md" >>"$GITHUB_STEP_SUMMARY"
+	printf '### %s\n\n%s\n' "$summary" "$body" >>"$GITHUB_STEP_SUMMARY"
 fi
 
 rm -f "$cur" "$base"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env sh
-# Run the test suite with cross-package coverage and print a per-package report.
-# Backs `make cover` and the CI coverage job. In GitHub Actions (where
-# $GITHUB_STEP_SUMMARY is set) the report is also appended to the run summary.
+# Run the test suite with cross-package coverage and render a per-package report.
+# Backs `make cover` and the CI coverage job. When COVER_BASELINE_REF is set
+# (e.g. origin/main) the report gains a "Δ vs main" column by measuring that ref
+# in a throwaway worktree. In GitHub Actions the report is appended to
+# $GITHUB_STEP_SUMMARY; it is always written to $COVER_REPORT for the PR comment.
 set -eu
 
 profile="${COVERPROFILE:-coverage.out}"
+report="${COVER_REPORT:-coverage-report.md}"
+marker="${COVER_MARKER:-<!-- wago-coverage -->}"
+baseline_ref="${COVER_BASELINE_REF:-}"
+tab=$(printf '\t')
 
 root=$(git rev-parse --show-toplevel) || {
 	printf 'wago: not inside a git repository\n' >&2
@@ -12,44 +18,90 @@ root=$(git rev-parse --show-toplevel) || {
 }
 cd "$root"
 
-# -coverpkg=./... so a test in one package counts toward coverage of the packages
-# it actually exercises (the spec/api suites drive the compiler and runtime, which
-# otherwise read as untested). atomic mode is safe across the parallel binaries.
-go test -count=1 -covermode=atomic -coverpkg=./... -coverprofile="$profile" ./...
-
-total=$(go tool cover -func="$profile" | awk '/^total:/{print $NF}')
-
-# Per-package, statement-weighted. The merged profile repeats each block once per
-# test binary, so dedup by block id (take the max hit count) before summing.
-report=$(awk 'NR>1 {
-	key=$1; stmts[key]=$2+0; c=$3+0; if (c>max[key]) max[key]=c; seen[key]=1
-}
-END {
-	for (k in seen) {
-		f=k; sub(/:[0-9]+\.[0-9]+,[0-9]+\.[0-9]+$/, "", f)
-		p=f; sub(/\/[^/]+\.go$/, "", p); sub(/^github.com\/wago-org\/wago\/?/, "./", p)
-		if (p == "") p = "./"
-		tot[p]+=stmts[k]; if (max[k]>0) cov[p]+=stmts[k]
+# measure <dir> <profile-out>: run coverage for the module rooted at <dir> and
+# print "covered<TAB>total<TAB>pkg" per package, plus a final TOTAL row. The
+# merged profile repeats each block once per test binary, so dedup by block id.
+measure() {
+	(cd "$1" && go test -count=1 -covermode=atomic -coverpkg=./... -coverprofile="$2" ./... >/dev/null)
+	awk 'NR>1 {
+		key=$1; stmts[key]=$2+0; c=$3+0; if (c>max[key]) max[key]=c; seen[key]=1
 	}
-	for (p in tot) printf "%6.1f%%\t%d/%d\t%s\n", 100*cov[p]/tot[p], cov[p], tot[p], p
-}' "$profile" | sort -n)
+	END {
+		for (k in seen) {
+			f=k; sub(/:[0-9]+\.[0-9]+,[0-9]+\.[0-9]+$/, "", f)
+			p=f; sub(/\/[^/]+\.go$/, "", p); sub(/^github.com\/wago-org\/wago\/?/, "./", p)
+			if (p == "") p = "./"
+			tot[p]+=stmts[k]; if (max[k]>0) cov[p]+=stmts[k]; T+=stmts[k]; if (max[k]>0) C+=stmts[k]
+		}
+		for (p in tot) printf "%d\t%d\t%s\n", cov[p], tot[p], p
+		printf "%d\t%d\tTOTAL\n", C, T
+	}' "$2"
+}
 
-printf '\nCoverage by package (statement-weighted):\n%s\nTOTAL: %s\n' "$report" "$total"
+cur=$(mktemp)
+measure "$root" "$profile" >"$cur"
 
-# Build the markdown report once and reuse it for the run summary and the PR
-# comment. The leading marker (an invisible HTML comment) lets the PR-comment
-# step find and update its own comment instead of posting a new one each run.
-tab=$(printf '\t')
+base=$(mktemp) # stays empty unless a resolvable baseline is measured
+if [ -n "$baseline_ref" ] && git rev-parse --verify -q "$baseline_ref^{commit}" >/dev/null 2>&1; then
+	wt=$(mktemp -d)
+	git worktree add --detach -q "$wt" "$baseline_ref"
+	measure "$wt" "$wt/coverage.out" >"$base" 2>/dev/null || : >"$base"
+	git worktree remove --force "$wt" 2>/dev/null || true
+fi
+
+# Render: route baseline rows by FILENAME (an empty baseline must not be mistaken
+# for the current summary), emit a TOTAL line + pct-keyed package rows.
+have_base=0
+[ -s "$base" ] && have_base=1
+rendered=$(awk -F"$tab" -v basef="$base" -v have_base="$have_base" '
+	function pct(c, t) { return t > 0 ? 100.0*c/t : 0 }
+	function delta(p, pc,   d) {
+		if (!have_base) return "-"
+		if (!(p in btot)) return "new"
+		d = pc - pct(bcov[p], btot[p])
+		if (d > 0.049) return sprintf("+%.1f", d)
+		if (d < -0.049) return sprintf("%.1f", d)
+		return "—"
+	}
+	FILENAME == basef { bcov[$3]=$1; btot[$3]=$2; next }
+	{
+		pc = pct($1, $2); d = delta($3, pc)
+		if ($3 == "TOTAL") { printf "TOTAL%s%.1f%s%s%s%d/%d\n", FS, pc, FS, d, FS, $1, $2; next }
+		printf "ROW%s%.1f%s%s%s%d/%d%s%s\n", FS, pc, FS, d, FS, $1, $2, FS, $3
+	}
+' "$base" "$cur")
+
+total_line=$(printf '%s\n' "$rendered" | awk -F"$tab" '$1=="TOTAL"{print}')
+total_pct=$(printf '%s' "$total_line" | cut -f2)
+total_delta=$(printf '%s' "$total_line" | cut -f3)
+
+# Header: "## Coverage: 68.6% (+0.2% vs main)"
+head="## Coverage: ${total_pct}%"
+if [ "$have_base" = 1 ] && [ -n "$total_delta" ] && [ "$total_delta" != "—" ]; then
+	head="$head (${total_delta}% vs main)"
+fi
+
+# Table, sorted by coverage ascending. Δ column only when a baseline was measured.
+rows=$(printf '%s\n' "$rendered" | awk -F"$tab" '$1=="ROW"' | sort -t"$tab" -k2,2n)
 md=$(
-	printf '%s\n' "${COVER_MARKER:-<!-- wago-coverage -->}"
-	printf '## Coverage: %s\n\n' "$total"
-	printf '| Coverage | Statements | Package |\n|---|---|---|\n'
-	printf '%s\n' "$report" | while IFS="$tab" read -r pct stmts pkg; do
-		printf '| %s | %s | `%s` |\n' "$pct" "$stmts" "$pkg"
-	done
+	printf '%s\n%s\n\n' "$marker" "$head"
+	if [ "$have_base" = 1 ]; then
+		printf '| Coverage | Δ vs main | Statements | Package |\n|---|---|---|---|\n'
+		printf '%s\n' "$rows" | while IFS="$tab" read -r _ pc d sc pkg; do
+			printf '| %s%% | %s | %s | `%s` |\n' "$pc" "${d:-—}" "$sc" "$pkg"
+		done
+	else
+		printf '| Coverage | Statements | Package |\n|---|---|---|\n'
+		printf '%s\n' "$rows" | while IFS="$tab" read -r _ pc d sc pkg; do
+			printf '| %s%% | %s | `%s` |\n' "$pc" "$sc" "$pkg"
+		done
+	fi
 )
 
-printf '%s\n' "$md" >"${COVER_REPORT:-coverage-report.md}"
+printf '\nCoverage by package (statement-weighted):\n%s\n' "$md"
+printf '%s\n' "$md" >"$report"
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
 	printf '%s\n' "$md" >>"$GITHUB_STEP_SUMMARY"
 fi
+
+rm -f "$cur" "$base"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -8,7 +8,8 @@ set -eu
 
 profile="${COVERPROFILE:-coverage.out}"
 report="${COVER_REPORT:-coverage-report.md}"
-baseline_ref="${COVER_BASELINE_REF:-}"
+# Shared across card producers; COVER_BASELINE_REF kept for `make cover` alone.
+baseline_ref="${COVER_BASELINE_REF:-${CARD_BASELINE_REF:-}}"
 tab=$(printf '\t')
 
 root=$(git rev-parse --show-toplevel) || {

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -36,14 +36,20 @@ END {
 
 printf '\nCoverage by package (statement-weighted):\n%s\nTOTAL: %s\n' "$report" "$total"
 
-# Markdown report into the GitHub Actions run summary, when present.
+# Build the markdown report once and reuse it for the run summary and the PR
+# comment. The leading marker (an invisible HTML comment) lets the PR-comment
+# step find and update its own comment instead of posting a new one each run.
+tab=$(printf '\t')
+md=$(
+	printf '%s\n' "${COVER_MARKER:-<!-- wago-coverage -->}"
+	printf '## Coverage: %s\n\n' "$total"
+	printf '| Coverage | Statements | Package |\n|---|---|---|\n'
+	printf '%s\n' "$report" | while IFS="$tab" read -r pct stmts pkg; do
+		printf '| %s | %s | `%s` |\n' "$pct" "$stmts" "$pkg"
+	done
+)
+
+printf '%s\n' "$md" >"${COVER_REPORT:-coverage-report.md}"
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-	tab=$(printf '\t')
-	{
-		printf '## Coverage: %s\n\n' "$total"
-		printf '| Coverage | Statements | Package |\n|---|---|---|\n'
-		printf '%s\n' "$report" | while IFS="$tab" read -r pct stmts pkg; do
-			printf '| %s | %s | `%s` |\n' "$pct" "$stmts" "$pkg"
-		done
-	} >>"$GITHUB_STEP_SUMMARY"
+	printf '%s\n' "$md" >>"$GITHUB_STEP_SUMMARY"
 fi

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+# Run the test suite with cross-package coverage and print a per-package report.
+# Backs `make cover` and the CI coverage job. In GitHub Actions (where
+# $GITHUB_STEP_SUMMARY is set) the report is also appended to the run summary.
+set -eu
+
+profile="${COVERPROFILE:-coverage.out}"
+
+root=$(git rev-parse --show-toplevel) || {
+	printf 'wago: not inside a git repository\n' >&2
+	exit 1
+}
+cd "$root"
+
+# -coverpkg=./... so a test in one package counts toward coverage of the packages
+# it actually exercises (the spec/api suites drive the compiler and runtime, which
+# otherwise read as untested). atomic mode is safe across the parallel binaries.
+go test -count=1 -covermode=atomic -coverpkg=./... -coverprofile="$profile" ./...
+
+total=$(go tool cover -func="$profile" | awk '/^total:/{print $NF}')
+
+# Per-package, statement-weighted. The merged profile repeats each block once per
+# test binary, so dedup by block id (take the max hit count) before summing.
+report=$(awk 'NR>1 {
+	key=$1; stmts[key]=$2+0; c=$3+0; if (c>max[key]) max[key]=c; seen[key]=1
+}
+END {
+	for (k in seen) {
+		f=k; sub(/:[0-9]+\.[0-9]+,[0-9]+\.[0-9]+$/, "", f)
+		p=f; sub(/\/[^/]+\.go$/, "", p); sub(/^github.com\/wago-org\/wago\/?/, "./", p)
+		if (p == "") p = "./"
+		tot[p]+=stmts[k]; if (max[k]>0) cov[p]+=stmts[k]
+	}
+	for (p in tot) printf "%6.1f%%\t%d/%d\t%s\n", 100*cov[p]/tot[p], cov[p], tot[p], p
+}' "$profile" | sort -n)
+
+printf '\nCoverage by package (statement-weighted):\n%s\nTOTAL: %s\n' "$report" "$total"
+
+# Markdown report into the GitHub Actions run summary, when present.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+	tab=$(printf '\t')
+	{
+		printf '## Coverage: %s\n\n' "$total"
+		printf '| Coverage | Statements | Package |\n|---|---|---|\n'
+		printf '%s\n' "$report" | while IFS="$tab" read -r pct stmts pkg; do
+			printf '| %s | %s | `%s` |\n' "$pct" "$stmts" "$pkg"
+		done
+	} >>"$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
-# Run the test suite with cross-package coverage and render a per-package report.
-# Backs `make cover` and the CI coverage job. When COVER_BASELINE_REF is set
-# (e.g. origin/main) the report gains a "Δ vs main" column by measuring that ref
-# in a throwaway worktree. In GitHub Actions the report is appended to
+# Run the test suite with cross-package coverage and render a compact per-package
+# report. Backs `make cover` and the CI coverage job. When COVER_BASELINE_REF is
+# set (e.g. origin/main) the report gains a "Δ vs main" column by measuring that
+# ref in a throwaway worktree. In GitHub Actions the report is appended to
 # $GITHUB_STEP_SUMMARY; it is always written to $COVER_REPORT for the PR comment.
 set -eu
 
@@ -50,7 +50,8 @@ if [ -n "$baseline_ref" ] && git rev-parse --verify -q "$baseline_ref^{commit}" 
 fi
 
 # Render: route baseline rows by FILENAME (an empty baseline must not be mistaken
-# for the current summary), emit a TOTAL line + pct-keyed package rows.
+# for the current summary). Emit a TOTAL line + pct-keyed rows with short package
+# names; the delta is computed against the full path before shortening.
 have_base=0
 [ -s "$base" ] && have_base=1
 rendered=$(awk -F"$tab" -v basef="$base" -v have_base="$have_base" '
@@ -63,42 +64,56 @@ rendered=$(awk -F"$tab" -v basef="$base" -v have_base="$have_base" '
 		if (d < -0.049) return sprintf("%.1f", d)
 		return "—"
 	}
+	function short(p) {
+		sub(/^\.\//, "", p); if (p == "") return "(root)"
+		sub(/^src\/core\/compiler\//, "", p); sub(/^src\/core\//, "", p)
+		sub(/^src\//, "", p); sub(/^internal\//, "", p); sub(/^testutil\//, "", p)
+		return p
+	}
 	FILENAME == basef { bcov[$3]=$1; btot[$3]=$2; next }
 	{
 		pc = pct($1, $2); d = delta($3, pc)
-		if ($3 == "TOTAL") { printf "TOTAL%s%.1f%s%s%s%d/%d\n", FS, pc, FS, d, FS, $1, $2; next }
-		printf "ROW%s%.1f%s%s%s%d/%d%s%s\n", FS, pc, FS, d, FS, $1, $2, FS, $3
+		if ($3 == "TOTAL") { printf "TOTAL%s%.1f%s%s\n", FS, pc, FS, d; next }
+		printf "ROW%s%.1f%s%s%s%s\n", FS, pc, FS, d, FS, short($3)
 	}
 ' "$base" "$cur")
 
 total_line=$(printf '%s\n' "$rendered" | awk -F"$tab" '$1=="TOTAL"{print}')
 total_pct=$(printf '%s' "$total_line" | cut -f2)
 total_delta=$(printf '%s' "$total_line" | cut -f3)
+rows=$(printf '%s\n' "$rendered" | awk -F"$tab" '$1=="ROW"' | sort -t"$tab" -k2,2n)
+n=$(printf '%s\n' "$rows" | grep -c .)
 
-# Header: "## Coverage: 68.6% (+0.2% vs main)"
+# Headline: "## Coverage: 68.8%" plus a parenthetical total delta when measured.
 head="## Coverage: ${total_pct}%"
-if [ "$have_base" = 1 ] && [ -n "$total_delta" ] && [ "$total_delta" != "—" ]; then
-	head="$head (${total_delta}% vs main)"
+if [ "$have_base" = 1 ]; then
+	case "$total_delta" in
+	"—" | "") head="$head (—)" ;;
+	*) head="$head ($total_delta%)" ;;
+	esac
 fi
 
-# Table, sorted by coverage ascending. Δ column only when a baseline was measured.
-rows=$(printf '%s\n' "$rendered" | awk -F"$tab" '$1=="ROW"' | sort -t"$tab" -k2,2n)
+# Compact: headline always visible, per-package table folded in <details>.
 md=$(
 	printf '%s\n%s\n\n' "$marker" "$head"
 	if [ "$have_base" = 1 ]; then
-		printf '| Coverage | Δ vs main | Statements | Package |\n|---|---|---|---|\n'
-		printf '%s\n' "$rows" | while IFS="$tab" read -r _ pc d sc pkg; do
-			printf '| %s%% | %s | %s | `%s` |\n' "$pc" "${d:-—}" "$sc" "$pkg"
+		printf '<details><summary>per-package (%s) · Δ vs main</summary>\n\n' "$n"
+		printf '| Cov | Δ | Package |\n|---|---|---|\n'
+		printf '%s\n' "$rows" | while IFS="$tab" read -r _ pc d pkg; do
+			printf '| %s%% | %s | `%s` |\n' "$pc" "$d" "$pkg"
 		done
+		printf '</details>\n'
 	else
-		printf '| Coverage | Statements | Package |\n|---|---|---|\n'
-		printf '%s\n' "$rows" | while IFS="$tab" read -r _ pc d sc pkg; do
-			printf '| %s%% | %s | `%s` |\n' "$pc" "$sc" "$pkg"
+		printf '<details><summary>per-package (%s)</summary>\n\n' "$n"
+		printf '| Cov | Package |\n|---|---|\n'
+		printf '%s\n' "$rows" | while IFS="$tab" read -r _ pc d pkg; do
+			printf '| %s%% | `%s` |\n' "$pc" "$pkg"
 		done
+		printf '</details>\n'
 	fi
 )
 
-printf '\nCoverage by package (statement-weighted):\n%s\n' "$md"
+printf '\n%s\nTOTAL: %s%%\n' "$head" "$total_pct"
 printf '%s\n' "$md" >"$report"
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
 	printf '%s\n' "$md" >>"$GITHUB_STEP_SUMMARY"

--- a/scripts/pr-card-comment.sh
+++ b/scripts/pr-card-comment.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env sh
-# Upsert a "sticky" coverage comment on a pull request: create it once, then
-# update the same comment on later runs (keyed by the marker line that
-# coverage.sh writes as the first line of the report). Runs in CI from the
-# coverage job; needs gh authenticated via GH_TOKEN with pull-requests: write.
+# Upsert a "sticky" CI info-card comment on a pull request: create it once, then
+# update the same comment on later runs (keyed by the marker line that pr-card.sh
+# writes as the first line of the card). Needs gh authenticated via GH_TOKEN with
+# pull-requests: write.
 #
 # Required env: GITHUB_REPOSITORY (owner/repo), PR_NUMBER.
 set -eu
 
-file="${COVER_REPORT:-coverage-report.md}"
+file="${CARD_FILE:-card.md}"
 repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
 pr="${PR_NUMBER:?PR_NUMBER not set}"
 
 [ -f "$file" ] || {
-	printf 'pr-coverage-comment: report %s not found (run coverage first)\n' "$file" >&2
+	printf 'pr-card-comment: card %s not found (build it first)\n' "$file" >&2
 	exit 1
 }
 
@@ -26,8 +26,8 @@ id=$(gh api "repos/$repo/issues/$pr/comments" --paginate \
 
 if [ -n "$id" ]; then
 	gh api -X PATCH "repos/$repo/issues/comments/$id" -f body="$body" >/dev/null
-	printf 'pr-coverage-comment: updated comment %s\n' "$id"
+	printf 'pr-card-comment: updated comment %s\n' "$id"
 else
 	gh api -X POST "repos/$repo/issues/$pr/comments" -f body="$body" >/dev/null
-	printf 'pr-coverage-comment: created comment\n'
+	printf 'pr-card-comment: created comment\n'
 fi

--- a/scripts/pr-card.sh
+++ b/scripts/pr-card.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Compose the wago CI info card posted on PRs: one collapsible <details> section
+# per topic (coverage, benchmarks, tests, memory, ...). Each producer drops a
+# fragment at $CARD_DIR/<key>.md whose first line is the section summary (the
+# visible <summary>) and whose rest is the body. Topics without a fragment render
+# as a blank placeholder, so the card's shape is stable as producers come online.
+set -eu
+
+dir="${CARD_DIR:-ci-card}"
+out="${CARD_FILE:-card.md}"
+marker="${CARD_MARKER:-<!-- wago-ci -->}"
+
+# Ordered sections: "<key>|<title>". Add a line here when a new producer lands.
+sections='coverage|Coverage
+benchmarks|Benchmarks
+tests|Tests
+memory|Memory'
+
+{
+	printf '%s\n' "$marker"
+	printf '### CI report\n\n'
+	printf '%s\n' "$sections" | while IFS='|' read -r key title; do
+		frag="$dir/$key.md"
+		if [ -s "$frag" ]; then
+			summary=$(head -n 1 "$frag")
+			body=$(tail -n +2 "$frag")
+		else
+			summary="$title — _not reported yet_"
+			body="_No data._"
+		fi
+		printf '<details><summary>%s</summary>\n\n%s\n</details>\n' "$summary" "$body"
+	done
+} >"$out"

--- a/scripts/pr-coverage-comment.sh
+++ b/scripts/pr-coverage-comment.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Upsert a "sticky" coverage comment on a pull request: create it once, then
+# update the same comment on later runs (keyed by the marker line that
+# coverage.sh writes as the first line of the report). Runs in CI from the
+# coverage job; needs gh authenticated via GH_TOKEN with pull-requests: write.
+#
+# Required env: GITHUB_REPOSITORY (owner/repo), PR_NUMBER.
+set -eu
+
+file="${COVER_REPORT:-coverage-report.md}"
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
+pr="${PR_NUMBER:?PR_NUMBER not set}"
+
+[ -f "$file" ] || {
+	printf 'pr-coverage-comment: report %s not found (run coverage first)\n' "$file" >&2
+	exit 1
+}
+
+marker=$(head -n 1 "$file")
+body=$(cat "$file")
+
+# Find an existing comment whose first body line is our marker.
+id=$(gh api "repos/$repo/issues/$pr/comments" --paginate \
+	--jq '.[] | [.id, (.body | split("\n")[0])] | @tsv' \
+	| awk -F '\t' -v m="$marker" '$2 == m { print $1; exit }')
+
+if [ -n "$id" ]; then
+	gh api -X PATCH "repos/$repo/issues/comments/$id" -f body="$body" >/dev/null
+	printf 'pr-coverage-comment: updated comment %s\n' "$id"
+else
+	gh api -X POST "repos/$repo/issues/$pr/comments" -f body="$body" >/dev/null
+	printf 'pr-coverage-comment: created comment\n'
+fi

--- a/scripts/tests-card.sh
+++ b/scripts/tests-card.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+# Emit the "Tests" section fragment for the CI card: passed/failed/skipped counts
+# from `go test -json ./...` (subtests included), with deltas vs CARD_BASELINE_REF
+# (e.g. origin/main) measured in a throwaway worktree. Fragment format matches the
+# other producers: line 1 is the <summary>, the rest is the body.
+set -eu
+
+report="${TESTS_REPORT:-ci-card/tests.md}"
+baseline_ref="${CARD_BASELINE_REF:-}"
+
+root=$(git rev-parse --show-toplevel) || {
+	printf 'wago: not inside a git repository\n' >&2
+	exit 1
+}
+cd "$root"
+
+# count <dir>: run the suite as JSON and print "pass<TAB>fail<TAB>skip" over the
+# final per-test events (those carry a "Test" field; package-level events do not).
+count() {
+	(cd "$1" && go test -count=1 -json ./... 2>/dev/null) | awk -F'"' '
+		{ action=""; hastest=0
+		  for (i=1; i<NF; i++) { if ($i=="Action") action=$(i+2); if ($i=="Test") hastest=1 }
+		  if (hastest) { if (action=="pass") p++; else if (action=="fail") f++; else if (action=="skip") s++ } }
+		END { printf "%d\t%d\t%d\n", p+0, f+0, s+0 }'
+}
+
+cur=$(count "$root")
+cp=$(printf '%s' "$cur" | cut -f1)
+cf=$(printf '%s' "$cur" | cut -f2)
+cs=$(printf '%s' "$cur" | cut -f3)
+
+have_base=0
+if [ -n "$baseline_ref" ] && git rev-parse --verify -q "$baseline_ref^{commit}" >/dev/null 2>&1; then
+	wt=$(mktemp -d)
+	git worktree add --detach -q "$wt" "$baseline_ref"
+	base=$(count "$wt" || printf '0\t0\t0\n')
+	git worktree remove --force "$wt" 2>/dev/null || true
+	bp=$(printf '%s' "$base" | cut -f1)
+	bf=$(printf '%s' "$base" | cut -f2)
+	bs=$(printf '%s' "$base" | cut -f3)
+	have_base=1
+fi
+
+# delta <cur> <base>: signed integer, or "—" when unchanged.
+delta() {
+	d=$(($1 - $2))
+	if [ "$d" -gt 0 ]; then printf '+%d' "$d"
+	elif [ "$d" -lt 0 ]; then printf '%d' "$d"
+	else printf '—'; fi
+}
+
+summary="Tests: ${cp} passed"
+[ "$cf" -gt 0 ] && summary="$summary, ${cf} failed"
+[ "$cs" -gt 0 ] && summary="$summary, ${cs} skipped"
+if [ "$have_base" = 1 ]; then
+	dt=$(delta "$((cp + cf + cs))" "$((bp + bf + bs))")
+	[ "$dt" != "—" ] && summary="$summary (${dt})"
+fi
+
+if [ "$have_base" = 1 ]; then
+	body=$(printf '| Result | Count | Δ vs main |\n|---|---|---|\n| Passed | %s | %s |\n| Failed | %s | %s |\n| Skipped | %s | %s |\n' \
+		"$cp" "$(delta "$cp" "$bp")" "$cf" "$(delta "$cf" "$bf")" "$cs" "$(delta "$cs" "$bs")")
+else
+	body=$(printf '| Result | Count |\n|---|---|\n| Passed | %s |\n| Failed | %s |\n| Skipped | %s |\n' "$cp" "$cf" "$cs")
+fi
+
+printf '%s\n%s\n' "$summary" "$body" >"$report"
+printf '%s\n' "$summary"


### PR DESCRIPTION
## What

Adds a **Coverage** job to CI that measures and reports test coverage.

- `make cover` (new) → `scripts/coverage.sh` runs `go test -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...`, then prints a **statement-weighted per-package report** + total.
- `-coverpkg=./...` so a test in one package counts toward the packages it actually exercises — the spec/api suites drive the compiler and runtime, which otherwise read as ~untested.
- In CI the report is appended to the **job summary** (`$GITHUB_STEP_SUMMARY`), and `coverage.out` is uploaded as an artifact.

## Reporting

The job summary renders like:

> ## Coverage: 68.6%
> | Coverage | Statements | Package |
> |---|---|---|
> | 62.7% | 1808/2883 | `./src/core/compiler/wasm` |
> | 82.1% | 1463/1783 | `./src/core/compiler/backend/amd64` |
> | … | | |

## Notes

- Report-only (no threshold gate) — easy to add a `COVERAGE_MIN` failure later if you want.
- No external service (Codecov/Coveralls) — native to GitHub, matching the repo's zero-dependency ethos. A README badge would need somewhere to host the JSON (could publish to `wago-org/docs` like the bench charts); happy to add if wanted.
- Verified locally via `act` (`./scripts/ci-local.sh coverage`): wabt installs, `make cover` succeeds, summary is written. (`act` can't run `upload-artifact` locally — works on real CI.)