### PR TITLE
perf(amd64): pin integer locals in registers (Valent-Block)

### DIFF
--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -25,11 +25,22 @@ var scratch = []Reg{RAX, RCX, RDX, RBX, R8, R9, R10, R11, R13, R14, R15}
 type vkind uint8
 
 const (
-	vConst vkind = iota // immediate constant (not yet materialized)
-	vLocal              // reference to a local's frame slot (lazy)
-	vReg                // value resident in a scratch register
-	vSpill              // value materialized in its canonical frame slot
+	vConst  vkind = iota // immediate constant (not yet materialized)
+	vLocal               // reference to a local's frame slot (lazy)
+	vReg                 // value resident in a scratch register
+	vSpill               // value materialized in its canonical frame slot
+	vPinned              // reference to a local pinned in a reserved register (lazy)
 )
+
+// regNone marks a local that is not pinned to a register (lives in its frame slot).
+const regNone Reg = 0xFF
+
+// pinnedLocal records an integer local kept resident in a dedicated register
+// for the whole function (spilled to its frame slot only around calls).
+type pinnedLocal struct {
+	local int
+	reg   Reg
+}
 
 type ventry struct {
 	kind  vkind
@@ -55,6 +66,9 @@ type cg struct {
 	nResults    int
 	relocs      []callReloc // internal call sites to patch at module layout
 	localFloat  []bool      // per-local: f32/f64?
+	localReg    []Reg       // per-local: pinned register, or regNone if frame-resident
+	pinned      []pinnedLocal
+	reserved    [16]bool // GPRs dedicated to pinned locals (not allocatable as scratch)
 }
 
 // Frame layout: saved ABI pointers, locals, then operand-stack spill slots.
@@ -73,7 +87,7 @@ func (g *cg) freeReg(r Reg) { g.busy[r] = false }
 
 func (g *cg) allocRegExcept(except Reg) Reg {
 	for _, r := range scratch {
-		if r != except && !g.busy[r] {
+		if r != except && !g.busy[r] && !g.reserved[r] {
 			g.busy[r] = true
 			return r
 		}
@@ -123,17 +137,27 @@ func (g *cg) loadInto(dst Reg, e ventry) {
 			g.a.MovReg64(dst, e.reg)
 			g.freeReg(e.reg)
 		}
+	case vPinned:
+		if e.reg != dst { // pinned reg is shared storage; copy out, never free
+			g.a.MovReg64(dst, e.reg)
+		}
 	case vSpill:
 		g.a.Load64(dst, RBP, g.slotOff(e.slot))
 	}
 }
 
 // materializeLocalRefs prevents lazy local.get entries from seeing later writes.
+// It captures pending reads of local x — both frame-resident (vLocal) and
+// register-pinned (vPinned) — to their canonical slots before x is overwritten.
 func (g *cg) materializeLocalRefs(x int) {
 	for i := range g.st {
-		if g.st[i].kind == vLocal && g.st[i].local == x {
+		switch {
+		case g.st[i].kind == vLocal && g.st[i].local == x:
 			g.a.Load64(RSI, RBP, g.localOff(x))
 			g.a.Store64(RBP, g.slotOff(i), RSI)
+			g.st[i] = ventry{kind: vSpill, slot: i}
+		case g.st[i].kind == vPinned && g.st[i].local == x:
+			g.a.Store64(RBP, g.slotOff(i), g.st[i].reg)
 			g.st[i] = ventry{kind: vSpill, slot: i}
 		}
 	}
@@ -264,6 +288,8 @@ func (g *cg) applyALU(d aluDesc, dst Reg, src ventry, w bool) {
 	case vReg:
 		g.a.AluRR(d.rr, dst, src.reg, w)
 		g.freeReg(src.reg)
+	case vPinned:
+		g.a.AluRR(d.rr, dst, src.reg, w) // pinned reg as RHS; shared storage, never freed
 	case vLocal:
 		g.a.AluRM(d.rm, dst, RBP, g.localOff(src.local), w)
 	case vSpill:
@@ -304,6 +330,8 @@ func (g *cg) mul(w bool) {
 	case vReg:
 		g.a.IMul(dst, src.reg, w)
 		g.freeReg(src.reg)
+	case vPinned:
+		g.a.IMul(dst, src.reg, w) // pinned reg as RHS; shared storage, never freed
 	case vLocal:
 		g.a.ImulRM(dst, RBP, g.localOff(src.local), w)
 	case vSpill:
@@ -428,7 +456,15 @@ func (g *cg) emitWrapperCall(p, rN int, emitCall func()) {
 	g.a.LeaRsp(RCX, int32(p*8)) // results
 	g.a.Load64(RSI, RBP, -16)   // linMem
 	g.a.Load64(RDX, RBP, -24)   // trap
+	// The callee clobbers our pinned-local registers (they are plain scratch in
+	// its frame), so spill them to their slots across the call and reload after.
+	for _, pl := range g.pinned {
+		g.a.Store64(RBP, g.localOff(pl.local), pl.reg)
+	}
 	emitCall()
+	for _, pl := range g.pinned {
+		g.a.Load64(pl.reg, RBP, g.localOff(pl.local))
+	}
 
 	g.a.Load64(RAX, RBP, -24)
 	g.a.Load32(RAX, RAX, 0)
@@ -631,6 +667,8 @@ func (g *cg) emitCompare(w bool) Reg {
 	case b.kind == vReg:
 		g.a.AluRR(0x39, dst, b.reg, w)
 		g.freeReg(b.reg)
+	case b.kind == vPinned:
+		g.a.AluRR(0x39, dst, b.reg, w) // pinned reg as RHS; shared storage, never freed
 	case b.kind == vLocal:
 		g.a.AluRM(0x3B, dst, RBP, g.localOff(b.local), w)
 	case b.kind == vSpill:
@@ -834,6 +872,7 @@ func compileFunc(m *wasm.Module, funcIdx int) (code []byte, relocs []callReloc, 
 			g.localFloat = append(g.localFloat, isFloatType(le.Type))
 		}
 	}
+	g.assignPinnedLocals()
 
 	a.Prologue()
 	subRspAt := a.Len() + 3
@@ -851,6 +890,10 @@ func compileFunc(m *wasm.Module, funcIdx int) (code []byte, relocs []callReloc, 
 		for i := nParams; i < nLocals; i++ {
 			a.Store64(RBP, g.localOff(i), RAX) // zero declared locals (full 8 bytes)
 		}
+	}
+	// Prime each pinned local's register from its now-initialized frame slot.
+	for _, pl := range g.pinned {
+		a.Load64(pl.reg, RBP, g.localOff(pl.local))
 	}
 
 	g.ctrl = append(g.ctrl, cframe{kind: ckFunc, height: 0, resultN: len(ft.Results), branchN: len(ft.Results)})
@@ -931,6 +974,33 @@ func (g *cg) body(r *wasm.Reader) error {
 	return nil
 }
 
+// pinnedPool lists the registers dedicated to integer locals, in priority order.
+// They are callee-clobbered scratch (spilled around calls) but never handed out
+// by the scratch allocator while pinned, so each holds one local for the whole
+// function. RAX/RCX/RDX are left free for div/shift/call-ABI fixed uses.
+var pinnedPool = []Reg{RBX, R13, R14, R15}
+
+// assignPinnedLocals pins the first few integer locals to dedicated registers.
+// Float locals stay frame-resident. Pinning the low-index locals favors params,
+// which are typically the hottest.
+func (g *cg) assignPinnedLocals() {
+	g.localReg = make([]Reg, g.nLocals)
+	for i := range g.localReg {
+		g.localReg[i] = regNone
+	}
+	k := 0
+	for x := 0; x < g.nLocals && k < len(pinnedPool); x++ {
+		if g.localFloat[x] {
+			continue
+		}
+		r := pinnedPool[k]
+		k++
+		g.localReg[x] = r
+		g.reserved[r] = true
+		g.pinned = append(g.pinned, pinnedLocal{local: x, reg: r})
+	}
+}
+
 // emitPlain lowers non-control opcodes while the current path is reachable.
 func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 	switch {
@@ -987,7 +1057,11 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 		if err != nil {
 			return err
 		}
-		g.push(ventry{kind: vLocal, local: int(x), fp: g.isFloatLocal(int(x))})
+		if pr := g.localReg[x]; pr != regNone {
+			g.push(ventry{kind: vPinned, reg: pr, local: int(x)})
+		} else {
+			g.push(ventry{kind: vLocal, local: int(x), fp: g.isFloatLocal(int(x))})
+		}
 	case op == 0x23: // global.get
 		return g.globalGet(r)
 	case op == 0x24: // global.set
@@ -1018,7 +1092,13 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 		}
 		e := g.pop()
 		g.materializeLocalRefs(int(x))
-		if g.isFloatLocal(int(x)) {
+		if pr := g.localReg[x]; pr != regNone {
+			// Pinned integer local: write the value straight into its register.
+			g.loadInto(pr, e)
+			if tee {
+				g.push(ventry{kind: vPinned, reg: pr, local: int(x)})
+			}
+		} else if g.isFloatLocal(int(x)) {
 			xmm := g.materializeF(e)
 			g.a.FStoreDisp(RBP, g.localOff(int(x)), xmm, true)
 			if tee {

--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -975,9 +975,13 @@ func (g *cg) body(r *wasm.Reader) error {
 }
 
 // pinnedPool lists the registers dedicated to integer locals, in priority order.
-// They are callee-clobbered scratch (spilled around calls) but never handed out
-// by the scratch allocator while pinned, so each holds one local for the whole
-// function. RAX/RCX/RDX are left free for div/shift/call-ABI fixed uses.
+// These registers are treated as clobbered by generated wasm callees under
+// wago's wrapper ABI, so callers spill/reload pinned locals around internal
+// calls. At the Go/native boundary, enterNative saves/restores the Go
+// callee-saved registers, so using RBX/R13/R14/R15 inside native wasm remains
+// safe. While pinned they are never handed out by the scratch allocator, so each
+// holds one local for the whole function. RAX/RCX/RDX are left free for
+// div/shift/call-ABI fixed uses.
 var pinnedPool = []Reg{RBX, R13, R14, R15}
 
 // assignPinnedLocals pins the first few integer locals to dedicated registers.

--- a/src/core/compiler/backend/amd64/control.go
+++ b/src/core/compiler/backend/amd64/control.go
@@ -92,6 +92,10 @@ func (g *cg) flush() {
 		case vLocal:
 			g.a.Load64(RSI, RBP, g.localOff(e.local))
 			g.a.Store64(RBP, g.slotOff(i), RSI)
+		case vPinned:
+			// The pinned register is stable storage; copy its value to the slot
+			// but leave the register holding the local across the boundary.
+			g.a.Store64(RBP, g.slotOff(i), e.reg)
 		case vSpill:
 			if e.slot != i {
 				g.a.Load64(RSI, RBP, g.slotOff(e.slot))

--- a/src/core/compiler/backend/amd64/localfuse_test.go
+++ b/src/core/compiler/backend/amd64/localfuse_test.go
@@ -83,11 +83,14 @@ func TestLocalSetGetCorrectness(t *testing.T) {
 // register. We check there is no `mov reg,[rbp-...]` that targets the same slot
 // a preceding store wrote — simplest proxy: the fused function is strictly
 // smaller than the same logic with a non-fusing barrier in between.
+//
+// Uses f32 locals, which are frame-resident: integer locals are pinned in
+// registers, where local.get is already free and the peephole is a no-op.
 func TestLocalSetGetShrinksCode(t *testing.T) {
-	fused := watToModule(t, `(module (func (export "f") (param i32) (result i32) (local i32)
-		local.get 0 local.get 1 i32.add local.set 1 local.get 1))`)
-	notFused := watToModule(t, `(module (func (export "f") (param i32) (result i32) (local i32)
-		local.get 0 local.get 1 i32.add local.set 1 i32.const 0 drop local.get 1))`)
+	fused := watToModule(t, `(module (func (export "f") (param f32) (result f32) (local f32)
+		local.get 0 local.get 1 f32.add local.set 1 local.get 1))`)
+	notFused := watToModule(t, `(module (func (export "f") (param f32) (result f32) (local f32)
+		local.get 0 local.get 1 f32.add local.set 1 i32.const 0 drop local.get 1))`)
 	fc, err := CompileFunction(fused, 0)
 	if err != nil {
 		t.Fatal(err)

--- a/src/core/compiler/backend/amd64/pinned_test.go
+++ b/src/core/compiler/backend/amd64/pinned_test.go
@@ -183,3 +183,24 @@ func TestPinnedLocalsSurviveInternalCallClobberingAllPinnedRegs(t *testing.T) {
 		t.Fatalf("pinned locals after internal call = %d, want 80", got)
 	}
 }
+
+// TestPinnedAliasCaptureMultiplePendingReadsCrossPinnedSet stresses
+// materializeLocalRefs for vPinned: several pending lazy reads of a pinned local
+// are live before local.tee overwrites that same pinned local. All pending reads
+// must capture the OLD value, not the value tee'd in.
+func TestPinnedAliasCaptureMultiplePendingReadsCrossPinnedSet(t *testing.T) {
+	m := watToModule(t, `(module
+		(func (export "f") (param $a i32) (param $b i32) (result i32)
+			local.get $a
+			local.get $a
+			local.get $b
+			local.tee $a
+			i32.add
+			i32.add))`)
+
+	// old(a) + old(a) + b = 7 + 7 + 11 = 25. Without materializing the pending
+	// vPinned reads before local.tee overwrites $a, this becomes 11 + 11 + 11.
+	if got := runI32(t, m, 7, 11); got != 25 {
+		t.Fatalf("multi-alias capture = %d, want 25", got)
+	}
+}

--- a/src/core/compiler/backend/amd64/pinned_test.go
+++ b/src/core/compiler/backend/amd64/pinned_test.go
@@ -204,3 +204,45 @@ func TestPinnedAliasCaptureMultiplePendingReadsCrossPinnedSet(t *testing.T) {
 		t.Fatalf("multi-alias capture = %d, want 25", got)
 	}
 }
+
+// TestPinnedBrTableControlFlow exercises opBrTable with pinned locals live
+// across branch targets. Each arm sets the pinned local $r and branches to
+// $exit; the post-block read joins on $r through the br_table flush/move-slot
+// path rather than the plain br/br_if/loop/if-else paths covered elsewhere.
+func TestPinnedBrTableControlFlow(t *testing.T) {
+	m := watToModule(t, `(module
+		(func (export "f") (param $sel i32) (param $x i32) (result i32)
+			(local $r i32)
+			(block $exit
+				(block $case2
+					(block $case1
+						(block $case0
+							local.get $sel
+							br_table $case0 $case1 $case2)
+						i32.const 10
+						local.set $r
+						br $exit)
+					i32.const 20
+					local.set $r
+					br $exit)
+				i32.const 30
+				local.set $r)
+			local.get $r
+			local.get $x
+			i32.add))`)
+
+	// br_table targets: 0=>case0(r=10), 1=>case1(r=20), default=>case2(r=30).
+	cases := []struct {
+		sel, x, want int32
+	}{
+		{0, 5, 15},
+		{1, 5, 25},
+		{2, 5, 35},  // index 2 falls through to the default target $case2
+		{99, 5, 35}, // out-of-range also takes the default target
+	}
+	for _, c := range cases {
+		if got := runI32(t, m, c.sel, c.x); got != c.want {
+			t.Fatalf("br_table sel=%d x=%d = %d, want %d", c.sel, c.x, got, c.want)
+		}
+	}
+}

--- a/src/core/compiler/backend/amd64/pinned_test.go
+++ b/src/core/compiler/backend/amd64/pinned_test.go
@@ -146,3 +146,40 @@ func TestPinnedIfElseJoin(t *testing.T) {
 		t.Fatalf("if-false = %d, want 20", got)
 	}
 }
+
+// TestPinnedLocalsSurviveInternalCallClobberingAllPinnedRegs proves a caller's
+// pinned locals survive an internal generated wasm call whose callee uses (and
+// thus clobbers) all four pinned registers. It fails if emitWrapperCall does not
+// spill/reload pinned locals around the call. runModuleI32 is required because
+// CompileFunction rejects calls/relocs.
+func TestPinnedLocalsSurviveInternalCallClobberingAllPinnedRegs(t *testing.T) {
+	m := watToModule(t, `(module
+		(func $clobber (param i32 i32 i32 i32) (result i32)
+			local.get 0 local.get 1 i32.add
+			local.get 2 i32.add
+			local.get 3 i32.add)
+
+		(func (export "f") (param $x i32) (result i32)
+			(local $a i32) (local $b i32) (local $c i32)
+
+			local.get $x i32.const 10 i32.add local.set $a
+			local.get $x i32.const 20 i32.add local.set $b
+			local.get $x i32.const 30 i32.add local.set $c
+
+			i32.const 1 i32.const 2 i32.const 3 i32.const 4
+			call $clobber
+			drop
+
+			local.get $x
+			local.get $a i32.add
+			local.get $b i32.add
+			local.get $c i32.add))`)
+
+	// $clobber is local function 0; the exported caller is local function 1.
+	// x=5, a=15, b=25, c=35 => 80. If the caller's pinned regs are not
+	// spilled/reloaded around the call, this tends to observe the callee's
+	// pinned values instead.
+	if got := runModuleI32(t, m, 1, 5); got != 80 {
+		t.Fatalf("pinned locals after internal call = %d, want 80", got)
+	}
+}

--- a/src/core/compiler/backend/amd64/pinned_test.go
+++ b/src/core/compiler/backend/amd64/pinned_test.go
@@ -1,0 +1,88 @@
+//go:build linux && amd64
+
+package amd64
+
+import "testing"
+
+// Integer locals are pinned to dedicated registers (first len(pinnedPool));
+// the rest stay frame-resident. These tests exercise the boundary cases that
+// the register-pinned-locals lowering introduces.
+
+// TestPinnedManyLocals sums six i32 params: indices 0..3 are pinned, 4..5 are
+// frame-resident, so this mixes pinned and spilled operands in one expression.
+func TestPinnedManyLocals(t *testing.T) {
+	m := watToModule(t, `(module (func (export "f")
+		(param i32 i32 i32 i32 i32 i32) (result i32)
+		local.get 0 local.get 1 i32.add
+		local.get 2 i32.add local.get 3 i32.add
+		local.get 4 i32.add local.get 5 i32.add))`)
+	if got := runI32(t, m, 1, 2, 4, 8, 16, 32); got != 63 {
+		t.Fatalf("sum6 = %d, want 63", got)
+	}
+}
+
+// TestPinnedDoubleUse reads the same pinned local twice in one expression.
+func TestPinnedDoubleUse(t *testing.T) {
+	m := watToModule(t, `(module (func (export "f") (param i32) (result i32)
+		local.get 0 local.get 0 i32.add))`)
+	if got := runI32(t, m, 21); got != 42 {
+		t.Fatalf("2*x = %d, want 42", got)
+	}
+	m64 := watToModule(t, `(module (func (export "f") (param i64) (result i64)
+		local.get 0 local.get 0 i64.mul))`)
+	if got := runI64(t, m64, 1<<20); got != 1<<40 {
+		t.Fatalf("x*x = %d, want %d", got, int64(1)<<40)
+	}
+}
+
+// TestPinnedAliasCapture guards materializeLocalRefs for vPinned: a pending
+// lazy read of a pinned local must keep the OLD value when local.tee overwrites
+// that local. If capture is missing, the first local.get sees the new value.
+func TestPinnedAliasCapture(t *testing.T) {
+	m := watToModule(t, `(module (func (export "f") (param i32) (result i32)
+		local.get 0 i32.const 5 local.tee 0 i32.add))`)
+	// old(arg) + 5; broken capture would give 5 + 5 = 10 regardless of arg.
+	if got := runI32(t, m, 3); got != 8 {
+		t.Fatalf("alias capture = %d, want 8 (3+5)", got)
+	}
+	if got := runI32(t, m, 100); got != 105 {
+		t.Fatalf("alias capture = %d, want 105", got)
+	}
+}
+
+// TestPinnedLoopAccumulator drives a pinned local across loop back-edges and a
+// br: the canonical-slot join must agree with the register-resident local.
+func TestPinnedLoopAccumulator(t *testing.T) {
+	m := watToModule(t, `(module (func (export "f") (param $n i32) (result i32)
+		(local $acc i32) (local $i i32)
+		(local.set $i (i32.const 1))
+		(block $brk (loop $cont
+			(br_if $brk (i32.gt_s (local.get $i) (local.get $n)))
+			(local.set $acc (i32.add (local.get $acc) (local.get $i)))
+			(local.set $i (i32.add (local.get $i) (i32.const 1)))
+			(br $cont)))
+		(local.get $acc)))`)
+	if got := runI32(t, m, 5); got != 15 {
+		t.Fatalf("sum 1..5 = %d, want 15", got)
+	}
+	if got := runI32(t, m, 100); got != 5050 {
+		t.Fatalf("sum 1..100 = %d, want 5050", got)
+	}
+}
+
+// TestPinnedIfElseJoin sets a pinned local on both arms of an if/else and reads
+// it afterward; both edges must leave the value in the same pinned register.
+func TestPinnedIfElseJoin(t *testing.T) {
+	m := watToModule(t, `(module (func (export "f") (param $c i32) (result i32)
+		(local $r i32)
+		(if (local.get $c)
+			(then (local.set $r (i32.const 10)))
+			(else (local.set $r (i32.const 20))))
+		(local.get $r)))`)
+	if got := runI32(t, m, 1); got != 10 {
+		t.Fatalf("if-true = %d, want 10", got)
+	}
+	if got := runI32(t, m, 0); got != 20 {
+		t.Fatalf("if-false = %d, want 20", got)
+	}
+}

--- a/src/core/compiler/backend/amd64/pinned_test.go
+++ b/src/core/compiler/backend/amd64/pinned_test.go
@@ -2,7 +2,67 @@
 
 package amd64
 
-import "testing"
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/src/core/runtime"
+)
+
+// runModuleI32 compiles the whole module, maps the combined code blob, and
+// executes the local function localFuncIdx with the given i32 args, returning
+// the first i32 result. Unlike runI32 (which uses CompileFunction and rejects
+// calls/relocs), this drives a full CompileModule blob so tests can exercise
+// internal generated-to-generated wasm calls.
+func runModuleI32(t *testing.T, m *wasm.Module, localFuncIdx int, args ...int32) int32 {
+	t.Helper()
+
+	cm, err := CompileModule(m)
+	if err != nil {
+		t.Fatalf("compile module: %v", err)
+	}
+	if localFuncIdx < 0 || localFuncIdx >= len(cm.Entry) {
+		t.Fatalf("local function index %d out of range", localFuncIdx)
+	}
+
+	eng, err := runtime.NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+
+	jm, err := runtime.NewJobMemory(65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jm.Close()
+
+	ar, err := runtime.NewArena(4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ar.Close()
+
+	mem, entry, err := runtime.MapCode(cm.Code)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	defer runtime.Unmap(mem)
+
+	serArgs := ar.Alloc(128)
+	results := ar.Alloc(128)
+	trap := ar.Alloc(8)
+	for i, a := range args {
+		binary.LittleEndian.PutUint32(serArgs[i*8:], uint32(a))
+	}
+
+	fn := entry + uintptr(cm.Entry[localFuncIdx])
+	if err := eng.Call(fn, serArgs, jm.LinearMemory(), trap, results); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	return int32(binary.LittleEndian.Uint32(results))
+}
 
 // Integer locals are pinned to dedicated registers (first len(pinnedPool));
 // the rest stay frame-resident. These tests exercise the boundary cases that


### PR DESCRIPTION
## What

Ports WARP's **locals-in-registers** optimization into the wago single-pass backend. The first few integer locals (params first — the hottest) are **pinned to dedicated registers** (`RBX`/`R13`/`R14`/`R15`) instead of living in frame slots, so `local.get`/`local.set`/`local.tee` avoid memory traffic and operands fold the register directly (e.g. `add dst, R_x`).

Until now every local lived in a frame slot (`vLocal`), read/written on each access. This is the flagship perf item from the porting backlog.

## Design (faithful in spirit; v1 scoped for low risk)

- **New lazy operand kind `vPinned`**: `local.get` of a pinned local pushes a reference to its register (emits nothing); source consumers fold it as an RHS, and it is *copied* (never reused as a mutable dest) when materialized.
- Pinned registers are removed from the scratch pool (`cg.reserved`), so they're never handed out as temporaries.
- **Canonical-slot joins need no extra work**: a pinned local always lives in the same register on every edge into a join, so branches/loops stay consistent for free. `flush()` copies the register to the operand slot but leaves the local in place.
- **Calls** clobber the registers (they're plain scratch in the callee), so `emitWrapperCall` spills pinned locals to their frame slots around the call and reloads after. Host calls (deferred log) don't clobber, so they're untouched.
- `materializeLocalRefs` captures pending `vPinned` reads before `local.set` overwrites the register (the lazy-aliasing hazard).
- Float locals stay frame-resident (integer-only in v1).

## Tests

- New `pinned_test.go`: >pool-size locals boundary (pinned + frame-resident mixed in one expr), double-use of one pinned local, alias capture, loop back-edge consistency, if/else join.
- Existing recursion / AssemblyScript payloads exercise pinned params across calls.
- Full `go test ./...` green incl. `-race`; CLI spot-checks `fib(25)=75025`, `sumto(100)=5050`.

## Performance (bench/ Exec suite, count=8, benchstat) — geomean **−17.1%** sec/op

| benchmark | before → after | delta |
|---|---|---|
| Exec/arith.run | 4.26µs → 1.48µs | **−65.3%** |
| Exec/fib_iter.fib | 65.8ns → 35.6ns | **−45.8%** |
| Exec/memory.sum | 821ns → 462ns | **−43.8%** |
| ExecFibLoop_wago | 34.7ns → 21.4ns | **−38.4%** (wazero 43.7ns) |
| Exec/globals.accumulate | 2.48µs → 1.76µs | **−29.1%** |
| Exec/tiny.add | 26.7ns → 25.1ns | **−6.1%** |

Regressions are confined to **call-heavy** paths — the known cost of spilling pinned locals around calls (option A): `ExecFibRec_wago` **+3.6%**, `Exec/dispatch.apply` (call_indirect) **+7.5%**. A register-based internal call ABI (a later port in this effort) is the natural fix. Exec allocs unchanged (0).

---
Port #2 of the WARP singlepass porting effort (interleaved feature/perf, one PR per port). Independent of #24 (sign-extension ops).