### PR TITLE
railshot: fix register exhaustion (unpinned retry + deferred-tree depth cap)

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -2,6 +2,7 @@ package amd64
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -449,9 +450,38 @@ func pickModuleGlobals(m *wasm.Module, nGlobals int, agg []int64) []moduleGlobal
 	return pins
 }
 
+// regExhausted is the sentinel panic allocReg raises when the register file is
+// fully blocked. compileFunc catches it and recompiles the function without local
+// pinning (see compileFuncAttempt).
+type regExhausted struct{}
+
+// errRegExhausted is regExhausted surfaced as an error from a compile attempt, so
+// compileFunc can distinguish a recoverable register-pressure failure (retry with
+// pinning off) from a genuine compile error (propagate).
+var errRegExhausted = errors.New("amd64: no register available to spill")
+
+// compileFunc compiles one function, retrying with local pinning disabled if the
+// first (pinned) attempt exhausts the register file. Pinning is a pure speed
+// optimization, so the unpinned recompile is always correct.
 func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats) (code []byte, relocs []callReloc, internalOff int, err error) {
+	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, true)
+	if errors.Is(err, errRegExhausted) {
+		resetFuncStats(stats)
+		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, false)
+		if err == nil {
+			stats.setUnpinnedRetry()
+		}
+	}
+	return
+}
+
+func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats, pinLocals bool) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			if _, ok := r.(regExhausted); ok {
+				err = errRegExhausted // recoverable: caller retries with pinning off
+				return
+			}
 			if os.Getenv("WAGO_DEBUG_PANIC") == "1" {
 				panic(r)
 			}
@@ -508,6 +538,16 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGl
 	}
 	if len(gpPool) > maxPins {
 		gpPool = gpPool[:maxPins]
+	}
+	// A pathologically register-heavy expression tree can pin its whole spine and
+	// exhaust the file even under the scratch floor (condenseShift/condenseBinary
+	// pin one register per nesting level). When that happens the first attempt
+	// panics with errRegExhausted and compileFunc recompiles with pinLocals=false:
+	// dropping every local/global VALUE pin frees the entire neutral file for
+	// scratch. Pinning is a pure speed optimization, so the unpinned compile is
+	// always correct.
+	if !pinLocals {
+		gpPool = nil
 	}
 	// Hot mutable-int globals share the GP pin pool with locals, holding their VALUE
 	// in the register (WARP's model). In call-free functions any loop-accessed global

