### PR TITLE
perf(railshot): test register-resident eqz operand in place

### DIFF
--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -71,9 +71,24 @@ func (f *fn) flushBelow(node *elem) int {
 func (f *fn) condenseToFlags(node *elem) Cond {
 	w := node.typ.is64()
 	if node.op == opEqz {
-		L := f.materialize(node.arg0)
+		// TEST does not write its operand, so a register-resident value (a pinned
+		// local — e.g. a loop counter — or an owned temp) is tested in place with no
+		// copy, mirroring the relational path below.
+		a := node.arg0
+		var L Reg
+		ownedL := false
+		switch {
+		case a.kind == ekValue && a.st.kind == stLocalReg:
+			L = a.st.reg
+		case a.kind == ekValue && a.st.kind == stReg:
+			L, ownedL = a.st.reg, true
+		default:
+			L, ownedL = f.materialize(a), true
+		}
 		f.a.TestSelf(L, w)
-		f.release(L)
+		if ownedL {
+			f.release(L)
+		}
 		f.consumeBlockBelow(node)
 		f.erase(node)
 		return condE


### PR DESCRIPTION
Small cleanup found while diagnosing loop-condition overhead. `condenseToFlags`'s **relational** compare path already tests a pinned local (e.g. a loop counter) in place — but the **eqz** path called `materialize`, which copies a pinned local to scratch first (`mov rdi,r14; test edi,edi`). `TEST` doesn't write its operand, so it can read the pinned register directly (`test r14d,r14d`), mirroring the relational path.

Removes one instruction from every `br_if (i32.eqz <local>)` loop guard. Neutral on this Zen4 host (the reg-reg `mov` is move-eliminated) but reduces loop-guard instruction count / code size and helps front-end-bound loops and µarchs without move elimination.

## Validation
- spec 1.0/2.0/3.0 pass; full `go test ./...` green
- corpus differential: all 104 exec results byte-identical

## Note on the bigger picture
This came out of testing local-access speed (#82 closed the locals lag). The residual gap in *tiny tight loops* is loop-control overhead: wago checks the counter at the loop top with a separate `test` while the bottom decrement already set the flags; wazero rotates to `dec; jnz`. Full loop rotation's win comes entirely from that flag-reuse (rotation alone is a wash), which needs matching the countdown idiom and connecting the decrement's flags to the backedge — a control-flow-critical change best done as a dedicated, fuzzer-backed effort. Filed as follow-up.