### PR TITLE
ci: nightly builds + prebuilt-binary curl installer

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,96 @@
+name: Nightly
+
+# Builds the size-minimized TinyGo CLI once a day and publishes it to a rolling
+# `nightly` prerelease (tag `nightly`, always pointed at the latest main commit).
+# The curl installer (wago.sh) fetches this when no stable release exists yet, or
+# when invoked with WAGO_VERSION=nightly.
+on:
+  schedule:
+    # 06:00 UTC daily (after most contributors' work has landed on main).
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION: "1.22"
+  TINYGO_VERSION: "0.41.1"
+
+jobs:
+  # Skip the build when main hasn't moved since the last nightly, so we don't
+  # churn out identical binaries. Manual runs always build.
+  check:
+    name: New commits since last nightly?
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Compare HEAD to the current nightly release
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "manual run: building"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          last=$(gh release view nightly \
+            --repo "${{ github.repository }}" \
+            --json targetCommitish -q .targetCommitish 2>/dev/null || true)
+          if [ "$last" = "$GITHUB_SHA" ]; then
+            echo "nightly already points at $GITHUB_SHA; skipping"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "main moved ($last -> $GITHUB_SHA); building"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Build & publish nightly (linux/amd64)
+    needs: check
+    if: needs.check.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: ${{ env.TINYGO_VERSION }}
+
+      # TinyGo links native linux/amd64 binaries with LLVM lld.
+      - name: Install lld
+        run: sudo apt-get update && sudo apt-get install -y lld
+
+      - name: Stamp version
+        id: ver
+        run: echo "version=nightly-$(date -u +%Y%m%d)-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      # Produces ./wago (size-minimized, version stamped via -ldflags -X).
+      - name: Build release binary
+        run: make build-release WAGO_VERSION="${{ steps.ver.outputs.version }}"
+
+      - name: Package + checksum
+        run: |
+          mv wago wago-linux-amd64
+          ./wago-linux-amd64 version
+          sha256sum wago-linux-amd64 | tee wago-linux-amd64.sha256
+
+      # Move the rolling `nightly` tag to this commit and refresh its release.
+      # Deleting first (with the tag) is what lets `create --target` retarget it.
+      - name: Publish rolling nightly release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete nightly --repo "${{ github.repository }}" --cleanup-tag --yes || true
+          gh release create nightly \
+            --repo "${{ github.repository }}" \
+            --target "$GITHUB_SHA" \
+            --title "Nightly ($(date -u +%Y-%m-%d))" \
+            --notes "Automated nightly build of \`${GITHUB_SHA::7}\` (${{ steps.ver.outputs.version }}), $(date -u +%Y-%m-%dT%H:%M:%SZ). Prerelease — unstable, may break without notice." \
+            --prerelease \
+            wago-linux-amd64 wago-linux-amd64.sha256

--- a/README.md
+++ b/README.md
@@ -47,17 +47,23 @@ Current target: **linux/amd64**.
 
 ## Installation
 
