### PR TITLE
feat(wago): Policy capability enforcement + HandleTable resources (plugin-api phase 6)

### DIFF
--- a/src/wago/class.go
+++ b/src/wago/class.go
@@ -57,6 +57,7 @@ type PoolOptions struct {
 type ClassOptions struct {
 	Name    string
 	Pool    PoolOptions
+	Policy  Policy  // capability/resource policy applied to every instance
 	Imports Imports // per-class imports merged on top of the runtime's extensions
 }
 
@@ -89,6 +90,10 @@ func (rt *Runtime) Class(mod *Module, opts ClassOptions) (*Class, error) {
 	min := opts.Pool.MinInstances
 	if min < 0 || min > max {
 		return nil, fmt.Errorf("wago: Class Pool.MinInstances (%d) must be in [0, MaxInstances=%d]", min, max)
+	}
+	// The policy applies to every instance of this module; validate it once here.
+	if err := applyPolicy(mod, opts.Policy); err != nil {
+		return nil, err
 	}
 	c := &Class{
 		rt: rt, mod: mod, name: opts.Name, reset: opts.Pool.Reset,

--- a/src/wago/handle.go
+++ b/src/wago/handle.go
@@ -1,0 +1,148 @@
+package wago
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Handle is an opaque integer reference an extension hands to a guest in place of
+// a Go pointer (for sockets, files, timers, subscriptions, …). Its upper 32 bits
+// are a generation counter and its lower 32 bits a slot index, so a stale handle
+// (one whose slot has since been closed and reused) fails cleanly instead of
+// aliasing a new resource.
+type Handle uint64
+
+func makeHandle(idx int, gen uint32) Handle {
+	return Handle(uint64(gen)<<32 | uint64(uint32(idx)))
+}
+
+func (h Handle) slot() int   { return int(uint32(uint64(h))) }
+func (h Handle) gen() uint32 { return uint32(uint64(h) >> 32) }
+
+// Resource is anything the runtime owns on a guest's behalf and closes when the
+// handle is released.
+type Resource interface {
+	Close() error
+}
+
+type handleSlot struct {
+	gen  uint32
+	kind string
+	res  Resource
+	used bool
+}
+
+// HandleTable maps opaque Handles to host-owned Resources with generation-checked
+// slots. It is safe for concurrent use.
+type HandleTable struct {
+	mu    sync.Mutex
+	slots []handleSlot
+	free  []int
+}
+
+// NewHandleTable returns an empty handle table.
+func NewHandleTable() *HandleTable { return &HandleTable{} }
+
+// Insert stores a resource under a kind tag and returns its handle.
+func (t *HandleTable) Insert(kind string, r Resource) Handle {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var idx int
+	if n := len(t.free); n > 0 {
+		idx = t.free[n-1]
+		t.free = t.free[:n-1]
+	} else {
+		idx = len(t.slots)
+		t.slots = append(t.slots, handleSlot{})
+	}
+	s := &t.slots[idx]
+	s.kind, s.res, s.used = kind, r, true
+	return makeHandle(idx, s.gen)
+}
+
+// Get returns the resource for a handle, requiring the kind tag to match. It
+// returns false for a stale, wrong-kind, or unknown handle.
+func (t *HandleTable) Get(h Handle, kind string) (Resource, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s, ok := t.live(h)
+	if !ok || s.kind != kind {
+		return nil, false
+	}
+	return s.res, true
+}
+
+// Close releases a handle, closing its resource and bumping the slot generation
+// so the handle can never be reused. It is idempotent-safe: a stale handle
+// returns ErrInvalidHandle without touching the slot.
+func (t *HandleTable) Close(h Handle) error {
+	t.mu.Lock()
+	s, ok := t.live(h)
+	if !ok {
+		t.mu.Unlock()
+		return fmt.Errorf("handle %d: %w", uint64(h), ErrInvalidHandle)
+	}
+	res := s.res
+	s.res, s.used = nil, false
+	s.gen++ // invalidate outstanding handles to this slot
+	s.kind = ""
+	t.free = append(t.free, h.slot())
+	t.mu.Unlock()
+	if res != nil {
+		return res.Close()
+	}
+	return nil
+}
+
+// CloseAll closes every live resource. It returns the first close error, if any,
+// after attempting all of them.
+func (t *HandleTable) CloseAll() error {
+	t.mu.Lock()
+	var resources []Resource
+	for i := range t.slots {
+		s := &t.slots[i]
+		if s.used {
+			resources = append(resources, s.res)
+			s.res, s.used, s.kind = nil, false, ""
+			s.gen++
+			t.free = append(t.free, i)
+		}
+	}
+	t.mu.Unlock()
+	var firstErr error
+	for _, r := range resources {
+		if r != nil {
+			if err := r.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+// Len returns the number of live handles.
+func (t *HandleTable) Len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := 0
+	for i := range t.slots {
+		if t.slots[i].used {
+			n++
+		}
+	}
+	return n
+}
+
+// live returns the slot for a handle if it is in range, in use, and its
+// generation matches. Caller holds t.mu.
+func (t *HandleTable) live(h Handle) (*handleSlot, bool) {
+	idx := h.slot()
+	if idx < 0 || idx >= len(t.slots) {
+		return nil, false
+	}
+	s := &t.slots[idx]
+	if !s.used || s.gen != h.gen() {
+		return nil, false
+	}
+	return s, true
+}

--- a/src/wago/handle_test.go
+++ b/src/wago/handle_test.go
@@ -1,0 +1,78 @@
+package wago
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeResource struct{ closed *int }
+
+func (r fakeResource) Close() error { *r.closed++; return nil }
+
+func TestHandleTableInsertGetClose(t *testing.T) {
+	tbl := NewHandleTable()
+	closed := 0
+	h := tbl.Insert("file", fakeResource{closed: &closed})
+
+	if got, ok := tbl.Get(h, "file"); !ok || got == nil {
+		t.Fatal("Get on live handle failed")
+	}
+	// Wrong kind is rejected.
+	if _, ok := tbl.Get(h, "socket"); ok {
+		t.Fatal("Get with wrong kind should fail")
+	}
+	if tbl.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", tbl.Len())
+	}
+	if err := tbl.Close(h); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("resource Close called %d times, want 1", closed)
+	}
+	// Stale handle no longer resolves, and double-close is reported.
+	if _, ok := tbl.Get(h, "file"); ok {
+		t.Fatal("Get on closed handle should fail")
+	}
+	if err := tbl.Close(h); !errors.Is(err, ErrInvalidHandle) {
+		t.Fatalf("double Close = %v, want ErrInvalidHandle", err)
+	}
+}
+
+func TestHandleTableGenerationGuard(t *testing.T) {
+	tbl := NewHandleTable()
+	c1, c2 := 0, 0
+	h1 := tbl.Insert("timer", fakeResource{closed: &c1})
+	if err := tbl.Close(h1); err != nil {
+		t.Fatalf("close h1: %v", err)
+	}
+	// The next insert reuses the slot but with a bumped generation, so the old
+	// handle must not resolve to the new resource.
+	h2 := tbl.Insert("timer", fakeResource{closed: &c2})
+	if h1 == h2 {
+		t.Fatal("reused slot must produce a distinct handle (generation bump)")
+	}
+	if _, ok := tbl.Get(h1, "timer"); ok {
+		t.Fatal("stale handle resolved to the reused slot")
+	}
+	if _, ok := tbl.Get(h2, "timer"); !ok {
+		t.Fatal("fresh handle should resolve")
+	}
+}
+
+func TestHandleTableCloseAll(t *testing.T) {
+	tbl := NewHandleTable()
+	n := 0
+	for i := 0; i < 3; i++ {
+		tbl.Insert("conn", fakeResource{closed: &n})
+	}
+	if err := tbl.CloseAll(); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("closed %d resources, want 3", n)
+	}
+	if tbl.Len() != 0 {
+		t.Fatalf("Len after CloseAll = %d, want 0", tbl.Len())
+	}
+}

--- a/src/wago/policy.go
+++ b/src/wago/policy.go
@@ -1,0 +1,70 @@
+package wago
+
+import (
+	"fmt"
+	"time"
+)
+
+// Policy bounds what a module instance or process may do: which capabilities it
+// may exercise and coarse resource limits. The zero Policy is fully permissive.
+type Policy struct {
+	// AllowedCapabilities, when non-empty, is the exclusive allow-list: a required
+	// capability outside it is denied. When empty, all capabilities are allowed
+	// (subject to DeniedCapabilities).
+	AllowedCapabilities []Capability
+	// DeniedCapabilities is always denied and takes precedence over Allowed.
+	DeniedCapabilities []Capability
+
+	// MaxMemoryBytes caps the module's maximum linear memory. 0 means unbounded.
+	MaxMemoryBytes uint64
+	// MaxTableEntries caps the module's table size. 0 means unbounded.
+	MaxTableEntries uint32
+
+	// MaxInvokeDuration bounds a single invocation. Accepted but not yet enforced
+	// by the low-level call path; reserved.
+	MaxInvokeDuration time.Duration
+	// MaxProcesses / MaxMailboxMessages / MaxMailboxBytes are reserved for the
+	// process layer; accepted but not yet enforced here.
+	MaxProcesses       uint32
+	MaxMailboxMessages uint32
+	MaxMailboxBytes    uint64
+}
+
+// allows reports whether the policy permits a capability.
+func (p Policy) allows(cap Capability) bool {
+	for _, d := range p.DeniedCapabilities {
+		if d == cap {
+			return false
+		}
+	}
+	if len(p.AllowedCapabilities) == 0 {
+		return true
+	}
+	for _, a := range p.AllowedCapabilities {
+		if a == cap {
+			return true
+		}
+	}
+	return false
+}
+
+// applyPolicy validates a module against a policy: every capability the module
+// requires must be permitted, and its declared limits must fit. It returns an
+// error wrapping ErrPermissionDenied on violation. The zero Policy passes.
+func applyPolicy(mod *Module, p Policy) error {
+	for _, cap := range mod.RequiredCapabilities() {
+		if !p.allows(cap) {
+			return fmt.Errorf("module requires capability %q which the policy does not allow: %w", cap, ErrPermissionDenied)
+		}
+	}
+	if p.MaxMemoryBytes > 0 && mod.c.HasMemory {
+		maxBytes := uint64(mod.c.MemMaxPages) * 65536
+		if maxBytes > p.MaxMemoryBytes {
+			return fmt.Errorf("module maximum memory %d bytes exceeds policy limit %d bytes: %w", maxBytes, p.MaxMemoryBytes, ErrPermissionDenied)
+		}
+	}
+	if p.MaxTableEntries > 0 && mod.c.HasTable && uint32(mod.c.TableSize) > p.MaxTableEntries {
+		return fmt.Errorf("module table size %d exceeds policy limit %d: %w", mod.c.TableSize, p.MaxTableEntries, ErrPermissionDenied)
+	}
+	return nil
+}

--- a/src/wago/policy_test.go
+++ b/src/wago/policy_test.go
@@ -1,0 +1,91 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// memoryModule builds a module declaring (and exporting) a memory of minP..maxP
+// pages. Exporting it keeps MemMaxPages at maxP (an unexported, non-growing
+// memory is pinned to its minimum).
+func memoryModule(t *testing.T, minP, maxP int) *Module {
+	t.Helper()
+	memType := append([]byte{0x01}, wasmtest.ULEB(uint32(minP))...) // flags 0x01: has max
+	memType = append(memType, wasmtest.ULEB(uint32(maxP))...)
+	mod := wasmtest.Module(
+		wasmtest.Section(5, wasmtest.Vec(memType)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("memory", 2, 0))),
+	)
+	m, err := NewRuntime().Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return m
+}
+
+func TestPolicyCapabilityAllowDeny(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil { // provides env.f, requires CapMetricsWrite
+		t.Fatalf("use: %v", err)
+	}
+	mod := callsEnvF(t, rt)
+
+	// Allowed list omitting the required capability → denied.
+	_, err := rt.Instantiate(context.Background(), mod, WithPolicy(Policy{AllowedCapabilities: []Capability{CapTimerRead}}))
+	if !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("instantiate with disallowed cap = %v, want ErrPermissionDenied", err)
+	}
+
+	// Explicit deny → denied even with a permissive allow-list.
+	_, err = rt.Instantiate(context.Background(), mod, WithPolicy(Policy{DeniedCapabilities: []Capability{CapMetricsWrite}}))
+	if !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("instantiate with denied cap = %v, want ErrPermissionDenied", err)
+	}
+
+	// Allowed list including the capability → permitted.
+	in, err := rt.Instantiate(context.Background(), mod, WithPolicy(Policy{AllowedCapabilities: []Capability{CapMetricsWrite}}))
+	if err != nil {
+		t.Fatalf("instantiate with allowed cap: %v", err)
+	}
+	in.Close()
+
+	// Zero policy is permissive.
+	in, err = rt.Instantiate(context.Background(), mod, WithPolicy(Policy{}))
+	if err != nil {
+		t.Fatalf("instantiate with zero policy: %v", err)
+	}
+	in.Close()
+}
+
+func TestPolicyMemoryLimit(t *testing.T) {
+	rt := NewRuntime()
+	mod := memoryModule(t, 2, 4) // min 2 pages, max 4 pages -> 256 KiB max
+	// 128 KiB limit is below the module's 256 KiB max → denied.
+	if _, err := rt.Instantiate(context.Background(), mod, WithPolicy(Policy{MaxMemoryBytes: 128 << 10})); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("instantiate over memory limit = %v, want ErrPermissionDenied", err)
+	}
+	// 256 KiB limit fits.
+	in, err := rt.Instantiate(context.Background(), mod, WithPolicy(Policy{MaxMemoryBytes: 256 << 10}))
+	if err != nil {
+		t.Fatalf("instantiate within memory limit: %v", err)
+	}
+	in.Close()
+}
+
+func TestPolicyOnClass(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	mod := callsEnvF(t, rt)
+	_, err := rt.Class(mod, ClassOptions{
+		Pool:   PoolOptions{MaxInstances: 1},
+		Policy: Policy{AllowedCapabilities: []Capability{CapTimerRead}},
+	})
+	if !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("class with disallowed cap = %v, want ErrPermissionDenied", err)
+	}
+}

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -66,6 +66,8 @@ type SpawnOptions struct {
 	Args []Value
 	// Name is an optional human label.
 	Name string
+	// Policy is the capability/resource policy applied to the process instance.
+	Policy Policy
 	// Links are existing processes to bidirectionally link the new process to;
 	// abnormal exit of either kills the other.
 	Links []PID
@@ -111,6 +113,9 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 	capN := opts.MailboxCapacity
 	if capN <= 0 {
 		capN = DefaultMailboxCapacity
+	}
+	if err := applyPolicy(class.mod, opts.Policy); err != nil {
+		return 0, err
 	}
 
 	rt.procMu.Lock()

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -175,6 +175,14 @@ type instantiateConfig struct {
 	imports Imports
 	gc      GCConfig
 	hasGC   bool
+	policy  Policy
+}
+
+// WithPolicy applies a capability/resource policy to the instance. A module that
+// requires a capability the policy does not allow (or that exceeds a resource
+// limit) is rejected with an error wrapping ErrPermissionDenied.
+func WithPolicy(p Policy) InstantiateOption {
+	return func(c *instantiateConfig) { c.policy = p }
 }
 
 // WithImports adds per-call imports on top of the extension-provided namespace.
@@ -213,6 +221,9 @@ func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...Instant
 	var cfg instantiateConfig
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+	if err := applyPolicy(mod, cfg.policy); err != nil {
+		return nil, err
 	}
 
 	rt.mu.Lock()

--- a/wago.go
+++ b/wago.go
@@ -36,6 +36,8 @@ type (
 	GlobalImport              = impl.GlobalImport
 	GlobalImportDef           = impl.GlobalImportDef
 	GuardPageUnavailableError = impl.GuardPageUnavailableError
+	Handle                    = impl.Handle
+	HandleTable               = impl.HandleTable
 	HookRegistry              = impl.HookRegistry
 	HostExit                  = impl.HostExit
 	HostFunc                  = impl.HostFunc
@@ -58,10 +60,12 @@ type (
 	ModuleMetadata            = impl.ModuleMetadata
 	OffsetInit                = impl.OffsetInit
 	PID                       = impl.PID
+	Policy                    = impl.Policy
 	PoolOptions               = impl.PoolOptions
 	Process                   = impl.Process
 	Registry                  = impl.Registry
 	ResetPolicy               = impl.ResetPolicy
+	Resource                  = impl.Resource
 	Runtime                   = impl.Runtime
 	RuntimeConfig             = impl.RuntimeConfig
 	RuntimeContext            = impl.RuntimeContext
@@ -204,6 +208,8 @@ func NewGlobalI32(v int32, mutable bool) *Global { return impl.NewGlobalI32(v, m
 
 func NewGlobalI64(v int64, mutable bool) *Global { return impl.NewGlobalI64(v, mutable) }
 
+func NewHandleTable() *HandleTable { return impl.NewHandleTable() }
+
 func NewMemory(minPages uint32, maxPages uint32) (*Memory, error) {
 	return impl.NewMemory(minPages, maxPages)
 }
@@ -235,5 +241,7 @@ func WithImportOverridePolicy(p ImportOverridePolicy) RuntimeOption {
 }
 
 func WithImports(im Imports) InstantiateOption { return impl.WithImports(im) }
+
+func WithPolicy(p Policy) InstantiateOption { return impl.WithPolicy(p) }
 
 func WithRuntimeConfig(cfg *RuntimeConfig) RuntimeOption { return impl.WithRuntimeConfig(cfg) }


### PR DESCRIPTION
Phase 6 of `docs/plugin-api-plan.md` — the safety boundary: capability/resource policy and the handle system, on top of #160–#164.

## What's here
- **`Policy`** (`policy.go`) — `AllowedCapabilities` (allow-list; empty = allow all), `DeniedCapabilities` (deny wins), `MaxMemoryBytes`, `MaxTableEntries`, plus reserved limit fields. The zero Policy is fully permissive.
- **Enforcement** — `applyPolicy(mod, policy)` rejects a module that requires a disallowed capability or whose declared memory/table exceeds the limits, wrapping `ErrPermissionDenied`. Wired into `Instantiate` (new `WithPolicy` option), `ClassOptions.Policy` (validated once at Class creation), and `SpawnOptions.Policy`.
- **`HandleTable` / `Handle` / `Resource`** (`handle.go`) — opaque integer handles (generation counter in the high 32 bits, slot index in the low 32) so extensions hand guests references to host resources (sockets, files, timers) instead of Go pointers. `Insert`/`Get`(kind-checked)/`Close`/`CloseAll`/`Len`; a closed slot bumps its generation so stale handles fail with `ErrInvalidHandle` rather than aliasing a reused resource. Safe for concurrent use.

`MaxInvokeDuration` and the mailbox/process limit fields are accepted but not yet enforced (documented) — they need per-instance policy storage on the low-level call path.

## Verification
- `go test ./src/wago -run 'TestPolicy|TestHandle'` — PASS: capability allow/deny/zero-policy, memory-limit reject/allow, class-level policy rejection; handle insert/get/kind-mismatch/close, generation guard (reused slot ≠ old handle), and CloseAll.
- Full `go test ./src/wago`, `go test ./internal/genfacade`, `go build ./...`, `go vet`, `tinygo test -scheduler=tasks ./src/wago` — all PASS. Facade regenerated.