### PR TITLE
feat(cli): --no-bounds-facts flag; thread P6.1 elision through RuntimeConfig

### DIFF
--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -60,6 +60,7 @@ func usage(w *os.File) {
 
 %s
   -e, --invoke <name>       export to call
+      --no-bounds-facts     disable straight-line bounds-check elision (explicit mode)
 
 %s
   wago add.wasm 2 3
@@ -115,14 +116,21 @@ func validateModuleBytes(src []byte) error {
 
 func runCmd(args []string) {
 	var invoke string
-	pos, err := extractOpts(args, map[string]*string{"-e": &invoke, "--invoke": &invoke})
+	var noBoundsFacts bool
+	pos, err := extractOpts(args,
+		map[string]*string{"-e": &invoke, "--invoke": &invoke},
+		map[string]*bool{"--no-bounds-facts": &noBoundsFacts})
 	if err != nil {
 		fatal("run: %v", err)
 	}
 	if len(pos) < 1 {
 		fatal("run: need a <file>")
 	}
-	c := mustLoad(pos[0])
+	cfg := wago.NewRuntimeConfig()
+	if noBoundsFacts {
+		cfg = cfg.WithBoundsFacts(false) // force every inline bounds check (P6.1 off)
+	}
+	c := mustLoad(pos[0], cfg)
 	export := mustResolveExport(c, invoke)
 	params, results, _ := c.Signature(export)
 	vals := mustParseArgs(pos[1:], params)
@@ -141,16 +149,16 @@ func runCmd(args []string) {
 
 // ---- loading & imports --------------------------------------------------
 
-func mustLoad(file string) *wago.Compiled {
+func mustLoad(file string, cfg *wago.RuntimeConfig) *wago.Compiled {
 	src, err := os.ReadFile(file)
 	if err != nil {
 		fatal("%v", err)
 	}
 	var c *wago.Compiled
 	if wago.IsCompiled(src) {
-		c, err = wago.Load(src) // precompiled .wago
+		c, err = wago.Load(src) // precompiled .wago — codegen options baked in already
 	} else {
-		c, err = wago.Compile(src)
+		c, err = wago.CompileWithConfig(cfg, src)
 	}
 	if err != nil {
 		fatal("%v", err)
@@ -316,8 +324,9 @@ func dim(s string) string  { return paint("2", s) }
 func red(s string) string  { return paint("31", s) }
 func cyan(s string) string { return paint("36", s) }
 
-// extractOpts accepts "-x val", "--x val", and "-x=val" forms anywhere.
-func extractOpts(args []string, opts map[string]*string) ([]string, error) {
+// extractOpts accepts "-x val", "--x val", and "-x=val" value forms plus bare
+// boolean flags ("--flag", or "--flag=true/false") anywhere.
+func extractOpts(args []string, opts map[string]*string, boolOpts map[string]*bool) ([]string, error) {
 	var pos []string
 	for i := 0; i < len(args); i++ {
 		a := args[i]
@@ -326,6 +335,10 @@ func extractOpts(args []string, opts map[string]*string) ([]string, error) {
 			if eq := strings.IndexByte(a, '='); eq >= 0 {
 				name, inline, hasInline = a[:eq], a[eq+1:], true
 			}
+		}
+		if b, ok := boolOpts[name]; ok {
+			*b = !hasInline || inline == "true" || inline == "1"
+			continue
 		}
 		dst, ok := opts[name]
 		if !ok {

--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -60,7 +60,7 @@ func usage(w *os.File) {
 
 %s
   -e, --invoke <name>       export to call
-      --no-bounds-facts     disable straight-line bounds-check elision (explicit mode)
+      --no-defer-bounds-checks  bounds-check every access (don't skip redundant checks)
 
 %s
   wago add.wasm 2 3
@@ -116,10 +116,10 @@ func validateModuleBytes(src []byte) error {
 
 func runCmd(args []string) {
 	var invoke string
-	var noBoundsFacts bool
+	var noDeferBounds bool
 	pos, err := extractOpts(args,
 		map[string]*string{"-e": &invoke, "--invoke": &invoke},
-		map[string]*bool{"--no-bounds-facts": &noBoundsFacts})
+		map[string]*bool{"--no-defer-bounds-checks": &noDeferBounds})
 	if err != nil {
 		fatal("run: %v", err)
 	}
@@ -127,8 +127,8 @@ func runCmd(args []string) {
 		fatal("run: need a <file>")
 	}
 	cfg := wago.NewRuntimeConfig()
-	if noBoundsFacts {
-		cfg = cfg.WithBoundsFacts(false) // force every inline bounds check (P6.1 off)
+	if noDeferBounds {
+		cfg = cfg.WithDeferBoundsChecks(false) // bounds-check every access (no redundant-check skipping)
 	}
 	c := mustLoad(pos[0], cfg)
 	export := mustResolveExport(c, invoke)

--- a/src/core/compiler/backend/railshot/bounds_facts_test.go
+++ b/src/core/compiler/backend/railshot/bounds_facts_test.go
@@ -49,6 +49,15 @@ func TestBoundsFactsElision(t *testing.T) {
 		t.Errorf("reset-by-set: bounds=%d elidable=%d, want 2/0", s.BoundsChecks, s.BoundsChecksElidable)
 	}
 
+	// The NoBoundsFacts compile option disables elision → both accesses checked.
+	var ms ModuleStats
+	if _, err := CompileModuleWith(modMem(t, 1, i32, nil, covered), CompileOptions{Stats: &ms, NoBoundsFacts: true}); err != nil {
+		t.Fatal(err)
+	}
+	if s := ms.Funcs[0]; s.BoundsChecks != 2 || s.BoundsChecksElidable != 0 {
+		t.Errorf("NoBoundsFacts: bounds=%d elidable=%d, want 2/0", s.BoundsChecks, s.BoundsChecksElidable)
+	}
+
 	// Guard mode elides all inline checks regardless — no facts machinery involved.
 	g := compileWithStats(t, modMem(t, 1, i32, nil, covered), true).Funcs[0]
 	if g.BoundsChecks != 0 || g.BoundsChecksElidable != 0 {

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -66,12 +66,13 @@ type fn struct {
 	fregUser [16]*elem
 	fpinned  regMask
 
-	maxSpill  int  // high-water number of operand spill slots used
-	subRspAt  int  // byte offset of the prologue's SubRsp imm32 (patched with frameSize)
-	addRspAt  int  // byte offset of the epilogue's AddRsp imm32 (patched with frameSize)
-	guardMode bool // elide inline bounds checks; rely on guard-page + SIGSEGV trap
-	lazyZero  bool // defer declared-local zeroing for small call+memory functions
-	skipFence bool // call-free leaf with a provably small frame: no stack-fence check
+	maxSpill    int  // high-water number of operand spill slots used
+	subRspAt    int  // byte offset of the prologue's SubRsp imm32 (patched with frameSize)
+	addRspAt    int  // byte offset of the epilogue's AddRsp imm32 (patched with frameSize)
+	guardMode   bool // elide inline bounds checks; rely on guard-page + SIGSEGV trap
+	boundsFacts bool // P6.1 straight-line bounds-check elision enabled (explicit mode)
+	lazyZero    bool // defer declared-local zeroing for small call+memory functions
+	skipFence   bool // call-free leaf with a provably small frame: no stack-fence check
 
 	// memSizeReg caches the linear-memory size in bytes ([RBX-bdCurBytes]) in a
 	// dedicated register for the whole module (WARP's REGS::memSize, which reserves
@@ -210,6 +211,11 @@ type CompileOptions struct {
 	// EXPERIMENTAL: only sound when the memory is backed by runtime guard pages.
 	ElideBoundsChecks bool
 
+	// NoBoundsFacts disables P6.1 straight-line bounds-check elision (explicit
+	// mode only; guard mode elides everything anyway). The WAGO_NO_BOUNDS_FACTS=1
+	// env var forces the same globally; this is the per-compile override.
+	NoBoundsFacts bool
+
 	// ImportBindings, when non-nil, resolves imported functions to host or
 	// cross-instance lowering (indexed by imported-function index). Used by the
 	// link-time recompile that wires cross-instance calls; nil means every import
@@ -257,6 +263,8 @@ func CompileModule(m *wasm.Module) (*amd64.CompiledModule, error) {
 // handler (the caller must back memory with runtime guard pages).
 func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModule, error) {
 	guardMode := opts.ElideBoundsChecks
+	// P6.1 elision is on unless disabled per-compile (opts) or globally (env).
+	boundsFacts := boundsFactsEnabled && !opts.NoBoundsFacts
 	n := len(m.Code)
 	relocs := make([][]callReloc, n)
 	entry := make([]int, n)
@@ -291,7 +299,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 			st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
 			ms.Funcs[i] = st
 		}
-		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, modGlobals, hints, opts.ImportBindings, st)
+		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, modGlobals, hints, opts.ImportBindings, st)
 		if err != nil {
 			return nil, fmt.Errorf("amd64: function %d: %w", i, err)
 		}
@@ -435,7 +443,7 @@ func pickModuleGlobals(m *wasm.Module, nGlobals int, agg []int64) []moduleGlobal
 	return pins
 }
 
-func compileFunc(m *wasm.Module, funcIdx int, guardMode bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if os.Getenv("WAGO_DEBUG_PANIC") == "1" {
@@ -455,7 +463,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode bool, modGlobals []modul
 		return nil, nil, 0, err
 	}
 
-	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
+	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
 	if !guardMode && len(m.Memories) > 0 {
 		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module
 	}

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -153,7 +153,7 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 	// dropped at every flush/flushBelow (all calls + control joins), memory.grow,
 	// and a set of the certified source — so the proving check dominates this one
 	// on every path. WAGO_NO_BOUNDS_FACTS=1 forces every check (A/B + kill switch).
-	if boundsFactsEnabled && f.boundsCertCovers(bcKind, bcIdx, leaDisp) {
+	if f.boundsFacts && f.boundsCertCovers(bcKind, bcIdx, leaDisp) {
 		f.stats.addBoundsElidable()
 		return ea, eaOwned, borrow, disp
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -65,7 +65,7 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	var code []byte
 	var entry, internalEntry []int
 	if !needsLink {
-		cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: elide, NoBoundsFacts: cfg.noBoundsFacts})
+		cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds})
 		if err != nil {
 			return nil, fmt.Errorf("compile: %w", err)
 		}
@@ -73,7 +73,7 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	}
 
 	importedFuncs := m.ImportedFuncCount()
-	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs, needsLink: needsLink, boundsElide: elide, noBoundsFacts: cfg.noBoundsFacts}
+	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs, needsLink: needsLink, boundsElide: elide, noDeferBounds: cfg.noDeferBounds}
 	// Retain the raw module for the link-time recompile whenever an import could be
 	// bound cross-instance (any function import), or codegen was deferred.
 	if needsLink || importedFuncs > 0 {
@@ -267,7 +267,7 @@ func (c *Compiled) linkModule(imports Imports) (*Compiled, error) {
 			}
 		}
 	}
-	cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noBoundsFacts, ImportBindings: bindings})
+	cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noDeferBounds, ImportBindings: bindings})
 	if err != nil {
 		return nil, fmt.Errorf("link: %w", err)
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -65,7 +65,7 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	var code []byte
 	var entry, internalEntry []int
 	if !needsLink {
-		cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: elide})
+		cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: elide, NoBoundsFacts: cfg.noBoundsFacts})
 		if err != nil {
 			return nil, fmt.Errorf("compile: %w", err)
 		}
@@ -73,7 +73,7 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	}
 
 	importedFuncs := m.ImportedFuncCount()
-	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs, needsLink: needsLink, boundsElide: elide}
+	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs, needsLink: needsLink, boundsElide: elide, noBoundsFacts: cfg.noBoundsFacts}
 	// Retain the raw module for the link-time recompile whenever an import could be
 	// bound cross-instance (any function import), or codegen was deferred.
 	if needsLink || importedFuncs > 0 {
@@ -267,7 +267,7 @@ func (c *Compiled) linkModule(imports Imports) (*Compiled, error) {
 			}
 		}
 	}
-	cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: c.boundsElide, ImportBindings: bindings})
+	cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noBoundsFacts, ImportBindings: bindings})
 	if err != nil {
 		return nil, fmt.Errorf("link: %w", err)
 	}

