### PR TITLE
docs(perf): B3 findings — WARP wat-27 diff, module-pinned global correction

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -121,32 +121,80 @@ consumer that stores 8 bits can skip the widening. Cheap, narrow.
 
 ### R4. json serialize gap (deserialize is solved)  · M–L · 🟩
 Deserialize now beats wazero and sits 1.13× from WARP. Serialize remains ~2× from
-WARP: 52% of it is one function (the serializer core, wat 27) writing JSON text
-through global bump pointers (globals 2/4) in `global.get; i64.store; global.set`
-bursts punctuated by ensure-capacity calls.
+WARP: 52% of it is one function (the serializer core, local fn 26 / wat 27)
+writing JSON text through global bump pointers in `global.get; i64.store;
+global.set` bursts punctuated by ensure-capacity calls. **Correction to earlier
+text in this section:** `pickModuleGlobals`'s aggregate score for the json-as
+bench module is **global 2 (score 4603) — the serializer's own output
+write-pointer** — not "the AS shadow-stack pointer" as PR #90's description
+assumed; that guess was never verified against this module's actual global
+indices. Global 4 (score 1350, the capacity watermark) is the *second*-highest
+candidate; a third candidate (global 25, score 737, identity unconfirmed — see
+below) is a distant third. Verified with a temporary
+`WAGO_DEBUG_MODGLOBALS=1` print in `pickModuleGlobals` (not shipped).
 
 **B1 landed (borrowed reads for value-pinned globals, `stGlobReg`):** `global.get`
 on a value-pinned global used to copy the register out (`materialize`'s ~30
 consumer sites all forced a copy); it now pushes a borrowed reference like a
