### PR TITLE
feat(amd64): port sign-extension ops (i32/i64.extend8/16/32_s)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -37,7 +37,7 @@ Later proposals and engine/platform capabilities beyond the MVP.
 
 | Feature | Planned | Status |
 |---|:---:|---|
-| Sign-extension ops (`i32.extend8_s`, …) | ✓ | ⬜ planned |
+| Sign-extension ops (`i32.extend8_s`, …) | ✓ | ✅ done |
 | Non-trapping float→int (`trunc_sat`) | ✓ | ⬜ planned |
 | Multi-value (multiple block/func results) | ✓ | 🚧 partial |
 | Reference types (`funcref`/`externref`, `select t`, `ref.*`, `table.get/set`, multi-table) | ✓ | 🚧 partial (`select t` done) |

--- a/src/core/compiler/backend/amd64/asm.go
+++ b/src/core/compiler/backend/amd64/asm.go
@@ -116,6 +116,24 @@ func (a *Asm) Movsxd(dst, src Reg) {
 	a.emit(rex(true, dst >= 8, false, src >= 8), 0x63, 0xC0|((byte(dst)&7)<<3)|byte(src&7))
 }
 
+// Movsx8 sign-extends the low byte of src into dst; w selects a 64-bit dest.
+// Scratch byte sources are AL/CL/DL/BL or R8B-R15B, so the standard REX rules
+// apply (none are SPL/BPL/SIL/DIL, which would need a mandatory REX prefix).
+func (a *Asm) Movsx8(dst, src Reg, w bool) {
+	if w || dst >= 8 || src >= 8 {
+		a.emit(rex(w, dst >= 8, false, src >= 8))
+	}
+	a.emit(0x0F, 0xBE, 0xC0|((byte(dst)&7)<<3)|byte(src&7))
+}
+
+// Movsx16 sign-extends the low word of src into dst; w selects a 64-bit dest.
+func (a *Asm) Movsx16(dst, src Reg, w bool) {
+	if w || dst >= 8 || src >= 8 {
+		a.emit(rex(w, dst >= 8, false, src >= 8))
+	}
+	a.emit(0x0F, 0xBF, 0xC0|((byte(dst)&7)<<3)|byte(src&7))
+}
+
 func (a *Asm) Load32(dst Reg, base Reg, disp int32)  { a.memOp(0x8B, byte(dst), base, disp, false) }
 func (a *Asm) Store32(base Reg, disp int32, src Reg) { a.memOp(0x89, byte(src), base, disp, false) }
 func (a *Asm) Load64(dst Reg, base Reg, disp int32)  { a.memOp(0x8B, byte(dst), base, disp, true) }

--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -1005,6 +1005,35 @@ func (g *cg) assignPinnedLocals() {
 	}
 }
 
+// signExtend sign-extends the low `bits` (8/16/32) of the top-of-stack integer.
+// wide selects an i64 result; otherwise the result is an i32 (upper bits zeroed).
+func (g *cg) signExtend(bits int, wide bool) {
+	a := g.pop()
+	if a.kind == vConst && !a.fp {
+		var v int64
+		switch bits {
+		case 8:
+			v = int64(int8(a.cval))
+		case 16:
+			v = int64(int16(a.cval))
+		default: // 32
+			v = int64(int32(a.cval))
+		}
+		g.push(ventry{kind: vConst, wide: wide, cval: v})
+		return
+	}
+	dst := g.materialize(a)
+	switch bits {
+	case 8:
+		g.a.Movsx8(dst, dst, wide)
+	case 16:
+		g.a.Movsx16(dst, dst, wide)
+	default: // 32
+		g.a.Movsxd(dst, dst)
+	}
+	g.pushReg(dst)
+}
+
 // emitPlain lowers non-control opcodes while the current path is reachable.
 func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	switch {
@@ -1244,6 +1273,16 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 		} else {
 			g.pushReg(g.materialize(a))
 		}
+	case op == 0xC0: // i32.extend8_s
+		g.signExtend(8, false)
+	case op == 0xC1: // i32.extend16_s
+		g.signExtend(16, false)
+	case op == 0xC2: // i64.extend8_s
+		g.signExtend(8, true)
+	case op == 0xC3: // i64.extend16_s
+		g.signExtend(16, true)
+	case op == 0xC4: // i64.extend32_s
+		g.signExtend(32, true)
 
 	case op == 0x43: // f32.const
 		b, err := r.Bytes(4)

