### PR TITLE
feat(wago): plugin registry + wago plugin list + run --plugin

### DIFF
--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -36,6 +36,8 @@ func main() {
 		runCmd(a[1:])
 	case "build":
 		notImplemented("build")
+	case "plugin", "plugins":
+		pluginCmd(a[1:])
 	case "validate":
 		validateCmd(a[1:])
 	case "version", "--version", "-v":
@@ -54,18 +56,21 @@ func usage(w *os.File) {
 
 %s
   run <file> [args...]      compile and execute an export   (default)
+  plugin list               list plugins compiled into this binary
   build                     not implemented
   validate <file>           decode and validate a module
   version                   print version and supported features
 
 %s
   -e, --invoke <name>       export to call
+      --plugin <names>      comma-separated plugins to enable (see: wago plugin list)
       --wasi                run as WASI preview 1: wire stdio/args/env, call _start
       --bounds <mode>       bounds checks: defer (skip provably-redundant; default) | all
 
 %s
   wago add.wasm 2 3
   wago run -e fib fib.wasm 30
+  wago run --plugin timer,log app.wasm
 
 For run, <file> is raw .wasm or a precompiled .wago. run args are typed by
 the signature; override per-arg with a suffix:  42   7:i64   3.5:f64
@@ -126,9 +131,9 @@ func runCmd(args []string) {
 		}
 		rest = append(rest, a)
 	}
-	var invoke, bounds string
+	var invoke, bounds, plugins string
 	pos, err := extractOpts(rest, map[string]*string{
-		"-e": &invoke, "--invoke": &invoke, "--bounds": &bounds,
+		"-e": &invoke, "--invoke": &invoke, "--bounds": &bounds, "--plugin": &plugins,
 	})
 	if err != nil {
 		fatal("run: %v", err)
@@ -155,7 +160,14 @@ func runCmd(args []string) {
 	params, results, _ := c.Signature(export)
 	vals := mustParseArgs(pos[1:], params)
 
-	in, err := wago.Instantiate(c, autoHosts(c, true))
+	// Satisfy imports: plugin-provided host functions first, then echo the rest.
+	imports := autoHosts(c, true)
+	if plugins != "" {
+		for k, v := range pluginImports(plugins) {
+			imports[k] = v
+		}
+	}
+	in, err := wago.Instantiate(c, imports)
 	if err != nil {
 		fatal("%v", err)
 	}

--- a/cli/wago/plugins.go
+++ b/cli/wago/plugins.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/wago-org/wago"
+	"github.com/wago-org/wago/src/wago/ext/log"
+	"github.com/wago-org/wago/src/wago/ext/metrics"
+	"github.com/wago-org/wago/src/wago/ext/timer"
+)
+
+// The built-in plugins compiled into this binary. Each is a small, dependency-
+// free package; the Go linker only keeps what is imported, so a leaner binary can
+// drop these imports (and heavier third-party plugins live in their own modules,
+// wired in via a custom build).
+func init() {
+	wago.RegisterExtension("timer", func() wago.Extension { return timer.Ext() })
+	wago.RegisterExtension("log", func() wago.Extension { return log.Ext() })
+	wago.RegisterExtension("metrics", func() wago.Extension { return metrics.Ext() })
+}
+
+// pluginCmd dispatches `wago plugin <sub>`.
+func pluginCmd(args []string) {
+	sub := "list"
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	switch sub {
+	case "list", "ls":
+		pluginList()
+	case "install", "add", "uninstall", "remove", "update", "build":
+		fatal("plugin %s: not yet implemented — third-party plugins are added by\n"+
+			"building a custom wago binary that imports them (a manifest-driven\n"+
+			"`wago plugin build` is planned). Built-in plugins are always available;\n"+
+			"see `wago plugin list`.", sub)
+	default:
+		fatal("plugin: unknown subcommand %q (have: list)", sub)
+	}
+}
+
+// pluginList prints the plugins compiled into this binary, with their id,
+// version, and the capabilities they require.
+func pluginList() {
+	names := wago.RegisteredPluginNames()
+	if len(names) == 0 {
+		fmt.Println(dim("no plugins compiled into this binary"))
+		return
+	}
+	fmt.Printf("%s\n", bold("plugins:"))
+	for _, name := range names {
+		ext, ok := wago.NewExtension(name)
+		if !ok {
+			continue
+		}
+		info := ext.Info()
+		caps := pluginCapabilities(ext)
+		line := fmt.Sprintf("  %s  %s %s", cyan(name), dim(info.ID), info.Version)
+		if len(caps) > 0 {
+			line += "  " + dim("caps: "+strings.Join(caps, ", "))
+		}
+		fmt.Println(line)
+		if info.Description != "" {
+			fmt.Printf("      %s\n", dim(info.Description))
+		}
+	}
+}
+
+// pluginCapabilities returns the capability names an extension declares, by
+// registering it on a throwaway runtime.
+func pluginCapabilities(ext wago.Extension) []string {
+	rt := wago.NewRuntime()
+	if err := rt.Use(ext); err != nil {
+		return nil
+	}
+	caps := rt.Capabilities()
+	out := make([]string, len(caps))
+	for i, c := range caps {
+		out[i] = string(c)
+	}
+	return out
+}
+
+// pluginImports builds the merged host imports for a comma-separated plugin list,
+// for wiring into the low-level Instantiate path. It fatals on an unknown plugin.
+func pluginImports(list string) wago.Imports {
+	rt := wago.NewRuntime()
+	for _, name := range strings.Split(list, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if err := rt.UsePlugin(name); err != nil {
+			fmt.Fprintf(os.Stderr, "%s %v\n", red("wago:"), err)
+			os.Exit(1)
+		}
+	}
+	return rt.HostImports()
+}

--- a/src/wago/plugins.go
+++ b/src/wago/plugins.go
@@ -1,0 +1,82 @@
+package wago
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// ExtensionFactory constructs a fresh extension instance. Plugins are registered
+// under a short name so a binary that compiles them in can enable them by name
+// (e.g. from a --plugin CLI flag). This is the database/sql-style registry: it
+// selects among what is compiled into the binary, since Go cannot load native
+// code at runtime.
+type ExtensionFactory func() Extension
+
+var (
+	pluginMu  sync.Mutex
+	pluginReg = map[string]ExtensionFactory{}
+)
+
+// RegisterExtension registers a plugin factory under a short, stable name (e.g.
+// "timer"). Call it from an init() in the binary that compiles the plugin in. It
+// panics on an empty name, a nil factory, or a duplicate name — all build-time
+// programming errors.
+func RegisterExtension(name string, factory ExtensionFactory) {
+	if name == "" || factory == nil {
+		panic("wago: RegisterExtension: empty name or nil factory")
+	}
+	pluginMu.Lock()
+	defer pluginMu.Unlock()
+	if _, dup := pluginReg[name]; dup {
+		panic("wago: RegisterExtension: duplicate plugin " + name)
+	}
+	pluginReg[name] = factory
+}
+
+// NewExtension constructs a registered plugin by name. The boolean is false for
+// an unregistered name.
+func NewExtension(name string) (Extension, bool) {
+	pluginMu.Lock()
+	f := pluginReg[name]
+	pluginMu.Unlock()
+	if f == nil {
+		return nil, false
+	}
+	return f(), true
+}
+
+// RegisteredPluginNames returns the names of all plugins compiled into this
+// binary, sorted.
+func RegisteredPluginNames() []string {
+	pluginMu.Lock()
+	defer pluginMu.Unlock()
+	names := make([]string, 0, len(pluginReg))
+	for n := range pluginReg {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// UsePlugin resolves a registered plugin by name and registers it on the runtime.
+func (rt *Runtime) UsePlugin(name string, opts ...UseOption) error {
+	ext, ok := NewExtension(name)
+	if !ok {
+		return fmt.Errorf("wago: unknown plugin %q (registered: %v)", name, RegisteredPluginNames())
+	}
+	return rt.Use(ext, opts...)
+}
+
+// HostImports returns a copy of the host-import bindings the runtime's registered
+// extensions provide, keyed by "module.name". It lets the low-level Instantiate
+// path be fed plugin-provided imports without going through Runtime.Instantiate.
+func (rt *Runtime) HostImports() Imports {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	out := make(Imports, len(rt.imports))
+	for k, v := range rt.imports {
+		out[k] = v
+	}
+	return out
+}

--- a/src/wago/plugins_test.go
+++ b/src/wago/plugins_test.go
@@ -1,0 +1,48 @@
+package wago
+
+import "testing"
+
+// Register a test plugin once for the whole package test binary (init runs once,
+// so this is safe under -count=N).
+func init() {
+	RegisterExtension("test.triple.plugin", func() Extension { return tripleExt{} })
+}
+
+func TestPluginRegistry(t *testing.T) {
+	found := false
+	for _, n := range RegisteredPluginNames() {
+		if n == "test.triple.plugin" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("registered names %v missing test.triple.plugin", RegisteredPluginNames())
+	}
+
+	ext, ok := NewExtension("test.triple.plugin")
+	if !ok || ext.Info().ID != "test.triple" {
+		t.Fatalf("NewExtension = %v, %v", ext, ok)
+	}
+	if _, ok := NewExtension("does.not.exist"); ok {
+		t.Fatal("NewExtension resolved an unknown plugin")
+	}
+}
+
+func TestUsePluginAndHostImports(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.UsePlugin("test.triple.plugin"); err != nil {
+		t.Fatalf("UsePlugin: %v", err)
+	}
+	if err := rt.UsePlugin("nope"); err == nil {
+		t.Fatal("expected error for unknown plugin")
+	}
+	hi := rt.HostImports()
+	if _, ok := hi["env.f"]; !ok {
+		t.Fatalf("HostImports missing env.f: %v keys present", len(hi))
+	}
+	// The returned map is a copy: mutating it does not affect the runtime.
+	hi["env.f"] = nil
+	if rt.HostImports()["env.f"] == nil {
+		t.Fatal("HostImports returned a live reference, not a copy")
+	}
+}

--- a/wago.go
+++ b/wago.go
@@ -26,6 +26,7 @@ type (
 	ExitReason                = impl.ExitReason
 	Extension                 = impl.Extension
 	ExtensionError            = impl.ExtensionError
+	ExtensionFactory          = impl.ExtensionFactory
 	ExtensionInfo             = impl.ExtensionInfo
 	FuncSig                   = impl.FuncSig
 	GCAllocatorKind           = impl.GCAllocatorKind
@@ -210,6 +211,8 @@ func Load(b []byte) (*Compiled, error) { return impl.Load(b) }
 
 func MustCompile(wasmBytes []byte) *Compiled { return impl.MustCompile(wasmBytes) }
 
+func NewExtension(name string) (Extension, bool) { return impl.NewExtension(name) }
+
 func NewGlobalF32(v float32, mutable bool) *Global { return impl.NewGlobalF32(v, mutable) }
 
 func NewGlobalF64(v float64, mutable bool) *Global { return impl.NewGlobalF64(v, mutable) }
@@ -229,6 +232,10 @@ func NewRuntime(opts ...RuntimeOption) *Runtime { return impl.NewRuntime(opts...
 func NewRuntimeConfig() *RuntimeConfig { return impl.NewRuntimeConfig() }
 
 func NewTable(minSize uint32, maxSize uint32) (*Table, error) { return impl.NewTable(minSize, maxSize) }
+
+func RegisterExtension(name string, factory ExtensionFactory) { impl.RegisterExtension(name, factory) }
+
+func RegisteredPluginNames() []string { return impl.RegisteredPluginNames() }
 
 func SupportedFeatures() CoreFeatures { return impl.SupportedFeatures() }
 


### PR DESCRIPTION
Adds a compile-time plugin registry and surfaces it in the CLI. Follows the design discussion: Go can't hot-load native plugins in a way compatible with TinyGo / small static binaries (the `plugin` `.so` package and subprocess/gRPC plugins are both out), so "plugins" means **selecting among what's compiled into the binary** — the `database/sql` driver model.

## What's here
**Registry (`src/wago/plugins.go`)**
- `ExtensionFactory` (named func type), `RegisterExtension(name, factory)` (init-time; panics on empty/nil/dup — build-time errors), `NewExtension(name)`, `RegisteredPluginNames()`.
- `rt.UsePlugin(name)` — resolve + `Use` by name.
- `rt.HostImports()` — copy of the merged extension host imports, so the low-level `Instantiate` path can be fed plugin-provided imports.

**CLI (`cli/wago/plugins.go`, `main.go`)**
- Registers the built-ins (`timer`, `log`, `metrics`) in `init()`.
- `wago plugin list` — shows plugins compiled into the binary with id / version / capabilities / description.
- `run --plugin=timer,log` — enables named plugins; their host functions satisfy the module's imports (merged over the echo-hosts).
- `wago plugin install|uninstall|update|build` print a clear "not yet implemented" pointer — the manifest-driven custom-binary build (xcaddy-style) is the planned follow-up.

## Size
The three built-ins are dependency-free; the Go linker keeps only what's imported, so leaner binaries can drop them and heavier third-party plugins live in their own modules. Stripped Go CLI with all three built-ins: ~3.0 MiB (dominated by the engine, not the plugins).

## Verification
- `go test ./src/wago -run 'TestPlugin|TestUsePlugin'` — PASS (registry resolve/unknown, `UsePlugin`, `HostImports` is a copy).
- Manual smoke: a guest importing `wago_timer.now_unix_ms` returns `0` with the import echoed, and a real timestamp under `--plugin timer`; `plugin list` and the `install` message render correctly.
- Full `go test ./src/wago ./src/wago/ext/... ./internal/genfacade`, `go build ./...`, `go vet`, `tinygo test -scheduler=tasks ./src/wago` — all PASS. Facade regenerated (`ExtensionFactory` is a named type so genfacade can render `RegisterExtension`).