### PR TITLE
perf(railshot): P6.1 straight-line bounds-check elision (explicit mode)

### DIFF
--- a/src/core/compiler/backend/railshot/bounds_facts_test.go
+++ b/src/core/compiler/backend/railshot/bounds_facts_test.go
@@ -1,0 +1,57 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestBoundsFactsElision checks P6.1 straight-line elision (docs/no-ir-plan.md
+// P6): a second access on the same address source, within the extent a prior
+// check proved, needs no check of its own. Correctness at scale is covered by
+// TestCorpusDifferential on the compute kernels (nbody/fannkuch/sha256/raytrace);
+// this pins the counter behaviour and the invalidation points.
+func TestBoundsFactsElision(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+
+	// func(p i32){ local.get p; i32.load off=4; drop;   // check proves p+8 <= mem
+	//              local.get p; i32.load off=0; drop }   // p+4 <= p+8 → elided
+	covered := []byte{0x00,
+		0x20, 0x00, 0x28, 0x02, 0x04, 0x1a,
+		0x20, 0x00, 0x28, 0x02, 0x00, 0x1a,
+		0x0b}
+	s := compileWithStats(t, modMem(t, 1, i32, nil, covered), false).Funcs[0]
+	if s.BoundsChecks != 1 || s.BoundsChecksElidable != 1 {
+		t.Errorf("covered: bounds=%d elidable=%d, want 1/1", s.BoundsChecks, s.BoundsChecksElidable)
+	}
+
+	// A LARGER later extent is not covered by a smaller prior one → both checked.
+	grow := []byte{0x00,
+		0x20, 0x00, 0x28, 0x02, 0x00, 0x1a, // off 0 → proves p+4
+		0x20, 0x00, 0x28, 0x02, 0x04, 0x1a, // off 4 → needs p+8 > p+4 → checked
+		0x0b}
+	s = compileWithStats(t, modMem(t, 1, i32, nil, grow), false).Funcs[0]
+	if s.BoundsChecks != 2 || s.BoundsChecksElidable != 0 {
+		t.Errorf("grow: bounds=%d elidable=%d, want 2/0", s.BoundsChecks, s.BoundsChecksElidable)
+	}
+
+	// A local.set of the certified base between the two accesses invalidates the
+	// certificate (the base value changed) → the second access is re-checked.
+	reset := []byte{0x00,
+		0x20, 0x00, 0x28, 0x02, 0x04, 0x1a, // load off 4 → proves p+8
+		0x20, 0x00, 0x21, 0x00, // local.set p (p = p)
+		0x20, 0x00, 0x28, 0x02, 0x00, 0x1a, // load off 0 → re-checked
+		0x0b}
+	s = compileWithStats(t, modMem(t, 1, i32, nil, reset), false).Funcs[0]
+	if s.BoundsChecks != 2 || s.BoundsChecksElidable != 0 {
+		t.Errorf("reset-by-set: bounds=%d elidable=%d, want 2/0", s.BoundsChecks, s.BoundsChecksElidable)
+	}
+
+	// Guard mode elides all inline checks regardless — no facts machinery involved.
+	g := compileWithStats(t, modMem(t, 1, i32, nil, covered), true).Funcs[0]
+	if g.BoundsChecks != 0 || g.BoundsChecksElidable != 0 {
+		t.Errorf("guard: bounds=%d elidable=%d, want 0/0", g.BoundsChecks, g.BoundsChecksElidable)
+	}
+}

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -147,7 +147,20 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 	if f.guardMode {
 		return ea, eaOwned, borrow, disp
 	}
-	f.boundsCertMeasure(bcKind, bcIdx, leaDisp)
+	// P6.1 straight-line bounds-check elision: skip the check when a prior
+	// same-source check in this straight-line region already proved this access
+	// in-bounds. Sound because linear memory only grows and the certificate is
+	// dropped at every flush/flushBelow (all calls + control joins), memory.grow,
+	// and a set of the certified source — so the proving check dominates this one
+	// on every path. WAGO_NO_BOUNDS_FACTS=1 forces every check (A/B + kill switch).
+	if boundsFactsEnabled && f.boundsCertCovers(bcKind, bcIdx, leaDisp) {
+		f.stats.addBoundsElidable()
+		return ea, eaOwned, borrow, disp
+	}
+	f.boundsCertUpdate(bcKind, bcIdx, leaDisp)
+	if bcKind != 0 && f.inLoop() {
+		f.stats.addBoundsInLoop()
+	}
 	if f.boundsHoistable(bcKind, bcIdx) {
 		f.stats.addBoundsHoistable()
 	}
@@ -168,24 +181,25 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 	return ea, eaOwned, borrow, disp
 }
 
-// boundsCertMeasure sizes P6.1 (count-only, no codegen change): would this check
-// be covered by the active straight-line certificate? A check proves
+// boundsCertCovers reports whether the active straight-line certificate already
+// proves this access in-bounds (P6.1): the same keyable source, with this
+// access's extent (off+size) within the proven extent. A check proves
 // source+extent <= memBytes; memBytes only ever grows, so a later access on the
