### PR TITLE
feat(wago): runtime wrappers — Module + typed Value + context-aware Call (plugin-api phase 2)

### DIFF
--- a/src/wago/hooks.go
+++ b/src/wago/hooks.go
@@ -37,6 +37,7 @@ type RuntimeContext struct {
 // scratch space extensions may use to carry state from Before to After.
 type InstantiateContext struct {
 	Runtime  *Runtime
+	Module   *Module
 	Compiled *Compiled
 	Imports  Imports
 	Metadata map[string]any

--- a/src/wago/instance_call.go
+++ b/src/wago/instance_call.go
@@ -1,0 +1,76 @@
+package wago
+
+import (
+	"context"
+	"fmt"
+)
+
+// Call is the high-level, context-aware, typed invocation: arguments and results
+// are typed Values checked against the export's signature. It wraps the low-level
+// Invoke (untyped uint64 slots). ctx is honored for cancellation before the call
+// begins. v128 parameters/results are not expressible as a Value; use Invoke for
+// those.
+func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]Value, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+	params, results, err := in.c.Signature(export)
+	if err != nil {
+		return nil, err
+	}
+	if len(args) != len(params) {
+		return nil, fmt.Errorf("%s expects %d arg(s), got %d", export, len(params), len(args))
+	}
+	slots := make([]uint64, len(args))
+	for i, a := range args {
+		if params[i] == ValV128 {
+			return nil, fmt.Errorf("%s param %d is v128; use Invoke for v128 values", export, i)
+		}
+		if a.typ != params[i] {
+			return nil, fmt.Errorf("%s param %d is %s, got %s", export, i, params[i], a.typ)
+		}
+		slots[i] = a.bits
+	}
+	for i, r := range results {
+		if r == ValV128 {
+			return nil, fmt.Errorf("%s result %d is v128; use Invoke for v128 values", export, i)
+		}
+	}
+	raw, err := in.Invoke(export, slots...)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Value, len(results))
+	for i, r := range results {
+		out[i] = Value{typ: r, bits: raw[i]}
+	}
+	return out, nil
+}
+
+// GlobalValue returns an exported global's current value, typed.
+func (in *Instance) GlobalValue(name string) (Value, error) {
+	bits, err := in.Global(name)
+	if err != nil {
+		return Value{}, err
+	}
+	idx, ok := in.c.GlobalExports[name]
+	if !ok || idx < 0 || idx >= len(in.c.Globals) {
+		return Value{}, fmt.Errorf("no exported global %q", name)
+	}
+	return Value{typ: in.c.Globals[idx].Type, bits: bits}, nil
+}
+
+// SetGlobalValue writes a mutable exported global, checking the value's type
+// against the global's declared type.
+func (in *Instance) SetGlobalValue(name string, v Value) error {
+	idx, ok := in.c.GlobalExports[name]
+	if !ok || idx < 0 || idx >= len(in.c.Globals) {
+		return fmt.Errorf("no exported global %q", name)
+	}
+	if want := in.c.Globals[idx].Type; v.typ != want {
+		return fmt.Errorf("global %q is %s, got %s", name, want, v.typ)
+	}
+	return in.SetGlobal(name, v.bits)
+}

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -1,0 +1,146 @@
+package wago
+
+// Module is the runtime-aware wrapper over a *Compiled: it carries the compiled
+// code plus the extension-derived view of the module (its imports, the
+// capabilities it requires, and lightweight metadata). rt.Compile returns one;
+// rt.Instantiate consumes one.
+type Module struct {
+	rt      *Runtime
+	c       *Compiled
+	imports []ImportSpec
+	reqCaps []Capability
+}
+
+// ImportKind classifies what a module imports.
+type ImportKind uint8
+
+const (
+	ImportFunc ImportKind = iota
+	ImportGlobal
+	ImportMemory
+	ImportTable
+)
+
+func (k ImportKind) String() string {
+	switch k {
+	case ImportGlobal:
+		return "global"
+	case ImportMemory:
+		return "memory"
+	case ImportTable:
+		return "table"
+	default:
+		return "func"
+	}
+}
+
+// ImportSpec describes one import a module declares, enriched (for function
+// imports) with the declared signature, required capability, and docs of the
+// extension providing it. Provided reports whether the runtime currently has a
+// binding for it.
+type ImportSpec struct {
+	Module        string
+	Name          string
+	Kind          ImportKind
+	Params        []ValType
+	Results       []ValType
+	Capability    Capability
+	HasCapability bool
+	Docs          string
+	Provided      bool
+}
+
+// Key returns the "module.name" import key.
+func (s ImportSpec) Key() string { return s.Module + "." + s.Name }
+
+// ModuleMetadata is a compact, inspectable summary of a module.
+type ModuleMetadata struct {
+	ExportedFuncs        []string
+	ExportedGlobals      []string
+	FuncImportCount      int
+	RequiredCapabilities []Capability
+}
+
+// buildModule wraps a freshly compiled module, resolving each import against the
+// runtime's registered extensions to attach signatures, capabilities, and
+// provided-state.
+func (rt *Runtime) buildModule(c *Compiled) *Module {
+	m := &Module{rt: rt, c: c}
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	capSeen := map[Capability]bool{}
+	for _, key := range c.Imports { // function imports, in "module.name" form
+		mod, name := splitImportKey(key)
+		spec := ImportSpec{Module: mod, Name: name, Kind: ImportFunc}
+		if _, ok := rt.imports[key]; ok {
+			spec.Provided = true
+		}
+		if meta := rt.importMeta[key]; meta != nil {
+			spec.Params = append([]ValType(nil), meta.params...)
+			spec.Results = append([]ValType(nil), meta.results...)
+			spec.Capability, spec.HasCapability = meta.cap, meta.hasCap
+			spec.Docs = meta.docs
+			if meta.hasCap && !capSeen[meta.cap] {
+				capSeen[meta.cap] = true
+				m.reqCaps = append(m.reqCaps, meta.cap)
+			}
+		}
+		m.imports = append(m.imports, spec)
+	}
+	for _, gi := range c.GlobalImports {
+		m.imports = append(m.imports, ImportSpec{
+			Module: gi.Module, Name: gi.Name, Kind: ImportGlobal,
+			Provided: rt.imports[gi.Module+"."+gi.Name] != nil,
+		})
+	}
+	if key, ok := c.MemoryImport(); ok {
+		mod, name := splitImportKey(key)
+		m.imports = append(m.imports, ImportSpec{Module: mod, Name: name, Kind: ImportMemory})
+	}
+	if key, ok := c.TableImport(); ok {
+		mod, name := splitImportKey(key)
+		m.imports = append(m.imports, ImportSpec{Module: mod, Name: name, Kind: ImportTable})
+	}
+	return m
+}
+
+// Compiled returns the underlying low-level compiled module.
+func (m *Module) Compiled() *Compiled { return m.c }
+
+// Exports returns the module's exported function names, sorted.
+func (m *Module) Exports() []string { return m.c.ExportedFunctions() }
+
+// Imports returns the module's declared imports with extension-derived metadata.
+func (m *Module) Imports() []ImportSpec { return append([]ImportSpec(nil), m.imports...) }
+
+// RequiredCapabilities returns the capabilities the module's function imports
+// require, deduplicated in first-seen order.
+func (m *Module) RequiredCapabilities() []Capability {
+	return append([]Capability(nil), m.reqCaps...)
+}
+
+// Metadata returns a compact summary for inspection/CLI use.
+func (m *Module) Metadata() ModuleMetadata {
+	return ModuleMetadata{
+		ExportedFuncs:        m.c.ExportedFunctions(),
+		ExportedGlobals:      m.c.ExportedGlobals(),
+		FuncImportCount:      len(m.c.Imports),
+		RequiredCapabilities: m.RequiredCapabilities(),
+	}
+}
+
+// Close releases module-level resources. The underlying compiled code is
+// reference-counted and reclaimed once its instances close, so this is currently
+// a no-op reserved for future extension-owned module state.
+func (m *Module) Close() error { return nil }
+
+// splitImportKey splits a "module.name" key at the first dot.
+func splitImportKey(key string) (module, name string) {
+	for i := 0; i < len(key); i++ {
+		if key[i] == '.' {
+			return key[:i], key[i+1:]
+		}
+	}
+	return key, ""
+}

