### PR TITLE
build: versioned WebAssembly spec suite (make spec1/2/3) + per-version CI card; bench guard-default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,18 @@ jobs:
           # No go.sum (stdlib-only module) -> nothing to cache; avoids a warning.
           cache: false
 
+      # TinyGo (+ lld) so the card's "Build size" producer can build the
+      # size-minimized release CLI (make build-release).
+      - uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: "0.41.1"
+      - name: Install lld
+        run: sudo apt-get update && sudo apt-get install -y lld
+
       # wabt provides wast2json for the WebAssembly spec-suite card producer (and
       # wat2wasm for the codegen tests that feed coverage).
       - name: Install wabt (wast2json / wat2wasm)
-        run: sudo apt-get update && sudo apt-get install -y wabt
+        run: sudo apt-get install -y wabt
 
       # The spec-suite card producer replays the WebAssembly/testsuite; fetch only
       # that submodule (not the large C++ warp/ one).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,17 @@ jobs:
           # No go.sum (stdlib-only module) -> nothing to cache; avoids a warning.
           cache: false
 
-      # Same wabt dependency as the test job, so the amd64 codegen tests run and
-      # count toward coverage instead of skipping.
-      - name: Install wabt (wat2wasm)
+      # wabt provides wast2json for the WebAssembly spec-suite card producer (and
+      # wat2wasm for the codegen tests that feed coverage).
+      - name: Install wabt (wast2json / wat2wasm)
         run: sudo apt-get update && sudo apt-get install -y wabt
 
-      # `make card` runs the coverage + tests producers and assembles the CI info
+      # The spec-suite card producer replays the WebAssembly/testsuite; fetch only
+      # that submodule (not the large C++ warp/ one).
+      - name: Fetch spec testsuite submodule
+        run: git submodule update --init tests/spec
+
+      # `make card` runs the coverage + tests + spec producers and assembles the CI info
       # card (benchmarks/memory are still blank placeholders). On PRs,
       # CARD_BASELINE_REF measures main in a worktree for the "Δ vs main" columns,
       # so fetch main first.

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ card: ## Build the PR CI info card -> card.md (coverage + tests filled)
 	COVER_REPORT=$(CARD_DIR)/coverage.md scripts/coverage.sh >/dev/null
 	TESTS_REPORT=$(CARD_DIR)/tests.md scripts/tests-card.sh >/dev/null
 	SPEC_REPORT=$(CARD_DIR)/spec.md scripts/spec-card.sh >/dev/null
+	SIZE_REPORT=$(CARD_DIR)/size.md scripts/size-card.sh >/dev/null
 	CARD_DIR=$(CARD_DIR) CARD_FILE=$(CARD_FILE) scripts/pr-card.sh
 	@cat $(CARD_FILE)
 

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,34 @@ test: ## Build and run the test suite (host)
 	go build ./...
 	go test -count=1 ./...
 
+# Run the WebAssembly spec suite (the WebAssembly/testsuite submodule at
+# tests/spec) as a native execution oracle for the x64 backend: TestSpecSuiteExec
+# replays every assert_return / assert_trap through compiled code. spec1 is the
+# MVP core; spec2 / spec3 run the proposal tests that version added (wago skips
+# the features it does not implement yet). Needs wast2json (wabt) on PATH;
+# the env var is absolute because `go test` runs in the package directory.
+SPEC_DIR = $(CURDIR)/tests/spec
+define run-spec
+	@command -v wast2json >/dev/null 2>&1 || { echo "wast2json (wabt) not on PATH; install wabt (e.g. apt-get install wabt)"; exit 1; }
+	@test -f tests/spec/i32.wast || git submodule update --init tests/spec
+	WAGO_SPECTEST_DIR=$(SPEC_DIR) WAGO_SPEC_VERSION=$(1) go test -count=1 -run TestSpecSuiteExec -v ./src/wago/
+endef
+
+.PHONY: spec1
+spec1: ## Run the WebAssembly 1.0 (MVP core) spec suite against x64 (needs wast2json)
+	$(call run-spec,1.0)
+
+.PHONY: spec2
+spec2: ## Run the WebAssembly 2.0 proposal spec tests against x64 (needs wast2json)
+	$(call run-spec,2.0)
+
+.PHONY: spec3
+spec3: ## Run the WebAssembly 3.0 proposal spec tests against x64 (needs wast2json)
+	$(call run-spec,3.0)
+
+.PHONY: spec
+spec: spec1 spec2 spec3 ## Run the WebAssembly spec suite for all versions
+
 TINYGO ?= tinygo
 # wago runs native code on a dedicated foreign stack. TinyGo's conservative
 # collector with a threaded scheduler can stop a thread mid-run and scan that
