### PR TITLE
perf(railshot): strength-reduce x*{3,5,9} to LEA

### DIFF
--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -104,6 +104,15 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 		}
 	}
 
+	// Strength-reduce x * {3,5,9} to a single LEA `[x + x*{2,4,8}]` (base == index
+	// == x), replacing an IMUL by a small constant. The multiplier sits on the
+	// right after the commutative swap above.
+	if node.op == opMul {
+		if r := f.tryLeaMul(node, left, right, dest); r != regNone {
+			return r
+		}
+	}
+
 	// Materialize the RHS into a safe, foldable operand BEFORE the LHS overwrites
 	// dest: condense a deferred RHS to a fresh register, and copy a register RHS
 	// out if it aliases dest.
@@ -258,6 +267,48 @@ func (f *fn) tryLeaScaledAdd(node, left, right *elem, dest Reg) Reg {
 	if yOwned && y != dest {
 		f.release(y)
 	}
+	if xOwned && x != dest {
+		f.release(x)
+	}
+	f.consumeBlockBelow(node)
+	f.occupy(node, dest)
+	node.op = opNone
+	return dest
+}
+
+// tryLeaMul lowers x * {3,5,9} as a single LEA `dest = [x + x*{2,4,8}]` (base ==
+// index == x), replacing an IMUL by a small constant. Returns regNone when the
+// shape doesn't match. The multiplicand must be concrete: condensing a deferred
+// operand here could hard-clobber RAX/RDX/RCX under the LEA (same hazard as
+// tryLeaScaledAdd guards against).
+func (f *fn) tryLeaMul(node, left, right *elem, dest Reg) Reg {
+	if right.kind != ekValue || right.st.kind != stConst {
+		return regNone
+	}
+	var scaleLog uint8
+	switch right.st.cval {
+	case 3:
+		scaleLog = 1
+	case 5:
+		scaleLog = 2
+	case 9:
+		scaleLog = 3
+	default:
+		return regNone
+	}
+	if left.kind != ekValue {
+		return regNone
+	}
+	w := node.typ.is64()
+	x, xOwned := f.materializeRead(left) // LEA never writes its sources; a pinned local reads in place
+	if dest == regNone {
+		if xOwned {
+			dest = x // reuse the owned multiplicand in place
+		} else {
+			dest = f.allocReg(0)
+		}
+	}
+	f.a.LeaScaledW(dest, x, x, scaleLog, 0, w)
 	if xOwned && x != dest {
 		f.release(x)
 	}

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1114,7 +1114,19 @@ func TestAmd64Phase1(t *testing.T) {
 		{"i32.mul", []wasm.ValType{i32, i32}, []wasm.ValType{i32},
 			[]byte{0x20, 0x00, 0x20, 0x01, 0x6c, 0x0b}, []uint64{6, 7}, 42},
 		{"i32.mul-imm", []wasm.ValType{i32}, []wasm.ValType{i32},
-			[]byte{0x20, 0x00, 0x41, 0x03, 0x6c, 0x0b}, []uint64{5}, 15},
+			[]byte{0x20, 0x00, 0x41, 0x03, 0x6c, 0x0b}, []uint64{5}, 15}, // x*3 → lea [x+x*2]
+		{"i32.mul5-lea", []wasm.ValType{i32}, []wasm.ValType{i32},
+			[]byte{0x20, 0x00, 0x41, 0x05, 0x6c, 0x0b}, []uint64{5}, 25}, // x*5 → lea [x+x*4]
+		{"i32.mul9-lea", []wasm.ValType{i32}, []wasm.ValType{i32},
+			[]byte{0x20, 0x00, 0x41, 0x09, 0x6c, 0x0b}, []uint64{5}, 45}, // x*9 → lea [x+x*8]
+		{"i32.mul7-imul", []wasm.ValType{i32}, []wasm.ValType{i32}, // not 3/5/9 → IMUL fall-through
+			[]byte{0x20, 0x00, 0x41, 0x07, 0x6c, 0x0b}, []uint64{5}, 35},
+		{"i32.mul3-wrap", []wasm.ValType{i32}, []wasm.ValType{i32}, // 32-bit LEA wraps mod 2^32
+			[]byte{0x20, 0x00, 0x41, 0x03, 0x6c, 0x0b}, []uint64{0x55555556}, 2},
+		{"i32.mul3-deferred-left", []wasm.ValType{i32}, []wasm.ValType{i32}, // (x+1)*3, deferred left → IMUL
+			[]byte{0x20, 0x00, 0x41, 0x01, 0x6a, 0x41, 0x03, 0x6c, 0x0b}, []uint64{4}, 15},
+		{"i64.mul5-lea", []wasm.ValType{i64}, []wasm.ValType{i64},
+			[]byte{0x20, 0x00, 0x42, 0x05, 0x7e, 0x0b}, []uint64{5}, 25}, // i64 x*5 → lea [x+x*4]
 		{"i32.div_s", []wasm.ValType{i32, i32}, []wasm.ValType{i32},
 			[]byte{0x20, 0x00, 0x20, 0x01, 0x6d, 0x0b}, []uint64{uint64(uint32(0xFFFFFFEC)), 3}, uint64(uint32(0xFFFFFFFA))}, // -20/3=-6
 		{"i32.div_u", []wasm.ValType{i32, i32}, []wasm.ValType{i32},


### PR DESCRIPTION
## What

Lower `x * 3`, `x * 5`, `x * 9` as a single scaled-index `lea dest, [x + x*{2,4,8}]` (base == index == x) instead of `IMUL r, imm`. LEA is 1 cycle / 1 port vs IMUL's 3-cycle latency. This mirrors the existing `add(x, shl(y,k)) → lea` fusion (`tryLeaScaledAdd`); `simplifyConstRHS` already strength-reduces mul by powers of two to `shl`, and 3/5/9 (= 2ᵏ+1) are the LEA-expressible non-power-of-two multipliers.

`tryLeaMul` only fires when the multiplicand is already concrete (same RAX/RDX/RCX-clobber guard as `tryLeaScaledAdd`); anything else falls through to the normal IMUL path.

## Correctness

New `TestAmd64Phase1` cases: x*3/5/9 (LEA), x*7 (IMUL fall-through), 32-bit LEA wrap (`0x55555556*3 mod 2³²`), deferred-left `(x+1)*3` (fall-through), and i64 `x*5`. Disasm-verified that x*5 emits `lea` with no `imul`, while x*7 keeps `imul`.

## Gates

- `go test ./...` (root + bench, both tag modes) — pass.
- `TestSpecExec` = pass=16500 fail=13 skip=1672 (only pre-existing `linking`); the i32/i64 suites exercise mul broadly.
- `TestCorpusDifferential` (guard) — pass.

Correctness-neutral codegen improvement; no single-module bench delta in the current corpus (none multiply by 3/5/9 hot), but it's a free win wherever those multipliers appear.