--- a/src/wago/module_test.go
+++ b/src/wago/module_test.go
@@ -1,0 +1,139 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+func TestInstanceCallTyped(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	mod := callsEnvF(t, rt)
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	out, err := in.Call(context.Background(), "g", ValueI32(7))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if len(out) != 1 || out[0].Type() != ValI32 || out[0].I32() != 21 {
+		t.Fatalf("g(7) = %v, want i32(21)", out)
+	}
+
+	// Wrong arg type is rejected.
+	if _, err := in.Call(context.Background(), "g", ValueI64(7)); err == nil {
+		t.Fatal("expected type-mismatch error for i64 arg to i32 param")
+	}
+	// Wrong arg count is rejected.
+	if _, err := in.Call(context.Background(), "g"); err == nil {
+		t.Fatal("expected arity error")
+	}
+}
+
+func TestInstanceCallCanceledContext(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), callsEnvF(t, rt))
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := in.Call(ctx, "g", ValueI32(1)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Call with canceled ctx = %v, want context.Canceled", err)
+	}
+}
+
+func TestModuleInspection(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	mod := callsEnvF(t, rt)
+
+	imps := mod.Imports()
+	if len(imps) != 1 {
+		t.Fatalf("Imports() = %+v, want 1", imps)
+	}
+	got := imps[0]
+	if got.Module != "env" || got.Name != "f" || got.Kind != ImportFunc {
+		t.Fatalf("import spec = %+v", got)
+	}
+	if !got.Provided {
+		t.Fatal("import should be marked Provided")
+	}
+	if !got.HasCapability || got.Capability != CapMetricsWrite {
+		t.Fatalf("import capability = %v (%v)", got.Capability, got.HasCapability)
+	}
+	if len(got.Params) != 1 || got.Params[0] != ValI32 || len(got.Results) != 1 || got.Results[0] != ValI32 {
+		t.Fatalf("import signature = %v -> %v", got.Params, got.Results)
+	}
+
+	if caps := mod.RequiredCapabilities(); len(caps) != 1 || caps[0] != CapMetricsWrite {
+		t.Fatalf("RequiredCapabilities() = %v", caps)
+	}
+	meta := mod.Metadata()
+	if meta.FuncImportCount != 1 || len(meta.ExportedFuncs) != 1 || meta.ExportedFuncs[0] != "g" {
+		t.Fatalf("metadata = %+v", meta)
+	}
+}
+
+func TestInstantiateMissingImportHint(t *testing.T) {
+	rt := NewRuntime() // no extension provides env.f
+	mod := callsEnvF(t, rt)
+	_, err := rt.Instantiate(context.Background(), mod)
+	if !errors.Is(err, ErrMissingImport) {
+		t.Fatalf("missing-import error = %v, want ErrMissingImport", err)
+	}
+}
+
+// TestInstanceGlobalValueTyped exercises typed global get/set through an exported
+// mutable i64 global.
+func TestInstanceGlobalValueTyped(t *testing.T) {
+	rt := NewRuntime()
+	// module: one exported mutable i64 global = 5.
+	// globaltype i64(0x7e) mutable(0x01); init: i64.const 5 (0x42 0x05), end (0x0b).
+	glob := []byte{0x7e, 0x01, 0x42, 0x05, 0x0b}
+	mod := wasmtest.Module(
+		wasmtest.Section(6, wasmtest.Vec(glob)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("g", 3, 0))), // export kind 3 = global, index 0
+	)
+	m, err := rt.Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), m)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	v, err := in.GlobalValue("g")
+	if err != nil {
+		t.Fatalf("GlobalValue: %v", err)
+	}
+	if v.Type() != ValI64 || v.I64() != 5 {
+		t.Fatalf("global g = %v, want i64(5)", v)
+	}
+	if err := in.SetGlobalValue("g", ValueI64(42)); err != nil {
+		t.Fatalf("SetGlobalValue: %v", err)
+	}
+	if v, _ := in.GlobalValue("g"); v.I64() != 42 {
+		t.Fatalf("after set, g = %v, want i64(42)", v)
+	}
+	// Type mismatch is rejected.
+	if err := in.SetGlobalValue("g", ValueI32(1)); err == nil {
+		t.Fatal("expected type-mismatch error setting i64 global with i32")
+	}
+}

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -38,9 +38,10 @@ type Runtime struct {
 	hooks          *HookRegistry
 
 	exts        []ExtensionInfo
-	imports     Imports           // "module.name" -> host fn (any)
-	importOwner map[string]string // "module.name" -> owning extension ID
-	moduleOwner map[string]string // import module -> owning extension ID
+	imports     Imports                      // "module.name" -> host fn (any)
+	importMeta  map[string]*registeredImport // "module.name" -> declared signature/cap/docs
+	importOwner map[string]string            // "module.name" -> owning extension ID
+	moduleOwner map[string]string            // import module -> owning extension ID
 	caps        map[Capability]string
 	capOrder    []Capability
 	closed      bool
@@ -66,6 +67,7 @@ func NewRuntime(opts ...RuntimeOption) *Runtime {
 		cfg:         NewRuntimeConfig(),
 		hooks:       &HookRegistry{},
 		imports:     Imports{},
+		importMeta:  map[string]*registeredImport{},
 		importOwner: map[string]string{},
 		moduleOwner: map[string]string{},
 		caps:        map[Capability]string{},
@@ -136,6 +138,7 @@ func (rt *Runtime) Use(ext Extension, _ ...UseOption) error {
 	// Commit.
 	for _, imp := range reg.imports {
 		rt.imports[imp.key()] = imp.fn
+		rt.importMeta[imp.key()] = imp
 		rt.importOwner[imp.key()] = info.ID
 		rt.moduleOwner[imp.module] = info.ID
 	}
@@ -149,9 +152,14 @@ func (rt *Runtime) Use(ext Extension, _ ...UseOption) error {
 	return nil
 }
 
-// Compile compiles a wasm module under the runtime's configuration.
-func (rt *Runtime) Compile(wasmBytes []byte) (*Compiled, error) {
-	return CompileWithConfig(rt.cfg, wasmBytes)
+// Compile compiles a wasm module under the runtime's configuration and wraps it
+// as a *Module, resolving its imports against the registered extensions.
+func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
+	c, err := CompileWithConfig(rt.cfg, wasmBytes)
+	if err != nil {
+		return nil, err
+	}
+	return rt.buildModule(c), nil
 }
 
 // InstantiateOption configures a single Instantiate call.
@@ -182,11 +190,14 @@ func WithGC(gc GCConfig) InstantiateOption {
 	return func(c *instantiateConfig) { c.gc, c.hasGC = gc, true }
 }
 
-// Instantiate instantiates a compiled module, wiring the runtime's extension
-// imports plus any per-call imports. ctx is accepted for forward compatibility
-// with the context-aware instance API and cancellation; it is honored for
-// cancellation before the (synchronous) instantiate work begins.
-func (rt *Runtime) Instantiate(ctx context.Context, c *Compiled, opts ...InstantiateOption) (*Instance, error) {
+// Instantiate instantiates a module, wiring the runtime's extension imports plus
+// any per-call imports. ctx is honored for cancellation before the (synchronous)
+// instantiate work begins. A function import that no extension or per-call import
+// provides is reported with a hint rather than a downstream binding failure.
+func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...InstantiateOption) (*Instance, error) {
+	if mod == nil {
+		return nil, fmt.Errorf("wago: Instantiate: nil module")
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -220,7 +231,18 @@ func (rt *Runtime) Instantiate(ctx context.Context, c *Compiled, opts ...Instant
 		merged[k] = v
 	}
 
-	hctx := &InstantiateContext{Runtime: rt, Compiled: c, Imports: merged, Metadata: map[string]any{}}
+	// Surface an unsatisfied function import as a clear, actionable error before
+	// the low-level binder fails on it.
+	for _, spec := range mod.imports {
+		if spec.Kind != ImportFunc {
+			continue
+		}
+		if _, ok := merged[spec.Key()]; !ok {
+			return nil, missingImportError(spec)
+		}
+	}
+
+	hctx := &InstantiateContext{Runtime: rt, Module: mod, Compiled: mod.c, Imports: merged, Metadata: map[string]any{}}
 	for _, fn := range rt.hooks.beforeInstantiate {
 		if err := fn(hctx); err != nil {
 			return nil, err
@@ -231,7 +253,7 @@ func (rt *Runtime) Instantiate(ctx context.Context, c *Compiled, opts ...Instant
 	if cfg.hasGC {
 		iopts.GC = cfg.gc
 	}
-	inst, err := InstantiateWithOptions(c, iopts)
+	inst, err := InstantiateWithOptions(mod.c, iopts)
 	if err != nil {
 		return nil, err
 	}
@@ -294,6 +316,16 @@ func importModule(key string) string {
 func isReserved(module string) bool {
 	_, ok := reservedModules[module]
 	return ok
+}
+
+// missingImportError explains an unsatisfied function import and hints at the
+// fix, wrapping ErrMissingImport for errors.Is.
+func missingImportError(spec ImportSpec) error {
+	hint := fmt.Sprintf("provide it via WithImports or an extension that registers module %q", spec.Module)
+	if isReserved(spec.Module) {
+		hint = fmt.Sprintf("register the extension that provides %q, e.g. rt.Use(<ext>.Ext(...))", spec.Module)
+	}
+	return fmt.Errorf("module imports %q, but nothing provides it; %s: %w", spec.Key(), hint, ErrMissingImport)
 }
 
 // compareVersions does a numeric dotted-version compare (e.g. "0.2.0" > "0.1.9").

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -35,15 +35,15 @@ func (e tripleExt) Register(reg *Registry) error {
 }
 
 // callsEnvF compiles a module: import env.f(i32)->i32, export g(x)=env.f(x).
-func callsEnvF(t *testing.T, rt *Runtime) *Compiled {
+func callsEnvF(t *testing.T, rt *Runtime) *Module {
 	t.Helper()
 	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
 	body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b} // local.get 0; call 0; end
-	c, err := rt.Compile(returningImportModule(sig, body))
+	m, err := rt.Compile(returningImportModule(sig, body))
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	return c
+	return m
 }
 
 func TestRuntimeUseAndInvoke(t *testing.T) {

--- a/src/wago/value.go
+++ b/src/wago/value.go
@@ -1,0 +1,50 @@
+package wago
+
+import "fmt"
+
+// Value is a typed WebAssembly value: a ValType plus its raw bits (i32/f32 live
+// in the low 32 bits). It is the currency of the high-level, context-aware
+// Instance.Call API, where the low-level Invoke uses untyped uint64 slots. v128
+// is not representable as a single Value; the two-slot Invoke form handles it.
+type Value struct {
+	typ  ValType
+	bits uint64
+}
+
+// ValueI32/I64/F32/F64 construct a typed Value.
+func ValueI32(v int32) Value   { return Value{ValI32, I32(v)} }
+func ValueI64(v int64) Value   { return Value{ValI64, I64(v)} }
+func ValueF32(v float32) Value { return Value{ValF32, F32(v)} }
+func ValueF64(v float64) Value { return Value{ValF64, F64(v)} }
+
+// ValueOf builds a Value from raw bits interpreted per t (i32/f32 in the low 32
+// bits). It is the escape hatch for callers already holding slot bits.
+func ValueOf(t ValType, bits uint64) Value { return Value{t, bits} }
+
+// Type returns the value's WebAssembly type.
+func (v Value) Type() ValType { return v.typ }
+
+// Bits returns the raw slot bits (i32/f32 in the low 32 bits).
+func (v Value) Bits() uint64 { return v.bits }
+
+// I32/I64/F32/F64 decode the value; the result is only meaningful when Type
+// matches.
+func (v Value) I32() int32   { return AsI32(v.bits) }
+func (v Value) I64() int64   { return AsI64(v.bits) }
+func (v Value) F32() float32 { return AsF32(v.bits) }
+func (v Value) F64() float64 { return AsF64(v.bits) }
+
+func (v Value) String() string {
+	switch v.typ {
+	case ValI64:
+		return fmt.Sprintf("i64(%d)", v.I64())
+	case ValF32:
+		return fmt.Sprintf("f32(%g)", v.F32())
+	case ValF64:
+		return fmt.Sprintf("f64(%g)", v.F64())
+	case ValV128:
+		return "v128(…)"
+	default:
+		return fmt.Sprintf("i32(%d)", v.I32())
+	}
+}

--- a/wago.go
+++ b/wago.go
@@ -37,8 +37,10 @@ type (
 	HostFunc                  = impl.HostFunc
 	HostModule                = impl.HostModule
 	ImportFuncBuilder         = impl.ImportFuncBuilder
+	ImportKind                = impl.ImportKind
 	ImportModuleBuilder       = impl.ImportModuleBuilder
 	ImportOverridePolicy      = impl.ImportOverridePolicy
+	ImportSpec                = impl.ImportSpec
 	Imports                   = impl.Imports
 	Instance                  = impl.Instance
 	InstanceExport            = impl.InstanceExport
@@ -46,6 +48,8 @@ type (
 	InstantiateOption         = impl.InstantiateOption
 	InstantiateOptions        = impl.InstantiateOptions
 	Memory                    = impl.Memory
+	Module                    = impl.Module
+	ModuleMetadata            = impl.ModuleMetadata
 	OffsetInit                = impl.OffsetInit
 	Registry                  = impl.Registry
 	Runtime                   = impl.Runtime
@@ -60,6 +64,7 @@ type (
 	UnsupportedFeatureError   = impl.UnsupportedFeatureError
 	UseOption                 = impl.UseOption
 	ValType                   = impl.ValType
+	Value                     = impl.Value
 	WASIConfig                = impl.WASIConfig
 )
 
@@ -102,6 +107,10 @@ const (
 	GCProfileTiny                              = impl.GCProfileTiny
 	GCRuntimeGenerational                      = impl.GCRuntimeGenerational
 	GCRuntimeIncrementalMarkSweep              = impl.GCRuntimeIncrementalMarkSweep
+	ImportFunc                                 = impl.ImportFunc
+	ImportGlobal                               = impl.ImportGlobal
+	ImportMemory                               = impl.ImportMemory
+	ImportTable                                = impl.ImportTable
 	NoExtensionOverrides                       = impl.NoExtensionOverrides
 	Stable                                     = impl.Stable
 	TrapBuiltin                                = impl.TrapBuiltin
@@ -188,6 +197,16 @@ func NewRuntimeConfig() *RuntimeConfig { return impl.NewRuntimeConfig() }
 func NewTable(minSize uint32, maxSize uint32) (*Table, error) { return impl.NewTable(minSize, maxSize) }
 
 func SupportedFeatures() CoreFeatures { return impl.SupportedFeatures() }
+
+func ValueF32(v float32) Value { return impl.ValueF32(v) }
+
+func ValueF64(v float64) Value { return impl.ValueF64(v) }
+
+func ValueI32(v int32) Value { return impl.ValueI32(v) }
+
+func ValueI64(v int64) Value { return impl.ValueI64(v) }
+
+func ValueOf(t ValType, bits uint64) Value { return impl.ValueOf(t, bits) }
 
 func WASI(cfg WASIConfig) Imports { return impl.WASI(cfg) }
 


### PR DESCRIPTION
Phase 2 of `docs/plugin-api-plan.md` — the runtime wrappers on top of the phase-1 spine (#160).

## What's here
- **`Module`** (`module.go`) — runtime-aware wrapper over `*Compiled`. `rt.Compile` now returns `*Module`; `rt.Instantiate` takes one. Methods: `Compiled()`, `Exports()`, `Imports() []ImportSpec`, `RequiredCapabilities()`, `Metadata()`, `Close()`. `ImportSpec` enriches each import with the providing extension's declared signature, capability, docs, and a `Provided` flag; `ImportKind` classifies func/global/memory/table.
- **`Value`** (`value.go`) — a typed wasm value (`ValueI32/I64/F32/F64`, `ValueOf`, `Type()`, `Bits()`, typed accessors). The currency of the high-level API.
- **Context-aware typed invocation** (`instance_call.go`) — `Instance.Call(ctx, export, ...Value) ([]Value, error)` validates arg count/types against the signature and honors ctx cancellation. Plus typed `GlobalValue`/`SetGlobalValue`. (The low-level `Invoke(...uint64)` is unchanged; `Call` layers on top. Single package → no separate colliding `Instance` type.)
- **Good errors** — an unsatisfied function import is reported up front with an actionable hint (`missingImportError`, wraps `ErrMissingImport`) instead of a downstream binder failure.
- Instantiate hooks now also receive the `*Module`.

## Verification
- `go test ./internal/genfacade ./src/wago` — PASS (Phase 2 tests: typed Call + arg/type/arity checks, canceled-ctx, module inspection, required-capabilities, missing-import hint, typed global get/set/mismatch).
- `go build ./...`, `go vet ./src/wago` — clean.
- `tinygo test -scheduler=tasks ./src/wago` — PASS.
- Facade `wago.go` regenerated.