@@ -122,6 +150,7 @@ card: ## Build the PR CI info card -> card.md (coverage + tests filled)
 	@mkdir -p $(CARD_DIR)
 	COVER_REPORT=$(CARD_DIR)/coverage.md scripts/coverage.sh >/dev/null
 	TESTS_REPORT=$(CARD_DIR)/tests.md scripts/tests-card.sh >/dev/null
+	SPEC_REPORT=$(CARD_DIR)/spec.md scripts/spec-card.sh >/dev/null
 	CARD_DIR=$(CARD_DIR) CARD_FILE=$(CARD_FILE) scripts/pr-card.sh
 	@cat $(CARD_FILE)
 
@@ -130,16 +159,16 @@ ci: ## Replay the full CI workflow locally in Docker (act)
 	scripts/ci-local.sh
 
 # Run the full suite and write the capture file, stamped with the current commit
-# (so bench-publish can tell whether it is current). Always runs.
+# (so bench-publish can tell whether it is current). Default to guard-page bounds
+# (-tags wago_guardpage + WAGO_BOUNDS=signals) — the faster, production-relevant
+# mode; use bench-noguard for explicit-bounds numbers.
 .PHONY: bench
-bench: ## Run the full suite and write the capture (bench/.bench-run.txt)
-	{ echo "# git $(HEAD_HASH)"; (cd bench && go test -run '^$$' -bench . -benchmem -count $(COUNT) -benchtime $(BENCHTIME) -timeout 0 .); } | tee $(BENCH_RUN)
+bench: ## Run the full suite under guard-page bounds and write the capture (bench/.bench-run.txt)
+	{ echo "# git $(HEAD_HASH)"; (cd bench && WAGO_BOUNDS=signals go test -run '^$$' -tags wago_guardpage -bench . -benchmem -count $(COUNT) -benchtime $(BENCHTIME) -timeout 0 .); } | tee $(BENCH_RUN)
 
-# Like `bench`, but builds with the guard-page bounds mode (-tags wago_guardpage)
-# so the capture reflects signals-based bounds checks.
-.PHONY: bench-guard
-bench-guard: ## Run the full suite under guard-page bounds and write the capture
-	{ echo "# git $(HEAD_HASH)"; (cd bench && go test -run '^$$' -tags wago_guardpage -bench . -benchmem -count $(COUNT) -benchtime $(BENCHTIME) -timeout 0 .); } | tee $(BENCH_RUN)
+.PHONY: bench-noguard
+bench-noguard: ## Run the full suite under explicit bounds and write the capture
+	{ echo "# git $(HEAD_HASH)"; (cd bench && go test -run '^$$' -bench . -benchmem -count $(COUNT) -benchtime $(BENCHTIME) -timeout 0 .); } | tee $(BENCH_RUN)
 
 # Build charts from the last capture into bench/out — no re-run, no publish.
 # Uses whatever capture exists. WARP is skipped unless WARP=<harness> is given.

--- a/docs/warp-x64-status-and-plan.md
+++ b/docs/warp-x64-status-and-plan.md
@@ -140,4 +140,4 @@ of wago's flush-to-canonical-memory-slots). **Measure on `memory_tree`, not json
 Do **A1 (spec-suite on x64)** — it's the gate that makes the whole port real.
 
 ## Housekeeping
-- `make bench-guard` runs the bench suite under guard-page bounds (`-tags wago_guardpage`).
+- `make bench` runs the bench suite under guard-page bounds by default (`-tags wago_guardpage` + `WAGO_BOUNDS=signals`); `make bench-noguard` for explicit bounds.

