### PR TITLE
perf(railshot): pin more hot locals in call-free functions

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -236,7 +236,12 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	}
 	hasCall := bodyHasCall(c.Body)
 	touchesMemory := bodyTouchesMemory(c.Body)
-	f.assignPinnedLocals(localHotness(c.Body, nLocals))
+	regABI := regABIEnabled && sigFitsRegABI(ft)
+	gpPool := gpPinPool(regABI, !hasCall, bodyUsesBulkMem(c.Body), f.nParams)
+	f.assignPinnedLocals(localHotness(c.Body, nLocals), gpPool)
+	if f.pinnedLocalMask.has(RBP) {
+		f.regMerge = false // RBP now holds a pinned local, so it can't be the merge register
+	}
 	// STACK_REG (lazy pinned-local spill) is disabled for memory-touching
 	// functions (#68): the explicit-bounds path's per-access scratch allocation
 	// (memAddr) adds register pressure that desyncs the lazy local state,
@@ -290,7 +295,30 @@ func (f *fn) runBody(c *wasm.Func) error {
 // assignPinnedLocals dedicates registers to the hottest integer locals (by the
 // hotness scores). Locals with a zero score (no AST / unused) are ordered by
 // index, so a body carrying only BodyBytes falls back to first-N pinning.
-func (f *fn) assignPinnedLocals(scores []int64) {
+// gpPinPool returns the registers available to hold pinned integer locals. The
+// base is R12-R15 (callee-saved and spill-managed around calls). A call-free
+// reg-ABI function has no call to clobber caller-saved registers, so it fills more
+// of the file: the non-argument registers RDI/RSI (free once the prologue consumes
+// linMem/trap — unless bulk-memory `rep movs` would clobber them), the argument
+// registers R9/R10/R11 when they carry no incoming parameter (nParams<=4, so the
+// prologue's arg→pinned moves can't clobber a live arg), and RBP (which then can't
+// serve as the block-merge register — the caller drops regMerge). RAX/RCX/RDX/R8
+// stay free for operand evaluation and the x86 fixed-role ops (div/shift/return).
+func gpPinPool(regABI, callFree, usesBulkMem bool, nParams int) []Reg {
+	pool := append([]Reg{}, pinnedLocalRegs...) // R12-R15
+	if !regABI || !callFree {
+		return pool
+	}
+	if !usesBulkMem {
+		pool = append(pool, RDI, RSI)
+	}
+	if nParams <= 4 {
+		pool = append(pool, R9, R10, R11)
+	}
+	return append(pool, RBP)
+}
+
+func (f *fn) assignPinnedLocals(scores []int64, gpPool []Reg) {
 	f.locals = make([]localDef, f.nLocals)
 	for i := range f.locals {
 		f.locals[i] = localDef{reg: regNone, typ: f.localType[i], state: lsReg}
@@ -313,11 +341,11 @@ func (f *fn) assignPinnedLocals(scores []int64) {
 		return c
 	}
 	for k, i := range rank(func(t machineType) bool { return !t.isFloat() }) {
-		if k >= len(pinnedLocalRegs) {
+		if k >= len(gpPool) {
 			break
 		}
-		f.locals[i].reg = pinnedLocalRegs[k]
-		f.pinnedLocalMask = f.pinnedLocalMask.add(pinnedLocalRegs[k])
+		f.locals[i].reg = gpPool[k]
+		f.pinnedLocalMask = f.pinnedLocalMask.add(gpPool[k])
 	}
 	for k, i := range rank(func(t machineType) bool { return t.isFloat() }) {
 		if k >= len(pinnedFLocalRegs) {

--- a/src/core/compiler/backend/railshot/hints.go
+++ b/src/core/compiler/backend/railshot/hints.go
@@ -82,6 +82,33 @@ func bodyCalls(body wasm.Expr, idx uint32) bool {
 // than STACK_REG: it leaves more registers available to the memory/address/value
 // path instead of reserving pinned-local registers that are repeatedly marked
 // clobbered by calls.
+// bodyUsesBulkMem reports whether the body contains memory.copy/fill, which lower
+// to `rep movs`/`stos` and hard-clobber RDI/RSI/RCX — so those registers can't hold
+// pinned locals in a function that uses them.
+func bodyUsesBulkMem(body wasm.Expr) bool {
+	var walk func(instrs []wasm.Instruction) bool
+	walk = func(instrs []wasm.Instruction) bool {
+		for i := range instrs {
+			in := &instrs[i]
+			if in.Kind == wasm.InstrMemoryCopy || in.Kind == wasm.InstrMemoryFill {
+				return true
+			}
+			switch in.Kind {
+			case wasm.InstrLoop, wasm.InstrBlock:
+				if walk(in.Body().Instrs) {
+					return true
+				}
+			case wasm.InstrIf:
+				if walk(in.Then()) || walk(in.Else()) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return walk(body.Instrs)
+}
+
 func bodyTouchesMemory(body wasm.Expr) bool {
 	var walk func(instrs []wasm.Instruction) bool
 	walk = func(instrs []wasm.Instruction) bool {

--- a/src/core/compiler/backend/railshot/stack_test.go
+++ b/src/core/compiler/backend/railshot/stack_test.go
@@ -58,7 +58,7 @@ func TestAssignPinnedLocalsUsesLocalDefs(t *testing.T) {
 		nLocals:   3,
 		localType: []machineType{mtI32, mtF64, mtI32},
 	}
-	f.assignPinnedLocals([]int64{1, 10, 5})
+	f.assignPinnedLocals([]int64{1, 10, 5}, pinnedLocalRegs)
 
 	r, isFloat, ok := f.pinReg(1)
 	if !ok || !isFloat || r != pinnedFLocalRegs[0] {


### PR DESCRIPTION
## Motivation
Testing local-access speed across local counts showed wago was 1.4–2.8× slower than wazero for functions with a handful of locals (worst at **8 locals: 2.78×**), while being *faster* at 32–64. Disassembly confirmed the cause: wago pins only **4** integer locals (R12–R15), and the hot loop counter eats one — so a function with ~4+ hot locals frames the rest, paying a `mov;add;mov` load-store trio per access. wazero keeps ~8 in registers.

## Change
The cost-based hotness ranking (`localHotness` — loop-weighted, get=1×/set=2×) and `assignPinnedLocals` already pick *which* locals to pin; this just gives them a bigger register pool. New `gpPinPool`: for **call-free reg-ABI** functions (no call to clobber caller-saved registers), the pool grows from 4 to as many as 10 by adding registers that are provably safe there:
- **RDI, RSI** — free once the prologue consumes linMem/trap; excluded when the body uses bulk-memory (`memory.copy/fill` `rep movs` clobber them).
- **R9, R10, R11** — argument registers, added only when `nParams ≤ 4` so the prologue's arg→pinned moves can't clobber a live incoming arg (declared locals pinned there are just zeroed).
- **RBP** — otherwise the block-merge register; when a local lands there, `regMerge` is turned off for that function.

RAX/RCX/RDX/R8 stay free for operand evaluation and the x86 fixed-role ops (div/shift/return). Call-making and non-reg-ABI functions keep the original 4 (caller-saved regs would need spilling around every call).

## Results (guard mode)
| locals | before | after | vs wazero |
|--:|--:|--:|--:|
| 4 | 814 ns | 446 ns (**1.83×**) | 0.95× (faster) |
| 8 | 1510 ns | 660 ns (**2.29×**) | 1.22× (was 2.78×) |
| 16 | 2858 ns | 1912 ns (**1.49×**) | 0.97× (faster) |

local_4 and local_16 now *beat* wazero; local_8 dropped from 2.78× to 1.22×. 32/64-local cases were already wago-faster.

## Validation
- spec 1.0/2.0/3.0 pass; full `go test ./...` green
- corpus differential: all 104 exec results **byte-identical**
- corpus perf: **no regressions** — every module neutral or slightly faster (linked_list −1.3%, memory_tree −0.6%, arith −0.6%, rest flat), confirming the larger pool doesn't starve operand scratch.