### PR TITLE
feat(cli): plugin manifest (wago-plugins.json) + plugin add/remove/manifest

### DIFF
--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -64,6 +64,9 @@ func usage(w *os.File) {
   run <file> [args...]      compile and execute an export   (default)
   plugin list               list plugins compiled into this binary
   plugin inspect <name>     show a plugin's imports and capabilities
+  plugin add <module>       declare a plugin in wago-plugins.json
+  plugin remove <name>      remove a plugin from the manifest
+  plugin manifest           show declared plugins (for a custom build)
   module imports <file>     list a module's imports (resolved vs plugins)
   module capabilities <f>   list the capabilities a module requires
   env                       print resolved config/cache/data directories

--- a/cli/wago/manifest.go
+++ b/cli/wago/manifest.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// manifestName is the per-project plugin manifest file. It is plain JSON — no
+// database — because it is a small, git-committable, human-editable list of which
+// plugins a custom wago binary should be built with. It is read whole and written
+// whole; there are no concurrent writers (it is edited by dev-time CLI actions).
+const manifestName = "wago-plugins.json"
+
+const manifestVersion = 1
+
+// Manifest is the declarative set of plugins for a custom wago build.
+type Manifest struct {
+	Version int           `json:"version"`
+	Plugins []PluginEntry `json:"plugins"`
+}
+
+// PluginEntry is one declared plugin. Module is "builtin" for a plugin already
+// compiled into wago, or a Go module path (e.g. github.com/acme/wago-redis) for a
+// third-party one. Version is the module version (empty = latest) and is unused
+// for builtins. Enabled plugins are included by `wago plugin build`.
+type PluginEntry struct {
+	Name    string `json:"name"`
+	Module  string `json:"module"`
+	Version string `json:"version,omitempty"`
+	Enabled bool   `json:"enabled"`
+}
+
+// Builtin reports whether the entry refers to a compiled-in plugin.
+func (e PluginEntry) Builtin() bool { return e.Module == "" || e.Module == "builtin" }
+
+// manifestPath returns the manifest file path (WAGO_PLUGIN_MANIFEST override, else
+// wago-plugins.json in the working directory).
+func manifestPath() string {
+	if p := os.Getenv("WAGO_PLUGIN_MANIFEST"); p != "" {
+		return p
+	}
+	return manifestName
+}
+
+// loadManifest reads the manifest, returning an empty one if the file is absent.
+func loadManifest(path string) (*Manifest, error) {
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &Manifest{Version: manifestVersion}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if m.Version == 0 {
+		m.Version = manifestVersion
+	}
+	return &m, nil
+}
+
+// save writes the manifest as indented JSON, sorted by name for stable diffs.
+func (m *Manifest) save(path string) error {
+	sort.Slice(m.Plugins, func(i, j int) bool { return m.Plugins[i].Name < m.Plugins[j].Name })
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+// find returns the index of the entry named name, or -1.
+func (m *Manifest) find(name string) int {
+	for i := range m.Plugins {
+		if m.Plugins[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// add inserts or updates an entry, returning whether it was newly added.
+func (m *Manifest) add(e PluginEntry) bool {
+	if i := m.find(e.Name); i >= 0 {
+		m.Plugins[i] = e
+		return false
+	}
+	m.Plugins = append(m.Plugins, e)
+	return true
+}
+
+// remove deletes the entry named name, returning whether it existed.
+func (m *Manifest) remove(name string) bool {
+	i := m.find(name)
+	if i < 0 {
+		return false
+	}
+	m.Plugins = append(m.Plugins[:i], m.Plugins[i+1:]...)
+	return true
+}
+
+// ---- CLI ----------------------------------------------------------------
+
+// deriveName picks a plugin name from a module path: the last path element with a
+// leading "wago-"/"wago_" stripped (github.com/acme/wago-redis -> redis).
+func deriveName(module string) string {
+	base := module
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	base = strings.TrimPrefix(base, "wago-")
+	base = strings.TrimPrefix(base, "wago_")
+	return base
+}
+
+// pluginManifestAdd records a plugin in the manifest. modOrName is a builtin
+// plugin name (no slash) or a Go module path; name/version override the derived
+// name and pin a version.
+func pluginManifestAdd(modOrName, name, version string) {
+	path := manifestPath()
+	m, err := loadManifest(path)
+	if err != nil {
+		fatal("plugin add: %v", err)
+	}
+	e := PluginEntry{Enabled: true, Version: version}
+	if strings.Contains(modOrName, "/") || strings.Contains(modOrName, ".") {
+		e.Module = modOrName
+		e.Name = name
+		if e.Name == "" {
+			e.Name = deriveName(modOrName)
+		}
+	} else {
+		// A bare token: a builtin plugin name.
+		e.Module = "builtin"
+		e.Name = modOrName
+		if name != "" {
+			e.Name = name
+		}
+	}
+	if e.Name == "" {
+		fatal("plugin add: could not derive a plugin name from %q; pass --name", modOrName)
+	}
+	newly := m.add(e)
+	if err := m.save(path); err != nil {
+		fatal("plugin add: %v", err)
+	}
+	verb := "updated"
+	if newly {
+		verb = "added"
+	}
+	fmt.Printf("%s %s (%s) in %s\n", verb, cyan(e.Name), e.Module, path)
+}
+
+// pluginAddCmd parses `plugin add <module> [--name x] [--version v]`.
+func pluginAddCmd(args []string) {
+	var name, version string
+	pos, err := extractOpts(args, map[string]*string{"--name": &name, "--version": &version})
+	if err != nil {
+		fatal("plugin add: %v", err)
+	}
+	if len(pos) != 1 {
+		fatal("plugin add: need exactly one <module-or-name>")
+	}
+	pluginManifestAdd(pos[0], name, version)
+}
+
+// pluginBuild previews the custom build described by the manifest. The codegen +
+// `go build` step is implemented in a follow-up; for now it reports what would be
+// built so the manifest can be validated.
+func pluginBuild(_ []string) {
+	path := manifestPath()
+	m, err := loadManifest(path)
+	if err != nil {
+		fatal("plugin build: %v", err)
+	}
+	var enabled []PluginEntry
+	for _, e := range m.Plugins {
+		if e.Enabled {
+			enabled = append(enabled, e)
+		}
+	}
+	if len(enabled) == 0 {
+		fatal("plugin build: no enabled plugins in %s (add one: wago plugin add <module>)", path)
+	}
+	fmt.Printf("%s\n", bold("would build a custom wago binary with:"))
+	for _, e := range enabled {
+		src := e.Module
+		if e.Builtin() {
+			src = "builtin"
+		} else if e.Version != "" {
+			src = e.Module + "@" + e.Version
+		}
+		fmt.Printf("  %s  %s\n", e.Name, dim(src))
+	}
+	fatal("plugin build: codegen + go build not yet wired (this preview validates the manifest)")
+}
+
+func pluginManifestRemove(name string) {
+	path := manifestPath()
+	m, err := loadManifest(path)
+	if err != nil {
+		fatal("plugin remove: %v", err)
+	}
+	if !m.remove(name) {
+		fatal("plugin remove: %q is not in %s", name, path)
+	}
+	if err := m.save(path); err != nil {
+		fatal("plugin remove: %v", err)
+	}
+	fmt.Printf("removed %s from %s\n", name, path)
+}
+
+func pluginManifestShow() {
+	path := manifestPath()
+	m, err := loadManifest(path)
+	if err != nil {
+		fatal("plugin manifest: %v", err)
+	}
+	if len(m.Plugins) == 0 {
+		fmt.Printf("%s\n", dim("no plugins declared in "+path+"; add one: wago plugin add <module>"))
+		return
+	}
+	fmt.Printf("%s %s\n", bold("manifest:"), dim(path))
+	for _, e := range m.Plugins {
+		state := cyan("enabled")
+		if !e.Enabled {
+			state = dim("disabled")
+		}
+		src := e.Module
+		if e.Builtin() {
+			src = dim("builtin")
+		} else if e.Version != "" {
+			src = e.Module + "@" + e.Version
+		}
+		fmt.Printf("  %s  %s  %s\n", e.Name, src, state)
+	}
+}

--- a/cli/wago/manifest_test.go
+++ b/cli/wago/manifest_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestManifestAddRemoveSaveLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wago-plugins.json")
+
+	m, err := loadManifest(path)
+	if err != nil {
+		t.Fatalf("load empty: %v", err)
+	}
+	if len(m.Plugins) != 0 || m.Version != manifestVersion {
+		t.Fatalf("empty manifest = %+v", m)
+	}
+
+	if newly := m.add(PluginEntry{Name: "redis", Module: "github.com/acme/wago-redis", Version: "v0.3.1", Enabled: true}); !newly {
+		t.Fatal("add should report newly-added")
+	}
+	m.add(PluginEntry{Name: "timer", Module: "builtin", Enabled: true})
+	// Re-adding updates in place (not newly).
+	if newly := m.add(PluginEntry{Name: "redis", Module: "github.com/acme/wago-redis", Version: "v0.4.0", Enabled: true}); newly {
+		t.Fatal("re-add should update, not add")
+	}
+	if err := m.save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Reload and verify contents + stable (name-sorted) order.
+	m2, err := loadManifest(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(m2.Plugins) != 2 {
+		t.Fatalf("reloaded %d plugins, want 2", len(m2.Plugins))
+	}
+	if m2.Plugins[0].Name != "redis" || m2.Plugins[1].Name != "timer" {
+		t.Fatalf("order = %s,%s want redis,timer", m2.Plugins[0].Name, m2.Plugins[1].Name)
+	}
+	if m2.Plugins[0].Version != "v0.4.0" {
+		t.Fatalf("redis version = %q, want v0.4.0 (updated)", m2.Plugins[0].Version)
+	}
+	if !m2.Plugins[1].Builtin() {
+		t.Fatal("timer entry should be builtin")
+	}
+
+	if !m2.remove("redis") {
+		t.Fatal("remove existing should return true")
+	}
+	if m2.remove("nope") {
+		t.Fatal("remove missing should return false")
+	}
+	if len(m2.Plugins) != 1 || m2.Plugins[0].Name != "timer" {
+		t.Fatalf("after remove = %+v", m2.Plugins)
+	}
+}
+
+func TestDeriveName(t *testing.T) {
+	cases := map[string]string{
+		"github.com/acme/wago-redis": "redis",
+		"github.com/acme/wago_kv":    "kv",
+		"example.com/foo/bar":        "bar",
+		"wago-auth":                  "auth",
+	}
+	for module, want := range cases {
+		if got := deriveName(module); got != want {
+			t.Fatalf("deriveName(%q) = %q, want %q", module, got, want)
+		}
+	}
+}

--- a/cli/wago/plugins.go
+++ b/cli/wago/plugins.go
@@ -35,13 +35,19 @@ func pluginCmd(args []string) {
 			fatal("plugin inspect: need a <name> (see: wago plugin list)")
 		}
 		pluginInspect(args[1])
-	case "install", "add", "uninstall", "remove", "update", "build":
-		fatal("plugin %s: not yet implemented — third-party plugins are added by\n"+
-			"building a custom wago binary that imports them (a manifest-driven\n"+
-			"`wago plugin build` is planned). Built-in plugins are always available;\n"+
-			"see `wago plugin list`.", sub)
+	case "add", "install":
+		pluginAddCmd(args[1:])
+	case "remove", "uninstall", "rm":
+		if len(args) < 2 {
+			fatal("plugin %s: need a <name>", sub)
+		}
+		pluginManifestRemove(args[1])
+	case "manifest", "declared":
+		pluginManifestShow()
+	case "build":
+		pluginBuild(args[1:])
 	default:
-		fatal("plugin: unknown subcommand %q (have: list)", sub)
+		fatal("plugin: unknown subcommand %q (have: list, inspect, add, remove, manifest, build)", sub)
 	}
 }
 


### PR DESCRIPTION
The JSON plugin manifest — the declarative "which plugins" source of truth a custom wago build will consume. Net-free (stdlib `encoding/json`), so it ships in every build including the lean TinyGo one.

## What's here
- **`wago-plugins.json`** schema: `{version, plugins: [{name, module, version, enabled}]}`. `module` is `"builtin"` for a compiled-in plugin or a Go module path for a third-party one. Plain JSON on purpose — small, git-committable, human-editable, read/written whole.
- **`wago plugin add <module-or-name> [--name x] [--version v]`** — records a plugin. A bare token (`timer`) is a builtin; a path (`github.com/acme/wago-redis`) is external, with the name auto-derived (`wago-redis` → `redis`).
- **`wago plugin remove <name>`** — drops an entry.
- **`wago plugin manifest`** — shows declared plugins (enabled/disabled, source).
- **`wago plugin build`** — for now, *previews* the custom build (lists enabled plugins, validates the manifest) and reports that codegen isn't wired yet. The `go build` codegen is the follow-up (it needs the CLI extracted into an importable entry package).
- `WAGO_PLUGIN_MANIFEST` overrides the path (default `wago-plugins.json` in cwd).

## Verification
- `go test ./cli/wago -run 'TestManifest|TestDeriveName'` — PASS: add (new vs update-in-place), remove (present vs missing), save/reload, name-sorted stable order, builtin detection, and module→name derivation.
- Manual: `plugin add timer`, `plugin add github.com/acme/wago-redis --version v0.3.1`, `plugin manifest` render correctly; the JSON is clean and sorted.
- Full `go test ./cli/wago`, `go build ./...`, `-tags wago_lean` build, `go vet`, `gofmt`, `make tinygo-build` — all PASS. Facade unchanged (CLI-only).

Follow-up: `wago plugin build` codegen — refactor the CLI into an importable `Main()`, generate a `main.go` that blank-imports the enabled plugins, and `go build` a tailored binary (xcaddy model).