### PR TITLE
feat(wago/ext): built-in timer, log, metrics extensions (plugin-api phase 3)

### DIFF
--- a/src/wago/ext/exttest/exttest.go
+++ b/src/wago/ext/exttest/exttest.go
@@ -1,0 +1,57 @@
+// Package exttest builds tiny wasm modules for testing built-in extensions: a
+// guest that imports one host function and exports a no-argument "run" whose
+// body calls it. It depends only on the low-level wasm-encoding test helpers, so
+// extension packages can be tested through the public wago API alone.
+package exttest
+
+import "github.com/wago-org/wago/testutil/wasmtest"
+
+// WebAssembly value-type bytes, for describing import/run signatures without
+// importing the internal wasm package.
+const (
+	I32 byte = 0x7f
+	I64 byte = 0x7e
+	F32 byte = 0x7d
+	F64 byte = 0x7c
+)
+
+// Module builds a module that imports (impMod.impName) with signature
+// impParams->impResults, and exports "run" with signature ()->runResults whose
+// body is runBody (raw instruction bytes, ending in 0x0b). runBody is expected to
+// push any import arguments as constants and call function 0 (the import). If mem
+// is non-nil the module declares and exports a 1-page "memory" holding mem as
+// active data at offset 0.
+func Module(impMod, impName string, impParams, impResults, runResults, runBody, mem []byte) []byte {
+	ft0 := functype(impParams, impResults)                                              // import signature (type 0)
+	ft1 := functype(nil, runResults)                                                    // run signature (type 1)
+	imp := append(append(wasmtest.Name(impMod), wasmtest.Name(impName)...), 0x00, 0x00) // func, type 0
+
+	secs := [][]byte{
+		wasmtest.Section(1, wasmtest.Vec(ft0, ft1)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))), // run: one local func, type 1
+	}
+	exports := [][]byte{wasmtest.ExportEntry("run", 0, 1)} // func index 1
+	if mem != nil {
+		memType := append([]byte{0x00}, wasmtest.ULEB(1)...) // flags 0 (no max), min 1 page
+		secs = append(secs, wasmtest.Section(5, wasmtest.Vec(memType)))
+		exports = append(exports, wasmtest.ExportEntry("memory", 2, 0))
+	}
+	secs = append(secs, wasmtest.Section(7, wasmtest.Vec(exports...)))
+	secs = append(secs, wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(runBody))))
+	if mem != nil {
+		// active data segment: flags 0, offset i32.const 0, then the bytes.
+		data := append([]byte{0x00, 0x41, 0x00, 0x0b}, append(wasmtest.ULEB(uint32(len(mem))), mem...)...)
+		secs = append(secs, wasmtest.Section(11, wasmtest.Vec(data)))
+	}
+	return wasmtest.Module(secs...)
+}
+
+func functype(params, results []byte) []byte {
+	out := []byte{0x60}
+	out = append(out, wasmtest.ULEB(uint32(len(params)))...)
+	out = append(out, params...)
+	out = append(out, wasmtest.ULEB(uint32(len(results)))...)
+	out = append(out, results...)
+	return out
+}

