### PR TITLE
perf: CodegenStats + explain mode (no-ir-plan P1)

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -130,12 +130,15 @@ The detailed, phase-by-phase execution plan for everything below is
 **`docs/no-ir-plan.md`** (2026-07-03, incorporating an external repo review that was
 triaged against the tree). R-numbers here are stable labels; Pn are that plan's phases.
 
-### R0. `CodegenStats` + explain mode  · S/M · 🟩 (promoted from R6 — do first)
-Per-function counters (spills/flushes/condensed vs folded deferred loads/bounds
-checks/calls by kind/pins/peephole hits) behind a `CompileConfig` option +
-`WAGO_EXPLAIN`, an explain dump, golden disassembly tests per optimization, and the
-`WAGO_DEBUG_MODGLOBALS` / `WAGO_PIN_GLOBAL_K` knobs. Every subsequent optimization must
-land with its counter moving and a golden test. (Plan P1.)
+### R0. `CodegenStats` + explain mode  · ✅ LANDED (`perf/codegen-stats`)
+Per-function counters (spills/flushes/condenses/store-forced deferred loads/bounds
+checks/trap stubs/calls by kind/pins/peephole hits) collected only on request via a
+nil-safe `stats` field on `fn` — byte-identical codegen when off. Surfaced through
+`CompileOptions.Stats`, `WAGO_EXPLAIN=1`, and `bench/cmd/explain`; ships the
+`WAGO_DEBUG_MODGLOBALS` / `WAGO_PIN_GLOBAL_K=auto|0..3` knobs and an objdump-based
+golden-disasm harness (`golden_test.go`). Every subsequent optimization lands with
+its counter moving and a golden. (Plan P1; see `docs/no-ir-plan.md` P1 for the
+counter list and on-corpus verification.)
 
 ### R1. `stFlags` — compare fusion past adjacency  · M · 🟩 (old P8)
 Fusion only fires when the branch immediately follows the compare. Misses

--- a/bench/cmd/explain/main.go
+++ b/bench/cmd/explain/main.go
@@ -1,0 +1,61 @@
+// Command explain compiles a wasm module through the railshot backend and prints
+// its per-function CodegenStats dashboard (docs/no-ir-plan.md P1) — the counters
+// every later optimization proves itself against: pins, flushes, condenses,
+// forced deferred loads, bounds checks, calls by kind, and peephole hits.
+//
+// Usage:
+//
+//	go run ./cmd/explain [-guard] [module.wasm]
+//
+// With no path it defaults to corpus/json-as.wasm. -guard selects guard-page
+// (bounds-elided) mode instead of explicit bounds. Equivalent to setting
+// WAGO_EXPLAIN=1 on any run that compiles the module, but standalone and
+// corpus-aware.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	amd64 "github.com/wago-org/wago/src/core/compiler/backend/railshot"
+	wasm "github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func main() {
+	guard := flag.Bool("guard", false, "guard-page (bounds-elided) mode instead of explicit bounds")
+	flag.Parse()
+
+	path := filepath.Join("corpus", "json-as.wasm")
+	if flag.NArg() > 0 {
+		path = flag.Arg(0)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read module:", err)
+		os.Exit(1)
+	}
+	m, err := wasm.DecodeModule(b)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "decode:", err)
+		os.Exit(1)
+	}
+
+	var ms amd64.ModuleStats
+	if _, err := amd64.CompileModuleWith(m, amd64.CompileOptions{
+		ElideBoundsChecks: *guard,
+		Stats:             &ms,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "compile:", err)
+		os.Exit(1)
+	}
+
+	mode := "explicit-bounds"
+	if *guard {
+		mode = "guard-page"
+	}
+	fmt.Printf("# %s  (%s)\n", path, mode)
+	fmt.Print(ms.String())
+}

--- a/docs/no-ir-plan.md
+++ b/docs/no-ir-plan.md
@@ -103,7 +103,7 @@ gate battery (§4), merges need an explicit user yes. Phases are ordered by
    ("Numeric completeness" block, memory.grow, reg-ABI calls, locals-in-regs);
    align with FEATURES.md + this plan.
 
-### P1. CodegenStats + explain mode (S/M) — *do first; everything after must prove itself*
+### P1. CodegenStats + explain mode (S/M) — ✅ LANDED (`perf/codegen-stats`)
 Was OPTIMIZATIONS R6; the review is right that it comes first.
 - `CodegenStats` per function, collected only when requested (nil when off —
   zero hot-path cost): code/frame bytes, max spill slots, flushes /
@@ -126,6 +126,26 @@ Was OPTIMIZATIONS R6; the review is right that it comes first.
 
 Exit: explain dump on json-as and blake matches the known facts (K pins, B2
 immediate stores, forward-copy path) — i.e. the counters are trustworthy.
+
+**Landed** (`src/core/compiler/backend/railshot/stats.go`): `CodegenStats` +
+`ModuleStats` threaded through the `fn` via a nil `stats` field — every counter
+is a nil-safe no-op when off, so codegen is byte-identical (proved by
+`TestCodegenStatsCodegenNeutral`). Counters: code/frame bytes, spill high-water,
+flushes/flushBelows, condenses, spills/reloads, `MemRefsForcedByStore` (the P2.1
+alias-blind signal), `BoundsChecks` (P6 target), trap stubs, `Calls` by kind
+(regabi/mixed/wrapper/host/indirect/crossinstance), pinned locals + value-pinned
+globals + module-pin K/regs, and a `Peephole` map (const-fold, alu-identity,
+strength-reduce, lea-scaled-index, store-imm, memcopy/memfill-unroll,
+cmp-branch-fuse, select-cmov, br-table-jump, call-localset-fuse). Surfaced via
+`CompileOptions.Stats` sink + `WAGO_EXPLAIN=1` (stderr dump) + a `bench/cmd/explain`
+tool; `WAGO_DEBUG_MODGLOBALS=1` and `WAGO_PIN_GLOBAL_K=auto|0..3` shipped.
+Verified on-corpus: json-as K=3 (g2/g4/g25), blake K=1 (g11). Deviations from the
+plan text: (a) there were **no** pre-existing objdump codegen tests to "extend" —
+the golden harness (`golden_test.go`, objdump-based, skips when absent) is new;
+(b) "deferred loads folded vs forced" ships as the single `MemRefsForcedByStore`
+counter (the number P2 must drive down); the "folded" side is implicit. Remaining
+P1 nice-to-haves deferred: `call; local.set` and reg-ABI `call_indirect` goldens
+(counters exist), and formalizing `WAGO_PERFMAP=1`.
 
 ### P2. Cheap railshot wins, one batch PR (S each)
 1. **Alias-aware pending loads** (VB §6, unchanged design):

