### PR TITLE
bench: make WARP benches runnable from a fresh clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,23 @@ cd bench && go run ./chart     # preview into bench/charts/ (gitignored)
 `bench/` is a separate Go module so the root package stays dependency-light; the
 chart generator is pure-Go SVG (no chart runtime).
 
+### Comparing against WARP
+
+wago is a Go port of [WARP](warp/), BMW's C++ single-pass compiler, so the suite
+can run WARP over the same corpus for a head-to-head. WARP ships as a git
+submodule; one command checks it out, builds its harness, and runs it:
+
+```bash
+make bench-warp        # needs cmake + a C++14 toolchain; no other setup
+```
+
+This checks out the `warp/` submodule, applies the bench harness patch
+([`bench/warp/bench-main.patch`](bench/warp/bench-main.patch)), builds `vb_bench`,
+and prints per-module WARP compile/exec numbers. `make bench WARP=auto` then folds
+them into the `compile-engines` / `exec-engines` comparison charts. The x86-64
+build needs none of WARP's own nested submodules. See
+[bench/README.md](bench/README.md#cross-engine-comparison) for details.
+
 ## Architecture
 
 For the full design — pipeline, Valent-Block backend, JobMemory/ABI layout, the

--- a/bench/README.md
+++ b/bench/README.md
@@ -86,8 +86,15 @@ dropped in via manifest `path` entries (skipped if absent; see `corpus/fetch.sh`
 and `benchpub -warp <harness>` shells out to **WARP**'s native harness for both
 compile and exec. The harness is `vb_bench`, built from `warp/bench/main.cpp` —
 since `warp/` is a submodule, the bench tweak (take real `i32` args, time a proper
-exec loop with a DCE sink) lives as `bench/warp/bench-main.patch`; build it with
-`./scripts/build-warp-bench.sh`. Two extra charts are produced:
+exec loop with a DCE sink) lives as `bench/warp/bench-main.patch`.
+
+From a fresh clone, `make bench-warp` does everything: it checks out the `warp/`
+submodule (non-recursive — the x86-64 bench build needs none of WARP's own nested
+submodules; the softfloat one is for the TriCore backend only), applies the patch
+to a pristine harness, builds `vb_bench` with the fair-comparison config (eager
+allocation on, interruption off), and runs it over the corpus. Only `cmake` and a
+C++14 toolchain are required. `scripts/build-warp-bench.sh` is the build step on
+its own. Two extra charts are produced:
 
 - `compile-engines.svg` — compile time per module, wago vs wazero vs WARP. Where
   the backend can't compile a module yet, wago's **validate** time is shown

--- a/bench/warp/bench-main.patch
+++ b/bench/warp/bench-main.patch
@@ -1,5 +1,5 @@
 diff --git a/bench/main.cpp b/bench/main.cpp
-index 52fbc20..cc42899 100644
+index 52fbc20..a16b07d 100644
 --- a/bench/main.cpp
 +++ b/bench/main.cpp
 @@ -18,6 +18,7 @@
@@ -10,7 +10,7 @@ index 52fbc20..cc42899 100644
  #include <cstdio>
  #include <cstdlib>
  #include <exception>
-@@ -92,42 +93,66 @@ int main(int argc, char *argv[]) {
+@@ -92,42 +93,58 @@ int main(int argc, char *argv[]) {
      auto const compend = std::chrono::steady_clock::now();
      float const compdur = static_cast<float>(std::chrono::duration_cast<std::chrono::microseconds>(compend - compstart).count()) / 1000.F;
  
@@ -29,14 +29,6 @@ index 52fbc20..cc42899 100644
  #else
        stackTop = nullptr;
  #endif
-+      { // warp-code-dump: write the compiled blob for offline disassembly
-+        auto const sp = compileResult.getModule().span();
-+        if (FILE *f = fopen("/tmp/warp-json.bin", "wb")) {
-+          fwrite(sp.data(), 1, sp.size(), f);
-+          fclose(f);
-+        }
-+        fprintf(stderr, "BLOB size=%zu data=%p\n", (size_t)sp.size(), (void*)sp.data());
-+      }
        module.initFromCompiledBinary(compileResult.getModule().span(), vb::Span<vb::NativeSymbol const>(), vb::Span<uint8_t const>());
 -
        module.start(stackTop);

--- a/scripts/build-warp-bench.sh
+++ b/scripts/build-warp-bench.sh
@@ -4,21 +4,33 @@
 # args and timing a proper exec loop — lives as a patch in this repo
 # (bench/warp/bench-main.patch) and is applied to the submodule's working tree
 # here rather than committed upstream. The result is warp/build-bench/bin/vb_bench,
-# the path benchpub's defaultWarpHarness expects. Needs cmake + a C++ compiler.
+# the path benchpub's defaultWarpHarness expects.
+#
+# Self-contained: on a fresh clone this checks out the warp submodule for you, so
+# `make bench-warp` works with nothing but cmake + a C++14 toolchain. The x86-64
+# bench build needs none of WARP's own nested submodules (the softfloat one is
+# only for the TriCore backend), so a plain, non-recursive checkout is enough.
 set -eu
 
 root=$(git rev-parse --show-toplevel)
 warp="$root/warp"
 patch="$root/bench/warp/bench-main.patch"
 
-[ -d "$warp/src" ] || { printf 'build-warp-bench: warp submodule not checked out (git submodule update --init warp)\n' >&2; exit 1; }
-command -v cmake >/dev/null 2>&1 || { printf 'build-warp-bench: cmake not found\n' >&2; exit 1; }
+command -v cmake >/dev/null 2>&1 || { printf 'build-warp-bench: cmake not found (install cmake + a C++ compiler)\n' >&2; exit 1; }
 
-# Apply the bench patch unless it's already in place (idempotent).
-if ! grep -q "exec_ns=" "$warp/bench/main.cpp" 2>/dev/null; then
-	printf 'build-warp-bench: applying bench patch...\n'
-	( cd "$warp" && git apply "$patch" )
+# Fresh clone: check out the warp submodule (non-recursive — see note above).
+if [ ! -d "$warp/src" ]; then
+	printf 'build-warp-bench: checking out warp submodule...\n'
+	git -C "$root" submodule update --init warp
 fi
+[ -d "$warp/src" ] || { printf 'build-warp-bench: warp submodule still missing (run: git submodule update --init warp)\n' >&2; exit 1; }
+
+# Apply the bench patch to a pristine copy of the harness, so the build always
+# reflects the committed patch — deterministic across machines and re-runs.
+( cd "$warp" && git checkout -- bench/main.cpp 2>/dev/null || true; git apply "$patch" )
+
+# Portable core count (Linux nproc, macOS/BSD sysctl, else a safe default).
+jobs=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 
 # Build with the fair-comparison config (eager allocation on, interruption off),
 # applied to the whole project so the library and harness agree.
@@ -26,5 +38,5 @@ cmake -S "$warp" -B "$warp/build-bench" \
 	-DENABLE_BENCH=ON -DVB_ENABLE_DEV_FEATURE=OFF -DENABLE_UNITTEST=OFF \
 	-DENABLE_SPECTEST=OFF -DENABLE_BINDING=OFF -DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_CXX_FLAGS="-DINTERRUPTION_REQUEST=0 -DEAGER_ALLOCATION=1" >/dev/null
-cmake --build "$warp/build-bench" --target vb_bench -j"$(nproc)" >/dev/null
+cmake --build "$warp/build-bench" --target vb_bench -j"$jobs" >/dev/null
 printf 'build-warp-bench: built %s\n' "$warp/build-bench/bin/vb_bench"


### PR DESCRIPTION
## What

Makes the WARP cross-engine comparison benches work end-to-end for anyone who clones the repo — one command, no manual submodule/harness setup.

```bash
make bench-warp        # needs only cmake + a C++14 toolchain
```

This checks out the `warp/` submodule, applies the harness patch, builds `vb_bench`, and runs WARP compile+exec over the whole corpus.

## Why

The WARP bench harness lived as `bench/warp/bench-main.patch` applied to the submodule working tree, but running it depended on local, uncommitted state and the build script hard-errored on a fresh clone. So a new contributor couldn't reproduce the wago-vs-WARP numbers.

## Changes

- **`scripts/build-warp-bench.sh`**
  - Auto-checks-out the `warp/` submodule on a fresh clone instead of erroring (non-recursive — the x86-64 bench build needs none of WARP's nested submodules; softfloat/`berkeley-softfloat-3` is TriCore-only).
  - Resets the harness to pristine before applying the patch, so the build is deterministic across machines and idempotent on re-runs.
  - Portable core count (`nproc` → `sysctl -n hw.ncpu` → `4`) for macOS/BSD.
- **`bench/warp/bench-main.patch`** — dropped the leftover `warp-code-dump` debug block that wrote `/tmp/warp-json.bin` and printed `BLOB size=...` to stderr on every exec run (disassembly scaffolding; also threw compiler warnings). The committed harness is now clean and reproducible.
- **`README.md` / `bench/README.md`** — documented the one-command flow under a "Comparing against WARP" section.

## Verified

In a throwaway worktree with a pristine `warp/` submodule checkout (real fresh-clone conditions):

- `make bench-warp` builds `vb_bench` and prints per-module WARP compile/exec numbers for the full corpus.
- Harness output is a single clean line (`WARP fib compile_ms=... exec_ns=... iters=... sink=0`) — no `/tmp` file written, no stderr noise.
- Clean patch applies to a pristine tree; build succeeds with all of WARP's nested submodules empty.

No wago source or submodule pointer changed.