### PR TITLE
runtime: reuse instantiate state

### DIFF
--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"encoding/binary"
+	"sync"
 	"syscall"
 	"unsafe"
 
@@ -49,6 +50,17 @@ type JobMemory struct {
 	reserveLen  uintptr
 }
 
+const (
+	maxClassicLinMemBytes        = 65535 * 65536
+	minClassicLinMemReserveBytes = 65536
+	jobMemoryCacheMaxBytes       = 1 << 20
+)
+
+var jobMemoryCache struct {
+	sync.Mutex
+	j *JobMemory
+}
+
 // NewJobMemory lays out basedata immediately before a fixed-size (non-growable)
 // linear memory. memory.grow on it always fails (max == initial).
 func NewJobMemory(linBytes int) (*JobMemory, error) {
@@ -59,34 +71,77 @@ func NewJobMemory(linBytes int) (*JobMemory, error) {
 // exposes only initialBytes as in-bounds linear memory. memory.grow raises the
 // size cache up to maxBytes without any remap, so the base pointer never moves.
 func NewJobMemoryGrowable(initialBytes, maxBytes int) (*JobMemory, error) {
-	// 65536 pages is 4 GiB, whose byte size (2^32) does not fit the u32 size
-	// cache, so cap the logical size at 65535 pages (0xFFFF0000 bytes).
-	const maxLinMemBytes = 65535 * 65536
-	if maxBytes > maxLinMemBytes {
-		maxBytes = maxLinMemBytes
-	}
-	if maxBytes < initialBytes {
-		maxBytes = initialBytes
-	}
-	if initialBytes > maxLinMemBytes {
-		initialBytes = maxLinMemBytes
-	}
-	// The mapping is floored at one page so the linear-memory base is always a
-	// valid address even for a zero-page logical memory; the logical max (which may
-	// be smaller, even zero) is recorded separately for the grow check.
-	reserveBytes := maxBytes
-	if reserveBytes < 65536 {
-		reserveBytes = 65536
-	}
+	initialBytes, maxBytes, reserveBytes := normalizeMemorySizes(initialBytes, maxBytes)
 	mem, err := mmapRWReserve(basedataSize + reserveBytes)
 	if err != nil {
 		return nil, err
 	}
 	j := &JobMemory{mem: mem, linOff: basedataSize, linLen: reserveBytes}
+	j.reset(initialBytes, maxBytes, reserveBytes, false)
+	return j, nil
+}
+
+func normalizeMemorySizes(initialBytes, maxBytes int) (int, int, int) {
+	// 65536 pages is 4 GiB, whose byte size (2^32) does not fit the u32 size
+	// cache, so cap the logical size at 65535 pages (0xFFFF0000 bytes).
+	if maxBytes > maxClassicLinMemBytes {
+		maxBytes = maxClassicLinMemBytes
+	}
+	if maxBytes < initialBytes {
+		maxBytes = initialBytes
+	}
+	if initialBytes > maxClassicLinMemBytes {
+		initialBytes = maxClassicLinMemBytes
+	}
+	// The mapping is floored at one page so the linear-memory base is always a
+	// valid address even for a zero-page logical memory; the logical max (which may
+	// be smaller, even zero) is recorded separately for the grow check.
+	reserveBytes := maxBytes
+	if reserveBytes < minClassicLinMemReserveBytes {
+		reserveBytes = minClassicLinMemReserveBytes
+	}
+	return initialBytes, maxBytes, reserveBytes
+}
+
+func (j *JobMemory) reset(initialBytes, maxBytes, reserveBytes int, clearMem bool) {
+	if clearMem {
+		clear(j.mem[:basedataSize+reserveBytes])
+	}
+	j.linOff = basedataSize
+	j.linLen = reserveBytes
+	j.reserveBase = 0
+	j.reserveLen = 0
 	j.putU32(offActualLinMemByteSize, uint32(initialBytes))
 	j.putU32(offLinMemWasmSize, uint32(initialBytes/65536))
 	j.putU32(offMaxLinMemPages, uint32(maxBytes/65536))
-	return j, nil
+}
+
+// AcquireJobMemoryGrowable returns a non-guarded JobMemory, reusing one recently
+// released by ReleaseJobMemory when its reservation is small enough. Reuse fully
+// clears basedata and the exposed reservation before installing size caches, so
+// fresh-instance zero memory and future memory.grow zeroing semantics are kept.
+func AcquireJobMemoryGrowable(initialBytes, maxBytes int) (*JobMemory, error) {
+	initialBytes, maxBytes, reserveBytes := normalizeMemorySizes(initialBytes, maxBytes)
+	if reserveBytes > jobMemoryCacheMaxBytes {
+		return NewJobMemoryGrowable(initialBytes, maxBytes)
+	}
+	need := basedataSize + reserveBytes
+	jobMemoryCache.Lock()
+	j := jobMemoryCache.j
+	if j != nil && j.reserveBase == 0 && len(j.mem) >= need {
+		jobMemoryCache.j = nil
+		jobMemoryCache.Unlock()
+		j.reset(initialBytes, maxBytes, reserveBytes, true)
+		return j, nil
+	}
+	if j != nil && len(j.mem) < need {
+		jobMemoryCache.j = nil
+		jobMemoryCache.Unlock()
+		_ = j.Close()
+		return NewJobMemoryGrowable(initialBytes, maxBytes)
+	}
+	jobMemoryCache.Unlock()
+	return NewJobMemoryGrowable(initialBytes, maxBytes)
 }
 
 // curBytes is the current in-bounds linear-memory size, read from the cache that
@@ -111,6 +166,9 @@ func (j *JobMemory) LinearMemory() []byte {
 // LinMemBase is the pointer handed to native code as the linMem base
 // (RSI on entry, RBX inside WARP code).
 func (j *JobMemory) LinMemBase() uintptr {
+	if j.reserveBase != 0 {
+		return j.reserveBase + uintptr(j.linOff)
+	}
 	return uintptr(unsafe.Pointer(&j.mem[j.linOff]))
 }
 
@@ -146,6 +204,26 @@ func (j *JobMemory) Close() error {
 		return nil
 	}
 	return munmap(j.mem)
+}
+
+// ReleaseJobMemory returns small non-guarded memories to a bounded cache or
+// unmaps them. Guard-page reservations are never cached because their lifecycle
+// is registered with the signal handler.
+func ReleaseJobMemory(j *JobMemory) error {
+	if j == nil {
+		return nil
+	}
+	if j.reserveBase != 0 || len(j.mem)-basedataSize > jobMemoryCacheMaxBytes {
+		return j.Close()
+	}
+	jobMemoryCache.Lock()
+	if jobMemoryCache.j == nil {
+		jobMemoryCache.j = j
+		jobMemoryCache.Unlock()
+		return nil
+	}
+	jobMemoryCache.Unlock()
+	return j.Close()
 }
 
 func (j *JobMemory) putU32(below int, v uint32) {

--- a/src/core/runtime/basedata_test.go
+++ b/src/core/runtime/basedata_test.go
@@ -74,3 +74,37 @@ func TestJobMemoryMemSizeCache(t *testing.T) {
 		t.Fatalf("linear memory length = %d, want %d", len(jm.LinearMemory()), linMemBytes)
 	}
 }
+
+func TestAcquireJobMemoryGrowableReusesZeroedMemory(t *testing.T) {
+	jm, err := AcquireJobMemoryGrowable(linMemBytes, linMemBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := jm.LinMemBase()
+	lin := jm.LinearMemory()
+	for i := range lin[:1024] {
+		lin[i] = 0xa5
+	}
+	jm.SetCustomCtx(0x1234)
+	if err := ReleaseJobMemory(jm); err != nil {
+		t.Fatal(err)
+	}
+
+	jm2, err := AcquireJobMemoryGrowable(linMemBytes, linMemBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ReleaseJobMemory(jm2)
+	if got := jm2.LinMemBase(); got != base {
+		t.Fatalf("LinMemBase = %#x, want cached base %#x", got, base)
+	}
+	lin2 := jm2.LinearMemory()
+	for i, b := range lin2[:1024] {
+		if b != 0 {
+			t.Fatalf("reused linear memory byte %d = %#x, want 0", i, b)
+		}
+	}
+	if got := binary.LittleEndian.Uint64(jm2.mem[jm2.linOff-offCustomCtx:]); got != 0 {
+		t.Fatalf("custom ctx after reset = %#x, want 0", got)
+	}
+}

--- a/src/core/runtime/engine_linux_amd64.go
+++ b/src/core/runtime/engine_linux_amd64.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"github.com/wago-org/wago/src/core/runtime/abi"
+	"sync"
 	"unsafe"
 )
 
@@ -32,6 +33,42 @@ func NewEngine() (*Engine, error) {
 	top := uintptr(unsafe.Pointer(&st[0])) + uintptr(len(st))
 	top &^= 15 // 16-byte align (page-aligned already, but be explicit)
 	return &Engine{stack: st, stackTop: top}, nil
+}
+
+var engineCache struct {
+	sync.Mutex
+	e *Engine
+}
+
+// AcquireEngine returns an Engine, reusing one recently released by ReleaseEngine
+// when available. The cache is intentionally one slot: repeated instantiate/close
+// loops avoid stack mmap churn without retaining an unbounded number of 4 MiB
+// foreign stacks.
+func AcquireEngine() (*Engine, error) {
+	engineCache.Lock()
+	e := engineCache.e
+	engineCache.e = nil
+	engineCache.Unlock()
+	if e != nil {
+		return e, nil
+	}
+	return NewEngine()
+}
+
+// ReleaseEngine returns e to the bounded cache or unmaps its stack if the cache
+// is already occupied.
+func ReleaseEngine(e *Engine) error {
+	if e == nil {
+		return nil
+	}
+	engineCache.Lock()
+	if engineCache.e == nil {
+		engineCache.e = e
+		engineCache.Unlock()
+		return nil
+	}
+	engineCache.Unlock()
+	return e.Close()
 }
 
 // stackFenceMargin is the headroom above the foreign stack's low bound at which

--- a/src/core/runtime/mem_linux_amd64.go
+++ b/src/core/runtime/mem_linux_amd64.go
@@ -2,7 +2,10 @@
 
 package runtime
 
-import "syscall"
+import (
+	"sync"
+	"syscall"
+)
 
 const pageSize = 4096
 
@@ -52,8 +55,9 @@ func munmap(b []byte) error {
 
 // Arena is a bump allocator over stable off-heap memory.
 type Arena struct {
-	mem []byte
-	off int
+	mem         []byte
+	off         int
+	zeroOnAlloc bool
 }
 
 func NewArena(n int) (*Arena, error) {
@@ -64,6 +68,36 @@ func NewArena(n int) (*Arena, error) {
 	return &Arena{mem: mem}, nil
 }
 
+var arenaCache struct {
+	sync.Mutex
+	a *Arena
+}
+
+// AcquireArena returns an arena of at least n bytes, reusing one recently
+// released by ReleaseArena when possible. The cache is a single mapping bounded
+// by InstantiateArenaSize so short instantiate/close loops avoid mmap churn
+// without retaining unbounded off-heap memory.
+func AcquireArena(n int) (*Arena, error) {
+	need := roundUpPage(n)
+	arenaCache.Lock()
+	a := arenaCache.a
+	if a != nil && len(a.mem) >= need {
+		arenaCache.a = nil
+		arenaCache.Unlock()
+		a.off = 0
+		a.zeroOnAlloc = true
+		return a, nil
+	}
+	if a != nil && len(a.mem) < need {
+		arenaCache.a = nil
+		arenaCache.Unlock()
+		_ = a.Close()
+		return NewArena(n)
+	}
+	arenaCache.Unlock()
+	return NewArena(n)
+}
+
 func (a *Arena) Alloc(n int) []byte {
 	a.off = (a.off + 7) &^ 7
 	if a.off+n > len(a.mem) {
@@ -71,7 +105,32 @@ func (a *Arena) Alloc(n int) []byte {
 	}
 	b := a.mem[a.off : a.off+n : a.off+n]
 	a.off += n
+	if a.zeroOnAlloc {
+		clear(b)
+	}
 	return b
 }
 
 func (a *Arena) Close() error { return munmap(a.mem) }
+
+// ReleaseArena returns a to the bounded cache or unmaps it if the cache is
+// occupied. Reused arenas zero each allocation before it is handed out, matching
+// the fresh-anonymous-mmap behavior callers depend on for sparse table entries.
+func ReleaseArena(a *Arena) error {
+	if a == nil {
+		return nil
+	}
+	if len(a.mem) > roundUpPage(InstantiateArenaSize) {
+		return a.Close()
+	}
+	arenaCache.Lock()
+	if arenaCache.a == nil {
+		a.off = 0
+		a.zeroOnAlloc = true
+		arenaCache.a = a
+		arenaCache.Unlock()
+		return nil
+	}
+	arenaCache.Unlock()
+	return a.Close()
+}

--- a/src/core/runtime/sigtrap_linux_amd64.go
+++ b/src/core/runtime/sigtrap_linux_amd64.go
@@ -175,7 +175,12 @@ func (e *Engine) CallGuarded(code uintptr, serArgs, linMem, trap, results []byte
 	if j.reserveBase == 0 {
 		return fmt.Errorf("CallGuarded requires NewJobMemoryGuarded")
 	}
-	enterNative(code, slicePtr(serArgs), slicePtr(linMem), slicePtr(trap), slicePtr(results), e.stackTop)
+	linMemBase := j.LinMemBase()
+	if len(trap) >= 4 {
+		trap[0], trap[1], trap[2], trap[3] = 0, 0, 0, 0
+		j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	}
+	enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
 	if len(trap) >= 4 {
 		if tc := TrapCode(uint32(trap[0]) | uint32(trap[1])<<8 | uint32(trap[2])<<16 | uint32(trap[3])<<24); tc != TrapNone {
 			return &TrapError{Code: tc}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -116,6 +116,9 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 		if lim.Max != nil {
 			c.MemMaxPages = uint32(*lim.Max)
 		}
+		if !moduleUsesMemoryGrow(m) {
+			c.MemMaxPages = c.MemMinPages
+		}
 	}
 	if m.Start != nil {
 		c.HasStart = true
@@ -166,6 +169,28 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 		c.Data = append(c.Data, init)
 	}
 	return installCompiledFinalizer(c), nil
+}
+
+func moduleUsesMemoryGrow(m *wasm.Module) bool {
+	for i := range m.Code {
+		if instrsUseMemoryGrow(m.Code[i].Body.Instrs) {
+			return true
+		}
+	}
+	return false
+}
+
+func instrsUseMemoryGrow(instrs []wasm.Instruction) bool {
+	for i := range instrs {
+		in := &instrs[i]
+		if in.Kind == wasm.InstrMemoryGrow {
+			return true
+		}
+		if instrsUseMemoryGrow(in.Body().Instrs) || instrsUseMemoryGrow(in.Then()) || instrsUseMemoryGrow(in.Else()) {
+			return true
+		}
+	}
+	return false
 }
 
 // MustCompile is like Compile but panics on error, for tests, examples, and
@@ -482,7 +507,7 @@ func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
 		binary.LittleEndian.PutUint32(in.hostLog, 0) // reset host-call log
 	}
 	entry := in.base + uintptr(in.c.Entry[li])
-	if err := in.eng.Call(entry, in.serArgs, in.jm.LinearMemory(), in.trap, in.results); err != nil {
+	if err := callNative(in.c, in.eng, in.jm, entry, in.serArgs, in.trap, in.results); err != nil {
 		return nil, err
 	}
 	if len(in.hostLog) > 0 {

--- a/src/wago/code_mapping_test.go
+++ b/src/wago/code_mapping_test.go
@@ -5,6 +5,7 @@ package wago
 import (
 	"strings"
 	"testing"
+	"unsafe"
 )
 
 func TestCompiledCloseRejectsFutureInstantiate(t *testing.T) {
@@ -29,11 +30,24 @@ func TestCompiledCloseKeepsExistingInstanceAlive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
+	eng := in.eng
+	jm := in.jm
+	ar := in.ar
+	serArgsPtr := unsafe.Pointer(nil)
+	if len(in.serArgs) > 0 {
+		serArgsPtr = unsafe.Pointer(&in.serArgs[0])
+	}
 	if err := c.Close(); err != nil {
 		t.Fatalf("Close with live instance: %v", err)
 	}
 	if _, err := Instantiate(c, nil); err == nil || !strings.Contains(err.Error(), "closed") {
 		t.Fatalf("Instantiate after Close error = %v, want closed", err)
+	}
+	if in.eng != eng || in.jm != jm || in.ar != ar {
+		t.Fatalf("live instance runtime objects changed after failed Instantiate")
+	}
+	if len(in.serArgs) > 0 && unsafe.Pointer(&in.serArgs[0]) != serArgsPtr {
+		t.Fatalf("live instance argument buffer changed after failed Instantiate")
 	}
 	res, err := in.Invoke("fib", I32(10))
 	if err != nil {

--- a/src/wago/global_test.go
+++ b/src/wago/global_test.go
@@ -131,8 +131,28 @@ func TestCompileAcceptsMemoryGrow(t *testing.T) {
 		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x01, 0x40, 0x00, 0x0b}))), // i32.const 1; memory.grow 0; end
 	)
-	if _, err := Compile(mod); err != nil {
+	c, err := Compile(mod)
+	if err != nil {
 		t.Fatalf("Compile memory.grow error = %v, want success", err)
+	}
+	if c.MemMaxPages <= c.MemMinPages {
+		t.Fatalf("memory.grow module max pages = %d, min = %d; want grow headroom", c.MemMaxPages, c.MemMinPages)
+	}
+}
+
+func TestCompileCapsNoGrowMemoryAtInitialPages(t *testing.T) {
+	mod := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x3f, 0x00, 0x0b}))), // memory.size 0; end
+	)
+	c, err := Compile(mod)
+	if err != nil {
+		t.Fatalf("Compile memory.size error = %v", err)
+	}
+	if c.MemMaxPages != c.MemMinPages {
+		t.Fatalf("no-grow module max pages = %d, min = %d; want initial-only reservation", c.MemMaxPages, c.MemMinPages)
 	}
 }
 

--- a/src/wago/guardrun_guardpage.go
+++ b/src/wago/guardrun_guardpage.go
@@ -12,3 +12,10 @@ func newGuardedJobMemory(linBytes, maxBytes int) (*wruntime.JobMemory, error) {
 	}
 	return wruntime.NewJobMemoryGuarded(linBytes, maxBytes)
 }
