### PR TITLE
perf(railshot): float min/max parity + deferred float loads

### DIFF
--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -73,8 +73,14 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 			// In guard-page mode the load itself is the OOB trap, so a dropped load
 			// must still be emitted; with explicit checks the bounds check already ran.
 			if f.guardMode {
-				r := f.memRefValue(e.st) // never write a borrowed address register
-				f.release(r)
+				if e.st.typ.isFloat() {
+					x := f.allocFReg(0)
+					f.loadFMemRef(x, e.st)
+					f.releaseF(x)
+				} else {
+					r := f.memRefValue(e.st) // never write a borrowed address register
+					f.release(r)
+				}
 			}
 			f.releaseMemRef(e.st)
 		}
@@ -436,13 +442,13 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x91:
 		f.fsqrt(false)
 	case 0x92:
-		f.fbin(f.a.VFAdd, false)
+		f.fbin(f.a.VFAdd, 0x58, false)
 	case 0x93:
-		f.fbin(f.a.VFSub, false)
+		f.fbin(f.a.VFSub, 0x5C, false)
 	case 0x94:
-		f.fbin(f.a.VFMul, false)
+		f.fbin(f.a.VFMul, 0x59, false)
 	case 0x95:
-		f.fbin(f.a.VFDiv, false)
+		f.fbin(f.a.VFDiv, 0x5E, false)
 	case 0x96:
 		f.fminmax(false, false)
 	case 0x97:
@@ -465,13 +471,13 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x9f:
 		f.fsqrt(true)
 	case 0xa0:
-		f.fbin(f.a.VFAdd, true)
+		f.fbin(f.a.VFAdd, 0x58, true)
 	case 0xa1:
-		f.fbin(f.a.VFSub, true)
+		f.fbin(f.a.VFSub, 0x5C, true)
 	case 0xa2:
-		f.fbin(f.a.VFMul, true)
+		f.fbin(f.a.VFMul, 0x59, true)
 	case 0xa3:
-		f.fbin(f.a.VFDiv, true)
+		f.fbin(f.a.VFDiv, 0x5E, true)
 	case 0xa4:
 		f.fminmax(true, false)
 	case 0xa5:
@@ -667,7 +673,11 @@ func (f *fn) realizeLocalRefs(x int, skipFrom *elem) {
 		case e.kind == ekValue && e.st.kind == stMemRef && e.st.memBorrow() == x:
 			// A deferred load addressing through x's pinned register: emit it
 			// before x is overwritten.
-			f.materialize(e)
+			if e.st.typ.isFloat() {
+				f.materializeF(e)
+			} else {
+				f.materialize(e)
+			}
 		case e.kind == ekDeferred && subtreeRefsLocal(e, x):
 			f.condense(e, regNone)
 		}

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -395,13 +395,30 @@ func TestAmd64Phase5Floats(t *testing.T) {
 		}
 	})
 