-pinned local (`stLocalReg`), realized on `global.set`/flush/call-arg staging. This
-was necessary but not sufficient by itself — with only global 25 (the AS
-shadow-stack pointer) module-pinned (K=1, the shipped default), ser/deser are
-unchanged, because globals 2/4 (the burst's write-pointer/capacity-watermark)
-aren't pinned at all yet.
+pinned local (`stLocalReg`), realized on `global.set`/flush/call-arg staging.
 
-**K-sweep re-run with borrowed reads** (`moduleGlobalRegs` in compile.go):
-K=2 {R14,R13} only fits one of {2,4} → still flat on json, and blake regresses
-~2% (39-local function loses a pool register). K=3 {R14,R13,R12} fits both →
-json-as ser/deser **improve ~6–8%** (guard ser 193→181ns, deser 191→182ns) —
-borrowed reads finally pay off once both burst globals are pinned together — but
-blake regresses **~7%** (it was already ~1.6× slower than wazero there; K=3 makes
-it worse). Judgment call: **shipped K=1** (no regression anywhere) rather than
-trade blake for json. Revisit if a future change lets the two burst globals share
-fewer reserved registers, or scores them together instead of independently.
+**B2 landed (immediate-only constant stores):** `i64.const; i64.store` used to
+materialize a 10-byte movabs into a register before storing; `memStore` now peeks
+the value for `stConst` and emits `mov r/m, imm` directly (two 4-byte immediate
+stores for i64, matching width for i32/i16/i8), via a new encoder op
+`StoreImmIdx`.
 
-Next on serialize: B2 (constant-store splitting — `i64.const; i64.store` still
-materializes a 10-byte movabs before storing) and B3 (WARP's exact wat-27 codegen
-diff) are unstarted.
+**B3 (WARP wat-27 diff):** Regenerated `/tmp/warp-json.bin` and disassembled both
+sides for the identical burst (`{"authenticated":` — the same struct field name
+appears in both benches' schema, confirmed by decoding the movabs immediates as
+UTF-16LE). The comparison **reverses the original hypothesis**:
+
+- **WARP does not keep the write-pointer in a register across the burst at all.**
+  It reloads it from a *fixed basedata offset* (`mov r10d,[rbx-0xf0]`) before
+  **every single 8-byte store**, and writes it back once at the end — no
+  cell-pointer indirection (globals live directly in basedata, one load, no
+  array-of-pointers), but no register residency either. Per store: reload (7B) +
+  movabs (10B) + store (4–5B) ≈ 3 instructions, ~21 bytes.
+- **wago (current, K=1, post B1+B2) keeps the write-pointer live in R14 for the
+  *entire* burst** — zero reloads between stores, bumped once at the end
+  (`add r14d,0x22`) — and B2 means zero movabs. Per store: one 7-byte immediate
+  store, period. For this exact burst wago now emits **fewer instructions and
+  less code than WARP**, with fewer memory accesses.
+- Confirmed by re-running the K-sweep with `WAGO_DEBUG_MODGLOBALS`: **K=2
+  {R14,R13} already pins BOTH burst globals** (2 and 4 are the top two
+  candidates by score) — this corrects the earlier claim that K=2 "only fits one
+  of {2,4}". Redisassembling fn26 at K=2 confirms global 4's capacity-watermark
+  bump goes fully register-resident too (`add r13d,0xaa`, no memory access) —
+  the codegen change is real. **But json-as ser/deser measured flat at K=2
+  anyway** (~193–200ns, indistinguishable from K=1, noisy). K=3's ~6–8%
+  improvement therefore is NOT explained by "both burst globals finally pinned
+  together" (they already are, at K=2) — it must come from module-pinning the
+  *third* candidate (global 25, score 737), whose identity and mechanism of
+  effect are **not yet confirmed** (possibly it helps a different hot function
+  entirely, since module-pinning benefits every function touching that global,
+  not just fn26 — fn26's own burst codegen doesn't visibly change between K=2
+  and K=3 in the region inspected).
+- **fn26 is still 52% of the serialize profile** (`perf record`/`report`,
+  unchanged from the original figure) despite the burst codegen now beating
+  WARP's instruction-for-instruction. This means **register residency of the
+  burst globals is not the remaining bottleneck** — B1+B2+the K-sweep have
+  exhausted what this angle can give. fn26 makes ~9–10 calls per invocation
+  (ensure-capacity checks + nested field writers); call/return overhead and
+  per-call setup are the next suspect, not yet measured or diffed against
+  WARP's equivalent call sites (attempted but the WARP blob's `call`-target
+  region didn't disassemble cleanly as a standalone slice — linear disassembly
+  desynced past a jump table or embedded constant; needs re-attempting with
+  proper function-boundary recovery, not a raw linear objdump).
+
+**Net:** ser/deser measured flat at the shipped K=1 default (both B1 and B2 are
+real, verified codegen improvements that don't move wall-clock time on this
+Zen4 machine — plausibly because register-vs-memory arithmetic for a few
+extra loads per burst is already hidden by out-of-order execution and
+store-to-load forwarding). K=3 gives a real ~6–8% win via a not-yet-understood
+third global, at a real ~7% cost to blake (already behind wazero there) —
+shipped K=1 (see the K-sweep judgment call, still valid). Next session should
+profile the *call* overhead in fn26, not further chase global register
+residency.
 
 ### R5. Runtime / infra from WARP
 | Item | Effort | Value | Notes |

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -184,6 +184,27 @@ func (f *fn) memStore(r *wasm.Reader, size int) error {
 		return err
 	}
 	f.materializePendingLoads() // deferred loads must read pre-store memory
+	// A constant value stores as an immediate directly (selectInstr's `mov r/m,
+	// imm` form) — no register, no load-then-store dependency chain. i64 needs
+	// two 4-byte immediate stores (low32 at disp, high32 at disp+4): a single
+	// 64-bit imm-store sign-extends imm32, which is wrong for an arbitrary
+	// 64-bit pattern; narrower stores truncate to the low `size` bytes exactly
+	// like a materialized constant would (i64.store8/16/32 route here too).
+	if top := f.s.back(); top != nil && top.kind == ekValue && top.st.kind == stConst {
+		v := top.st.cval
+		f.erase(top)
+		ea, eaOwned, _, disp := f.memAddr(off, size, true)
+		if size == 8 {
+			f.a.StoreImmIdx(RBX, ea, disp, int32(v), 4)
+			f.a.StoreImmIdx(RBX, ea, disp+4, int32(v>>32), 4)
+		} else {
+			f.a.StoreImmIdx(RBX, ea, disp, int32(v), size)
+		}
+		if eaOwned {
+			f.release(ea)
+		}
+		return nil
+	}
 	// Both the value and the address are immediate read-only uses here, so a
 	// pinned local feeds the store in place — no copy (nothing between the reads
 	// and the StoreIdx can write a local).

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -164,6 +164,35 @@ func (a *Asm) StoreImm32Mem(base Reg, disp int32, v int32) {
 	a.imm32(v)
 }
 
