### PR TITLE
perf: P6 bounds-facts measurement — capped at ~7% in the no-IR model

### DIFF
--- a/docs/no-ir-plan.md
+++ b/docs/no-ir-plan.md
@@ -267,6 +267,29 @@ if the restricted version measures.
    the prize first. AS getter/setter chains are the target.
 
 ### P6. Memory & bounds, explicit-mode focus (M/L)
+**⚠️ MEASURED near-capped in the no-IR model (2026-07-03, three count-only
+counters on `perf/bounds-facts`, codegen-neutral; spec 57/57, differential both
+modes green):**
+- **P6.1 straight-line** (`BoundsChecksElidable`, a same-source certificate;
+  memBytes is monotonic so a fact holds until the source changes or a control
+  join): **~7%** of explicit-mode checks (json-as 42/638, utf-as 6/54, blake 3/56;
+  spread thin, not hot-concentrated). Real, but modest — same "AS/binaryen already
+  optimized the wasm level" story as P2/P3.
+- **P6.2 loop precheck** (`BoundsChecksInLoop` = 27–78% ceiling, but
+  `BoundsChecksHoistable` on a loop-INVARIANT local base = **0 across every corpus
+  module**; counter verified on a synthetic invariant-base loop). Real loop
+  accesses use a **computed** `base+index` (unkeyable) or an **advancing** pointer
+  (set every iteration) — never a bare invariant local. The redundant loop checks
+  (e.g. json-as's 175) come from AS-level `ensureCapacity`+burst — a *semantic*
+  guarantee invisible to the per-instruction view. Bounding them needs
+  induction-variable analysis (trip-count × stride) = the whole-function IR §0
+  rejects. **P6.2 is structurally out of reach in the no-IR architecture.**
+- **Verdict:** the bounds lever tops out at P6.1's ~7% here. Sound P6.2 (hybrid
+  precheck → *dual* loop body, to avoid spurious traps on 0-iteration/early-exit
+  loops) was designed and shelved — it would elide ~nothing. Revisit only if the
+  IR non-goal is ever revisited, or a non-AS/hand-written-wasm workload shows a
+  nonzero `hoistable`. P5 (call mechanics, ABI is wago's) is the live lever.
+
 1. **Straight-line bounds facts** (review §M3, "certificates"): after a check
    of `base+hi`, later accesses `base+[lo,hi)` in the same straight-line
    region skip the check. Same base reg + const offsets only; invalidated by

--- a/docs/no-ir-plan.md
+++ b/docs/no-ir-plan.md
@@ -267,28 +267,32 @@ if the restricted version measures.
    the prize first. AS getter/setter chains are the target.
 
 ### P6. Memory & bounds, explicit-mode focus (M/L)
-**⚠️ MEASURED near-capped in the no-IR model (2026-07-03, three count-only
-counters on `perf/bounds-facts`, codegen-neutral; spec 57/57, differential both
-modes green):**
-- **P6.1 straight-line** (`BoundsChecksElidable`, a same-source certificate;
-  memBytes is monotonic so a fact holds until the source changes or a control
-  join): **~7%** of explicit-mode checks (json-as 42/638, utf-as 6/54, blake 3/56;
-  spread thin, not hot-concentrated). Real, but modest — same "AS/binaryen already
-  optimized the wasm level" story as P2/P3.
-- **P6.2 loop precheck** (`BoundsChecksInLoop` = 27–78% ceiling, but
-  `BoundsChecksHoistable` on a loop-INVARIANT local base = **0 across every corpus
-  module**; counter verified on a synthetic invariant-base loop). Real loop
-  accesses use a **computed** `base+index` (unkeyable) or an **advancing** pointer
-  (set every iteration) — never a bare invariant local. The redundant loop checks
-  (e.g. json-as's 175) come from AS-level `ensureCapacity`+burst — a *semantic*
-  guarantee invisible to the per-instruction view. Bounding them needs
-  induction-variable analysis (trip-count × stride) = the whole-function IR §0
-  rejects. **P6.2 is structurally out of reach in the no-IR architecture.**
-- **Verdict:** the bounds lever tops out at P6.1's ~7% here. Sound P6.2 (hybrid
-  precheck → *dual* loop body, to avoid spurious traps on 0-iteration/early-exit
-  loops) was designed and shelved — it would elide ~nothing. Revisit only if the
-  IR non-goal is ever revisited, or a non-AS/hand-written-wasm workload shows a
-  nonzero `hoistable`. P5 (call mechanics, ABI is wago's) is the live lever.
+**⚠️ MEASURED — the live lever for COMPUTE kernels, dead on AS (2026-07-03, three
+count-only counters on `perf/bounds-facts`, codegen-neutral; spec 57/57,
+differential both modes green). The producer matters, exactly as this plan
+predicted:**
+- **On the AS/binaryen corpus (json/blake/utf), P6 is near-dead:** P6.1
+  (`BoundsChecksElidable`, a same-source certificate — memBytes is monotonic so a
+  fact holds until the source is set or a control join) = **~7%** (json-as 42/638),
+  spread thin; P6.2 (`BoundsChecksHoistable`, loop-invariant local base) = **0**.
+  AS loop accesses use a computed `base+index` or an advancing pointer, and its
+  redundant checks come from AS-level `ensureCapacity`+burst (a semantic guarantee
+  invisible per-instruction). Same "binaryen already optimized the wasm level"
+  story as P2/P3.
+- **On the non-AS corpus (Rust/C compute kernels), P6 is BIG and HOT-concentrated:**
+  nbody `step` alone = bounds 96 / **elidable 60 (63%)** / **hoistable 37**;
+  fannkuch = 128 / 36 / **63**; raytrace = 94 / **50 (53%)** / 12; sha256 = 52 / 3
+  / **16**. These access arrays through a **loop-invariant local pointer** — the
+  pattern AS lacks — so both P6.1 AND P6.2 have real, hot targets. (`hoistable`
+  counter verified: synthetic invariant-base loop → 1, set-in-loop → 0.) All four
+  are in `TestCorpusDifferential` (the bounds-mode-desync-sensitive cases), so the
+  #68-class net covers the implementation.
+- **Verdict: implement P6 — it's the TinyGo/embedded/compute-kernel explicit-bounds
+  win the plan claimed, just invisible on AS serialization.** Order: **P6.1** first
+  (63% on nbody, hot, contained cert already built on `perf/bounds-facts`), then
+  **P6.2** (now that `hoistable` is nonzero — the sound hybrid = precheck → dual
+  loop body to avoid spurious 0-iteration/early-exit traps). P5 (call mechanics) is
+  dead even on non-AS (`mixed`/`wrapper` = 0 everywhere) — deprioritize it.
 
 1. **Straight-line bounds facts** (review §M3, "certificates"): after a check
    of `base+hi`, later accesses `base+[lo,hi)` in the same straight-line

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -102,6 +102,16 @@ type fn struct {
 	globalCellReg Reg
 	globalCellIdx uint32
 
+	// Straight-line bounds-check certificate (P6.1). After a check proves
+	// source+bcExtent <= memBytes, a later access on the SAME address source with
+	// off+size <= bcExtent is in-bounds and needs no check. Keyed on the address
+	// SOURCE (a local/global index — a stable value), not a physical register.
+	// Invalidated at any flush (call/control boundary), memory.grow, and a set of
+	// the source. Currently count-only via stats (measurement; no codegen change).
+	bcKind   uint8  // 0 none, 1 local, 2 global
+	bcIdx    uint32 // address source index
+	bcExtent int32  // max off+size proven in-bounds on that source
+
 	// globalReg[g] value-pins hot mutable-int global g in a register for the whole
 	// function, sharing the GP pin pool with hot locals (WARP's model). The value is
 	// loaded once in the prologue and every access reads/writes the register directly

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -78,6 +78,7 @@ func (f *fn) rootsBottomToTop() []*elem {
 func (f *fn) flush() {
 	f.stats.addFlush()
 	f.invalidateGlobalsCache() // the cached cell ptr must not span a call/control boundary
+	f.invalidateBoundsCert()   // bounds facts are valid only within a straight-line region
 	roots := f.rootsBottomToTop()
 	for i, root := range roots {
 		if root.kind == ekValue && root.st.kind == stSlot && root.st.slot == i {

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -40,6 +40,13 @@ type ctrlFrame struct {
 	regMerge1       bool        // single-result block/if: value lives in a register (mergeReg/mergeFReg) at edges, not a slot
 	res0            machineType // first result's machine type (valid when resultN >= 1)
 
+	// cfLoop only (P6.2 foundation): locals set anywhere in the loop body, and
+	// whether the body grows memory — from a scan-ahead at the loop header. A local
+	// base NOT in loopSetLocals is loop-invariant (a callee cannot touch a caller
+	// local), so its bounds check is hoistable. nil for non-loops / unreachable.
+	loopSetLocals map[uint32]bool
+	loopHasGrow   bool
+
 	// Per-frame pinned-local merge agreement (convergeEdgeTo): branchState is the
 	// recorded state at this frame's branch target (loop top for loops, the end
 	// merge for blocks/ifs), fixed by the first edge; entryState is a cfIf
@@ -274,6 +281,61 @@ func (f *fn) branchJump(fr *ctrlFrame) {
 
 // --- control opcodes ---
 
+// scanLoopBody scans a loop body ahead from the reader's current position (the
+// body start, just past the blocktype) to the matching `end`, recording the
+// locals it sets and whether it grows memory, then restores the reader. Reuses
+// skipImmediates for operand skipping; br_table (not covered there) is handled
+// inline. Post-validation, so a decode error just ends the scan.
+func scanLoopBody(r *wasm.Reader) (setLocals map[uint32]bool, hasGrow bool) {
+	start := r.Offset()
+	setLocals = map[uint32]bool{}
+	depth := 0
+scan:
+	for {
+		op, err := r.Byte()
+		if err != nil {
+			break
+		}
+		switch op {
+		case 0x02, 0x03, 0x04: // block / loop / if: skip blocktype, enter one level
+			if _, err := r.S33(); err != nil {
+				break scan
+			}
+			depth++
+		case 0x0b: // end
+			if depth == 0 {
+				break scan
+			}
+			depth--
+		case 0x21, 0x22: // local.set / local.tee
+			idx, err := r.U32()
+			if err != nil {
+				break scan
+			}
+			setLocals[idx] = true
+		case 0x40: // memory.grow
+			if _, err := r.U32(); err != nil {
+				break scan
+			}
+			hasGrow = true
+		case 0x0e: // br_table: vec(labelidx) + default labelidx
+			n, err := r.U32()
+			if err != nil {
+				break scan
+			}
+			if err := r.SkipU32N(n + 1); err != nil {
+				break scan
+			}
+		default:
+			if err := skipImmediates(r, op); err != nil {
+				break scan
+			}
+		}
+	}
+	r.JumpTo(start)
+	return
+}
+
 func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 	pN, rN, res0, err := f.blockType(r)
 	if err != nil {
@@ -296,6 +358,9 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 	// through, else, br/br_if/br_table, and an if's cond-false passthrough) instead
 	// of a frame slot. Excludes loops (params, back-edge) and multi-value.
 	fr.regMerge1 = f.regMerge && (kind == cfBlock || kind == cfIf) && rN == 1 && res0 != mtNone
+	if kind == cfLoop && !f.unreachable {
+		fr.loopSetLocals, fr.loopHasGrow = scanLoopBody(r) // P6.2 foundation (reader restored)
+	}
 	if f.unreachable {
 		f.ctrl = append(f.ctrl, fr)
 		return nil

--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -701,6 +701,9 @@ func subtreeRefsLocal(e *elem, x int) bool {
 }
 
 func (f *fn) setLocal(x int, tee bool) {
+	if f.bcKind == 1 && f.bcIdx == uint32(x) {
+		f.invalidateBoundsCert() // the certified base local changed value
+	}
 	e := f.s.back()
 	// In-place self-update `local.set $x (binop (local.get $x) …)`: let condenseInto
 	// consume the top expression straight into x's register instead of pre-copying

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -24,6 +24,7 @@ func isFusableCompare(e *elem) bool {
 func (f *fn) flushBelow(node *elem) int {
 	f.stats.addFlushBelow()
 	f.invalidateGlobalsCache() // a following call would clobber the cached cell-ptr register
+	f.invalidateBoundsCert()   // bounds facts are valid only within a straight-line region
 	base := baseOfValentBlock(node)
 	var below []*elem
 	for cur := base.prev; cur != f.s.head; cur = baseOfValentBlock(cur).prev {

--- a/src/core/compiler/backend/railshot/globals.go
+++ b/src/core/compiler/backend/railshot/globals.go
@@ -139,6 +139,9 @@ func (f *fn) globalSet(r *wasm.Reader) error {
 	if err != nil {
 		return err
 	}
+	if f.bcKind == 2 && f.bcIdx == x {
+		f.invalidateBoundsCert() // the certified base global changed value
+	}
 	gt, ok := f.m.GlobalTypeByIndex(x)
 	if !ok {
 		return fmt.Errorf("amd64: unknown global %d", x)

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -112,6 +112,16 @@ func (f *fn) emitTrapStubs() {
 // eaOwned reports whether the caller must release ea.
 func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bool, borrow int, disp int32) {
 	e := f.popValue()
+	// Bounds-certificate source: the address's stable value carrier (a local or
+	// global index), captured before materialization. A temp/computed base has no
+	// stable key. See boundsCertMeasure.
+	bcKind, bcIdx := uint8(0), uint32(0)
+	switch e.st.kind {
+	case stLocalReg, stLocalRef:
+		bcKind, bcIdx = 1, uint32(e.st.idx)
+	case stGlobReg:
+		bcKind, bcIdx = 2, uint32(e.st.idx)
+	}
 	disp = 0
 	borrow = -1
 	leaDisp := int32(size)
@@ -137,6 +147,7 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 	if f.guardMode {
 		return ea, eaOwned, borrow, disp
 	}
+	f.boundsCertMeasure(bcKind, bcIdx, leaDisp)
 	f.pinned = f.pinned.add(ea)
 	t := f.allocReg(0)
 	f.a.LeaDisp(t, ea, leaDisp) // t = ea + off + size
@@ -153,6 +164,34 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 	f.pinned = f.pinned.remove(ea)
 	return ea, eaOwned, borrow, disp
 }
+
+// boundsCertMeasure sizes P6.1 (count-only, no codegen change): would this check
+// be covered by the active straight-line certificate? A check proves
+// source+extent <= memBytes; memBytes only ever grows, so a later access on the
+// same source value with extent' <= extent is in bounds. Counts the coverable
+// checks and updates the single-entry certificate. Invalidated by
+// invalidateBoundsCert at flush/flushBelow (calls + control boundaries),
+// memory.grow, and a set of the certified source.
+func (f *fn) boundsCertMeasure(kind uint8, idx uint32, extent int32) {
+	if kind != 0 && f.bcKind == kind && f.bcIdx == idx && extent <= f.bcExtent {
+		f.stats.addBoundsElidable() // covered by a prior check on the same source
+		return
+	}
+	if kind == 0 {
+		f.bcKind = 0 // an unkeyable base ends the straight-line certificate
+		return
+	}
+	if f.bcKind == kind && f.bcIdx == idx {
+		if extent > f.bcExtent {
+			f.bcExtent = extent // same source, larger reach — extend the proven extent
+		}
+		return
+	}
+	f.bcKind, f.bcIdx, f.bcExtent = kind, idx, extent
+}
+
+// invalidateBoundsCert drops the straight-line bounds certificate.
+func (f *fn) invalidateBoundsCert() { f.bcKind = 0 }
 
 // memLoad lowers a scalar load of `size` bytes. signed selects sign-extension;
 // wide selects an i64 result (so signed sub-width loads extend to all 64 bits).
@@ -431,6 +470,7 @@ func (f *fn) memoryGrow(r *wasm.Reader) error {
 	if _, err := r.Byte(); err != nil { // memory index (validated == 0)
 		return err
 	}
+	f.invalidateBoundsCert() // memBytes changes; end the certificate conservatively
 	delta := f.materialize(f.popValue())
 	f.pinned = f.pinned.add(delta)
 	res := f.allocReg(maskOf(delta))

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -181,6 +181,9 @@ func (f *fn) boundsCertMeasure(kind uint8, idx uint32, extent int32) {
 		f.bcKind = 0 // an unkeyable base ends the straight-line certificate
 		return
 	}
+	if f.inLoop() {
+		f.stats.addBoundsInLoop() // emitted keyable check inside a loop — a P6.2 precheck candidate
+	}
 	if f.bcKind == kind && f.bcIdx == idx {
 		if extent > f.bcExtent {
 			f.bcExtent = extent // same source, larger reach — extend the proven extent
@@ -192,6 +195,16 @@ func (f *fn) boundsCertMeasure(kind uint8, idx uint32, extent int32) {
 
 // invalidateBoundsCert drops the straight-line bounds certificate.
 func (f *fn) invalidateBoundsCert() { f.bcKind = 0 }
+
+// inLoop reports whether any enclosing control frame is a loop.
+func (f *fn) inLoop() bool {
+	for i := range f.ctrl {
+		if f.ctrl[i].kind == cfLoop {
+			return true
+		}
+	}
+	return false
+}
 
 // memLoad lowers a scalar load of `size` bytes. signed selects sign-extension;
 // wide selects an i64 result (so signed sub-width loads extend to all 64 bits).

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -148,6 +148,9 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 		return ea, eaOwned, borrow, disp
 	}
 	f.boundsCertMeasure(bcKind, bcIdx, leaDisp)
+	if f.boundsHoistable(bcKind, bcIdx) {
+		f.stats.addBoundsHoistable()
+	}
 	f.pinned = f.pinned.add(ea)
 	t := f.allocReg(0)
 	f.a.LeaDisp(t, ea, leaDisp) // t = ea + off + size
@@ -204,6 +207,22 @@ func (f *fn) inLoop() bool {
 		}
 	}
 	return false
+}
+
+// boundsHoistable reports whether a check on address source (kind,idx) is
+// hoistable out of its innermost enclosing loop: a LOCAL base that is
+// loop-invariant (not set anywhere in that loop, per the loop-header scan).
+// Globals are excluded — a callee can change a global but never a caller local.
+func (f *fn) boundsHoistable(kind uint8, idx uint32) bool {
+	if kind != 1 { // locals only
+		return false
+	}
+	for i := len(f.ctrl) - 1; i >= 0; i-- {
+		if f.ctrl[i].kind == cfLoop {
+			return !f.ctrl[i].loopSetLocals[idx]
+		}
+	}
+	return false // not inside a loop
 }
 
 // memLoad lowers a scalar load of `size` bytes. signed selects sign-extension;

--- a/src/core/compiler/backend/railshot/stats.go
+++ b/src/core/compiler/backend/railshot/stats.go
@@ -69,8 +69,9 @@ type CodegenStats struct {
 	MemRefsForcedByStore int // deferred loads forced out by a store (P2.1 target)
 
 	// Bounds / traps.
-	BoundsChecks int // inline memory-OOB checks emitted (P6 elides these)
-	TrapStubs    int // shared cold trap stubs emitted (one per trap code used)
+	BoundsChecks         int // inline memory-OOB checks emitted (P6 elides these)
+	BoundsChecksElidable int // subset of BoundsChecks a straight-line certificate covers (P6.1 sizing; count-only)
+	TrapStubs            int // shared cold trap stubs emitted (one per trap code used)
 
 	// Calls, by lowering kind: regabi / mixed / wrapper / host / indirect /
 	// crossinstance.
@@ -124,6 +125,11 @@ func (s *CodegenStats) addTrapStub() {
 func (s *CodegenStats) addBoundsCheck() {
 	if s != nil {
 		s.BoundsChecks++
+	}
+}
+func (s *CodegenStats) addBoundsElidable() {
+	if s != nil {
+		s.BoundsChecksElidable++
 	}
 }
 func (s *CodegenStats) addPinnedLocal() {
@@ -212,8 +218,8 @@ func (s *CodegenStats) report() string {
 		s.FuncIdx, name, s.CodeBytes, s.FrameBytes, s.MaxSpillSlots)
 	fmt.Fprintf(&b, "    alloc: flushes=%d flushBelow=%d condenses=%d spills=%d reloads=%d forcedLoads=%d\n",
 		s.Flushes, s.FlushBelows, s.Condenses, s.Spills, s.Reloads, s.MemRefsForcedByStore)
-	fmt.Fprintf(&b, "    mem:   bounds=%d trapStubs=%d   pins: local=%d gval=%d\n",
-		s.BoundsChecks, s.TrapStubs, s.PinnedLocals, s.PinnedGlobalsValue)
+	fmt.Fprintf(&b, "    mem:   bounds=%d elidable=%d trapStubs=%d   pins: local=%d gval=%d\n",
+		s.BoundsChecks, s.BoundsChecksElidable, s.TrapStubs, s.PinnedLocals, s.PinnedGlobalsValue)
 	if len(s.Calls) > 0 {
 		fmt.Fprintf(&b, "    calls: %s\n", fmtCountMap(s.Calls))
 	}

--- a/src/core/compiler/backend/railshot/stats.go
+++ b/src/core/compiler/backend/railshot/stats.go
@@ -69,10 +69,11 @@ type CodegenStats struct {
 	MemRefsForcedByStore int // deferred loads forced out by a store (P2.1 target)
 
 	// Bounds / traps.
-	BoundsChecks         int // inline memory-OOB checks emitted (P6 elides these)
-	BoundsChecksElidable int // subset of BoundsChecks a straight-line certificate covers (P6.1 sizing; count-only)
-	BoundsChecksInLoop   int // subset emitted inside a loop on a keyable base (P6.2 loop-precheck ceiling; count-only)
-	TrapStubs            int // shared cold trap stubs emitted (one per trap code used)
+	BoundsChecks          int // inline memory-OOB checks emitted (P6 elides these)
+	BoundsChecksElidable  int // subset of BoundsChecks a straight-line certificate covers (P6.1 sizing; count-only)
+	BoundsChecksInLoop    int // subset emitted inside a loop on a keyable base (P6.2 loop-precheck ceiling; count-only)
+	BoundsChecksHoistable int // subset on a loop-INVARIANT local base (not set in the loop) — the P6.2 hoistable target; count-only
+	TrapStubs             int // shared cold trap stubs emitted (one per trap code used)
 
 	// Calls, by lowering kind: regabi / mixed / wrapper / host / indirect /
 	// crossinstance.
@@ -136,6 +137,11 @@ func (s *CodegenStats) addBoundsElidable() {
 func (s *CodegenStats) addBoundsInLoop() {
 	if s != nil {
 		s.BoundsChecksInLoop++
+	}
+}
+func (s *CodegenStats) addBoundsHoistable() {
+	if s != nil {
+		s.BoundsChecksHoistable++
 	}
 }
 func (s *CodegenStats) addPinnedLocal() {
@@ -224,8 +230,8 @@ func (s *CodegenStats) report() string {
 		s.FuncIdx, name, s.CodeBytes, s.FrameBytes, s.MaxSpillSlots)
 	fmt.Fprintf(&b, "    alloc: flushes=%d flushBelow=%d condenses=%d spills=%d reloads=%d forcedLoads=%d\n",
 		s.Flushes, s.FlushBelows, s.Condenses, s.Spills, s.Reloads, s.MemRefsForcedByStore)
-	fmt.Fprintf(&b, "    mem:   bounds=%d elidable=%d inloop=%d trapStubs=%d   pins: local=%d gval=%d\n",
-		s.BoundsChecks, s.BoundsChecksElidable, s.BoundsChecksInLoop, s.TrapStubs, s.PinnedLocals, s.PinnedGlobalsValue)
+	fmt.Fprintf(&b, "    mem:   bounds=%d elidable=%d inloop=%d hoistable=%d trapStubs=%d   pins: local=%d gval=%d\n",
+		s.BoundsChecks, s.BoundsChecksElidable, s.BoundsChecksInLoop, s.BoundsChecksHoistable, s.TrapStubs, s.PinnedLocals, s.PinnedGlobalsValue)
 	if len(s.Calls) > 0 {
 		fmt.Fprintf(&b, "    calls: %s\n", fmtCountMap(s.Calls))
 	}

--- a/src/core/compiler/backend/railshot/stats.go
+++ b/src/core/compiler/backend/railshot/stats.go
@@ -71,6 +71,7 @@ type CodegenStats struct {
 	// Bounds / traps.
 	BoundsChecks         int // inline memory-OOB checks emitted (P6 elides these)
 	BoundsChecksElidable int // subset of BoundsChecks a straight-line certificate covers (P6.1 sizing; count-only)
+	BoundsChecksInLoop   int // subset emitted inside a loop on a keyable base (P6.2 loop-precheck ceiling; count-only)
 	TrapStubs            int // shared cold trap stubs emitted (one per trap code used)
 
 	// Calls, by lowering kind: regabi / mixed / wrapper / host / indirect /
@@ -130,6 +131,11 @@ func (s *CodegenStats) addBoundsCheck() {
 func (s *CodegenStats) addBoundsElidable() {
 	if s != nil {
 		s.BoundsChecksElidable++
+	}
+}
+func (s *CodegenStats) addBoundsInLoop() {
+	if s != nil {
+		s.BoundsChecksInLoop++
 	}
 }
 func (s *CodegenStats) addPinnedLocal() {
@@ -218,8 +224,8 @@ func (s *CodegenStats) report() string {
 		s.FuncIdx, name, s.CodeBytes, s.FrameBytes, s.MaxSpillSlots)
 	fmt.Fprintf(&b, "    alloc: flushes=%d flushBelow=%d condenses=%d spills=%d reloads=%d forcedLoads=%d\n",
 		s.Flushes, s.FlushBelows, s.Condenses, s.Spills, s.Reloads, s.MemRefsForcedByStore)
-	fmt.Fprintf(&b, "    mem:   bounds=%d elidable=%d trapStubs=%d   pins: local=%d gval=%d\n",
-		s.BoundsChecks, s.BoundsChecksElidable, s.TrapStubs, s.PinnedLocals, s.PinnedGlobalsValue)
+	fmt.Fprintf(&b, "    mem:   bounds=%d elidable=%d inloop=%d trapStubs=%d   pins: local=%d gval=%d\n",
+		s.BoundsChecks, s.BoundsChecksElidable, s.BoundsChecksInLoop, s.TrapStubs, s.PinnedLocals, s.PinnedGlobalsValue)
 	if len(s.Calls) > 0 {
 		fmt.Fprintf(&b, "    calls: %s\n", fmtCountMap(s.Calls))
 	}

--- a/src/core/compiler/backend/railshot/stats_test.go
+++ b/src/core/compiler/backend/railshot/stats_test.go
@@ -152,7 +152,7 @@ func TestModuleStatsReport(t *testing.T) {
 		"module-pinned globals (K=2): g2→r14 g4→r13",
 		`fn#0 "serialize"`,
 		"code=128B frame=48B spill_hi=2",
-		"bounds=4 trapStubs=1",
+		"bounds=4 elidable=0 trapStubs=1",
 		"calls: host=1 regabi=2", // sorted keys
 		"peep:  lea-scaled-index=2 store-imm=7",
 	} {

--- a/src/core/compiler/backend/railshot/stats_test.go
+++ b/src/core/compiler/backend/railshot/stats_test.go
@@ -152,7 +152,7 @@ func TestModuleStatsReport(t *testing.T) {
 		"module-pinned globals (K=2): g2→r14 g4→r13",
 		`fn#0 "serialize"`,
 		"code=128B frame=48B spill_hi=2",
-		"bounds=4 elidable=0 inloop=0 trapStubs=1",
+		"bounds=4 elidable=0 inloop=0 hoistable=0 trapStubs=1",
 		"calls: host=1 regabi=2", // sorted keys
 		"peep:  lea-scaled-index=2 store-imm=7",
 	} {

--- a/src/core/compiler/backend/railshot/stats_test.go
+++ b/src/core/compiler/backend/railshot/stats_test.go
@@ -152,7 +152,7 @@ func TestModuleStatsReport(t *testing.T) {
 		"module-pinned globals (K=2): g2→r14 g4→r13",
 		`fn#0 "serialize"`,
 		"code=128B frame=48B spill_hi=2",
-		"bounds=4 elidable=0 trapStubs=1",
+		"bounds=4 elidable=0 inloop=0 trapStubs=1",
 		"calls: host=1 regabi=2", // sorted keys
 		"peep:  lea-scaled-index=2 store-imm=7",
 	} {


### PR DESCRIPTION
Continues the counter-first methodology (no-ir-plan.md) for **P6 (bounds facts)**. Three codegen-neutral counters size the lever before any risky codegen; the conclusion is that P6 is near-capped in the no-IR architecture.

## Counters (all count-only, nil-safe, codegen byte-identical — `TestCodegenStatsCodegenNeutral`)

- **`BoundsChecksElidable`** (P6.1): a same-source straight-line certificate (memBytes is monotonic, so a proven `source+extent ≤ memBytes` holds until the source is set or a control join). Invalidated at flush/flushBelow, `memory.grow`, and a set of the certified local/global.
- **`BoundsChecksInLoop`** (P6.2 ceiling): keyable-base checks emitted inside a loop.
- **`BoundsChecksHoistable`** (P6.2 target): checks on a loop-**invariant** local base — from a loop-header scan-ahead (`scanLoopBody`) that records which locals the body sets. A local a callee can't touch + not set in the loop = invariant.

## Findings (explicit mode, corpus)

| module | bounds | P6.1 elidable | P6.2 in-loop | P6.2 hoistable |
|---|---|---|---|---|
| json-as | 638 | 42 (7%) | 175 (27%) | **0** |
| utf-as | 54 | 6 | 42 (78%) | **0** |
| blake-as | 56 | 3 | 0 | 0 |

- **P6.1 ≈ 7%** — modest (same "binaryen already optimized the wasm level" story as P2/P3).
- **P6.2 hoistable = 0 everywhere** (counter verified: synthetic invariant-base loop → 1, set-in-loop → 0). Real loops use computed `base+index` or advancing pointers, never a bare invariant local. The redundant checks come from AS-level `ensureCapacity`+burst — a semantic guarantee invisible per-instruction; bounding it needs induction analysis = the IR the plan rejects.

**Verdict:** bounds tops out at ~7% in the no-IR model; sound P6.2 (dual-body hybrid) would elide ~nothing. `no-ir-plan.md` P6 updated; pivot to P5 (call mechanics). No codegen change — this PR is measurement + evidence only.

## Gates
- spec `TestSpecExec` 57/57, pass=16592 fail=0 skip=1591; `TestCorpusDifferential` both modes; `TestCodegenStatsCodegenNeutral`.