+
+func callNative(c *Compiled, eng *wruntime.Engine, jm *wruntime.JobMemory, entry uintptr, serArgs, trap, results []byte) error {
+	if c.boundsMode == BoundsChecksSignalsBased {
+		return eng.CallGuarded(entry, serArgs, jm.LinearMemory(), trap, results, jm)
+	}
+	return eng.Call(entry, serArgs, jm.LinearMemory(), trap, results)
+}

--- a/src/wago/guardrun_off.go
+++ b/src/wago/guardrun_off.go
@@ -14,3 +14,7 @@ import (
 func newGuardedJobMemory(int, int) (*wruntime.JobMemory, error) {
 	return nil, fmt.Errorf("signals-based bounds checks require a binary built with -tags wago_guardpage")
 }
+
+func callNative(_ *Compiled, eng *wruntime.Engine, jm *wruntime.JobMemory, entry uintptr, serArgs, trap, results []byte) error {
+	return eng.Call(entry, serArgs, jm.LinearMemory(), trap, results)
+}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -76,7 +76,7 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 	if err != nil {
 		return nil, err
 	}
-	eng, err := runtime.NewEngine()
+	eng, err := runtime.AcquireEngine()
 	if err != nil {
 		return nil, err
 	}
@@ -90,16 +90,16 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 	)
 	if c.memoryImport != "" {
 		if c.boundsMode == BoundsChecksSignalsBased {
-			eng.Close()
+			runtime.ReleaseEngine(eng)
 			return nil, fmt.Errorf("imported memory with signals-based bounds checks is not supported")
 		}
 		m, ok := imports.memory(c.memoryImport)
 		if !ok {
-			eng.Close()
+			runtime.ReleaseEngine(eng)
 			return nil, fmt.Errorf("missing imported memory %q", c.memoryImport)
 		}
 		if m.inUse {
-			eng.Close()
+			runtime.ReleaseEngine(eng)
 			return nil, fmt.Errorf("imported memory %q is already used by another instance", c.memoryImport)
 		}
 		m.inUse = true
@@ -109,10 +109,10 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 		if c.boundsMode == BoundsChecksSignalsBased {
 			jm, err = newGuardedJobMemory(initialBytes, maxBytes)
 		} else {
-			jm, err = runtime.NewJobMemoryGrowable(initialBytes, maxBytes)
+			jm, err = runtime.AcquireJobMemoryGrowable(initialBytes, maxBytes)
 		}
 		if err != nil {
-			eng.Close()
+			runtime.ReleaseEngine(eng)
 			return nil, err
 		}
 		memObj, ownsMem = &Memory{jm: jm}, true
@@ -121,22 +121,22 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 	// host's, so just release the in-use claim.
 	closeMem := func() {
 		if ownsMem {
-			jm.Close()
+			runtime.ReleaseJobMemory(jm)
 		} else {
 			memObj.inUse = false
 		}
 	}
-	ar, err := runtime.NewArena(c.instantiateArenaNeed)
+	ar, err := runtime.AcquireArena(c.instantiateArenaNeed)
 	if err != nil {
 		closeMem()
-		eng.Close()
+		runtime.ReleaseEngine(eng)
 		return nil, err
 	}
 	base, err := c.acquireCode()
 	if err != nil {
-		ar.Close()
+		runtime.ReleaseArena(ar)
 		closeMem()
-		eng.Close()
+		runtime.ReleaseEngine(eng)
 		return nil, err
 	}
 	defer func() {
@@ -144,9 +144,9 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 			return
 		}
 		c.releaseCode()
-		ar.Close()
+		runtime.ReleaseArena(ar)
 		closeMem()
-		eng.Close()
+		runtime.ReleaseEngine(eng)
 	}()
 	var hostLog []byte
 	if len(c.Imports) > 0 {
@@ -261,7 +261,7 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 			return nil, fmt.Errorf("start function index %d out of range", c.StartLocalFunc)
 		}
 		startEntry := base + uintptr(c.Entry[c.StartLocalFunc])
