### PR TITLE
feat(cli): wago plugin inspect + wago module imports/capabilities

### DIFF
--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -38,6 +38,8 @@ func main() {
 		notImplemented("build")
 	case "plugin", "plugins":
 		pluginCmd(a[1:])
+	case "module", "mod":
+		moduleCmd(a[1:])
 	case "env":
 		envCmd()
 	case "validate":
@@ -61,6 +63,9 @@ func usage(w *os.File) {
 %s
   run <file> [args...]      compile and execute an export   (default)
   plugin list               list plugins compiled into this binary
+  plugin inspect <name>     show a plugin's imports and capabilities
+  module imports <file>     list a module's imports (resolved vs plugins)
+  module capabilities <f>   list the capabilities a module requires
   env                       print resolved config/cache/data directories
   build                     not implemented
   validate <file>           decode and validate a module

--- a/cli/wago/module.go
+++ b/cli/wago/module.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/wago-org/wago"
+)
+
+// moduleCmd dispatches `wago module <sub> <file>`: inspection of a wasm module's
+// imports and required capabilities, resolved against the built-in plugins.
+func moduleCmd(args []string) {
+	if len(args) < 1 {
+		fatal("module: need a subcommand (imports, capabilities)")
+	}
+	sub := args[0]
+	switch sub {
+	case "imports":
+		moduleImports(singleFileArg("module imports", args[1:]))
+	case "capabilities", "caps":
+		moduleCapabilities(singleFileArg("module capabilities", args[1:]))
+	default:
+		fatal("module: unknown subcommand %q (have: imports, capabilities)", sub)
+	}
+}
+
+// runtimeWithAllPlugins builds a runtime with every compiled-in plugin registered,
+// so a module's imports resolve to their providing plugin's signatures and caps.
+func runtimeWithAllPlugins() *wago.Runtime {
+	rt := wago.NewRuntime()
+	for _, name := range wago.RegisteredPluginNames() {
+		_ = rt.UsePlugin(name)
+	}
+	return rt
+}
+
+func compileForInspect(rt *wago.Runtime, file string) *wago.Module {
+	src, err := os.ReadFile(file)
+	if err != nil {
+		fatal("%v", err)
+	}
+	mod, err := rt.Compile(src)
+	if err != nil {
+		fatal("compile: %v", err)
+	}
+	return mod
+}
+
+func moduleImports(file string) {
+	mod := compileForInspect(runtimeWithAllPlugins(), file)
+	imports := mod.Imports()
+	if len(imports) == 0 {
+		fmt.Println(dim("module has no imports"))
+		return
+	}
+	fmt.Printf("%s\n", bold("imports:"))
+	for _, s := range imports {
+		mark := red("unresolved")
+		if s.Provided {
+			mark = cyan("provided")
+		}
+		line := fmt.Sprintf("  %s  %s  %s", s.Key(), dim(s.Kind.String()), mark)
+		if s.Kind == wago.ImportFunc && (len(s.Params) > 0 || len(s.Results) > 0) {
+			line += "  " + dim(sigString(s.Params, s.Results))
+		}
+		if s.HasCapability {
+			line += "  " + dim("["+string(s.Capability)+"]")
+		}
+		fmt.Println(line)
+	}
+}
+
+func moduleCapabilities(file string) {
+	mod := compileForInspect(runtimeWithAllPlugins(), file)
+	caps := mod.RequiredCapabilities()
+	if len(caps) == 0 {
+		fmt.Println(dim("module requires no capabilities"))
+		return
+	}
+	fmt.Printf("%s\n", bold("required capabilities:"))
+	for _, c := range caps {
+		fmt.Printf("  %s\n", string(c))
+	}
+}

--- a/cli/wago/plugins.go
+++ b/cli/wago/plugins.go
@@ -30,6 +30,11 @@ func pluginCmd(args []string) {
 	switch sub {
 	case "list", "ls":
 		pluginList()
+	case "inspect", "show":
+		if len(args) < 2 {
+			fatal("plugin inspect: need a <name> (see: wago plugin list)")
+		}
+		pluginInspect(args[1])
 	case "install", "add", "uninstall", "remove", "update", "build":
 		fatal("plugin %s: not yet implemented — third-party plugins are added by\n"+
 			"building a custom wago binary that imports them (a manifest-driven\n"+
@@ -65,6 +70,64 @@ func pluginList() {
 			fmt.Printf("      %s\n", dim(info.Description))
 		}
 	}
+}
+
+// pluginInspect prints one plugin's identity, capabilities, and the host imports
+// it provides (with signatures, required capability, and docs).
+func pluginInspect(name string) {
+	ext, ok := wago.NewExtension(name)
+	if !ok {
+		fatal("plugin inspect: unknown plugin %q (see: wago plugin list)", name)
+	}
+	info := ext.Info()
+	rt := wago.NewRuntime()
+	if err := rt.Use(ext); err != nil {
+		fatal("plugin inspect: %v", err)
+	}
+
+	fmt.Printf("%s  %s %s  %s\n", bold(name), dim(info.ID), info.Version, dim(string(info.Stability)))
+	if info.Description != "" {
+		fmt.Printf("  %s\n", info.Description)
+	}
+	if caps := rt.Capabilities(); len(caps) > 0 {
+		strs := make([]string, len(caps))
+		for i, c := range caps {
+			strs[i] = string(c)
+		}
+		fmt.Printf("  %s %s\n", dim("capabilities:"), strings.Join(strs, ", "))
+	}
+	imports := rt.ProvidedImports()
+	if len(imports) == 0 {
+		return
+	}
+	fmt.Printf("  %s\n", dim("imports:"))
+	for _, s := range imports {
+		line := fmt.Sprintf("    %s  %s", cyan(s.Key()), dim(sigString(s.Params, s.Results)))
+		if s.HasCapability {
+			line += "  " + dim("["+string(s.Capability)+"]")
+		}
+		fmt.Println(line)
+		if s.Docs != "" {
+			fmt.Printf("        %s\n", dim(s.Docs))
+		}
+	}
+}
+
+// sigString renders a wasm signature like "(i32, i32) -> i32".
+func sigString(params, results []wago.ValType) string {
+	ps := make([]string, len(params))
+	for i, p := range params {
+		ps[i] = p.String()
+	}
+	sig := "(" + strings.Join(ps, ", ") + ")"
+	if len(results) == 0 {
+		return sig
+	}
+	rs := make([]string, len(results))
+	for i, r := range results {
+		rs[i] = r.String()
+	}
+	return sig + " -> " + strings.Join(rs, ", ")
 }
 
 // pluginCapabilities returns the capability names an extension declares, by

--- a/src/wago/plugins.go
+++ b/src/wago/plugins.go
@@ -80,3 +80,28 @@ func (rt *Runtime) HostImports() Imports {
 	}
 	return out
 }
+
+// ProvidedImports returns the host imports the runtime's registered extensions
+// provide, as ImportSpecs (module, name, declared signature, capability, docs),
+// sorted by "module.name". It powers inspection/CLI output. Provided is always
+// true here (these are the bindings the runtime supplies).
+func (rt *Runtime) ProvidedImports() []ImportSpec {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	specs := make([]ImportSpec, 0, len(rt.importMeta))
+	for _, meta := range rt.importMeta {
+		specs = append(specs, ImportSpec{
+			Module:        meta.module,
+			Name:          meta.name,
+			Kind:          ImportFunc,
+			Params:        append([]ValType(nil), meta.params...),
+			Results:       append([]ValType(nil), meta.results...),
+			Capability:    meta.cap,
+			HasCapability: meta.hasCap,
+			Docs:          meta.docs,
+			Provided:      true,
+		})
+	}
+	sort.Slice(specs, func(i, j int) bool { return specs[i].Key() < specs[j].Key() })
+	return specs
+}

--- a/src/wago/plugins_test.go
+++ b/src/wago/plugins_test.go
@@ -28,6 +28,27 @@ func TestPluginRegistry(t *testing.T) {
 	}
 }
 
