### PR TITLE
fix(wago): repair broken build — stray return value in Compile

### DIFF
--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -87,7 +87,7 @@ func Compile(wasmBytes []byte) (*Compiled, error) {
 			continue // runtime has no bulk element operations yet, so inactive segments are unused
 		}
 		if e.Kind.Kind == wasm.ElemFuncExprs || e.Kind.Kind == wasm.ElemTypedExprs {
-			return nil, t, fmt.Errorf("compile: active element expression segment %d unsupported", i)
+			return nil, fmt.Errorf("compile: active element expression segment %d unsupported", i)
 		}
 		if e.Kind.Kind != wasm.ElemFuncs || len(e.Kind.Funcs) == 0 {
 			continue


### PR DESCRIPTION
**main does not currently build.** #22 (f42f79e, the SSA-builder merge) left a 3-value return in the active-element-segment guard of `Compile`:

```go
return nil, t, fmt.Errorf("compile: active element expression segment %d unsupported", i)
```

but `Compile` returns `(*Compiled, error)` and `t` is undefined:

```
src/wago/api.go:90:16: undefined: t
```

This drops the stray `t,` operand. After the fix, `go build ./...` and the full `go test ./...` pass.

One-line hotfix; should land ASAP to unblock CI and other branches.