+// StoreImmIdx stores an immediate directly to [base+index+disp] — `mov r/m,
+// imm` (C6 /0 for a byte, C7 /0 for 16/32-bit; the reg field is the /0 digit,
+// not a register). size selects the store width: 1, 2, or 4 bytes. An 8-byte
+// (i64) store is NOT a single form here — `mov r/m64, imm32` sign-extends the
+// immediate, which is wrong for an arbitrary 64-bit pattern; callers emit two
+// 4-byte immediate stores (low32 at disp, high32 at disp+4) instead.
+func (a *Asm) StoreImmIdx(base, index Reg, disp int32, imm int32, size int) {
+	if size == 2 {
+		a.emit(0x66) // operand-size prefix for 16-bit
+	}
+	if index >= 8 || base >= 8 {
+		a.emit(rex(false, false, index >= 8, base >= 8))
+	}
+	op := byte(0xC7)
+	if size == 1 {
+		op = 0xC6
+	}
+	a.emit(op)
+	a.sibAddr(RAX, base, index, disp) // reg field = 0 (the /0 digit)
+	switch size {
+	case 1:
+		a.emit(byte(imm))
+	case 2:
+		a.emit(byte(imm), byte(imm>>8))
+	default:
+		a.imm32(imm)
+	}
+}
+
 func (a *Asm) alu(opcode byte, dst, src Reg, w bool) {
 	if w || src >= 8 || dst >= 8 {
 		a.emit(rex(w, src >= 8, false, dst >= 8))


### PR DESCRIPTION
Stacked on #94 (auto-retargets to main when it merges).

Workstream B3 from docs/perf-plan-2026-07.md: diagnostic-only, diffs WARP's actual wat-27 codegen against wago's current (post B1+B2) codegen for the identical hot burst.

**Headline: the burst-pattern hypothesis behind R4 is now outdated.** WARP does NOT keep its write-pointer in a register across the burst — it reloads from a fixed basedata offset before every single store (no cell-pointer indirection, but no register residency either). wago (post B1+B2) keeps the write-pointer live in a register for the whole burst with zero reloads and zero movabs (B2). For this exact construct, **wago's codegen is now smaller and has fewer instructions than WARP's**.

Also corrects a factual error carried from PR #90's description into #93's write-up: the module-pinned global at K=1 is **global 2** (the write-pointer itself, highest aggregate hotness score) — not "the AS shadow-stack pointer" as previously assumed (never independently verified). Confirmed via a temporary debug print in `pickModuleGlobals` (not shipped).

Redid the K-sweep measurement with this corrected understanding: K=2 already pins BOTH burst globals (2 and 4 are the top two scores), not "only one" as previously written — confirmed via disassembly that global 4's arithmetic goes fully register-resident at K=2. But json-as measured flat at K=2 anyway. K=3's real ~6-8% win must come from a third, not-yet-identified global — a genuinely open question for the next session, not the clean "both burst globals finally pinned" story from before.

Conclusion for R4: register residency of the burst globals has been fully explored (B1, B2, and the corrected K-sweep) and is not the remaining bottleneck — fn26 is still 52% of the serialize profile despite its burst codegen now beating WARP's. Next suspect is call/return overhead (fn26 makes ~9-10 calls per invocation); attempted to diff WARP's ensure-capacity call site but the blob's disassembly desynced past that point (needs proper function-boundary recovery, not a raw linear objdump) — flagged as the concrete next step rather than chased further this session.

No code changes — OPTIMIZATIONS.md only.