### PR TITLE
runtime: reuse guard-page instantiate reservations

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -60,18 +60,25 @@ func BenchmarkCompile_wazero(b *testing.B) {
 	}
 }
 
+// BenchmarkInstantiate_wago times a full wago.Instantiate + Close of a compiled
+// module through the public API — the same lifecycle wazero's InstantiateModule +
+// Close measures below — so the two are comparable and the instantiate-state
+// reuse (engine stack, arena, linear memory) is exercised. The earlier version
+// timed the raw mmap/munmap primitives directly, which bypassed those reuse
+// caches. Built with -tags wago_guardpage this runs the signals-based
+// (guard-page) path.
 func BenchmarkInstantiate_wago(b *testing.B) {
-	m, _ := wasm.DecodeModule(fibWasm)
-	wasm.ValidateModule(m)
-	cm, _ := amd64.CompileModule(m)
+	c, err := wago.Compile(fibWasm)
+	if err != nil {
+		b.Fatal(err)
+	}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		eng, _ := runtime.NewEngine()
-		jm, _ := runtime.NewJobMemory(1 << 16)
-		mem, _, _ := runtime.MapCode(cm.Code)
-		runtime.Unmap(mem)
-		jm.Close()
-		eng.Close()
+		in, err := wago.Instantiate(c, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		in.Close()
 	}
 }
 