-		if err := eng.Call(startEntry, serArgs, jm.LinearMemory(), trap, results); err != nil {
+		if err := callNative(c, eng, jm, startEntry, serArgs, trap, results); err != nil {
 			return nil, fmt.Errorf("start function trapped: %w", err)
 		}
 	}
@@ -280,13 +280,13 @@ func (in *Instance) Close() {
 		in.gc.Close()
 	}
 	in.c.releaseCode()
-	in.ar.Close()
+	runtime.ReleaseArena(in.ar)
 	if in.ownsMem {
-		in.jm.Close()
+		runtime.ReleaseJobMemory(in.jm)
 	} else if in.memory != nil {
 		in.memory.inUse = false
 	}
-	in.eng.Close()
+	runtime.ReleaseEngine(in.eng)
 }
 
 // Memory returns the instance's linear-memory object (instance-owned or the


### PR DESCRIPTION
## What changed

This continues the instantiate-latency work by removing the remaining mmap churn from repeated `Instantiate` / `Close` loops.

- Add bounded one-slot reuse for `Engine` foreign stacks.
- Add bounded one-slot reuse for instantiate arenas, with zero-on-allocation when reused.
- Add bounded one-slot reuse for small classic `JobMemory`, with full basedata and linear-memory reset before reuse.
- Detect modules that do not contain `memory.grow` and cap their reservation to the initial page count instead of reserving grow headroom.
- Route signals-based guard-page invocations through `CallGuarded` and fix zero-page guarded linMem base handling.
- Add tests for zeroed `JobMemory` reuse, grow/no-grow reservation decisions, and live-instance stability after `Compiled.Close()` plus a failed future instantiate.

