### PR TITLE
perf(railshot): in-place local self-update — memory.sum -31%, memory_tree -21% (beats/closes WARP)

### DIFF
--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -645,8 +645,16 @@ func mtI32OrWide(wide bool) machineType {
 // registers before x is overwritten, preserving wasm's semantics that a
 // local.get reads the value at get-time (WARP recoverLocalToReg). A lazy
 // stLocalRef is loaded; a deferred node whose subtree reads x is condensed.
-func (f *fn) realizeLocalRefs(x int) {
+func (f *fn) realizeLocalRefs(x int, skipFrom *elem) {
+	// skipFrom (non-nil) marks the base of the value-being-set's valent block for
+	// an in-place self-update (`local.set $x (binop (local.get $x) …)`): refs to x
+	// inside that block are consumed directly into x's register by condenseInto, so
+	// realizing them here would force the wasteful copy-out + copy-back. Refs BELOW
+	// it still need x's pre-set value and are realized.
 	for e := f.s.head.next; e != f.s.head; {
+		if e == skipFrom {
+			break
+		}
 		next := e.next
 		switch {
 		case e.kind == ekValue && (e.st.kind == stLocalRef || e.st.kind == stLocalReg) && e.st.idx == x:
@@ -677,8 +685,15 @@ func subtreeRefsLocal(e *elem, x int) bool {
 }
 
 func (f *fn) setLocal(x int, tee bool) {
-	f.realizeLocalRefs(x)
 	e := f.s.back()
+	// In-place self-update `local.set $x (binop (local.get $x) …)`: let condenseInto
+	// consume the top expression straight into x's register instead of pre-copying
+	// its (local.get $x) operand. condenseBinary handles an operand aliasing dest.
+	var skipFrom *elem
+	if !tee && e != nil && e.isDeferred() && isBinALU(e.op) {
+		skipFrom = baseOfValentBlock(e)
+	}
+	f.realizeLocalRefs(x, skipFrom)
 	if pr, isFloat, ok := f.pinReg(x); ok && !isFloat {
 		// Register-pinned local: compute/load directly into the local's register.
 		// condenseInto may temporarily mark pr as an owned result for deferred

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -124,7 +124,10 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 		}
 		right = &elem{kind: ekValue, st: storage{kind: stReg, typ: node.typ, reg: rr}}
 		rightReleaseAfter = rr
-	} else if right.st.kind == stReg && dest != regNone && right.st.reg == dest {
+	} else if (right.st.kind == stReg || right.st.kind == stLocalReg) && dest != regNone && right.st.reg == dest {
+		// The RHS lives in dest — either an owned reg or a borrowed pinned local
+		// whose register is also the target (an in-place self-update like
+		// `x = c - x`). Copy it out before the LHS overwrites dest.
 		t := f.allocReg(maskOf(dest))
 		f.a.MovReg64(t, dest)
 		right = &elem{kind: ekValue, st: storage{kind: stReg, typ: node.typ, reg: t}}

--- a/src/core/compiler/backend/railshot/selfupdate_test.go
+++ b/src/core/compiler/backend/railshot/selfupdate_test.go
@@ -1,0 +1,50 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// In-place local self-update (`local.set $x (binop (local.get $x) …)`) condenses
+// straight into x's register. These exercise the tricky aliasing cases that path
+// newly relies on in condenseBinary: the self-local as the RIGHT operand of a
+// non-commutative op (must be copied out before dest is overwritten), and both
+// operands being the same self-local.
+func TestInPlaceSelfUpdate(t *testing.T) {
+	// x = 100 - x; return x   (x is the RHS of a non-commutative sub, aliasing dest)
+	subRev := []byte{
+		0x00,
+		0x41, 0xE4, 0x00, // i32.const 100 (signed LEB128: 0x64 alone is -28)
+		0x20, 0x00, // local.get 0
+		0x6B,       // i32.sub  -> 100 - x
+		0x21, 0x00, // local.set 0
+		0x20, 0x00, // local.get 0
+		0x0B,
+	}
+	m := mod1(t, []wasm.ValType{i32}, []wasm.ValType{i32}, subRev)
+	for _, tc := range []struct{ x, want int32 }{{30, 70}, {0, 100}, {-5, 105}, {100, 0}} {
+		if got := runAmd64(t, m, tc.x); got != tc.want {
+			t.Errorf("(100-x) x=%d = %d, want %d", tc.x, got, tc.want)
+		}
+	}
+
+	// x = x - x; return x   (both operands the same self-local → always 0)
+	subSelf := []byte{
+		0x00,
+		0x20, 0x00, // local.get 0
+		0x20, 0x00, // local.get 0
+		0x6B,       // i32.sub -> 0
+		0x21, 0x00, // local.set 0
+		0x20, 0x00, // local.get 0
+		0x0B,
+	}
+	m2 := mod1(t, []wasm.ValType{i32}, []wasm.ValType{i32}, subSelf)
+	for _, x := range []int32{7, -1, 0} {
+		if got := runAmd64(t, m2, x); got != 0 {
+			t.Errorf("(x-x) x=%d = %d, want 0", x, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

`local.set $x (binop (local.get $x) …)` — a self-update of a register-pinned local (loop counters, accumulators) — now compiles to an **in-place** `op xreg, …` instead of copy-out + copy-back. Two small changes:
- `realizeLocalRefs` skips the value-being-set's own valent block (its `local.get $x` is consumed directly into x's register by `condenseInto`), still realizing refs *below* it that need x's pre-set value.
- `condenseBinary` extends its "operand aliases dest" relocation to cover `stLocalReg` (a borrowed pinned local as the RHS of e.g. `x = c - x`), not just owned `stReg`.

Before, `memory.sum`'s hot loop emitted 6 dead `mov`s/iteration (`mov rdi,r13; mov r13,rdi; add r13d,8` ×3); now the counter/accumulator updates are `add r13d,8` / `sub r12d,1` / `add r14,[…]` in place.

## Perf (guard mode, interleaved, n=12, wazero control neutral)

| workload | main | this | Δ | vs WARP now |
|---|--:|--:|--:|--:|
| **memory.sum** | 347ns | 238ns | **−31.4%** | **238 < 260 (beats WARP)** |
| **memory_tree** | 11.9µs | 9.37µs | **−21.3%** | 9.37 vs 8.64 (1.08×, was 1.37×) |
| json-as deserialize | 445ns | 436ns | −2.1% | |
| json-as serialize / fib_rec / dispatch / branches | | | ~neutral | |
| fib_iter | | | +1.8% (noise — code byte-identical) | 26–31 < 36 (beats WARP) |
| sieve | 96µs | 106µs | **+10.9%** | ← see below |

## The sieve regression is an alignment artifact

sieve's changed code is **strictly fewer instructions** (353→323 bytes) yet ~11% slower — its hot loop shifted to a worse µop-cache/fetch alignment. I tried 16-byte loop-header alignment: it was **erratic and net-harmful** (sieve +30%, memory.sum *lost* its win, fib_iter −16%) on this Zen4, so I dropped it — naive alignment is a per-loop gamble here. sieve is **not** in the acceptance set (memory_tree/fib_rec/json-as, all fine); the change is genuinely-better codegen and the wins are large and target-relevant (memory, the point of this work).

## Validation
- Spec **1.0/2.0/3.0** pass; `go test ./...` green.
- Full corpus + AS differential: **18/18 exec results identical** vs main.
- Committed `TestInPlaceSelfUpdate` covering the aliasing cases (`x = c - x`, `x = x - x`).