--- a/src/core/compiler/backend/amd64/signext_test.go
+++ b/src/core/compiler/backend/amd64/signext_test.go
@@ -1,0 +1,70 @@
+//go:build linux && amd64
+
+package amd64
+
+import "testing"
+
+// TestSignExtendI32 covers i32.extend8_s / i32.extend16_s on register operands.
+func TestSignExtendI32(t *testing.T) {
+	cases := []struct {
+		name string
+		wat  string
+		in   int32
+		want int32
+	}{
+		{"extend8_s/-1", `local.get 0 i32.extend8_s`, 0xFF, -1},
+		{"extend8_s/127", `local.get 0 i32.extend8_s`, 0x1234567F, 127},
+		{"extend8_s/-128", `local.get 0 i32.extend8_s`, 0x80, -128},
+		{"extend16_s/-1", `local.get 0 i32.extend16_s`, 0xFFFF, -1},
+		{"extend16_s/min", `local.get 0 i32.extend16_s`, 0x8000, -32768},
+		{"extend16_s/keeplow", `local.get 0 i32.extend16_s`, 0x12347FFF, 0x7FFF},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := watToModule(t, `(module (func (export "f") (param i32) (result i32)`+"\n"+c.wat+"))")
+			if got := runI32(t, m, c.in); got != c.want {
+				t.Fatalf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// TestSignExtendI64 covers i64.extend8/16/32_s on register operands.
+func TestSignExtendI64(t *testing.T) {
+	cases := []struct {
+		name string
+		wat  string
+		in   int64
+		want int64
+	}{
+		{"extend8_s/-1", `local.get 0 i64.extend8_s`, 0xFF, -1},
+		{"extend8_s/-128", `local.get 0 i64.extend8_s`, 0xFFFFFF80, -128},
+		{"extend16_s/-1", `local.get 0 i64.extend16_s`, 0xFFFF, -1},
+		{"extend16_s/min", `local.get 0 i64.extend16_s`, 0x8000, -32768},
+		{"extend32_s/-1", `local.get 0 i64.extend32_s`, 0xFFFFFFFF, -1},
+		{"extend32_s/min", `local.get 0 i64.extend32_s`, 0x80000000, -2147483648},
+		{"extend32_s/keeplow", `local.get 0 i64.extend32_s`, 0x1122334400000001, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := watToModule(t, `(module (func (export "f") (param i64) (result i64)`+"\n"+c.wat+"))")
+			if got := runI64(t, m, c.in); got != c.want {
+				t.Fatalf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// TestSignExtendConstFold covers the compile-time constant-folding path.
+func TestSignExtendConstFold(t *testing.T) {
+	m32 := watToModule(t, `(module (func (export "f") (param i32) (result i32)
+		i32.const 255 i32.extend8_s))`)
+	if got := runI32(t, m32, 0); got != -1 {
+		t.Fatalf("i32.const 255 i32.extend8_s = %d, want -1", got)
+	}
+	m64 := watToModule(t, `(module (func (export "f") (param i64) (result i64)
+		i64.const 0xFFFFFFFF i64.extend32_s))`)
+	if got := runI64(t, m64, 0); got != -1 {
+		t.Fatalf("i64.const 0xFFFFFFFF i64.extend32_s = %d, want -1", got)
+	}
+}

--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -460,6 +460,7 @@ func (p supportPass) instructionKind(k wasm.InstrKind, context string) error {
 		wasm.InstrI64Add, wasm.InstrI64Sub, wasm.InstrI64Mul, wasm.InstrI64DivS, wasm.InstrI64DivU, wasm.InstrI64RemS, wasm.InstrI64RemU, wasm.InstrI64And, wasm.InstrI64Or, wasm.InstrI64Xor, wasm.InstrI64Shl, wasm.InstrI64ShrS, wasm.InstrI64ShrU, wasm.InstrI64Rotl, wasm.InstrI64Rotr,
 		wasm.InstrF32Abs, wasm.InstrF32Neg, wasm.InstrF32Sqrt, wasm.InstrF32Add, wasm.InstrF32Sub, wasm.InstrF32Mul, wasm.InstrF32Div, wasm.InstrF32Min, wasm.InstrF32Max,
 		wasm.InstrF64Abs, wasm.InstrF64Neg, wasm.InstrF64Sqrt, wasm.InstrF64Add, wasm.InstrF64Sub, wasm.InstrF64Mul, wasm.InstrF64Div, wasm.InstrF64Min, wasm.InstrF64Max,
+		wasm.InstrI32Extend8S, wasm.InstrI32Extend16S, wasm.InstrI64Extend8S, wasm.InstrI64Extend16S, wasm.InstrI64Extend32S,
 		wasm.InstrI32WrapI64, wasm.InstrI32TruncF32S, wasm.InstrI32TruncF32U, wasm.InstrI32TruncF64S, wasm.InstrI32TruncF64U,
 		wasm.InstrI64ExtendI32S, wasm.InstrI64ExtendI32U, wasm.InstrI64TruncF32S, wasm.InstrI64TruncF32U, wasm.InstrI64TruncF64S, wasm.InstrI64TruncF64U,
 		wasm.InstrF32ConvertI32S, wasm.InstrF32ConvertI32U, wasm.InstrF32ConvertI64S, wasm.InstrF32ConvertI64U, wasm.InstrF32DemoteF64,

--- a/src/core/compiler/frontend/frontend_test.go
+++ b/src/core/compiler/frontend/frontend_test.go
@@ -28,6 +28,37 @@ func TestDecodeValidateAcceptsSupportedMVPModule(t *testing.T) {
 	}
 }
 
+func TestDecodeValidateAcceptsSignExtensionOps(t *testing.T) {
+	// i32.extend8_s/16_s (0xc0/0xc1) and i64.extend8_s/16_s/32_s (0xc2/0xc3/0xc4)
+	// are MVP sign-extension ops the backend now lowers; the support pass must
+	// accept them.
+	cases := []struct {
+		name   string
+		params []wasm.ValType
+		result wasm.ValType
+		op     byte
+	}{
+		{"i32.extend8_s", []wasm.ValType{wasm.I32}, wasm.I32, 0xc0},
+		{"i32.extend16_s", []wasm.ValType{wasm.I32}, wasm.I32, 0xc1},
+		{"i64.extend8_s", []wasm.ValType{wasm.I64}, wasm.I64, 0xc2},
+		{"i64.extend16_s", []wasm.ValType{wasm.I64}, wasm.I64, 0xc3},
+		{"i64.extend32_s", []wasm.ValType{wasm.I64}, wasm.I64, 0xc4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mod := wasmtest.Module(
+				wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(tc.params, []wasm.ValType{tc.result}))),
+				wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+				wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
+				wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x00, tc.op, 0x0b}))),
+			)
+			if _, err := DecodeValidate(mod); err != nil {
+				t.Fatalf("DecodeValidate %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
 func TestRejectUnsupportedGlobalTypes(t *testing.T) {
 	mod := wasmtest.Module(wasmtest.Section(2, wasmtest.Vec(wasmtest.GlobalImportEntry("env", "vec", wasm.V128, false))))
 	_, err := DecodeValidate(mod)


### PR DESCRIPTION
## What

Ports the five MVP **sign-extension** opcodes (`0xC0`–`0xC4`) from WARP into the wago single-pass backend:

- `i32.extend8_s`, `i32.extend16_s`
- `i64.extend8_s`, `i64.extend16_s`, `i64.extend32_s`

The decoder and validator already handled these; this PR wires the **backend codegen** and lifts the **frontend support-pass gate**.

## Changes

- **`asm.go`** — new `Movsx8`/`Movsx16` encoders (`0F BE` / `0F BF`, REX.W-aware). `i64.extend32_s` reuses the existing `Movsxd` (`movsxd`, `0x63`).
- **`compile.go`** — `signExtend(bits, wide)` helper: a compile-time **constant-folding** path (folds an extend of a `vConst`) plus a register path (movsx in place).
- **`frontend.go`** — added the five `InstrI32/I64Extend*` kinds to the `instructionKind` allowlist so `DecodeValidate` accepts them.
- **`FEATURES.md`** — sign-extension ops flipped to ✅ done.

## Tests

- Backend register + constant-fold coverage for all five ops (`signext_test.go`).
- Frontend acceptance test (`TestDecodeValidateAcceptsSignExtensionOps`).
- CLI spot-check: `e8(255)=-1`, `e8(127)=127`, `e16_64(65535)=-1`, `e32_64(2^31)=-2147483648`.
- Full `go test ./...` green.

## Performance delta

`BenchmarkCompile` (count=6, benchstat before/after) — **neutral**, as expected for a coverage-only port:

| metric | Δ |
|---|---|
| sec/op (geomean) | +0.03% (noise) |
| B/op | +0.00% (identical) |
| allocs/op | +0.00% (identical) |

No corpus module exercises these opcodes, so this confirms the added allowlist case introduces **no compile-path regression**. Exec deltas are N/A (no benchmark uses the ops).

---
Port #1 of the WARP singlepass porting effort (interleaved feature/perf, one PR per port).