### PR TITLE
feat(wago): extension API spine (plugin-api phase 1)

### DIFF
--- a/docs/plugin-api-plan.md
+++ b/docs/plugin-api-plan.md
@@ -1,0 +1,1795 @@
+# Final-product Wago extension API plan
+
+The final product should feel like this:
+
+```go
+rt := wago.NewRuntime()
+
+rt.Use(timer.Ext())
+rt.Use(metrics.Ext())
+rt.Use(process.Ext())
+rt.Use(mailbox.Ext())
+rt.Use(http.Ext(http.WithClient(client)))
+
+mod, err := rt.Compile(wasmBytes)
+if err != nil {
+    return err
+}
+
+class, err := rt.Class(mod, wago.ClassOptions{
+    Pool: wago.PoolOptions{
+        MinInstances: 1024,
+        MaxInstances: 100_000,
+        Reset:        wago.ResetMemorySnapshot,
+    },
+})
+if err != nil {
+    return err
+}
+
+pid, err := rt.Spawn(ctx, class, wago.SpawnOptions{
+    Entry: "main",
+})
+```
+
+And for a simple user who does not care about actors:
+
+```go
+rt := wago.NewRuntime()
+rt.Use(timer.Ext())
+
+mod, _ := rt.Compile(wasmBytes)
+inst, _ := rt.Instantiate(mod)
+
+out, err := inst.Invoke(ctx, "run", wago.I32(123))
+```
+
+That is the whole vibe: **simple first, absurdly powerful underneath**. The API should not punish normal people for not wanting to become runtime architects before lunch.
+
+---
+
+# Core design principle
+
+Wago extensions should be built around one idea:
+
+```text
+Extensions register capabilities into a runtime.
+The runtime owns orchestration.
+Modules consume those capabilities through imports, hooks, policies, and optionally compiler integration.
+```
+
+Do **not** make extensions directly mutate random runtime internals. That feels powerful until someone’s logging plugin redefines memory growth. Humanity has suffered enough.
+
+---
+
+# The four-layer model
+
+```text
+Layer 1: Runtime extensions
+  Host imports, hooks, resources, capabilities, policies.
+
+Layer 2: Module extensions
+  Wasm transforms, validation rules, required capabilities, metadata.
+
+Layer 3: Process extensions
+  Actors, mailboxes, timers, supervision, distributed routing.
+
+Layer 4: Compiler extensions
+  Intrinsics, backend selection, instrumentation, trusted codegen.
+```
+
+Most users only touch layer 1.
+
+Most extension authors touch layer 1 and maybe layer 2.
+
+Only Wago/core trusted packages touch layer 4.
+
+---
+
+# Why this fits Wago
+
+Wago already has the right bones:
+
+* `Compile` is separate from `Instantiate`, so extensions can hook compile-time and runtime separately.
+* `InstantiateWithOptions` already accepts imports and GC config, which is exactly where extension-provided host APIs belong.
+* Host imports already have a sync path that can access the calling instance’s memory through `HostModule.Memory()`, which is what serious extensions need.
+* Compiled code is already cached/refcounted, so class/pool/process semantics can share native code instead of duplicating executable mappings like animals.
+
+So the extension API should wrap and organize what Wago already wants to be.
+
+---
+
+# Final public API shape
+
+## Runtime
+
+```go
+type Runtime struct {
+    // internal
+}
+
+func NewRuntime(opts ...RuntimeOption) *Runtime
+
+func (rt *Runtime) Use(ext Extension, opts ...UseOption) error
+func (rt *Runtime) Compile(wasmBytes []byte, opts ...CompileOption) (*Module, error)
+func (rt *Runtime) Load(blob []byte, opts ...LoadOption) (*Module, error)
+
+func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...InstantiateOption) (*Instance, error)
+func (rt *Runtime) Class(mod *Module, opts ClassOptions) (*Class, error)
+
+func (rt *Runtime) Close() error
+func (rt *Runtime) Extensions() []ExtensionInfo
+func (rt *Runtime) Capabilities() []Capability
+```
+
+`Runtime` is the high-level entry point. Existing package-level APIs can remain as low-level convenience.
+
+```go
+c, err := wago.Compile(wasmBytes)
+in, err := wago.Instantiate(c, imports)
+```
+
+That should stay. The extension runtime is an additive higher layer.
+
+---
+
+## Module
+
+```go
+type Module struct {
+    // wraps *Compiled plus extension metadata
+}
+
+func (m *Module) Compiled() *Compiled
+func (m *Module) Exports() []string
+func (m *Module) Imports() []ImportSpec
+func (m *Module) RequiredCapabilities() []Capability
+func (m *Module) Metadata() ModuleMetadata
+func (m *Module) Close() error
+```
+
+`Module` is the runtime-aware wrapper over `Compiled`.
+
+It should know:
+
+```text
+compiled code
+declared imports
+required capabilities
+extension manifest
+transform history
+debug metadata
+```
+
+---
+
+## Instance
+
+```go
+type Instance struct {
+    // wraps current low-level *wago.Instance
+}
+
+func (in *Instance) Invoke(ctx context.Context, export string, args ...Value) ([]Value, error)
+func (in *Instance) Memory() *Memory
+func (in *Instance) Global(name string) (Value, error)
+func (in *Instance) SetGlobal(name string, value Value) error
+func (in *Instance) Close() error
+
+func (in *Instance) Raw() *wago.Instance
+```
+
+Use `context.Context` in the high-level API. This gives timers, cancellation, deadlines, tracing, process scheduling, and host import cancellation somewhere sane to live. Wild concept, I know.
+
+---
+
+## Class
+
+A `Class` is the deployable unit for massive instance pools and actor processes.
+
+```go
+type Class struct {
+    // module + pool + policy + extension state
+}
+
+type ClassOptions struct {
+    Name   string
+    Pool   PoolOptions
+    Policy Policy
+    Config ProcessConfig
+}
+
+func (rt *Runtime) Class(mod *Module, opts ClassOptions) (*Class, error)
+
+func (c *Class) Instantiate(ctx context.Context) (*Instance, error)
+func (c *Class) Acquire(ctx context.Context) (*Lease, error)
+func (c *Class) Close() error
+```
+
+A class is basically:
+
+```text
+compiled module
+plus import environment
+plus policy
+plus pool
+plus reset strategy
+```
+
+This is the foundation for “compile once, spawn a galaxy.”
+
+---
+
+# Extension interface
+
+This is the most important part.
+
+I would **not** use a giant interface with 400 methods. That is not complete. That is a cry for help.
+
+Use one simple interface:
+
+```go
+type Extension interface {
+    Info() ExtensionInfo
+    Register(reg *Registry) error
+}
+```
+
+That’s it.
+
+Everything else happens through the registry.
+
+```go
+type ExtensionInfo struct {
+    ID          string
+    Name        string
+    Version     string
+    Description string
+    MinWago     string
+    Stability   Stability
+}
+```
+
+Example:
+
+```go
+type TimerExtension struct{}
+
+func (TimerExtension) Info() wago.ExtensionInfo {
+    return wago.ExtensionInfo{
+        ID:          "wago.timer",
+        Name:        "Timer",
+        Version:     "1.0.0",
+        Description: "Monotonic and wall-clock time for Wasm guests.",
+        MinWago:     "0.1.0",
+        Stability:   wago.Stable,
+    }
+}
+
+func (TimerExtension) Register(reg *wago.Registry) error {
+    reg.Capability(wago.CapTimer)
+
+    reg.ImportModule("wago_timer").
+        Func("now_unix_ms", timerNowUnixMS).
+        Results(wago.I64)
+
+    reg.ImportModule("wago_timer").
+        Func("now_monotonic_ns", timerNowMonotonicNS).
+        Results(wago.I64)
+
+    return nil
+}
+```
+
+This is lovable because extension authors learn **one** method: `Register`.
+
+---
+
+# Registry API
+
+The registry is the extension builder surface.
+
+```go
+type Registry struct {
+    // internal
+}
+
+func (r *Registry) Capability(cap Capability, opts ...CapabilityOption)
+func (r *Registry) ImportModule(name string) *ImportModuleBuilder
+func (r *Registry) Hooks() *HookRegistry
+func (r *Registry) Resources() *ResourceRegistry
+func (r *Registry) Policies() *PolicyRegistry
+func (r *Registry) Memory() *MemoryRegistry
+func (r *Registry) Processes() *ProcessRegistry
+func (r *Registry) Compiler() *CompilerRegistry
+```
+
+This keeps the API discoverable:
+
+```go
+reg.ImportModule(...)
+reg.Hooks().BeforeInvoke(...)
+reg.Resources().Kind(...)
+reg.Compiler().Intrinsic(...)
+```
+
+No mystery subinterface bingo.
+
+---
+
+# Import registration
+
+## Host function builder
+
+```go
+type ImportModuleBuilder struct {
+    // internal
+}
+
+func (m *ImportModuleBuilder) Func(name string, fn any) *ImportFuncBuilder
+```
+
+Then:
+
+```go
+reg.ImportModule("wago_timer").
+    Func("now_unix_ms", func() int64 {
+        return time.Now().UnixMilli()
+    }).
+    Results(wago.I64)
+```
+
+For memory-accessing functions:
+
+```go
+reg.ImportModule("wago_env").
+    Func("log", func(mod wago.HostModule, ptr uint32, len uint32) int32 {
+        msg := mod.Memory()[ptr : ptr+len]
+        log.Printf("%s", msg)
+        return 0
+    }).
+    Params(wago.I32, wago.I32).
+    Results(wago.I32)
+```
+
+This maps naturally to Wago’s existing sync host import model.
+
+## Supported host signatures
+
+Allow both:
+
+```go
+func(a int32, b int32) int32
+func(mod wago.HostModule, ptr uint32, len uint32) int32
+```
+
+And low-level:
+
+```go
+type SyncHostFunc func(m HostModule, params, results []uint64)
+```
+
+So advanced authors can avoid reflection and allocation.
+
+---
+
+# Import collision rules
+
+This needs to be boring and deterministic.
+
+```text
+1. Extension import namespaces must be unique.
+2. User imports cannot override reserved wago_* modules unless explicitly allowed.
+3. Later extensions cannot override earlier extension imports by default.
+4. Runtime options can allow controlled override for tests.
+```
+
+Reserved namespaces:
+
+```text
+wago_process
+wago_mailbox
+wago_timer
+wago_metrics
+wago_log
+wago_fs
+wago_net
+wago_http
+wago_kv
+wago_crypto
+wago_debug
+wago_runtime
+```
+
+API:
+
+```go
+rt := wago.NewRuntime(
+    wago.WithImportOverridePolicy(wago.NoExtensionOverrides),
+)
+```
+
+Test-only escape hatch:
+
+```go
+rt := wago.NewRuntime(
+    wago.WithImportOverridePolicy(wago.AllowTestOverrides),
+)
+```
+
+---
+
+# Hook system
+
+Hooks should be complete, but not ridiculous.
+
+## Runtime hooks
+
+```go
+type RuntimeHooks struct {
+    OnRuntimeStart []func(*RuntimeContext) error
+    OnRuntimeClose []func(*RuntimeContext)
+}
+```
+
+## Compile hooks
+
+```go
+type CompileHooks struct {
+    BeforeDecode    []func(*CompileContext, []byte) ([]byte, error)
+    AfterDecode     []func(*CompileContext, *wasm.Module) error
+    BeforeValidate  []func(*CompileContext, *wasm.Module) error
+    AfterValidate   []func(*CompileContext, *wasm.Module) error
+    BeforeCompile   []func(*CompileContext, *wasm.Module) error
+    AfterCompile    []func(*CompileContext, *Module) error
+}
+```
+
+Compile pipeline:
+
+```text
+raw wasm bytes
+  -> BeforeDecode
+decode
+  -> AfterDecode
+  -> transforms
+  -> BeforeValidate
+validate
+  -> AfterValidate
+  -> BeforeCompile
+compile
+  -> AfterCompile
+```
+
+The important rule:
+
+```text
+Any module transform must happen before final validation.
+```
+
+No plugin gets to smuggle invalid Wasm into codegen. We live in a society, allegedly.
+
+## Instantiate hooks
+
+```go
+type InstantiateHooks struct {
+    BeforeInstantiate []func(*InstantiateContext) error
+    AfterInstantiate  []func(*InstantiateContext, *Instance) error
+}
+```
+
+Use for:
+
+```text
+capability checks
+memory plan selection
+resource attachment
+metrics
+debug labels
+initial snapshots
+```
+
+## Invoke hooks
+
+```go
+type InvokeHooks struct {
+    BeforeInvoke []func(*InvokeContext) error
+    AfterInvoke  []func(*InvokeContext, []Value, error)
+}
+```
+
+Use for:
+
+```text
+metrics
+tracing
+fuel accounting
+policy checks
+panic/trap reporting
+debug stepping later
+```
+
+## Instance lifecycle hooks
+
+```go
+type InstanceHooks struct {
+    BeforeReset []func(*InstanceContext) error
+    AfterReset  []func(*InstanceContext) error
+    BeforeClose []func(*InstanceContext)
+    AfterClose  []func(*InstanceContext)
+}
+```
+
+Use for pools.
+
+## Process hooks
+
+```go
+type ProcessHooks struct {
+    OnSpawn          []func(*ProcessContext, PID)
+    OnExit           []func(*ProcessContext, PID, ExitReason)
+    OnMessageSend    []func(*MessageContext)
+    OnMessageReceive []func(*MessageContext)
+    OnLink           []func(*ProcessContext, PID, PID)
+    OnMonitor        []func(*ProcessContext, PID, PID)
+}
+```
+
+Use for actor/process extensions, distributed routing, debug visualizers, and supervisors.
+
+---
+
+# Context objects
+
+Every hook gets a context object. No global sludge.
+
+```go
+type RuntimeContext struct {
+    Runtime *Runtime
+    Logger  Logger
+}
+
+type CompileContext struct {
+    Runtime *Runtime
+    ModuleID ModuleID
+    Metadata map[string]any
+}
+
+type InstantiateContext struct {
+    Runtime *Runtime
+    Module  *Module
+    Imports Imports
+    Policy  Policy
+    Metadata map[string]any
+}
+
+type InvokeContext struct {
+    Runtime  *Runtime
+    Instance *Instance
+    Export   string
+    Args     []Value
+    Start    time.Time
+    Metadata map[string]any
+}
+```
+
+Hooks should be allowed to stash extension-local metadata.
+
+```go
+ctx.Metadata["wago.metrics.start"] = time.Now()
+```
+
+For a nicer API:
+
+```go
+ctx.Set(extID, key, value)
+value, ok := ctx.Get(extID, key)
+```
+
+---
+
+# Capabilities and policy
+
+This is mandatory for a complete extension API.
+
+## Capability
+
+```go
+type Capability string
+
+const (
+    CapTimerRead       Capability = "timer.read"
+    CapProcessSpawn    Capability = "process.spawn"
+    CapProcessKill     Capability = "process.kill"
+    CapMailboxSend     Capability = "mailbox.send"
+    CapMailboxReceive  Capability = "mailbox.receive"
+    CapNetworkOutbound Capability = "net.outbound"
+    CapFilesystemRead  Capability = "fs.read"
+    CapFilesystemWrite Capability = "fs.write"
+    CapHTTPClient      Capability = "http.client"
+    CapKVRead          Capability = "kv.read"
+    CapKVWrite         Capability = "kv.write"
+    CapMetricsWrite    Capability = "metrics.write"
+    CapCompilerCodegen Capability = "compiler.codegen"
+)
+```
+
+## Policy
+
+```go
+type Policy struct {
+    AllowedCapabilities []Capability
+    DeniedCapabilities  []Capability
+
+    MaxMemoryBytes      uint64
+    MaxTableEntries     uint32
+    MaxInstances        uint32
+    MaxProcesses        uint32
+    MaxMailboxMessages  uint32
+    MaxMailboxBytes     uint64
+    MaxInvokeDuration   time.Duration
+}
+```
+
+Usage:
+
+```go
+inst, err := rt.Instantiate(ctx, mod,
+    wago.WithPolicy(wago.Policy{
+        AllowedCapabilities: []wago.Capability{
+            wago.CapTimerRead,
+            wago.CapMetricsWrite,
+        },
+        MaxMemoryBytes:    64 << 20,
+        MaxInvokeDuration: 50 * time.Millisecond,
+    }),
+)
+```
+
+Extensions check through the runtime:
+
+```go
+if err := ctx.Require(wago.CapNetworkOutbound); err != nil {
+    return err
+}
+```
+
+This makes host APIs safe by default.
+
+---
+
+# Resource and handle system
+
+Extensions need handles. PIDs, sockets, timers, files, KV connections, HTTP clients, subscriptions.
+
+Do not pass Go pointers to Wasm. Use integer handles.
+
+```go
+type Handle uint64
+
+type Resource interface {
+    Close() error
+}
+
+type ResourceRegistry struct {
+    // internal
+}
+
+func (r *ResourceRegistry) Kind(name string, opts ...ResourceKindOption)
+```
+
+Runtime owns handle tables:
+
+```go
+type HandleTable struct {
+    // internal
+}
+
+func (h *HandleTable) Insert(kind string, value Resource) Handle
+func (h *HandleTable) Get(handle Handle, kind string) (Resource, bool)
+func (h *HandleTable) Close(handle Handle) error
+```
+
+Guest sees:
+
+```wat
+(func $timer_cancel (param i64) (result i32))
+(func $file_close   (param i64) (result i32))
+(func $pid_kill     (param i64 i32) (result i32))
+```
+
+Handle layout:
+
+```text
+u64 handle
+upper bits: kind/generation
+lower bits: slot index
+```
+
+Use generation counters so stale handles fail cleanly.
+
+---
+
+# Guest ABI
+
+The guest ABI should be tiny and consistent.
+
+## Values
+
+```text
+i32 for status codes
+i64 for handles, PIDs, timestamps
+ptr + len for guest buffers
+ptr + cap for output buffers
+```
+
+## Return convention
+
+Use status codes:
+
+```text
+0  = ok
+1  = not found
+2  = permission denied
+3  = invalid handle
+4  = buffer too small
+5  = would block
+6  = timed out
+7  = trap/error
+```
+
+For variable-length output:
+
+```wat
+(import "wago_mailbox" "recv"
+  (func $recv
+    (param $buf_ptr i32)
+    (param $buf_cap i32)
+    (param $timeout_ms i64)
+    (result i32))) ;; bytes read or negative error
+```
+
+Or more explicit:
+
+```wat
+(import "wago_mailbox" "recv"
+  (func $recv
+    (param $buf_ptr i32)
+    (param $buf_cap i32)
+    (param $out_len_ptr i32)
+    (param $timeout_ms i64)
+    (result i32)))
+```
+
+I’d pick explicit status + out pointer for anything nontrivial:
+
+```text
+status result
+output length written to memory
+```
+
+It is less cute, but APIs that are too cute tend to become haunted.
+
+---
+
+# Guest bindings
+
+Developer experience matters here.
+
+Provide official bindings for:
+
+```text
+AssemblyScript
+TinyGo
+Rust
+C
+```
+
+Example AssemblyScript:
+
+```ts
+import { nowMonotonicNs } from "@wago/timer";
+import { send, recv } from "@wago/mailbox";
+
+export function main(): void {
+  let t = nowMonotonicNs();
+}
+```
+
+TinyGo:
+
+```go
+package main
+
+import "github.com/wago-org/guest/timer"
+
+func main() {
+    now := timer.NowMonotonicNS()
+    _ = now
+}
+```
+
+Rust:
+
+```rust
+let now = wago_timer::now_monotonic_ns();
+```
+
+Bindings should be generated from an extension manifest.
+
+---
+
+# Extension manifest
+
+Each extension should be able to expose a manifest.
+
+```go
+type ExtensionManifest struct {
+    Info         ExtensionInfo
+    Imports      []ImportSpec
+    Capabilities []CapabilitySpec
+    Resources    []ResourceSpec
+}
+```
+
+Import spec:
+
+```go
+type ImportSpec struct {
+    Module  string
+    Name    string
+    Params  []ValType
+    Results []ValType
+    Capability Capability
+    Docs    string
+}
+```
+
+Use this for:
+
+```text
+docs generation
+guest bindings
+validation errors
+debugging
+CLI inspection
+```
+
+CLI:
+
+```bash
+wago ext list
+wago ext inspect wago.timer
+wago module imports app.wasm
+wago module capabilities app.wasm
+```
+
+Nice error:
+
+```text
+module imports wago_http.fetch, but runtime has no extension providing module "wago_http"
+hint: rt.Use(http.Ext(...))
+```
+
+That’s lovable. Slightly less lovable than a nap, but close.
+
+---
+
+# Built-in extension packages
+
+Use boring package names.
+
+```text
+wago/ext/timer
+wago/ext/log
+wago/ext/metrics
+wago/ext/process
+wago/ext/mailbox
+wago/ext/supervisor
+wago/ext/http
+wago/ext/fs
+wago/ext/kv
+wago/ext/crypto
+wago/ext/debug
+wago/ext/wasi
+```
+
+Example:
+
+```go
+import (
+    "github.com/wago-org/wago"
+    "github.com/wago-org/wago/ext/timer"
+    "github.com/wago-org/wago/ext/process"
+)
+```
+
+Not `grafts`, not `kits`, not `arcane_dragon_modules`. Save the poetry for tier names. APIs should be obvious.
+
+---
+
+# Built-in extension set
+
+## `timer`
+
+Imports:
+
+```text
+wago_timer.now_unix_ms() -> i64
+wago_timer.now_monotonic_ns() -> i64
+wago_timer.sleep_ms(ms: i64) -> i32
+wago_timer.send_after_ms(pid: i64, ms: i64, ptr: i32, len: i32) -> i64
+wago_timer.cancel(handle: i64) -> i32
+```
+
+## `log`
+
+```text
+wago_log.write(level: i32, ptr: i32, len: i32) -> i32
+```
+
+## `metrics`
+
+```text
+wago_metrics.counter_add(name_ptr, name_len, delta: i64) -> i32
+wago_metrics.histogram_observe(name_ptr, name_len, value: f64) -> i32
+```
+
+## `process`
+
+```text
+wago_process.self() -> i64
+wago_process.spawn(class_ptr, class_len, entry_ptr, entry_len, arg_ptr, arg_len) -> i64
+wago_process.kill(pid: i64, reason: i32) -> i32
+wago_process.link(pid: i64) -> i32
+wago_process.unlink(pid: i64) -> i32
+wago_process.monitor(pid: i64) -> i64
+```
+
+## `mailbox`
+
+```text
+wago_mailbox.send(pid: i64, ptr: i32, len: i32) -> i32
+wago_mailbox.recv(buf_ptr: i32, buf_cap: i32, out_len_ptr: i32, timeout_ms: i64) -> i32
+wago_mailbox.try_recv(buf_ptr: i32, buf_cap: i32, out_len_ptr: i32) -> i32
+wago_mailbox.len() -> i32
+```
+
+## `supervisor`
+
+Host-level first, guest-level later.
+
+```go
+sup := supervisor.New(wago.OneForOne,
+    supervisor.Child("worker", workerClass),
+)
+rt.Use(sup)
+```
+
+## `http`
+
+```text
+wago_http.request(req_ptr, req_len, out_handle_ptr) -> i32
+wago_http.read_body(handle, ptr, cap, out_len_ptr) -> i32
+wago_http.close(handle) -> i32
+```
+
+## `kv`
+
+```text
+wago_kv.get(key_ptr, key_len, out_ptr, out_cap, out_len_ptr) -> i32
+wago_kv.set(key_ptr, key_len, val_ptr, val_len) -> i32
+wago_kv.delete(key_ptr, key_len) -> i32
+```
+
+## `debug`
+
+```text
+wago_debug.breakpoint(code: i32) -> i32
+wago_debug.trace_event(ptr, len) -> i32
+```
+
+---
+
+# Process model
+
+This is the Lunatic-like layer.
+
+## Runtime API
+
+```go
+type PID uint64
+
+func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (PID, error)
+func (rt *Runtime) Send(ctx context.Context, pid PID, msg []byte) error
+func (rt *Runtime) Kill(ctx context.Context, pid PID, reason ExitReason) error
+func (rt *Runtime) Monitor(ctx context.Context, pid PID) (<-chan ExitEvent, error)
+```
+
+## Spawn options
+
+```go
+type SpawnOptions struct {
+    Entry string
+    Args  []Value
+    Init  []byte
+
+    Name  string
+    Policy Policy
+
+    LinkToParent bool
+}
+```
+
+## Process internals
+
+```go
+type Process struct {
+    PID      PID
+    Class    *Class
+    Instance *Lease
+    Mailbox  *Mailbox
+    Policy   Policy
+    Links    map[PID]struct{}
+    Monitors map[PID]struct{}
+}
+```
+
+Processes are not green threads. They are Wago instance leases with mailboxes and lifecycle. That is simpler, more honest, and much less likely to turn your stack management into a Victorian illness.
+
+---
+
+# Pool integration
+
+A class owns a pool.
+
+```go
+type PoolOptions struct {
+    MinInstances int
+    MaxInstances int
+    Reset        ResetPolicy
+
+    MaxIdleTime time.Duration
+    WarmStart   bool
+}
+
+type ResetPolicy int
+
+const (
+    ResetReinstantiate ResetPolicy = iota
+    ResetMemorySnapshot
+    ResetCopyOnWrite
+)
+```
+
+Class usage:
+
+```go
+worker, err := rt.Class(mod, wago.ClassOptions{
+    Name: "worker",
+    Pool: wago.PoolOptions{
+        MinInstances: 4096,
+        MaxInstances: 100_000,
+        Reset:        wago.ResetMemorySnapshot,
+    },
+})
+```
+
+This is where Wago can become nasty-fast.
+
+---
+
+# Module transforms
+
+Extensions can transform Wasm before final validation.
+
+```go
+reg.Hooks().AfterDecode(func(ctx *CompileContext, m *wasm.Module) error {
+    return instrumentModule(m)
+})
+```
+
+Or a nicer builder:
+
+```go
+reg.Transform("inject-metrics", func(ctx *CompileContext, m *wasm.Module) error {
+    return metrics.Inject(m)
+})
+```
+
+Allowed transforms:
+
+```text
+add imports
+rewrite imports
+inject function calls
+add custom sections
+add wrappers
+instrument memory accesses
+insert fuel checks
+```
+
+Disallowed:
+
+```text
+skip validation
+mutate compiled code after validation without revalidation
+change runtime ABI
+lie about signatures
+```
+
+---
+
+# Compiler extension API
+
+This should exist, but separate from normal extensions.
+
+```go
+type CompilerExtension interface {
+    Info() ExtensionInfo
+    RegisterCompiler(reg *CompilerRegistry) error
+}
+```
+
+Register separately:
+
+```go
+rt.UseCompiler(simd.Codegen())
+rt.UseCompiler(crypto.Intrinsics())
+```
+
+Not:
+
+```go
+rt.Use(randomDownloadedCompilerPlugin())
+```
+
+That way normal runtime plugins stay safe.
+
+## Compiler registry
+
+```go
+type CompilerRegistry struct {
+    // internal
+}
+
+func (r *CompilerRegistry) Backend(name string, backend codegen.Backend[*wasm.Module])
+func (r *CompilerRegistry) Intrinsic(spec IntrinsicSpec)
+func (r *CompilerRegistry) Instrumentation(pass InstrumentationPass)
+func (r *CompilerRegistry) ObjectPass(pass ObjectPass)
+```
+
+## Intrinsics
+
+This is the most important compiler extension feature.
+
+```go
+type IntrinsicSpec struct {
+    ImportModule string
+    ImportName   string
+    Params       []ValType
+    Results      []ValType
+    Lower        IntrinsicLowering
+}
+```
+
+Example:
+
+```go
+reg.Compiler().Intrinsic(wago.IntrinsicSpec{
+    ImportModule: "wago_crypto",
+    ImportName:   "blake3_chunk",
+    Params:       []wago.ValType{wago.I32, wago.I32, wago.I32},
+    Results:      []wago.ValType{wago.I32},
+    Lower:        lowerBlake3ChunkAMD64,
+})
+```
+
+Guest sees a normal import.
+
+Without compiler extension:
+
+```text
+guest import -> host call
+```
+
+With compiler extension:
+
+```text
+guest import -> inlined native lowering
+```
+
+That is a lovely trick. Ergonomic, compatible, and fast.
+
+## Backend selection
+
+```go
+rt := wago.NewRuntime(
+    wago.WithBackend("railshot"),
+)
+
+rt.UseCompiler(mybackend.Ext())
+```
+
+Possible backends:
+
+```text
+railshot
+debug interpreter
+optimizing backend
+gpu backend
+aot backend
+instrumented backend
+```
+
+Keep this trusted.
+
+---
+
+# Safety boundary
+
+Normal extensions can:
+
+```text
+register imports
+register hooks
+register resources
+declare capabilities
+transform modules before validation
+observe lifecycle events
+enforce policy
+```
+
+Normal extensions cannot:
+
+```text
+patch machine code
+change ABI layout
+override trap handling
+mutate register allocation
+change stack layout
+install arbitrary signal handlers
+override reserved imports
+skip validation
+```
+
+Compiler extensions can do some dangerous things, but only through trusted APIs.
+
+---
+
+# Error model
+
+Use typed errors.
+
+```go
+var (
+    ErrPermissionDenied = errors.New("wago: permission denied")
+    ErrMissingImport    = errors.New("wago: missing import")
+    ErrInvalidHandle    = errors.New("wago: invalid handle")
+    ErrExtensionConflict = errors.New("wago: extension conflict")
+)
+```
+
+Rich error:
+
+```go
+type ExtensionError struct {
+    Extension string
+    Operation string
+    Err       error
+}
+
+func (e *ExtensionError) Error() string {
+    return fmt.Sprintf("wago extension %s: %s: %v", e.Extension, e.Operation, e.Err)
+}
+```
+
+Example message:
+
+```text
+wago extension wago.http: import registration failed:
+module "wago_http" function "request" conflicts with extension "custom.http"
+```
+
+This matters. Bad errors are unpaid technical debt with a user interface.
+
+---
+
+# Developer experience checklist
+
+## Good DX features
+
+```text
+rt.Use(ext)
+one Register method
+clear import collision errors
+reserved namespace protection
+extension manifest inspection
+generated guest bindings
+typed host functions
+low-level SyncHostFunc escape hatch
+test harness
+CLI inspection
+stable capability names
+context-aware invoke API
+```
+
+## Test harness
+
+```go
+package myext_test
+
+func TestExtension(t *testing.T) {
+    rt := wagotest.NewRuntime(t)
+    rt.Use(myext.Ext())
+
+    wagotest.RequireImport(t, rt, "wago_myext", "do_thing")
+    wagotest.RequireCapability(t, rt, myext.CapDoThing)
+}
+```
+
+For guest tests:
+
+```go
+inst := wagotest.MustInstantiateWat(t, rt, `
+(module
+  (import "wago_timer" "now_unix_ms" (func $now (result i64)))
+  (func (export "run") (result i64)
+    call $now))
+`)
+```
+
+## Debug inspection
+
+```go
+rt.Extensions()
+rt.Capabilities()
+mod.RequiredCapabilities()
+mod.Imports()
+```
+
+CLI:
+
+```bash
+wago ext list
+wago ext inspect wago.timer
+wago inspect imports app.wasm
+wago inspect capabilities app.wasm
+```
+
+---
+
+# Configuration
+
+Prefer typed Go options over generic maps.
+
+```go
+rt.Use(http.Ext(
+    http.WithClient(client),
+    http.WithAllowedHosts("api.example.com"),
+    http.WithTimeout(2*time.Second),
+))
+```
+
+Avoid this as the main Go API:
+
+```go
+rt.Use(http.Ext(), wago.Config{
+    "timeout": "2s",
+})
+```
+
+Stringly typed config is where bugs go to reproduce.
+
+But still allow manifests/config files for CLI:
+
+```toml
+[extensions.timer]
+
+[extensions.http]
+allowed_hosts = ["api.example.com"]
+timeout = "2s"
+```
+
+---
+
+# Versioning and stability
+
+```go
+type Stability string
+
+const (
+    Experimental Stability = "experimental"
+    Stable       Stability = "stable"
+    Deprecated   Stability = "deprecated"
+)
+```
+
+Runtime should reject incompatible extensions:
+
+```go
+if ext.Info().MinWago > currentVersion {
+    return fmt.Errorf(...)
+}
+```
+
+Extension IDs should be stable:
+
+```text
+wago.timer
+wago.process
+wago.mailbox
+company.redis
+company.auth
+```
+
+Import module names should be stable:
+
+```text
+wago_timer
+wago_process
+company_redis
+```
+
+---
+
+# Suggested file/package layout
+
+```text
+src/wago/runtime.go
+src/wago/extension.go
+src/wago/registry.go
+src/wago/hooks.go
+src/wago/policy.go
+src/wago/resource.go
+src/wago/module_runtime.go
+src/wago/class.go
+src/wago/pool.go
+src/wago/process.go
+
+src/wago/ext/timer
+src/wago/ext/log
+src/wago/ext/metrics
+src/wago/ext/process
+src/wago/ext/mailbox
+src/wago/ext/http
+src/wago/ext/kv
+src/wago/ext/wasi
+
+src/wago/compilerext
+```
+
+Or if you want shorter import paths later:
+
+```text
+ext/timer
+ext/process
+ext/mailbox
+```
+
+But keeping them under `src/wago/ext/...` while private is fine.
+
+---
+
+# Final API example: extension author
+
+```go
+package timer
+
+type Extension struct {
+    clock Clock
+}
+
+func Ext(opts ...Option) *Extension {
+    e := &Extension{clock: realClock{}}
+    for _, opt := range opts {
+        opt(e)
+    }
+    return e
+}
+
+func (e *Extension) Info() wago.ExtensionInfo {
+    return wago.ExtensionInfo{
+        ID:          "wago.timer",
+        Name:        "Timer",
+        Version:     "1.0.0",
+        Description: "Time functions for Wago guests.",
+        MinWago:     "0.1.0",
+        Stability:   wago.Stable,
+    }
+}
+
+func (e *Extension) Register(reg *wago.Registry) error {
+    reg.Capability(CapRead)
+
+    reg.ImportModule("wago_timer").
+        Func("now_unix_ms", func() int64 {
+            return e.clock.Now().UnixMilli()
+        }).
+        Results(wago.I64).
+        Capability(CapRead)
+
+    reg.ImportModule("wago_timer").
+        Func("now_monotonic_ns", func() int64 {
+            return e.clock.MonotonicNS()
+        }).
+        Results(wago.I64).
+        Capability(CapRead)
+
+    return nil
+}
+```
+
+User:
+
+```go
+rt := wago.NewRuntime()
+rt.Use(timer.Ext())
+
+mod, _ := rt.Compile(wasmBytes)
+inst, _ := rt.Instantiate(context.Background(), mod)
+
+out, err := inst.Invoke(context.Background(), "run")
+```
+
+---
+
+# Final API example: process + mailbox
+
+```go
+rt := wago.NewRuntime()
+
+rt.Use(timer.Ext())
+rt.Use(process.Ext())
+rt.Use(mailbox.Ext())
+rt.Use(metrics.Ext())
+
+mod, err := rt.Compile(workerWasm)
+if err != nil {
+    return err
+}
+
+worker, err := rt.Class(mod, wago.ClassOptions{
+    Name: "worker",
+    Pool: wago.PoolOptions{
+        MinInstances: 256,
+        MaxInstances: 20_000,
+        Reset:        wago.ResetMemorySnapshot,
+    },
+    Policy: wago.Policy{
+        AllowedCapabilities: []wago.Capability{
+            process.CapSpawn,
+            mailbox.CapSend,
+            mailbox.CapReceive,
+            timer.CapRead,
+        },
+        MaxMemoryBytes:     32 << 20,
+        MaxMailboxMessages: 1024,
+    },
+})
+if err != nil {
+    return err
+}
+
+pid, err := rt.Spawn(ctx, worker, wago.SpawnOptions{
+    Entry: "main",
+})
+if err != nil {
+    return err
+}
+
+err = rt.Send(ctx, pid, []byte("hello"))
+```
+
+Guest:
+
+```ts
+import { self } from "@wago/process";
+import { recv, send } from "@wago/mailbox";
+
+export function main(): void {
+  let me = self();
+  let msg = recv();
+}
+```
+
+---
+
+# “Simple, lovable, complete” evaluation
+
+## Simple
+
+A user learns:
+
+```go
+rt := wago.NewRuntime()
+rt.Use(ext)
+mod := rt.Compile(...)
+inst := rt.Instantiate(...)
+inst.Invoke(...)
+```
+
+An extension author learns:
+
+```go
+type Extension interface {
+    Info() ExtensionInfo
+    Register(*Registry) error
+}
+```
+
+That is simple.
+
+## Lovable
+
+Lovable parts:
+
+```text
+typed host functions
+one Register method
+good errors
+guest bindings
+CLI inspection
+reserved namespaces
+test helpers
+safe defaults
+context-aware invoke
+```
+
+This is the difference between “technically extensible” and “people will actually use it without muttering.”
+
+## Complete
+
+It supports:
+
+```text
+host APIs
+runtime hooks
+module transforms
+policies
+capabilities
+resources/handles
+processes
+mailboxes
+timers
+supervision
+pooling
+compiler intrinsics
+backend replacement
+observability
+distributed later
+```
+
+That is complete without dumping every dangerous internal into the public API like a yard sale.
+
+---
+
+# Implementation phases
+
+## Phase 1: Extension spine
+
+```text
+Runtime
+Extension
+Registry
+Import registration
+Basic hooks
+```
+
+## Phase 2: Runtime wrappers
+
+```text
+Module
+Instance
+context-aware Invoke
+extension-aware Instantiate
+good errors
+manifest inspection
+```
+
+## Phase 3: Built-ins
+
+```text
+timer
+log
+metrics
+```
+
+## Phase 4: Pool/class
+
+```text
+Class
+Pool
+Lease
+Reset policies
+```
+
+## Phase 5: Process/mailbox
+
+```text
+PID
+Spawn
+Send
+Recv
+Kill
+Monitor
+Link
+```
+
+## Phase 6: Policy/resources
+
+```text
+Capabilities
+Handle table
+Resource cleanup
+Per-instance/process limits
+```
+
+## Phase 7: Supervisors
+
+```text
+one-for-one
+one-for-all
+restart windows
+exit reasons
+```
+
+## Phase 8: Compiler extensions
+
+```text
+intrinsics
+backend selection
+instrumentation hooks
+```
+
+## Phase 9: Distributed
+
+```text
+node IDs
+remote PIDs
+spawn remote
+send remote
+routing
+backpressure
+```
+
+---
+
+# The final shape, condensed
+
+```go
+type Extension interface {
+    Info() ExtensionInfo
+    Register(*Registry) error
+}
+
+type Registry struct{}
+
+func (r *Registry) ImportModule(name string) *ImportModuleBuilder
+func (r *Registry) Hooks() *HookRegistry
+func (r *Registry) Capability(cap Capability, opts ...CapabilityOption)
+func (r *Registry) Resources() *ResourceRegistry
+func (r *Registry) Compiler() *CompilerRegistry
+```
+
+Runtime:
+
+```go
+type Runtime struct{}
+
+func NewRuntime(opts ...RuntimeOption) *Runtime
+func (rt *Runtime) Use(ext Extension, opts ...UseOption) error
+func (rt *Runtime) UseCompiler(ext CompilerExtension) error
+func (rt *Runtime) Compile([]byte, ...CompileOption) (*Module, error)
+func (rt *Runtime) Instantiate(context.Context, *Module, ...InstantiateOption) (*Instance, error)
+func (rt *Runtime) Class(*Module, ClassOptions) (*Class, error)
+func (rt *Runtime) Spawn(context.Context, *Class, SpawnOptions) (PID, error)
+```
+
+That is the product.
+
+Small enough to understand.
+Nice enough to use.
+Powerful enough to grow into Lunatic-style actors, pools, distributed processes, and compiler intrinsics without detonating the API later.
+
+Tiny spine. Big dragon. Unfortunately coherent.

