### PR TITLE
fix: address Copilot review feedback

### DIFF
--- a/src/core/compiler/frontend/frontend_test.go
+++ b/src/core/compiler/frontend/frontend_test.go
@@ -106,6 +106,27 @@ func TestAcceptsMemoryImport(t *testing.T) {
 	}
 }
 
+func TestAcceptsMultiPageMemory(t *testing.T) {
+	// A defined memory with min 2 pages must be accepted (memory.grow made the
+	// single-page restriction obsolete).
+	mod := wasmtest.Module(wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x02}))) // flags 0, min 2
+	if _, err := DecodeValidate(mod); err != nil {
+		t.Fatalf("multi-page memory (min 2) should be accepted: %v", err)
+	}
+}
+
+func TestAcceptsTableExport(t *testing.T) {
+	// A module that defines a table and exports it must be accepted (the export is
+	// metadata-only; the table stays internal for call_indirect).
+	mod := wasmtest.Module(
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x00, 0x01})),        // table funcref, min 1
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("t", 1, 0))), // export table 0 as "t"
+	)
+	if _, err := DecodeValidate(mod); err != nil {
+		t.Fatalf("table export should be accepted: %v", err)
+	}
+}
+
 func TestRejectUnsupportedImports(t *testing.T) {
 	t.Run("memory min above the 65535-page cap", func(t *testing.T) {
 		memImport := append(wasmtest.Name("env"), wasmtest.Name("mem")...)

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -149,6 +149,23 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	return c, nil
 }
 
+// replayHostCalls dispatches the host-import calls a native call deferred into
+// the host-call log (the void, one-i32-arg model), on the Go stack. hostLog's
+// first u32 is the entry count; each 8-byte entry is [importIdx u32][arg u32].
+func replayHostCalls(hostLog []byte, imports []string, hosts map[string]HostFunc) {
+	n := binary.LittleEndian.Uint32(hostLog)
+	for i := uint32(0); i < n; i++ {
+		off := 8 + i*8
+		imp := binary.LittleEndian.Uint32(hostLog[off:])
+		arg := int32(binary.LittleEndian.Uint32(hostLog[off+4:]))
+		if int(imp) < len(imports) {
+			if fn := hosts[imports[imp]]; fn != nil {
+				fn(arg)
+			}
+		}
+	}
+}
+
 // MustCompile is like Compile but panics on error, for tests, examples, and
 // package-level initialization.
 func MustCompile(wasmBytes []byte) *Compiled {
@@ -263,6 +280,9 @@ func (c *Compiled) validate() error {
 		if off < 0 || off >= len(c.Code) {
 			return fmt.Errorf("compiled metadata invalid: Entry[%d] offset %d out of code range %d", i, off, len(c.Code))
 		}
+	}
+	if c.HasStart && (c.StartLocalFunc < 0 || c.StartLocalFunc >= len(c.Funcs)) {
+		return fmt.Errorf("compiled metadata invalid: start function index %d out of range", c.StartLocalFunc)
 	}
 	totalFuncs := c.NumImports + len(c.Funcs)
 	if len(c.FuncTypeID) != totalFuncs {
@@ -380,7 +400,7 @@ func (c *Compiled) validateDeferredOffsetGlobal(kind string, seg, idx int) error
 }
 
 const wagoMagic = "WAGO"
-const wagoVersion = 8
+const wagoVersion = 9
 
 // MarshalBinary serializes the precompiled module to a ".wago" blob.
 //
@@ -453,17 +473,7 @@ func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
 	if err := in.eng.Call(entry, in.serArgs, in.jm.LinearMemory(), in.trap, in.results); err != nil {
 		return nil, err
 	}
-	n := binary.LittleEndian.Uint32(in.hostLog)
-	for i := uint32(0); i < n; i++ {
-		off := 8 + i*8
-		imp := binary.LittleEndian.Uint32(in.hostLog[off:])
-		arg := int32(binary.LittleEndian.Uint32(in.hostLog[off+4:]))
-		if int(imp) < len(in.c.Imports) {
-			if fn := in.hosts[in.c.Imports[imp]]; fn != nil {
-				fn(arg)
-			}
-		}
-	}
+	replayHostCalls(in.hostLog, in.c.Imports, in.hosts)
 	out := in.resultVals[:len(sig.Results)]
 	for i := range sig.Results {
 		off := i * 8

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -37,6 +37,11 @@ func marshalCompiled(c *Compiled) ([]byte, error) {
 	w.elems(c.Elems)
 	w.data(c.Data)
 	w.str(c.memoryImport)
+	w.bool(c.HasMemory)
+	w.u32(c.MemMinPages)
+	w.u32(c.MemMaxPages)
+	w.bool(c.HasStart)
+	w.uvar(uint64(c.StartLocalFunc))
 	return w.buf, nil
 }
 
@@ -285,6 +290,23 @@ func unmarshalCompiled(c *Compiled, data []byte) error {
 	if err != nil {
 		return err
 	}
+	if c.HasMemory, err = r.bool(); err != nil {
+		return err
+	}
+	if c.MemMinPages, err = r.u32(); err != nil {
+		return err
+	}
+	if c.MemMaxPages, err = r.u32(); err != nil {
+		return err
+	}
+	if c.HasStart, err = r.bool(); err != nil {
+		return err
+	}
+	sf, err := r.uvar()
+	if err != nil {
+		return err
+	}
+	c.StartLocalFunc = int(sf)
 	if len(r.data) != 0 {
 		return fmt.Errorf("trailing %d byte(s)", len(r.data))
 	}

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -241,8 +241,13 @@ func (c *Compiled) memorySizeBytes() (initial, max int) {
 		maxPages = maxPagesCeil
 	}
 	// Honor the declared minimum exactly, including 0: a (memory 0) module has
-	// no in-bounds pages and memory.size reports 0 until it grows.
+	// no in-bounds pages and memory.size reports 0 until it grows. The one
+	// exception is guard-page (signals-based) mode, which maps exactly the initial
+	// size and needs a valid, non-empty linear-memory base — keep one page there.
 	initialPages := c.MemMinPages
+	if initialPages == 0 && c.boundsMode == BoundsChecksSignalsBased {
+		initialPages = 1
+	}
 	if initialPages > maxPages {
 		maxPages = initialPages
 	}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -226,15 +226,19 @@ func Instantiate(c *Compiled, imports Imports) (*Instance, error) {
 	trap := ar.Alloc(8)
 
 	// Run the start function (() -> ()) now that memory, globals, table, and data
-	// are initialized. A trap here aborts instantiation.
+	// are initialized. A trap here aborts instantiation. Host imports the start
+	// calls are deferred to the log, so reset it before and replay it after,
+	// exactly as Invoke does.
 	if c.HasStart {
 		if c.StartLocalFunc < 0 || c.StartLocalFunc >= len(c.Entry) {
 			return nil, fmt.Errorf("start function index %d out of range", c.StartLocalFunc)
 		}
+		binary.LittleEndian.PutUint32(hostLog, 0)
 		startEntry := base + uintptr(c.Entry[c.StartLocalFunc])
 		if err := eng.Call(startEntry, serArgs, jm.LinearMemory(), trap, results); err != nil {
 			return nil, fmt.Errorf("start function trapped: %w", err)
 		}
+		replayHostCalls(hostLog, c.Imports, imports.hostFuncs())
 	}
 
 	success = true

--- a/src/wago/start_test.go
+++ b/src/wago/start_test.go
@@ -30,6 +30,46 @@ func TestStartFunctionRuns(t *testing.T) {
 	}
 }
 
+// Marshal/Load must preserve the start function and memory-sizing metadata, and
+// the loaded module must still run its start.
+func TestCompiledRoundtripPreservesStartAndMemory(t *testing.T) {
+	bin := watToWasmCA(t, `(module
+		(memory 2 5)
+		(func $init (i32.store8 (i32.const 100000) (i32.const 7)))
+		(start $init)
+		(func (export "get") (result i32) (i32.load8_u (i32.const 100000))))`)
+	c, err := Compile(bin)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	c2, err := Load(blob)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !c2.HasStart || c2.StartLocalFunc != c.StartLocalFunc {
+		t.Fatalf("start metadata lost: HasStart=%v idx=%d", c2.HasStart, c2.StartLocalFunc)
+	}
+	if c2.MemMinPages != 2 || c2.MemMaxPages != 5 {
+		t.Fatalf("memory metadata lost: min=%d max=%d", c2.MemMinPages, c2.MemMaxPages)
+	}
+	in, err := Instantiate(c2, nil) // runs start on the loaded module
+	if err != nil {
+		t.Fatalf("instantiate loaded: %v", err)
+	}
+	defer in.Close()
+	res, err := in.Invoke("get")
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if AsI32(res[0]) != 7 {
+		t.Errorf("loaded module: get() = %d, want 7 (start ran into page 2)", AsI32(res[0]))
+	}
+}
+
 // A trap in the start function aborts instantiation.
 func TestStartFunctionTrapAbortsInstantiate(t *testing.T) {
 	bin := watToWasmCA(t, `(module (func $boom unreachable) (start $boom))`)


### PR DESCRIPTION
Addresses the five Copilot review comments on the recently-merged #52 (start), #54 (multi-page), #57 (memory floor), and #58 (table export).

## Real bugs
- **Guard-page 0-page crash (#57).** Dropping the 1-page floor let a `(memory 0)` module map 0 pages; in signals-based (guard-page) mode `NewJobMemoryGuarded(0)` yields an empty `LinearMemory()` slice → null base → fault. `memorySizeBytes` now keeps at least one page **only in signals-based mode**; explicit mode still honors `(memory 0)` exactly (so the spec `memory*` files stay green).
- **Start's deferred host calls dropped (#52).** `Instantiate` ran the start function without resetting/replaying the host-call log, so any host import a start triggered was silently lost. It now resets the log before and replays it after, exactly like `Invoke` (factored into a shared `replayHostCalls`).
- **Codec didn't persist start/memory metadata (#52).** `HasStart`/`StartLocalFunc` — and, already unnoticed, `HasMemory`/`MemMinPages`/`MemMaxPages` from #46 — weren't serialized, so a `Load`ed module skipped its start and lost its memory sizing. All five fields are now marshaled, `wagoVersion` bumped 8→9, and `validate()` rejects an out-of-range `StartLocalFunc`.

## Missing tests
- **Multi-page memory accepted (#54):** `TestAcceptsMultiPageMemory` (defined `min 2`).
- **Table export accepted (#58):** `TestAcceptsTableExport`.
- **Round-trip (#52):** `TestCompiledRoundtripPreservesStartAndMemory` marshals/loads a module with `(memory 2 5)` + a start, checks the fields survive, and confirms the loaded module still runs its start into page 2.

Full suite + guard-page build pass.