### PR TITLE
perf(railshot): operand-stack-in-registers, phase 2 — register-merge single-int blocks (flag-gated)

### DIFF
--- a/docs/operand-stack-registers-plan.md
+++ b/docs/operand-stack-registers-plan.md
@@ -1,0 +1,89 @@
+# Operand-stack-in-registers refactor (WARP RegisterCopyResolver)
+
+## Goal
+
+Replace railshot's **canonical-slot** reconciliation at control boundaries with
+**register** reconciliation — WARP's model. Today, at every block / if / loop /
+branch / end, `flush()` writes the whole operand stack to position-indexed frame
+slots (`spillOff(i)`) and `setDepth` rebuilds it as slot entries; merges are
+trivial because all edges agree on slots. This costs a store+reload per operand
+per boundary. WARP instead keeps operands in registers across merges and shuffles
+them into a canonical register assignment at each edge via a parallel-move
+resolver. Target win: call/branch-heavy code (`memory_tree`), not json-as
+(memory-bound; leave it alone).
+
+Infra already present: `regcopy.go` `resolveRegMoves` (parallel move with cycle
+handling), used today for call args. Reuse it for edge reconciliation.
+
+## Current model (facts)
+
+- `flush()` (control.go): each operand i → `spillOff(i)`, deferred nodes
+  condensed, all registers freed, stack rebuilt as `stSlot` entries. Idempotent
+  for already-canonical slots.
+- `moveSlots(from,to,n)`: copy n slots (used to place branch values at the target
+  frame's `height`).
+- `ctrlFrame{height, paramN, resultN, branchN, ...}`: `branchN` = values
+  transferred to this label (results for block/if, params for loop).
+- Branch (`opBr`/`brIfFused`/`br_table`): `flush(); moveSlots(d-branchN, fr.height, branchN); jmp`.
+- Merge (`opEnd`): fallthrough `reconcileLocals(); flush()`; result slots at
+  `[height, height+resultN)`.
+- Pinned locals already live in registers (R12-R15) with the STACK_REG/eager
+  state machine (`localstate.go`), reconciled at merges by `reconcileLocals`.
+
+## Design
+
+**Canonical branch registers.** Assign branch/result values (up to K) to a fixed
+ordered register set `branchRegs` (GP) + `branchFRegs` (XMM), disjoint from
+`pinnedLocalRegs`, RBX (linMem), and RSP. Value at branch-position j → `branchRegs[j]`
+(by class). Overflow beyond K, and mixed layouts that don't fit, spill the
+remainder to slots `[height+K, ...)` (hybrid — never worse than today).
+
+**Edge reconciliation (`reconcileToBranchRegs(fr)`).** Replaces `flush+moveSlots`
+at a branch and the result-placement at a merge:
+1. Materialize the top `branchN` operands, assigning each a target = its canonical
+   branch reg (or slot for overflow).
+2. Feed (dst,src) pairs to `resolveRegMoves` (regcopy.go) — handles cross-target
+   cycles with xchg.
+3. Operands **below** `fr.height` keep the existing rule: they must already be in
+   canonical slots (they were flushed when the frame was entered and untouched
+   since), so nothing to do. (Phase 3 lifts below-operands into registers too.)
+
+**Merge landing.** At the block/if end and loop header, the branchN values are
+known to be in `branchRegs`/slots; push them as `stReg`/`stSlot` elems so post-merge
+code consumes them from registers. Mark those registers occupied.
+
+**Register pressure.** `branchRegs` are normal allocatable regs. Between the header
+and an edge they may hold other values; `reconcileToBranchRegs` runs immediately
+before the jmp / at the merge, so nothing executes between reconciliation and the
+join. The allocator must treat branchRegs as occupied by the pushed result elems
+after the merge (so subsequent ops spill them normally).
+
+## Phases (each: `go test ./...` + spec 1.0/2.0/3.0 green, bench memory_tree, no
+>3% regression on fib_rec/memory_tree/json-as guard)
+
+1. **Infra, no behavior change.** Add `branchRegs`/`branchFRegs`, a
+   `reconcileToBranchRegs` that currently just calls flush+moveSlots (identity),
+   and unit tests for the reg-assignment mapping. Land as a no-op scaffold.
+2. **Single-value merges (branchN==1) in a register.** if/else and block with one
+   result: reconcile the result to `branchRegs[0]` (or FReg) at every edge
+   (fallthrough, else, br/br_if/br_table); land it in a register at the merge.
+   Everything else keeps slots. Highest-frequency case, smallest blast radius.
+3. **Multi-value merges up to K** (K≈4 GP + 4 FPR), slot fallback for overflow.
+4. **Below-operands in registers** across the block (full WARP): stop flushing the
+   sub-`height` stack to slots on entry; reconcile the *entire* live operand
+   stack at edges. Biggest change; needs a spill policy when live operands exceed
+   the register file.
+5. **Loops.** Loop-carried operand values (non-locals) stay in `branchRegs` across
+   iterations; back-edge reconciles to the header's assignment. (Locals already
+   register-resident, so gate on real loop-carried operand stack depth.)
+
+## Risks / invariants
+
+- Every edge into a join MUST agree on the register assignment — derive it purely
+  from `(branchN, per-value class)` so all edges compute the same mapping.
+- Unreachable edges must not emit reconciliation.
+- Interaction with pinned-local reconcile (`reconcileLocals`) — keep it; it runs
+  on the same edges. branchRegs must exclude pinnedLocalRegs.
+- Traps/`return` already handled by the register-return hint (RAX/XMM0); keep.
+- Fallback path (slots) stays for overflow and until a phase covers a case, so the
+  refactor is never a regression relative to today.