--- a/src/wago/ext/log/log.go
+++ b/src/wago/ext/log/log.go
@@ -1,0 +1,95 @@
+// Package log provides a logging host import for wasm guests under the
+// "wago_log" module.
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	wago "github.com/wago-org/wago"
+)
+
+// Level is a log severity passed by the guest.
+type Level int32
+
+const (
+	LevelDebug Level = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
+func (l Level) String() string {
+	switch l {
+	case LevelInfo:
+		return "INFO"
+	case LevelWarn:
+		return "WARN"
+	case LevelError:
+		return "ERROR"
+	case LevelDebug:
+		return "DEBUG"
+	default:
+		return fmt.Sprintf("LVL%d", int32(l))
+	}
+}
+
+// Extension is the logging extension.
+type Extension struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// Option configures the log extension.
+type Option func(*Extension)
+
+// WithWriter sets the destination writer (default os.Stderr).
+func WithWriter(w io.Writer) Option { return func(e *Extension) { e.w = w } }
+
+// Ext constructs the log extension.
+func Ext(opts ...Option) *Extension {
+	e := &Extension{w: os.Stderr}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Info identifies the extension.
+func (e *Extension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{
+		ID:          "wago.log",
+		Name:        "Log",
+		Version:     "1.0.0",
+		Description: "Structured logging for wasm guests.",
+		MinWago:     "0.1.0",
+		Stability:   wago.Stable,
+	}
+}
+
+// Register wires the wago_log host import.
+func (e *Extension) Register(reg *wago.Registry) error {
+	reg.ImportModule("wago_log").
+		Func("write", wago.SyncHostFunc(func(m wago.HostModule, p, res []uint64) {
+			level := Level(wago.AsI32(p[0]))
+			ptr, n := uint32(p[1]), uint32(p[2])
+			mem := m.Memory()
+			if int64(ptr)+int64(n) > int64(len(mem)) {
+				res[0] = wago.I32(4) // buffer out of range
+				return
+			}
+			e.write(level, mem[ptr:ptr+n])
+			res[0] = wago.I32(0)
+		})).
+		Params(wago.ValI32, wago.ValI32, wago.ValI32).Results(wago.ValI32).
+		Docs("write a log message: (level i32, ptr i32, len i32) -> status i32")
+	return nil
+}
+
+func (e *Extension) write(level Level, msg []byte) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	fmt.Fprintf(e.w, "[%s] %s\n", level, msg)
+}

--- a/src/wago/ext/log/log_test.go
+++ b/src/wago/ext/log/log_test.go
@@ -1,0 +1,51 @@
+package log_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/src/wago/ext/exttest"
+	"github.com/wago-org/wago/src/wago/ext/log"
+)
+
+func TestLogWrite(t *testing.T) {
+	var buf bytes.Buffer
+	rt := wago.NewRuntime()
+	if err := rt.Use(log.Ext(log.WithWriter(&buf))); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	// run() -> i32 = write(level=2 (WARN), ptr=0, len=5) over memory "hello".
+	body := []byte{
+		0x41, 0x02, // i32.const 2 (level)
+		0x41, 0x00, // i32.const 0 (ptr)
+		0x41, 0x05, // i32.const 5 (len)
+		0x10, 0x00, // call 0
+		0x0b, // end
+	}
+	mod := exttest.Module("wago_log", "write",
+		[]byte{exttest.I32, exttest.I32, exttest.I32}, []byte{exttest.I32},
+		[]byte{exttest.I32}, body, []byte("hello"))
+	m, err := rt.Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), m)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	out, err := in.Call(context.Background(), "run")
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if out[0].I32() != 0 {
+		t.Fatalf("write status = %d, want 0", out[0].I32())
+	}
+	got := buf.String()
+	if !strings.Contains(got, "hello") || !strings.Contains(got, "WARN") {
+		t.Fatalf("log output = %q, want it to contain WARN and hello", got)
+	}
+}

