### PR TITLE
wago: support imported memory under signals-based (guard-page) bounds checks

### DIFF
--- a/src/wago/cross_instance_test.go
+++ b/src/wago/cross_instance_test.go
@@ -18,7 +18,7 @@ func funcImportEntry(module, name string, typeIdx uint32) []byte {
 // TestCrossInstanceMemoryShared: A owns a memory with data; B imports A's memory,
 // writes into it, and A observes the write (shared bytes).
 func TestCrossInstanceMemoryShared(t *testing.T) {
-	t.Setenv("WAGO_BOUNDS", "explicit") // imported memory is unsupported under signals-based (the guard-tag default)
+	t.Setenv("WAGO_BOUNDS", "explicit") // pin the explicit-bounds path (guard-page sharing is covered in memory_guardpage_test.go)
 	// A: memory 1; data at offset 10 = {1,2,3}; load(a)->i32 = i32.load8_u; store(a,v).
 	modA := wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -101,14 +101,19 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 		ownsMem bool
 	)
 	if c.memoryImport != "" {
-		if c.boundsMode == BoundsChecksSignalsBased {
-			runtime.ReleaseEngine(eng)
-			return nil, fmt.Errorf("imported memory with signals-based bounds checks is not supported")
-		}
 		m, ok := imports.memory(c.memoryImport)
 		if !ok {
 			runtime.ReleaseEngine(eng)
 			return nil, fmt.Errorf("missing imported memory %q", c.memoryImport)
+		}
+		// A signals-based module elides inline bounds checks and relies on the
+		// guard-page fault, so the imported memory must be guard-page backed. Host
+		// NewMemory and guard-page instance owners provide one only in a
+		// wago_guardpage build; reject a plain mapping (e.g. an explicit-bounds
+		// owner's memory, or a deserialized signals-based module in a default binary).
+		if c.boundsMode == BoundsChecksSignalsBased && !m.guarded {
+			runtime.ReleaseEngine(eng)
+			return nil, fmt.Errorf("imported memory %q is not guard-page backed; signals-based bounds checks require a guard-page memory (build with -tags wago_guardpage)", c.memoryImport)
 		}
 		if m.shared {
 			// Cross-instance shared memory: the importer runs on the owner's jm, so
@@ -141,7 +146,7 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 			runtime.ReleaseEngine(eng)
 			return nil, err
 		}
-		memObj, ownsMem = &Memory{jm: jm}, true
+		memObj, ownsMem = &Memory{jm: jm, guarded: c.boundsMode == BoundsChecksSignalsBased}, true
 	}
 	// Release the memory only if this instance owns it; an imported *Memory is the
 	// host's, so just release the in-use claim.

--- a/src/wago/memory.go
+++ b/src/wago/memory.go
@@ -10,14 +10,20 @@ import (
 // mirroring JS WebAssembly.Memory. The host owns it: read and write Bytes(), and
 // Close() it when no instance importing it is still in use.
 type Memory struct {
-	jm     *coreruntime.JobMemory
-	inUse  bool // a single instance is using it (host memories are single-use)
-	shared bool // cross-instance: several instances may reference it (Instance.ExportedMemory)
+	jm      *coreruntime.JobMemory
+	inUse   bool // a single instance is using it (host memories are single-use)
+	shared  bool // cross-instance: several instances may reference it (Instance.ExportedMemory)
+	guarded bool // backed by a guard-page reservation (usable by signals-based modules)
 }
 
 // NewMemory creates a host-owned linear memory. minPages/maxPages are in 64 KiB
 // wasm pages. It is growable up to maxPages (via a memory.grow from wasm) without
 // the base pointer moving; maxPages == 0 means a fixed memory pinned at minPages.
+//
+// In a signals-based (guard-page) build it is backed by a guard-page reservation,
+// so it can be imported by modules compiled with either explicit or signals-based
+// bounds checks; a default build produces an explicitly-bounded mapping usable
+// only by explicit-bounds modules.
 func NewMemory(minPages, maxPages uint32) (*Memory, error) {
 	if maxPages != 0 && maxPages < minPages {
 		return nil, fmt.Errorf("wago: memory maximum %d < minimum %d", maxPages, minPages)
@@ -27,6 +33,17 @@ func NewMemory(minPages, maxPages uint32) (*Memory, error) {
 	max := initial
 	if maxPages != 0 {
 		max = int(maxPages) * pageBytes
+	}
+	// Prefer a guard-page reservation when this build supports it: it works for
+	// explicit-bounds importers too (they read the size caches and check inline),
+	// and it is the only layout a signals-based importer can safely elide checks
+	// against, so one host memory serves modules compiled in either mode.
+	if guardPageBuilt {
+		jm, err := newGuardedJobMemory(initial, max)
+		if err != nil {
+			return nil, err
+		}
+		return &Memory{jm: jm, guarded: true}, nil
 	}
 	jm, err := coreruntime.NewJobMemoryGrowable(initial, max)
 	if err != nil {

--- a/src/wago/memory_guardpage_test.go
+++ b/src/wago/memory_guardpage_test.go
@@ -1,0 +1,172 @@
+//go:build linux && amd64 && wago_guardpage
+
+package wago
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// TestImportedMemoryGuardPage drives a module importing host memory under
+// signals-based (guard-page) bounds checks: in-bounds store/load work against the
+// guard-page-backed host memory, and an out-of-range access faults into a wasm
+// trap via the signal handler rather than an inline check.
+func TestImportedMemoryGuardPage(t *testing.T) {
+	cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksSignalsBased)
+	c, err := CompileWithConfig(cfg, importMemModule())
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if c.boundsMode != BoundsChecksSignalsBased {
+		t.Fatal("module did not record signals-based mode")
+	}
+	mem, err := NewMemory(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mem.Close()
+	if !mem.guarded {
+		t.Fatal("NewMemory should be guard-page backed in a wago_guardpage build")
+	}
+	in, err := Instantiate(c, Imports{"env.mem": mem})
+	if err != nil {
+		t.Fatalf("instantiate imported memory under guard-page mode: %v", err)
+	}
+	defer in.Close()
+
+	// wasm write -> host observes.
+	if _, err := in.Invoke("store", I32(8), I32(0xCAFE)); err != nil {
+		t.Fatal(err)
+	}
+	if got := binary.LittleEndian.Uint32(mem.Bytes()[8:]); got != 0xCAFE {
+		t.Fatalf("host sees mem[8] = %#x, want 0xCAFE", got)
+	}
+	// host write -> wasm observes.
+	binary.LittleEndian.PutUint32(mem.Bytes()[16:], 0x1234)
+	if r, err := in.Invoke("load", I32(16)); err != nil || AsI32(r[0]) != 0x1234 {
+		t.Fatalf("wasm load = %#x err=%v, want 0x1234", AsI32(r[0]), err)
+	}
+	// Out-of-range load (memory is 1 page = 64 KiB) traps via the guard page.
+	if _, err := in.Invoke("load", I32(1<<20)); err == nil {
+		t.Fatal("out-of-bounds load did not trap")
+	}
+}
+
+// TestImportedMemoryGuardPageCrossInstance shares a guard-page memory between two
+// signals-based instances: A owns it, B imports A's export, and writes are
+// mutually visible through the one guarded reservation.
+func TestImportedMemoryGuardPageCrossInstance(t *testing.T) {
+	// A: memory 1; load8_u(a)->i32; store8(a,v).
+	modA := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32}, nil),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})), // 1 memory, min 1
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("load", 0, 0),
+			wasmtest.ExportEntry("store", 0, 1),
+			wasmtest.ExportEntry("mem", 2, 0),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x20, 0x00, 0x2d, 0x00, 0x00, 0x0b}),             // load8_u
+			wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b}), // store8
+		)),
+	)
+	inA, err := Instantiate(MustCompile(modA), nil)
+	if err != nil {
+		t.Fatalf("instantiate A: %v", err)
+	}
+	defer inA.Close()
+	if !inA.memory.guarded {
+		t.Fatal("A's memory should be guard-page backed under the guard tag")
+	}
+	memImport, err := inA.ExportedMemory("mem")
+	if err != nil {
+		t.Fatalf("export mem: %v", err)
+	}
+
+	// B imports env.mem; write8(a,v); load8_u(a)->i32.
+	memEntry := append(wasmtest.Name("env"), wasmtest.Name("mem")...)
+	memEntry = append(memEntry, 0x02, 0x00, 0x01) // ExternMem, min 1
+	modB := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32}, nil),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(memEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("write", 0, 0),
+			wasmtest.ExportEntry("load", 0, 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b}), // store8
+			wasmtest.Code([]byte{0x20, 0x00, 0x2d, 0x00, 0x00, 0x0b}),             // load8_u
+		)),
+	)
+	inB, err := Instantiate(MustCompile(modB), Imports{"env.mem": memImport})
+	if err != nil {
+		t.Fatalf("instantiate B on shared guard-page memory: %v", err)
+	}
+	defer inB.Close()
+
+	// B writes byte 11 = 99 -> A observes.
+	if _, err := inB.Invoke("write", I32(11), I32(99)); err != nil {
+		t.Fatal(err)
+	}
+	if r, _ := inA.Invoke("load", I32(11)); AsI32(r[0]) != 99 {
+		t.Fatalf("A.load(11) = %d, want 99 (B's write)", AsI32(r[0]))
+	}
+	// A writes byte 20 = 55 -> B observes.
+	if _, err := inA.Invoke("store", I32(20), I32(55)); err != nil {
+		t.Fatal(err)
+	}
+	if r, _ := inB.Invoke("load", I32(20)); AsI32(r[0]) != 55 {
+		t.Fatalf("B.load(20) = %d, want 55 (A's write)", AsI32(r[0]))
+	}
+}
+
+// TestImportedMemoryGuardPageRejectsPlainMemory checks the guard gate: a
+// signals-based module may not import a memory that is not guard-page backed. An
+// explicit-bounds instance's memory is a plain mapping, so importing it into a
+// signals-based module must be refused rather than silently eliding checks against
+// an unguarded region.
+func TestImportedMemoryGuardPageRejectsPlainMemory(t *testing.T) {
+	// Owner compiled with explicit bounds -> its owned memory is not guarded.
+	explicitCfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit)
+	ownerMod := wasmtest.Module(
+		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})), // 1 memory, min 1
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("mem", 2, 0))),
+	)
+	owner, err := CompileWithConfig(explicitCfg, ownerMod)
+	if err != nil {
+		t.Fatalf("compile owner: %v", err)
+	}
+	inOwner, err := Instantiate(owner, nil)
+	if err != nil {
+		t.Fatalf("instantiate owner: %v", err)
+	}
+	defer inOwner.Close()
+	if inOwner.memory.guarded {
+		t.Fatal("explicit-bounds owner memory should not be guarded")
+	}
+	memImport, err := inOwner.ExportedMemory("mem")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Importer compiled signals-based: it must reject the unguarded memory.
+	sigCfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksSignalsBased)
+	importer, err := CompileWithConfig(sigCfg, importMemModule())
+	if err != nil {
+		t.Fatalf("compile importer: %v", err)
+	}
+	if _, err := Instantiate(importer, Imports{"env.mem": memImport}); err == nil {
+		t.Fatal("signals-based module importing an unguarded memory should be rejected")
+	}
+}

