### PR TITLE
feat(wago): Class/Pool/Lease instance pooling (plugin-api phase 4)

### DIFF
--- a/src/wago/class.go
+++ b/src/wago/class.go
@@ -1,0 +1,254 @@
+package wago
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ResetPolicy selects how a pooled instance is returned to a reusable initial
+// state between leases.
+type ResetPolicy int
+
+const (
+	// ResetReinstantiate discards the used instance and instantiates a fresh one.
+	// This is the fully-supported policy today.
+	ResetReinstantiate ResetPolicy = iota
+	// ResetMemorySnapshot restores linear memory and globals from an initial
+	// snapshot. Accepted, but currently implemented as reinstantiation until the
+	// engine grows an in-place reset; behavior (fresh initial state) is identical,
+	// only the performance differs.
+	ResetMemorySnapshot
+	// ResetCopyOnWrite resets via copy-on-write memory pages. Accepted, currently
+	// implemented as reinstantiation (see ResetMemorySnapshot).
+	ResetCopyOnWrite
+)
+
+func (p ResetPolicy) String() string {
+	switch p {
+	case ResetMemorySnapshot:
+		return "memory-snapshot"
+	case ResetCopyOnWrite:
+		return "copy-on-write"
+	default:
+		return "reinstantiate"
+	}
+}
+
+// PoolOptions configures a Class's instance pool.
+type PoolOptions struct {
+	// MinInstances is the number of instances pre-instantiated at Class creation
+	// (warm start). Must be <= MaxInstances.
+	MinInstances int
+	// MaxInstances is the hard cap on live instances (outstanding + idle). It must
+	// be > 0.
+	MaxInstances int
+	// Reset selects the between-lease reset strategy.
+	Reset ResetPolicy
+	// MaxIdleTime is reserved for idle-instance reaping; not yet enforced.
+	MaxIdleTime time.Duration
+	// WarmStart forces pre-instantiation even when MinInstances is 0 (currently a
+	// no-op beyond MinInstances).
+	WarmStart bool
+}
+
+// ClassOptions configures a Class.
+type ClassOptions struct {
+	Name    string
+	Pool    PoolOptions
+	Imports Imports // per-class imports merged on top of the runtime's extensions
+}
+
+// Class is a deployable unit: a compiled Module plus an instance pool. It is the
+// foundation for large instance fleets (and, later, actor processes) — compile
+// once, spawn many, share the native code.
+type Class struct {
+	rt      *Runtime
+	mod     *Module
+	name    string
+	reset   ResetPolicy
+	max     int
+	imports Imports
+
+	idle    chan *Instance
+	mu      sync.Mutex
+	created int // live instances: outstanding + idle
+	closed  bool
+}
+
+// Class builds a Class over mod with the given pool and options.
+func (rt *Runtime) Class(mod *Module, opts ClassOptions) (*Class, error) {
+	if mod == nil {
+		return nil, fmt.Errorf("wago: Class: nil module")
+	}
+	max := opts.Pool.MaxInstances
+	if max <= 0 {
+		return nil, fmt.Errorf("wago: Class requires Pool.MaxInstances > 0")
+	}
+	min := opts.Pool.MinInstances
+	if min < 0 || min > max {
+		return nil, fmt.Errorf("wago: Class Pool.MinInstances (%d) must be in [0, MaxInstances=%d]", min, max)
+	}
+	c := &Class{
+		rt: rt, mod: mod, name: opts.Name, reset: opts.Pool.Reset,
+		max: max, imports: opts.Imports, idle: make(chan *Instance, max),
+	}
+	for i := 0; i < min; i++ {
+		in, err := c.newInstance(context.Background())
+		if err != nil {
+			c.Close()
+			return nil, fmt.Errorf("wago: Class warm start: %w", err)
+		}
+		c.created++
+		c.idle <- in
+	}
+	return c, nil
+}
+
+// Name returns the class name.
+func (c *Class) Name() string { return c.name }
+
+// Module returns the class's compiled module.
+func (c *Class) Module() *Module { return c.mod }
+
+// newInstance instantiates one fresh instance in the class's initial state.
+func (c *Class) newInstance(ctx context.Context) (*Instance, error) {
+	if len(c.imports) > 0 {
+		return c.rt.Instantiate(ctx, c.mod, WithImports(c.imports))
+	}
+	return c.rt.Instantiate(ctx, c.mod)
+}
+
+// Instantiate returns a standalone instance from the class (not pool-managed);
+// the caller owns it and must Close it.
+func (c *Class) Instantiate(ctx context.Context) (*Instance, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return nil, fmt.Errorf("wago: Instantiate on a closed class")
+	}
+	return c.newInstance(ctx)
+}
+
+// Acquire leases a pooled instance, reusing a warm idle one when available,
+// creating a new one while under MaxInstances, or blocking until one is released
+// (or ctx is done) at the cap.
+func (c *Class) Acquire(ctx context.Context) (*Lease, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// Fast path: a warm instance is ready.
+	select {
+	case in := <-c.idle:
+		return &Lease{inst: in, class: c}, nil
+	default:
+	}
+	// Create a new instance while under the cap.
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("wago: Acquire on a closed class")
+	}
+	if c.created < c.max {
+		c.created++
+		c.mu.Unlock()
+		in, err := c.newInstance(ctx)
+		if err != nil {
+			c.mu.Lock()
+			c.created--
+			c.mu.Unlock()
+			return nil, err
+		}
+		return &Lease{inst: in, class: c}, nil
+	}
+	c.mu.Unlock()
+	// At capacity: wait for a release or cancellation.
+	select {
+	case in := <-c.idle:
+		return &Lease{inst: in, class: c}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Close releases all idle instances and marks the class unusable. Outstanding
+// leases are closed as they are released.
+func (c *Class) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	c.mu.Unlock()
+	for {
+		select {
+		case in := <-c.idle:
+			in.Close()
+			c.mu.Lock()
+			c.created--
+			c.mu.Unlock()
+		default:
+			return nil
+		}
+	}
+}
+
+// Lease is a borrowed pooled instance. Use Instance to access it; Release returns
+// it to the pool (resetting it to the class's initial state) and invalidates the
+// lease.
+type Lease struct {
+	inst     *Instance
+	class    *Class
+	released bool
+}
+
+// Instance returns the leased instance. It is valid until Release.
+func (l *Lease) Instance() *Instance { return l.inst }
+
+// Release resets the instance to the class's initial state and returns capacity
+// to the pool. The reset is currently a reinstantiation: the used instance is
+// closed and a fresh one is placed in the pool so the next Acquire stays warm.
+func (l *Lease) Release() error {
+	if l.released {
+		return nil
+	}
+	l.released = true
+	c := l.class
+
+	l.inst.Close()
+
+	c.mu.Lock()
+	if c.closed {
+		c.created--
+		c.mu.Unlock()
+		return nil
+	}
+	c.mu.Unlock()
+
+	fresh, err := c.newInstance(context.Background())
+	if err != nil {
+		c.mu.Lock()
+		c.created--
+		c.mu.Unlock()
+		return fmt.Errorf("wago: Release reset: %w", err)
+	}
+	select {
+	case c.idle <- fresh:
+	default:
+		// Pool unexpectedly full; drop the replacement rather than leak it.
+		fresh.Close()
+		c.mu.Lock()
+		c.created--
+		c.mu.Unlock()
+	}
+	return nil
+}

