### PR TITLE
fix(runtime): guard trap handler writes trap cell in basedata, not [rsp]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Build & test
         run: make test
 
+      # Guard-page (signals-based) mode is behind a build tag, so `make test`
+      # never exercises it — which is how a broken SIGSEGV fault->trap handler
+      # stayed CI-invisible. This runs the fault->trap path plus in-bounds
+      # differential correctness under the tag.
+      - name: Guard-page trap tests
+        run: make test-guard
+
   tinygo:
     name: TinyGo build & test
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ test: ## Build and run the test suite (host)
 	go build ./...
 	go test -count=1 ./...
 
+.PHONY: test-guard
+test-guard: ## Guard-page (signals-based) tests: the SIGSEGV fault->trap path + in-bounds correctness
+	go test -count=1 -tags wago_guardpage -run 'TestConfigSignalsBasedEndToEnd|TestSignalsBasedNotSerializable' ./src/wago/
+	cd bench && go test -count=1 -tags wago_guardpage -run 'TestCorpusDifferential|TestJsonAsGuardCorrect' .
+
 # Run the WebAssembly spec suite (the WebAssembly/testsuite submodule at
 # tests/spec) as a native execution oracle for the x64 backend: TestSpecSuiteExec
 # replays every assert_return / assert_trap through compiled code. spec1 is the

--- a/src/core/runtime/sigtrap_amd64.s
+++ b/src/core/runtime/sigtrap_amd64.s
@@ -28,7 +28,7 @@ scan:
 	JCC	next                    // addr >= end
 
 	// addr is inside this reservation. First try the frameless x64 ABI: RBX is
-	// pinned to linMem and the trap pointer is at [RSP+0].
+	// pinned to linMem and the trap cell pointer lives at [linMem-TrapCellPtrOffset].
 	MOVQ	16(R10), R9             // region.linMem
 	MOVQ	128(DX), AX             // AX = saved RBX (x64 linMem)
 	CMPQ	AX, R9
@@ -74,10 +74,14 @@ dotrap:
 	MOVQ	R9, 168(DX)             // saved RIP = nativeTrapExitFramed
 	RET                             // -> restorer -> rt_sigreturn -> nativeTrapExitFramed
 dotrap_x64:
-	MOVQ	0(R15), CX              // CX = [RSP+0] = frameless trap pointer
+	// The trap cell moved off the stack into basedata: [linMem-TrapCellPtrOffset]
+	// holds the trap-cell POINTER (CX is still linMem here) and the code is written
+	// through it, exactly as emitTrap does. (It was [RSP+0] under the pre-basedata
+	// ABI.) TrapCellPtrOffset is asserted == 104 in sigtrap_linux_amd64.go.
+	MOVQ	-104(CX), CX            // CX = trap cell pointer = [linMem - 104]
 	MOVL	$3, (CX)                // TrapLinMemOutOfBounds
 	MOVQ	·guardTrapExitHandlerJumpPC(SB), R9
-	MOVQ	R9, 168(DX)             // saved RIP = nativeTrapExit
+	MOVQ	R9, 168(DX)             // saved RIP = nativeTrapExitHandlerJump
 	RET                             // -> restorer -> rt_sigreturn -> nativeTrapExit
 next:
 	ADDQ	$32, R10                // sizeof(guardRegion)

--- a/src/core/runtime/sigtrap_linux_amd64.go
+++ b/src/core/runtime/sigtrap_linux_amd64.go
@@ -7,6 +7,16 @@ import (
 	"sync"
 	"syscall"
 	"unsafe"
+
+	"github.com/wago-org/wago/src/core/runtime/abi"
+)
+
+// The asm handler (sigtrap_amd64.s, dotrap_x64) hardcodes the trap-cell-pointer
+// basedata displacement as -104. These two assertions fail to compile if
+// abi.TrapCellPtrOffset ever changes, forcing the asm to be updated in lockstep.
+const (
+	_ = uint(abi.TrapCellPtrOffset - 104)
+	_ = uint(104 - abi.TrapCellPtrOffset)
 )
 
 // Guard-page trap handler (EXPERIMENTAL). When linear memory is backed by a


### PR DESCRIPTION
## The bug

Guard-page mode's SIGSEGV handler (`sigtrap_amd64.s`) converted an out-of-bounds fault into a wasm trap by writing the trap code through a pointer it read from **`[RSP+0]`** — the pre-basedata ABI. But #90 moved the trap cell into basedata: `emitTrap` now loads the trap-cell pointer from **`[linMem − TrapCellPtrOffset]`**. So on a real OOB fault the handler wrote `TrapLinMemOutOfBounds` through whatever garbage sat at `[RSP+0]` — a wild store **inside the signal handler** → nested fault → hard SIGSEGV with no Go traceback.

### Why it was invisible
**No bench guard test ever triggers an OOB fault** — json-as/blake/etc. are correct programs that run in-bounds, so the guard page is never hit and the fault→trap path is never exercised. Only `src/wago`'s `TestConfigSignalsBasedEndToEnd` (an intentional OOB load) drives it, and that whole package's guard-tag build was crashing early, masking it.

## The fix

At `dotrap_x64`, load the trap-cell pointer from basedata (`CX` still holds linMem there) and write through it — mirroring `emitTrap` exactly. The re-entry path (`nativeTrapExitHandlerJump` using `[RBX−24]`) already matched #90; only the trap-cell write was stale. Added a compile-time assertion in `sigtrap_linux_amd64.go` so the asm's hardcoded `−104` can't silently drift from `abi.TrapCellPtrOffset`.

## Verification

- `TestConfigSignalsBasedEndToEnd` (the OOB-trap test) now **passes** — the OOB load traps instead of crashing.
- Bench guard tests (`TestCorpusDifferential`, `TestJsonAsGuard`) and `src/core/runtime` tests pass under both build tags — no regression (the change only touches the OOB trap path).

## Known follow-ups (pre-existing, separate — unmasked once the binary stops aborting here)

1. **No-/small-memory modules crash under guard** (`TestAssemblyScriptFib/Fact/Mathops`): `enterNative` gets `linMem=0` and faults at `[linMem−24]`. `slicePtr` collapses a len-0 `LinearMemory()` to nil, and `NewJobMemoryGuarded` doesn't floor the mapping at one page the way explicit's `NewJobMemoryGrowable` does. Needs its own fix.
2. **Config/imported-memory test expectations** (`TestConfigImmutable`, `TestConfigValidateAndIntrospection`, `TestImportedMemory*`): logic-level failures under the guard tag (some assert imported-memory-with-signals, which is explicitly unsupported). Need guard-aware expectations.

A `-tags wago_guardpage` CI job for `./src/wago/...` should be added once (1) and (2) are resolved so the suite is green.