### PR TITLE
fix(railshot): explicit-bounds STACK_REG desync corrupts pinned pointer in call+memory funcs

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -170,7 +170,16 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	hasCall := bodyHasCall(c.Body)
 	touchesMemory := bodyTouchesMemory(c.Body)
 	f.assignPinnedLocals(localHotness(c.Body, nLocals))
-	f.usesCalls = hasCall && !(guardMode && touchesMemory) && !noStackReg
+	// STACK_REG (lazy pinned-local spill) is disabled for memory-touching
+	// functions: the explicit-bounds path's per-access scratch allocation
+	// (memAddr) adds register pressure that desyncs the lazy local state,
+	// corrupting a pinned pointer local (observed on AssemblyScript blake3, a
+	// 39-local call+memory function — traps as a false OOB). Guard mode already
+	// excluded these (its memory-base pin conflicts with the pinned-local regs);
+	// making it unconditional keeps the eager save/reload model — correct in both
+	// modes — for any call+memory function. Compute-only call functions keep the
+	// lazy model (no memAddr pressure, so no desync).
+	f.usesCalls = hasCall && !touchesMemory && !noStackReg
 	selfIdx := uint32(m.ImportedFuncCount() + funcIdx)
 	f.lazyZero = bodyCalls(c.Body, selfIdx) && touchesMemory && len(c.BodyBytes) <= 192 && nLocals-len(ft.Params) <= 8
 

--- a/src/core/compiler/backend/railshot/hints.go
+++ b/src/core/compiler/backend/railshot/hints.go
@@ -122,8 +122,13 @@ func instrTouchesMemory(k wasm.InstrKind) bool {
 	}
 }
 
+// bodyUseStackReg mirrors the f.usesCalls gate (compile.go): the lazy STACK_REG
+// pinned-local model is used only for call functions that do NOT touch memory.
+// guardMode is retained for the signature but no longer affects the decision —
+// memory-touching functions are excluded in both modes (see compile.go).
 func bodyUseStackReg(body wasm.Expr, guardMode bool) bool {
-	return bodyHasCall(body) && !(guardMode && bodyTouchesMemory(body)) && !noStackReg
+	_ = guardMode
+	return bodyHasCall(body) && !bodyTouchesMemory(body) && !noStackReg
 }
 
 // localHotness returns per-local usage scores for the function body.

--- a/src/core/compiler/backend/railshot/hints_test.go
+++ b/src/core/compiler/backend/railshot/hints_test.go
@@ -34,11 +34,14 @@ func TestBodyMemoryCallHints(t *testing.T) {
 	if !bodyTouchesMemory(callMemory) {
 		t.Fatal("call+memory body should report memory")
 	}
+	// Memory-touching call functions use the eager spill/reload model in BOTH
+	// modes: STACK_REG's lazy state desyncs against the explicit-bounds memAddr
+	// scratch allocation (see compile.go).
 	if bodyUseStackReg(callMemory, true) {
 		t.Fatal("guard-mode call+memory body should use eager spill/reload")
 	}
-	if !bodyUseStackReg(callMemory, false) {
-		t.Fatal("explicit-bounds call+memory body should keep STACK_REG")
+	if bodyUseStackReg(callMemory, false) {
+		t.Fatal("explicit-bounds call+memory body should use eager spill/reload")
 	}
 	callMemory.Instrs[2].Index = 7
 	if !bodyCalls(callMemory, 7) {


### PR DESCRIPTION
## Bug

The railshot backend under **explicit bounds** miscompiled AssemblyScript's blake3 (a 39-local call+memory function): a pinned pointer local got corrupted, producing a wild address (`0x11A69F50`) → false `linear memory access out of bounds` trap. Guard mode and wazero both ran it correctly, and it worked on the pre-#63 backend — so it's a railshot explicit-bounds regression, surfaced by the new real-world corpus (blake-as) in #67.

## Root cause

The STACK_REG lazy pinned-local model (`f.usesCalls`) was active for **explicit-bounds** call+memory functions. The explicit path's per-access bounds check (`memAddr`) allocates scratch registers on every load/store; in a high-pressure call+memory function that extra allocation/spill desyncs the lazy pinned-local state, leaving a stale pinned register that later feeds a memory address.

Guard mode already excluded memory-touching functions from STACK_REG (`!(guardMode && touchesMemory)`) — that exclusion is exactly why guard mode was unaffected.

## Fix

Make the exclusion unconditional: use the eager save/reload local model (known-correct) for **any** call+memory function, in both bounds modes. Compute-only call functions keep the lazy STACK_REG model (no `memAddr` pressure → no desync), so the fast path for tight call loops (e.g. fib_rec) is unchanged. Guard mode (the default) is behaviorally unchanged.

## Validation

- blake `hashN(100)` explicit = `-1321215924` — matches guard mode and wazero exactly (correct, previously trapped).
- json-as / utf-as explicit exec correct.
- **Spec suite passes for 1.0 (15,346 assertions), 2.0, and 3.0.**
- `go test ./...` green; railshot package tests green; gofmt clean.

## How it was found

Diagnosed by instrumenting the trap path: leaked the failing effective address and function index (func 0, 39 locals), confirmed via a neuter test that the *address* was corrupted (not the check math), and isolated the subsystem with `WAGO_Amd64_NOSTACKREG=1` (which made it pass).
