### PR TITLE
fix(amd64): float results from calls land in XMM registers

### DIFF
--- a/src/core/compiler/backend/amd64/compile.go
+++ b/src/core/compiler/backend/amd64/compile.go
@@ -513,7 +513,7 @@ func (g *cg) callInternal(localIdx int, ft *wasm.CompType) error {
 		g.emitRegisterCall(localIdx, ft)
 		return nil
 	}
-	g.emitWrapperCall(len(ft.Params), len(ft.Results), func() {
+	g.emitWrapperCall(ft.Params, ft.Results, func() {
 		site := g.a.CallRel32()
 		g.relocs = append(g.relocs, callReloc{at: site, target: localIdx})
 	})
@@ -557,7 +557,8 @@ func (g *cg) storeArgToRsp(disp int32, e ventry) {
 // emitWrapperCall uses the WasmWrapper ABI over native-stack arg/result slots.
 // Operands below the arguments are flushed to their slots; the arguments
 // themselves are written straight into the buffer from their live locations.
-func (g *cg) emitWrapperCall(p, rN int, emitCall func()) {
+func (g *cg) emitWrapperCall(params, results []wasm.ValType, emitCall func()) {
+	p, rN := len(params), len(results)
 	depth := len(g.st)
 	g.flushBelow(depth - p)
 	buf := align16((p + rN) * 8)
@@ -601,16 +602,31 @@ func (g *cg) emitWrapperCall(p, rN int, emitCall func()) {
 	g.a.PatchRel32(ok, g.a.Len())
 
 	g.st = g.st[:depth-p]
+	// Load each result out of the rsp buffer. Float results must land in an XMM
+	// register (via RSI, a non-allocatable scratch) and be pushed as fp entries;
+	// loading them into a GPR would corrupt the operand stack's type.
 	res := make([]Reg, rN)
+	fp := make([]bool, rN)
 	for i := 0; i < rN; i++ {
-		res[i] = g.allocReg()
-		g.a.LoadRsp64(res[i], int32(p*8+i*8))
+		if isFloatType(results[i]) {
+			xmm := g.allocFReg()
+			g.a.LoadRsp64(RSI, int32(p*8+i*8))
+			g.a.MovGprToXmm(xmm, RSI, wasm.EqualValType(results[i], wasm.F64))
+			res[i], fp[i] = xmm, true
+		} else {
+			res[i] = g.allocReg()
+			g.a.LoadRsp64(res[i], int32(p*8+i*8))
+		}
 	}
 	if buf > 0 {
 		g.a.AddRsp(int32(buf))
 	}
 	for i := 0; i < rN; i++ {
-		g.pushReg(res[i])
+		if fp[i] {
+			g.pushFReg(res[i])
+		} else {
+			g.pushReg(res[i])
+		}
 	}
 }
 
@@ -674,7 +690,7 @@ func (g *cg) callIndirect(r *wasm.Reader) error {
 	g.freeReg(code)
 	g.freeReg(lm)
 
-	g.emitWrapperCall(len(ft.Params), len(ft.Results), func() {
+	g.emitWrapperCall(ft.Params, ft.Results, func() {
 		g.a.Load64(RAX, RSI, -int32(offSpillRegion)) // RSI = linMem; reload codePtr
 		g.a.CallReg(RAX)
 	})

--- a/src/core/compiler/backend/amd64/floatcall_test.go
+++ b/src/core/compiler/backend/amd64/floatcall_test.go
@@ -1,0 +1,53 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/runtime"
+)
+
+// A float result returned by a call must land in an XMM register, so a
+// subsequent float op consumes it correctly (regression: it was pushed as an
+// integer and read from the wrong register file).
+func TestCallFloatResult(t *testing.T) {
+	// f() = f32.neg(callee()) where callee() returns 1.5 → -1.5
+	m := watToModule(t, `(module
+		(func $c (result f32) f32.const 1.5)
+		(func (export "f") (result f32) call $c f32.neg)
+		(func $cd (result f64) f64.const 2.25)
+		(func (export "g") (result f64) call $cd f64.neg)
+		(func $id (param f32) (result f32) local.get 0)
+		(func (export "h") (result f32) f32.const 3.5 call $id f32.abs))`)
+	cm, err := CompileModuleWith(m, CompileOptions{})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	eng, _ := runtime.NewEngine()
+	defer eng.Close()
+	jm, _ := runtime.NewJobMemory(1 << 16)
+	defer jm.Close()
+	ar, _ := runtime.NewArena(4096)
+	defer ar.Close()
+	mem, base, _ := runtime.MapCode(cm.Code)
+	defer runtime.Unmap(mem)
+	sa, rs, tp := ar.Alloc(64), ar.Alloc(16), ar.Alloc(8)
+	call := func(fn int) uint64 {
+		if err := eng.Call(base+uintptr(cm.Entry[fn]), sa, jm.LinearMemory(), tp, rs); err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		return binary.LittleEndian.Uint64(rs)
+	}
+	if got := math.Float32frombits(uint32(call(1))); got != -1.5 { // f
+		t.Errorf("f32.neg(call) = %v, want -1.5", got)
+	}
+	if got := math.Float64frombits(call(3)); got != -2.25 { // g
+		t.Errorf("f64.neg(call) = %v, want -2.25", got)
+	}
+	if got := math.Float32frombits(uint32(call(5))); got != 3.5 { // h: abs(id(3.5))
+		t.Errorf("f32.abs(call arg passthrough) = %v, want 3.5", got)
+	}
+}


### PR DESCRIPTION
Fixes wrong values for **float results returned by `call`/`call_indirect`** — the last real correctness bug in the core call path.

## Cause
`emitWrapperCall` loaded *every* result out of the rsp buffer into a **GP register** and pushed it as an integer operand-stack entry. A float result then had its bits sitting in a GPR but tagged as an integer, so a subsequent float op (or float return) read it from the wrong register file. `emitWrapperCall` didn't even receive the result types.

## Fix
Thread the result types into `emitWrapperCall`. For a float result, load the bits into an XMM register (via the non-allocatable `RSI` scratch) and push it as an `fp` entry; integer results are unchanged. Arguments already round-trip correctly through the GP intermediary.

## Result
- `call`: **PASS** (72/0); `call_indirect`: **PASS** (122/0) — both were FAIL.
- Spec suite: **48 → 50/58 files**.

## Tests
`TestCallFloatResult` covers `f32.neg`/`f64.neg` applied to a call result and a float argument passed through a call. Full suite passes.