-	// f64.min with NaN → NaN ; f64.max signed zero: max(-0,+0) = +0
+	// f64/f32 min/max with NaN → NaN; signed zeros obey wasm min(+0,-0)
+	// = -0 and max(-0,+0) = +0.
 	t.Run("f64.min-nan", func(t *testing.T) {
 		m := mod1(t, []wasm.ValType{f64, f64}, []wasm.ValType{f64}, []byte{0x00,
 			0x20, 0x00, 0x20, 0x01, 0xa4, 0x0b})
-		got := math.Float64frombits(runAmd64u(t, m, f64b(1), f64b(math.NaN())))
-		if !math.IsNaN(got) {
-			t.Fatalf("f64.min(1,NaN) = %v, want NaN", got)
+		bits := runAmd64u(t, m, f64b(1), 0x7ff8000000000001)
+		if !math.IsNaN(math.Float64frombits(bits)) {
+			t.Fatalf("f64.min(1,NaN) bits = %#x, want NaN", bits)
+		}
+	})
+	t.Run("f32.max-nan", func(t *testing.T) {
+		m := mod1(t, []wasm.ValType{f32, f32}, []wasm.ValType{f32}, []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, 0x97, 0x0b})
+		bits := uint32(runAmd64u(t, m, f32b(1), 0x7fc00001))
+		if !math.IsNaN(float64(math.Float32frombits(bits))) {
+			t.Fatalf("f32.max(1,NaN) bits = %#x, want NaN", bits)
+		}
+	})
+	t.Run("f64.min-signed-zero", func(t *testing.T) {
+		m := mod1(t, []wasm.ValType{f64, f64}, []wasm.ValType{f64}, []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, 0xa4, 0x0b})
+		bits := runAmd64u(t, m, f64b(0), f64b(math.Copysign(0, -1)))
+		if bits != 0x8000000000000000 {
+			t.Fatalf("f64.min(+0,-0) bits = %#x, want -0", bits)
 		}
 	})
 	t.Run("f64.max-signed-zero", func(t *testing.T) {
@@ -410,6 +427,82 @@ func TestAmd64Phase5Floats(t *testing.T) {
 		bits := runAmd64u(t, m, f64b(math.Copysign(0, -1)), f64b(0))
 		if bits != 0 { // +0.0 has all-zero bits; -0.0 would be 0x8000...
 			t.Fatalf("f64.max(-0,+0) bits = %#x, want +0", bits)
+		}
+	})
+	t.Run("f64.load-add-fold", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{f64}, []byte{
+			0x00,
+			0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x3f, // f64.const 1.5
+			0x20, 0x00, // local.get 0
+			0x2b, 0x03, 0x00, // f64.load align=3 offset=0
+			0xa0, // f64.add
+			0x0b,
+		})
+		got, _, err := runMemAmd64(t, m, func(mem []byte) {
+			binary.LittleEndian.PutUint64(mem, f64b(2.25))
+		}, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v := math.Float64frombits(got); v != 3.75 {
+			t.Fatalf("f64.const+load = %v, want 3.75", v)
+		}
+	})
+	t.Run("f64.deferred-load-before-store", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{f64}, []byte{
+			0x00,
+			0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x3f, // f64.const 1.5
+			0x20, 0x00, // local.get 0
+			0x2b, 0x03, 0x00, // f64.load align=3 offset=0
+			0x20, 0x00, // local.get 0
+			0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x40, // f64.const 9
+			0x39, 0x03, 0x00, // f64.store align=3 offset=0
+			0xa0, // f64.add; must use the pre-store loaded value
+			0x0b,
+		})
+		got, mem, err := runMemAmd64(t, m, func(mem []byte) {
+			binary.LittleEndian.PutUint64(mem, f64b(2.25))
+		}, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v := math.Float64frombits(got); v != 3.75 {
+			t.Fatalf("pre-store f64 load result = %v, want 3.75", v)
+		}
+		if v := math.Float64frombits(binary.LittleEndian.Uint64(mem)); v != 9 {
+			t.Fatalf("post-store memory = %v, want 9", v)
+		}
+	})
+	t.Run("f64.deferred-load-before-local-overwrite", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{f64}, []byte{
+			0x00,
+			0x20, 0x00, // local.get 0
+			0x2b, 0x03, 0x00, // f64.load align=3 offset=0
+			0x41, 0x08, // i32.const 8
+			0x21, 0x00, // local.set 0; must not redirect the pending load
+			0x0b,
+		})
+		got, _, err := runMemAmd64(t, m, func(mem []byte) {
+			binary.LittleEndian.PutUint64(mem, f64b(2.25))
+			binary.LittleEndian.PutUint64(mem[8:], f64b(9))
+		}, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v := math.Float64frombits(got); v != 2.25 {
+			t.Fatalf("pre-local-set f64 load result = %v, want 2.25", v)
+		}
+	})
+	t.Run("f64.drop-deferred-load-guard-compile", func(t *testing.T) {
+		m := modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{}, []byte{
+			0x00,
+			0x20, 0x00, // local.get 0
+			0x2b, 0x03, 0x00, // f64.load align=3 offset=0
+			0x1a, // drop
+			0x0b,
+		})
+		if _, err := CompileModuleWith(m, CompileOptions{ElideBoundsChecks: true}); err != nil {
+			t.Fatalf("guard compile: %v", err)
 		}
 	})
 

