### PR TITLE
perf(railshot): WARP regalloc parity — memSize in R15, STACK_REG everywhere (root-causes #68), full pin pool

### DIFF
--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -124,13 +124,15 @@ func (f *fn) callHost(importIdx int, ft *wasm.CompType) error {
 	} else {
 		f.a.XorSelf32(RAX)
 	}
-	f.a.Load64(RDI, RBX, -offCustomCtx) // RDI = host-call log
-	f.a.Load32(RCX, RDI, 0)             // count
-	f.a.LeaScaled(RDX, RDI, RCX, 3, 8)  // entry = log + count*8 + 8
+	// Scratch entirely in RAX/RCX/RDX/R8: a host call clobbers no wasm register
+	// state, so pinned locals (which may live in RDI/RSI) stay untouched.
+	f.a.Load64(R8, RBX, -offCustomCtx) // R8 = host-call log
+	f.a.Load32(RCX, R8, 0)             // count
+	f.a.LeaScaled(RDX, R8, RCX, 3, 8)  // entry = log + count*8 + 8
 	f.a.StoreImm32Mem(RDX, 0, int32(importIdx))
 	f.a.Store32(RDX, 4, RAX)
 	f.a.AluRI(0, RCX, 1, false) // count++ (digit 0 = add)
-	f.a.Store32(RDI, 0, RCX)
+	f.a.Store32(R8, 0, RCX)
 	f.setDepth(d - p)
 	return nil
 }
@@ -205,6 +207,13 @@ func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType) {
 	} else {
 		f.flush()
 	}
