### PR TITLE
perf(railshot): backlog sweep — trap stubs, strength reduction, scaled-index LEA, lazy merges, jump tables, reg-ABI call_indirect, const bulk-mem

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -4,296 +4,140 @@ Two complementary lenses on the same question — *how do we make wago faster wi
 destroying the reason it exists* (fast compile, no cgo, tiny footprint, single pass):
 
 1. **Make the single-pass backend smarter** — better-informed choices inside the existing
-   Valent-Block tier (the bulk of the actionable near-term work).
-2. **Port what's still worth porting from WARP** (`warp/`) — the C++ reference engine wago
-   is a port of. Used here as a *reference axis*, not a target to clone.
+   railshot tier.
+2. **Port what's still worth porting from WARP** (`warp/`) — the C++ reference engine the
+   backend is a port of. Used as a *reference axis*, not a target to clone.
 
 The headline architectural decision (see the end): **keep two tiers and do not blend them.**
 The single-pass tier stays single-pass; the `src/core/compiler/ir` SSA package becomes an
 *optional* optimizing tier later, never something a plain `Compile` pays for.
 
-Legend: effort S/M/L · value ⬜ low · 🟦 medium · 🟩 high · ⭐ very high ·
-status ✅ done · 🚧 partial · ⬜ todo. All wago citations verified against current source.
+Legend: effort S/M/L · value ⬜ low · 🟦 medium · 🟩 high · ⭐ very high.
 
 ---
 
-## What's already in place
+## What's in place (updated 2026-07-02)
 
-The backend (`src/core/compiler/backend/railshot`) is a single-pass x86-64 codegen fused with
-register allocation over a symbolic operand stack (`vConst`/`vLocal`/`vReg`/`vSpill`/`vPinned`),
-flushing to deterministic frame slots at control-flow joins. Already done:
+The backend (`src/core/compiler/backend/railshot`) is the full WARP-architecture port: a
+single-pass x86-64 codegen over a valent-block operand stack (deferred-action trees,
+condense engine) with an on-the-fly whole-register-file allocator. Landed, in rough order:
 