--- a/src/wago/extension.go
+++ b/src/wago/extension.go
@@ -1,0 +1,83 @@
+package wago
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Version is the wago runtime version, compared against an extension's MinWago at
+// Use time so a runtime rejects an extension that needs a newer host.
+const Version = "0.1.0"
+
+// Stability marks how settled an extension's public surface is.
+type Stability string
+
+const (
+	Experimental Stability = "experimental"
+	Stable       Stability = "stable"
+	Deprecated   Stability = "deprecated"
+)
+
+// ExtensionInfo is an extension's self-description: a stable ID, human metadata,
+// the minimum wago version it needs, and its stability level. IDs should be
+// dotted and stable (e.g. "wago.timer", "company.redis").
+type ExtensionInfo struct {
+	ID          string
+	Name        string
+	Version     string
+	Description string
+	MinWago     string
+	Stability   Stability
+}
+
+// Extension is the one interface an extension author implements. Everything an
+// extension contributes — host imports, capabilities, hooks — is declared through
+// the Registry inside Register; the runtime owns orchestration.
+type Extension interface {
+	Info() ExtensionInfo
+	Register(reg *Registry) error
+}
+
+// Capability names a coarse permission an extension provides and a policy can
+// allow or deny. Names are stable strings so they can appear in configs and
+// audit output.
+type Capability string
+
+const (
+	CapTimerRead       Capability = "timer.read"
+	CapProcessSpawn    Capability = "process.spawn"
+	CapProcessKill     Capability = "process.kill"
+	CapMailboxSend     Capability = "mailbox.send"
+	CapMailboxReceive  Capability = "mailbox.receive"
+	CapNetworkOutbound Capability = "net.outbound"
+	CapFilesystemRead  Capability = "fs.read"
+	CapFilesystemWrite Capability = "fs.write"
+	CapHTTPClient      Capability = "http.client"
+	CapKVRead          Capability = "kv.read"
+	CapKVWrite         Capability = "kv.write"
+	CapMetricsWrite    Capability = "metrics.write"
+	CapCompilerCodegen Capability = "compiler.codegen"
+)
+
+// Extension-layer sentinel errors. Wrap them with ExtensionError to attach the
+// offending extension and operation.
+var (
+	ErrPermissionDenied  = errors.New("wago: permission denied")
+	ErrMissingImport     = errors.New("wago: missing import")
+	ErrInvalidHandle     = errors.New("wago: invalid handle")
+	ErrExtensionConflict = errors.New("wago: extension conflict")
+)
+
+// ExtensionError attributes a failure to a specific extension and operation while
+// preserving the underlying error for errors.Is/As.
+type ExtensionError struct {
+	Extension string
+	Operation string
+	Err       error
+}
+
+func (e *ExtensionError) Error() string {
+	return fmt.Sprintf("wago extension %s: %s: %v", e.Extension, e.Operation, e.Err)
+}
+
+func (e *ExtensionError) Unwrap() error { return e.Err }

