### PR TITLE
bench: run the regex crate end-to-end + website rows (previously SIGSEGV'd)

### DIFF
--- a/bench/wasi_run_test.go
+++ b/bench/wasi_run_test.go
@@ -19,7 +19,7 @@ import (
 // iteration). It's the run-side companion to the same programs' Compile-tab
 // numbers; wago's fast compile + execution outweigh its (separately) heavier
 // instantiate, so it wins here even though pure instantiate favours wazero.
-var wasiRunProgs = []string{"markdown", "jsonproc", "blake3sum", "base64x", "crcsum", "script"}
+var wasiRunProgs = []string{"markdown", "jsonproc", "blake3sum", "base64x", "crcsum", "script", "regexmatch"}
 
 func BenchmarkRunWago(b *testing.B) {
 	for _, name := range wasiRunProgs {

--- a/scripts/update-website-bench.mjs
+++ b/scripts/update-website-bench.mjs
@@ -115,6 +115,7 @@ const TABS = [
       rs("base64", "base64 · 64 KB", "InstBigWago/base64x", "InstBigWazero/base64x"),
       rs("CRC-32", "crc · 51 KB", "InstBigWago/crcsum", "InstBigWazero/crcsum"),
       rs("rhai", "scripting engine · 2.4 MB", "InstBigWago/script", "InstBigWazero/script"),
+      rs("regex", "regex engine · 1.2 MB", "InstBigWago/regexmatch", "InstBigWazero/regexmatch"),
     ],
   },
   {
@@ -164,6 +165,7 @@ const TABS = [
       rs("base64", "encode + decode roundtrip", "RunWago/base64x", "RunWazero/base64x"),
       rs("CRC-32", "crc crate checksum", "RunWago/crcsum", "RunWazero/crcsum"),
       rs("rhai", "run a script (scripting engine)", "RunWago/script", "RunWazero/script"),
+      rs("regex", "compile pattern + count matches", "RunWago/regexmatch", "RunWazero/regexmatch"),
     ],
   },
 ];


### PR DESCRIPTION
The Rust `regex` crate SIGSEGV'd on wago until #152 (the br_table register-allocator fix). Now that it runs, add it to the end-to-end corpus benchmarks and surface it on wago.sh — the "previously crashed, now runs" proof point.

## What
- `bench/wasi_run_test.go`: add `regexmatch` to `wasiRunProgs`, so `BenchmarkRunWago/Wazero` (compile + instantiate + execute) and `BenchmarkInstBigWago/Wazero` (warm instantiate) both cover it.
- `scripts/update-website-bench.mjs`: add a **regex** row to the Exec "runs end-to-end" group and the Instantiate "warm instantiate" group.

`regexmatch.wasm` (the `regex` crate compiling `(\w+)@(\w+)\.(com|org|net)` and counting matches) was already committed to `bench/corpus/` in #152.

## Numbers (guard-page, COUNT=6)
| | wago | wazero | |
|---|---|---|---|
| regex — run end-to-end | 146.6 ms | 341 ms | **2.3× faster** |
| regex — warm instantiate | 139 µs | 297 µs | **2.1× faster** |

Verified end-to-end output `regex:3000:99780` (src/wago `TestWASIApps/regexmatch`).

https://claude.ai/code/session_01TkjQSnLKKa9Skn7rpPxwtj