### PR TITLE
feat: reduce instantiate latency

### DIFF
--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -372,12 +372,13 @@ func (p supportPass) runtimeFootprint() error {
 	}
 	maxParams, maxResults := p.maxLocalFuncSlots()
 	need, err := runtime.InstantiateArenaNeed(runtime.InstantiateFootprint{
-		GlobalCount:    p.m.GlobalCount(),
-		HasTable:       hasTable,
-		TableSize:      tableSize,
-		ElemCount:      len(p.m.Elements),
-		MaxParamSlots:  maxParams,
-		MaxResultSlots: maxResults,
+		FuncImportCount: p.m.ImportedFuncCount(),
+		GlobalCount:     p.m.GlobalCount(),
+		HasTable:        hasTable,
+		TableSize:       tableSize,
+		ElemCount:       len(p.m.Elements),
+		MaxParamSlots:   maxParams,
+		MaxResultSlots:  maxResults,
 	})
 	if err != nil {
 		return p.unsupported("runtime footprint", err.Error(), "instantiate arena")

--- a/src/core/runtime/limits.go
+++ b/src/core/runtime/limits.go
@@ -2,9 +2,10 @@ package runtime
 
 import "fmt"
 
-// InstantiateArenaSize is the fixed arena size used for per-instance runtime
-// metadata: host-call log, globals, table descriptor, call buffers, and trap
-// buffer. Keep footprint checks in compiler/front-end support code in sync with
+// InstantiateArenaSize is the maximum supported arena size for per-instance
+// runtime metadata: host-call log, globals, table descriptor, call buffers, and
+// trap buffer. Instantiate maps the exact validated footprint, bounded by this
+// limit. Keep footprint checks in compiler/front-end support code in sync with
 // allocations in InstantiateWithImports.
 const InstantiateArenaSize = 1 << 20
 
@@ -29,19 +30,20 @@ func SlotBytes(n int) (int, error) {
 // InstantiateFootprint describes the per-instance runtime metadata allocations
 // made by InstantiateWithImports.
 type InstantiateFootprint struct {
-	GlobalCount    int
-	HasTable       bool
-	TableSize      int
-	ElemCount      int
-	MaxParamSlots  int
-	MaxResultSlots int
+	FuncImportCount int
+	GlobalCount     int
+	HasTable        bool
+	TableSize       int
+	ElemCount       int
+	MaxParamSlots   int
+	MaxResultSlots  int
 }
 
 // InstantiateArenaNeed estimates the exact sequence of arena allocations made
 // during instance creation, plus a small alignment slack for the allocator's
 // 8-byte rounding before each allocation.
 func InstantiateArenaNeed(fp InstantiateFootprint) (int, error) {
-	if fp.GlobalCount < 0 || fp.TableSize < 0 || fp.ElemCount < 0 || fp.MaxParamSlots < 0 || fp.MaxResultSlots < 0 {
+	if fp.FuncImportCount < 0 || fp.GlobalCount < 0 || fp.TableSize < 0 || fp.ElemCount < 0 || fp.MaxParamSlots < 0 || fp.MaxResultSlots < 0 {
 		return 0, fmt.Errorf("negative instantiate footprint input")
 	}
 	if !fp.HasTable && fp.TableSize != 0 {
@@ -61,7 +63,10 @@ func InstantiateArenaNeed(fp InstantiateFootprint) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	need := HostCallLogBytes
+	need := 0
+	if fp.FuncImportCount > 0 {
+		need += HostCallLogBytes
+	}
 	if fp.GlobalCount > (maxInt()-need)/16 {
 		return 0, fmt.Errorf("global count %d overflows arena allocation", fp.GlobalCount)
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -165,7 +165,7 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 		applyDataOffset(&init, off.Init())
 		c.Data = append(c.Data, init)
 	}
-	return c, nil
+	return installCompiledFinalizer(c), nil
 }
 
 // MustCompile is like Compile but panics on error, for tests, examples, and
@@ -356,12 +356,13 @@ func (c *Compiled) validateArenaFootprint() error {
 		return fmt.Errorf("compiled metadata invalid: %w", err)
 	}
 	need, err := wruntime.InstantiateArenaNeed(wruntime.InstantiateFootprint{
-		GlobalCount:    len(c.Globals),
-		HasTable:       c.HasTable,
-		TableSize:      c.TableSize,
-		ElemCount:      len(c.Elems),
-		MaxParamSlots:  maxParams,
-		MaxResultSlots: maxResults,
+		FuncImportCount: len(c.Imports),
+		GlobalCount:     len(c.Globals),
+		HasTable:        c.HasTable,
+		TableSize:       c.TableSize,
+		ElemCount:       len(c.Elems),
+		MaxParamSlots:   maxParams,
+		MaxResultSlots:  maxResults,
 	})
 	if err != nil {
 		return fmt.Errorf("compiled metadata invalid: %w", err)
@@ -369,6 +370,9 @@ func (c *Compiled) validateArenaFootprint() error {
 	if need > wruntime.InstantiateArenaSize {
 		return fmt.Errorf("compiled metadata invalid: instantiate arena need %d > limit %d", need, wruntime.InstantiateArenaSize)
 	}
+	c.maxParamSlots = maxParams
+	c.maxResultSlots = maxResults
+	c.instantiateArenaNeed = need
 	return nil
 }
 
@@ -428,7 +432,11 @@ func (c *Compiled) UnmarshalBinary(data []byte) error {
 	if err := unmarshalCompiled(c, data[5:]); err != nil {
 		return err
 	}
-	return c.validate()
+	if err := c.validate(); err != nil {
+		return err
+	}
+	installCompiledFinalizer(c)
+	return nil
 }
 
 // IsCompiled reports whether b is a precompiled wago module (vs raw wasm).
@@ -470,19 +478,23 @@ func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
 	for i, a := range args {
 		binary.LittleEndian.PutUint64(in.serArgs[i*8:], a)
 	}
-	binary.LittleEndian.PutUint32(in.hostLog, 0) // reset host-call log
+	if len(in.hostLog) > 0 {
+		binary.LittleEndian.PutUint32(in.hostLog, 0) // reset host-call log
+	}
 	entry := in.base + uintptr(in.c.Entry[li])
 	if err := in.eng.Call(entry, in.serArgs, in.jm.LinearMemory(), in.trap, in.results); err != nil {
 		return nil, err
 	}
-	n := binary.LittleEndian.Uint32(in.hostLog)
-	for i := uint32(0); i < n; i++ {
-		off := 8 + i*8
-		imp := binary.LittleEndian.Uint32(in.hostLog[off:])
-		arg := int32(binary.LittleEndian.Uint32(in.hostLog[off+4:]))
-		if int(imp) < len(in.c.Imports) {
-			if fn := in.hosts[in.c.Imports[imp]]; fn != nil {
-				fn(arg)
+	if len(in.hostLog) > 0 {
+		n := binary.LittleEndian.Uint32(in.hostLog)
+		for i := uint32(0); i < n; i++ {
+			off := 8 + i*8
+			imp := binary.LittleEndian.Uint32(in.hostLog[off:])
+			arg := int32(binary.LittleEndian.Uint32(in.hostLog[off+4:]))
+			if int(imp) < len(in.c.Imports) {
+				if fn := in.hosts[in.c.Imports[imp]]; fn != nil {
+					fn(arg)
+				}
 			}
 		}
 	}

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -1,0 +1,90 @@
+package wago
+
+import (
+	"fmt"
+	goruntime "runtime"
+	"sync"
+
+	coreruntime "github.com/wago-org/wago/src/core/runtime"
+)
+
+type compiledCodeCache struct {
+	mu     sync.Mutex
+	mem    []byte
+	base   uintptr
+	refs   int
+	closed bool
+}
+
+func installCompiledFinalizer(c *Compiled) *Compiled {
+	c.ensureCodeCache()
+	goruntime.SetFinalizer(c, func(c *Compiled) {
+		_ = c.Close()
+	})
+	return c
+}
+
+func (c *Compiled) ensureCodeCache() {
+	if c != nil && c.codeCache == nil {
+		c.codeCache = &compiledCodeCache{}
+	}
+}
+
+func (c *Compiled) acquireCode() (uintptr, error) {
+	c.ensureCodeCache()
+	cc := c.codeCache
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	if cc.closed {
+		return 0, fmt.Errorf("compiled module is closed")
+	}
+	if cc.mem == nil {
+		mem, base, err := coreruntime.MapCode(c.Code)
+		if err != nil {
+			return 0, err
+		}
+		cc.mem, cc.base = mem, base
+	}
+	cc.refs++
+	return cc.base, nil
+}
+
+func (c *Compiled) releaseCode() {
+	cc := c.codeCache
+	if cc == nil {
+		return
+	}
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	if cc.refs > 0 {
+		cc.refs--
+	}
+	if cc.refs == 0 && cc.closed && cc.mem != nil {
+		_ = coreruntime.Unmap(cc.mem)
+		cc.mem = nil
+		cc.base = 0
+	}
+}
+
+// Close releases the executable code mapping cached for this compiled module.
+// Existing instances keep the mapping alive until they are closed; subsequent
+// Instantiate calls fail. Closing is optional, but long-running hosts that create
+// many Compiled modules should call it when the module is no longer needed.
+func (c *Compiled) Close() error {
+	if c == nil {
+		return nil
+	}
+	c.ensureCodeCache()
+	cc := c.codeCache
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	cc.closed = true
+	goruntime.SetFinalizer(c, nil)
+	if cc.refs != 0 || cc.mem == nil {
+		return nil
+	}
+	mem := cc.mem
+	cc.mem = nil
+	cc.base = 0
+	return coreruntime.Unmap(mem)
+}

--- a/src/wago/code_mapping_test.go
+++ b/src/wago/code_mapping_test.go
@@ -1,0 +1,49 @@
+//go:build linux && amd64
+
+package wago
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompiledCloseRejectsFutureInstantiate(t *testing.T) {
+	c, err := Compile(fibWasm)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := Instantiate(c, nil); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("Instantiate after Close error = %v, want closed", err)
+	}
+}
+
+func TestCompiledCloseKeepsExistingInstanceAlive(t *testing.T) {
+	c, err := Compile(fibWasm)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	in, err := Instantiate(c, nil)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close with live instance: %v", err)
+	}
+	if _, err := Instantiate(c, nil); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("Instantiate after Close error = %v, want closed", err)
+	}
+	res, err := in.Invoke("fib", I32(10))
+	if err != nil {
+		t.Fatalf("Invoke after Compiled.Close: %v", err)
+	}
+	if got := AsI32(res[0]); got != 55 {
+		t.Fatalf("fib(10) = %d, want 55", got)
+	}
+	in.Close()
+	if err := c.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -231,6 +231,15 @@ type Compiled struct {
 	memoryImport string
 
 	GCTypeDescs []gc.TypeDesc // immutable Wasm GC descriptor metadata; per-instance heaps own collection state
+
+	// Cached during validateArenaFootprint. Compiled is intentionally still
+	// revalidated at Instantiate boundaries because its fields are exported and
+	// test code can construct it by hand.
+	maxParamSlots        int
+	maxResultSlots       int
+	instantiateArenaNeed int
+
+	codeCache *compiledCodeCache
 }
 
 // memorySizeBytes returns the initial and maximum (grow ceiling) linear-memory

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -18,7 +18,6 @@ type Instance struct {
 	ownsMem                bool    // false when memory is host-imported (don't close it)
 	ar                     *runtime.Arena
 	base                   uintptr
-	mem                    []byte // mapped code (for Unmap)
 	linMem                 []byte // linear memory, cached once (wago has no memory.grow, so it never moves)
 	hosts                  map[string]HostFunc
 	imports                Imports // the imports as provided to Instantiate
@@ -127,13 +126,13 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 			memObj.inUse = false
 		}
 	}
-	ar, err := runtime.NewArena(runtime.InstantiateArenaSize)
+	ar, err := runtime.NewArena(c.instantiateArenaNeed)
 	if err != nil {
 		closeMem()
 		eng.Close()
 		return nil, err
 	}
-	mem, base, err := runtime.MapCode(c.Code)
+	base, err := c.acquireCode()
 	if err != nil {
 		ar.Close()
 		closeMem()
@@ -144,14 +143,16 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 		if success {
 			return
 		}
-		runtime.Unmap(mem)
+		c.releaseCode()
 		ar.Close()
 		closeMem()
 		eng.Close()
 	}()
-	const maxEntries = (1 << 16) / 8
-	hostLog := ar.Alloc(8 + maxEntries*8)
-	jm.SetCustomCtx(uintptr(unsafe.Pointer(&hostLog[0])))
+	var hostLog []byte
+	if len(c.Imports) > 0 {
+		hostLog = ar.Alloc(runtime.HostCallLogBytes)
+		jm.SetCustomCtx(uintptr(unsafe.Pointer(&hostLog[0])))
+	}
 	jm.SetStackFence(eng.StackLimit()) // trap runaway recursion instead of faulting
 
 	var globals []byte
@@ -241,15 +242,11 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 		}
 	}
 
-	maxParams, maxResults, err := c.maxCallSlots()
+	argsBytes, err := runtime.SlotBytes(c.maxParamSlots)
 	if err != nil {
 		return nil, fmt.Errorf("compiled metadata invalid: %w", err)
 	}
-	argsBytes, err := runtime.SlotBytes(maxParams)
-	if err != nil {
-		return nil, fmt.Errorf("compiled metadata invalid: %w", err)
-	}
-	resultsBytes, err := runtime.SlotBytes(maxResults)
+	resultsBytes, err := runtime.SlotBytes(c.maxResultSlots)
 	if err != nil {
 		return nil, fmt.Errorf("compiled metadata invalid: %w", err)
 	}
@@ -271,8 +268,8 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 
 	success = true
 	return &Instance{
-		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, mem: mem, linMem: jm.CurrentBytes(), hosts: imports.hostFuncs(), imports: imports, hostLog: hostLog, globals: globals, globalCells: globalCells, gc: collector,
-		serArgs: serArgs, results: results, trap: trap, resultVals: make([]uint64, maxResults),
+		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, linMem: jm.CurrentBytes(), hosts: imports.hostFuncs(), imports: imports, hostLog: hostLog, globals: globals, globalCells: globalCells, gc: collector,
+		serArgs: serArgs, results: results, trap: trap, resultVals: make([]uint64, c.maxResultSlots),
 	}, nil
 }
 
@@ -282,7 +279,7 @@ func (in *Instance) Close() {
 	if in.gc != nil {
 		in.gc.Close()
 	}
-	runtime.Unmap(in.mem)
+	in.c.releaseCode()
 	in.ar.Close()
 	if in.ownsMem {
 		in.jm.Close()


### PR DESCRIPTION
## What changed

This reduces repeated instantiation latency by moving the expensive executable code mapping lifecycle from each `Instance` to the owning `Compiled` module.

- Cache executable code mappings on `Compiled` and ref-count live instances.
- Add `Compiled.Close()` so hosts can explicitly release cached executable code and reject future instantiates while allowing existing instances to finish.
- Cache validated call-slot and arena footprint metadata during compilation/unmarshal validation.
- Map the exact validated per-instance arena size instead of the fixed 1 MiB limit.
- Skip host-call log allocation and replay when a module has no function imports.
- Add close/lifetime tests for shared code mappings.

## Why

Initialization was paying setup costs that are invariant for a compiled module on every instantiate, especially `MapCode`/copy/`mprotect`. That dominated startup latency for repeated instantiation workflows.

## Measurements

Focused instantiate benchmarks before vs after:

| Benchmark | Before | After |
| --- | ---: | ---: |
| `BenchmarkInstantiate/tiny` | ~20.1 us | ~12.1-12.5 us |
| `BenchmarkInstantiate/fib_rec` | ~19.9 us | ~12.0 us |
| `BenchmarkInstantiate/many_funcs` | ~25.5 us | ~12.5 us |
| `BenchmarkInstantiate/json-as` | ~56 us | ~24.0 us |
| `BenchmarkInstantiate/blake-as` | ~32.5 us | ~21.3-21.4 us |

## Validation

- `GOCACHE=/tmp/wago-gocache go vet ./...`
- `GOCACHE=/tmp/wago-gocache go test ./...`
- `(cd bench && GOCACHE=/tmp/wago-gocache go test ./...)`
- `GOCACHE=/tmp/wago-gocache go test ./src/wago`
- `git diff --check`