### PR TITLE
refactor(wago): plugin host imports are stack-based (SyncHostFunc) — identical on Go and TinyGo

### DIFF
--- a/plugins/log/log.go
+++ b/plugins/log/log.go
@@ -72,7 +72,7 @@ func (e *Extension) Info() wago.ExtensionInfo {
 // Register wires the wago_log host import.
 func (e *Extension) Register(reg *wago.Registry) error {
 	reg.ImportModule("wago_log").
-		Func("write", wago.SyncHostFunc(func(m wago.HostModule, p, res []uint64) {
+		Func("write", func(m wago.HostModule, p, res []uint64) {
 			level := Level(wago.AsI32(p[0]))
 			ptr, n := uint32(p[1]), uint32(p[2])
 			mem := m.Memory()
@@ -82,7 +82,7 @@ func (e *Extension) Register(reg *wago.Registry) error {
 			}
 			e.write(level, mem[ptr:ptr+n])
 			res[0] = wago.I32(0)
-		})).
+		}).
 		Params(wago.ValI32, wago.ValI32, wago.ValI32).Results(wago.ValI32).
 		Docs("write a log message: (level i32, ptr i32, len i32) -> status i32")
 	return nil

--- a/plugins/metrics/metrics.go
+++ b/plugins/metrics/metrics.go
@@ -60,7 +60,7 @@ func (e *Extension) Register(reg *wago.Registry) error {
 	reg.Capability(CapWrite, wago.CapabilityDocs("record counters and histograms"))
 
 	reg.ImportModule("wago_metrics").
-		Func("counter_add", wago.SyncHostFunc(func(m wago.HostModule, p, res []uint64) {
+		Func("counter_add", func(m wago.HostModule, p, res []uint64) {
 			name, ok := readName(m, uint32(p[0]), uint32(p[1]))
 			if !ok {
 				res[0] = wago.I32(4)
@@ -68,12 +68,12 @@ func (e *Extension) Register(reg *wago.Registry) error {
 			}
 			e.counterAdd(name, wago.AsI64(p[2]))
 			res[0] = wago.I32(0)
-		})).
+		}).
 		Params(wago.ValI32, wago.ValI32, wago.ValI64).Results(wago.ValI32).Capability(CapWrite).
 		Docs("add to a counter: (name_ptr i32, name_len i32, delta i64) -> status i32")
 
 	reg.ImportModule("wago_metrics").
-		Func("histogram_observe", wago.SyncHostFunc(func(m wago.HostModule, p, res []uint64) {
+		Func("histogram_observe", func(m wago.HostModule, p, res []uint64) {
 			name, ok := readName(m, uint32(p[0]), uint32(p[1]))
 			if !ok {
 				res[0] = wago.I32(4)
@@ -81,7 +81,7 @@ func (e *Extension) Register(reg *wago.Registry) error {
 			}
 			e.histObserve(name, wago.AsF64(p[2]))
 			res[0] = wago.I32(0)
-		})).
+		}).
 		Params(wago.ValI32, wago.ValI32, wago.ValF64).Results(wago.ValI32).Capability(CapWrite).
 		Docs("observe a histogram value: (name_ptr i32, name_len i32, value f64) -> status i32")
 

--- a/plugins/timer/timer.go
+++ b/plugins/timer/timer.go
@@ -67,27 +67,27 @@ func (e *Extension) Register(reg *wago.Registry) error {
 	reg.Capability(CapRead, wago.CapabilityDocs("read wall-clock and monotonic time"))
 
 	reg.ImportModule("wago_timer").
-		Func("now_unix_ms", wago.SyncHostFunc(func(_ wago.HostModule, _, res []uint64) {
+		Func("now_unix_ms", func(_ wago.HostModule, _, res []uint64) {
 			res[0] = wago.I64(e.clock.UnixMilli())
-		})).
+		}).
 		Results(wago.ValI64).Capability(CapRead).
 		Docs("current wall-clock time in milliseconds since the Unix epoch")
 
 	reg.ImportModule("wago_timer").
-		Func("now_monotonic_ns", wago.SyncHostFunc(func(_ wago.HostModule, _, res []uint64) {
+		Func("now_monotonic_ns", func(_ wago.HostModule, _, res []uint64) {
 			res[0] = wago.I64(e.clock.MonotonicNanos())
-		})).
+		}).
 		Results(wago.ValI64).Capability(CapRead).
 		Docs("monotonic timer reading in nanoseconds")
 
 	reg.ImportModule("wago_timer").
-		Func("sleep_ms", wago.SyncHostFunc(func(_ wago.HostModule, p, res []uint64) {
+		Func("sleep_ms", func(_ wago.HostModule, p, res []uint64) {
 			ms := wago.AsI64(p[0])
 			if ms > 0 {
 				e.clock.Sleep(time.Duration(ms) * time.Millisecond)
 			}
 			res[0] = wago.I32(0)
-		})).
+		}).
 		Params(wago.ValI64).Results(wago.ValI32).Capability(CapRead).
 		Docs("block the calling guest for the given milliseconds")
 

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -19,12 +19,12 @@ type capabilitySpec struct {
 // registeredImport is one host function an extension exposes to guests, keyed by
 // its wasm ("module", "name"). params/results are the declared signature (used
 // for the manifest and later validation); the actual binding uses the importing
-// module's own signature. fn is a SyncHostFunc, the legacy HostFunc, or a native
-// Go function — the same shapes Instantiate already accepts.
+// module's own signature. fn is always a SyncHostFunc — the reflection-free stack
+// form — so a plugin's host imports bind identically under standard Go and TinyGo.
 type registeredImport struct {
 	module  string
 	name    string
-	fn      any
+	fn      SyncHostFunc
 	params  []ValType
 	results []ValType
 	cap     Capability
@@ -67,11 +67,15 @@ type ImportModuleBuilder struct {
 	module string
 }
 
-// Func declares a host function named `name` in this module. fn may be a
-// SyncHostFunc, a HostFunc, or a native Go function whose numeric signature
-// matches the importing module's declared type. Chain Params/Results/Capability
-// on the returned builder to record the signature and required capability.
-func (m *ImportModuleBuilder) Func(name string, fn any) *ImportFuncBuilder {
+// Func declares a host function named `name` in this module. fn is a
+// SyncHostFunc: it reads its wasm params from params (i32/f32 in the low 32 bits)
+// and writes results into results, with the calling instance's memory available
+// via the HostModule. This reflection-free stack form is the single, portable way
+// to write a plugin host import — it binds identically under standard Go and
+// TinyGo. A bare func literal of the same shape is accepted without an explicit
+// SyncHostFunc conversion. Chain Params/Results/Capability on the returned builder
+// to record the signature and required capability.
+func (m *ImportModuleBuilder) Func(name string, fn SyncHostFunc) *ImportFuncBuilder {
 	imp := &registeredImport{module: m.module, name: name, fn: fn}
 	m.reg.imports = append(m.reg.imports, imp)
 	return &ImportFuncBuilder{imp: imp}

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -22,8 +22,9 @@ func (e tripleExt) Info() ExtensionInfo {
 
 func (e tripleExt) Register(reg *Registry) error {
 	reg.Capability(CapMetricsWrite, CapabilityDocs("demo capability"))
+	// Bare func literal (no explicit SyncHostFunc conversion) — the portable form.
 	reg.ImportModule("env").
-		Func("f", SyncHostFunc(func(_ HostModule, p, r []uint64) { r[0] = I32(AsI32(p[0]) * 3) })).
+		Func("f", func(_ HostModule, p, r []uint64) { r[0] = I32(AsI32(p[0]) * 3) }).
 		Params(ValI32).Results(ValI32).Capability(CapMetricsWrite)
 	if e.onInstantiate != nil {
 		reg.Hooks().AfterInstantiate(func(_ *InstantiateContext, _ *Instance) error {


### PR DESCRIPTION
Makes the reflection-free **stack form** the single way plugins register host imports, so plugin-authoring code is identical — and works — on both standard Go and TinyGo. This is wazero's `WithGoModuleFunction` (`stack []uint64`) form, promoted from escape hatch to the default.

## Why
`reg.Func(name, fn any)` previously accepted native Go funcs and bound them via reflection. But TinyGo's `reflect.Value.Call` is unimplemented, so a native-func import that compiled on `go build` would **fail to bind under `tinygo build`** — a silent portability cliff. The stack form (`SyncHostFunc`) is the one shape that binds identically on both toolchains.

## Change
- `ImportModuleBuilder.Func` is now typed `func(name string, fn SyncHostFunc)` instead of `fn any`. No reflection path in the plugin registry → portable by construction. A **bare func literal** of the stack shape binds with no explicit `SyncHostFunc(...)` conversion (Go converts an untyped literal to the named param type), so ergonomics are unchanged — actually cleaner:
  ```go
  reg.ImportModule("wago_timer").
      Func("now_unix_ms", func(_ wago.HostModule, _, res []uint64) {
          res[0] = wago.I64(now())
      }).Results(wago.ValI64)
  ```
- Built-ins (timer/log/metrics) and the in-package test extension simplified to the bare-literal form (dogfood).
- The low-level `wago.Instantiate(c, Imports{...})` path keeps its std-Go reflection convenience for direct (non-plugin) callers — unchanged; this only affects the plugin registry.

## Verification
- `go test ./src/wago ./cli/wago ./plugins/...` — PASS.
- **`tinygo test ./src/wago`** — PASS: the core tests now register a plugin import via a **bare func literal** through `reg.Func`, proving it binds under TinyGo.
- `make tinygo-build` (lean CLI importing timer/log/metrics) builds under TinyGo.
- `go build ./...`, `go vet`, `gofmt` clean; facade unchanged.