### PR TITLE
perf(railshot): forward rep movsb for disjoint memory.copy

### DIFF
--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1661,7 +1661,7 @@ func TestExecDynamicBulkMem(t *testing.T) {
 		}
 	}
 	params := []wasm.ValType{i32, i32, i32}
-	for _, n := range []int{0, 1, 7, 8, 9, 63, 95, 96, 97, 200} {
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 63, 95, 96, 97, 200} {
 		t.Run(fmt.Sprintf("copy-n%d", n), func(t *testing.T) {
 			m := modMem(t, 1, params, []wasm.ValType{i32}, copyBody)
 			_, lin, err := runMemAmd64(t, m, seq, 2000, 1000, uint64(n))

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -315,17 +315,26 @@ func (f *fn) memoryCopy(r *wasm.Reader) error {
 	f.a.PatchRel32(f.a.JccPlaceholder(condNE), fwd1)
 	joins = append(joins, f.a.JmpPlaceholder())
 
-	// Large: overlap-safe rep movsb (backward via DF when dst > src).
+	// Large: overlap-safe rep movsb. Backward (DF=1) is only REQUIRED when the
+	// regions truly overlap with dst ahead of src; a disjoint copy (dst >= src+n,
+	// e.g. AssemblyScript __renew growing a buffer) is forward-safe. This matters
+	// because backward `rep movsb` gets no ERMSB/FSRM acceleration — it runs at
+	// ~1 byte/cycle — while forward does, so route disjoint high-dst copies to
+	// the fast forward path instead of the slow backward one.
 	f.a.PatchRel32(big, f.a.Len())
 	f.a.Cmp64(RDI, RSI)
-	fwd := f.a.JccPlaceholder(condBE)
-	f.a.LeaScaled(RDI, RDI, RCX, 0, -1) // last dst byte
-	f.a.LeaScaled(RSI, RSI, RCX, 0, -1) // last src byte
+	fwd := f.a.JccPlaceholder(condBE)  // dst <= src → forward
+	f.a.LeaScaled(RDX, RSI, RCX, 0, 0) // rdx = src + n
+	f.a.Cmp64(RDI, RDX)
+	fwdDisjoint := f.a.JccPlaceholder(condAE) // dst >= src+n → disjoint → forward
+	f.a.LeaScaled(RDI, RDI, RCX, 0, -1)       // last dst byte
+	f.a.LeaScaled(RSI, RSI, RCX, 0, -1)       // last src byte
 	f.a.Std()
 	f.a.RepMovsb()
 	f.a.Cld()
 	done := f.a.JmpPlaceholder()
 	f.a.PatchRel32(fwd, f.a.Len())
+	f.a.PatchRel32(fwdDisjoint, f.a.Len())
 	f.a.RepMovsb() // forward (DF=0 by ABI)
 	f.a.PatchRel32(done, f.a.Len())
 	for _, j := range joins {


### PR DESCRIPTION
## Why

Profiling the json-as **serialize** hot path (fn26 = 52% of serialize self-time) found that **~89% of its samples land in a single instruction: the backward `std; rep movsb`** in the large-copy (`n ≥ 96`) path of `memoryCopy`.

`memory.copy` has memmove semantics, so the lowering picks a backward copy (DF=1) whenever `dst > src`. But backward `rep movsb` gets **no ERMSB/FSRM acceleration** — it runs at ~1 byte/cycle — while forward `rep movsb` does. AssemblyScript's `__renew` (buffer growth) produces a **disjoint** copy where the new buffer is at a higher address (`dst > src` but `dst >= src + n`), which is forward-safe yet was needlessly taking the slow backward path.

(Context: this landed while measuring `docs/valent-blocks-expansion-plan.md` Phase V0. That measurement **refuted** the plan's hypothesis that serialize was call-overhead-bound — it's `memory.copy`-bound — so the fix is here, not in valent blocks.)

## What

In `memoryCopy`'s large path, add a disjoint check: when `dst > src`, if `dst >= src + n` the regions don't overlap, so use the fast **forward** `rep movsb`. True overlap (`src < dst < src+n`) still uses backward. Correctness-preserving; monotonically non-regressing (all other cases unchanged).

## Result (json-as, guard mode, ns/unit)

| | before | after |
|---|---|---|
| serialize | ~190 | **~111** (−42%) |
| deserialize | ~187 | ~187 (unchanged) |

Closes most of the gap to WARP (ser 97) — from ~2× to ~1.15×.

## Gates

- `go test ./...` (root + bench, with and without `-tags wago_guardpage`) — pass.
- `TestSpecExec` = pass=16500 fail=13 skip=1672 (only pre-existing `linking` FAIL).
- `TestCorpusDifferential` (guard): explicit == guard == golden, all six modules.
- `TestExecDynamicBulkMem`: expanded the dynamic-copy `n` sweep to 0–17 (every small size class + boundary) × non-overlap / fwd-overlap / bwd-overlap.