### PR TITLE
perf(railshot): value-pin globals in call-making functions (WARP SP model)

### DIFF
--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -169,6 +169,7 @@ func (f *fn) callInternal(localIdx int, ft *wasm.CompType) error {
 func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType) {
 	p, rN := len(ft.Params), len(ft.Results)
 	d := f.depth()
+	f.storePinnedGlobals(false) // spill value-pinned globals to their cells before the call (scratch is free here)
 
 	// Identify the p argument roots (top of stack), deepest first.
 	argRoots := make([]*elem, p)
@@ -239,6 +240,7 @@ func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType) {
 		f.pinned = f.pinned.add(resReg)
 	}
 	f.reloadLocalsForCall() // non-STACK_REG model only
+	f.derivePinnedGlobals() // reload value-pinned globals: the callee may have changed the shared cell
 	// No post-call trap check: a callee trap jumps straight back to enterNative
 	// via emitTrap's handler-jump, so control never returns here with *trap set.
 
@@ -257,6 +259,7 @@ func (f *fn) emitMixedRegisterCall(localIdx int, ft *wasm.CompType) {
 	d := f.depth()
 
 	f.flush()
+	f.storePinnedGlobals(false) // spill value-pinned globals to their cells before the call
 	gp, fp := 0, 0
 	for i, t := range ft.Params {
 		slot := d - p + i
@@ -277,6 +280,7 @@ func (f *fn) emitMixedRegisterCall(localIdx int, ft *wasm.CompType) {
 	site := f.a.CallRel32()
 	f.relocs = append(f.relocs, callReloc{at: site, target: localIdx, internal: true})
 	f.reloadLocalsForCall() // non-STACK_REG model only
+	f.derivePinnedGlobals() // reload value-pinned globals: the callee may have changed the shared cell
 
 	if rN == 1 {
 		rt := mtOf(ft.Results[0])
@@ -371,7 +375,8 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 func (f *fn) emitWrapperCall(ft *wasm.CompType, emitCall func()) {
 	p, rN := len(ft.Params), len(ft.Results)
 	d := f.depth()
-	f.flush() // all operands to canonical slots; args are slots [d-p, d)
+	f.flush()                   // all operands to canonical slots; args are slots [d-p, d)
+	f.storePinnedGlobals(false) // spill value-pinned globals to their cells before the call
 
 	// Reserve the result slots [d, d+rN) in the frame.
 	if need := d + rN; need > f.maxSpill {
@@ -394,6 +399,7 @@ func (f *fn) emitWrapperCall(ft *wasm.CompType, emitCall func()) {
 	// in one jump (emitTrap's handler-jump back to enterNative), so control never
 	// returns here with *trap set.
 	f.reloadLocalsForCall() // non-STACK_REG model only
+	f.derivePinnedGlobals() // reload value-pinned globals: the callee may have changed the shared cell
 
 	// Pop the args; load results out of their slots [d, d+rN) into fresh registers.
 	f.setDepth(d - p)

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -480,17 +480,6 @@ func (f *fn) storePinnedGlobals(dirtyOnly bool) {
 	}
 }
 
-// hasPinnedGlobals reports whether any global is value-pinned (fast bail for the
-// call spill/reload path).
-func (f *fn) hasPinnedGlobals() bool {
-	for _, reg := range f.globalReg {
-		if reg != regNone {
-			return true
-		}
-	}
-	return false
-}
-
 // prologue: frameless — one `sub rsp,frameSize` (no frame-pointer push), pin
 // linMem in RBX (moved from RSI per WARP's convention), stash trap/results in the
 // RSP-relative header, load params into their register or slot, zero declared

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -89,11 +89,13 @@ type fn struct {
 	globalCellIdx uint32
 
 	// globalReg[g] value-pins hot mutable-int global g in a register for the whole
-	// function (call-free functions only), sharing the GP pin pool with hot locals
-	// (WARP's model). The value is loaded once in the prologue and every access
-	// reads/writes the register directly — no per-access memory traffic — with a
-	// single coherent write-back to the cell at the epilogue. regNone when g is not
-	// pinned. See globals.go / assignPinnedLocals / derivePinnedGlobals.
+	// function, sharing the GP pin pool with hot locals (WARP's model). The value is
+	// loaded once in the prologue and every access reads/writes the register directly
+	// (no per-access memory traffic); dirty values are written back to the cell at the
+	// epilogue. In call-making functions the value is spilled to / reloaded from the
+	// cell around each internal call for coherence, so only globals accessed in a
+	// CALL-FREE loop are pinned there (the spill/reload lands on out-of-loop calls).
+	// regNone when g is not pinned. See globals.go / assignPinnedLocals.
 	globalReg   []Reg
 	globalDirty []bool // value-pinned global g was written → needs epilogue write-back
 
@@ -248,15 +250,21 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	touchesMemory := bodyTouchesMemory(c.Body)
 	regABI := regABIEnabled && sigFitsRegABI(ft)
 	gpPool := gpPinPool(regABI, !hasCall, bodyUsesBulkMem(c.Body), f.nParams)
-	// Hot globals share the GP pin pool with locals, but only in call-free reg-ABI
-	// functions: their cell pointer stays register-resident across the whole body
-	// (no call to clobber it), derived once in the prologue. Elsewhere globals use
-	// the per-run cell-pointer cache (globalCellPtr).
+	// Hot mutable-int globals share the GP pin pool with locals, holding their VALUE
+	// in the register (WARP's model). In call-free functions any loop-accessed global
+	// qualifies; in call-making functions only globals accessed inside a CALL-FREE
+	// loop do — the spill/reload keeping the cell coherent then lands on the sparse
+	// out-of-loop calls, not per iteration. Non-eligible globals use the per-run
+	// cell-pointer cache (globalCellPtr).
 	var globalScores []int64
-	if regABI && !hasCall {
+	var globalElig []bool
+	if regABI {
 		globalScores = globalHotness(c.Body, f.m.GlobalCount())
+		if hasCall {
+			globalElig = globalCallFreeLoopAccess(c.Body, f.m.GlobalCount())
+		}
 	}
-	f.assignPinnedLocals(localHotness(c.Body, nLocals), globalScores, gpPool)
+	f.assignPinnedLocals(localHotness(c.Body, nLocals), globalScores, globalElig, gpPool)
 	if f.pinnedLocalMask.has(RBP) {
 		f.regMerge = false // RBP now holds a pinned local/global, so it can't be the merge register
 	}
@@ -336,7 +344,7 @@ func gpPinPool(regABI, callFree, usesBulkMem bool, nParams int) []Reg {
 	return append(pool, RBP)
 }
 
-func (f *fn) assignPinnedLocals(scores, globalScores []int64, gpPool []Reg) {
+func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool, gpPool []Reg) {
 	f.locals = make([]localDef, f.nLocals)
 	for i := range f.locals {
 		f.locals[i] = localDef{reg: regNone, typ: f.localType[i], state: lsReg}
@@ -365,6 +373,13 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, gpPool []Reg) {
 	loopMin := loopWeight(1)
 	for g := 0; g < len(globalScores); g++ {
 		if globalScores[g] < loopMin {
+			continue
+		}
+		// In a call-making function (globalElig non-nil) only globals accessed in a
+		// call-free loop qualify — otherwise the per-call spill/reload would land in
+		// the hot loop and regress. In a call-free function every loop-accessed global
+		// qualifies (globalElig nil).
+		if globalElig != nil && !globalElig[g] {
 			continue
 		}
 		gt, ok := f.m.GlobalTypeByIndex(uint32(g))
@@ -419,9 +434,15 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, gpPool []Reg) {
 // derivePinnedGlobals loads each pinned global's cell pointer into its dedicated
 // register, once, in the prologue (RBX = linMem must already be set). A no-op when
 // no globals are pinned. Every later access reads/writes through the register.
+func (f *fn) globalIs64(g int) bool {
+	gt, _ := f.m.GlobalTypeByIndex(uint32(g))
+	return wasm.EqualValType(wasm.GlobalValueType(gt), wasm.I64)
+}
+
 // derivePinnedGlobals loads each value-pinned global's current value into its
-// register, once, in the prologue (RBX = linMem must already be set): base →
-// &cell → value. A no-op when no globals are pinned.
+// register from memory (base → &cell → value, reusing the register for the chain).
+// Used in the prologue and to reload after a call (the callee may have changed the
+// shared global). A no-op when no globals are pinned.
 func (f *fn) derivePinnedGlobals() {
 	for g, reg := range f.globalReg {
 		if reg == regNone {
@@ -429,8 +450,7 @@ func (f *fn) derivePinnedGlobals() {
 		}
 		f.a.Load64(reg, RBX, -int32(abi.GlobalsPtrOffset)) // globals array base
 		f.a.Load64(reg, reg, int32(g*8))                   // &cell[g]
-		gt, _ := f.m.GlobalTypeByIndex(uint32(g))
-		if wasm.EqualValType(wasm.GlobalValueType(gt), wasm.I64) {
+		if f.globalIs64(g) {
 			f.a.Load64(reg, reg, 0)
 		} else {
 			f.a.Load32(reg, reg, 0) // i32: low half, zero-extended
@@ -438,27 +458,37 @@ func (f *fn) derivePinnedGlobals() {
 	}
 }
 
-// storePinnedGlobals writes each dirty value-pinned global's register back to its
-// memory cell — emitted once at the function epilogue (all returns route there via
-// retSites). The value-pinning scope is call-free, so no coherent observer exists
-// mid-function; a single write-back at exit is sufficient. Avoids RAX (the int
-// result register) when picking the cell-address scratch.
-func (f *fn) storePinnedGlobals() {
+// storePinnedGlobals writes value-pinned globals' registers back to their memory
+// cells. dirtyOnly (epilogue) writes only the globals this function actually set;
+// the call path (dirtyOnly=false) writes all of them before a call so the callee
+// observes the current value. Avoids RAX (the int result register) for the
+// cell-address scratch.
+func (f *fn) storePinnedGlobals(dirtyOnly bool) {
 	for g, reg := range f.globalReg {
-		if reg == regNone || !f.globalDirty[g] {
+		if reg == regNone || (dirtyOnly && !f.globalDirty[g]) {
 			continue
 		}
 		t := f.allocReg(maskOf(reg, RAX))
 		f.a.Load64(t, RBX, -int32(abi.GlobalsPtrOffset))
 		f.a.Load64(t, t, int32(g*8))
-		gt, _ := f.m.GlobalTypeByIndex(uint32(g))
-		if wasm.EqualValType(wasm.GlobalValueType(gt), wasm.I64) {
+		if f.globalIs64(g) {
 			f.a.Store64(t, 0, reg)
 		} else {
 			f.a.Store32(t, 0, reg)
 		}
 		f.release(t)
 	}
+}
+
+// hasPinnedGlobals reports whether any global is value-pinned (fast bail for the
+// call spill/reload path).
+func (f *fn) hasPinnedGlobals() bool {
+	for _, reg := range f.globalReg {
+		if reg != regNone {
+			return true
+		}
+	}
+	return false
 }
 
 // prologue: frameless — one `sub rsp,frameSize` (no frame-pointer push), pin
@@ -600,7 +630,7 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 	if err := f.runBody(c); err != nil {
 		return 0, err
 	}
-	f.storePinnedGlobals() // write dirty value-pinned globals back to their cells (all returns land here)
+	f.storePinnedGlobals(true) // write dirty value-pinned globals back to their cells (all returns land here)
 	if rN == 1 && !f.singleRegResult {
 		rt := mtOf(f.ft.Results[0])
 		if rt.isFloat() {

--- a/src/core/compiler/backend/railshot/hints.go
+++ b/src/core/compiler/backend/railshot/hints.go
@@ -116,6 +116,53 @@ func globalHotness(body wasm.Expr, nGlobals int) []int64 {
 	return scores
 }
 
+// globalCallFreeLoopAccess marks each global that is accessed inside a loop whose
+// body contains NO call. Value-pinning such a global in a call-making function is a
+// win: its per-iteration memory traffic is removed, while the spill/reload that
+// keeps the cell coherent lands only on the (sparse) calls OUTSIDE that loop — not
+// once per iteration (which would happen, and regress, if the loop itself called).
+func globalCallFreeLoopAccess(body wasm.Expr, nGlobals int) []bool {
+	elig := make([]bool, nGlobals)
+	var mark func(instrs []wasm.Instruction) // mark every global accessed anywhere within
+	mark = func(instrs []wasm.Instruction) {
+		for i := range instrs {
+			in := &instrs[i]
+			switch in.Kind {
+			case wasm.InstrGlobalGet, wasm.InstrGlobalSet:
+				if int(in.Index) < nGlobals {
+					elig[in.Index] = true
+				}
+			case wasm.InstrLoop, wasm.InstrBlock:
+				mark(in.Body().Instrs)
+			case wasm.InstrIf:
+				mark(in.Then())
+				mark(in.Else())
+			}
+		}
+	}
+	var walk func(instrs []wasm.Instruction)
+	walk = func(instrs []wasm.Instruction) {
+		for i := range instrs {
+			in := &instrs[i]
+			switch in.Kind {
+			case wasm.InstrLoop:
+				if bodyHasCall(wasm.Expr{Instrs: in.Body().Instrs}) {
+					walk(in.Body().Instrs) // has a call — but a nested call-free loop still qualifies
+				} else {
+					mark(in.Body().Instrs) // call-free loop — its globals are eligible
+				}
+			case wasm.InstrBlock:
+				walk(in.Body().Instrs)
+			case wasm.InstrIf:
+				walk(in.Then())
+				walk(in.Else())
+			}
+		}
+	}
+	walk(body.Instrs)
+	return elig
+}
+
 // bodyUsesBulkMem reports whether the body contains memory.copy/fill, which lower
 // to `rep movs`/`stos` and hard-clobber RDI/RSI/RCX — so those registers can't hold
 // pinned locals in a function that uses them.

--- a/src/core/compiler/backend/railshot/stack_test.go
+++ b/src/core/compiler/backend/railshot/stack_test.go
@@ -58,7 +58,7 @@ func TestAssignPinnedLocalsUsesLocalDefs(t *testing.T) {
 		nLocals:   3,
 		localType: []machineType{mtI32, mtF64, mtI32},
 	}
-	f.assignPinnedLocals([]int64{1, 10, 5}, nil, pinnedLocalRegs)
+	f.assignPinnedLocals([]int64{1, 10, 5}, nil, nil, pinnedLocalRegs)
 
 	r, isFloat, ok := f.pinReg(1)
 	if !ok || !isFloat || r != pinnedFLocalRegs[0] {


### PR DESCRIPTION
Follow-up to #85 (which value-pinned globals in call-free functions only). This extends value-pinning to **call-making** functions — the case WARP actually targets (the `__stack_pointer`), where the register value must be kept coherent with the cell around calls.

## The tradeoff, measured
- Global in a loop that **contains a call**: wago already *beats* wazero (the per-iteration call dominates). Value-pinning here would add per-iteration spill/reload → **regression**.
- Global in a loop with the call **outside** it (setup-then-compute): wago was **1.84× slower** than wazero (the loop re-derives the cell each iteration).

So a naive "pin + spill around every call" would help the second and hurt the first. The fix: **pin a global in a call-making function only when its hot accesses are in a call-free loop** (`globalCallFreeLoopAccess`) — then the spill-to-cell before a call / reload-after lands on the sparse *out-of-loop* calls, never per iteration.

Spill is emitted early in the call lowering (registers free); reload reuses the value register (no scratch); `callHost` (log-and-replay) needs neither. Epilogue write-back unchanged.

## Results (guard mode)
- call-outside-loop micro: **869 → 657 ns (1.32×)**; gap to wazero 1.84× → 1.38×
- call-in-loop micro: **1.00× — no regression** (not eligible; wago still beats wazero)
- No corpus regressions; json-as / fib_rec / dispatch (call-heavy) neutral

## Validation
- spec 1.0/2.0/3.0 pass; full `go test ./...` green
- both micros return identical results on wago and wazero
- corpus differential: all 104 exec results byte-identical