### PR TITLE
railshot: codegen for returning host imports via sync re-entry (P8.1 PR2)

### DIFF
--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -106,7 +106,10 @@ func (f *fn) callOp(r *wasm.Reader) error {
 		if f.importBindings != nil && int(idx) < len(f.importBindings) && f.importBindings[idx].CrossInstance {
 			return f.emitCrossInstanceCall(f.importBindings[idx], ft)
 		}
-		return f.callHost(int(idx), ft)
+		if len(ft.Results) != 0 {
+			return f.callHostSync(int(idx), ft) // synchronous re-entry, returns a value
+		}
+		return f.callHost(int(idx), ft) // void: async log-and-replay
 	}
 	// `call f; local.set x` fusion: an int-only register-ABI call whose single
 	// int result feeds a pinned local moves RAX straight into the local's
@@ -131,16 +134,14 @@ func (f *fn) callOp(r *wasm.Reader) error {
 	return f.callInternal(int(idx)-imported, ft, hint)
 }
 
-// callHost lowers a call to an imported (host) function. Since native wasm code
-// cannot call back into Go without cgo, the call is LOGGED to an in-memory buffer
-// (at [linMem-offCustomCtx]) and replayed on the Go stack after the wasm function
-// returns. This matches the runtime's log format (backend/railshot/amd64). Fire-and-forget:
-// a single i32 argument, no result.
+// callHost lowers a call to a VOID imported (host) function. Native wasm code
+// cannot call back into Go without cgo, so the call is LOGGED to an in-memory
+// buffer (at [linMem-offCustomCtx]) and replayed on the Go stack after the wasm
+// function returns. Fire-and-forget: no result. Returning imports take the
+// synchronous re-entry path instead (callHostSync). The caller (emitCall) routes
+// by result arity, so ft here always has zero results.
 func (f *fn) callHost(importIdx int, ft *wasm.CompType) error {
 	f.stats.call("host")
-	if len(ft.Results) != 0 {
-		return fmt.Errorf("amd64: host import with results not supported (func %d)", importIdx)
-	}
 	p := len(ft.Params)
 	f.flush()
 	d := f.depth()
@@ -159,6 +160,83 @@ func (f *fn) callHost(importIdx int, ft *wasm.CompType) error {
 	f.a.AluRI(0, RCX, 1, false) // count++ (digit 0 = add)
 	f.a.Store32(R8, 0, RCX)
 	f.setDepth(d - p)
+	return nil
+}
+
+// callHostSync lowers a call to a RETURNING imported (host) function via the
+// synchronous re-entry protocol (see src/core/runtime/hostcall_amd64.go). The p
+// params are marshaled into the off-heap control frame (at [linMem-offCustomCtx]);
+// `call [ctrl+hcTrampoline]` runs the shared hostCallStub, which saves the wasm
+// register state and unwinds to Go; Go runs the host function, writes the
+// results, and resumes here; the rN results are read out of the control frame
+// onto the operand stack.
+//
+// hostCallStub saves and resumeNative restores the callee-saved registers
+// (RBX/RBP/R12..R15), so pinned locals and linMem survive the round trip and need
+// no spilling — unlike a wasm→wasm call, whose callee reuses those registers.
+// Value-pinned and module-pinned globals ARE synced around the call: the host may
+// read or write the instance's globals through their cells.
+func (f *fn) callHostSync(importIdx int, ft *wasm.CompType) error {
+	f.stats.call("hostsync")
+	p, rN := len(ft.Params), len(ft.Results)
+	d := f.depth()
+	f.flush()                   // operands to canonical slots; args at [d-p, d)
+	f.storePinnedGlobals(false) // coherence: the host may read the current values
+	f.storeModuleGlobals(RAX)
+
+	// Marshal the p params into the control frame and set the header. Load each
+	// arg at its natural width (i32/f32 zero-extended) so the Go side sees a clean
+	// slot value.
+	f.a.Load64(R8, RBX, -offCustomCtx) // R8 = control frame
+	for i := 0; i < p; i++ {
+		if mtOf(ft.Params[i]).is64() {
+			f.a.Load64(RAX, RSP, f.spillOff(d-p+i))
+		} else {
+			f.a.Load32(RAX, RSP, f.spillOff(d-p+i)) // zero-extends into RAX
+		}
+		f.a.Store64(R8, hcArgs+int32(i)*8, RAX)
+	}
+	f.a.StoreImm32Mem(R8, hcImportIdx, int32(importIdx))
+	f.a.StoreImm32Mem(R8, hcNArgs, int32(p))
+
+	// Park at the host call. Like the wrapper path, no post-call trap check: a
+	// trap unwinds the whole native tree in one jump (it never returns here).
+	f.a.CallMem(R8, hcTrampoline)
+
+	f.deriveModuleGlobals() // the host may have written global cells
+	f.derivePinnedGlobals()
+	f.setDepth(d - p)
+
+	// Read the rN results out of the control frame onto the operand stack. R8 is
+	// scratch-reserved (never allocated), so it safely carries the control-frame
+	// pointer across the result loads.
+	f.a.Load64(R8, RBX, -offCustomCtx) // reload ctrl (clobbered by the round trip)
+	res := make([]Reg, rN)
+	isFP := make([]bool, rN)
+	for j := 0; j < rN; j++ {
+		if mtOf(ft.Results[j]).isFloat() {
+			tmp := f.allocReg(0)
+			f.a.Load64(tmp, R8, hcResults+int32(j)*8)
+			res[j] = f.allocFReg(0)
+			f.a.MovGprToXmm(res[j], tmp, true)
+			f.release(tmp)
+			f.fpinned = f.fpinned.add(res[j])
+			isFP[j] = true
+		} else {
+			res[j] = f.allocReg(0)
+			f.a.Load64(res[j], R8, hcResults+int32(j)*8)
+			f.pinned = f.pinned.add(res[j]) // keep across the remaining loads
+		}
+	}
+	for j := 0; j < rN; j++ {
+		if isFP[j] {
+			f.fpinned = f.fpinned.remove(res[j])
+			f.pushFReg(res[j], mtOf(ft.Results[j]))
+		} else {
+			f.pinned = f.pinned.remove(res[j])
+			f.pushReg(res[j], mtOf(ft.Results[j]))
+		}
+	}
 	return nil
 }
 
@@ -189,11 +267,23 @@ func HostIndirectThunk(importIdx uint32) []byte {
 // flush, and the indirect-call table descriptor pointer.
 const (
 	offTrapReentry = 24 // handler-jump re-entry SP (set per native entry)
-	offCustomCtx   = 40 // host-call log pointer
+	offCustomCtx   = 40 // host-call log pointer / sync host-call control frame
 	offSpillRegion = 48 // 8B scratch
 	offStackFence  = 72 // low stack bound for the fence check
 	offTablePtr    = 80 // table descriptor pointer
 	// offTrapCellPtr (== abi.TrapCellPtrOffset) is defined in memory.go.
+)
+
+// Control-frame field offsets for the synchronous host-call protocol. A
+// returning host import needs no async log, so it reuses the customCtx slot
+// (offCustomCtx) for its control frame. These MUST match
+// src/core/runtime/hostcall_amd64.go (hcSavedRSP..hcResults, maxHostArity=8).
+const (
+	hcTrampoline = 56  // u64: hostCallStub address (published per-instance by CallWithHost)
+	hcImportIdx  = 64  // u32: native -> Go
+	hcNArgs      = 68  // u32: native -> Go
+	hcArgs       = 72  // [8]u64: native -> Go
+	hcResults    = 136 // [8]u64: Go -> native (== hcArgs + 8*8)
 )
 
 // emitCrossInstanceCall lowers a call to an imported function that is bound to

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"unsafe"
 
 	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -318,6 +319,109 @@ func TestAmd64HostImportCompile(t *testing.T) {
 	}
 	if _, err := CompileModule(m); err != nil {
 		t.Fatalf("host import compile: %v", err)
+	}
+}
+
+// runHostSync compiles m (func index 1 is the export, func 0 the import) and runs
+// it via the synchronous host-call protocol with the given i32 args, returning
+// the first i32 result and the host-call count.
+func runHostSync(t *testing.T, m *wasm.Module, host runtime.HostCall, args ...int32) uint32 {
+	t.Helper()
+	cm, err := CompileModule(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	eng, err := runtime.NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+	jm, err := runtime.NewJobMemory(65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jm.Close()
+	ar, err := runtime.NewArena(4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ar.Close()
+	mem, entry, err := runtime.MapCode(cm.Code)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	defer runtime.Unmap(mem)
+
+	serArgs := ar.Alloc(128)
+	results := ar.Alloc(128)
+	trap := ar.Alloc(8)
+	ctrl := ar.Alloc(runtime.HostCtrlFrameBytes)
+	jm.SetCustomCtx(uintptr(unsafe.Pointer(&ctrl[0]))) // install the control frame as import ctx
+	for i, a := range args {
+		binary.LittleEndian.PutUint32(serArgs[i*8:], uint32(a))
+	}
+	if err := eng.CallWithHost(entry+uintptr(cm.Entry[0]), serArgs, jm.LinearMemory(), trap, results, ctrl, host); err != nil {
+		t.Fatalf("CallWithHost: %v", err)
+	}
+	return binary.LittleEndian.Uint32(results)
+}
+
+// hostSyncModule builds a module whose func 0 is an import of type `sig` and func
+// 1 (exported "g") has body `body`.
+func hostSyncModule(sig []byte, body []byte) *wasm.Module {
+	imp := append(append(wasmtest.Name("env"), wasmtest.Name("f")...), 0x00, 0x00) // func, type 0
+	fnBody := append(wasmtest.ULEB(uint32(len(body))), body...)
+	b := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(sig)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("g", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(fnBody)),
+	)
+	m, err := wasm.DecodeModule(b)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// TestAmd64HostImportSyncResult runs a RETURNING host import end-to-end through
+// the synchronous re-entry protocol (callHostSync): g(x) calls env.f(x) and
+// returns its result; the Go host doubles x. This exercises the full path —
+// codegen marshals the arg into the control frame, calls the shared stub, and
+// reads the result back.
+func TestAmd64HostImportSyncResult(t *testing.T) {
+	// type 0: (i32)->(i32). g(x): local.get 0; call 0; end.
+	sig := wasmtest.FuncType([]wasm.ValType{i32}, []wasm.ValType{i32})
+	m := hostSyncModule(sig, []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b})
+	calls := 0
+	host := func(imp uint32, args, res []uint64) {
+		calls++
+		if imp != 0 {
+			t.Errorf("host importIdx = %d, want 0", imp)
+		}
+		res[0] = args[0] * 2
+	}
+	if got := runHostSync(t, m, host, 21); got != 42 {
+		t.Fatalf("result = %d, want 42 (double(21))", got)
+	}
+	if calls != 1 {
+		t.Fatalf("host invoked %d times, want 1", calls)
+	}
+}
+
+// TestAmd64HostImportSyncMultiParam exercises multi-param marshaling AND a local
+// surviving the host round trip: k(a,b) = env.add(a,b) + a. The host adds; the
+// caller then re-reads local 0 (a) after the call and adds it.
+func TestAmd64HostImportSyncMultiParam(t *testing.T) {
+	// type 0: (i32,i32)->(i32).
+	sig := wasmtest.FuncType([]wasm.ValType{i32, i32}, []wasm.ValType{i32})
+	// k(a,b): local.get 0; local.get 1; call 0; local.get 0; i32.add; end
+	body := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x10, 0x00, 0x20, 0x00, 0x6a, 0x0b}
+	m := hostSyncModule(sig, body)
+	host := func(imp uint32, args, res []uint64) { res[0] = args[0] + args[1] }
+	if got := runHostSync(t, m, host, 20, 3); got != 43 { // env.add(20,3)=23, +a(20)=43
+		t.Fatalf("result = %d, want 43 (add(20,3)+20)", got)
 	}
 }
 

--- a/src/core/runtime/hostcall_amd64.go
+++ b/src/core/runtime/hostcall_amd64.go
@@ -43,6 +43,15 @@ const (
 // loop to run a host import and resume. It is outside the TrapCode range.
 const hostCallPending = 0x10000
 
+// HostCtrlFrameBytes is the size of the off-heap control frame the synchronous
+// host-call protocol needs. A caller of CallWithHost allocates a buffer of at
+// least this many bytes and installs it as the import ctx (SetCustomCtx).
+const HostCtrlFrameBytes = ctrlFrameSize
+
+// MaxHostArity is the largest number of params or results a single host import
+// may carry through the control frame.
+const MaxHostArity = maxHostArity
+
 // HostCall runs the bound host import importIdx with the argument slots args and
 // writes its results into results (results has len maxHostArity; only the leading
 // slots the import's signature defines are meaningful). It runs on the goroutine


### PR DESCRIPTION
Second of 4 PRs for **P8.1 — sync host imports with results**. Builds on #131 (the runtime save/resume protocol). This PR teaches the railshot backend to emit the protocol for **returning** host imports; the public API + WASI come in PR3/PR4.

## What

- **\`callHostSync\`** (`call.go`): a returning host import now compiles instead of erroring. After \`flush()\`, it marshals the N params (at natural width — i32/f32 zero-extended) into the off-heap control frame at \`[linMem-offCustomCtx]\`, sets \`hcImportIdx\`/\`hcNArgs\`, \`call [ctrl+hcTrampoline]\` (the shared \`hostCallStub\` from #131), then reads the M results back onto the operand stack.
- **Dispatch** (`emitCall`): imports route by result arity — returning → \`callHostSync\` (sync re-entry), void → \`callHost\` (unchanged async log-and-replay). The old \`"host import with results not supported"\` error is gone.
- **No extra spilling**: the protocol saves/restores RBX/RBP/R12–R15, so pinned locals + linMem survive the round trip (unlike a wasm→wasm call). Value- and module-pinned **globals** *are* synced around the call (\`storePinnedGlobals\`/\`storeModuleGlobals\` before, \`derive*\` after) since the host may read/write them through their cells.
- Runtime exports \`HostCtrlFrameBytes\` + \`MaxHostArity\` (PR3 needs them to size the control frame).
- Stats gain a \`hostsync\` call kind.

## Tests (end-to-end, not compile-only)

Both run a real module through the runtime \`CallWithHost\` loop:
- \`TestAmd64HostImportSyncResult\` — \`g(x) = env.f(x)\`, host doubles → \`g(21)=42\`.
- \`TestAmd64HostImportSyncMultiParam\` — \`k(a,b) = env.add(a,b) + a\`, exercising multi-param marshaling **and** a local surviving the round trip → \`k(20,3)=43\`.

## Gates

Root + bench (plain **and** \`-tags wago_guardpage\`), \`make test-guard\`, gofmt, vet, and **TinyGo build + test** all green. The void host-import path and the rest of the railshot suite are unchanged. (Spec suite runs in CI; returning host imports don't appear in it — spectest imports are void.)

Next: PR3 — public reflection \`HostFunc\` API + \`Imports\` binding + route returning-import modules through \`CallWithHost\` + lift the linker gate.