### PR TITLE
wago: public API for returning host imports (reflection + slot form) (P8.1 PR3)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -45,7 +45,7 @@ Later proposals and engine/platform capabilities beyond the MVP.
 | Tail calls (`return_call` / `return_call_indirect`) | ✓ | ⬜ planned |
 | SIMD (`v128`) | ✓ | ⬜ planned |
 | Threads & atomics | ✓ | ⬜ planned |
-| Synchronous host-import results | ✓ | ⬜ planned |
+| Synchronous host-import results | ✓ | ✅ done |
 | WASI preview 1 | ✓ | ⬜ planned |
 | Architectures beyond linux/amd64 (arm64, macOS, Windows) | ✓ | ⬜ planned |
 | Multi-memory | ✗ | ❌ not planned |

--- a/src/core/compiler/backend/railshot/call.go
+++ b/src/core/compiler/backend/railshot/call.go
@@ -106,8 +106,12 @@ func (f *fn) callOp(r *wasm.Reader) error {
 		if f.importBindings != nil && int(idx) < len(f.importBindings) && f.importBindings[idx].CrossInstance {
 			return f.emitCrossInstanceCall(f.importBindings[idx], ft)
 		}
-		if len(ft.Results) != 0 {
-			return f.callHostSync(int(idx), ft) // synchronous re-entry, returns a value
+		// A module with any returning host import uses the synchronous control
+		// frame for ALL its host calls, so the async log and the control frame
+		// never both occupy offCustomCtx. Otherwise void imports keep the cheaper
+		// async log-and-replay path.
+		if f.syncHostCalls || len(ft.Results) != 0 {
+			return f.callHostSync(int(idx), ft) // synchronous re-entry
 		}
 		return f.callHost(int(idx), ft) // void: async log-and-replay
 	}
@@ -161,6 +165,23 @@ func (f *fn) callHost(importIdx int, ft *wasm.CompType) error {
 	f.a.Store32(R8, 0, RCX)
 	f.setDepth(d - p)
 	return nil
+}
+
+// moduleUsesSyncHostCalls reports whether the module has any returning host
+// import (a function import with results, not bound cross-instance). Such a
+// module routes ALL host calls through the synchronous control frame, so the
+// async host-call log and the control frame never both occupy offCustomCtx.
+func moduleUsesSyncHostCalls(m *wasm.Module, bindings []ImportBinding) bool {
+	imported := m.ImportedFuncCount()
+	for i := 0; i < imported; i++ {
+		if bindings != nil && i < len(bindings) && bindings[i].CrossInstance {
+			continue
+		}
+		if ft, ok := m.FuncSignature(uint32(i)); ok && len(ft.Results) != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // callHostSync lowers a call to a RETURNING imported (host) function via the

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -147,6 +147,12 @@ type fn struct {
 	// on the link-time recompile of a module with cross-instance imports.
 	importBindings []ImportBinding
 
+	// syncHostCalls is set when the module has any returning host import, so every
+	// host call in the module uses the synchronous control frame (callHostSync)
+	// rather than the async log — the two share offCustomCtx and must not both be
+	// live. Computed once per module in compileFunc.
+	syncHostCalls bool
+
 	// trapSites[code] lists the branch sites (Jcc/Jmp rel32 placeholders) that
 	// target this function's shared trap stub for `code`; emitTrapStubs emits the
 	// stubs after the epilogue and patches them. See trapIf.
@@ -464,6 +470,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGl
 	}
 
 	f := &fn{a: &amd64.Asm{}, s: newStack(), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
+	f.syncHostCalls = moduleUsesSyncHostCalls(m, importBindings)
 	if !guardMode && len(m.Memories) > 0 {
 		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -253,18 +253,22 @@ func (c *Compiled) linkModule(imports Imports) (*Compiled, error) {
 		return nil, fmt.Errorf("link: decode: %w", err)
 	}
 	imported := m.ImportedFuncCount()
-	for i := 0; i < imported && i < len(bindings); i++ {
+	importSigs := make([]FuncSig, imported)
+	syncHost := false
+	for i := 0; i < imported; i++ {
 		ft, ok := m.FuncSignature(uint32(i))
 		if !ok {
 			continue
 		}
-		if !bindings[i].CrossInstance && len(ft.Results) != 0 {
-			return nil, fmt.Errorf("imported function %q returns a value but is not bound to another instance's function", c.Imports[i])
-		}
-		if bindings[i].CrossInstance {
-			if ex := imports[c.Imports[i]].(*InstanceExport); !sigMatches(ft, ex) {
+		importSigs[i] = FuncSig{valTypesFromWasm(ft.Params), valTypesFromWasm(ft.Results)}
+		if i < len(bindings) && bindings[i].CrossInstance {
+			if ex, ok := imports[c.Imports[i]].(*InstanceExport); !ok || !sigMatches(ft, ex) {
 				return nil, fmt.Errorf("cross-instance import %q signature mismatch", c.Imports[i])
 			}
+		} else if len(ft.Results) != 0 {
+			// A returning import bound as a host function uses the synchronous
+			// re-entry protocol (callHostSync). No longer an error.
+			syncHost = true
 		}
 	}
 	cm, err := amd64.CompileModuleWith(m, amd64.CompileOptions{ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noDeferBounds, ImportBindings: bindings})
@@ -278,6 +282,8 @@ func (c *Compiled) linkModule(imports Imports) (*Compiled, error) {
 	linked.needsLink = false
 	linked.wasmBytes = nil
 	linked.codeCache = nil // fresh, instance-specific code mapping
+	linked.syncHostImports = syncHost
+	linked.importFuncSigs = importSigs
 	return installCompiledFinalizer(&linked), nil
 }
 
@@ -688,10 +694,16 @@ func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
 		binary.LittleEndian.PutUint32(in.hostLog, 0) // reset host-call log
 	}
 	entry := in.base + uintptr(in.c.Entry[li])
-	if err := callNative(in.c, in.eng, in.jm, entry, in.serArgs, in.trap, in.results); err != nil {
-		return nil, err
+	if in.syncMode {
+		if err := in.callNativeSync(entry); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := callNative(in.c, in.eng, in.jm, entry, in.serArgs, in.trap, in.results); err != nil {
+			return nil, err
+		}
+		in.replayHostLog()
 	}
-	in.replayHostLog()
 	out := in.resultVals[:len(sig.Results)]
 	for i := range sig.Results {
 		off := i * 8
@@ -732,10 +744,16 @@ func (in *Instance) invokeLocal(li int, args []uint64) ([]uint64, error) {
 		binary.LittleEndian.PutUint32(in.hostLog, 0)
 	}
 	entry := in.base + uintptr(in.c.Entry[li])
-	if err := callNative(in.c, in.eng, in.jm, entry, in.serArgs, in.trap, in.results); err != nil {
-		return nil, err
+	if in.syncMode {
+		if err := in.callNativeSync(entry); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := callNative(in.c, in.eng, in.jm, entry, in.serArgs, in.trap, in.results); err != nil {
+			return nil, err
+		}
+		in.replayHostLog()
 	}
-	in.replayHostLog()
 	out := in.resultVals[:len(sig.Results)]
 	for i, rt := range sig.Results {
 		off := i * 8

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -247,6 +247,14 @@ type Compiled struct {
 	boundsElide   bool // cached ElideBoundsChecks decision, for the link-time recompile
 	noDeferBounds bool // cached DeferBoundsChecks=false decision, for the link-time recompile
 
+	// syncHostImports is set by linkModule when the module has a returning host
+	// import: all its host calls use the synchronous control frame and Invoke
+	// drives the CallWithHost re-entry loop. importFuncSigs holds the function
+	// imports' signatures (imports first), needed to bind host functions. Both are
+	// instance-specific and never serialized.
+	syncHostImports bool
+	importFuncSigs  []FuncSig
+
 	GCTypeDescs []gc.TypeDesc // immutable Wasm GC descriptor metadata; per-instance heaps own collection state
 
 	// Cached during validateArenaFootprint.

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -1,0 +1,96 @@
+package wago
+
+import (
+	"fmt"
+
+	"github.com/wago-org/wago/src/core/runtime"
+)
+
+// HostModule gives a synchronous host import access to the instance that called
+// it. It is passed as the optional leading parameter of a host function.
+type HostModule interface {
+	// Memory returns the calling instance's linear memory as a mutable slice
+	// (empty if the module declares no memory). Writes are visible to wasm; the
+	// slice is valid only for the duration of the host call.
+	Memory() []byte
+}
+
+// SyncHostFunc is a returning host import in reflection-free slot form: it reads
+// its wasm params from params (i32/f32 in the low 32 bits) and writes its
+// results into results. It works under every toolchain, including TinyGo, and is
+// the form the reflection convenience (a native Go function passed in Imports)
+// compiles down to.
+type SyncHostFunc func(m HostModule, params, results []uint64)
+
+// instanceHostModule is the HostModule handed to sync host functions.
+type instanceHostModule struct{ in *Instance }
+
+func (h instanceHostModule) Memory() []byte { return h.in.linMem }
+
+// bindHostImport normalizes an Imports value into a SyncHostFunc for the
+// synchronous host-call path, given the import's signature. It accepts a
+// SyncHostFunc, the legacy void HostFunc, or — on standard Go — any native Go
+// function whose numeric signature matches sig, optionally with a leading
+// HostModule parameter (reflectSyncHost). Under TinyGo, only the first two forms
+// are available.
+func bindHostImport(v any, sig FuncSig) (SyncHostFunc, error) {
+	switch f := v.(type) {
+	case SyncHostFunc:
+		return f, nil
+	case HostFunc: // legacy void, first i32 arg only
+		return func(_ HostModule, params, results []uint64) {
+			var a int32
+			if len(params) > 0 {
+				a = int32(uint32(params[0]))
+			}
+			f(a)
+		}, nil
+	case nil:
+		return nil, fmt.Errorf("no host function provided")
+	default:
+		return reflectSyncHost(v, sig) // native Go function (standard Go only)
+	}
+}
+
+// buildSyncHosts resolves every function import of a sync-mode module to a
+// SyncHostFunc, indexed by import function index. c.Imports lists the function
+// imports in order; c.importFuncSigs (set by linkModule) holds their signatures.
+func (c *Compiled) buildSyncHosts(imports Imports) ([]SyncHostFunc, error) {
+	hosts := make([]SyncHostFunc, len(c.Imports))
+	for i, key := range c.Imports {
+		if i >= len(c.importFuncSigs) {
+			return nil, fmt.Errorf("import %q: missing signature", key)
+		}
+		// A cross-instance binding is a native call, not a host function; skip it.
+		if _, cross := imports[key].(*InstanceExport); cross {
+			continue
+		}
+		fn, err := bindHostImport(imports[key], c.importFuncSigs[i])
+		if err != nil {
+			return nil, fmt.Errorf("import %q: %w", key, err)
+		}
+		hosts[i] = fn
+	}
+	return hosts, nil
+}
+
+// hostDispatch builds the runtime callback the CallWithHost loop invokes: it maps
+// the wasm import index to the bound SyncHostFunc and runs it with a HostModule
+// bound to this instance.
+func (in *Instance) hostDispatch() runtime.HostCall {
+	mod := instanceHostModule{in: in}
+	return func(importIdx uint32, args, results []uint64) {
+		if int(importIdx) < len(in.syncHosts) {
+			if fn := in.syncHosts[importIdx]; fn != nil {
+				fn(mod, args, results)
+			}
+		}
+	}
+}
+
+// callNativeSync runs a native entry that may make synchronous host calls,
+// driving the re-entry loop with this instance's host dispatch.
+func (in *Instance) callNativeSync(entry uintptr) error {
+	in.jm.SetStackFence(in.eng.StackLimit())
+	return in.eng.CallWithHost(entry, in.serArgs, in.jm.LinearMemory(), in.trap, in.results, in.ctrl, in.hostDispatch())
+}

--- a/src/wago/hostcall_reflect.go
+++ b/src/wago/hostcall_reflect.go
@@ -1,0 +1,127 @@
+//go:build !tinygo
+
+package wago
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+)
+
+var hostModuleType = reflect.TypeOf((*HostModule)(nil)).Elem()
+
+// reflectSyncHost adapts a native Go function to a SyncHostFunc by reflection.
+// The function's numeric params/results must match sig — i32↔int32/uint32,
+// i64↔int64/uint64, f32↔float32, f64↔float64 (named types with those kinds are
+// accepted, e.g. `type Errno uint32`). An optional leading HostModule parameter
+// receives the calling instance.
+func reflectSyncHost(v any, sig FuncSig) (SyncHostFunc, error) {
+	rv := reflect.ValueOf(v)
+	rt := rv.Type()
+	if rt.Kind() != reflect.Func {
+		return nil, fmt.Errorf("host import must be a function, got %T", v)
+	}
+	off := 0
+	if rt.NumIn() > 0 && rt.In(0) == hostModuleType {
+		off = 1
+	}
+	if got := rt.NumIn() - off; got != len(sig.Params) {
+		return nil, fmt.Errorf("host func takes %d wasm params, import expects %d", got, len(sig.Params))
+	}
+	if rt.NumOut() != len(sig.Results) {
+		return nil, fmt.Errorf("host func returns %d values, import expects %d", rt.NumOut(), len(sig.Results))
+	}
+	inTypes := make([]reflect.Type, rt.NumIn())
+	for i := range inTypes {
+		inTypes[i] = rt.In(i)
+	}
+	for i, pt := range sig.Params {
+		if !goTypeMatches(inTypes[off+i], pt) {
+			return nil, fmt.Errorf("host func param %d is %s, want %s", i, inTypes[off+i], pt)
+		}
+	}
+	for i, rtp := range sig.Results {
+		if !goTypeMatches(rt.Out(i), rtp) {
+			return nil, fmt.Errorf("host func result %d is %s, want %s", i, rt.Out(i), rtp)
+		}
+	}
+	wantMod := off == 1
+	params := append([]ValType(nil), sig.Params...)
+	results := append([]ValType(nil), sig.Results...)
+	return func(m HostModule, args, res []uint64) {
+		in := make([]reflect.Value, len(inTypes))
+		if wantMod {
+			in[0] = reflect.ValueOf(m)
+		}
+		for i, pt := range params {
+			in[off+i] = decodeArg(inTypes[off+i], pt, args[i])
+		}
+		out := rv.Call(in)
+		for i, rt := range results {
+			res[i] = encodeResult(out[i], rt)
+		}
+	}, nil
+}
+
+func goTypeMatches(t reflect.Type, vt ValType) bool {
+	switch vt {
+	case ValI32:
+		return t.Kind() == reflect.Int32 || t.Kind() == reflect.Uint32
+	case ValI64:
+		return t.Kind() == reflect.Int64 || t.Kind() == reflect.Uint64
+	case ValF32:
+		return t.Kind() == reflect.Float32
+	case ValF64:
+		return t.Kind() == reflect.Float64
+	}
+	return false
+}
+
+// decodeArg builds a reflect.Value of Go type t from a wasm slot (vt gives the
+// wasm type; i32/f32 occupy the low 32 bits).
+func decodeArg(t reflect.Type, vt ValType, bits uint64) reflect.Value {
+	var v reflect.Value
+	switch vt {
+	case ValI32:
+		if t.Kind() == reflect.Uint32 {
+			v = reflect.ValueOf(uint32(bits))
+		} else {
+			v = reflect.ValueOf(int32(uint32(bits)))
+		}
+	case ValI64:
+		if t.Kind() == reflect.Uint64 {
+			v = reflect.ValueOf(bits)
+		} else {
+			v = reflect.ValueOf(int64(bits))
+		}
+	case ValF32:
+		v = reflect.ValueOf(math.Float32frombits(uint32(bits)))
+	case ValF64:
+		v = reflect.ValueOf(math.Float64frombits(bits))
+	}
+	if v.Type() != t {
+		v = v.Convert(t) // named types (e.g. `type Errno uint32`)
+	}
+	return v
+}
+
+// encodeResult packs a returned reflect.Value into a wasm slot per vt.
+func encodeResult(v reflect.Value, vt ValType) uint64 {
+	switch vt {
+	case ValI32:
+		if v.Kind() == reflect.Uint32 {
+			return uint64(uint32(v.Uint()))
+		}
+		return uint64(uint32(v.Int()))
+	case ValI64:
+		if v.Kind() == reflect.Uint64 {
+			return v.Uint()
+		}
+		return uint64(v.Int())
+	case ValF32:
+		return uint64(math.Float32bits(float32(v.Float())))
+	case ValF64:
+		return math.Float64bits(v.Float())
+	}
+	return 0
+}

--- a/src/wago/hostcall_reflect_test.go
+++ b/src/wago/hostcall_reflect_test.go
@@ -1,0 +1,58 @@
+//go:build !tinygo
+
+package wago
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// TestSyncHostImportReflected binds a returning host import as a native Go
+// function (adapted by reflection — standard Go only).
+func TestSyncHostImportReflected(t *testing.T) {
+	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32}, []wasm.ValType{wasm.I32})
+	body := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x10, 0x00, 0x0b} // local.get 0,1; call 0; end
+	c := MustCompile(returningImportModule(sig, body))
+	calls := 0
+	in, err := Instantiate(c, Imports{"env.f": func(a, b int32) int32 { calls++; return a + b }})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	res, err := in.Invoke("g", I32(20), I32(22))
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if AsI32(res[0]) != 42 {
+		t.Fatalf("g(20,22) = %d, want 42", AsI32(res[0]))
+	}
+	if calls != 1 {
+		t.Fatalf("host called %d times, want 1", calls)
+	}
+}
+
+// TestSyncHostImportMemory verifies a host function can read the caller's linear
+// memory through the leading HostModule parameter: g(addr) = env.peek(addr),
+// where env.peek returns mem[addr].
+func TestSyncHostImportMemory(t *testing.T) {
+	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b}           // local.get 0; call 0; end
+	mem := wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})) // 1 memory, min 1 page
+	c := MustCompile(returningImportModule(sig, body, mem))
+	peek := func(m HostModule, addr int32) int32 { return int32(m.Memory()[addr]) }
+	in, err := Instantiate(c, Imports{"env.f": peek})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	in.Memory().Bytes()[5] = 99
+	res, err := in.Invoke("g", I32(5))
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if AsI32(res[0]) != 99 {
+		t.Fatalf("g(5) = %d, want 99 (mem[5])", AsI32(res[0]))
+	}
+}

--- a/src/wago/hostcall_reflect_tinygo.go
+++ b/src/wago/hostcall_reflect_tinygo.go
@@ -1,0 +1,12 @@
+//go:build tinygo
+
+package wago
+
+import "fmt"
+
+// reflectSyncHost is unavailable under TinyGo: its reflect package cannot call
+// arbitrary functions (reflect.Value.Call is unimplemented). TinyGo builds must
+// provide host imports as wago.SyncHostFunc (the reflection-free slot form).
+func reflectSyncHost(v any, _ FuncSig) (SyncHostFunc, error) {
+	return nil, fmt.Errorf("wago: native-function host imports need standard Go; use wago.SyncHostFunc under TinyGo (got %T)", v)
+}

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -1,0 +1,47 @@
+package wago
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// returningImportModule builds a module whose func 0 is an import of type `sig`
+// (env.f) and func 1 (exported "g") has body `body`. Optional extra sections
+// (e.g. a memory) are appended before the export section.
+func returningImportModule(sig, body []byte, extra ...[]byte) []byte {
+	imp := append(append(wasmtest.Name("env"), wasmtest.Name("f")...), 0x00, 0x00) // func, type 0
+	fnBody := append(wasmtest.ULEB(uint32(len(body))), body...)
+	secs := [][]byte{
+		wasmtest.Section(1, wasmtest.Vec(sig)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+	}
+	secs = append(secs, extra...)
+	secs = append(secs,
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("g", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(fnBody)),
+	)
+	return wasmtest.Module(secs...)
+}
+
+// TestSyncHostImportSlotForm binds a returning host import as a reflection-free
+// SyncHostFunc (the TinyGo-safe form) and runs it through the public API.
+func TestSyncHostImportSlotForm(t *testing.T) {
+	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b} // local.get 0; call 0; end
+	c := MustCompile(returningImportModule(sig, body))
+	in, err := Instantiate(c, Imports{"env.f": SyncHostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] * 3 })})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	res, err := in.Invoke("g", I32(7))
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if AsI32(res[0]) != 21 {
+		t.Fatalf("g(7) = %d, want 21", AsI32(res[0]))
+	}
+}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -23,7 +23,10 @@ type Instance struct {
 	hosts                  map[string]HostFunc
 	imports                Imports // the imports as provided to Instantiate
 	hostLog                []byte
-	globals                []byte // pointer table handed to JIT code
+	syncMode               bool           // true when host imports use the synchronous re-entry protocol
+	ctrl                   []byte         // sync host-call control frame (nil in async mode)
+	syncHosts              []SyncHostFunc // per import-func-index host, sync mode only
+	globals                []byte         // pointer table handed to JIT code
 	globalCells            []*Global
 	tableDesc              []byte        // owned table descriptor (nil when imported), for cross-instance export
 	thunkMem               []byte        // executable mapping for host-func-in-table log thunks (nil if none)
@@ -175,8 +178,18 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 		closeMem()
 		runtime.ReleaseEngine(eng)
 	}()
-	var hostLog []byte
-	if len(c.Imports) > 0 {
+	var hostLog, ctrl []byte
+	var syncHosts []SyncHostFunc
+	if c.syncHostImports {
+		// Synchronous host-call path: install the control frame (not the async
+		// log) as the import ctx and bind every host import to a SyncHostFunc.
+		ctrl = ar.AllocNoZero(runtime.HostCtrlFrameBytes)
+		jm.SetCustomCtx(uintptr(unsafe.Pointer(&ctrl[0])))
+		syncHosts, err = c.buildSyncHosts(imports)
+		if err != nil {
+			return nil, fmt.Errorf("instantiate: %w", err)
+		}
+	} else if len(c.Imports) > 0 {
 		// The log's count header is reset at the start of every Invoke and its
 		// body is written by native code before the host reads it, so the ~64 KiB
 		// buffer needs no instantiate-time zero-fill.
@@ -352,7 +365,7 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 
 	success = true
 	return &Instance{
-		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, linMem: jm.CurrentBytes(), hosts: imports.hostFuncs(), imports: imports, hostLog: hostLog, globals: globals, globalCells: globalCells, tableDesc: tableDesc, thunkMem: thunkMem, gc: collector,
+		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, linMem: jm.CurrentBytes(), hosts: imports.hostFuncs(), imports: imports, hostLog: hostLog, syncMode: c.syncHostImports, ctrl: ctrl, syncHosts: syncHosts, globals: globals, globalCells: globalCells, tableDesc: tableDesc, thunkMem: thunkMem, gc: collector,
 		serArgs: serArgs, results: results, trap: trap, resultVals: make([]uint64, c.maxResultSlots),
 	}, nil
 }

--- a/wago.go
+++ b/wago.go
@@ -27,6 +27,7 @@ type (
 	GlobalImportDef           = impl.GlobalImportDef
 	GuardPageUnavailableError = impl.GuardPageUnavailableError
 	HostFunc                  = impl.HostFunc
+	HostModule                = impl.HostModule
 	Imports                   = impl.Imports
 	Instance                  = impl.Instance
 	InstanceExport            = impl.InstanceExport
@@ -34,6 +35,7 @@ type (
 	Memory                    = impl.Memory
 	OffsetInit                = impl.OffsetInit
 	RuntimeConfig             = impl.RuntimeConfig
+	SyncHostFunc              = impl.SyncHostFunc
 	Table                     = impl.Table
 	TrapCode                  = impl.TrapCode
 	TrapError                 = impl.TrapError


### PR DESCRIPTION
Third of 4 PRs for **P8.1 — sync host imports with results**. Builds on #131 (runtime) + #132 (codegen). This PR exposes returning host imports through the public `wago` API. **A wasm import can now call Go synchronously and get a typed value back.**

## Public API

```go
in, _ := wago.Instantiate(c, wago.Imports{
    // native Go signatures, adapted by reflection (standard Go):
    "wasi.fd_write": func(m wago.HostModule, fd, iov, n, pw int32) int32 { ... },
    // or the reflection-free slot form (works everywhere, incl. TinyGo):
    "env.add": wago.SyncHostFunc(func(m wago.HostModule, p, r []uint64) { r[0] = p[0]+p[1] }),
})
```

- **`HostModule`** interface (`.Memory() []byte`) — an optional leading param giving the host access to the caller's linear memory (what WASI needs).
- **`SyncHostFunc`** — the canonical reflection-free form; all toolchains.
- **Reflection binder** (`!tinygo`) adapts native Go funcs: params/results map i32↔int32/uint32, i64↔int64/uint64, f32↔float32, f64↔float64 (named types OK). **TinyGo can't `reflect.Value.Call`** (verified), so under TinyGo a native-func import errors with a clear message pointing to `SyncHostFunc`.

## Wiring

- **Per-module policy**: a module with any returning host import routes ALL its host calls through the sync control frame (`syncHostCalls` in the backend), so the async void log and the control frame never collide at `offCustomCtx` — no new basedata slot. Bonus: void imports in such a module (e.g. WASI `proc_exit`) become synchronous too.
- `linkModule` lifts the old "returns a value but not cross-instance" error, computes the import sigs + sync flag.
- `Instantiate` installs the control frame + binds every host import; `Invoke`/`invokeLocal` drive `CallWithHost` in sync mode, `Call`+replay otherwise.
- Facade regenerated; `FEATURES.md` row flipped to done.

## Tests

Public-API end-to-end: reflected native func (`g(20,22)=42`), slot form (`g(7)=21`), and **memory access** via `HostModule` (`g(5)` reads `mem[5]=99`). All pass under **explicit AND signals-based (guard-page)** modes, and the slot-form test passes under **TinyGo**.

## Gates

Root + bench (plain **and** `-tags wago_guardpage`), `make test-guard`, gofmt, vet, facade, and **TinyGo build + test** all green.

Next: PR4 — minimal WASI preview 1 on top of this.