### PR TITLE
strip non-run CLI commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,7 @@ Target platform today: **linux/amd64**.
 returns a `*Compiled`: machine code plus the instantiate-time metadata
 (signatures, imports/exports, globals, element/data segments, table size).
 `Instantiate` turns a `*Compiled` into a runnable `*Instance`. `Invoke` calls an
-exported function. `CompileTimed` exposes per-phase `Timings`.
+exported function.
 
 ---
 
@@ -48,7 +48,7 @@ exported function. `CompileTimed` exposes per-phase `Timings`.
 src/wago/                         public API implementation (package wago)
 wago.go                           generated root facade (re-exports src/wago)
 internal/genfacade/               generator for wago.go (+ up-to-date test)
-cli/wago/                         CLI: run / compile / profile / validate
+cli/wago/                         CLI: run; compile/profile/validate are stubs
 src/core/compiler/wasm/           decoder + validator (front end)
 src/core/compiler/backend/amd64/  single-pass x86-64 codegen (Valent-Block)
 src/core/runtime/                 mmap, foreign stack, JobMemory, traps
@@ -123,11 +123,13 @@ re-decoding:
 - `TableSize`, `FuncTypeID`, `Elems` (active element segments)
 - `Data` (active data segments)
 
-`Compiled` is `gob`-serializable to a versioned **`.wago` blob**
+`Compiled` serializes to a compact versioned **`.wago` blob**
 (`MarshalBinary`/`UnmarshalBinary`, magic `WAGO` + version byte). `Load` accepts
 either a precompiled blob (fast reload, no recompile) or raw wasm (compiled on
 load); `IsCompiled` distinguishes them. `validate()` hardens every blob against
-malformed metadata before any memory is mapped.
+malformed metadata before any memory is mapped. The size-focused CLI `run` path
+accepts only raw wasm today, so the serialization path stays available to the Go
+API without being pulled into the CLI binary.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ engine, then keeps the Go side intentionally small:
 - one stable wrapper ABI for every export
 - native wasm code on an off-heap foreign stack
 - mmap-backed linear memory exposed directly as `[]byte`
-- optional precompiled `.wago` blobs for fast reloads
+- optional precompiled `.wago` blobs for fast reloads through the Go API
 
 Current target: **linux/amd64**.
 
@@ -80,11 +80,9 @@ go install ./cli/wago
 ./wago run tests/testdata/fib.wasm 30
 ./wago run -e hypot tests/testdata/fprog.wasm 3.0 4.0
 
-./wago compile -o /tmp/fib.wago tests/testdata/fib.wasm
-./wago run /tmp/fib.wago 30
-
-./wago profile tests/testdata/fib.wasm 30
-./wago validate tests/testdata/fib.wasm
+./wago compile   # not implemented in the size-focused CLI
+./wago profile   # not implemented in the size-focused CLI
+./wago validate  # not implemented in the size-focused CLI
 ```
 
 Arguments are typed from the target export signature. You can override a parsed
@@ -172,8 +170,6 @@ blob, err := c.MarshalBinary()
 c, err = wago.Load(blob)      // precompiled .wago
 c, err = wago.Load(wasmBytes) // raw wasm, compiled on load
 ```
-
-Use `CompileTimed` when you want decode, validate, and compile timings.
 
 ### `Instance`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,8 +33,9 @@ For an at-a-glance support matrix of every WebAssembly feature, see
   trap→error, zero-copy linear memory
 
 **Tooling**
-- [x] `wago` CLI: `run` / `compile` (→ precompiled `.wago`) / `profile` /
-  `validate` / `version`, typed args
+- [x] `wago` CLI: `run` / `version`, typed args. `compile`, `profile`, and
+  `validate` are intentionally stubbed as not implemented in the size-focused
+  CLI.
 - [x] Public API: `Run`/`RunValues`, `Compile`/`Compiled`, `Instance`
 - [x] Benchmarks vs wazero (compile ~34× faster, cross-boundary call ~3× faster)
 
@@ -69,7 +70,8 @@ For an at-a-glance support matrix of every WebAssembly feature, see
 
 - [ ] Differential oracle: fuzz modules, compare results/traps against C++ WARP
 - [ ] Byte-for-byte codegen diffing against WARP for shared inputs
-- [ ] True disassembler for `compile --emit asm` (today: annotated hex)
+- [ ] Reintroduce a size-aware disassembler/AOT command when the CLI budget can
+  absorb it.
 
 ## Bigger bets
 