+	// Store dirty pinned locals BEFORE the argument staging: a pinned local may
+	// live in an argument register (R9-R11 for 5+-arg calls) or in RDI/RSI
+	// (clobbered by the linMem/trap setup below), not just in a callee-clobbered
+	// register. Their values were already copied out above where an argument reads
+	// them. Lazy reload on the next read — WARP's STACK_REG model.
+	f.spillLocalsForCall()
+
 	// Unpin the owned source registers, then resolve the parallel move into targets.
 	for _, m := range moves {
 		f.pinned = f.pinned.remove(m.src)
@@ -224,9 +233,6 @@ func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType) {
 	// Consume the args; the operand model is now the k below-operands in slots.
 	f.setDepth(d - p)
 
-	// Store dirty pinned locals; the callee clobbers their registers (lazy reload
-	// on the next read — WARP's STACK_REG model).
-	f.spillLocalsForCall()
 	f.a.MovReg64(RDI, RBX)          // linMem
 	f.a.Load64(RSI, RSP, frTrapOff) // trap
 	site := f.a.CallRel32()
@@ -260,6 +266,9 @@ func (f *fn) emitMixedRegisterCall(localIdx int, ft *wasm.CompType) {
 
 	f.flush()
 	f.storePinnedGlobals(false) // spill value-pinned globals to their cells before the call
+	// Store dirty pinned locals BEFORE the argument loads: a pinned local may live
+	// in an argument register (R9-R11) or in RDI/RSI (clobbered by the setup below).
+	f.spillLocalsForCall()
 	gp, fp := 0, 0
 	for i, t := range ft.Params {
 		slot := d - p + i
@@ -274,7 +283,6 @@ func (f *fn) emitMixedRegisterCall(localIdx int, ft *wasm.CompType) {
 	}
 	f.setDepth(d - p)
 
-	f.spillLocalsForCall()
 	f.a.MovReg64(RDI, RBX)          // linMem
 	f.a.Load64(RSI, RSP, frTrapOff) // trap
 	site := f.a.CallRel32()
@@ -386,13 +394,14 @@ func (f *fn) emitWrapperCall(ft *wasm.CompType, emitCall func()) {
 	if p > 0 {
 		argOff = f.spillOff(d - p)
 	}
+	// Store dirty pinned locals BEFORE the call-setup writes below: a pinned
+	// local may live in RDI/RSI (clobbered by the setup itself), not just in a
+	// callee-clobbered register. Lazy reload on the next read — WARP's STACK_REG.
+	f.spillLocalsForCall()
 	f.a.LeaRsp(RDI, argOff)         // args = &slot[d-p]
 	f.a.LeaRsp(RCX, f.spillOff(d))  // results = &slot[d]
 	f.a.MovReg64(RSI, RBX)          // linMem (kept in RBX)
 	f.a.Load64(RDX, RSP, frTrapOff) // trap ptr
-	// Store dirty pinned locals; the callee clobbers their registers (lazy reload
-	// on the next read — WARP's STACK_REG model).
-	f.spillLocalsForCall()
 	emitCall()
 
 	// No post-call trap check: a callee trap unwinds the whole native call tree

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -71,6 +71,16 @@ type fn struct {
 	addRspAt  int  // byte offset of the epilogue's AddRsp imm32 (patched with frameSize)
 	guardMode bool // elide inline bounds checks; rely on guard-page + SIGSEGV trap
 	lazyZero  bool // defer declared-local zeroing for small call+memory functions
+
+	// memSizeReg caches the linear-memory size in bytes ([RBX-bdCurBytes]) in a
+	// dedicated register for the whole module (WARP's REGS::memSize, which reserves
+	// RSI when bounds checks are on). regNone in guard mode or when the module has
+	// no memory. wago's ABI keeps RSI busy at every call boundary (trap/linMem), so
+	// R15 is used instead: it has no fixed role, so it is preserved by construction
+	// across wasm→wasm calls (reserved out of every pool module-wide), refreshed by
+	// memory.grow, and established once at every offset-0 entry (wrapper prologue /
+	// reg-ABI adapter — the only ways an activation enters from Go).
+	memSizeReg Reg
 	// singleRegResult: this function uses the register-return ABI with exactly one
 	// result. Its exits produce that result directly in the return register — RAX
 	// (int) or XMM0 (float) — via the WARP-style target hint, skipping the
@@ -233,7 +243,10 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 		return nil, nil, 0, err
 	}
 
-	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, regMerge: regMergeEnabled, globalCellReg: regNone}
+	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone}
+	if !guardMode && len(m.Memories) > 0 {
+		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module
+	}
 	f.localType = make([]machineType, nLocals)
 	i := 0
 	for _, p := range ft.Params {
@@ -250,6 +263,9 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	touchesMemory := bodyTouchesMemory(c.Body)
 	regABI := regABIEnabled && sigFitsRegABI(ft)
 	gpPool := gpPinPool(regABI, !hasCall, bodyUsesBulkMem(c.Body), f.nParams)
+	if f.memSizeReg != regNone {
+		gpPool = withoutReg(gpPool, f.memSizeReg) // R15 is the module-wide memBytes cache
+	}
 	// Hot mutable-int globals share the GP pin pool with locals, holding their VALUE
 	// in the register (WARP's model). In call-free functions any loop-accessed global
 	// qualifies; in call-making functions only globals accessed inside a CALL-FREE
@@ -342,6 +358,17 @@ func gpPinPool(regABI, callFree, usesBulkMem bool, nParams int) []Reg {
 		pool = append(pool, R9, R10, R11)
 	}
 	return append(pool, RBP)
+}
+
+// withoutReg returns pool with r removed (order preserved).
+func withoutReg(pool []Reg, r Reg) []Reg {
+	out := pool[:0]
+	for _, p := range pool {
+		if p != r {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool, gpPool []Reg) {
@@ -491,6 +518,11 @@ func (f *fn) prologue() {
 	a.MovReg64(RBX, RSI)              // linMem → RBX (pinned for the whole function)
 	a.Store64(RSP, frTrapOff, RDX)    // trap ptr
 	a.Store64(RSP, frResultsOff, RCX) // results ptr
+	if f.memSizeReg != regNone {
+		// Offset-0 entry: establish the module-wide memBytes cache. Direct wasm→wasm
+		// register-ABI calls skip this (the caller's value is valid by construction).
+		a.Load32(f.memSizeReg, RBX, -bdCurBytes)
+	}
 	f.emitStackFenceCheck(RBX, RAX)
 	for i := 0; i < f.nParams; i++ {
 		if pr, isFloat, ok := f.pinReg(i); ok && !isFloat {
@@ -559,6 +591,11 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 	// Host→internal adapter (offset 0): in RDI=serArgs, RSI=linMem, RDX=trap,
 	// RCX=results; loads args into registers, calls the internal entry, stores the
 	// single register result.
+	if f.memSizeReg != regNone {
+		// Offset-0 entry (from Go, or an indirect call): establish the module-wide
+		// memBytes cache before the internal entry runs (which relies on it).
+		a.Load32(f.memSizeReg, RSI, -bdCurBytes)
+	}
 	a.Push(RCX)
 	a.Push(RDX)
 	a.Push(RSI)

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -229,6 +229,9 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			if os.Getenv("WAGO_DEBUG_PANIC") == "1" {
+				panic(r)
+			}
 			err = fmt.Errorf("amd64: %v", r)
 		}
 	}()
@@ -266,6 +269,17 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	if f.memSizeReg != regNone {
 		gpPool = withoutReg(gpPool, f.memSizeReg) // R15 is the module-wide memBytes cache
 	}
+	// Cap pins so at least numScratchGP+1 GPRs stay allocatable: the reserved
+	// scratch four plus one spare for allocations that must avoid RAX/RDX/RCX and a
+	// target (condenseBinary's RHS-relocation). Pinning deeper than this exhausts
+	// the allocator on high-pressure expression trees.
+	maxPins := len(gpAlloc) - numScratchGP - 1
+	if f.memSizeReg != regNone {
+		maxPins-- // R15 is reserved out of the allocatable file too
+	}
+	if len(gpPool) > maxPins {
+		gpPool = gpPool[:maxPins]
+	}
 	// Hot mutable-int globals share the GP pin pool with locals, holding their VALUE
 	// in the register (WARP's model). In call-free functions any loop-accessed global
 	// qualifies; in call-making functions only globals accessed inside a CALL-FREE
@@ -284,12 +298,12 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	if f.pinnedLocalMask.has(RBP) {
 		f.regMerge = false // RBP now holds a pinned local/global, so it can't be the merge register
 	}
-	// STACK_REG (lazy pinned-local spill) is disabled for memory-touching
-	// functions (#68): the explicit-bounds path's per-access scratch allocation
-	// (memAddr) adds register pressure that desyncs the lazy local state,
-	// corrupting a pinned pointer local. Eager save/reload is correct in both modes
-	// for any call+memory function; compute-only call functions keep the lazy model.
-	f.usesCalls = hasCall && !touchesMemory && !noStackReg
+	// STACK_REG (lazy pinned-local spill) for every call-making function,
+	// including memory-touching ones: dirty-only stores before a call, lazy reload
+	// on the next read (WARP's model). #68 disabled this for memory functions as a
+	// workaround; the actual root cause was the opElse merge edge skipping
+	// reconcileLocals (fixed in control.go, TestExecIfElseLocalMerge).
+	f.usesCalls = hasCall && !noStackReg
 	// The return-in-register hint helps compute/call-heavy code (recursion,
 	// dispatch) but adds register pressure in the deep, memory-bound call graphs
 	// (json-as's TLSF/GC) where it measured as a small regression. Gate it on

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -265,15 +265,15 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	hasCall := bodyHasCall(c.Body)
 	touchesMemory := bodyTouchesMemory(c.Body)
 	regABI := regABIEnabled && sigFitsRegABI(ft)
-	gpPool := gpPinPool(regABI, !hasCall, bodyUsesBulkMem(c.Body), f.nParams)
+	gpPool := gpPinPool(regABI, bodyUsesBulkMem(c.Body), f.nParams)
 	if f.memSizeReg != regNone {
 		gpPool = withoutReg(gpPool, f.memSizeReg) // R15 is the module-wide memBytes cache
 	}
-	// Cap pins so at least numScratchGP+1 GPRs stay allocatable: the reserved
-	// scratch four plus one spare for allocations that must avoid RAX/RDX/RCX and a
-	// target (condenseBinary's RHS-relocation). Pinning deeper than this exhausts
-	// the allocator on high-pressure expression trees.
-	maxPins := len(gpAlloc) - numScratchGP - 1
+	// Cap pins so the reserved scratch four (RAX/RDX/RCX/R8) always stay
+	// allocatable — WARP's resScratchRegsGPR floor. Deeper pressure (nested
+	// RHS-relocation hazards) degrades gracefully to spill slots via
+	// allocRegOrNone's fallback in condenseBinary.
+	maxPins := len(gpAlloc) - numScratchGP
 	if f.memSizeReg != regNone {
 		maxPins-- // R15 is reserved out of the allocatable file too
 	}
@@ -351,24 +351,26 @@ func (f *fn) runBody(c *wasm.Func) error {
 // assignPinnedLocals dedicates registers to the hottest integer locals (by the
 // hotness scores). Locals with a zero score (no AST / unused) are ordered by
 // index, so a body carrying only BodyBytes falls back to first-N pinning.
-// gpPinPool returns the registers available to hold pinned integer locals. The
-// base is R12-R15 (callee-saved and spill-managed around calls). A call-free
-// reg-ABI function has no call to clobber caller-saved registers, so it fills more
-// of the file: the non-argument registers RDI/RSI (free once the prologue consumes
-// linMem/trap — unless bulk-memory `rep movs` would clobber them), the argument
-// registers R9/R10/R11 when they carry no incoming parameter (nParams<=4, so the
-// prologue's arg→pinned moves can't clobber a live arg), and RBP (which then can't
-// serve as the block-merge register — the caller drops regMerge). RAX/RCX/RDX/R8
-// stay free for operand evaluation and the x86 fixed-role ops (div/shift/return).
-func gpPinPool(regABI, callFree, usesBulkMem bool, nParams int) []Reg {
+// gpPinPool returns the registers available to hold pinned integer locals, in
+// priority order (hottest local gets the first). The base is R12-R15. Call-making
+// functions extend over the rest of the file too (WARP's model: locals fill the
+// whole pool minus the reserved scratch): every pin is spill-managed around calls
+// by the STACK_REG model regardless of which register holds it — R12-R15 are
+// clobbered by the callee, RDI/RSI by the call setup itself, R9-R11 by 5+-arg
+// staging — so the only structural exclusions are:
+//   - RDI/RSI when bulk-memory `rep movs` would clobber them mid-body;
+//   - R9/R10/R11 in reg-ABI functions with >4 params (the internal entry's
+//     incoming args would collide with the prologue's arg→pinned moves);
+//   - RBP costs the block-merge register (the caller drops regMerge).
+//
+// RAX/RCX/RDX/R8 always stay free for operand evaluation and the x86 fixed-role
+// ops (div/shift/return); callHost's scratch also lives there.
+func gpPinPool(regABI, usesBulkMem bool, nParams int) []Reg {
 	pool := append([]Reg{}, pinnedLocalRegs...) // R12-R15
-	if !regABI || !callFree {
-		return pool
-	}
 	if !usesBulkMem {
 		pool = append(pool, RDI, RSI)
 	}
-	if nParams <= 4 {
+	if !regABI || nParams <= 4 {
 		pool = append(pool, R9, R10, R11)
 	}
 	return append(pool, RBP)
@@ -440,6 +442,13 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 	})
 	for k, c := range gp {
 		if k >= len(gpPool) {
+			break
+		}
+		// The extended pool slots (beyond the R12-R15 base) only take locals that
+		// are actually used (score > 0): pinning a cold local there costs prologue
+		// and call-spill traffic for nothing. Zero-score candidates still fill the
+		// base slots so AST-less bodies keep the first-N fallback.
+		if k >= len(pinnedLocalRegs) && c.score == 0 {
 			break
 		}
 		if c.global {
@@ -538,8 +547,13 @@ func (f *fn) prologue() {
 		a.Load32(f.memSizeReg, RBX, -bdCurBytes)
 	}
 	f.emitStackFenceCheck(RBX, RAX)
+	rdiParam := -1 // a param pinned in RDI must load LAST: RDI is the args base
 	for i := 0; i < f.nParams; i++ {
 		if pr, isFloat, ok := f.pinReg(i); ok && !isFloat {
+			if pr == RDI {
+				rdiParam = i
+				continue
+			}
 			a.Load64(pr, RDI, int32(8*i)) // pinned int param → its GP register
 		} else if ok && isFloat {
 			a.FLoadDisp(pr, RDI, int32(8*i), f.localType[i] == mtF64) // pinned float param → XMM
@@ -547,6 +561,9 @@ func (f *fn) prologue() {
 			a.Load64(RAX, RDI, int32(8*i))
 			a.Store64(RSP, f.localOff(i), RAX)
 		}
+	}
+	if rdiParam >= 0 {
+		a.Load64(RDI, RDI, int32(8*rdiParam))
 	}
 	f.zeroDeclaredLocals()
 	f.derivePinnedGlobals()

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -303,6 +303,7 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 		}
 		f.flush()
 		if kind == cfLoop {
+			f.a.Align16() // loop-top alignment: the pad runs on entry, not per iteration
 			fr.loopStart = f.a.Len()
 		}
 	}

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -318,6 +318,12 @@ func (f *fn) opElse() error {
 	if f.unreachable {
 		f.unreachable = false // else edge is reachable (cond-false analogue)
 	} else {
+		// The then-branch jumps to the if's end — a merge edge like any br, so its
+		// locals must converge to lsStackReg first (a dirty local's register would
+		// otherwise silently diverge from its slot across the merge, and a
+		// call-clobbered one would arrive with a stale register). WARP's
+		// recoverAllLocalsToRegForBranch does the same at every diverge point.
+		f.reconcileLocals()
 		if fr.regMerge1 {
 			f.reconcileMerge1(fr) // then-branch result → mergeReg
 		} else {

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -115,23 +115,37 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 			if dest != regNone {
 				avoid = avoid.union(maskOf(dest))
 			}
-			safe := f.allocReg(avoid)
-			f.a.MovReg64(safe, rr)
-			f.release(rr)
-			rr = safe
-			f.pinned = f.pinned.add(rr)
-			pinnedRight = rr
+			if safe := f.allocRegOrNone(avoid); safe != regNone {
+				f.a.MovReg64(safe, rr)
+				f.release(rr)
+				rr = safe
+				f.pinned = f.pinned.add(rr)
+				pinnedRight = rr
+				right = &elem{kind: ekValue, st: storage{kind: stReg, typ: node.typ, reg: rr}}
+				rightReleaseAfter = rr
+			} else {
+				// Nested hazards can exhaust the hazard-free registers (each level
+				// pins one relocated RHS). Park this RHS in a tracked spill slot
+				// instead — the ALU folds it back as an r/m operand. `right` is the
+				// on-stack condensed node, so the slot stays visible to the
+				// allocator until consumeBlockBelow erases it.
+				f.spill(right)
+			}
+		} else {
+			right = &elem{kind: ekValue, st: storage{kind: stReg, typ: node.typ, reg: rr}}
+			rightReleaseAfter = rr
 		}
-		right = &elem{kind: ekValue, st: storage{kind: stReg, typ: node.typ, reg: rr}}
-		rightReleaseAfter = rr
 	} else if (right.st.kind == stReg || right.st.kind == stLocalReg) && dest != regNone && right.st.reg == dest {
 		// The RHS lives in dest — either an owned reg or a borrowed pinned local
 		// whose register is also the target (an in-place self-update like
 		// `x = c - x`). Copy it out before the LHS overwrites dest.
-		t := f.allocReg(maskOf(dest))
-		f.a.MovReg64(t, dest)
-		right = &elem{kind: ekValue, st: storage{kind: stReg, typ: node.typ, reg: t}}
-		rightReleaseAfter = t
+		if t := f.allocRegOrNone(maskOf(dest)); t != regNone {
+			f.a.MovReg64(t, dest)
+			right = &elem{kind: ekValue, st: storage{kind: stReg, typ: node.typ, reg: t}}
+			rightReleaseAfter = t
+		} else {
+			f.spill(right) // same fallback: fold from a spill slot
+		}
 	}
 
 	if dest == regNone {

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1134,3 +1134,76 @@ func TestAmd64Phase1(t *testing.T) {
 		})
 	}
 }
+
+// TestExecIfElseLocalMerge is the regression test for the opElse merge-edge
+// reconcile (the root cause of #68): the then-branch of an if/else jumps to the
+// if's end, and that edge must converge pinned-local state (STACK_REG) like any
+// branch. Two variants:
+//   - dirty: the then-branch writes a pinned local and jumps; without the
+//     reconcile the merge believes reg==slot, a later call skips the dirty store,
+//     and the lazy reload reads the stale slot.
+//   - stale-reg: the then-branch makes a call (clobbering pinned regs) and jumps;
+//     without the reconcile the merge believes the register is valid and a later
+//     read uses the callee's leftover garbage.
+//
+// clobber3 is a call-free callee with three pinned locals, guaranteeing the
+// caller's pinned registers are deterministically overwritten.
+func TestExecIfElseLocalMerge(t *testing.T) {
+	clobber3 := funcDef{nil, []wasm.ValType{i32}, []byte{
+		0x01, 0x03, 0x7f, // 3 × i32 locals
+		0x41, 0x01, 0x21, 0x00, // a = 1
+		0x41, 0x02, 0x21, 0x01, // b = 2
+		0x41, 0x03, 0x21, 0x02, // c = 3
+		0x20, 0x00, 0x20, 0x01, 0x6a, 0x20, 0x02, 0x6a, // a+b+c
+		0x0b,
+	}}
+
+	t.Run("dirty-then-edge", func(t *testing.T) {
+		// f(x): l=7; if x { l=13 } else { nop }; call clobber3; return l
+		m := modFuncs(t,
+			funcDef{[]wasm.ValType{i32}, []wasm.ValType{i32}, []byte{
+				0x01, 0x01, 0x7f, // 1 × i32 local (idx 1)
+				0x41, 0x07, 0x21, 0x01, // l = 7
+				0x20, 0x00, // x
+				0x04, 0x40, // if (void)
+				0x41, 0x0d, 0x21, 0x01, // l = 13
+				0x05, 0x01, // else; nop
+				0x0b,             // end
+				0x10, 0x01, 0x1a, // call clobber3; drop
+				0x20, 0x01, // l
+				0x0b,
+			}},
+			clobber3,
+		)
+		if got := uint32(runAmd64u(t, m, 1)); got != 13 {
+			t.Fatalf("then path: l = %d, want 13", got)
+		}
+		if got := uint32(runAmd64u(t, m, 0)); got != 7 {
+			t.Fatalf("else path: l = %d, want 7", got)
+		}
+	})
+
+	t.Run("stale-reg-then-edge", func(t *testing.T) {
+		// f(x): l=7; if x { call clobber3; drop } else { nop }; return l
+		m := modFuncs(t,
+			funcDef{[]wasm.ValType{i32}, []wasm.ValType{i32}, []byte{
+				0x01, 0x01, 0x7f, // 1 × i32 local (idx 1)
+				0x41, 0x07, 0x21, 0x01, // l = 7
+				0x20, 0x00, // x
+				0x04, 0x40, // if (void)
+				0x10, 0x01, 0x1a, // call clobber3; drop
+				0x05, 0x01, // else; nop
+				0x0b,       // end
+				0x20, 0x01, // l
+				0x0b,
+			}},
+			clobber3,
+		)
+		if got := uint32(runAmd64u(t, m, 1)); got != 7 {
+			t.Fatalf("then path: l = %d, want 7", got)
+		}
+		if got := uint32(runAmd64u(t, m, 0)); got != 7 {
+			t.Fatalf("else path: l = %d, want 7", got)
+		}
+	})
+}

--- a/src/core/compiler/backend/railshot/fp.go
+++ b/src/core/compiler/backend/railshot/fp.go
@@ -632,10 +632,12 @@ func (f *fn) fload(r *wasm.Reader, f64 bool) error {
 	if f64 {
 		size = 8
 	}
-	ea, disp := f.memAddr(off, size)
+	ea, eaOwned, disp := f.memAddr(off, size, true) // float loads emit immediately
 	xmm := f.allocFReg(0)
 	f.a.FLoadIdx(xmm, RBX, ea, disp, f64)
-	f.release(ea)
+	if eaOwned {
+		f.release(ea)
+	}
 	f.pushFReg(xmm, mtOf2(f64))
 	return nil
 }
@@ -654,10 +656,12 @@ func (f *fn) fstore(r *wasm.Reader, f64 bool) error {
 	}
 	xmm := f.materializeF(f.popValue())
 	f.fpinned = f.fpinned.add(xmm)
-	ea, disp := f.memAddr(off, size)
+	ea, eaOwned, disp := f.memAddr(off, size, true)
 	f.a.FStoreIdx(RBX, ea, xmm, disp, f64)
 	f.fpinned = f.fpinned.remove(xmm)
-	f.release(ea)
+	if eaOwned {
+		f.release(ea)
+	}
 	f.releaseF(xmm)
 	return nil
 }

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -134,7 +134,7 @@ func (f *fn) trapUnlessLE(t, mb Reg) {
 
 // memoryCopy lowers memory.copy with memmove semantics (rep movsb, overlap-safe).
 // The three i32 operands (dst, src, n) are read from canonical slots into the
-// fixed rep registers RDI/RSI/RCX; R8/R9 are free scratch after the flush.
+// fixed rep registers RDI/RSI/RCX; RDX/R8 are the free scratch after the flush.
 func (f *fn) memoryCopy(r *wasm.Reader) error {
 	if _, err := r.U32(); err != nil { // dst memidx
 		return err
@@ -149,15 +149,16 @@ func (f *fn) memoryCopy(r *wasm.Reader) error {
 	f.a.Load64(RSI, RSP, f.spillOff(d-2)) // src offset
 	f.a.Load64(RCX, RSP, f.spillOff(d-1)) // n
 
+	// Scratch in RDX/R8 only (never pinnable); R9 may hold a pinned local.
 	mb := f.memSizeReg
 	if mb == regNone {
 		mb = R8
 		f.a.Load32(R8, RBX, -bdCurBytes) // memBytes
 	}
-	f.a.LeaScaled(R9, RDI, RCX, 0, 0) // dst + n
-	f.trapUnlessLE(R9, mb)
-	f.a.LeaScaled(R9, RSI, RCX, 0, 0) // src + n
-	f.trapUnlessLE(R9, mb)
+	f.a.LeaScaled(RDX, RDI, RCX, 0, 0) // dst + n
+	f.trapUnlessLE(RDX, mb)
+	f.a.LeaScaled(RDX, RSI, RCX, 0, 0) // src + n
+	f.trapUnlessLE(RDX, mb)
 
 	f.a.Add64(RDI, RBX) // absolute dst
 	f.a.Add64(RSI, RBX) // absolute src
@@ -190,13 +191,14 @@ func (f *fn) memoryFill(r *wasm.Reader) error {
 	f.a.Load64(RAX, RSP, f.spillOff(d-2)) // AL = fill byte
 	f.a.Load64(RCX, RSP, f.spillOff(d-1)) // n
 
+	// Scratch in RDX/R8 only (never pinnable); R9 may hold a pinned local.
 	mb := f.memSizeReg
 	if mb == regNone {
 		mb = R8
 		f.a.Load32(R8, RBX, -bdCurBytes)
 	}
-	f.a.LeaScaled(R9, RDI, RCX, 0, 0) // dst + n
-	f.trapUnlessLE(R9, mb)
+	f.a.LeaScaled(RDX, RDI, RCX, 0, 0) // dst + n
+	f.trapUnlessLE(RDX, mb)
 
 	f.a.Add64(RDI, RBX) // absolute dst
 	f.a.RepStosb()      // [RDI..] = AL, RCX times (DF=0)

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -70,14 +70,18 @@ func (f *fn) memAddr(off uint32, size int) (ea Reg, disp int32) {
 	f.pinned = f.pinned.add(ea)
 	t := f.allocReg(0)
 	f.a.LeaDisp(t, ea, leaDisp) // t = ea + off + size
-	mb := f.allocReg(maskOf(t))
-	f.a.Load32(mb, RBX, -bdCurBytes) // memory size in bytes
-	f.a.Cmp64(t, mb)
+	if f.memSizeReg != regNone {
+		f.a.Cmp64(t, f.memSizeReg) // memBytes lives in a register (WARP REGS::memSize)
+	} else {
+		mb := f.allocReg(maskOf(t))
+		f.a.Load32(mb, RBX, -bdCurBytes) // memory size in bytes
+		f.a.Cmp64(t, mb)
+		f.release(mb)
+	}
 	ok := f.a.JccPlaceholder(condBE) // in bounds when ea+off+size <= memBytes
 	f.emitTrap(trapMemOOB)
 	f.a.PatchRel32(ok, f.a.Len())
 	f.release(t)
-	f.release(mb)
 	f.pinned = f.pinned.remove(ea)
 	return ea, disp
 }
@@ -145,11 +149,15 @@ func (f *fn) memoryCopy(r *wasm.Reader) error {
 	f.a.Load64(RSI, RSP, f.spillOff(d-2)) // src offset
 	f.a.Load64(RCX, RSP, f.spillOff(d-1)) // n
 
-	f.a.Load32(R8, RBX, -bdCurBytes)  // memBytes
+	mb := f.memSizeReg
+	if mb == regNone {
+		mb = R8
+		f.a.Load32(R8, RBX, -bdCurBytes) // memBytes
+	}
 	f.a.LeaScaled(R9, RDI, RCX, 0, 0) // dst + n
-	f.trapUnlessLE(R9, R8)
+	f.trapUnlessLE(R9, mb)
 	f.a.LeaScaled(R9, RSI, RCX, 0, 0) // src + n
-	f.trapUnlessLE(R9, R8)
+	f.trapUnlessLE(R9, mb)
 
 	f.a.Add64(RDI, RBX) // absolute dst
 	f.a.Add64(RSI, RBX) // absolute src
@@ -182,9 +190,13 @@ func (f *fn) memoryFill(r *wasm.Reader) error {
 	f.a.Load64(RAX, RSP, f.spillOff(d-2)) // AL = fill byte
 	f.a.Load64(RCX, RSP, f.spillOff(d-1)) // n
 
-	f.a.Load32(R8, RBX, -bdCurBytes)
+	mb := f.memSizeReg
+	if mb == regNone {
+		mb = R8
+		f.a.Load32(R8, RBX, -bdCurBytes)
+	}
 	f.a.LeaScaled(R9, RDI, RCX, 0, 0) // dst + n
-	f.trapUnlessLE(R9, R8)
+	f.trapUnlessLE(R9, mb)
 
 	f.a.Add64(RDI, RBX) // absolute dst
 	f.a.RepStosb()      // [RDI..] = AL, RCX times (DF=0)
@@ -232,6 +244,9 @@ func (f *fn) memoryGrow(r *wasm.Reader) error {
 	f.a.PatchRel32(failMax, f.a.Len())
 	f.a.MovImm32(res, -1)
 	f.a.PatchRel32(done, f.a.Len())
+	if f.memSizeReg != regNone {
+		f.a.Load32(f.memSizeReg, RBX, -bdCurBytes) // refresh the memBytes cache (both paths)
+	}
 	f.pinned = f.pinned.remove(delta)
 	f.release(delta)
 	f.release(nw)

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -50,10 +50,19 @@ func (f *fn) emitTrap(code uint32) {
 // memAddr pops the address operand, folds the static memarg offset, emits the
 // bounds check (unless guard-page mode elides it), and returns the register
 // holding the effective offset plus the displacement to fold into the access.
-func (f *fn) memAddr(off uint32, size int) (ea Reg, disp int32) {
-	ea = f.materialize(f.popValue()) // ea = addr (u32, zero-extended)
+// aliasPinned lets a pinned-local address be used in place (no copy) — only
+// valid when the access is emitted immediately (stores), not deferred (loads);
+// eaOwned reports whether the caller must release ea.
+func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bool, disp int32) {
+	e := f.popValue()
 	disp = 0
 	leaDisp := int32(size)
+	needAdd := int64(off)+int64(size) > 0x7FFFFFFF && off != 0
+	if aliasPinned && !needAdd {
+		ea, eaOwned = f.materializeRead(e) // a pinned local's reg is read in place
+	} else {
+		ea, eaOwned = f.materialize(e), true // ea = addr (u32, zero-extended)
+	}
 	if int64(off)+int64(size) <= 0x7FFFFFFF {
 		disp = int32(off)
 		leaDisp = int32(off) + int32(size)
@@ -65,7 +74,7 @@ func (f *fn) memAddr(off uint32, size int) (ea Reg, disp int32) {
 	}
 
 	if f.guardMode {
-		return ea, disp
+		return ea, eaOwned, disp
 	}
 	f.pinned = f.pinned.add(ea)
 	t := f.allocReg(0)
@@ -83,7 +92,7 @@ func (f *fn) memAddr(off uint32, size int) (ea Reg, disp int32) {
 	f.a.PatchRel32(ok, f.a.Len())
 	f.release(t)
 	f.pinned = f.pinned.remove(ea)
-	return ea, disp
+	return ea, eaOwned, disp
 }
 
 // memLoad lowers a scalar load of `size` bytes. signed selects sign-extension;
@@ -96,7 +105,7 @@ func (f *fn) memLoad(r *wasm.Reader, size int, signed, wide bool) error {
 	if err != nil {
 		return err
 	}
-	ea, disp := f.memAddr(off, size)
+	ea, _, disp := f.memAddr(off, size, false) // deferred use: ea must be owned
 	// Defer the load: push a bounds-checked memory reference (the mov is emitted
 	// when the value is materialized, or folded as an r/m operand into a consumer).
 	e := f.pushValue(memRefStorage(ea, disp, size, signed, wide))
@@ -114,13 +123,20 @@ func (f *fn) memStore(r *wasm.Reader, size int) error {
 		return err
 	}
 	f.materializePendingLoads() // deferred loads must read pre-store memory
-	vreg := f.materialize(f.popValue())
+	// Both the value and the address are immediate read-only uses here, so a
+	// pinned local feeds the store in place — no copy (nothing between the reads
+	// and the StoreIdx can write a local).
+	vreg, vOwned := f.materializeRead(f.popValue())
 	f.pinned = f.pinned.add(vreg)
-	ea, disp := f.memAddr(off, size)
+	ea, eaOwned, disp := f.memAddr(off, size, true)
 	f.a.StoreIdx(RBX, ea, vreg, disp, size)
 	f.pinned = f.pinned.remove(vreg)
-	f.release(ea)
-	f.release(vreg)
+	if eaOwned {
+		f.release(ea)
+	}
+	if vOwned {
+		f.release(vreg)
+	}
 	return nil
 }
 

--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -167,6 +167,19 @@ func (f *fn) materialize(e *elem) Reg {
 	panic("amd64: cannot materialize storage")
 }
 
+// materializeRead returns a register holding e's value for an IMMEDIATE,
+// READ-ONLY use, plus whether the caller owns (and must release) it. A borrowed
+// pinned-local register is returned in place — no copy (WARP's
+// liftToRegInPlace with writable=false) — which is safe only when the use is
+// emitted before anything that could write the local (no deferral, no
+// local.set in between).
+func (f *fn) materializeRead(e *elem) (Reg, bool) {
+	if e.kind == ekValue && e.st.kind == stLocalReg {
+		return e.st.reg, false
+	}
+	return f.materialize(e), true
+}
+
 // loadMemRef emits the actual load for a deferred memory value into dst.
 func (f *fn) loadMemRef(dst Reg, st storage) {
 	f.a.LoadIdx(dst, RBX, st.reg, st.memDisp(), st.memSize(), st.memSigned(), st.typ.is64())

--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -43,6 +43,9 @@ func (f *fn) release(r Reg) {
 // scratch regs (gpAlloc lists scratch last, so first-fit does this naturally).
 func (f *fn) allocReg(avoid regMask) Reg {
 	block := avoid.union(f.pinned).union(f.pinnedLocalMask)
+	if f.memSizeReg != regNone {
+		block = block.add(f.memSizeReg) // module-wide memBytes cache is never allocatable
+	}
 	for _, r := range gpAlloc {
 		if f.regUser[r] == nil && !block.has(r) {
 			return r

--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -42,6 +42,18 @@ func (f *fn) release(r Reg) {
 // f.pinned are never chosen. Prefers freely-allocatable regs over the reserved
 // scratch regs (gpAlloc lists scratch last, so first-fit does this naturally).
 func (f *fn) allocReg(avoid regMask) Reg {
+	r := f.allocRegOrNone(avoid)
+	if r == regNone {
+		panic("amd64: no register available to spill")
+	}
+	return r
+}
+
+// allocRegOrNone is allocReg's non-panicking form: regNone when every candidate
+// is blocked and nothing on the stack is spillable. Callers with a memory-operand
+// fallback (condenseBinary's RHS relocation) use it to degrade to a spill slot
+// instead of failing under extreme pressure.
+func (f *fn) allocRegOrNone(avoid regMask) Reg {
 	block := avoid.union(f.pinned).union(f.pinnedLocalMask)
 	if f.memSizeReg != regNone {
 		block = block.add(f.memSizeReg) // module-wide memBytes cache is never allocatable
@@ -71,7 +83,7 @@ func (f *fn) allocReg(avoid regMask) Reg {
 			return r
 		}
 	}
-	panic("amd64: no register available to spill")
+	return regNone
 }
 
 // spillIfUsed evicts register r's occupant to a frame slot if one is resident,

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -506,3 +506,33 @@ func (a *Asm) SetccReg(c Cond, dst Reg) {
 	}
 	a.emit(0x0F, 0xB6, 0xC0|((byte(dst)&7)<<3)|byte(dst&7))
 }
+
+// nopSeqs[n] is the canonical n-byte NOP (Intel SDM recommended multi-byte
+// forms), used for code alignment padding.
+var nopSeqs = [10][]byte{
+	1: {0x90},
+	2: {0x66, 0x90},
+	3: {0x0F, 0x1F, 0x00},
+	4: {0x0F, 0x1F, 0x40, 0x00},
+	5: {0x0F, 0x1F, 0x44, 0x00, 0x00},
+	6: {0x66, 0x0F, 0x1F, 0x44, 0x00, 0x00},
+	7: {0x0F, 0x1F, 0x80, 0x00, 0x00, 0x00, 0x00},
+	8: {0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
+	9: {0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
+}
+
+// Align16 pads with multi-byte NOPs so the next emitted instruction starts on a
+// 16-byte boundary. Used for loop-top alignment: the pad sits on the entry path
+// (before the backward-branch target), so it executes once per loop entry, never
+// per iteration.
+func (a *Asm) Align16() {
+	pad := (16 - len(a.B)%16) % 16
+	for pad > 0 {
+		n := pad
+		if n > 9 {
+			n = 9
+		}
+		a.B = append(a.B, nopSeqs[n]...)
+		pad -= n
+	}
+}


### PR DESCRIPTION
Closes the largest codegen gaps vs WARP found by profiling json-as + a line-by-line diff against WARP's x86-64 backend (full findings: perf report of 2026-07-02). Four changes, in dependency order:

## ③ memBytes cached in a register (WARP `REGS::memSize`)

Explicit-bounds mode reloaded the memory size from `[RBX-8]` on **every** access — 628 loads in json-as (3.2% of all instructions), plus a second scratch register per check. WARP keeps it in RSI for the whole function; wago's ABI keeps RSI busy at every call boundary, so **R15** is used instead: reserved module-wide, established at every offset-0 entry (wrapper prologue / reg-ABI adapter), preserved across wasm→wasm calls by construction, refreshed by `memory.grow`. The check is now `lea t,[ea+k]; cmp t,r15; jbe` — no load, one temp.

## ② STACK_REG for memory functions — actual root cause of #68

#68 disabled the lazy pinned-local model for memory-touching functions as a workaround; the real bug was never found. Found here: **`opElse` never reconciled the then→end merge edge.** The then-branch could leave a pinned local dirty (`lsReg`) or call-clobbered (`lsMem`) and jump to the merge, where `resetLocalsToStackReg` asserted every edge arrived clean — so a later call skipped the dirty store (blake's stale pointer) or a later read used the stale register (json's silent corruption). Mode-independent, and **live on main for compute+call functions too**. One-line fix (reconcile on the then edge, exactly WARP's `recoverAllLocalsToRegForBranch`); `TestExecIfElseLocalMerge` covers both variants and fails without the fix. With the root cause fixed, the #68 exclusion is dropped: memory functions get dirty-only stores + lazy reloads.

## ① Full pin pool for call-making functions (WARP parity)

Call-making functions pinned locals only in R12-R15; WARP fills the whole file minus 4 reserved scratch (~9 registers). The pool is now `R12-R14(+R15 in guard) + RDI/RSI (no bulk-mem) + R9-R11 (wrapper ABI, or ≤4 params) + RBP`. Hazards handled:
- `spillLocalsForCall` moved **before** call-setup register writes in all three call paths
- `callHost` scratch RDI→R8; `memory.copy/fill` scratch R9→RDX (never pinnable)
- wrapper prologue loads an RDI-pinned param last
- cold locals (zero hotness score) don't take extended slots
- `allocRegOrNone` + spill-slot fallback in `condenseBinary`'s RHS relocation removes the register-exhaustion cliff that nested hazards could hit at high pin counts (previously a latent compile panic one register away on main)

Also: loop tops are now 16-byte aligned (multi-byte NOPs on the entry path) — sieve swung ±12% on pure code-placement luck without it.

## ④ In-place pinned-local reads for stores

`materialize(stLocalReg)` always copied the pinned register to a temp. Immediate read-only uses (store value/address, float load/store address) now read the pinned register in place (WARP's `liftToRegInPlace(writable=false)`). Deferred integer loads keep the copy (aliasing would dodge local.set realization).

## Results (explicit bounds, vs main)

| bench | main | this PR | Δ |
|---|---:|---:|---:|
| json-as serialize | 257 ns | 220 ns | **−14%** |
| json-as deserialize | 420 ns | 399 ns | −5% |
| memory.sum | 552 ns | 336 ns | **−39%** |
| memory_tree | 17.2 µs | 14.6 µs | **−15%** |
| utf-as | 222 µs | 200 µs | −10% |
| blake-as | 754 µs | 732 µs | −3% |
| sieve / fib_rec / linked_list | | | flat / flat / −5% |

vs wazero on json-as: 0.56x → 0.65x (ser), 0.70x → 0.74x (deser).

## Validation

- Spec suite (`TestSpecExec`): unchanged — all files pass except the pre-existing linking/data import limitations
- `go test ./...` green; new `TestExecIfElseLocalMerge` regression tests (verified to fail pre-fix)
- Explicit-vs-guard differential on blake/utf/json/memory_tree/sieve/memory: all match
- `TestJsonAsGuardCorrect` (serialize/deserialize equivalence): pass