### PR TITLE
docs: no-IR decision + optimization plan from external review triage

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -8,15 +8,16 @@ destroying the reason it exists* (fast compile, no cgo, tiny footprint, single p
 2. **Port what's still worth porting from WARP** (`warp/`) — the C++ reference engine the
    backend is a port of. Used as a *reference axis*, not a target to clone.
 
-The headline architectural decision (see the end): **keep two tiers and do not blend them.**
-The single-pass tier stays single-pass; the `src/core/compiler/ir` SSA package becomes an
-*optional* optimizing tier later, never something a plain `Compile` pays for.
+The headline architectural decision (see the end, **revised 2026-07-03**): **no IR on any
+execution path.** Railshot is the one and only backend; the `src/core/compiler/ir` SSA
+package stays as an off-path research/debug tool, not a planned tier. The ceiling SSA was
+reserved for is attacked incrementally instead — see `docs/no-ir-plan.md`.
 
 Legend: effort S/M/L · value ⬜ low · 🟦 medium · 🟩 high · ⭐ very high.
 
 ---
 
-## What's in place (updated 2026-07-02)
+## What's in place (updated 2026-07-03)
 
 The backend (`src/core/compiler/backend/railshot`) is the full WARP-architecture port: a
 single-pass x86-64 codegen over a valent-block operand stack (deferred-action trees,
@@ -72,6 +73,21 @@ truncation + trunc_sat, start function, multi-value, imported/mutable globals.
 **Compile speed**: decoded modules keep byte-backed function bodies. The optional
 `scanBody` instruction walk is used only for programmatically constructed modules that
 provide decoded instructions; normal decoded modules use BodyBytes and first-N pinning.
+Validation is byte-backed and no-body too (#96: type-cache + validator/reader reuse,
+validation allocs −90%).
+
+**Landed since the #87/#88 sweep (2026-07-02 → 07-03)**
+- **Borrowed reads for value-pinned globals** (`stGlobReg`, #93) and
+  **immediate-only constant stores** (`StoreImmIdx`, #94).
+- **Float parity batch** (#97): `minss/maxss`-based min/max with NaN fixup + deferred
+  float loads (VEX 3-op float ops were #79).
+- **Forward `rep movsb` for disjoint `memory.copy`** (#99) — the json serialize fix; the
+  backward-copy path gets no ERMSB/FSRM and was ~89% of serializer samples.
+- **Adaptive per-module global-pin K (1–3)** (#100) and **`x*{3,5,9}` → LEA** (#101).
+- **Instantiate reuse** (#105 explicit, #108 guard: 12→3.4µs) and faster validation (#96).
+- **Full wasm 1.0 MVP: 57/57 spec files, 0 failing assertions** (#111–#115: spectest host
+  module, cross-instance function/global/table/memory linking, host functions as table
+  funcrefs).
 
 ### Measured (2026-07-02, explicit bounds, vs the pre-sweep #87 baseline)
 
@@ -101,140 +117,119 @@ memory.copy/fill instead of `rep movsb` (whose startup latency dominated the
 string-append copies AssemblyScript's `__renew` makes constantly). wago-guard
 deser is now within 1.13× of WARP.
 
+**Update (post #97/#99/#100/#101, guard mode):** json ser **93ns / deser 175ns**
+per unit — **serialize now beats WARP (97)**; deser is 1.07× WARP (164). wago
+beats wazero (147/305) on both json directions. The serialize chase is closed;
+see R4.
+
 ---
 
 ## Remaining roadmap (priority-ordered)
 
-### R1. `vFlags` — compare fusion past adjacency  · M · 🟦 (old P8)
-Fusion only fires when the branch immediately follows the compare. Misses
-`cmp; local.tee $c; br_if` and `eqz; local.set/get; if`. Add a flags-resident stack
-entry carrying its `Cond`, materialized the instant any flag-clobbering op appears.
-Start pattern-constrained; don't birth a second compiler.
+The detailed, phase-by-phase execution plan for everything below is
+**`docs/no-ir-plan.md`** (2026-07-03, incorporating an external repo review that was
+triaged against the tree). R-numbers here are stable labels; Pn are that plan's phases.
 
-### R2. Float lowering parity  · M · 🟦
-ISA suite lags: floats ~1.65× (no in-place XMM accumulation — the int path has it),
-min/max 2.2× (branchy lowering; use `minss/maxss` + NaN fixup), and float pinned locals
-use the eager call model. Mechanical, well-scoped.
+### R0. `CodegenStats` + explain mode  · S/M · 🟩 (promoted from R6 — do first)
+Per-function counters (spills/flushes/condensed vs folded deferred loads/bounds
+checks/calls by kind/pins/peephole hits) behind a `CompileConfig` option +
+`WAGO_EXPLAIN`, an explain dump, golden disassembly tests per optimization, and the
+`WAGO_DEBUG_MODGLOBALS` / `WAGO_PIN_GLOBAL_K` knobs. Every subsequent optimization must
+land with its counter moving and a golden test. (Plan P1.)
+
+### R1. `stFlags` — compare fusion past adjacency  · M · 🟩 (old P8)
+Fusion only fires when the branch immediately follows the compare. Misses
+`cmp; local.tee $c; br_if` and `eqz; local.set/get; if`. One-deep deferred-set window
+first, then a flags-resident storage kind (`{stFlags, cond}`, single owner, demoted
+before any flag-clobbering emission), consumers: br_if/if, select-from-flags, store8,
+eqz chains, `and(x,c); eqz → TEST`, float compares (ucomis* + parity fixup). Value
+raised from 🟦: it's the main remaining single-pass codegen unlock. (Plan P3.)
+
+### R2. Float lowering parity — remaining half  · M · 🟦
+~~min/max branchy lowering~~ (done #97, with deferred float loads; VEX 3-op #79).
+Still open: in-place XMM accumulation (int path has it), float pinned locals still on
+the eager call-spill model, float `call; local.set` fusion (int-only today), mixed-call
+parallel staging (`emitMixedRegisterCall` still does full `flush()` + slot staging).
+(Plan P5.1–.2.)
 
 ### R3. Store-narrowing peephole  · S · ⬜
-`setcc; movzx; store8` keeps a dead `movzx` (sieve's inner loop). A deferred-compare
-consumer that stores 8 bits can skip the widening. Cheap, narrow.
+`setcc; movzx; store8` keeps a dead `movzx` (sieve's inner loop). Ships standalone if
+trivial, otherwise falls out of `stFlags` for free — don't build scaffolding twice.
+(Plan P2.5/P3.)
 
-### R4. json serialize gap (deserialize is solved)  · M–L · 🟩
-Deserialize now beats wazero and sits 1.13× from WARP. Serialize remains ~2× from
-WARP: 52% of it is one function (the serializer core, local fn 26 / wat 27)
-writing JSON text through global bump pointers in `global.get; i64.store;
-global.set` bursts punctuated by ensure-capacity calls. **Correction to earlier
-text in this section:** `pickModuleGlobals`'s aggregate score for the json-as
-bench module is **global 2 (score 4603) — the serializer's own output
-write-pointer** — not "the AS shadow-stack pointer" as PR #90's description
-assumed; that guess was never verified against this module's actual global
-indices. Global 4 (score 1350, the capacity watermark) is the *second*-highest
-candidate; a third candidate (global 25, score 737, identity unconfirmed — see
-below) is a distant third. Verified with a temporary
-`WAGO_DEBUG_MODGLOBALS=1` print in `pickModuleGlobals` (not shipped).
+### R4. json serialize gap — ✅ RESOLVED (2026-07-02)
+Closed by #99 + #100: guard-mode ser 190→**93ns (beats WARP's 97)**; deser 175ns
+(1.07× WARP). The forensic trail (B1 `stGlobReg` #93, B2 immediate stores #94, the B3
+WARP wat-27 burst diff, the K-sweep) is preserved in PR #95's findings doc and
+`docs/valent-blocks-expansion-plan.md` §0–§2. The punchline for posterity: the
+bottleneck was never call overhead or global register residency — **~89% of serializer
+samples were one backward `std; rep movsb`** in `memory.copy` (no ERMSB/FSRM on
+backward copies) on copies that were disjoint and forward-safe. B1+B2 remain as real
+codegen improvements (wago's burst emits fewer instructions than WARP's), and the
+V0 measurement discipline that found this is now doctrine: profile before chasing a
+hypothesis (memory `wago-serialize-memcopy-win`; ≤0x18 perf bins). Serialize is now
+flat/GC-bound; no further wago-side lever identified.
 
-**B1 landed (borrowed reads for value-pinned globals, `stGlobReg`):** `global.get`
-on a value-pinned global used to copy the register out (`materialize`'s ~30
-consumer sites all forced a copy); it now pushes a borrowed reference like a
-pinned local (`stLocalReg`), realized on `global.set`/flush/call-arg staging.
-
-**B2 landed (immediate-only constant stores):** `i64.const; i64.store` used to
-materialize a 10-byte movabs into a register before storing; `memStore` now peeks
-the value for `stConst` and emits `mov r/m, imm` directly (two 4-byte immediate
-stores for i64, matching width for i32/i16/i8), via a new encoder op
-`StoreImmIdx`.
-
-**B3 (WARP wat-27 diff):** Regenerated `/tmp/warp-json.bin` and disassembled both
-sides for the identical burst (`{"authenticated":` — the same struct field name
-appears in both benches' schema, confirmed by decoding the movabs immediates as
-UTF-16LE). The comparison **reverses the original hypothesis**:
-
-- **WARP does not keep the write-pointer in a register across the burst at all.**
-  It reloads it from a *fixed basedata offset* (`mov r10d,[rbx-0xf0]`) before
-  **every single 8-byte store**, and writes it back once at the end — no
-  cell-pointer indirection (globals live directly in basedata, one load, no
-  array-of-pointers), but no register residency either. Per store: reload (7B) +
-  movabs (10B) + store (4–5B) ≈ 3 instructions, ~21 bytes.
-- **wago (current, K=1, post B1+B2) keeps the write-pointer live in R14 for the
-  *entire* burst** — zero reloads between stores, bumped once at the end
-  (`add r14d,0x22`) — and B2 means zero movabs. Per store: one 7-byte immediate
-  store, period. For this exact burst wago now emits **fewer instructions and
-  less code than WARP**, with fewer memory accesses.
-- Confirmed by re-running the K-sweep with `WAGO_DEBUG_MODGLOBALS`: **K=2
-  {R14,R13} already pins BOTH burst globals** (2 and 4 are the top two
-  candidates by score) — this corrects the earlier claim that K=2 "only fits one
-  of {2,4}". Redisassembling fn26 at K=2 confirms global 4's capacity-watermark
-  bump goes fully register-resident too (`add r13d,0xaa`, no memory access) —
-  the codegen change is real. **But json-as ser/deser measured flat at K=2
-  anyway** (~193–200ns, indistinguishable from K=1, noisy). K=3's ~6–8%
-  improvement therefore is NOT explained by "both burst globals finally pinned
-  together" (they already are, at K=2) — it must come from module-pinning the
-  *third* candidate (global 25, score 737), whose identity and mechanism of
-  effect are **not yet confirmed** (possibly it helps a different hot function
-  entirely, since module-pinning benefits every function touching that global,
-  not just fn26 — fn26's own burst codegen doesn't visibly change between K=2
-  and K=3 in the region inspected).
-- **fn26 is still 52% of the serialize profile** (`perf record`/`report`,
-  unchanged from the original figure) despite the burst codegen now beating
-  WARP's instruction-for-instruction. This means **register residency of the
-  burst globals is not the remaining bottleneck** — B1+B2+the K-sweep have
-  exhausted what this angle can give. fn26 makes ~9–10 calls per invocation
-  (ensure-capacity checks + nested field writers); call/return overhead and
-  per-call setup are the next suspect, not yet measured or diffed against
-  WARP's equivalent call sites (attempted but the WARP blob's `call`-target
-  region didn't disassemble cleanly as a standalone slice — linear disassembly
-  desynced past a jump table or embedded constant; needs re-attempting with
-  proper function-boundary recovery, not a raw linear objdump).
-
-**Net:** ser/deser measured flat at the shipped K=1 default (both B1 and B2 are
-real, verified codegen improvements that don't move wall-clock time on this
-Zen4 machine — plausibly because register-vs-memory arithmetic for a few
-extra loads per burst is already hidden by out-of-order execution and
-store-to-load forwarding). K=3 gives a real ~6–8% win via a not-yet-understood
-third global, at a real ~7% cost to blake (already behind wazero there) —
-shipped K=1 (see the K-sweep judgment call, still valid). Next session should
-profile the *call* overhead in fn26, not further chase global register
-residency.
-
-### R5. Runtime / infra from WARP
+### R5. Runtime / infra from WARP (plan P8)
 | Item | Effort | Value | Notes |
 |---|:--:|:--:|---|
-| Interruption / cooperative cancel | S–M | 🟩 | `checkForInterruptionRequest`; kills runaway loops |
-| Wasm-level stack trace on trap | M | 🟩 | frame-ref chain |
+| Sync host calls w/ return values (V2 imports) | L | ⭐ | runtime half spiked; biggest functional unlock (WASI). #111/#115 added typed params + host funcrefs; **results** still missing |
+| WASI preview 1 (minimal) | M | 🟩 | after sync imports |
+| Interruption / cooperative cancel | S–M | 🟩 | loop backedges + entries; same machinery as Go-GC safe points |
+| Wasm-level stack trace on trap | M | 🟩 | trap site → func idx → wasm pc |
 | Debug mode + bytecode→machine map | M | 🟦 | |
 | arm64 backend | L | 🟩¹ | WARP `backend/aarch64` as reference |
-| Sync host calls w/ return values (V2 imports) | L | ⭐ | runtime half spiked; biggest functional unlock (WASI) |
 
 ¹ if Apple Silicon / arm64 Linux matters.
 
-### R6. Measurement hardening  · S · 🟦 (old P0, still worth doing)
-`CodegenStats` (spills/flushes/bounds-checks/code-bytes per function) + golden
-disassembly tests per optimization. The sweep found layout-luck swings of ±20% on tight
-loops — per-function code-byte tracking would catch silent bloat, and golden disasm
-would catch silently-disabled peepholes.
+### R6. Measurement hardening → **promoted to R0**, see above.
+
+### R7. Adopted from the 2026-07-03 external review (new items; plan §2)
+Codegen, cheap-and-safe first: **alias-aware pending loads** (any store currently
+flushes ALL deferred loads — keep same-base provably-disjoint ones, plan P2.1) ·
+**pure-tree `drop` discard** (P2.2) · **const-fold pack** — compares/eqz/clz/ctz/
+popcnt/extensions + narrow-load mask elision (P2.3) · **same-operand int compare
+identities** (P2.4). Then: **limited multi-result register ABI** (RAX,RDX / XMM0,XMM1 —
+unblocks multi-value, with `regMerge2`, P5.3) · **straight-line bounds facts** +
+**hybrid loop precheck** (explicit mode; the TinyGo story, P6.1–.2) · **store
+combining** (explicit-only, cold-path sequential replay for trap semantics, P6.3) ·
+**CPUID probe** (JIT'd stub, zero deps) gating **BMI2 shifts** + `smallBulkMax`
+tuning (P6.5) · **immutable-global const folding** incl. link-time specialization of
+imported ones (fits the existing link-time recompile) · **`call_indirect` inline
+caches** behind a table epoch (P8.6) · **`.wago` cache keys + CLI**
+(compile/run/inspect, P8.7) · **call-surviving valent trees** and a **tiny bytecode
+inliner** (both decision-gated on R0 counters, P5.4–.5) · **fused validate+compile**
+(premise re-measured post-#96, P7). Rejected (with reasons — plan §1.3): `stAddrExpr`,
+known-bits lattice, general pending sets with owned regs, tiny unroll, SIMD copy/fill
+now, `memory.size` micro-opt.
 
 ### Greenfield (not in WARP either)
 SIMD/v128, threads & atomics, exception handling, tail calls, full reference types +
 `table.*`, remaining bulk-memory (`memory.init`/`data.drop`), passive segments,
-memory64, multi-memory, imported memory/table (the `linking`/`data` spec files).
+memory64, multi-memory. (Cross-instance linking + imported memory/table/global landed
+in #112–#115; the `linking`/`data` spec files now pass.)
 
 ---
 
-## The one architecture choice
+## The one architecture choice (revised 2026-07-03)
 
-Keep **two tiers, unblended**:
+**No IR on any execution path — railshot is the only backend.** The earlier "Tier 2
+optional SSA" framing is retired; the E-gate SSA-spike question in the perf plans is
+answered: no.
 
-- **Tier 1 — single-pass baseline JIT** (railshot): `validated wasm → scanBody pre-scan →
-  single-pass codegen`. Goals: very fast compile, good-enough code, tiny footprint,
-  predictable. Everything above lives here. This tier is now broadly at or beyond
-  WARP-parity per construct; its remaining structural ceiling is register allocation
-  across basic blocks, which is exactly what Tier 2 is for.
-- **Tier 2 — optional SSA optimizing tier**: the `src/core/compiler/ir` scalar SSA
-  package exists but no runtime path imports it. Use it only for hot modules / AOT
-  `.wago` / an explicit `Optimize` option — never on the default `Compile` path. The
-  grounded case for it: wazero's remaining edge on json-as is its SSA register
-  allocator, not its (minimal) optimization passes.
+- **The pipeline is the identity**: `decode → validate (byte-backed) → scanBody hints
+  (summary facts only) → railshot single-pass codegen → native`. Fast validated bytes →
+  direct native code; no AST, no SSA, no whole-function IR on the hot path.
+- **The ceiling gets attacked incrementally** ("Tier 1.5"): flags-resident values,
+  restricted pending sets, call-surviving trees, alias-aware load windows, bounds
+  facts — each a small extension of the valent-block storage model, each individually
+  gated and measured (`docs/no-ir-plan.md`). The original case for SSA (wazero's json
+  edge = its register allocator) has weakened: wago now beats wazero on both json
+  directions and most of the corpus without it.
+- **`src/core/compiler/ir` stays off-path** as a research/debug package (potential
+  differential oracle); it is not a planned tier, not deleted, and not grown.
+- **Guardrail**: `scanBody` stays summary-only (scores, shape flags). If it starts
+  storing instruction graphs, it has become IR in a trench coat — reject in review.
 
-wago's identity is **low-latency compile**. The single-pass tier is now informed,
-flush-light, and register-resident; SSA is the expensive opt-in tier, later.
+wago's identity is **low-latency compile**: the single-pass tier is informed,
+flush-light, and register-resident, and it stays single-pass.

--- a/docs/no-ir-plan.md
+++ b/docs/no-ir-plan.md
@@ -1,0 +1,307 @@
+# No-IR plan — railshot optimization & product roadmap (2026-07-03)
+
+Triage of an external repo review (LLM with GitHub read access; code/doc
+inspection only — no local build or bench run) against actual repo state,
+turned into an implementation plan. The review independently converged on the
+same strategy as `docs/valent-blocks-expansion-plan.md` — *shrink the hard
+sinks, measurement first* — and contributed a number of genuinely new items
+(bounds facts, inline caches, CPUID gating, multi-result ABI, product/CLI
+work). This doc schedules both.
+
+How to read: `docs/perf-plan-2026-07.md` §1 (measurement protocol) and
+`docs/valent-blocks-expansion-plan.md` (the V-phase designs) still apply and
+are referenced as "VB §n" below. This doc **supersedes both docs' ordering**
+(and the SSA/E-gate decision framing) but not their designs or pitfalls.
+
+## 0. The architecture decision: no IR on the execution path
+
+Decided 2026-07-03: **wago builds no SSA and no whole-function IR on any
+execution path. Railshot is the one and only backend.** The prior framing
+(OPTIMIZATIONS.md "two tiers, SSA optional later"; the E-gate SSA spike in
+`perf-plan-2026-07.md` §0 / VB §0.3) is retired. Consequences:
+
+- `src/core/compiler/ir` stays in-tree as an **off-path research/debug
+  package** (future differential oracle, dominance-checked shape tests). It is
+  not a planned execution tier; no runtime path imports it (verified — no
+  non-test imports outside the package). Don't delete it; don't grow it.
+- The structural ceiling the SSA tier was reserved for (cross-block register
+  allocation) is attacked incrementally instead: flags-resident values,
+  pending sets, call-surviving trees, bounds facts — "Tier 1.5", VB's framing.
+- The public identity line: *wago compiles validated Wasm bytes directly to
+  native code — no AST, no SSA, no IR pilgrimage — using valent-block deferred
+  expression trees and a single-pass whole-register-file allocator.*
+- `scanBody`/`scanBodyBytes` (`hints.go`) stays **summary-only** (hotness
+  scores, feature/shape flags, small-function classification). The moment it
+  stores instruction graphs it has become IR in a trench coat. Guard this in
+  review.
+
+## 1. Review triage — verified against the tree (2026-07-03, post-#115)
+
+### 1.1 Correct and open (adopted — scheduled in §2)
+
+| Claim | Evidence |
+|---|---|
+| `materializePendingLoads` is alias-blind: any store/copy/fill forces ALL deferred loads | `regalloc.go:227` takes no args; call sites `memory.go` (memStore + 3 more) |
+| `drop` condenses a deferred tree just to discard it | `driver.go:63` handles concrete kinds only; `popValue` (`driver.go:583`) condenses first |
+| No flags-resident compare results (`stFlags`); fusion is adjacency-only | only `condenseToFlags` (`fuse.go:71`) used by fused `br_if`/`if` |
+| `setcc; movzx; store8` keeps a dead `movzx` | OPTIMIZATIONS R3, unchanged |
+| Mixed (float-carrying) reg-ABI calls do full `flush()` + canonical-slot staging | `call.go:419` (`emitMixedRegisterCall`), comment says so explicitly |
+| `call; local.set` result fusion is int-only | `call.go:111` |
+| Float pinned locals still use the eager spill-all call model; no in-place XMM accumulation | OPTIMIZATIONS R2; `fp.go` has no in-place path |
+| Reg ABI is single-result only | `sigFitsRegABI` rejects `len(Results) > 1` (`call.go:69`) |
+| No CPUID/feature probe anywhere; `smallBulkMax` fixed at 96 | grep; `memory.go:43` |
+| No BMI2 shifts (RCX round-trip on variable shifts) | grep; VB §9.4 |
+| Immutable numeric globals are not const-folded at `global.get` | `globals.go:56`; `Mutable` only consulted for pin selection (`compile.go:352`) |
+| Block/if merges >1 result go through slots (`regMerge1` is single-result) | `control.go:296` |
+| Sync host-import **results** still missing — the biggest functional unlock (WASI) | FEATURES: host imports are void-result batched-replay; #111/#115 added typed params, funcref use, not results |
+| Only ~8 `WAGO_*` env flags; no per-optimization A/B switches or explain output | grep `os.Getenv("WAGO` |
+| ROADMAP.md badly stale (lists float traps, memory.grow, reg-ABI calls as "next" — all long done) | ROADMAP "Next"/"Engine & performance" sections |
+
+### 1.2 Stale in the review (already done/changed — do NOT redo)
+
+| Review said | Reality |
+|---|---|
+| Float min/max branchy (2.2×) | **Done #97** (min/max parity + deferred float loads; VEX 3-op in #79) |
+| json serialize ~2× WARP, chase call overhead | **Resolved #99/#100**: backward `rep movsb` was the bottleneck; guard ser **93ns beats WARP 97**; deser 175 vs WARP 164. Serialize chase is CLOSED (V0/V1 premise refuted, VB §1–2) |
+| Validation builds a 424 B/instr AST; fused validation kills the compile bottleneck | **#96 landed**: validation is byte-backed, no-body, validator/reader reuse, allocs −90%. V7's premise must be re-measured before any fused-validation work (§2 P7) |
+| `hints.go` walks the AST | Byte scanner `scanBodyBytes` (`hints.go:115`) for decoded modules; AST walk only for programmatically-built modules |
+| Spec gate = 16500 pass / 13 fail, `linking` FAIL / `data` BLOCKED | **57/57 files, pass=16592 fail=0 skip=1591** since #111–#115 (SPECTEST.md). Gate expectations updated in §4 |
+| "adaptive threshold" global pinning could use a K override + debug print | Adaptive K **landed #100**; the K override + `WAGO_DEBUG_MODGLOBALS` print are adopted into P1 |
+
+### 1.3 Rejected / deferred (with reasons)
+
+- **SSA/IR execution tier** — decided against, §0.
+- **`stAddrExpr` storage kind** — mini-IR risk the review itself flags; squeeze
+  `memAddr`/`stMemRef` + bounds facts (P6) first. Revisit only with disasm
+  evidence of repeated re-computed addresses that P6 can't catch.
+- **General pending `local.set` with owned registers** (VB §5 options a/b) —
+  allocator-invisible trees; only the register-free restriction (c) is
+  scheduled (P4). Revisit a/b only if (c) measures well but misses cases.
+- **known-bits lattice struct** — rejected as a struct; its two profitable
+  cases ship as plain peepholes: narrow-load mask elision (P2) and boolean-ness
+  (subsumed by `stFlags`, P3).
+- **Tiny unroll (const trip ≤4)** — layout-luck risk (±20% swings) exceeds the
+  expected win; not now.
+- **Induction/accumulator pattern recognition + extra hint scoring terms** —
+  defer until a bench demands it; pinning already covers the measured hot cases.
+  Exception: the *loop-header facts* byte-scan record is adopted (P6.2 needs it).
+- **SIMD `memory.copy`/`fill`** — after SIMD exists at all.
+- **Store queue beyond a one-entry combining window** — no; V6 is already the
+  delicate edge of what trap semantics allow.
+- **`memory.size` micro-optimization** — skip until it shows up in a profile.
+- **Deleting `warp/` or `ir/`** — no. Reference axis + future oracle.
+
+## 2. Phase plan
+
+Every phase: own branch (`perf/<topic>` or `feat/<topic>`) off `main`, own PR,
+gate battery (§4), merges need an explicit user yes. Phases are ordered by
+(leverage ÷ risk); P8 is a parallel product track, not last in urgency.
+
+### P0. Housekeeping (S) — this PR + one follow-up
+1. This doc + OPTIMIZATIONS.md rewrite (no-IR decision, post-sweep state).
+2. **ROADMAP.md refresh** (separate PR): delete the done-items-as-planned rot
+   ("Numeric completeness" block, memory.grow, reg-ABI calls, locals-in-regs);
+   align with FEATURES.md + this plan.
+
+### P1. CodegenStats + explain mode (S/M) — *do first; everything after must prove itself*
+Was OPTIMIZATIONS R6; the review is right that it comes first.
+- `CodegenStats` per function, collected only when requested (nil when off —
+  zero hot-path cost): code/frame bytes, max spill slots, flushes /
+  `flushBelow`s, condenses, deferred loads folded vs forced, bounds checks
+  emitted (elided later, P6), trap stubs, calls by kind
+  (reg-ABI/mixed/wrapper/indirect/host), pins (locals, value-pinned globals,
+  module-pinned K + which regs), spills/reloads, peephole hits by name
+  (`map[string]int` is fine off the hot path).
+- Surfacing: `CompileConfig` option + `WAGO_EXPLAIN=1` env; a
+  `bench/cmd/explain` (or test helper) that dumps the per-function report like
+  the review's mock. Ship `WAGO_DEBUG_MODGLOBALS=1` (the #90-era temp print)
+  and `WAGO_PIN_GLOBAL_K=auto|0..3` override here.
+- Golden disassembly tests: extend the existing objdump-based codegen tests
+  into per-optimization goldens — cmp→branch fusion, immediate stores, LEA
+  mul/scaled-index, `call; local.set`, reg-ABI `call_indirect`, forward
+  `memory.copy`, guard-vs-explicit shapes. Every later phase adds its golden
+  here as its regression net.
+- Optional: formalize `WAGO_PERFMAP=1` (the jsonprof memfd offset protocol,
+  `perf-plan-2026-07.md` §1) as a first-class runtime flag.
+
+Exit: explain dump on json-as and blake matches the known facts (K pins, B2
+immediate stores, forward-copy path) — i.e. the counters are trustworthy.
+
+### P2. Cheap railshot wins, one batch PR (S each)
+1. **Alias-aware pending loads** (VB §6, unchanged design):
+   `materializePendingLoadsBeforeStore(base Reg, disp int32, size int)` — keep
+   a deferred load iff same base register and provably disjoint
+   `[disp,disp+size)`. Different base regs → conservative flush. Stores pass
+   the window; `memory.copy`/`fill`/`grow` keep flush-all.
+2. **`drop` of side-effect-free trees** (VB §9.2): recursive
+   `discardTreeIfPure` — pure ALU/compare/const/local/slot trees release with
+   no emission; div/rem (trap), float→int trunc (trap), and guard-mode loads
+   (the load IS the trap) still condense. Wire into `popValue`'s drop path.
+3. **Const-fold pack** (`stack.go` fold table): compares, eqz, clz/ctz/popcnt,
+   sign/zero extensions, wrap/extend, reinterpret-of-const; div/rem only when
+   divisor is a nonzero const and the `INT_MIN / −1` case is excluded.
+   Plus **narrow-load mask elision**: `load8_u & 0xff` / `load16_u & 0xffff`
+   drop the `and` on the deferred-load node (the useful half of known-bits).
+4. **Same-operand int compare identities**: `x==x→1`, `x!=x→0`, `≤/≥→1`,
+   `</>→0` — same-local-no-intervening-set keying as the existing `x-x→0`.
+   **Int only** (NaN forbids it for floats).
+5. **Store-narrowing peephole** (R3): `setcc; movzx; store8` → byte store of
+   the setcc reg. Standalone version here if trivial; else it falls out of
+   `stFlags` (P3) for free — don't build scaffolding twice.
+
+Gates: spec (i32/i64/int_exprs/conversions/memory/address/align/endianness),
+corpus differential both modes, ISA micro-suite before/after, new goldens.
+
+### P3. Flags: V2 window → `stFlags` (M) — *the main near-term codegen unlock*
+Designs unchanged from VB §3–4; the review adds consumers worth listing:
+1. **V2 one-deep window**: `cmp; local.set/tee $c; br_if/if` — setcc into the
+   local is flag-transparent before `jcc`.
+2. **V3 `stFlags` storage kind**: `{kind: stFlags, cond}` single owner
+   (`f.flagsOwner`), demoted (setcc+movzx) before any flag-clobbering emission;
+   clobber discipline via railshot-level emit helpers, encoder stays dumb.
+3. Consumers: `br_if`/`if` (exists), `select` (cmov straight from flags),
+   `local.set/tee`, `i32.store8` (subsumes P2.5), nested/double `eqz`
+   (condition inversion, no materialization), `and(x,const); eqz` → `TEST`.
+4. **Float compares → stFlags**: `ucomiss/ucomisd` with the unordered/parity
+   fixup (NaN → JP handling per predicate) — the cond mapping exists for the
+   cmov path; reuse it.
+
+Gates: spec br_if/if/block/loop/select/local_*/f32_cmp/f64_cmp; sieve,
+dispatch, branches benches (likely winners); json/blake no-regression; goldens
+for each consumer; `WAGO_NO_STFLAGS=1` A/B flag.
+
+### P4. Locals: restricted pending `local.set`/`tee` (M, decision-gated)
+VB §5 restriction (c) only: pending binding iff the tree is register-free
+(const/slot/localref leaves — the V1 predicate). Flush points exactly as VB §5.
+Wins: dead-set elimination (incl. at returns), set→get forwarding, const/copy
+forwarding. **Gate on P1 data**: count set→get-adjacent pairs and overwritten
+sets per corpus module first; if the counters say <1% of instructions, park it.
+Local const/copy *facts* (zero-propagation beyond init, `y=x` forwarding) only
+if the restricted version measures.
+
+### P5. Calls (M)
+1. **Mixed-call parallel staging**: extend the parallel-move resolver to the
+   XMM bank; replace `emitMixedRegisterCall`'s `flush()` + slot staging with
+   `flushBelow(argRoots[0])` like the int path.
+2. **Float `call; local.set` fusion**: XMM0 result → pinned float local
+   (int-only today, `call.go:111`).
+3. **Limited multi-result reg ABI**: 2 int → RAX,RDX; 2 float → XMM0,XMM1;
+   mixed → RAX+XMM0. Internal calls first; pairs with a `regMerge2` for
+   two-result block/if merges (review §C4). Unblocks "multi-value 🚧".
+4. **Call-surviving valent trees** (VB §2, correctness table unchanged) — a
+   breadth bet, NOT a serialize fix (premise refuted). Only start with P1
+   counters showing call-adjacent flush traffic somewhere real (fib_rec,
+   dispatch are the candidates).
+5. **Tiny bytecode inliner** (review §I4) — byte-prescan classifier (≤N body
+   bytes, no loops/calls/grow/branches, ≤1 result), inline by recursive
+   restricted body walk. Riskiest P5 item; needs P1 call-site counters to size
+   the prize first. AS getter/setter chains are the target.
+
+### P6. Memory & bounds, explicit-mode focus (M/L)
+1. **Straight-line bounds facts** (review §M3, "certificates"): after a check
+   of `base+hi`, later accesses `base+[lo,hi)` in the same straight-line
+   region skip the check. Same base reg + const offsets only; invalidated by
+   call (callee may grow), `memory.grow`, base redefinition, any label/join.
+   Explicit mode only (guard mode has nothing to elide). Counters: `BoundsChecksElided`.
+2. **Hybrid loop precheck** (review §M2): `if ptr+n ≤ memBytes` → unchecked
+   loop body, else checked loop. Needs the loop-header byte-scan record
+   (bodyStart, touchesMemory, hasCall, hasGrow — the adopted slice of §N1).
+   Big for the TinyGo/embedded (explicit-bounds) story.
+3. **Store combining** (VB §7, unchanged): explicit-only, union check on the
+   hot path + sequential replay on the cold trap path; guard mode excluded
+   (precise-fault commit semantics). Gate hard on memory_trap/address/align.
+4. **Load-after-store forwarding**: same base+disp+width within the window,
+   no intervening aliasing store/call — pairs naturally with 1.
+5. **CPUID probe + gated codegen**: JIT a ~20-byte CPUID stub through the
+   existing trampoline at engine init (keeps zero deps, TinyGo-safe), cache a
+   feature set. Then: **BMI2** `shlx/shrx/sarx` (kills the RCX round-trip,
+   VB §9.4), `smallBulkMax` tuned by FSRM/ERMSB (lower when present — `rep`
+   is cheap earlier; keep 96 otherwise), future paths gated the same way.
+
+### P7. Compile path (M, premise-gated)
+#96 already removed the validator's AST and 90% of its allocs — the review's
+"fused validation kills the AST bottleneck" is stale. So: **re-profile
+`CompileModule` first** (decode / validate / hints / railshot split, allocs
+and ns). Only if standalone validation still shows up: fuse validation into
+railshot's walk behind `WAGO_FUSED_VALIDATE=1` (VB §8's checks: per-op typing
+against the machine stack, label arity, the polymorphic-unreachable hard 20%),
+differential-fuzzed old-vs-fused on accept/reject agreement. Keep the
+standalone validator as the API surface either way. Add compile-side stats
+(allocs, arena high-water) to P1's stats while in here.
+
+### P8. Runtime & product track (parallel; feature value, not exec perf)
+In order:
+1. **Sync host imports with results** (⭐ — the WASI unlock; runtime half
+   already spiked per ARCHITECTURE §V2). Design per review §P1: host-call
+   frame in basedata, HOST_CALL status back through the trampoline, Go invokes,
+   writes results, resumes at continuation. Do NOT let this force wrapper-level
+   conservatism on the pure-wasm call path.
+2. **WASI preview 1, minimal**: fd_write, clocks, args/env, random, proc_exit.
+3. **Interruption / cooperative cancel**: check at loop backedges + function
+   entries; same machinery later serves Go-GC safe points (ROADMAP item).
+4. **Wasm-level stack traces on trap**: trap site → func idx → wasm pc table.
+5. **Remaining post-MVP semantics**: `memory.init`/`data.drop`, passive
+   segments, `table.get/set/size/grow/fill/copy/init`, `elem.drop` — completes
+   the bulk-memory + reference-types FEATURES rows.
+6. **`call_indirect` inline caches** (review §J): table epoch (cheap once
+   `table.set/grow` exist and bump it), then monomorphic IC
+   (cached idx+epoch → direct call), then a small polymorphic IC if dispatch
+   benches justify. Constant-index devirtualization falls out of the epoch.
+7. **`.wago` productization**: cache key = module hash + compiler version +
+   CPU features + bounds mode + ABI version; `wago compile/run/inspect` CLI
+   (size-gated or a separate `wagoc` binary); blob verification hardening.
+8. **arm64 backend** (L) — after the above; WARP `backend/aarch64` as the
+   reference axis, same port discipline as the x64 effort.
+
+## 3. New env flags (A/B discipline)
+
+Every risk-carrying optimization lands with a kill switch, named consistently:
+
+| Flag | Phase |
+|---|---|
+| `WAGO_EXPLAIN`, `WAGO_DEBUG_MODGLOBALS`, `WAGO_PIN_GLOBAL_K` | P1 |
+| `WAGO_NO_ALIAS_LOADS` | P2 |
+| `WAGO_NO_STFLAGS` | P3 |
+| `WAGO_NO_PENDING_SET` | P4 |
+| `WAGO_NO_BOUNDS_FACTS`, `WAGO_NO_STORE_COMBINE`, `WAGO_NO_BMI2` | P6 |
+| `WAGO_FUSED_VALIDATE` (opt-in, flips to opt-out when proven) | P7 |
+
+Existing: `WAGO_BOUNDS`, `WAGO_REG_MERGE`, `WAGO_Amd64_NOREGABI`,
+`WAGO_Amd64_NOSTACKREG`, `WAGO_DEBUG_PANIC`, `WAGO_JSON_MODULE`,
+`WAGO_JSONPROF_ONLY`, `WAGO_SPECTEST_DIR`, `WAGO_SPEC_VERSION`.
+
+## 4. Gate battery (updated counts — supersedes VB §11 / perf-plan §1 line 2)
+
+1. `go test ./...` at root; `cd bench && go test ./...` — both plain and
+   `-tags wago_guardpage`.
+2. `WAGO_BOUNDS= go test -run TestSpecExec -count=1 -v .` → **57/57 applicable
+   files, pass=16592 fail=0 skip=1591** (SPECTEST.md). Any new fail/crash is
+   yours.
+3. `TestCorpusDifferential` (bench, both modes) — the #68-class net; run it
+   early and often, not just pre-PR.
+4. Bench the touched dimension + one unrelated module, 2–3 runs (±20%
+   layout-luck rule: diff disassembly before believing any single number).
+5. From P1 on: the phase's golden disasm test + its CodegenStats counter
+   moving in the right direction.
+
+KNOWN: `src/wago` package tests segfault under `-tags wago_guardpage`
+(pre-existing, needs its own session — see `perf-session3-plan.md` §3).
+
+## 5. Sequencing (the review's closing advice, adjusted)
+
+```
+P0 docs (this PR + ROADMAP refresh)
+→ P1 CodegenStats + explain            [the dashboard everything else reports to]
+→ P2 cheap-wins batch                  [alias loads + pure drop + fold pack]
+→ P3 V2 window → stFlags               [the codegen unlock]
+→ P5.1–.3 call mechanics               [mixed staging, float fusion, 2-result ABI]
+→ P6.1–.2 bounds facts + loop precheck [explicit/TinyGo story]
+→ P4 / P5.4–.5 / P6.3–.5               [each gated on P1 counters]
+→ P7 compile-path                      [premise re-measured first]
+P8 runs in parallel whenever exec-perf work is blocked or a feature is wanted;
+   P8.1 (sync host imports) is the single highest-value item in this file.
+```
+
+Pitfalls: VB §12 applies verbatim (branch before first edit; warp/ submodule
+stays dirty; wat idx = wago idx + 1; short commit subjects; explicit merge
+consent; layout-luck discipline).


### PR DESCRIPTION
Triages the external repo review (LLM code/doc inspection) against the actual tree and turns it into an execution plan.

**New: `docs/no-ir-plan.md`**
- §0 records the architecture decision: no SSA/IR on any execution path; railshot is the only backend; `ir/` stays as an off-path research/debug package. Retires the E-gate SSA-spike framing.
- §1 triage with receipts: 16 review claims verified correct+open (alias-blind pending loads, drop-condenses-to-discard, no stFlags, mixed-call full flush, single-result reg ABI, no CPUID, no immutable-global folding, …), 6 claims stale (float min/max done #97, serialize resolved #99/#100, validation already byte-backed #96, spec gate now 57/57, …), 10 items rejected with reasons (stAddrExpr, known-bits lattice, tiny unroll, …).
- §2 phase plan P0–P8: CodegenStats/explain first, then cheap-wins batch (alias-aware loads, pure-tree drop, const-fold pack), stFlags, restricted pending sets, call mechanics (mixed staging, float fusion, 2-result ABI), bounds facts + loop precheck + CPUID/BMI2, compile-path re-measure, and the runtime/product track (sync host imports → WASI → interruption → traces → table.* → call_indirect ICs → .wago CLI → arm64).
- §3–§5: A/B env-flag discipline, updated gate battery (57/57, pass=16592), sequencing.

**OPTIMIZATIONS.md refresh**
- "What's in place" brought current through #115 (post-sweep landings, MVP 57/57); measured section gets the post-#99/#100 json numbers (ser 93ns beats WARP; wago now beats wazero on both json directions).
- Roadmap: R0 added (measurement promoted to first), R1 stFlags value raised, R2 float parity halved (#97), R4 json serialize marked RESOLVED and condensed (forensics preserved via pointers), R5 reordered around sync host imports, R7 added for the review's adopted items.
- Final section rewritten: two-tier/SSA-optional framing replaced by the no-IR decision + "Tier 1.5" incremental attack + the scanBody summary-only guardrail.

https://claude.ai/code/session_01J92SW4tm9qCAKHzGtXSU2i