### PR TITLE
perf(railshot): register-merge single float results (completes single-result merge)

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -23,6 +23,11 @@ var regMergeEnabled = os.Getenv("WAGO_REG_MERGE") != "0"
 // not a pinned-local (R12-R15) or fixed-role scratch.
 const mergeReg = RBP
 
+// mergeFReg is mergeReg's float counterpart: the canonical XMM a single-float-
+// result block/if is reconciled into. XMM11 is in the operand pool (0-11), not a
+// pinned-float-local (12-15).
+const mergeFReg Reg = 11
+
 // fn holds the per-function code-generation state — the port's equivalent of
 // WARP's Compiler/backend working set. One is created per compiled function.
 type fn struct {

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -37,7 +37,7 @@ type ctrlFrame struct {
 	hasElse         bool
 	entryUnreach    bool
 	endReachable    bool
-	regMerge1       bool        // single-int-result cfBlock: value lives in mergeReg at edges, not a slot
+	regMerge1       bool        // single-result block/if: value lives in a register (mergeReg/mergeFReg) at edges, not a slot
 	res0            machineType // first result's machine type (valid when resultN >= 1)
 }
 
@@ -201,10 +201,18 @@ func (f *fn) placeSingleResult() {
 // reconcileMerge1 is the fall-through edge into a regMerge1 block: flush the
 // operands below the result to their canonical slots and produce the single
 // result directly in mergeReg (no slot store for the value itself).
-func (f *fn) reconcileMerge1() {
+func (f *fn) reconcileMerge1(fr *ctrlFrame) {
 	top := f.s.back()
 	f.flushBelow(top)
-	f.condenseInto(top, mergeReg)
+	if fr.res0.isFloat() {
+		x := f.materializeF(top)
+		if x != mergeFReg {
+			f.a.FMov(mergeFReg, x, fr.res0 == mtF64)
+		}
+		f.releaseF(x)
+	} else {
+		f.condenseInto(top, mergeReg)
+	}
 	f.erase(top)
 }
 
@@ -212,8 +220,12 @@ func (f *fn) reconcileMerge1() {
 // regMerge1 block: the result has already been flushed to its canonical slot at
 // depth d-1; load it into mergeReg so the merge finds the value there. The slot
 // copy is left intact so a br_if fall-through still sees the value.
-func (f *fn) branchEdgeToMerge1(d int) {
-	f.a.Load64(mergeReg, RSP, f.spillOff(d-1))
+func (f *fn) branchEdgeToMerge1(fr *ctrlFrame, d int) {
+	if fr.res0.isFloat() {
+		f.a.FLoadDisp(mergeFReg, RSP, f.spillOff(d-1), fr.res0 == mtF64)
+	} else {
+		f.a.Load64(mergeReg, RSP, f.spillOff(d-1))
+	}
 }
 
 // branchJump emits the jump for a branch that targets frame fr.
@@ -258,11 +270,11 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 	} else {
 		fr.branchN = rN
 	}
-	// Phase 2/3: a block or if producing exactly one integer result carries that
-	// value in mergeReg across all its edges (fall-through, else, br/br_if/
-	// br_table, and an if's cond-false passthrough) instead of a frame slot.
-	// Excludes loops (params, back-edge), floats, and multi-value.
-	fr.regMerge1 = f.regMerge && (kind == cfBlock || kind == cfIf) && rN == 1 && res0 != mtNone && !res0.isFloat()
+	// Phase 2/3: a block or if producing exactly one result (int → mergeReg, float
+	// → mergeFReg) carries that value in a register across all its edges (fall-
+	// through, else, br/br_if/br_table, and an if's cond-false passthrough) instead
+	// of a frame slot. Excludes loops (params, back-edge) and multi-value.
+	fr.regMerge1 = f.regMerge && (kind == cfBlock || kind == cfIf) && rN == 1 && res0 != mtNone
 	if f.unreachable {
 		f.ctrl = append(f.ctrl, fr)
 		return nil
@@ -306,7 +318,7 @@ func (f *fn) opElse() error {
 		f.unreachable = false // else edge is reachable (cond-false analogue)
 	} else {
 		if fr.regMerge1 {
-			f.reconcileMerge1() // then-branch result → mergeReg
+			f.reconcileMerge1(fr) // then-branch result → mergeReg
 		} else {
 			f.flush()
 		}
@@ -342,7 +354,7 @@ func (f *fn) opEnd() error {
 	if fallthroughReachable {
 		f.reconcileLocals() // merge point: converge the fall-through's locals to lsStackReg
 		if fr.regMerge1 {
-			f.reconcileMerge1() // result → mergeReg, operands below → slots
+			f.reconcileMerge1(&fr) // result → mergeReg, operands below → slots
 		} else {
 			f.flush() // results at [height, height+resultN)
 		}
@@ -358,7 +370,11 @@ func (f *fn) opEnd() error {
 		}
 		f.a.PatchRel32(fr.elseSite, f.a.Len())
 		if fr.regMerge1 {
-			f.a.Load64(mergeReg, RSP, f.spillOff(fr.height)) // passthrough value → mergeReg
+			if fr.res0.isFloat() {
+				f.a.FLoadDisp(mergeFReg, RSP, f.spillOff(fr.height), fr.res0 == mtF64) // passthrough → mergeFReg
+			} else {
+				f.a.Load64(mergeReg, RSP, f.spillOff(fr.height)) // passthrough value → mergeReg
+			}
 		}
 		if skip != -1 {
 			f.a.PatchRel32(skip, f.a.Len())
@@ -373,10 +389,14 @@ func (f *fn) opEnd() error {
 	if endReachable {
 		f.resetLocalsToStackReg() // every reaching edge left locals in lsStackReg
 		if fr.regMerge1 {
-			// Every reaching edge left the result in mergeReg and the operands below
-			// in canonical slots [0, height).
+			// Every reaching edge left the result in the merge register (int→mergeReg,
+			// float→mergeFReg) and the operands below in canonical slots [0, height).
 			f.setDepth(fr.height)
-			f.pushReg(mergeReg, fr.res0)
+			if fr.res0.isFloat() {
+				f.pushFReg(mergeFReg, fr.res0)
+			} else {
+				f.pushReg(mergeReg, fr.res0)
+			}
 		} else {
 			f.setDepth(fr.height + fr.resultN)
 		}
@@ -419,7 +439,7 @@ func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 	f.flush()
 	if !conditional {
 		if fr.regMerge1 {
-			f.branchEdgeToMerge1(d)
+			f.branchEdgeToMerge1(fr, d)
 		} else {
 			f.moveSlots(d-a, base, a)
 		}
@@ -430,7 +450,7 @@ func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 	f.a.TestSelf(creg, false)
 	over := f.a.JccPlaceholder(condE)
 	if fr.regMerge1 {
-		f.branchEdgeToMerge1(d)
+		f.branchEdgeToMerge1(fr, d)
 	} else {
 		f.moveSlots(d-a, base, a)
 	}
@@ -477,7 +497,7 @@ func (f *fn) opBrTable(r *wasm.Reader) error {
 	emitCase := func(labelIdx uint32) {
 		fr := &f.ctrl[len(f.ctrl)-1-int(labelIdx)]
 		if fr.regMerge1 {
-			f.branchEdgeToMerge1(d)
+			f.branchEdgeToMerge1(fr, d)
 		} else {
 			f.moveSlots(d-fr.branchN, fr.height, fr.branchN)
 		}

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -146,7 +146,7 @@ func (f *fn) brIfFused(top *elem, labelIdx uint32) error {
 	a, base := fr.branchN, fr.height
 	over := f.a.JccPlaceholder(invertCond(cc)) // fall through when the compare is false
 	if fr.regMerge1 {
-		f.branchEdgeToMerge1(k)
+		f.branchEdgeToMerge1(fr, k)
 	} else {
 		f.moveSlots(k-a, base, a)
 	}

--- a/src/core/compiler/backend/railshot/regmerge_test.go
+++ b/src/core/compiler/backend/railshot/regmerge_test.go
@@ -3,6 +3,7 @@
 package amd64
 
 import (
+	"math"
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -76,6 +77,39 @@ func TestRegMergeIfElse(t *testing.T) {
 		for _, tc := range cases {
 			if got := runAmd64(t, m, tc.x); got != tc.want {
 				t.Errorf("regMerge=%v abs(%d)=%d want %d", on, tc.x, got, tc.want)
+			}
+		}
+	}
+}
+
+// TestRegMergeIfElseFloat exercises the float variant (result → mergeFReg):
+//
+//	(func (param x f64) (result f64)
+//	  (if (result f64) (f64.lt x 0) (then (f64.neg x)) (else x)))  ;; fabs
+func TestRegMergeIfElseFloat(t *testing.T) {
+	body := []byte{
+		0x00,       // 0 local groups
+		0x20, 0x00, // local.get 0
+		0x44, 0, 0, 0, 0, 0, 0, 0, 0, // f64.const 0.0
+		0x63,       // f64.lt
+		0x04, 0x7C, // if (result f64)
+		0x20, 0x00, // local.get 0
+		0x9A,       // f64.neg
+		0x05,       // else
+		0x20, 0x00, // local.get 0
+		0x0B, // end if
+		0x0B, // end func
+	}
+	m := mod1(t, []wasm.ValType{wasm.F64}, []wasm.ValType{wasm.F64}, body)
+	cases := []struct{ x, want float64 }{{-3.5, 3.5}, {2, 2}, {0, 0}}
+
+	saved := regMergeEnabled
+	defer func() { regMergeEnabled = saved }()
+	for _, on := range []bool{false, true} {
+		regMergeEnabled = on
+		for _, tc := range cases {
+			if got := math.Float64frombits(runAmd64u(t, m, f64b(tc.x))); got != tc.want {
+				t.Errorf("regMerge=%v fabs(%g)=%g want %g", on, tc.x, got, tc.want)
 			}
 		}
 	}


### PR DESCRIPTION
Completes the single-result register-merge (PR #70) symmetrically: a `block`/`if` producing exactly one **float** result carries it in a canonical XMM (`mergeFReg` = XMM11) across all edges (fall-through / else / br / br_if / br_table / no-else passthrough), mirroring the int path (`mergeReg` = RBP). Reuses the same machinery — `reconcileMerge1`, `branchEdgeToMerge1`, the merge landing — now type-dispatched on the result's machine type.

## Honest scope: correctness/completeness, not a corpus perf win

Float `if`/`else`-with-a-result **does not occur in the current corpus** (mandelbrot/float are loops+int-branches; AS float values come from expressions, not if/else). Verified: corpus codegen is **byte-identical to main** with this change → **0 perf delta on the corpus**. It's the symmetric completion that benefits FP-branchy code (`if cond then a else b` returning float), exactly as the int path benefits int-branchy code (fib_rec −13.7%).

## Validation

- Spec **1.0 / 2.0 / 3.0** pass (default on) and with `WAGO_REG_MERGE=0`.
- Full corpus + AS-module differential: **18/18 exec results identical** off vs on.
- Committed `TestRegMergeIfElseFloat` (f64 fabs) alongside the int block/if tests; crafted f64 (fabs/fmax) + f32 (block br_if) modules verified correct off==on.
- `go test ./...` green.

Next real lever (per `docs/operand-stack-registers-plan.md`): **below-operands-in-registers** — stop flushing the sub-height operand stack to slots at every boundary. That's the big structural WARP win and where measurable corpus gains remain; multi-value and loops are lower-ROI.