-- **Immediate compare/branch fusion** — a compare/`eqz` keeps EFLAGS live for exactly one step
-  and fuses into an adjacent `if`/`br_if`/`select`, skipping `setcc`+`test` (`fuse.go:26`).
-- **Constant folding** — integer arith, shifts, compares, unary, safe div/rem, some float
-  (`fold.go`).
-- **Lazy + pinned locals** — `local.get` stays symbolic (`vLocal`); first few integer locals
-  pinned to `RBX/R13/R14/R15` (`compile.go:38-43,81-82`).
-- **Pinned mutable integer globals** — lazy write-back, using pinned slots left after locals
-  (`compile.go:45-53,1164-1228`).
-- **Memarg offset folding** — constant memarg offset folded into the addressing mode (PR #36,
-  `−17%` on an offset-heavy sum, bounds check preserved).
-- **Experimental guard-page bounds-check elision** — `4096`-load array sum `3566 → 2686 ns/op`
-  (`−24.7%`); see `docs/guardpage-spike.md`.
-- **Multi-value** — block params + multiple results, end-to-end (`ir/build.go:1417`,
-  `control.go:50-71,202-207`). (Listed as a gap in older notes; it isn't one.)
+**Storage model / register allocation**
+- **Register-ABI internal calls** (old P1) — args/results in registers between wasm
+  functions; wrapper ABI kept at the Go boundary. Includes the parallel-move resolver.
+- **Hotness-aware local pinning** (old P2) — loop-weighted scores from a one-pass
+  `scanBody` pre-scan (`hints.go`), WARP-style whole-file pin pool for call-making
+  functions too (up to `file − 4 scratch`), STACK_REG lazy spill (dirty-only stores at
+  calls, lazy reload) for **all** call-making functions. #68's real root cause (the
+  `opElse` merge edge skipping reconciliation) was found and fixed with regression tests.
+- **Value-pinned hot globals** sharing the pin pool (#84–#86).
+- **memBytes in R15** (old P3) — explicit-bounds mode keeps the memory size in a
+  module-wide reserved register (WARP `REGS::memSize`); checks are `lea; cmp; ja stub`.
+- **Lazy per-frame merge agreement** (old P6, locals half) — control-flow edges agree
+  per-frame on each pinned local's merge state (`lsStackReg` or `lsMem`), so a
+  call-clobbered local can stay slot-only across a merge until actually read. Loop tops
+  stay eager (reloads hoisted out of bodies). Conditional returns converge nothing.
 
-So the roadmap is not "invent an optimizer." It's: make the existing tier more *informed*, less
-*flush-happy*, and less *wrapper-ABI-dependent*.
+**Bounds checks / traps**
+- **Guard-page mode** (old P5) is first-class behind `-tags wago_guardpage` and is the
+  *default* bounds mode in such builds (`WAGO_BOUNDS=explicit` overrides).
+- **Shared cold trap stubs** (old P9) — one stub per trap code per function; every check
+  is a fall-through `ja stub`. (~23% smaller code on memory-heavy modules.)
+- **Stack-fence elision for small call-free leaves** — a leaf's one unchecked frame is
+  absorbed by the fence's 256 KiB margin.
 
----
+**Instruction selection**
+- Compare→branch fusion; constant folding; memarg offset folding; deferred loads folded
+  as ALU r/m operands; in-place accumulation; cmov select.
+- **Algebraic identities + strength reduction** (old P4) — `x±0`, `x&~0`, `x|0`, `x^0`,
+  shifts by 0, `x*1`, `x*0`, `x*2ⁿ→shl`, `x*{3,5,9}→lea`, `x/ᵤ2ⁿ→shr`, `x%ᵤ2ⁿ→and`,
+  `x-x`/`x^x→0`, `x&x`/`x|x→x` — at `pushBinOp`, before a node exists.
+- **Scaled-index LEA fusion** — `add(x, shl(y, k≤3))` → `lea [x + y*2ᵏ]` (the
+  AssemblyScript array-address shape).
+- **`br_table` jump tables** (old P7) — n≥5 dispatches through a RIP-relative offset
+  table with deduplicated per-case stubs; smaller tables keep the cmp/jne chain.
+- **Small constant `memory.fill`/`copy` unrolled** — n≤32 lowers to overlap-safe
+  load-all/store-all chunks (memmove semantics preserved); no `rep` microcode startup.
+- **`call; local.set` result fusion** — a register-ABI call result lands directly in the
+  pinned local's register.
+- **Register-ABI `call_indirect`** — the table entry's pad word carries the internal-entry
+  delta, so compatible signatures skip the wrapper adapter.
+- **Code layout** — 16-byte aligned functions, internal entries, and loop tops (multi-byte
+  NOPs on the entry path). Tight-loop benchmarks swing ±20% on layout luck without this;
+  treat any single-module regression as suspect until the disassembly is diffed.
 
-## Phase 0 — build the measurement harness first (prerequisite)
+**MVP completeness** (old "completion batch"): memory.grow/size, trapping float→int
+truncation + trunc_sat, start function, multi-value, imported/mutable globals.
 
-Do this before adding cleverness. Every optimization below needs before/after evidence or it
-becomes folklore.
+**Compile speed**: the pre-scan is a single AST walk (`scanBody`) feeding pinning, pool
+selection, model gating, and lazy-zero decisions.
 
-- **Backend stats mode** (debug/test-only config): a `CodegenStats` counting
-  `BytesEmitted, Spills, Reloads, Flushes, FlushSlots, Calls/InternalCalls/HostCalls,
-  BoundsChecks, BoundsChecksElided, ConstFolds, CompareFusions, PinnedLocals/Globals,
-  MaxStackDepth`. The decision-driving numbers are **spills/fn, flushes/fn, flush-slots/fn,
-  bounds-checks/fn, code-bytes/fn, internal-call count, control-join count**.
-- **Golden disassembly tests per optimization** — extend the `valent_test.go` instinct
-  (asserting zero push/pop beyond prologue) with tiny `.wat` fixtures asserting instruction-
-  pattern deltas for: local peepholes, compare→branch fusion, bounds-check folding,
-  loop-carried local pinning, internal-call ABI, `br_table` lowering, `memory.copy`/`fill`.
-- **Workload fixtures**: recursive-call, memory-walking (AssemblyScript-ish), branch-heavy,
-  switch-heavy — so the priority items below each have a target benchmark.
+### Measured (2026-07-02, explicit bounds, vs the pre-sweep #87 baseline)
 
----
+| bench | #87 | sweep | Δ |
+|---|---:|---:|---:|
+| sieve | 163µs | 123µs | **−24%** (beats wazero) |
+| memory_tree | 14.6µs | 11.8µs | **−19%** |
+| linked_list | 11.3µs | 9.4µs | **−17%** |
+| dispatch (call_indirect) | 19.1ns | 17.6ns | −8% |
+| blake-as | 729µs | 700µs | −4% |
+| json-as ser / deser | 218 / 396 | 214 / 380 | −2% / −4% |
+| memory.sum (explicit vs guard) | 337 | 230 | **explicit == guard** |
 
-## Part 1 — single-pass roadmap (priority-ordered, actionable)
-
-### P1. Register-based internal-call ABI  · L · 🟩 (highest runtime upside)
-
-The known loss: recursive calls, the one microbench wazero wins. Today `callInternal` →
-`emitWrapperCall` (`compile.go:514-572`) marshals **all** args/results through a 16-aligned
-`rsp` buffer with fixed *pointer* regs (`RDI`=args, `RCX`=results, `RSI`=linMem, `RDX`=trap) —
-no value crosses the boundary in a register — then spills/reloads pinned locals+globals and
-checks the trap slot. `flush()` (`control.go:111-148`) additionally spills the entire operand
-stack to frame slots at every control boundary.
-
-WARP instead passes 4 GPR + 4 FPR params / 2 GPR + 2 FPR results **in registers** via its
-`WasmABI` (`x86_64_backend.cpp:1158-1207`, `x86_64_cc.hpp:44-94`).
-
-Plan:
-- Keep the wrapper ABI at the **public entry** (Go → wasm exports). Add a second entry offset
-  per function (`EntryWrapper` / `EntryInternal`); the wrapper prologue unpacks export slots
-  into the internal ABI.
-- Internal wasm→wasm calls jump directly to `EntryInternal` with a register ABI:
-  `RDI`=linMem, `RSI`=trap; int args `RAX,RCX,RDX,R8,R9,…`; float args `XMM0..7`; results in
-  `RAX/RDX` or `XMM0/XMM1`; stack spill only on overflow. No need to cosplay the C ABI — wago
-  compiles both sides.
-- Fall back to wrapper-call lowering for host imports, `call_indirect` (initially), and
-  multi-result until stable.
-
-**This requires `RegisterCopyResolver` to land *with* it, not after.** Once args live in
-registers, moving each into its ABI slot is a parallel-move problem with cycles
-(`RAX→RCX` while `RCX→RAX`). Port WARP's resolver
-(`warp/src/core/compiler/common/RegisterCopyResolver.hpp`): emit every move whose target isn't
-someone's source, then break the remaining pure cycles — GPR with `XCHG`, XMM with a 3-move
-dance through a scratch reg (`x86_64_call_dispatch.cpp:204-237`).
-
-Wins: big recursive-call win, less `rsp` traffic, less pinned-local churn, smaller call-site
-code, a foundation for tail-call-ish transforms.
-
-### P2. Hotness-aware local pinning  · M · 🟩 · low risk
-
-`assignPinnedLocals` pins the *first* few integer locals (params assumed hottest). Misses loop
-counters, accumulators, compiler temporaries. Replace with a cheap **bytecode pre-scan** (not
-an IR pass) that scores locals:
-
-```
-+1 local.get   ·  +2 local.set/tee  ·  +4 used at loop depth > 0
-+8 carried across a loop back-edge  ·  −10 live across calls in a call-heavy fn
-```
-
-Pin the top-N integer locals by score. Fits Valent directly — it's assignment *quality*, not a
-backend rewrite (`vLocal`/`vPinned` already exist). Gate behind a tier enum
-(`PinningNone`/`PinningParams`/`PinningUseCount`), default to use-count once tests pass.
-
-### P3. Memory-base / memory-size pinning  · S–M · 🟦 (memory-loop win)
-
-Every scalar access reloads `linMem` from `[RBP-16]`; explicit-bounds mode also reloads memory
-size from `[linMem-8]`. For memory-heavy, call-free functions, reserve `R15`=linMem,
-`R14`=memBytes (note: `R12` is a poor base — forces a SIB byte, `compile.go:22`). Gate on a
-pre-scan heuristic (`memOps ≥ 4 && calls == 0`). Reduces per-load
-`load linMem; load memBytes; lea; cmp; branch; mem` to `lea; cmp pinned; branch; mem`.
-**Constraint:** once `memory.grow` exists, a call can grow/move memory — pinned base+size must
-be reloaded around calls (trivial today: no grow yet).
-
-### P4. Algebraic peepholes + strength reduction  · S · 🟦 · low risk
-
-Folding currently fires only when *both* operands are constant (`fold.go`). Add
-*partial*-constant simplification in the centralized `binALU`/`mul` paths:
-
-```
-add/sub:  x+0→x · x-0→x · 0-x→neg · x+x→lea x*2 · x+small→lea
-mul:      x*0→0 · x*1→x · x*-1→neg · x*2ⁿ→shl · x*{3,5,9}→lea
-bitwise:  x&0→0 · x&-1→x · x|0→x · x^0→x · x^x→0 (if same ventry identity)
-shift:    x<<0→x · x>>0→x  (const mask already in foldShift)
-```
-
-(Note: WARP itself has *no* strength reduction — this is a beyond-WARP single-pass idea, safe
-because it's local and operand-level.)
-
-### P5. Graduate guard-page mode behind a runtime config  · L · 🟦 (riskier)
-
-The spike (`docs/guardpage-spike.md`) reserves ~8 GiB virtual space, commits active pages,
-elides scalar load/store checks, and turns faults into wasm traps via a process-wide signal
-handler (`memory.copy`/`fill` keep explicit checks — `rep movsb` can partially write). Make it
-a first-class mode gated on: linux/amd64 only, no imported memory, no `memory.grow` (until
-remap/protect is handled), documented signal-handler caveat. Add benchmark variants (tight
-`i32.load` loop, mixed load/store, bounds-heavy AssemblyScript, string/JSON memory walking).
-
-### P6. Reduce flushes at control joins ("compatible state joins")  · M–H · 🟩 · higher risk
-
-`flush()` materializes the whole operand stack to canonical slots and clears reg state at every
-boundary — correct but conservative. Add a per-frame join-state cache: the first incoming edge
-records a preferred layout (`joinLoc{kind: slot|reg|const, …}`); later edges either match it or
-trigger materialization. If all edges agree, skip the slot stores/reloads at the join. Keep the
-first version constrained: single-or-zero result, no nested `br_table`, no pinned-global alias
-ambiguity, no float-spill type ambiguity. (This is the single-pass analogue of WARP's
-"block params/results in registers", `Common.cpp:332-383` — without adopting the deferred tree.)
-
-### P7. `br_table` jump tables  · M · 🟦 (switch-heavy win)
-
-`opBrTable` (`control.go:322`) emits a linear `cmp/jne` chain — fine for small `n`, tragic as it
-grows. Threshold it: `n≤4` linear; `5≤n≤~64` bounds-check + inline `rip`-relative jump table
-(`movsxd target,[tbl+idx*4]; add target,tbl; jmp target`); larger watched for code size. Because
-cases target different control frames (`branchN`/`height`), table entries land on per-case
-stubs emitted after the dispatch, not direct shared-end jumps.
-
-### P8. Extend compare fusion past adjacency (`vFlags`)  · M · 🟦 · medium risk
-
-Immediate fusion only fires when the branch *immediately* follows the compare (EFLAGS live one
-step). Misses `cmp; local.tee $c; br_if` and `eqz; local.set/get; if`. Add a `vFlags` stack
-entry (a boolean held in flags, carrying its `Cond`), materialized to `0/1` the instant any
-flag-clobbering op appears. Start *pattern-constrained* (only `cmp;tee;br_if`,
-`cmp;set;get;if`, `eqz;tee;if`), reusing the existing fusion lowering helpers — don't birth a
-second compiler.
-
-### P9. Cold trap stubs (hot/cold split)  · S–M · 🟦
-
-`emitTrap` (`control.go:171-176`) inlines `store trap code; leave; ret` at every bounds/div/
-indirect/unreachable site. Emit per-function cold stubs (`trap_mem_oob`, `trap_div_zero`, …)
-and make hot checks `jcc ok; jmp trap_stub; ok:`. Smaller hot code, better I-cache, cleaner
-layout, friendlier to the guard-page path. Keep inline traps for tiny functions if the extra
-jump hurts.
-
-### P10. Float spill type tracking  · S · 🟦 · low risk (correctness smell)
-
-`isFloatOperand` returns false for `vSpill` ("type not tracked; assume integer",
-`compile.go:801`), so float select/reload paths can guess wrong. Carry `fp`/`wide` metadata on
-spills consistently. Cheap, removes a latent bug class, unlocks float-correct select/reload.
-
-### P11. Compile-speed hygiene (don't give back the 34× edge)  · S · ⬜ · low risk
-
-- Replace `map[byte]Cond` opcode dispatch (`i32cmp`/`i64cmp`, `compile.go:1083,1441,1701`) with
-  `[256]Cond` + `[256]bool` tables — same codegen, less compile overhead.
-- Pre-size the compiler slices in `cg` (symbolic stack, control stack, relocs, local/pinned
-  arrays) from validation metadata.
-
-### Tiny enabling pre-pass: `FuncHints`  · S · low risk
-
-The one "pass" worth adding without betraying single-pass. A reconnaissance scan (not SSA)
-producing per-function: local/global get/set lists, `MemOps`, `Calls`/`InternalCalls`/
-`HostCalls`, `LoopDepthMax`, `HasBrTable`/`MaxBrTable`, `ConstMemOps`, `HasIndirectCall`. Feeds
-P2 (local pinning), P3 (mem pinning), P7 (jump-table threshold), P1 (internal-ABI eligibility),
-P9 (trap-stub choice), and buffer pre-sizing. Build the drone, not the aircraft carrier.
+Cumulative from before #87 (main@22c09be): json ser 257→214, deser 420→380;
+memory.sum 552→230; sieve 165→123; memory_tree 17.2→11.8; wazero-relative json
+0.56x→0.66x ser / 0.70x→0.77x deser. wago beats wazero on fib_rec, sieve,
+memory_tree, linked_list, dispatch, branches; loses on json-as (memory/GC-bound) and
+blake.
 
 ---
 
-## Part 2 — WARP-port reference axis
+## Remaining roadmap (priority-ordered)
 
-WARP is essentially **MVP-scoped**: SIMD, threads/atomics, exception handling, tail calls, full
-reference types, the bulk-memory remainder, multi-memory, memory64 are **not in WARP either**
-(it throws `FeatureNotSupportedException`) — those are greenfield. wago is already **ahead** of
-WARP on `trunc_sat`, `select t`, and imported/mutable/typed globals.
+### R1. `vFlags` — compare fusion past adjacency  · M · 🟦 (old P8)
+Fusion only fires when the branch immediately follows the compare. Misses
+`cmp; local.tee $c; br_if` and `eqz; local.set/get; if`. Add a flags-resident stack
+entry carrying its `Cond`, materialized the instant any flag-clobbering op appears.
+Start pattern-constrained; don't birth a second compiler.
 
-### Feature gaps with a real WARP reference
+### R2. Float lowering parity  · M · 🟦
+ISA suite lags: floats ~1.65× (no in-place XMM accumulation — the int path has it),
+min/max 2.2× (branchy lowering; use `minss/maxss` + NaN fixup), and float pinned locals
+use the eager call model. Mechanical, well-scoped.
 
-| Feature | Effort | Value | Status | Notes (verified) |
-|---|:--:|:--:|:--:|---|
-| **memory.grow / memory.size** | S–M | 🟩 | ⬜ | Decoder+validator+IR already model it (`ir/op.go:22-23`, `build.go:887-908`); only the frontend whitelist (`frontend.go:485-516`), backend lowering, and runtime remap/size-cache remain. *The* remaining MVP gap. |
-| **Float→int trapping truncation** | S | 🟦 | ⬜ | Opcodes wired (`compile.go:1628-1639`) but lower to a bare `Cvttf2si` with no NaN/overflow guard (`fp.go:259-266`); `TrapTruncOverflow` already exists (`runtime/trap.go:22`). Smallest correctness gap. |
-| **start function** | S | ⬜ | ⬜ | Hard-rejected today (`frontend.go:120-122`); needs instantiate-time invocation. |
-| **Sync host calls w/ return values (V2 imports)** | L | ⭐ | 🚧 | Runtime re-entry half is spiked — `HostFunc`/`CallWithHost`/`hostCallPending` (`runtime/engine_linux_amd64.go:50-78`) + `stubHostCall` blob (`runtime/stubs_amd64.go:117-126`). Compiled path is still deferred-log (void, ≤1 i32 arg, `compile.go:646-670`). Missing piece: the JIT emitter generating the protocol. Biggest functional unlock (WASI). `offCustomCtx` already reserved. |
+### R3. Store-narrowing peephole  · S · ⬜
+`setcc; movzx; store8` keeps a dead `movzx` (sieve's inner loop). A deferred-compare
+consumer that stores 8 bits can skip the widening. Cheap, narrow.
 
-### Codegen items from WARP (the deferred-tree family)
+### R4. Deser gap (the remaining json-as loss)  · L · 🟩
+wago loses to wazero only on allocation/GC-heavy call graphs (TLSF + AS GC). The
+lazy-merge work removed the reload traffic (−17% rsp-loads); wall time is now dominated
+by the memory-bound allocator path itself. Next candidates, in order of evidence needed:
+profile the TLSF hot loop for dependent-load chains; block-param registers for the
+hottest if/else diamonds (WARP `Common.cpp:332`); the SSA tier for exactly these
+functions.
 
-WARP defers every arithmetic op into a **deferred-action tree** and condenses a whole
-sub-expression at once (side-effects → scratch-pressure → target-hints), vs wago's eager
-one-op-at-a-time. The tree is the keystone that unlocks the rest:
-
-| WARP optimization | Effort | Value | WARP ref |
+### R5. Runtime / infra from WARP
+| Item | Effort | Value | Notes |
 |---|:--:|:--:|---|
-| **Deferred-action tree** (keystone) | L | 🟩 | `Common.cpp:524-612` |
-| **Target hints** (result lands in its final reg) | L | 🟩 | `condenseWithTargetHint`, `Common.cpp:560` |
-| **Block params/results in registers** | L | 🟩 | `Common.cpp:332-383` (see P6 for the single-pass approximation) |
-| Side-effect scheduling (hoist div/loads) | M | 🟦 | `condenseSideEffectInstructionBelow`, `Common.cpp:420` |
-| Cost-ordered `selectInstr` + reg-mem operand folding | M | 🟦 | `x86_64_assembler.cpp:218-590` |
-| Reg-mem operand folding for loads (`add r,[mem]`) | M | 🟦 | fold a bounds-checked load as its sole consumer's ALU source |
+| Interruption / cooperative cancel | S–M | 🟩 | `checkForInterruptionRequest`; kills runaway loops |
+| Wasm-level stack trace on trap | M | 🟩 | frame-ref chain |
+| Debug mode + bytecode→machine map | M | 🟦 | |
+| arm64 backend | L | 🟩¹ | WARP `backend/aarch64` as reference |
+| Sync host calls w/ return values (V2 imports) | L | ⭐ | runtime half spiked; biggest functional unlock (WASI) |
 
-Do **not** port: `SKIP` stack elements (vestigial — never written in WARP).
+¹ if Apple Silicon / arm64 Linux matters.
 
-### Runtime / infra from WARP
+### R6. Measurement hardening  · S · 🟦 (old P0, still worth doing)
+`CodegenStats` (spills/flushes/bounds-checks/code-bytes per function) + golden
+disassembly tests per optimization. The sweep found layout-luck swings of ±20% on tight
+loops — per-function code-byte tracking would catch silent bloat, and golden disasm
+would catch silently-disabled peepholes.
 
-| Item | Effort | Value | WARP ref |
-|---|:--:|:--:|---|
-| **Interruption / cooperative cancel** (kill runaway loops) | S–M | 🟩 | `checkForInterruptionRequest` (`x86_64_backend.cpp:616`) |
-| **Wasm-level stack trace on trap** | M | 🟩 | `emitStackTraceCollector`, frame-ref chain |
-| **Debug mode + bytecode→machine debug map** | M | 🟦 | `Compiler.hpp` `enableDebugMode`/`retrieveDebugMap` |
-| **arm64 backend** | L | 🟩¹ | `backend/aarch64/` (self-contained; reuses ported `common/`) |
-| Native disassembler (drop objdump dep) | S–M | ⬜ | `disassembler/` (wraps Capstone) |
-| Passive (guard-page) memory protection | L | 🟦 | conflicts with no-signal default; see P5 |
-
-¹ value high only if arm64 (Apple Silicon / arm64 Linux) matters. tricore backend: skip.
-
-### Small constant bulk-memory specialization  · M · 🟦
-
-`memory.copy`/`fill` lower to `rep movsb`/`stosb` with operands spilled to fixed regs
-(`memory.go`) — sensible for dynamic sizes, overkill for tiny constant `n`. When `n` is a
-`vConst`: `fill` → scalar store (`n≤8`) or short unrolled stores (`n≤32`); `copy` similar but
-overlap-safe (wasm requires memmove semantics — the current fwd/bwd direction logic must be
-preserved). Start with `fill`; it's easier.
-
----
-
-## Greenfield (NOT in WARP — no reference)
-
-SIMD/v128, threads & atomics, exception handling, tail calls (`return_call*`), full reference
-types + `table.*` ops, bulk-memory remainder (`memory.init`/`data.drop`/`table.*`), passive
-data/element segments, memory64, multi-memory, imported memory/table.
-
----
-
-## Merged priority order
-
-```
-P0. Measurement: CodegenStats + golden disasm tests + workload fixtures   (prerequisite)
- 1. FuncHints pre-scan                                                     (enables 2,3,7)
- 2. Hotness-aware local pinning
- 3. Memory base / memory-size pinning (no-call memory-heavy fns)
- 4. Algebraic peepholes + strength reduction
- 5. Register-based internal-call ABI  (+ RegisterCopyResolver, together)   ← biggest perf
- 6. MVP-completion batch: memory.grow/size · trunc traps · start fn        (cheap, ships MVP)
- 7. Graduate guard-page mode behind runtime config
- 8. vFlags / limited compare-local-branch fusion
- 9. Cold trap stubs
-10. br_table jump tables
-11. Compatible join-state optimization
-12. Sync host calls (V2 imports) — finish the spiked runtime half
- -- only then: wire the ir/ SSA package as an OPTIONAL optimizing tier
-```
-
-Biggest likely wins: recursive/internal-call perf (P5 register ABI) · memory-loop perf
-(P7 guard pages + P3 pinned linMem/memSize) · general scalar code (P2 pinning + P4 peepholes) ·
-branchy code (P8 fusion + P6 fewer flushes) · switch-heavy code (P10 jump tables).
-
-Independent quick wins worth pulling early: the **MVP-completion batch** (item 6) — three small,
-high-confidence, independently-shippable PRs (`memory.grow` is the headline MVP gap; trunc-trap
-and `start` are tiny).
+### Greenfield (not in WARP either)
+SIMD/v128, threads & atomics, exception handling, tail calls, full reference types +
+`table.*`, remaining bulk-memory (`memory.init`/`data.drop`), passive segments,
+memory64, multi-memory, imported memory/table (the `linking`/`data` spec files).
 
 ---
 
@@ -301,14 +145,16 @@ and `start` are tiny).
 
 Keep **two tiers, unblended**:
 
-- **Tier 1 — single-pass baseline JIT** (today's Valent-Block backend):
-  `validated wasm → FuncHints pre-scan → single-pass codegen`. Goals: very fast compile, good-
-  enough code, tiny footprint, predictable. Everything in Part 1 lives here.
-- **Tier 2 — optional SSA optimizing tier**: the `src/core/compiler/ir` scalar SSA package
-  already exists but no runtime path imports it. Keep it that way until the baseline is strong.
-  Use it only for hot modules / AOT `.wago` / an explicit `Optimize` option / benchmarks — never
-  on the default `Compile` path.
+- **Tier 1 — single-pass baseline JIT** (railshot): `validated wasm → scanBody pre-scan →
+  single-pass codegen`. Goals: very fast compile, good-enough code, tiny footprint,
+  predictable. Everything above lives here. This tier is now broadly at or beyond
+  WARP-parity per construct; its remaining structural ceiling is register allocation
+  across basic blocks, which is exactly what Tier 2 is for.
+- **Tier 2 — optional SSA optimizing tier**: the `src/core/compiler/ir` scalar SSA
+  package exists but no runtime path imports it. Use it only for hot modules / AOT
+  `.wago` / an explicit `Optimize` option — never on the default `Compile` path. The
+  grounded case for it: wazero's remaining edge on json-as is its SSA register
+  allocator, not its (minimal) optimization passes.
 
-wago's identity is **low-latency compile**, not "Cranelift written by one mortal." Make the
-single-pass tier more informed, less flush-happy, and less wrapper-ABI-dependent first; SSA is
-the expensive opt-in tier, later.
+wago's identity is **low-latency compile**. The single-pass tier is now informed,
+flush-light, and register-resident; SSA is the expensive opt-in tier, later.

--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -104,7 +104,26 @@ func (f *fn) callOp(r *wasm.Reader) error {
 	if int(idx) < imported {
 		return f.callHost(int(idx), ft)
 	}
-	return f.callInternal(int(idx)-imported, ft)
+	// `call f; local.set x` fusion: an int-only register-ABI call whose single
+	// int result feeds a pinned local moves RAX straight into the local's
+	// register — no intermediate result register, no separate set lowering.
+	hint := -1
+	if regABIEnabled && sigFitsRegABI(ft) && sigIsIntOnly(ft) && len(ft.Results) == 1 {
+		r2 := *r // peek past the call without committing
+		if b, err := r2.Byte(); err == nil && b == 0x21 {
+			if x, err := r2.U32(); err == nil {
+				if pr, isFloat, ok := f.pinReg(int(x)); ok && !isFloat && pr != regNone {
+					// All operand-stack refs to x are flushed to slots by the call
+					// sequence itself, so skipping setLocal's realizeLocalRefs is safe.
+					hint = int(x)
+					if err := r.JumpTo(r2.Offset()); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return f.callInternal(int(idx)-imported, ft, hint)
 }
 
 // callHost lowers a call to an imported (host) function. Since native wasm code
@@ -149,10 +168,10 @@ const (
 // callInternal lowers a direct call to another local function. Integer-only
 // callees use the fast register ABI (args/result in registers); others go
 // through the wrapper (rsp-buffer) ABI.
-func (f *fn) callInternal(localIdx int, ft *wasm.CompType) error {
+func (f *fn) callInternal(localIdx int, ft *wasm.CompType, resHint int) error {
 	if regABIEnabled && sigFitsRegABI(ft) {
 		if sigIsIntOnly(ft) {
-			f.emitRegisterCall(localIdx, ft)
+			f.emitRegisterCall(localIdx, ft, resHint)
 		} else {
 			f.emitMixedRegisterCall(localIdx, ft)
 		}
@@ -168,7 +187,18 @@ func (f *fn) callInternal(localIdx int, ft *wasm.CompType) error {
 // emitRegisterCall lowers an internal call to a register-ABI function: the top p
 // operands become the argument registers (via a parallel move), the callee is
 // entered at its internal entry, and the single result is taken from RAX.
-func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType) {
+// resHint >= 0 fuses a following `local.set resHint`: RAX moves straight into
+// the pinned local's register instead of an allocated result register.
+func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType, resHint int) {
+	f.emitRegisterCallVia(ft, resHint, func() {
+		site := f.a.CallRel32()
+		f.relocs = append(f.relocs, callReloc{at: site, target: localIdx, internal: true})
+	})
+}
+
+// emitRegisterCallVia is emitRegisterCall with a pluggable call emitter
+// (direct rel32 or an indirect `call [mem]` for call_indirect).
+func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, emitCall func()) {
 	p, rN := len(ft.Params), len(ft.Results)
 	d := f.depth()
 	f.storePinnedGlobals(false) // spill value-pinned globals to their cells before the call (scratch is free here)
@@ -235,12 +265,11 @@ func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType) {
 
 	f.a.MovReg64(RDI, RBX)          // linMem
 	f.a.Load64(RSI, RSP, frTrapOff) // trap
-	site := f.a.CallRel32()
-	f.relocs = append(f.relocs, callReloc{at: site, target: localIdx, internal: true})
+	emitCall()
 
 	// Capture the result out of RAX before RAX is reused as scratch.
 	resReg := regNone
-	if rN == 1 {
+	if rN == 1 && resHint < 0 {
 		resReg = f.allocReg(maskOf(RAX))
 		f.a.MovReg64(resReg, RAX)
 		f.pinned = f.pinned.add(resReg)
@@ -250,7 +279,16 @@ func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType) {
 	// No post-call trap check: a callee trap jumps straight back to enterNative
 	// via emitTrap's handler-jump, so control never returns here with *trap set.
 
-	if rN == 1 {
+	if rN == 1 && resHint >= 0 {
+		// Fused `local.set`: the result lands directly in the pinned local's
+		// register — after any eager post-call reload, which would otherwise
+		// overwrite it with the stale slot value.
+		pr, _, _ := f.pinReg(resHint)
+		f.a.MovReg64(pr, RAX)
+		f.markLocalDirty(resHint)
+	}
+
+	if rN == 1 && resHint < 0 {
 		f.pinned = f.pinned.remove(resReg)
 		f.pushReg(resReg, mtOf(ft.Results[0]))
 	}
@@ -350,15 +388,32 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 
 	code := f.allocReg(0)
 	f.a.Load64(code, idxReg, 8) // entry code ptr
-	f.pinned = f.pinned.remove(idxReg)
-	f.release(idxReg)
 	f.a.TestSelf(code, true)
 	f.trapIf(condE, trapIndirectOOB) // null entry
 
-	// Stash the code ptr in linMem scratch so it survives the wrapper-call flush.
+	// Register-ABI fast path: the type-id check proved the callee's signature
+	// exactly, so a register-ABI-compatible signature guarantees the callee has
+	// an internal entry. Its offset delta sits in the table entry's pad word.
+	fast := regABIEnabled && sigFitsRegABI(ft) && sigIsIntOnly(ft)
+	if fast {
+		d := f.allocReg(maskOf(idxReg, code))
+		f.a.Load32(d, idxReg, 20)      // internal-entry delta
+		f.a.AluRR(0x01, code, d, true) // code += delta → internal entry
+		f.release(d)
+	}
+	f.pinned = f.pinned.remove(idxReg)
+	f.release(idxReg)
+
+	// Stash the code ptr in linMem scratch so it survives the call staging.
 	f.a.Store64(RBX, -int32(offSpillRegion), code)
 	f.release(code)
 
+	if fast {
+		f.emitRegisterCallVia(ft, -1, func() {
+			f.a.CallMem(RBX, -int32(offSpillRegion)) // RBX = linMem throughout staging
+		})
+		return nil
+	}
 	f.emitWrapperCall(ft, func() {
 		f.a.Load64(RAX, RSI, -int32(offSpillRegion)) // RSI = linMem in the call setup
 		f.a.CallReg(RAX)

--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -334,9 +334,7 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 	f.a.Load32(ln, tbl, 0) // table length
 	f.a.AluRR(0x39, idxReg, ln, false)
 	f.release(ln)
-	inb := f.a.JccPlaceholder(condB)
-	f.emitTrap(trapIndirectOOB)
-	f.a.PatchRel32(inb, f.a.Len())
+	f.trapIf(condAE, trapIndirectOOB) // idx >= length → cold stub
 
 	// 64-bit pointer arithmetic: slot address = tbl + idx*16.
 	f.a.ShiftImm(4, idxReg, 4, true)   // idx *= 16
@@ -348,18 +346,14 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 	f.a.Load32(tid, idxReg, 16) // entry type id
 	f.a.AluRI(cmpDigit, tid, canon, false)
 	f.release(tid)
-	okSig := f.a.JccPlaceholder(condE)
-	f.emitTrap(trapIndirectSig)
-	f.a.PatchRel32(okSig, f.a.Len())
+	f.trapIf(condNE, trapIndirectSig)
 
 	code := f.allocReg(0)
 	f.a.Load64(code, idxReg, 8) // entry code ptr
 	f.pinned = f.pinned.remove(idxReg)
 	f.release(idxReg)
 	f.a.TestSelf(code, true)
-	okNull := f.a.JccPlaceholder(condNE)
-	f.emitTrap(trapIndirectOOB)
-	f.a.PatchRel32(okNull, f.a.Len())
+	f.trapIf(condE, trapIndirectOOB) // null entry
 
 	// Stash the code ptr in linMem scratch so it survives the wrapper-call flush.
 	f.a.Store64(RBX, -int32(offSpillRegion), code)

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -71,6 +71,7 @@ type fn struct {
 	addRspAt  int  // byte offset of the epilogue's AddRsp imm32 (patched with frameSize)
 	guardMode bool // elide inline bounds checks; rely on guard-page + SIGSEGV trap
 	lazyZero  bool // defer declared-local zeroing for small call+memory functions
+	skipFence bool // call-free leaf with a provably small frame: no stack-fence check
 
 	// memSizeReg caches the linear-memory size in bytes ([RBX-bdCurBytes]) in a
 	// dedicated register for the whole module (WARP's REGS::memSize, which reserves
@@ -267,10 +268,12 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 			i++
 		}
 	}
-	hasCall := bodyHasCall(c.Body)
-	touchesMemory := bodyTouchesMemory(c.Body)
+	selfIdx := uint32(m.ImportedFuncCount() + funcIdx)
+	hints := scanBody(c.Body, nLocals, f.m.GlobalCount(), selfIdx)
+	hasCall := hints.hasCall
+	touchesMemory := hints.touchesMemory
 	regABI := regABIEnabled && sigFitsRegABI(ft)
-	gpPool := gpPinPool(regABI, bodyUsesBulkMem(c.Body), f.nParams)
+	gpPool := gpPinPool(regABI, hints.usesBulkMem, f.nParams)
 	if f.memSizeReg != regNone {
 		gpPool = withoutReg(gpPool, f.memSizeReg) // R15 is the module-wide memBytes cache
 	}
@@ -294,12 +297,12 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	var globalScores []int64
 	var globalElig []bool
 	if regABI {
-		globalScores = globalHotness(c.Body, f.m.GlobalCount())
+		globalScores = hints.globalScore
 		if hasCall {
-			globalElig = globalCallFreeLoopAccess(c.Body, f.m.GlobalCount())
+			globalElig = hints.globalElig
 		}
 	}
-	f.assignPinnedLocals(localHotness(c.Body, nLocals), globalScores, globalElig, gpPool)
+	f.assignPinnedLocals(hints.localScore, globalScores, globalElig, gpPool)
 	if f.pinnedLocalMask.has(RBP) {
 		f.regMerge = false // RBP now holds a pinned local/global, so it can't be the merge register
 	}
@@ -309,6 +312,11 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	// workaround; the actual root cause was the opElse merge edge skipping
 	// reconcileLocals (fixed in control.go, TestExecIfElseLocalMerge).
 	f.usesCalls = hasCall && !noStackReg
+	// A call-free leaf extends the deepest checked stack by exactly one frame; the
+	// fence's 256 KiB margin (runtime stackFenceMargin) absorbs that when the frame
+	// is provably small. frameSize isn't known until after the body, so bound it:
+	// spill slots never exceed the body's operand pushes (< one per body byte).
+	f.skipFence = !hasCall && frameHdrBytes+8*nLocals+8*len(c.BodyBytes) <= 4096
 	// The return-in-register hint helps compute/call-heavy code (recursion,
 	// dispatch) but adds register pressure in the deep, memory-bound call graphs
 	// (json-as's TLSF/GC) where it measured as a small regression. Gate it on
@@ -319,8 +327,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 		f.resultFloat = rt.isFloat()
 		f.resultF64 = rt == mtF64
 	}
-	selfIdx := uint32(m.ImportedFuncCount() + funcIdx)
-	f.lazyZero = bodyCalls(c.Body, selfIdx) && touchesMemory && len(c.BodyBytes) <= 192 && nLocals-len(ft.Params) <= 8
+	f.lazyZero = hints.callsSelf && touchesMemory && len(c.BodyBytes) <= 192 && nLocals-len(ft.Params) <= 8
 
 	if regABIEnabled && sigFitsRegABI(ft) {
 		internalOff, err := f.emitRegABI(c)
@@ -606,7 +613,7 @@ func (f *fn) zeroDeclaredLocals() {
 // dropped below the fence stored at [linMem-72], turning unbounded recursion into
 // a clean trap instead of a fault. A zero fence disables the check (RSP > 0).
 func (f *fn) emitStackFenceCheck(linMemReg, scratch Reg) {
-	if noStackFence {
+	if noStackFence || f.skipFence {
 		return
 	}
 	f.a.Load64(scratch, linMemReg, -72)
@@ -660,6 +667,7 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 	a.Ret()
 
 	// Internal entry (frameless): in RDI=linMem, RSI=trap, args in GP/XMM regs.
+	a.Align16() // internal entries are hot call targets; align like function starts
 	internalOff := a.Len()
 	f.subRspAt = a.Len() + 3
 	a.SubRsp(0)

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -117,6 +117,11 @@ type fn struct {
 	// Call state (Phase 4).
 	relocs []callReloc // CallRel32 sites to patch at module layout
 
+	// trapSites[code] lists the branch sites (Jcc/Jmp rel32 placeholders) that
+	// target this function's shared trap stub for `code`; emitTrapStubs emits the
+	// stubs after the epilogue and patches them. See trapIf.
+	trapSites map[uint32][]int
+
 	// Occurrence tracking (WARP ModuleInfo referencesToLastOccurrenceOnStack):
 	// maps local refs, owned scratch regs, and spill slots to the topmost stack
 	// element currently representing that storage. This is infrastructure for the
@@ -330,6 +335,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 		return nil, nil, 0, err
 	}
 	f.epilogue()
+	f.emitTrapStubs()
 	f.a.PatchU32(f.subRspAt, uint32(f.frameSize()))
 	f.a.PatchU32(f.addRspAt, uint32(f.frameSize()))
 	return f.a.B, f.relocs, 0, nil
@@ -605,9 +611,7 @@ func (f *fn) emitStackFenceCheck(linMemReg, scratch Reg) {
 	}
 	f.a.Load64(scratch, linMemReg, -72)
 	f.a.Cmp64(RSP, scratch)
-	ok := f.a.JccPlaceholder(condAE)
-	f.emitTrap(trapStackFence)
-	f.a.PatchRel32(ok, f.a.Len())
+	f.trapIf(condB, trapStackFence) // RSP below the fence → cold stub
 }
 
 // emitRegABI emits a register-ABI function as [host adapter | internal entry].
@@ -702,6 +706,7 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 	f.addRspAt = a.Len() + 3
 	a.AddRsp(0) // undo the frame; imm32 patched after body
 	a.Ret()
+	f.emitTrapStubs()
 
 	a.PatchU32(f.subRspAt, uint32(f.frameSize()))
 	a.PatchU32(f.addRspAt, uint32(f.frameSize()))

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -229,7 +229,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 			binary.LittleEndian.PutUint32(code[site:], uint32(int32(target-(site+4))))
 		}
 	}
-	return &amd64.CompiledModule{Code: code, Entry: entry}, nil
+	return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
 }
 
 func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relocs []callReloc, internalOff int, err error) {

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -544,6 +544,9 @@ func (f *fn) opBrTable(r *wasm.Reader) error {
 	d := f.depth()
 	f.pinned = f.pinned.add(ireg) // survive the flush
 	f.flush()
+	// After the flush + reconcile, per-case edge code (converge / slot moves /
+	// merge-reg load) uses only fixed scratch and pinned registers and mutates no
+	// compile-time state — so case bodies can be emitted in any order and shared.
 	emitCase := func(labelIdx uint32) {
 		fr := &f.ctrl[len(f.ctrl)-1-int(labelIdx)]
 		f.convergeBranchLocals(fr) // post-reconcile state records/no-op converges (no code, no flags)
@@ -553,6 +556,44 @@ func (f *fn) opBrTable(r *wasm.Reader) error {
 			f.moveSlots(d-fr.branchN, fr.height, fr.branchN)
 		}
 		f.branchJump(fr)
+	}
+	if len(labels) >= brTableJumpMin {
+		// Jump table (P7): bounds-check the index, then one indirect jump through
+		// a table of stub offsets — O(1) dispatch instead of a cmp/jne chain.
+		// RAX/RDX are free after the flush; case stubs are deduplicated per label.
+		f.a.AluRI(cmpDigit, ireg, int32(len(labels)), false)
+		defSite := f.a.JccPlaceholder(condAE) // idx >= n → default
+		leaSite := f.a.LeaRipPlaceholder(RAX) // RAX = &table
+		f.a.ShiftImm(4, ireg, 2, false)       // idx *= 4 (u32 entries)
+		f.a.LoadIdx(RDX, RAX, ireg, 0, 4, true, true)
+		f.a.AluRR(0x01, RDX, RAX, true) // target = table base + entry
+		f.a.JmpReg(RDX)
+		tablePos := f.a.Len()
+		f.a.PatchRel32(leaSite, tablePos)
+		for range labels {
+			f.a.B = append(f.a.B, 0, 0, 0, 0) // placeholder entries
+		}
+		stubAt := map[uint32]int{}
+		stub := func(lbl uint32) int {
+			if p, ok := stubAt[lbl]; ok {
+				return p
+			}
+			p := f.a.Len()
+			stubAt[lbl] = p
+			emitCase(lbl)
+			return p
+		}
+		for i, lbl := range labels {
+			f.a.PatchU32(tablePos+4*i, uint32(stub(lbl)-tablePos))
+		}
+		if p, ok := stubAt[def]; ok {
+			f.a.PatchRel32(defSite, p)
+		} else {
+			f.a.PatchRel32(defSite, f.a.Len())
+			emitCase(def)
+		}
+		f.unreachable = true
+		return nil
 	}
 	for i, lbl := range labels {
 		f.a.AluRI(cmpDigit, ireg, int32(i), false) // cmp ireg, i
@@ -650,3 +691,7 @@ func skipImmediates(r *wasm.Reader, op byte) error {
 	}
 	return nil
 }
+
+// brTableJumpMin is the label count at which br_table switches from a linear
+// cmp/jne chain to an indirect jump table.
+const brTableJumpMin = 5

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -39,6 +39,14 @@ type ctrlFrame struct {
 	endReachable    bool
 	regMerge1       bool        // single-result block/if: value lives in a register (mergeReg/mergeFReg) at edges, not a slot
 	res0            machineType // first result's machine type (valid when resultN >= 1)
+
+	// Per-frame pinned-local merge agreement (convergeEdgeTo): branchState is the
+	// recorded state at this frame's branch target (loop top for loops, the end
+	// merge for blocks/ifs), fixed by the first edge; entryState is a cfIf
+	// header snapshot — the else body's entry state, and the cond-false edge's
+	// state for an if without else.
+	branchState []locState
+	entryState  []locState
 }
 
 // --- operand-stack canonicalization ---
@@ -229,6 +237,16 @@ func (f *fn) branchEdgeToMerge1(fr *ctrlFrame, d int) {
 	}
 }
 
+// convergeBranchLocals converges pinned-local state for a br/br_if/br_table
+// edge into fr's branch target. Function-frame targets (returns) need nothing —
+// the locals die — so nothing is emitted, keeping conditional returns free.
+func (f *fn) convergeBranchLocals(fr *ctrlFrame) {
+	if fr.kind == cfFunc {
+		return
+	}
+	f.convergeEdgeTo(&fr.branchState)
+}
+
 // branchJump emits the jump for a branch that targets frame fr.
 func (f *fn) branchJump(fr *ctrlFrame) {
 	switch fr.kind {
@@ -281,7 +299,7 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 		return nil
 	}
 	if kind == cfIf {
-		f.reconcileLocals() // diverge point: both then and else start from lsStackReg
+		f.convergeEdgeTo(&fr.entryState) // header snapshot: else entry / cond-false edge state
 		if isFusableCompare(f.s.back()) {
 			cond := f.s.back()
 			f.flushBelow(cond)
@@ -299,7 +317,11 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 	} else {
 		fr.height = f.depth() - pN
 		if kind == cfLoop {
-			f.reconcileLocals() // loop-top merge: back-edges skip this (loopStart is set after)
+			// Loop tops converge eagerly (all lsStackReg): hoists any post-call
+			// reload OUT of the body — a lazy (lsMem) loop target would push the
+			// reload into every iteration instead.
+			f.reconcileLocals()
+			f.convergeEdgeTo(&fr.branchState) // records the all-lsStackReg target
 		}
 		f.flush()
 		if kind == cfLoop {
@@ -319,12 +341,10 @@ func (f *fn) opElse() error {
 	if f.unreachable {
 		f.unreachable = false // else edge is reachable (cond-false analogue)
 	} else {
-		// The then-branch jumps to the if's end — a merge edge like any br, so its
-		// locals must converge to lsStackReg first (a dirty local's register would
-		// otherwise silently diverge from its slot across the merge, and a
-		// call-clobbered one would arrive with a stale register). WARP's
-		// recoverAllLocalsToRegForBranch does the same at every diverge point.
-		f.reconcileLocals()
+		// The then-branch jumps to the if's end — a merge edge like any br
+		// (#68's root cause was skipping this). Converge to the end's recorded
+		// state; as the chronologically first end edge it usually fixes it.
+		f.convergeEdgeTo(&fr.branchState)
 		if fr.regMerge1 {
 			f.reconcileMerge1(fr) // then-branch result → mergeReg
 		} else {
@@ -337,9 +357,9 @@ func (f *fn) opElse() error {
 	fr.elseSite = -1
 	fr.hasElse = true
 	f.setDepth(fr.height + fr.paramN)
-	// The else body is entered via the if's false edge, where locals were already
-	// reconciled to lsStackReg at the if header — reset the tracked state (no code).
-	f.resetLocalsToStackReg()
+	// The else body is entered via the if's false edge: locals are exactly in the
+	// header-snapshot state (no code).
+	f.setLocalsState(fr.entryState)
 	return nil
 }
 
@@ -360,7 +380,12 @@ func (f *fn) opEnd() error {
 
 	fallthroughReachable := !f.unreachable
 	if fallthroughReachable {
-		f.reconcileLocals() // merge point: converge the fall-through's locals to lsStackReg
+		if fr.kind != cfLoop {
+			// Merge edge: converge to the end's recorded state (or fix it).
+			// A loop end is NOT a merge — br edges target the loop TOP — so the
+			// fall-through's state simply flows out.
+			f.convergeEdgeTo(&fr.branchState)
+		}
 		if fr.regMerge1 {
 			f.reconcileMerge1(&fr) // result → mergeReg, operands below → slots
 		} else {
@@ -369,11 +394,21 @@ func (f *fn) opEnd() error {
 	}
 	// An if without else: the cond-false path reaches end with params == results.
 	if fr.kind == cfIf && !fr.hasElse && !fr.entryUnreach {
-		// For a regMerge1 passthrough, the cond-false path still has the value in
-		// its canonical slot; the then-fall-through already put it in mergeReg, so it
-		// jumps over a small stub that loads mergeReg for the cond-false path.
+		// The cond-false edge arrives in the header-snapshot state; if then-side
+		// edges fixed a stronger end state (or a regMerge1 passthrough needs its
+		// value in mergeReg), a stub on this edge converges it. The then
+		// fall-through jumps over the stub.
+		needLoads := false
+		if f.usesCalls && fr.branchState != nil && fr.entryState != nil {
+			for x := 0; x < f.nLocals; x++ {
+				if _, _, ok := f.pinReg(x); ok && fr.branchState[x] == lsStackReg && fr.entryState[x] == lsMem {
+					needLoads = true
+					break
+				}
+			}
+		}
 		skip := -1
-		if fr.regMerge1 && fallthroughReachable {
+		if (fr.regMerge1 || needLoads) && fallthroughReachable {
 			skip = f.a.JmpPlaceholder()
 		}
 		f.a.PatchRel32(fr.elseSite, f.a.Len())
@@ -384,6 +419,10 @@ func (f *fn) opEnd() error {
 				f.a.Load64(mergeReg, RSP, f.spillOff(fr.height)) // passthrough value → mergeReg
 			}
 		}
+		// Converge the cond-false edge from the header snapshot into the end state
+		// (records it when this is the only end edge).
+		f.setLocalsState(fr.entryState)
+		f.convergeEdgeTo(&fr.branchState)
 		if skip != -1 {
 			f.a.PatchRel32(skip, f.a.Len())
 		}
@@ -395,7 +434,9 @@ func (f *fn) opEnd() error {
 	endReachable := fallthroughReachable || fr.endReachable
 	f.unreachable = !endReachable
 	if endReachable {
-		f.resetLocalsToStackReg() // every reaching edge left locals in lsStackReg
+		if fr.kind != cfLoop {
+			f.setLocalsState(fr.branchState) // merge: what every edge guaranteed
+		}
 		if fr.regMerge1 {
 			// Every reaching edge left the result in the merge register (int→mergeReg,
 			// float→mergeFReg) and the operands below in canonical slots [0, height).
@@ -420,8 +461,8 @@ func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 		_, err := r.U32() // label
 		return err
 	}
-	f.reconcileLocals() // diverge point: the target and the fall-through agree on lsStackReg
-	// Fuse `<compare> br_if L` into CMP + conditional jump.
+	// Fuse `<compare> br_if L` into CMP + conditional jump. (Local convergence is
+	// per-target and happens after the label frame is resolved.)
 	if conditional && isFusableCompare(f.s.back()) {
 		top := f.s.back()
 		idx, err := r.U32()
@@ -443,6 +484,7 @@ func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 		return errBadLabel
 	}
 	fr := &f.ctrl[fi]
+	f.convergeBranchLocals(fr)
 	a, base, d := fr.branchN, fr.height, f.depth()
 	f.flush()
 	if !conditional {
@@ -480,7 +522,7 @@ func (f *fn) opBrTable(r *wasm.Reader) error {
 		}
 		return nil
 	}
-	f.reconcileLocals() // diverge point: all targets and the default agree on lsStackReg
+	f.reconcileLocals() // eager: one state (all lsStackReg) satisfies every target
 	ireg := f.materialize(f.popValue())
 	n, err := r.U32()
 	if err != nil {
@@ -504,6 +546,7 @@ func (f *fn) opBrTable(r *wasm.Reader) error {
 	f.flush()
 	emitCase := func(labelIdx uint32) {
 		fr := &f.ctrl[len(f.ctrl)-1-int(labelIdx)]
+		f.convergeBranchLocals(fr) // post-reconcile state records/no-op converges (no code, no flags)
 		if fr.regMerge1 {
 			f.branchEdgeToMerge1(fr, d)
 		} else {

--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -21,7 +21,7 @@ func (f *fn) body(code []byte) error {
 		switch op {
 		case 0x00: // unreachable
 			if !f.unreachable {
-				f.emitTrap(trapUnreachable)
+				f.trapAlways(trapUnreachable)
 				f.unreachable = true
 			}
 		case 0x01: // nop

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -95,6 +95,15 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 		left, right = right, left
 	}
 
+	// Scaled-index fusion: add(x, shl(y, k∈1..3)) → `lea dest,[x + y*2ᵏ]` — one
+	// instruction replacing shl+add. The common AssemblyScript array-address
+	// shape (`base + (i << log2size)`).
+	if node.op == opAdd {
+		if r := f.tryLeaScaledAdd(node, left, right, dest); r != regNone {
+			return r
+		}
+	}
+
 	// Materialize the RHS into a safe, foldable operand BEFORE the LHS overwrites
 	// dest: condense a deferred RHS to a fresh register, and copy a register RHS
 	// out if it aliases dest.
@@ -183,6 +192,75 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 	}
 	f.release(rightReleaseAfter)
 
+	f.consumeBlockBelow(node)
+	f.occupy(node, dest)
+	node.op = opNone
+	return dest
+}
+
+// shlByConst123 reports whether e is a deferred shl of node-typ t by a constant
+// masked count in 1..3 (an LEA-encodable scale), returning the count.
+func shlByConst123(e *elem, t machineType) (int, bool) {
+	if e == nil || e.kind != ekDeferred || e.op != opShl || e.typ != t {
+		return 0, false
+	}
+	c := e.arg1
+	if c == nil || c.kind != ekValue || c.st.kind != stConst {
+		return 0, false
+	}
+	mask := int64(31)
+	if t.is64() {
+		mask = 63
+	}
+	if k := c.st.cval & mask; k >= 1 && k <= 3 {
+		return int(k), true
+	}
+	return 0, false
+}
+
+// tryLeaScaledAdd lowers add(x, shl(y,k)) (either operand order) as a single
+// scaled-index LEA. Returns the result register, or regNone when the shape
+// doesn't match.
+func (f *fn) tryLeaScaledAdd(node, left, right *elem, dest Reg) Reg {
+	w := node.typ.is64()
+	shl, other := right, left
+	k, ok := shlByConst123(shl, node.typ)
+	if !ok {
+		shl, other = left, right
+		if k, ok = shlByConst123(shl, node.typ); !ok {
+			return regNone
+		}
+	}
+	// Only fuse when both the base and the shifted value are already concrete
+	// values: condensing a deferred operand here could hard-clobber RAX/RDX/RCX
+	// (div/shift) underneath the other operand. The AS address shape
+	// (local/global base + local index) is concrete by the time the add is built.
+	if other.kind != ekValue || shl.arg0 == nil || shl.arg0.kind != ekValue {
+		return regNone
+	}
+	// The index: read a pinned local in place (LEA never writes its sources);
+	// anything else materializes into an owned register.
+	y, yOwned := f.materializeRead(shl.arg0)
+	f.pinned = f.pinned.add(y) // survive the base's materialization
+	x, xOwned := f.materializeRead(other)
+	f.pinned = f.pinned.remove(y)
+	if dest == regNone {
+		switch {
+		case xOwned:
+			dest = x // reuse the owned base in place
+		case yOwned:
+			dest = y
+		default:
+			dest = f.allocReg(0)
+		}
+	}
+	f.a.LeaScaledW(dest, x, y, uint8(k), 0, w)
+	if yOwned && y != dest {
+		f.release(y)
+	}
+	if xOwned && x != dest {
+		f.release(x)
+	}
 	f.consumeBlockBelow(node)
 	f.occupy(node, dest)
 	node.op = opNone

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -418,19 +418,15 @@ func (f *fn) condenseDivRem(node *elem, dest Reg) Reg {
 
 	// Divide-by-zero traps for every division op.
 	f.a.TestSelf(divisor, w)
-	nz := f.a.JccPlaceholder(condNE)
-	f.emitTrap(trapDivZero)
-	f.a.PatchRel32(nz, f.a.Len())
+	f.trapIf(condE, trapDivZero)
 
 	switch {
 	case signed && !wantRem: // div_s: INT_MIN / -1 would raise #DE — trap it as overflow
 		f.a.AluRI(7, divisor, -1, w) // cmp divisor, -1
 		noOvf := f.a.JccPlaceholder(condNE)
 		f.cmpIntMin(w) // cmp dividend (RAX), INT_MIN
-		noOvf2 := f.a.JccPlaceholder(condNE)
-		f.emitTrap(trapDivOverflow)
+		f.trapIf(condE, trapDivOverflow)
 		f.a.PatchRel32(noOvf, f.a.Len())
-		f.a.PatchRel32(noOvf2, f.a.Len())
 		f.a.Cdq(w) // sign-extend RAX → RDX:RAX
 		f.a.Idiv(divisor, w)
 	case signed: // rem_s: x % -1 == 0, computed directly to avoid the #DE on INT_MIN/-1

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -545,6 +545,13 @@ func (f *fn) applyALU(enc aluEnc, dest Reg, right *elem, w bool) {
 func (f *fn) applyMul(dest Reg, right *elem, w bool) {
 	switch right.st.kind {
 	case stConst:
+		// x*{3,5,9} → one-cycle LEA [x+x*{2,4,8}] (powers of two already became
+		// shifts at pushBinOp).
+		switch right.st.cval {
+		case 3, 5, 9:
+			f.a.LeaScaledW(dest, dest, dest, uint8(log2u(uint64(right.st.cval-1))), 0, w)
+			return
+		}
 		if fitsImm32(right.st.cval) {
 			f.a.ImulRI(dest, int32(right.st.cval), w)
 		} else {

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1296,3 +1296,123 @@ func TestExecScaledIndexAdd(t *testing.T) {
 		t.Fatalf("i64 scaled add = %d, want %d", got, uint64(1<<40)+40)
 	}
 }
+
+// TestExecLazyMergeLocals covers the per-frame merge-state agreement
+// (convergeEdgeTo): edges may leave a call-clobbered pinned local in its slot
+// across a merge (lsMem target) as long as every edge and the merge agree; a
+// stronger edge (register still valid) must not fool the merge, and asymmetric
+// call placement must converge correctly in both directions.
+func TestExecLazyMergeLocals(t *testing.T) {
+	clobber3 := funcDef{nil, []wasm.ValType{i32}, []byte{
+		0x01, 0x03, 0x7f,
+		0x41, 0x01, 0x21, 0x00,
+		0x41, 0x02, 0x21, 0x01,
+		0x41, 0x03, 0x21, 0x02,
+		0x20, 0x00, 0x20, 0x01, 0x6a, 0x20, 0x02, 0x6a,
+		0x0b,
+	}}
+	run := func(t *testing.T, body []byte, arg uint64, want uint32) {
+		t.Helper()
+		m := modFuncs(t,
+			funcDef{[]wasm.ValType{i32}, []wasm.ValType{i32}, body},
+			clobber3,
+		)
+		if got := uint32(runAmd64u(t, m, arg)); got != want {
+			t.Fatalf("f(%d) = %d, want %d", arg, got, want)
+		}
+	}
+
+	// call in BOTH branches: both edges arrive lsMem; merge stays lazy; the read
+	// after the merge must reload from the slot.
+	bothCall := []byte{
+		0x01, 0x01, 0x7f, // 1 local (idx 1)
+		0x41, 0x07, 0x21, 0x01, // l = 7
+		0x20, 0x00, // x
+		0x04, 0x40, // if
+		0x10, 0x01, 0x1a, // call; drop
+		0x05,                   // else
+		0x41, 0x09, 0x21, 0x01, // l = 9
+		0x10, 0x01, 0x1a, // call; drop
+		0x0b,
+		0x20, 0x01, // l
+		0x0b,
+	}
+	t.Run("both-branches-call", func(t *testing.T) {
+		run(t, bothCall, 1, 7)
+		run(t, bothCall, 0, 9)
+	})
+
+	// call in THEN only: the then edge fixes the target as lsMem; the else edge
+	// arrives stronger (register valid) — merge must still read via the slot.
+	thenCall := []byte{
+		0x01, 0x01, 0x7f,
+		0x41, 0x07, 0x21, 0x01,
+		0x20, 0x00,
+		0x04, 0x40,
+		0x10, 0x01, 0x1a, // then: call; drop
+		0x05,
+		0x41, 0x09, 0x21, 0x01, // else: l = 9 (dirty, stored at the edge)
+		0x0b,
+		0x20, 0x01,
+		0x0b,
+	}
+	t.Run("then-call-only", func(t *testing.T) {
+		run(t, thenCall, 1, 7)
+		run(t, thenCall, 0, 9)
+	})
+
+	// call in ELSE only: the then edge fixes lsStackReg; the else edge must LOAD
+	// to converge.
+	elseCall := []byte{
+		0x01, 0x01, 0x7f,
+		0x41, 0x07, 0x21, 0x01,
+		0x20, 0x00,
+		0x04, 0x40,
+		0x41, 0x09, 0x21, 0x01, // then: l = 9
+		0x05,
+		0x10, 0x01, 0x1a, // else: call; drop
+		0x0b,
+		0x20, 0x01,
+		0x0b,
+	}
+	t.Run("else-call-only", func(t *testing.T) {
+		run(t, elseCall, 1, 9)
+		run(t, elseCall, 0, 7)
+	})
+
+	// if WITHOUT else + call in then: the cond-false edge takes the stub path;
+	// both outcomes must read the right value.
+	noElse := []byte{
+		0x01, 0x01, 0x7f,
+		0x41, 0x07, 0x21, 0x01,
+		0x20, 0x00,
+		0x04, 0x40,
+		0x41, 0x09, 0x21, 0x01, // l = 9
+		0x10, 0x01, 0x1a, // call; drop
+		0x0b,
+		0x20, 0x01,
+		0x0b,
+	}
+	t.Run("no-else-then-call", func(t *testing.T) {
+		run(t, noElse, 1, 9)
+		run(t, noElse, 0, 7)
+	})
+
+	// conditional RETURN (br_if to the function label) must not disturb the
+	// fall-through's local state.
+	condRet := []byte{
+		0x01, 0x01, 0x7f,
+		0x41, 0x07, 0x21, 0x01, // l = 7
+		0x10, 0x01, 0x1a, // call; drop (l now slot-only)
+		0x41, 0x05, // 5 (result if returning)
+		0x20, 0x00, // x
+		0x0d, 0x00, // br_if 0 → return 5
+		0x1a,       // drop the 5
+		0x20, 0x01, // l
+		0x0b,
+	}
+	t.Run("cond-return", func(t *testing.T) {
+		run(t, condRet, 1, 5)
+		run(t, condRet, 0, 7)
+	})
+}

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1416,3 +1416,27 @@ func TestExecLazyMergeLocals(t *testing.T) {
 		run(t, condRet, 0, 7)
 	})
 }
+
+// TestExecCallSetFusion covers the `call f; local.set x` result-hint fusion
+// (RAX straight into the pinned local) including a later read after another call.
+func TestExecCallSetFusion(t *testing.T) {
+	// f(x): l = double(x); call clobber3; return l + double(l)
+	m := modFuncs(t,
+		funcDef{[]wasm.ValType{i32}, []wasm.ValType{i32}, []byte{
+			0x01, 0x01, 0x7f, // 1 local (idx 1)
+			0x20, 0x00, 0x10, 0x01, 0x21, 0x01, // l = double(x)   ← fused set
+			0x10, 0x02, 0x1a, // call clobber3; drop
+			0x20, 0x01, 0x20, 0x01, 0x10, 0x01, 0x6a, // l + double(l)
+			0x0b,
+		}},
+		funcDef{[]wasm.ValType{i32}, []wasm.ValType{i32}, []byte{0x00,
+			0x20, 0x00, 0x20, 0x00, 0x6a, 0x0b}}, // double
+		funcDef{nil, []wasm.ValType{i32}, []byte{
+			0x01, 0x03, 0x7f,
+			0x41, 0x01, 0x21, 0x00, 0x41, 0x02, 0x21, 0x01, 0x41, 0x03, 0x21, 0x02,
+			0x20, 0x00, 0x20, 0x01, 0x6a, 0x20, 0x02, 0x6a, 0x0b}}, // clobber3
+	)
+	if got := uint32(runAmd64u(t, m, 5)); got != 30 { // l=10; 10+20
+		t.Fatalf("fused call+set = %d, want 30", got)
+	}
+}

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1252,3 +1252,47 @@ func TestExecAlgebraicSimplify(t *testing.T) {
 		})
 	}
 }
+
+// TestExecScaledIndexAdd covers the add(x, shl(y,k)) → LEA scaled-index fusion:
+// both operand orders, i32/i64, k inside and outside the encodable 1..3 range,
+// and the memory-address shape (fused ea feeding a bounds-checked load).
+func TestExecScaledIndexAdd(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+		args []uint64
+		want uint64
+	}{
+		// f(b,i) = b + (i<<3)
+		{"i32-b-plus-i-shl3", []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, 0x41, 0x03, 0x74, 0x6a, 0x0b}, []uint64{100, 5}, 140},
+		// f(b,i) = (i<<2) + b  (shl on the left)
+		{"i32-shl-left", []byte{0x00,
+			0x20, 0x01, 0x41, 0x02, 0x74, 0x20, 0x00, 0x6a, 0x0b}, []uint64{100, 5}, 120},
+		// k=4 (not encodable): falls back, still correct
+		{"i32-shl4-fallback", []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, 0x41, 0x04, 0x74, 0x6a, 0x0b}, []uint64{100, 5}, 180},
+		// i32 wrap-around: (0xFFFFFFFF<<1)+2 = 0x1_FFFFFFFE+2 mod 2^32 = 0
+		{"i32-wrap", []byte{0x00,
+			0x41, 0x02, 0x20, 0x00, 0x41, 0x01, 0x74, 0x6a, 0x0b}, []uint64{0xFFFFFFFF}, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			params := []wasm.ValType{i32}
+			if len(c.args) == 2 {
+				params = []wasm.ValType{i32, i32}
+			}
+			m := mod1(t, params, []wasm.ValType{i32}, c.body)
+			if got := uint32(runAmd64u(t, m, c.args...)); got != uint32(c.want) {
+				t.Fatalf("%s = %d, want %d", c.name, got, uint32(c.want))
+			}
+		})
+	}
+
+	// i64: f(b,i) = b + (i<<3)
+	m := mod1(t, []wasm.ValType{i64, i64}, []wasm.ValType{i64}, []byte{0x00,
+		0x20, 0x00, 0x20, 0x01, 0x42, 0x03, 0x86, 0x7c, 0x0b})
+	if got := runAmd64u(t, m, 1<<40, 5); got != (1<<40)+40 {
+		t.Fatalf("i64 scaled add = %d, want %d", got, uint64(1<<40)+40)
+	}
+}

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1207,3 +1207,48 @@ func TestExecIfElseLocalMerge(t *testing.T) {
 		}
 	})
 }
+
+// TestExecAlgebraicSimplify covers the pushBinOp constant-RHS identities and
+// strength reductions (P4): results must match the unsimplified semantics,
+// including unsigned div/rem edge values and shift-count masking.
+func TestExecAlgebraicSimplify(t *testing.T) {
+	g0 := []byte{0x20, 0x00} // local.get 0
+	cases := []struct {
+		name string
+		body []byte
+		arg  uint64
+		want uint32
+	}{
+		{"add0", append(g0, 0x41, 0x00, 0x6a, 0x0b), 7, 7},
+		{"sub0", append(g0, 0x41, 0x00, 0x6b, 0x0b), 7, 7},
+		{"or0", append(g0, 0x41, 0x00, 0x72, 0x0b), 7, 7},
+		{"xor0", append(g0, 0x41, 0x00, 0x73, 0x0b), 7, 7},
+		{"and-1", append(g0, 0x41, 0x7f, 0x71, 0x0b), 7, 7},
+		{"and0", append(g0, 0x41, 0x00, 0x71, 0x0b), 7, 0},
+		{"mul1", append(g0, 0x41, 0x01, 0x6c, 0x0b), 7, 7},
+		{"mul0", append(g0, 0x41, 0x00, 0x6c, 0x0b), 7, 0},
+		{"mul8-shl", append(g0, 0x41, 0x08, 0x6c, 0x0b), 5, 40},
+		{"mul5-lea", append(g0, 0x41, 0x05, 0x6c, 0x0b), 5, 25},
+		{"mul9-lea", append(g0, 0x41, 0x09, 0x6c, 0x0b), 7, 63},
+		{"divu8-shr", append(g0, 0x41, 0x08, 0x6e, 0x0b), 100, 12},
+		{"divu8-shr-big", append(g0, 0x41, 0x08, 0x6e, 0x0b), 0xFFFFFFF0, 0x1FFFFFFE},
+		{"divu1", append(g0, 0x41, 0x01, 0x6e, 0x0b), 100, 100},
+		{"remu8-and", append(g0, 0x41, 0x08, 0x70, 0x0b), 100, 4},
+		{"remu1", append(g0, 0x41, 0x01, 0x70, 0x0b), 100, 0},
+		{"shl0", append(g0, 0x41, 0x00, 0x74, 0x0b), 7, 7},
+		{"shl32-masked", append(g0, 0x41, 0x20, 0x74, 0x0b), 7, 7},
+		{"sub-self", append(append([]byte{}, g0...), append(g0, 0x6b, 0x0b)...), 9, 0},
+		{"xor-self", append(append([]byte{}, g0...), append(g0, 0x73, 0x0b)...), 9, 0},
+		{"and-self", append(append([]byte{}, g0...), append(g0, 0x71, 0x0b)...), 9, 9},
+		{"or-self", append(append([]byte{}, g0...), append(g0, 0x72, 0x0b)...), 9, 9},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body := append([]byte{0x00}, c.body...) // no local decls
+			m := mod1(t, []wasm.ValType{i32}, []wasm.ValType{i32}, body)
+			if got := uint32(runAmd64u(t, m, c.arg)); got != c.want {
+				t.Fatalf("%s(%d) = %d, want %d", c.name, c.arg, got, c.want)
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -4,6 +4,7 @@ package amd64
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 	"testing"
 
@@ -1439,4 +1440,112 @@ func TestExecCallSetFusion(t *testing.T) {
 	if got := uint32(runAmd64u(t, m, 5)); got != 30 { // l=10; 10+20
 		t.Fatalf("fused call+set = %d, want 30", got)
 	}
+}
+
+// TestExecConstBulkMem covers the unrolled small-constant memory.fill/copy
+// paths: chunk tails, overlapping copies (memmove semantics both directions),
+// pattern replication for const and dynamic fill values, n=0, and the n>32
+// fallback to rep movs/stos.
+func TestExecConstBulkMem(t *testing.T) {
+	fillBody := func(n byte) []byte { // f(dst, val) { fill(dst, val, n) }
+		return []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, 0x41, n,
+			0xfc, 0x0b, 0x00,
+			0x41, 0x00, 0x0b}
+	}
+	for _, n := range []byte{0, 1, 3, 5, 8, 13, 16, 21, 32, 33} {
+		t.Run(fmt.Sprintf("fill-n%d", n), func(t *testing.T) {
+			m := modMem(t, 1, []wasm.ValType{i32, i32}, []wasm.ValType{i32}, fillBody(n))
+			_, lin, err := runMemAmd64(t, m, nil, 64, 0x5A)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < int(n); i++ {
+				if lin[64+i] != 0x5A {
+					t.Fatalf("byte %d = %#x, want 0x5A", i, lin[64+i])
+				}
+			}
+			if lin[64+int(n)] == 0x5A {
+				t.Fatal("fill overran")
+			}
+		})
+	}
+	t.Run("fill-dynamic-val-masks-low-byte", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32, i32}, []wasm.ValType{i32}, fillBody(9))
+		_, lin, err := runMemAmd64(t, m, nil, 64, 0x1CD) // only 0xCD may be written
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 9; i++ {
+			if lin[64+i] != 0xCD {
+				t.Fatalf("byte %d = %#x, want 0xCD", i, lin[64+i])
+			}
+		}
+	})
+	t.Run("fill-oob-traps", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32, i32}, []wasm.ValType{i32}, fillBody(16))
+		if _, _, err := runMemAmd64(t, m, nil, 65536-8, 1); err == nil {
+			t.Fatal("expected OOB trap")
+		}
+	})
+
+	copyBody := func(n byte) []byte { // f(dst, src) { copy(dst, src, n) }
+		return []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, 0x41, n,
+			0xfc, 0x0a, 0x00, 0x00,
+			0x41, 0x00, 0x0b}
+	}
+	seq := func(l []byte) {
+		for i := 0; i < 64; i++ {
+			l[100+i] = byte(i + 1)
+		}
+	}
+	for _, n := range []byte{0, 1, 3, 5, 8, 13, 16, 21, 32, 33} {
+		t.Run(fmt.Sprintf("copy-n%d", n), func(t *testing.T) {
+			m := modMem(t, 1, []wasm.ValType{i32, i32}, []wasm.ValType{i32}, copyBody(n))
+			_, lin, err := runMemAmd64(t, m, seq, 300, 100)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < int(n); i++ {
+				if lin[300+i] != byte(i+1) {
+					t.Fatalf("byte %d = %#x, want %#x", i, lin[300+i], i+1)
+				}
+			}
+		})
+	}
+	// Overlapping copies must behave like memmove in both directions.
+	t.Run("copy-overlap-fwd", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32, i32}, []wasm.ValType{i32}, copyBody(16))
+		_, lin, err := runMemAmd64(t, m, seq, 104, 100) // dst > src, overlap 12
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 16; i++ {
+			if lin[104+i] != byte(i+1) {
+				t.Fatalf("overlap-fwd byte %d = %#x, want %#x", i, lin[104+i], i+1)
+			}
+		}
+	})
+	t.Run("copy-overlap-bwd", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32, i32}, []wasm.ValType{i32}, copyBody(16))
+		_, lin, err := runMemAmd64(t, m, seq, 100, 104) // dst < src
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 16; i++ {
+			if lin[100+i] != byte(i+5) {
+				t.Fatalf("overlap-bwd byte %d = %#x, want %#x", i, lin[100+i], i+5)
+			}
+		}
+	})
+	t.Run("copy-oob-traps", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32, i32}, []wasm.ValType{i32}, copyBody(16))
+		if _, _, err := runMemAmd64(t, m, nil, 65536-8, 0); err == nil {
+			t.Fatal("expected OOB trap (dst)")
+		}
+		if _, _, err := runMemAmd64(t, m, nil, 0, 65536-8); err == nil {
+			t.Fatal("expected OOB trap (src)")
+		}
+	})
 }

--- a/src/core/compiler/backend/railshot/fp.go
+++ b/src/core/compiler/backend/railshot/fp.go
@@ -444,22 +444,15 @@ func (f *fn) f2iTrunc(dstWide, srcF64, signed bool) {
 
 	minBits, maxBits := truncLimitBits(signed, srcF64, dstWide)
 	f.a.Ucomis(x, x, srcF64)
-	jNaN := f.a.JccPlaceholder(condP)
+	f.trapIf(condP, trapTruncOverflow) // NaN
 	lo := f.loadFConstBits(minBits, srcF64)
 	f.a.Ucomis(x, lo, srcF64)
 	f.releaseF(lo)
-	jLo := f.a.JccPlaceholder(condBE)
+	f.trapIf(condBE, trapTruncOverflow) // x <= lower-exclusive limit
 	hi := f.loadFConstBits(maxBits, srcF64)
 	f.a.Ucomis(x, hi, srcF64)
 	f.releaseF(hi)
-	jHi := f.a.JccPlaceholder(condAE)
-	skip := f.a.JmpPlaceholder()
-	trapAt := f.a.Len()
-	f.emitTrap(trapTruncOverflow)
-	f.a.PatchRel32(skip, f.a.Len())
-	f.a.PatchRel32(jNaN, trapAt)
-	f.a.PatchRel32(jLo, trapAt)
-	f.a.PatchRel32(jHi, trapAt)
+	f.trapIf(condAE, trapTruncOverflow) // x >= upper-exclusive limit
 
 	r := f.allocReg(0)
 	switch {

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -152,13 +152,14 @@ func (f *fn) condenseToFlags(node *elem) Cond {
 
 // brIfFused lowers `<compare> br_if L` as CMP + conditional jump.
 func (f *fn) brIfFused(top *elem, labelIdx uint32) error {
-	k := f.flushBelow(top)
-	cc := f.condenseToFlags(top)
 	fi := len(f.ctrl) - 1 - int(labelIdx)
 	if fi < 0 {
 		return errBadLabel
 	}
 	fr := &f.ctrl[fi]
+	f.convergeBranchLocals(fr) // before the compare: loads/stores stay clear of the flags window
+	k := f.flushBelow(top)
+	cc := f.condenseToFlags(top)
 	a, base := fr.branchN, fr.height
 	over := f.a.JccPlaceholder(invertCond(cc)) // fall through when the compare is false
 	if fr.regMerge1 {

--- a/src/core/compiler/backend/railshot/hints.go
+++ b/src/core/compiler/backend/railshot/hints.go
@@ -2,12 +2,13 @@ package amd64
 
 import "github.com/wago-org/wago/src/core/compiler/wasm"
 
-// Local hotness scan (ported from backend/railshot/amd64 funchints): a single walk of the
-// decoded instruction AST that scores each local by use, weighting uses inside
-// loops far higher since loops dominate runtime. assignPinnedLocals pins the
-// highest-scoring integer locals. When the AST is unavailable (a programmatically
-// built module carrying only BodyBytes), all scores are zero and pinning falls
-// back to the first-N integer locals.
+// Function pre-scan (OPTIMIZATIONS.md "FuncHints"): ONE walk of the decoded
+// instruction AST collects every fact the compiler wants before emission —
+// call/memory shape for model and pool gating, and loop-weighted hotness scores
+// for register pinning. Uses inside loops score far higher since loops dominate
+// runtime. When the AST is unavailable (a programmatically built module carrying
+// only BodyBytes), all scores are zero and pinning falls back to the first-N
+// integer locals.
 
 const (
 	loopWeightFactor   = 10
@@ -25,193 +26,101 @@ func loopWeight(depth int) int64 {
 	return w
 }
 
-// bodyHasCall reports whether the function makes any (direct or indirect) call.
-// Call-free functions keep the always-in-register local model; call-making ones
-// may use WARP's lazy STACK_REG spill model (store-dirty-around-call, lazy
-// reload), depending on bodyUseStackReg.
-func bodyHasCall(body wasm.Expr) bool {
-	var walk func(instrs []wasm.Instruction) bool
-	walk = func(instrs []wasm.Instruction) bool {
-		for i := range instrs {
-			in := &instrs[i]
-			switch in.Kind {
-			case wasm.InstrCall, wasm.InstrCallIndirect:
-				return true
-			case wasm.InstrLoop, wasm.InstrBlock:
-				if walk(in.Body().Instrs) {
-					return true
-				}
-			case wasm.InstrIf:
-				if walk(in.Then()) || walk(in.Else()) {
-					return true
-				}
-			}
-		}
-		return false
-	}
-	return walk(body.Instrs)
+// funcHints is everything scanBody yields.
+type funcHints struct {
+	hasCall       bool // any direct or indirect call
+	callsSelf     bool // a direct call to the function's own index
+	touchesMemory bool // any linear-memory op
+	usesBulkMem   bool // memory.copy/fill (rep movs/stos clobber RDI/RSI/RCX)
+
+	// Loop-weighted hotness: local.get/global.get = 1×, set/tee = 2×, ×loopWeight
+	// per enclosing loop level.
+	localScore  []int64
+	globalScore []int64
+
+	// globalElig[g]: global g is accessed inside a loop whose subtree contains NO
+	// call. Value-pinning such a global in a call-making function is a win: the
+	// per-iteration memory traffic disappears while the coherence spill/reload
+	// lands only on the (sparse) calls outside that loop. The innermost enclosing
+	// loop decides — if it calls, no outer loop can be call-free.
+	globalElig []bool
 }
 
-func bodyCalls(body wasm.Expr, idx uint32) bool {
-	var walk func(instrs []wasm.Instruction) bool
-	walk = func(instrs []wasm.Instruction) bool {
+// scanBody performs the single pre-scan walk. selfIdx is the function's global
+// function index (for callsSelf).
+func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
+	h := funcHints{
+		localScore:  make([]int64, nLocals),
+		globalScore: make([]int64, nGlobals),
+		globalElig:  make([]bool, nGlobals),
+	}
+	// walk returns whether the subtree contains a call. cur collects the globals
+	// whose innermost enclosing loop is the currently open one (nil outside loops).
+	var walk func(instrs []wasm.Instruction, depth int, cur *[]uint32) bool
+	walk = func(instrs []wasm.Instruction, depth int, cur *[]uint32) bool {
+		w := loopWeight(depth)
+		sub := false
 		for i := range instrs {
 			in := &instrs[i]
 			switch in.Kind {
 			case wasm.InstrCall:
-				if in.Index == idx {
-					return true
+				sub, h.hasCall = true, true
+				if in.Index == selfIdx {
+					h.callsSelf = true
 				}
-			case wasm.InstrLoop, wasm.InstrBlock:
-				if walk(in.Body().Instrs) {
-					return true
+			case wasm.InstrCallIndirect:
+				sub, h.hasCall = true, true
+			case wasm.InstrLocalGet:
+				if int(in.Index) < nLocals {
+					h.localScore[in.Index] += w
 				}
-			case wasm.InstrIf:
-				if walk(in.Then()) || walk(in.Else()) {
-					return true
+			case wasm.InstrLocalSet, wasm.InstrLocalTee:
+				if int(in.Index) < nLocals {
+					h.localScore[in.Index] += 2 * w
 				}
-			}
-		}
-		return false
-	}
-	return walk(body.Instrs)
-}
-
-// bodyTouchesMemory reports whether the function executes linear-memory ops.
-// In guard-mode call+memory code the eager spill/reload model benchmarks faster
-// than STACK_REG: it leaves more registers available to the memory/address/value
-// path instead of reserving pinned-local registers that are repeatedly marked
-// clobbered by calls.
-// globalHotness scores each global by loop-weighted reference count (mirrors
-// localHotness): global.get = 1×, global.set = 2×, ×loopWeight per loop level. Used
-// to pick which globals' cell pointers to pin in registers.
-func globalHotness(body wasm.Expr, nGlobals int) []int64 {
-	scores := make([]int64, nGlobals)
-	add := func(g uint32, delta int64) {
-		if int(g) < nGlobals {
-			scores[g] += delta
-		}
-	}
-	var walk func(instrs []wasm.Instruction, loopDepth int)
-	walk = func(instrs []wasm.Instruction, loopDepth int) {
-		w := loopWeight(loopDepth)
-		for i := range instrs {
-			in := &instrs[i]
-			switch in.Kind {
-			case wasm.InstrGlobalGet:
-				add(in.Index, w)
-			case wasm.InstrGlobalSet:
-				add(in.Index, 2*w)
-			case wasm.InstrLoop:
-				walk(in.Body().Instrs, loopDepth+1)
-			case wasm.InstrBlock:
-				walk(in.Body().Instrs, loopDepth)
-			case wasm.InstrIf:
-				walk(in.Then(), loopDepth)
-				walk(in.Else(), loopDepth)
-			}
-		}
-	}
-	walk(body.Instrs, 0)
-	return scores
-}
-
-// globalCallFreeLoopAccess marks each global that is accessed inside a loop whose
-// body contains NO call. Value-pinning such a global in a call-making function is a
-// win: its per-iteration memory traffic is removed, while the spill/reload that
-// keeps the cell coherent lands only on the (sparse) calls OUTSIDE that loop — not
-// once per iteration (which would happen, and regress, if the loop itself called).
-func globalCallFreeLoopAccess(body wasm.Expr, nGlobals int) []bool {
-	elig := make([]bool, nGlobals)
-	var mark func(instrs []wasm.Instruction) // mark every global accessed anywhere within
-	mark = func(instrs []wasm.Instruction) {
-		for i := range instrs {
-			in := &instrs[i]
-			switch in.Kind {
 			case wasm.InstrGlobalGet, wasm.InstrGlobalSet:
 				if int(in.Index) < nGlobals {
-					elig[in.Index] = true
+					if in.Kind == wasm.InstrGlobalSet {
+						h.globalScore[in.Index] += 2 * w
+					} else {
+						h.globalScore[in.Index] += w
+					}
+					if cur != nil {
+						*cur = append(*cur, in.Index)
+					}
 				}
-			case wasm.InstrLoop, wasm.InstrBlock:
-				mark(in.Body().Instrs)
-			case wasm.InstrIf:
-				mark(in.Then())
-				mark(in.Else())
-			}
-		}
-	}
-	var walk func(instrs []wasm.Instruction)
-	walk = func(instrs []wasm.Instruction) {
-		for i := range instrs {
-			in := &instrs[i]
-			switch in.Kind {
 			case wasm.InstrLoop:
-				if bodyHasCall(wasm.Expr{Instrs: in.Body().Instrs}) {
-					walk(in.Body().Instrs) // has a call — but a nested call-free loop still qualifies
+				var mine []uint32
+				if walk(in.Body().Instrs, depth+1, &mine) {
+					sub = true // call inside: its globals are not eligible
 				} else {
-					mark(in.Body().Instrs) // call-free loop — its globals are eligible
+					for _, g := range mine {
+						h.globalElig[g] = true
+					}
 				}
 			case wasm.InstrBlock:
-				walk(in.Body().Instrs)
-			case wasm.InstrIf:
-				walk(in.Then())
-				walk(in.Else())
-			}
-		}
-	}
-	walk(body.Instrs)
-	return elig
-}
-
-// bodyUsesBulkMem reports whether the body contains memory.copy/fill, which lower
-// to `rep movs`/`stos` and hard-clobber RDI/RSI/RCX — so those registers can't hold
-// pinned locals in a function that uses them.
-func bodyUsesBulkMem(body wasm.Expr) bool {
-	var walk func(instrs []wasm.Instruction) bool
-	walk = func(instrs []wasm.Instruction) bool {
-		for i := range instrs {
-			in := &instrs[i]
-			if in.Kind == wasm.InstrMemoryCopy || in.Kind == wasm.InstrMemoryFill {
-				return true
-			}
-			switch in.Kind {
-			case wasm.InstrLoop, wasm.InstrBlock:
-				if walk(in.Body().Instrs) {
-					return true
+				if walk(in.Body().Instrs, depth, cur) {
+					sub = true
 				}
 			case wasm.InstrIf:
-				if walk(in.Then()) || walk(in.Else()) {
-					return true
+				if walk(in.Then(), depth, cur) {
+					sub = true
+				}
+				if walk(in.Else(), depth, cur) {
+					sub = true
+				}
+			case wasm.InstrMemoryCopy, wasm.InstrMemoryFill:
+				h.usesBulkMem, h.touchesMemory = true, true
+			default:
+				if instrTouchesMemory(in.Kind) {
+					h.touchesMemory = true
 				}
 			}
 		}
-		return false
+		return sub
 	}
-	return walk(body.Instrs)
-}
-
-func bodyTouchesMemory(body wasm.Expr) bool {
-	var walk func(instrs []wasm.Instruction) bool
-	walk = func(instrs []wasm.Instruction) bool {
-		for i := range instrs {
-			in := &instrs[i]
-			if instrTouchesMemory(in.Kind) {
-				return true
-			}
-			switch in.Kind {
-			case wasm.InstrLoop, wasm.InstrBlock:
-				if walk(in.Body().Instrs) {
-					return true
-				}
-			case wasm.InstrIf:
-				if walk(in.Then()) || walk(in.Else()) {
-					return true
-				}
-			}
-		}
-		return false
-	}
-	return walk(body.Instrs)
+	walk(body.Instrs, 0, nil)
+	return h
 }
 
 func instrTouchesMemory(k wasm.InstrKind) bool {
@@ -228,45 +137,4 @@ func instrTouchesMemory(k wasm.InstrKind) bool {
 	default:
 		return false
 	}
-}
-
-// bodyUseStackReg mirrors the f.usesCalls gate (compile.go): the lazy STACK_REG
-// pinned-local model is used only for call functions that do NOT touch memory.
-// guardMode is retained for the signature but no longer affects the decision —
-// memory-touching functions are excluded in both modes (see compile.go).
-func bodyUseStackReg(body wasm.Expr, guardMode bool) bool {
-	_ = guardMode
-	return bodyHasCall(body) && !bodyTouchesMemory(body) && !noStackReg
-}
-
-// localHotness returns per-local usage scores for the function body.
-func localHotness(body wasm.Expr, nLocals int) []int64 {
-	scores := make([]int64, nLocals)
-	var walk func(instrs []wasm.Instruction, loopDepth int)
-	add := func(local uint32, delta int64) {
-		if int(local) < nLocals {
-			scores[local] += delta
-		}
-	}
-	walk = func(instrs []wasm.Instruction, loopDepth int) {
-		w := loopWeight(loopDepth)
-		for i := range instrs {
-			in := &instrs[i]
-			switch in.Kind {
-			case wasm.InstrLocalGet:
-				add(in.Index, w)
-			case wasm.InstrLocalSet, wasm.InstrLocalTee:
-				add(in.Index, 2*w)
-			case wasm.InstrLoop:
-				walk(in.Body().Instrs, loopDepth+1)
-			case wasm.InstrBlock:
-				walk(in.Body().Instrs, loopDepth)
-			case wasm.InstrIf:
-				walk(in.Then(), loopDepth)
-				walk(in.Else(), loopDepth)
-			}
-		}
-	}
-	walk(body.Instrs, 0)
-	return scores
 }

--- a/src/core/compiler/backend/railshot/hints_test.go
+++ b/src/core/compiler/backend/railshot/hints_test.go
@@ -6,48 +6,73 @@ import (
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
 )
 
-func TestBodyMemoryCallHints(t *testing.T) {
+func TestScanBodyHints(t *testing.T) {
 	callOnly := wasm.Expr{Instrs: []wasm.Instruction{
 		{Kind: wasm.InstrLocalGet},
-		{Kind: wasm.InstrCall},
+		{Kind: wasm.InstrCall, Index: 7},
 	}}
-	if !bodyHasCall(callOnly) {
-		t.Fatal("call-only body should report a call")
+	h := scanBody(callOnly, 1, 0, 7)
+	if !h.hasCall || h.touchesMemory || !h.callsSelf {
+		t.Fatalf("call-only body: hasCall=%v touchesMemory=%v callsSelf=%v", h.hasCall, h.touchesMemory, h.callsSelf)
 	}
-	if bodyTouchesMemory(callOnly) {
-		t.Fatal("call-only body should not report memory")
+	if h.localScore[0] != 1 {
+		t.Fatalf("local 0 score = %d, want 1", h.localScore[0])
 	}
-	if !bodyUseStackReg(callOnly, true) {
-		t.Fatal("call-only body should use STACK_REG")
+	if h2 := scanBody(callOnly, 1, 0, 8); h2.callsSelf {
+		t.Fatal("call to 7 should not count as self for index 8")
 	}
 
 	callMemory := wasm.Expr{Instrs: []wasm.Instruction{
 		{Kind: wasm.InstrLocalGet},
 		{Kind: wasm.InstrI32Load},
 		{Kind: wasm.InstrCall},
+		{Kind: wasm.InstrMemoryFill},
 	}}
-	if !bodyHasCall(callMemory) {
-		t.Fatal("call+memory body should report a call")
+	h = scanBody(callMemory, 1, 0, 99)
+	if !h.hasCall || !h.touchesMemory || !h.usesBulkMem {
+		t.Fatalf("call+memory body: %+v", h)
 	}
-	if !bodyTouchesMemory(callMemory) {
-		t.Fatal("call+memory body should report memory")
+}
+
+func TestScanBodyLoopWeightAndGlobalElig(t *testing.T) {
+	// f(x): loop { local.get 0 drop; global.get 1 drop }   — call-free: global 1 eligible
+	//       loop { global.get 2 drop; local.get 0; call 0 } — calls: global 2 NOT eligible
+	//       global.get 0 drop                               — outside loops: not eligible
+	global := []byte{0x7f, 0x01, 0x41, 0x00, 0x0b} // (mut i32) = 0
+	body := []byte{
+		0x00,                                                 // no local decls
+		0x03, 0x40, 0x20, 0x00, 0x1a, 0x23, 0x01, 0x1a, 0x0b, // loop1
+		0x03, 0x40, 0x23, 0x02, 0x1a, 0x20, 0x00, 0x10, 0x00, 0x0b, // loop2 (self call)
+		0x23, 0x00, 0x1a, // global.get 0; drop
+		0x0b,
 	}
-	// Memory-touching call functions use the eager spill/reload model in BOTH
-	// modes: STACK_REG's lazy state desyncs against the explicit-bounds memAddr
-	// scratch allocation (see compile.go).
-	if bodyUseStackReg(callMemory, true) {
-		t.Fatal("guard-mode call+memory body should use eager spill/reload")
+	b := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{wasm.I32}, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(6, wasmtest.Vec(global, global, global)),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+	m, err := wasm.DecodeModule(b)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
 	}
-	if bodyUseStackReg(callMemory, false) {
-		t.Fatal("explicit-bounds call+memory body should use eager spill/reload")
+	h := scanBody(m.Code[0].Body, 1, 3, 0)
+	if !h.callsSelf {
+		t.Fatal("self call not detected")
 	}
-	callMemory.Instrs[2].Index = 7
-	if !bodyCalls(callMemory, 7) {
-		t.Fatal("call+memory body should report the matching call target")
+	if want := 2 * loopWeight(1); h.localScore[0] != want {
+		t.Fatalf("loop-weighted local score = %d, want %d", h.localScore[0], want)
 	}
-	if bodyCalls(callMemory, 8) {
-		t.Fatal("call+memory body should not report a different call target")
+	if !h.globalElig[1] {
+		t.Fatal("global 1 (call-free loop) should be eligible")
+	}
+	if h.globalElig[2] {
+		t.Fatal("global 2 (call-having loop) should not be eligible")
+	}
+	if h.globalElig[0] {
+		t.Fatal("global 0 (outside loops) should not be eligible")
 	}
 }

--- a/src/core/compiler/backend/railshot/localstate.go
+++ b/src/core/compiler/backend/railshot/localstate.go
@@ -169,6 +169,9 @@ func (f *fn) reloadLocalsForCall() {
 // locals are materialized before paths diverge so unpinned locals have a real
 // slot value on every edge. In call-making functions, pinned locals are also
 // converged to lsStackReg so branches and fall-through agree on storage.
+// Used where an eager full converge is the right call: loop entries (hoisting
+// post-call reloads out of the body) and br_table (one state satisfying every
+// target). Other edges use convergeEdgeTo's lazier per-frame agreement.
 func (f *fn) reconcileLocals() {
 	for x := 0; x < f.nLocals; x++ {
 		if f.locals[x].state == lsConstZero {
@@ -192,17 +195,72 @@ func (f *fn) reconcileLocals() {
 	}
 }
 
-// resetLocalsToStackReg sets every pinned local's tracked state to lsStackReg
-// WITHOUT emitting code — used where the incoming edge is known to already have
-// reconciled the locals at runtime (an else body entered via the if's false edge,
-// or a merge reached only by already-reconciled branch edges).
-func (f *fn) resetLocalsToStackReg() {
+// convergeEdgeTo converges pinned-local state for a control edge into the
+// per-frame target *target, RECORDING the target from the current state when
+// this is the frame's first edge. Targets are per-local, ∈ {lsStackReg, lsMem}:
+//   - lsStackReg: register AND slot valid at the merge;
+//   - lsMem: only the slot is guaranteed — a call-clobbered local stays
+//     unloaded across the merge until a read actually needs it (the lazy-merge
+//     win: post-call branch-dense code stops reloading every pinned local at
+//     every boundary).
+//
+// An edge may arrive STRONGER than the target (lsStackReg where lsMem is
+// recorded) — always safe: the merge assumes only the target. The merge point
+// itself must then install the recorded target as the tracked state
+// (setLocalsState).
+func (f *fn) convergeEdgeTo(target *[]locState) {
+	// Dirty registers and lazy zeros always materialize to the slot: every
+	// target guarantees at least "slot is current".
+	for x := 0; x < f.nLocals; x++ {
+		if f.locals[x].state == lsConstZero {
+			f.materializeZeroLocal(x, true)
+			continue
+		}
+		if !f.usesCalls {
+			continue
+		}
+		reg, isFloat, ok := f.pinReg(x)
+		if !ok {
+			continue
+		}
+		if f.locals[x].state == lsReg {
+			f.storeLocalReg(x, reg, isFloat)
+			f.locals[x].state = lsStackReg
+		}
+	}
 	if !f.usesCalls {
+		return
+	}
+	if *target == nil { // first edge fixes the frame's merge state
+		t := make([]locState, f.nLocals)
+		for x := range t {
+			t[x] = f.locals[x].state
+		}
+		*target = t
+		return
+	}
+	t := *target
+	for x := 0; x < f.nLocals; x++ {
+		reg, isFloat, ok := f.pinReg(x)
+		if !ok {
+			continue
+		}
+		if t[x] == lsStackReg && f.locals[x].state == lsMem {
+			f.loadLocalReg(x, reg, isFloat)
+			f.locals[x].state = lsStackReg
+		}
+	}
+}
+
+// setLocalsState installs a merge point's recorded target as the tracked state
+// (no code): every reaching edge guaranteed at least this much.
+func (f *fn) setLocalsState(t []locState) {
+	if !f.usesCalls || t == nil {
 		return
 	}
 	for x := 0; x < f.nLocals; x++ {
 		if _, _, ok := f.pinReg(x); ok {
-			f.locals[x].state = lsStackReg
+			f.locals[x].state = t[x]
 		}
 	}
 }

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -191,6 +191,12 @@ func (f *fn) memoryCopy(r *wasm.Reader) error {
 	if _, err := r.U32(); err != nil { // src memidx
 		return err
 	}
+	if top := f.s.back(); top != nil && top.kind == ekValue && top.st.kind == stConst {
+		if n := uint64(uint32(top.st.cval)); n <= 32 {
+			f.memoryCopyConst(int(n))
+			return nil
+		}
+	}
 	f.materializePendingLoads()
 	f.flush()
 	d := f.depth()
@@ -232,6 +238,12 @@ func (f *fn) memoryCopy(r *wasm.Reader) error {
 func (f *fn) memoryFill(r *wasm.Reader) error {
 	if _, err := r.U32(); err != nil { // memidx
 		return err
+	}
+	if top := f.s.back(); top != nil && top.kind == ekValue && top.st.kind == stConst {
+		if n := uint64(uint32(top.st.cval)); n <= 32 {
+			f.memoryFillConst(int(n))
+			return nil
+		}
 	}
 	f.materializePendingLoads()
 	f.flush()
@@ -304,4 +316,118 @@ func (f *fn) memoryGrow(r *wasm.Reader) error {
 	f.release(mx)
 	f.pushReg(res, mtI32)
 	return nil
+}
+
+// bulkChunks returns the (offset, size) store/load plan for a small constant
+// bulk-memory op: 8-byte blocks with an overlapping tail (memmove's small-size
+// technique), so n bytes are covered by at most 4 chunks for n <= 32.
+func bulkChunks(n int) [][2]int {
+	switch {
+	case n == 0:
+		return nil
+	case n == 1 || n == 2 || n == 4 || n == 8:
+		return [][2]int{{0, n}}
+	case n < 4:
+		return [][2]int{{0, 2}, {n - 2, 2}} // n == 3
+	case n < 8:
+		return [][2]int{{0, 4}, {n - 4, 4}}
+	case n <= 16:
+		return [][2]int{{0, 8}, {n - 8, 8}}
+	case n <= 24:
+		return [][2]int{{0, 8}, {8, 8}, {n - 8, 8}}
+	default:
+		return [][2]int{{0, 8}, {8, 8}, {16, 8}, {n - 8, 8}}
+	}
+}
+
+// bulkBoundsCheck emits `trap unless base+n <= memBytes` for an unrolled bulk
+// op (skipped in guard mode: the stores/loads fault like scalar accesses).
+func (f *fn) bulkBoundsCheck(base Reg, n int) {
+	if f.guardMode {
+		return
+	}
+	f.pinned = f.pinned.add(base)
+	t := f.allocReg(0)
+	f.a.LeaDisp(t, base, int32(n))
+	if f.memSizeReg != regNone {
+		f.a.Cmp64(t, f.memSizeReg)
+	} else {
+		mb := f.allocReg(maskOf(t))
+		f.a.Load32(mb, RBX, -bdCurBytes)
+		f.a.Cmp64(t, mb)
+		f.release(mb)
+	}
+	f.trapIf(condA, trapMemOOB)
+	f.release(t)
+	f.pinned = f.pinned.remove(base)
+}
+
+// memoryFillConst lowers memory.fill with a small constant length as unrolled
+// stores of a byte-replicated pattern — no flush, no rep-stos microcode startup.
+func (f *fn) memoryFillConst(n int) {
+	f.materializePendingLoads() // pending loads must read pre-fill memory
+	f.erase(f.s.back())         // n (const)
+	valElem := f.popValue()
+	pat := regNone
+	if n > 0 {
+		if valElem.st.kind == stConst {
+			b := uint64(valElem.st.cval) & 0xFF
+			pat = f.allocReg(0)
+			f.a.MovImm64(pat, b*0x0101010101010101)
+		} else {
+			v := f.materialize(valElem)  // owned: the low-byte mask below mutates it
+			f.a.AluRI(4, v, 0xFF, false) // v &= 0xFF (only AL matters, like rep stosb)
+			pat = f.allocReg(maskOf(v))
+			f.a.MovImm64(pat, 0x0101010101010101)
+			f.a.IMul(pat, v, true) // replicate the byte across all 8 lanes
+			f.release(v)
+		}
+		f.pinned = f.pinned.add(pat)
+	}
+	dst, dstOwned := f.materializeRead(f.popValue())
+	f.bulkBoundsCheck(dst, n)
+	for _, c := range bulkChunks(n) {
+		f.a.StoreIdx(RBX, dst, pat, int32(c[0]), c[1])
+	}
+	if pat != regNone {
+		f.pinned = f.pinned.remove(pat)
+		f.release(pat)
+	}
+	if dstOwned {
+		f.release(dst)
+	}
+}
+
+// memoryCopyConst lowers memory.copy with a small constant length as
+// load-all-then-store-all chunks — inherently overlap-safe (memmove semantics).
+func (f *fn) memoryCopyConst(n int) {
+	f.materializePendingLoads()
+	f.erase(f.s.back()) // n (const)
+	src, srcOwned := f.materializeRead(f.popValue())
+	f.pinned = f.pinned.add(src)
+	dst, dstOwned := f.materializeRead(f.popValue())
+	f.pinned = f.pinned.add(dst)
+	f.bulkBoundsCheck(dst, n)
+	f.bulkBoundsCheck(src, n)
+	chunks := bulkChunks(n)
+	regs := make([]Reg, len(chunks))
+	avoid := maskOf(src, dst)
+	for i, c := range chunks {
+		r := f.allocReg(avoid)
+		f.a.LoadIdx(r, RBX, src, int32(c[0]), c[1], false, c[1] == 8)
+		regs[i] = r
+		avoid = avoid.add(r)
+	}
+	for i, c := range chunks {
+		f.a.StoreIdx(RBX, dst, regs[i], int32(c[0]), c[1])
+		f.release(regs[i])
+	}
+	f.pinned = f.pinned.remove(src)
+	f.pinned = f.pinned.remove(dst)
+	if srcOwned {
+		f.release(src)
+	}
+	if dstOwned {
+		f.release(dst)
+	}
 }

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -47,6 +47,43 @@ func (f *fn) emitTrap(code uint32) {
 	f.a.Ret()                                  // pop enterNative's return address → back to Go
 }
 
+// trapIf records a conditional jump to this function's shared trap stub for
+// `code` (emitted once, after the body, by emitTrapStubs). Checks branch TO the
+// cold stub on failure, so the hot path falls through — instead of jumping over
+// a ~20-byte inline trap block at every site (better I-cache, not-taken hot
+// branches, one stub per trap code instead of one block per check).
+func (f *fn) trapIf(cc Cond, code uint32) {
+	if f.trapSites == nil {
+		f.trapSites = map[uint32][]int{}
+	}
+	f.trapSites[code] = append(f.trapSites[code], f.a.JccPlaceholder(cc))
+}
+
+// trapAlways is trapIf's unconditional form (`unreachable`): a 5-byte jmp to the
+// shared stub instead of the inline 20-byte trap block.
+func (f *fn) trapAlways(code uint32) {
+	if f.trapSites == nil {
+		f.trapSites = map[uint32][]int{}
+	}
+	f.trapSites[code] = append(f.trapSites[code], f.a.JmpPlaceholder())
+}
+
+// emitTrapStubs emits one trap stub per trap code used by this function and
+// patches every recorded site to it. Called once, after the epilogue.
+func (f *fn) emitTrapStubs() {
+	for code := uint32(1); code <= trapStackFence; code++ { // deterministic order
+		sites := f.trapSites[code]
+		if len(sites) == 0 {
+			continue
+		}
+		pos := f.a.Len()
+		f.emitTrap(code)
+		for _, s := range sites {
+			f.a.PatchRel32(s, pos)
+		}
+	}
+}
+
 // memAddr pops the address operand, folds the static memarg offset, emits the
 // bounds check (unless guard-page mode elides it), and returns the register
 // holding the effective offset plus the displacement to fold into the access.
@@ -87,9 +124,7 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 		f.a.Cmp64(t, mb)
 		f.release(mb)
 	}
-	ok := f.a.JccPlaceholder(condBE) // in bounds when ea+off+size <= memBytes
-	f.emitTrap(trapMemOOB)
-	f.a.PatchRel32(ok, f.a.Len())
+	f.trapIf(condA, trapMemOOB) // out of bounds when ea+off+size > memBytes
 	f.release(t)
 	f.pinned = f.pinned.remove(ea)
 	return ea, eaOwned, disp
@@ -140,12 +175,10 @@ func (f *fn) memStore(r *wasm.Reader, size int) error {
 	return nil
 }
 
-// trapUnlessLE emits `cmp t, mb; jbe ok; trap(MemOOB); ok:` — trap when t > mb.
+// trapUnlessLE emits `cmp t, mb; ja trap-stub` — trap when t > mb.
 func (f *fn) trapUnlessLE(t, mb Reg) {
 	f.a.Cmp64(t, mb)
-	ok := f.a.JccPlaceholder(condBE)
-	f.emitTrap(trapMemOOB)
-	f.a.PatchRel32(ok, f.a.Len())
+	f.trapIf(condA, trapMemOOB)
 }
 
 // memoryCopy lowers memory.copy with memmove semantics (rep movsb, overlap-safe).

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -206,10 +206,144 @@ func (f *fn) pushBinOp(op wOp, typ machineType) {
 		f.pushValue(storage{kind: stConst, typ: typ, cval: v})
 		return
 	}
+	// One-constant algebraic simplification + strength reduction (P4): identities
+	// collapse without emitting a node; expensive ops rewrite to cheaper ones.
+	if right.kind == ekValue && right.st.kind == stConst {
+		if op2, done := f.simplifyConstRHS(op, typ, left, right); done {
+			return
+		} else if op2 != op {
+			op = op2 // strength-reduced (mul 2ⁿ → shl, div_u 2ⁿ → shr_u, rem_u 2ⁿ → and)
+		}
+	}
+	if f.simplifySameOperand(op, typ, left, right) {
+		return
+	}
 	node := f.s.alloc()
 	node.kind, node.op, node.typ = ekDeferred, op, typ
 	node.arg0, node.arg1 = left, right
 	f.s.push(node)
+}
+
+// simplifyConstRHS applies algebraic identities and strength reduction for a
+// constant right operand. Returns (newOp, true) when fully handled (identity
+// collapsed or constant result pushed), or (possibly rewritten op, false) when a
+// deferred node should still be created. The right elem's cval may be rewritten
+// (shift count / mask) alongside an op rewrite.
+func (f *fn) simplifyConstRHS(op wOp, typ machineType, left, right *elem) (wOp, bool) {
+	w := typ.is64()
+	c := right.st.cval
+	cu := uint64(c)
+	ones := ^uint64(0)
+	shiftMask := int64(63)
+	if !w {
+		cu = uint64(uint32(c))
+		ones = uint64(^uint32(0))
+		shiftMask = 31
+	}
+	dropRight := func() (wOp, bool) { f.erase(right); return op, true }
+	switch op {
+	case opAdd, opSub, opOr, opXor:
+		if cu == 0 {
+			return dropRight() // x±0, x|0, x^0 → x
+		}
+	case opShl, opShrU, opShrS, opRotl, opRotr:
+		if c&shiftMask == 0 {
+			return dropRight() // shift/rotate by 0 (mod width) → x
+		}
+	case opAnd:
+		if cu == ones {
+			return dropRight() // x & ~0 → x
+		}
+		if cu == 0 && f.discardSimple(left) {
+			f.erase(right)
+			f.pushValue(storage{kind: stConst, typ: typ})
+			return op, true // x & 0 → 0
+		}
+	case opMul:
+		switch {
+		case cu == 1:
+			return dropRight() // x*1 → x
+		case cu == 0 && f.discardSimple(left):
+			f.erase(right)
+			f.pushValue(storage{kind: stConst, typ: typ})
+			return op, true // x*0 → 0
+		case cu != 0 && cu&(cu-1) == 0: // x * 2ⁿ → x << n
+			right.st.cval = int64(log2u(cu))
+			return opShl, false
+		}
+	case opDivU:
+		switch {
+		case cu == 1:
+			return dropRight() // x/1 → x
+		case cu != 0 && cu&(cu-1) == 0: // x /ᵤ 2ⁿ → x >>ᵤ n
+			right.st.cval = int64(log2u(cu))
+			return opShrU, false
+		}
+	case opRemU:
+		switch {
+		case cu == 1 && f.discardSimple(left): // x %ᵤ 1 → 0
+			f.erase(right)
+			f.pushValue(storage{kind: stConst, typ: typ})
+			return op, true
+		case cu != 0 && cu&(cu-1) == 0: // x %ᵤ 2ⁿ → x & (2ⁿ-1)
+			right.st.cval = int64(cu - 1)
+			return opAnd, false
+		}
+	}
+	return op, false
+}
+
+// simplifySameOperand handles `local.get x; local.get x; <op>` — both operands
+// reading the same local (borrowed or lazy): sub/xor → 0, and/or → x.
+func (f *fn) simplifySameOperand(op wOp, typ machineType, left, right *elem) bool {
+	if left.kind != ekValue || right.kind != ekValue {
+		return false
+	}
+	sameLocal := (left.st.kind == stLocalRef || left.st.kind == stLocalReg) &&
+		left.st.kind == right.st.kind && left.st.idx == right.st.idx
+	if !sameLocal {
+		return false
+	}
+	switch op {
+	case opSub, opXor:
+		f.erase(right)
+		f.erase(left)
+		f.pushValue(storage{kind: stConst, typ: typ})
+		return true
+	case opAnd, opOr:
+		f.erase(right) // x stays
+		return true
+	}
+	return false
+}
+
+// discardSimple erases a left operand whose value is no longer needed (x*0,
+// x&0) — only for simple, resource-light elems: a deferred tree or a pending
+// memRef keeps its node (the simplification is skipped) rather than growing a
+// full recursive release path for a rare case.
+func (f *fn) discardSimple(left *elem) bool {
+	if left.kind != ekValue {
+		return false
+	}
+	switch left.st.kind {
+	case stConst, stLocalRef, stLocalReg, stSlot:
+		f.erase(left)
+		return true
+	case stReg:
+		f.release(left.st.reg)
+		f.erase(left)
+		return true
+	}
+	return false
+}
+
+func log2u(v uint64) int {
+	n := 0
+	for v > 1 {
+		v >>= 1
+		n++
+	}
+	return n
 }
 
 // pushUnOp pushes a deferred unary operation over the top valent block (clz/ctz/

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -346,6 +346,10 @@ func (a *Asm) MovFromRsp(dst Reg) {
 
 func (a *Asm) CallRel32() int { a.emit(0xE8); off := a.Len(); a.imm32(0); return off }
 
+// CallMem emits CALL qword [base+disp] (FF /2) — an indirect call through a
+// memory-resident code pointer, leaving all registers free for arguments.
+func (a *Asm) CallMem(base Reg, disp int32) { a.memOp(0xFF, 2, base, disp, false) }
+
 func (a *Asm) CallReg(r Reg) {
 	if r >= 8 {
 		a.emit(0x41)

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -540,3 +540,25 @@ func (a *Asm) Align16() {
 		pad -= n
 	}
 }
+
+// JmpReg emits JMP r64 (FF /4) — an indirect jump for jump-table dispatch.
+func (a *Asm) JmpReg(r Reg) {
+	if r >= 8 {
+		a.emit(0x41)
+	}
+	a.emit(0xFF, 0xE0|byte(r&7))
+}
+
+// LeaRipPlaceholder emits `lea dst, [rip+disp32]` with a zero displacement and
+// returns the displacement's byte offset for PatchRel32 (the displacement is
+// relative to the end of the instruction, exactly like a jump's rel32).
+func (a *Asm) LeaRipPlaceholder(dst Reg) int {
+	rex := byte(0x48)
+	if dst >= 8 {
+		rex |= 0x04 // REX.R
+	}
+	a.emit(rex, 0x8D, byte(dst&7)<<3|0x05) // ModRM mod=00 rm=101 → RIP-relative
+	off := a.Len()
+	a.imm32(0)
+	return off
+}

--- a/src/core/encoder/amd64/module.go
+++ b/src/core/encoder/amd64/module.go
@@ -8,4 +8,9 @@ package amd64
 type CompiledModule struct {
 	Code  []byte // all local functions concatenated, 16-byte aligned
 	Entry []int  // Entry[localFuncIdx] = byte offset of that function in Code
+
+	// InternalEntry[localFuncIdx] = byte offset of the function's register-ABI
+	// internal entry (== Entry[i] when the function has none). Lets indirect
+	// calls with a register-ABI-compatible signature bypass the wrapper adapter.
+	InternalEntry []int
 }

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -63,7 +63,7 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 		return nil, fmt.Errorf("compile: %w", err)
 	}
 
-	c := &Compiled{Code: cm.Code, Entry: cm.Entry, NumImports: m.ImportedFuncCount(), Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs}
+	c := &Compiled{Code: cm.Code, Entry: cm.Entry, InternalEntry: cm.InternalEntry, NumImports: m.ImportedFuncCount(), Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs}
 	for i := range m.Imports {
 		im := &m.Imports[i]
 		switch im.Type.Kind {
@@ -402,7 +402,7 @@ func (c *Compiled) validateDeferredOffsetGlobal(kind string, seg, idx int) error
 }
 
 const wagoMagic = "WAGO"
-const wagoVersion = 8
+const wagoVersion = 9
 
 // MarshalBinary serializes the precompiled module to a ".wago" blob.
 //

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -18,6 +18,7 @@ func marshalCompiled(c *Compiled) ([]byte, error) {
 	w.u8(wagoVersion)
 	w.bytes(c.Code)
 	w.intSlice(c.Entry)
+	w.intSlice(c.InternalEntry)
 	w.uvar(uint64(c.NumImports))
 	w.stringSlice(c.Imports)
 	if err := w.funcSigs(c.Funcs); err != nil {
@@ -241,6 +242,10 @@ func unmarshalCompiled(c *Compiled, data []byte) error {
 		return err
 	}
 	c.Entry, err = r.intSlice()
+	if err != nil {
+		return err
+	}
+	c.InternalEntry, err = r.intSlice()
 	if err != nil {
 		return err
 	}

--- a/src/wago/codec_count_test.go
+++ b/src/wago/codec_count_test.go
@@ -251,11 +251,20 @@ func TestCompiledReaderRejectsMaliciousCountsBeforeAllocation(t *testing.T) {
 			},
 		},
 		{
+			name: "internal entry slice",
+			write: func(w *compiledWriter) {
+				w.bytes(nil)
+				w.intSlice(nil)
+				w.uvar(huge)
+			},
+		},
+		{
 			name: "imports slice",
 			write: func(w *compiledWriter) {
 				w.bytes(nil)
 				w.intSlice(nil)
-				w.uvar(0) // NumImports.
+				w.intSlice(nil) // InternalEntry.
+				w.uvar(0)       // NumImports.
 				w.uvar(huge)
 			},
 		},

--- a/src/wago/codec_test_helpers_test.go
+++ b/src/wago/codec_test_helpers_test.go
@@ -5,8 +5,9 @@ import "testing"
 func writeCompiledCodecPrefixAfterFuncs(t testing.TB, w *compiledWriter) {
 	t.Helper()
 	w.bytes(nil)
-	w.intSlice(nil)
-	w.uvar(0) // NumImports.
+	w.intSlice(nil) // Entry.
+	w.intSlice(nil) // InternalEntry.
+	w.uvar(0)       // NumImports.
 	w.stringSlice(nil)
 	if err := w.funcSigs(nil); err != nil {
 		t.Fatalf("write funcs: %v", err)

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -133,12 +133,19 @@ type RuntimeConfig struct {
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
 
 // NewRuntimeConfig returns the default configuration: wago's supported feature
-// set and explicit bounds checks.
+// set, and the fastest available bounds-check mode — signals-based (guard-page)
+// when the binary was built with -tags wago_guardpage, explicit otherwise.
+// WAGO_BOUNDS overrides either way ("explicit" / "signals").
 func NewRuntimeConfig() *RuntimeConfig {
 	bounds := BoundsChecksExplicit
+	if guardPageBuilt {
+		bounds = BoundsChecksSignalsBased
+	}
 	switch strings.ToLower(os.Getenv("WAGO_BOUNDS")) {
 	case "signals", "signal", "guard", "guardpage", "guard-page":
 		bounds = BoundsChecksSignalsBased
+	case "explicit", "inline":
+		bounds = BoundsChecksExplicit
 	}
 	return &RuntimeConfig{
 		features:       coreFeaturesWago,

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -189,13 +189,17 @@ type GlobalImportDef struct {
 
 // Compiled is emitted machine code plus instantiate-time metadata.
 type Compiled struct {
-	Code       []byte
-	Entry      []int          // entry offset per local function
-	Funcs      []FuncSig      // signature per local function
-	Imports    []string       // "module.name" per imported function
-	Exports    map[string]int // exported function name -> global function index
-	NumImports int
-	Names      *wasm.NameSec // parsed debug names from the wasm name custom section
+	Code  []byte
+	Entry []int // entry offset per local function
+	// InternalEntry mirrors Entry with each function's register-ABI internal
+	// entry offset (== Entry[i] when none): indirect calls to compatible
+	// signatures bypass the wrapper adapter via the table's delta field.
+	InternalEntry []int
+	Funcs         []FuncSig      // signature per local function
+	Imports       []string       // "module.name" per imported function
+	Exports       map[string]int // exported function name -> global function index
+	NumImports    int
+	Names         *wasm.NameSec // parsed debug names from the wasm name custom section
 
 	GlobalImports []GlobalImportDef // imported global entries, preceding local globals
 	Globals       []GlobalDef       // global entries in wasm global-index order

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -209,6 +209,11 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 				off := 8 + slot*16
 				if li := int(fidx) - c.NumImports; li >= 0 && li < len(c.Entry) {
 					binary.LittleEndian.PutUint64(desc[off:], uint64(base)+uint64(c.Entry[li]))
+					if li < len(c.InternalEntry) {
+						// Register-ABI internal-entry delta (entry pad word): indirect
+						// calls with a compatible signature add this to the code ptr.
+						binary.LittleEndian.PutUint32(desc[off+12:], uint32(c.InternalEntry[li]-c.Entry[li]))
+					}
 				}
 				if int(fidx) < len(c.FuncTypeID) {
 					binary.LittleEndian.PutUint32(desc[off+8:], c.FuncTypeID[fidx])


### PR DESCRIPTION
The full perf/overhead backlog from the #87 investigation plus the still-open items from OPTIMIZATIONS.md (which this PR also rewrites to match reality). Eight changes, each gated on the spec suite + full tests + the explicit-vs-guard differential corpus, and benchmarked individually:

1. **Shared cold trap stubs (P9)** — every bounds/div/indirect/fence check was jumping over a ~20-byte inline trap block; now one stub per trap code per function and hot checks fall through (`ja stub`). json-as module code −23%; sieve −25%, memory_tree −19% on their own.
2. **Leaf fence skip + one-pass pre-scan + guard default** — call-free leaves with provably small frames skip the stack-fence check (the 256 KiB margin absorbs one unchecked frame); `hints.go`'s seven AST walks fused into one `scanBody`; `-tags wago_guardpage` builds now default to guard bounds (`WAGO_BOUNDS=explicit` overrides).
3. **Algebraic identities + strength reduction (P4)** — `x±0`, `x&~0`, `x*2ⁿ→shl`, `x*{3,5,9}→lea`, `x/ᵤ2ⁿ→shr`, `x%ᵤ2ⁿ→and`, `x^x→0`, … applied at `pushBinOp` before a deferred node exists. 24 exec tests incl. unsigned edge values.
4. **Scaled-index LEA fusion** — `add(x, shl(y,k≤3))` → `lea [x+y*2ᵏ]` (the AS array-address shape). linked_list −17%.
5. **Lazy per-frame merge agreement (P6, locals)** — control edges record/converge per-frame pinned-local states, so call-clobbered locals can stay slot-only across branch-dense merges until read; loop tops stay eager (reloads hoisted); conditional returns converge nothing. −17% reload traffic on json-as. Exec tests cover both-edges-lazy, asymmetric-both-ways, no-else stubs, cond-returns.
6. **Register-ABI `call_indirect` + `call;local.set` fusion** — table entries carry the internal-entry delta in their pad word (codec v9), so type-checked compatible signatures bypass the wrapper adapter; a register call's result lands directly in a pinned local's register. dispatch −8%.
7. **`br_table` jump tables (P7)** — n≥5 dispatches through a RIP-relative offset table with deduplicated case stubs (new `JmpReg`/`LeaRipPlaceholder` encoder ops).
8. **Small constant `memory.fill`/`copy` unrolled** — n≤32 lowers to overlap-safe load-all/store-all chunks, preserving memmove semantics (25 exec tests incl. both overlap directions). blake −4%.

Also: internal reg-ABI entries and loop tops are 16-byte aligned (tight-loop benchmarks swing ±20% on layout luck otherwise — sieve and fib_rec both demonstrated this during the work).

## Results (explicit bounds, vs main/#87)

| bench | main | this PR | Δ |
|---|---:|---:|---:|
| sieve | 163µs | 123µs | **−24%** (now beats wazero) |
| memory_tree | 14.6µs | 11.8µs | **−19%** |
| linked_list | 11.3µs | 9.4µs | **−17%** |
| dispatch | 19.1ns | 17.6ns | −8% |
| blake-as | 729µs | 700µs | −4% |
| json-as ser/deser | 218/396 | 214/380 | −2%/−4% |
| memory.sum | 337ns | 230ns | **explicit == guard mode** |

Cumulative including #87: json ser 257→214, deser 420→380; memory.sum 552→230 (−58%); sieve −25%; memory_tree −32%.

## Validation
- Spec suite: unchanged (all files pass except pre-existing linking/data import gaps); br_table 146/146, call_indirect 122/122
- `go test ./...` green; ~60 new exec-test assertions across the new paths
- Explicit-vs-guard differential corpus (blake/utf/json/memory_tree/sieve/memory): all match
- `.wago` codec bumped to v9 (InternalEntry); malicious-count reader tests extended

OPTIMIZATIONS.md rewritten: P1/P2/P3/P4/P5/P6/P7/P9 and the MVP batch marked landed with measurements; remaining roadmap is vFlags (P8), float parity, the deser/SSA question, WARP runtime infra (cancel, stack traces, arm64, V2 imports), and CodegenStats.