--- a/src/wago/class_test.go
+++ b/src/wago/class_test.go
@@ -1,0 +1,120 @@
+package wago
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// counterModule builds an import-free module with one exported mutable i32 global
+// and an exported run() -> i32 that increments the global and returns the new
+// value. A fresh instance always starts the global at 0, so reset behavior is
+// observable.
+func counterModule(t *testing.T) *Module {
+	t.Helper()
+	sig := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	glob := []byte{0x7f, 0x01, 0x41, 0x00, 0x0b} // i32 mutable, init i32.const 0
+	body := []byte{
+		0x23, 0x00, // global.get 0
+		0x41, 0x01, // i32.const 1
+		0x6a,       // i32.add
+		0x24, 0x00, // global.set 0
+		0x23, 0x00, // global.get 0
+		0x0b, // end
+	}
+	mod := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(sig)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))), // one func, type 0
+		wasmtest.Section(6, wasmtest.Vec(glob)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+	m, err := NewRuntime().Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return m
+}
+
+func TestClassAcquireReleaseReset(t *testing.T) {
+	rt := NewRuntime()
+	mod := counterModule(t)
+	class, err := rt.Class(mod, ClassOptions{
+		Name: "counter",
+		Pool: PoolOptions{MinInstances: 1, MaxInstances: 2, Reset: ResetMemorySnapshot},
+	})
+	if err != nil {
+		t.Fatalf("class: %v", err)
+	}
+	defer class.Close()
+
+	lease, err := class.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	out, err := lease.Instance().Call(context.Background(), "run")
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if out[0].I32() != 1 {
+		t.Fatalf("first run = %d, want 1", out[0].I32())
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	// After release the pooled instance is reset: run() starts from 0 again.
+	lease2, err := class.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire 2: %v", err)
+	}
+	out, err = lease2.Instance().Call(context.Background(), "run")
+	if err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+	if out[0].I32() != 1 {
+		t.Fatalf("run after reset = %d, want 1 (state reset)", out[0].I32())
+	}
+	lease2.Release()
+}
+
+func TestClassCapacityBlocksUntilRelease(t *testing.T) {
+	rt := NewRuntime()
+	class, err := rt.Class(counterModule(t), ClassOptions{
+		Pool: PoolOptions{MaxInstances: 1},
+	})
+	if err != nil {
+		t.Fatalf("class: %v", err)
+	}
+	defer class.Close()
+
+	l1, err := class.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire 1: %v", err)
+	}
+	// At capacity: a second acquire with an already-expired deadline must fail.
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := class.Acquire(ctx); err == nil {
+		t.Fatal("expected acquire at capacity to time out")
+	}
+	// After releasing, acquire succeeds.
+	if err := l1.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	l2, err := class.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	l2.Release()
+}
+
+func TestClassRequiresMaxInstances(t *testing.T) {
+	rt := NewRuntime()
+	if _, err := rt.Class(counterModule(t), ClassOptions{}); err == nil {
+		t.Fatal("expected error for MaxInstances <= 0")
+	}
+}