--- a/docs/operand-stack-registers-plan.md
+++ b/docs/operand-stack-registers-plan.md
@@ -64,10 +64,15 @@ after the merge (so subsequent ops spill them normally).
 1. **Infra, no behavior change.** Add `branchRegs`/`branchFRegs`, a
    `reconcileToBranchRegs` that currently just calls flush+moveSlots (identity),
    and unit tests for the reg-assignment mapping. Land as a no-op scaffold.
-2. **Single-value merges (branchN==1) in a register.** if/else and block with one
-   result: reconcile the result to `branchRegs[0]` (or FReg) at every edge
-   (fallthrough, else, br/br_if/br_table); land it in a register at the merge.
-   Everything else keeps slots. Highest-frequency case, smallest blast radius.
+2. **Single-value block merges (branchN==1) in a register.** ✅ DONE. A `block`
+   with one integer result reconciles to `mergeReg` (RBP) at every edge; slot
+   fallback otherwise. (Inert on the corpus — no single-result blocks — but lands
+   the machinery.)
+3b. **Single-value if/else merges.** ✅ DONE — extends phase 2 to `if`/`else`
+   (then-edge at opElse, else-edge fall-through, br edges, and the no-else
+   cond-false passthrough stub). Default ON. **fib_rec −13.7%**, json-as serialize
+   −1.5%, rest neutral, no regressions; spec 1.0/2.0/3.0 + full corpus differential
+   (18/18 identical) green. `WAGO_REG_MERGE=0` keeps the slot oracle.
 3. **Multi-value merges up to K** (K≈4 GP + 4 FPR), slot fallback for overflow.
 4. **Below-operands in registers** across the block (full WARP): stop flushing the
    sub-`height` stack to slots on entry; reconcile the *entire* live operand

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -3,11 +3,24 @@ package amd64
 import (
 	"encoding/binary"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/encoder/amd64"
 )
+
+// regMergeEnabled turns on WARP-style register reconciliation of single-int-result
+// blocks at control merges (phase 2 of docs/operand-stack-registers-plan.md),
+// instead of the flush-to-slot + reload. Off by default while it soaks; the slot
+// path remains the reference oracle for differential validation.
+var regMergeEnabled = os.Getenv("WAGO_REG_MERGE") == "1"
+
+// mergeReg is the canonical register a single-int-result block's value is
+// reconciled into at every edge (fall-through, br, br_if, br_table) so the merge
+// needs no slot round trip. RBP is a plain allocatable GPR (frameless backend),
+// not a pinned-local (R12-R15) or fixed-role scratch.
+const mergeReg = RBP
 
 // fn holds the per-function code-generation state — the port's equivalent of
 // WARP's Compiler/backend working set. One is created per compiled function.
@@ -58,6 +71,7 @@ type fn struct {
 	singleRegResult bool
 	resultFloat     bool
 	resultF64       bool
+	regMerge        bool // reconcile single-int-result blocks in mergeReg (phase 2)
 
 	// Control-flow state (Phase 3).
 	ctrl        []ctrlFrame // open block/loop/if frames; ctrl[0] is the function frame
@@ -162,7 +176,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 		return nil, nil, 0, err
 	}
 
