### PR TITLE
perf(railshot): reuse compile scratch across a module's functions

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -325,12 +325,12 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		ms.Funcs = make([]*CodegenStats, n)
 		ms.ModuleGlobalPins = moduleGlobalPinInfos(modGlobals)
 	}
-	// One operand stack, reused across every function in the module: the arena
-	// is per-function scratch that never outlives a function's compile, so
-	// resetting it (rather than allocating a fresh one per function) removes the
-	// single largest compile allocation. Sized at the max cap once; small
-	// functions simply use a subset. Compile is sequential, so sharing is safe.
-	sharedStack := newStackWithCap(defaultStackArenaCap)
+	// Compile scratch reused across every function in the module. The operand
+	// stack arena and the occurrence-tracking refs map are per-function scratch
+	// that never outlives a function's compile, so resetting them (rather than
+	// allocating fresh per function) removes the largest compile allocations.
+	// Compile is sequential, so sharing one scratch is safe.
+	sc := newScratch()
 	var code []byte
 	for i := range m.Code {
 		hints, err := computeFuncHints(m, i, nGlobals, importedFuncs)
@@ -342,7 +342,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 			st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
 			ms.Funcs[i] = st
 		}
-		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, modGlobals, hints, opts.ImportBindings, st, sharedStack)
+		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, modGlobals, hints, opts.ImportBindings, st, sc)
 		if err != nil {
 			return nil, fmt.Errorf("amd64: function %d: %w", i, err)
 		}
@@ -499,11 +499,11 @@ var errRegExhausted = errors.New("amd64: no register available to spill")
 // compileFunc compiles one function, retrying with local pinning disabled if the
 // first (pinned) attempt exhausts the register file. Pinning is a pure speed
 // optimization, so the unpinned recompile is always correct.
-func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats, sharedStack *stack) (code []byte, relocs []callReloc, internalOff int, err error) {
-	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, true, sharedStack)
+func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
+	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, true, sc)
 	if errors.Is(err, errRegExhausted) {
 		resetFuncStats(stats)
-		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, false, sharedStack)
+		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, false, sc)
 		if err == nil {
 			stats.setUnpinnedRetry()
 		}
@@ -511,7 +511,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGl
 	return
 }
 
-func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats, pinLocals bool, sharedStack *stack) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats, pinLocals bool, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(regExhausted); ok {
@@ -535,8 +535,8 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool
 		return nil, nil, 0, err
 	}
 
-	sharedStack.reset()
-	f := &fn{a: &amd64.Asm{B: make([]byte, 0, asmCapForBody(len(c.BodyBytes)))}, s: sharedStack, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
+	sc.reset()
+	f := &fn{a: &amd64.Asm{B: make([]byte, 0, asmCapForBody(len(c.BodyBytes)))}, s: sc.stack, refs: sc.refs, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
 	f.syncHostCalls = moduleUsesSyncHostCalls(m, importBindings)
 	if !guardMode && len(m.Memories) > 0 {
 		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -325,6 +325,12 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		ms.Funcs = make([]*CodegenStats, n)
 		ms.ModuleGlobalPins = moduleGlobalPinInfos(modGlobals)
 	}
+	// One operand stack, reused across every function in the module: the arena
+	// is per-function scratch that never outlives a function's compile, so
+	// resetting it (rather than allocating a fresh one per function) removes the
+	// single largest compile allocation. Sized at the max cap once; small
+	// functions simply use a subset. Compile is sequential, so sharing is safe.
+	sharedStack := newStackWithCap(defaultStackArenaCap)
 	var code []byte
 	for i := range m.Code {
 		hints, err := computeFuncHints(m, i, nGlobals, importedFuncs)
@@ -336,7 +342,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 			st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
 			ms.Funcs[i] = st
 		}
-		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, modGlobals, hints, opts.ImportBindings, st)
+		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, modGlobals, hints, opts.ImportBindings, st, sharedStack)
 		if err != nil {
 			return nil, fmt.Errorf("amd64: function %d: %w", i, err)
 		}
@@ -493,11 +499,11 @@ var errRegExhausted = errors.New("amd64: no register available to spill")
 // compileFunc compiles one function, retrying with local pinning disabled if the
 // first (pinned) attempt exhausts the register file. Pinning is a pure speed
 // optimization, so the unpinned recompile is always correct.
-func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats) (code []byte, relocs []callReloc, internalOff int, err error) {
-	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, true)
+func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats, sharedStack *stack) (code []byte, relocs []callReloc, internalOff int, err error) {
+	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, true, sharedStack)
 	if errors.Is(err, errRegExhausted) {
 		resetFuncStats(stats)
-		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, false)
+		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, modGlobals, hints, importBindings, stats, false, sharedStack)
 		if err == nil {
 			stats.setUnpinnedRetry()
 		}
