### PR TITLE
feat(amd64): opt-in CodegenStats backend counters

### DIFF
--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -85,6 +85,7 @@ type cg struct {
 	poolUsed    int            // number of pinnedPool registers taken by pinned locals
 	reserved    [16]bool       // GPRs dedicated to pinned locals/globals (not allocatable as scratch)
 	opts        CompileOptions
+	stats       *CodegenStats // nil unless opts.Stats requested collection
 }
 
 // CompileOptions tunes code generation. The zero value is the safe default
@@ -94,6 +95,10 @@ type CompileOptions struct {
 	// a guard-page mapping + SIGSEGV handler (see runtime/sigtrap_linux_amd64.go).
 	// EXPERIMENTAL: only sound when the memory is backed by runtime guard pages.
 	ElideBoundsChecks bool
+
+	// Stats, when non-nil, accumulates backend code-generation counters across
+	// every function compiled with these options. It does not affect codegen.
+	Stats *CodegenStats
 }
 
 // Frame layout: saved ABI pointers, locals, then operand-stack spill slots.
@@ -124,6 +129,7 @@ func (g *cg) allocRegExcept(except Reg) Reg {
 			g.a.Store64(RBP, g.slotOff(i), r)
 			g.st[i] = ventry{kind: vSpill, slot: i}
 			g.busy[r] = true
+			g.stats.noteSpill()
 			return r
 		}
 	}
@@ -140,6 +146,7 @@ func (g *cg) ensureFree(r Reg) {
 		if g.st[i].kind == vReg && !g.st[i].fp && g.st[i].reg == r {
 			g.a.Store64(RBP, g.slotOff(i), r)
 			g.st[i] = ventry{kind: vSpill, slot: i}
+			g.stats.noteSpill()
 			break
 		}
 	}
@@ -168,6 +175,7 @@ func (g *cg) loadInto(dst Reg, e ventry) {
 		}
 	case vSpill:
 		g.a.Load64(dst, RBP, g.slotOff(e.slot))
+		g.stats.noteReload()
 	}
 }
 