--- a/src/wago/ext/metrics/metrics.go
+++ b/src/wago/ext/metrics/metrics.go
@@ -1,0 +1,134 @@
+// Package metrics provides counter and histogram host imports for wasm guests
+// under the "wago_metrics" module.
+package metrics
+
+import (
+	"sync"
+
+	wago "github.com/wago-org/wago"
+)
+
+// CapWrite is the capability guarding the metrics imports.
+const CapWrite = wago.CapMetricsWrite
+
+// Sink receives metric updates. The default in-memory sink (see Ext) records
+// them for inspection via the extension's Counter/Histogram accessors.
+type Sink interface {
+	CounterAdd(name string, delta int64)
+	HistogramObserve(name string, value float64)
+}
+
+// Extension is the metrics extension. When constructed without WithSink it keeps
+// metrics in memory, queryable through Counter and Histogram.
+type Extension struct {
+	sink Sink
+
+	mu       sync.Mutex
+	counters map[string]int64
+	hists    map[string][]float64
+}
+
+// Option configures the metrics extension.
+type Option func(*Extension)
+
+// WithSink routes metric updates to a custom sink instead of the in-memory store.
+func WithSink(s Sink) Option { return func(e *Extension) { e.sink = s } }
+
+// Ext constructs the metrics extension.
+func Ext(opts ...Option) *Extension {
+	e := &Extension{counters: map[string]int64{}, hists: map[string][]float64{}}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Info identifies the extension.
+func (e *Extension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{
+		ID:          "wago.metrics",
+		Name:        "Metrics",
+		Version:     "1.0.0",
+		Description: "Counters and histograms for wasm guests.",
+		MinWago:     "0.1.0",
+		Stability:   wago.Stable,
+	}
+}
+
+// Register wires the wago_metrics host imports.
+func (e *Extension) Register(reg *wago.Registry) error {
+	reg.Capability(CapWrite, wago.CapabilityDocs("record counters and histograms"))
+
+	reg.ImportModule("wago_metrics").
+		Func("counter_add", wago.SyncHostFunc(func(m wago.HostModule, p, res []uint64) {
+			name, ok := readName(m, uint32(p[0]), uint32(p[1]))
+			if !ok {
+				res[0] = wago.I32(4)
+				return
+			}
+			e.counterAdd(name, wago.AsI64(p[2]))
+			res[0] = wago.I32(0)
+		})).
+		Params(wago.ValI32, wago.ValI32, wago.ValI64).Results(wago.ValI32).Capability(CapWrite).
+		Docs("add to a counter: (name_ptr i32, name_len i32, delta i64) -> status i32")
+
+	reg.ImportModule("wago_metrics").
+		Func("histogram_observe", wago.SyncHostFunc(func(m wago.HostModule, p, res []uint64) {
+			name, ok := readName(m, uint32(p[0]), uint32(p[1]))
+			if !ok {
+				res[0] = wago.I32(4)
+				return
+			}
+			e.histObserve(name, wago.AsF64(p[2]))
+			res[0] = wago.I32(0)
+		})).
+		Params(wago.ValI32, wago.ValI32, wago.ValF64).Results(wago.ValI32).Capability(CapWrite).
+		Docs("observe a histogram value: (name_ptr i32, name_len i32, value f64) -> status i32")
+
+	return nil
+}
+
+// Counter returns the current value of a counter recorded by the in-memory sink.
+func (e *Extension) Counter(name string) int64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.counters[name]
+}
+
+// Histogram returns a copy of the observations recorded for a histogram by the
+// in-memory sink.
+func (e *Extension) Histogram(name string) []float64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]float64(nil), e.hists[name]...)
+}
+
+func (e *Extension) counterAdd(name string, delta int64) {
+	if e.sink != nil {
+		e.sink.CounterAdd(name, delta)
+		return
+	}
+	e.mu.Lock()
+	e.counters[name] += delta
+	e.mu.Unlock()
+}
+
+func (e *Extension) histObserve(name string, value float64) {
+	if e.sink != nil {
+		e.sink.HistogramObserve(name, value)
+		return
+	}
+	e.mu.Lock()
+	e.hists[name] = append(e.hists[name], value)
+	e.mu.Unlock()
+}
+
+// readName reads a UTF-8 name from guest memory, returning false if the range is
+// out of bounds.
+func readName(m wago.HostModule, ptr, n uint32) (string, bool) {
+	mem := m.Memory()
+	if int64(ptr)+int64(n) > int64(len(mem)) {
+		return "", false
+	}
+	return string(mem[ptr : ptr+n]), true
+}