--- a/scripts/pr-card.sh
+++ b/scripts/pr-card.sh
@@ -14,6 +14,7 @@ marker="${CARD_MARKER:-<!-- wago-ci -->}"
 sections='coverage|Coverage
 benchmarks|Benchmarks
 tests|Tests
+spec|WebAssembly spec
 memory|Memory'
 
 {

--- a/scripts/pr-card.sh
+++ b/scripts/pr-card.sh
@@ -15,6 +15,7 @@ sections='coverage|Coverage
 benchmarks|Benchmarks
 tests|Tests
 spec|WebAssembly spec
+size|Build size
 memory|Memory'
 
 {

--- a/scripts/size-card.sh
+++ b/scripts/size-card.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# Emit the "Build size" section fragment for the CI card: the size of the
+# size-minimized TinyGo release CLI (`make build-release`), with a delta vs
+# CARD_BASELINE_REF (e.g. origin/main) built in a throwaway worktree. Fragment
+# format matches the other producers: line 1 is the <summary>, the rest is the
+# body. Degrades to a placeholder when TinyGo is unavailable.
+set -eu
+
+report="${SIZE_REPORT:-ci-card/size.md}"
+baseline_ref="${CARD_BASELINE_REF:-}"
+
+root=$(git rev-parse --show-toplevel) || {
+	printf 'wago: not inside a git repository\n' >&2
+	exit 1
+}
+cd "$root"
+
+placeholder() {
+	printf 'Build size — _%s_\n\n_No data._\n' "$1" >"$report"
+	printf 'Build size — %s\n' "$1"
+	exit 0
+}
+
+command -v tinygo >/dev/null 2>&1 || placeholder "TinyGo not installed"
+
+# build_size <dir>: build the release CLI in dir and echo its byte size (empty on
+# failure). The binary is written as <dir>/wago by `make build-release`.
+build_size() {
+	( cd "$1" && make build-release >/dev/null 2>&1 && wc -c < wago ) 2>/dev/null | tr -d ' '
+}
+
+human() {
+	awk -v b="$1" 'BEGIN { if (b>=1048576) printf "%.2f MB", b/1048576; else printf "%.0f KB", b/1024 }'
+}
+
+cur=$(build_size "$root"); cur=${cur:-0}
+[ "$cur" -gt 0 ] || placeholder "release build failed"
+
+have_base=0
+if [ -n "$baseline_ref" ] && git rev-parse --verify -q "$baseline_ref^{commit}" >/dev/null 2>&1; then
+	wt=$(mktemp -d)
+	if git worktree add --detach -q "$wt" "$baseline_ref" 2>/dev/null; then
+		base=$(build_size "$wt"); base=${base:-0}
+		[ "$base" -gt 0 ] && have_base=1
+	fi
+	git worktree remove --force "$wt" 2>/dev/null || true
+fi
+
+summary="Build size: $(human "$cur") (TinyGo release CLI)"
+if [ "$have_base" = 1 ]; then
+	d=$((cur - base))
+	dkb=$(awk -v d="$d" 'BEGIN { printf (d==0 ? "—" : "%+.1f KB"), d/1024 }')
+	[ "$dkb" != "—" ] && summary="$summary (Δ ${dkb} vs main)"
+	body=$(printf '| Binary | Size | Δ vs main |\n|---|---|---|\n| wago (TinyGo release, stripped) | %s | %s |\n' "$(human "$cur")" "$dkb")
+else
+	body=$(printf '| Binary | Size |\n|---|---|\n| wago (TinyGo release, stripped) | %s |\n' "$(human "$cur")")
+fi
+
+printf '%s\n%s\n' "$summary" "$body" >"$report"
+printf '%s\n' "$summary"

--- a/scripts/spec-card.sh
+++ b/scripts/spec-card.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+# Emit the "WebAssembly spec" section fragment for the CI card: per-version
+# pass/skip counts from TestSpecSuiteExec (1.0 MVP core + the 2.0/3.0 proposal
+# tests wago attempts). Fragment format matches the other producers: line 1 is the
+# <summary>, the rest is the body. Degrades to a placeholder when wast2json or the
+# tests/spec submodule is unavailable.
+set -eu
+
+report="${SPEC_REPORT:-ci-card/spec.md}"
+
+root=$(git rev-parse --show-toplevel) || {
+	printf 'wago: not inside a git repository\n' >&2
+	exit 1
+}
+cd "$root"
+
+placeholder() {
+	printf 'WebAssembly spec — _%s_\n\n_No data._\n' "$1" >"$report"
+	printf 'WebAssembly spec — %s\n' "$1"
+	exit 0
+}
+
+command -v wast2json >/dev/null 2>&1 || placeholder "wast2json (wabt) not installed"
+[ -f tests/spec/i32.wast ] || git submodule update --init tests/spec >/dev/null 2>&1 || true
+[ -f tests/spec/i32.wast ] || placeholder "tests/spec submodule not present"
+
+suite="$root/tests/spec"
+rows=""
+summary=""
+for v in 1.0 2.0 3.0; do
+	line=$(WAGO_SPECTEST_DIR="$suite" WAGO_SPEC_VERSION="$v" \
+		go test -count=1 -run TestSpecSuiteExec -v ./src/wago/ 2>/dev/null \
+		| grep -oE "TOTAL\[$v\]: assertions passed=[0-9]+ \| skipped modules=[0-9]+ skipped assertions=[0-9]+" || true)
+	passed=$(printf '%s' "$line" | sed -nE 's/.*passed=([0-9]+).*/\1/p'); passed=${passed:-0}
+	smod=$(printf '%s' "$line" | sed -nE 's/.*modules=([0-9]+).*/\1/p'); smod=${smod:-0}
+	sass=$(printf '%s' "$line" | sed -nE 's/.*assertions=([0-9]+)$/\1/p'); sass=${sass:-0}
+	case "$v" in
+		1.0) label="1.0 (MVP core)" ;;
+		*)   label="$v (proposals)" ;;
+	esac
+	rows="${rows}| ${label} | ${passed} | ${smod} / ${sass} |
+"
+	summary="${summary}${v} ${passed} · "
+done
+summary="WebAssembly spec: $(printf '%s' "$summary" | sed 's/ · $//')"
+
+body=$(printf '| Version | Passed | Skipped (modules / assertions) |\n|---|---|---|\n%s' "$rows")
+printf '%s\n%s\n' "$summary" "$body" >"$report"
+printf '%s\n' "$summary"