-CLI:
+CLI — the installer downloads a prebuilt `linux/amd64` binary from GitHub
+Releases (falling back to the rolling [nightly](https://github.com/wago-org/wago/releases/tag/nightly)
+build until a stable release exists):
 
 ```bash
-./wago.sh
+curl -fsSL https://wago.sh/install.sh | sh
 ```
 
-Once the hosted installer is live:
+Until wago.sh serves the installer, run it straight from the repo:
 
 ```bash
-curl -fsSL https://wago.sh | sh
+curl -fsSL https://raw.githubusercontent.com/wago-org/wago/main/wago.sh | sh
 ```
+
+Knobs: `WAGO_VERSION` (`latest`, `nightly`, or a tag like `v0.1.0`),
+`WAGO_BIN_DIR` (default `~/.local/bin`), `WAGO_FROM_SOURCE=1` to build with
+`go install` instead. From a checkout, just run `./wago.sh`.
 
 Library:
 

--- a/wago.sh
+++ b/wago.sh
@@ -1,84 +1,143 @@
 #!/bin/sh
+# wago installer — fetches a prebuilt binary from GitHub Releases.
+#
+#   curl -fsSL https://wago.sh/install.sh | sh
+#
+# Environment:
+#   WAGO_VERSION      release tag to install: "latest" (default), "nightly",
+#                     or an explicit tag like "v0.1.0". "latest" falls back to
+#                     the nightly build until a stable release exists.
+#   WAGO_BIN_DIR      install directory (default: $HOME/.local/bin)
+#   WAGO_FROM_SOURCE  set to 1 to build from source with `go install` instead
+#   WAGO_DRY_RUN      set to 1 to print what would happen and exit
+#   NO_COLOR          set to disable colored output
 set -eu
 
-repo="github.com/wago-org/wago"
-cmd="$repo/cli/wago"
+repo="wago-org/wago"
+asset="wago-linux-amd64"
 version="${WAGO_VERSION:-latest}"
-bin_dir="${WAGO_BIN_DIR:-}"
+bin_dir="${WAGO_BIN_DIR:-$HOME/.local/bin}"
+from_source="${WAGO_FROM_SOURCE:-0}"
 dry_run="${WAGO_DRY_RUN:-0}"
 
-say() {
-	printf '%s\n' "$*"
+# --- pretty output (the wago.sh "sparkle" palette) -------------------------
+if [ -z "${NO_COLOR:-}" ] && [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ]; then
+	e=$(printf '\033')
+	lilac="${e}[38;2;195;168;255m"
+	green="${e}[38;2;116;224;173m"
+	pink="${e}[38;2;255;158;196m"
+	dim="${e}[38;2;125;114;176m"
+	bold="${e}[1m"
+	reset="${e}[0m"
+else
+	lilac="" green="" pink="" dim="" bold="" reset=""
+fi
+
+banner() {
+	printf '%s' "$lilac"
+	printf '  ╦ ╦ ╔═╗ ╔═╗ ╔═╗\n'
+	printf '  ║║║ ╠═╣ ║ ╦ ║ ║\n'
+	printf '  ╚╩╝ ╩ ╩ ╚═╝ ╚═╝%s\n' "$reset"
+	printf '  %sa pure-Go WebAssembly JIT%s\n\n' "$dim" "$reset"
 }
 
+step() { printf '%s▸%s %s\n' "$lilac" "$reset" "$*"; }
+ok() { printf '  %s✓%s %s\n' "$green" "$reset" "$*"; }
+info() { printf '  %s%s%s\n' "$dim" "$*" "$reset"; }
 die() {
-	printf 'wago: %s\n' "$*" >&2
+	printf '%s✗ wago:%s %s\n' "$pink" "$reset" "$*" >&2
 	exit 1
 }
 
-need() {
-	command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
-}
+have() { command -v "$1" >/dev/null 2>&1; }
 
-go_env() {
-	go env "$1" 2>/dev/null || true
-}
-
-go_version_ok() {
-	v=$(go env GOVERSION 2>/dev/null || go version | awk '{print $3}')
-	v=${v#go}
-	major=${v%%.*}
-	rest=${v#*.}
-	minor=${rest%%[!0-9]*}
-	case "$major:$minor" in
-		*[!0-9:]*|:|*:|"") return 1 ;;
-	esac
-	[ "$major" -gt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -ge 22 ]; }
-}
-
-os=$(uname -s 2>/dev/null || true)
-arch=$(uname -m 2>/dev/null || true)
-
-[ "$os" = "Linux" ] || die "unsupported OS: $os (wago currently targets linux/amd64)"
-case "$arch" in
-	x86_64|amd64) ;;
-	*) die "unsupported architecture: $arch (wago currently targets linux/amd64)" ;;
-esac
-
-need go
-go_version_ok || die "Go 1.22 or newer is required"
-
-if [ -z "$bin_dir" ]; then
-	gobin=$(go_env GOBIN)
-	if [ -n "$gobin" ]; then
-		bin_dir=$gobin
-	else
-		gopath=$(go_env GOPATH)
-		[ -n "$gopath" ] || gopath="$HOME/go"
-		bin_dir="$gopath/bin"
-	fi
-fi
-
-pkg="$cmd@$version"
-
-say "installing wago from $pkg"
-say "target: $bin_dir/wago"
-
-if [ "$dry_run" = "1" ]; then
-	say "dry run: GOBIN=$bin_dir go install $pkg"
-	exit 0
-fi
-
-mkdir -p "$bin_dir"
-GOBIN="$bin_dir" go install "$pkg"
-
-if [ -x "$bin_dir/wago" ]; then
-	"$bin_dir/wago" version
+# --- download helpers ------------------------------------------------------
+if have curl; then
+	fetch() { curl -fsSL "$1"; }
+	download() { curl -fsSL -o "$2" "$1"; }
+elif have wget; then
+	fetch() { wget -qO- "$1"; }
+	download() { wget -qO "$2" "$1"; }
 else
-	say "installed $bin_dir/wago"
+	fetch() { die "need curl or wget"; }
+	download() { die "need curl or wget"; }
 fi
 