--- a/src/wago/bounds_facts_config_test.go
+++ b/src/wago/bounds_facts_config_test.go
@@ -1,0 +1,56 @@
+//go:build linux && amd64
+
+package wago
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// twoLoadModule: func(p i32){ i32.load(p+4); drop; i32.load(p+0); drop } over a
+// 1-page memory. The second load is within the extent the first check proved, so
+// P6.1 elides it in explicit mode.
+func twoLoadModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{wasm.I32}, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})), // memory: min 1 page
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{
+			0x20, 0x00, 0x28, 0x02, 0x04, 0x1a, // local.get 0; i32.load off=4; drop
+			0x20, 0x00, 0x28, 0x02, 0x00, 0x1a, // local.get 0; i32.load off=0; drop
+			0x0b,
+		}))),
+	)
+}
+
+func TestWithBoundsFacts(t *testing.T) {
+	// Force explicit mode so the facts machinery applies regardless of build tag.
+	base := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit)
+	if !base.BoundsFacts() {
+		t.Fatal("bounds-facts should default on")
+	}
+	off := base.WithBoundsFacts(false)
+	if off.BoundsFacts() {
+		t.Fatal("WithBoundsFacts(false) did not disable")
+	}
+	if !base.BoundsFacts() {
+		t.Fatal("WithBoundsFacts mutated the base config")
+	}
+
+	// The option reaches codegen through the public API: eliding the redundant
+	// second check shrinks the emitted code.
+	on, err := CompileWithConfig(base, twoLoadModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dis, err := CompileWithConfig(off, twoLoadModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(on.Code) >= len(dis.Code) {
+		t.Errorf("elision-on code (%d B) not smaller than facts-off (%d B)", len(on.Code), len(dis.Code))
+	}
+}

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -128,6 +128,7 @@ type RuntimeConfig struct {
 	features       CoreFeatures
 	maxMemoryPages uint32
 	boundsChecks   BoundsCheckMode
+	noBoundsFacts  bool // disable P6.1 straight-line bounds-check elision (default: enabled)
 }
 
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
@@ -202,11 +203,24 @@ func (c *RuntimeConfig) WithBoundsChecks(mode BoundsCheckMode) *RuntimeConfig {
 	return &n
 }
 
+// WithBoundsFacts enables or disables P6.1 straight-line bounds-check elision
+// (explicit mode only; guard mode elides all checks regardless). On by default —
+// pass false to force every access to be checked (e.g. for A/B, or to minimize
+// codegen surface). The WAGO_NO_BOUNDS_FACTS=1 env var disables it globally.
+func (c *RuntimeConfig) WithBoundsFacts(enabled bool) *RuntimeConfig {
+	n := *c
+	n.noBoundsFacts = !enabled
+	return &n
+}
+
 // CoreFeatures reports the configured feature set.
 func (c *RuntimeConfig) CoreFeatures() CoreFeatures { return c.features }
 
 // BoundsChecks reports the configured bounds-check mode.
 func (c *RuntimeConfig) BoundsChecks() BoundsCheckMode { return c.boundsChecks }
+
+// BoundsFacts reports whether straight-line bounds-check elision is enabled.
+func (c *RuntimeConfig) BoundsFacts() bool { return !c.noBoundsFacts }
 
 // MemoryLimitPages reports the configured maximum linear-memory size in pages.
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -128,7 +128,7 @@ type RuntimeConfig struct {
 	features       CoreFeatures
 	maxMemoryPages uint32
 	boundsChecks   BoundsCheckMode
-	noBoundsFacts  bool // disable P6.1 straight-line bounds-check elision (default: enabled)
+	noDeferBounds  bool // disable skipping of provably-redundant bounds checks (default: enabled)
 }
 
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
@@ -203,13 +203,14 @@ func (c *RuntimeConfig) WithBoundsChecks(mode BoundsCheckMode) *RuntimeConfig {
 	return &n
 }
 
-// WithBoundsFacts enables or disables P6.1 straight-line bounds-check elision
-// (explicit mode only; guard mode elides all checks regardless). On by default —
-// pass false to force every access to be checked (e.g. for A/B, or to minimize
-// codegen surface). The WAGO_NO_BOUNDS_FACTS=1 env var disables it globally.
-func (c *RuntimeConfig) WithBoundsFacts(enabled bool) *RuntimeConfig {
+// WithDeferBoundsChecks controls whether the compiler skips a bounds check that a
+// prior check in the same straight-line region already proved safe (explicit mode
+// only; guard-page mode has no inline checks). On by default — pass false to bounds-
+// check every memory access, e.g. for A/B testing or maximal defensiveness. The
+// WAGO_NO_BOUNDS_FACTS=1 env var disables it globally.
+func (c *RuntimeConfig) WithDeferBoundsChecks(enabled bool) *RuntimeConfig {
 	n := *c
-	n.noBoundsFacts = !enabled
+	n.noDeferBounds = !enabled
 	return &n
 }
 
@@ -219,8 +220,9 @@ func (c *RuntimeConfig) CoreFeatures() CoreFeatures { return c.features }
 // BoundsChecks reports the configured bounds-check mode.
 func (c *RuntimeConfig) BoundsChecks() BoundsCheckMode { return c.boundsChecks }
 
-// BoundsFacts reports whether straight-line bounds-check elision is enabled.
-func (c *RuntimeConfig) BoundsFacts() bool { return !c.noBoundsFacts }
+// DeferBoundsChecks reports whether skipping of provably-redundant bounds checks
+// is enabled.
+func (c *RuntimeConfig) DeferBoundsChecks() bool { return !c.noDeferBounds }
 
 // MemoryLimitPages reports the configured maximum linear-memory size in pages.
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }

--- a/src/wago/defer_bounds_checks_test.go
+++ b/src/wago/defer_bounds_checks_test.go
@@ -26,18 +26,18 @@ func twoLoadModule() []byte {
 	)
 }
 
