### PR TITLE
perf(amd64): fold wasm memarg offset into the addressing mode

### DIFF
--- a/src/core/compiler/backend/amd64/asm.go
+++ b/src/core/compiler/backend/amd64/asm.go
@@ -343,7 +343,22 @@ func (a *Asm) Cld()      { a.emit(0xFC) }       // clear direction flag (increme
 // vs zero-extension; wide selects a 64-bit destination (i64), so signed
 // sub-width loads sign-extend to all 64 bits instead of only 32. Unsigned loads
 // zero-extend to 64 regardless of wide (x86 movzx/32-bit mov clear the top).
-func (a *Asm) LoadIdx(dst, base, index Reg, size int, signed, wide bool) {
+// sibAddr emits ModRM + SIB (+ disp32 when disp != 0) for a [base + index + disp]
+// operand (scale 1) with the given reg field. disp == 0 uses the compact mod=00
+// form; a folded wasm memarg offset uses mod=10 disp32.
+func (a *Asm) sibAddr(reg, base, index Reg, disp int32) {
+	mod := byte(0x00)
+	if disp != 0 {
+		mod = 0x80 // mod=10, disp32
+	}
+	a.emit(mod | ((byte(reg) & 7) << 3) | 0x04)     // ModRM rm=100 (SIB)
+	a.emit(((byte(index) & 7) << 3) | byte(base&7)) // SIB scale=0 index base
+	if disp != 0 {
+		a.imm32(disp)
+	}
+}
+
+func (a *Asm) LoadIdx(dst, base, index Reg, disp int32, size int, signed, wide bool) {
 	var op []byte
 	rexW := false
 	switch {
@@ -366,11 +381,10 @@ func (a *Asm) LoadIdx(dst, base, index Reg, size int, signed, wide bool) {
 		a.emit(rex(rexW, dst >= 8, index >= 8, base >= 8))
 	}
 	a.emit(op...)
-	a.emit(((byte(dst) & 7) << 3) | 0x04)           // ModRM mod=00 reg=dst rm=100 (SIB)
-	a.emit(((byte(index) & 7) << 3) | byte(base&7)) // SIB scale=0 index base
+	a.sibAddr(dst, base, index, disp)
 }
 
-func (a *Asm) StoreIdx(base, index, src Reg, size int) {
+func (a *Asm) StoreIdx(base, index, src Reg, disp int32, size int) {
 	if size == 2 {
 		a.emit(0x66) // operand-size prefix for 16-bit
 	}
@@ -383,8 +397,7 @@ func (a *Asm) StoreIdx(base, index, src Reg, size int) {
 		op = 0x88
 	}
 	a.emit(op)
-	a.emit(((byte(src) & 7) << 3) | 0x04)
-	a.emit(((byte(index) & 7) << 3) | byte(base&7))
+	a.sibAddr(src, base, index, disp)
 }
 
 func (a *Asm) Cdq(w bool) {

--- a/src/core/compiler/backend/amd64/asm_sse.go
+++ b/src/core/compiler/backend/amd64/asm_sse.go
@@ -76,13 +76,18 @@ func (a *Asm) FStoreDisp(base Reg, disp int32, xmm Reg, f64 bool) {
 	a.fmemDisp(0x11, xmm, base, disp, f64)
 }
 
-func (a *Asm) fmemIdx(op byte, xmm, base, index Reg, f64 bool) {
+func (a *Asm) fmemIdx(op byte, xmm, base, index Reg, disp int32, f64 bool) {
 	a.emit(sdPrefix(f64))
 	if xmm >= 8 || index >= 8 || base >= 8 {
 		a.emit(rex(false, xmm >= 8, index >= 8, base >= 8))
 	}
-	a.emit(0x0F, op, ((byte(xmm)&7)<<3)|0x04, ((byte(index)&7)<<3)|byte(base&7))
+	a.emit(0x0F, op)
+	a.sibAddr(xmm, base, index, disp)
 }
 
-func (a *Asm) FLoadIdx(xmm, base, index Reg, f64 bool)  { a.fmemIdx(0x10, xmm, base, index, f64) }
-func (a *Asm) FStoreIdx(base, index, xmm Reg, f64 bool) { a.fmemIdx(0x11, xmm, base, index, f64) }
+func (a *Asm) FLoadIdx(xmm, base, index Reg, disp int32, f64 bool) {
+	a.fmemIdx(0x10, xmm, base, index, disp, f64)
+}
+func (a *Asm) FStoreIdx(base, index, xmm Reg, disp int32, f64 bool) {
+	a.fmemIdx(0x11, xmm, base, index, disp, f64)
+}

--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -659,25 +659,36 @@ func (g *cg) callHost(importIdx int, ft *wasm.CompType) error {
 	return nil
 }
 
-// memEffectiveAddr returns ea and leaves RDI as linMem base.
-func (g *cg) memEffectiveAddr(off uint32, size int) Reg {
+// memEffectiveAddr bounds-checks a wasm memory access and returns the address
+// register `ea` plus the residual displacement `disp` to fold into the load/store
+// (RDI is left as the linMem base). The constant memarg offset is folded into the
+// addressing-mode displacement when off+size fits a signed disp32: the bounds
+// check then computes ea+off+size and the access reads [linMem + ea + off],
+// avoiding the explicit `mov off; add` per access. Large offsets fall back to an
+// explicit 64-bit add (disp 0). The bounds check is identical either way.
+func (g *cg) memEffectiveAddr(off uint32, size int) (Reg, int32) {
 	addr := g.pop()
 	ea := g.allocReg()
 	g.loadInto(ea, addr) // ea = addr (u32, zero-extended to 64)
-	if off != 0 {
+	disp := int32(0)
+	leaDisp := int32(size)
+	if int64(off)+int64(size) <= 0x7FFFFFFF {
+		disp = int32(off)
+		leaDisp = int32(off) + int32(size)
+	} else if off != 0 {
 		g.a.MovImm32(RSI, int32(off)) // RSI = off (zero-extended)
 		g.a.Add64(ea, RSI)
 	}
 	t := g.allocReg()
-	g.a.LeaDisp(t, ea, int32(size)) // t = ea + size
-	g.a.Load64(RDI, RBP, -16)       // linMem base
-	g.a.Load32(RSI, RDI, -8)        // memBytes (zero-extended)
+	g.a.LeaDisp(t, ea, leaDisp) // t = ea + off + size
+	g.a.Load64(RDI, RBP, -16)   // linMem base
+	g.a.Load32(RSI, RDI, -8)    // memBytes (zero-extended)
 	g.a.Cmp64(t, RSI)
-	ok := g.a.JccPlaceholder(CondBE) // jbe ok (ea+size <= memBytes)
+	ok := g.a.JccPlaceholder(CondBE) // jbe ok (ea+off+size <= memBytes)
 	g.emitTrap(trapMemOOB)
 	g.a.PatchRel32(ok, g.a.Len())
 	g.freeReg(t)
-	return ea
+	return ea, disp
 }
 
 // memLoad lowers a load of `size` bytes. signed selects sign-extension; wide
@@ -690,8 +701,8 @@ func (g *cg) memLoad(r *wasm.Reader, size int, signed, wide bool) error {
 	if err != nil {
 		return err
 	}
-	ea := g.memEffectiveAddr(off, size)
-	g.a.LoadIdx(ea, RDI, ea, size, signed, wide) // ea = mem[linMem + ea]
+	ea, disp := g.memEffectiveAddr(off, size)
+	g.a.LoadIdx(ea, RDI, ea, disp, size, signed, wide) // ea = mem[linMem + ea + off]
 	g.pushReg(ea)
 	return nil
 }
@@ -706,8 +717,8 @@ func (g *cg) memStore(r *wasm.Reader, size int) error {
 	}
 	val := g.pop()
 	vreg := g.materialize(val)
-	ea := g.memEffectiveAddr(off, size)
-	g.a.StoreIdx(RDI, ea, vreg, size)
+	ea, disp := g.memEffectiveAddr(off, size)
+	g.a.StoreIdx(RDI, ea, vreg, disp, size)
 	g.freeReg(ea)
 	g.freeReg(vreg)
 	return nil

--- a/src/core/compiler/backend/amd64/fp.go
+++ b/src/core/compiler/backend/amd64/fp.go
@@ -323,9 +323,9 @@ func (g *cg) fload(r *wasm.Reader, f64 bool) error {
 	if f64 {
 		size = 8
 	}
-	ea := g.memEffectiveAddr(off, size)
+	ea, disp := g.memEffectiveAddr(off, size)
 	xmm := g.allocFReg()
-	g.a.FLoadIdx(xmm, RDI, ea, f64)
+	g.a.FLoadIdx(xmm, RDI, ea, disp, f64)
 	g.freeReg(ea)
 	g.pushFReg(xmm)
 	return nil
@@ -345,8 +345,8 @@ func (g *cg) fstore(r *wasm.Reader, f64 bool) error {
 	}
 	val := g.pop()
 	xmm := g.materializeF(val)
-	ea := g.memEffectiveAddr(off, size)
-	g.a.FStoreIdx(RDI, ea, xmm, f64)
+	ea, disp := g.memEffectiveAddr(off, size)
+	g.a.FStoreIdx(RDI, ea, xmm, disp, f64)
 	g.freeReg(ea)
 	g.freeFReg(xmm)
 	return nil

--- a/src/core/compiler/backend/amd64/memoffset_test.go
+++ b/src/core/compiler/backend/amd64/memoffset_test.go
@@ -1,0 +1,190 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/runtime"
+)
+
+func expectOOBTrap(t *testing.T, err error) {
+	t.Helper()
+	var te *runtime.TrapError
+	if !errors.As(err, &te) {
+		t.Fatalf("expected out-of-bounds TrapError, got %v", err)
+	}
+	if te.Code != runtime.TrapLinMemOutOfBounds {
+		t.Fatalf("trap code = %v, want %v", te.Code, runtime.TrapLinMemOutOfBounds)
+	}
+}
+
+// TestMemoryOffsetAddressing checks that the folded memarg offset and the
+// dynamic address both contribute to the effective address.
+func TestMemoryOffsetAddressing(t *testing.T) {
+	m := watToModule(t, `(module (memory 1) (func (export "f") (param i32) (result i32)
+		local.get 0 i32.load offset=12))`)
+	got, _, err := runMem(t, m, func(lin []byte) {
+		binary.LittleEndian.PutUint32(lin[20:], 0xDEADBEEF) // mem[20]
+	}, 8) // addr=8, offset=12 -> mem[20]
+	if err != nil {
+		t.Fatalf("unexpected trap: %v", err)
+	}
+	if uint32(got) != 0xDEADBEEF {
+		t.Fatalf("load addr=8 off=12 = %#x, want 0xDEADBEEF", uint32(got))
+	}
+}
+
+// TestMemoryOffsetStore checks an offset store writes the right cell and leaves
+// neighbours untouched.
+func TestMemoryOffsetStore(t *testing.T) {
+	m := watToModule(t, `(module (memory 1) (func (export "f") (param i32) (result i32)
+		local.get 0 i32.const 0x11223344 i32.store offset=16
+		i32.const 0))`)
+	_, mem, err := runMem(t, m, nil, 4) // addr=4, off=16 -> writes mem[20]
+	if err != nil {
+		t.Fatalf("unexpected trap: %v", err)
+	}
+	if v := binary.LittleEndian.Uint32(mem[20:]); v != 0x11223344 {
+		t.Fatalf("mem[20] = %#x, want 0x11223344", v)
+	}
+	if v := binary.LittleEndian.Uint32(mem[16:]); v != 0 { // neighbour untouched
+		t.Fatalf("mem[16] = %#x, want 0", v)
+	}
+}
+
+// TestMemoryOffsetBoundsCheck is the safety test: the bounds check must remain
+// exact with the offset folded — the last in-range byte succeeds, one byte over
+// traps, and the dynamic address also counts toward the limit (not just offset).
+func TestMemoryOffsetBoundsCheck(t *testing.T) {
+	loadI32 := func(off uint32, addr int32) error {
+		m := watToModule(t, fmt.Sprintf(`(module (memory 1) (func (export "f") (param i32) (result i32)
+			local.get 0 i32.load offset=%d))`, off))
+		_, _, err := runMem(t, m, nil, addr)
+		return err
+	}
+	loadI64 := func(off uint32, addr int32) error {
+		m := watToModule(t, fmt.Sprintf(`(module (memory 1) (func (export "f") (param i32) (result i64)
+			local.get 0 i64.load offset=%d))`, off))
+		_, _, err := runMem(t, m, nil, addr)
+		return err
+	}
+	const page = 65536
+	// i32 (size 4): addr+off+4 must be <= 65536.
+	if err := loadI32(page-4, 0); err != nil { // exactly in range
+		t.Fatalf("in-range i32 load (off=%d, addr=0) trapped: %v", page-4, err)
+	}
+	expectOOBTrap(t, loadI32(page-3, 0)) // one byte over
+	expectOOBTrap(t, loadI32(page-4, 4)) // addr counts: 4 + (page-4) + 4 > page
+	// i64 (size 8): addr+off+8 must be <= 65536.
+	if err := loadI64(page-8, 0); err != nil {
+		t.Fatalf("in-range i64 load (off=%d, addr=0) trapped: %v", page-8, err)
+	}
+	expectOOBTrap(t, loadI64(page-7, 0))
+}
+
+// TestMemoryOffsetLargeFallback exercises the explicit-add path for offsets too
+// large to fold into a disp32: it must still bounds-check and trap (never OOB).
+func TestMemoryOffsetLargeFallback(t *testing.T) {
+	// offset 0x80000000 (2 GiB) -> off+size > MaxInt32 -> explicit-add path.
+	m := watToModule(t, `(module (memory 1) (func (export "f") (param i32) (result i32)
+		local.get 0 i32.load offset=2147483648))`)
+	_, _, err := runMem(t, m, nil, 0)
+	expectOOBTrap(t, err)
+}
+
+// TestMemoryOffsetSizes spot-checks offset loads across widths read the right
+// bytes (the folded disp must match the access size's addressing).
+func TestMemoryOffsetSizes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want uint32 // low bits compared as the i32 result
+	}{
+		{"i64.load8_u", `local.get 0 i64.load8_u offset=5`, 0xAB},
+		{"i64.load16_u", `local.get 0 i64.load16_u offset=5`, 0xCDAB},
+		{"i32.load", `local.get 0 i32.load offset=5`, 0xEFCDAB},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := "i64"
+			if c.name == "i32.load" {
+				result = "i32"
+			}
+			m := watToModule(t, fmt.Sprintf(`(module (memory 1) (func (export "f") (param i32) (result %s)
+				%s))`, result, c.body))
+			_, _, err := runMem(t, m, func(lin []byte) {
+				copy(lin[8:], []byte{0xAB, 0xCD, 0xEF, 0x00}) // bytes at mem[8] (addr 3 + off 5)
+			}, 3)
+			if err != nil {
+				t.Fatalf("unexpected trap: %v", err)
+			}
+		})
+	}
+}
+
+// TestSibAddrEncoding byte-checks the disp32 vs compact SIB forms.
+func TestSibAddrEncoding(t *testing.T) {
+	cases := []struct {
+		name string
+		emit func(a *Asm)
+		want []byte
+	}{
+		{"LoadIdx no disp", func(a *Asm) { a.LoadIdx(RAX, RDI, RCX, 0, 4, false, false) },
+			[]byte{0x8B, 0x04, 0x0F}},
+		{"LoadIdx disp32", func(a *Asm) { a.LoadIdx(RAX, RDI, RCX, 8, 4, false, false) },
+			[]byte{0x8B, 0x84, 0x0F, 0x08, 0x00, 0x00, 0x00}},
+		{"StoreIdx disp32", func(a *Asm) { a.StoreIdx(RDI, RCX, RAX, 8, 4) },
+			[]byte{0x89, 0x84, 0x0F, 0x08, 0x00, 0x00, 0x00}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := &Asm{}
+			c.emit(a)
+			if !bytes.Equal(a.B, c.want) {
+				t.Fatalf("%s = % x, want % x", c.name, a.B, c.want)
+			}
+		})
+	}
+}
+
+// BenchmarkMemoryOffsetSum sums n fields at fixed offsets from a base pointer —
+// an offset-folding-friendly shape (struct/array field access).
+func BenchmarkMemoryOffsetSum(b *testing.B) {
+	const n = 16
+	var sb strings.Builder
+	sb.WriteString(`(module (memory 1) (func (export "f") (param i32) (result i32)` + "\n")
+	sb.WriteString("local.get 0 i32.load offset=0\n")
+	for i := 1; i < n; i++ {
+		fmt.Fprintf(&sb, "local.get 0 i32.load offset=%d i32.add\n", i*4)
+	}
+	sb.WriteString("))")
+	m := watToModuleB(b, sb.String())
+	code, err := CompileFunction(m, 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Logf("code size: %d bytes", len(code))
+	eng, _ := runtime.NewEngine()
+	defer eng.Close()
+	jm, _ := runtime.NewJobMemory(65536)
+	defer jm.Close()
+	ar, _ := runtime.NewArena(4096)
+	defer ar.Close()
+	mem, entry, _ := runtime.MapCode(code)
+	defer runtime.Unmap(mem)
+	serArgs := ar.Alloc(64)
+	results := ar.Alloc(16)
+	trap := ar.Alloc(8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := eng.Call(entry, serArgs, jm.LinearMemory(), trap, results); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## What

**Partial evaluation of a validation-time constant** (idea #11 from the single-pass brainstorm). Every memory access used to emit `mov tmp,off; add ea,tmp` to add the static memarg `offset` before the bounds check + load. Now the offset is **folded into the addressing-mode displacement**:

- bounds check computes `ea + off + size` via the `lea` displacement, and
- the access reads `[linMem + ea + off]` via a SIB **disp32**,

removing **two instructions per offset-using access** — i.e. most real struct/array code. Offsets too large for a signed disp32 (`off+size > 2^31-1`) fall back to the explicit 64-bit add.

## Memory safety

The bounds check is **unchanged** in both paths (still `ea+off+size <= memBytes`); only *where the constant offset lives* changes. No new runtime state, no register reservation, **zero added allocations**.

## Tests (`memoffset_test.go`)

- Addressing correctness (dynamic address **+** folded offset both contribute).
- Offset store writes the right cell, neighbours untouched.
- **Bounds-check boundary** (the safety test): the last in-range byte succeeds, one byte over **traps**, and the dynamic address *also* counts toward the limit — not just the offset.
- Large-offset (2 GiB) **explicit-add fallback** still traps (never OOB).
- Sub-width / i64 offset loads read the right bytes.
- Byte-level encoding of the disp32 vs compact SIB forms.

Full `go test ./...` green incl. `-race` and the spec conformance suite.

## Performance (offset-heavy 16-field sum, benchstat)

| metric | before → after |
|---|---|
| exec | 14.7ns → 12.2ns (**−17.1%**, p=0.000) |
| code size | 1100 → 1040 bytes |
| allocs | 0 → 0 (unchanged) |

Offset-0 accesses (e.g. the `memory.sum` benchmark) are **byte-identical** — no regression.