### PR TITLE
chore: ignore dirty content in warp submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,7 @@
 	path = warp
 	url = https://github.com/wasm-ecosystem/wasm-compiler
 	branch = develop
+	ignore = dirty
 [submodule "tests/spec"]
 	path = tests/spec
 	url = https://github.com/WebAssembly/testsuite


### PR DESCRIPTION
`warp/` is a reference submodule (upstream `wasm-ecosystem/wasm-compiler`) that accumulates local build output (`build-bench/`) and local bench instrumentation (`bench/main.cpp`), so `git status` was permanently noisy.

Set `ignore = dirty` so working-tree changes in the submodule are silenced, while still reporting if the pinned commit ever changes.