--- a/src/core/compiler/backend/railshot/fp.go
+++ b/src/core/compiler/backend/railshot/fp.go
@@ -94,6 +94,12 @@ func (f *fn) materializeF(e *elem) Reg {
 		f.a.FMov(x, e.st.reg, e.st.typ == mtF64)
 		f.occupyF(e, x)
 		return x
+	case stMemRef:
+		x := f.allocFReg(0)
+		f.loadFMemRef(x, e.st)
+		f.releaseMemRef(e.st)
+		f.occupyF(e, x)
+		return x
 	}
 	panic("amd64: cannot materialize float storage")
 }
@@ -171,9 +177,13 @@ func (f *fn) fconst(bits uint64, typ machineType) {
 // operands are read directly (a pinned local is borrowed, never copied), and the
 // result lands in a reused owned-operand register or a fresh one — so no operand is
 // pre-copied to scratch the way legacy 2-operand SSE requires.
-func (f *fn) fbin(vop func(dst, s1, s2 Reg, f64 bool), f64 bool) {
+func (f *fn) fbin(vop func(dst, s1, s2 Reg, f64 bool), memOp byte, f64 bool) {
 	b := f.popValue()
 	a := f.popValue()
+	if b.kind == ekValue && b.st.kind == stMemRef && b.st.typ.isFloat() && b.st.memSize() == fsize(f64) {
+		f.fbinMemRight(a, b, memOp, f64)
+		return
+	}
 	s1, o1 := f.operandRegF(a)
 	f.fpinned = f.fpinned.add(s1)
 	s2, o2 := f.operandRegF(b)
@@ -201,9 +211,22 @@ func (f *fn) fbin(vop func(dst, s1, s2 Reg, f64 bool), f64 bool) {
 	f.pushFReg(dst, mtOf2(f64))
 }
 
+func (f *fn) fbinMemRight(a, b *elem, memOp byte, f64 bool) {
+	src, owned := f.operandRegF(a)
+	dst := src
+	if !owned {
+		dst = f.allocFReg(maskOf(src))
+		f.a.FMov(dst, src, f64)
+	}
+	f.a.SseIdx(scalarFloatPrefix(f64), memOp, dst, RBX, b.st.reg, b.st.memDisp())
+	f.releaseMemRef(b.st)
+	f.pushFReg(dst, mtOf2(f64))
+}
+
 // fminmax implements wasm min/max, which x86 minss/maxss get wrong on signed
-// zeros and NaN. Branch on the ordered compare; equal → bitwise combine
-// (OR keeps -0 for min, AND keeps +0 for max); unordered → propagate quiet NaN.
+// zeros and NaN. Branch on the ordered compare; equal uses bitwise zero fixups,
+// distinct ordered operands use packed min/max like wazero, and unordered
+// propagates a quiet NaN through scalar add.
 func (f *fn) fminmax(f64, isMax bool) {
 	b := f.popValue()
 	a := f.popValue()
@@ -220,23 +243,27 @@ func (f *fn) fminmax(f64, isMax bool) {
 		prefix = 0x66
 	}
 	if isMax {
-		bitOp = 0x54 // andps/pd
+		bitOp = 0x54 // andps/pd: max(-0,+0) = +0
 	} else {
-		bitOp = 0x56 // orps/pd
+		bitOp = 0x56 // orps/pd: min(+0,-0) = -0
 	}
 	f.a.SseRR(prefix, bitOp, xa, xb, false)
 	jdone := f.a.JmpPlaceholder()
 
 	f.a.PatchRel32(jdist, f.a.Len())
+	packedPrefix := byte(0)
+	if f64 {
+		packedPrefix = 0x66
+	}
 	if isMax {
-		f.a.FMax(xa, xb, f64)
+		f.a.SseRR(packedPrefix, 0x5F, xa, xb, false) // maxps/pd, matching wazero
 	} else {
-		f.a.FMin(xa, xb, f64)
+		f.a.SseRR(packedPrefix, 0x5D, xa, xb, false) // minps/pd, matching wazero
 	}
 	jdone2 := f.a.JmpPlaceholder()
 
 	f.a.PatchRel32(jnan, f.a.Len())
-	f.a.FAdd(xa, xb, f64) // NaN + x → quiet NaN
+	f.a.FAdd(xa, xb, f64) // NaN + x -> quiet NaN, matching wazero
 
 	f.a.PatchRel32(jdone, f.a.Len())
 	f.a.PatchRel32(jdone2, f.a.Len())
@@ -625,13 +652,11 @@ func (f *fn) fload(r *wasm.Reader, f64 bool) error {
 	if f64 {
 		size = 8
 	}
-	ea, eaOwned, _, disp := f.memAddr(off, size, true) // float loads emit immediately
-	xmm := f.allocFReg(0)
-	f.a.FLoadIdx(xmm, RBX, ea, disp, f64)
+	ea, eaOwned, borrow, disp := f.memAddr(off, size, true)
+	e := f.pushValue(fmemRefStorage(ea, disp, f64, borrow))
 	if eaOwned {
-		f.release(ea)
+		f.regUser[ea] = e
 	}
-	f.pushFReg(xmm, mtOf2(f64))
 	return nil
 }
 
@@ -647,6 +672,7 @@ func (f *fn) fstore(r *wasm.Reader, f64 bool) error {
 	if f64 {
 		size = 8
 	}
+	f.materializePendingLoads() // deferred loads must read pre-store memory
 	xmm := f.materializeF(f.popValue())
 	f.fpinned = f.fpinned.add(xmm)
 	ea, eaOwned, _, disp := f.memAddr(off, size, true)
@@ -660,6 +686,24 @@ func (f *fn) fstore(r *wasm.Reader, f64 bool) error {
 }
 
 // helpers
+
+func (f *fn) loadFMemRef(dst Reg, st storage) {
+	f.a.FLoadIdx(dst, RBX, st.reg, st.memDisp(), st.typ == mtF64)
+}
+
+func fsize(f64 bool) int {
+	if f64 {
+		return 8
+	}
+	return 4
+}
+
+func scalarFloatPrefix(f64 bool) byte {
+	if f64 {
+		return 0xF2
+	}
+	return 0xF3
+}
 
 func mtOf2(f64 bool) machineType {
 	if f64 {

--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -74,9 +74,17 @@ func (f *fn) allocRegOrNone(avoid regMask) Reg {
 	for e := f.s.head.next; e != f.s.head; e = e.next {
 		if e.kind == ekValue && e.st.kind == stMemRef && !block.has(e.st.reg) {
 			r := e.st.reg
-			f.loadMemRef(r, e.st)
-			f.occupy(e, r)
-			f.spill(e)
+			if e.st.typ.isFloat() {
+				x := f.allocFReg(0)
+				f.loadFMemRef(x, e.st)
+				f.releaseMemRef(e.st)
+				f.occupyF(e, x)
+				f.spillF(e)
+			} else {
+				f.loadMemRef(r, e.st)
+				f.occupy(e, r)
+				f.spill(e)
+			}
 			return r
 		}
 	}
@@ -219,7 +227,11 @@ func (f *fn) loadMemRef(dst Reg, st storage) {
 func (f *fn) materializePendingLoads() {
 	for e := f.s.head.next; e != f.s.head; e = e.next {
 		if e.kind == ekValue && e.st.kind == stMemRef {
-			f.materialize(e)
+			if e.st.typ.isFloat() {
+				f.materializeF(e)
+			} else {
+				f.materialize(e)
+			}
 		}
 	}
 }

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -64,6 +64,16 @@ func memRefStorage(ea Reg, disp int32, size int, signed, wide bool, borrow int) 
 	return storage{kind: stMemRef, typ: typ, reg: ea, slot: int(disp), idx: sidx, cval: int64(borrow + 1)}
 }
 
+func fmemRefStorage(ea Reg, disp int32, f64 bool, borrow int) storage {
+	typ := mtF32
+	size := 4
+	if f64 {
+		typ = mtF64
+		size = 8
+	}
+	return storage{kind: stMemRef, typ: typ, reg: ea, slot: int(disp), idx: size, cval: int64(borrow + 1)}
+}
+
 func (st storage) memDisp() int32  { return int32(st.slot) }
 func (st storage) memSize() int    { return st.idx & 0xff }
 func (st storage) memSigned() bool { return st.idx&0x100 != 0 }

--- a/src/core/encoder/amd64/asm_sse.go
+++ b/src/core/encoder/amd64/asm_sse.go
@@ -144,3 +144,17 @@ func (a *Asm) FLoadIdx(xmm, base, index Reg, disp int32, f64 bool) {
 func (a *Asm) FStoreIdx(base, index, xmm Reg, disp int32, f64 bool) {
 	a.fmemIdx(0x11, xmm, base, index, disp, f64)
 }
+
+// SseIdx emits a raw SSE reg, [base+index+disp] instruction. It is used for
+// scalar float ALU memory folds (addss/addsd/etc.) and packed logical/min/max
+// forms where the caller chooses the exact legacy prefix.
+func (a *Asm) SseIdx(prefix, op byte, xmm, base, index Reg, disp int32) {
+	if prefix != 0 {
+		a.emit(prefix)
+	}
+	if xmm >= 8 || index >= 8 || base >= 8 {
+		a.emit(rex(false, xmm >= 8, index >= 8, base >= 8))
+	}
+	a.emit(0x0F, op)
+	a.sibAddr(xmm, base, index, disp)
+}


### PR DESCRIPTION
Workstream C (float lowering parity), session-3 items **C2** + **C3**.

## What

- **C2 — min/max parity fixups.** Rewrite `fminmax` to use packed `minps`/`maxps` for distinct ordered operands (was branchy scalar `FMin`/`FMax`), keeping the bitwise zero fixup (`max(-0,+0)=+0`, `min(+0,-0)=-0`) and quiet-NaN propagation. Perf-only; wasm semantics preserved.
- **C3 — deferred float loads + r/m folding.** `fload` now pushes a *deferred* float memref (`fmemRefStorage`, mirroring the integer `stMemRef` path — bounds-checked, load deferred); `materializeF` gains the `stMemRef` case; float ALU ops fold a matching-size deferred right operand as `addss xmm,[rbx+ea+disp]` (`fbinMemRight`). `fstore` calls `materializePendingLoads()` first for load-before-store ordering. New encoder form `SseIdx(prefix, op, xmm, base, index, disp)`.

Integer codegen is untouched — the `regalloc.go` changes are all gated on `st.typ.isFloat()`, and `stack.go`/`driver.go` only add float paths.

## Gates (all green)

- `go test ./...` (root + bench), spec `TestSpecExec` = **pass=16500 fail=13 skip=1672** (only the pre-existing `linking` FAIL) — every float file (`f32`/`f64`/`float_misc`/`float_exprs`/…) passes with `fail=0`.
- `TestCorpusDifferential` (guard tag): explicit == guard == golden for all six modules.
- `TestJsonAsGuardCorrect`: guard == explicit.
- New `TestAmd64Phase5Floats` subtests cover NaN/signed-zero parity, the load-add fold, deferred-load-before-store/local-overwrite ordering, and dropped-load guard-mode compile.