-	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode}
+	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, regMerge: regMergeEnabled}
 	f.localType = make([]machineType, nLocals)
 	i := 0
 	for _, p := range ft.Params {

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -11,10 +11,11 @@ import (
 )
 
 // regMergeEnabled turns on WARP-style register reconciliation of single-int-result
-// blocks at control merges (phase 2 of docs/operand-stack-registers-plan.md),
-// instead of the flush-to-slot + reload. Off by default while it soaks; the slot
-// path remains the reference oracle for differential validation.
-var regMergeEnabled = os.Getenv("WAGO_REG_MERGE") == "1"
+// block/if merges (docs/operand-stack-registers-plan.md) instead of the
+// flush-to-slot + reload. Default ON (fib_rec −13.7%, json-as serialize −1.5%, no
+// regressions; validated against the spec suite + full corpus differential).
+// WAGO_REG_MERGE=0 restores the slot path — kept as the reference oracle for A/B.
+var regMergeEnabled = os.Getenv("WAGO_REG_MERGE") != "0"
 
 // mergeReg is the canonical register a single-int-result block's value is
 // reconciled into at every edge (fall-through, br, br_if, br_table) so the merge

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -258,10 +258,11 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 	} else {
 		fr.branchN = rN
 	}
-	// Phase 2: a plain block producing exactly one integer result carries that
-	// value in mergeReg across all its edges instead of a frame slot. Excludes
-	// loops (params, back-edge), if (else/passthrough edges), floats, multi-value.
-	fr.regMerge1 = f.regMerge && kind == cfBlock && rN == 1 && res0 != mtNone && !res0.isFloat()
+	// Phase 2/3: a block or if producing exactly one integer result carries that
+	// value in mergeReg across all its edges (fall-through, else, br/br_if/
+	// br_table, and an if's cond-false passthrough) instead of a frame slot.
+	// Excludes loops (params, back-edge), floats, and multi-value.
+	fr.regMerge1 = f.regMerge && (kind == cfBlock || kind == cfIf) && rN == 1 && res0 != mtNone && !res0.isFloat()
 	if f.unreachable {
 		f.ctrl = append(f.ctrl, fr)
 		return nil
@@ -304,7 +305,11 @@ func (f *fn) opElse() error {
 	if f.unreachable {
 		f.unreachable = false // else edge is reachable (cond-false analogue)
 	} else {
-		f.flush()
+		if fr.regMerge1 {
+			f.reconcileMerge1() // then-branch result → mergeReg
+		} else {
+			f.flush()
+		}
 		fr.ends = append(fr.ends, f.a.JmpPlaceholder())
 		fr.endReachable = true
 	}
@@ -344,7 +349,20 @@ func (f *fn) opEnd() error {
 	}
 	// An if without else: the cond-false path reaches end with params == results.
 	if fr.kind == cfIf && !fr.hasElse && !fr.entryUnreach {
+		// For a regMerge1 passthrough, the cond-false path still has the value in
+		// its canonical slot; the then-fall-through already put it in mergeReg, so it
+		// jumps over a small stub that loads mergeReg for the cond-false path.
+		skip := -1
+		if fr.regMerge1 && fallthroughReachable {
+			skip = f.a.JmpPlaceholder()
+		}
 		f.a.PatchRel32(fr.elseSite, f.a.Len())
+		if fr.regMerge1 {
+			f.a.Load64(mergeReg, RSP, f.spillOff(fr.height)) // passthrough value → mergeReg
+		}
+		if skip != -1 {
+			f.a.PatchRel32(skip, f.a.Len())
+		}
 		fr.endReachable = true
 	}
 	for _, site := range fr.ends {

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -37,6 +37,8 @@ type ctrlFrame struct {
 	hasElse         bool
 	entryUnreach    bool
 	endReachable    bool
+	regMerge1       bool        // single-int-result cfBlock: value lives in mergeReg at edges, not a slot
+	res0            machineType // first result's machine type (valid when resultN >= 1)
 }
 
 // --- operand-stack canonicalization ---
@@ -133,29 +135,49 @@ func isValByte(b byte) bool {
 	return false
 }
 
-// blockType decodes a block's parameter and result counts.
-func (f *fn) blockType(r *wasm.Reader) (pN, rN int, err error) {
+// valByteMT maps a value-type byte to its machine type (mtNone if not scalar).
+func valByteMT(b byte) machineType {
+	switch b {
+	case 0x7F:
+		return mtI32
+	case 0x7E:
+		return mtI64
+	case 0x7D:
+		return mtF32
+	case 0x7C:
+		return mtF64
+	}
+	return mtNone
+}
+
+// blockType decodes a block's parameter and result counts, plus the first
+// result's machine type (res0; mtNone when resultN == 0).
+func (f *fn) blockType(r *wasm.Reader) (pN, rN int, res0 machineType, err error) {
 	b, ok := r.Peek()
 	if !ok {
-		return 0, 0, fmt.Errorf("eof in blocktype")
+		return 0, 0, mtNone, fmt.Errorf("eof in blocktype")
 	}
 	if b == 0x40 { // empty
 		_, _ = r.Byte()
-		return 0, 0, nil
+		return 0, 0, mtNone, nil
 	}
 	if isValByte(b) {
 		_, _ = r.Byte()
-		return 0, 1, nil
+		return 0, 1, valByteMT(b), nil
 	}
 	x, e := r.I64()
 	if e != nil {
-		return 0, 0, e
+		return 0, 0, mtNone, e
 	}
 	ft, ok := f.m.TypeFunc(uint32(x))
 	if x < 0 || !ok {
-		return 0, 0, fmt.Errorf("bad blocktype index %d", x)
+		return 0, 0, mtNone, fmt.Errorf("bad blocktype index %d", x)
 	}
-	return len(ft.Params), len(ft.Results), nil
+	r0 := mtNone
+	if len(ft.Results) > 0 {
+		r0 = mtOf(ft.Results[0])
+	}
+	return len(ft.Params), len(ft.Results), r0, nil
 }
 
 // placeSingleResult produces the single result value (top of the operand stack)
@@ -174,6 +196,24 @@ func (f *fn) placeSingleResult() {
 		f.condenseInto(e, RAX)
 	}
 	f.erase(e)
+}
+
+// reconcileMerge1 is the fall-through edge into a regMerge1 block: flush the
+// operands below the result to their canonical slots and produce the single
+// result directly in mergeReg (no slot store for the value itself).
+func (f *fn) reconcileMerge1() {
+	top := f.s.back()
+	f.flushBelow(top)
+	f.condenseInto(top, mergeReg)
+	f.erase(top)
+}
+
+// branchEdgeToMerge1 is a branch edge (br / br_if / br_table / fused) into a
+// regMerge1 block: the result has already been flushed to its canonical slot at
+// depth d-1; load it into mergeReg so the merge finds the value there. The slot
+// copy is left intact so a br_if fall-through still sees the value.
+func (f *fn) branchEdgeToMerge1(d int) {
+	f.a.Load64(mergeReg, RSP, f.spillOff(d-1))
 }
 
 // branchJump emits the jump for a branch that targets frame fr.
@@ -202,7 +242,7 @@ func (f *fn) branchJump(fr *ctrlFrame) {
 // --- control opcodes ---
 
 func (f *fn) opBlock(r *wasm.Reader, op byte) error {
-	pN, rN, err := f.blockType(r)
+	pN, rN, res0, err := f.blockType(r)
 	if err != nil {
 		return err
 	}
@@ -212,12 +252,16 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 	} else if op == 0x04 {
 		kind = cfIf
 	}
-	fr := ctrlFrame{kind: kind, paramN: pN, resultN: rN, elseSite: -1, entryUnreach: f.unreachable}
+	fr := ctrlFrame{kind: kind, paramN: pN, resultN: rN, elseSite: -1, entryUnreach: f.unreachable, res0: res0}
 	if kind == cfLoop {
 		fr.branchN = pN
 	} else {
 		fr.branchN = rN
 	}
+	// Phase 2: a plain block producing exactly one integer result carries that
+	// value in mergeReg across all its edges instead of a frame slot. Excludes
+	// loops (params, back-edge), if (else/passthrough edges), floats, multi-value.
+	fr.regMerge1 = f.regMerge && kind == cfBlock && rN == 1 && res0 != mtNone && !res0.isFloat()
 	if f.unreachable {
 		f.ctrl = append(f.ctrl, fr)
 		return nil
@@ -292,7 +336,11 @@ func (f *fn) opEnd() error {
 	fallthroughReachable := !f.unreachable
 	if fallthroughReachable {
 		f.reconcileLocals() // merge point: converge the fall-through's locals to lsStackReg
-		f.flush()           // results at [height, height+resultN)
+		if fr.regMerge1 {
+			f.reconcileMerge1() // result → mergeReg, operands below → slots
+		} else {
+			f.flush() // results at [height, height+resultN)
+		}
 	}
 	// An if without else: the cond-false path reaches end with params == results.
 	if fr.kind == cfIf && !fr.hasElse && !fr.entryUnreach {
@@ -306,7 +354,14 @@ func (f *fn) opEnd() error {
 	f.unreachable = !endReachable
 	if endReachable {
 		f.resetLocalsToStackReg() // every reaching edge left locals in lsStackReg
-		f.setDepth(fr.height + fr.resultN)
+		if fr.regMerge1 {
+			// Every reaching edge left the result in mergeReg and the operands below
+			// in canonical slots [0, height).
+			f.setDepth(fr.height)
+			f.pushReg(mergeReg, fr.res0)
+		} else {
+			f.setDepth(fr.height + fr.resultN)
+		}
 	}
 	return nil
 }
@@ -345,14 +400,22 @@ func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 	a, base, d := fr.branchN, fr.height, f.depth()
 	f.flush()
 	if !conditional {
-		f.moveSlots(d-a, base, a)
+		if fr.regMerge1 {
+			f.branchEdgeToMerge1(d)
+		} else {
+			f.moveSlots(d-a, base, a)
+		}
 		f.branchJump(fr)
 		f.unreachable = true
 		return nil
 	}
 	f.a.TestSelf(creg, false)
 	over := f.a.JccPlaceholder(condE)
-	f.moveSlots(d-a, base, a)
+	if fr.regMerge1 {
+		f.branchEdgeToMerge1(d)
+	} else {
+		f.moveSlots(d-a, base, a)
+	}
 	f.branchJump(fr)
 	f.a.PatchRel32(over, f.a.Len())
 	return nil
@@ -395,7 +458,11 @@ func (f *fn) opBrTable(r *wasm.Reader) error {
 	f.flush()
 	emitCase := func(labelIdx uint32) {
 		fr := &f.ctrl[len(f.ctrl)-1-int(labelIdx)]
-		f.moveSlots(d-fr.branchN, fr.height, fr.branchN)
+		if fr.regMerge1 {
+			f.branchEdgeToMerge1(d)
+		} else {
+			f.moveSlots(d-fr.branchN, fr.height, fr.branchN)
+		}
 		f.branchJump(fr)
 	}
 	for i, lbl := range labels {

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -145,7 +145,11 @@ func (f *fn) brIfFused(top *elem, labelIdx uint32) error {
 	fr := &f.ctrl[fi]
 	a, base := fr.branchN, fr.height
 	over := f.a.JccPlaceholder(invertCond(cc)) // fall through when the compare is false
-	f.moveSlots(k-a, base, a)
+	if fr.regMerge1 {
+		f.branchEdgeToMerge1(k)
+	} else {
+		f.moveSlots(k-a, base, a)
+	}
 	f.branchJump(fr)
 	f.a.PatchRel32(over, f.a.Len())
 	return nil

--- a/src/core/compiler/backend/railshot/regmerge_test.go
+++ b/src/core/compiler/backend/railshot/regmerge_test.go
@@ -1,0 +1,45 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestRegMergeBlockResult exercises the phase-2 register-merge path: a block with
+// a single i32 result reached by a br_if edge (value carried) and a fall-through
+// edge must produce identical, correct results with the reg-merge path on and off.
+//
+//	(func (param x i32) (param c i32) (result i32)
+//	  (block (result i32)
+//	    (local.get x)
+//	    (br_if 0 (local.get c))   ;; taken: block result = x
+//	    (drop) (i32.const 999)))  ;; fall-through: result = 999
+func TestRegMergeBlockResult(t *testing.T) {
+	body := []byte{
+		0x00,       // 0 local groups
+		0x02, 0x7F, // block (result i32)
+		0x20, 0x00, // local.get 0 (x)
+		0x20, 0x01, // local.get 1 (c)
+		0x0D, 0x00, // br_if 0
+		0x1A,             // drop
+		0x41, 0xE7, 0x07, // i32.const 999
+		0x0B, // end block
+		0x0B, // end func
+	}
+	m := mod1(t, []wasm.ValType{i32, i32}, []wasm.ValType{i32}, body)
+	cases := []struct{ x, c, want int32 }{{5, 1, 5}, {5, 0, 999}, {-3, 42, -3}, {7, 0, 999}}
+
+	saved := regMergeEnabled
+	defer func() { regMergeEnabled = saved }()
+	for _, on := range []bool{false, true} {
+		regMergeEnabled = on
+		for _, tc := range cases {
+			if got := runAmd64(t, m, tc.x, tc.c); got != tc.want {
+				t.Errorf("regMerge=%v sel(%d,%d)=%d want %d", on, tc.x, tc.c, got, tc.want)
+			}
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/regmerge_test.go
+++ b/src/core/compiler/backend/railshot/regmerge_test.go
@@ -43,3 +43,40 @@ func TestRegMergeBlockResult(t *testing.T) {
 		}
 	}
 }
+
+// TestRegMergeIfElse exercises the phase-3 if/else register-merge: an if with a
+// single i32 result must produce identical, correct values with reg-merge on/off.
+//
+//	(func (param x i32) (result i32)
+//	  (if (result i32) (i32.lt_s x 0)
+//	    (then (i32.sub 0 x))   ;; abs
+//	    (else x)))
+func TestRegMergeIfElse(t *testing.T) {
+	body := []byte{
+		0x00,       // 0 local groups
+		0x20, 0x00, // local.get 0
+		0x41, 0x00, // i32.const 0
+		0x48,       // i32.lt_s
+		0x04, 0x7F, // if (result i32)
+		0x41, 0x00, // i32.const 0
+		0x20, 0x00, // local.get 0
+		0x6B,       // i32.sub  -> -x
+		0x05,       // else
+		0x20, 0x00, // local.get 0 -> x
+		0x0B, // end if
+		0x0B, // end func
+	}
+	m := mod1(t, []wasm.ValType{i32}, []wasm.ValType{i32}, body)
+	cases := []struct{ x, want int32 }{{-5, 5}, {7, 7}, {0, 0}, {-2147483647, 2147483647}}
+
+	saved := regMergeEnabled
+	defer func() { regMergeEnabled = saved }()
+	for _, on := range []bool{false, true} {
+		regMergeEnabled = on
+		for _, tc := range cases {
+			if got := runAmd64(t, m, tc.x); got != tc.want {
+				t.Errorf("regMerge=%v abs(%d)=%d want %d", on, tc.x, got, tc.want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
First implementation step of the operand-stack-in-registers refactor (`docs/operand-stack-registers-plan.md`) — WARP's RegisterCopyResolver model, replacing the flush-to-slot reconciliation at control boundaries.

## What (phase 2, flag-gated)

A plain `block` producing exactly **one integer result** carries that value in a canonical register (`mergeReg` = RBP) across **all** its edges instead of a frame slot:
- **fall-through** end: result computed straight into `mergeReg` (no slot store).
- **br / br_if / br_table / fused-br_if** edges: result loaded into `mergeReg` from its canonical slot (slot copy kept intact so a `br_if` fall-through still sees the value).
- **merge landing**: below-operands rebuilt as slots `[0,height)`, result pushed as a register-resident value.

Excludes loops (params/back-edge), `if` (else/passthrough edges), floats, and multi-value — those are later phases. Gated behind `WAGO_REG_MERGE` (**default off**), so main behavior is unchanged; the slot path stays as the reference oracle.

## Validation

- **Correctness (flag on):** spec suite **1.0 (15,346), 2.0, 3.0** all pass (value-checked, not just no-trap); `go test ./...` green.
- **Differential:** every corpus + AS-module exec entry (18) produces **identical** results flag-off vs flag-on.
- **Path is real:** committed `TestRegMergeBlockResult` + a crafted module (`block (result i32)` via br_if / br_table / nesting / result-as-operand) confirm the reg path *fires* (codeLen 528→497, fewer slot round-trips) and matches the slot path exactly.

## Scope note

Single-result `block`s don't appear in the current corpus (AS/wat control flow uses `if`/`loop`), so this is **inert on the corpus today** — it lands and validates the reconciliation machinery (`reconcileMerge1`, `branchEdgeToMerge1`, merge landing, all edge types) that phases 3+ (`if`/`else`, multi-value, below-operands-in-registers, loops) build on. Default stays off until a phase covers the constructs real code uses; then flip after a soak.
