### PR TITLE
perf(railshot): WARP head-to-head replication — deserialize now beats wazero (1.43x)

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -81,14 +81,24 @@ selection, model gating, and lazy-zero decisions.
 | linked_list | 11.3µs | 9.4µs | **−17%** |
 | dispatch (call_indirect) | 19.1ns | 17.6ns | −8% |
 | blake-as | 729µs | 700µs | −4% |
-| json-as ser / deser | 218 / 396 | 214 / 380 | −2% / −4% |
+| json-as ser / deser | 218 / 396 | 197 / 204 | −10% / **−48%** |
 | memory.sum (explicit vs guard) | 337 | 230 | **explicit == guard** |
 
-Cumulative from before #87 (main@22c09be): json ser 257→214, deser 420→380;
-memory.sum 552→230; sieve 165→123; memory_tree 17.2→11.8; wazero-relative json
-0.56x→0.66x ser / 0.70x→0.77x deser. wago beats wazero on fib_rec, sieve,
-memory_tree, linked_list, dispatch, branches; loses on json-as (memory/GC-bound) and
-blake.
+Cumulative from before #87 (main@22c09be): json ser 257→197, deser 420→204;
+memory.sum 552→230; sieve 165→95; memory_tree 17.2→11.6; wazero-relative json
+0.56x→0.72x ser / **0.70x→1.43x deser (wago now wins)**. wago beats wazero on
+fib_rec, sieve, memory_tree, linked_list, dispatch, branches, and json deserialize;
+loses on json serialize and blake.
+
+The deserialize flip came from running WARP itself on json-as (passive/bounds-off
+build, ser 97ns / deser 164ns per unit) and replicating its remaining structural
+edges: no per-call environment protocol (RBX/linMem as module invariant, trap cell
+in basedata — no trap-clear on returns), module-wide global register pinning (the
+AS shadow-stack pointer), pinned-register-borrowed load addresses, and — decisive
+for deserialize — an inline 8-byte chunk-loop memmove for small dynamic
+memory.copy/fill instead of `rep movsb` (whose startup latency dominated the
+string-append copies AssemblyScript's `__renew` makes constantly). wago-guard
+deser is now within 1.13× of WARP.
 
 ---
 
@@ -109,13 +119,15 @@ use the eager call model. Mechanical, well-scoped.
 `setcc; movzx; store8` keeps a dead `movzx` (sieve's inner loop). A deferred-compare
 consumer that stores 8 bits can skip the widening. Cheap, narrow.
 
-### R4. Deser gap (the remaining json-as loss)  · L · 🟩
-wago loses to wazero only on allocation/GC-heavy call graphs (TLSF + AS GC). The
-lazy-merge work removed the reload traffic (−17% rsp-loads); wall time is now dominated
-by the memory-bound allocator path itself. Next candidates, in order of evidence needed:
-profile the TLSF hot loop for dependent-load chains; block-param registers for the
-hottest if/else diamonds (WARP `Common.cpp:332`); the SSA tier for exactly these
-functions.
+### R4. json serialize gap (deserialize is solved)  · M–L · 🟩
+Deserialize now beats wazero and sits 1.13× from WARP. Serialize remains ~2× from
+WARP: 52% of it is one function (the serializer core, wat 27) writing JSON text
+through global bump pointers (globals 2/4) in `global.get; i64.store; global.set`
+bursts punctuated by ensure-capacity calls. Module-pinning those globals (K>1)
+measured nearly flat — the burst's cost is the dependent stores and calls, not the
+global derives. Next: look at WARP's exact codegen for wat 27's store bursts, and
+consider write-combining/hoisting the bump pointer across a burst (it's only
+observable at calls).
 
 ### R5. Runtime / infra from WARP
 | Item | Effort | Value | Notes |

--- a/bench/cmd/jsonprof/main.go
+++ b/bench/cmd/jsonprof/main.go
@@ -64,20 +64,25 @@ func main() {
 	fmt.Printf("jsonprof pid=%d running %s (perf map at /tmp/perf-%d.map)\n", os.Getpid(), dur, os.Getpid())
 	deadline := time.Now().Add(dur)
 	var sink int64
+	only := os.Getenv("WAGO_JSONPROF_ONLY") // "ser" / "deser" / "" (both)
 	for time.Now().Before(deadline) {
 		for i := 0; i < 200; i++ {
-			r, err := in.Invoke("serializeN", 256)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "serializeN:", err)
-				os.Exit(1)
+			if only != "deser" {
+				r, err := in.Invoke("serializeN", 256)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "serializeN:", err)
+					os.Exit(1)
+				}
+				sink += int64(r[0])
 			}
-			sink += int64(r[0])
-			r, err = in.Invoke("deserializeN", 256)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "deserializeN:", err)
-				os.Exit(1)
+			if only != "ser" {
+				r, err := in.Invoke("deserializeN", 256)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "deserializeN:", err)
+					os.Exit(1)
+				}
+				sink += int64(r[0])
 			}
-			sink += int64(r[0])
 		}
 	}
 	fmt.Printf("done (sink=%d)\n", sink&1)

