### PR TITLE
perf(railshot): pin hot globals' cell pointers in the shared register pool

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/encoder/amd64"
+	"github.com/wago-org/wago/src/core/runtime/abi"
 )
 
 // regMergeEnabled turns on WARP-style register reconciliation of single-int-result
@@ -86,6 +87,13 @@ type fn struct {
 	// invalidated at every flush (calls + control-flow boundaries). See globals.go.
 	globalCellReg Reg
 	globalCellIdx uint32
+
+	// globalReg[g] pins hot global g's cell pointer in a register for the whole
+	// function (call-free functions only), sharing the GP pin pool with hot locals.
+	// The pointer is derived once in the prologue and every access reads/writes
+	// through it — no per-access (or per-iteration) re-derivation or single-entry
+	// cache thrashing. regNone when g is not pinned. See globals.go / assignPinnedLocals.
+	globalReg []Reg
 
 	// Control-flow state (Phase 3).
 	ctrl        []ctrlFrame // open block/loop/if frames; ctrl[0] is the function frame
@@ -238,9 +246,17 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	touchesMemory := bodyTouchesMemory(c.Body)
 	regABI := regABIEnabled && sigFitsRegABI(ft)
 	gpPool := gpPinPool(regABI, !hasCall, bodyUsesBulkMem(c.Body), f.nParams)
-	f.assignPinnedLocals(localHotness(c.Body, nLocals), gpPool)
+	// Hot globals share the GP pin pool with locals, but only in call-free reg-ABI
+	// functions: their cell pointer stays register-resident across the whole body
+	// (no call to clobber it), derived once in the prologue. Elsewhere globals use
+	// the per-run cell-pointer cache (globalCellPtr).
+	var globalScores []int64
+	if regABI && !hasCall {
+		globalScores = globalHotness(c.Body, f.m.GlobalCount())
+	}
+	f.assignPinnedLocals(localHotness(c.Body, nLocals), globalScores, gpPool)
 	if f.pinnedLocalMask.has(RBP) {
-		f.regMerge = false // RBP now holds a pinned local, so it can't be the merge register
+		f.regMerge = false // RBP now holds a pinned local/global, so it can't be the merge register
 	}
 	// STACK_REG (lazy pinned-local spill) is disabled for memory-touching
 	// functions (#68): the explicit-bounds path's per-access scratch allocation
@@ -318,42 +334,90 @@ func gpPinPool(regABI, callFree, usesBulkMem bool, nParams int) []Reg {
 	return append(pool, RBP)
 }
 
-func (f *fn) assignPinnedLocals(scores []int64, gpPool []Reg) {
+func (f *fn) assignPinnedLocals(scores, globalScores []int64, gpPool []Reg) {
 	f.locals = make([]localDef, f.nLocals)
 	for i := range f.locals {
 		f.locals[i] = localDef{reg: regNone, typ: f.localType[i], state: lsReg}
 	}
-	// Rank integer and float locals separately by hotness (desc), then index (asc),
-	// and pin the hottest of each to their dedicated register file.
-	rank := func(want func(machineType) bool) []int {
-		var c []int
-		for i := 0; i < f.nLocals; i++ {
-			if want(f.localType[i]) {
-				c = append(c, i)
-			}
-		}
-		sort.SliceStable(c, func(a, b int) bool {
-			if scores[c[a]] != scores[c[b]] {
-				return scores[c[a]] > scores[c[b]]
-			}
-			return c[a] < c[b]
-		})
-		return c
+	f.globalReg = make([]Reg, len(globalScores))
+	for i := range f.globalReg {
+		f.globalReg[i] = regNone
 	}
-	for k, i := range rank(func(t machineType) bool { return !t.isFloat() }) {
+	// The GP pin pool is shared by hot INT locals (value-in-register) and hot globals
+	// (cell-pointer-in-register — even a float global's cell pointer is a GP value).
+	// A global is a candidate only when accessed inside a loop (score >= one loop
+	// level): pinning costs a one-time prologue derivation, worth it only when the
+	// per-iteration re-derivation it replaces would otherwise repeat.
+	type gpCand struct {
+		global bool
+		idx    int
+		score  int64
+	}
+	var gp []gpCand
+	for i := 0; i < f.nLocals; i++ {
+		if !f.localType[i].isFloat() {
+			gp = append(gp, gpCand{idx: i, score: scores[i]})
+		}
+	}
+	loopMin := loopWeight(1)
+	for g := 0; g < len(globalScores); g++ {
+		if globalScores[g] >= loopMin {
+			gp = append(gp, gpCand{global: true, idx: g, score: globalScores[g]})
+		}
+	}
+	sort.SliceStable(gp, func(a, b int) bool {
+		if gp[a].score != gp[b].score {
+			return gp[a].score > gp[b].score
+		}
+		if gp[a].global != gp[b].global {
+			return !gp[a].global // tie: prefer a local (value) over a global (pointer)
+		}
+		return gp[a].idx < gp[b].idx
+	})
+	for k, c := range gp {
 		if k >= len(gpPool) {
 			break
 		}
-		f.locals[i].reg = gpPool[k]
+		if c.global {
+			f.globalReg[c.idx] = gpPool[k]
+		} else {
+			f.locals[c.idx].reg = gpPool[k]
+		}
 		f.pinnedLocalMask = f.pinnedLocalMask.add(gpPool[k])
 	}
-	for k, i := range rank(func(t machineType) bool { return t.isFloat() }) {
+	// Float locals use the separate XMM pin pool.
+	var fc []int
+	for i := 0; i < f.nLocals; i++ {
+		if f.localType[i].isFloat() {
+			fc = append(fc, i)
+		}
+	}
+	sort.SliceStable(fc, func(a, b int) bool {
+		if scores[fc[a]] != scores[fc[b]] {
+			return scores[fc[a]] > scores[fc[b]]
+		}
+		return fc[a] < fc[b]
+	})
+	for k, i := range fc {
 		if k >= len(pinnedFLocalRegs) {
 			break
 		}
 		f.locals[i].reg = pinnedFLocalRegs[k]
 		f.locals[i].isFloat = true
 		f.fpinnedLocalMask = f.fpinnedLocalMask.add(pinnedFLocalRegs[k])
+	}
+}
+
+// derivePinnedGlobals loads each pinned global's cell pointer into its dedicated
+// register, once, in the prologue (RBX = linMem must already be set). A no-op when
+// no globals are pinned. Every later access reads/writes through the register.
+func (f *fn) derivePinnedGlobals() {
+	for g, reg := range f.globalReg {
+		if reg == regNone {
+			continue
+		}
+		f.a.Load64(reg, RBX, -int32(abi.GlobalsPtrOffset))
+		f.a.Load64(reg, reg, int32(g*8))
 	}
 }
 
@@ -380,6 +444,7 @@ func (f *fn) prologue() {
 		}
 	}
 	f.zeroDeclaredLocals()
+	f.derivePinnedGlobals()
 }
 
 // zeroDeclaredLocals initializes non-parameter locals. Most functions keep the
@@ -491,6 +556,7 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 		}
 	}
 	f.zeroDeclaredLocals()
+	f.derivePinnedGlobals()
 	if err := f.runBody(c); err != nil {
 		return 0, err
 	}

--- a/src/core/compiler/backend/railshot/globals.go
+++ b/src/core/compiler/backend/railshot/globals.go
@@ -22,6 +22,11 @@ import (
 // it never spans a call or control-flow boundary; the pointer never changes, so
 // re-deriving it after a boundary is always correct.
 func (f *fn) globalCellPtr(x uint32) Reg {
+	// Function-scoped pinned cell pointer (call-free hot globals): derived once in
+	// the prologue, held in a reserved register for the whole body.
+	if int(x) < len(f.globalReg) && f.globalReg[x] != regNone {
+		return f.globalReg[x]
+	}
 	if f.globalCellReg != regNone && f.globalCellIdx == x {
 		return f.globalCellReg
 	}

--- a/src/core/compiler/backend/railshot/hints.go
+++ b/src/core/compiler/backend/railshot/hints.go
@@ -82,6 +82,40 @@ func bodyCalls(body wasm.Expr, idx uint32) bool {
 // than STACK_REG: it leaves more registers available to the memory/address/value
 // path instead of reserving pinned-local registers that are repeatedly marked
 // clobbered by calls.
+// globalHotness scores each global by loop-weighted reference count (mirrors
+// localHotness): global.get = 1×, global.set = 2×, ×loopWeight per loop level. Used
+// to pick which globals' cell pointers to pin in registers.
+func globalHotness(body wasm.Expr, nGlobals int) []int64 {
+	scores := make([]int64, nGlobals)
+	add := func(g uint32, delta int64) {
+		if int(g) < nGlobals {
+			scores[g] += delta
+		}
+	}
+	var walk func(instrs []wasm.Instruction, loopDepth int)
+	walk = func(instrs []wasm.Instruction, loopDepth int) {
+		w := loopWeight(loopDepth)
+		for i := range instrs {
+			in := &instrs[i]
+			switch in.Kind {
+			case wasm.InstrGlobalGet:
+				add(in.Index, w)
+			case wasm.InstrGlobalSet:
+				add(in.Index, 2*w)
+			case wasm.InstrLoop:
+				walk(in.Body().Instrs, loopDepth+1)
+			case wasm.InstrBlock:
+				walk(in.Body().Instrs, loopDepth)
+			case wasm.InstrIf:
+				walk(in.Then(), loopDepth)
+				walk(in.Else(), loopDepth)
+			}
+		}
+	}
+	walk(body.Instrs, 0)
+	return scores
+}
+
 // bodyUsesBulkMem reports whether the body contains memory.copy/fill, which lower
 // to `rep movs`/`stos` and hard-clobber RDI/RSI/RCX — so those registers can't hold
 // pinned locals in a function that uses them.

--- a/src/core/compiler/backend/railshot/stack_test.go
+++ b/src/core/compiler/backend/railshot/stack_test.go
@@ -58,7 +58,7 @@ func TestAssignPinnedLocalsUsesLocalDefs(t *testing.T) {
 		nLocals:   3,
 		localType: []machineType{mtI32, mtF64, mtI32},
 	}
-	f.assignPinnedLocals([]int64{1, 10, 5}, pinnedLocalRegs)
+	f.assignPinnedLocals([]int64{1, 10, 5}, nil, pinnedLocalRegs)
 
 	r, isFloat, ok := f.pinReg(1)
 	if !ok || !isFloat || r != pinnedFLocalRegs[0] {


### PR DESCRIPTION
Per request: have globals share the local register pool. Hot globals now compete with hot locals for the same GP pin pool, ranked by the same loop-weighted cost model.

## Before
After #80, a global access still derives its cell pointer (`[RBX-88] → [base+x*8]`) via a **single-entry** per-run cache that's invalidated at every flush — so a global in a loop re-derives **per iteration**, and a loop touching *two* globals **thrashes** the cache, re-deriving on nearly every access (four `mov rdi,[rbx-88]` in a 2-global loop body).

## Change
`globalHotness` scores globals (get 1×, set 2×, ×loop weight), and `assignPinnedLocals` now ranks **int locals + globals together** for the GP pool. A pinned global holds its **cell pointer** in a reserved register (even a float global — a pointer is a GP value), derived **once** in the prologue; every access reads/writes through it. Scoped to **call-free reg-ABI** functions (no call to clobber the pointer, no spill machinery), and only globals accessed **inside a loop** are candidates (a pinning pays for its one-time derivation only when it replaces per-iteration re-derivation). Non-pinned globals keep the #80 per-run cache. If a global lands in RBP, `regMerge` is dropped (as for locals).

## Results (guard mode)
- 2-globals-in-a-loop micro: **1299 → 669 ns (1.94× faster)**; 2.75× → 1.41× vs wazero.
- `globals.accumulate` (single global): −1% (the #80 cache already amortized one global; the win scales with global count / thrashing).
- No corpus regressions (all modules neutral or slightly faster).

## Validation
- spec 1.0/2.0/3.0 pass; full `go test ./...` green
- cross-engine: the 2-global loop returns identical results on wago and wazero
- corpus differential: all 104 exec results byte-identical