--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -193,6 +193,14 @@ func (j *JobMemory) ReserveRange() (base, length uintptr) { return j.reserveBase
 // from the trap handler's registry before it is unmapped. nil otherwise.
 var guardCloseHook func(reserveBase uintptr)
 
+// guardReleaseHook, set by the wago_guardpage build, offers a released guarded
+// reservation to the guard-page reuse cache (keeping its registry entry) instead
+// of unmapping it. It returns true when it took ownership; a false result means
+// the caller should fall back to Close. nil otherwise (guarded memory is only
+// created under the wago_guardpage build, so this is only nil in impossible
+// configurations, where Close is the correct fallback).
+var guardReleaseHook func(j *JobMemory) bool
+
 func (j *JobMemory) Close() error {
 	if j.reserveBase != 0 { // guard-page reservation
 		if guardCloseHook != nil {
@@ -206,14 +214,22 @@ func (j *JobMemory) Close() error {
 	return munmap(j.mem)
 }
 
-// ReleaseJobMemory returns small non-guarded memories to a bounded cache or
-// unmaps them. Guard-page reservations are never cached because their lifecycle
-// is registered with the signal handler.
+// ReleaseJobMemory returns a memory to a bounded reuse cache or unmaps it.
+// Guard-page reservations go through guardReleaseHook, which keeps the mapping
+// (and its signal-handler registry entry) warm for the next instantiate; classic
+// mappings use the small non-guarded cache. Anything the caches decline is
+// unmapped.
 func ReleaseJobMemory(j *JobMemory) error {
 	if j == nil {
 		return nil
 	}
-	if j.reserveBase != 0 || len(j.mem)-basedataSize > jobMemoryCacheMaxBytes {
+	if j.reserveBase != 0 {
+		if guardReleaseHook != nil && guardReleaseHook(j) {
+			return nil
+		}
+		return j.Close()
+	}
+	if len(j.mem)-basedataSize > jobMemoryCacheMaxBytes {
 		return j.Close()
 	}
 	jobMemoryCache.Lock()

--- a/src/core/runtime/guardmem_linux_amd64.go
+++ b/src/core/runtime/guardmem_linux_amd64.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"fmt"
+	"sync"
 	"syscall"
 	"unsafe"
 )
@@ -61,11 +62,22 @@ func NewJobMemoryGuarded(linBytes, maxBytes int) (*JobMemory, error) {
 		reserveBase: base,
 		reserveLen:  guardReserveBytes,
 	}
+	j.putGuardedSizeCaches(linBytes, maxBytes)
+	if err := registerGuardRegion(base, base+guardReserveBytes, base+uintptr(linOff)); err != nil {
+		_, _, _ = syscall.Syscall(syscall.SYS_MUNMAP, base, guardReserveBytes, 0)
+		return nil, err
+	}
+	return j, nil
+}
+
+// putGuardedSizeCaches writes the three basedata size caches native code reads:
+// the current byte size, the current wasm-page count, and the grow ceiling.
+// memory.grow raises the logical size (and thus the region the fault handler
+// commits on demand) up to maxBytes; cap at 65535 pages, since 65536 pages
+// (4 GiB) overflows the u32 byte-size cache.
+func (j *JobMemory) putGuardedSizeCaches(linBytes, maxBytes int) {
 	j.putU32(offActualLinMemByteSize, uint32(linBytes))
 	j.putU32(offLinMemWasmSize, uint32(linBytes/wasmPageBytes))
-	// Grow ceiling: memory.grow raises the logical size (and thus the region the
-	// fault handler will commit-on-demand) up to maxBytes. Cap at 65535 pages,
-	// since 65536 pages (4 GiB) overflows the u32 byte-size cache.
 	maxPages := maxBytes / wasmPageBytes
 	if maxPages > 65535 {
 		maxPages = 65535
@@ -74,9 +86,106 @@ func NewJobMemoryGuarded(linBytes, maxBytes int) (*JobMemory, error) {
 		maxPages = linBytes / wasmPageBytes
 	}
 	j.putU32(offMaxLinMemPages, uint32(maxPages))
-	if err := registerGuardRegion(base, base+guardReserveBytes, base+uintptr(linOff)); err != nil {
-		_, _, _ = syscall.Syscall(syscall.SYS_MUNMAP, base, guardReserveBytes, 0)
-		return nil, err
+}
+
+// jobMemoryGuardedCache parks at most one released guarded reservation, kept
+// mapped and still registered with the trap handler, so the next
+// AcquireJobMemoryGuarded skips the ~8 GiB reserve mmap + registry churn that
+// otherwise dominates guard-page instantiate. A reused reservation is fully
+// re-armed to PROT_NONE and zero-reclaimed first, so a fresh instance still sees
+// zeroed linear memory and out-of-range accesses still fault.
+var jobMemoryGuardedCache struct {
+	sync.Mutex
+	j *JobMemory
+}
+
+func init() { guardReleaseHook = releaseGuardedJobMemory }
+
+// AcquireJobMemoryGuarded returns a guard-page linear memory of the requested
+// size, reusing the cached reservation when one is parked. Every guarded
+// reservation shares the same fixed geometry (guardReserveBytes, linOff), so any
+// cached reservation can back any request — only the committed initial region and
+// the basedata size caches differ, which rearmGuarded installs.
+func AcquireJobMemoryGuarded(linBytes, maxBytes int) (*JobMemory, error) {
+	jobMemoryGuardedCache.Lock()
+	j := jobMemoryGuardedCache.j
+	jobMemoryGuardedCache.j = nil
+	jobMemoryGuardedCache.Unlock()
+	if j == nil {
+		return NewJobMemoryGuarded(linBytes, maxBytes)
+	}
+	if err := j.rearmGuarded(linBytes, maxBytes); err != nil {
+		// The reservation is unusable; drop it (unregister + unmap) and start clean.
+		_ = j.Close()
+		return NewJobMemoryGuarded(linBytes, maxBytes)
 	}
 	return j, nil
+}
+
+// releaseGuardedJobMemory decommits a finished guarded reservation to a clean,
+// fully-guarded, zeroed state and parks it in the one-slot cache. It returns
+// false — leaving ReleaseJobMemory to Close it — when the slot is taken or the
+// decommit fails, so at most one reservation is ever retained and the mapping is
+// never leaked on error. The reservation keeps its trap-handler registry entry
+// while parked; nothing accesses the idle range, so the handler never matches it.
+func releaseGuardedJobMemory(j *JobMemory) bool {
+	if j == nil || j.reserveBase == 0 {
+		return false
+	}
+	if err := j.decommitGuarded(); err != nil {
+		return false
+	}
+	jobMemoryGuardedCache.Lock()
+	if jobMemoryGuardedCache.j == nil {
+		jobMemoryGuardedCache.j = j
+		jobMemoryGuardedCache.Unlock()
+		return true
+	}
+	jobMemoryGuardedCache.Unlock()
+	return false
+}
+
+// decommitGuarded re-arms every page the instance could have committed — the
+// initial region plus any pages a memory.grow access faulted in, all within the
+// current logical size — back to PROT_NONE, then drops them with MADV_DONTNEED so
+// they zero-refill on next commit. This restores the same state a fresh
+// reserve+PROT_NONE mmap would have (basedata aside, reset in rearmGuarded), so a
+// reused reservation cannot leak a previous instance's memory and out-of-range
+// accesses fault again. Runs before the reservation is parked, off the cache lock.
+func (j *JobMemory) decommitGuarded() error {
+	used := uintptr(roundUpPage(j.curBytes()))
+	if used == 0 {
+		return nil
+	}
+	linBase := j.reserveBase + uintptr(j.linOff)
+	if _, _, errno := syscall.Syscall(syscall.SYS_MPROTECT, linBase, used, syscall.PROT_NONE); errno != 0 {
+		return errno
+	}
+	if _, _, errno := syscall.Syscall(syscall.SYS_MADVISE, linBase, used, syscall.MADV_DONTNEED); errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// rearmGuarded prepares a decommitted, parked reservation for a new instance:
+// commit [0,linBytes) of linear memory RW (zero-filled, since decommitGuarded
+// dropped it), re-slice the basedata+initial view, clear basedata to fresh-mmap
+// zero, and install the size caches. The reservation and its registry entry are
+// unchanged, so no re-registration is needed. Runs off the cache lock.
+func (j *JobMemory) rearmGuarded(linBytes, maxBytes int) error {
+	linBase := j.reserveBase + uintptr(j.linOff)
+	if linBytes > 0 {
+		if _, _, errno := syscall.Syscall(syscall.SYS_MPROTECT, linBase, uintptr(linBytes),
+			syscall.PROT_READ|syscall.PROT_WRITE); errno != 0 {
+			return errno
+		}
+	}
+	// j.mem's base pointer is the reservation base; re-slice through the existing
+	// *byte (not the reserveBase uintptr) so the length covers basedata + the newly
+	// committed initial region without a uintptr->Pointer round-trip.
+	j.mem = unsafe.Slice(&j.mem[0], j.linOff+linBytes)
+	j.linLen = linBytes
+	clear(j.mem[:j.linOff]) // basedata: match fresh-mmap zeroing
+	j.putGuardedSizeCaches(linBytes, maxBytes)
+	return nil
 }

--- a/src/core/runtime/guardmem_reuse_test.go
+++ b/src/core/runtime/guardmem_reuse_test.go
@@ -1,0 +1,98 @@
+//go:build linux && amd64 && wago_guardpage
+
+package runtime
+
+import (
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+// commitPage mprotects the page holding off (bytes into linear memory) RW,
+// mimicking the fault handler committing a page after a memory.grow. It does not
+// write, so a subsequent read observes whatever the kernel faults in.
+func commitPage(t *testing.T, j *JobMemory, off uintptr) {
+	t.Helper()
+	addr := j.reserveBase + uintptr(j.linOff) + off
+	page := addr &^ uintptr(pageSize-1)
+	if _, _, errno := syscall.Syscall(syscall.SYS_MPROTECT, page, uintptr(pageSize),
+		syscall.PROT_READ|syscall.PROT_WRITE); errno != 0 {
+		t.Fatalf("mprotect commit: %v", errno)
+	}
+}
+
+// pokeByte commits the page at off and writes v, dirtying a grown page.
+func pokeByte(t *testing.T, j *JobMemory, off uintptr, v byte) {
+	t.Helper()
+	commitPage(t, j, off)
+	*(*byte)(unsafe.Pointer(j.reserveBase + uintptr(j.linOff) + off)) = v
+}
+
+func peekByte(j *JobMemory, off uintptr) byte {
+	return *(*byte)(unsafe.Pointer(j.reserveBase + uintptr(j.linOff) + off))
+}
+
+// TestGuardedJobMemoryReuse verifies the one-slot guard-page reuse cache: a
+// released reservation is handed back by the next Acquire (same base, proving no
+// re-mmap), and every page the previous instance dirtied — the initial region and
+// a grown page beyond it — reads back zero, so instances cannot leak memory
+// through a reused reservation.
+func TestGuardedJobMemoryReuse(t *testing.T) {
+	if err := InstallGuardTrapHandler(); err != nil {
+		t.Fatal(err)
+	}
+	const page = wasmPageBytes
+
+	j1, err := AcquireJobMemoryGuarded(page, 4*page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := j1.reserveBase
+	if base == 0 {
+		t.Fatal("guarded memory has no reservation base")
+	}
+	// Dirty the whole initial page.
+	lin := j1.LinearMemory()
+	for i := range lin {
+		lin[i] = 0xAB
+	}
+	// Simulate a memory.grow to 3 pages and dirty a byte in the third page, as a
+	// faulting store would after growing the logical size.
+	j1.putU32(offActualLinMemByteSize, uint32(3*page))
+	pokeByte(t, j1, 2*page+123, 0xCD)
+
+	// Release -> parked in the cache (decommitted + re-armed + zero-reclaimed).
+	if err := ReleaseJobMemory(j1); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	// Reacquire with a different initial/max: must reuse the SAME reservation.
+	j2, err := AcquireJobMemoryGuarded(2*page, 8*page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j2.reserveBase != base {
+		t.Fatalf("reservation not reused: base %#x != %#x", j2.reserveBase, base)
+	}
+	// Size caches reflect the new instance, not the old one.
+	if got := j2.curBytes(); got != 2*page {
+		t.Fatalf("reused curBytes = %d, want %d", got, 2*page)
+	}
+	// The new initial region (2 pages) must be zero — no 0xAB leak.
+	lin2 := j2.LinearMemory()
+	for i, b := range lin2 {
+		if b != 0 {
+			t.Fatalf("reused initial memory byte %d = %#x, want 0", i, b)
+		}
+	}
+	// The page the previous instance grew into and dirtied must read back zero
+	// once recommitted (MADV_DONTNEED dropped it on release; mprotect alone would
+	// keep the old 0xCD physical page and leak it).
+	commitPage(t, j2, 2*page+123)
+	if got := peekByte(j2, 2*page+123); got != 0 {
+		t.Fatalf("recommitted grown page byte = %#x, want 0 (leak from previous instance)", got)
+	}
+	if err := j2.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}

--- a/src/wago/guardrun_guardpage.go
+++ b/src/wago/guardrun_guardpage.go
@@ -10,7 +10,7 @@ func newGuardedJobMemory(linBytes, maxBytes int) (*wruntime.JobMemory, error) {
 	if err := wruntime.InstallGuardTrapHandler(); err != nil {
 		return nil, err
 	}
-	return wruntime.NewJobMemoryGuarded(linBytes, maxBytes)
+	return wruntime.AcquireJobMemoryGuarded(linBytes, maxBytes)
 }
 
 func callNative(c *Compiled, eng *wruntime.Engine, jm *wruntime.JobMemory, entry uintptr, serArgs, trap, results []byte) error {


### PR DESCRIPTION
## What changed

PR #105 added bounded one-slot reuse for engine stacks, arenas, and classic `JobMemory`, giving a large `Instantiate` speedup — but **only under explicit bounds**. Guard-page (signals-based) memory went through `newGuardedJobMemory` → `NewJobMemoryGuarded`, which mmaps a fresh ~8 GiB reservation every time and unmaps it on `Close`, so the win never reached the production-relevant `wago_guardpage` mode (what `make bench` and the website measure).

This extends the reuse to guarded reservations:

- `AcquireJobMemoryGuarded` / `releaseGuardedJobMemory` (`guardmem_linux_amd64.go`): a one-slot cache parking a released guarded reservation, kept mapped **and** still registered with the trap handler, so acquire skips the reserve mmap + registry churn. All guarded reservations share the same fixed geometry, so any cached one can back any request.
- Reset is security-preserving: on release, `decommitGuarded` re-arms every page the instance could have committed (initial + grown) to `PROT_NONE` and drops them with `MADV_DONTNEED`; on acquire, `rearmGuarded` commits `[0,initial)` RW (zero-filled), clears basedata, and installs the size caches. A reused reservation therefore cannot leak a previous instance's memory, and out-of-range accesses still fault.
- `ReleaseJobMemory` routes guarded memory through a new `guardReleaseHook` (mirrors `guardCloseHook`); classic path unchanged.
- Factored the basedata size-cache writes into `putGuardedSizeCaches`, shared by new + reused reservations.

## Measurements (guard-page `BenchmarkInstantiate`, count=4)

| module | before | after | speedup |
| --- | ---: | ---: | ---: |
| `tiny` | 12238 ns | 3419 ns | 3.6× |
| `fib_rec` | 12160 ns | 3396 ns | 3.6× |
| `many_funcs` | 12800 ns | 3837 ns | 3.3× |
| `blake-as` | 14223 ns | 6191 ns | 2.3× |
| `json-as` | 18700 ns | 10914 ns | 1.7× |
| `utf-as` | 21722 ns | 14087 ns | 1.5× |

The residual gap vs explicit mode (~0.73 µs) is the three guard re-arm syscalls (`mprotect` ×2 + `madvise`), inherent to safely resetting guard pages; a no-grow fast path that zeroes with `clear()` instead of syscalls is possible follow-up.

## Validation

- `go test -tags wago_guardpage ./src/core/runtime/` — incl. new `TestGuardedJobMemoryReuse` (reuse identity + initial & grown-page zeroing). Mutation-checked: disabling `MADV_DONTNEED` makes the test fail on a leak.
- `make spec1/2/3` (guard-page x64 oracle): 1.0 = 16026 assertions pass (memory_grow/memory_trap/store/load), 2.0/3.0 pass.
- `cd bench && WAGO_BOUNDS=signals go test -tags wago_guardpage -run 'TestCorpusDifferential|TestJsonAsGuardCorrect' .`
- `go test ./...` (default/explicit build) — classic reuse path unaffected.