### PR TITLE
perf: cache the host-only link recompile so repeated Instantiate reuses code

### DIFF
--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -79,6 +79,11 @@ func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	if needsLink || importedFuncs > 0 {
 		c.wasmBytes = append([]byte(nil), wasmBytes...)
 	}
+	// A deferred-codegen module memoizes its host-only link so repeated Instantiate
+	// (the common WASI case) reuses the code instead of recompiling every time.
+	if needsLink {
+		c.hostLink = &hostLinkCache{}
+	}
 	for i := range m.Imports {
 		im := &m.Imports[i]
 		switch im.Type.Kind {
@@ -245,6 +250,23 @@ func (c *Compiled) linkModule(imports Imports) (*Compiled, error) {
 	if !c.needsLink && !anyCross {
 		return c, nil // host-only (or void host-bound imports): use the prebuilt code
 	}
+	// Host-only link (deferred codegen, no cross-instance binding): the recompiled
+	// code does not depend on which host functions are supplied, so produce it once
+	// and reuse it — every later Instantiate then skips re-running the backend and
+	// shares the one executable mapping. (bindings here are all zero-value.)
+	if !anyCross {
+		if hl := c.hostLink; hl != nil {
+			hl.once.Do(func() { hl.c, hl.err = c.recompileLinked(nil, bindings) })
+			return hl.c, hl.err
+		}
+	}
+	return c.recompileLinked(imports, bindings)
+}
+
+// recompileLinked re-runs codegen with the given import bindings and returns a
+// fresh linked Compiled. bindings is all zero-value for a host-only link and
+// carries per-instance callee addresses for cross-instance imports.
+func (c *Compiled) recompileLinked(imports Imports, bindings []amd64.ImportBinding) (*Compiled, error) {
 	if len(c.wasmBytes) == 0 {
 		return nil, fmt.Errorf("cross-instance linking requires the retained module source")
 	}
@@ -281,7 +303,8 @@ func (c *Compiled) linkModule(imports Imports) (*Compiled, error) {
 	linked.InternalEntry = cm.InternalEntry
 	linked.needsLink = false
 	linked.wasmBytes = nil
-	linked.codeCache = nil // fresh, instance-specific code mapping
+	linked.codeCache = nil // fresh code mapping (shared across instances of this linked module)
+	linked.hostLink = nil  // the linked module is already linked; never re-links
 	linked.syncHostImports = syncHost
 	linked.importFuncSigs = importSigs
 	return installCompiledFinalizer(&linked), nil

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -78,6 +78,12 @@ func (c *Compiled) Close() error {
 	if c == nil {
 		return nil
 	}
+	// Release the memoized host-only linked module's mapping too (its finalizer
+	// would eventually, but a caller closing c wants the code freed promptly). Live
+	// instances keep it mapped via the code refcount until they close.
+	if hl := c.hostLink; hl != nil && hl.c != nil {
+		_ = hl.c.Close()
+	}
 	c.ensureCodeCache()
 	cc := c.codeCache
 	cc.mu.Lock()

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -247,6 +247,16 @@ type Compiled struct {
 	boundsElide   bool // cached ElideBoundsChecks decision, for the link-time recompile
 	noDeferBounds bool // cached DeferBoundsChecks=false decision, for the link-time recompile
 
+	// hostLink caches the host-only link recompile. A needsLink module (returning
+	// import) defers codegen to Instantiate; when every import binds to a host
+	// function (no cross-instance) the recompiled code is IDENTICAL regardless of
+	// which host functions are supplied (host dispatch is a runtime table, not baked
+	// into code), so it is produced once and reused — turning repeated Instantiate
+	// of a WASI/host module from "re-run the whole backend" into "reuse the code +
+	// its executable mapping". A pointer so the link-time `linked := *c` copy carries
+	// no lock. nil for modules that never defer codegen (or hand-built/deserialized).
+	hostLink *hostLinkCache
+
 	// syncHostImports is set by linkModule when the module has a returning host
 	// import: all its host calls use the synchronous control frame and Invoke
 	// drives the CallWithHost re-entry loop. importFuncSigs holds the function
@@ -276,6 +286,15 @@ type Compiled struct {
 
 type validateMemo struct {
 	once sync.Once
+	err  error
+}
+
+// hostLinkCache memoizes the host-only link recompile of a needsLink module (see
+// Compiled.hostLink). once guards the single recompile; c/err hold its result,
+// shared by every subsequent host Instantiate.
+type hostLinkCache struct {
+	once sync.Once
+	c    *Compiled
 	err  error
 }
 

--- a/src/wago/hostlink_test.go
+++ b/src/wago/hostlink_test.go
@@ -1,0 +1,40 @@
+//go:build linux && amd64 && !tinygo
+
+package wago
+
+import (
+	"os"
+	"testing"
+)
+
+// TestHostLinkCached verifies the host-only link recompile is memoized: a
+// needsLink module (WASI, returning imports) links once and every later host
+// Instantiate reuses that linked module + its code mapping instead of re-running
+// the backend. Guards the large-module instantiate optimization.
+func TestHostLinkCached(t *testing.T) {
+	src, err := os.ReadFile("../../bench/corpus/jsonproc.wasm")
+	if err != nil {
+		t.Skip("jsonproc.wasm not present")
+	}
+	c, err := Compile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.needsLink || c.hostLink == nil {
+		t.Fatalf("expected a deferred-codegen (needsLink) module with a host-link cache")
+	}
+	l1, err := c.linkModule(WASI(WASIConfig{}))
+	if err != nil {
+		t.Fatalf("link 1: %v", err)
+	}
+	l2, err := c.linkModule(WASI(WASIConfig{}))
+	if err != nil {
+		t.Fatalf("link 2: %v", err)
+	}
+	if l1 == c {
+		t.Fatal("host link should recompile to a fresh linked module")
+	}
+	if l1 != l2 {
+		t.Fatal("host link not cached: repeated linkModule produced different linked modules")
+	}
+}


### PR DESCRIPTION
## The problem
Instantiating a large WASI module was slow — **~238 ms for the 2.4 MB rhai** — and a CPU profile showed why: it was **re-running the whole backend** (`emitPlain`, the encoder, instruction classification) on every `Instantiate`.

Root cause: a module with a *returning* import (WASI's `fd_write` etc. return an errno) is marked `needsLink`, and `Compile` **defers all codegen** to a link-time recompile in `Instantiate` (`linkModule` → `amd64.CompileModuleWith`). The comment assumed returning imports would be bound cross-instance, but the common case is host binding (WASI), where the recompiled code is **identical every time** — host dispatch is a runtime table, not baked into the code. So every instantiate re-compiled the module from scratch.

## The fix
Memoize the host-only link. A `needsLink` module gets a `hostLink` cache (`sync.Once`); the first host `Instantiate` recompiles, and every later one reuses the same linked `Compiled` — sharing both the codegen result and its executable mapping. Cross-instance links (which bake per-instance addresses) still recompile per instance. The added memory is one retained linked module per `Compiled` (freed on `Close`/GC) — and per-instantiate memory drops massively since it no longer recompiles.

## Result (rhai, 2.4 MB, repeated Instantiate)
| | before | after |
|---|---|---|
| time | 237 ms | **0.061 ms** (3,865×) |
| bytes/op | 164 MB | **4.5 KB** (36,000×) |
| allocs/op | 942,704 | **57** (16,500×) |

markdown 31 ms → 0.037 ms, crc 4.6 ms → 0.010 ms.

(A cold single run — compile a fresh module then instantiate once — is unchanged: the codegen still happens once, now at first instantiate. The win is the realistic serving path: compile once, instantiate per request.)

## Validation
`TestHostLinkCached` (new) asserts the memoization; 16,026 spec assertions pass in both bounds modes; full wago suite + cross-instance/host/Close tests green; `-race` clean under concurrent Instantiate.

https://claude.ai/code/session_01Muzv5VGqFhM4FnsDpyLbCF