--- a/scripts/spec-card.sh
+++ b/scripts/spec-card.sh
@@ -34,16 +34,19 @@ for v in 1.0 2.0 3.0; do
 	passed=$(printf '%s' "$line" | sed -nE 's/.*passed=([0-9]+).*/\1/p'); passed=${passed:-0}
 	smod=$(printf '%s' "$line" | sed -nE 's/.*modules=([0-9]+).*/\1/p'); smod=${smod:-0}
 	sass=$(printf '%s' "$line" | sed -nE 's/.*assertions=([0-9]+)$/\1/p'); sass=${sass:-0}
+	# Pass rate = passed / (passed + skipped assertions): the share of that
+	# version's testsuite assertions wago runs and gets right.
+	pct=$(awk -v p="$passed" -v s="$sass" 'BEGIN { t=p+s; printf (t>0 ? "%.1f" : "0.0"), (t>0 ? 100*p/t : 0) }')
 	case "$v" in
 		1.0) label="1.0 (MVP core)" ;;
 		*)   label="$v (proposals)" ;;
 	esac
-	rows="${rows}| ${label} | ${passed} | ${smod} / ${sass} |
+	rows="${rows}| ${label} | ${pct}% | ${passed} | ${smod} / ${sass} |
 "
-	summary="${summary}${v} ${passed} · "
+	summary="${summary}${pct}% (${v}) · "
 done
 summary="WebAssembly spec: $(printf '%s' "$summary" | sed 's/ · $//')"
 