@@ -470,6 +478,7 @@ func (g *cg) callOp(r *wasm.Reader) error {
 }
 
 func (g *cg) callInternal(localIdx int, ft *wasm.CompType) error {
+	g.stats.noteDirectCall()
 	g.emitWrapperCall(len(ft.Params), len(ft.Results), func() {
 		site := g.a.CallRel32()
 		g.relocs = append(g.relocs, callReloc{at: site, target: localIdx})
@@ -573,6 +582,7 @@ func (g *cg) emitWrapperCall(p, rN int, emitCall func()) {
 
 // callIndirect uses table entries {codePtr u64, sigID u32, pad u32}.
 func (g *cg) callIndirect(r *wasm.Reader) error {
+	g.stats.noteIndirectCall()
 	typeIdx, err := r.U32()
 	if err != nil {
 		return err
@@ -645,6 +655,7 @@ const (
 
 // callHost records imports for dispatch after returning to Go.
 func (g *cg) callHost(importIdx int, ft *wasm.CompType) error {
+	g.stats.noteHostCall()
 	if len(ft.Results) != 0 {
 		return fmt.Errorf("amd64: host import with results not yet supported")
 	}
@@ -700,8 +711,10 @@ func (g *cg) memEffectiveAddr(off uint32, size int) (Reg, int32) {
 	if g.opts.ElideBoundsChecks {
 		// Guard-page mode: linMem+ea+off+size lands in the 8 GiB reservation; an
 		// out-of-range ea hits a PROT_NONE page → SIGSEGV → trap. No inline check.
+		g.stats.noteBoundsElided()
 		return ea, disp
 	}
+	g.stats.noteBoundsCheck()
 	t := g.allocReg()
 	g.a.LeaDisp(t, ea, leaDisp) // t = ea + off + size
 	g.a.Load32(RSI, RDI, -8)    // memBytes (zero-extended)
@@ -998,7 +1011,7 @@ func compileFunc(m *wasm.Module, funcIdx int, opts CompileOptions) (code []byte,
 	}
 
 	a := &Asm{}
-	g := &cg{a: a, m: m, nLocals: nLocals, nResults: len(ft.Results), localParams: ft.Params, localRuns: c.Locals.Runs, opts: opts}
+	g := &cg{a: a, m: m, nLocals: nLocals, nResults: len(ft.Results), localParams: ft.Params, localRuns: c.Locals.Runs, opts: opts, stats: opts.Stats}
 	g.assignPinnedLocals()
 	g.assignPinnedGlobals()
 
@@ -1077,6 +1090,7 @@ func compileFunc(m *wasm.Module, funcIdx int, opts CompileOptions) (code []byte,
 	frame := 40 + 8*nLocals + 8*g.maxDepth
 	frame = (frame + 15) &^ 15
 	a.PatchU32(subRspAt, uint32(frame))
+	g.stats.noteFunction(len(a.B), g.maxDepth, len(g.pinned), len(g.pinnedGlob))
 	return a.B, g.relocs, nil
 }
 

--- a/src/core/compiler/backend/amd64/control.go
+++ b/src/core/compiler/backend/amd64/control.go
@@ -110,6 +110,7 @@ func (g *cg) flushBelow(n int) {
 
 // flush materializes the operand stack into canonical slots.
 func (g *cg) flush() {
+	g.stats.noteFlush(len(g.st))
 	for i := range g.st {
 		e := g.st[i]
 		switch e.kind {

--- a/src/core/compiler/backend/amd64/fuse.go
+++ b/src/core/compiler/backend/amd64/fuse.go
@@ -38,18 +38,21 @@ func (g *cg) cmpFused(r *wasm.Reader, cond Cond, w bool) error {
 			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
 				return err
 			}
+			g.stats.noteCompareFusion()
 			g.freeReg(g.emitCompare(w))
 			return g.fusedIf(r, cond)
 		case 0x0D: // br_if
 			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
 				return err
 			}
+			g.stats.noteCompareFusion()
 			g.freeReg(g.emitCompare(w))
 			return g.fusedBrIf(r, cond)
 		case 0x1B: // select
 			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
 				return err
 			}
+			g.stats.noteCompareFusion()
 			g.freeReg(g.emitCompare(w))
 			g.fusedSelect(cond, false, false)
 			return nil
@@ -76,18 +79,21 @@ func (g *cg) eqzFused(r *wasm.Reader, w bool) error {
 			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
 				return err
 			}
+			g.stats.noteCompareFusion()
 			g.freeReg(g.emitEqzTest(w))
 			return g.fusedIf(r, CondE)
 		case 0x0D: // br_if
 			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
 				return err
 			}
+			g.stats.noteCompareFusion()
 			g.freeReg(g.emitEqzTest(w))
 			return g.fusedBrIf(r, CondE)
 		case 0x1B: // select
 			if _, err := r.Byte(); err != nil { // consume the peeked consumer opcode
 				return err
 			}
+			g.stats.noteCompareFusion()
 			g.freeReg(g.emitEqzTest(w))
 			g.fusedSelect(CondE, false, false)
 			return nil

--- a/src/core/compiler/backend/amd64/stats.go
+++ b/src/core/compiler/backend/amd64/stats.go
@@ -1,0 +1,101 @@
+package amd64
+
+// CodegenStats accumulates backend code-generation counters. It is opt-in: set
+// CompileOptions.Stats to a non-nil value to collect. The default compile path
+// leaves it nil, and every helper below is a no-op on a nil receiver, so
+// instrumentation costs nothing when stats are not requested.
+//
+// Counters are running totals across every function compiled with the same
+// CompileOptions, with Functions tracking how many fed the bucket — divide by it
+// for the per-function ratios that drive single-pass tuning: spills/fn,
+// flushes/fn, flush-slots/fn, bounds-checks/fn, bytes/fn, and the call counts.
+//
+// This is a deliberately small first cut. The chokepoints instrumented here are
+// the ones with a single, unambiguous emit site; finer counters (constant folds,
+// local/tee peepholes) can be added as those paths gain dedicated helpers.
+type CodegenStats struct {
+	Functions          int // functions compiled into this bucket
+	BytesEmitted       int // machine-code bytes across function bodies (excludes inter-function padding)
+	Spills             int // register values forced to their canonical frame slot
+	Reloads            int // spilled values reloaded from a frame slot
+	Flushes            int // flush() calls (operand stack materialized at a control boundary)
+	FlushSlots         int // total stack entries materialized across all flushes
+	BoundsChecks       int // inline linear-memory bounds checks emitted
+	BoundsChecksElided int // memory accesses with the check elided (guard-page mode)
+	CompareFusions     int // comparisons fused into a following if/br_if/select (no setcc)
+	DirectCalls        int // direct internal calls (call)
+	IndirectCalls      int // call_indirect
+	HostCalls          int // imported host calls
+	PinnedLocals       int // integer locals pinned to registers
+	PinnedGlobals      int // mutable integer globals pinned to registers
+	MaxStackDepth      int // deepest symbolic operand stack seen across functions
+}
+
+func (s *CodegenStats) noteSpill() {
+	if s != nil {
+		s.Spills++
+	}
+}
+
+func (s *CodegenStats) noteReload() {
+	if s != nil {
+		s.Reloads++
+	}
+}
+
+func (s *CodegenStats) noteFlush(slots int) {
+	if s != nil {
+		s.Flushes++
+		s.FlushSlots += slots
+	}
+}
+
+func (s *CodegenStats) noteBoundsCheck() {
+	if s != nil {
+		s.BoundsChecks++
+	}
+}
+
+func (s *CodegenStats) noteBoundsElided() {
+	if s != nil {
+		s.BoundsChecksElided++
+	}
+}
+
+func (s *CodegenStats) noteCompareFusion() {
+	if s != nil {
+		s.CompareFusions++
+	}
+}
+
+func (s *CodegenStats) noteDirectCall() {
+	if s != nil {
+		s.DirectCalls++
+	}
+}
+
+func (s *CodegenStats) noteIndirectCall() {
+	if s != nil {
+		s.IndirectCalls++
+	}
+}
+
+func (s *CodegenStats) noteHostCall() {
+	if s != nil {
+		s.HostCalls++
+	}
+}
+
+// noteFunction records one compiled function's per-function totals.
+func (s *CodegenStats) noteFunction(bytes, maxDepth, pinnedLocals, pinnedGlobals int) {
+	if s == nil {
+		return
+	}
+	s.Functions++
+	s.BytesEmitted += bytes
+	s.PinnedLocals += pinnedLocals
+	s.PinnedGlobals += pinnedGlobals
+	if maxDepth > s.MaxStackDepth {
+		s.MaxStackDepth = maxDepth
+	}
+}

--- a/src/core/compiler/backend/amd64/stats_test.go
+++ b/src/core/compiler/backend/amd64/stats_test.go
@@ -1,0 +1,94 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"bytes"
+	"testing"
+)
+
+// statsWAT has two functions: $add (straight-line) and $main, which does a
+// bounds-checked load, a comparison fused into an `if`, and a direct call.
+const statsWAT = `(module
+  (memory 1)
+  (func $add (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add)
+  (func $main (param i32) (result i32)
+    local.get 0
+    i32.load
+    local.get 0
+    i32.const 10
+    i32.lt_s
+    (if (result i32)
+      (then local.get 0 i32.const 1 call $add)
+      (else i32.const 0))
+    i32.add))`
+
+func TestCodegenStatsCounters(t *testing.T) {
+	m := watToModule(t, statsWAT)
+
+	var s CodegenStats
+	if _, err := CompileModuleWith(m, CompileOptions{Stats: &s}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	if s.Functions != 2 {
+		t.Errorf("Functions = %d, want 2", s.Functions)
+	}
+	if s.BytesEmitted <= 0 {
+		t.Errorf("BytesEmitted = %d, want > 0", s.BytesEmitted)
+	}
+	if s.DirectCalls != 1 {
+		t.Errorf("DirectCalls = %d, want 1 (main calls add)", s.DirectCalls)
+	}
+	if s.BoundsChecks != 1 {
+		t.Errorf("BoundsChecks = %d, want 1 (one i32.load in default mode)", s.BoundsChecks)
+	}
+	if s.BoundsChecksElided != 0 {
+		t.Errorf("BoundsChecksElided = %d, want 0 in default mode", s.BoundsChecksElided)
+	}
+	if s.CompareFusions != 1 {
+		t.Errorf("CompareFusions = %d, want 1 (i32.lt_s fused into if)", s.CompareFusions)
+	}
+	if s.MaxStackDepth < 2 {
+		t.Errorf("MaxStackDepth = %d, want >= 2", s.MaxStackDepth)
+	}
+}
+
+// In guard-page mode the inline bounds check is elided, so the same load is
+// counted as elided rather than checked.
+func TestCodegenStatsBoundsElided(t *testing.T) {
+	m := watToModule(t, statsWAT)
+
+	var s CodegenStats
+	if _, err := CompileModuleWith(m, CompileOptions{ElideBoundsChecks: true, Stats: &s}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if s.BoundsChecks != 0 {
+		t.Errorf("BoundsChecks = %d, want 0 with ElideBoundsChecks", s.BoundsChecks)
+	}
+	if s.BoundsChecksElided != 1 {
+		t.Errorf("BoundsChecksElided = %d, want 1 with ElideBoundsChecks", s.BoundsChecksElided)
+	}
+}
+
+// Collecting stats must not perturb code generation: the bytes emitted with and
+// without a Stats sink must be identical.
+func TestCodegenStatsDoesNotAffectCodegen(t *testing.T) {
+	m := watToModule(t, statsWAT)
+
+	plain, err := CompileModuleWith(m, CompileOptions{})
+	if err != nil {
+		t.Fatalf("compile (plain): %v", err)
+	}
+	var s CodegenStats
+	withStats, err := CompileModuleWith(m, CompileOptions{Stats: &s})
+	if err != nil {
+		t.Fatalf("compile (stats): %v", err)
+	}
+	if !bytes.Equal(plain.Code, withStats.Code) {
+		t.Errorf("stats collection changed codegen: %d vs %d bytes", len(plain.Code), len(withStats.Code))
+	}
+}


### PR DESCRIPTION
Implements Phase 0 of OPTIMIZATIONS.md — the measurement harness that every subsequent single-pass optimization needs for before/after evidence.

## What
Adds an opt-in `CodegenStats` collected by the amd64 backend. Set `CompileOptions.Stats` to a non-nil sink; the default compile path leaves it nil and every counter helper no-ops on a nil receiver, so there is **zero cost and zero codegen change** when stats aren't requested (covered by a test).

Counters (module-wide totals + `Functions` for per-function ratios):
`BytesEmitted`, `Spills`, `Reloads`, `Flushes`, `FlushSlots`, `BoundsChecks`, `BoundsChecksElided`, `CompareFusions`, `DirectCalls`, `IndirectCalls`, `HostCalls`, `PinnedLocals`, `PinnedGlobals`, `MaxStackDepth`.

Instrumented at unambiguous chokepoints: register spill (`allocRegExcept`/`ensureFree`), reload (`loadInto`), `flush()`, the explicit/elided bounds-check split in `memEffectiveAddr`, the six fusion sites in `cmpFused`/`eqzFused`, the three call leaves, and the per-function tail.

## Scope
Deliberately a small first cut — only single-emit-site counters. Constant folds and local/tee peepholes are scattered across many sites and are left for when those paths gain dedicated helpers (noted in the type doc).

## Tests
`stats_test.go`: counter correctness (default + guard-page bounds modes) and a check that collecting stats does not perturb emitted bytes. Full backend suite + vet pass.