### PR TITLE
warp: point submodule at wago-org fork (wago branch)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "warp"]
 	path = warp
-	url = https://github.com/wasm-ecosystem/wasm-compiler
-	branch = develop
+	url = https://github.com/wago-org/warp
+	branch = wago
 [submodule "tests/spec"]
 	path = tests/spec
 	url = https://github.com/WebAssembly/testsuite


### PR DESCRIPTION
Repoints the `warp` submodule from upstream `wasm-ecosystem/wasm-compiler` to our fork **wago-org/warp**, tracking a dedicated **`wago`** branch.

Why: we carry local WARP bench instrumentation (`bench/main.cpp`) for wago comparison that can't be pushed upstream, so the submodule was permanently dirty. It now lives as a real commit on the fork.

- Baseline **unchanged**: `wago` = pinned `b928711` + the instrumentation commit. The fork's `develop` stays a clean upstream mirror; upstream's post-b928711 codegen commits (incl. the #808 i32.div fix) are intentionally *not* pulled in, so bench comparisons stay apples-to-apples.
- Submodule pointer: `b928711 → e0836b9`.
- Fetch over HTTPS (anon-cloneable, verified), push over SSH via the fork remote.
- `build-bench/` build output stays ignored locally (submodule info/exclude).

Supersedes #109 (the `ignore = dirty` workaround is no longer needed now that the instrumentation is committed to the fork).