--- a/src/wago/extension.go
+++ b/src/wago/extension.go
@@ -1,9 +1,6 @@
 package wago
 
-import (
-	"errors"
-	"fmt"
-)
+import "fmt"
 
 // Version is the wago runtime version, compared against an extension's MinWago at
 // Use time so a runtime rejects an extension that needs a newer host.
@@ -59,13 +56,20 @@ const (
 	CapCompilerCodegen Capability = "compiler.codegen"
 )
 
+// extErr is a comparable, constant error type so the extension-layer sentinels
+// can be package-level consts (the root facade re-exports consts but not vars)
+// while still working with errors.Is.
+type extErr string
+
+func (e extErr) Error() string { return string(e) }
+
 // Extension-layer sentinel errors. Wrap them with ExtensionError to attach the
-// offending extension and operation.
-var (
-	ErrPermissionDenied  = errors.New("wago: permission denied")
-	ErrMissingImport     = errors.New("wago: missing import")
-	ErrInvalidHandle     = errors.New("wago: invalid handle")
-	ErrExtensionConflict = errors.New("wago: extension conflict")
+// offending extension and operation; match them with errors.Is.
+const (
+	ErrPermissionDenied  = extErr("wago: permission denied")
+	ErrMissingImport     = extErr("wago: missing import")
+	ErrInvalidHandle     = extErr("wago: invalid handle")
+	ErrExtensionConflict = extErr("wago: extension conflict")
 )
 
 // ExtensionError attributes a failure to a specific extension and operation while

--- a/src/wago/hooks.go
+++ b/src/wago/hooks.go
@@ -1,0 +1,43 @@
+package wago
+
+// HookRegistry collects lifecycle callbacks contributed by extensions. Phase 1
+// wires the runtime-lifecycle and instantiate hooks (the points the Runtime
+// itself drives); compile, invoke, and process hooks are added in later phases.
+type HookRegistry struct {
+	onRuntimeClose    []func(*RuntimeContext)
+	beforeInstantiate []func(*InstantiateContext) error
+	afterInstantiate  []func(*InstantiateContext, *Instance) error
+}
+
+// OnRuntimeClose registers a callback run when the runtime is closed, in reverse
+// registration order (last registered runs first), so extensions tear down after
+// the ones that depend on them.
+func (h *HookRegistry) OnRuntimeClose(fns ...func(*RuntimeContext)) {
+	h.onRuntimeClose = append(h.onRuntimeClose, fns...)
+}
+
+// BeforeInstantiate registers a callback run before each Instantiate. Returning
+// an error aborts instantiation.
+func (h *HookRegistry) BeforeInstantiate(fns ...func(*InstantiateContext) error) {
+	h.beforeInstantiate = append(h.beforeInstantiate, fns...)
+}
+
+// AfterInstantiate registers a callback run after each successful Instantiate.
+func (h *HookRegistry) AfterInstantiate(fns ...func(*InstantiateContext, *Instance) error) {
+	h.afterInstantiate = append(h.afterInstantiate, fns...)
+}
+
+// RuntimeContext is passed to runtime-lifecycle hooks.
+type RuntimeContext struct {
+	Runtime *Runtime
+}
+
+// InstantiateContext is passed to instantiate hooks. Imports is the fully merged
+// import namespace (extension-provided plus any per-call additions). Metadata is
+// scratch space extensions may use to carry state from Before to After.
+type InstantiateContext struct {
+	Runtime  *Runtime
+	Compiled *Compiled
+	Imports  Imports
+	Metadata map[string]any
+}

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -1,0 +1,109 @@
+package wago
+
+// Registry is the builder surface an extension uses inside Register. It records
+// the capabilities, host imports, and hooks the extension contributes; the
+// runtime reads the recorded state after Register returns and wires it in.
+type Registry struct {
+	info    ExtensionInfo
+	caps    []capabilitySpec
+	imports []*registeredImport
+	hooks   *HookRegistry
+}
+
+// capabilitySpec is a declared capability plus optional docs.
+type capabilitySpec struct {
+	cap  Capability
+	docs string
+}
+
+// registeredImport is one host function an extension exposes to guests, keyed by
+// its wasm ("module", "name"). params/results are the declared signature (used
+// for the manifest and later validation); the actual binding uses the importing
+// module's own signature. fn is a SyncHostFunc, the legacy HostFunc, or a native
+// Go function — the same shapes Instantiate already accepts.
+type registeredImport struct {
+	module  string
+	name    string
+	fn      any
+	params  []ValType
+	results []ValType
+	cap     Capability
+	hasCap  bool
+	docs    string
+}
+
+func (i *registeredImport) key() string { return i.module + "." + i.name }
+
+// Capability declares that this extension provides cap. A policy can then allow
+// or deny it, and inspection surfaces it to users.
+func (r *Registry) Capability(cap Capability, opts ...CapabilityOption) {
+	spec := capabilitySpec{cap: cap}
+	for _, opt := range opts {
+		opt(&spec)
+	}
+	r.caps = append(r.caps, spec)
+}
+
+// CapabilityOption configures a declared capability.
+type CapabilityOption func(*capabilitySpec)
+
+// CapabilityDocs attaches a human description to a capability declaration.
+func CapabilityDocs(docs string) CapabilityOption {
+	return func(s *capabilitySpec) { s.docs = docs }
+}
+
+// ImportModule begins declaring host imports under a wasm import module name
+// (e.g. "wago_timer"). Call Func on the returned builder for each function.
+func (r *Registry) ImportModule(name string) *ImportModuleBuilder {
+	return &ImportModuleBuilder{reg: r, module: name}
+}
+
+// Hooks returns the hook registry for observing runtime and instance lifecycle.
+func (r *Registry) Hooks() *HookRegistry { return r.hooks }
+
+// ImportModuleBuilder scopes host-import declarations to one wasm module name.
+type ImportModuleBuilder struct {
+	reg    *Registry
+	module string
+}
+
+// Func declares a host function named `name` in this module. fn may be a
+// SyncHostFunc, a HostFunc, or a native Go function whose numeric signature
+// matches the importing module's declared type. Chain Params/Results/Capability
+// on the returned builder to record the signature and required capability.
+func (m *ImportModuleBuilder) Func(name string, fn any) *ImportFuncBuilder {
+	imp := &registeredImport{module: m.module, name: name, fn: fn}
+	m.reg.imports = append(m.reg.imports, imp)
+	return &ImportFuncBuilder{imp: imp}
+}
+
+// ImportFuncBuilder records the declared signature and metadata of one host
+// import. The methods mutate the import in place and return the builder for
+// chaining.
+type ImportFuncBuilder struct {
+	imp *registeredImport
+}
+
+// Params records the host function's wasm parameter types.
+func (f *ImportFuncBuilder) Params(types ...ValType) *ImportFuncBuilder {
+	f.imp.params = append(f.imp.params[:0], types...)
+	return f
+}
+
+// Results records the host function's wasm result types.
+func (f *ImportFuncBuilder) Results(types ...ValType) *ImportFuncBuilder {
+	f.imp.results = append(f.imp.results[:0], types...)
+	return f
+}
+
+// Capability records the capability a guest must hold to call this import.
+func (f *ImportFuncBuilder) Capability(cap Capability) *ImportFuncBuilder {
+	f.imp.cap, f.imp.hasCap = cap, true
+	return f
+}
+
+// Docs attaches a human description used by manifest/CLI inspection.
+func (f *ImportFuncBuilder) Docs(docs string) *ImportFuncBuilder {
+	f.imp.docs = docs
+	return f
+}

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -1,0 +1,343 @@
+package wago
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// ImportOverridePolicy controls whether later registrations may replace earlier
+// import bindings.
+type ImportOverridePolicy int
+
+const (
+	// NoExtensionOverrides is the default: extension import namespaces must be
+	// unique, and per-call imports may not replace a reserved wago_* module.
+	NoExtensionOverrides ImportOverridePolicy = iota
+	// AllowTestOverrides relaxes both rules, for tests that need to stub a
+	// reserved module or a previously-registered import.
+	AllowTestOverrides
+)
+
+// reservedModules are the wago_* import namespaces the built-in extensions own.
+// A per-call import may not shadow one unless the override policy allows it.
+var reservedModules = map[string]struct{}{
+	"wago_process": {}, "wago_mailbox": {}, "wago_timer": {}, "wago_metrics": {},
+	"wago_log": {}, "wago_fs": {}, "wago_net": {}, "wago_http": {}, "wago_kv": {},
+	"wago_crypto": {}, "wago_debug": {}, "wago_runtime": {},
+}
+
+// Runtime is the high-level entry point: extensions register capabilities and
+// host imports into it, and it threads those through Compile/Instantiate. The
+// package-level Compile/Instantiate remain available as the low-level API.
+type Runtime struct {
+	mu             sync.Mutex
+	cfg            *RuntimeConfig
+	overridePolicy ImportOverridePolicy
+	hooks          *HookRegistry
+
+	exts        []ExtensionInfo
+	imports     Imports           // "module.name" -> host fn (any)
+	importOwner map[string]string // "module.name" -> owning extension ID
+	moduleOwner map[string]string // import module -> owning extension ID
+	caps        map[Capability]string
+	capOrder    []Capability
+	closed      bool
+}
+
+// RuntimeOption configures a Runtime at construction.
+type RuntimeOption func(*Runtime)
+
+// WithRuntimeConfig sets the compile/instantiate configuration (feature gating,
+// bounds-check mode). Defaults to NewRuntimeConfig.
+func WithRuntimeConfig(cfg *RuntimeConfig) RuntimeOption {
+	return func(rt *Runtime) { rt.cfg = cfg }
+}
+
+// WithImportOverridePolicy sets how import collisions are resolved.
+func WithImportOverridePolicy(p ImportOverridePolicy) RuntimeOption {
+	return func(rt *Runtime) { rt.overridePolicy = p }
+}
+
+// NewRuntime creates a runtime with no extensions registered.
+func NewRuntime(opts ...RuntimeOption) *Runtime {
+	rt := &Runtime{
+		cfg:         NewRuntimeConfig(),
+		hooks:       &HookRegistry{},
+		imports:     Imports{},
+		importOwner: map[string]string{},
+		moduleOwner: map[string]string{},
+		caps:        map[Capability]string{},
+	}
+	for _, opt := range opts {
+		opt(rt)
+	}
+	if rt.cfg == nil {
+		rt.cfg = NewRuntimeConfig()
+	}
+	return rt
+}
+
+// UseOption reserved for per-registration configuration (none yet).
+type UseOption func(*useConfig)
+
+type useConfig struct{}
+
+// Use registers an extension: it runs the extension's Register, checks version
+// compatibility, and merges the declared capabilities and host imports. Import
+// collisions are rejected per the runtime's override policy, leaving the runtime
+// unchanged on error.
+func (rt *Runtime) Use(ext Extension, _ ...UseOption) error {
+	if ext == nil {
+		return fmt.Errorf("wago: Use: nil extension")
+	}
+	info := ext.Info()
+	if info.ID == "" {
+		return fmt.Errorf("wago: Use: extension has no ID")
+	}
+	if info.MinWago != "" && compareVersions(info.MinWago, Version) > 0 {
+		return &ExtensionError{Extension: info.ID, Operation: "use",
+			Err: fmt.Errorf("requires wago >= %s, have %s", info.MinWago, Version)}
+	}
+
+	// Register into a scratch registry so a failure leaves the runtime untouched.
+	reg := &Registry{info: info, hooks: rt.hooks}
+	if err := ext.Register(reg); err != nil {
+		return &ExtensionError{Extension: info.ID, Operation: "register", Err: err}
+	}
+
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.closed {
+		return fmt.Errorf("wago: Use on a closed runtime")
+	}
+	for _, id := range rt.exts {
+		if id.ID == info.ID {
+			return &ExtensionError{Extension: info.ID, Operation: "use", Err: ErrExtensionConflict}
+		}
+	}
+	// Validate all imports before mutating any runtime state.
+	for _, imp := range reg.imports {
+		if imp.fn == nil {
+			return &ExtensionError{Extension: info.ID, Operation: "register",
+				Err: fmt.Errorf("import %q has no function", imp.key())}
+		}
+		if owner, ok := rt.moduleOwner[imp.module]; ok && owner != info.ID && rt.overridePolicy != AllowTestOverrides {
+			return &ExtensionError{Extension: info.ID, Operation: "register",
+				Err: fmt.Errorf("import module %q already owned by extension %q: %w", imp.module, owner, ErrExtensionConflict)}
+		}
+		if owner, ok := rt.importOwner[imp.key()]; ok && owner != info.ID && rt.overridePolicy != AllowTestOverrides {
+			return &ExtensionError{Extension: info.ID, Operation: "register",
+				Err: fmt.Errorf("import %q already provided by extension %q: %w", imp.key(), owner, ErrExtensionConflict)}
+		}
+	}
+
+	// Commit.
+	for _, imp := range reg.imports {
+		rt.imports[imp.key()] = imp.fn
+		rt.importOwner[imp.key()] = info.ID
+		rt.moduleOwner[imp.module] = info.ID
+	}
+	for _, spec := range reg.caps {
+		if _, ok := rt.caps[spec.cap]; !ok {
+			rt.capOrder = append(rt.capOrder, spec.cap)
+		}
+		rt.caps[spec.cap] = info.ID
+	}
+	rt.exts = append(rt.exts, info)
+	return nil
+}
+
+// Compile compiles a wasm module under the runtime's configuration.
+func (rt *Runtime) Compile(wasmBytes []byte) (*Compiled, error) {
+	return CompileWithConfig(rt.cfg, wasmBytes)
+}
+
+// InstantiateOption configures a single Instantiate call.
+type InstantiateOption func(*instantiateConfig)
+
+type instantiateConfig struct {
+	imports Imports
+	gc      GCConfig
+	hasGC   bool
+}
+
+// WithImports adds per-call imports on top of the extension-provided namespace.
+// A per-call import may not shadow a reserved wago_* module unless the runtime's
+// override policy is AllowTestOverrides.
+func WithImports(im Imports) InstantiateOption {
+	return func(c *instantiateConfig) {
+		if c.imports == nil {
+			c.imports = Imports{}
+		}
+		for k, v := range im {
+			c.imports[k] = v
+		}
+	}
+}
+
+// WithGC sets the GC configuration for this instance.
+func WithGC(gc GCConfig) InstantiateOption {
+	return func(c *instantiateConfig) { c.gc, c.hasGC = gc, true }
+}
+
+// Instantiate instantiates a compiled module, wiring the runtime's extension
+// imports plus any per-call imports. ctx is accepted for forward compatibility
+// with the context-aware instance API and cancellation; it is honored for
+// cancellation before the (synchronous) instantiate work begins.
+func (rt *Runtime) Instantiate(ctx context.Context, c *Compiled, opts ...InstantiateOption) (*Instance, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var cfg instantiateConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	rt.mu.Lock()
+	if rt.closed {
+		rt.mu.Unlock()
+		return nil, fmt.Errorf("wago: Instantiate on a closed runtime")
+	}
+	// Merge extension imports first, then per-call imports on top.
+	merged := make(Imports, len(rt.imports)+len(cfg.imports))
+	for k, v := range rt.imports {
+		merged[k] = v
+	}
+	policy := rt.overridePolicy
+	rt.mu.Unlock()
+
+	for k, v := range cfg.imports {
+		if module := importModule(k); isReserved(module) && policy != AllowTestOverrides {
+			if _, provided := merged[k]; provided {
+				return nil, fmt.Errorf("wago: import %q may not override reserved module %q", k, module)
+			}
+		}
+		merged[k] = v
+	}
+
+	hctx := &InstantiateContext{Runtime: rt, Compiled: c, Imports: merged, Metadata: map[string]any{}}
+	for _, fn := range rt.hooks.beforeInstantiate {
+		if err := fn(hctx); err != nil {
+			return nil, err
+		}
+	}
+
+	iopts := InstantiateOptions{Imports: merged}
+	if cfg.hasGC {
+		iopts.GC = cfg.gc
+	}
+	inst, err := InstantiateWithOptions(c, iopts)
+	if err != nil {
+		return nil, err
+	}
+	for _, fn := range rt.hooks.afterInstantiate {
+		if err := fn(hctx, inst); err != nil {
+			inst.Close()
+			return nil, err
+		}
+	}
+	return inst, nil
+}
+
+// Extensions returns the registered extensions in registration order.
+func (rt *Runtime) Extensions() []ExtensionInfo {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return append([]ExtensionInfo(nil), rt.exts...)
+}
+
+// Capabilities returns the capabilities declared by registered extensions,
+// sorted.
+func (rt *Runtime) Capabilities() []Capability {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	caps := append([]Capability(nil), rt.capOrder...)
+	sort.Slice(caps, func(i, j int) bool { return caps[i] < caps[j] })
+	return caps
+}
+
+// Close runs runtime-close hooks (in reverse registration order) and marks the
+// runtime unusable. It does not close instances the caller still holds.
+func (rt *Runtime) Close() error {
+	rt.mu.Lock()
+	if rt.closed {
+		rt.mu.Unlock()
+		return nil
+	}
+	rt.closed = true
+	hooks := rt.hooks.onRuntimeClose
+	rt.mu.Unlock()
+
+	rctx := &RuntimeContext{Runtime: rt}
+	for i := len(hooks) - 1; i >= 0; i-- {
+		hooks[i](rctx)
+	}
+	return nil
+}
+
+// importModule returns the module part of a "module.name" import key (up to the
+// first dot), matching how Compile builds the key.
+func importModule(key string) string {
+	for i := 0; i < len(key); i++ {
+		if key[i] == '.' {
+			return key[:i]
+		}
+	}
+	return key
+}
+
+func isReserved(module string) bool {
+	_, ok := reservedModules[module]
+	return ok
+}
+
+// compareVersions does a numeric dotted-version compare (e.g. "0.2.0" > "0.1.9").
+// Non-numeric or ragged components compare lexically / by presence. It returns
+// -1, 0, or 1.
+func compareVersions(a, b string) int {
+	as, bs := splitVersion(a), splitVersion(b)
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var av, bv int
+		if i < len(as) {
+			av = as[i]
+		}
+		if i < len(bs) {
+			bv = bs[i]
+		}
+		if av != bv {
+			if av < bv {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+func splitVersion(v string) []int {
+	var out []int
+	cur, has := 0, false
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c >= '0' && c <= '9' {
+			cur, has = cur*10+int(c-'0'), true
+			continue
+		}
+		if c == '.' {
+			out = append(out, cur)
+			cur, has = 0, false
+			continue
+		}
+		// Stop at the first non-numeric, non-dot char (e.g. a pre-release suffix).
+		break
+	}
+	if has || len(out) == 0 {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -1,0 +1,206 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// tripleExt is a minimal extension that provides env.f(i32)->i32 = 3*x, declares
+// a capability, and (optionally) records an instantiate hook.
+type tripleExt struct {
+	minWago       string
+	onInstantiate func()
+}
+
+func (e tripleExt) Info() ExtensionInfo {
+	return ExtensionInfo{ID: "test.triple", Name: "Triple", Version: "1.0.0", MinWago: e.minWago, Stability: Stable}
+}
+
+func (e tripleExt) Register(reg *Registry) error {
+	reg.Capability(CapMetricsWrite, CapabilityDocs("demo capability"))
+	reg.ImportModule("env").
+		Func("f", func(x int32) int32 { return x * 3 }).
+		Params(ValI32).Results(ValI32).Capability(CapMetricsWrite)
+	if e.onInstantiate != nil {
+		reg.Hooks().AfterInstantiate(func(_ *InstantiateContext, _ *Instance) error {
+			e.onInstantiate()
+			return nil
+		})
+	}
+	return nil
+}
+
+// callsEnvF compiles a module: import env.f(i32)->i32, export g(x)=env.f(x).
+func callsEnvF(t *testing.T, rt *Runtime) *Compiled {
+	t.Helper()
+	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b} // local.get 0; call 0; end
+	c, err := rt.Compile(returningImportModule(sig, body))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return c
+}
+
+func TestRuntimeUseAndInvoke(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	c := callsEnvF(t, rt)
+	in, err := rt.Instantiate(context.Background(), c)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	res, err := in.Invoke("g", I32(7))
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if AsI32(res[0]) != 21 {
+		t.Fatalf("g(7) = %d, want 21", AsI32(res[0]))
+	}
+}
+
+func TestRuntimeInspection(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	if exts := rt.Extensions(); len(exts) != 1 || exts[0].ID != "test.triple" {
+		t.Fatalf("Extensions() = %+v", exts)
+	}
+	caps := rt.Capabilities()
+	if len(caps) != 1 || caps[0] != CapMetricsWrite {
+		t.Fatalf("Capabilities() = %v", caps)
+	}
+}
+
+func TestRuntimeAfterInstantiateHook(t *testing.T) {
+	fired := 0
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{onInstantiate: func() { fired++ }}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	c := callsEnvF(t, rt)
+	in, err := rt.Instantiate(context.Background(), c)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	in.Close()
+	if fired != 1 {
+		t.Fatalf("AfterInstantiate fired %d times, want 1", fired)
+	}
+}
+
+func TestRuntimeDuplicateExtension(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	err := rt.Use(tripleExt{})
+	if !errors.Is(err, ErrExtensionConflict) {
+		t.Fatalf("duplicate Use error = %v, want ErrExtensionConflict", err)
+	}
+}
+
+// otherEnvExt claims module "env" under a different extension ID.
+type otherEnvExt struct{}
+
+func (otherEnvExt) Info() ExtensionInfo {
+	return ExtensionInfo{ID: "test.other", Version: "1.0.0", Stability: Stable}
+}
+func (otherEnvExt) Register(reg *Registry) error {
+	reg.ImportModule("env").Func("f", func(x int32) int32 { return x }).Params(ValI32).Results(ValI32)
+	return nil
+}
+
+func TestRuntimeImportModuleCollision(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	err := rt.Use(otherEnvExt{})
+	if !errors.Is(err, ErrExtensionConflict) {
+		t.Fatalf("colliding module Use error = %v, want ErrExtensionConflict", err)
+	}
+	// The failed Use must not have registered the extension.
+	if len(rt.Extensions()) != 1 {
+		t.Fatalf("failed Use left %d extensions registered", len(rt.Extensions()))
+	}
+}
+
+func TestRuntimeMinWagoTooNew(t *testing.T) {
+	rt := NewRuntime()
+	err := rt.Use(tripleExt{minWago: "999.0.0"})
+	if err == nil {
+		t.Fatal("expected version-incompatibility error")
+	}
+}
+
+// timerLikeExt provides a reserved wago_timer module, to test user override
+// protection.
+type timerLikeExt struct{}
+
+func (timerLikeExt) Info() ExtensionInfo {
+	return ExtensionInfo{ID: "wago.timer", Version: "1.0.0", Stability: Stable}
+}
+func (timerLikeExt) Register(reg *Registry) error {
+	reg.ImportModule("wago_timer").Func("now", func() int64 { return 0 }).Results(ValI64)
+	return nil
+}
+
+func TestReservedModuleUserOverrideRejected(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(timerLikeExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	// A module importing wago_timer.now, exported g()=now().
+	sig := wasmtest.FuncType(nil, []wasm.ValType{wasm.I64})
+	body := []byte{0x00, 0x10, 0x00, 0x0b} // call 0; end
+	imp := append(append(wasmtest.Name("wago_timer"), wasmtest.Name("now")...), 0x00, 0x00)
+	fnBody := append(wasmtest.ULEB(uint32(len(body))), body...)
+	mod := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(sig)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("g", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(fnBody)),
+	)
+	c, err := rt.Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	_, err = rt.Instantiate(context.Background(), c,
+		WithImports(Imports{"wago_timer.now": SyncHostFunc(func(_ HostModule, _, r []uint64) { r[0] = 99 })}))
+	if err == nil {
+		t.Fatal("expected reserved-module override to be rejected")
+	}
+
+	// With AllowTestOverrides the same override is permitted.
+	rt2 := NewRuntime(WithImportOverridePolicy(AllowTestOverrides))
+	if err := rt2.Use(timerLikeExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	c2, err := rt2.Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := rt2.Instantiate(context.Background(), c2,
+		WithImports(Imports{"wago_timer.now": SyncHostFunc(func(_ HostModule, _, r []uint64) { r[0] = 99 })}))
+	if err != nil {
+		t.Fatalf("instantiate with override: %v", err)
+	}
+	defer in.Close()
+	res, err := in.Invoke("g")
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if AsI64(res[0]) != 99 {
+		t.Fatalf("g() = %d, want 99 (overridden)", AsI64(res[0]))
+	}
+}

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -23,7 +23,7 @@ func (e tripleExt) Info() ExtensionInfo {
 func (e tripleExt) Register(reg *Registry) error {
 	reg.Capability(CapMetricsWrite, CapabilityDocs("demo capability"))
 	reg.ImportModule("env").
-		Func("f", func(x int32) int32 { return x * 3 }).
+		Func("f", SyncHostFunc(func(_ HostModule, p, r []uint64) { r[0] = I32(AsI32(p[0]) * 3) })).
 		Params(ValI32).Results(ValI32).Capability(CapMetricsWrite)
 	if e.onInstantiate != nil {
 		reg.Hooks().AfterInstantiate(func(_ *InstantiateContext, _ *Instance) error {
@@ -115,7 +115,9 @@ func (otherEnvExt) Info() ExtensionInfo {
 	return ExtensionInfo{ID: "test.other", Version: "1.0.0", Stability: Stable}
 }
 func (otherEnvExt) Register(reg *Registry) error {
-	reg.ImportModule("env").Func("f", func(x int32) int32 { return x }).Params(ValI32).Results(ValI32)
+	reg.ImportModule("env").
+		Func("f", SyncHostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] })).
+		Params(ValI32).Results(ValI32)
 	return nil
 }
 
@@ -150,7 +152,9 @@ func (timerLikeExt) Info() ExtensionInfo {
 	return ExtensionInfo{ID: "wago.timer", Version: "1.0.0", Stability: Stable}
 }
 func (timerLikeExt) Register(reg *Registry) error {
-	reg.ImportModule("wago_timer").Func("now", func() int64 { return 0 }).Results(ValI64)
+	reg.ImportModule("wago_timer").
+		Func("now", SyncHostFunc(func(_ HostModule, _, r []uint64) { r[0] = 0 })).
+		Results(ValI64)
 	return nil
 }
 

--- a/wago.go
+++ b/wago.go
@@ -12,11 +12,16 @@ import impl "github.com/wago-org/wago/src/wago"
 
 type (
 	BoundsCheckMode           = impl.BoundsCheckMode
+	Capability                = impl.Capability
+	CapabilityOption          = impl.CapabilityOption
 	Compiled                  = impl.Compiled
 	CoreFeatures              = impl.CoreFeatures
 	DataInit                  = impl.DataInit
 	ElemInit                  = impl.ElemInit
 	ExitError                 = impl.ExitError
+	Extension                 = impl.Extension
+	ExtensionError            = impl.ExtensionError
+	ExtensionInfo             = impl.ExtensionInfo
 	FuncSig                   = impl.FuncSig
 	GCAllocatorKind           = impl.GCAllocatorKind
 	GCConfig                  = impl.GCConfig
@@ -27,28 +32,54 @@ type (
 	GlobalImport              = impl.GlobalImport
 	GlobalImportDef           = impl.GlobalImportDef
 	GuardPageUnavailableError = impl.GuardPageUnavailableError
+	HookRegistry              = impl.HookRegistry
 	HostExit                  = impl.HostExit
 	HostFunc                  = impl.HostFunc
 	HostModule                = impl.HostModule
+	ImportFuncBuilder         = impl.ImportFuncBuilder
+	ImportModuleBuilder       = impl.ImportModuleBuilder
+	ImportOverridePolicy      = impl.ImportOverridePolicy
 	Imports                   = impl.Imports
 	Instance                  = impl.Instance
 	InstanceExport            = impl.InstanceExport
+	InstantiateContext        = impl.InstantiateContext
+	InstantiateOption         = impl.InstantiateOption
 	InstantiateOptions        = impl.InstantiateOptions
 	Memory                    = impl.Memory
 	OffsetInit                = impl.OffsetInit
+	Registry                  = impl.Registry
+	Runtime                   = impl.Runtime
 	RuntimeConfig             = impl.RuntimeConfig
+	RuntimeContext            = impl.RuntimeContext
+	RuntimeOption             = impl.RuntimeOption
+	Stability                 = impl.Stability
 	SyncHostFunc              = impl.SyncHostFunc
 	Table                     = impl.Table
 	TrapCode                  = impl.TrapCode
 	TrapError                 = impl.TrapError
 	UnsupportedFeatureError   = impl.UnsupportedFeatureError
+	UseOption                 = impl.UseOption
 	ValType                   = impl.ValType
 	WASIConfig                = impl.WASIConfig
 )
 
 const (
+	AllowTestOverrides                         = impl.AllowTestOverrides
 	BoundsChecksExplicit                       = impl.BoundsChecksExplicit
 	BoundsChecksSignalsBased                   = impl.BoundsChecksSignalsBased
+	CapCompilerCodegen                         = impl.CapCompilerCodegen
+	CapFilesystemRead                          = impl.CapFilesystemRead
+	CapFilesystemWrite                         = impl.CapFilesystemWrite
+	CapHTTPClient                              = impl.CapHTTPClient
+	CapKVRead                                  = impl.CapKVRead
+	CapKVWrite                                 = impl.CapKVWrite
+	CapMailboxReceive                          = impl.CapMailboxReceive
+	CapMailboxSend                             = impl.CapMailboxSend
+	CapMetricsWrite                            = impl.CapMetricsWrite
+	CapNetworkOutbound                         = impl.CapNetworkOutbound
+	CapProcessKill                             = impl.CapProcessKill
+	CapProcessSpawn                            = impl.CapProcessSpawn
+	CapTimerRead                               = impl.CapTimerRead
 	CoreFeatureBulkMemoryOperations            = impl.CoreFeatureBulkMemoryOperations
 	CoreFeatureMultiValue                      = impl.CoreFeatureMultiValue
 	CoreFeatureMutableGlobal                   = impl.CoreFeatureMutableGlobal
@@ -59,12 +90,20 @@ const (
 	CoreFeatureTailCall                        = impl.CoreFeatureTailCall
 	CoreFeaturesV1                             = impl.CoreFeaturesV1
 	CoreFeaturesV2                             = impl.CoreFeaturesV2
+	Deprecated                                 = impl.Deprecated
+	ErrExtensionConflict                       = impl.ErrExtensionConflict
+	ErrInvalidHandle                           = impl.ErrInvalidHandle
+	ErrMissingImport                           = impl.ErrMissingImport
+	ErrPermissionDenied                        = impl.ErrPermissionDenied
+	Experimental                               = impl.Experimental
 	GCAllocatorPagedSizeClass                  = impl.GCAllocatorPagedSizeClass
 	GCAllocatorTinyFixedBlock                  = impl.GCAllocatorTinyFixedBlock
 	GCProfileThroughput                        = impl.GCProfileThroughput
 	GCProfileTiny                              = impl.GCProfileTiny
 	GCRuntimeGenerational                      = impl.GCRuntimeGenerational
 	GCRuntimeIncrementalMarkSweep              = impl.GCRuntimeIncrementalMarkSweep
+	NoExtensionOverrides                       = impl.NoExtensionOverrides
+	Stable                                     = impl.Stable
 	TrapBuiltin                                = impl.TrapBuiltin
 	TrapCalledFnNotLinked                      = impl.TrapCalledFnNotLinked
 	TrapDivOverflow                            = impl.TrapDivOverflow
@@ -85,6 +124,7 @@ const (
 	ValI32                                     = impl.ValI32
 	ValI64                                     = impl.ValI64
 	ValV128                                    = impl.ValV128
+	Version                                    = impl.Version
 )
 
 func AsF32(b uint64) float32 { return impl.AsF32(b) }
@@ -94,6 +134,8 @@ func AsF64(b uint64) float64 { return impl.AsF64(b) }
 func AsI32(b uint64) int32 { return impl.AsI32(b) }
 
 func AsI64(b uint64) int64 { return impl.AsI64(b) }
+
+func CapabilityDocs(docs string) CapabilityOption { return impl.CapabilityDocs(docs) }
 
 func Compile(wasmBytes []byte) (*Compiled, error) { return impl.Compile(wasmBytes) }
 
@@ -139,6 +181,8 @@ func NewMemory(minPages uint32, maxPages uint32) (*Memory, error) {
 	return impl.NewMemory(minPages, maxPages)
 }
 
+func NewRuntime(opts ...RuntimeOption) *Runtime { return impl.NewRuntime(opts...) }
+
 func NewRuntimeConfig() *RuntimeConfig { return impl.NewRuntimeConfig() }
 
 func NewTable(minSize uint32, maxSize uint32) (*Table, error) { return impl.NewTable(minSize, maxSize) }
@@ -146,3 +190,13 @@ func NewTable(minSize uint32, maxSize uint32) (*Table, error) { return impl.NewT
 func SupportedFeatures() CoreFeatures { return impl.SupportedFeatures() }
 
 func WASI(cfg WASIConfig) Imports { return impl.WASI(cfg) }
+
+func WithGC(gc GCConfig) InstantiateOption { return impl.WithGC(gc) }
+
+func WithImportOverridePolicy(p ImportOverridePolicy) RuntimeOption {
+	return impl.WithImportOverridePolicy(p)
+}
+
+func WithImports(im Imports) InstantiateOption { return impl.WithImports(im) }
+
+func WithRuntimeConfig(cfg *RuntimeConfig) RuntimeOption { return impl.WithRuntimeConfig(cfg) }


### PR DESCRIPTION
Phase 1 of the extension/plugin API in `docs/plugin-api-plan.md` — the spine.

## What's here
- `extension.go` — `Extension` interface (`Info()`/`Register(*Registry)`), `ExtensionInfo`, `Stability`, `Capability` constants, `ExtensionError` + sentinels, `Version`.
- `registry.go` — `Registry` builder: `Capability(...)`, `ImportModule(name).Func(name, fn).Params/Results/Capability/Docs`, `Hooks()`.
- `hooks.go` — `HookRegistry` + context objects (phase 1 wires runtime-close + before/after-instantiate; invoke/compile/process hooks land in later phases).
- `runtime.go` — `NewRuntime`, `Use`, `Compile`, context-aware `Instantiate`, `Extensions`, `Capabilities`, `Close`. Import-collision rules (reserved `wago_*` modules, unique per-extension module ownership, `AllowTestOverrides` escape hatch). Merges extension host imports into the existing `Imports` map and threads them through `InstantiateWithOptions`.
- `docs/plugin-api-plan.md` — the full 9-phase design.

The package-level `Compile`/`Instantiate` low-level API is unchanged; this is a purely additive higher layer.

## Verification
- `go test ./src/wago` — PASS (7 new tests: end-to-end use→compile→instantiate→invoke, inspection, instantiate hook, duplicate/module-collision conflicts, MinWago rejection, reserved-module override both ways).
- `go build ./...`, `go vet ./src/wago` — clean.
- Runtime files use no reflection (TinyGo-safe).