### PR TITLE
feat: accept table exports

### DIFF
--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -277,7 +277,9 @@ func (p supportPass) exports() error {
 		case wasm.ExternFunc, wasm.ExternGlobal:
 			// Supported metadata is serialized for function and numeric-global exports.
 		case wasm.ExternTable:
-			return p.unsupported("export", "table", ctx)
+			// Table exports are metadata-only for wago today: the instance keeps
+			// its table internally for call_indirect. Accepting them keeps MVP
+			// modules that export a table runnable (there is no host table object).
 		case wasm.ExternMem:
 			// Memory exports are metadata-only for wago today; the instance exposes
 			// linear memory directly, and preserving this keeps current MVP modules


### PR DESCRIPTION
Accept `(export "..." (table N))` at the support pass instead of rejecting it. wago keeps its table internally for `call_indirect`; a table export is metadata-only (there is no host-facing table object yet), exactly like the memory export it sits next to. This lets MVP modules that export a table compile and run.

Spec suite: `exports` file → **PASS**; **53 → 54/58 files**. Full suite passes.