### PR TITLE
feat: support multi-page linear memory

### DIFF
--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -241,8 +241,9 @@ func (p supportPass) memories() error {
 	return nil
 }
 
-// checkMemType rejects memory shapes outside wago's current single-page,
-// non-shared, 32-bit model (used for both defined and imported memories).
+// checkMemType rejects memory shapes outside wago's non-shared, 32-bit model
+// (used for both defined and imported memories). Multi-page memories are
+// supported up to the 65535-page cap (4 GiB minus one page).
 func (p supportPass) checkMemType(mem wasm.MemType, ctx string) error {
 	if mem.Shared {
 		return p.unsupported("memory", "shared", ctx)
@@ -250,8 +251,8 @@ func (p supportPass) checkMemType(mem wasm.MemType, ctx string) error {
 	if mem.Limits.Addr64 {
 		return p.unsupported("memory", "memory64", ctx)
 	}
-	if mem.Limits.Min > 1 {
-		return p.unsupported("memory", fmt.Sprintf("minimum %d pages", mem.Limits.Min), ctx)
+	if mem.Limits.Min > 65535 {
+		return p.unsupported("memory", fmt.Sprintf("minimum %d pages exceeds 65535", mem.Limits.Min), ctx)
 	}
 	return nil
 }

--- a/src/core/compiler/frontend/frontend_test.go
+++ b/src/core/compiler/frontend/frontend_test.go
@@ -107,12 +107,12 @@ func TestAcceptsMemoryImport(t *testing.T) {
 }
 
 func TestRejectUnsupportedImports(t *testing.T) {
-	t.Run("memory min > 1 page", func(t *testing.T) {
+	t.Run("memory min above the 65535-page cap", func(t *testing.T) {
 		memImport := append(wasmtest.Name("env"), wasmtest.Name("mem")...)
-		memImport = append(memImport, 0x02, 0x00, 0x02) // min 2 pages
+		memImport = append(memImport, 0x02, 0x00, 0x80, 0x80, 0x04) // min 65536 pages (LEB)
 		mod := wasmtest.Module(wasmtest.Section(2, wasmtest.Vec(memImport)))
 		_, err := DecodeValidate(mod)
-		assertErrContains(t, err, "unsupported memory minimum 2 pages")
+		assertErrContains(t, err, "exceeds 65535")
 	})
 	t.Run("table", func(t *testing.T) {
 		tblImport := append(wasmtest.Name("env"), wasmtest.Name("t")...)


### PR DESCRIPTION
The frontend still rejected memories with `min > 1` page ("single-page model") — a restriction made stale by `memory.grow` (#46), which already reserves and sizes up to 65535 pages. This lifts it to the real 65535-page cap for both defined and imported memory types.

- `checkMemType`: reject `min > 65535` instead of `min > 1`.
- Updated the frontend test (min-2 is now accepted; the ceiling test uses min 65536).

Verified a defined 3-page module stores/loads correctly at an offset in page 3. `imports` spec file advances past the memory-min block (now gated on table exports, a separate feature). Full suite passes.