### PR TITLE
feat(cli): bundled version manager (nvm-style), gated out of the lean build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,13 +152,14 @@ build: ## Build the CLI (standard Go) -> ./wago
 .PHONY: build-release
 build-release: ## Size-minimized release CLI via TinyGo (no cgo, ~0.43 MB) -> ./wago
 	$(TINYGO) build -scheduler=$(TINYGO_SCHEDULER) -no-debug -opt=z -gc=conservative \
+		-tags wago_lean \
 		-ldflags "-X main.version=$(WAGO_VERSION)" -o wago ./cli/wago
 	strip -s wago
 	@echo "wago $(WAGO_VERSION): $$(du -h wago | cut -f1)"
 
 .PHONY: tinygo-build
 tinygo-build: ## Build the CLI with TinyGo (no cgo, debug) -> ./wago-tinygo  (see docs/tinygo.md)
-	$(TINYGO) build -scheduler=$(TINYGO_SCHEDULER) -o wago-tinygo ./cli/wago
+	$(TINYGO) build -scheduler=$(TINYGO_SCHEDULER) -tags wago_lean -o wago-tinygo ./cli/wago
 
 .PHONY: tinygo-test
 tinygo-test: ## Run the runtime + public-API suites under TinyGo

--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -43,7 +43,7 @@ func main() {
 	case "validate":
 		validateCmd(a[1:])
 	case "version", "--version", "-v":
-		versionCmd()
+		versionCmd(a[1:])
 	case "help", "-h", "--help":
 		usage(os.Stdout)
 	default:
@@ -63,6 +63,7 @@ func usage(w *os.File) {
   build                     not implemented
   validate <file>           decode and validate a module
   version                   print version and supported features
+  version <sub>             manage installed versions (list, use, install, …)
 
 %s
   -e, --invoke <name>       export to call
@@ -78,14 +79,6 @@ func usage(w *os.File) {
 For run, <file> is raw .wasm or a precompiled .wago. run args are typed by
 the signature; override per-arg with a suffix:  42   7:i64   3.5:f64
 `, bold("wago"), bold("Usage:"), bold("Commands:"), bold("Flags:"), bold("Examples:"))
-}
-
-func versionCmd() {
-	fmt.Printf("%s %s (linux/amd64)\n", bold("wago"), versionString())
-	fmt.Printf("%s %s\n", dim("features:"), wago.SupportedFeatures())
-	if wago.GuardPageSupported() {
-		fmt.Printf("%s signals-based bounds checks available\n", dim("guard-page:"))
-	}
 }
 
 func notImplemented(cmd string) { fatal("%s: not implemented", cmd) }

--- a/cli/wago/version_common.go
+++ b/cli/wago/version_common.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/wago-org/wago"
+)
+
+// printVersion prints the binary version and supported features. Shared by both
+// the full version manager and the lean stub.
+func printVersion() {
+	fmt.Printf("%s %s (linux/amd64)\n", bold("wago"), versionString())
+	fmt.Printf("%s %s\n", dim("features:"), wago.SupportedFeatures())
+	if wago.GuardPageSupported() {
+		fmt.Printf("%s signals-based bounds checks available\n", dim("guard-page:"))
+	}
+}

--- a/cli/wago/version_mgr.go
+++ b/cli/wago/version_mgr.go
@@ -1,0 +1,321 @@
+//go:build !wago_lean
+
+// The full version manager pulls in net/http, encoding/json, and crypto/sha256.
+// It is excluded from the size-optimized/TinyGo build (-tags wago_lean), which
+// gets the stub in version_stub.go instead, keeping the release binary lean.
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/wago-org/wago"
+)
+
+// versionCmd handles `wago version` (print version, default) and the version
+// manager subcommands (`wago version list|install|use|...`).
+func versionCmd(args []string) {
+	if len(args) == 0 {
+		printVersion()
+		return
+	}
+	d := wago.DirsFor(versionString())
+	switch args[0] {
+	case "list", "ls":
+		vmList(d)
+	case "current":
+		vmCurrent(d)
+	case "which":
+		vmWhich(d)
+	case "use":
+		vmUse(d, versionArg("use", args[1:]))
+	case "install", "add":
+		vmInstall(d, versionArg("install", args[1:]))
+	case "uninstall", "remove", "rm":
+		vmUninstall(d, versionArg("uninstall", args[1:]))
+	case "list-remote", "ls-remote":
+		vmListRemote()
+	default:
+		fatal("version: unknown subcommand %q (have: list, current, which, use, install, uninstall, list-remote)", args[0])
+	}
+}
+
+func versionArg(sub string, args []string) string {
+	if len(args) != 1 || args[0] == "" {
+		fatal("version %s: need a <version>", sub)
+	}
+	return args[0]
+}
+
+// ---- installed-version state --------------------------------------------
+
+// installedVersions returns the versions that have an installed binary, sorted.
+func installedVersions(d wago.Dirs) []string {
+	entries, err := os.ReadDir(d.Versions)
+	if err != nil {
+		return nil
+	}
+	var vers []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if fi, err := os.Stat(d.VersionBinary(e.Name())); err == nil && !fi.IsDir() {
+			vers = append(vers, e.Name())
+		}
+	}
+	sort.Slice(vers, func(i, j int) bool { return compareSemver(vers[i], vers[j]) < 0 })
+	return vers
+}
+
+func activeVersion(d wago.Dirs) string {
+	b, err := os.ReadFile(d.ConfigFile("active-version"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func setActiveVersion(d wago.Dirs, ver string) error {
+	if err := d.Ensure(); err != nil {
+		return err
+	}
+	if err := os.WriteFile(d.ConfigFile("active-version"), []byte(ver+"\n"), 0o644); err != nil {
+		return err
+	}
+	// Best-effort convenience symlink: <data>/bin/wago -> the active binary. Add
+	// <data>/bin to PATH to make `wago` resolve to the selected version.
+	binDir := filepath.Join(d.Data, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err == nil {
+		link := filepath.Join(binDir, "wago")
+		_ = os.Remove(link)
+		_ = os.Symlink(d.VersionBinary(ver), link)
+	}
+	return nil
+}
+
+// ---- subcommands --------------------------------------------------------
+
+func vmList(d wago.Dirs) {
+	vers := installedVersions(d)
+	if len(vers) == 0 {
+		fmt.Println(dim("no versions installed; try: wago version install <ver>"))
+		return
+	}
+	active := activeVersion(d)
+	for _, v := range vers {
+		marker := "  "
+		if v == active {
+			marker = cyan("* ")
+		}
+		fmt.Printf("%s%s\n", marker, v)
+	}
+}
+
+func vmCurrent(d wago.Dirs) {
+	if a := activeVersion(d); a != "" {
+		fmt.Println(a)
+		return
+	}
+	fmt.Println(dim("no active version set"))
+}
+
+func vmWhich(d wago.Dirs) {
+	a := activeVersion(d)
+	if a == "" {
+		fatal("version which: no active version set")
+	}
+	fmt.Println(d.VersionBinary(a))
+}
+
+func vmUse(d wago.Dirs, ver string) {
+	if fi, err := os.Stat(d.VersionBinary(ver)); err != nil || fi.IsDir() {
+		fatal("version use: %s is not installed (try: wago version install %s)", ver, ver)
+	}
+	if err := setActiveVersion(d, ver); err != nil {
+		fatal("version use: %v", err)
+	}
+	fmt.Printf("now using wago %s\n", cyan(ver))
+}
+
+func vmUninstall(d wago.Dirs, ver string) {
+	dir := filepath.Join(d.Versions, ver)
+	if _, err := os.Stat(dir); err != nil {
+		fatal("version uninstall: %s is not installed", ver)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		fatal("version uninstall: %v", err)
+	}
+	if activeVersion(d) == ver {
+		_ = os.Remove(d.ConfigFile("active-version"))
+	}
+	fmt.Printf("uninstalled wago %s\n", ver)
+}
+
+func vmInstall(d wago.Dirs, ver string) {
+	dest := d.VersionBinary(ver)
+	if fi, err := os.Stat(dest); err == nil && !fi.IsDir() {
+		fmt.Printf("wago %s already installed\n", ver)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		fatal("version install: %v", err)
+	}
+	if err := downloadBinary(releaseBase(), ver, dest); err != nil {
+		fatal("version install: %v", err)
+	}
+	fmt.Printf("installed wago %s -> %s\n", cyan(ver), dest)
+}
+
+func vmListRemote() {
+	base := releaseAPI()
+	resp, err := http.Get(base + "/repos/wago-org/wago/releases")
+	if err != nil {
+		fatal("version list-remote: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fatal("version list-remote: GitHub returned %s", resp.Status)
+	}
+	var releases []struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		fatal("version list-remote: %v", err)
+	}
+	if len(releases) == 0 {
+		fmt.Println(dim("no releases published"))
+		return
+	}
+	for _, r := range releases {
+		fmt.Println(strings.TrimPrefix(r.TagName, "v"))
+	}
+}
+
+// ---- download -----------------------------------------------------------
+
+// downloadBinary fetches the linux/amd64 wago binary for ver from baseURL,
+// verifies its SHA-256 against the sibling ".sha256" file, and writes it to dest
+// (0755). It writes nothing on a checksum mismatch.
+func downloadBinary(baseURL, ver, dest string) error {
+	asset := "wago-linux-amd64"
+	url := fmt.Sprintf("%s/%s/%s", strings.TrimRight(baseURL, "/"), ver, asset)
+
+	body, err := httpGetBytes(url)
+	if err != nil {
+		return err
+	}
+	sumRaw, err := httpGetBytes(url + ".sha256")
+	if err != nil {
+		return fmt.Errorf("fetch checksum: %w", err)
+	}
+	want := strings.TrimSpace(string(sumRaw))
+	if fields := strings.Fields(want); len(fields) > 0 {
+		want = fields[0] // accept "<hash>  <filename>" form
+	}
+	got := sha256.Sum256(body)
+	if !strings.EqualFold(hex.EncodeToString(got[:]), want) {
+		return fmt.Errorf("checksum mismatch for %s (want %s, got %x)", asset, want, got)
+	}
+	tmp := dest + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(tmp, dest)
+}
+
+func httpGetBytes(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// releaseBase is the base URL for release binary assets, overridable for testing.
+func releaseBase() string {
+	if v := os.Getenv("WAGO_RELEASE_BASE"); v != "" {
+		return v
+	}
+	return "https://github.com/wago-org/wago/releases/download"
+}
+
+// releaseAPI is the GitHub API base, overridable for testing.
+func releaseAPI() string {
+	if v := os.Getenv("WAGO_RELEASE_API"); v != "" {
+		return v
+	}
+	return "https://api.github.com"
+}
+
+// compareSemver does a numeric dotted compare of two version strings, ignoring a
+// leading 'v'. Non-numeric components sort after numeric ones.
+func compareSemver(a, b string) int {
+	as := strings.Split(strings.TrimPrefix(a, "v"), ".")
+	bs := strings.Split(strings.TrimPrefix(b, "v"), ".")
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var av, bv int
+		var ao, bo bool
+		if i < len(as) {
+			av, ao = atoiOK(as[i])
+		}
+		if i < len(bs) {
+			bv, bo = atoiOK(bs[i])
+		}
+		if ao && bo {
+			if av != bv {
+				return sign(av - bv)
+			}
+			continue
+		}
+		if c := strings.Compare(get(as, i), get(bs, i)); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+func atoiOK(s string) (int, bool) {
+	n := 0
+	if s == "" {
+		return 0, false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, true
+}
+
+func get(s []string, i int) string {
+	if i < len(s) {
+		return s[i]
+	}
+	return ""
+}
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/cli/wago/version_mgr_test.go
+++ b/cli/wago/version_mgr_test.go
@@ -1,0 +1,113 @@
+//go:build !wago_lean
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wago-org/wago"
+)
+
+// installFake writes a fake installed binary for ver under d.
+func installFake(t *testing.T, d wago.Dirs, ver string) {
+	t.Helper()
+	dir := filepath.Join(d.Versions, ver)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(d.VersionBinary(ver), []byte("#!/bin/true\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVersionManagerState(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	d := wago.DirsFor("test")
+
+	if got := installedVersions(d); len(got) != 0 {
+		t.Fatalf("expected no versions, got %v", got)
+	}
+	installFake(t, d, "0.3.0")
+	installFake(t, d, "0.5.0")
+	installFake(t, d, "0.10.0")
+
+	got := installedVersions(d)
+	want := []string{"0.3.0", "0.5.0", "0.10.0"} // numeric semver order, not lexical
+	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("installedVersions = %v, want %v", got, want)
+	}
+
+	if activeVersion(d) != "" {
+		t.Fatal("expected no active version")
+	}
+	if err := setActiveVersion(d, "0.5.0"); err != nil {
+		t.Fatalf("setActiveVersion: %v", err)
+	}
+	if activeVersion(d) != "0.5.0" {
+		t.Fatalf("activeVersion = %q, want 0.5.0", activeVersion(d))
+	}
+}
+
+func TestDownloadBinaryChecksum(t *testing.T) {
+	payload := []byte("fake wago binary bytes")
+	sum := sha256.Sum256(payload)
+	hexsum := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/0.9.0/wago-linux-amd64":
+			w.Write(payload)
+		case r.URL.Path == "/0.9.0/wago-linux-amd64.sha256":
+			w.Write([]byte(hexsum + "  wago-linux-amd64\n"))
+		case r.URL.Path == "/bad/wago-linux-amd64":
+			w.Write(payload)
+		case r.URL.Path == "/bad/wago-linux-amd64.sha256":
+			w.Write([]byte("deadbeef  wago-linux-amd64\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "wago")
+	if err := downloadBinary(srv.URL, "0.9.0", dest); err != nil {
+		t.Fatalf("downloadBinary: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil || string(got) != string(payload) {
+		t.Fatalf("downloaded content mismatch: %v", err)
+	}
+
+	// A checksum mismatch must fail and write nothing.
+	badDest := filepath.Join(t.TempDir(), "wago")
+	if err := downloadBinary(srv.URL, "bad", badDest); err == nil {
+		t.Fatal("expected checksum mismatch error")
+	}
+	if _, err := os.Stat(badDest); !os.IsNotExist(err) {
+		t.Fatal("checksum mismatch must not write the destination file")
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"0.3.0", "0.5.0", -1},
+		{"0.10.0", "0.9.0", 1},
+		{"1.0.0", "1.0.0", 0},
+		{"v1.2.0", "1.2.0", 0},
+		{"1.2.0", "1.2.1", -1},
+	}
+	for _, c := range cases {
+		if got := compareSemver(c.a, c.b); got != c.want {
+			t.Fatalf("compareSemver(%q,%q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/cli/wago/version_stub.go
+++ b/cli/wago/version_stub.go
@@ -1,0 +1,16 @@
+//go:build wago_lean
+
+// Lean build: the version manager (which needs net/http) is compiled out to keep
+// the size-optimized/TinyGo release binary small. `wago version` still reports the
+// binary version; the management subcommands point at a full build.
+
+package main
+
+func versionCmd(args []string) {
+	if len(args) == 0 {
+		printVersion()
+		return
+	}
+	fatal("version %s: version management is not built into this lean binary\n"+
+		"(build without -tags wago_lean, or use a full wago binary)", args[0])
+}


### PR DESCRIPTION
An nvm-style version manager built on `wago.DirsFor` (#168), living entirely in `cli/wago` so the embeddable `package wago` never pulls in `net/http`.

## Commands (`wago version <sub>`)
- `list` — installed versions, active one marked
- `current` / `which` — active version / its binary path
- `use <ver>` — set active (records `active-version`, updates a `<data>/bin/wago` PATH symlink)
- `install <ver>` — download the linux/amd64 binary from GitHub releases, **SHA-256 verified against the sibling `.sha256`** (writes nothing on mismatch)
- `uninstall <ver>`
- `list-remote` — tags from the GitHub releases API

`wago version` with no args still prints the version/features. Download/API base URLs are overridable (`WAGO_RELEASE_BASE`, `WAGO_RELEASE_API`) for testing.

## Keeping the release binary lean
The manager pulls in `net/http` + `encoding/json` + `crypto/sha256`, so it is **build-tag-gated out of the size-optimized/TinyGo build**:
- default standard build → full manager (and CI's `go test ./...` exercises it)
- `-tags wago_lean` (added to `make build-release` and `make tinygo-build`) → a stub `wago version` that reports the version and points management subcommands at a full build

TinyGo release binary stays small — **688 K** with the manager excluded; a build carrying `net/http` would be several MB. (The current 688 K vs the old ~430 K baseline is from the earlier plugin PR bundling timer/log/metrics unconditionally — happy to gate those too if you want the smaller floor back.)

## Verification
- `go test ./cli/wago` — PASS: installed-version discovery in **numeric semver order** (0.10.0 after 0.5.0, not lexical), active get/set, `downloadBinary` against an `httptest` server (checksum match writes the file; **mismatch errors and writes nothing**), and `compareSemver`.
- Both build configs compile (`go build ./...` and `-tags wago_lean`); `make tinygo-build` (lean) and `make build-release` succeed under TinyGo.
- Manual: `list/use/current/which` + PATH symlink verified end-to-end under a temp `WAGO_HOME`.
- Full `go test ./src/wago`, `go vet`, `tinygo test ./src/wago`, facade unchanged.