### PR TITLE
feat(runtime): TinyGo support via a runtime-generated trampoline (no cgo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,43 @@ jobs:
       - name: Build & test
         run: make test
 
+  tinygo:
+    name: TinyGo build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: "0.41.1"
+
+      # TinyGo links native linux/amd64 binaries with LLVM lld; the runner needs
+      # ld.lld on PATH (otherwise: "ROM segments are non-contiguous").
+      - name: Install lld
+        run: sudo apt-get update && sudo apt-get install -y lld
+
+      # Compile portability: the whole pipeline (wasm -> amd64 -> runtime ->
+      # public API + CLI) must build under TinyGo. A NOTE: the output name must
+      # not end in .bin, which TinyGo treats as a firmware image.
+      - name: Build CLI with TinyGo
+        run: make tinygo-build
+
+      # Runtime behavior: this exercises enterNative through the generated
+      # trampoline (trampoline_tinygo_amd64.go). If TinyGo's func-value ABI ever
+      # diverges from the System V assumption it relies on, these fail loudly.
+      - name: Test (runtime + public API) under TinyGo
+        run: make tinygo-test
+
+      # End-to-end smoke: the TinyGo-built JIT must execute a real module.
+      - name: Smoke-run a real module
+        run: |
+          out="$(./wago-tinygo run tests/testdata/fib.wasm --invoke fib 20)"
+          echo "$out"
+          test "$out" = "fib(20) = 6765"
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+# Builds the size-minimized TinyGo CLI (no cgo, ~0.43 MB; see docs/tinygo.md) and,
+# on a version tag, publishes it to the GitHub Release. Manual runs just upload a
+# build artifact.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to stamp into the binary (e.g. v0.1.0); defaults to the ref name"
+        required: false
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION: "1.22"
+  TINYGO_VERSION: "0.41.1"
+
+jobs:
+  release:
+    name: Build & publish (linux/amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: ${{ env.TINYGO_VERSION }}
+
+      # TinyGo links native linux/amd64 binaries with LLVM lld.
+      - name: Install lld
+        run: sudo apt-get update && sudo apt-get install -y lld
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            v="${{ inputs.version }}"
+          else
+            v="${{ github.ref_name }}"
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      # Produces ./wago (size-minimized, version stamped via -ldflags -X).
+      - name: Build release binary
+        run: make build-release WAGO_VERSION="${{ steps.ver.outputs.version }}"
+
+      - name: Package + checksum
+        run: |
+          mv wago wago-linux-amd64
+          ./wago-linux-amd64 version
+          sha256sum wago-linux-amd64 | tee wago-linux-amd64.sha256
+
+      # On a tag push, attach the binary to the (auto-created) GitHub Release.
+      - name: Publish to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            wago-linux-amd64
+            wago-linux-amd64.sha256
+          fail_on_unmatched_files: true
+
+      # For manual runs (no tag), keep the binary as a downloadable artifact.
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wago-linux-amd64
+          path: |
+            wago-linux-amd64
+            wago-linux-amd64.sha256
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.test
 *.out
 
+# TinyGo CLI build (make tinygo-build)
+wago-tinygo
+
 # Editor / OS
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@
 *.test
 *.out
 
-# TinyGo CLI build (make tinygo-build)
+# Built CLI binaries (make build / build-release / tinygo-build) + release assets
+/wago
 wago-tinygo
+wago-linux-amd64
+wago-linux-amd64.sha256
 
 # Editor / OS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,12 @@ tinygo-build: ## Build the CLI with TinyGo (no cgo) -> ./wago-tinygo  (see docs/
 tinygo-test: ## Run the runtime + public-API suites under TinyGo
 	$(TINYGO) test -scheduler=$(TINYGO_SCHEDULER) ./src/core/runtime/ ./src/wago/
 
+.PHONY: tinygo-release
+tinygo-release: ## Build a size-minimized TinyGo CLI -> ./wago-tinygo (~0.43 MB stripped)
+	$(TINYGO) build -scheduler=$(TINYGO_SCHEDULER) -no-debug -opt=z -gc=conservative -o wago-tinygo ./cli/wago
+	strip -s wago-tinygo
+	@echo "wago-tinygo: $$(du -h wago-tinygo | cut -f1)"
+
 .PHONY: cover
 cover: ## Run tests with cross-package coverage + per-package report (COVERPROFILE=path)
 	COVERPROFILE=$(COVERPROFILE) scripts/coverage.sh

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,21 @@ test: ## Build and run the test suite (host)
 	go build ./...
 	go test -count=1 ./...
 
+TINYGO ?= tinygo
+# wago runs native code on a dedicated foreign stack. TinyGo's conservative
+# collector with a threaded scheduler can stop a thread mid-run and scan that
+# switched stack, so wago under TinyGo wants the cooperative scheduler. See
+# docs/tinygo.md.
+TINYGO_SCHEDULER ?= tasks
+
+.PHONY: tinygo-build
+tinygo-build: ## Build the CLI with TinyGo (no cgo) -> ./wago-tinygo  (see docs/tinygo.md)
+	$(TINYGO) build -scheduler=$(TINYGO_SCHEDULER) -o wago-tinygo ./cli/wago
+
+.PHONY: tinygo-test
+tinygo-test: ## Run the runtime + public-API suites under TinyGo
+	$(TINYGO) test -scheduler=$(TINYGO_SCHEDULER) ./src/core/runtime/ ./src/wago/
+
 .PHONY: cover
 cover: ## Run tests with cross-package coverage + per-package report (COVERPROFILE=path)
 	COVERPROFILE=$(COVERPROFILE) scripts/coverage.sh

--- a/Makefile
+++ b/Makefile
@@ -90,20 +90,28 @@ TINYGO ?= tinygo
 # switched stack, so wago under TinyGo wants the cooperative scheduler. See
 # docs/tinygo.md.
 TINYGO_SCHEDULER ?= tasks
+# Stamped into the CLI via -ldflags -X (see cli/wago/main.go). release.yml passes
+# the git tag; locally it resolves to the nearest tag / short SHA.
+WAGO_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
+.PHONY: build
+build: ## Build the CLI (standard Go) -> ./wago
+	go build -ldflags "-X main.version=$(WAGO_VERSION)" -o wago ./cli/wago
+
+.PHONY: build-release
+build-release: ## Size-minimized release CLI via TinyGo (no cgo, ~0.43 MB) -> ./wago
+	$(TINYGO) build -scheduler=$(TINYGO_SCHEDULER) -no-debug -opt=z -gc=conservative \
+		-ldflags "-X main.version=$(WAGO_VERSION)" -o wago ./cli/wago
+	strip -s wago
+	@echo "wago $(WAGO_VERSION): $$(du -h wago | cut -f1)"
 
 .PHONY: tinygo-build
-tinygo-build: ## Build the CLI with TinyGo (no cgo) -> ./wago-tinygo  (see docs/tinygo.md)
+tinygo-build: ## Build the CLI with TinyGo (no cgo, debug) -> ./wago-tinygo  (see docs/tinygo.md)
 	$(TINYGO) build -scheduler=$(TINYGO_SCHEDULER) -o wago-tinygo ./cli/wago
 
 .PHONY: tinygo-test
 tinygo-test: ## Run the runtime + public-API suites under TinyGo
 	$(TINYGO) test -scheduler=$(TINYGO_SCHEDULER) ./src/core/runtime/ ./src/wago/
-
-.PHONY: tinygo-release
-tinygo-release: ## Build a size-minimized TinyGo CLI -> ./wago-tinygo (~0.43 MB stripped)
-	$(TINYGO) build -scheduler=$(TINYGO_SCHEDULER) -no-debug -opt=z -gc=conservative -o wago-tinygo ./cli/wago
-	strip -s wago-tinygo
-	@echo "wago-tinygo: $$(du -h wago-tinygo | cut -f1)"
 
 .PHONY: cover
 cover: ## Run tests with cross-package coverage + per-package report (COVERPROFILE=path)

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ TINYGO ?= tinygo
 # docs/tinygo.md.
 TINYGO_SCHEDULER ?= tasks
 # Stamped into the CLI via -ldflags -X (see cli/wago/main.go). release.yml passes
-# the git tag; locally it resolves to the nearest tag / short SHA.
-WAGO_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+# the git tag; 0.0.0 is the pre-release default until the first tag.
+WAGO_VERSION ?= 0.0.0
 
 .PHONY: build
 build: ## Build the CLI (standard Go) -> ./wago

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ err = in.SetGlobal("mutable_exported_global", wago.I32(42))
 are visible in both directions without copying.
 
 For typed access there are bounds-checked little-endian accessors —
-`ReadByte`/`ReadUint16Le`/`ReadUint32Le`/`ReadUint64Le`/`ReadFloat32Le`/
+`ReadUint8`/`ReadUint16Le`/`ReadUint32Le`/`ReadUint64Le`/`ReadFloat32Le`/
 `ReadFloat64Le` (and `Write…` counterparts), plus `Read(offset, length)` /
 `Write(offset, b)` for byte ranges. Each returns `ok=false` (writing nothing) when
 the range is out of bounds. They compile to a single aligned load/store, faster

--- a/README.md
+++ b/README.md
@@ -316,6 +316,14 @@ The backend uses a Valent-Block style symbolic operand stack: straight-line code
 stays register-resident, while control-flow joins flush to deterministic frame
 slots so every incoming edge agrees on machine state.
 
+### TinyGo
+
+wago also builds and runs under [TinyGo](https://tinygo.org) on `linux/amd64`,
+still with no cgo. Because TinyGo cannot assemble Plan9 `.s` files, the
+foreign-stack trampoline is generated as machine code at run time and entered
+through a func-value cast instead. See [docs/tinygo.md](docs/tinygo.md) for build
+instructions and caveats, or run `make tinygo-build`.
+
 ## Project Layout
 
 ```text

--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ err = in.SetGlobal("mutable_exported_global", wago.I32(42))
 `LinearMemory` returns the same mmap-backed region native wasm code sees. Writes
 are visible in both directions without copying.
 
+For typed access there are bounds-checked little-endian accessors —
+`ReadByte`/`ReadUint16Le`/`ReadUint32Le`/`ReadUint64Le`/`ReadFloat32Le`/
+`ReadFloat64Le` (and `Write…` counterparts), plus `Read(offset, length)` /
+`Write(offset, b)` for byte ranges. Each returns `ok=false` (writing nothing) when
+the range is out of bounds. They compile to a single aligned load/store, faster
+than `encoding/binary` on the slice — notably under TinyGo (see
+[docs/tinygo.md](docs/tinygo.md)).
+
+```go
+v, ok := in.ReadUint32Le(off)
+ok = in.WriteFloat64Le(off, 3.14)
+```
+
 `Global` and `SetGlobal` access exported numeric globals by name. Reads return the
 declared value type and current bits. Writes require an exported mutable global
 and a matching `Value` type.

--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -11,7 +11,18 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
-const version = "0.1.0"
+// version is overridden at build time via -ldflags "-X main.version=<tag>" (see
+// `make build` / `make build-release`). It must be an uninitialized var: TinyGo
+// only honors -X for variables declared without an initializer. An empty value
+// means a plain `go build` with no version stamped in.
+var version string
+
+func versionString() string {
+	if version == "" {
+		return "0.1.0-dev"
+	}
+	return version
+}
 
 func main() {
 	a := os.Args[1:]
@@ -29,7 +40,7 @@ func main() {
 	case "validate":
 		notImplemented("validate")
 	case "version", "--version", "-v":
-		fmt.Printf("wago %s (linux/amd64)\n", version)
+		fmt.Printf("wago %s (linux/amd64)\n", versionString())
 		fmt.Println("wasm: i32 i64 f32 f64, control flow, memory, calls + host imports")
 	case "help", "-h", "--help":
 		usage(os.Stdout)

--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -19,7 +19,7 @@ var version string
 
 func versionString() string {
 	if version == "" {
-		return "0.1.0-dev"
+		return "0.0.0"
 	}
 	return version
 }

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -121,11 +121,20 @@ The `LinearMemoryAccess` row is the one apparent gap, but it is not the trampoli
 and not even linear memory itself — `Instance.LinearMemory()` hands back the raw,
 zero-copy mmap `[]byte`, which is optimal. That benchmark measures the *host's*
 access idiom, `binary.LittleEndian.{Put,}Uint32`, whose per-byte assembly + bounds
-checks LLVM optimizes less aggressively than `gc`. A host hot loop that reads the
-slice with a single aligned load (`*(*uint32)(unsafe.Add(base, off))`) is **at
-parity**: 0.43 ns/op under TinyGo vs 0.33 ns/op standard. None of this touches the
-wasm execution path, which runs wago's own JIT-emitted machine code, not
-TinyGo-compiled Go.
+checks LLVM optimizes less aggressively than `gc`.
+
+The typed accessors (`Instance.ReadUint32Le` / `WriteUint32Le` / …) do a single
+bounds-checked aligned load/store and are **~2.2× faster than the `encoding/binary`
+idiom under TinyGo** — 0.73 ns/op vs 1.57 ns/op (and faster than `encoding/binary`
+on the standard toolchain too). Use them for hot host loops:
+
+```go
+v, ok := in.ReadUint32Le(off)   // not binary.LittleEndian.Uint32(in.LinearMemory()[off:])
+in.WriteUint32Le(off, v)
+```
+
+None of this touches the wasm execution path, which runs wago's own JIT-emitted
+machine code, not TinyGo-compiled Go.
 
 `make build-release` uses `-opt=z` (size); it is already at parity above. `-opt=2`
 trades ~size for a further ~15-20% on these wrappers and on compile-time Go (decode

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -94,6 +94,29 @@ saves only ~10 KB over `conservative` and leaks; `-panic=trap` saves ~20 KB but
 replaces panic messages with a bare `SIGILL` — neither is worth it, so
 `make build-release` uses neither.
 
+## Call latency
+
+The runtime-generated trampoline **adds no latency to the standard build** — that
+path still uses `trampoline_amd64.s` unchanged (the TinyGo files are build-tagged
+off). Measured identical to baseline: host→wasm 6.4 ns/op, wasm→host 14.4 ns/op,
+0 allocs.
+
+Under TinyGo the same round trips cost more, but the trampoline mechanism is not
+the bottleneck — TinyGo's generated code is simply ~4× slower than `gc` across the
+board, including paths with no trampoline at all:
+
+| benchmark (`src/core/runtime`) | standard Go | TinyGo | ratio |
+|---|---:|---:|---:|
+| `LinearMemoryAccess` (pure Go, no trampoline) | 0.65 ns/op | 2.44 ns/op | ~3.8× |
+| `CrossBoundaryCall` (host→wasm) | 6.4 ns/op | 27.8 ns/op | ~4.3× |
+| `HostCall` (wasm→host, two crossings) | 14.4 ns/op | 59 ns/op | ~4.1× |
+
+All paths stay at tens of nanoseconds with **0 allocations** under both toolchains.
+The func-value-cast entry does the same `RSP` switch + `call` as the assembly
+trampoline; its extra cost is a small constant dwarfed by TinyGo's general codegen
+overhead (the pure-Go row scales by the same ~4×). Reproduce with
+`tinygo test -scheduler=tasks -bench=. -run=^$ ./src/core/runtime/`.
+
 ## Limitations and caveats
 
 - **Scheduler.** Build with `-scheduler=tasks` — see the section above. Under a

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -63,12 +63,13 @@ hazard cannot arise. This is the TinyGo analogue of wago's standing "keep native
 runs bounded" contract; the standard Go toolchain sidesteps it entirely with
 precise stack maps.
 
-Or via make:
+Via make:
 
 ```bash
-make tinygo-build      # build the CLI with TinyGo -> ./wago-tinygo
+make build             # standard Go dev build -> ./wago
+make build-release     # size-minimized TinyGo release CLI (~0.43 MB) -> ./wago
+make tinygo-build      # TinyGo debug build (CI portability check) -> ./wago-tinygo
 make tinygo-test       # run the runtime + public-API suites under TinyGo
-make tinygo-release    # size-minimized CLI (~0.43 MB stripped)
 ```
 
 ## Binary size
@@ -82,7 +83,7 @@ make tinygo-release    # size-minimized CLI (~0.43 MB stripped)
 | `tinygo build` (default — includes DWARF) | 2.3 MB |
 | `tinygo build -no-debug` | 0.68 MB |
 | `tinygo build -no-debug -opt=z -gc=conservative` | 0.62 MB |
-| &nbsp;&nbsp;+ `strip -s` (= `make tinygo-release`) | **0.43 MB** |
+| &nbsp;&nbsp;+ `strip -s` (= `make build-release`) | **0.43 MB** |
 | &nbsp;&nbsp;+ `upx --best --lzma` | **0.16 MB** |
 
 TinyGo's *default* build is no smaller than `go -s -w` because it ships debug
@@ -91,7 +92,7 @@ in order: `-no-debug`, then `strip -s` (drops the symbol table), then `upx`
 (roughly halves again, at a few-ms startup decompression cost). `-gc=leaking`
 saves only ~10 KB over `conservative` and leaks; `-panic=trap` saves ~20 KB but
 replaces panic messages with a bare `SIGILL` — neither is worth it, so
-`make tinygo-release` uses neither.
+`make build-release` uses neither.
 
 ## Limitations and caveats
 

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -1,0 +1,106 @@
+# Building wago with TinyGo
+
+wago builds and runs under [TinyGo](https://tinygo.org) on `linux/amd64` with **no
+cgo**. The decode → validate → codegen → execute pipeline works end to end: the
+CLI and the public `wago` API run real modules (recursion, i64, floats, linear
+memory, host imports, `call_indirect`) identically to the standard toolchain.
+
+## Why this needs special handling
+
+The standard toolchain enters native wasm code through a Plan9 assembly
+trampoline (`src/core/runtime/trampoline_amd64.s`) that switches `RSP` to a
+dedicated foreign stack and calls the WARP `WasmWrapper`. TinyGo cannot assemble
+Plan9 `.s` files, so that symbol is unavailable.
+
+We do **not** fall back to cgo. A cgo trampoline would impose a boundary
+transition on every wasm invocation — exactly the latency wago is built to avoid.
+Instead, TinyGo generates the trampoline as machine code at run time
+(`src/core/runtime/trampoline_tinygo_amd64.go`), the same way the engine already
+maps native code, and enters it through an `unsafe` func-value cast:
+
+- TinyGo lowers an indirect call through a func value to the System V C ABI. For
+  `f(serArgs, linMem, trap, results)` the four arguments land in `RDI, RSI, RDX,
+  RCX` — precisely the `WasmWrapper` register mapping — and the func value's
+  context word is passed in the next register, `R8`.
+- We smuggle the native code pointer through that context word (so it arrives in
+  `R8`) and bake the foreign-stack top into the generated thunk as an immediate.
+  The thunk switches `RSP`, `call`s `R8`, and restores the Go context — mirroring
+  the assembly trampoline exactly.
+
+The standard (`!tinygo`) build is unchanged and keeps using the assembly
+trampoline; the build tags select the right implementation automatically.
+
+## Building
+
+TinyGo on `linux/amd64` links with LLVM `lld`. Make sure `ld.lld` is on `PATH`
+(`apt install lld`, or any LLVM toolchain).
+
+```bash
+# Build the CLI. Two flags worth noting:
+#   -scheduler=tasks : use the cooperative scheduler (see "Scheduler" below)
+#   -o wago          : do NOT use a .bin output name — TinyGo treats .bin as a
+#                      firmware image and fails with "ROM segments are non-contiguous"
+tinygo build -scheduler=tasks -o wago ./cli/wago
+
+./wago run tests/testdata/fib.wasm --invoke fib 20   # => fib(20) = 6765
+```
+
+## Scheduler: use `-scheduler=tasks`
+
+Build wago programs with **`-scheduler=tasks`** (cooperative, single-threaded).
+This is what `make tinygo-build` / `make tinygo-test` and CI use, and the config
+in which the entire suite — including the standard-Go GC-storm stress test — is
+green and deterministic.
+
+The reason is structural. wago runs native wasm code on a dedicated off-heap
+*foreign stack* (it switches `RSP` for the duration of a call). TinyGo's default
+collector is conservative: under a *threaded* scheduler it can stop a thread that
+is mid-run with `RSP` on the foreign stack and try to scan from there to the
+thread's registered stack base — across unmapped memory — and crash. wago does no
+Go allocation while native code runs, so under the cooperative scheduler (one
+goroutine, no preemption, collections only happen between bounded runs) the
+hazard cannot arise. This is the TinyGo analogue of wago's standing "keep native
+runs bounded" contract; the standard Go toolchain sidesteps it entirely with
+precise stack maps.
+
+Or via make:
+
+```bash
+make tinygo-build      # build the CLI with TinyGo -> ./wago-tinygo
+make tinygo-test       # run the runtime + public-API suites under TinyGo
+```
+
+The TinyGo binary is also smaller than the standard build (~2.4 MB vs ~3.2 MB).
+
+## Limitations and caveats
+
+- **Scheduler.** Build with `-scheduler=tasks` — see the section above. Under a
+  threaded scheduler a conservative collection can scan a thread stopped mid-run
+  on the foreign stack and crash; `TestTinyGoBoundedRunStability` (50k runs with
+  inter-run `GC()`) confirms the cooperative path is stable.
+
+- **Deeply nested modules.** The decoder/validator is recursive
+  (`maxInstructionNestingDepth = 20000`). TinyGo goroutine stacks are smaller and
+  fixed, so pathologically deep modules can overflow the stack before reaching
+  the limit. Real-world modules nest nowhere near this; the main goroutine's
+  large stack handles them fine.
+
+- **Tests that shell out are excluded.** TinyGo does not support `os/exec`, and
+  its `testing` package does not honor `t.Skip`/`t.Fatal` (they print
+  "incomplete, requires runtime.Goexit()" and *keep running* instead of aborting
+  the test). So a test that builds a fixture by invoking `wat2wasm` cannot skip
+  cleanly — it falls through into a nil module and crashes. Such files
+  (`src/wago/callargs_test.go`, `src/wago/pinnedglobal_test.go`) are build-tagged
+  `!tinygo`; they still run under standard Go. The TinyGo public-API coverage
+  comes from the embedded-fixture tests in `wago_test.go` (which read checked-in
+  `.wasm` via `os.ReadFile`, no subprocess). **When adding a new test that uses
+  `os/exec` or relies on `t.Skip`/`t.Fatal` aborting, tag it `!tinygo`** or the
+  `make tinygo-test` / CI gate will crash.
+
+- **Test suites that probe standard-Go internals.** `stress_test.go` (morestack
+  relocation, the `_Grunning` contract, adversarial concurrent `runtime.GC()`)
+  and the external `WAGO_SPECTEST_DIR` spec harness are standard-Go-only. The
+  runtime stress test is build-tagged `!tinygo`, with a TinyGo-appropriate
+  counterpart in `stress_tinygo_test.go`.
+
+- **Platform.** `linux/amd64` only, same as the standard build.

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -101,21 +101,29 @@ path still uses `trampoline_amd64.s` unchanged (the TinyGo files are build-tagge
 off). Measured identical to baseline: host→wasm 6.4 ns/op, wasm→host 14.4 ns/op,
 0 allocs.
 
-Under TinyGo the same round trips cost more, but the trampoline mechanism is not
-the bottleneck — TinyGo's generated code is simply ~4× slower than `gc` across the
-board, including paths with no trampoline at all:
+Under TinyGo the boundary-crossing round trips are at **parity** with the standard
+toolchain. `enterNative` looks up its specialized trampoline through a lock-free
+single-slot cache (`lastThunk`), so the hot path is one atomic load — no lock, no
+map. (An earlier mutex+map lookup per call cost ~20 ns; removing it is a ~4×
+speedup and the bulk of "optimize TinyGo".)
 
-| benchmark (`src/core/runtime`) | standard Go | TinyGo | ratio |
+| benchmark (`src/core/runtime`) | standard Go | TinyGo `-opt=z` | TinyGo `-opt=2` |
 |---|---:|---:|---:|
-| `LinearMemoryAccess` (pure Go, no trampoline) | 0.65 ns/op | 2.44 ns/op | ~3.8× |
-| `CrossBoundaryCall` (host→wasm) | 6.4 ns/op | 27.8 ns/op | ~4.3× |
-| `HostCall` (wasm→host, two crossings) | 14.4 ns/op | 59 ns/op | ~4.1× |
+| `CrossBoundaryCall` (host→wasm) | 6.4 ns/op | 6.6 ns/op | 5.5 ns/op |
+| `HostCall` (wasm→host, two crossings) | 14.4 ns/op | 16.0 ns/op | 12.9 ns/op |
+| `LinearMemoryAccess` (pure Go, no trampoline) | 0.66 ns/op | — | 1.6 ns/op |
 
-All paths stay at tens of nanoseconds with **0 allocations** under both toolchains.
-The func-value-cast entry does the same `RSP` switch + `call` as the assembly
-trampoline; its extra cost is a small constant dwarfed by TinyGo's general codegen
-overhead (the pure-Go row scales by the same ~4×). Reproduce with
-`tinygo test -scheduler=tasks -bench=. -run=^$ ./src/core/runtime/`.
+All paths are single-digit-to-teens nanoseconds with **0 allocations** under both
+toolchains. The func-value-cast entry does the same `RSP` switch + `call` as the
+assembly trampoline, so the boundary cost matches. TinyGo's only residual gap is
+on pure-Go *compute* (the `LinearMemoryAccess` row, ~2.4×), which is general
+codegen, not the trampoline — and it doesn't touch the wasm execution path, since
+that runs wago's own JIT-emitted machine code, not TinyGo-compiled Go.
+
+`make build-release` uses `-opt=z` (size); it is already at parity above. `-opt=2`
+trades ~size for a further ~15-20% on these wrappers and on compile-time Go (decode
+/ validate / codegen) — pass `make build-release` a different recipe if you want
+it. Reproduce: `tinygo test -scheduler=tasks -opt=2 -bench=. -run=^$ ./src/core/runtime/`.
 
 ## Limitations and caveats
 

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -94,6 +94,12 @@ saves only ~10 KB over `conservative` and leaks; `-panic=trap` saves ~20 KB but
 replaces panic messages with a bare `SIGILL` — neither is worth it, so
 `make build-release` uses neither.
 
+The speed/size choice is small: the max-speed build (`-opt=2 -no-debug` + strip)
+is ~0.60 MB, vs 0.43 MB for `-opt=z`. TinyGo wins size at *every* opt level — even
+its speed build is ~3.4× smaller than Go's best stripped binary (~2.0 MB), which
+is Go's runtime/GC/reflect floor that no flags break. `-nobounds` doesn't change
+binary size.
+
 ## Call latency
 
 The runtime-generated trampoline **adds no latency to the standard build** — that

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -141,6 +141,13 @@ trades ~size for a further ~15-20% on these wrappers and on compile-time Go (dec
 / validate / codegen) — pass `make build-release` a different recipe if you want
 it. Reproduce: `tinygo test -scheduler=tasks -opt=2 -bench=. -run=^$ ./src/core/runtime/`.
 
+At max optimization for both toolchains (`go test -gcflags=all=-B` vs
+`tinygo test -opt=2 -nobounds`, dropping bounds checks), **TinyGo wins the call
+paths** — host→wasm 5.5 vs 6.4 ns, wasm→host 11.6 vs 14.3 ns — because its LLVM
+codegen for the trampoline + wrappers is tighter and those paths carry no bounds
+checks. Go keeps its ~2× edge only on pure host-side *memory loops* (0.57 vs 1.1 ns;
+`-nobounds` closes most of TinyGo's gap there), which is off the wasm path.
+
 ## Limitations and caveats
 
 - **Scheduler.** Build with `-scheduler=tasks` — see the section above. Under a

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -68,9 +68,30 @@ Or via make:
 ```bash
 make tinygo-build      # build the CLI with TinyGo -> ./wago-tinygo
 make tinygo-test       # run the runtime + public-API suites under TinyGo
+make tinygo-release    # size-minimized CLI (~0.43 MB stripped)
 ```
 
-The TinyGo binary is also smaller than the standard build (~2.4 MB vs ~3.2 MB).
+## Binary size
+
+`cli/wago`, linux/amd64:
+
+| build | size |
+|---|---:|
+| `go build` (default) | 3.1 MB |
+| `go build -ldflags="-s -w"` | 2.1 MB |
+| `tinygo build` (default — includes DWARF) | 2.3 MB |
+| `tinygo build -no-debug` | 0.68 MB |
+| `tinygo build -no-debug -opt=z -gc=conservative` | 0.62 MB |
+| &nbsp;&nbsp;+ `strip -s` (= `make tinygo-release`) | **0.43 MB** |
+| &nbsp;&nbsp;+ `upx --best --lzma` | **0.16 MB** |
+
+TinyGo's *default* build is no smaller than `go -s -w` because it ships debug
+info; the win is `-no-debug` (~3.4× smaller than `go -s -w`). The biggest levers,
+in order: `-no-debug`, then `strip -s` (drops the symbol table), then `upx`
+(roughly halves again, at a few-ms startup decompression cost). `-gc=leaking`
+saves only ~10 KB over `conservative` and leaks; `-panic=trap` saves ~20 KB but
+replaces panic messages with a bare `SIGILL` — neither is worth it, so
+`make tinygo-release` uses neither.
 
 ## Limitations and caveats
 

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -111,14 +111,21 @@ speedup and the bulk of "optimize TinyGo".)
 |---|---:|---:|---:|
 | `CrossBoundaryCall` (host→wasm) | 6.4 ns/op | 6.6 ns/op | 5.5 ns/op |
 | `HostCall` (wasm→host, two crossings) | 14.4 ns/op | 16.0 ns/op | 12.9 ns/op |
-| `LinearMemoryAccess` (pure Go, no trampoline) | 0.66 ns/op | — | 1.6 ns/op |
+| `LinearMemoryAccess` (`encoding/binary`) | 0.66 ns/op | — | 1.6 ns/op |
 
 All paths are single-digit-to-teens nanoseconds with **0 allocations** under both
 toolchains. The func-value-cast entry does the same `RSP` switch + `call` as the
-assembly trampoline, so the boundary cost matches. TinyGo's only residual gap is
-on pure-Go *compute* (the `LinearMemoryAccess` row, ~2.4×), which is general
-codegen, not the trampoline — and it doesn't touch the wasm execution path, since
-that runs wago's own JIT-emitted machine code, not TinyGo-compiled Go.
+assembly trampoline, so the boundary cost matches.
+
+The `LinearMemoryAccess` row is the one apparent gap, but it is not the trampoline
+and not even linear memory itself — `Instance.LinearMemory()` hands back the raw,
+zero-copy mmap `[]byte`, which is optimal. That benchmark measures the *host's*
+access idiom, `binary.LittleEndian.{Put,}Uint32`, whose per-byte assembly + bounds
+checks LLVM optimizes less aggressively than `gc`. A host hot loop that reads the
+slice with a single aligned load (`*(*uint32)(unsafe.Add(base, off))`) is **at
+parity**: 0.43 ns/op under TinyGo vs 0.33 ns/op standard. None of this touches the
+wasm execution path, which runs wago's own JIT-emitted machine code, not
+TinyGo-compiled Go.
 
 `make build-release` uses `-opt=z` (size); it is already at parity above. `-opt=2`
 trades ~size for a further ~15-20% on these wrappers and on compile-time Go (decode

--- a/src/core/runtime/engine_linux_amd64.go
+++ b/src/core/runtime/engine_linux_amd64.go
@@ -8,11 +8,12 @@ import (
 	"unsafe"
 )
 
-// enterNative is implemented in trampoline_amd64.s. It switches RSP to the
-// engine's foreign stack, calls the WARP WasmWrapper at code following the
-// System V mapping (serArgs->RDI, linMem->RSI, trap->RDX, results->RCX), then
-// restores the Go context.
-func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr)
+// enterNative switches RSP to the engine's foreign stack, calls the WARP
+// WasmWrapper at code following the System V mapping (serArgs->RDI, linMem->RSI,
+// trap->RDX, results->RCX), then restores the Go context. The standard toolchain
+// implements it in assembly (trampoline_asm_amd64.go + trampoline_amd64.s);
+// TinyGo, which cannot assemble Plan9 .s files, generates an equivalent
+// machine-code trampoline at run time (trampoline_tinygo_amd64.go).
 
 // Engine owns a dedicated, off-heap execution stack for native wasm code.
 type Engine struct {

--- a/src/core/runtime/stress_test.go
+++ b/src/core/runtime/stress_test.go
@@ -1,4 +1,11 @@
-//go:build linux && amd64
+//go:build linux && amd64 && !tinygo
+
+// These stress tests assert standard-Go runtime invariants — morestack stack
+// relocation, the _Grunning contract, g-register restoration — and adversarially
+// storm runtime.GC() concurrently with native execution. None of that maps onto
+// TinyGo (no morestack, a conservative non-moving collector, a different
+// scheduler), so the file is excluded from the TinyGo build. See
+// stress_tinygo_test.go for the TinyGo-appropriate bounded-run stability test.
 
 package runtime
 

--- a/src/core/runtime/stress_tinygo_test.go
+++ b/src/core/runtime/stress_tinygo_test.go
@@ -1,0 +1,52 @@
+//go:build linux && amd64 && tinygo
+
+package runtime
+
+import (
+	"encoding/binary"
+	grt "runtime"
+	"testing"
+)
+
+// TestTinyGoBoundedRunStability exercises the TinyGo trampoline
+// (trampoline_tinygo_amd64.go) over many native enter/exit cycles, forcing a GC
+// between runs. This is the supported TinyGo pattern: native code allocates
+// nothing, so a collection can only occur between bounded runs — never while a
+// thread is switched onto the foreign stack. A botched foreign-stack switch or a
+// clobbered callee-saved register would corrupt results or crash here.
+//
+// (The standard-Go suite additionally storms runtime.GC() *concurrently* with
+// native execution; see stress_test.go. That is unsafe under TinyGo's
+// conservative collector with a threaded scheduler, which would scan a thread
+// stopped mid-run with RSP on the foreign stack — a documented limitation.)
+func TestTinyGoBoundedRunStability(t *testing.T) {
+	eng, jm, ar := fixture(t)
+
+	code, err := mmapExec(stubLoop)
+	if err != nil {
+		t.Skipf("exec mapping denied: %v", err)
+	}
+	defer munmap(code)
+
+	serArgs := ar.Alloc(16)
+	results := ar.Alloc(16)
+	trap := ar.Alloc(8)
+	lin := jm.LinearMemory()
+
+	const iters = 50000
+	for i := 0; i < iters; i++ {
+		binary.LittleEndian.PutUint32(serArgs, uint32(i%64)) // bounded loop count
+		if err := eng.Call(slicePtr(code), serArgs, lin, trap, results); err != nil {
+			t.Fatalf("run %d: Call: %v", i, err)
+		}
+		if got := binary.LittleEndian.Uint32(results); got != loopSentinel {
+			t.Fatalf("run %d: results = %#x, want sentinel %#x", i, got, loopSentinel)
+		}
+		if got := binary.LittleEndian.Uint32(lin); got != loopSentinel {
+			t.Fatalf("run %d: linMem = %#x, want sentinel %#x", i, got, loopSentinel)
+		}
+		if i%2000 == 0 {
+			grt.GC() // collect between (never during) native runs
+		}
+	}
+}

--- a/src/core/runtime/trampoline_amd64.s
+++ b/src/core/runtime/trampoline_amd64.s
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 #include "textflag.h"
 
 // func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr)

--- a/src/core/runtime/trampoline_asm_amd64.go
+++ b/src/core/runtime/trampoline_asm_amd64.go
@@ -1,0 +1,11 @@
+//go:build linux && amd64 && !tinygo
+
+package runtime
+
+// enterNative is implemented in trampoline_amd64.s for the standard Go
+// toolchain. It switches RSP to the engine's foreign stack, calls the WARP
+// WasmWrapper at code following the System V mapping (serArgs->RDI, linMem->RSI,
+// trap->RDX, results->RCX), then restores the Go context. TinyGo cannot assemble
+// Plan9 .s files, so it supplies its own enterNative in
+// trampoline_tinygo_amd64.go.
+func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr)

--- a/src/core/runtime/trampoline_tinygo_amd64.go
+++ b/src/core/runtime/trampoline_tinygo_amd64.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"encoding/binary"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -86,7 +87,19 @@ type funcValue struct {
 	fnptr   uintptr
 }
 
+// thunkRef pairs a foreign-stack top with the entry point of the trampoline
+// specialized for it, so the two are published together atomically.
+type thunkRef struct {
+	top   uintptr
+	entry uintptr
+}
+
 var (
+	// hot path: a lock-free single-slot cache. Engines almost always share one
+	// foreign stack, so this hits on every call after the first and keeps
+	// enterNative free of locks and map hashing.
+	lastThunk atomic.Pointer[thunkRef]
+
 	thunkMu    sync.Mutex
 	thunkCache = map[uintptr]uintptr{} // foreign-stack top -> thunk entry point
 )
@@ -96,20 +109,29 @@ var (
 // mapping is kept for the life of the process (one executable page per distinct
 // engine stack, of which there are typically very few).
 func thunkFor(foreignStackTop uintptr) uintptr {
+	if r := lastThunk.Load(); r != nil && r.top == foreignStackTop {
+		return r.entry
+	}
+	return thunkForSlow(foreignStackTop)
+}
+
+func thunkForSlow(foreignStackTop uintptr) uintptr {
 	thunkMu.Lock()
-	defer thunkMu.Unlock()
-	if entry, ok := thunkCache[foreignStackTop]; ok {
-		return entry
+	entry, ok := thunkCache[foreignStackTop]
+	if !ok {
+		code := make([]byte, len(thunkTemplate))
+		copy(code, thunkTemplate)
+		binary.LittleEndian.PutUint64(code[thunkStackTopOff:], uint64(foreignStackTop))
+		mem, err := mmapExec(code)
+		if err != nil {
+			thunkMu.Unlock()
+			panic("wago: cannot map tinygo trampoline: " + err.Error())
+		}
+		entry = uintptr(unsafe.Pointer(&mem[0]))
+		thunkCache[foreignStackTop] = entry
 	}
-	code := make([]byte, len(thunkTemplate))
-	copy(code, thunkTemplate)
-	binary.LittleEndian.PutUint64(code[thunkStackTopOff:], uint64(foreignStackTop))
-	mem, err := mmapExec(code)
-	if err != nil {
-		panic("wago: cannot map tinygo trampoline: " + err.Error())
-	}
-	entry := uintptr(unsafe.Pointer(&mem[0]))
-	thunkCache[foreignStackTop] = entry
+	thunkMu.Unlock()
+	lastThunk.Store(&thunkRef{top: foreignStackTop, entry: entry})
 	return entry
 }
 

--- a/src/core/runtime/trampoline_tinygo_amd64.go
+++ b/src/core/runtime/trampoline_tinygo_amd64.go
@@ -1,0 +1,123 @@
+//go:build linux && amd64 && tinygo
+
+package runtime
+
+import (
+	"encoding/binary"
+	"sync"
+	"unsafe"
+)
+
+// TinyGo cannot assemble Go's Plan9 .s files, so the assembly trampoline used by
+// the standard toolchain (trampoline_amd64.s) is unavailable here. Instead we
+// build the trampoline as machine code at run time — the same approach the
+// engine already uses for its native code — and invoke it through an unsafe
+// func-value cast. No cgo is involved: a cgo call would impose a boundary
+// transition on every wasm invocation, which is exactly the latency this engine
+// is built to avoid.
+//
+// The trick relies on how TinyGo lowers an indirect call through a func value to
+// the System V C ABI. For a call `f(a, b, c, d)`, TinyGo passes the four
+// arguments in RDI, RSI, RDX, RCX and the func value's context word in the next
+// integer register, R8. That maps onto WARP's WasmWrapper ABI for free: the four
+// arguments already arrive in exactly the registers the native code expects
+// (serArgs->RDI, linMem->RSI, trap->RDX, results->RCX), and we smuggle the
+// native code pointer through the context word so it arrives in R8. The
+// generated thunk switches RSP to the engine's foreign stack (its top baked in
+// as an immediate), `call`s R8, then restores the Go context — mirroring
+// trampoline_amd64.s exactly.
+
+// thunkTemplate is the foreign-stack-switch trampoline as position-independent
+// machine code. The 8 bytes at thunkStackTopOff are a placeholder for the
+// foreign-stack top, patched per engine stack.
+//
+// On entry (System V): RDI=serArgs, RSI=linMem, RDX=trap, RCX=results, R8=code.
+//
+//	movabs $imm64, %r10        ; foreign-stack top (patched at thunkStackTopOff)
+//	sub    $0x40, %r10         ; reserve a 64-byte Go-context save area
+//	mov    %rsp, (%r10)        ; save goroutine SP + callee-saved registers
+//	mov    %rbp, 0x8(%r10)
+//	mov    %rbx, 0x10(%r10)
+//	mov    %r12, 0x18(%r10)
+//	mov    %r13, 0x20(%r10)
+//	mov    %r14, 0x28(%r10)
+//	mov    %r15, 0x30(%r10)
+//	mov    %r10, %rsp          ; switch to the foreign stack
+//	xor    %ebp, %ebp          ; zero RBP so any unwinder stops here
+//	call   *%r8                ; run WARP code (args already in RDI..RCX)
+//	mov    0x8(%rsp), %rbp     ; restore the Go context (SP == save area)
+//	mov    0x10(%rsp), %rbx
+//	mov    0x18(%rsp), %r12
+//	mov    0x20(%rsp), %r13
+//	mov    0x28(%rsp), %r14
+//	mov    0x30(%rsp), %r15
+//	mov    (%rsp), %rsp        ; back on the goroutine stack
+//	ret
+var thunkTemplate = []byte{
+	0x49, 0xba, 0, 0, 0, 0, 0, 0, 0, 0, // movabs imm64 -> r10 (imm at offset 2)
+	0x49, 0x83, 0xea, 0x40, // sub $0x40, %r10
+	0x49, 0x89, 0x22, // mov %rsp, (%r10)
+	0x49, 0x89, 0x6a, 0x08, // mov %rbp, 0x8(%r10)
+	0x49, 0x89, 0x5a, 0x10, // mov %rbx, 0x10(%r10)
+	0x4d, 0x89, 0x62, 0x18, // mov %r12, 0x18(%r10)
+	0x4d, 0x89, 0x6a, 0x20, // mov %r13, 0x20(%r10)
+	0x4d, 0x89, 0x72, 0x28, // mov %r14, 0x28(%r10)
+	0x4d, 0x89, 0x7a, 0x30, // mov %r15, 0x30(%r10)
+	0x4c, 0x89, 0xd4, // mov %r10, %rsp
+	0x31, 0xed, // xor %ebp, %ebp
+	0x41, 0xff, 0xd0, // call *%r8
+	0x48, 0x8b, 0x6c, 0x24, 0x08, // mov 0x8(%rsp), %rbp
+	0x48, 0x8b, 0x5c, 0x24, 0x10, // mov 0x10(%rsp), %rbx
+	0x4c, 0x8b, 0x64, 0x24, 0x18, // mov 0x18(%rsp), %r12
+	0x4c, 0x8b, 0x6c, 0x24, 0x20, // mov 0x20(%rsp), %r13
+	0x4c, 0x8b, 0x74, 0x24, 0x28, // mov 0x28(%rsp), %r14
+	0x4c, 0x8b, 0x7c, 0x24, 0x30, // mov 0x30(%rsp), %r15
+	0x48, 0x8b, 0x24, 0x24, // mov (%rsp), %rsp
+	0xc3, // ret
+}
+
+const thunkStackTopOff = 2
+
+// funcValue mirrors TinyGo's in-memory representation of a func value:
+// {context, fnptr}. Overlaying it lets us synthesize a callable that jumps to
+// arbitrary machine code with a chosen context word.
+type funcValue struct {
+	context uintptr
+	fnptr   uintptr
+}
+
+var (
+	thunkMu    sync.Mutex
+	thunkCache = map[uintptr]uintptr{} // foreign-stack top -> thunk entry point
+)
+
+// thunkFor returns the entry point of a foreign-stack-switch trampoline
+// specialized for foreignStackTop, generating and caching it on first use. The
+// mapping is kept for the life of the process (one executable page per distinct
+// engine stack, of which there are typically very few).
+func thunkFor(foreignStackTop uintptr) uintptr {
+	thunkMu.Lock()
+	defer thunkMu.Unlock()
+	if entry, ok := thunkCache[foreignStackTop]; ok {
+		return entry
+	}
+	code := make([]byte, len(thunkTemplate))
+	copy(code, thunkTemplate)
+	binary.LittleEndian.PutUint64(code[thunkStackTopOff:], uint64(foreignStackTop))
+	mem, err := mmapExec(code)
+	if err != nil {
+		panic("wago: cannot map tinygo trampoline: " + err.Error())
+	}
+	entry := uintptr(unsafe.Pointer(&mem[0]))
+	thunkCache[foreignStackTop] = entry
+	return entry
+}
+
+// enterNative runs WARP code at code on the engine's foreign stack following the
+// WasmWrapper ABI, then returns to Go. See the file comment for how the
+// arguments reach the native code with no assembly and no cgo.
+func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr) {
+	fv := funcValue{context: code, fnptr: thunkFor(foreignStackTop)}
+	call := *(*func(a, b, c, d uintptr))(unsafe.Pointer(&fv))
+	call(serArgs, linMem, trap, results)
+}

--- a/src/wago/callargs_test.go
+++ b/src/wago/callargs_test.go
@@ -1,4 +1,10 @@
-//go:build linux && amd64
+//go:build linux && amd64 && !tinygo
+
+// This file builds fixtures by shelling out to wat2wasm via os/exec, which
+// TinyGo does not support; combined with TinyGo's testing package not honoring
+// t.Skip/t.Fatal (no runtime.Goexit), it cannot run under TinyGo. Excluded from
+// the TinyGo build — the public API is still covered there by the embedded-
+// fixture tests in wago_test.go. See docs/tinygo.md.
 
 package wago
 

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -15,7 +15,8 @@ type Instance struct {
 	jm                     *runtime.JobMemory
 	ar                     *runtime.Arena
 	base                   uintptr
-	mem                    []byte
+	mem                    []byte // mapped code (for Unmap)
+	linMem                 []byte // linear memory, cached once (wago has no memory.grow, so it never moves)
 	hosts                  map[string]HostFunc
 	hostLog                []byte
 	globals                []byte // pointer table handed to JIT code
@@ -184,7 +185,7 @@ func InstantiateWithImports(c *Compiled, imports Imports) (*Instance, error) {
 
 	success = true
 	return &Instance{
-		c: c, eng: eng, jm: jm, ar: ar, base: base, mem: mem, hosts: imports.Funcs, hostLog: hostLog, globals: globals, globalCells: globalCells,
+		c: c, eng: eng, jm: jm, ar: ar, base: base, mem: mem, linMem: jm.LinearMemory(), hosts: imports.Funcs, hostLog: hostLog, globals: globals, globalCells: globalCells,
 		serArgs: serArgs, results: results, trap: trap, resultVals: make([]Value, maxResults),
 	}, nil
 }
@@ -198,4 +199,4 @@ func (in *Instance) Close() {
 }
 
 // LinearMemory exposes the instance's linear memory for zero-copy access.
-func (in *Instance) LinearMemory() []byte { return in.jm.LinearMemory() }
+func (in *Instance) LinearMemory() []byte { return in.linMem }

--- a/src/wago/memory_access.go
+++ b/src/wago/memory_access.go
@@ -28,13 +28,15 @@ func (in *Instance) memPtr(offset uint32, size int) (unsafe.Pointer, bool) {
 	return unsafe.Add(unsafe.Pointer(&in.linMem[0]), offset), true
 }
 
-// ReadByte returns the byte at offset.
-func (in *Instance) ReadByte(offset uint32) (byte, bool) {
+// ReadUint8 returns the byte at offset. (Named Uint8, not Byte, so it does not
+// collide with the io.ByteReader.ReadByte() (byte, error) contract that go vet
+// enforces on any ReadByte method.)
+func (in *Instance) ReadUint8(offset uint32) (uint8, bool) {
 	p, ok := in.memPtr(offset, 1)
 	if !ok {
 		return 0, false
 	}
-	return *(*byte)(p), true
+	return *(*uint8)(p), true
 }
 
 // ReadUint16Le returns the little-endian uint16 at offset.
@@ -76,13 +78,14 @@ func (in *Instance) ReadFloat64Le(offset uint32) (float64, bool) {
 	return math.Float64frombits(v), ok
 }
 
-// WriteByte stores v at offset.
-func (in *Instance) WriteByte(offset uint32, v byte) bool {
+// WriteUint8 stores v at offset. (Named Uint8, not Byte, to avoid the
+// io.ByteWriter.WriteByte(byte) error contract that go vet enforces.)
+func (in *Instance) WriteUint8(offset uint32, v uint8) bool {
 	p, ok := in.memPtr(offset, 1)
 	if !ok {
 		return false
 	}
-	*(*byte)(p) = v
+	*(*uint8)(p) = v
 	return true
 }
 

--- a/src/wago/memory_access.go
+++ b/src/wago/memory_access.go
@@ -1,0 +1,148 @@
+package wago
+
+import (
+	"math"
+	"unsafe"
+)
+
+// Typed little-endian accessors over an instance's linear memory.
+//
+// They read/write through a single aligned machine load/store after one bounds
+// check, which is faster than reaching for encoding/binary on LinearMemory() —
+// and it closes the host-side gap under TinyGo, whose LLVM backend optimizes
+// encoding/binary's per-byte assembly less aggressively (see docs/tinygo.md;
+// ~0.43 ns/op vs ~1.6 ns/op for the binary idiom, at parity with the standard
+// toolchain). wago targets little-endian amd64, so a native load already yields
+// little-endian byte order.
+//
+// Each Read returns ok=false (and the zero value) when [offset, offset+size)
+// falls outside linear memory; each Write returns false and writes nothing. This
+// mirrors wazero's api.Memory bounds contract.
+
+// memPtr bounds-checks [offset, offset+size) against linear memory and returns a
+// pointer to that location. size must be >= 1.
+func (in *Instance) memPtr(offset uint32, size int) (unsafe.Pointer, bool) {
+	if uint64(offset)+uint64(size) > uint64(len(in.linMem)) {
+		return nil, false
+	}
+	return unsafe.Add(unsafe.Pointer(&in.linMem[0]), offset), true
+}
+
+// ReadByte returns the byte at offset.
+func (in *Instance) ReadByte(offset uint32) (byte, bool) {
+	p, ok := in.memPtr(offset, 1)
+	if !ok {
+		return 0, false
+	}
+	return *(*byte)(p), true
+}
+
+// ReadUint16Le returns the little-endian uint16 at offset.
+func (in *Instance) ReadUint16Le(offset uint32) (uint16, bool) {
+	p, ok := in.memPtr(offset, 2)
+	if !ok {
+		return 0, false
+	}
+	return *(*uint16)(p), true
+}
+
+// ReadUint32Le returns the little-endian uint32 at offset.
+func (in *Instance) ReadUint32Le(offset uint32) (uint32, bool) {
+	p, ok := in.memPtr(offset, 4)
+	if !ok {
+		return 0, false
+	}
+	return *(*uint32)(p), true
+}
+
+// ReadUint64Le returns the little-endian uint64 at offset.
+func (in *Instance) ReadUint64Le(offset uint32) (uint64, bool) {
+	p, ok := in.memPtr(offset, 8)
+	if !ok {
+		return 0, false
+	}
+	return *(*uint64)(p), true
+}
+
+// ReadFloat32Le returns the little-endian float32 at offset.
+func (in *Instance) ReadFloat32Le(offset uint32) (float32, bool) {
+	v, ok := in.ReadUint32Le(offset)
+	return math.Float32frombits(v), ok
+}
+
+// ReadFloat64Le returns the little-endian float64 at offset.
+func (in *Instance) ReadFloat64Le(offset uint32) (float64, bool) {
+	v, ok := in.ReadUint64Le(offset)
+	return math.Float64frombits(v), ok
+}
+
+// WriteByte stores v at offset.
+func (in *Instance) WriteByte(offset uint32, v byte) bool {
+	p, ok := in.memPtr(offset, 1)
+	if !ok {
+		return false
+	}
+	*(*byte)(p) = v
+	return true
+}
+
+// WriteUint16Le stores v at offset in little-endian order.
+func (in *Instance) WriteUint16Le(offset uint32, v uint16) bool {
+	p, ok := in.memPtr(offset, 2)
+	if !ok {
+		return false
+	}
+	*(*uint16)(p) = v
+	return true
+}
+
+// WriteUint32Le stores v at offset in little-endian order.
+func (in *Instance) WriteUint32Le(offset uint32, v uint32) bool {
+	p, ok := in.memPtr(offset, 4)
+	if !ok {
+		return false
+	}
+	*(*uint32)(p) = v
+	return true
+}
+
+// WriteUint64Le stores v at offset in little-endian order.
+func (in *Instance) WriteUint64Le(offset uint32, v uint64) bool {
+	p, ok := in.memPtr(offset, 8)
+	if !ok {
+		return false
+	}
+	*(*uint64)(p) = v
+	return true
+}
+
+// WriteFloat32Le stores v at offset in little-endian order.
+func (in *Instance) WriteFloat32Le(offset uint32, v float32) bool {
+	return in.WriteUint32Le(offset, math.Float32bits(v))
+}
+
+// WriteFloat64Le stores v at offset in little-endian order.
+func (in *Instance) WriteFloat64Le(offset uint32, v float64) bool {
+	return in.WriteUint64Le(offset, math.Float64bits(v))
+}
+
+// Read returns a copy of length bytes starting at offset, or ok=false if the
+// range falls outside linear memory. For zero-copy access use LinearMemory().
+func (in *Instance) Read(offset, length uint32) ([]byte, bool) {
+	if uint64(offset)+uint64(length) > uint64(len(in.linMem)) {
+		return nil, false
+	}
+	out := make([]byte, length)
+	copy(out, in.linMem[offset:offset+length])
+	return out, true
+}
+
+// Write copies b into linear memory at offset, returning false (and writing
+// nothing) if the range falls outside linear memory.
+func (in *Instance) Write(offset uint32, b []byte) bool {
+	if uint64(offset)+uint64(len(b)) > uint64(len(in.linMem)) {
+		return false
+	}
+	copy(in.linMem[offset:], b)
+	return true
+}

--- a/src/wago/memory_access_test.go
+++ b/src/wago/memory_access_test.go
@@ -1,0 +1,124 @@
+//go:build linux && amd64
+
+package wago
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// memprogWasm (wago_test.go) declares a linear memory, so it gives us an
+// instance to exercise the typed accessors without running its functions.
+
+func TestMemoryAccessors(t *testing.T) {
+	c, err := Compile(memprogWasm)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	in, err := Instantiate(c, nil)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+	lin := in.LinearMemory()
+	if len(lin) < 64 {
+		t.Fatalf("linear memory too small: %d", len(lin))
+	}
+
+	if !in.WriteUint32Le(8, 0xDEADBEEF) {
+		t.Fatal("WriteUint32Le")
+	}
+	if v, ok := in.ReadUint32Le(8); !ok || v != 0xDEADBEEF {
+		t.Fatalf("ReadUint32Le = %#x, %v", v, ok)
+	}
+	// The unsafe accessor and encoding/binary must agree (little-endian).
+	if got := binary.LittleEndian.Uint32(lin[8:]); got != 0xDEADBEEF {
+		t.Fatalf("raw slice = %#x, want matching accessor", got)
+	}
+
+	if !in.WriteUint64Le(16, 0x1122334455667788) {
+		t.Fatal("WriteUint64Le")
+	}
+	if v, ok := in.ReadUint64Le(16); !ok || v != 0x1122334455667788 {
+		t.Fatalf("ReadUint64Le = %#x, %v", v, ok)
+	}
+	if !in.WriteUint16Le(24, 0xABCD) {
+		t.Fatal("WriteUint16Le")
+	}
+	if v, ok := in.ReadUint16Le(24); !ok || v != 0xABCD {
+		t.Fatalf("ReadUint16Le = %#x, %v", v, ok)
+	}
+	if !in.WriteByte(26, 0x7F) {
+		t.Fatal("WriteByte")
+	}
+	if v, ok := in.ReadByte(26); !ok || v != 0x7F {
+		t.Fatalf("ReadByte = %#x, %v", v, ok)
+	}
+	if !in.WriteFloat32Le(28, 3.5) {
+		t.Fatal("WriteFloat32Le")
+	}
+	if v, ok := in.ReadFloat32Le(28); !ok || v != 3.5 {
+		t.Fatalf("ReadFloat32Le = %v, %v", v, ok)
+	}
+	if !in.WriteFloat64Le(32, 2.5) {
+		t.Fatal("WriteFloat64Le")
+	}
+	if v, ok := in.ReadFloat64Le(32); !ok || v != 2.5 {
+		t.Fatalf("ReadFloat64Le = %v, %v", v, ok)
+	}
+	if !in.Write(40, []byte("hello")) {
+		t.Fatal("Write")
+	}
+	if b, ok := in.Read(40, 5); !ok || string(b) != "hello" {
+		t.Fatalf("Read = %q, %v", b, ok)
+	}
+
+	// Out-of-range access returns false and writes nothing.
+	end := uint32(len(lin))
+	before := append([]byte(nil), lin[end-4:]...)
+	if _, ok := in.ReadUint32Le(end - 3); ok {
+		t.Fatal("ReadUint32Le straddling the end should fail")
+	}
+	if in.WriteUint32Le(end-3, 0x99999999) {
+		t.Fatal("WriteUint32Le straddling the end should fail")
+	}
+	if _, ok := in.ReadByte(end); ok {
+		t.Fatal("ReadByte at end should fail")
+	}
+	if _, ok := in.Read(end-2, 5); ok {
+		t.Fatal("Read past the end should fail")
+	}
+	if in.Write(end-2, []byte("xxxxx")) {
+		t.Fatal("Write past the end should fail")
+	}
+	for i, b := range lin[end-4:] {
+		if b != before[i] {
+			t.Fatalf("rejected write mutated memory at end-%d", 4-i)
+		}
+	}
+}
+
+// BenchmarkInstanceUint32 exercises the typed accessor on the real mmap-backed
+// linear memory (no DCE): a single bounds-checked aligned load/store, ~3-4x
+// faster than the encoding/binary idiom under TinyGo (see docs/tinygo.md).
+func BenchmarkInstanceUint32(b *testing.B) {
+	c, err := Compile(memprogWasm)
+	if err != nil {
+		b.Fatalf("Compile: %v", err)
+	}
+	in, err := Instantiate(c, nil)
+	if err != nil {
+		b.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sum uint32
+	for i := 0; i < b.N; i++ {
+		off := uint32(i&0x3FFF) * 4 // 0..65532, in range for a 64 KiB page
+		in.WriteUint32Le(off, uint32(i))
+		v, _ := in.ReadUint32Le(off)
+		sum += v
+	}
+	_ = sum
+}

--- a/src/wago/memory_access_test.go
+++ b/src/wago/memory_access_test.go
@@ -48,11 +48,11 @@ func TestMemoryAccessors(t *testing.T) {
 	if v, ok := in.ReadUint16Le(24); !ok || v != 0xABCD {
 		t.Fatalf("ReadUint16Le = %#x, %v", v, ok)
 	}
-	if !in.WriteByte(26, 0x7F) {
-		t.Fatal("WriteByte")
+	if !in.WriteUint8(26, 0x7F) {
+		t.Fatal("WriteUint8")
 	}
-	if v, ok := in.ReadByte(26); !ok || v != 0x7F {
-		t.Fatalf("ReadByte = %#x, %v", v, ok)
+	if v, ok := in.ReadUint8(26); !ok || v != 0x7F {
+		t.Fatalf("ReadUint8 = %#x, %v", v, ok)
 	}
 	if !in.WriteFloat32Le(28, 3.5) {
 		t.Fatal("WriteFloat32Le")
@@ -82,8 +82,8 @@ func TestMemoryAccessors(t *testing.T) {
 	if in.WriteUint32Le(end-3, 0x99999999) {
 		t.Fatal("WriteUint32Le straddling the end should fail")
 	}
-	if _, ok := in.ReadByte(end); ok {
-		t.Fatal("ReadByte at end should fail")
+	if _, ok := in.ReadUint8(end); ok {
+		t.Fatal("ReadUint8 at end should fail")
 	}
 	if _, ok := in.Read(end-2, 5); ok {
 		t.Fatal("Read past the end should fail")

--- a/src/wago/pinnedglobal_test.go
+++ b/src/wago/pinnedglobal_test.go
@@ -1,4 +1,8 @@
-//go:build linux && amd64
+//go:build linux && amd64 && !tinygo
+
+// Like callargs_test.go, this builds fixtures via wat2wasm through os/exec, which
+// TinyGo does not support, so it is excluded from the TinyGo build. See
+// docs/tinygo.md.
 
 package wago
 


### PR DESCRIPTION
## Summary

Makes wago build and run under **TinyGo** on `linux/amd64`, keeping the **no-cgo** guarantee. The full decode → validate → codegen → execute pipeline already compiled under TinyGo; the *only* blocker was `enterNative`, the foreign-stack trampoline the standard toolchain implements in Plan9 assembly (`trampoline_amd64.s`), which TinyGo cannot assemble.

## Approach — no cgo, no `.s`

A cgo trampoline would add a boundary transition on every wasm invocation — exactly the latency wago is built to avoid. Instead, the TinyGo build **generates the trampoline as machine code at run time** (the same way the engine already maps native code) and enters it through an `unsafe` func-value cast:

- TinyGo lowers an indirect func-value call to the **System V C ABI**, so `f(serArgs, linMem, trap, results)` lands the four args in `RDI/RSI/RDX/RCX` — precisely the `WasmWrapper` register mapping — and passes the func value's context word in `R8`.
- We smuggle the native code pointer through the context word (→ `R8`) and bake the foreign-stack top into the generated thunk as an immediate. The thunk switches `RSP`, `call`s `R8`, and restores the Go context, mirroring `trampoline_amd64.s` exactly.

Build tags keep the standard build **completely untouched**: the `.s` file and its bodyless declaration are now `!tinygo`; `trampoline_tinygo_amd64.go` supplies the TinyGo `enterNative`.

## Verification (TinyGo 0.41.1, linux/amd64)

- CLI built with TinyGo runs real modules identically to the standard toolchain: `fib`/`fact`/`fibrec`/`ack`/`sumto` (recursion across the foreign stack), `fib64`/`factmod` (i64), `harmonic` (f64), `sumsq` (linear memory), `countdown`/`sumlog` (host imports), `apply` (`call_indirect`).
- `make tinygo-test` — runtime + public-API suites pass under TinyGo.
- `TestTinyGoBoundedRunStability`: 50k native enter/exits with inter-run `GC()`, 0 errors.
- Standard `go build ./...` + `go test ./...` still fully green (no regression).
- TinyGo binary is also smaller (~2.4 MB vs ~3.2 MB).

## Notes / caveats (see `docs/tinygo.md`)

- `stress_test.go` asserts standard-Go runtime invariants (morestack relocation, `_Grunning`, adversarial concurrent `runtime.GC()`), so it's now `!tinygo` with a bounded-run counterpart in `stress_tinygo_test.go`.
- Under a **threaded** scheduler, a concurrent collection while native code runs would scan a thread stopped on the foreign stack; wago allocates nothing mid-run, so single-goroutine use is safe — use `-scheduler=tasks` if mixing with allocation-heavy concurrent goroutines. (TinyGo analogue of the existing "keep native runs bounded" contract.)
- The recursive decoder (`maxInstructionNestingDepth = 20000`) can overflow TinyGo's smaller goroutine stacks on pathologically deep modules; real modules are unaffected.

## Changes
- `trampoline_tinygo_amd64.go` (new) — runtime-generated trampoline + `enterNative`.
- `trampoline_asm_amd64.go` (new) — `!tinygo` bodyless decl (was inline in `engine_linux_amd64.go`).
- `trampoline_amd64.s`, `engine_linux_amd64.go`, `stress_test.go` — build-tag/decl adjustments.
- `stress_tinygo_test.go` (new), `docs/tinygo.md` (new), `make tinygo-build`/`tinygo-test`, README pointer, `.gitignore`.