### PR TITLE
perf: cut instantiate latency for growable/import modules

### DIFF
--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -53,7 +53,6 @@ type JobMemory struct {
 const (
 	maxClassicLinMemBytes        = 65535 * 65536
 	minClassicLinMemReserveBytes = 65536
-	jobMemoryCacheMaxBytes       = 1 << 20
 )
 
 var jobMemoryCache struct {
@@ -116,22 +115,24 @@ func (j *JobMemory) reset(initialBytes, maxBytes, reserveBytes int, clearMem boo
 	j.putU32(offMaxLinMemPages, uint32(maxBytes/65536))
 }
 
-// AcquireJobMemoryGrowable returns a non-guarded JobMemory, reusing one recently
-// released by ReleaseJobMemory when its reservation is small enough. Reuse fully
-// clears basedata and the exposed reservation before installing size caches, so
-// fresh-instance zero memory and future memory.grow zeroing semantics are kept.
+// AcquireJobMemoryGrowable returns a non-guarded JobMemory, reusing one parked by
+// ReleaseJobMemory when the parked reservation is at least as large as this
+// module needs. ReleaseJobMemory zero-reclaims (madvise MADV_DONTNEED) everything
+// the previous instance could have dirtied, and every access is confined to
+// [0,curBytes) by bounds checks, so the whole reservation already reads back as
+// zero — reset only reinstalls the size caches, with no clear() proportional to
+// the (possibly multi-GiB) reservation. This lets even growable/exported-memory
+// modules, whose reservation is the full ~4 GiB logical max, reuse the mapping
+// instead of paying a fresh mmap+munmap of that range on every instantiate.
 func AcquireJobMemoryGrowable(initialBytes, maxBytes int) (*JobMemory, error) {
 	initialBytes, maxBytes, reserveBytes := normalizeMemorySizes(initialBytes, maxBytes)
-	if reserveBytes > jobMemoryCacheMaxBytes {
-		return NewJobMemoryGrowable(initialBytes, maxBytes)
-	}
 	need := basedataSize + reserveBytes
 	jobMemoryCache.Lock()
 	j := jobMemoryCache.j
 	if j != nil && j.reserveBase == 0 && len(j.mem) >= need {
 		jobMemoryCache.j = nil
 		jobMemoryCache.Unlock()
-		j.reset(initialBytes, maxBytes, reserveBytes, true)
+		j.reset(initialBytes, maxBytes, reserveBytes, false)
 		return j, nil
 	}
 	if j != nil && len(j.mem) < need {
@@ -142,6 +143,34 @@ func AcquireJobMemoryGrowable(initialBytes, maxBytes int) (*JobMemory, error) {
 	}
 	jobMemoryCache.Unlock()
 	return NewJobMemoryGrowable(initialBytes, maxBytes)
+}
+
+// jobMemoryReclaimThreshold splits reclaimForReuse's two zeroing strategies. At
+// or below it, an in-place clear() is cheaper and keeps the pages committed, so
+// the next reuse skips minor page faults — this keeps small, frequently-cycled
+// modules (tiny/fib) near their ~0.7µs best. Above it, clearing a large (up to
+// ~4 GiB) region dominates, so MADV_DONTNEED wins by dropping the pages instead.
+// The crossover (clear cost ≈ madvise+refault cost) measures near ~384 KiB.
+const jobMemoryReclaimThreshold = 384 << 10
+
+// reclaimForReuse returns this non-guarded reservation to a zeroed state so it
+// can be parked and reused without the old whole-reservation clear(). It only
+// needs to reclaim what the instance could have dirtied — basedata plus linear
+// memory up to its current logical size — because memory.grow just raises the
+// size cache and bounds checks confine every access to [0,curBytes). Small
+// regions are cleared in place (pages stay committed); large regions are dropped
+// with MADV_DONTNEED (mirrors the guard-page path's decommitGuarded, minus the
+// PROT_NONE re-arm — explicit bounds never fault, so the mapping stays RW).
+func (j *JobMemory) reclaimForReuse() error {
+	used := roundUpPage(basedataSize + j.curBytes())
+	if used > len(j.mem) {
+		used = len(j.mem)
+	}
+	if used <= jobMemoryReclaimThreshold {
+		clear(j.mem[:used])
+		return nil
+	}
+	return madviseDontNeed(j.mem[:used])
 }
 
 // curBytes is the current in-bounds linear-memory size, read from the cache that
@@ -229,7 +258,11 @@ func ReleaseJobMemory(j *JobMemory) error {
 		}
 		return j.Close()
 	}
-	if len(j.mem)-basedataSize > jobMemoryCacheMaxBytes {
+	// Zero-reclaim the region this instance could have dirtied so the reservation
+	// can be reused without a full clear(), then park it in the one-slot cache.
+	// Any size fits the slot now (the reservation costs address space, not RAM,
+	// once decommitted), so growable modules stop churning fresh mmaps.
+	if err := j.reclaimForReuse(); err != nil {
 		return j.Close()
 	}
 	jobMemoryCache.Lock()

--- a/src/core/runtime/basedata_test.go
+++ b/src/core/runtime/basedata_test.go
@@ -108,3 +108,73 @@ func TestAcquireJobMemoryGrowableReusesZeroedMemory(t *testing.T) {
 		t.Fatalf("custom ctx after reset = %#x, want 0", got)
 	}
 }
+
+// TestAcquireJobMemoryGrowableReusesLargeReservation exercises the MADV_DONTNEED
+// reclaim path (used region above jobMemoryReclaimThreshold): a large, dirtied
+// reservation must read back fully zeroed on reuse, and the mapping must be
+// reused (same base), not freshly mmap'd.
+func TestAcquireJobMemoryGrowableReusesLargeReservation(t *testing.T) {
+	const initial = jobMemoryReclaimThreshold + 512<<10 // forces the madvise path
+	jm, err := AcquireJobMemoryGrowable(initial, initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := jm.LinMemBase()
+	lin := jm.LinearMemory()
+	for i := range lin {
+		lin[i] = 0xa5
+	}
+	if err := ReleaseJobMemory(jm); err != nil {
+		t.Fatal(err)
+	}
+
+	jm2, err := AcquireJobMemoryGrowable(initial, initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ReleaseJobMemory(jm2)
+	if got := jm2.LinMemBase(); got != base {
+		t.Fatalf("LinMemBase = %#x, want reused base %#x", got, base)
+	}
+	for i, b := range jm2.LinearMemory() {
+		if b != 0 {
+			t.Fatalf("reused linear memory byte %d = %#x, want 0", i, b)
+		}
+	}
+}
+
+// TestAcquireJobMemoryGrowableReuseZeroesGrownPages verifies the reclaim covers
+// pages faulted in by memory.grow, not just the initial region: an instance that
+// grows and dirties a page beyond its initial size must not leak that data to a
+// later, smaller-initial reuse of the same reservation.
+func TestAcquireJobMemoryGrowableReuseZeroesGrownPages(t *testing.T) {
+	const maxBytes = 4 << 20
+	jm, err := AcquireJobMemoryGrowable(linMemBytes, maxBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate memory.grow: native code raises the size cache in place, then the
+	// guest writes into the newly in-bounds region. Dirty a page well past the
+	// initial size to catch a reclaim that only zeroes [0,initial).
+	grownBytes := maxBytes
+	jm.putU32(offActualLinMemByteSize, uint32(grownBytes))
+	full := jm.mem[jm.linOff : jm.linOff+grownBytes]
+	full[grownBytes-1] = 0xff
+	full[linMemBytes+8] = 0xff
+	if err := ReleaseJobMemory(jm); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reacquire with the original small initial; the grown region must read zero.
+	jm2, err := AcquireJobMemoryGrowable(linMemBytes, maxBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ReleaseJobMemory(jm2)
+	view := jm2.mem[jm2.linOff : jm2.linOff+grownBytes]
+	for i, b := range view {
+		if b != 0 {
+			t.Fatalf("reused grown page byte %d = %#x, want 0", i, b)
+		}
+	}
+}

--- a/src/core/runtime/mem_arena_test.go
+++ b/src/core/runtime/mem_arena_test.go
@@ -1,0 +1,40 @@
+//go:build linux && amd64
+
+package runtime
+
+import "testing"
+
+// TestArenaAllocZeroingContract pins the difference between Alloc (zero-fills a
+// reused arena's region) and AllocNoZero (leaves prior contents for the caller to
+// overwrite). Instantiate relies on Alloc's zeroing for sparse table entries and
+// on AllocNoZero for the write-before-read host-call log.
+func TestArenaAllocZeroingContract(t *testing.T) {
+	a, err := NewArena(4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	a.zeroOnAlloc = true // as a reused (AcquireArena) arena would be
+	for i := range a.mem {
+		a.mem[i] = 0xbb // stale data from a prior instance
+	}
+
+	z := a.Alloc(128)
+	for i, b := range z {
+		if b != 0 {
+			t.Fatalf("Alloc byte %d = %#x, want 0 (reused arena must zero)", i, b)
+		}
+	}
+
+	nz := a.AllocNoZero(128)
+	sawStale := false
+	for _, b := range nz {
+		if b == 0xbb {
+			sawStale = true
+			break
+		}
+	}
+	if !sawStale {
+		t.Fatal("AllocNoZero zeroed its region; it must skip the clear so callers own initialization")
+	}
+}

--- a/src/core/runtime/mem_linux_amd64.go
+++ b/src/core/runtime/mem_linux_amd64.go
@@ -5,9 +5,25 @@ package runtime
 import (
 	"sync"
 	"syscall"
+	"unsafe"
 )
 
 const pageSize = 4096
+
+// madviseDontNeed drops the physical pages backing b (a private anonymous
+// mapping), so the range reads back as zero on next access without being
+// unmapped. Used to zero-reclaim a reused reservation's dirtied region cheaply,
+// avoiding a full clear() of a possibly multi-GiB reservation.
+func madviseDontNeed(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	if _, _, errno := syscall.Syscall(syscall.SYS_MADVISE,
+		uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)), syscall.MADV_DONTNEED); errno != 0 {
+		return errno
+	}
+	return nil
+}
 
 func roundUpPage(n int) int {
 	if n <= 0 {
@@ -99,15 +115,25 @@ func AcquireArena(n int) (*Arena, error) {
 }
 
 func (a *Arena) Alloc(n int) []byte {
+	b := a.AllocNoZero(n)
+	if a.zeroOnAlloc {
+		clear(b)
+	}
+	return b
+}
+
+// AllocNoZero is Alloc without the reused-arena zero-fill. The returned bytes may
+// contain stale data from a prior instance, so the caller MUST fully initialize
+// them (or otherwise not read them) before use. Intended for large buffers that
+// native/host code writes before it reads — e.g. the host-call log, whose count
+// header is reset at the start of every Invoke.
+func (a *Arena) AllocNoZero(n int) []byte {
 	a.off = (a.off + 7) &^ 7
 	if a.off+n > len(a.mem) {
 		panic("jit: arena out of memory")
 	}
 	b := a.mem[a.off : a.off+n : a.off+n]
 	a.off += n
-	if a.zeroOnAlloc {
-		clear(b)
-	}
 	return b
 }
 

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -18,6 +18,10 @@ type compiledCodeCache struct {
 
 func installCompiledFinalizer(c *Compiled) *Compiled {
 	c.ensureCodeCache()
+	// Give this compiler/deserialize-produced module its own validation memo so
+	// Instantiate validates it once. A fresh memo (not the source's) is essential
+	// for the link-time `linked := *c` copy, whose Code/Entry differ from c.
+	c.validateMemo = &validateMemo{}
 	goruntime.SetFinalizer(c, func(c *Compiled) {
 		_ = c.Close()
 	})

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	coreruntime "github.com/wago-org/wago/src/core/runtime"
@@ -247,14 +248,36 @@ type Compiled struct {
 
 	GCTypeDescs []gc.TypeDesc // immutable Wasm GC descriptor metadata; per-instance heaps own collection state
 
-	// Cached during validateArenaFootprint. Compiled is intentionally still
-	// revalidated at Instantiate boundaries because its fields are exported and
-	// test code can construct it by hand.
+	// Cached during validateArenaFootprint.
 	maxParamSlots        int
 	maxResultSlots       int
 	instantiateArenaNeed int
 
+	// validateMemo memoizes the instantiate-boundary metadata validation for
+	// modules produced by Compile/UnmarshalBinary, which are immutable: the full
+	// check (which loops all funcs/globals/exports/GC descs) then only runs once
+	// instead of on every Instantiate. It is a pointer so a by-value Compiled copy
+	// (the link-time recompile) doesn't copy a lock; a nil memo means "validate
+	// every time" — which is what a hand-constructed Compiled (exported fields,
+	// no memo) gets, preserving its first-use validation.
+	validateMemo *validateMemo
+
 	codeCache *compiledCodeCache
+}
+
+type validateMemo struct {
+	once sync.Once
+	err  error
+}
+
+// validateCached returns the metadata-validation result, running the full check
+// once per compiler-produced Compiled and every time for a hand-constructed one.
+func (c *Compiled) validateCached() error {
+	if c == nil || c.validateMemo == nil {
+		return c.validate()
+	}
+	c.validateMemo.once.Do(func() { c.validateMemo.err = c.validate() })
+	return c.validateMemo.err
 }
 
 // memorySizeBytes returns the initial and maximum (grow ceiling) linear-memory

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -64,7 +64,7 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 	if err != nil {
 		return nil, err
 	}
-	if err := c.validate(); err != nil {
+	if err := c.validateCached(); err != nil {
 		return nil, err
 	}
 	var collector *gc.Collector
@@ -177,7 +177,10 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 	}()
 	var hostLog []byte
 	if len(c.Imports) > 0 {
-		hostLog = ar.Alloc(runtime.HostCallLogBytes)
+		// The log's count header is reset at the start of every Invoke and its
+		// body is written by native code before the host reads it, so the ~64 KiB
+		// buffer needs no instantiate-time zero-fill.
+		hostLog = ar.AllocNoZero(runtime.HostCallLogBytes)
 		jm.SetCustomCtx(uintptr(unsafe.Pointer(&hostLog[0])))
 	}
 	jm.SetStackFence(eng.StackLimit()) // trap runaway recursion instead of faulting
@@ -186,6 +189,10 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 	globalCells := make([]*Global, len(c.Globals))
 	if len(c.Globals) > 0 {
 		globals = ar.Alloc(8 * len(c.Globals))
+		// One heap allocation backs every module-local global cell (a *Global into
+		// this slab) instead of one allocation per global; imported globals keep
+		// their own cached *Global.
+		localCells := make([]Global, len(c.Globals))
 		// Wasm global indexes are stored in order in a pointer table: imported
 		// global objects first, followed by module-local cells initialized from
 		// literal bits or by copying an earlier imported immutable global's value.
@@ -205,7 +212,9 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 					}
 					bits = readGlobalObject(globalCells[g.InitGlobal], c.Globals[g.InitGlobal].Type)
 				}
-				cell = newGlobalInCell(g.Type, bits, g.Mutable, ar.Alloc(8), nil)
+				cell = &localCells[i]
+				cell.Type, cell.Mutable, cell.cell = g.Type, g.Mutable, ar.Alloc(8)
+				writeGlobalObject(cell, g.Type, bits)
 			}
 			globalCells[i] = cell
 			binary.LittleEndian.PutUint64(globals[i*8:], uint64(uintptr(unsafe.Pointer(&cell.cell[0]))))


### PR DESCRIPTION
## Summary

Instantiate latency regressed for the modules added in the corpus expansion (#124) — anything that **grows or exports its memory** (Rust kernels, AssemblyScript programs). Those get `MemMaxPages=65535` (~4 GiB), and explicit mode reserved the full max, which blew past the 1 MiB reuse-cache cap → a fresh `mmap`+`munmap` of a 4 GiB VMA on *every* instantiate. This PR fixes that and does a broader hot-path pass.

### Changes
1. **Zero-reclaim memory reuse** (`basedata.go`, `mem_linux_amd64.go`): removed the 1 MiB cap; `ReleaseJobMemory` now reclaims only what the instance could have dirtied (`basedata + curBytes()`) via `reclaimForReuse` — in-place `clear()` for small regions (≤384 KiB, keeps pages committed, no refault), `madvise(MADV_DONTNEED)` for large ones. Growable/exported-memory modules now reuse the reservation instead of churning 4 GiB mmaps. Guard-page path untouched.
2. **Global-cell slab** (`instantiate.go`): one `make([]Global, n)` slab instead of a heap `&Global{}` per global (json-as 36→8 allocs).
3. **Memoized `validate()`** (`globals.go`, `code_mapping.go`): the immutable module's metadata check runs once, not per-instantiate. Pointer-to-`sync.Once` so the link-time `linked := *c` copy doesn't copy a lock; a nil memo (hand-constructed `Compiled`) still validates on first use.
4. **`Arena.AllocNoZero`** for the ~64 KiB host-call log (`mem_linux_amd64.go`, `instantiate.go`): its count header is reset each Invoke and its body is written-before-read, so no instantiate-time zero-fill is needed.

### Results (explicit `BenchmarkInstantiate`, vs pre-change)
| module | before | after | |
|---|---|---|---|
| json-as | 16376 ns | 1757 ns | **9.3×** |
| blake-as | 13452 ns | 899 ns | **15×** |
| utf-as | 19284 ns | 1999 ns | 9.6× |
| nbody / spectralnorm | ~11.5 µs | ~3.1 µs | 3.7× |
| sha256 / crc32 | 12–13 µs | ~4.9 µs | 2.6× |
| many_funcs | 1192 ns | 703 ns | 1.7× |
| tiny / fib | ~0.8 µs | ~0.7 µs | flat |

Allocs down across the board (tiny 5→3, nbody 9→5, json-as 37→8).

### Memory
No physical-RAM cost: the reused reservation is `MAP_NORESERVE` address space and is madvise-dropped on release, so idle RSS stays flat (~0.5 MiB parked overhead, unchanged). Measured a per-release engine-stack/arena decommit and rejected it — ~0 RAM benefit, large latency hit from TLB shootdowns.

### Verification
`make test`, `make test-guard`, corpus differential (explicit + signals), `TestJsonAsGuard`/`TestMemSumGuard` (real host calls through the reused log), spec1/2/3 explicit + guard-page, `-race`, `go vet`. Added unit tests for the memory-reuse reclaim (clear/madvise/grow-then-reuse zeroing) and the `Alloc`/`AllocNoZero` contract.

https://claude.ai/code/session_01XiDFM1Sa9gVf2fUKEnjgqG