### PR TITLE
feat: enable trunc_sat conversions

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -38,7 +38,7 @@ Later proposals and engine/platform capabilities beyond the MVP.
 | Feature | Planned | Status |
 |---|:---:|---|
 | Sign-extension ops (`i32.extend8_s`, …) | ✓ | ✅ done |
-| Non-trapping float→int (`trunc_sat`) | ✓ | ⬜ planned |
+| Non-trapping float→int (`trunc_sat`) | ✓ | ✅ done |
 | Multi-value (multiple block/func results) | ✓ | 🚧 partial |
 | Reference types (`funcref`/`externref`, `select t`, `ref.*`, `table.get/set`, multi-table) | ✓ | 🚧 partial (`select t` done) |
 | Bulk memory (`memory.copy`/`fill`/`init`, `data.drop`, `table.*`) | ✓ | 🚧 partial (`memory.copy`/`memory.fill` done; `memory.init`, `data.drop`, `table.*` planned) |

--- a/spectest_exec_test.go
+++ b/spectest_exec_test.go
@@ -419,7 +419,9 @@ func (st *specState) assertTrap(c specCmd) (ok, skip bool, why string) {
 	case "undefined element":
 		matches = strings.Contains(msg, "indirect call") && strings.Contains(msg, "out of bounds")
 	case "integer overflow":
-		matches = strings.Contains(msg, "division overflow")
+		// wasm names both integer-division overflow and out-of-range float→int
+		// truncation "integer overflow"; wago reports them distinctly.
+		matches = strings.Contains(msg, "division overflow") || strings.Contains(msg, "conversion overflow")
 	case "integer divide by zero":
 		matches = strings.Contains(msg, "division by zero")
 	case "invalid conversion to integer":

--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -42,13 +42,16 @@ func DecodeValidate(data []byte) (*wasm.Module, error) {
 // It is a plain frontend-side set (no dependency on the public wago config) that
 // callers map their feature configuration onto.
 type Features struct {
-	SignExtension bool // i32/i64.extend{8,16,32}_s
-	BulkMemory    bool // memory.copy / memory.fill
+	SignExtension   bool // i32/i64.extend{8,16,32}_s
+	BulkMemory      bool // memory.copy / memory.fill
+	SaturatingTrunc bool // i32/i64.trunc_sat_f32/f64_s/u (non-trapping float→int)
 }
 
 // AllFeatures is the full optional set wago's backend lowers today; it is the
 // default applied by RejectUnsupported.
-func AllFeatures() Features { return Features{SignExtension: true, BulkMemory: true} }
+func AllFeatures() Features {
+	return Features{SignExtension: true, BulkMemory: true, SaturatingTrunc: true}
+}
 
 // RejectUnsupported rejects modules that require features not explicitly wired
 // through the current JIT/runtime, accepting wago's full optional feature set.
@@ -479,6 +482,12 @@ func (p supportPass) instructionKind(k wasm.InstrKind, context string) error {
 	case wasm.InstrMemoryCopy, wasm.InstrMemoryFill:
 		if !p.feat.BulkMemory {
 			return p.unsupported("instruction", k.String()+" (bulk-memory-operations disabled)", context)
+		}
+		return nil
+	case wasm.InstrI32TruncSatF32S, wasm.InstrI32TruncSatF32U, wasm.InstrI32TruncSatF64S, wasm.InstrI32TruncSatF64U,
+		wasm.InstrI64TruncSatF32S, wasm.InstrI64TruncSatF32U, wasm.InstrI64TruncSatF64S, wasm.InstrI64TruncSatF64U:
+		if !p.feat.SaturatingTrunc {
+			return p.unsupported("instruction", k.String()+" (nontrapping-float-to-int-conversion disabled)", context)
 		}
 		return nil
 	}

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -49,12 +49,12 @@ const (
 	// coreFeaturesWago is the optional set wago's single-pass backend lowers
 	// today; it is the default and the ceiling WithCoreFeatures is validated
 	// against. Bulk-memory here means the supported subset (memory.copy/fill).
-	// Multi-value, reference-types, SIMD, tail-call, and the non-trapping
-	// float-to-int conversions are not yet wired, so enabling them is rejected up
-	// front rather than silently mis-running.
+	// Multi-value, reference-types, SIMD, and tail-call are not yet wired, so
+	// enabling them is rejected up front rather than silently mis-running.
 	coreFeaturesWago = CoreFeatureMutableGlobal |
 		CoreFeatureSignExtensionOps |
-		CoreFeatureBulkMemoryOperations
+		CoreFeatureBulkMemoryOperations |
+		CoreFeatureNonTrappingFloatToIntConversion
 )
 
 // IsEnabled returns true if all bits in feature are set.
@@ -274,8 +274,9 @@ func (e *UnsupportedFeatureError) Error() string {
 // pass's gate.
 func (c *RuntimeConfig) frontendFeatures() frontend.Features {
 	return frontend.Features{
-		SignExtension: c.features.IsEnabled(CoreFeatureSignExtensionOps),
-		BulkMemory:    c.features.IsEnabled(CoreFeatureBulkMemoryOperations),
+		SignExtension:   c.features.IsEnabled(CoreFeatureSignExtensionOps),
+		BulkMemory:      c.features.IsEnabled(CoreFeatureBulkMemoryOperations),
+		SaturatingTrunc: c.features.IsEnabled(CoreFeatureNonTrappingFloatToIntConversion),
 	}
 }
 

--- a/src/wago/example_test.go
+++ b/src/wago/example_test.go
@@ -40,14 +40,14 @@ func Example_compileAndInvoke() {
 // SupportedFeatures reports what this build can compile.
 func ExampleSupportedFeatures() {
 	fmt.Println(wago.SupportedFeatures())
-	// Output: bulk-memory-operations|mutable-global|sign-extension-ops
+	// Output: bulk-memory-operations|mutable-global|nontrapping-float-to-int-conversion|sign-extension-ops
 }
 
 // A config is immutable; WithFeature returns a copy with one proposal toggled.
 func ExampleRuntimeConfig_WithFeature() {
 	cfg := wago.NewRuntimeConfig().WithFeature(wago.CoreFeatureBulkMemoryOperations, false)
 	fmt.Println(cfg.CoreFeatures())
-	// Output: mutable-global|sign-extension-ops
+	// Output: mutable-global|nontrapping-float-to-int-conversion|sign-extension-ops
 }
 
 func ExampleCoreFeatures_IsEnabled() {


### PR DESCRIPTION
Enables the non-trapping float→int (`trunc_sat`) conversions — the backend already implemented them (`truncsat.go`), but the frontend support pass rejected them, blocking the entire `conversions` spec file.

## Changes
- **Frontend:** new `Features.SaturatingTrunc`, gating the 8 `i32/i64.trunc_sat_f32/f64_s/u` kinds (mirrors the `SignExtension`/`BulkMemory` pattern).
- **Config:** added `CoreFeatureNonTrappingFloatToIntConversion` to `coreFeaturesWago` (the supported/default set) and mapped it in `frontendFeatures()`. The feature bit and name already existed.
- **Spec harness:** the spec names both integer-division overflow and out-of-range float→int truncation `"integer overflow"`; wago reports them with distinct messages, so the harness's `"integer overflow"` matcher now accepts the trunc-overflow message too.
- Updated the two feature-list `Example` tests and the FEATURES.md row (→ ✅).

## Result
- `conversions`: BLOCKED (618 skipped) → **581 passing** (12 remaining failures are a *separate* `convert_i64_u` sign bug, fixed next).
- Spec suite: **+581 passing assertions** (15,833 → 16,414), skips 2,295 → 1,702.

## Tests
Full suite + spec pass.