--- a/wago.go
+++ b/wago.go
@@ -14,6 +14,8 @@ type (
 	BoundsCheckMode           = impl.BoundsCheckMode
 	Capability                = impl.Capability
 	CapabilityOption          = impl.CapabilityOption
+	Class                     = impl.Class
+	ClassOptions              = impl.ClassOptions
 	Compiled                  = impl.Compiled
 	CoreFeatures              = impl.CoreFeatures
 	DataInit                  = impl.DataInit
@@ -47,11 +49,14 @@ type (
 	InstantiateContext        = impl.InstantiateContext
 	InstantiateOption         = impl.InstantiateOption
 	InstantiateOptions        = impl.InstantiateOptions
+	Lease                     = impl.Lease
 	Memory                    = impl.Memory
 	Module                    = impl.Module
 	ModuleMetadata            = impl.ModuleMetadata
 	OffsetInit                = impl.OffsetInit
+	PoolOptions               = impl.PoolOptions
 	Registry                  = impl.Registry
+	ResetPolicy               = impl.ResetPolicy
 	Runtime                   = impl.Runtime
 	RuntimeConfig             = impl.RuntimeConfig
 	RuntimeContext            = impl.RuntimeContext
@@ -112,6 +117,9 @@ const (
 	ImportMemory                               = impl.ImportMemory
 	ImportTable                                = impl.ImportTable
 	NoExtensionOverrides                       = impl.NoExtensionOverrides
+	ResetCopyOnWrite                           = impl.ResetCopyOnWrite
+	ResetMemorySnapshot                        = impl.ResetMemorySnapshot
+	ResetReinstantiate                         = impl.ResetReinstantiate
 	Stable                                     = impl.Stable
 	TrapBuiltin                                = impl.TrapBuiltin
 	TrapCalledFnNotLinked                      = impl.TrapCalledFnNotLinked


### PR DESCRIPTION
Phase 4 of `docs/plugin-api-plan.md` — the deployable unit and instance pool, on top of #160/#161/#162.

## What's here (`class.go`)
- **`Class`** — a compiled `Module` plus an instance pool: `rt.Class(mod, ClassOptions{...})`. Compile once, spawn many, share the native code.
- **`PoolOptions`** — `MinInstances` (warm start), `MaxInstances` (hard cap), `Reset`, `MaxIdleTime` (reserved), `WarmStart`.
- **`Lease` / `Acquire` / `Release`** — `Acquire` reuses a warm idle instance, creates one under the cap, or blocks until a release / ctx cancellation at the cap. `Release` resets the instance and returns capacity, keeping the pool warm.
- **`ResetPolicy`** — `ResetReinstantiate` / `ResetMemorySnapshot` / `ResetCopyOnWrite`.
- `Class.Instantiate` (standalone, non-pooled), `Close`, `Name`, `Module`.

## Design note on reset
The low-level `*Instance` has no in-place reset through the public API (only exported globals are settable; internal globals and grown memory can't be rewound). So **reset is implemented as reinstantiation** — a fresh instance in the module's initial state — for *all* `ResetPolicy` values. `ResetMemorySnapshot`/`ResetCopyOnWrite` are accepted and behave identically (fresh initial state); only the perf optimization (in-place snapshot restore) is deferred to a future engine change. `Release` pays the reinstantiation cost off the `Acquire` hot path by pre-warming a replacement.

## Verification
- `go test ./src/wago -run TestClass` — PASS: warm-start reuse, **reset semantics** (a mutable global incremented during a lease reads 0 again after Release+Acquire), capacity blocking (2nd Acquire at cap times out, succeeds after Release), and `MaxInstances<=0` validation.
- `go test ./internal/genfacade ./src/wago`, `go build ./...`, `go vet`, `tinygo test -scheduler=tasks ./src/wago` — all PASS. Facade regenerated.