### PR TITLE
feat(wago): Dirs store layout (XDG, version-keyed cache) + wago env

### DIFF
--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -38,6 +38,8 @@ func main() {
 		notImplemented("build")
 	case "plugin", "plugins":
 		pluginCmd(a[1:])
+	case "env":
+		envCmd()
 	case "validate":
 		validateCmd(a[1:])
 	case "version", "--version", "-v":
@@ -57,6 +59,7 @@ func usage(w *os.File) {
 %s
   run <file> [args...]      compile and execute an export   (default)
   plugin list               list plugins compiled into this binary
+  env                       print resolved config/cache/data directories
   build                     not implemented
   validate <file>           decode and validate a module
   version                   print version and supported features
@@ -86,6 +89,16 @@ func versionCmd() {
 }
 
 func notImplemented(cmd string) { fatal("%s: not implemented", cmd) }
+
+// envCmd prints wago's resolved on-disk directories.
+func envCmd() {
+	d := wago.DirsFor(versionString())
+	fmt.Printf("%s %s\n", dim("WAGO_VERSION"), d.Version)
+	fmt.Printf("%s %s\n", dim("WAGO_CONFIG  "), d.Config)
+	fmt.Printf("%s %s\n", dim("WAGO_DATA    "), d.Data)
+	fmt.Printf("%s %s\n", dim("WAGO_VERSIONS"), d.Versions)
+	fmt.Printf("%s %s\n", dim("WAGO_CACHE   "), d.Cache)
+}
 
 // ---- validate -----------------------------------------------------------
 

--- a/src/wago/paths.go
+++ b/src/wago/paths.go
@@ -1,0 +1,87 @@
+package wago
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Dirs resolves wago's on-disk locations. It follows the XDG base-directory
+// layout with one deliberate split: config and installed version binaries are
+// SHARED across wago versions, while the compiled-module cache is ISOLATED per
+// version (keyed by the version string) so a codegen change between versions can
+// never serve a stale compiled artifact.
+//
+// Resolution order: WAGO_HOME (if set) roots everything under one directory;
+// otherwise XDG_CONFIG_HOME / XDG_CACHE_HOME / XDG_DATA_HOME, each falling back to
+// the usual ~/.config, ~/.cache, ~/.local/share.
+type Dirs struct {
+	Config   string // shared: user config + plugin manifest
+	Data     string // shared: root for installed version binaries
+	Versions string // shared: Data/versions/<ver>/
+	Cache    string // isolated: per-version compiled-module cache
+	Version  string // the version this Dirs was keyed to
+}
+
+// DirsFor returns the resolved directories for a given wago version. The version
+// keys the compiled-module cache; pass the running binary's version.
+func DirsFor(version string) Dirs {
+	if version == "" {
+		version = "unknown"
+	}
+	if root := os.Getenv("WAGO_HOME"); root != "" {
+		data := filepath.Join(root, "data")
+		return Dirs{
+			Config:   filepath.Join(root, "config"),
+			Data:     data,
+			Versions: filepath.Join(data, "versions"),
+			Cache:    filepath.Join(root, "cache", version),
+			Version:  version,
+		}
+	}
+	data := filepath.Join(xdgDir("XDG_DATA_HOME", ".local", "share"), "wago")
+	return Dirs{
+		Config:   filepath.Join(xdgDir("XDG_CONFIG_HOME", ".config"), "wago"),
+		Data:     data,
+		Versions: filepath.Join(data, "versions"),
+		Cache:    filepath.Join(xdgDir("XDG_CACHE_HOME", ".cache"), "wago", version),
+		Version:  version,
+	}
+}
+
+// VersionBinary returns the path to an installed wago binary for a version.
+func (d Dirs) VersionBinary(version string) string {
+	return filepath.Join(d.Versions, version, "wago")
+}
+
+// CachePath returns the path to a per-version compiled-module cache entry keyed
+// by a caller-chosen key (e.g. a content hash), with a .wago extension.
+func (d Dirs) CachePath(key string) string {
+	return filepath.Join(d.Cache, key+".wago")
+}
+
+// ConfigFile returns the path to a shared config file by name.
+func (d Dirs) ConfigFile(name string) string {
+	return filepath.Join(d.Config, name)
+}
+
+// Ensure creates the config, cache, and versions directories if missing.
+func (d Dirs) Ensure() error {
+	for _, dir := range []string{d.Config, d.Cache, d.Versions} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// xdgDir returns $env if set, else $HOME joined with the fallback path elements.
+func xdgDir(env string, fallback ...string) string {
+	if v := os.Getenv(env); v != "" {
+		return v
+	}
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = "."
+	}
+	return filepath.Join(append([]string{home}, fallback...)...)
+}

--- a/src/wago/paths_test.go
+++ b/src/wago/paths_test.go
@@ -1,0 +1,104 @@
+package wago
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func statDir(path string) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return fi.IsDir(), nil
+}
+
+func TestDirsWagoHome(t *testing.T) {
+	t.Setenv("WAGO_HOME", "/opt/wagohome")
+	d := DirsFor("1.2.3")
+	if d.Config != "/opt/wagohome/config" {
+		t.Fatalf("Config = %q", d.Config)
+	}
+	if d.Versions != "/opt/wagohome/data/versions" {
+		t.Fatalf("Versions = %q", d.Versions)
+	}
+	if d.Cache != "/opt/wagohome/cache/1.2.3" {
+		t.Fatalf("Cache = %q", d.Cache)
+	}
+	if got := d.VersionBinary("0.9.0"); got != "/opt/wagohome/data/versions/0.9.0/wago" {
+		t.Fatalf("VersionBinary = %q", got)
+	}
+	if got := d.CachePath("abc"); got != "/opt/wagohome/cache/1.2.3/abc.wago" {
+		t.Fatalf("CachePath = %q", got)
+	}
+}
+
+func TestDirsXDG(t *testing.T) {
+	t.Setenv("WAGO_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "/x/config")
+	t.Setenv("XDG_CACHE_HOME", "/x/cache")
+	t.Setenv("XDG_DATA_HOME", "/x/data")
+	d := DirsFor("2.0.0")
+	if d.Config != "/x/config/wago" {
+		t.Fatalf("Config = %q", d.Config)
+	}
+	if d.Cache != "/x/cache/wago/2.0.0" {
+		t.Fatalf("Cache = %q", d.Cache)
+	}
+	if d.Versions != "/x/data/wago/versions" {
+		t.Fatalf("Versions = %q", d.Versions)
+	}
+}
+
+func TestDirsHomeFallback(t *testing.T) {
+	t.Setenv("WAGO_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("HOME", "/home/tester")
+	d := DirsFor("0.1.0")
+	if d.Config != "/home/tester/.config/wago" {
+		t.Fatalf("Config = %q", d.Config)
+	}
+	if d.Cache != "/home/tester/.cache/wago/0.1.0" {
+		t.Fatalf("Cache = %q", d.Cache)
+	}
+	if d.Data != "/home/tester/.local/share/wago" {
+		t.Fatalf("Data = %q", d.Data)
+	}
+}
+
+// Different versions must get isolated caches but share config.
+func TestDirsCacheIsolatedConfigShared(t *testing.T) {
+	t.Setenv("WAGO_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("HOME", "/home/tester")
+	a, b := DirsFor("0.3.0"), DirsFor("0.5.0")
+	if a.Cache == b.Cache {
+		t.Fatal("caches must be isolated per version")
+	}
+	if a.Config != b.Config {
+		t.Fatal("config must be shared across versions")
+	}
+}
+
+func TestDirsEnsure(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("WAGO_HOME", filepath.Join(root, "wh"))
+	d := DirsFor("0.1.0")
+	if err := d.Ensure(); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	for _, dir := range []string{d.Config, d.Cache, d.Versions} {
+		if !strings.HasPrefix(dir, root) {
+			t.Fatalf("unexpected dir outside temp root: %q", dir)
+		}
+		if fi, err := statDir(dir); err != nil || !fi {
+			t.Fatalf("dir %q not created: %v", dir, err)
+		}
+	}
+}

--- a/wago.go
+++ b/wago.go
@@ -20,6 +20,7 @@ type (
 	Compiled                  = impl.Compiled
 	CoreFeatures              = impl.CoreFeatures
 	DataInit                  = impl.DataInit
+	Dirs                      = impl.Dirs
 	ElemInit                  = impl.ElemInit
 	ExitError                 = impl.ExitError
 	ExitEvent                 = impl.ExitEvent
@@ -184,6 +185,8 @@ func Compile(wasmBytes []byte) (*Compiled, error) { return impl.Compile(wasmByte
 func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
 	return impl.CompileWithConfig(cfg, wasmBytes)
 }
+
+func DirsFor(version string) Dirs { return impl.DirsFor(version) }
 
 func F32(v float32) uint64 { return impl.F32(v) }
 


### PR DESCRIPTION
The on-disk store layout foundation for the plugin manifest, compiled-module cache, and the upcoming version manager.

## What's here (`src/wago/paths.go`)
- **`wago.DirsFor(version)`** resolves wago's directories following XDG, with the deliberate **shared-vs-isolated** split from the design discussion:
  - **Config** (`$XDG_CONFIG_HOME/wago`) and installed-version **binaries** (`$XDG_DATA_HOME/wago/versions`) are **shared** across wago versions.
  - The compiled-module **cache** (`$XDG_CACHE_HOME/wago/<version>`) is **isolated per version**, so a codegen change between versions can never serve a stale artifact.
  - `WAGO_HOME` overrides everything under one root; otherwise XDG vars with `~/.config`, `~/.cache`, `~/.local/share` fallbacks.
- Helpers: `VersionBinary(v)`, `CachePath(key)`, `ConfigFile(name)`, `Ensure()`.
- **`wago env`** CLI command prints the resolved directories.

Path resolution is env-based (`os.Getenv` + `HOME`), avoiding `os.UserConfigDir`/`os.UserCacheDir` so it stays **TinyGo-safe**.

## Verification
- `go test ./src/wago -run TestDirs` — PASS: `WAGO_HOME` rooting, XDG vars, `~/.config`-style fallback, caches isolated per version while config stays shared, and `Ensure()` creating dirs.
- Manual: `wago env` renders correct paths under both `WAGO_HOME` and XDG fallback.
- Full `go test ./src/wago ./internal/genfacade`, `go build ./...`, `go vet`, `tinygo test -scheduler=tasks ./src/wago` — all PASS. Facade regenerated.

Next: the JSON plugin manifest + `wago plugin install/uninstall/build` on top of this, then the version manager.