### PR TITLE
feat: run the start function at instantiate

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -29,7 +29,7 @@ notable MVP gap that blocks running arbitrary compiler output.
 | Tables + active element segments | ✓ | ✅ done |
 | Function imports / exports | ✓ | ✅ done (host imports: void, batched) |
 | Memory / table / global imports & exports | ✓ | 🚧 partial (global imports/exports done; memory/table import gaps, memory.grow pending) |
-| `start` function | ✓ | ⬜ planned |
+| `start` function | ✓ | ✅ done (local; imported/host start rejected) |
 
 ## Extra features (post-1.0)
 

--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -117,8 +117,8 @@ func (p supportPass) run() error {
 	if len(p.m.StringRefs) != 0 {
 		return p.unsupported("stringref", "section", "stringrefs section")
 	}
-	if p.m.Start != nil {
-		return p.unsupported("start", "function", fmt.Sprintf("start function %d", *p.m.Start))
+	if p.m.Start != nil && int(*p.m.Start) < p.m.ImportedFuncCount() {
+		return p.unsupported("start", "imported function", fmt.Sprintf("start function %d", *p.m.Start))
 	}
 	if err := p.globals(); err != nil {
 		return err

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -98,6 +98,10 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 			c.MemMaxPages = uint32(*lim.Max)
 		}
 	}
+	if m.Start != nil {
+		c.HasStart = true
+		c.StartLocalFunc = int(*m.Start) - m.ImportedFuncCount() // validated local & () -> ()
+	}
 	// Table 0 is the only table wired through the current runtime ABI.
 	for i := range m.Imports {
 		if m.Imports[i].Type.Kind == wasm.ExternFunc {

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -211,6 +211,9 @@ type Compiled struct {
 	MemMinPages uint32 // initial linear-memory size (pages); allocated at instantiate
 	MemMaxPages uint32 // grow ceiling (pages); 0 means use the engine default
 
+	HasStart       bool // module declares a (local) start function to run at instantiate
+	StartLocalFunc int  // its local function index (valid only when HasStart)
+
 	// boundsMode records how this code was compiled: BoundsChecksSignalsBased
 	// means the inline checks were elided and execution requires a guard-page
 	// memory + trap handler (Instantiate wires this up). Not serialized:

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -225,6 +225,18 @@ func Instantiate(c *Compiled, imports Imports) (*Instance, error) {
 	results := ar.Alloc(resultsBytes)
 	trap := ar.Alloc(8)
 
+	// Run the start function (() -> ()) now that memory, globals, table, and data
+	// are initialized. A trap here aborts instantiation.
+	if c.HasStart {
+		if c.StartLocalFunc < 0 || c.StartLocalFunc >= len(c.Entry) {
+			return nil, fmt.Errorf("start function index %d out of range", c.StartLocalFunc)
+		}
+		startEntry := base + uintptr(c.Entry[c.StartLocalFunc])
+		if err := eng.Call(startEntry, serArgs, jm.LinearMemory(), trap, results); err != nil {
+			return nil, fmt.Errorf("start function trapped: %w", err)
+		}
+	}
+
 	success = true
 	return &Instance{
 		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, mem: mem, linMem: jm.CurrentBytes(), hosts: imports.hostFuncs(), imports: imports, hostLog: hostLog, globals: globals, globalCells: globalCells,

--- a/src/wago/start_test.go
+++ b/src/wago/start_test.go
@@ -1,3 +1,5 @@
+//go:build linux && amd64 && !tinygo
+
 package wago
 
 import "testing"

--- a/src/wago/start_test.go
+++ b/src/wago/start_test.go
@@ -1,0 +1,41 @@
+package wago
+
+import "testing"
+
+// The start function runs during Instantiate, after memory/globals/data are set
+// up, so its side effects are visible to the first Invoke.
+func TestStartFunctionRuns(t *testing.T) {
+	bin := watToWasmCA(t, `(module
+		(memory 1)
+		(func $init (i32.store8 (i32.const 0) (i32.const 42)))
+		(start $init)
+		(func (export "get") (result i32) (i32.load8_u (i32.const 0))))`)
+	c, err := Compile(bin)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := Instantiate(c, nil)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	res, err := in.Invoke("get")
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if AsI32(res[0]) != 42 {
+		t.Errorf("start function did not run: get() = %d, want 42", AsI32(res[0]))
+	}
+}
+
+// A trap in the start function aborts instantiation.
+func TestStartFunctionTrapAbortsInstantiate(t *testing.T) {
+	bin := watToWasmCA(t, `(module (func $boom unreachable) (start $boom))`)
+	c, err := Compile(bin)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if _, err := Instantiate(c, nil); err == nil {
+		t.Fatal("trapping start should abort instantiation")
+	}
+}


### PR DESCRIPTION
Implements the WebAssembly `start` function — the last MVP feature gap. Independent of the conversions PRs (#50/#51).

## Changes
- **Frontend:** the support pass no longer blanket-rejects start; it allows a valid *local* start function (the validator already enforces it exists and is `() -> ()`), and rejects only an *imported* (host) start, which wago's deferred-log host model can't run at instantiate.
- **Metadata:** `Compiled.HasStart` + `StartLocalFunc` (a `HasStart` flag, not a sentinel, so a zero-value/deserialized `Compiled` never accidentally runs function 0).
- **Instantiate:** after memory/globals/table/data are initialized, the start function runs via `eng.Call`; a trap there aborts instantiation.

## Result
`start` spec file: BLOCKED → **PARTIAL** (6 local-start assertions pass, 0 fail; the 5 skips are imported/host start — `spectest.print_i32` — which remain unsupported). FEATURES.md MVP row → ✅.

## Tests
`TestStartFunctionRuns` (start's memory write is visible to the first Invoke) and `TestStartFunctionTrapAbortsInstantiate`. Full suite passes.