### PR TITLE
website: drop the Scale tab (real-large binaries now race in the Compile tab)

### DIFF
--- a/scripts/update-website-bench.mjs
+++ b/scripts/update-website-bench.mjs
@@ -154,18 +154,6 @@ const TABS = [
       rs("rhai", "run a script (scripting engine)", "RunWago/script", "RunWazero/script"),
     ],
   },
-  {
-    id: "scale",
-    label: "Scale",
-    items: [
-      grp("Front-end at scale — decode + validate real-world binaries"),
-      dv("wasm3", "interpreter · 180 KB", "Decode/wasm3", "Validate/wasm3", 184108),
-      dv("Lua 5.4", "interpreter · 270 KB", "Decode/lua", "Validate/lua", 271581),
-      dv("SQLite 3.46", "database engine · 920 KB", "Decode/sqlite3", "Validate/sqlite3", 938882),
-      dv("esbuild", "Go bundler · 11 MB", "Decode/esbuild", "Validate/esbuild", 11655844),
-      dv("Ruby 3.3", "interpreter · 16 MB, 17k funcs", "Decode/ruby", "Validate/ruby", 16243226),
-    ],
-  },
 ];
 
 const html = await readFile(indexPath, "utf8");


### PR DESCRIPTION
The Scale tab was a wago-only decode+validate throughput view for the real-large binaries (wasm3/lua/sqlite/esbuild/ruby), added back when the backend couldn't compile them. They now appear in the **Compile** tab as a full wago-vs-wazero compile race (#142), so the Scale tab is redundant. Removed from the generator's TABS; the live site's index.html was updated to match.

https://claude.ai/code/session_01Muzv5VGqFhM4FnsDpyLbCF