### PR TITLE
bench: default suite count to 1

### DIFF
--- a/bench/cmd/benchpub/main.go
+++ b/bench/cmd/benchpub/main.go
@@ -86,7 +86,7 @@ func main() {
 	out := flag.String("out", "bench-out", "output directory for bench.json/history.json and charts")
 	historyPath := flag.String("history", "", "existing history.json to read and append to (defaults to <out>/history.json)")
 	benchtime := flag.String("benchtime", "1s", "benchtime for the suite run")
-	count := flag.Int("count", 6, "count for the suite run (median is taken)")
+	count := flag.Int("count", 1, "count for the suite run (median is taken)")
 	warp := flag.String("warp", "", "WARP harness path for the comparison; \"auto\" uses the cmake-built vb_bench; empty skips")
 	base := flag.String("base", "", "load this bench.json as the run and skip the suite (only re-collect WARP and re-render)")
 	warpRun := flag.Bool("warp-run", false, "run the WARP harness over the corpus, print the numbers, and exit (no charts/publish)")
@@ -281,7 +281,8 @@ func median(s []Metric) Metric {
 }
 
 // medianFloat/medianInt return the true median of a sorted slice, averaging the
-// two middle elements for an even length (e.g. the default -count=6).
+// two middle elements for an even length (relevant when -count>1 is requested;
+// the default -count=1 leaves a single sample per benchmark).
 func medianFloat(x []float64) float64 {
 	n := len(x)
 	if n == 0 {

--- a/scripts/publish-bench.sh
+++ b/scripts/publish-bench.sh
@@ -11,7 +11,7 @@ set -eu
 docs_remote="${WAGO_DOCS_REMOTE:-git@github.com:wago-org/docs.git}"
 docs_branch="main"
 benchtime="${WAGO_BENCHTIME:-1s}"
-count="${WAGO_BENCH_COUNT:-6}"
+count="${WAGO_BENCH_COUNT:-1}"
 bench_isa="${WAGO_BENCH_ISA:-0}"
 benchpub_isa_flag=""
 if [ "$bench_isa" = 1 ] || [ "$bench_isa" = true ] || [ "$bench_isa" = yes ]; then
@@ -20,7 +20,7 @@ fi
 
 # WAGO_BENCH_IN: publish a previously captured `go test -bench` output instead of
 # re-running the suite. Capture one (once) with:
-#   cd bench && go test -run '^$' -bench . -benchmem -count 6 -timeout 0 . | tee run.txt
+#   cd bench && go test -run '^$' -bench . -benchmem -count 1 -timeout 0 . | tee run.txt
 # then: WAGO_BENCH_IN=run.txt make bench-publish
 # Resolve to an absolute path now, before the script cd's into the docs clone.
 bench_in="${WAGO_BENCH_IN:-}"


### PR DESCRIPTION
Make `count=1` the default for the benchmark harness so a bare `make bench` / `benchpub` / `publish-bench.sh` run does a single pass instead of six.

- `bench/cmd/benchpub/main.go`: `-count` flag default 6 → 1 (median path still works for explicit `-count>1`).
- `scripts/publish-bench.sh`: `WAGO_BENCH_COUNT` default 6 → 1.
- `Makefile` already defaulted `COUNT ?= 1`; stale `-count=6` comments updated.

Callers that want stable published medians can still pass a higher count (e.g. `make bench COUNT=6`).