--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -119,6 +119,7 @@ func (f *fn) callOp(r *wasm.Reader) error {
 				if pr, isFloat, ok := f.pinReg(int(x)); ok && !isFloat && pr != regNone {
 					// All operand-stack refs to x are flushed to slots by the call
 					// sequence itself, so skipping setLocal's realizeLocalRefs is safe.
+					f.stats.peep("call-localset-fuse")
 					hint = int(x)
 					if err := r.JumpTo(r2.Offset()); err != nil {
 						return err
@@ -136,6 +137,7 @@ func (f *fn) callOp(r *wasm.Reader) error {
 // returns. This matches the runtime's log format (backend/railshot/amd64). Fire-and-forget:
 // a single i32 argument, no result.
 func (f *fn) callHost(importIdx int, ft *wasm.CompType) error {
+	f.stats.call("host")
 	if len(ft.Results) != 0 {
 		return fmt.Errorf("amd64: host import with results not supported (func %d)", importIdx)
 	}
@@ -205,6 +207,7 @@ const (
 // the callee unwinds to this execution's enterNative. Callee linMem/entry are
 // baked as immediates by the link-time recompile.
 func (f *fn) emitCrossInstanceCall(b ImportBinding, ft *wasm.CompType) error {
+	f.stats.call("crossinstance")
 	p, rN := len(ft.Params), len(ft.Results)
 	d := f.depth()
 	f.flush()
@@ -293,12 +296,15 @@ func (f *fn) emitCrossInstanceCall(b ImportBinding, ft *wasm.CompType) error {
 func (f *fn) callInternal(localIdx int, ft *wasm.CompType, resHint int) error {
 	if regABIEnabled && sigFitsRegABI(ft) {
 		if sigIsIntOnly(ft) {
+			f.stats.call("regabi")
 			f.emitRegisterCall(localIdx, ft, resHint)
 		} else {
+			f.stats.call("mixed")
 			f.emitMixedRegisterCall(localIdx, ft)
 		}
 		return nil
 	}
+	f.stats.call("wrapper")
 	f.emitWrapperCall(ft, func() {
 		site := f.a.CallRel32()
 		f.relocs = append(f.relocs, callReloc{at: site, target: localIdx})
@@ -465,6 +471,7 @@ func (f *fn) emitMixedRegisterCall(localIdx int, ft *wasm.CompType) {
 // pointer via the wrapper ABI. Table layout matches the runtime (16-byte slots;
 // +8 code ptr, +16 type id) with the descriptor pointer at [linMem-offTablePtr].
 func (f *fn) callIndirect(r *wasm.Reader) error {
+	f.stats.call("indirect")
 	typeIdx, err := r.U32()
 	if err != nil {
 		return err

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -146,6 +146,11 @@ type fn struct {
 	// element currently representing that storage. This is infrastructure for the
 	// fuller WARP local/storage model; current codegen behavior stays unchanged.
 	refs map[refKey]*elem
+
+	// stats collects per-function codegen counters (docs/no-ir-plan.md P1). nil
+	// unless the caller requested collection, in which case every counter method
+	// is a no-op — the hot compile path is unaffected. See stats.go.
+	stats *CodegenStats
 }
 
 func align16(n int) int { return (n + 15) &^ 15 }
@@ -206,6 +211,11 @@ type CompileOptions struct {
 	// threading the option here lets that work use the same HeapABI as the IR
 	// backend instead of hard-coding allocator or collector choices.
 	Codegen codegen.Options
+
+	// Stats, when non-nil, collects per-function codegen counters into it (the
+	// "explain" dashboard, docs/no-ir-plan.md P1). Independent of WAGO_EXPLAIN,
+	// which prints the same dump to stderr. nil = no collection, zero overhead.
+	Stats *ModuleStats
 }
 
 // DirectBackend adapts the direct wasm-to-amd64 compiler to the shared
@@ -248,13 +258,30 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		return nil, fmt.Errorf("amd64: %w", err)
 	}
 	modGlobals := pickModuleGlobals(m, nGlobals, globalScores)
+	// Stats collection is opt-in: an explicit sink (opts.Stats) or WAGO_EXPLAIN=1.
+	// nil ms => st stays nil in the loop => zero-overhead counter no-ops.
+	var ms *ModuleStats
+	if opts.Stats != nil {
+		ms = opts.Stats
+	} else if explainEnabled {
+		ms = &ModuleStats{}
+	}
+	if ms != nil {
+		ms.Funcs = make([]*CodegenStats, n)
+		ms.ModuleGlobalPins = moduleGlobalPinInfos(modGlobals)
+	}
 	var code []byte
 	for i := range m.Code {
 		hints, err := computeFuncHints(m, i, nGlobals, importedFuncs)
 		if err != nil {
 			return nil, fmt.Errorf("amd64: function %d hints: %w", i, err)
 		}
-		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, modGlobals, hints, opts.ImportBindings)
+		var st *CodegenStats
+		if ms != nil {
+			st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
+			ms.Funcs[i] = st
+		}
+		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, modGlobals, hints, opts.ImportBindings, st)
 		if err != nil {
 			return nil, fmt.Errorf("amd64: function %d: %w", i, err)
 		}
@@ -278,7 +305,23 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 			binary.LittleEndian.PutUint32(code[site:], uint32(int32(target-(site+4))))
 		}
 	}
+	if explainEnabled && ms != nil {
+		fmt.Fprint(os.Stderr, ms.String())
+	}
 	return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
+}
+
+// moduleGlobalPinInfos converts the internal module-global pin assignments to the
+// display form used by ModuleStats (register names instead of Reg values).
+func moduleGlobalPinInfos(pins []moduleGlobalPin) []ModuleGlobalPinInfo {
+	if len(pins) == 0 {
+		return nil
+	}
+	out := make([]ModuleGlobalPinInfo, len(pins))
+	for i, p := range pins {
+		out[i] = ModuleGlobalPinInfo{Global: p.global, Reg: regName(p.reg)}
+	}
+	return out
 }
 
 // moduleGlobalPin is a module-wide global→register assignment (WARP's model).
@@ -355,20 +398,34 @@ func pickModuleGlobals(m *wasm.Module, nGlobals int, agg []int64) []moduleGlobal
 		cs = append(cs, cand{g, agg[g]})
 	}
 	sort.SliceStable(cs, func(a, b int) bool { return cs[a].score > cs[b].score })
+	// K = number of module-wide registers to spend. auto (pinGlobalK<0) applies the
+	// extraBar gate for the 2nd/3rd; WAGO_PIN_GLOBAL_K forces a fixed cap (0..3),
+	// bypassing the gate — for A/B measuring the adaptive choice.
+	limit := len(moduleGlobalRegs)
+	if pinGlobalK >= 0 && pinGlobalK < limit {
+		limit = pinGlobalK
+	}
 	var pins []moduleGlobalPin
 	for k, c := range cs {
-		if k >= len(moduleGlobalRegs) {
+		if k >= limit {
 			break
 		}
-		if k >= 1 && c.score < extraBar {
-			break // cs is score-descending: no later candidate clears the bar either
+		if pinGlobalK < 0 && k >= 1 && c.score < extraBar {
+			break // auto: cs is score-descending, so no later candidate clears the bar
 		}
 		pins = append(pins, moduleGlobalPin{global: uint32(c.g), reg: moduleGlobalRegs[k]})
+	}
+	if debugModGlobals {
+		fmt.Fprintf(os.Stderr, "wago: module-pinned globals (K=%d):", len(pins))
+		for _, p := range pins {
+			fmt.Fprintf(os.Stderr, " g%d→%s", p.global, regName(p.reg))
+		}
+		fmt.Fprintln(os.Stderr)
 	}
 	return pins
 }
 
-func compileFunc(m *wasm.Module, funcIdx int, guardMode bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFunc(m *wasm.Module, funcIdx int, guardMode bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if os.Getenv("WAGO_DEBUG_PANIC") == "1" {
@@ -388,7 +445,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool, modGlobals []modul
 		return nil, nil, 0, err
 	}
 
-	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings}
+	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
 	if !guardMode && len(m.Memories) > 0 {
 		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module
 	}
@@ -474,6 +531,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool, modGlobals []modul
 		if err != nil {
 			return nil, nil, 0, err
 		}
+		f.finalizeStats(len(f.a.B))
 		return f.a.B, f.relocs, internalOff, nil
 	}
 
@@ -485,7 +543,21 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool, modGlobals []modul
 	f.emitTrapStubs()
 	f.a.PatchU32(f.subRspAt, uint32(f.frameSize()))
 	f.a.PatchU32(f.addRspAt, uint32(f.frameSize()))
+	f.finalizeStats(len(f.a.B))
 	return f.a.B, f.relocs, 0, nil
+}
+
+// finalizeStats fills the per-function size counters from final compiler state
+// (no-op when collection is off). Per-event counters are incremented at their
+// emission sites during the body.
+func (f *fn) finalizeStats(codeLen int) {
+	s := f.stats
+	if s == nil {
+		return
+	}
+	s.CodeBytes = codeLen
+	s.FrameBytes = f.frameSize()
+	s.MaxSpillSlots = f.maxSpill
 }
 
 // runBody opens the function control frame, lowers the body, and patches every
@@ -615,8 +687,10 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 		}
 		if c.global {
 			f.globalReg[c.idx] = gpPool[k]
+			f.stats.addPinnedGlobalValue()
 		} else {
 			f.locals[c.idx].reg = gpPool[k]
+			f.stats.addPinnedLocal()
 		}
 		f.pinnedLocalMask = f.pinnedLocalMask.add(gpPool[k])
 	}
@@ -640,6 +714,7 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 		f.locals[i].reg = pinnedFLocalRegs[k]
 		f.locals[i].isFloat = true
 		f.fpinnedLocalMask = f.fpinnedLocalMask.add(pinnedFLocalRegs[k])
+		f.stats.addPinnedLocal()
 	}
 }
 

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -76,6 +76,7 @@ func (f *fn) rootsBottomToTop() []*elem {
 // spillOff(i)), condensing deferred nodes, then rebuilds the stack model as a run
 // of canonical slot entries with all registers freed.
 func (f *fn) flush() {
+	f.stats.addFlush()
 	f.invalidateGlobalsCache() // the cached cell ptr must not span a call/control boundary
 	roots := f.rootsBottomToTop()
 	for i, root := range roots {
@@ -568,6 +569,7 @@ func (f *fn) opBrTable(r *wasm.Reader) error {
 		// Jump table (P7): bounds-check the index, then one indirect jump through
 		// a table of stub offsets — O(1) dispatch instead of a cmp/jne chain.
 		// RAX/RDX are free after the flush; case stubs are deduplicated per label.
+		f.stats.peep("br-table-jump")
 		f.a.AluRI(cmpDigit, ireg, int32(len(labels)), false)
 		defSite := f.a.JccPlaceholder(condAE) // idx >= n → default
 		leaSite := f.a.LeaRipPlaceholder(RAX) // RAX = &table

--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -628,6 +628,7 @@ func (f *fn) emitSelect() {
 	bReg := f.materialize(b)
 	f.pinned = f.pinned.add(bReg)
 	aReg := f.materialize(a)
+	f.stats.peep("select-cmov")
 	f.a.TestSelf(condReg, false)
 	f.a.Cmovcc(condE, aReg, bReg, w) // cond == 0 → a = b
 	f.pinned = f.pinned.remove(condReg)

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -32,6 +32,7 @@ const (
 // regNone to pick a fresh one. Returns the register now holding the value and
 // converts `node` into that value on the stack (its operands are consumed).
 func (f *fn) condense(node *elem, dest Reg) Reg {
+	f.stats.addCondense()
 	switch {
 	case isBinALU(node.op):
 		return f.condenseBinary(node, dest)
@@ -263,6 +264,7 @@ func (f *fn) tryLeaScaledAdd(node, left, right *elem, dest Reg) Reg {
 			dest = f.allocReg(0)
 		}
 	}
+	f.stats.peep("lea-scaled-index")
 	f.a.LeaScaledW(dest, x, y, uint8(k), 0, w)
 	if yOwned && y != dest {
 		f.release(y)

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -22,6 +22,7 @@ func isFusableCompare(e *elem) bool {
 // fused compare so the subsequent branch's moveSlots reads canonical slots and no
 // flag-clobbering flush happens between the CMP and the Jcc.
 func (f *fn) flushBelow(node *elem) int {
+	f.stats.addFlushBelow()
 	f.invalidateGlobalsCache() // a following call would clobber the cached cell-ptr register
 	base := baseOfValentBlock(node)
 	var below []*elem
@@ -69,6 +70,7 @@ func (f *fn) flushBelow(node *elem) int {
 // comparison holds. The CMP must be the last flag-affecting instruction before
 // the branch, so callers flush everything below first.
 func (f *fn) condenseToFlags(node *elem) Cond {
+	f.stats.peep("cmp-branch-fuse")
 	w := node.typ.is64()
 	if node.op == opEqz {
 		// TEST does not write its operand, so a register-resident value (a pinned

--- a/src/core/compiler/backend/railshot/golden_test.go
+++ b/src/core/compiler/backend/railshot/golden_test.go
@@ -1,0 +1,110 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// Golden disassembly tests: the per-optimization shape regression net
+// (docs/no-ir-plan.md P1). Each later phase adds its golden here alongside its
+// CodegenStats counter, so a codegen change that silently drops an optimization
+// is caught by shape, not just by a benchmark. These shell out to objdump and
+// skip cleanly where it is unavailable.
+
+// disasm returns the objdump Intel-syntax disassembly of raw machine code,
+// lowercased for stable substring matching. Skips when objdump is absent.
+func disasm(t *testing.T, code []byte) string {
+	t.Helper()
+	objdump, err := exec.LookPath("objdump")
+	if err != nil {
+		t.Skip("objdump not found on PATH; skipping golden disassembly")
+	}
+	bin := filepath.Join(t.TempDir(), "code.bin")
+	if err := os.WriteFile(bin, code, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(objdump, "-D", "-b", "binary", "-m", "i386:x86-64", "-Mintel", bin).CombinedOutput()
+	if err != nil {
+		t.Fatalf("objdump: %v\n%s", err, out)
+	}
+	return strings.ToLower(string(out))
+}
+
+// compileCode compiles m and returns the raw code blob (one function per module
+// here, so the blob is that function).
+func compileCode(t *testing.T, m *wasm.Module, guard bool) []byte {
+	t.Helper()
+	cm, err := CompileModuleWith(m, CompileOptions{ElideBoundsChecks: guard})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return cm.Code
+}
+
+// TestGoldenImmediateStore: a constant store lowers to a `mov [mem],imm` — the
+// constant goes straight into the store as an immediate, no register load.
+func TestGoldenImmediateStore(t *testing.T) {
+	// (guard: no bounds-check noise) i32.const 16; i32.const 42; i32.store
+	m := modMem(t, 1, nil, nil, []byte{0x00, 0x41, 0x10, 0x41, 0x2a, 0x36, 0x02, 0x00, 0x0b})
+	d := disasm(t, compileCode(t, m, true))
+	if !strings.Contains(d, "0x2a") || !strings.Contains(d, "[rbx") {
+		t.Errorf("expected `mov dword ptr [rbx...],0x2a` immediate store, got:\n%s", d)
+	}
+}
+
+// TestGoldenLeaScaledIndex: base + (index << k) lowers to a single scaled-index
+// LEA (the AssemblyScript array-address shape).
+func TestGoldenLeaScaledIndex(t *testing.T) {
+	// local.get 0; local.get 1; i32.const 2; i32.shl; i32.add → lea [x + y*4]
+	m := mod1(t, []wasm.ValType{wasm.I32, wasm.I32}, []wasm.ValType{wasm.I32},
+		[]byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x41, 0x02, 0x74, 0x6a, 0x0b})
+	d := disasm(t, compileCode(t, m, false))
+	if !strings.Contains(d, "lea") || !strings.Contains(d, "*4") {
+		t.Errorf("expected scaled-index `lea ...[..*4]`, got:\n%s", d)
+	}
+}
+
+// TestGoldenBoundsMode: an explicit-mode load carries an inline bounds compare +
+// `ja` to the trap stub; guard-page mode elides it, so the code is strictly
+// smaller and has no bounds branch.
+func TestGoldenBoundsMode(t *testing.T) {
+	// local.get 0; i32.load align=2 offset=0
+	m := mod1Mem(t)
+	explicitCode := compileCode(t, m, false)
+	guardCode := compileCode(t, m, true)
+	explicit := disasm(t, explicitCode)
+	if !strings.Contains(explicit, "cmp") || !strings.Contains(explicit, "ja ") {
+		t.Errorf("explicit-mode load missing bounds `cmp; ja`:\n%s", explicit)
+	}
+	if len(guardCode) >= len(explicitCode) {
+		t.Errorf("guard code (%dB) not smaller than explicit (%dB) — bounds check not elided",
+			len(guardCode), len(explicitCode))
+	}
+}
+
+// TestGoldenMemoryCopyRepMovs: a dynamic-length memory.copy lowers a hybrid path
+// that includes the `rep movs` block (the forward-safe fast path from #99).
+func TestGoldenMemoryCopyRepMovs(t *testing.T) {
+	// local.get 0 (dst); local.get 1 (src); local.get 2 (n); memory.copy 0 0
+	m := modMem(t, 1, []wasm.ValType{wasm.I32, wasm.I32, wasm.I32}, nil,
+		[]byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfc, 0x0a, 0x00, 0x00, 0x0b})
+	d := disasm(t, compileCode(t, m, true))
+	if !strings.Contains(d, "movs") {
+		t.Errorf("expected `rep movs` in memory.copy lowering, got:\n%s", d)
+	}
+}
+
+// mod1Mem builds a one-memory module whose exported function does a single
+// i32.load of its i32 parameter (the guard-vs-explicit bounds shape probe).
+func mod1Mem(t *testing.T) *wasm.Module {
+	t.Helper()
+	return modMem(t, 1, []wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32},
+		[]byte{0x00, 0x20, 0x00, 0x28, 0x02, 0x00, 0x0b})
+}

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -68,6 +68,9 @@ func (f *fn) emitTrap(code uint32) {
 // a ~20-byte inline trap block at every site (better I-cache, not-taken hot
 // branches, one stub per trap code instead of one block per check).
 func (f *fn) trapIf(cc Cond, code uint32) {
+	if code == trapMemOOB {
+		f.stats.addBoundsCheck() // inline linear-memory OOB check (P6 elides these)
+	}
 	if f.trapSites == nil {
 		f.trapSites = map[uint32][]int{}
 	}
@@ -91,6 +94,7 @@ func (f *fn) emitTrapStubs() {
 		if len(sites) == 0 {
 			continue
 		}
+		f.stats.addTrapStub()
 		pos := f.a.Len()
 		f.storeModuleGlobals(RSI) // post-trap global state stays observable (RSI is trap-path scratch)
 		f.emitTrap(code)
@@ -191,6 +195,7 @@ func (f *fn) memStore(r *wasm.Reader, size int) error {
 	// 64-bit pattern; narrower stores truncate to the low `size` bytes exactly
 	// like a materialized constant would (i64.store8/16/32 route here too).
 	if top := f.s.back(); top != nil && top.kind == ekValue && top.st.kind == stConst {
+		f.stats.peep("store-imm")
 		v := top.st.cval
 		f.erase(top)
 		ea, eaOwned, _, disp := f.memAddr(off, size, true)
@@ -240,6 +245,7 @@ func (f *fn) memoryCopy(r *wasm.Reader) error {
 	}
 	if top := f.s.back(); top != nil && top.kind == ekValue && top.st.kind == stConst {
 		if n := uint64(uint32(top.st.cval)); n <= 32 {
+			f.stats.peep("memcopy-unroll")
 			f.memoryCopyConst(int(n))
 			return nil
 		}
@@ -504,6 +510,7 @@ func (f *fn) bulkBoundsCheck(base Reg, n int) {
 // memoryFillConst lowers memory.fill with a small constant length as unrolled
 // stores of a byte-replicated pattern — no flush, no rep-stos microcode startup.
 func (f *fn) memoryFillConst(n int) {
+	f.stats.peep("memfill-unroll")
 	f.materializePendingLoads() // pending loads must read pre-fill memory
 	f.erase(f.s.back())         // n (const)
 	valElem := f.popValue()

--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -101,6 +101,7 @@ func (f *fn) spillIfUsed(r Reg) {
 
 // spill evicts the register-resident value elem e to a fresh frame slot.
 func (f *fn) spill(e *elem) {
+	f.stats.addSpill()
 	r := e.st.reg
 	slot := f.allocSpillSlot()
 	f.a.Store64(RSP, f.spillOff(slot), r)
@@ -147,6 +148,7 @@ func (f *fn) materialize(e *elem) Reg {
 		f.occupy(e, r)
 		return r
 	case stSlot:
+		f.stats.addReload()
 		r := f.allocReg(0)
 		f.a.Load64(r, RSP, f.spillOff(e.st.slot))
 		f.occupy(e, r)
@@ -227,6 +229,7 @@ func (f *fn) loadMemRef(dst Reg, st storage) {
 func (f *fn) materializePendingLoads() {
 	for e := f.s.head.next; e != f.s.head; e = e.next {
 		if e.kind == ekValue && e.st.kind == stMemRef {
+			f.stats.addForcedLoad()
 			if e.st.typ.isFloat() {
 				f.materializeF(e)
 			} else {

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -218,6 +218,7 @@ func (f *fn) pushBinOp(op wOp, typ machineType) {
 	if foldable(op) &&
 		right.kind == ekValue && right.st.kind == stConst &&
 		left.kind == ekValue && left.st.kind == stConst {
+		f.stats.peep("const-fold")
 		v := foldBin(op, left.st.cval, right.st.cval, typ.is64())
 		f.erase(right)
 		f.erase(left)
@@ -228,12 +229,15 @@ func (f *fn) pushBinOp(op wOp, typ machineType) {
 	// collapse without emitting a node; expensive ops rewrite to cheaper ones.
 	if right.kind == ekValue && right.st.kind == stConst {
 		if op2, done := f.simplifyConstRHS(op, typ, left, right); done {
+			f.stats.peep("alu-identity")
 			return
 		} else if op2 != op {
+			f.stats.peep("strength-reduce")
 			op = op2 // strength-reduced (mul 2ⁿ → shl, div_u 2ⁿ → shr_u, rem_u 2ⁿ → and)
 		}
 	}
 	if f.simplifySameOperand(op, typ, left, right) {
+		f.stats.peep("same-operand")
 		return
 	}
 	node := f.s.alloc()

--- a/src/core/compiler/backend/railshot/stats.go
+++ b/src/core/compiler/backend/railshot/stats.go
@@ -1,0 +1,294 @@
+package amd64
+
+// CodegenStats is the railshot "explain" dashboard: per-function counters that
+// make every later optimization prove itself (docs/no-ir-plan.md P1). Collection
+// is opt-in — a *CodegenStats is threaded through the fn only when the caller asks
+// (CompileOptions.Stats) or WAGO_EXPLAIN=1 is set. When off, the field is nil and
+// every counter method is a no-op (nil-receiver methods), so the hot compile path
+// pays nothing.
+//
+// The counters are the sinks the plan's phases target: MemRefsForcedByStore is
+// what P2's alias-aware loads shrink, BoundsChecks is what P6's bounds facts
+// elide, Calls[...] by kind is what P5's call work moves between buckets, and the
+// Peephole map records which instruction-selection rewrites actually fired.
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// Explain/debug knobs, parsed once. Kept here next to the stats they drive.
+var (
+	// explainEnabled prints a per-module CodegenStats dump to stderr after every
+	// compile. Independent of the programmatic CompileOptions.Stats sink.
+	explainEnabled = os.Getenv("WAGO_EXPLAIN") == "1"
+	// debugModGlobals prints the module-pinned-global choices (the #90-era temp
+	// print, now first-class).
+	debugModGlobals = os.Getenv("WAGO_DEBUG_MODGLOBALS") == "1"
+	// pinGlobalK overrides the adaptive module-global pin count K: -1 = auto (the
+	// pickModuleGlobals heuristic), 0..len(moduleGlobalRegs) = force that many.
+	pinGlobalK = parsePinGlobalK(os.Getenv("WAGO_PIN_GLOBAL_K"))
+)
+
+func parsePinGlobalK(s string) int {
+	switch s {
+	case "0":
+		return 0
+	case "1":
+		return 1
+	case "2":
+		return 2
+	case "3":
+		return 3
+	default: // "", "auto", or anything unrecognized
+		return -1
+	}
+}
+
+// CodegenStats holds one function's codegen counters. All fields are zero when a
+// phenomenon did not occur; maps are nil until first use.
+type CodegenStats struct {
+	FuncIdx int    // local function index (0-based over m.Code)
+	Name    string // name-section / export name, or "" if anonymous
+
+	// Size.
+	CodeBytes     int // emitted machine-code length
+	FrameBytes    int // stack frame size (sub rsp, N)
+	MaxSpillSlots int // high-water operand spill slots
+
+	// Register allocator / condense engine traffic.
+	Flushes              int // full operand-stack flushes (control boundaries + calls)
+	FlushBelows          int // partial flushes below a fused node
+	Condenses            int // deferred-tree condensations to a register
+	Spills               int // register→slot evictions under pressure
+	Reloads              int // slot→register reloads of a spilled value
+	MemRefsForcedByStore int // deferred loads forced out by a store (P2.1 target)
+
+	// Bounds / traps.
+	BoundsChecks int // inline memory-OOB checks emitted (P6 elides these)
+	TrapStubs    int // shared cold trap stubs emitted (one per trap code used)
+
+	// Calls, by lowering kind: regabi / mixed / wrapper / host / indirect /
+	// crossinstance.
+	Calls map[string]int
+
+	// Pins.
+	PinnedLocals       int // integer/float locals given a dedicated register
+	PinnedGlobalsValue int // hot mutable-int globals value-pinned in this function
+
+	// Peephole/instruction-selection rewrites that fired, by stable name.
+	Peephole map[string]int
+}
+
+// --- nil-safe counter methods (no-op when collection is off) ---
+
+func (s *CodegenStats) addFlush() {
+	if s != nil {
+		s.Flushes++
+	}
+}
+func (s *CodegenStats) addFlushBelow() {
+	if s != nil {
+		s.FlushBelows++
+	}
+}
+func (s *CodegenStats) addCondense() {
+	if s != nil {
+		s.Condenses++
+	}
+}
+func (s *CodegenStats) addSpill() {
+	if s != nil {
+		s.Spills++
+	}
+}
+func (s *CodegenStats) addReload() {
+	if s != nil {
+		s.Reloads++
+	}
+}
+func (s *CodegenStats) addForcedLoad() {
+	if s != nil {
+		s.MemRefsForcedByStore++
+	}
+}
+func (s *CodegenStats) addTrapStub() {
+	if s != nil {
+		s.TrapStubs++
+	}
+}
+func (s *CodegenStats) addBoundsCheck() {
+	if s != nil {
+		s.BoundsChecks++
+	}
+}
+func (s *CodegenStats) addPinnedLocal() {
+	if s != nil {
+		s.PinnedLocals++
+	}
+}
+func (s *CodegenStats) addPinnedGlobalValue() {
+	if s != nil {
+		s.PinnedGlobalsValue++
+	}
+}
+
+// call records one call lowering of the given kind.
+func (s *CodegenStats) call(kind string) {
+	if s == nil {
+		return
+	}
+	if s.Calls == nil {
+		s.Calls = make(map[string]int)
+	}
+	s.Calls[kind]++
+}
+
+// peep records one peephole/instruction-selection rewrite by stable name.
+func (s *CodegenStats) peep(name string) {
+	if s == nil {
+		return
+	}
+	if s.Peephole == nil {
+		s.Peephole = make(map[string]int)
+	}
+	s.Peephole[name]++
+}
+
+// ModuleGlobalPinInfo describes one module-wide global→register reservation.
+type ModuleGlobalPinInfo struct {
+	Global uint32
+	Reg    string
+}
+
+// ModuleStats aggregates one module's per-function stats plus the module-wide
+// decisions. The zero value is ready to collect into.
+type ModuleStats struct {
+	Funcs            []*CodegenStats
+	ModuleGlobalPins []ModuleGlobalPinInfo
+}
+
+// String renders the explain dump: a module summary line, the module-pinned
+// globals, then one block per function.
+func (ms *ModuleStats) String() string {
+	if ms == nil {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "=== codegen explain: %d function(s) ===\n", len(ms.Funcs))
+	if len(ms.ModuleGlobalPins) == 0 {
+		fmt.Fprintf(&b, "module-pinned globals: none (K=0)\n")
+	} else {
+		fmt.Fprintf(&b, "module-pinned globals (K=%d):", len(ms.ModuleGlobalPins))
+		for _, p := range ms.ModuleGlobalPins {
+			fmt.Fprintf(&b, " g%d→%s", p.Global, p.Reg)
+		}
+		b.WriteByte('\n')
+	}
+	for _, s := range ms.Funcs {
+		if s == nil {
+			continue
+		}
+		b.WriteString(s.report())
+	}
+	return b.String()
+}
+
+// report renders one function's counters as an indented block.
+func (s *CodegenStats) report() string {
+	if s == nil {
+		return ""
+	}
+	name := s.Name
+	if name == "" {
+		name = "(anon)"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "fn#%d %q: code=%dB frame=%dB spill_hi=%d\n",
+		s.FuncIdx, name, s.CodeBytes, s.FrameBytes, s.MaxSpillSlots)
+	fmt.Fprintf(&b, "    alloc: flushes=%d flushBelow=%d condenses=%d spills=%d reloads=%d forcedLoads=%d\n",
+		s.Flushes, s.FlushBelows, s.Condenses, s.Spills, s.Reloads, s.MemRefsForcedByStore)
+	fmt.Fprintf(&b, "    mem:   bounds=%d trapStubs=%d   pins: local=%d gval=%d\n",
+		s.BoundsChecks, s.TrapStubs, s.PinnedLocals, s.PinnedGlobalsValue)
+	if len(s.Calls) > 0 {
+		fmt.Fprintf(&b, "    calls: %s\n", fmtCountMap(s.Calls))
+	}
+	if len(s.Peephole) > 0 {
+		fmt.Fprintf(&b, "    peep:  %s\n", fmtCountMap(s.Peephole))
+	}
+	return b.String()
+}
+
+// fmtCountMap renders a map[string]int as "k1=v1 k2=v2" in stable key order.
+func fmtCountMap(m map[string]int) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%s=%d", k, m[k])
+	}
+	return strings.Join(parts, " ")
+}
+
+// funcDisplayName resolves a friendly name for local function index localIdx: the
+// name-section function name if present, else a matching function export, else "".
+// regName maps a Reg to its lowercase x86-64 mnemonic for the explain dump.
+func regName(r Reg) string {
+	switch r {
+	case RAX:
+		return "rax"
+	case RCX:
+		return "rcx"
+	case RDX:
+		return "rdx"
+	case RBX:
+		return "rbx"
+	case RSP:
+		return "rsp"
+	case RBP:
+		return "rbp"
+	case RSI:
+		return "rsi"
+	case RDI:
+		return "rdi"
+	case R8:
+		return "r8"
+	case R9:
+		return "r9"
+	case R10:
+		return "r10"
+	case R11:
+		return "r11"
+	case R12:
+		return "r12"
+	case R13:
+		return "r13"
+	case R14:
+		return "r14"
+	case R15:
+		return "r15"
+	default:
+		return fmt.Sprintf("r?%d", r)
+	}
+}
+
+func funcDisplayName(m *wasm.Module, localIdx, importedFuncs int) string {
+	global := uint32(importedFuncs + localIdx)
+	if n, ok := m.NameSec.FuncName(global); ok && n != "" {
+		return n
+	}
+	for i := range m.Exports {
+		ex := &m.Exports[i]
+		if ex.Index.Kind == wasm.ExternFunc && ex.Index.Index == global {
+			return ex.Name
+		}
+	}
+	return ""
+}

--- a/src/core/compiler/backend/railshot/stats_test.go
+++ b/src/core/compiler/backend/railshot/stats_test.go
@@ -1,0 +1,207 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// compileWithStats compiles m collecting per-function codegen stats and returns
+// the module stats. guard selects guard-page (elide) vs explicit bounds mode.
+func compileWithStats(t *testing.T, m *wasm.Module, guard bool) *ModuleStats {
+	t.Helper()
+	var ms ModuleStats
+	if _, err := CompileModuleWith(m, CompileOptions{ElideBoundsChecks: guard, Stats: &ms}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if len(ms.Funcs) != len(m.Code) {
+		t.Fatalf("stats funcs = %d, want %d", len(ms.Funcs), len(m.Code))
+	}
+	return &ms
+}
+
+// TestCodegenStatsPeepholes checks that each instruction-selection rewrite bumps
+// its named counter exactly once for a body built to trigger it precisely once,
+// and does not fire the others. This is the trustworthiness net the plan's exit
+// criterion asks for (docs/no-ir-plan.md P1).
+func TestCodegenStatsPeepholes(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	i32x2 := []wasm.ValType{wasm.I32, wasm.I32}
+	cases := []struct {
+		name string
+		in   []wasm.ValType
+		out  []wasm.ValType
+		body []byte
+		peep string
+	}{
+		{
+			// (0 locals) i32.const 3; i32.const 4; i32.add  → folded to const 7
+			name: "const-fold", in: nil, out: i32,
+			body: []byte{0x00, 0x41, 0x03, 0x41, 0x04, 0x6a, 0x0b},
+			peep: "const-fold",
+		},
+		{
+			// (0 locals) local.get 0; i32.const 0; i32.add  → x+0 → x
+			name: "alu-identity", in: i32, out: i32,
+			body: []byte{0x00, 0x20, 0x00, 0x41, 0x00, 0x6a, 0x0b},
+			peep: "alu-identity",
+		},
+		{
+			// (0 locals) local.get 0; i32.const 8; i32.mul  → x*8 → x<<3
+			name: "strength-reduce", in: i32, out: i32,
+			body: []byte{0x00, 0x20, 0x00, 0x41, 0x08, 0x6c, 0x0b},
+			peep: "strength-reduce",
+		},
+		{
+			// (0 locals) local.get 0; local.get 1; i32.const 2; i32.shl; i32.add → lea [x+y*4]
+			name: "lea-scaled-index", in: i32x2, out: i32,
+			body: []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x41, 0x02, 0x74, 0x6a, 0x0b},
+			peep: "lea-scaled-index",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mod1(t, tc.in, tc.out, tc.body)
+			s := compileWithStats(t, m, false).Funcs[0]
+			if got := s.Peephole[tc.peep]; got != 1 {
+				t.Errorf("Peephole[%q] = %d, want 1 (all: %v)", tc.peep, got, s.Peephole)
+			}
+			// No unrelated rewrite from this list should have fired.
+			for _, other := range cases {
+				if other.peep == tc.peep {
+					continue
+				}
+				if got := s.Peephole[other.peep]; got != 0 {
+					t.Errorf("unexpected Peephole[%q] = %d for body %q", other.peep, got, tc.name)
+				}
+			}
+		})
+	}
+}
+
+// TestCodegenStatsStoreAndBounds checks the immediate-store peephole and that the
+// bounds-check counter tracks the bounds mode: one inline check in explicit mode,
+// none in guard-page mode.
+func TestCodegenStatsStoreAndBounds(t *testing.T) {
+	// (0 locals) i32.const 16; i32.const 42; i32.store align=2 offset=0
+	body := []byte{0x00, 0x41, 0x10, 0x41, 0x2a, 0x36, 0x02, 0x00, 0x0b}
+	m := modMem(t, 1, nil, nil, body)
+
+	explicit := compileWithStats(t, m, false).Funcs[0]
+	if explicit.Peephole["store-imm"] != 1 {
+		t.Errorf("explicit store-imm = %d, want 1", explicit.Peephole["store-imm"])
+	}
+	if explicit.BoundsChecks != 1 {
+		t.Errorf("explicit BoundsChecks = %d, want 1", explicit.BoundsChecks)
+	}
+	if explicit.TrapStubs < 1 {
+		t.Errorf("explicit TrapStubs = %d, want >=1", explicit.TrapStubs)
+	}
+
+	guard := compileWithStats(t, m, true).Funcs[0]
+	if guard.Peephole["store-imm"] != 1 {
+		t.Errorf("guard store-imm = %d, want 1", guard.Peephole["store-imm"])
+	}
+	if guard.BoundsChecks != 0 {
+		t.Errorf("guard BoundsChecks = %d, want 0 (guard-page elides)", guard.BoundsChecks)
+	}
+}
+
+// TestCodegenStatsSizeCounters checks the always-on finalize counters are filled.
+func TestCodegenStatsSizeCounters(t *testing.T) {
+	// (0 locals) local.get 0; i32.const 8; i32.mul
+	m := mod1(t, []wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32},
+		[]byte{0x00, 0x20, 0x00, 0x41, 0x08, 0x6c, 0x0b})
+	s := compileWithStats(t, m, false).Funcs[0]
+	if s.CodeBytes <= 0 {
+		t.Errorf("CodeBytes = %d, want > 0", s.CodeBytes)
+	}
+	if s.FrameBytes <= 0 {
+		t.Errorf("FrameBytes = %d, want > 0", s.FrameBytes)
+	}
+	if s.Name != "f" { // mod1 exports the function as "f"
+		t.Errorf("Name = %q, want \"f\"", s.Name)
+	}
+}
+
+// TestModuleStatsReport checks the explain dump renders the module-pin line and
+// the per-function counters in a stable, greppable form.
+func TestModuleStatsReport(t *testing.T) {
+	ms := &ModuleStats{
+		ModuleGlobalPins: []ModuleGlobalPinInfo{{Global: 2, Reg: "r14"}, {Global: 4, Reg: "r13"}},
+		Funcs: []*CodegenStats{{
+			FuncIdx: 0, Name: "serialize", CodeBytes: 128, FrameBytes: 48, MaxSpillSlots: 2,
+			Flushes: 3, Condenses: 5, BoundsChecks: 4, TrapStubs: 1, PinnedLocals: 3,
+			Calls:    map[string]int{"regabi": 2, "host": 1},
+			Peephole: map[string]int{"store-imm": 7, "lea-scaled-index": 2},
+		}},
+	}
+	out := ms.String()
+	for _, want := range []string{
+		"module-pinned globals (K=2): g2→r14 g4→r13",
+		`fn#0 "serialize"`,
+		"code=128B frame=48B spill_hi=2",
+		"bounds=4 trapStubs=1",
+		"calls: host=1 regabi=2", // sorted keys
+		"peep:  lea-scaled-index=2 store-imm=7",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// TestCodegenStatsCodegenNeutral proves that collecting stats does not change a
+// single emitted byte: the counters live in CodegenStats, never in the Asm
+// buffer. This is the guardrail that lets every later phase trust the dashboard
+// without suspecting it perturbs the code it measures.
+func TestCodegenStatsCodegenNeutral(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	i32x2 := []wasm.ValType{wasm.I32, wasm.I32}
+	shapes := []struct {
+		name    string
+		mem     bool
+		in, out []wasm.ValType
+		body    []byte
+	}{
+		{"lea", false, i32x2, i32, []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x41, 0x02, 0x74, 0x6a, 0x0b}},
+		{"strength", false, i32, i32, []byte{0x00, 0x20, 0x00, 0x41, 0x08, 0x6c, 0x0b}},
+		{"store", true, nil, nil, []byte{0x00, 0x41, 0x10, 0x41, 0x2a, 0x36, 0x02, 0x00, 0x0b}},
+		{"load", true, i32, i32, []byte{0x00, 0x20, 0x00, 0x28, 0x02, 0x00, 0x0b}},
+	}
+	for _, sh := range shapes {
+		for _, guard := range []bool{false, true} {
+			var m *wasm.Module
+			if sh.mem {
+				m = modMem(t, 1, sh.in, sh.out, sh.body)
+			} else {
+				m = mod1(t, sh.in, sh.out, sh.body)
+			}
+			off, err := CompileModuleWith(m, CompileOptions{ElideBoundsChecks: guard})
+			if err != nil {
+				t.Fatalf("%s off: %v", sh.name, err)
+			}
+			on, err := CompileModuleWith(m, CompileOptions{ElideBoundsChecks: guard, Stats: &ModuleStats{}})
+			if err != nil {
+				t.Fatalf("%s on: %v", sh.name, err)
+			}
+			if !bytes.Equal(off.Code, on.Code) {
+				t.Errorf("%s guard=%v: stats collection changed emitted code (%d vs %d bytes)",
+					sh.name, guard, len(off.Code), len(on.Code))
+			}
+		}
+	}
+}
+
+func TestParsePinGlobalK(t *testing.T) {
+	cases := map[string]int{"": -1, "auto": -1, "bogus": -1, "0": 0, "1": 1, "2": 2, "3": 3}
+	for in, want := range cases {
+		if got := parsePinGlobalK(in); got != want {
+			t.Errorf("parsePinGlobalK(%q) = %d, want %d", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Implements **P1** of `docs/no-ir-plan.md` — the "explain" dashboard every later
optimization must prove itself against. *Do first; everything after reports to it.*

## What lands
- **`CodegenStats` / `ModuleStats`** (`stats.go`): per-function counters threaded
  through `fn` via a **nil `stats` field** — every counter is a nil-safe no-op when
  off, so **codegen is byte-identical** (proved by `TestCodegenStatsCodegenNeutral`,
  on/off × explicit/guard).
- **Counters**: code/frame bytes, spill high-water, flushes/flushBelows, condenses,
  spills/reloads, `MemRefsForcedByStore` (the P2.1 alias-blind signal), `BoundsChecks`
  (P6 target), trap stubs, `Calls` by kind (regabi/mixed/wrapper/host/indirect/
  crossinstance), pinned locals + value-pinned globals + module-pin K/regs, and a
  `Peephole` map (const-fold, alu-identity, strength-reduce, lea-scaled-index,
  store-imm, memcopy/memfill-unroll, cmp-branch-fuse, select-cmov, br-table-jump,
  call-localset-fuse).
- **Surfacing**: `CompileOptions.Stats` sink · `WAGO_EXPLAIN=1` (stderr dump) ·
  `bench/cmd/explain` tool (`go run ./cmd/explain [-guard] [module.wasm]`).
- **Knobs**: `WAGO_DEBUG_MODGLOBALS=1` (the #90-era temp print, now first-class) and
  `WAGO_PIN_GLOBAL_K=auto|0..3` (force the module-global pin count for A/B).
- **Golden-disasm harness** (`golden_test.go`, objdump-based, skips when absent):
  immediate store, scaled-index LEA, guard-vs-explicit bounds shape, forward
  `rep movs`. The regression net later phases extend.

## Exit criterion — verified on corpus
```
$ go run ./cmd/explain -guard corpus/json-as.wasm
module-pinned globals (K=3): g2→r14 g4→r13 g25→r12   # matches pickModuleGlobals
$ go run ./cmd/explain -guard corpus/blake-as.wasm
module-pinned globals (K=1): g11→r14
```
json-as shows B2 immediate stores (up to 24/fn), lea-scaled-index, call-localset-fuse,
and calls-by-kind (34 regabi / 20 host). K-override + debug knobs confirmed live.

## Gates
- `go test ./...` (root) and `cd bench && go test ./...` — green, plain **and**
  `-tags wago_guardpage` (incl. `TestCorpusDifferential` both modes).
- New: `TestCodegenStats*`, `TestGolden*`, `TestModuleStatsReport`, `TestParsePinGlobalK`.
- Spec suite not run locally (no WebAssembly/testsuite checkout in this env; the
  `warp/tests/testsuite` dir holds WARP's own files, not the core suite). Safe here:
  the change is codegen-neutral by construction and the corpus differential passes.

## Plan deviations (documented in `no-ir-plan.md` P1)
- There were **no** pre-existing objdump codegen tests to "extend" — the golden
  harness is new.
- "Deferred loads folded vs forced" ships as the single `MemRefsForcedByStore`
  (the number P2 drives down); the "folded" side is implicit.

Also refreshes OPTIMIZATIONS.md R0 (→ landed). Merges need explicit consent per the plan.

https://claude.ai/code/session_01J92SW4tm9qCAKHzGtXSU2i