### PR TITLE
perf(railshot): borrowed reads for value-pinned globals (stGlobReg)

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -123,11 +123,30 @@ consumer that stores 8 bits can skip the widening. Cheap, narrow.
 Deserialize now beats wazero and sits 1.13× from WARP. Serialize remains ~2× from
 WARP: 52% of it is one function (the serializer core, wat 27) writing JSON text
 through global bump pointers (globals 2/4) in `global.get; i64.store; global.set`
-bursts punctuated by ensure-capacity calls. Module-pinning those globals (K>1)
-measured nearly flat — the burst's cost is the dependent stores and calls, not the
-global derives. Next: look at WARP's exact codegen for wat 27's store bursts, and
-consider write-combining/hoisting the bump pointer across a burst (it's only
-observable at calls).
+bursts punctuated by ensure-capacity calls.
+
+**B1 landed (borrowed reads for value-pinned globals, `stGlobReg`):** `global.get`
+on a value-pinned global used to copy the register out (`materialize`'s ~30
+consumer sites all forced a copy); it now pushes a borrowed reference like a
+pinned local (`stLocalReg`), realized on `global.set`/flush/call-arg staging. This
+was necessary but not sufficient by itself — with only global 25 (the AS
+shadow-stack pointer) module-pinned (K=1, the shipped default), ser/deser are
+unchanged, because globals 2/4 (the burst's write-pointer/capacity-watermark)
+aren't pinned at all yet.
+
+**K-sweep re-run with borrowed reads** (`moduleGlobalRegs` in compile.go):
+K=2 {R14,R13} only fits one of {2,4} → still flat on json, and blake regresses
+~2% (39-local function loses a pool register). K=3 {R14,R13,R12} fits both →
+json-as ser/deser **improve ~6–8%** (guard ser 193→181ns, deser 191→182ns) —
+borrowed reads finally pay off once both burst globals are pinned together — but
+blake regresses **~7%** (it was already ~1.6× slower than wazero there; K=3 makes
+it worse). Judgment call: **shipped K=1** (no regression anywhere) rather than
+trade blake for json. Revisit if a future change lets the two burst globals share
+fewer reserved registers, or scores them together instead of independently.
+
+Next on serialize: B2 (constant-store splitting — `i64.const; i64.store` still
+materializes a 10-byte movabs before storing) and B3 (WARP's exact wat-27 codegen
+diff) are unstarted.
 
 ### R5. Runtime / infra from WARP
 | Item | Effort | Value | Notes |

--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -224,7 +224,7 @@ func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, emitCall func()
 	var deferred []deferredArg
 	for i := 0; i < p; i++ {
 		root := argRoots[i]
-		if root.isDeferred() || (root.kind == ekValue && (root.st.kind == stReg || root.st.kind == stLocalReg || root.st.kind == stMemRef)) {
+		if root.isDeferred() || (root.kind == ekValue && (root.st.kind == stReg || root.st.kind == stLocalReg || root.st.kind == stGlobReg || root.st.kind == stMemRef)) {
 			reg := f.materialize(root) // stMemRef → emits the deferred load into its addr reg
 			f.pinned = f.pinned.add(reg)
 			moves = append(moves, regMove{dst: intArgRegs[i], src: reg})

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -82,11 +82,11 @@ func (f *fn) flush() {
 		if root.kind == ekValue && root.st.kind == stSlot && root.st.slot == i {
 			continue // already canonical
 		}
-		if root.kind == ekValue && root.st.kind == stLocalReg {
+		if root.kind == ekValue && (root.st.kind == stLocalReg || root.st.kind == stGlobReg) {
 			if root.st.typ.isFloat() {
 				f.a.FStoreDisp(RSP, f.spillOff(i), root.st.reg, true)
 			} else {
-				f.a.Store64(RSP, f.spillOff(i), root.st.reg) // copy pinned local's value; never release
+				f.a.Store64(RSP, f.spillOff(i), root.st.reg) // copy pinned local/global's value; never release
 			}
 			continue
 		}

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -144,9 +144,9 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 			right = &elem{kind: ekValue, st: storage{kind: stReg, typ: node.typ, reg: rr}}
 			rightReleaseAfter = rr
 		}
-	} else if (right.st.kind == stReg || right.st.kind == stLocalReg) && dest != regNone && right.st.reg == dest {
-		// The RHS lives in dest — either an owned reg or a borrowed pinned local
-		// whose register is also the target (an in-place self-update like
+	} else if (right.st.kind == stReg || right.st.kind == stLocalReg || right.st.kind == stGlobReg) && dest != regNone && right.st.reg == dest {
+		// The RHS lives in dest — either an owned reg or a borrowed pinned local/
+		// global whose register is also the target (an in-place self-update like
 		// `x = c - x`). Copy it out before the LHS overwrites dest.
 		if t := f.allocRegOrNone(maskOf(dest)); t != regNone {
 			f.a.MovReg64(t, dest)
@@ -164,7 +164,7 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 		//    preceding copy for).
 		//  - in-place: reuse an owned-register left as the destination, so the op
 		//    accumulates in place with no preceding mov.
-		if node.op == opAdd && left.kind == ekValue && left.st.kind == stLocalReg && leaRightOK(right) {
+		if node.op == opAdd && left.kind == ekValue && (left.st.kind == stLocalReg || left.st.kind == stGlobReg) && leaRightOK(right) {
 			dest = f.allocReg(0)
 			f.emitLeaAdd(dest, left.st.reg, right, w)
 			f.release(rightReleaseAfter)
@@ -273,7 +273,7 @@ func leaRightOK(right *elem) bool {
 		return false
 	}
 	switch right.st.kind {
-	case stReg, stLocalReg:
+	case stReg, stLocalReg, stGlobReg:
 		return true
 	case stConst:
 		return fitsImm32(right.st.cval)
@@ -290,8 +290,8 @@ func (f *fn) emitLeaAdd(dst, base Reg, right *elem, w bool) {
 	case stReg:
 		f.a.LeaScaledW(dst, base, right.st.reg, 0, 0, w)
 		f.release(right.st.reg)
-	case stLocalReg:
-		f.a.LeaScaledW(dst, base, right.st.reg, 0, 0, w) // pinned local; never released
+	case stLocalReg, stGlobReg:
+		f.a.LeaScaledW(dst, base, right.st.reg, 0, 0, w) // pinned local/global; never released
 	}
 }
 
@@ -388,8 +388,8 @@ func (f *fn) condenseCompare(node *elem, dest Reg) Reg {
 		case stReg:
 			f.cmpRR(L, right.st.reg, w)
 			f.release(right.st.reg)
-		case stLocalReg:
-			f.cmpRR(L, right.st.reg, w) // pinned local; never release
+		case stLocalReg, stGlobReg:
+			f.cmpRR(L, right.st.reg, w) // pinned local/global; never release
 		case stSlot:
 			f.a.AluRM(cmpRMcode, L, RSP, f.spillOff(right.st.slot), w)
 		case stLocalRef:
@@ -427,8 +427,8 @@ func (f *fn) condenseUnary(node *elem, dest Reg) Reg {
 	arg := node.arg0
 	var src Reg
 	srcOwned := true
-	if arg.kind == ekValue && arg.st.kind == stLocalReg {
-		src, srcOwned = arg.st.reg, false // pinned local: read directly, never release
+	if arg.kind == ekValue && (arg.st.kind == stLocalReg || arg.st.kind == stGlobReg) {
+		src, srcOwned = arg.st.reg, false // pinned local/global: read directly, never release
 	} else {
 		src = f.materialize(arg)
 	}
@@ -576,9 +576,9 @@ func (f *fn) condenseInto(e *elem, dest Reg) {
 		f.a.Load64(dest, RSP, f.spillOff(e.st.slot))
 	case stLocalRef:
 		f.a.Load64(dest, RSP, f.localOff(e.st.idx))
-	case stLocalReg:
+	case stLocalReg, stGlobReg:
 		if e.st.reg != dest {
-			f.a.MovReg64(dest, e.st.reg) // copy from the pinned local; never release it
+			f.a.MovReg64(dest, e.st.reg) // copy from the pinned local/global; never release it
 		}
 	case stMemRef:
 		f.loadMemRef(dest, e.st) // emit the deferred load into dest
@@ -602,8 +602,8 @@ func (f *fn) applyALU(enc aluEnc, dest Reg, right *elem, w bool) {
 	case stReg:
 		f.a.AluRR(enc.rr, dest, right.st.reg, w)
 		f.release(right.st.reg)
-	case stLocalReg:
-		f.a.AluRR(enc.rr, dest, right.st.reg, w) // pinned local; never release
+	case stLocalReg, stGlobReg:
+		f.a.AluRR(enc.rr, dest, right.st.reg, w) // pinned local/global; never release
 	case stSlot:
 		f.a.AluRM(enc.rm, dest, RSP, f.spillOff(right.st.slot), w)
 	case stLocalRef:
@@ -643,8 +643,8 @@ func (f *fn) applyMul(dest Reg, right *elem, w bool) {
 	case stReg:
 		f.a.IMul(dest, right.st.reg, w)
 		f.release(right.st.reg)
-	case stLocalReg:
-		f.a.IMul(dest, right.st.reg, w) // pinned local; never release
+	case stLocalReg, stGlobReg:
+		f.a.IMul(dest, right.st.reg, w) // pinned local/global; never release
 	case stSlot:
 		f.a.ImulRM(dest, RSP, f.spillOff(right.st.slot), w)
 	case stLocalRef:

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -35,7 +35,7 @@ func (f *fn) flushBelow(node *elem) int {
 		if root.kind == ekValue && root.st.kind == stSlot && root.st.slot == i {
 			continue
 		}
-		if root.kind == ekValue && root.st.kind == stLocalReg {
+		if root.kind == ekValue && (root.st.kind == stLocalReg || root.st.kind == stGlobReg) {
 			if root.st.typ.isFloat() {
 				f.a.FStoreDisp(RSP, f.spillOff(i), root.st.reg, true)
 			} else {
@@ -78,7 +78,7 @@ func (f *fn) condenseToFlags(node *elem) Cond {
 		var L Reg
 		ownedL := false
 		switch {
-		case a.kind == ekValue && a.st.kind == stLocalReg:
+		case a.kind == ekValue && (a.st.kind == stLocalReg || a.st.kind == stGlobReg):
 			L = a.st.reg
 		case a.kind == ekValue && a.st.kind == stReg:
 			L, ownedL = a.st.reg, true
@@ -100,7 +100,7 @@ func (f *fn) condenseToFlags(node *elem) Cond {
 	var L Reg
 	ownedL := false
 	switch {
-	case left.kind == ekValue && left.st.kind == stLocalReg:
+	case left.kind == ekValue && (left.st.kind == stLocalReg || left.st.kind == stGlobReg):
 		L = left.st.reg
 	case left.kind == ekValue && left.st.kind == stReg:
 		L, ownedL = left.st.reg, true
@@ -126,7 +126,7 @@ func (f *fn) condenseToFlags(node *elem) Cond {
 	case stReg:
 		f.cmpRR(L, right.st.reg, w)
 		f.release(right.st.reg)
-	case stLocalReg:
+	case stLocalReg, stGlobReg:
 		f.cmpRR(L, right.st.reg, w)
 	case stSlot:
 		f.a.AluRM(cmpRMcode, L, RSP, f.spillOff(right.st.slot), w)

--- a/src/core/compiler/backend/railshot/globals.go
+++ b/src/core/compiler/backend/railshot/globals.go
@@ -63,17 +63,16 @@ func (f *fn) globalGet(r *wasm.Reader) error {
 		return fmt.Errorf("amd64: unknown global %d", x)
 	}
 	gtv := wasm.GlobalValueType(gt)
-	// Value-pinned (int) global: the current value already lives in a register; copy
-	// it out (a reg-reg move, free on this µarch) — no memory access at all.
+	// Value-pinned (int) global: the current value already lives in a register.
+	// Push a borrowed reference (WARP liftToRegInPlace) — no copy, no memory access
+	// at all — kept sound by realize-on-set (realizeGlobalRefs) and by flush/
+	// flushBelow materializing it before a call or control-flow boundary.
 	if reg, ok := f.pinnedGlobalValueReg(x); ok {
-		dst := f.allocReg(0)
+		typ := mtI32
 		if wasm.EqualValType(gtv, wasm.I64) {
-			f.a.MovReg64(dst, reg)
-			f.pushReg(dst, mtI64)
-		} else {
-			f.a.MovRegReg32(dst, reg)
-			f.pushReg(dst, mtI32)
+			typ = mtI64
 		}
+		f.pushValue(storage{kind: stGlobReg, typ: typ, reg: reg, idx: int(x)})
 		return nil
 	}
 	cell := f.globalCellPtr(x) // cached, pinned — read the value into a separate reg
@@ -95,6 +94,44 @@ func (f *fn) globalGet(r *wasm.Reader) error {
 		return fmt.Errorf("amd64: global.get type %s not yet supported (global %d)", gtv, x)
 	}
 	return nil
+}
+
+// realizeGlobalRefs forces any pending operand-stack references to value-pinned
+// global x into registers before x's register is overwritten, mirroring
+// realizeLocalRefs. skipFrom (non-nil) marks the base of the value-being-set's
+// valent block for an in-place self-update (`global.set $x (binop (global.get
+// $x) …)`): refs to x inside that block are consumed directly into x's register
+// by condenseInto, so realizing them here would force a wasteful copy-out +
+// copy-back. Refs BELOW it still need x's pre-set value and are realized.
+func (f *fn) realizeGlobalRefs(x uint32, skipFrom *elem) {
+	for e := f.s.head.next; e != f.s.head; {
+		if e == skipFrom {
+			break
+		}
+		next := e.next
+		switch {
+		case e.kind == ekValue && e.st.kind == stGlobReg && uint32(e.st.idx) == x:
+			f.materialize(e)
+		case e.kind == ekDeferred && subtreeRefsGlobal(e, x):
+			f.condense(e, regNone)
+		}
+		e = next
+	}
+}
+
+// subtreeRefsGlobal reports whether the valent block rooted at e reads
+// value-pinned global x.
+func subtreeRefsGlobal(e *elem, x uint32) bool {
+	if e == nil {
+		return false
+	}
+	if e.kind == ekValue {
+		return e.st.kind == stGlobReg && uint32(e.st.idx) == x
+	}
+	if e.kind == ekDeferred {
+		return subtreeRefsGlobal(e.arg0, x) || subtreeRefsGlobal(e.arg1, x)
+	}
+	return false
 }
 
 func (f *fn) globalSet(r *wasm.Reader) error {
@@ -122,6 +159,14 @@ func (f *fn) globalSet(r *wasm.Reader) error {
 	// function epilogue, since value-pinning is only used in call-free functions).
 	if reg, ok := f.pinnedGlobalValueReg(x); ok {
 		e := f.s.back()
+		// In-place self-update `global.set $x (binop (global.get $x) …)`: let
+		// condenseInto consume the top expression straight into x's register instead
+		// of pre-copying its (global.get $x) operand (mirrors setLocal's skipFrom).
+		var skipFrom *elem
+		if e != nil && e.isDeferred() && isBinALU(e.op) {
+			skipFrom = baseOfValentBlock(e)
+		}
+		f.realizeGlobalRefs(x, skipFrom)
 		f.condenseInto(e, reg)
 		f.release(reg)
 		f.erase(e)


### PR DESCRIPTION
Workstream B1 from docs/perf-plan-2026-07.md (note: the first slice of this — the `stGlobReg` storage kind + `materialize`/`materializeRead` — landed directly on main as ed2e433 outside the normal PR flow; this PR completes the rest of that change and gates it properly).

`global.get` on a value-pinned (mutable int) global used to copy the register out on every read (`materialize`'s consumer sites all forced a copy, mirroring nothing like `stLocalReg`'s borrow). Added `stGlobReg` — a borrowed global-register reference, exactly mirroring `stLocalReg` — so a pinned-global read is free (no copy, no memory access) until something needs an owned register or the global is overwritten:

- `globalGet` pushes a borrowed `stGlobReg` instead of copying.
- `globalSet` gained the self-update fusion (`global.set $x (binop (global.get $x) …)` computes straight into $x's register, mirroring `setLocal`'s skipFrom) plus `realizeGlobalRefs` (realize-on-set, mirroring `realizeLocalRefs`) so a stale borrowed reference is never read past the point $x's register changes.
- Audited and extended every `stLocalReg` consumer site for read-only or store-to-slot semantics: `materialize`/`materializeRead` (regalloc.go), `condenseInto`/`applyALU`/`applyMul`/`condenseCompare`/`condenseUnary`/`leaRightOK`/`emitLeaAdd`/the RHS-aliases-dest check (emit.go), `condenseToFlags`/`flushBelow` (fuse.go), `flush` (control.go). One site was a real correctness gap, not just a missed optimization: the register-ABI call-argument staging (call.go) only special-cased `stReg`/`stLocalReg`/`stMemRef` before flush — a `stGlobReg` argument would have fallen into the `deferred` arg list, whose switch has no case for it, silently passing a garbage register. Fixed by adding it to the eager-materialize condition.
- Added a `refGlobal` ref-kind (references.go) so global refs don't collide with `refLocal`'s local-index space.

## Validation
- Full gate green: `go test ./...` (host + guard tag), `TestSpecExec` (exactly 16500/13/1672, matching the golden table — zero drift), bench module `go test ./...` under both tags (includes `TestCorpusDifferential` and `TestJsonAsGuard{,Correct}`), and the existing global-specific suite (`TestPinnedGlobalAccumulateAndPersist`/`AcrossCall`/`AliasCapture`, `TestGlobalGetSetEndToEnd`, etc.) under both bounds modes.
- Found and confirmed a **pre-existing, unrelated** guard-mode segfault (`TestConfigSignalsBasedEndToEnd` and others touching real memory under `-tags wago_guardpage`) reproduces on a clean main checkout with none of this PR's changes — not introduced here, not covered by CI's `make test` (which doesn't pass the guard tag), and out of scope for this PR.

## K-sweep (re-run with borrowed reads, per the plan's decision gate)
Module-pinning globals 2/4 (json-as's write-pointer/capacity-watermark — the R4 serialize-gap burst) was previously measured flat; borrowed reads were the suspected fix. Re-ran `moduleGlobalRegs` K=1/2/3:

- K=1 (current default, only global 25 pinned): unchanged, as expected — 2/4 aren't pinned yet.
- K=2 {R14,R13}: only fits one of {2,4} → json-as still flat, and blake regresses ~2% (39-local function loses a pool register).
- K=3 {R14,R13,R12}: fits both → json-as ser/deser **improve ~6-8%** (guard ser 193→181ns, deser 191→182ns) — borrowed reads finally pay off once both burst globals are pinned together. But blake regresses **~7%** (already ~1.6x slower than wazero there).

**Shipped K=1** — no regression anywhere. K=3's tradeoff (real json-as win vs. real blake regression) is a judgment call, not an engineering one; documented in OPTIMIZATIONS.md R4 for a future call once B2/B3 close more of the gap or the two burst globals can be scored/pinned more cheaply together.