### PR TITLE
runtime: synchronous host-call save/resume protocol (P8.1 PR1)

### DIFF
--- a/docs/host-import-results-plan.md
+++ b/docs/host-import-results-plan.md
@@ -1,0 +1,187 @@
+# Sync host imports with results — plan (P8.1, the WASI unlock)
+
+Status: design. Supersedes the ARCHITECTURE §11 "V2 spike" paragraph as the
+implementation plan. `no-ir-plan.md` §P8.1 calls this the single highest-value
+item in the file.
+
+## 0. Goal
+
+A wasm import can call a Go function **synchronously and get a typed result
+back**, so imports like `wasi_snapshot_preview1.fd_write() -> errno` work. Today
+host imports are void-only, first-i32-only, run *after* the wasm call returns
+(async log-and-replay). WASI is impossible without synchronous, value-returning
+re-entry.
+
+## 1. Why the async model can't return a value
+
+`callHost` (`backend/railshot/call.go:139`) appends `(importIdx, arg_i32)` to an
+off-heap log at `[linMem-offCustomCtx]` (basedata offset 40); `Invoke` replays
+the log against the Go `HostFunc`s **after** `Engine.Call` has fully returned
+(`src/wago/api.go:754 replayHostLog`). By then there is no live wasm
+continuation to receive a result. Enforced gates: backend `call.go:141`, linker
+`api.go:261` (a returning import is legal only as a *cross-instance* binding),
+frontend `frontend.go:184`.
+
+## 2. Mechanism: save-state + resume trampoline (WARP/wazero model)
+
+The spike (`CallWithHost` + `stubHostCall`, `hostCallPending=0x10000`) proves the
+Go-side loop and trap-slot signaling, but re-enters via `enterNative(code,…)`
+which **resets RSP to the foreign-stack top** (`trampoline_amd64.s:36-47`). That
+only resumes a *stateless* stub. A real function's operand stack, spilled
+locals, and nested frames live on the foreign stack below the top and would be
+clobbered by re-entry from the top.
+
+The trampoline already contains the two primitives we need:
+- Go callee-saved regs are stashed in a 64-byte save area at
+  `foreignStackTop-64` on entry (`.s:38-47`); restored on return (`.s:63-71`).
+- A trap anywhere in the call tree unwinds in one jump via
+  `mov rsp,[linMem-offTrapStackReentry(24)]; ret` back into `enterNative` right
+  after `CALL R11`, which then runs its Go-context epilogue.
+
+So a host call reuses the trap-unwind to get back to Go, but **saves the wasm
+deep state first** and adds a **resume** entry that restores it:
+
+**Host-call site (codegen, returning imports only):**
+1. `flush()` the operand stack + spill any pinned locals held in caller-saved
+   regs (RDI/RSI) to slots — as `callHost` already flushes today.
+2. Marshal the N typed params into the control frame's arg slots.
+3. Store `importIdx` into the control frame.
+4. `CALL hostCallStub` (shared per-engine stub; pointer read from a new basedata
+   slot `offHostTrampoline`).
+5. On return: read the M typed results from the control frame; push onto the
+   operand stack (reload locals as needed).
+
+**`hostCallStub` (shared native code, entered via CALL so [RSP]=resume addr):**
+1. Save wasm callee-saved `RBX,RBP,R12,R13,R14,R15` + current `RSP` into the
+   control frame's save area. (`RSP` points at the resume return address.)
+2. Write `hostCallPending` into the trap cell (`[linMem-TrapCellPtrOffset(104)]`).
+3. Unwind to Go: `mov rsp,[linMem-offTrapStackReentry(24)]; ret`. `enterNative`'s
+   epilogue restores the Go context and returns to the exec loop. The deep wasm
+   frames (below the save area) are untouched while Go runs.
+
+**Go exec loop (generalized `CallWithHost`):** on `hostCallPending`, read
+`importIdx` + typed args from the control frame, invoke the bound host func,
+write typed results back, then re-enter via `resumeNative`.
+
+**`resumeNative` (new asm, mirror of `enterNative`):**
+1. Re-stash the Go callee-saved + goroutine SP into the `foreignStackTop-64`
+   save area and re-arm `[linMem-offTrapStackReentry]` (identical prologue to
+   `enterNative`), so a later trap/host-call still unwinds correctly.
+2. Restore wasm `RBX,RBP,R12,R13,R14,R15` + `RSP` from the control frame.
+3. `ret` — pops the saved resume address, resuming the wasm function on the
+   instruction after `CALL hostCallStub`, with its full stack intact.
+
+Register save set rationale: at a host call the operand stack is flushed, so the
+only live wasm state is the module invariants (`RBX`=linMem, `R14`=globals,
+`R15`=memBytes) + pinned locals in callee-saved regs (`R12,R13,RBP`); caller-
+saved pinned locals (`RDI,RSI`) are flushed by codegen. Saving the 6 callee-saved
+regs + RSP covers all of it. `RAX/RCX/RDX/R8-R11` are scratch — dead across the
+flush.
+
+## 3. ABI additions
+
+- **Control frame** replaces the flat V2 ctrl block (`stubs_amd64.go:103`). Off-
+  heap (arena), pointer installed at `offCustomCtx(40)` — reuses the host-log
+  slot (a returning import needs no async log). Layout (u32/u64 fields, 16B
+  aligned):
+  - `importIdx u32`
+  - `nargs u32`, `nresults u32` (or derive from the resolved signature — TBD)
+  - saved `RSP u64`, saved `RBX,RBP,R12,R13,R14,R15` (6×u64 = 48B)
+  - `args[K] u64` slots, `results[K] u64` slots (K = max import arity in module)
+  - i32/f32 in the low 32 bits, matching the wrapper ABI.
+- **`offHostTrampoline`** — new basedata u64 slot holding the `hostCallStub`
+  pointer, so `callHost` emits `call [linMem-offHostTrampoline]`. Extends
+  `BasedataSize` from 112 to 128 (16B step; re-derive `basedata_test.go` +
+  `runtime-abi.md` + guard tests). Alternatively map the stub once per engine
+  and thread its pointer at instantiate — decide in PR1.
+- `hostCallPending` stays `0x10000` (outside `TrapCode` range).
+- **`wagoVersion` bump** (codec.go): any `Compiled` shape/ABI change. Update
+  `codec_test_helpers_test.go` + malicious-count fixtures.
+
+## 4. Public API — DECIDED: reflection-ergonomic over a slot core
+
+Users write **native-typed Go functions**, adapted to the slot ABI by
+reflection at bind time (decision 2026-07-04). Current void `func(arg int32)`
+(`globals.go:35`) stays valid (a subset). New capabilities:
+
+- **Any numeric signature:** `func(a int32, b int64) int32`,
+  `func(f float64) int64`, `func()`… params/results map i32↔int32, i64↔int64,
+  f32↔float32, f64↔float64. Multiple results → multiple wasm results (needs the
+  multi-result path; single-result first).
+- **Optional leading `HostModule` for memory/instance access** (this is how WASI
+  reaches guest memory — the bare reflection form can't): if the first Go param
+  is `wago.HostModule`, reflection injects it and maps the *remaining* params to
+  the wasm signature. `HostModule` exposes `.Memory() []byte` (+ later
+  re-entrant `.Invoke`). So `func(m wago.HostModule, fd, iov, cnt, pw int32) int32`
+  binds to a `(i32,i32,i32,i32)->i32` import with memory access.
+- **Void imports keep the async log-and-replay fast path** (cheap, batched,
+  back-compatible); **returning** imports use the sync re-entry path (§2).
+
+Layering: the engine/runtime/codegen (PR1/PR2) is **slot-based** — the control
+frame carries `[]uint64` params/results. A public slot form
+`HostFunc func(m HostModule, params, results []uint64)` is the zero-alloc escape
+hatch and the reflection adapter's target. Reflection lives entirely in
+`src/wago` (PR3); the ABI never sees it.
+
+Caveats to handle in PR3: `reflect.Value.Call` allocates per host call and is
+slower — fine for WASI (syscalls dominate), documented for hot user imports
+(point them at the slot form). **TinyGo `reflect` is partial** — verify
+`reflect.Value.Call` works under TinyGo (memory: wago supports TinyGo, PR #39);
+if not, the slot form is the TinyGo-supported path and the reflection adapter is
+gated to standard Go.
+
+## 5. Phasing (own branch + PR each; gate battery §7)
+
+1. **PR1 — runtime save/resume protocol.** New `resumeNative` asm +
+   `hostCallStub` + generalized control frame + `CallWithHost` loop taking typed
+   arg/result slots. Prove with a runtime test that does a **deep nested call
+   then a host call**, resumes, and returns a value (the spike only tested a
+   flat stub). Highest asm risk — de-risk here, no codegen/API churn yet.
+2. **PR2 — codegen.** `callHost` result path: marshal N params → control frame,
+   `call [linMem-offHostTrampoline]`, read M results. Drop the `call.go:141`
+   gate. Golden disasm test; `WAGO_*` A/B not needed (new capability, not a
+   behavior change to existing code).
+3. **PR3 — public API + wiring.** New returning-`HostFunc` type + `Imports`
+   binding; `Invoke`/`invokeLocal` route modules with returning imports through
+   `CallWithHost`; update `HostIndirectThunk` (table path) + imported-start;
+   lift the linker gate (`api.go:261`). FEATURES/ARCHITECTURE/runtime-abi docs.
+4. **PR4 — minimal WASI preview 1.** `wasi_snapshot_preview1`: `fd_write`,
+   `clock_time_get`, `args_get/sizes_get`, `environ_get/sizes_get`,
+   `random_get`, `proc_exit`. A `wago.WASI(...)` imports bundle + a CLI
+   `--wasi`. Demonstrates the unlock end-to-end (a real WASI hello-world; the
+   lua/ruby corpus modules that fail today with "host import with results not
+   supported").
+
+## 6. Resolved — API shape
+
+Decided 2026-07-04: **reflection-ergonomic public API** (native Go signatures)
+**layered on a slot-based core** (`func(m HostModule, params, results []uint64)`).
+Memory access via an optional leading `HostModule` param. Rationale + caveats in
+§4. Rejected: bare reflection with no memory access (WASI-incompatible), and
+combinatorial typed variants (`HostFuncR`, `HostFunc2R`…).
+
+## 7. Gate battery (per no-ir-plan §4)
+
+- `go test ./...` root + `cd bench && go test ./...`, both plain and
+  `-tags wago_guardpage`.
+- Spec suite 57/57 (`WAGO_BOUNDS= go test -run TestSpecExec`).
+- `TestCorpusDifferential` both modes.
+- New: a wasm→host(returning)→wasm round-trip exec test; a WASI hello-world
+  (PR4); golden disasm for the `callHost` result path (PR2).
+- Runtime asm: a deep-stack resume test in `src/core/runtime` (PR1) — the spike's
+  flat-stub test is necessary but not sufficient.
+
+## 8. Risks / pitfalls
+
+- **Re-entrancy (host calls back into wasm):** a single control frame is
+  overwritten if a host func calls `Instance.Invoke`. MVP: the save area is on
+  the *stack* (via the CALL-based stub), so nested wasm→host→wasm→host naturally
+  gets distinct RSPs — but the control-frame arg/result/importIdx slots are
+  single. Either stack the control frame or defer host→wasm re-entry to a
+  follow-up; WASI preview 1 needs neither.
+- **GC safepoints:** host runs on the goroutine stack in normal Go context
+  (safe, as the spike comment notes) — the foreign stack is never scanned.
+- **Guard mode:** the sync path must work under `-tags wago_guardpage` too
+  (SIGSEGV handler + host re-entry coexist); test both.
+- **Trap during a host call's arg marshaling** must still unwind cleanly.
+- Layout-luck / basedata overlap discipline (16B steps) per perf-plan §8.

--- a/src/core/runtime/bench_test.go
+++ b/src/core/runtime/bench_test.go
@@ -74,7 +74,7 @@ func BenchmarkHostCall(b *testing.B) {
 		b.Fatal(err)
 	}
 	defer ar.Close()
-	code, err := mmapExec(stubHostCall)
+	code, err := mmapExec(stubHostRoundtrip)
 	if err != nil {
 		b.Skipf("exec mapping denied: %v", err)
 	}
@@ -83,12 +83,12 @@ func BenchmarkHostCall(b *testing.B) {
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
 	trap := ar.Alloc(8)
-	ctrl := ar.Alloc(ctrlSize)
+	ctrl := ar.Alloc(ctrlFrameSize)
 	jm.SetCustomCtx(slicePtr(ctrl))
 	lin := jm.LinearMemory()
 	binary.LittleEndian.PutUint32(serArgs, 20)
 	codePtr := slicePtr(code)
-	host := func(arg uint32) uint32 { return arg * 2 }
+	host := func(imp uint32, args, res []uint64) { res[0] = args[0] * 2 }
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -98,8 +98,8 @@ func BenchmarkHostCall(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	if got := binary.LittleEndian.Uint32(results); got != 41 {
-		b.Fatalf("result = %d, want 41", got)
+	if got := binary.LittleEndian.Uint32(results); got != 151 {
+		b.Fatalf("result = %d, want 151 (double(20)+111 sentinel)", got)
 	}
 }
 

--- a/src/core/runtime/engine_linux_amd64.go
+++ b/src/core/runtime/engine_linux_amd64.go
@@ -115,29 +115,51 @@ func installTrapCell(linMem, trap []byte) {
 	*(*uint64)(unsafe.Pointer(uintptr(unsafe.Pointer(&linMem[0])) - abi.TrapCellPtrOffset)) = uint64(slicePtr(trap))
 }
 
-// HostFunc is a V2-style host import for the spike: it reads its argument and
-// returns a result. The real engine will pass slot buffers; this single-scalar
-// shape is enough to prove the round trip.
-type HostFunc func(arg uint32) uint32
-
-// CallWithHost runs native code that may request host imports via the safe
-// re-entry protocol. When the stub signals hostCallPending (via *trap), the Go
-// host function is run here — on the goroutine stack, in normal Go context, so
-// arbitrary host code is safe (no foreign-stack/morestack hazard) — and native
-// code is re-entered to resume. This mirrors wazero's host-call exec loop.
+// CallWithHost runs native code that may request returning host imports via the
+// synchronous re-entry protocol (hostcall_amd64.go). The first crossing is a
+// normal enterNative; whenever native code parks at a host call (trap cell ==
+// hostCallPending), the bound host function is run here — on the goroutine stack,
+// in normal Go context, so arbitrary host code is safe (no foreign-stack /
+// morestack hazard) — and native code is resumed via resumeNative. This mirrors
+// wazero's host-call exec loop.
 //
-// ctrl must point at an off-heap control block (see ctrl* offsets) whose address
-// has been installed as the import ctx via JobMemory.SetCustomCtx.
-func (e *Engine) CallWithHost(code uintptr, serArgs, linMem, trap, results, ctrl []byte, host HostFunc) error {
+// ctrl must point at an off-heap control frame of at least ctrlFrameSize bytes
+// whose address has been installed as the import ctx via JobMemory.SetCustomCtx.
+func (e *Engine) CallWithHost(code uintptr, serArgs, linMem, trap, results, ctrl []byte, host HostCall) error {
+	stub, err := hostCallStubPtr()
+	if err != nil {
+		return fmt.Errorf("jit: host-call stub: %w", err)
+	}
 	installTrapCell(linMem, trap)
+	binary.LittleEndian.PutUint64(ctrl[hcTrampoline:], uint64(stub)) // native calls [ctrl+hcTrampoline]
+	ctrlPtr := slicePtr(ctrl)
+	var argBuf, resBuf [maxHostArity]uint64
 	const maxReentries = 1 << 20
 	for i := 0; i < maxReentries; i++ {
-		enterNative(code, slicePtr(serArgs), slicePtr(linMem), slicePtr(trap), slicePtr(results), e.stackTop)
+		if i == 0 {
+			enterNative(code, slicePtr(serArgs), slicePtr(linMem), slicePtr(trap), slicePtr(results), e.stackTop)
+		} else {
+			binary.LittleEndian.PutUint32(trap, 0) // clear the pending marker before resuming
+			resumeNative(ctrlPtr, e.stackTop)
+		}
 		switch tc := binary.LittleEndian.Uint32(trap); {
 		case tc == hostCallPending:
-			arg := binary.LittleEndian.Uint32(ctrl[ctrlArg:])
-			binary.LittleEndian.PutUint32(ctrl[ctrlRet:], host(arg))
-			// fall through the loop to re-enter and resume native code
+			imp := binary.LittleEndian.Uint32(ctrl[hcImportIdx:])
+			n := int(binary.LittleEndian.Uint32(ctrl[hcNArgs:]))
+			if n > maxHostArity {
+				return fmt.Errorf("jit: host call arity %d exceeds %d", n, maxHostArity)
+			}
+			for k := 0; k < n; k++ {
+				argBuf[k] = binary.LittleEndian.Uint64(ctrl[hcArgs+k*8:])
+			}
+			for k := range resBuf {
+				resBuf[k] = 0
+			}
+			host(imp, argBuf[:n], resBuf[:])
+			for k := 0; k < maxHostArity; k++ {
+				binary.LittleEndian.PutUint64(ctrl[hcResults+k*8:], resBuf[k])
+			}
+			// loop: resumeNative continues native code after the host call
 		case tc != 0:
 			return &TrapError{Code: TrapCode(tc)}
 		default:

--- a/src/core/runtime/hostcall_amd64.go
+++ b/src/core/runtime/hostcall_amd64.go
@@ -1,0 +1,95 @@
+//go:build linux && amd64
+
+package runtime
+
+import "sync"
+
+// Synchronous host-import re-entry protocol (P8.1). A returning host import
+// cannot use the async log-and-replay path (the host must run *during* the wasm
+// call to hand a value back). Instead native code parks itself: it calls the
+// shared hostCallStub, which saves the live wasm register state into an off-heap
+// control frame and unwinds to Go through the existing trap re-entry SP; Go runs
+// the host function on the goroutine stack and writes the results; resumeNative
+// restores the saved register state and returns to the instruction after the
+// call. See docs/host-import-results-plan.md §2.
+
+// maxHostArity bounds the params/results a single host import may carry through
+// the control frame. WASI preview 1 tops out well below this. Changing it shifts
+// hcResults, so the hand-assembled stubs that hard-code that offset must move
+// too.
+const maxHostArity = 8
+
+// Control-frame field offsets (bytes). Off-heap; the frame's address is
+// installed in basedata at offCustomCtx, so native code reaches it as
+// [linMem-offCustomCtx]. hostCallStub writes the hcSaved* slots; Go reads
+// hcImportIdx/hcNArgs/hcArgs and writes hcResults; resumeNative reads hcSaved*.
+const (
+	hcSavedRSP    = 0                       // u64: wasm RSP at the call site (points at the resume address)
+	hcSavedRBX    = 8                       // u64
+	hcSavedRBP    = 16                      // u64
+	hcSavedR12    = 24                      // u64
+	hcSavedR13    = 32                      // u64
+	hcSavedR14    = 40                      // u64
+	hcSavedR15    = 48                      // u64
+	hcTrampoline  = 56                      // u64: hostCallStub address (per-instance constant, published by CallWithHost)
+	hcImportIdx   = 64                      // u32: native -> Go, which import
+	hcNArgs       = 68                      // u32: native -> Go, number of marshaled args
+	hcArgs        = 72                      // [maxHostArity]u64: native -> Go
+	hcResults     = hcArgs + maxHostArity*8 // [maxHostArity]u64: Go -> native (== 136 for maxHostArity=8)
+	ctrlFrameSize = hcResults + maxHostArity*8
+)
+
+// hostCallPending is written to the trap cell by hostCallStub to ask the Go exec
+// loop to run a host import and resume. It is outside the TrapCode range.
+const hostCallPending = 0x10000
+
+// HostCall runs the bound host import importIdx with the argument slots args and
+// writes its results into results (results has len maxHostArity; only the leading
+// slots the import's signature defines are meaningful). It runs on the goroutine
+// stack in normal Go context, so arbitrary host code — allocation, even a nested
+// wasm invocation — is safe (no foreign-stack/morestack hazard).
+type HostCall func(importIdx uint32, args, results []uint64)
+
+// hostCallStub is shared, position-independent machine code entered by native
+// code via `call [ctrl+hcTrampoline]` (rbx = linMem, rsp -> the wasm resume
+// address). It saves the wasm callee-saved registers + RSP into the control
+// frame at [rbx-offCustomCtx], writes hostCallPending into the trap cell at
+// [rbx-TrapCellPtrOffset], then unwinds to Go via the trap re-entry SP at
+// [rbx-offTrapStackReentry] exactly like the trap path. Assembled from
+// hoststub.s (`as` + objdump); the disassembly offsets are -0x28 (offCustomCtx
+// 40), -0x68 (TrapCellPtrOffset 104), -0x18 (offTrapStackReentry 24).
+var hostCallStub = []byte{
+	0x4c, 0x8b, 0x4b, 0xd8, // mov  -0x28(%rbx),%r9      ; r9 = ctrl
+	0x49, 0x89, 0x21, //       mov  %rsp,(%r9)           ; hcSavedRSP
+	0x49, 0x89, 0x59, 0x08, // mov  %rbx,0x8(%r9)        ; hcSavedRBX
+	0x49, 0x89, 0x69, 0x10, // mov  %rbp,0x10(%r9)       ; hcSavedRBP
+	0x4d, 0x89, 0x61, 0x18, // mov  %r12,0x18(%r9)
+	0x4d, 0x89, 0x69, 0x20, // mov  %r13,0x20(%r9)
+	0x4d, 0x89, 0x71, 0x28, // mov  %r14,0x28(%r9)
+	0x4d, 0x89, 0x79, 0x30, // mov  %r15,0x30(%r9)
+	0x4c, 0x8b, 0x43, 0x98, // mov  -0x68(%rbx),%r8      ; r8 = trap cell ptr
+	0x41, 0xc7, 0x00, 0x00, 0x00, 0x01, 0x00, // movl $0x10000,(%r8)  ; hostCallPending
+	0x48, 0x8b, 0x63, 0xe8, // mov  -0x18(%rbx),%rsp     ; trap re-entry SP
+	0xc3, //                   ret                       ; -> shared enterNative epilogue
+}
+
+// hostCallStub is mapped once for the process: it is position-independent and
+// identical for every engine, so a single executable page (never unmapped)
+// serves all of them.
+var (
+	hostStubOnce sync.Once
+	hostStubPtr  uintptr
+	hostStubErr  error
+)
+
+func hostCallStubPtr() (uintptr, error) {
+	hostStubOnce.Do(func() {
+		mem, err := mmapExec(hostCallStub)
+		if err != nil {
+			hostStubErr = err
+			return
+		}
+		hostStubPtr = slicePtr(mem) // retained for the life of the process
+	})
+	return hostStubPtr, hostStubErr
+}

--- a/src/core/runtime/hostcall_test.go
+++ b/src/core/runtime/hostcall_test.go
@@ -1,0 +1,151 @@
+//go:build linux && amd64
+
+package runtime
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// Test "wasm function" stubs for the synchronous host-call protocol, assembled
+// from teststubs.s (`as` + objdump). Each is entered with the WasmWrapper ABI
+// (RDI=serArgs, RSI=linMem, RDX=trap, RCX=results). They establish RBX=linMem
+// (the invariant hostCallStub relies on), marshal one arg into the control frame,
+// `call [ctrl+hcTrampoline]`, and on resume combine the host result with a stack
+// sentinel — so a wrong result means the parked stack was not preserved across
+// the Go round trip. Control-frame offsets are hard-coded (hcArgs=0x48,
+// hcImportIdx=0x40, hcNArgs=0x44, hcTrampoline=0x38, hcResults=0x88).
+
+// stubHostRoundtrip: single frame. result = host(serArgs[0]) + 111 (its stack
+// sentinel).
+var stubHostRoundtrip = []byte{
+	0x48, 0x89, 0xf3, // mov %rsi,%rbx        ; RBX = linMem
+	0x49, 0x89, 0xce, // mov %rcx,%r14        ; stash results ptr
+	0x48, 0x83, 0xec, 0x10, // sub $0x10,%rsp
+	0xc7, 0x04, 0x24, 0x6f, 0x00, 0x00, 0x00, // movl $0x6f,(%rsp)  ; sentinel 111
+	0x4c, 0x8b, 0x4b, 0xd8, // mov -0x28(%rbx),%r9   ; ctrl
+	0x8b, 0x07, // mov (%rdi),%eax                    ; serArgs[0]
+	0x49, 0x89, 0x41, 0x48, // mov %rax,0x48(%r9)     ; hcArgs[0]
+	0x41, 0xc7, 0x41, 0x40, 0x07, 0x00, 0x00, 0x00, // movl $7,0x40(%r9)   ; hcImportIdx
+	0x41, 0xc7, 0x41, 0x44, 0x01, 0x00, 0x00, 0x00, // movl $1,0x44(%r9)   ; hcNArgs
+	0x41, 0xff, 0x51, 0x38, // call *0x38(%r9)        ; hcTrampoline
+	0x4c, 0x8b, 0x4b, 0xd8, // mov -0x28(%rbx),%r9    ; reload ctrl
+	0x41, 0x8b, 0x81, 0x88, 0x00, 0x00, 0x00, // mov 0x88(%r9),%eax  ; hcResults[0]
+	0x03, 0x04, 0x24, // add (%rsp),%eax              ; + sentinel
+	0x48, 0x83, 0xc4, 0x10, // add $0x10,%rsp
+	0x41, 0x89, 0x06, // mov %eax,(%r14)              ; results[0]
+	0xc3, // ret
+}
+
+// stubHostNested: outer frame calls inner; inner performs the host call. Proves
+// both frames survive the round trip. result = host(serArgs[0]) + 100 (inner) +
+// 222 (outer). The entry is stubHostNested; inner follows contiguously (the
+// relative `call inner` depends on that layout).
+var stubHostNested = []byte{
+	// stubHostNested:
+	0x48, 0x89, 0xf3, // mov %rsi,%rbx
+	0x49, 0x89, 0xce, // mov %rcx,%r14
+	0x4c, 0x8b, 0x2f, // mov (%rdi),%r13      ; serArgs[0] (must survive)
+	0x48, 0x83, 0xec, 0x10, // sub $0x10,%rsp
+	0xc7, 0x04, 0x24, 0xde, 0x00, 0x00, 0x00, // movl $0xde,(%rsp)  ; outer sentinel 222
+	0xe8, 0x0b, 0x00, 0x00, 0x00, // call inner (+0x0b)
+	0x03, 0x04, 0x24, // add (%rsp),%eax      ; + outer sentinel
+	0x48, 0x83, 0xc4, 0x10, // add $0x10,%rsp
+	0x41, 0x89, 0x06, // mov %eax,(%r14)
+	0xc3, // ret
+	// inner:
+	0x48, 0x83, 0xec, 0x10, // sub $0x10,%rsp
+	0xc7, 0x04, 0x24, 0x64, 0x00, 0x00, 0x00, // movl $0x64,(%rsp)  ; inner sentinel 100
+	0x4c, 0x8b, 0x4b, 0xd8, // mov -0x28(%rbx),%r9
+	0x4d, 0x89, 0x69, 0x48, // mov %r13,0x48(%r9)    ; hcArgs[0]
+	0x41, 0xc7, 0x41, 0x40, 0x07, 0x00, 0x00, 0x00, // movl $7,0x40(%r9)
+	0x41, 0xc7, 0x41, 0x44, 0x01, 0x00, 0x00, 0x00, // movl $1,0x44(%r9)
+	0x41, 0xff, 0x51, 0x38, // call *0x38(%r9)
+	0x4c, 0x8b, 0x4b, 0xd8, // mov -0x28(%rbx),%r9   ; reload ctrl
+	0x41, 0x8b, 0x81, 0x88, 0x00, 0x00, 0x00, // mov 0x88(%r9),%eax
+	0x03, 0x04, 0x24, // add (%rsp),%eax
+	0x48, 0x83, 0xc4, 0x10, // add $0x10,%rsp
+	0xc3, // ret
+}
+
+// hostCallFixture allocates the buffers a CallWithHost run needs and installs the
+// control frame as the import ctx.
+func hostCallFixture(t *testing.T, jm *JobMemory, ar *Arena) (serArgs, results, trap, ctrl []byte) {
+	t.Helper()
+	serArgs = ar.Alloc(16)
+	results = ar.Alloc(16)
+	trap = ar.Alloc(8)
+	ctrl = ar.Alloc(ctrlFrameSize)
+	jm.SetCustomCtx(slicePtr(ctrl))
+	return
+}
+
+// TestHostCallRoundtrip: native marshals one arg, the Go host doubles it, native
+// resumes and adds its stack sentinel. double(20)+111 == 151, host called once
+// with importIdx 7 and arg 20.
+func TestHostCallRoundtrip(t *testing.T) {
+	eng, jm, ar := fixture(t)
+	code, err := mmapExec(stubHostRoundtrip)
+	if err != nil {
+		t.Skipf("exec mapping denied: %v", err)
+	}
+	defer munmap(code)
+
+	serArgs, results, trap, ctrl := hostCallFixture(t, jm, ar)
+	binary.LittleEndian.PutUint32(serArgs, 20)
+
+	calls := 0
+	var sawImport uint32
+	var sawArg uint64
+	host := func(imp uint32, args, res []uint64) {
+		calls++
+		sawImport = imp
+		sawArg = args[0]
+		res[0] = args[0] * 2
+	}
+
+	if err := eng.CallWithHost(slicePtr(code), serArgs, jm.LinearMemory(), trap, results, ctrl, host); err != nil {
+		t.Fatalf("CallWithHost: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("host fn invoked %d times, want 1", calls)
+	}
+	if sawImport != 7 || sawArg != 20 {
+		t.Fatalf("host saw importIdx=%d arg=%d, want 7 and 20", sawImport, sawArg)
+	}
+	if got := binary.LittleEndian.Uint32(results); got != 151 {
+		t.Fatalf("round-trip result = %d, want 151 (double(20)+111 sentinel)", got)
+	}
+}
+
+// TestHostCallDeepStack: the host call happens inside a nested call, so the
+// parked foreign stack holds two frames (both sentinels + the outer return
+// address). If resume clobbered or mis-restored the stack, the sentinels would be
+// wrong. double(20)+100+222 == 362.
+func TestHostCallDeepStack(t *testing.T) {
+	eng, jm, ar := fixture(t)
+	code, err := mmapExec(stubHostNested)
+	if err != nil {
+		t.Skipf("exec mapping denied: %v", err)
+	}
+	defer munmap(code)
+
+	serArgs, results, trap, ctrl := hostCallFixture(t, jm, ar)
+	binary.LittleEndian.PutUint32(serArgs, 20)
+
+	calls := 0
+	host := func(imp uint32, args, res []uint64) {
+		calls++
+		res[0] = args[0] * 2
+	}
+
+	if err := eng.CallWithHost(slicePtr(code), serArgs, jm.LinearMemory(), trap, results, ctrl, host); err != nil {
+		t.Fatalf("CallWithHost: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("host fn invoked %d times, want 1", calls)
+	}
+	if got := binary.LittleEndian.Uint32(results); got != 362 {
+		t.Fatalf("deep-stack result = %d, want 362 (double(20)+100+222 sentinels)", got)
+	}
+}

--- a/src/core/runtime/jit_test.go
+++ b/src/core/runtime/jit_test.go
@@ -133,34 +133,5 @@ func TestLinearMemoryZeroCopy(t *testing.T) {
 	}
 }
 
-// Test 5: V2 host-import callback (item e) via the safe re-entry protocol.
-// native marshals arg -> Go host fn (double) -> result back -> native resumes
-// and finalizes (+1). double(20)+1 == 41, host called exactly once.
-func TestV2HostImport(t *testing.T) {
-	eng, jm, ar := fixture(t)
-	code, err := mmapExec(stubHostCall)
-	if err != nil {
-		t.Skipf("exec mapping denied: %v", err)
-	}
-	defer munmap(code)
-
-	serArgs := ar.Alloc(16)
-	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
-	ctrl := ar.Alloc(ctrlSize)
-	jm.SetCustomCtx(slicePtr(ctrl)) // [linMem-40] -> control block pointer
-	binary.LittleEndian.PutUint32(serArgs, 20)
-
-	calls := 0
-	host := func(arg uint32) uint32 { calls++; return arg * 2 }
-
-	if err := eng.CallWithHost(slicePtr(code), serArgs, jm.LinearMemory(), trap, results, ctrl, host); err != nil {
-		t.Fatalf("CallWithHost: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("host fn invoked %d times, want 1", calls)
-	}
-	if got := binary.LittleEndian.Uint32(results); got != 41 {
-		t.Fatalf("host round-trip: results = %d, want 41 (double(20)+1)", got)
-	}
-}
+// The synchronous host-import round trip is covered by TestHostCallRoundtrip and
+// TestHostCallDeepStack in hostcall_test.go.

--- a/src/core/runtime/resume_amd64.s
+++ b/src/core/runtime/resume_amd64.s
@@ -1,0 +1,54 @@
+//go:build !tinygo
+
+#include "textflag.h"
+
+// func resumeNative(ctrl, foreignStackTop uintptr)
+//
+// Resumes native wasm code parked at a returning host import by hostCallStub.
+// hostCallStub saved the wasm callee-saved registers + RSP into the control
+// frame and unwound to Go through the trap re-entry SP; resumeNative reverses
+// that. It re-stashes the *current* Go context into the same save area at
+// foreignStackTop-64 that enterNative uses, so when the resumed wasm eventually
+// unwinds (completion, trap, or another host call) it returns through
+// enterNative's shared epilogue — reached via the return address still parked at
+// foreignStackTop-72 — which restores this Go context and returns here. Then it
+// reloads the saved wasm registers + RSP and RETs into wasm at the instruction
+// after the host CALL. See docs/host-import-results-plan.md §2.
+//
+// The deep wasm frames below the save area are untouched while Go runs (Go
+// executes on the goroutine stack), so the parked stack is intact on resume.
+TEXT ·resumeNative(SB), NOSPLIT, $0-16
+	MOVQ ctrl+0(FP), R9            // read args before altering SP (FP still valid)
+	MOVQ foreignStackTop+8(FP), R10
+
+	// enterNative is non-leaf, so the linker frames it with PUSHQ BP / ... /
+	// POPQ BP; RET, and the goroutine SP it stashes points at that pushed BP with
+	// the return address just above. resumeNative reuses enterNative's epilogue
+	// (via the return address parked at foreignStackTop-72), so it must stash an
+	// SP of the SAME shape — otherwise the epilogue's POPQ BP eats the return
+	// address and RET jumps into the control frame. Emulate `PUSHQ BP; MOVQ SP,BP`
+	// with SUBQ/MOVQ so the assembler's PUSH/POP balance check (resumeNative never
+	// pops — it RETs into wasm) does not reject it.
+	SUBQ $8, SP
+	MOVQ BP, 0(SP)                 // [SP] = caller BP; return address now at 8(SP)
+	MOVQ SP, BP
+
+	SUBQ $64, R10                  // save-area base (identical to enterNative)
+	MOVQ SP,  0(R10)               // goroutine SP, now pointing at the pushed BP
+	MOVQ BP,  8(R10)
+	MOVQ BX, 16(R10)
+	MOVQ R12, 24(R10)
+	MOVQ R13, 32(R10)
+	MOVQ R14, 40(R10)              // g
+	MOVQ R15, 48(R10)
+
+	// Reload the wasm register state hostCallStub saved into the control frame.
+	MOVQ  8(R9), BX                // hcSavedRBX (linMem)
+	MOVQ 16(R9), BP                // hcSavedRBP
+	MOVQ 24(R9), R12               // hcSavedR12
+	MOVQ 32(R9), R13               // hcSavedR13
+	MOVQ 40(R9), R14               // hcSavedR14
+	MOVQ 48(R9), R15               // hcSavedR15
+	MOVQ  0(R9), SP                // hcSavedRSP -> the parked deep wasm stack
+
+	RET                            // pop the wasm resume address, continue in wasm

--- a/src/core/runtime/stubs_amd64.go
+++ b/src/core/runtime/stubs_amd64.go
@@ -100,47 +100,9 @@ var stubLoop = []byte{
 
 const loopSentinel = 0x5A5A5A5A
 
-// Control-block layout for the V2 host-import re-entry protocol (off-heap; its
-// address is stored in basedata at [linMem-offCustomCtx], so native code reaches
-// it as ctx). All fields are u32.
-const (
-	ctrlState = 0  // 0 = fresh, 1 = host call requested/in-flight
-	ctrlArg   = 8  // native -> Go: argument for the host function
-	ctrlRet   = 12 // Go -> native: host function result
-	ctrlSize  = 16
-)
-
-// hostCallPending is the sentinel written to *trap by a stub that wants the Go
-// side to run a host import and re-enter. It is outside the TrapCode range.
-const hostCallPending = 0x10000
-
-// stubHostCall demonstrates a V2 host-import call via the safe re-entry protocol
-// (never calls Go from the foreign stack). It is a small state machine reached
-// possibly twice per logical wasm call:
-//
-//	ctx = [linMem - 40]              ; control block pointer (WARP customCtxOffset)
-//	state 0: stash serArgs[0] as the host arg, set state=1, *trap=HOSTCALL_PENDING, ret
-//	state 1: results[0] = hostResult + 1 (proves native runs after the call), *trap=NONE, ret
-//
-// Bytes assembled with `as` and verified via objdump (see job tmp/hoststub.s).
-var stubHostCall = []byte{
-	0x4c, 0x8b, 0x4e, 0xd8, // mov r9, [rsi-0x28]      ; r9 = ctx (control block)
-	0x41, 0x8b, 0x01, //       mov eax, [r9]           ; eax = state
-	0x85, 0xc0, //             test eax, eax
-	0x75, 0x14, //             jne resume
-	0x8b, 0x07, //             mov eax, [rdi]          ; arg = serArgs[0]
-	0x41, 0x89, 0x41, 0x08, // mov [r9+8], eax         ; cb.callArg = arg
-	0x41, 0xc7, 0x01, 0x01, 0x00, 0x00, 0x00, // mov dword [r9], 1   ; cb.state = 1
-	0xc7, 0x02, 0x00, 0x00, 0x01, 0x00, //       mov dword [rdx], 0x10000 ; *trap = pending
-	0xc3, //                   ret
-	// resume:
-	0x41, 0x8b, 0x41, 0x0c, // mov eax, [r9+0xc]       ; eax = cb.callRet
-	0x83, 0xc0, 0x01, //       add eax, 1              ; +1 (post-call native work)
-	0x89, 0x01, //             mov [rcx], eax          ; results[0]
-	0x41, 0xc7, 0x01, 0x00, 0x00, 0x00, 0x00, // mov dword [r9], 0   ; cb.state = 0
-	0xc7, 0x02, 0x00, 0x00, 0x00, 0x00, //       mov dword [rdx], 0  ; *trap = NONE
-	0xc3, //                   ret
-}
+// The synchronous host-import re-entry protocol (control-frame layout,
+// hostCallStub, hostCallPending, resumeNative) lives in hostcall_amd64.go; the
+// earlier single-scalar "V2 spike" stub that lived here was superseded by it.
 
 // stubLoopHeartbeat is like stubLoop but writes the live counter into linMem[0]
 // on every iteration, so another goroutine can observe that native code is

--- a/src/core/runtime/trampoline_asm_amd64.go
+++ b/src/core/runtime/trampoline_asm_amd64.go
@@ -9,3 +9,10 @@ package runtime
 // Plan9 .s files, so it supplies its own enterNative in
 // trampoline_tinygo_amd64.go.
 func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr)
+
+// resumeNative is implemented in resume_amd64.s. It resumes native code parked
+// at a returning host import (see hostcall_amd64.go): it restores the wasm
+// register state + RSP saved in the control frame and returns into wasm after
+// the host CALL. TinyGo supplies its own resumeNative in
+// trampoline_tinygo_amd64.go.
+func resumeNative(ctrl, foreignStackTop uintptr)

--- a/src/core/runtime/trampoline_tinygo_amd64.go
+++ b/src/core/runtime/trampoline_tinygo_amd64.go
@@ -147,3 +147,55 @@ func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr) 
 	call := *(*func(a, b, c, d uintptr))(unsafe.Pointer(&fv))
 	call(serArgs, linMem, trap, results)
 }
+
+// resumeThunkTemplate is the TinyGo counterpart of resume_amd64.s: a position-
+// independent (and foreign-stack-top-independent, since that arrives in a
+// register) resume trampoline. Entered via a func-value cast with RDI=ctrl,
+// RSI=foreignStackTop. Unlike the standard toolchain's enterNative, the TinyGo
+// enterNative thunk's epilogue is `mov (%rsp),%rsp; ret` (no POPQ BP), so this
+// stashes the goroutine SP pointing directly at the return address. Assembled
+// from resumethunk.s (`as` + objdump).
+var resumeThunkTemplate = []byte{
+	0x48, 0x83, 0xee, 0x40, // sub $0x40, %rsi          ; save-area base
+	0x48, 0x89, 0x26, //       mov %rsp, (%rsi)         ; goroutine SP (-> return address)
+	0x48, 0x89, 0x6e, 0x08, // mov %rbp, 0x8(%rsi)
+	0x48, 0x89, 0x5e, 0x10, // mov %rbx, 0x10(%rsi)
+	0x4c, 0x89, 0x66, 0x18, // mov %r12, 0x18(%rsi)
+	0x4c, 0x89, 0x6e, 0x20, // mov %r13, 0x20(%rsi)
+	0x4c, 0x89, 0x76, 0x28, // mov %r14, 0x28(%rsi)
+	0x4c, 0x89, 0x7e, 0x30, // mov %r15, 0x30(%rsi)
+	0x48, 0x8b, 0x5f, 0x08, // mov 0x8(%rdi), %rbx      ; restore wasm state from ctrl
+	0x48, 0x8b, 0x6f, 0x10, // mov 0x10(%rdi), %rbp
+	0x4c, 0x8b, 0x67, 0x18, // mov 0x18(%rdi), %r12
+	0x4c, 0x8b, 0x6f, 0x20, // mov 0x20(%rdi), %r13
+	0x4c, 0x8b, 0x77, 0x28, // mov 0x28(%rdi), %r14
+	0x4c, 0x8b, 0x7f, 0x30, // mov 0x30(%rdi), %r15
+	0x48, 0x8b, 0x27, //       mov (%rdi), %rsp         ; hcSavedRSP -> deep wasm stack
+	0xc3, //                   ret
+}
+
+var (
+	resumeThunkOnce  sync.Once
+	resumeThunkEntry uintptr
+)
+
+func resumeThunkPtr() uintptr {
+	resumeThunkOnce.Do(func() {
+		code := make([]byte, len(resumeThunkTemplate))
+		copy(code, resumeThunkTemplate)
+		mem, err := mmapExec(code)
+		if err != nil {
+			panic("wago: cannot map tinygo resume trampoline: " + err.Error())
+		}
+		resumeThunkEntry = uintptr(unsafe.Pointer(&mem[0])) // retained for the process
+	})
+	return resumeThunkEntry
+}
+
+// resumeNative resumes native code parked at a host call (see hostcall_amd64.go).
+// It mirrors resume_amd64.s. The thunk ignores the func-value context word.
+func resumeNative(ctrl, foreignStackTop uintptr) {
+	fv := funcValue{context: 0, fnptr: resumeThunkPtr()}
+	call := *(*func(a, b uintptr))(unsafe.Pointer(&fv))
+	call(ctrl, foreignStackTop)
+}


### PR DESCRIPTION
First of 4 PRs for **P8.1 — sync host imports with results** (the WASI unlock; plan: \`docs/host-import-results-plan.md\`, added here). This PR builds and de-risks the **runtime save/resume mechanism**; no codegen or public-API change yet.

## What

A returning host import can't use the async log-and-replay path (the host must run *during* the wasm call to hand a value back). This PR generalizes the throwaway V2 spike into a real protocol:

- **\`hostCallStub\`** (shared, position-independent machine code): native code parks itself via \`call [ctrl+hcTrampoline]\`; the stub saves the wasm callee-saved regs + RSP into an off-heap **control frame**, writes \`hostCallPending\` to the trap cell, and unwinds to Go through the existing trap re-entry SP (deep foreign-stack frames stay intact — Go runs on the goroutine stack).
- **\`resumeNative\`** (new \`resume_amd64.s\` + a TinyGo runtime-generated thunk): restores the saved register state + RSP and returns to the instruction after the host call.
- **\`CallWithHost\`** generalized to a typed slot ABI: reads \`importIdx\` + arg slots from the control frame, runs the bound \`HostCall\`, writes result slots, and resumes. The old single-scalar spike (\`stubHostCall\`, \`ctrlState/Arg/Ret\`) is removed.

## The subtle bug (documented for the next reader)

\`enterNative\` is non-leaf, so the linker frames it with \`PUSHQ BP / … / POPQ BP; RET\`. \`resumeNative\` reuses that shared epilogue, so it must stash a goroutine SP of the **same shape** (pointing at a pushed BP, return address just above) — otherwise the epilogue's \`POPQ BP\` eats the return address and \`RET\` jumps into the control frame. Fixed by emulating the frame-pointer push. The TinyGo enterNative thunk's epilogue has no \`POPQ BP\`, so its resume thunk stashes SP pointing directly at the return address.

## Tests

- \`TestHostCallRoundtrip\` — single frame: host doubles the arg, native resumes and adds a stack sentinel.
- \`TestHostCallDeepStack\` — the host call happens **inside a nested call**, so the parked foreign stack holds two frames (both sentinels + the outer return address); a wrong result means the stack wasn't preserved across the round trip.

## Gates

Full battery green: root + bench (plain **and** \`-tags wago_guardpage\`), \`make test-guard\`, gofmt, and **TinyGo build + test** (the host-call tests run under TinyGo too, exercising the resume thunk).

Next: PR2 wires \`callHost\` codegen to emit the protocol for returning imports.