--- a/src/wago/ext/metrics/metrics_test.go
+++ b/src/wago/ext/metrics/metrics_test.go
@@ -1,0 +1,59 @@
+package metrics_test
+
+import (
+	"context"
+	"testing"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/src/wago/ext/exttest"
+	"github.com/wago-org/wago/src/wago/ext/metrics"
+)
+
+func TestMetricsCounterAdd(t *testing.T) {
+	rt := wago.NewRuntime()
+	m := metrics.Ext()
+	if err := rt.Use(m); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	// run() -> i32 = counter_add(ptr=0, len=4, delta=5) over memory "reqs".
+	body := []byte{
+		0x41, 0x00, // i32.const 0 (name_ptr)
+		0x41, 0x04, // i32.const 4 (name_len)
+		0x42, 0x05, // i64.const 5 (delta)
+		0x10, 0x00, // call 0
+		0x0b, // end
+	}
+	mod := exttest.Module("wago_metrics", "counter_add",
+		[]byte{exttest.I32, exttest.I32, exttest.I64}, []byte{exttest.I32},
+		[]byte{exttest.I32}, body, []byte("reqs"))
+	comp, err := rt.Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), comp)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	if _, err := in.Call(context.Background(), "run"); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if _, err := in.Call(context.Background(), "run"); err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+	if got := m.Counter("reqs"); got != 10 {
+		t.Fatalf("counter reqs = %d, want 10", got)
+	}
+}
+
+func TestMetricsInMemorySink(t *testing.T) {
+	m := metrics.Ext()
+	// Exercise the in-memory sink directly through the extension accessors.
+	if got := m.Counter("absent"); got != 0 {
+		t.Fatalf("absent counter = %d, want 0", got)
+	}
+	if h := m.Histogram("absent"); len(h) != 0 {
+		t.Fatalf("absent histogram = %v, want empty", h)
+	}
+}

--- a/src/wago/ext/timer/timer.go
+++ b/src/wago/ext/timer/timer.go
@@ -1,0 +1,95 @@
+// Package timer provides wall-clock and monotonic time host imports for wasm
+// guests under the "wago_timer" module.
+package timer
+
+import (
+	"time"
+
+	wago "github.com/wago-org/wago"
+)
+
+// CapRead is the capability guarding the timer imports.
+const CapRead = wago.CapTimerRead
+
+// Clock is the time source the extension reads. Inject a fake with WithClock for
+// deterministic tests.
+type Clock interface {
+	// UnixMilli returns the current wall-clock time in milliseconds since the
+	// Unix epoch.
+	UnixMilli() int64
+	// MonotonicNanos returns a monotonic timer reading in nanoseconds. Only
+	// differences between readings are meaningful.
+	MonotonicNanos() int64
+	// Sleep blocks for at least d.
+	Sleep(d time.Duration)
+}
+
+type realClock struct{ start time.Time }
+
+func (c realClock) UnixMilli() int64      { return time.Now().UnixMilli() }
+func (c realClock) MonotonicNanos() int64 { return int64(time.Since(c.start)) }
+func (c realClock) Sleep(d time.Duration) { time.Sleep(d) }
+
+// Extension is the timer extension.
+type Extension struct {
+	clock Clock
+}
+
+// Option configures the timer extension.
+type Option func(*Extension)
+
+// WithClock overrides the time source (for tests or virtual clocks).
+func WithClock(c Clock) Option { return func(e *Extension) { e.clock = c } }
+
+// Ext constructs the timer extension.
+func Ext(opts ...Option) *Extension {
+	e := &Extension{clock: realClock{start: time.Now()}}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Info identifies the extension.
+func (e *Extension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{
+		ID:          "wago.timer",
+		Name:        "Timer",
+		Version:     "1.0.0",
+		Description: "Wall-clock and monotonic time for wasm guests.",
+		MinWago:     "0.1.0",
+		Stability:   wago.Stable,
+	}
+}
+
+// Register wires the wago_timer host imports.
+func (e *Extension) Register(reg *wago.Registry) error {
+	reg.Capability(CapRead, wago.CapabilityDocs("read wall-clock and monotonic time"))
+
+	reg.ImportModule("wago_timer").
+		Func("now_unix_ms", wago.SyncHostFunc(func(_ wago.HostModule, _, res []uint64) {
+			res[0] = wago.I64(e.clock.UnixMilli())
+		})).
+		Results(wago.ValI64).Capability(CapRead).
+		Docs("current wall-clock time in milliseconds since the Unix epoch")
+
+	reg.ImportModule("wago_timer").
+		Func("now_monotonic_ns", wago.SyncHostFunc(func(_ wago.HostModule, _, res []uint64) {
+			res[0] = wago.I64(e.clock.MonotonicNanos())
+		})).
+		Results(wago.ValI64).Capability(CapRead).
+		Docs("monotonic timer reading in nanoseconds")
+
+	reg.ImportModule("wago_timer").
+		Func("sleep_ms", wago.SyncHostFunc(func(_ wago.HostModule, p, res []uint64) {
+			ms := wago.AsI64(p[0])
+			if ms > 0 {
+				e.clock.Sleep(time.Duration(ms) * time.Millisecond)
+			}
+			res[0] = wago.I32(0)
+		})).
+		Params(wago.ValI64).Results(wago.ValI32).Capability(CapRead).
+		Docs("block the calling guest for the given milliseconds")
+
+	return nil
+}

--- a/src/wago/ext/timer/timer_test.go
+++ b/src/wago/ext/timer/timer_test.go
@@ -1,0 +1,57 @@
+package timer_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/src/wago/ext/exttest"
+	"github.com/wago-org/wago/src/wago/ext/timer"
+)
+
+type fakeClock struct{ mono int64 }
+
+func (f fakeClock) UnixMilli() int64      { return 12345 }
+func (f fakeClock) MonotonicNanos() int64 { return f.mono }
+func (f fakeClock) Sleep(d time.Duration) {}
+
+func TestTimerNowUnixMs(t *testing.T) {
+	rt := wago.NewRuntime()
+	if err := rt.Use(timer.Ext(timer.WithClock(fakeClock{}))); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	// run() -> i64 = now_unix_ms()
+	body := []byte{0x10, 0x00, 0x0b} // call 0; end
+	mod := exttest.Module("wago_timer", "now_unix_ms", nil, []byte{exttest.I64}, []byte{exttest.I64}, body, nil)
+	m, err := rt.Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), m)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	out, err := in.Call(context.Background(), "run")
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if out[0].I64() != 12345 {
+		t.Fatalf("now_unix_ms = %d, want 12345", out[0].I64())
+	}
+}
+
+func TestTimerCapabilityAndInfo(t *testing.T) {
+	rt := wago.NewRuntime()
+	if err := rt.Use(timer.Ext()); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	if exts := rt.Extensions(); len(exts) != 1 || exts[0].ID != "wago.timer" {
+		t.Fatalf("extensions = %+v", exts)
+	}
+	caps := rt.Capabilities()
+	if len(caps) != 1 || caps[0] != timer.CapRead {
+		t.Fatalf("capabilities = %v", caps)
+	}
+}


