### PR TITLE
website: retitle Performance section to 'No IR, no compromise'

### DIFF
--- a/scripts/update-website-bench.mjs
+++ b/scripts/update-website-bench.mjs
@@ -236,14 +236,15 @@ function renderSection(tabs) {
   return `            <section id="performance" class="section">
                 <div class="eyebrow eyebrow--center">Performance</div>
                 <h2 class="section__title">
-                    Cold start in
-                    <span class="section__title-accent">microseconds</span>
+                    No IR,
+                    <span class="section__title-accent">no compromise</span>
                 </h2>
                 <p class="section__lead">
-                    One-shot compilation to native using the novel Valent-Block
-                    architecture, avoiding complex SSA, IR, and optimization
-                    passes while maintaining extraordinarily competitive
-                    performance.
+                    wago compiles straight to native in a single pass: no SSA,
+                    no IR, no optimizer, just the novel Valent-Block
+                    architecture. It still keeps pace with runtimes that run a
+                    full optimizing backend. Every stage, head-to-head with
+                    wazero.
                 </p>
                 <div class="vs">
                     <div class="vs__head">


### PR DESCRIPTION
The website's Performance section header is templated in `scripts/update-website-bench.mjs` (regenerated on every `make bench-website`). The site now uses "Cold start in microseconds" for the new **Startup latency** section, so this updates the generated Performance header to "No IR, no compromise" (with a single-pass/Valent-Block subtitle) to avoid a duplicate title.

Without this, the next `bench-website` run reverts the live header back to "Cold start in microseconds", duplicating the startup heading.

https://claude.ai/code/session_01XiDFM1Sa9gVf2fUKEnjgqG