+# Resolve WAGO_VERSION to a concrete release tag.
+resolve_tag() {
+	case "$version" in
+	nightly) printf 'nightly' ;;
+	latest | "")
+		# Newest stable release, or the rolling nightly if there are none yet.
+		tag=$(fetch "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null |
+			sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
+		[ -n "$tag" ] && printf '%s' "$tag" || printf 'nightly'
+		;;
+	*) printf '%s' "$version" ;;
+	esac
+}
+
+install_prebuilt() {
+	tag=$(resolve_tag)
+	base="https://github.com/$repo/releases/download/$tag"
+
+	step "installing wago ${bold}$tag${reset} (linux/amd64)"
+	if [ "$dry_run" = "1" ]; then
+		info "dry run: download $base/$asset -> $bin_dir/wago"
+		exit 0
+	fi
+
+	tmp=$(mktemp -d 2>/dev/null || mktemp -d -t wago)
+	trap 'rm -rf "$tmp"' EXIT
+
+	download "$base/$asset" "$tmp/wago" ||
+		die "could not download $base/$asset (try WAGO_FROM_SOURCE=1 to build from source)"
+
+	# Verify the checksum when sha256sum and the .sha256 asset are both available.
+	if have sha256sum && download "$base/$asset.sha256" "$tmp/wago.sha256" 2>/dev/null; then
+		expected=$(awk '{print $1}' "$tmp/wago.sha256")
+		actual=$(sha256sum "$tmp/wago" | awk '{print $1}')
+		[ "$expected" = "$actual" ] || die "checksum mismatch (expected $expected, got $actual)"
+		ok "checksum verified"
+	fi
+
+	mkdir -p "$bin_dir"
+	chmod +x "$tmp/wago"
+	mv "$tmp/wago" "$bin_dir/wago" || die "could not install to $bin_dir (set WAGO_BIN_DIR to a writable path)"
+	ok "installed $bin_dir/wago"
+}
+
+install_from_source() {
+	have go || die "Go 1.22+ is required to build from source (install Go, or use a prebuilt binary on linux/amd64)"
+	pkg="github.com/$repo/cli/wago@$version"
+	step "building wago from ${bold}$pkg${reset}"
+	if [ "$dry_run" = "1" ]; then
+		info "dry run: GOBIN=$bin_dir go install $pkg"
+		exit 0
+	fi
+	mkdir -p "$bin_dir"
+	GOBIN="$bin_dir" go install "$pkg"
+	ok "installed $bin_dir/wago"
+}
+
+banner
+
+os=$(uname -s 2>/dev/null || echo unknown)
+arch=$(uname -m 2>/dev/null || echo unknown)
+
+# Prebuilt binaries are linux/amd64 only; everything else builds from source.
+if [ "$from_source" != "1" ] && [ "$os" = "Linux" ] && { [ "$arch" = "x86_64" ] || [ "$arch" = "amd64" ]; }; then
+	install_prebuilt
+else
+	[ "$from_source" = "1" ] || info "no prebuilt binary for $os/$arch — building from source"
+	install_from_source
+fi
+
+# Confirm the install and nudge about PATH.
+if [ -x "$bin_dir/wago" ]; then
+	"$bin_dir/wago" version || true
+fi
 case ":$PATH:" in
-	*":$bin_dir:"*) ;;
-	*) say "add $bin_dir to PATH to run: wago" ;;
+*":$bin_dir:"*) ;;
+*) info "add $bin_dir to your PATH to run: wago" ;;
 esac


### PR DESCRIPTION
## What

- **Nightly builds & releases** — new `.github/workflows/nightly.yml` builds the size-minimized TinyGo `linux/amd64` binary daily (06:00 UTC) + on demand, and publishes it to a rolling `nightly` prerelease (tag always retargeted to the latest `main` commit). A pre-check skips the build when `main` hasn't moved since the last nightly.
- **Curl installer** — reworked `wago.sh` into a proper `curl … | sh` installer that downloads a prebuilt binary from GitHub Releases and verifies its sha256, instead of requiring a Go toolchain. `WAGO_VERSION=latest` (default) resolves to the newest stable release and falls back to `nightly` until one exists. Knobs: `WAGO_VERSION` / `WAGO_BIN_DIR` / `WAGO_FROM_SOURCE` / `WAGO_DRY_RUN` / `NO_COLOR`. Still builds from source (`go install`) for non-linux/amd64 or on `WAGO_FROM_SOURCE=1`.
- **Prettified output** — colored banner + step/ok/error output using the wago.sh website "sparkle" palette (lilac `#c3a8ff`, green `#74e0ad`, pink `#ff9ec4`), truecolor with graceful degradation for non-tty / `NO_COLOR` / `TERM=dumb`.
- **README** — updated the install section to the `curl -fsSL https://wago.sh/install.sh | sh` command, a raw-URL fallback, and the env knobs.

## Follow-up

For the branded `https://wago.sh/install.sh` URL to work, the website (`wago.sh`) needs to serve this script at `/install.sh` — tracked separately in the website repo.

## Test

- `sh -n wago.sh` passes; dry-runs verified for the prebuilt (nightly) and from-source paths, with and without color.
- `nightly.yml` validated as well-formed YAML; build steps mirror the proven `release.yml`.