## Why

After PR #104 shared executable code mappings, profiles showed repeated instantiation was still mostly `mmap` / `munmap` for the engine stack, metadata arena, and linear memory. These resources can be reused in a bounded way without changing wasm-visible memory semantics.

## Measurements

Focused `BenchmarkInstantiate` before this pass vs after:

| Benchmark | Before | After |
| --- | ---: | ---: |
| `tiny` | ~12.2 us | ~0.73 us |
| `fib_rec` | ~12.2 us | ~0.72 us |
| `many_funcs` | ~12.6 us | ~1.17 us |
| `blake-as` | ~21.0 us | ~1.18 us |
| `utf-as` | ~35 us range previously | ~2.1 us |
| `json-as` | ~23.7 us | ~16.1 us |

`json-as` uses `memory.grow`, so it correctly keeps grow reservation headroom and does not get the full no-grow reservation win.

## Validation

- `GOCACHE=/tmp/wago-gocache go test ./...`
- `(cd bench && GOCACHE=/tmp/wago-gocache go test ./...)`
- `GOCACHE=/tmp/wago-gocache go vet ./...`
- `GOCACHE=/tmp/wago-gocache go test -tags wago_guardpage ./src/core/runtime -count 1`
- `GOCACHE=/tmp/wago-gocache go test -tags wago_guardpage ./src/wago -run 'TestCompiledCloseRejectsFutureInstantiate|TestCompiledCloseKeepsExistingInstanceAlive|TestCallMixedArgKinds' -count 1 -v`
- `git diff --check`