### PR TITLE
perf(railshot): immediate-only memory stores for constant values

### DIFF
--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -184,6 +184,27 @@ func (f *fn) memStore(r *wasm.Reader, size int) error {
 		return err
 	}
 	f.materializePendingLoads() // deferred loads must read pre-store memory
+	// A constant value stores as an immediate directly (selectInstr's `mov r/m,
+	// imm` form) — no register, no load-then-store dependency chain. i64 needs
+	// two 4-byte immediate stores (low32 at disp, high32 at disp+4): a single
+	// 64-bit imm-store sign-extends imm32, which is wrong for an arbitrary
+	// 64-bit pattern; narrower stores truncate to the low `size` bytes exactly
+	// like a materialized constant would (i64.store8/16/32 route here too).
+	if top := f.s.back(); top != nil && top.kind == ekValue && top.st.kind == stConst {
+		v := top.st.cval
+		f.erase(top)
+		ea, eaOwned, _, disp := f.memAddr(off, size, true)
+		if size == 8 {
+			f.a.StoreImmIdx(RBX, ea, disp, int32(v), 4)
+			f.a.StoreImmIdx(RBX, ea, disp+4, int32(v>>32), 4)
+		} else {
+			f.a.StoreImmIdx(RBX, ea, disp, int32(v), size)
+		}
+		if eaOwned {
+			f.release(ea)
+		}
+		return nil
+	}
 	// Both the value and the address are immediate read-only uses here, so a
 	// pinned local feeds the store in place — no copy (nothing between the reads
 	// and the StoreIdx can write a local).

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -164,6 +164,35 @@ func (a *Asm) StoreImm32Mem(base Reg, disp int32, v int32) {
 	a.imm32(v)
 }
 
+// StoreImmIdx stores an immediate directly to [base+index+disp] — `mov r/m,
+// imm` (C6 /0 for a byte, C7 /0 for 16/32-bit; the reg field is the /0 digit,
+// not a register). size selects the store width: 1, 2, or 4 bytes. An 8-byte
+// (i64) store is NOT a single form here — `mov r/m64, imm32` sign-extends the
+// immediate, which is wrong for an arbitrary 64-bit pattern; callers emit two
+// 4-byte immediate stores (low32 at disp, high32 at disp+4) instead.
+func (a *Asm) StoreImmIdx(base, index Reg, disp int32, imm int32, size int) {
+	if size == 2 {
+		a.emit(0x66) // operand-size prefix for 16-bit
+	}
+	if index >= 8 || base >= 8 {
+		a.emit(rex(false, false, index >= 8, base >= 8))
+	}
+	op := byte(0xC7)
+	if size == 1 {
+		op = 0xC6
+	}
+	a.emit(op)
+	a.sibAddr(RAX, base, index, disp) // reg field = 0 (the /0 digit)
+	switch size {
+	case 1:
+		a.emit(byte(imm))
+	case 2:
+		a.emit(byte(imm), byte(imm>>8))
+	default:
+		a.imm32(imm)
+	}
+}
+
 func (a *Asm) alu(opcode byte, dst, src Reg, w bool) {
 	if w || src >= 8 || dst >= 8 {
 		a.emit(rex(w, src >= 8, false, dst >= 8))


### PR DESCRIPTION
Workstream B2 from docs/perf-plan-2026-07.md: `i64.const; i64.store` (and every other const-value store) used to materialize the constant into a register (a 10-byte movabs for i64) before storing it — a register plus a load-store dependency chain for every literal write, everywhere.

- New encoder op `StoreImmIdx(base, index, disp, imm, size)` — `mov r/m, imm` direct-to-memory (C6 /0 for a byte, C7 /0 for 16/32-bit; size 2 adds the 0x66 prefix).
- `memStore` peeks the value operand for `stConst` before calling `materializeRead`. i64 stores split into two 4-byte immediate stores (low32 at disp, high32 at disp+4) — `mov r/m64, imm32` sign-extends the immediate, which is wrong for an arbitrary 64-bit constant. i32/i16/i8 stores (including i64.store8/16/32, which route through the same size-parameterized `memStore`) use a single immediate store of the matching width.

Verified via disassembly (scratch module: `i64.store`/`i32.store`/`i32.store8` of constants) that all three forms now emit a direct `mov [mem], imm` with zero register traffic — no movabs, no load.

## Validation
- Full gate green: `go test ./...` (host + guard tag on the unaffected packages — see [[wago-guardpage-segfault-preexisting]] via memory, a pre-existing unrelated segfault), `TestSpecExec` (exact golden 16500/13/1672), bench module `go test ./...` under both tags (`TestCorpusDifferential` exercises json-as's real const-store bursts under both bounds modes).
- json-as ser/deser measured flat at the current K=1 default — expected at this stage; the plan evaluates Workstream B (B1+B2+B3) cumulatively, and B3 (diffing WARP's exact wat-27 codegen) is next.