### PR TITLE
feat(cli): wago version = version manager; wago -v/--version = version string

### DIFF
--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -42,7 +42,9 @@ func main() {
 		envCmd()
 	case "validate":
 		validateCmd(a[1:])
-	case "version", "--version", "-v":
+	case "--version", "-v":
+		printVersion()
+	case "version":
 		versionCmd(a[1:])
 	case "help", "-h", "--help":
 		usage(os.Stdout)
@@ -62,10 +64,10 @@ func usage(w *os.File) {
   env                       print resolved config/cache/data directories
   build                     not implemented
   validate <file>           decode and validate a module
-  version                   print version and supported features
-  version <sub>             manage installed versions (list, use, install, …)
+  version [sub]             manage installed versions (list, use, install, …)
 
 %s
+  -v, --version             print version and supported features
   -e, --invoke <name>       export to call
       --plugin <names>      comma-separated plugins to enable (see: wago plugin list)
       --wasi                run as WASI preview 1: wire stdio/args/env, call _start

--- a/cli/wago/version_mgr.go
+++ b/cli/wago/version_mgr.go
@@ -21,14 +21,15 @@ import (
 	"github.com/wago-org/wago"
 )
 
-// versionCmd handles `wago version` (print version, default) and the version
-// manager subcommands (`wago version list|install|use|...`).
+// versionCmd is the version manager (`wago version list|install|use|...`). The
+// binary's own version is printed by `wago --version` / `wago -v`. With no
+// subcommand it lists installed versions.
 func versionCmd(args []string) {
+	d := wago.DirsFor(versionString())
 	if len(args) == 0 {
-		printVersion()
+		vmList(d)
 		return
 	}
-	d := wago.DirsFor(versionString())
 	switch args[0] {
 	case "list", "ls":
 		vmList(d)

--- a/cli/wago/version_stub.go
+++ b/cli/wago/version_stub.go
@@ -7,10 +7,10 @@
 package main
 
 func versionCmd(args []string) {
-	if len(args) == 0 {
-		printVersion()
-		return
+	sub := "list"
+	if len(args) > 0 {
+		sub = args[0]
 	}
 	fatal("version %s: version management is not built into this lean binary\n"+
-		"(build without -tags wago_lean, or use a full wago binary)", args[0])
+		"(build without -tags wago_lean; use `wago --version` for the version number)", sub)
 }


### PR DESCRIPTION
Reassigns the `version` verb as requested: `wago version` is now purely the version manager, and the version number is printed by `wago -v` / `wago --version`.

## Changes
- `wago -v` / `wago --version` → print version + supported features (the old `wago version` no-arg behavior).
- `wago version` → version manager; with no subcommand it defaults to `version list`.
- Lean build (`-tags wago_lean`): `wago -v` still prints the version; `wago version …` reports that management isn't built in and points at `wago --version`.
- Usage text updated.

## Verification
- `wago -v` / `wago --version` → version string; `wago version` → installed-version list; `wago version install` → arg error. Lean binary: `-v` works, `version` reports not-built-in.
- `go build ./...`, `go build -tags wago_lean ./cli/wago`, `go vet`, `go test ./cli/wago` — all PASS. No CI script referenced `wago version`.