### PR TITLE
feat(wago): invoke + compile hooks (BeforeInvoke/AfterInvoke/AfterCompile)

### DIFF
--- a/src/wago/hooks.go
+++ b/src/wago/hooks.go
@@ -1,12 +1,18 @@
 package wago
 
-// HookRegistry collects lifecycle callbacks contributed by extensions. Phase 1
-// wires the runtime-lifecycle and instantiate hooks (the points the Runtime
-// itself drives); compile, invoke, and process hooks are added in later phases.
+import "time"
+
+// HookRegistry collects lifecycle callbacks contributed by extensions: runtime
+// close, compile, instantiate, and invoke. Hooks fire on the Runtime-aware paths
+// (rt.Compile, rt.Instantiate, and Instance.Call) — the low-level package-level
+// Compile/Instantiate/Invoke are hook-free.
 type HookRegistry struct {
 	onRuntimeClose    []func(*RuntimeContext)
+	afterCompile      []func(*CompileContext, *Module) error
 	beforeInstantiate []func(*InstantiateContext) error
 	afterInstantiate  []func(*InstantiateContext, *Instance) error
+	beforeInvoke      []func(*InvokeContext) error
+	afterInvoke       []func(*InvokeContext, []Value, error)
 }
 
 // OnRuntimeClose registers a callback run when the runtime is closed, in reverse
@@ -27,6 +33,25 @@ func (h *HookRegistry) AfterInstantiate(fns ...func(*InstantiateContext, *Instan
 	h.afterInstantiate = append(h.afterInstantiate, fns...)
 }
 
+// AfterCompile registers a callback run after each rt.Compile produces a Module.
+// Returning an error fails the compile.
+func (h *HookRegistry) AfterCompile(fns ...func(*CompileContext, *Module) error) {
+	h.afterCompile = append(h.afterCompile, fns...)
+}
+
+// BeforeInvoke registers a callback run before each Instance.Call. Returning an
+// error aborts the call (the export is not run).
+func (h *HookRegistry) BeforeInvoke(fns ...func(*InvokeContext) error) {
+	h.beforeInvoke = append(h.beforeInvoke, fns...)
+}
+
+// AfterInvoke registers a callback run after each Instance.Call returns, with the
+// results and error. It runs even when the call errored (results is nil then),
+// so it is the place for timing, metrics, and trap reporting.
+func (h *HookRegistry) AfterInvoke(fns ...func(*InvokeContext, []Value, error)) {
+	h.afterInvoke = append(h.afterInvoke, fns...)
+}
+
 // RuntimeContext is passed to runtime-lifecycle hooks.
 type RuntimeContext struct {
 	Runtime *Runtime
@@ -40,5 +65,23 @@ type InstantiateContext struct {
 	Module   *Module
 	Compiled *Compiled
 	Imports  Imports
+	Metadata map[string]any
+}
+
+// CompileContext is passed to compile hooks.
+type CompileContext struct {
+	Runtime  *Runtime
+	Metadata map[string]any
+}
+
+// InvokeContext is passed to invoke hooks. Start is set when the Before hooks run,
+// so an After hook can measure the call duration. Metadata carries extension-local
+// state from Before to After (e.g. a metrics start marker).
+type InvokeContext struct {
+	Runtime  *Runtime
+	Instance *Instance
+	Export   string
+	Args     []Value
+	Start    time.Time
 	Metadata map[string]any
 }

--- a/src/wago/hooks_test.go
+++ b/src/wago/hooks_test.go
@@ -1,0 +1,137 @@
+package wago
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// hookExt is an extension that registers invoke/compile hooks driven by callbacks,
+// so a test can observe when they fire.
+type hookExt struct {
+	afterCompile func(*Module)
+	beforeInvoke func(*InvokeContext) error
+	afterInvoke  func(*InvokeContext, []Value, error)
+}
+
+func (hookExt) Info() ExtensionInfo {
+	return ExtensionInfo{ID: "test.hooks", Version: "1.0.0", Stability: Stable}
+}
+
+func (e hookExt) Register(reg *Registry) error {
+	// Provide env.f so callsEnvF modules instantiate.
+	reg.ImportModule("env").
+		Func("f", func(_ HostModule, p, r []uint64) { r[0] = p[0] }).
+		Params(ValI32).Results(ValI32)
+	if e.afterCompile != nil {
+		reg.Hooks().AfterCompile(func(_ *CompileContext, m *Module) error { e.afterCompile(m); return nil })
+	}
+	if e.beforeInvoke != nil {
+		reg.Hooks().BeforeInvoke(e.beforeInvoke)
+	}
+	if e.afterInvoke != nil {
+		reg.Hooks().AfterInvoke(e.afterInvoke)
+	}
+	return nil
+}
+
+func TestInvokeHooksFire(t *testing.T) {
+	var before, after int
+	var sawExport string
+	var sawResult int32
+	rt := NewRuntime()
+	if err := rt.Use(hookExt{
+		beforeInvoke: func(ic *InvokeContext) error { before++; sawExport = ic.Export; return nil },
+		afterInvoke: func(_ *InvokeContext, out []Value, _ error) {
+			after++
+			if len(out) == 1 {
+				sawResult = out[0].I32()
+			}
+		},
+	}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), callsEnvF(t, rt))
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	if _, err := in.Call(context.Background(), "g", ValueI32(41)); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if before != 1 || after != 1 {
+		t.Fatalf("hooks fired before=%d after=%d, want 1/1", before, after)
+	}
+	if sawExport != "g" {
+		t.Fatalf("BeforeInvoke saw export %q, want g", sawExport)
+	}
+	if sawResult != 41 {
+		t.Fatalf("AfterInvoke saw result %d, want 41", sawResult)
+	}
+}
+
+func TestBeforeInvokeVetoAbortsCall(t *testing.T) {
+	afterErr := "none"
+	rt := NewRuntime()
+	if err := rt.Use(hookExt{
+		beforeInvoke: func(_ *InvokeContext) error { return fmt.Errorf("denied") },
+		afterInvoke: func(_ *InvokeContext, out []Value, err error) {
+			if err != nil {
+				afterErr = err.Error()
+			}
+		},
+	}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), callsEnvF(t, rt))
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	_, err = in.Call(context.Background(), "g", ValueI32(1))
+	if err == nil || err.Error() != "denied" {
+		t.Fatalf("Call error = %v, want denied", err)
+	}
+	if afterErr != "denied" {
+		t.Fatalf("AfterInvoke saw err %q, want denied", afterErr)
+	}
+}
+
+func TestAfterCompileHookFires(t *testing.T) {
+	fired := 0
+	var gotExports []string
+	rt := NewRuntime()
+	if err := rt.Use(hookExt{afterCompile: func(m *Module) { fired++; gotExports = m.Exports() }}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	_ = callsEnvF(t, rt) // rt.Compile triggers AfterCompile
+	if fired != 1 {
+		t.Fatalf("AfterCompile fired %d times, want 1", fired)
+	}
+	if len(gotExports) != 1 || gotExports[0] != "g" {
+		t.Fatalf("AfterCompile module exports = %v, want [g]", gotExports)
+	}
+}
+
+// TestLowLevelInvokeSkipsHooks confirms the low-level Invoke path is hook-free.
+func TestLowLevelInvokeSkipsHooks(t *testing.T) {
+	rt := NewRuntime()
+	fired := 0
+	if err := rt.Use(hookExt{beforeInvoke: func(_ *InvokeContext) error { fired++; return nil }}); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), callsEnvF(t, rt))
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	// Low-level Invoke (untyped) must not fire the runtime's invoke hooks.
+	if _, err := in.Invoke("g", I32(3)); err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if fired != 0 {
+		t.Fatalf("low-level Invoke fired %d invoke hooks, want 0", fired)
+	}
+}