--- a/src/wago/memory_test.go
+++ b/src/wago/memory_test.go
@@ -34,7 +34,7 @@ func importMemModule() []byte {
 }
 
 func TestImportedMemoryShared(t *testing.T) {
-	t.Setenv("WAGO_BOUNDS", "explicit") // imported memory is unsupported under signals-based (the guard-tag default)
+	t.Setenv("WAGO_BOUNDS", "explicit") // pin the explicit-bounds path (guard-page imports are covered in memory_guardpage_test.go)
 	c, err := Compile(importMemModule())
 	if err != nil {
 		t.Fatalf("compile (memory import should be accepted now): %v", err)
@@ -83,7 +83,7 @@ func TestImportedMemoryMissing(t *testing.T) {
 }
 
 func TestImportedMemorySingleInstance(t *testing.T) {
-	t.Setenv("WAGO_BOUNDS", "explicit") // imported memory is unsupported under signals-based (the guard-tag default)
+	t.Setenv("WAGO_BOUNDS", "explicit") // pin the explicit-bounds path (guard-page imports are covered in memory_guardpage_test.go)
 	c, _ := Compile(importMemModule())
 	mem, _ := NewMemory(1, 1)
 	defer mem.Close()
@@ -98,7 +98,7 @@ func TestImportedMemorySingleInstance(t *testing.T) {
 }
 
 func TestImportedMemorySurvivesMarshalLoad(t *testing.T) {
-	t.Setenv("WAGO_BOUNDS", "explicit") // imported memory + serialization are unsupported under signals-based (the guard-tag default)
+	t.Setenv("WAGO_BOUNDS", "explicit") // pin explicit: serializing a signals-based module is unsupported (see TestSignalsBasedNotSerializable)
 	c, err := Compile(importMemModule())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What

Imported memory already worked in the default (explicit-bounds) build, but `Instantiate` rejected it outright in signals-based (guard-page) mode: `"imported memory with signals-based bounds checks is not supported"`. This closes that gap so a module importing a host or cross-instance memory runs under guard-page bounds checks too.

## Why it was blocked

Signals-based codegen elides inline bounds checks and relies on a large `PROT_NONE` guard reservation to fault on out-of-range access. Host `NewMemory` produced a plain growable mapping with no guard pages, so eliding checks against it would corrupt adjacent memory instead of trapping — hence the hard rejection.

## Changes

- **`memory.go`** — `NewMemory` allocates a guard-page reservation in `wago_guardpage` builds. A guarded reservation is valid for explicit-bounds importers too (they read the size caches and check inline), so one host memory serves modules compiled in either mode. New `Memory.guarded` field tracks this.
- **`instantiate.go`** — replaced the blanket rejection with a precise gate: a signals-based importer requires `m.guarded`. This admits guard-page-backed host and cross-instance memories while still rejecting the unsafe cases (an explicit-bounds owner's plain memory imported into a signals module, or a deserialized signals module in a default binary). Instance-owned memories now record `guarded` so `ExportedMemory` carries it across cross-instance links.
- **`memory_guardpage_test.go`** (new) — host-imported memory under signals mode (store/load + OOB guard-page trap), cross-instance sharing of a guarded memory between two signals-based instances, and the mixed-mode rejection.
- Updated now-stale comments in existing tests that claimed imported memory was unsupported under signals-based mode.

## Verification

- `go vet` clean in both build modes.
- Full `./src/wago/` suite green in default and `-tags wago_guardpage` builds.
- New guard-page tests pass, including OOB access trapping through the signal handler — proving the `CallGuarded` path works end-to-end with imported guarded memory.

https://claude.ai/code/session_0135ZA4YWd9gEV2CtiGu3YU1