### PR DESCRIPTION
Phase 3 of `docs/plugin-api-plan.md` — the first built-in extensions, on top of the phase-1/2 spine (#160, #161).

New packages under `src/wago/ext/` (each depends only on the public `github.com/wago-org/wago` facade, modeling how external extension authors will write theirs):

- **`ext/timer`** — `wago_timer.now_unix_ms`/`now_monotonic_ns`/`sleep_ms`, guarded by `CapTimerRead`. Injectable `Clock` (`WithClock`) for deterministic tests.
- **`ext/log`** — `wago_log.write(level, ptr, len)` reading the message from guest memory; configurable `io.Writer` sink (`WithWriter`, default stderr) and severity levels.
- **`ext/metrics`** — `wago_metrics.counter_add`/`histogram_observe`, guarded by `CapMetricsWrite`. Default in-memory sink queryable via `Counter`/`Histogram`; swappable with `WithSink`.
- **`ext/exttest`** — small test-only wasm module builder (imports one host func, exports `run`) so extensions can be tested end-to-end through the public API.

Host functions use the reflection-free `SyncHostFunc` slot form, keeping them TinyGo-safe.

## Verification
- `go test ./src/wago/ext/...` — PASS (each extension exercised end-to-end: a guest calls the host import through `rt.Compile`/`Instantiate`/`Call`; timer via fake clock, log captures memory-read output, metrics counter accumulates across calls).
- `go build ./...`, `go vet ./src/wago/ext/...`, `gofmt` — clean.
- Root facade unchanged (ext packages are imported directly, not re-exported).