### PR TITLE
bench: warm instantiate of large WASI modules + Instantiate-tab rows

### DIFF
--- a/bench/wasi_instantiate_test.go
+++ b/bench/wasi_instantiate_test.go
@@ -1,0 +1,70 @@
+package wagobench
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	wago "github.com/wago-org/wago"
+)
+
+// Warm instantiate of the real Rust/WASI modules: compile once, then time a fresh
+// instance per iteration (no _start) — the realistic serving path (compile a
+// module once, instantiate it per request). Companion to the Run/Compile rows;
+// reuses wasiRunProgs from wasi_run_test.go.
+
+func BenchmarkInstBigWago(b *testing.B) {
+	for _, name := range wasiRunProgs {
+		src, err := os.ReadFile("corpus/" + name + ".wasm")
+		if err != nil {
+			continue
+		}
+		c, err := wago.Compile(src)
+		if err != nil {
+			b.Fatalf("%s compile: %v", name, err)
+		}
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				in, err := wago.Instantiate(c, wago.WASI(wago.WASIConfig{Stdout: io.Discard, Args: []string{name}}))
+				if err != nil {
+					b.Fatalf("instantiate: %v", err)
+				}
+				in.Close()
+			}
+		})
+	}
+}
+
+func BenchmarkInstBigWazero(b *testing.B) {
+	ctx := context.Background()
+	for _, name := range wasiRunProgs {
+		src, err := os.ReadFile("corpus/" + name + ".wasm")
+		if err != nil {
+			continue
+		}
+		r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
+		wasi_snapshot_preview1.MustInstantiate(ctx, r)
+		cm, err := r.CompileModule(ctx, src)
+		if err != nil {
+			r.Close(ctx)
+			b.Fatalf("%s compile: %v", name, err)
+		}
+		// WithStartFunctions() (empty) => instantiate without running _start.
+		cfg := wazero.NewModuleConfig().WithStdout(io.Discard).WithArgs(name).WithName("").WithStartFunctions()
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				mod, err := r.InstantiateModule(ctx, cm, cfg)
+				if err != nil {
+					b.Fatalf("instantiate: %v", err)
+				}
+				mod.Close(ctx)
+			}
+		})
+		r.Close(ctx)
+	}
+}

--- a/scripts/update-website-bench.mjs
+++ b/scripts/update-website-bench.mjs
@@ -104,6 +104,16 @@ const TABS = [
       rs("Cold start", "fib_rec startup + mapping", "Instantiate_wago", "Instantiate_wazero"),
       rs("Heap footprint", "bytes allocated", "Instantiate_wago", "Instantiate_wazero", "leaner", "bytes"),
       rs("Allocations", "objects allocated", "Instantiate_wago", "Instantiate_wazero", "leaner", "count"),
+      // Warm instantiate of large real programs (compile once, fresh instance per
+      // request — the serving path). wago reuses the compiled code + mapping; these
+      // are the same programs as the Compile/Exec "runs end-to-end" groups.
+      grp("Large real programs — warm instantiate (Rust / WASI)"),
+      rs("markdown", "pulldown-cmark · 320 KB", "InstBigWago/markdown", "InstBigWazero/markdown"),
+      rs("serde_json", "serde_json · 96 KB", "InstBigWago/jsonproc", "InstBigWazero/jsonproc"),
+      rs("blake3", "blake3 · 57 KB", "InstBigWago/blake3sum", "InstBigWazero/blake3sum"),
+      rs("base64", "base64 · 64 KB", "InstBigWago/base64x", "InstBigWazero/base64x"),
+      rs("CRC-32", "crc · 51 KB", "InstBigWago/crcsum", "InstBigWazero/crcsum"),
+      rs("rhai", "scripting engine · 2.4 MB", "InstBigWago/script", "InstBigWazero/script"),
     ],
   },
   {


### PR DESCRIPTION
Adds a warm-instantiate benchmark (compile once, fresh instance per iteration — the serving path) for the real Rust/WASI programs, and an Instantiate-tab group showing it. This surfaces the #150 win: before that fix wago re-ran the whole backend on every instantiate (12 ms–238 ms for these modules); now it reuses the compiled code.

## Result (guard-page, warm instantiate): wago 3–20× faster than wazero
| program | wago | wazero |
|---|---|---|
| CRC-32 | 12 µs | 239 µs |
| serde_json | 15 µs | 218 µs |
| markdown | 40 µs | 165 µs |
| rhai (2.4 MB) | 65 µs | 224 µs |

(wazero instantiated with `WithStartFunctions()` to measure instantiate-only, mirroring wago's `Instantiate` without `_start`.)

https://claude.ai/code/session_01Muzv5VGqFhM4FnsDpyLbCF