-// same source value with extent' <= extent is in bounds. Counts the coverable
-// checks and updates the single-entry certificate. Invalidated by
-// invalidateBoundsCert at flush/flushBelow (calls + control boundaries),
-// memory.grow, and a set of the certified source.
-func (f *fn) boundsCertMeasure(kind uint8, idx uint32, extent int32) {
-	if kind != 0 && f.bcKind == kind && f.bcIdx == idx && extent <= f.bcExtent {
-		f.stats.addBoundsElidable() // covered by a prior check on the same source
-		return
-	}
+// same source value with a smaller-or-equal extent is in bounds. The certificate
+// is dropped by invalidateBoundsCert at flush/flushBelow (every call + control
+// join), memory.grow, and a set of the certified source — exactly the set that
+// makes the proving check dominate this one on every path, so eliding is sound.
+func (f *fn) boundsCertCovers(kind uint8, idx uint32, extent int32) bool {
+	return kind != 0 && f.bcKind == kind && f.bcIdx == idx && extent <= f.bcExtent
+}
+
+// boundsCertUpdate records the check about to be emitted: establish or extend the
+// single-entry certificate for a keyable source; an unkeyable (computed) base
+// ends the straight-line certificate.
+func (f *fn) boundsCertUpdate(kind uint8, idx uint32, extent int32) {
 	if kind == 0 {
-		f.bcKind = 0 // an unkeyable base ends the straight-line certificate
+		f.bcKind = 0
 		return
-	}
-	if f.inLoop() {
-		f.stats.addBoundsInLoop() // emitted keyable check inside a loop — a P6.2 precheck candidate
 	}
 	if f.bcKind == kind && f.bcIdx == idx {
 		if extent > f.bcExtent {

--- a/src/core/compiler/backend/railshot/stats.go
+++ b/src/core/compiler/backend/railshot/stats.go
@@ -32,6 +32,9 @@ var (
 	// pinGlobalK overrides the adaptive module-global pin count K: -1 = auto (the
 	// pickModuleGlobals heuristic), 0..len(moduleGlobalRegs) = force that many.
 	pinGlobalK = parsePinGlobalK(os.Getenv("WAGO_PIN_GLOBAL_K"))
+	// boundsFactsEnabled gates P6.1 straight-line bounds-check elision (explicit
+	// mode). WAGO_NO_BOUNDS_FACTS=1 forces every check — the A/B oracle + kill switch.
+	boundsFactsEnabled = os.Getenv("WAGO_NO_BOUNDS_FACTS") != "1"
 )
 
 func parsePinGlobalK(s string) int {


### PR DESCRIPTION
Implements **P6.1** (no-ir-plan.md P6) — the elision the `#126` measurement identified as the live lever for **compute kernels** (dead on the AS corpus, big on Rust/C wasm). Flips the count-only certificate from #126 into an actual codegen change.

## What

In `memAddr` (explicit mode only — guard mode has no inline check), skip the bounds check when a **prior same-source check in the current straight-line region already proved this access in-bounds**: same keyable base (a local/global index — a stable *value*, not a physical register), and this access's extent (`off+size`) within the proven extent.

**Soundness.** A check proves `source + extent ≤ memBytes`. Linear memory only ever **grows**, so once proven the fact holds for any smaller-or-equal extent on the same source *value* — until the certificate is dropped. It is dropped (`invalidateBoundsCert`) at exactly the points that would let a non-checking path reach the access or change the base:
- `flush` / `flushBelow` — every call and every control join (block/loop/if/else/end, br_if); after a plain `br` the code is unreachable until a label that flushes. (Audited: `opLoop` flushes at the loop top, so no elision rides a pre-loop check across the back-edge.)
- `memory.grow` (conservative; grow only increases memBytes).
- a `local.set`/`global.set` of the certified source.

`WAGO_NO_BOUNDS_FACTS=1` forces every check (A/B oracle + kill switch).

## Effect

nbody `step`: **96 → 36** emitted checks (−63%, matches the measured elidable); `WAGO_NO_BOUNDS_FACTS=1` restores 96. Runtime (explicit mode): nbody ~2%, fannkuch ~1% faster — modest (explicit checks are cheap not-taken branches) but real, plus the code-size/I-cache win. This is the **TinyGo/embedded/compute-kernel** story; AS serialization is unaffected (it's memory/GC-bound and had ~0 hoistable).

## Gates (memory-safety-critical — eliding a needed check = OOB)

- **`TestCorpusDifferential` both modes** — explicit(with elision) == guard(no elision) == golden, across nbody/fannkuch/sha256/raytrace/crc32 (the bounds-mode-desync-sensitive cases). The #68-class net.
- `TestSpecExec` 57/57, pass=16592 fail=0 skip=1591 — **memory_trap 171/0, address 255/0** (trap-timing correct: no spurious/missed traps).
- New `TestBoundsFactsElision`: covered→elided, larger-extent→checked, set-of-source→re-checked, guard→0.
- `go test ./...` (root + bench, both tag modes) + `make test-guard`.
- Codegen-neutral stats guardrail still holds (elision isn't stats-gated).

⚠️ **Requests a security review before merge** — this removes memory-safety checks. The invalidation-completeness argument is above; the differential/spec nets pass, but a second set of eyes on the "every join drops the cert" claim is warranted (the plan flags P6 for review).