-body=$(printf '| Version | Passed | Skipped (modules / assertions) |\n|---|---|---|\n%s' "$rows")
+body=$(printf '| Version | Pass rate | Passed | Skipped (modules / assertions) |\n|---|---|---|---|\n%s' "$rows")
 printf '%s\n%s\n' "$summary" "$body" >"$report"
 printf '%s\n' "$summary"

--- a/src/wago/spectest_exec_test.go
+++ b/src/wago/spectest_exec_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -18,12 +19,12 @@ import (
 	"github.com/wago-org/wago/src/wago"
 )
 
-// execFiles are official WebAssembly testsuite .wast files whose modules are
-// within the runtime's execution scope. Each contributes assert_return /
-// assert_trap execution assertions that run compiled native code and compare
-// results against the spec's expected values — the real correctness oracle for
-// the code generator (bugs unit tests miss).
-var execFiles = []string{
+// coreFiles1_0 are the WebAssembly 1.0 (MVP) core testsuite .wast files whose
+// modules are within the runtime's execution scope. Each contributes
+// assert_return / assert_trap execution assertions that run compiled native code
+// and compare results against the spec's expected values — the real correctness
+// oracle for the code generator (bugs unit tests miss).
+var coreFiles1_0 = []string{
 	"i32", "i64", "f32", "f64", "f32_cmp", "f64_cmp", "f32_bitwise", "f64_bitwise",
 	"int_exprs", "int_literals", "float_literals", "float_exprs", "float_misc",
 	"conversions", "forward", "fac", "block", "loop", "if", "br", "br_if",
@@ -33,9 +34,90 @@ var execFiles = []string{
 	"memory_redundancy", "memory_size", "memory_grow", "left-to-right", "func_ptrs",
 }
 
+// proposalDirs maps a post-1.0 WebAssembly version to the testsuite proposal
+// directories that version introduced. wago is a 1.0 engine, so most of these are
+// skipped (its frontend rejects the features); the ones it does implement
+// (bulk-memory, sign-extension, non-trapping conversions) contribute real
+// assertions. The mapping lets `make spec-2.0` / `spec-3.0` and the CI card track
+// coverage as features are added.
+var proposalDirs = map[string][]string{
+	"2.0": {"bulk-memory-operations", "reference-types", "simd"},
+	"3.0": {"tail-call", "exception-handling", "function-references", "memory64"},
+}
+
+// versionOrder lists the post-1.0 versions from oldest to newest, so each new
+// test file is attributed to the earliest version that introduced it.
+var versionOrder = []string{"2.0", "3.0"}
+
+// specFilesForVersion returns the testsuite paths (relative to the suite root,
+// without the .wast extension) contributing to the given spec version. 1.0 is the
+// curated MVP core list; 2.0/3.0 are the proposal files that version *adds*.
+//
+// Each proposal directory is a full testsuite snapshot (the 1.0 core plus the
+// proposal's new tests, and it also inherits earlier proposals' files), so a file
+// is only counted once — for the earliest version that introduced it — by
+// excluding every basename already claimed by the suite root or a lower version.
+func specFilesForVersion(version, dir string) []string {
+	if version == "1.0" {
+		return coreFiles1_0
+	}
+	claimed := map[string]bool{} // .wast basenames already attributed
+	for _, name := range wastNames(dir) {
+		claimed[name] = true // the full 1.0 core at the suite root
+	}
+	var out []string
+	for _, v := range versionOrder {
+		for _, p := range proposalDirs[v] {
+			for _, name := range wastNames(filepath.Join(dir, "proposals", p)) {
+				if claimed[name] {
+					continue
+				}
+				claimed[name] = true
+				if v == version {
+					out = append(out, filepath.Join("proposals", p, strings.TrimSuffix(name, ".wast")))
+				}
+			}
+		}
+		if v == version {
+			break
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// wastNames returns the .wast file names directly in dir (empty if dir is absent).
+func wastNames(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".wast") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
 type specValue struct {
-	Type  string `json:"type"`
-	Value string `json:"value"`
+	Type string `json:"type"`
+	// Value is a JSON scalar string for numeric types (wast2json emits the bit
+	// pattern as a decimal string), but SIMD/reference proposals emit structured
+	// values (e.g. v128 lane arrays). Keep it raw so those files still parse; str()
+	// reports whether it is a plain string (numeric/NaN) this harness can handle.
+	Value json.RawMessage `json:"value"`
+}
+
+// str returns the value as a plain JSON string and whether it was one (false for
+// structured values like v128 lane arrays, which are out of this harness's scope).
+func (v specValue) str() (string, bool) {
+	var s string
+	if err := json.Unmarshal(v.Value, &s); err != nil {
+		return "", false
+	}
+	return s, true
 }
 
 type specAction struct {
@@ -61,8 +143,12 @@ type specExecFile struct {
 // Invoke expects: 32-bit types occupy the low word, 64-bit types the full word;
 // float bit patterns are carried verbatim (wast2json emits the bit pattern as an
 // unsigned decimal for every type, so int/float differ only by width).
-func specArgBits(t *testing.T, v specValue) (bits uint64, ok bool) {
-	n, err := strconv.ParseUint(v.Value, 10, 64)
+func specArgBits(v specValue) (bits uint64, ok bool) {
+	s, ok := v.str()
+	if !ok {
+		return 0, false // structured value (v128 lanes) — out of scope
+	}
+	n, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
 		return 0, false // non-numeric (e.g. ref.null / externref) — out of scope
 	}
@@ -75,13 +161,17 @@ func valueWidth64(typ string) bool { return typ == "i64" || typ == "f64" }
 // matchResult reports whether a raw Invoke result word matches the spec's
 // expected value, including the two NaN result classes.
 func matchResult(got uint64, want specValue) bool {
-	switch want.Value {
+	s, ok := want.str()
+	if !ok {
+		return false // structured expected value (v128) — unsupported here
+	}
+	switch s {
 	case "nan:canonical":
 		return isNaNClass(got, want.Type, true)
 	case "nan:arithmetic":
 		return isNaNClass(got, want.Type, false)
 	}
-	wbits, err := strconv.ParseUint(want.Value, 10, 64)
+	wbits, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
 		return false
 	}
@@ -137,18 +227,26 @@ func TestSpecSuiteExec(t *testing.T) {
 	if err != nil {
 		t.Skip("wast2json (wabt) not on PATH")
 	}
-	runSpecExec(t, wast2json, dir)
+	version := os.Getenv("WAGO_SPEC_VERSION")
+	if version == "" {
+		version = "1.0"
+	}
+	runSpecExec(t, wast2json, dir, version)
 }
 
-func runSpecExec(t *testing.T, wast2json, dir string) {
+func runSpecExec(t *testing.T, wast2json, dir, version string) {
 	tmp := t.TempDir()
+	files := specFilesForVersion(version, dir)
 	var totPass, totSkipMod, totSkipAssert int
-	for _, base := range execFiles {
+	for _, base := range files {
 		wast := filepath.Join(dir, base+".wast")
 		if _, err := os.Stat(wast); err != nil {
 			continue
 		}
-		jsonPath := filepath.Join(tmp, base+".json")
+		// base may contain path separators (proposal files); flatten it for the
+		// wast2json output name so all .json/.wasm land in tmp's root.
+		name := strings.ReplaceAll(base, string(filepath.Separator), "_")
+		jsonPath := filepath.Join(tmp, name+".json")
 		if out, err := exec.Command(wast2json, "--enable-all", wast, "-o", jsonPath).CombinedOutput(); err != nil {
 			t.Logf("%s: wast2json failed (%v): %s", base, err, out)
 			continue
@@ -166,11 +264,13 @@ func runSpecExec(t *testing.T, wast2json, dir string) {
 		totPass += pass
 		totSkipMod += skipMod
 		totSkipAssert += skipAssert
-		t.Logf("%-18s pass=%d  skip(mod=%d assert=%d)", base, pass, skipMod, skipAssert)
+		t.Logf("%-40s pass=%d  skip(mod=%d assert=%d)", base, pass, skipMod, skipAssert)
 	}
-	t.Logf("TOTAL[x64]: assertions passed=%d | skipped modules=%d skipped assertions=%d",
-		totPass, totSkipMod, totSkipAssert)
-	if totPass == 0 {
+	t.Logf("TOTAL[%s]: assertions passed=%d | skipped modules=%d skipped assertions=%d",
+		version, totPass, totSkipMod, totSkipAssert)
+	// 1.0 must exercise real assertions; 2.0/3.0 legitimately skip everything wago
+	// does not implement yet, so zero passes there is expected, not a misconfig.
+	if version == "1.0" && totPass == 0 {
 		t.Errorf("no execution assertions ran — harness or corpus misconfigured")
 	}
 }
@@ -255,7 +355,7 @@ func invokeAction(c specExecCmd, m specModule, t *testing.T) (res []uint64, inSc
 	}
 	args := make([]uint64, len(c.Action.Args))
 	for i, a := range c.Action.Args {
-		bits, ok := specArgBits(t, a)
+		bits, ok := specArgBits(a)
 		if !ok {
 			return nil, false, nil // non-numeric arg — out of scope
 		}
@@ -302,7 +402,7 @@ func runTrapAssert(t *testing.T, base string, c specExecCmd, m specModule) bool 
 func argValues(args []specValue) string {
 	parts := make([]string, len(args))
 	for i, a := range args {
-		parts[i] = a.Value
+		parts[i] = string(a.Value)
 	}
 	return strings.Join(parts, ",")
 }


### PR DESCRIPTION
Runs the WebAssembly spec suite against the x64 backend, **versioned**, and surfaces per-version pass rates on the PR CI card. Also defaults `make bench` to guard-page bounds.

The `WebAssembly/testsuite` submodule already lives at `tests/spec` (pinned to `a8bcbaf`, which the widely-available wabt 1.0.34 parses cleanly).

### Make targets
```
make spec1   # WebAssembly 1.0 (MVP core)  -> 15346 assertions pass
make spec2   # 2.0 proposals               -> 4481 pass (bulk-memory subset; reftypes/SIMD skipped)
make spec3   # 3.0 proposals               -> ~none yet (tail-call/EH/func-refs/memory64 unsupported)
make spec    # all of the above
```
Each replays every `assert_return` / `assert_trap` through compiled x64 code. `WAGO_SPECTEST_DIR` is passed absolute (`go test` runs in the package dir); the submodule auto-inits if missing.

### bench defaults to guard-page bounds
`make bench` now runs under guard-page bounds (`-tags wago_guardpage` + `WAGO_BOUNDS=signals`) — the faster, production-relevant mode (e.g. `memory_tree` ~12µs vs ~17µs explicit). `make bench-noguard` gives explicit-bounds numbers. (Replaces the old `bench-guard`, which only set the build tag and so never actually benched guard mode.)

### Harness
`TestSpecSuiteExec` reads `WAGO_SPEC_VERSION`. 1.0 is the curated MVP core list; 2.0/3.0 are the proposal files that version *adds* — each proposal dir is a full testsuite snapshot, so files are deduped by basename against the suite root and lower versions, counting each new-feature file once in its earliest version. Value fields are parsed as `json.RawMessage` so SIMD/reference structured values (v128 lane arrays) no longer break parsing (treated as out-of-scope). 2.0/3.0 don't fail on all-skips (only 1.0 must exercise real assertions).

### CI card
A new **WebAssembly spec** section (`scripts/spec-card.sh`) reports a per-version table:

| Version | Passed | Skipped (modules / assertions) |
|---|---|---|
| 1.0 (MVP core) | 15346 | 2 / 48 |
| 2.0 (proposals) | 4481 | 511 / 26028 |
| 3.0 (proposals) | 1 | 75 / 747 |

The coverage job fetches only the `tests/spec` submodule (not the large C++ `warp/`). Degrades to a placeholder when wast2json or the submodule is unavailable.

---
**Update:** the spec card now reports **pass rates as percentages** — `WebAssembly spec: 99.7% (1.0) · 14.7% (2.0) · 0.1% (3.0)` (rate = passed / (passed + skipped assertions)). Added a **Build size** card section reporting the size-minimized TinyGo release CLI (`make build-release`, ~457 KB) with a Δ-vs-main; the coverage job gains TinyGo + lld to build it.
