### PR TITLE
railshot: stop pinning hot locals to RDI/RSI (fixes register corruption; sqlite runs)

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -519,7 +519,7 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool
 	hasCall := hints.hasCall
 	touchesMemory := hints.touchesMemory
 	regABI := regABIEnabled && sigFitsRegABI(ft)
-	gpPool := gpPinPool(regABI, hints.usesBulkMem, f.nParams)
+	gpPool := gpPinPool(regABI, f.nParams)
 	if f.memSizeReg != regNone {
 		gpPool = withoutReg(gpPool, f.memSizeReg) // R15 is the module-wide memBytes cache
 		f.reserved = f.reserved.add(f.memSizeReg)
@@ -643,24 +643,28 @@ func (f *fn) runBody(c *wasm.Func) error {
 // unused) are ordered by index, so byte-backed bodies fall back to first-N
 // pinning.
 // gpPinPool returns the registers available to hold pinned integer locals, in
-// priority order (hottest local gets the first). The base is R12-R15. Call-making
-// functions extend over the rest of the file too (WARP's model: locals fill the
-// whole pool minus the reserved scratch): every pin is spill-managed around calls
-// by the STACK_REG model regardless of which register holds it — R12-R15 are
-// clobbered by the callee, RDI/RSI by the call setup itself, R9-R11 by 5+-arg
-// staging — so the only structural exclusions are:
-//   - RDI/RSI when bulk-memory `rep movs` would clobber them mid-body;
-//   - R9/R10/R11 in reg-ABI functions with >4 params (the internal entry's
-//     incoming args would collide with the prologue's arg→pinned moves);
-//   - RBP costs the block-merge register (the caller drops regMerge).
+// priority order (hottest local gets the first). The base is R12-R15; call-making
+// functions also pin the arg-staging registers R9/R10/R11 and the block-merge
+// register RBP, all spill-managed around calls by the STACK_REG model.
 //
-// RAX/RCX/RDX/R8 always stay free for operand evaluation and the x86 fixed-role
-// ops (div/shift/return); callHost's scratch also lives there.
-func gpPinPool(regABI, usesBulkMem bool, nParams int) []Reg {
+// RDI/RSI are deliberately NOT pinned. A call's linMem/trap setup clobbers them
+// (they are not arg registers here — intArgRegs is RAX/RCX/RDX/R8/R9/R10/R11), and
+// in a register-heavy function that both touches memory (which reserves R15,
+// pushing pins onto RDI/RSI) and makes multi-arg calls, having a pinned local live
+// in RDI/RSI on top of the arg-register pins over-subscribed the file: the call's
+// arg-staging + setup ran out of free scratch and silently corrupted a pinned
+// local's value. The observable repro is sqlite's tokenizer — every SQL keyword
+// misreads as an identifier ("near \"SELECT\": syntax error") — while wazero runs
+// the same module correctly. Excluding RDI/RSI removes the hazard; R9/R10/R11 pins
+// (which the STACK_REG spill/reload does handle) stay. See TestSyncSQLiteQuery.
+//
+// R9/R10/R11 are still excluded in reg-ABI functions with >4 params (the internal
+// entry's incoming args would collide with the prologue's arg→pinned moves). RBP
+// costs the block-merge register (the caller drops regMerge). RAX/RCX/RDX/R8 always
+// stay free for operand evaluation and the x86 fixed-role ops (div/shift/return);
+// callHost's scratch also lives there.
+func gpPinPool(regABI bool, nParams int) []Reg {
 	pool := append([]Reg{}, pinnedLocalRegs...) // R12-R15
-	if !usesBulkMem {
-		pool = append(pool, RDI, RSI)
-	}
 	if !regABI || nParams <= 4 {
 		pool = append(pool, R9, R10, R11)
 	}

--- a/src/wago/sqlite_regression_test.go
+++ b/src/wago/sqlite_regression_test.go
@@ -1,0 +1,113 @@
+//go:build linux && amd64 && !tinygo
+
+package wago
+
+import (
+	"encoding/binary"
+	"os"
+	"testing"
+
+	wasm "github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestSyncSQLiteQuery is a codegen regression test: it runs a real in-memory
+// SQLite query (the corpus sqlite3.wasm, an emscripten build that imports
+// env.memory) end to end and checks the result. It guards a register-allocator
+// bug where pinning a hot local to RDI/RSI in a memory-touching, multi-arg-call
+// function silently corrupted the local's value — SQLite's tokenizer then misread
+// every keyword ("near \"CREATE\": syntax error"). See gpPinPool in the amd64
+// backend. Skips if the corpus binary isn't present.
+func TestSyncSQLiteQuery(t *testing.T) {
+	src, err := os.ReadFile("../../bench/corpus/sqlite3.wasm")
+	if err != nil {
+		t.Skip("bench/corpus/sqlite3.wasm not present")
+	}
+	c, err := Compile(src)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	key, ok := c.MemoryImport()
+	if !ok {
+		t.Fatalf("expected sqlite3.wasm to import a memory")
+	}
+	mod, err := wasm.DecodeModule(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var minP, maxP uint32
+	for _, im := range mod.Imports {
+		if im.Type.Kind == wasm.ExternMem {
+			minP = uint32(im.Type.Mem.Limits.Min)
+			if im.Type.Mem.Limits.Max != nil {
+				maxP = uint32(*im.Type.Mem.Limits.Max)
+			}
+		}
+	}
+	mem, err := NewMemory(minP, maxP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imp := Imports{key: mem}
+	for _, fn := range c.Imports { // no-op stubs for the emscripten env.* / wasi imports
+		imp[fn] = HostFunc(func(int32) {})
+	}
+	in, err := Instantiate(c, imp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	call := func(name string, a ...uint64) uint64 {
+		r, err := in.Invoke(name, a...)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(r) == 0 {
+			return 0
+		}
+		return r[0]
+	}
+	cstr := func(s string) uint32 {
+		b := append([]byte(s), 0)
+		p := uint32(call("malloc", uint64(len(b))))
+		if !in.Write(p, b) {
+			t.Fatalf("write %q to memory", s)
+		}
+		return p
+	}
+	rd32 := func(p uint32) uint32 {
+		b, ok := in.Read(p, 4)
+		if !ok {
+			t.Fatalf("read @%d", p)
+		}
+		return binary.LittleEndian.Uint32(b)
+	}
+
+	in.Invoke("__wasm_call_ctors")
+	call("sqlite3_initialize")
+
+	ppDb := uint32(call("malloc", 8))
+	if rc := call("sqlite3_open", uint64(cstr(":memory:")), uint64(ppDb)); rc != 0 {
+		t.Fatalf("sqlite3_open rc=%d", rc)
+	}
+	db := uint64(rd32(ppDb))
+
+	rc := call("sqlite3_exec", db, uint64(cstr("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (42),(58),(900);")), 0, 0, 0)
+	if rc != 0 {
+		e := uint32(call("sqlite3_errmsg", db))
+		b, _ := in.Read(e, 48)
+		t.Fatalf("sqlite3_exec(CREATE/INSERT) rc=%d errmsg=%q — tokenizer/codegen regression", rc, string(b))
+	}
+
+	ppStmt := uint32(call("malloc", 8))
+	if rc := call("sqlite3_prepare_v2", db, uint64(cstr("SELECT sum(x) FROM t")), uint64(uint32(0xFFFFFFFF)), uint64(ppStmt), 0); rc != 0 {
+		t.Fatalf("sqlite3_prepare_v2 rc=%d", rc)
+	}
+	stmt := uint64(rd32(ppStmt))
+	call("sqlite3_step", stmt)
+	sum := int32(uint32(call("sqlite3_column_int", stmt, 0)))
+	call("sqlite3_finalize", stmt)
+	if sum != 1000 {
+		t.Fatalf("SELECT sum(x) = %d, want 1000", sum)
+	}
+}


### PR DESCRIPTION
## The bug

A register-heavy function that **both touches memory and makes multi-arg calls** could silently corrupt a hot local's value. The observable repro is SQLite: driving the corpus `sqlite3.wasm` (now instantiable via imported memory, #143) through a real query, its tokenizer misreads **every** SQL keyword as an identifier — `near "CREATE": syntax error` — even though `sqlite3_open(":memory:")` and `sqlite3_libversion_number()` (→ 3046000) work. **wazero runs the identical module correctly** (`SELECT sum(x) FROM t` → 1000), so it's a wago codegen bug, not the harness.

## Root cause

`gpPinPool` let hot locals be pinned into **RDI/RSI**. Those aren't argument registers here (`intArgRegs` is `RAX/RCX/RDX/R8/R9/R10/R11`) — they're clobbered by each call's linMem/trap setup. In a function that touches memory (which reserves R15, pushing pins onto RDI/RSI) and makes multi-arg calls (which also pin R9/R10/R11), pinning a local into RDI/RSI on top of the arg-register pins over-subscribed the GP file: the call's arg-staging + setup ran out of free scratch and clobbered a pinned local.

Bisected with an env A/B kill-switch: base pool (R12–R15) is correct; excluding RDI/RSI fixes it across the **entire** sqlite binary while keeping the STACK_REG-handled R9/R10/R11 arg-register pins.

## The fix

Don't pin locals to RDI/RSI. One-line pool change (they were already conditionally excluded for bulk-memory functions; this makes it unconditional). R9/R10/R11 pinning — which the STACK_REG spill/reload *does* handle — stays.

## Validation

- **`TestSyncSQLiteQuery`** (new regression test): real in-memory `CREATE/INSERT/SELECT` → 1000, passes in explicit **and** guard-page builds.
- **Spec suite: 16,026 assertions pass in both bounds modes**, 0 skipped.
- Corpus differential (golden values) + full unit suite green.

## Perf

Clean A/B (1s benchtime): every kernel within ±1% noise **except quicksort −13%** (a recursive integer sort that genuinely benefited from the extra RDI/RSI pins). Real programs are unaffected, and correctness is restored. A more surgical fix that keeps RDI/RSI pinning where provably safe is possible once the exact spill/pressure interaction is isolated; this conservative fix trades ~13% on one micro-kernel for correctness on real programs.

https://claude.ai/code/session_01Muzv5VGqFhM4FnsDpyLbCF