### PR TITLE
perf(railshot): adaptive per-module global-pin K (1-3)

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -257,8 +257,11 @@ type moduleGlobalPin struct {
 
 // moduleGlobalRegs are the registers reserved for module-pinned globals, in
 // assignment order. They are carved out of every function's pin pool and the
-// allocator, like RBX (linMem) and R15 (memSize).
-var moduleGlobalRegs = []Reg{R14}
+// allocator, like RBX (linMem) and R15 (memSize). Up to K of these are spent per
+// module, chosen adaptively by pickModuleGlobals: the first is cheap, each extra
+// one demands a much hotter global (it steals a pinned-local register from every
+// function module-wide).
+var moduleGlobalRegs = []Reg{R14, R13, R12}
 
 // pickModuleGlobals aggregates loop-weighted global hotness across the whole
 // module and assigns the top mutable int globals a module-wide register. The
@@ -283,6 +286,13 @@ func pickModuleGlobals(m *wasm.Module) []moduleGlobalPin {
 	}
 	var cs []cand
 	minScore := 3 * loopWeight(1)
+	// A global must clear extraBar (much higher than minScore) to justify a
+	// SECOND or THIRD module-wide register: each extra reservation removes a
+	// pinned-local register from every function, so it only pays off for a global
+	// accessed dramatically more than a typical hot local. Empirically this pins
+	// json-as's burst globals (g2/g4/g25 = 4603/1350/737 → K=3) while keeping
+	// blake-as at K=1 (its 2nd/3rd globals score only ~125/98).
+	extraBar := 50 * loopWeight(1)
 	for g := 0; g < nG; g++ {
 		if agg[g] < minScore {
 			continue
@@ -298,6 +308,9 @@ func pickModuleGlobals(m *wasm.Module) []moduleGlobalPin {
 	for k, c := range cs {
 		if k >= len(moduleGlobalRegs) {
 			break
+		}
+		if k >= 1 && c.score < extraBar {
+			break // cs is score-descending: no later candidate clears the bar either
 		}
 		pins = append(pins, moduleGlobalPin{global: uint32(c.g), reg: moduleGlobalRegs[k]})
 	}


### PR DESCRIPTION
## Why

B1 shipped module-global pinning at a hard **K=1** (`moduleGlobalRegs = []Reg{R14}`) because raising it helps json-as but hurts blake-as: reserving a register module-wide for a global steals it from every function's pinned-local pool, which only pays off when the global is *much* hotter than the locals it displaces.

Measured per-module global hotness (loop-weighted access score) confirms the split is stark:

| module | top mutable-int global scores |
|---|---|
| json-as | g2=**4603**, g4=**1350**, g25=**737**, g1=351, … |
| blake-as | g11=133, g10=125, g8=98, … |
| utf-as | g0=3 |

## What

Make K adaptive per module. `moduleGlobalRegs` now offers up to 3 registers (R14, R13, R12), but `pickModuleGlobals` spends the 2nd/3rd only on a global clearing a much higher bar (`extraBar = 50*loopWeight(1) = 500`, vs the base `minScore = 30`). json-as's burst globals clear it (→ K=3); blake-as's don't (→ stays K=1). Modules are only affected if they actually have a 2nd+ global above the bar — in the corpus, only json-as does.

## Result (guard mode, ns/unit)

| | K=1 (before) | adaptive (after) |
|---|---|---|
| json serialize | 111 | **94** (−15%, now < WARP's 97) |
| json deserialize | 187 | **176** (−6%) |
| blake hashN | 695µs | **695µs** (unchanged — stays K=1) |

(Stacks on the #99 memcopy fix: json serialize is now **190→94 ns** across both.)

## Gates

- `go test ./...` (root + bench, both tag modes) — pass.
- `TestSpecExec` = pass=16500 fail=13 skip=1672 (only pre-existing `linking`).
- `TestCorpusDifferential` (guard): explicit == guard == golden, all six modules — the net for json's changed register allocation.