### PR TITLE
fix(amd64): unsigned i64 to float conversion

### DIFF
--- a/src/core/compiler/backend/amd64/asm.go
+++ b/src/core/compiler/backend/amd64/asm.go
@@ -209,6 +209,7 @@ const (
 	CondG  Cond = 0xF
 	CondP  Cond = 0xA // parity (ucomis unordered: PF=1)
 	CondNP Cond = 0xB // not parity (ordered: PF=0)
+	CondS  Cond = 0x8 // sign flag set (negative / top bit set)
 )
 
 func (a *Asm) SetccAL(c Cond) {

--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -1779,16 +1779,20 @@ func (g *cg) emitPlain(r *wasm.Reader, op byte) error {
 		g.i2f(false, false)
 	case op == 0xB3: // f32.convert_i32_u (zero-extended i32 as i64)
 		g.i2f(false, true)
-	case op == 0xB4, op == 0xB5: // f32.convert_i64_s/u
+	case op == 0xB4: // f32.convert_i64_s
 		g.i2f(false, true)
+	case op == 0xB5: // f32.convert_i64_u
+		g.i2fU64(false)
 	case op == 0xB6: // f32.demote_f64
 		g.fdemote()
 	case op == 0xB7: // f64.convert_i32_s
 		g.i2f(true, false)
 	case op == 0xB8: // f64.convert_i32_u
 		g.i2f(true, true)
-	case op == 0xB9, op == 0xBA: // f64.convert_i64_s/u
+	case op == 0xB9: // f64.convert_i64_s
 		g.i2f(true, true)
+	case op == 0xBA: // f64.convert_i64_u
+		g.i2fU64(true)
 	case op == 0xBB: // f64.promote_f32
 		g.fpromote()
 	case op == 0xBC: // i32.reinterpret_f32

--- a/src/core/compiler/backend/amd64/convert_test.go
+++ b/src/core/compiler/backend/amd64/convert_test.go
@@ -1,0 +1,57 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/runtime"
+)
+
+// Unsigned i64→float must treat the top bit as magnitude, not sign: a signed
+// cvtsi2sd is wrong for values >= 2^63.
+func TestConvertI64UToFloat(t *testing.T) {
+	run := func(op, resTy string, arg uint64) uint64 {
+		m := watToModule(t, "(module (func (export \"f\") (param i64) (result "+resTy+") local.get 0 "+op+"))")
+		code, err := CompileFunction(m, 0)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		eng, _ := runtime.NewEngine()
+		defer eng.Close()
+		jm, _ := runtime.NewJobMemory(1 << 16)
+		defer jm.Close()
+		ar, _ := runtime.NewArena(4096)
+		defer ar.Close()
+		mem, entry, _ := runtime.MapCode(code)
+		defer runtime.Unmap(mem)
+		sa, rs, tp := ar.Alloc(64), ar.Alloc(16), ar.Alloc(8)
+		binary.LittleEndian.PutUint64(sa, arg)
+		if err := eng.Call(entry, sa, jm.LinearMemory(), tp, rs); err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		return binary.LittleEndian.Uint64(rs)
+	}
+
+	cases := []uint64{
+		0,
+		1,
+		1 << 62,
+		1 << 63,            // 2^63: signed cvt would yield a negative
+		0x8000000000000001, // just above 2^63
+		0xFFFFFFFFFFFFFFFF, // 2^64-1
+		0xFFFFFFFFFFFFFC00, // exercises rounding near the top
+	}
+	for _, v := range cases {
+		gotD := math.Float64frombits(run("f64.convert_i64_u", "f64", v))
+		if want := float64(v); gotD != want {
+			t.Errorf("f64.convert_i64_u(%#x) = %v, want %v", v, gotD, want)
+		}
+		gotS := math.Float32frombits(uint32(run("f32.convert_i64_u", "f32", v)))
+		if want := float32(v); gotS != want {
+			t.Errorf("f32.convert_i64_u(%#x) = %v, want %v", v, gotS, want)
+		}
+	}
+}

--- a/src/core/compiler/backend/amd64/fp.go
+++ b/src/core/compiler/backend/amd64/fp.go
@@ -303,6 +303,30 @@ func (g *cg) i2f(f64, srcWide bool) {
 	g.pushFReg(xmm)
 }
 
+// i2fU64 converts an unsigned 64-bit integer to f32/f64. cvtsi2ss/sd is signed,
+// so for values >= 2^63 (top bit set) we halve with round-to-odd, convert, then
+// double — the standard sequence that avoids a double-rounding error.
+func (g *cg) i2fU64(f64 bool) {
+	gpr := g.materialize(g.pop())
+	xmm := g.allocFReg()
+	g.a.TestSelf(gpr, true) // test gpr,gpr (64-bit): SF = bit 63
+	big := g.a.JccPlaceholder(CondS)
+	g.a.Cvtsi2f(xmm, gpr, f64, true) // < 2^63: signed convert is exact
+	done := g.a.JmpPlaceholder()
+	g.a.PatchRel32(big, g.a.Len())
+	half := g.allocReg()
+	g.a.MovReg64(half, gpr)
+	g.a.ShiftImm(5, half, 1, true)   // shr half, 1
+	g.a.AluRI(4, gpr, 1, true)       // and gpr, 1  (round-to-odd: preserve the low bit)
+	g.a.AluRR(0x09, half, gpr, true) // or half, gpr
+	g.a.Cvtsi2f(xmm, half, f64, true)
+	g.a.FAdd(xmm, xmm, f64) // double
+	g.freeReg(half)
+	g.a.PatchRel32(done, g.a.Len())
+	g.freeReg(gpr)
+	g.pushFReg(xmm)
+}
+
 func (g *cg) fpromote() { // f32 -> f64
 	a := g.pop()
 	x := g.materializeF(a)


### PR DESCRIPTION
Fixes `f32/f64.convert_i64_u` for values ≥ 2^63. **Stacked on #50.**

## Cause
The wiring conflated the signed and unsigned i64→float opcodes — `0xB5` (`f32.convert_i64_u`) and `0xBA` (`f64.convert_i64_u`) both used the signed `cvtsi2ss/sd`, which interprets the top bit as a sign. So a u64 like `0xFFFF…` came out negative.

## Fix
A dedicated `i2fU64`: for values < 2^63 the signed convert is exact; for values ≥ 2^63 it halves with round-to-odd (`(x>>1) | (x&1)`), converts, and doubles — the standard sequence that avoids a double-rounding error. Added the `CondS` (sign-flag) condition the branch needs.

## Result
With trunc_sat already enabled (#50), this clears the rest of `conversions` **and** `float_exprs`:
- `conversions`: **PASS** (593/0)
- `float_exprs`: **PASS** (794/0)
- Spec suite: **46 → 48/58 files**.

## Tests
`TestConvertI64UToFloat` covers 0, 2^62, 2^63, just-above-2^63, 2^64−1, and a rounding case, for both f32 and f64. Full suite passes.