### PR TITLE
fix: go vet unsafe.Pointer misuse in installTrapCell

### DIFF
--- a/src/core/runtime/engine_linux_amd64.go
+++ b/src/core/runtime/engine_linux_amd64.go
@@ -75,7 +75,7 @@ func installTrapCell(linMem, trap []byte) {
 		return
 	}
 	binary.LittleEndian.PutUint32(trap, 0)
-	*(*uint64)(unsafe.Pointer(slicePtr(linMem) - abi.TrapCellPtrOffset)) = uint64(slicePtr(trap))
+	*(*uint64)(unsafe.Pointer(uintptr(unsafe.Pointer(&linMem[0])) - abi.TrapCellPtrOffset)) = uint64(slicePtr(trap))
 }
 
 // HostFunc is a V2-style host import for the spike: it reads its argument and


### PR DESCRIPTION
main's push CI is currently red: #90 merged before this one-line fix (pushed to the PR branch after CI had already started, landed too late) made it in. Same fix, applied directly to main.

\`go vet\` flagged \`unsafe.Pointer(slicePtr(linMem) - abi.TrapCellPtrOffset)\` because the uintptr crosses a function call boundary before the arithmetic+reconversion. Inlined the \`&linMem[0]\` address-of so the arithmetic happens in a single expression, matching vet's recognized safe pattern. No behavior change (slicePtr's mmap-backed slices never move).