--- a/src/core/compiler/backend/railshot/reg_pressure_test.go
+++ b/src/core/compiler/backend/railshot/reg_pressure_test.go
@@ -1,0 +1,103 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// regHeavyShiftChain builds a one-function module (with linear memory, so R15 is
+// reserved as memSizeReg) whose body computes a deep left-spine of variable-count
+// shifts inside a loop: acc = ((((p0 << c1) << c2) ...). Each i32.shl reserves RCX
+// for the count and a neutral scratch for the value; nesting `depth` of them pins
+// one register per level. With the loop making the params hot enough to pin, a
+// large-enough depth exhausts the register file — the exact shape that made
+// json-as/sqlite fail to link ("no register available to spill"). The module also
+// serves as the correctness oracle for the unpinned recompile.
+func regHeavyShiftChain(t *testing.T, nParams, depth int) *wasm.Module {
+	t.Helper()
+	params := make([]wasm.ValType, nParams)
+	for i := range params {
+		params[i] = i32
+	}
+	acc := byte(nParams)                       // accumulator local index (after the params)
+	body := []byte{0x01, 0x01, 0x7f}           // one run of one i32 local
+	body = append(body, 0x20, 0x00, 0x21, acc) // acc = p0
+	body = append(body, 0x03, 0x40)            // loop (void) — runs once, boosts local scores
+	body = append(body, 0x20, acc)             // acc
+	for c := 0; c < depth; c++ {
+		body = append(body, 0x20, byte(1+c%(nParams-1)), 0x74) // local.get p ; i32.shl
+	}
+	body = append(body, 0x21, acc) // acc = spine
+	body = append(body, 0x0b)      // end loop
+	body = append(body, 0x20, acc, 0x0b)
+
+	entry := append(wasmtest.ULEB(uint32(len(body))), body...)
+	memType := append([]byte{0x00}, wasmtest.ULEB(1)...)
+	b := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(params, []wasm.ValType{i32}))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(5, wasmtest.Vec(memType)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(entry)),
+	)
+	m, err := wasm.DecodeModule(b)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return m
+}
+
+// TestExecRegHeavyUnpinnedRetry is the regression for the register-allocator
+// exhaustion: a register-heavy nested-shift tree must compile (via the pinning-off
+// retry) instead of failing to link, and must still compute the right value.
+func TestExecRegHeavyUnpinnedRetry(t *testing.T) {
+	const nParams, depth = 8, 7
+	m := regHeavyShiftChain(t, nParams, depth)
+
+	// The pinned attempt exhausts the file; assert the fix recompiled it unpinned.
+	ms := &ModuleStats{}
+	if _, err := CompileModuleWith(m, CompileOptions{Stats: ms}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !ms.Funcs[0].UnpinnedRetry {
+		t.Fatalf("expected UnpinnedRetry (register-pressure recompile) to fire")
+	}
+
+	// Correctness: p0=5, all counts=1 → acc = 5 << depth.
+	args := make([]uint64, nParams)
+	args[0] = 5
+	for i := 1; i < nParams; i++ {
+		args[i] = 1
+	}
+	want := uint32(5) << depth
+	if got := uint32(runAmd64u(t, m, args...)); got != want {
+		t.Fatalf("reg-heavy shift chain = %d, want %d", got, want)
+	}
+}
+
+// TestExecRegHeavyDeepCapped covers trees FAR deeper than the register file: the
+// deferred-tree depth cap (maxDeferDepth) must break the chain into
+// register-sized segments so it compiles at all, and still compute the right
+// value. Depths past ~14 used to hard-fail with "no register available to spill".
+func TestExecRegHeavyDeepCapped(t *testing.T) {
+	const nParams = 8
+	for _, depth := range []int{15, 20, 40, 100} {
+		m := regHeavyShiftChain(t, nParams, depth)
+		if _, err := CompileModuleWith(m, CompileOptions{}); err != nil {
+			t.Fatalf("depth %d: compile: %v", depth, err)
+		}
+		args := make([]uint64, nParams)
+		args[0] = 5
+		for i := 1; i < nParams; i++ {
+			args[i] = 1 // every shift count is 1, so the result is 5 << depth (0 once depth ≥ 32)
+		}
+		want := uint32(5) << depth
+		if got := uint32(runAmd64u(t, m, args...)); got != want {
+			t.Fatalf("depth %d: shift chain = %d, want %d", depth, got, want)
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -44,7 +44,9 @@ func (f *fn) release(r Reg) {
 func (f *fn) allocReg(avoid regMask) Reg {
 	r := f.allocRegOrNone(avoid)
 	if r == regNone {
-		panic("amd64: no register available to spill")
+		// Recoverable under extreme register pressure: compileFunc catches this and
+		// recompiles the function without local pinning, freeing the whole file.
+		panic(regExhausted{})
 	}
 	return r
 }

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -132,7 +132,30 @@ type elem struct {
 	// Deferred operation payload.
 	op  wOp
 	typ machineType // result type of a deferred op
+
+	// deferDepth is the height of this deferred subtree (1 + max child height;
+	// leaves/values are 0). Used to cap how deep a tree condense() may recurse so a
+	// pathological left-spine cannot pin one register per level and exhaust the
+	// file — see maxDeferDepth in pushBinOp. Valid only when kind == ekDeferred.
+	deferDepth int16
 }
+
+// deferDepthOf is the subtree height contributed by an operand: its deferDepth
+// when deferred, else 0 (a concrete value is a leaf).
+func deferDepthOf(e *elem) int16 {
+	if e != nil && e.kind == ekDeferred {
+		return e.deferDepth
+	}
+	return 0
+}
+
+// maxDeferDepth caps deferred-tree height. condense() pins up to one register per
+// level, so an unbounded left-spine (e.g. a long chain of variable shifts or
+// adds) exhausts the register file. When a new node would exceed this, the deeper
+// operand is condensed now, breaking the chain into register-sized segments. Set
+// well under the neutral-register count so the segment always fits (even on the
+// pinning-off recompile).
+const maxDeferDepth = 6
 
 // isDeferred reports whether e is an un-emitted operation.
 func (e *elem) isDeferred() bool { return e.kind == ekDeferred }
@@ -240,10 +263,28 @@ func (f *fn) pushBinOp(op wOp, typ machineType) {
 		f.stats.peep("same-operand")
 		return
 	}
+	// Cap deferred-tree height: condense the deeper operand now if deferring this
+	// op would push the subtree past maxDeferDepth, so the tree condense() later
+	// walks never pins more registers than the file holds. Rare on real code
+	// (shallow trees), essential for pathological chains.
+	if deferDepthOf(left) >= maxDeferDepth {
+		f.materialize(left)
+	}
+	if deferDepthOf(right) >= maxDeferDepth {
+		f.materialize(right)
+	}
 	node := f.s.alloc()
 	node.kind, node.op, node.typ = ekDeferred, op, typ
 	node.arg0, node.arg1 = left, right
+	node.deferDepth = 1 + max16(deferDepthOf(left), deferDepthOf(right))
 	f.s.push(node)
+}
+
+func max16(a, b int16) int16 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // simplifyConstRHS applies algebraic identities and strength reduction for a
@@ -373,8 +414,12 @@ func log2u(v uint64) int {
 // when condensed.
 func (f *fn) pushUnOp(op wOp, typ machineType) {
 	operand := f.s.back()
+	if deferDepthOf(operand) >= maxDeferDepth {
+		f.materialize(operand) // cap deferred-tree height (see pushBinOp)
+	}
 	node := f.s.alloc()
 	node.kind, node.op, node.typ = ekDeferred, op, typ
 	node.arg0 = operand
+	node.deferDepth = 1 + deferDepthOf(operand)
 	f.s.push(node)
 }

--- a/src/core/compiler/backend/railshot/stats.go
+++ b/src/core/compiler/backend/railshot/stats.go
@@ -86,8 +86,30 @@ type CodegenStats struct {
 	PinnedLocals       int // integer/float locals given a dedicated register
 	PinnedGlobalsValue int // hot mutable-int globals value-pinned in this function
 
+	// UnpinnedRetry is set when the pinned compile exhausted the register file
+	// (a pathologically deep expression tree) and the function was recompiled with
+	// local pinning disabled — a diagnostic flag for such register-heavy functions.
+	UnpinnedRetry bool
+
 	// Peephole/instruction-selection rewrites that fired, by stable name.
 	Peephole map[string]int
+}
+
+// resetFuncStats clears every accumulated counter/map of s, keeping only its
+// identity (FuncIdx, Name), so a recompile of the same function (the pinning-off
+// retry) starts from a clean slate instead of double-counting the failed attempt.
+func resetFuncStats(s *CodegenStats) {
+	if s == nil {
+		return
+	}
+	idx, name := s.FuncIdx, s.Name
+	*s = CodegenStats{FuncIdx: idx, Name: name}
+}
+
+func (s *CodegenStats) setUnpinnedRetry() {
+	if s != nil {
+		s.UnpinnedRetry = true
+	}
 }
 
 // --- nil-safe counter methods (no-op when collection is off) ---

--- a/src/wago/wasitest_exec_test.go
+++ b/src/wago/wasitest_exec_test.go
@@ -34,14 +34,9 @@ type wasiManifest struct {
 // differs on. Keyed by test base name. Curated to keep TestWASISuite green; each
 // entry is a concrete growth target.
 var wasiSkip = map[string]bool{
-	// Backend register allocator hits "no register available to spill" on these
-	// (a pre-existing limitation surfaced by large Rust binaries — see the corpus
-	// notes; unrelated to WASI). Growth target: fix the allocator, then unskip.
-	"big_random_buf":       true,
-	"clock_time_get":       true,
-	"sched_yield":          true,
-	"poll_oneoff_stdio":    true,
-	"fopen-with-no-access": true,
+	// poll_oneoff is stubbed ENOSYS, so the guest's unwrap() panics. Growth
+	// target: a minimal poll_oneoff (stdio is always ready).
+	"poll_oneoff_stdio": true,
 
 	// Import ONLY the void proc_exit, so the module uses the async host-call path
 	// where proc_exit is a no-op (it never returns to wasm to trap/exit). Programs


### PR DESCRIPTION
The backend hard-failed to compile valid modules with `amd64: no register available to spill` — a real credibility gap for "runs real programs" (it blocked sqlite/esbuild-class binaries and several WASI Rust tests). This fixes it with two complementary mechanisms, each targeting a distinct source of register pressure.

## The two failure modes

1. **Local-pin pressure.** A register-ABI internal call whose argument setup, plus the function's pinned hot locals + reserved registers, covers the whole file — `materialize` in `emitRegisterCallVia` then can't find a scratch. → **Unpinned retry**: `compileFunc` catches the exhaustion (`regExhausted` → `errRegExhausted`) and recompiles the function with local pinning disabled (`gpPool=nil`), freeing the neutral file. Pinning is a pure speed optimization, so the recompile is always correct.

2. **Tree-depth pressure.** A deep left-spine (e.g. a chain of variable shifts or adds) pins one register per nesting level in `condense`, exhausting the file even *unpinned* — deterministic reproducer: `regHeavyShiftChain(8, depth)` failed at depth ≥ 15. → **Deferred-tree depth cap**: `elem` gains a `deferDepth`; `pushBinOp`/`pushUnOp` materialize the deeper operand when a new node would exceed `maxDeferDepth` (6), breaking the chain into register-sized segments. Rare on real code (shallow trees → byte-identical codegen), essential for pathological ones.

## Result

- Deep chains at depth **15, 20, 40, 100** now compile **and** compute the correct value (`TestExecRegHeavyDeepCapped`); the local-pin case is covered by `TestExecRegHeavyUnpinnedRetry`.
- **WASI suite 14 → 18**: the four modules previously skipped as "regalloc" (`big_random_buf`, `clock_time_get`, `sched_yield`, `fopen-with-no-access`) now pass; the skip-list is corrected and `poll_oneoff_stdio` reclassified as the real gap (poll_oneoff stubbed ENOSYS).

## Gates

Spec 1.0 (16026 assertions, 0 skipped), corpus differential both modes, `make test-guard`, root + guard, TinyGo build+test, gofmt, vet — all green. Perf-neutral: the cap only triggers on trees deeper than 6, so real (compiler-emitted, local-heavy) code is unaffected — nbody `step(2000)` unchanged.