-func TestWithBoundsFacts(t *testing.T) {
+func TestWithDeferBoundsChecks(t *testing.T) {
 	// Force explicit mode so the facts machinery applies regardless of build tag.
 	base := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit)
-	if !base.BoundsFacts() {
-		t.Fatal("bounds-facts should default on")
+	if !base.DeferBoundsChecks() {
+		t.Fatal("defer-bounds-checks should default on")
 	}
-	off := base.WithBoundsFacts(false)
-	if off.BoundsFacts() {
-		t.Fatal("WithBoundsFacts(false) did not disable")
+	off := base.WithDeferBoundsChecks(false)
+	if off.DeferBoundsChecks() {
+		t.Fatal("WithDeferBoundsChecks(false) did not disable")
 	}
-	if !base.BoundsFacts() {
-		t.Fatal("WithBoundsFacts mutated the base config")
+	if !base.DeferBoundsChecks() {
+		t.Fatal("WithDeferBoundsChecks mutated the base config")
 	}
 
 	// The option reaches codegen through the public API: eliding the redundant

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -245,7 +245,7 @@ type Compiled struct {
 	wasmBytes     []byte
 	needsLink     bool
 	boundsElide   bool // cached ElideBoundsChecks decision, for the link-time recompile
-	noBoundsFacts bool // cached NoBoundsFacts decision, for the link-time recompile
+	noDeferBounds bool // cached DeferBoundsChecks=false decision, for the link-time recompile
 
 	GCTypeDescs []gc.TypeDesc // immutable Wasm GC descriptor metadata; per-instance heaps own collection state
 

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -242,9 +242,10 @@ type Compiled struct {
 	// recompile candidates). needsLink marks a module whose codegen was deferred
 	// because it has a returning import that must be bound to another instance's
 	// function at Instantiate; its Code/Entry are empty until then.
-	wasmBytes   []byte
-	needsLink   bool
-	boundsElide bool // cached ElideBoundsChecks decision, for the link-time recompile
+	wasmBytes     []byte
+	needsLink     bool
+	boundsElide   bool // cached ElideBoundsChecks decision, for the link-time recompile
+	noBoundsFacts bool // cached NoBoundsFacts decision, for the link-time recompile
 
 	GCTypeDescs []gc.TypeDesc // immutable Wasm GC descriptor metadata; per-instance heaps own collection state
 


### PR DESCRIPTION
Makes the P6.1 straight-line bounds-check elision (#128) a first-class, CLI-controllable option instead of only the `WAGO_NO_BOUNDS_FACTS` env var.

## Plumbing (config → codegen)

- **`RuntimeConfig.WithBoundsFacts(enabled bool)`** + `BoundsFacts()` — on by default (the field is `noBoundsFacts`, so the zero value is elision-on). Immutable-style like the other `With*`.
- **`amd64.CompileOptions.NoBoundsFacts`** — threaded to a new `fn.boundsFacts` field; `memAddr` checks `f.boundsFacts` instead of the package global. Effective elision = `boundsFactsEnabled (env) && !opts.NoBoundsFacts` — env var still works as a global override, and the per-instance link-time recompile caches the decision (`Compiled.noBoundsFacts`) like `boundsElide`.
- **`api.go`** passes `cfg.noBoundsFacts` through on both the initial compile and the link recompile.

## CLI

`wago run` gains `--no-bounds-facts` (bare boolean flag; `extractOpts` now supports boolean flags). `mustLoad` compiles raw wasm via `CompileWithConfig(cfg, …)` (a precompiled `.wago` already has its codegen baked in, so the flag only affects fresh compiles). Documented in `wago help`.

## Verification

- End-to-end through the built CLI: `wago run -e step nbody.wasm 2000` = `-169071606` **identically** with and without `--no-bounds-facts` (correctness), and the flag genuinely toggles codegen — nbody compiles to **4873 B with elision vs 5849 B without** (~17% smaller).
- New tests: `TestWithBoundsFacts` (config toggle + immutability + the option shrinks emitted code through `CompileWithConfig`), and a `NoBoundsFacts` case in `TestBoundsFactsElision` (option off → both checks emitted).
- Full battery: `go test ./...` (root + bench, both tag modes), `make test-guard`, spec 57/57 (pass=16592 fail=0 skip=1591). Correctness of the elision itself is covered by #128's differential-both-modes gate.