### PR TITLE
perf(railshot): cache global cell pointer, not just the array base

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -80,11 +80,12 @@ type fn struct {
 	resultF64       bool
 	regMerge        bool // reconcile single-int-result blocks in mergeReg (phase 2)
 
-	// globalsBaseReg caches the globals slot-array pointer ([RBX-GlobalsPtrOffset])
-	// in a register across a straight-line run of global accesses, so each one skips
-	// re-loading that loop-invariant base. regNone when not cached; invalidated at
-	// every flush (calls + control-flow boundaries). See globals.go.
-	globalsBaseReg Reg
+	// globalCellReg caches the cell pointer (&global[globalCellIdx]) of the most
+	// recently accessed global in a register across a straight-line run, so repeated
+	// accesses skip re-deriving that loop-invariant pointer. regNone when not cached;
+	// invalidated at every flush (calls + control-flow boundaries). See globals.go.
+	globalCellReg Reg
+	globalCellIdx uint32
 
 	// Control-flow state (Phase 3).
 	ctrl        []ctrlFrame // open block/loop/if frames; ctrl[0] is the function frame
@@ -220,7 +221,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 		return nil, nil, 0, err
 	}
 
-	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, regMerge: regMergeEnabled, globalsBaseReg: regNone}
+	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, regMerge: regMergeEnabled, globalCellReg: regNone}
 	f.localType = make([]machineType, nLocals)
 	i := 0
 	for _, p := range ft.Params {

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -68,7 +68,7 @@ func (f *fn) rootsBottomToTop() []*elem {
 // spillOff(i)), condensing deferred nodes, then rebuilds the stack model as a run
 // of canonical slot entries with all registers freed.
 func (f *fn) flush() {
-	f.invalidateGlobalsBase() // the cached base must not span a call/control boundary
+	f.invalidateGlobalsCache() // the cached cell ptr must not span a call/control boundary
 	roots := f.rootsBottomToTop()
 	for i, root := range roots {
 		if root.kind == ekValue && root.st.kind == stSlot && root.st.slot == i {

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -22,7 +22,7 @@ func isFusableCompare(e *elem) bool {
 // fused compare so the subsequent branch's moveSlots reads canonical slots and no
 // flag-clobbering flush happens between the CMP and the Jcc.
 func (f *fn) flushBelow(node *elem) int {
-	f.invalidateGlobalsBase() // a following call would clobber the cached base register
+	f.invalidateGlobalsCache() // a following call would clobber the cached cell-ptr register
 	base := baseOfValentBlock(node)
 	var below []*elem
 	for cur := base.prev; cur != f.s.head; cur = baseOfValentBlock(cur).prev {

--- a/src/core/compiler/backend/railshot/globals.go
+++ b/src/core/compiler/backend/railshot/globals.go
@@ -12,31 +12,34 @@ import (
 // i32 values occupy the low half of the 8-byte cell. (Float globals land with the
 // SSE work in Phase 5.) Matches src/core/encoder/amd64's layout against this runtime.
 
-// globalsBase returns a register holding the globals slot-array pointer
-// ([RBX-GlobalsPtrOffset]), caching it across a straight-line run so repeated
-// global accesses don't each reload this loop-invariant base. The register is
-// pinned while cached (so nothing reallocates it) and allocated clear of the
-// div/shift fixed-role registers RAX/RCX/RDX (which those ops clobber without
-// consulting the operand model). Invalidated at every flush — see
-// invalidateGlobalsBase. The pointer's value never changes, so re-deriving it
-// after a boundary is always correct.
-func (f *fn) globalsBase() Reg {
-	if f.globalsBaseReg != regNone {
-		return f.globalsBaseReg
+// globalCellPtr returns a register holding &global[x]'s cell (the pointer at
+// [[RBX-GlobalsPtrOffset] + x*8]), caching it across a straight-line run. Both the
+// array base and each cell pointer are loop-invariant, so a hot global reloads
+// neither after its first access: the value load/store then reads/writes [cellReg]
+// directly. Single-entry — a different global evicts the previous one. The pinned
+// register is allocated clear of the div/shift fixed-role registers RAX/RCX/RDX
+// (clobbered without consulting the operand model). Invalidated at every flush, so
+// it never spans a call or control-flow boundary; the pointer never changes, so
+// re-deriving it after a boundary is always correct.
+func (f *fn) globalCellPtr(x uint32) Reg {
+	if f.globalCellReg != regNone && f.globalCellIdx == x {
+		return f.globalCellReg
 	}
+	f.invalidateGlobalsCache() // evict a stale cell for a different global
 	r := f.allocReg(maskOf(RAX, RCX, RDX))
-	f.a.Load64(r, RBX, -int32(abi.GlobalsPtrOffset))
+	f.a.Load64(r, RBX, -int32(abi.GlobalsPtrOffset)) // r = slot array (base), used transiently
+	f.a.Load64(r, r, int32(x*8))                     // r = &global[x]
 	f.pinned = f.pinned.add(r)
-	f.globalsBaseReg = r
+	f.globalCellReg, f.globalCellIdx = r, x
 	return r
 }
 
-// invalidateGlobalsBase drops the cached globals base (unpins its register).
-// Called from flush, so the cache never spans a call or control-flow boundary.
-func (f *fn) invalidateGlobalsBase() {
-	if f.globalsBaseReg != regNone {
-		f.pinned = f.pinned.remove(f.globalsBaseReg)
-		f.globalsBaseReg = regNone
+// invalidateGlobalsCache drops the cached global cell pointer (unpins its
+// register). Called from flush, so the cache never spans a call/control boundary.
+func (f *fn) invalidateGlobalsCache() {
+	if f.globalCellReg != regNone {
+		f.pinned = f.pinned.remove(f.globalCellReg)
+		f.globalCellReg = regNone
 	}
 }
 
@@ -50,24 +53,22 @@ func (f *fn) globalGet(r *wasm.Reader) error {
 		return fmt.Errorf("amd64: unknown global %d", x)
 	}
 	gtv := wasm.GlobalValueType(gt)
-	base := f.globalsBase()            // cached, pinned — must not be clobbered below
-	cell := f.allocReg(0)              // fresh (base excluded via its pin)
-	f.a.Load64(cell, base, int32(x*8)) // cell = &global[x]
+	cell := f.globalCellPtr(x) // cached, pinned — read the value into a separate reg
 	switch {
 	case wasm.EqualValType(gtv, wasm.I64):
-		f.a.Load64(cell, cell, 0)
-		f.pushReg(cell, mtI64)
+		dst := f.allocReg(0)
+		f.a.Load64(dst, cell, 0)
+		f.pushReg(dst, mtI64)
 	case wasm.EqualValType(gtv, wasm.I32):
-		f.a.Load32(cell, cell, 0) // low half of the 8-byte cell
-		f.pushReg(cell, mtI32)
+		dst := f.allocReg(0)
+		f.a.Load32(dst, cell, 0) // low half of the 8-byte cell
+		f.pushReg(dst, mtI32)
 	case wasm.EqualValType(gtv, wasm.F32) || wasm.EqualValType(gtv, wasm.F64):
 		f64 := wasm.EqualValType(gtv, wasm.F64)
 		xmm := f.allocFReg(0)
 		f.a.FLoadDisp(xmm, cell, 0, f64)
-		f.release(cell)
 		f.pushFReg(xmm, mtOf2(f64))
 	default:
-		f.release(cell)
 		return fmt.Errorf("amd64: global.get type %s not yet supported (global %d)", gtv, x)
 	}
 	return nil
@@ -87,20 +88,15 @@ func (f *fn) globalSet(r *wasm.Reader) error {
 		f64 := wasm.EqualValType(gtv, wasm.F64)
 		xmm := f.materializeF(f.popValue())
 		f.fpinned = f.fpinned.add(xmm)
-		base := f.globalsBase()
-		cell := f.allocReg(0) // fresh (base excluded via its pin)
-		f.a.Load64(cell, base, int32(x*8))
+		cell := f.globalCellPtr(x) // cached, pinned
 		f.a.FStoreDisp(cell, 0, xmm, f64)
-		f.release(cell)
 		f.fpinned = f.fpinned.remove(xmm)
 		f.releaseF(xmm)
 		return nil
 	}
 	rg := f.materialize(f.popValue())
 	f.pinned = f.pinned.add(rg)
-	base := f.globalsBase()
-	cell := f.allocReg(maskOf(rg)) // fresh (base + rg excluded)
-	f.a.Load64(cell, base, int32(x*8))
+	cell := f.globalCellPtr(x) // cached, pinned (rg excluded)
 	switch {
 	case wasm.EqualValType(gtv, wasm.I64):
 		f.a.Store64(cell, 0, rg)
@@ -109,11 +105,9 @@ func (f *fn) globalSet(r *wasm.Reader) error {
 	default:
 		f.pinned = f.pinned.remove(rg)
 		f.release(rg)
-		f.release(cell)
 		return fmt.Errorf("amd64: global.set type %s not yet supported (global %d)", gtv, x)
 	}
 	f.pinned = f.pinned.remove(rg)
 	f.release(rg)
-	f.release(cell)
 	return nil
 }


### PR DESCRIPTION
Follow-up to #76. That PR cached the globals array base (`[RBX-GlobalsPtrOffset]`); each access still re-derived the cell pointer (`[base + x*8]`). Since a global's **cell address is also loop-invariant**, this caches the cell pointer itself — so a hot global reloads *nothing* after its first access (the value load/store reads/writes `[cellReg]` directly).

Uses the **same one pinned register** as #76 (the cell-ptr reg replaces the base reg; the array base becomes a transient load only when a new cell pointer must be derived), so no extra register pressure. Single-entry: a different global evicts the previous one, falling back to a fresh derivation. Reuses #76's invalidation (flush/flushBelow), allocated clear of RAX/RCX/RDX.

`global.get`/`global.set` now load the value into a *separate* register so the pinned cell pointer isn't clobbered.

## Results (guard mode)
`isa_var.global_getset`: **1.50× faster than #76** (13.2µs → 8.8µs). The lag vs wazero over the series: **2.72× → 1.87× (#76) → 1.25×** — near parity. Disasm: for a single-global loop the cell pointer is derived once per straight-line region instead of per access.

## Validation
- spec 1.0/2.0/3.0 pass; full `go test ./...` green
- corpus differential: all 104 exec results **byte-identical** vs main (behavior-preserving)