### PR TITLE
test(spec): full WASM 1.0 execution suite passing with zero skips

### DIFF
--- a/src/wago/spectest_exec_test.go
+++ b/src/wago/spectest_exec_test.go
@@ -32,6 +32,7 @@ var coreFiles1_0 = []string{
 	"unwind", "func", "labels", "switch", "stack", "local_get", "local_set",
 	"local_tee", "global", "load", "store", "address", "align", "endianness",
 	"memory_redundancy", "memory_size", "memory_grow", "left-to-right", "func_ptrs",
+	"memory", "float_memory", "memory_trap", "traps", "const",
 }
 
 // proposalDirs maps a post-1.0 WebAssembly version to the testsuite proposal
@@ -275,6 +276,20 @@ func runSpecExec(t *testing.T, wast2json, dir, version string) {
 	}
 }
 
+// spectestImports supplies the WebAssembly testsuite's standard "spectest" host
+// module. wago is a 1.0 engine without the full linking harness, so this provides
+// the pieces the 1.0 corpus actually depends on: the four well-known immutable
+// globals (each == 666 in the reference interpreter). Extra entries are ignored by
+// modules that don't import them, so this is safe to pass to every instantiate.
+func spectestImports() wago.Imports {
+	return wago.Imports{
+		"spectest.global_i32": wago.GlobalImport{Type: wago.ValI32, Bits: wago.I32(666)},
+		"spectest.global_i64": wago.GlobalImport{Type: wago.ValI64, Bits: wago.I64(666)},
+		"spectest.global_f32": wago.GlobalImport{Type: wago.ValF32, Bits: wago.F32(666)},
+		"spectest.global_f64": wago.GlobalImport{Type: wago.ValF64, Bits: wago.F64(666)},
+	}
+}
+
 // runSpecExecFile replays one .wast's commands. The "current" instance is the
 // most recently instantiated module; when a module is out of scope (nil inst),
 // its assertions are skipped until the next module command.
@@ -297,7 +312,7 @@ func runSpecExecFile(t *testing.T, base, tmp string, sf specExecFile) (pass, ski
 				skipMod++
 				continue // unsupported module (feature out of scope) — not a miscompile
 			}
-			in, err := wago.Instantiate(compiled, nil)
+			in, err := wago.Instantiate(compiled, spectestImports())
 			if err != nil {
 				skipMod++
 				continue // needs imports / unsupported instantiate — out of scope


### PR DESCRIPTION
Before proceeding with more codegen perf work, lock down the WASM 1.0 correctness baseline. The spec-exec harness (`TestSpecSuiteExec`) is the real codegen oracle, but it silently skips modules/assertions it can't set up. This closes those gaps for 1.0.

## Two gaps found and fixed
1. **`global.wast` — 2 modules skipped → 48 assertions skipped.** They import the testsuite's standard `spectest.global_i32`/`global_i64`. The harness instantiated with `nil` imports. Added `spectestImports()` supplying the four well-known immutable spectest globals (each == 666); wago already fully supports imported globals via the `Imports` map. A wrong value would hard-fail (`t.Errorf`), so this is a real oracle now, not a rubber stamp.
2. **Curated file list under-covered execution.** Added five execution-bearing 1.0 core files that were omitted: `memory`, `float_memory`, `memory_trap`, `traps`, `const` — **+632 passing assertions**, zero skips.

Deliberately still excluded (no execution assertions for this oracle): format/validation files (`binary*`, `utf8-*`, `custom`, `comments`, `type`, `token`, `inline-module`, `unreached-invalid`), linking/start files (`imports`, `linking`, `exports`, `names`, `start`, `elem`, `table`), and `data` (entirely assert_invalid/assert_unlinkable — 0 assert_return/assert_trap).

## Result
`make spec1`: **TOTAL[1.0] assertions passed = 16,026, skipped modules = 0, skipped assertions = 0** (was 15,346 with 2 skipped modules / 48 skipped assertions). No failures — every 1.0 execution assertion in scope passes. spec 2.0/3.0 unchanged.

Test-only change (`src/wago/spectest_exec_test.go`).