--- a/src/wago/instance_call.go
+++ b/src/wago/instance_call.go
@@ -3,13 +3,15 @@ package wago
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 // Call is the high-level, context-aware, typed invocation: arguments and results
 // are typed Values checked against the export's signature. It wraps the low-level
 // Invoke (untyped uint64 slots). ctx is honored for cancellation before the call
-// begins. v128 parameters/results are not expressible as a Value; use Invoke for
-// those.
+// begins. When the instance was created through a Runtime, its BeforeInvoke and
+// AfterInvoke hooks fire around the call. v128 parameters/results are not
+// expressible as a Value; use Invoke for those.
 func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]Value, error) {
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
@@ -38,6 +40,32 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 			return nil, fmt.Errorf("%s result %d is v128; use Invoke for v128 values", export, i)
 		}
 	}
+
+	// Fast path: no runtime or no invoke hooks — invoke directly, zero overhead.
+	if in.rt == nil || (len(in.rt.hooks.beforeInvoke) == 0 && len(in.rt.hooks.afterInvoke) == 0) {
+		return in.callInner(export, slots, results)
+	}
+
+	ictx := &InvokeContext{Runtime: in.rt, Instance: in, Export: export, Args: args, Start: time.Now(), Metadata: map[string]any{}}
+	for _, fn := range in.rt.hooks.beforeInvoke {
+		if err := fn(ictx); err != nil {
+			// A BeforeInvoke veto aborts the call; report it to AfterInvoke too so
+			// paired hooks can unwind.
+			for _, af := range in.rt.hooks.afterInvoke {
+				af(ictx, nil, err)
+			}
+			return nil, err
+		}
+	}
+	out, err := in.callInner(export, slots, results)
+	for _, fn := range in.rt.hooks.afterInvoke {
+		fn(ictx, out, err)
+	}
+	return out, err
+}
+
+// callInner performs the actual invocation and result decoding.
+func (in *Instance) callInner(export string, slots []uint64, results []ValType) ([]Value, error) {
 	raw, err := in.Invoke(export, slots...)
 	if err != nil {
 		return nil, err

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -33,6 +33,11 @@ type Instance struct {
 	serArgs, results, trap []byte
 	resultVals             []uint64    // reusable Invoke result buffer (valid until the next call)
 	ic                     invokeCache // single-entry export resolution cache
+
+	// rt is set when the instance is created through a Runtime (rt.Instantiate /
+	// Spawn), so Instance.Call can fire the runtime's invoke hooks. It is nil for
+	// the low-level package-level Instantiate, which stays hook-free.
+	rt *Runtime
 }
 
 // invokeCache memoizes per-export work so a hot Invoke loop on one export skips

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -167,7 +167,12 @@ func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, e
 	for k, v := range rt.processImports(proc) {
 		merged[k] = v // per-process imports take precedence
 	}
-	return InstantiateWithOptions(class.mod.c, InstantiateOptions{Imports: merged})
+	inst, err := InstantiateWithOptions(class.mod.c, InstantiateOptions{Imports: merged})
+	if err != nil {
+		return nil, err
+	}
+	inst.rt = rt // enable Instance.Call invoke hooks for the process body
+	return inst, nil
 }
 
 // processImports builds the per-process wago_process/wago_mailbox host bindings.

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -159,13 +159,23 @@ func (rt *Runtime) Use(ext Extension, _ ...UseOption) error {
 }
 
 // Compile compiles a wasm module under the runtime's configuration and wraps it
-// as a *Module, resolving its imports against the registered extensions.
+// as a *Module, resolving its imports against the registered extensions and
+// running any AfterCompile hooks.
 func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
 	c, err := CompileWithConfig(rt.cfg, wasmBytes)
 	if err != nil {
 		return nil, err
 	}
-	return rt.buildModule(c), nil
+	mod := rt.buildModule(c)
+	if len(rt.hooks.afterCompile) > 0 {
+		cctx := &CompileContext{Runtime: rt, Metadata: map[string]any{}}
+		for _, fn := range rt.hooks.afterCompile {
+			if err := fn(cctx, mod); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return mod, nil
 }
 
 // InstantiateOption configures a single Instantiate call.
@@ -274,6 +284,7 @@ func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...Instant
 	if err != nil {
 		return nil, err
 	}
+	inst.rt = rt // enable Instance.Call invoke hooks
 	for _, fn := range rt.hooks.afterInstantiate {
 		if err := fn(hctx, inst); err != nil {
 			inst.Close()

--- a/wago.go
+++ b/wago.go
@@ -17,6 +17,7 @@ type (
 	ChildSpec                 = impl.ChildSpec
 	Class                     = impl.Class
 	ClassOptions              = impl.ClassOptions
+	CompileContext            = impl.CompileContext
 	Compiled                  = impl.Compiled
 	CoreFeatures              = impl.CoreFeatures
 	DataInit                  = impl.DataInit
@@ -56,6 +57,7 @@ type (
 	InstantiateContext        = impl.InstantiateContext
 	InstantiateOption         = impl.InstantiateOption
 	InstantiateOptions        = impl.InstantiateOptions
+	InvokeContext             = impl.InvokeContext
 	Lease                     = impl.Lease
 	Mailbox                   = impl.Mailbox
 	Memory                    = impl.Memory


### PR DESCRIPTION
Wires the invoke and compile hooks that were declared in the plan but never implemented — the capability gap that blocked observability plugins (a metrics/tracing extension can now auto-instrument invocations).

## What's here
- **`HookRegistry.BeforeInvoke` / `AfterInvoke`** — fire around each `Instance.Call` when the instance was created through a Runtime (`rt.Instantiate` or `Spawn`). `AfterInvoke` runs even on error (results nil), so it's the place for timing/metrics/trap reporting. A `BeforeInvoke` returning an error **vetoes the call** (the export isn't run) and is reported to `AfterInvoke` so paired hooks unwind.
- **`HookRegistry.AfterCompile`** — fires after `rt.Compile` produces a `*Module`; an error fails the compile.
- New context types `InvokeContext` (Runtime/Instance/Export/Args/Start/Metadata) and `CompileContext`.
- Instance carries a runtime backref (`in.rt`) set only on the Runtime-aware paths.

## Design
- Hooks fire on the **Runtime-aware** paths (`rt.Compile`, `Instance.Call`); the **low-level** package-level `Compile`/`Invoke` stay hook-free (verified by test).
- **Zero overhead when unused:** `Call` fast-paths straight to the invocation when there's no runtime or no invoke hooks registered — no context allocation.

## Verification
- `go test ./src/wago -run 'TestInvokeHooks|TestBeforeInvoke|TestAfterCompile|TestLowLevelInvoke'` — PASS: before/after fire once with correct export + result; a BeforeInvoke veto aborts the call and reaches AfterInvoke with the error; AfterCompile fires with the module's exports; low-level `Invoke` fires no hooks.
- Full `go test ./src/wago`, `go build ./...`, `go vet`, `gofmt`, `tinygo test ./src/wago` — all PASS. Facade regenerated.