### PR TITLE
website: perf card header — tabs top, legend top-right; general tab linked list

### DIFF
--- a/scripts/update-website-bench.mjs
+++ b/scripts/update-website-bench.mjs
@@ -45,7 +45,7 @@ const TABS = [
       rs("Call overhead", "host → wasm", "ExecCallOverhead_wago", "ExecCallOverhead_wazero"),
       rs("Exec latency", "fib_rec recursion", "ExecFibRec_wago", "ExecFibRec_wazero"),
       rs("Recursive tree", "memory_tree, loads + calls", "Exec/memory_tree.run", "WazeroExec/memory_tree.run"),
-      rs("JSON serialize", "json-as, SWAR", "Exec/json-as.serializeN", "WazeroExec/json-as.serializeN"),
+      rs("Linked list", "dependent-load chase", "Exec/linked_list.sum", "WazeroExec/linked_list.sum"),
       rs("JSON deserialize", "json-as, SWAR", "Exec/json-as.deserializeN", "WazeroExec/json-as.deserializeN"),
     ],
   },

--- a/scripts/update-website-bench.mjs
+++ b/scripts/update-website-bench.mjs
@@ -233,22 +233,25 @@ function renderSection(tabs) {
                     performance.
                 </p>
                 <div class="vs">
-                    <div class="vs__legend">
-                        <span class="vs__key"
-                            ><i class="vs__dot vs__dot--wago"></i>wago</span
+                    <div class="vs__head">
+                        <div
+                            class="vs__tabs"
+                            role="tablist"
+                            aria-label="Benchmark categories"
+                            data-tabs
                         >
-                        <span class="vs__key"
-                            ><i class="vs__dot vs__dot--wazero"></i>wazero</span
-                        >
-                        <span class="vs__legend-note">shorter is faster</span>
-                    </div>
-                    <div
-                        class="vs__tabs"
-                        role="tablist"
-                        aria-label="Benchmark categories"
-                        data-tabs
-                    >
 ${tablist}
+                        </div>
+                        <div class="vs__legend">
+                            <span class="vs__key"
+                                ><i class="vs__dot vs__dot--wago"></i>wago</span
+                            >
+                            <span class="vs__key"
+                                ><i
+                                    class="vs__dot vs__dot--wazero"
+                                ></i>wazero</span
+                            >
+                        </div>
                     </div>
 ${panels}
                 </div>


### PR DESCRIPTION
Generator layout update: category tabs move to the top of the perf card with the wago/wazero legend on the same row top-right, the "shorter is faster" note is dropped, and the General tab swaps JSON serialize for the linked-list row. Matching CSS/markup already live on wago-org/website.

https://claude.ai/code/session_01CeQXiRFxEWDrTAmaga2Qoi