--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -432,6 +432,7 @@ func (f *fn) emitWrapperCall(ft *wasm.CompType, emitCall func()) {
 	d := f.depth()
 	f.flush()                   // all operands to canonical slots; args are slots [d-p, d)
 	f.storePinnedGlobals(false) // spill value-pinned globals to their cells before the call
+	f.storeModuleGlobals(RAX)   // wrapper callee's offset-0 prologue reloads from the cells
 
 	// Reserve the result slots [d, d+rN) in the frame.
 	if need := d + rN; need > f.maxSpill {

--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -263,8 +263,8 @@ func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, emitCall func()
 	// Consume the args; the operand model is now the k below-operands in slots.
 	f.setDepth(d - p)
 
-	f.a.MovReg64(RDI, RBX)          // linMem
-	f.a.Load64(RSI, RSP, frTrapOff) // trap
+	// No environment passing: RBX (linMem) is a whole-module invariant and the
+	// trap cell pointer lives in basedata — the callee inherits both (WARP model).
 	emitCall()
 
 	// Capture the result out of RAX before RAX is reused as scratch.
@@ -321,8 +321,6 @@ func (f *fn) emitMixedRegisterCall(localIdx int, ft *wasm.CompType) {
 	}
 	f.setDepth(d - p)
 
-	f.a.MovReg64(RDI, RBX)          // linMem
-	f.a.Load64(RSI, RSP, frTrapOff) // trap
 	site := f.a.CallRel32()
 	f.relocs = append(f.relocs, callReloc{at: site, target: localIdx, internal: true})
 	f.reloadLocalsForCall() // non-STACK_REG model only
@@ -447,10 +445,9 @@ func (f *fn) emitWrapperCall(ft *wasm.CompType, emitCall func()) {
 	// local may live in RDI/RSI (clobbered by the setup itself), not just in a
 	// callee-clobbered register. Lazy reload on the next read — WARP's STACK_REG.
 	f.spillLocalsForCall()
-	f.a.LeaRsp(RDI, argOff)         // args = &slot[d-p]
-	f.a.LeaRsp(RCX, f.spillOff(d))  // results = &slot[d]
-	f.a.MovReg64(RSI, RBX)          // linMem (kept in RBX)
-	f.a.Load64(RDX, RSP, frTrapOff) // trap ptr
+	f.a.LeaRsp(RDI, argOff)        // args = &slot[d-p]
+	f.a.LeaRsp(RCX, f.spillOff(d)) // results = &slot[d]
+	f.a.MovReg64(RSI, RBX)         // linMem (kept in RBX); trap ptr lives in basedata
 	emitCall()
 
 	// No post-call trap check: a callee trap unwinds the whole native call tree

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -138,10 +138,13 @@ func align16(n int) int { return (n + 15) &^ 15 }
 // the whole body (wrapper-call arg/result buffers reuse spill slots, so no
 // transient SubRsp/AddRsp). Layout, low→high address from RSP:
 //
-//	[rsp+0] trap ptr · [rsp+8] results ptr · locals · spill slots
+//	[rsp+0] (spare) · [rsp+8] results ptr · locals · spill slots
+//
+// The trap cell pointer is NOT frame state: it lives in basedata
+// ([linMem-offTrapCellPtr], installed once per entry by the runtime) since only
+// the cold trap path reads it.
 const (
-	frameHdrBytes = 16 // trap ptr + results ptr
-	frTrapOff     = 0  // *TrapCode pointer
+	frameHdrBytes = 16 // spare + results ptr (keeps locals 16-aligned)
 	frResultsOff  = 8  // results buffer pointer
 )
 
@@ -552,8 +555,7 @@ func (f *fn) prologue() {
 	f.subRspAt = len(a.B) + 3         // SubRsp opcode is 3 bytes (48 81 EC), then imm32
 	a.SubRsp(0)                       // frame; imm32 patched after body
 	a.MovReg64(RBX, RSI)              // linMem → RBX (pinned for the whole function)
-	a.Store64(RSP, frTrapOff, RDX)    // trap ptr
-	a.Store64(RSP, frResultsOff, RCX) // results ptr
+	a.Store64(RSP, frResultsOff, RCX) // results ptr (trap cell ptr lives in basedata)
 	if f.memSizeReg != regNone {
 		// Offset-0 entry: establish the module-wide memBytes cache. Direct wasm→wasm
 		// register-ABI calls skip this (the caller's value is valid by construction).
@@ -633,14 +635,13 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 	// Host→internal adapter (offset 0): in RDI=serArgs, RSI=linMem, RDX=trap,
 	// RCX=results; loads args into registers, calls the internal entry, stores the
 	// single register result.
+	a.MovReg64(RBX, RSI) // linMem → RBX: the module-wide invariant the internal entry inherits
 	if f.memSizeReg != regNone {
 		// Offset-0 entry (from Go, or an indirect call): establish the module-wide
 		// memBytes cache before the internal entry runs (which relies on it).
-		a.Load32(f.memSizeReg, RSI, -bdCurBytes)
+		a.Load32(f.memSizeReg, RBX, -bdCurBytes)
 	}
-	a.Push(RCX)
-	a.Push(RDX)
-	a.Push(RSI)
+	a.Push(RCX) // results ptr (also keeps RSP 16-aligned at the internal call)
 	gp, fp := 0, 0
 	for i := 0; i < np; i++ {
 		mt := f.localType[i]
@@ -652,8 +653,6 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 			gp++
 		}
 	}
-	a.Pop(RDI) // linMem
-	a.Pop(RSI) // trap
 	adapterCall := a.CallRel32()
 	a.Pop(RCX) // results
 	if rN == 1 {
@@ -666,13 +665,14 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 	}
 	a.Ret()
 
-	// Internal entry (frameless): in RDI=linMem, RSI=trap, args in GP/XMM regs.
+	// Internal entry (frameless): RBX (linMem) is inherited from the caller —
+	// every wasm function keeps it pinned, and the adapter establishes it at the
+	// Go boundary — and the trap cell pointer lives in basedata, so the entry
+	// carries no environment setup at all (WARP's model). Args in GP/XMM regs.
 	a.Align16() // internal entries are hot call targets; align like function starts
 	internalOff := a.Len()
 	f.subRspAt = a.Len() + 3
 	a.SubRsp(0)
-	a.MovReg64(RBX, RDI)           // linMem → RBX
-	a.Store64(RSP, frTrapOff, RSI) // trap ptr
 	f.emitStackFenceCheck(RBX, RSI)
 	gp, fp = 0, 0
 	for i := 0; i < np; i++ {
@@ -709,8 +709,8 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 		}
 	}
 	// singleRegResult: every exit already produced the result in RAX/XMM0.
-	a.Load64(RCX, RSP, frTrapOff) // clear trap (RCX is never the result register)
-	a.StoreImm32Mem(RCX, 0, 0)
+	// No trap-slot protocol on return: the runtime zeroes the trap cell before
+	// entry, and a trap never returns through here (handler-jump).
 	f.addRspAt = a.Len() + 3
 	a.AddRsp(0) // undo the frame; imm32 patched after body
 	a.Ret()
@@ -732,8 +732,6 @@ func (f *fn) epilogue() {
 		a.Load64(RAX, RSP, f.spillOff(i))
 		a.Store64(RDI, int32(8*i), RAX)
 	}
-	a.Load64(RSI, RSP, frTrapOff) // trap ptr
-	a.StoreImm32Mem(RSI, 0, 0)
 	f.addRspAt = a.Len() + 3
 	a.AddRsp(0) // undo the frame; imm32 patched after body
 	a.Ret()

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -82,6 +82,9 @@ type fn struct {
 	// memory.grow, and established once at every offset-0 entry (wrapper prologue /
 	// reg-ABI adapter — the only ways an activation enters from Go).
 	memSizeReg Reg
+	// reserved is the module-wide never-allocatable register set: memSizeReg and
+	// the module-pinned global registers.
+	reserved regMask
 	// singleRegResult: this function uses the register-return ABI with exactly one
 	// result. Its exits produce that result directly in the return register — RAX
 	// (int) or XMM0 (float) — via the WARP-style target hint, skipping the
@@ -109,6 +112,16 @@ type fn struct {
 	// regNone when g is not pinned. See globals.go / assignPinnedLocals.
 	globalReg   []Reg
 	globalDirty []bool // value-pinned global g was written → needs epilogue write-back
+
+	// moduleGlobal[g] marks g as MODULE-pinned (WARP's model): every function in
+	// the module holds g's live value in the SAME reserved register, making it a
+	// whole-module invariant like RBX/linMem — register-ABI calls and returns
+	// carry no spill/reload for it at all. The cell is synced only at the
+	// wasm↔native boundary (offset-0 prologues/epilogues, adapter exit, trap
+	// stubs) and around wrapper-ABI calls (whose callee's offset-0 prologue
+	// reloads). This is what makes the AssemblyScript shadow-stack pointer
+	// (touched in every function) free at call boundaries.
+	moduleGlobal []bool
 
 	// Control-flow state (Phase 3).
 	ctrl        []ctrlFrame // open block/loop/if frames; ctrl[0] is the function frame
@@ -206,9 +219,10 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	relocs := make([][]callReloc, n)
 	entry := make([]int, n)
 	internalEntry := make([]int, n)
+	modGlobals := pickModuleGlobals(m)
 	var code []byte
 	for i := range m.Code {
-		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode)
+		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, modGlobals)
 		if err != nil {
 			return nil, fmt.Errorf("amd64: function %d: %w", i, err)
 		}
@@ -235,7 +249,62 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
 }
 
-func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relocs []callReloc, internalOff int, err error) {
+// moduleGlobalPin is a module-wide global→register assignment (WARP's model).
+type moduleGlobalPin struct {
+	global uint32
+	reg    Reg
+}
+
+// moduleGlobalRegs are the registers reserved for module-pinned globals, in
+// assignment order. They are carved out of every function's pin pool and the
+// allocator, like RBX (linMem) and R15 (memSize).
+var moduleGlobalRegs = []Reg{R14}
+
+// pickModuleGlobals aggregates loop-weighted global hotness across the whole
+// module and assigns the top mutable int globals a module-wide register. The
+// bar (an aggregate score of one loop-level use in several functions) keeps the
+// reservation from costing pin-pool registers on modules that barely touch
+// globals.
+func pickModuleGlobals(m *wasm.Module) []moduleGlobalPin {
+	nG := m.GlobalCount()
+	if nG == 0 || len(m.Code) == 0 {
+		return nil
+	}
+	agg := make([]int64, nG)
+	for i := range m.Code {
+		h := scanBody(m.Code[i].Body, 0, nG, ^uint32(0))
+		for g := range h.globalScore {
+			agg[g] += h.globalScore[g]
+		}
+	}
+	type cand struct {
+		g     int
+		score int64
+	}
+	var cs []cand
+	minScore := 3 * loopWeight(1)
+	for g := 0; g < nG; g++ {
+		if agg[g] < minScore {
+			continue
+		}
+		gt, ok := m.GlobalTypeByIndex(uint32(g))
+		if !ok || !gt.Mutable || !isIntValType(wasm.GlobalValueType(gt)) {
+			continue
+		}
+		cs = append(cs, cand{g, agg[g]})
+	}
+	sort.SliceStable(cs, func(a, b int) bool { return cs[a].score > cs[b].score })
+	var pins []moduleGlobalPin
+	for k, c := range cs {
+		if k >= len(moduleGlobalRegs) {
+			break
+		}
+		pins = append(pins, moduleGlobalPin{global: uint32(c.g), reg: moduleGlobalRegs[k]})
+	}
+	return pins
+}
+
+func compileFunc(m *wasm.Module, funcIdx int, guardMode bool, modGlobals []moduleGlobalPin) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if os.Getenv("WAGO_DEBUG_PANIC") == "1" {
@@ -279,6 +348,11 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 	gpPool := gpPinPool(regABI, hints.usesBulkMem, f.nParams)
 	if f.memSizeReg != regNone {
 		gpPool = withoutReg(gpPool, f.memSizeReg) // R15 is the module-wide memBytes cache
+		f.reserved = f.reserved.add(f.memSizeReg)
+	}
+	for _, mg := range modGlobals {
+		gpPool = withoutReg(gpPool, mg.reg) // module-pinned global registers
+		f.reserved = f.reserved.add(mg.reg)
 	}
 	// Cap pins so the reserved scratch four (RAX/RDX/RCX/R8) always stay
 	// allocatable — WARP's resScratchRegsGPR floor. Deeper pressure (nested
@@ -305,6 +379,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool) (code []byte, relo
 			globalElig = hints.globalElig
 		}
 	}
+	f.installModuleGlobals(modGlobals)
 	f.assignPinnedLocals(hints.localScore, globalScores, globalElig, gpPool)
 	if f.pinnedLocalMask.has(RBP) {
 		f.regMerge = false // RBP now holds a pinned local/global, so it can't be the merge register
@@ -408,10 +483,18 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 	for i := range f.locals {
 		f.locals[i] = localDef{reg: regNone, typ: f.localType[i], state: lsReg}
 	}
-	f.globalReg = make([]Reg, len(globalScores))
-	f.globalDirty = make([]bool, len(globalScores))
-	for i := range f.globalReg {
-		f.globalReg[i] = regNone
+	// Module-pinned globals (installModuleGlobals) already occupy globalReg
+	// entries; keep them and size for whichever view is larger.
+	if len(f.globalReg) < len(globalScores) {
+		gr := make([]Reg, len(globalScores))
+		for i := range gr {
+			gr[i] = regNone
+		}
+		copy(gr, f.globalReg)
+		f.globalReg = gr
+		gd := make([]bool, len(globalScores))
+		copy(gd, f.globalDirty)
+		f.globalDirty = gd
 	}
 	// The GP pin pool is shared by hot INT locals and hot globals, both holding their
 	// VALUE in the register (WARP's model). A global is a candidate only when it is a
@@ -431,7 +514,7 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 	}
 	loopMin := loopWeight(1)
 	for g := 0; g < len(globalScores); g++ {
-		if globalScores[g] < loopMin {
+		if globalScores[g] < loopMin || f.isModuleGlobal(g) {
 			continue
 		}
 		// In a call-making function (globalElig non-nil) only globals accessed in a
@@ -505,13 +588,77 @@ func (f *fn) globalIs64(g int) bool {
 	return wasm.EqualValType(wasm.GlobalValueType(gt), wasm.I64)
 }
 
+// installModuleGlobals records the module-wide global→register pins on this
+// function (every function in the module shares the same assignment).
+func (f *fn) installModuleGlobals(pins []moduleGlobalPin) {
+	if len(pins) == 0 {
+		return
+	}
+	nG := f.m.GlobalCount()
+	if len(f.globalReg) < nG {
+		gr := make([]Reg, nG)
+		for i := range gr {
+			gr[i] = regNone
+		}
+		copy(gr, f.globalReg)
+		f.globalReg = gr
+		gd := make([]bool, nG)
+		copy(gd, f.globalDirty)
+		f.globalDirty = gd
+	}
+	f.moduleGlobal = make([]bool, nG)
+	for _, p := range pins {
+		f.globalReg[p.global] = p.reg
+		f.moduleGlobal[p.global] = true
+	}
+}
+
+func (f *fn) isModuleGlobal(g int) bool {
+	return f.moduleGlobal != nil && g < len(f.moduleGlobal) && f.moduleGlobal[g]
+}
+
+// deriveModuleGlobals / storeModuleGlobals sync the module-pinned globals with
+// their cells at wasm↔native boundaries (offset-0 prologues and epilogues, the
+// adapter's Go exit, trap stubs) and before wrapper-ABI calls (whose callee's
+// offset-0 prologue reloads). Register-ABI calls and returns carry nothing.
+// scratch must be a register safe to clobber at the call site.
+func (f *fn) deriveModuleGlobals() {
+	for g, reg := range f.globalReg {
+		if reg == regNone || !f.isModuleGlobal(g) {
+			continue
+		}
+		f.a.Load64(reg, RBX, -int32(abi.GlobalsPtrOffset))
+		f.a.Load64(reg, reg, int32(g*8))
+		if f.globalIs64(g) {
+			f.a.Load64(reg, reg, 0)
+		} else {
+			f.a.Load32(reg, reg, 0)
+		}
+	}
+}
+
+func (f *fn) storeModuleGlobals(scratch Reg) {
+	for g, reg := range f.globalReg {
+		if reg == regNone || !f.isModuleGlobal(g) {
+			continue
+		}
+		f.a.Load64(scratch, RBX, -int32(abi.GlobalsPtrOffset))
+		f.a.Load64(scratch, scratch, int32(g*8))
+		if f.globalIs64(g) {
+			f.a.Store64(scratch, 0, reg)
+		} else {
+			f.a.Store32(scratch, 0, reg)
+		}
+	}
+}
+
 // derivePinnedGlobals loads each value-pinned global's current value into its
 // register from memory (base → &cell → value, reusing the register for the chain).
 // Used in the prologue and to reload after a call (the callee may have changed the
 // shared global). A no-op when no globals are pinned.
 func (f *fn) derivePinnedGlobals() {
 	for g, reg := range f.globalReg {
-		if reg == regNone {
+		if reg == regNone || f.isModuleGlobal(g) {
 			continue
 		}
 		f.a.Load64(reg, RBX, -int32(abi.GlobalsPtrOffset)) // globals array base
@@ -531,7 +678,7 @@ func (f *fn) derivePinnedGlobals() {
 // cell-address scratch.
 func (f *fn) storePinnedGlobals(dirtyOnly bool) {
 	for g, reg := range f.globalReg {
-		if reg == regNone || (dirtyOnly && !f.globalDirty[g]) {
+		if reg == regNone || f.isModuleGlobal(g) || (dirtyOnly && !f.globalDirty[g]) {
 			continue
 		}
 		t := f.allocReg(maskOf(reg, RAX))
@@ -582,6 +729,7 @@ func (f *fn) prologue() {
 	}
 	f.zeroDeclaredLocals()
 	f.derivePinnedGlobals()
+	f.deriveModuleGlobals() // offset-0 entry: cells → module-pinned registers
 }
 
 // zeroDeclaredLocals initializes non-parameter locals. Most functions keep the
@@ -641,7 +789,8 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 		// memBytes cache before the internal entry runs (which relies on it).
 		a.Load32(f.memSizeReg, RBX, -bdCurBytes)
 	}
-	a.Push(RCX) // results ptr (also keeps RSP 16-aligned at the internal call)
+	f.deriveModuleGlobals() // offset-0 entry: cells → module-pinned registers
+	a.Push(RCX)             // results ptr (also keeps RSP 16-aligned at the internal call)
 	gp, fp := 0, 0
 	for i := 0; i < np; i++ {
 		mt := f.localType[i]
@@ -654,7 +803,8 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 		}
 	}
 	adapterCall := a.CallRel32()
-	a.Pop(RCX) // results
+	a.Pop(RCX)                // results
+	f.storeModuleGlobals(RDX) // Go exit: module-pinned registers → cells (RAX holds the result)
 	if rN == 1 {
 		rt := mtOf(f.ft.Results[0])
 		if rt.isFloat() {
@@ -727,6 +877,7 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 // the function label) has already placed the results in slots [0, resultN).
 func (f *fn) epilogue() {
 	a := f.a
+	f.storeModuleGlobals(RDX)        // Go exit: module-pinned registers → cells
 	a.Load64(RDI, RSP, frResultsOff) // results ptr
 	for i := range f.ft.Results {
 		a.Load64(RAX, RSP, f.spillOff(i))

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -309,10 +309,13 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 			f.ctrl = append(f.ctrl, fr)
 			return nil
 		}
-		creg := f.materialize(f.popValue())
+		creg, cOwned := f.materializeRead(f.popValue()) // TEST only reads: a pinned local needs no copy
 		fr.height = f.depth() - pN
 		f.flush()
 		f.a.TestSelf(creg, false)
+		if cOwned {
+			f.release(creg)
+		}
 		fr.elseSite = f.a.JccPlaceholder(condE) // jz else/end
 	} else {
 		fr.height = f.depth() - pN
@@ -472,8 +475,9 @@ func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 		return f.brIfFused(top, idx)
 	}
 	var creg Reg
+	cOwned := false
 	if conditional {
-		creg = f.materialize(f.popValue())
+		creg, cOwned = f.materializeRead(f.popValue()) // TEST only reads
 	}
 	idx, err := r.U32()
 	if err != nil {
@@ -498,6 +502,9 @@ func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 		return nil
 	}
 	f.a.TestSelf(creg, false)
+	if cOwned {
+		f.release(creg)
+	}
 	over := f.a.JccPlaceholder(condE)
 	if fr.regMerge1 {
 		f.branchEdgeToMerge1(fr, d)

--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -73,9 +73,10 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 			// In guard-page mode the load itself is the OOB trap, so a dropped load
 			// must still be emitted; with explicit checks the bounds check already ran.
 			if f.guardMode {
-				f.loadMemRef(e.st.reg, e.st)
+				r := f.memRefValue(e.st) // never write a borrowed address register
+				f.release(r)
 			}
-			f.release(e.st.reg)
+			f.releaseMemRef(e.st)
 		}
 	case 0x1b: // select
 		f.emitSelect()
@@ -663,6 +664,10 @@ func (f *fn) realizeLocalRefs(x int, skipFrom *elem) {
 			} else {
 				f.materialize(e)
 			}
+		case e.kind == ekValue && e.st.kind == stMemRef && e.st.memBorrow() == x:
+			// A deferred load addressing through x's pinned register: emit it
+			// before x is overwritten.
+			f.materialize(e)
 		case e.kind == ekDeferred && subtreeRefsLocal(e, x):
 			f.condense(e, regNone)
 		}

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -582,7 +582,7 @@ func (f *fn) condenseInto(e *elem, dest Reg) {
 		}
 	case stMemRef:
 		f.loadMemRef(dest, e.st) // emit the deferred load into dest
-		f.release(e.st.reg)
+		f.releaseMemRef(e.st)
 	}
 }
 
@@ -611,11 +611,13 @@ func (f *fn) applyALU(enc aluEnc, dest Reg, right *elem, w bool) {
 	case stMemRef:
 		if memRefFoldable(right.st, w) {
 			f.a.AluIdx(enc.rm, dest, RBX, right.st.reg, right.st.memDisp(), w) // op dest, [mem]
+			f.releaseMemRef(right.st)
 		} else {
-			f.loadMemRef(right.st.reg, right.st)
-			f.a.AluRR(enc.rr, dest, right.st.reg, w)
+			r := f.memRefValue(right.st)
+			f.a.AluRR(enc.rr, dest, r, w)
+			f.release(r)
+			f.releaseMemRef(right.st)
 		}
-		f.release(right.st.reg)
 	}
 }
 
@@ -650,9 +652,12 @@ func (f *fn) applyMul(dest Reg, right *elem, w bool) {
 	case stMemRef:
 		if memRefFoldable(right.st, w) {
 			f.a.ImulIdx(dest, RBX, right.st.reg, right.st.memDisp(), w)
+			f.releaseMemRef(right.st)
 		} else {
-			f.loadMemRef(right.st.reg, right.st)
-			f.a.IMul(dest, right.st.reg, w)
+			r := f.memRefValue(right.st)
+			f.a.IMul(dest, r, w)
+			f.release(r)
+			f.releaseMemRef(right.st)
 		}
 		f.release(right.st.reg)
 	}

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1549,3 +1549,79 @@ func TestExecConstBulkMem(t *testing.T) {
 		}
 	})
 }
+
+// TestExecDynamicBulkMem covers the hybrid dynamic memory.copy/fill lowering:
+// the small inline chunk-loop path (n < 96) in both overlap directions, the
+// large rep path, and the boundary sizes.
+func TestExecDynamicBulkMem(t *testing.T) {
+	copyBody := []byte{0x00,
+		0x20, 0x00, 0x20, 0x01, 0x20, 0x02, // dst, src, n (all dynamic)
+		0xfc, 0x0a, 0x00, 0x00,
+		0x41, 0x00, 0x0b}
+	fillBody := []byte{0x00,
+		0x20, 0x00, 0x20, 0x01, 0x20, 0x02,
+		0xfc, 0x0b, 0x00,
+		0x41, 0x00, 0x0b}
+	seq := func(l []byte) {
+		for i := 0; i < 256; i++ {
+			l[1000+i] = byte(i + 1)
+		}
+	}
+	params := []wasm.ValType{i32, i32, i32}
+	for _, n := range []int{0, 1, 7, 8, 9, 63, 95, 96, 97, 200} {
+		t.Run(fmt.Sprintf("copy-n%d", n), func(t *testing.T) {
+			m := modMem(t, 1, params, []wasm.ValType{i32}, copyBody)
+			_, lin, err := runMemAmd64(t, m, seq, 2000, 1000, uint64(n))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < n; i++ {
+				if lin[2000+i] != byte(i+1) {
+					t.Fatalf("byte %d = %#x, want %#x", i, lin[2000+i], byte(i+1))
+				}
+			}
+			if n < 256 && lin[2000+n] == byte(n+1) {
+				t.Fatal("copy overran")
+			}
+		})
+		t.Run(fmt.Sprintf("copy-overlap-fwd-n%d", n), func(t *testing.T) {
+			m := modMem(t, 1, params, []wasm.ValType{i32}, copyBody)
+			_, lin, err := runMemAmd64(t, m, seq, 1004, 1000, uint64(n)) // dst > src
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < n; i++ {
+				if lin[1004+i] != byte(i+1) {
+					t.Fatalf("fwd-overlap byte %d = %#x, want %#x", i, lin[1004+i], byte(i+1))
+				}
+			}
+		})
+		t.Run(fmt.Sprintf("copy-overlap-bwd-n%d", n), func(t *testing.T) {
+			m := modMem(t, 1, params, []wasm.ValType{i32}, copyBody)
+			_, lin, err := runMemAmd64(t, m, seq, 1000, 1004, uint64(n)) // dst < src
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < n; i++ {
+				if lin[1000+i] != byte(i+5) {
+					t.Fatalf("bwd-overlap byte %d = %#x, want %#x", i, lin[1000+i], byte(i+5))
+				}
+			}
+		})
+		t.Run(fmt.Sprintf("fill-n%d", n), func(t *testing.T) {
+			m := modMem(t, 1, params, []wasm.ValType{i32}, fillBody)
+			_, lin, err := runMemAmd64(t, m, nil, 3000, 0x1A7, uint64(n)) // low byte 0xA7
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < n; i++ {
+				if lin[3000+i] != 0xA7 {
+					t.Fatalf("fill byte %d = %#x, want 0xA7", i, lin[3000+i])
+				}
+			}
+			if lin[3000+n] == 0xA7 {
+				t.Fatal("fill overran")
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/fp.go
+++ b/src/core/compiler/backend/railshot/fp.go
@@ -625,7 +625,7 @@ func (f *fn) fload(r *wasm.Reader, f64 bool) error {
 	if f64 {
 		size = 8
 	}
-	ea, eaOwned, disp := f.memAddr(off, size, true) // float loads emit immediately
+	ea, eaOwned, _, disp := f.memAddr(off, size, true) // float loads emit immediately
 	xmm := f.allocFReg(0)
 	f.a.FLoadIdx(xmm, RBX, ea, disp, f64)
 	if eaOwned {
@@ -649,7 +649,7 @@ func (f *fn) fstore(r *wasm.Reader, f64 bool) error {
 	}
 	xmm := f.materializeF(f.popValue())
 	f.fpinned = f.fpinned.add(xmm)
-	ea, eaOwned, disp := f.memAddr(off, size, true)
+	ea, eaOwned, _, disp := f.memAddr(off, size, true)
 	f.a.FStoreIdx(RBX, ea, xmm, disp, f64)
 	f.fpinned = f.fpinned.remove(xmm)
 	if eaOwned {

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -136,10 +136,11 @@ func (f *fn) condenseToFlags(node *elem) Cond {
 		if memRefFoldable(right.st, w) {
 			f.a.AluIdx(cmpRMcode, L, RBX, right.st.reg, right.st.memDisp(), w)
 		} else {
-			f.loadMemRef(right.st.reg, right.st)
-			f.cmpRR(L, right.st.reg, w)
+			r := f.memRefValue(right.st)
+			f.cmpRR(L, r, w)
+			f.release(r)
 		}
-		f.release(right.st.reg)
+		f.releaseMemRef(right.st)
 	}
 	f.pinned = f.pinned.remove(L)
 	if ownedL {

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -1,6 +1,10 @@
 package amd64
 
-import "github.com/wago-org/wago/src/core/compiler/wasm"
+import (
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+
+	"github.com/wago-org/wago/src/core/runtime/abi"
+)
 
 // Linear-memory access: scalar loads/stores with a linear bounds check, plus
 // memory.size/grow. Ported from WARP's memory lowering, adapted to wago's runtime
@@ -34,14 +38,21 @@ const (
 // see runtime/basedata.go offTrapStackReentry.
 const offTrapStackReentry = 24
 
-// emitTrap writes the trap code to *trapPtr ([rsp+frTrapOff]) then unwinds the
+// offTrapCellPtr is the basedata slot holding the address of the trap cell
+// (runtime installTrapCell / abi.TrapCellPtrOffset). The trap pointer is NOT
+// part of any call ABI: only the cold trap path reads it, so calls and returns
+// carry no trap protocol (WARP's model — its passive mode has no trap cell).
+const offTrapCellPtr = abi.TrapCellPtrOffset
+
+// emitTrap writes the trap code to the trap cell (via [linMem-offTrapCellPtr])
+// then unwinds the
 // ENTIRE native call tree in one jump: it restores RSP to the entry SP the
 // trampoline recorded at [linMem-offTrapStackReentry] and RETs straight back into
 // enterNative (WARP's handler-jump model). This is what lets callers skip the
 // per-call "load *trap; test; branch" check — a trap never returns through an
 // intermediate frame. Terminal, so it may freely clobber RSI (and RSP last).
 func (f *fn) emitTrap(code uint32) {
-	f.a.Load64(RSI, RSP, frTrapOff)
+	f.a.Load64(RSI, RBX, -offTrapCellPtr)
 	f.a.StoreImm32Mem(RSI, 0, int32(code))
 	f.a.Load64(RSP, RBX, -offTrapStackReentry) // rsp = entry SP (trampoline's post-CALL SP)
 	f.a.Ret()                                  // pop enterNative's return address → back to Go

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -38,6 +38,10 @@ const (
 // see runtime/basedata.go offTrapStackReentry.
 const offTrapStackReentry = 24
 
+// smallBulkMax is the dynamic memory.copy/fill length below which the inline
+// chunk loops beat `rep movs/stos` startup latency.
+const smallBulkMax = 96
+
 // offTrapCellPtr is the basedata slot holding the address of the trap cell
 // (runtime installTrapCell / abi.TrapCellPtrOffset). The trap pointer is NOT
 // part of any call ABI: only the cold trap path reads it, so calls and returns
@@ -239,7 +243,59 @@ func (f *fn) memoryCopy(r *wasm.Reader) error {
 
 	f.a.Add64(RDI, RBX) // absolute dst
 	f.a.Add64(RSI, RBX) // absolute src
-	// Copy forward when dst <= src, else backward, for overlap safety.
+
+	// Hybrid dispatch: small dynamic copies take an inline 8-byte-chunk memmove
+	// loop (WARP emitMemcpyNoBoundsCheck) — `rep movsb`'s ~30-cycle startup
+	// dominates the string-append copies AssemblyScript's __renew makes
+	// constantly; large copies keep rep movsb (ERMSB wins at size).
+	var joins []int
+	f.a.AluRI(cmpDigit, RCX, smallBulkMax, true)
+	big := f.a.JccPlaceholder(condAE)
+
+	f.a.Cmp64(RSI, RDI)
+	fwdSmall := f.a.JccPlaceholder(condA) // src > dst → forward copy is overlap-safe
+	// dst >= src: copy backward, indexing [ptr+rcx-k] while counting rcx down.
+	back8 := f.a.Len()
+	f.a.AluRI(cmpDigit, RCX, 8, false)
+	b8done := f.a.JccPlaceholder(condB)
+	f.a.LoadIdx(RDX, RSI, RCX, -8, 8, false, true)
+	f.a.StoreIdx(RDI, RCX, RDX, -8, 8)
+	f.a.AluRI(5, RCX, 8, false) // rcx -= 8
+	f.a.JmpBack(back8)
+	f.a.PatchRel32(b8done, f.a.Len())
+	f.a.TestSelf(RCX, false)
+	joins = append(joins, f.a.JccPlaceholder(condE))
+	back1 := f.a.Len()
+	f.a.LoadIdx(RDX, RSI, RCX, -1, 1, false, false)
+	f.a.StoreIdx(RDI, RCX, RDX, -1, 1)
+	f.a.AluRI(5, RCX, 1, false)
+	f.a.PatchRel32(f.a.JccPlaceholder(condNE), back1)
+	joins = append(joins, f.a.JmpPlaceholder())
+
+	// src > dst: copy forward via a negative index climbing to zero (WARP's shape).
+	f.a.PatchRel32(fwdSmall, f.a.Len())
+	f.a.Add64(RSI, RCX)
+	f.a.Add64(RDI, RCX)
+	f.a.Neg(RCX, true)
+	fwd8 := f.a.Len()
+	f.a.AluRI(cmpDigit, RCX, -8, true)
+	f8done := f.a.JccPlaceholder(condG)
+	f.a.LoadIdx(RDX, RSI, RCX, 0, 8, false, true)
+	f.a.StoreIdx(RDI, RCX, RDX, 0, 8)
+	f.a.AluRI(0, RCX, 8, true) // rcx += 8
+	f.a.JmpBack(fwd8)
+	f.a.PatchRel32(f8done, f.a.Len())
+	f.a.TestSelf(RCX, true)
+	joins = append(joins, f.a.JccPlaceholder(condE))
+	fwd1 := f.a.Len()
+	f.a.LoadIdx(RDX, RSI, RCX, 0, 1, false, false)
+	f.a.StoreIdx(RDI, RCX, RDX, 0, 1)
+	f.a.AluRI(0, RCX, 1, true)
+	f.a.PatchRel32(f.a.JccPlaceholder(condNE), fwd1)
+	joins = append(joins, f.a.JmpPlaceholder())
+
+	// Large: overlap-safe rep movsb (backward via DF when dst > src).
+	f.a.PatchRel32(big, f.a.Len())
 	f.a.Cmp64(RDI, RSI)
 	fwd := f.a.JccPlaceholder(condBE)
 	f.a.LeaScaled(RDI, RDI, RCX, 0, -1) // last dst byte
@@ -251,6 +307,9 @@ func (f *fn) memoryCopy(r *wasm.Reader) error {
 	f.a.PatchRel32(fwd, f.a.Len())
 	f.a.RepMovsb() // forward (DF=0 by ABI)
 	f.a.PatchRel32(done, f.a.Len())
+	for _, j := range joins {
+		f.a.PatchRel32(j, f.a.Len())
+	}
 
 	f.setDepth(d - 3)
 	return nil
@@ -284,7 +343,35 @@ func (f *fn) memoryFill(r *wasm.Reader) error {
 	f.trapUnlessLE(RDX, mb)
 
 	f.a.Add64(RDI, RBX) // absolute dst
-	f.a.RepStosb()      // [RDI..] = AL, RCX times (DF=0)
+
+	// Byte-replicate the fill value once (rep stosb only reads AL, so the
+	// pattern's low byte keeps the big path compatible).
+	f.a.AluRI(4, RAX, 0xFF, false) // and eax, 0xff
+	f.a.MovImm64(RDX, 0x0101010101010101)
+	f.a.IMul(RAX, RDX, true)
+
+	// Small dynamic fills: inline 8-byte pattern stores (rep stosb startup
+	// dominates); large keep rep stosb.
+	f.a.AluRI(cmpDigit, RCX, smallBulkMax, true)
+	bigF := f.a.JccPlaceholder(condAE)
+	fill8 := f.a.Len()
+	f.a.AluRI(cmpDigit, RCX, 8, false)
+	f8done := f.a.JccPlaceholder(condB)
+	f.a.StoreIdx(RDI, RCX, RAX, -8, 8)
+	f.a.AluRI(5, RCX, 8, false)
+	f.a.JmpBack(fill8)
+	f.a.PatchRel32(f8done, f.a.Len())
+	f.a.TestSelf(RCX, false)
+	fillDone := f.a.JccPlaceholder(condE)
+	fill1 := f.a.Len()
+	f.a.StoreIdx(RDI, RCX, RAX, -1, 1)
+	f.a.AluRI(5, RCX, 1, false)
+	f.a.PatchRel32(f.a.JccPlaceholder(condNE), fill1)
+	skipRep := f.a.JmpPlaceholder()
+	f.a.PatchRel32(bigF, f.a.Len())
+	f.a.RepStosb() // [RDI..] = AL, RCX times (DF=0)
+	f.a.PatchRel32(skipRep, f.a.Len())
+	f.a.PatchRel32(fillDone, f.a.Len())
 
 	f.setDepth(d - 3)
 	return nil

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -88,6 +88,7 @@ func (f *fn) emitTrapStubs() {
 			continue
 		}
 		pos := f.a.Len()
+		f.storeModuleGlobals(RSI) // post-trap global state stays observable (RSI is trap-path scratch)
 		f.emitTrap(code)
 		for _, s := range sites {
 			f.a.PatchRel32(s, pos)

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -101,13 +101,17 @@ func (f *fn) emitTrapStubs() {
 // aliasPinned lets a pinned-local address be used in place (no copy) — only
 // valid when the access is emitted immediately (stores), not deferred (loads);
 // eaOwned reports whether the caller must release ea.
-func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bool, disp int32) {
+func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bool, borrow int, disp int32) {
 	e := f.popValue()
 	disp = 0
+	borrow = -1
 	leaDisp := int32(size)
 	needAdd := int64(off)+int64(size) > 0x7FFFFFFF && off != 0
 	if aliasPinned && !needAdd {
 		ea, eaOwned = f.materializeRead(e) // a pinned local's reg is read in place
+		if !eaOwned {
+			borrow = e.st.idx
+		}
 	} else {
 		ea, eaOwned = f.materialize(e), true // ea = addr (u32, zero-extended)
 	}
@@ -122,7 +126,7 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 	}
 
 	if f.guardMode {
-		return ea, eaOwned, disp
+		return ea, eaOwned, borrow, disp
 	}
 	f.pinned = f.pinned.add(ea)
 	t := f.allocReg(0)
@@ -138,7 +142,7 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 	f.trapIf(condA, trapMemOOB) // out of bounds when ea+off+size > memBytes
 	f.release(t)
 	f.pinned = f.pinned.remove(ea)
-	return ea, eaOwned, disp
+	return ea, eaOwned, borrow, disp
 }
 
 // memLoad lowers a scalar load of `size` bytes. signed selects sign-extension;
@@ -151,11 +155,17 @@ func (f *fn) memLoad(r *wasm.Reader, size int, signed, wide bool) error {
 	if err != nil {
 		return err
 	}
-	ea, _, disp := f.memAddr(off, size, false) // deferred use: ea must be owned
+	// The address may read a pinned local's register in place (WARP
+	// liftToRegInPlace): the deferred load records the borrow so a local.set of
+	// that local realizes the load first, and consumers neither write nor
+	// release the register.
+	ea, eaOwned, borrow, disp := f.memAddr(off, size, true)
 	// Defer the load: push a bounds-checked memory reference (the mov is emitted
 	// when the value is materialized, or folded as an r/m operand into a consumer).
-	e := f.pushValue(memRefStorage(ea, disp, size, signed, wide))
-	f.regUser[ea] = e // ea (the address register) is owned by the deferred load
+	e := f.pushValue(memRefStorage(ea, disp, size, signed, wide, borrow))
+	if eaOwned {
+		f.regUser[ea] = e // an owned address register belongs to the deferred load
+	}
 	return nil
 }
 
@@ -174,7 +184,7 @@ func (f *fn) memStore(r *wasm.Reader, size int) error {
 	// and the StoreIdx can write a local).
 	vreg, vOwned := f.materializeRead(f.popValue())
 	f.pinned = f.pinned.add(vreg)
-	ea, eaOwned, disp := f.memAddr(off, size, true)
+	ea, eaOwned, _, disp := f.memAddr(off, size, true)
 	f.a.StoreIdx(RBX, ea, vreg, disp, size)
 	f.pinned = f.pinned.remove(vreg)
 	if eaOwned {

--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -159,10 +159,15 @@ func (f *fn) materialize(e *elem) Reg {
 		f.occupy(e, r)
 		return r
 	case stMemRef:
-		// Deferred load: emit the mov now, reusing the address register as the dest.
-		f.loadMemRef(e.st.reg, e.st)
-		f.occupy(e, e.st.reg)
-		return e.st.reg
+		// Deferred load: emit the mov now, reusing an OWNED address register as
+		// the destination; a borrowed (pinned-local) address loads into a fresh one.
+		dst := e.st.reg
+		if e.st.memBorrow() >= 0 {
+			dst = f.allocReg(maskOf(e.st.reg))
+		}
+		f.loadMemRef(dst, e.st)
+		f.occupy(e, dst)
+		return dst
 	}
 	panic("amd64: cannot materialize storage")
 }
@@ -178,6 +183,26 @@ func (f *fn) materializeRead(e *elem) (Reg, bool) {
 		return e.st.reg, false
 	}
 	return f.materialize(e), true
+}
+
+// memRefValue emits a deferred load and returns an OWNED register holding the
+// value (the address register is reused when owned; a borrowed pinned-local
+// address loads into a fresh register). The caller releases the result.
+func (f *fn) memRefValue(st storage) Reg {
+	dst := st.reg
+	if st.memBorrow() >= 0 {
+		dst = f.allocReg(maskOf(st.reg))
+	}
+	f.loadMemRef(dst, st)
+	return dst
+}
+
+// releaseMemRef frees a consumed deferred load's address register — unless it
+// was a borrowed pinned-local register, which is never allocator-owned.
+func (f *fn) releaseMemRef(st storage) {
+	if st.memBorrow() < 0 {
+		f.release(st.reg)
+	}
 }
 
 // loadMemRef emits the actual load for a deferred memory value into dst.

--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -54,10 +54,7 @@ func (f *fn) allocReg(avoid regMask) Reg {
 // fallback (condenseBinary's RHS relocation) use it to degrade to a spill slot
 // instead of failing under extreme pressure.
 func (f *fn) allocRegOrNone(avoid regMask) Reg {
-	block := avoid.union(f.pinned).union(f.pinnedLocalMask)
-	if f.memSizeReg != regNone {
-		block = block.add(f.memSizeReg) // module-wide memBytes cache is never allocatable
-	}
+	block := avoid.union(f.pinned).union(f.pinnedLocalMask).union(f.reserved)
 	for _, r := range gpAlloc {
 		if f.regUser[r] == nil && !block.has(r) {
 			return r

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -47,8 +47,11 @@ const (
 
 // memRefStorage builds the storage for a deferred integer load: the bounds check
 // has already run and `ea` holds the effective address, but the mov is deferred
-// so it can be folded as an r/m operand into a consuming op.
-func memRefStorage(ea Reg, disp int32, size int, signed, wide bool) storage {
+// so it can be folded as an r/m operand into a consuming op. borrow >= 0 marks
+// ea as local `borrow`'s pinned register read in place (WARP liftToRegInPlace):
+// consumers must not write or release it, and a local.set of that local
+// materializes the load first (realizeLocalRefs).
+func memRefStorage(ea Reg, disp int32, size int, signed, wide bool, borrow int) storage {
 	typ := mtI32
 	if wide {
 		typ = mtI64
@@ -57,12 +60,16 @@ func memRefStorage(ea Reg, disp int32, size int, signed, wide bool) storage {
 	if signed {
 		sidx |= 0x100
 	}
-	return storage{kind: stMemRef, typ: typ, reg: ea, slot: int(disp), idx: sidx}
+	return storage{kind: stMemRef, typ: typ, reg: ea, slot: int(disp), idx: sidx, cval: int64(borrow + 1)}
 }
 
 func (st storage) memDisp() int32  { return int32(st.slot) }
 func (st storage) memSize() int    { return st.idx & 0xff }
 func (st storage) memSigned() bool { return st.idx&0x100 != 0 }
+
+// memBorrow returns the local whose pinned register serves as this deferred
+// load's address, or -1 when the address register is owned.
+func (st storage) memBorrow() int { return int(st.cval) - 1 }
 
 // memRefFoldable reports whether a deferred load can be folded directly as an
 // ALU/CMP r/m operand of the given width — only full-width loads (no sub-width

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -562,3 +562,18 @@ func (a *Asm) LeaRipPlaceholder(dst Reg) int {
 	a.imm32(0)
 	return off
 }
+
+// Neg emits NEG r (F7 /3): two's-complement negation.
+func (a *Asm) Neg(r Reg, w bool) {
+	rex := byte(0x40)
+	if w {
+		rex |= 0x08
+	}
+	if r >= 8 {
+		rex |= 0x01
+	}
+	if rex != 0x40 || w {
+		a.emit(rex)
+	}
+	a.emit(0xF7, 0xD8|byte(r&7))
+}

--- a/src/core/runtime/abi/basedata.go
+++ b/src/core/runtime/abi/basedata.go
@@ -8,7 +8,13 @@ const (
 	// slot-array pointer, addressed by JIT code as [linMem - GlobalsPtrOffset].
 	GlobalsPtrOffset = 88
 
+	// TrapCellPtrOffset is the basedata slot holding the address of the trap
+	// cell ([linMem - TrapCellPtrOffset], u64), installed once per native entry
+	// by the runtime. Only the cold trap path reads it — calls and returns carry
+	// no trap protocol.
+	TrapCellPtrOffset = 104
+
 	// BasedataSize keeps the linear-memory base 16-byte aligned after the wago
 	// extension fields appended to the WARP-compatible basedata layout.
-	BasedataSize = 96
+	BasedataSize = 112
 )

--- a/src/core/runtime/engine_linux_amd64.go
+++ b/src/core/runtime/engine_linux_amd64.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"encoding/binary"
 	"fmt"
+	"github.com/wago-org/wago/src/core/runtime/abi"
 	"unsafe"
 )
 
@@ -50,7 +51,13 @@ func (e *Engine) StackLimit() uintptr {
 // linMem, trap and results MUST be backed by off-heap memory (Arena/JobMemory)
 // so their addresses are stable across the call. It returns a *TrapError if the
 // wrapper set a non-zero trap code.
+//
+// The trap cell is zeroed and its pointer installed in basedata here, once per
+// entry, so generated code never passes or clears it: emitTrap (the only
+// consumer, cold) reads [linMem-abi.TrapCellPtrOffset], and function returns
+// carry no trap protocol at all (WARP's model).
 func (e *Engine) Call(code uintptr, serArgs, linMem, trap, results []byte) error {
+	installTrapCell(linMem, trap)
 	enterNative(code, slicePtr(serArgs), slicePtr(linMem), slicePtr(trap), slicePtr(results), e.stackTop)
 	if len(trap) >= 4 {
 		if tc := TrapCode(binary.LittleEndian.Uint32(trap)); tc != TrapNone {
@@ -58,6 +65,17 @@ func (e *Engine) Call(code uintptr, serArgs, linMem, trap, results []byte) error
 		}
 	}
 	return nil
+}
+
+// installTrapCell zeroes the trap cell and writes its address into the
+// basedata trap-cell slot so generated code can reach it on the (cold) trap
+// path without any per-call plumbing.
+func installTrapCell(linMem, trap []byte) {
+	if len(trap) < 4 || len(linMem) == 0 {
+		return
+	}
+	binary.LittleEndian.PutUint32(trap, 0)
+	*(*uint64)(unsafe.Pointer(slicePtr(linMem) - abi.TrapCellPtrOffset)) = uint64(slicePtr(trap))
 }
 
 // HostFunc is a V2-style host import for the spike: it reads its argument and
@@ -74,6 +92,7 @@ type HostFunc func(arg uint32) uint32
 // ctrl must point at an off-heap control block (see ctrl* offsets) whose address
 // has been installed as the import ctx via JobMemory.SetCustomCtx.
 func (e *Engine) CallWithHost(code uintptr, serArgs, linMem, trap, results, ctrl []byte, host HostFunc) error {
+	installTrapCell(linMem, trap)
 	const maxReentries = 1 << 20
 	for i := 0; i < maxReentries; i++ {
 		enterNative(code, slicePtr(serArgs), slicePtr(linMem), slicePtr(trap), slicePtr(results), e.stackTop)


### PR DESCRIPTION
Re-opened from #89, whose commits were stranded when #88 was squash-merged before the stacked branch integrated (main was missing all four changes — json deser measured 394ns instead of 204ns). Same content, cherry-picked cleanly onto current main, full gate battery re-run (spec suite, `go test ./...`, explicit-vs-guard differential corpus — all green; json explicit ser/deser 205/213 on this branch vs 223/394 on main).

See #89 for the full write-up. Summary:

Ran WARP itself on json-as (passive-bounds build → compared against wago guard mode): **WARP 97ns ser / 164ns deser per unit**. Per-function disassembly diff showed wago's codegen already at parity (our TLSF `removeBlock` is smaller than WARP's); the 2× gap was four structural conventions, replicated here:

1. **No per-call environment protocol** — RBX/linMem as whole-module invariant; trap-cell pointer in basedata (`abi.TrapCellPtrOffset`, installed + zeroed once per entry by `Engine.Call`); no trap-clear on returns. fib_rec −13%.
2. **Borrowed load addresses** (`memBorrow` on deferred loads, realize-on-`local.set`) **+ read-only branch conditions**. sieve −23%.
3. **Module-wide global register pinning** (K=1: the AS shadow-stack pointer in R14 in every function; cells sync only at native boundaries, wrapper calls, trap stubs).
4. **Inline 8-byte chunk-loop memmove for small dynamic `memory.copy`/`fill`** (n<96; `rep movsb` startup dominated AS `__renew`'s string-append copies = 47% of deserialization). **Deserialize −43%.**

| json-as ns/unit (guard) | ser | deser |
|---|---:|---:|
| WARP | 97 | 164 |
| wazero | 141 | 293 |
| wago before | 204 | 342 |
| **wago after** | **189** | **185** |

Deserialize: **1.43× faster than wazero, within 1.13× of WARP.** 40 new dynamic bulk-mem exec tests (overlap both directions, boundary sizes); codec unchanged (v9 landed with #88).