### PR TITLE
[codex] redesign README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,61 @@
-<h1 align="center"><pre>╦ ╦ ╔═╗ ╔═╗ ╔═╗
-║║║ ╠═╣ ║ ╦ ║ ║
-╚╩╝ ╩ ╩ ╚═╝ ╚═╝</pre></h1>
-
 <p align="center">
-  A pure-Go WebAssembly JIT built for low-latency host ↔ wasm calls.
+  <a href="https://wago.sh">
+    <img src="https://wago.sh/assets/wago-logo.png" width="104" height="104" alt="wago logo">
+  </a>
 </p>
 
-<details>
-<summary>Table of Contents</summary>
+<h1 align="center">wago</h1>
 
-- [What](#what)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [CLI](#cli)
-  - [Go API](#go-api)
-- [API](#api)
-  - [`Value`](#value)
-  - [`Compile` / `Load`](#compile--load)
-  - [`Instance`](#instance)
-  - [Host imports](#host-imports)
-- [Feature Support](#feature-support)
-- [Performance](#performance)
-- [Architecture](#architecture)
-- [Project Layout](#project-layout)
-- [Running Tests](#running-tests)
-- [Contributing](#contributing)
-- [License](#license)
-- [Contact](#contact)
+<p align="center">
+  A WebAssembly engine, written in pure Go.
+</p>
 
-</details>
+<p align="center">
+  <a href="https://wago.sh">Website</a>
+  ·
+  <a href="FEATURES.md">Features</a>
+  ·
+  <a href="ROADMAP.md">Roadmap</a>
+  ·
+  <a href="ARCHITECTURE.md">Architecture</a>
+  ·
+  <a href="bench/README.md">Benchmarks</a>
+</p>
 
-## What
+<pre align="center">
+╦ ╦ ╔═╗ ╔═╗ ╔═╗
+║║║ ╠═╣ ║ ╦ ║ ║
+╚╩╝ ╩ ╩ ╚═╝ ╚═╝
+</pre>
 
-`wago` is a **no-cgo** WebAssembly engine for Go. It decodes, validates,
-compiles, and runs wasm modules through a single-pass x86-64 backend.
-
-It borrows the host-boundary shape from [WARP](warp/), BMW's C++ single-pass
-engine, then keeps the Go side intentionally small:
-
-- one stable wrapper ABI for every export
-- native wasm code on an off-heap foreign stack
-- mmap-backed linear memory exposed directly as `[]byte`
-- optional precompiled `.wago` blobs for fast reloads through the Go API
+`wago` decodes, validates, compiles, and runs WebAssembly through a no-cgo
+single-pass x86-64 JIT. It is built for Go programs that want native wasm calls
+without a C toolchain, and for small systems where startup time, memory shape,
+and operational simplicity matter.
 
 Current target: **linux/amd64**.
 
-## Installation
+## Install
 
-CLI — wago is private during development, so the installer **builds from source
-over SSH**. You need read access to the repo and Go 1.22+:
+CLI:
 
 ```bash
 curl -fsSL https://wago.sh/install.sh | sh
 ```
 
-No access yet? Sit tight — wago goes public with **v0.1.0**, and the same command
-will install a prebuilt binary with no access required.
+During private development this builds from source over SSH, so you need read
+access to `git@github.com:wago-org/wago` and Go 1.22+. The same installer is the
+public entry point for v0.1.0.
 
-Knobs: `WAGO_VERSION` (git ref to build — branch, tag, or commit; default
-`main`), `WAGO_BIN_DIR` (default `~/.local/bin`). From a checkout, just run
-`./install.sh`.
+Useful installer knobs:
 
-Library:
+```bash
+WAGO_VERSION=main        # branch, tag, or commit
+WAGO_BIN_DIR=~/.local/bin
+WAGO_DRY_RUN=1
+```
+
+Go library:
 
 ```bash
 go get github.com/wago-org/wago
@@ -74,27 +68,25 @@ go build -o wago ./cli/wago
 go install ./cli/wago
 ```
 
-## Usage
+## Try It
 
-### CLI
-
-```bash
-./wago run tests/testdata/fib.wasm 30
-./wago run -e hypot tests/testdata/fprog.wasm 3.0 4.0
-
-./wago validate tests/testdata/fib.wasm
-```
-
-Arguments are typed from the target export signature. You can override a parsed
-type with a suffix:
+Run a wasm export:
 
 ```bash
-./wago run -e hypot tests/testdata/fprog.wasm 3:f64 4:f64
+wago run tests/testdata/fib.wasm 30
+wago run -e hypot tests/testdata/fprog.wasm 3:f64 4:f64
 ```
 
-Replace the `tests/testdata/*.wasm` paths with your own module.
+Validate a module:
 
-### Go API
+```bash
+wago validate tests/testdata/fib.wasm
+```
+
+Arguments are typed from the export signature. Add a suffix when the literal
+needs a precise wasm type: `42`, `7:i64`, `3.5:f64`.
+
+## Embed It
 
 ```go
 package main
@@ -112,55 +104,26 @@ func main() {
 		panic(err)
 	}
 
-	c, err := wago.Compile(wasmBytes)
+	mod, err := wago.Compile(wasmBytes)
 	if err != nil {
 		panic(err)
 	}
-	in, err := wago.Instantiate(c, nil)
+
+	inst, err := wago.Instantiate(mod, nil)
 	if err != nil {
 		panic(err)
 	}
-	defer in.Close()
-	out, err := in.Invoke("hypot", wago.F64(3), wago.F64(4))
+	defer inst.Close()
+
+	out, err := inst.Invoke("hypot", wago.F64(3), wago.F64(4))
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(wago.AsF64(out[0])) // 5
+	fmt.Println(wago.AsF64(out[0]))
 }
 ```
 
-For repeated calls, compile and instantiate explicitly:
-
-```go
-wasmBytes, err := os.ReadFile("tests/testdata/fib.wasm")
-if err != nil {
-	panic(err)
-}
-
-c, err := wago.Compile(wasmBytes)
-if err != nil {
-	panic(err)
-}
-
-in, err := wago.Instantiate(c, nil)
-if err != nil {
-	panic(err)
-}
-defer in.Close()
-
-out, err := in.Invoke("fib", wago.I32(30))
-if err != nil {
-	panic(err)
-}
-fmt.Println(wago.AsI32(out[0]))
-```
-
-## API
-
-### Call Slots
-
-Arguments and results use raw 8-byte wasm call slots. The function signature
-defines how each `uint64` is interpreted.
+Arguments and results use raw 8-byte wasm call slots:
 
 ```go
 wago.I32(1)
@@ -171,246 +134,104 @@ wago.F64(1.5)
 
 Read results with `AsI32`, `AsI64`, `AsF32`, or `AsF64`.
 
-### `Compile` / `Load`
-
-```go
-c, err := wago.Compile(wasmBytes)
-blob, err := c.MarshalBinary()
-
-c, err = wago.Load(blob)      // precompiled .wago
-c, err = wago.Load(wasmBytes) // raw wasm, compiled on load
-```
-
-### `Instance`
-
-```go
-in, err := wago.Instantiate(c, hosts)
-defer in.Close()
-
-_ = in.Memory().Bytes()
-_, err = in.Invoke("exported", args...)
-_, err = in.Global("exported_global")
-err = in.SetGlobal("mutable_exported_global", wago.I32(42))
-```
-
-`Memory().Bytes()` returns the same mmap-backed region native wasm code sees.
-Writes are visible in both directions without copying.
-
-For typed access there are bounds-checked little-endian accessors —
-`ReadUint8`/`ReadUint16Le`/`ReadUint32Le`/`ReadUint64Le`/`ReadFloat32Le`/
-`ReadFloat64Le` (and `Write…` counterparts), plus `Read(offset, length)` /
-`Write(offset, b)` for byte ranges. Each returns `ok=false` (writing nothing) when
-the range is out of bounds. They compile to a single aligned load/store, faster
-than `encoding/binary` on the slice — notably under TinyGo (see
-[docs/tinygo.md](docs/tinygo.md)).
-
-```go
-v, ok := in.ReadUint32Le(off)
-ok = in.WriteFloat64Le(off, 3.14)
-```
-
-`Global` and `SetGlobal` access exported numeric globals by name. Reads return the
-current raw bits. Writes require an exported mutable global and use the global's
-declared type to interpret the bits.
-
-### Host imports
-
-Host imports are keyed by `"module.name"`:
-
-```go
-hosts := wago.Imports{
-	"env.log": wago.HostFunc(func(arg int32) {
-		fmt.Println(arg)
-	}),
-}
-
-in, err := wago.Instantiate(c, hosts)
-```
-
-Current host function imports are void and receive the first `i32` argument.
-Native code logs import calls, then Go dispatches them after the wasm call
-returns.
-
-Imported globals and memories use the same `Imports` namespace:
-
-```go
-counter := wago.NewGlobalI32(10, true)
-defer counter.Close()
-mem, err := wago.NewMemory(1, 1)
-
-imports := wago.Imports{
-	"env.log":     wago.HostFunc(func(arg int32) { fmt.Println(arg) }),
-	"env.counter": wago.GlobalImport{Global: counter},
-	"env.mem":     mem,
-}
-
-in, err := wago.Instantiate(c, imports)
-out, err := in.Invoke("get_counter")
-```
-
-Use `GlobalImport{Global: g}` for shared imported globals, especially mutable
-ones. The instance stores that host-owned global cell directly: wasm writes,
-`Instance.SetGlobal`, `g.Set`, and other instances importing the same `*Global`
-all observe the same value. Call `g.Close()` only after every instance that uses
-it has been closed.
-
-For one-shot or immutable imports, `GlobalImport{Type, Mutable, Bits}` is a
-convenience shorthand. `GlobalImport.Bits` uses the raw wasm numeric encoding:
-`i32`/`f32` use the low 32 bits (integer bits or IEEE-754 f32 bits), and
-`i64`/`f64` use all 64 bits (integer bits or IEEE-754 f64 bits). In this
-shorthand form, wago creates the imported global object during instantiation;
-mutating the original `GlobalImport` value after `Instantiate` returns is not
-observed by the instance.
-
-## Feature Support
-
-`wago` runs real AssemblyScript modules across the core scalar types:
+## What Ships
 
 | Area | Status |
 |---|---|
-| Values | `i32`, `i64`, `f32`, `f64` arithmetic, compares, conversions, reinterpret |
-| Control flow | `block`, `loop`, `if`, `else`, `br`, `br_if`, `br_table`, `return`, `select` |
-| Memory | bounds-checked linear-memory loads/stores, checked active data segments |
-| Globals | numeric immutable/mutable globals, global imports/exports, `Global`/`SetGlobal` accessors |
-| Calls | direct calls, recursion, `call_indirect`, checked active element segments |
-| Host imports | void/log-style imports, batched back to Go |
-| Serialization | precompiled `.wago` blobs |
+| WebAssembly 1.0 MVP | Complete; pinned pre-reference-types spectest passes in full |
+| Values | `i32`, `i64`, `f32`, `f64`, conversions, reinterpret, trunc traps |
+| Control flow | `block`, `loop`, `if`, `else`, branches, `select`, recursion |
+| Calls | direct calls, `call_indirect`, host imports, cross-instance function links |
+| Memory | all scalar load/store widths, `memory.size`, `memory.grow`, `memory.copy`, `memory.fill` |
+| Imports/exports | functions, memories, tables, globals, mutable shared globals |
+| Runtime | W^X mmap code, foreign stack, trap-to-error path, zero-copy linear memory |
+| Platform | linux/amd64 today; more targets planned |
 
-See [FEATURES.md](FEATURES.md) for the full matrix and [ROADMAP.md](ROADMAP.md)
-for the plan.
+See [FEATURES.md](FEATURES.md) for the full support matrix and
+[ROADMAP.md](ROADMAP.md) for planned work.
 
-Notable gaps today: `memory.grow`, start functions, remaining bulk-memory
-ops (`memory.init`, `data.drop`, `table.*`), exact float trunc traps / NaN
-min-max behavior, i64 sub-width loads, WASI, and platforms beyond linux/amd64.
+## Why Wago
+
+- **No cgo.** Build and deploy with the Go toolchain only.
+- **JIT-only.** Wasm compiles to native x86-64 code; there is no interpreter tier.
+- **Small runtime shape.** Linear memory is mmap-backed and exposed directly as
+  `[]byte`.
+- **Fast startup path.** The compiler is single-pass and consumes validated wasm
+  bytes directly.
+- **Auditable backend.** The railshot backend follows WARP's Valent-Block style:
+  register-resident straight-line code with deterministic frame slots at joins.
 
 ## Performance
 
-The local `bench/` suite compares against wazero v1.9. On the development
-machine used for this snapshot:
+The benchmark suite compares wago against wazero over the same wasm corpus. The
+current project snapshot reports:
 
-- compile is ~**34x faster**
-- host-to-wasm call overhead is ~**3x lower**
-- host-to-wasm calls allocate **0 bytes**
-- loop execution is competitive
-- recursion and instantiate currently trail wazero (see [ROADMAP.md](ROADMAP.md))
+| Workload | Direction |
+|---|---|
+| Compile latency | about 34x faster than wazero |
+| Host-to-wasm calls | lower overhead, 0 B/op on the hot call path |
+| Scalar loops and memory kernels | competitive to faster on several corpus cases |
+| Recursion and some larger real-world kernels | still active optimization targets |
 
-<img src="https://raw.githubusercontent.com/wago-org/docs/main/charts/speedup.svg" alt="wago speedup vs wazero" width="100%">
-
-<img src="https://raw.githubusercontent.com/wago-org/docs/main/charts/latency.svg" alt="latency: ns/op, wago vs wazero" width="100%">
-
-The charts live in the [`wago-org/docs`](https://github.com/wago-org/docs) repo
-and are embedded here via raw URLs, so regenerating them never churns this repo's
-history. Preview locally and publish:
+Run the local suite:
 
 ```bash
-cd bench && go run ./chart     # preview into bench/charts/ (gitignored)
-./scripts/publish-charts.sh    # regenerate on a stable machine, push to wago-org/docs
+cd bench
+go test ./...
+go test -bench .
 ```
 
-`bench/` is a separate Go module so the root package stays dependency-light; the
-chart generator is pure-Go SVG (no chart runtime).
-
-### Comparing against WARP
-
-wago is a Go port of [WARP](warp/), BMW's C++ single-pass compiler, so the suite
-can run WARP over the same corpus for a head-to-head. WARP ships as a git
-submodule; one command checks it out, builds its harness, and runs it:
-
-```bash
-make bench-warp        # needs cmake + a C++14 toolchain; no other setup
-```
-
-This checks out the `warp/` submodule, applies the bench harness patch
-([`bench/warp/bench-main.patch`](bench/warp/bench-main.patch)), builds `vb_bench`,
-and prints per-module WARP compile/exec numbers. `make bench WARP=auto` then folds
-them into the `compile-engines` / `exec-engines` comparison charts. The x86-64
-build needs none of WARP's own nested submodules. See
-[bench/README.md](bench/README.md#cross-engine-comparison) for details.
+The methodology and chart publishing flow live in [bench/README.md](bench/README.md).
 
 ## Architecture
 
-For the full design — pipeline, Valent-Block backend, JobMemory/ABI layout, the
-no-cgo execution mechanism, globals, host imports, and conformance — see
-[ARCHITECTURE.md](ARCHITECTURE.md).
-
-The core path is:
-
 ```text
 wasm bytes
-  -> src/core/compiler/wasm        byte-backed DecodeModule + validate + support filtering
-  -> src/core/compiler/backend     single-pass amd64 codegen over validated BodyBytes
-  -> src/core/runtime              W^X mmap + foreign-stack trampoline
+  -> decode + validate
+  -> byte-backed module body
+  -> railshot single-pass x86-64 codegen
+  -> no-cgo runtime: mmap code, foreign stack, trap cell, linear memory
 ```
 
-`DecodeModule` keeps function bodies byte-backed (locals + raw BodyBytes) instead
-of materializing production instruction trees. Production compile consumes those
-validated bytes directly; IR build/verify is not on the hot compile path unless a
-codegen path explicitly consumes IR.
+For the full design, including ABI layout, memory/trap handling, globals, host
+imports, and conformance strategy, read [ARCHITECTURE.md](ARCHITECTURE.md).
 
-The public CLI validation entry point is `wago validate <file>`.
-
-The runtime calls every export through a single wrapper shape:
+## Project Map
 
 ```text
-WasmWrapper(serArgs, linMem, trap, results)
+cli/wago/                         CLI
+src/wago/                         public API implementation
+wago.go                           root package facade
+src/core/compiler/wasm/           decoder and validator
+src/core/compiler/backend/railshot/ single-pass x86-64 backend
+src/core/runtime/                 no-cgo execution runtime
+bench/                            corpus and comparison benchmarks
+tests/testdata/                   small wasm fixtures
+docs/                             design notes and active plans
 ```
 
-Arguments and results are 8-byte slots. `linMem` points at the mmap-backed
-linear memory. Traps are reported through a small trap slot.
-
-The backend uses a Valent-Block style symbolic operand stack: straight-line code
-stays register-resident, while control-flow joins flush to deterministic frame
-slots so every incoming edge agrees on machine state.
-
-### TinyGo
-
-wago also builds and runs under [TinyGo](https://tinygo.org) on `linux/amd64`,
-still with no cgo. Because TinyGo cannot assemble Plan9 `.s` files, the
-foreign-stack trampoline is generated as machine code at run time and entered
-through a func-value cast instead. See [docs/tinygo.md](docs/tinygo.md) for build
-instructions and caveats, or run `make tinygo-build`.
-
-## Project Layout
-
-```text
-.
-  wago.go                         public Go API (generated facade over src/wago)
-  src/wago/                       public API implementation
-  internal/genfacade/             generator for wago.go
-  cli/wago/                       CLI
-  src/core/compiler/wasm/         decoder + validator
-  src/core/compiler/backend/railshot/ single-pass x86-64 backend
-  src/core/runtime/               no-cgo execution runtime
-  tests/testdata/                 wasm fixtures
-  bench/                          wazero comparison benchmarks
-  warp/                           reference C++ WARP tree
-```
-
-## Running Tests
+## Development
 
 ```bash
 go test ./...
 
 cd bench
 go test ./...
-go test -bench .
 ```
 
-The wasm frontend can also run the official WebAssembly spec testsuite when
-`WAGO_SPECTEST_DIR` points at a checkout and `wast2json` is on `PATH`.
+Optional checks:
 
-## Contributing
+```bash
+make spectest      # requires WAGO_SPECTEST_DIR and wast2json
+make tinygo-build  # requires TinyGo + lld
+make bench-warp    # requires cmake + a C++14 toolchain
+```
 
-This project is early and intentionally small. [ROADMAP.md](ROADMAP.md) has the
-best list of useful work. Keep changes narrow, include regression tests, and
-prefer the existing WARP-shaped layout over new abstractions.
+Contributors should start with [CONTRIBUTING.md](CONTRIBUTING.md), then check
+[ROADMAP.md](ROADMAP.md) before changing feature support or priorities.
 
 ## License
 
-See [LICENSE](LICENSE).
+Apache-2.0. See [LICENSE](LICENSE).
 
 The reference WARP tree under [warp/](warp/) keeps its original license headers.
-
-## Contact
-
-Open an issue or discussion on the project repository.


### PR DESCRIPTION
## What

- Rewrites the top-level README as a concise project entry point.
- Uses the wago.sh logo and ASCII banner styling.
- Updates the support snapshot to match the current feature and roadmap docs.
- Points deeper API, architecture, benchmark, and contribution details at their source docs instead of duplicating them in the front page.

## Why

The previous README had grown into a long reference document and included stale feature gaps. This keeps the repository front page aligned with the public site style and current project status.

## Impact

Developers get a shorter path through install, first run, embedding, feature support, performance context, architecture, and development commands.

## Validation

- `git diff --check`
- `go test ./...`