### PR TITLE
test(wago): guard-tag-aware src/wago suite; run full package in test-guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ test: ## Build and run the test suite (host)
 	go test -count=1 ./...
 
 .PHONY: test-guard
-test-guard: ## Guard-page (signals-based) tests: the SIGSEGV fault->trap path + in-bounds correctness
-	go test -count=1 -tags wago_guardpage -run 'TestConfigSignalsBasedEndToEnd|TestSignalsBasedNotSerializable' ./src/wago/
+test-guard: ## Guard-page (signals-based) tests: full public-API suite (incl. the SIGSEGV fault->trap path) + in-bounds differential
+	go test -count=1 -tags wago_guardpage ./src/wago/
 	cd bench && go test -count=1 -tags wago_guardpage -run 'TestCorpusDifferential|TestJsonAsGuardCorrect' .
 
 # Run the WebAssembly spec suite (the WebAssembly/testsuite submodule at

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -67,8 +67,9 @@ func TestConfigBoundsEnv(t *testing.T) {
 
 func TestConfigImmutable(t *testing.T) {
 	base := NewRuntimeConfig()
+	baseMode := base.BoundsChecks() // default depends on the build tag; capture it
 	derived := base.WithBoundsChecks(BoundsChecksSignalsBased).WithMemoryLimitPages(10)
-	if base.BoundsChecks() != BoundsChecksExplicit {
+	if base.BoundsChecks() != baseMode {
 		t.Fatal("WithBoundsChecks mutated the base config")
 	}
 	if derived.BoundsChecks() != BoundsChecksSignalsBased {
@@ -121,8 +122,9 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	if GuardPageSupported() != guardPageBuilt {
 		t.Fatal("GuardPageSupported should mirror the build tag")
 	}
-	// String is non-empty / informative.
-	if s := NewRuntimeConfig().String(); !strings.Contains(s, "explicit") {
+	// String is non-empty / informative. The default bounds mode depends on the
+	// build tag (explicit normally, signals-based under wago_guardpage).
+	if s := NewRuntimeConfig().String(); !strings.Contains(s, "explicit") && !strings.Contains(s, "signals-based") {
 		t.Fatalf("config String missing bounds mode: %q", s)
 	}
 }

--- a/src/wago/cross_instance_test.go
+++ b/src/wago/cross_instance_test.go
@@ -18,6 +18,7 @@ func funcImportEntry(module, name string, typeIdx uint32) []byte {
 // TestCrossInstanceMemoryShared: A owns a memory with data; B imports A's memory,
 // writes into it, and A observes the write (shared bytes).
 func TestCrossInstanceMemoryShared(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit") // imported memory is unsupported under signals-based (the guard-tag default)
 	// A: memory 1; data at offset 10 = {1,2,3}; load(a)->i32 = i32.load8_u; store(a,v).
 	modA := wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(

--- a/src/wago/memory_test.go
+++ b/src/wago/memory_test.go
@@ -34,6 +34,7 @@ func importMemModule() []byte {
 }
 
 func TestImportedMemoryShared(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit") // imported memory is unsupported under signals-based (the guard-tag default)
 	c, err := Compile(importMemModule())
 	if err != nil {
 		t.Fatalf("compile (memory import should be accepted now): %v", err)
@@ -82,6 +83,7 @@ func TestImportedMemoryMissing(t *testing.T) {
 }
 
 func TestImportedMemorySingleInstance(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit") // imported memory is unsupported under signals-based (the guard-tag default)
 	c, _ := Compile(importMemModule())
 	mem, _ := NewMemory(1, 1)
 	defer mem.Close()
@@ -96,6 +98,7 @@ func TestImportedMemorySingleInstance(t *testing.T) {
 }
 
 func TestImportedMemorySurvivesMarshalLoad(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit") // imported memory + serialization are unsupported under signals-based (the guard-tag default)
 	c, err := Compile(importMemModule())
 	if err != nil {
 		t.Fatal(err)

--- a/src/wago/wago_test.go
+++ b/src/wago/wago_test.go
@@ -344,6 +344,7 @@ func TestAssemblyScriptFloat(t *testing.T) {
 }
 
 func TestCompiledRoundtrip(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit") // signals-based modules can't be serialized (the guard-tag default)
 	c, err := Compile(fibWasm)
 	if err != nil {
 		t.Fatal(err)
@@ -377,6 +378,7 @@ func TestCompiledRoundtrip(t *testing.T) {
 }
 
 func TestCompiledRoundtripPreservesDebugNames(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit") // signals-based modules can't be serialized (the guard-tag default)
 	importEntry := append(wasmtest.Name("env"), wasmtest.Name("imp")...)
 	importEntry = append(importEntry, 0x00) // func import
 	importEntry = append(importEntry, wasmtest.ULEB(0)...)


### PR DESCRIPTION
Follow-up to #103. With the guard-mode crashes fixed (#103 trap-cell handler + the `CallGuarded` `LinMemBase` change), the `-tags wago_guardpage` `./src/wago` suite had only **test-expectation** failures left — tests that assume the explicit-mode default, which flips to signals-based under the guard build tag. This makes them tag-aware so the whole package is green under the tag, and widens the CI `test-guard` step to run it.

## Changes

- **Config tests** (`config_test.go`) — tag-agnostic: `TestConfigImmutable` captures the base's default mode and asserts it's unchanged (rather than hardcoding `explicit`); the `String()` check accepts either `explicit` or `signals-based`.
- **Explicit-only feature tests** — `t.Setenv("WAGO_BOUNDS", "explicit")` so they exercise their feature regardless of the build-tag default (no-op in normal builds, where explicit is already the default):
  - imported memory (unsupported under signals-based): `TestImportedMemoryShared`, `TestImportedMemorySingleInstance`, `TestImportedMemorySurvivesMarshalLoad`, `TestCrossInstanceMemoryShared`
  - serialization (signals-based modules can't be marshaled): `TestCompiledRoundtrip`, `TestCompiledRoundtripPreservesDebugNames`
- **`make test-guard`** now runs the full `go test -tags wago_guardpage ./src/wago/` (was two named tests), so the entire public-API suite is exercised under guard mode in CI.

## Verification

- `go test -tags wago_guardpage ./src/wago/` — **green**.
- `go test ./src/wago/` (no tag) — green (the env/immutability changes are no-ops there).
- `make test-guard` — green.