--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -1,4 +1,4 @@
-// Command wago runs, compiles, profiles, and validates wasm modules.
+// Command wago runs wasm modules.
 package main
 
 import (
@@ -6,10 +6,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/wago-org/wago"
-	"github.com/wago-org/wago/src/core/compiler/frontend"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
@@ -25,11 +23,11 @@ func main() {
 	case "run":
 		runCmd(a[1:])
 	case "compile":
-		compileCmd(a[1:])
+		notImplemented("compile")
 	case "profile":
-		profileCmd(a[1:])
+		notImplemented("profile")
 	case "validate":
-		validateCmd(a[1:])
+		notImplemented("validate")
 	case "version", "--version", "-v":
 		fmt.Printf("wago %s (linux/amd64)\n", version)
 		fmt.Println("wasm: i32 i64 f32 f64, control flow, memory, calls + host imports")
@@ -41,28 +39,29 @@ func main() {
 }
 
 func usage(w *os.File) {
-	fmt.Fprint(w, `wago — a pure-Go (no cgo) WebAssembly engine
+	fmt.Fprint(w, `wago - a pure-Go (no cgo) WebAssembly engine
 
 usage (options may appear before or after the <file>):
   wago <file> [args...]                      run (alias)
   wago run [-e name] <file> [args...]        JIT-compile and execute
       -e, --invoke <name>    export to call (default: _start, main, or sole export)
-  wago compile [opts] <file>                 AOT-compile to a precompiled .wago module
-      -o, --output <path>    output (default <file>.wago)
-      --target <triple>      target (default linux/amd64)
-      --emit <module|asm>    module = loadable blob (default), asm = x86-64 hex
-  wago profile [-e name] [--runs N] <file> [args...]   timings + codegen stats
-  wago validate <file>                       decode + validate + wago support check
+  wago compile                               not implemented
+  wago profile                               not implemented
+  wago validate                              not implemented
   wago version
 
-a <file> may be raw .wasm or a precompiled .wago. args are typed by the
-function signature; override with a suffix:  42   7:i64   3.5:f64   1.5:f32
+a <file> must be raw .wasm. args are typed by the function signature; override
+with a suffix:  42   7:i64   3.5:f64   1.5:f32
 `)
 }
 
 func fatal(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "wago: "+format+"\n", args...)
 	os.Exit(1)
+}
+
+func notImplemented(cmd string) {
+	fatal("%s: not implemented", cmd)
 }
 
 // extractOpts accepts "-x val", "--x val", and "-x=val" forms anywhere.
@@ -119,194 +118,15 @@ func runCmd(args []string) {
 	fmt.Println(format(export, vals, res))
 }
 
-func compileCmd(args []string) {
-	var out, target, emit string
-	pos, err := extractOpts(args, map[string]*string{
-		"-o": &out, "--output": &out, "--target": &target, "--emit": &emit,
-	})
-	if err != nil {
-		fatal("compile: %v", err)
-	}
-	if target == "" {
-		target = "linux/amd64"
-	}
-	if emit == "" {
-		emit = "module"
-	}
-	if len(pos) < 1 {
-		fatal("compile: need a <file>")
-	}
-	file := pos[0]
-	if target != "linux/amd64" {
-		fatal("unsupported target %q (only linux/amd64)", target)
-	}
-	src, err := os.ReadFile(file)
-	if err != nil {
-		fatal("%v", err)
-	}
-	if wago.IsCompiled(src) {
-		fatal("%s is already a precompiled wago module", file)
-	}
-	c, err := wago.Compile(src)
-	if err != nil {
-		fatal("%v", err)
-	}
-
-	switch emit {
-	case "module":
-		if out == "" {
-			out = strings.TrimSuffix(file, ".wasm") + ".wago"
-		}
-		data, err := c.MarshalBinary()
-		if err != nil {
-			fatal("%v", err)
-		}
-		if err := os.WriteFile(out, data, 0o644); err != nil {
-			fatal("%v", err)
-		}
-		fmt.Printf("wrote %s (precompiled, %d funcs, %d B code)\n", out, len(c.Funcs), len(c.Code))
-	case "asm":
-		emitAsm(c, out)
-	default:
-		fatal("--emit must be 'module' or 'asm'")
-	}
-}
-
-func emitAsm(c *wago.Compiled, out string) {
-	w := os.Stdout
-	if out != "" {
-		f, err := os.Create(out)
-		if err != nil {
-			fatal("%v", err)
-		}
-		defer f.Close()
-		w = f
-	}
-	names := map[int]string{}
-	for n, gfi := range c.Exports {
-		names[gfi-c.NumImports] = n
-	}
-	for li := range c.Entry {
-		start := c.Entry[li]
-		end := len(c.Code)
-		if li+1 < len(c.Entry) && c.Entry[li+1] > start {
-			end = c.Entry[li+1]
-		}
-		name := names[li]
-		if name == "" {
-			name = fmt.Sprintf("func%d", li)
-		}
-		fmt.Fprintf(w, "%s: (offset 0x%x, %d bytes)\n", name, start, end-start)
-		code := c.Code[start:end]
-		for i := 0; i < len(code); i += 16 {
-			j := i + 16
-			if j > len(code) {
-				j = len(code)
-			}
-			fmt.Fprintf(w, "  %06x  % x\n", start+i, code[i:j])
-		}
-		fmt.Fprintln(w)
-	}
-}
-
-func profileCmd(args []string) {
-	var invoke, runsStr string
-	pos, err := extractOpts(args, map[string]*string{
-		"-e": &invoke, "--invoke": &invoke, "--runs": &runsStr,
-	})
-	if err != nil {
-		fatal("profile: %v", err)
-	}
-	runs := 1000
-	if runsStr != "" {
-		if n, e := strconv.Atoi(runsStr); e == nil && n > 0 {
-			runs = n
-		} else {
-			fatal("profile: bad --runs %q", runsStr)
-		}
-	}
-	if len(pos) < 1 {
-		fatal("profile: need a <file>")
-	}
-	file := pos[0]
-	src, err := os.ReadFile(file)
-	if err != nil {
-		fatal("%v", err)
-	}
-	if wago.IsCompiled(src) {
-		fatal("profile needs raw .wasm (it times decode/validate/compile)")
-	}
-	c, tm, err := wago.CompileTimed(src)
-	if err != nil {
-		fatal("%v", err)
-	}
-	export := mustResolveExport(c, invoke)
-	params, _, _ := c.Signature(export)
-	vals := mustParseArgs(pos[1:], params)
-
-	in, err := wago.Instantiate(c, autoHosts(c, false))
-	if err != nil {
-		fatal("%v", err)
-	}
-	defer in.Close()
-	best := time.Duration(1) << 62
-	for i := 0; i < runs; i++ {
-		t0 := time.Now()
-		if _, err := in.Invoke(export, vals...); err != nil {
-			fatal("%v", err)
-		}
-		if d := time.Since(t0); d < best {
-			best = d
-		}
-	}
-
-	big, bigIdx := 0, 0
-	for li := range c.Entry {
-		end := len(c.Code)
-		if li+1 < len(c.Entry) && c.Entry[li+1] > c.Entry[li] {
-			end = c.Entry[li+1]
-		}
-		if sz := end - c.Entry[li]; sz > big {
-			big, bigIdx = sz, li
-		}
-	}
-	fmt.Printf("module:    %s\n", file)
-	fmt.Printf("decode:    %v\n", tm.Decode)
-	fmt.Printf("validate:  %v\n", tm.Validate)
-	fmt.Printf("compile:   %v   (%d B code, %d funcs)\n", tm.Compile, len(c.Code), len(c.Funcs))
-	fmt.Printf("exec:      %v/call   (min of %d, invoking %s)\n", best, runs, export)
-	fmt.Printf("largest:   func%d  (%d B)\n", bigIdx, big)
-}
-
-func validateCmd(args []string) {
-	if len(args) < 1 {
-		fatal("validate: need a <file>")
-	}
-	msg, err := validateFile(args[0])
-	if err != nil {
-		fatal("invalid: %v", err)
-	}
-	fmt.Print(msg)
-}
-
-func validateFile(file string) (string, error) {
-	src, err := os.ReadFile(file)
-	if err != nil {
-		return "", err
-	}
-	m, err := frontend.DecodeValidate(src)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s: OK (%d funcs, %d exports)\n", file, len(m.Code), len(m.Exports)), nil
-}
-
 func mustLoad(file string) *wago.Compiled {
 	src, err := os.ReadFile(file)
 	if err != nil {
 		fatal("%v", err)
 	}
-	c, err := wago.Load(src)
+	if wago.IsCompiled(src) {
+		fatal("precompiled .wago modules are not implemented")
+	}
+	c, err := wago.Compile(src)
 	if err != nil {
 		fatal("%v", err)
 	}

--- a/cli/wago/main_test.go
+++ b/cli/wago/main_test.go
@@ -4,12 +4,9 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/wago-org/wago/src/core/compiler/wasm"
-	"github.com/wago-org/wago/testutil/wasmtest"
 )
 
-func TestUsageDocumentsValidateSupportCheck(t *testing.T) {
+func TestUsageDocumentsRunOnlyCommandSurface(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "usage-*.txt")
 	if err != nil {
 		t.Fatal(err)
@@ -22,66 +19,16 @@ func TestUsageDocumentsValidateSupportCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// validateFile uses frontend.DecodeValidate, which includes RejectUnsupported,
-	// so the help text should not promise spec validation only.
-	if !strings.Contains(string(b), "decode + validate + wago support check") {
-		t.Fatalf("usage validate text = %q", string(b))
+	text := string(b)
+	for _, want := range []string{
+		"wago run [-e name] <file> [args...]",
+		"wago compile                               not implemented",
+		"wago profile                               not implemented",
+		"wago validate                              not implemented",
+		"a <file> must be raw .wasm",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("usage text missing %q:\n%s", want, text)
+		}
 	}
-}
-
-func TestValidateFileUsesWasm3FrontendForSupportedModule(t *testing.T) {
-	mod := wasmtest.Module(
-		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}))),
-		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
-		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("main", 0, 0))),
-		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x07, 0x0b}))),
-	)
-	path := writeTempWasm(t, mod)
-	msg, err := validateFile(path)
-	if err != nil {
-		t.Fatalf("validateFile: %v", err)
-	}
-	if !strings.Contains(msg, ": OK (1 funcs, 1 exports)") {
-		t.Fatalf("validateFile message = %q", msg)
-	}
-}
-
-func TestValidateFileRejectsRuntimeArenaFootprint(t *testing.T) {
-	mod := wasmtest.Module(
-		wasmtest.Section(4, wasmtest.Vec(append([]byte{0x70, 0x00}, wasmtest.ULEB(70000)...))),
-	)
-	_, err := validateFile(writeTempWasm(t, mod))
-	if err == nil || !strings.Contains(err.Error(), "unsupported runtime footprint") {
-		t.Fatalf("validateFile error = %v, want runtime-footprint rejection", err)
-	}
-}
-
-func TestValidateFileRejectsProposalFeatureDecodedByWasm3(t *testing.T) {
-	body := []byte{0xfd, 0x0c}
-	body = append(body, make([]byte, 16)...)
-	body = append(body, 0x1a, 0x0b)
-	mod := wasmtest.Module(
-		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
-		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
-		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
-	)
-	_, err := validateFile(writeTempWasm(t, mod))
-	if err == nil || !strings.Contains(err.Error(), "unsupported instruction V128Const") {
-		t.Fatalf("validateFile error = %v, want wasm unsupported-instruction rejection", err)
-	}
-}
-
-func writeTempWasm(t *testing.T, mod []byte) string {
-	t.Helper()
-	f, err := os.CreateTemp(t.TempDir(), "*.wasm")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := f.Write(mod); err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-	return f.Name()
 }

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -2,11 +2,8 @@
 package wago
 
 import (
-	"bytes"
 	"encoding/binary"
-	"encoding/gob"
 	"fmt"
-	"time"
 
 	"github.com/wago-org/wago/src/core/compiler/backend/amd64"
 	"github.com/wago-org/wago/src/core/compiler/frontend"
@@ -14,42 +11,22 @@ import (
 	wruntime "github.com/wago-org/wago/src/core/runtime"
 )
 
-type Timings struct{ Decode, Validate, Compile time.Duration }
-
 // Compile decodes, validates, and compiles a wasm module to native code.
 func Compile(wasmBytes []byte) (*Compiled, error) {
-	c, _, err := compile(wasmBytes, false)
-	return c, err
-}
-
-// CompileTimed is Compile with per-phase timings.
-func CompileTimed(wasmBytes []byte) (*Compiled, Timings, error) {
-	return compile(wasmBytes, true)
-}
-
-// compile builds the serialized metadata needed to instantiate without re-decoding.
-func compile(wasmBytes []byte, timed bool) (*Compiled, Timings, error) {
-	var t Timings
-	t0 := time.Now()
 	m3, err := wasm.DecodeModule(wasmBytes)
 	if err != nil {
-		return nil, t, fmt.Errorf("decode: %w", err)
+		return nil, fmt.Errorf("decode: %w", err)
 	}
-	t1 := time.Now()
 	if err := wasm.ValidateModule(m3); err != nil {
-		return nil, t, fmt.Errorf("validate: %w", err)
+		return nil, fmt.Errorf("validate: %w", err)
 	}
 	if err := frontend.RejectUnsupported(m3); err != nil {
-		return nil, t, fmt.Errorf("compile: %w", err)
+		return nil, fmt.Errorf("compile: %w", err)
 	}
-	t2 := time.Now()
 	m := m3
 	cm, err := amd64.CompileModule(m)
 	if err != nil {
-		return nil, t, fmt.Errorf("compile: %w", err)
-	}
-	if timed {
-		t = Timings{t1.Sub(t0), t2.Sub(t1), time.Since(t2)}
+		return nil, fmt.Errorf("compile: %w", err)
 	}
 
 	c := &Compiled{Code: cm.Code, Entry: cm.Entry, NumImports: m.ImportedFuncCount(), Exports: map[string]int{}, GlobalExports: map[string]int{}}
@@ -67,14 +44,14 @@ func compile(wasmBytes []byte, timed bool) (*Compiled, Timings, error) {
 	for li := range m.FuncTypes {
 		ft, ok := m.LocalFuncType(li)
 		if !ok {
-			return nil, t, fmt.Errorf("function %d: unknown type", li)
+			return nil, fmt.Errorf("function %d: unknown type", li)
 		}
 		c.Funcs = append(c.Funcs, FuncSig{ft.Params, ft.Results})
 	}
 	for i := range m.Globals {
 		v, err := evalConstExprWithModule(m.Globals[i].Init, m.Globals[i].Type.Type, m)
 		if err != nil {
-			return nil, t, fmt.Errorf("global %d initializer: %w", i, err)
+			return nil, fmt.Errorf("global %d initializer: %w", i, err)
 		}
 		g := GlobalDef{Type: m.Globals[i].Type.Type, Mutable: m.Globals[i].Type.Mutable}
 		applyGlobalInit(&g, v.Init())
@@ -91,7 +68,7 @@ func compile(wasmBytes []byte, timed bool) (*Compiled, Timings, error) {
 
 	hasTable, tableSize, err := frontend.SupportedTableRuntimeShape(m)
 	if err != nil {
-		return nil, t, fmt.Errorf("compile: %w", err)
+		return nil, fmt.Errorf("compile: %w", err)
 	}
 	c.HasTable = hasTable
 	c.TableSize = tableSize
@@ -111,7 +88,7 @@ func compile(wasmBytes []byte, timed bool) (*Compiled, Timings, error) {
 		}
 		base, err := evalConstExprWithModule(e.Mode.Offset, wasm.I32, m)
 		if err != nil {
-			return nil, t, fmt.Errorf("element %d offset: %w", i, err)
+			return nil, fmt.Errorf("element %d offset: %w", i, err)
 		}
 		init := ElemInit{Funcs: make([]uint32, len(e.Kind.Funcs))}
 		for j, fidx := range e.Kind.Funcs {
@@ -127,13 +104,13 @@ func compile(wasmBytes []byte, timed bool) (*Compiled, Timings, error) {
 		}
 		off, err := evalConstExprWithModule(d.Mode.Offset, wasm.I32, m)
 		if err != nil {
-			return nil, t, fmt.Errorf("data %d offset: %w", i, err)
+			return nil, fmt.Errorf("data %d offset: %w", i, err)
 		}
 		init := DataInit{Bytes: d.Init}
 		applyDataOffset(&init, off.Init())
 		c.Data = append(c.Data, init)
 	}
-	return c, t, nil
+	return c, nil
 }
 
 // Signature returns the parameter and result types of an exported function.
@@ -309,20 +286,11 @@ func (c *Compiled) validateDeferredOffsetGlobal(kind string, seg, idx int) error
 }
 
 const wagoMagic = "WAGO"
-const wagoVersion = 5
-
-// plain avoids recursive gob encoding through MarshalBinary.
-type plain Compiled
+const wagoVersion = 6
 
 // MarshalBinary serializes the precompiled module to a ".wago" blob.
 func (c *Compiled) MarshalBinary() ([]byte, error) {
-	var buf bytes.Buffer
-	buf.WriteString(wagoMagic)
-	buf.WriteByte(wagoVersion)
-	if err := gob.NewEncoder(&buf).Encode((*plain)(c)); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return marshalCompiled(c)
 }
 
 // UnmarshalBinary loads a ".wago" blob produced by MarshalBinary.
@@ -333,7 +301,7 @@ func (c *Compiled) UnmarshalBinary(data []byte) error {
 	if data[4] != wagoVersion {
 		return fmt.Errorf("wago module version %d unsupported (want %d)", data[4], wagoVersion)
 	}
-	if err := gob.NewDecoder(bytes.NewReader(data[5:])).Decode((*plain)(c)); err != nil {
+	if err := unmarshalCompiled(c, data[5:]); err != nil {
 		return err
 	}
 	return c.validate()

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -1,0 +1,571 @@
+package wago
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func marshalCompiled(c *Compiled) ([]byte, error) {
+	if c == nil {
+		return nil, fmt.Errorf("compiled module is nil")
+	}
+	w := compiledWriter{buf: make([]byte, 0, len(c.Code)+256)}
+	w.buf = append(w.buf, wagoMagic...)
+	w.u8(wagoVersion)
+	w.bytes(c.Code)
+	w.intSlice(c.Entry)
+	w.uvar(uint64(c.NumImports))
+	w.stringSlice(c.Imports)
+	if err := w.funcSigs(c.Funcs); err != nil {
+		return nil, err
+	}
+	w.stringIntMap(c.Exports)
+	if err := w.globalImports(c.GlobalImports); err != nil {
+		return nil, err
+	}
+	if err := w.globals(c.Globals); err != nil {
+		return nil, err
+	}
+	w.stringIntMap(c.GlobalExports)
+	w.bool(c.HasTable)
+	w.uvar(uint64(c.TableSize))
+	w.u32Slice(c.FuncTypeID)
+	w.elems(c.Elems)
+	w.data(c.Data)
+	return w.buf, nil
+}
+
+type compiledWriter struct {
+	buf []byte
+	tmp [binary.MaxVarintLen64]byte
+}
+
+func (w *compiledWriter) u8(v byte) { w.buf = append(w.buf, v) }
+func (w *compiledWriter) bool(v bool) {
+	if v {
+		w.u8(1)
+	} else {
+		w.u8(0)
+	}
+}
+func (w *compiledWriter) uvar(v uint64) {
+	n := binary.PutUvarint(w.tmp[:], v)
+	w.buf = append(w.buf, w.tmp[:n]...)
+}
+func (w *compiledWriter) ivar(v int) {
+	n := binary.PutVarint(w.tmp[:], int64(v))
+	w.buf = append(w.buf, w.tmp[:n]...)
+}
+func (w *compiledWriter) u32(v uint32) {
+	w.buf = binary.LittleEndian.AppendUint32(w.buf, v)
+}
+func (w *compiledWriter) u64(v uint64) {
+	w.buf = binary.LittleEndian.AppendUint64(w.buf, v)
+}
+func (w *compiledWriter) bytes(b []byte) {
+	w.uvar(uint64(len(b)))
+	w.buf = append(w.buf, b...)
+}
+func (w *compiledWriter) str(s string) {
+	w.uvar(uint64(len(s)))
+	w.buf = append(w.buf, s...)
+}
+func (w *compiledWriter) stringSlice(v []string) {
+	w.uvar(uint64(len(v)))
+	for _, s := range v {
+		w.str(s)
+	}
+}
+func (w *compiledWriter) intSlice(v []int) {
+	w.uvar(uint64(len(v)))
+	for _, x := range v {
+		w.ivar(x)
+	}
+}
+func (w *compiledWriter) u32Slice(v []uint32) {
+	w.uvar(uint64(len(v)))
+	for _, x := range v {
+		w.u32(x)
+	}
+}
+func (w *compiledWriter) stringIntMap(m map[string]int) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	w.uvar(uint64(len(keys)))
+	for _, k := range keys {
+		w.str(k)
+		w.ivar(m[k])
+	}
+}
+func (w *compiledWriter) valType(t wasm.ValType) error {
+	code, ok := wasm.EncodeValType(t)
+	if !ok {
+		return fmt.Errorf("compiled metadata contains unsupported value type %s", t)
+	}
+	w.u8(code)
+	return nil
+}
+func (w *compiledWriter) funcSigs(v []FuncSig) error {
+	w.uvar(uint64(len(v)))
+	for _, sig := range v {
+		w.uvar(uint64(len(sig.Params)))
+		for _, t := range sig.Params {
+			if err := w.valType(t); err != nil {
+				return err
+			}
+		}
+		w.uvar(uint64(len(sig.Results)))
+		for _, t := range sig.Results {
+			if err := w.valType(t); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+func (w *compiledWriter) offset(o OffsetInit) {
+	w.u32(o.Base)
+	w.bool(o.HasGlobal)
+	w.ivar(o.Global)
+}
+func (w *compiledWriter) elems(v []ElemInit) {
+	w.uvar(uint64(len(v)))
+	for _, e := range v {
+		w.offset(e.Offset)
+		w.uvar(uint64(len(e.Funcs)))
+		for _, f := range e.Funcs {
+			w.u32(f)
+		}
+	}
+}
+func (w *compiledWriter) data(v []DataInit) {
+	w.uvar(uint64(len(v)))
+	for _, d := range v {
+		w.offset(d.Offset)
+		w.bytes(d.Bytes)
+	}
+}
+func (w *compiledWriter) globals(v []GlobalDef) error {
+	w.uvar(uint64(len(v)))
+	for _, g := range v {
+		if err := w.valType(g.Type); err != nil {
+			return err
+		}
+		w.bool(g.Mutable)
+		w.u64(g.Bits)
+		w.bool(g.HasInitGlobal)
+		w.ivar(g.InitGlobal)
+	}
+	return nil
+}
+func (w *compiledWriter) globalImports(v []GlobalImportDef) error {
+	w.uvar(uint64(len(v)))
+	for _, g := range v {
+		w.str(g.Module)
+		w.str(g.Name)
+		if err := w.valType(g.Type); err != nil {
+			return err
+		}
+		w.bool(g.Mutable)
+	}
+	return nil
+}
+
+func unmarshalCompiled(c *Compiled, data []byte) error {
+	r := compiledReader{data: data}
+	var err error
+	c.Code, err = r.bytes()
+	if err != nil {
+		return err
+	}
+	c.Entry, err = r.intSlice()
+	if err != nil {
+		return err
+	}
+	n, err := r.uvar()
+	if err != nil {
+		return err
+	}
+	if n > uint64(maxInt()) {
+		return fmt.Errorf("NumImports overflows int")
+	}
+	c.NumImports = int(n)
+	c.Imports, err = r.stringSlice()
+	if err != nil {
+		return err
+	}
+	c.Funcs, err = r.funcSigs()
+	if err != nil {
+		return err
+	}
+	c.Exports, err = r.stringIntMap()
+	if err != nil {
+		return err
+	}
+	c.GlobalImports, err = r.globalImports()
+	if err != nil {
+		return err
+	}
+	c.Globals, err = r.globals()
+	if err != nil {
+		return err
+	}
+	c.GlobalExports, err = r.stringIntMap()
+	if err != nil {
+		return err
+	}
+	c.HasTable, err = r.bool()
+	if err != nil {
+		return err
+	}
+	n, err = r.uvar()
+	if err != nil {
+		return err
+	}
+	if n > uint64(maxInt()) {
+		return fmt.Errorf("TableSize overflows int")
+	}
+	c.TableSize = int(n)
+	c.FuncTypeID, err = r.u32Slice()
+	if err != nil {
+		return err
+	}
+	c.Elems, err = r.elems()
+	if err != nil {
+		return err
+	}
+	c.Data, err = r.dataInits()
+	if err != nil {
+		return err
+	}
+	if len(r.data) != 0 {
+		return fmt.Errorf("trailing %d byte(s)", len(r.data))
+	}
+	return nil
+}
+
+type compiledReader struct{ data []byte }
+
+func (r *compiledReader) take(n int) ([]byte, error) {
+	if n < 0 || n > len(r.data) {
+		return nil, fmt.Errorf("unexpected EOF")
+	}
+	b := r.data[:n]
+	r.data = r.data[n:]
+	return b, nil
+}
+func (r *compiledReader) u8() (byte, error) {
+	b, err := r.take(1)
+	if err != nil {
+		return 0, err
+	}
+	return b[0], nil
+}
+func (r *compiledReader) bool() (bool, error) {
+	b, err := r.u8()
+	if err != nil {
+		return false, err
+	}
+	switch b {
+	case 0:
+		return false, nil
+	case 1:
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid bool %d", b)
+	}
+}
+func (r *compiledReader) uvar() (uint64, error) {
+	v, n := binary.Uvarint(r.data)
+	if n <= 0 {
+		return 0, fmt.Errorf("invalid uvarint")
+	}
+	r.data = r.data[n:]
+	return v, nil
+}
+func (r *compiledReader) ivar() (int, error) {
+	v, n := binary.Varint(r.data)
+	if n <= 0 {
+		return 0, fmt.Errorf("invalid varint")
+	}
+	r.data = r.data[n:]
+	if int64(int(v)) != v {
+		return 0, fmt.Errorf("int overflows")
+	}
+	return int(v), nil
+}
+func (r *compiledReader) u32() (uint32, error) {
+	b, err := r.take(4)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint32(b), nil
+}
+func (r *compiledReader) u64() (uint64, error) {
+	b, err := r.take(8)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint64(b), nil
+}
+func (r *compiledReader) count() (int, error) {
+	n, err := r.uvar()
+	if err != nil {
+		return 0, err
+	}
+	if n > uint64(maxInt()) {
+		return 0, fmt.Errorf("count overflows int")
+	}
+	return int(n), nil
+}
+func (r *compiledReader) bytes() ([]byte, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	return r.take(n)
+}
+func (r *compiledReader) str() (string, error) {
+	b, err := r.bytes()
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+func (r *compiledReader) stringSlice() ([]string, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, n)
+	for i := range out {
+		out[i], err = r.str()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) intSlice() ([]int, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]int, n)
+	for i := range out {
+		out[i], err = r.ivar()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) u32Slice() ([]uint32, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]uint32, n)
+	for i := range out {
+		out[i], err = r.u32()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) stringIntMap() (map[string]int, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]int, n)
+	for i := 0; i < n; i++ {
+		k, err := r.str()
+		if err != nil {
+			return nil, err
+		}
+		v, err := r.ivar()
+		if err != nil {
+			return nil, err
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+func (r *compiledReader) valType() (wasm.ValType, error) {
+	code, err := r.u8()
+	if err != nil {
+		return wasm.ValType{}, err
+	}
+	switch code {
+	case 0x7f:
+		return wasm.I32, nil
+	case 0x7e:
+		return wasm.I64, nil
+	case 0x7d:
+		return wasm.F32, nil
+	case 0x7c:
+		return wasm.F64, nil
+	case 0x7b:
+		return wasm.V128, nil
+	case 0x70:
+		return wasm.FuncRef, nil
+	case 0x6f:
+		return wasm.ExternRef, nil
+	default:
+		return wasm.ValType{}, fmt.Errorf("unsupported value type code 0x%02x", code)
+	}
+}
+func (r *compiledReader) funcSigs() ([]FuncSig, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]FuncSig, n)
+	for i := range out {
+		pn, err := r.count()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Params = make([]wasm.ValType, pn)
+		for j := range out[i].Params {
+			out[i].Params[j], err = r.valType()
+			if err != nil {
+				return nil, err
+			}
+		}
+		rn, err := r.count()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Results = make([]wasm.ValType, rn)
+		for j := range out[i].Results {
+			out[i].Results[j], err = r.valType()
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) offset() (OffsetInit, error) {
+	base, err := r.u32()
+	if err != nil {
+		return OffsetInit{}, err
+	}
+	has, err := r.bool()
+	if err != nil {
+		return OffsetInit{}, err
+	}
+	glob, err := r.ivar()
+	if err != nil {
+		return OffsetInit{}, err
+	}
+	return OffsetInit{Base: base, HasGlobal: has, Global: glob}, nil
+}
+func (r *compiledReader) elems() ([]ElemInit, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ElemInit, n)
+	for i := range out {
+		out[i].Offset, err = r.offset()
+		if err != nil {
+			return nil, err
+		}
+		fn, err := r.count()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Funcs = make([]uint32, fn)
+		for j := range out[i].Funcs {
+			out[i].Funcs[j], err = r.u32()
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) dataInits() ([]DataInit, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]DataInit, n)
+	for i := range out {
+		out[i].Offset, err = r.offset()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Bytes, err = r.bytes()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) globals() ([]GlobalDef, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]GlobalDef, n)
+	for i := range out {
+		out[i].Type, err = r.valType()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Mutable, err = r.bool()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Bits, err = r.u64()
+		if err != nil {
+			return nil, err
+		}
+		out[i].HasInitGlobal, err = r.bool()
+		if err != nil {
+			return nil, err
+		}
+		out[i].InitGlobal, err = r.ivar()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+func (r *compiledReader) globalImports() ([]GlobalImportDef, error) {
+	n, err := r.count()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]GlobalImportDef, n)
+	for i := range out {
+		out[i].Module, err = r.str()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Name, err = r.str()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Type, err = r.valType()
+		if err != nil {
+			return nil, err
+		}
+		out[i].Mutable, err = r.bool()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}

--- a/wago.go
+++ b/wago.go
@@ -23,13 +23,10 @@ type (
 	Imports         = impl.Imports
 	Instance        = impl.Instance
 	OffsetInit      = impl.OffsetInit
-	Timings         = impl.Timings
 	Value           = impl.Value
 )
 
 func Compile(wasmBytes []byte) (*Compiled, error) { return impl.Compile(wasmBytes) }
-
-func CompileTimed(wasmBytes []byte) (*Compiled, Timings, error) { return impl.CompileTimed(wasmBytes) }
 
 func F32(v float32) Value { return impl.F32(v) }
 


### PR DESCRIPTION
## What changed

- Makes the CLI size-focused around `run`; `compile`, `profile`, and `validate` now report `not implemented`.
- Keeps CLI `run` on raw `.wasm` input only so the precompiled-load path is not linked into the executable.
- Removes `CompileTimed` from the public facade/API.
- Replaces gob-based `.wago` serialization with a compact explicit codec for the Go API.
- Updates README, architecture, roadmap, and CLI tests for the reduced command surface.

## Why

The release CLI was above the desired 1-2 MiB target. The largest removable feature paths were AOT compile/profile/validate and gob-based serialization support in the linked CLI.

## Impact

The CLI is now intentionally run-only. Go API users can still use `Compile`, `Load`, `MarshalBinary`, and `UnmarshalBinary`; existing gob-format `.wago` blobs are rejected by the version bump.

## Validation

- `go test -count=1 ./...`
- `CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-s -w -buildid=' -o /tmp/wago-pr-min ./cli/wago`
- `/tmp/wago-pr-min` size: `2,146,439` bytes / `2.05 MiB`
- `/tmp/wago-pr-min compile` reports `wago: compile: not implemented`