### PR TITLE
perf(railshot): 3-operand VEX float ops

### DIFF
--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -435,13 +435,13 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x91:
 		f.fsqrt(false)
 	case 0x92:
-		f.fbin(f.a.FAdd, false)
+		f.fbin(f.a.VFAdd, false)
 	case 0x93:
-		f.fbin(f.a.FSub, false)
+		f.fbin(f.a.VFSub, false)
 	case 0x94:
-		f.fbin(f.a.FMul, false)
+		f.fbin(f.a.VFMul, false)
 	case 0x95:
-		f.fbin(f.a.FDiv, false)
+		f.fbin(f.a.VFDiv, false)
 	case 0x96:
 		f.fminmax(false, false)
 	case 0x97:
@@ -464,13 +464,13 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x9f:
 		f.fsqrt(true)
 	case 0xa0:
-		f.fbin(f.a.FAdd, true)
+		f.fbin(f.a.VFAdd, true)
 	case 0xa1:
-		f.fbin(f.a.FSub, true)
+		f.fbin(f.a.VFSub, true)
 	case 0xa2:
-		f.fbin(f.a.FMul, true)
+		f.fbin(f.a.VFMul, true)
 	case 0xa3:
-		f.fbin(f.a.FDiv, true)
+		f.fbin(f.a.VFDiv, true)
 	case 0xa4:
 		f.fminmax(true, false)
 	case 0xa5:

--- a/src/core/compiler/backend/railshot/fp.go
+++ b/src/core/compiler/backend/railshot/fp.go
@@ -167,19 +167,36 @@ func (f *fn) fconst(bits uint64, typ machineType) {
 	f.pushValue(storage{kind: stConst, typ: typ, cval: int64(bits)})
 }
 