@@ -505,7 +511,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGl
 	return
 }
 
-func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats, pinLocals bool) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, stats *CodegenStats, pinLocals bool, sharedStack *stack) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(regExhausted); ok {
@@ -529,7 +535,8 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool
 		return nil, nil, 0, err
 	}
 
-	f := &fn{a: &amd64.Asm{B: make([]byte, 0, asmCapForBody(len(c.BodyBytes)))}, s: newStackWithCap(stackArenaCapForHints(len(c.BodyBytes), nLocals, hints.stackArenaNodes)), m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
+	sharedStack.reset()
+	f := &fn{a: &amd64.Asm{B: make([]byte, 0, asmCapForBody(len(c.BodyBytes)))}, s: sharedStack, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
 	f.syncHostCalls = moduleUsesSyncHostCalls(m, importBindings)
 	if !guardMode && len(m.Memories) > 0 {
 		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -203,6 +203,27 @@ func asmCapForBody(bodyLen int) int {
 	return capHint
 }
 
+// scratch bundles the per-function compile buffers reused across all functions in
+// one module compile. Every field is pure scratch that never outlives a
+// function's compile — the emitted code is copied into the module buffer before
+// the next function runs — so reset-and-reuse replaces per-function allocation.
+// Compile is sequential, so a single scratch is shared safely.
+type scratch struct {
+	stack *stack           // the valent-block operand stack
+	refs  map[refKey]*elem // occurrence tracking for local/global-aliasing values
+	asm   *amd64.Asm       // the x86-64 encoder byte buffer
+}
+
+func newScratch() *scratch {
+	return &scratch{stack: newStackWithCap(defaultStackArenaCap), refs: make(map[refKey]*elem), asm: &amd64.Asm{}}
+}
+
+func (sc *scratch) reset() {
+	sc.stack.reset()
+	clear(sc.refs)
+	sc.asm.B = sc.asm.B[:0]
+}
+
 // Frameless layout (WARP-style, RSP-relative). RBP is NOT a frame pointer — it is
 // a general allocatable register — so the frame is a single `sub rsp,frameSize`
 // with everything addressed at non-negative offsets from RSP, which stays put for
@@ -536,7 +557,8 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool
 	}
 
 	sc.reset()
-	f := &fn{a: &amd64.Asm{B: make([]byte, 0, asmCapForBody(len(c.BodyBytes)))}, s: sc.stack, refs: sc.refs, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
+	sc.asm.Grow(asmCapForBody(len(c.BodyBytes)))
+	f := &fn{a: sc.asm, s: sc.stack, refs: sc.refs, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, importBindings: importBindings, stats: stats}
 	f.syncHostCalls = moduleUsesSyncHostCalls(m, importBindings)
 	if !guardMode && len(m.Memories) > 0 {
 		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -204,7 +204,7 @@ func (f *fn) setDepth(l int) {
 
 func (f *fn) setDepthTypes(types []machineType) {
 	f.s.head.prev, f.s.head.next = f.s.head, f.s.head
-	f.refs = nil
+	clear(f.refs)
 	slot := 0
 	for _, typ := range types {
 		f.pushValue(storage{kind: stSlot, typ: typ, slot: slot})

--- a/src/core/compiler/backend/railshot/references.go
+++ b/src/core/compiler/backend/railshot/references.go
@@ -103,7 +103,7 @@ func (f *fn) refHead(k refKey) *elem {
 }
 
 func (f *fn) rebuildRefs() {
-	f.refs = nil
+	clear(f.refs)
 	for e := f.s.head.next; e != f.s.head; e = e.next {
 		e.refPrev, e.refNext = nil, nil
 		f.addRef(e)

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -182,24 +182,6 @@ const (
 	minStackArenaCap     = 16
 )
 
-// scratch bundles the per-function compile buffers that are reused across all
-// functions in one module compile. Every field is pure scratch that never
-// outlives a function's compile, so reset-and-reuse replaces per-function
-// allocation. Compile is sequential, so a single scratch is shared safely.
-type scratch struct {
-	stack *stack           // the valent-block operand stack
-	refs  map[refKey]*elem // occurrence tracking for local/global-aliasing values
-}
-
-func newScratch() *scratch {
-	return &scratch{stack: newStackWithCap(defaultStackArenaCap), refs: make(map[refKey]*elem)}
-}
-
-func (sc *scratch) reset() {
-	sc.stack.reset()
-	clear(sc.refs)
-}
-
 func newStack() *stack { return newStackWithCap(defaultStackArenaCap) }
 
 func newStackWithCap(capHint int) *stack {

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -182,6 +182,24 @@ const (
 	minStackArenaCap     = 16
 )
 
+// scratch bundles the per-function compile buffers that are reused across all
+// functions in one module compile. Every field is pure scratch that never
+// outlives a function's compile, so reset-and-reuse replaces per-function
+// allocation. Compile is sequential, so a single scratch is shared safely.
+type scratch struct {
+	stack *stack           // the valent-block operand stack
+	refs  map[refKey]*elem // occurrence tracking for local/global-aliasing values
+}
+
+func newScratch() *scratch {
+	return &scratch{stack: newStackWithCap(defaultStackArenaCap), refs: make(map[refKey]*elem)}
+}
+
+func (sc *scratch) reset() {
+	sc.stack.reset()
+	clear(sc.refs)
+}
+
 func newStack() *stack { return newStackWithCap(defaultStackArenaCap) }
 
 func newStackWithCap(capHint int) *stack {

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -198,6 +198,19 @@ func newStackWithCap(capHint int) *stack {
 	return s
 }
 
+// reset rewinds the stack to empty for reuse by the next function in a module
+// compile, preserving the arena's backing capacity so the common case allocates
+// nothing per function. The prior function's nodes are dead by the time this is
+// called (its code is already emitted), so dropping them is safe; standalone
+// spill nodes are simply released to the GC. alloc rezeroes every reused arena
+// slot, so no stale fields survive.
+func (s *stack) reset() {
+	s.arena = s.arena[:0]
+	s.arena = append(s.arena, elem{}) // sentinel
+	s.head = &s.arena[0]
+	s.head.prev, s.head.next = s.head, s.head
+}
+
 func stackArenaCapForBody(bodyLen, nLocals int) int {
 	return stackArenaCapForHints(bodyLen, nLocals, 0)
 }

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -29,6 +29,17 @@ const (
 
 type Asm struct{ B []byte }
 
+// Grow ensures B has capacity for at least n bytes, reusing the existing backing
+// array when it is already large enough. Used to pre-size a reused encoder buffer
+// per function so ordinary emits don't repeatedly re-grow the slice.
+func (a *Asm) Grow(n int) {
+	if cap(a.B) < n {
+		b := make([]byte, len(a.B), n)
+		copy(b, a.B)
+		a.B = b
+	}
+}
+
 func (a *Asm) emit(bs ...byte) { a.B = append(a.B, bs...) }
 func (a *Asm) imm32(v int32) {
 	var t [4]byte


### PR DESCRIPTION
## Summary

P7 (compile-path throughput) from `docs/no-ir-plan.md`. Profiling the decode/validate/compile split on the real-world corpus showed **compile dominates startup** (~2–3× validate, ~15× decode) and is heavily allocation-bound — roughly 1 alloc + 230 B per instruction. The three biggest per-function allocations were pure compile scratch that never outlives a function's compile, so this PR reuses them across the module's function loop instead of reallocating.

Three commits, each an independent reuse:
1. **Operand stack** — one `scratch` in `CompileModuleWith`, reset per function; `stack.reset()` keeps the arena capacity (was `newStackWithCap`, 34% of compile allocation).
2. **Occurrence-refs map** — `f.refs = sc.refs`; the two all-clear sites (`rebuildRefs`, `setDepthTypes`) switch `f.refs = nil` → `clear(f.refs)` so the reused map survives.
3. **Encoder byte buffer** — `f.a = sc.asm`; reset to `[:0]` per function. Safe because `compileFuncAttempt` returns `f.a.B` and the caller copies it into the module buffer before the next function runs. Adds `Asm.Grow(n)` to pre-size without realloc.

Compile is sequential, so sharing one scratch is safe.

## Measured (cumulative vs baseline)

| module | compile alloc bytes | alloc count | wall time |
|---|---|---|---|
| json-as | −57% | −22% | −9% |
| crcsum | −55% | −25% | −9% |
| lua | −52% | −22% | −7% |
| sqlite3 | −50% | −23% | −11% |
| markdown | −43% | −20% | −5% |

Wall-time gain is modest because compile is CPU-bound, not GC-bound, once allocs drop — the remaining wall-time lever is `ClassifyInstructionImmediate` (~22%), a separate follow-up.

## Gates
- Spec exec: 57/57 files, pass=16592 fail=0 (unchanged)
- `TestCorpusDifferential` both bounds modes: PASS
- `go test ./...` at root + `bench`: green