+func TestProvidedImports(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(tripleExt{}); err != nil { // provides env.f(i32)->i32, cap MetricsWrite
+		t.Fatalf("use: %v", err)
+	}
+	specs := rt.ProvidedImports()
+	if len(specs) != 1 {
+		t.Fatalf("ProvidedImports = %+v, want 1", specs)
+	}
+	s := specs[0]
+	if s.Key() != "env.f" || s.Kind != ImportFunc || !s.Provided {
+		t.Fatalf("spec = %+v", s)
+	}
+	if len(s.Params) != 1 || s.Params[0] != ValI32 || len(s.Results) != 1 || s.Results[0] != ValI32 {
+		t.Fatalf("spec signature = %v -> %v", s.Params, s.Results)
+	}
+	if !s.HasCapability || s.Capability != CapMetricsWrite {
+		t.Fatalf("spec capability = %v (%v)", s.Capability, s.HasCapability)
+	}
+}
+
 func TestUsePluginAndHostImports(t *testing.T) {
 	rt := NewRuntime()
 	if err := rt.UsePlugin("test.triple.plugin"); err != nil {


### PR DESCRIPTION
CLI inspection for plugins and modules, built on data that already exists (`Module.Imports()`, `RequiredCapabilities()`).

## New commands
- **`wago plugin inspect <name>`** — a plugin's id/version/stability, capabilities, and every host import it provides with signature, required capability, and docs:
  ```
  timer  wago.timer 1.0.0  stable
    Wall-clock and monotonic time for wasm guests.
    capabilities: timer.read
    imports:
      wago_timer.now_unix_ms  () -> i64  [timer.read]
          current wall-clock time in milliseconds since the Unix epoch
      ...
  ```
- **`wago module imports <file>`** — a module's imports, each marked `provided`/`unresolved` against the compiled-in plugins, with signature + capability.
- **`wago module capabilities <file>`** — the capabilities a module requires (derived from its imports' providers).

## Supporting API
- New `(*Runtime).ProvidedImports() []ImportSpec` — enumerates the runtime's registered extension imports (module, name, signature, capability, docs), sorted. Powers `plugin inspect` and is generally useful for inspection.

## Verification
- `go test ./src/wago -run TestProvidedImports` — PASS (spec key/kind/signature/capability).
- Manual: `plugin inspect timer` renders all three imports with sigs + docs; `module imports timer.wasm` shows `wago_timer.now_unix_ms … provided () -> i64 [timer.read]`; `module capabilities timer.wasm` → `timer.read`.
- Full `go test ./src/wago ./cli/wago ./plugins/...`, `go build ./...`, `go vet`, `gofmt`, `make tinygo-build` (lean CLI) — all PASS. Facade unchanged (method rides the Runtime alias).