-// fbin lowers add/sub/mul/div: the left operand becomes the (writable) dst, the
-// right is used read-only as the source (borrowed directly when it is a pinned
-// local, no copy), then the dst is pushed.
-func (f *fn) fbin(op func(dst, src Reg, f64 bool), f64 bool) {
+// fbin lowers add/sub/mul/div via the 3-operand VEX form dst = s1 <op> s2. Both
+// operands are read directly (a pinned local is borrowed, never copied), and the
+// result lands in a reused owned-operand register or a fresh one — so no operand is
+// pre-copied to scratch the way legacy 2-operand SSE requires.
+func (f *fn) fbin(vop func(dst, s1, s2 Reg, f64 bool), f64 bool) {
 	b := f.popValue()
 	a := f.popValue()
-	dst := f.materializeF(a)
-	f.fpinned = f.fpinned.add(dst)
-	src, owned := f.operandRegF(b)
-	f.fpinned = f.fpinned.remove(dst)
-	op(dst, src, f64)
-	if owned {
-		f.releaseF(src)
+	s1, o1 := f.operandRegF(a)
+	f.fpinned = f.fpinned.add(s1)
+	s2, o2 := f.operandRegF(b)
+	// Destination: reuse an owned operand's register in place (it is being
+	// consumed), else a fresh register so a borrowed pinned local isn't clobbered.
+	var dst Reg
+	switch {
+	case o1:
+		dst = s1
+	case o2:
+		dst = s2
+	default:
+		// Both operands are borrowed pinned locals (blocked from allocation via the
+		// pinned-local mask); s1 is also fpinned here, so a fresh dst avoids both.
+		dst = f.allocFReg(0)
+	}
+	f.fpinned = f.fpinned.remove(s1)
+	vop(dst, s1, s2, f64)
+	if o1 && dst != s1 {
+		f.releaseF(s1)
+	}
+	if o2 && dst != s2 {
+		f.releaseF(s2)
 	}
 	f.pushFReg(dst, mtOf2(f64))
 }
@@ -239,20 +256,26 @@ func (f *fn) fsqrt(f64 bool) {
 	f.pushFReg(dst, mtOf2(f64))
 }
 
-// fsign applies a sign/magnitude bit op (neg = xorps sign; abs = andps magnitude).
+// fsign applies a sign/magnitude bit op (neg = xorps sign; abs = andps magnitude)
+// via the 3-operand VEX form so a borrowed pinned-local operand is read directly
+// (dst = src <op> mask) instead of copied into the destination first.
 func (f *fn) fsign(op byte, mask64 uint64, mask32 uint32, f64 bool) {
-	x := f.materializeF(f.popValue())
-	f.fpinned = f.fpinned.add(x)
+	src, owned := f.operandRegF(f.popValue())
+	f.fpinned = f.fpinned.add(src)
 	m := f.allocFReg(0)
 	f.loadFMask(m, mask64, mask32, f64)
-	var prefix byte
-	if f64 {
-		prefix = 0x66
+	f.fpinned = f.fpinned.remove(src)
+	dst := src
+	if !owned { // borrowed pinned local: write a fresh dest, leave the local intact
+		dst = f.allocFReg(maskOf(src, m))
 	}
-	f.a.SseRR(prefix, op, x, m, false)
+	var pp byte // VEX pp: 66 (pd) for f64, none (ps) for f32
+	if f64 {
+		pp = 0b01
+	}
+	f.a.VSseRRR(pp, op, dst, src, m)
 	f.releaseF(m)
-	f.fpinned = f.fpinned.remove(x)
-	f.pushFReg(x, mtOf2(f64))
+	f.pushFReg(dst, mtOf2(f64))
 }
 
 func (f *fn) fneg(f64 bool) { f.fsign(0x57, fSignMask64, fSignMask32, f64) }

--- a/src/core/encoder/amd64/asm_sse.go
+++ b/src/core/encoder/amd64/asm_sse.go
@@ -33,6 +33,50 @@ func (a *Asm) FSqrt(dst, src Reg, f64 bool) { a.sseRR(sdPrefix(f64), 0x51, dst, 
 
 func (a *Asm) FMov(dst, src Reg, f64 bool) { a.sseRR(sdPrefix(f64), 0x10, dst, src, false) }
 
+// --- VEX 3-operand (AVX) forms -------------------------------------------------
+//
+// The non-destructive `dst = op(src1, src2)` encoding lets a float op read both
+// operands directly and write a distinct destination, avoiding the movsd-to-scratch
+// that legacy 2-operand SSE needs to preserve an operand. wago already emits
+// LZCNT/TZCNT (BMI1/ABM, ~2013), which is newer than AVX (2011), so this raises no
+// effective ISA baseline. Always uses the 3-byte VEX form (0xC4) so every xmm0-15
+// combination encodes uniformly.
+
+// vexPP is the VEX pp field for scalar F2 (f64) / F3 (f32) ops.
+func vexPP(f64 bool) byte {
+	if f64 {
+		return 0b11 // F2
+	}
+	return 0b10 // F3
+}
+
+// vex3RRR emits a 3-byte-VEX 0F-map op in 3-operand register form: reg=dst,
+// vvvv=src1, rm=src2. pp selects the implied legacy prefix (0=none,1=66,2=F3,3=F2).
+func (a *Asm) vex3RRR(pp, op byte, dst, src1, src2 Reg) {
+	rBit, bBit := byte(1), byte(1) // inverted REX.R / REX.B
+	if dst >= 8 {
+		rBit = 0
+	}
+	if src2 >= 8 {
+		bBit = 0
+	}
+	byte1 := (rBit << 7) | (1 << 6) | (bBit << 5) | 0b00001 // X̄=1, mmmmm=0F
+	vvvv := (^byte(src1)) & 0x0F
+	byte2 := (vvvv << 3) | pp // W=0, L=0 (scalar/128)
+	a.emit(0xC4, byte1, byte2, op, 0xC0|((byte(dst)&7)<<3)|byte(src2&7))
+}
+
+// Scalar float arithmetic, 3-operand: dst = src1 <op> src2.
+func (a *Asm) VFAdd(dst, s1, s2 Reg, f64 bool) { a.vex3RRR(vexPP(f64), 0x58, dst, s1, s2) }
+func (a *Asm) VFSub(dst, s1, s2 Reg, f64 bool) { a.vex3RRR(vexPP(f64), 0x5C, dst, s1, s2) }
+func (a *Asm) VFMul(dst, s1, s2 Reg, f64 bool) { a.vex3RRR(vexPP(f64), 0x59, dst, s1, s2) }
+func (a *Asm) VFDiv(dst, s1, s2 Reg, f64 bool) { a.vex3RRR(vexPP(f64), 0x5E, dst, s1, s2) }
+
+// VSseRRR is the 3-operand form of SseRR (for the packed-logical ops andps/pd,
+// orps/pd, xorps/pd used by neg/abs/copysign): dst = src1 <op> src2. pp is the
+// legacy prefix code (0 = none = ps, 1 = 66 = pd).
+func (a *Asm) VSseRRR(pp, op byte, dst, s1, s2 Reg) { a.vex3RRR(pp, op, dst, s1, s2) }
+
 // Round emits ROUNDSS/ROUNDSD (SSE4.1): dst = round(src) using rounding-mode
 // imm8 (bits 0-1 select nearest/floor/ceil/trunc; bit 3 suppresses precision).
 func (a *Asm) Round(dst, src Reg, f64 bool, mode byte) {

--- a/src/core/encoder/amd64/asm_vex_test.go
+++ b/src/core/encoder/amd64/asm_vex_test.go
@@ -1,0 +1,31 @@
+package amd64
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Golden VEX byte encodings, cross-checked against the AVX spec / a reference
+// assembler (3-byte VEX form).
+func TestVexEncoding(t *testing.T) {
+	cases := []struct {
+		name string
+		emit func(a *Asm)
+		want []byte
+	}{
+		{"vaddsd xmm0,xmm1,xmm2", func(a *Asm) { a.VFAdd(0, 1, 2, true) }, []byte{0xC4, 0xE1, 0x73, 0x58, 0xC2}},
+		{"vmulsd xmm0,xmm1,xmm2", func(a *Asm) { a.VFMul(0, 1, 2, true) }, []byte{0xC4, 0xE1, 0x73, 0x59, 0xC2}},
+		{"vsubss xmm0,xmm1,xmm2", func(a *Asm) { a.VFSub(0, 1, 2, false) }, []byte{0xC4, 0xE1, 0x72, 0x5C, 0xC2}},
+		{"vaddsd xmm8,xmm1,xmm2", func(a *Asm) { a.VFAdd(8, 1, 2, true) }, []byte{0xC4, 0x61, 0x73, 0x58, 0xC2}},
+		{"vaddsd xmm0,xmm1,xmm10", func(a *Asm) { a.VFAdd(0, 1, 10, true) }, []byte{0xC4, 0xC1, 0x73, 0x58, 0xC2}},
+		{"vandpd xmm0,xmm1,xmm2", func(a *Asm) { a.VSseRRR(0b01, 0x54, 0, 1, 2) }, []byte{0xC4, 0xE1, 0x71, 0x54, 0xC2}},
+		{"vxorps xmm3,xmm3,xmm5", func(a *Asm) { a.VSseRRR(0b00, 0x57, 3, 3, 5) }, []byte{0xC4, 0xE1, 0x60, 0x57, 0xDD}},
+	}
+	for _, c := range cases {
+		a := &Asm{}
+		c.emit(a)
+		if !bytes.Equal(a.B, c.want) {
+			t.Errorf("%s: got % x want % x", c.name, a.B, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Continues closing the float lags the ISA micro-suite (#74) surfaced, building on the operand-borrow work (#75).

## Rationale
Legacy 2-operand SSE must copy an operand into the destination to preserve it (`movsd dst,src; andpd dst,mask`). The 3-operand VEX form reads both operands and writes a distinct destination (`vandpd dst,src,mask`), removing the copy. wago **already** emits LZCNT/TZCNT unconditionally (BMI1/ABM, ~2013 hardware) — newer than AVX (2011) — so this raises **no** effective ISA baseline.

## Change
- Encoder: 3-byte VEX emitter (`vex3RRR`) + `VFAdd/VFSub/VFMul/VFDiv` (scalar) and `VSseRRR` (packed logical), with a golden byte-encoding test.
- `fbin` (add/sub/mul/div): `dst = s1 <op> s2`, reading both operands directly (pinned locals borrowed, never copied); result in a reused owned-operand reg or a fresh one.
- `fsign` (abs/neg): `vandpd/vxorps dst,src,mask` — no operand pre-copy.

## Results (guard mode, VEX off → on)
- **sqrt 1.74×** (→ ~parity with wazero; its benchmark's `abs` was the copy-bound part)
- **abs / neg 1.28×**
- **mandelbrot.render 1.19×** (real f64 kernel; compounds with #75 → ~1.6× vs pre-#75)
- add/sub/mul flat in the isolated self-update micro (Zen4 hides the removed reg-reg `movsd` there), but the 3-operand form removes real operand copies in non-self-update expressions (hence mandelbrot) and does not regress.

## Validation
- VEX golden encoding test (cross-checked against the AVX spec)
- spec 1.0/2.0/3.0 pass; full `go test ./...` green
- corpus differential: all 104 exec results **byte-identical** with VEX off vs on