### PR TITLE
docs: extensive examples/ folder for the wago + plugin API

### DIFF
--- a/examples/01-hello/main.go
+++ b/examples/01-hello/main.go
@@ -1,0 +1,37 @@
+// Example 01: hello — the lowest-level API.
+//
+// Compile a wasm module to native code, instantiate it, and invoke an export.
+// This is the raw path (no Runtime, no plugins). Run:
+//
+//	go run ./examples/01-hello
+package main
+
+import (
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	// mods.Add() returns the bytes of a module exporting add(a, b i32) -> i32.
+	// In a real project these bytes come from a .wasm file on disk.
+	compiled, err := wago.Compile(mods.Add())
+	if err != nil {
+		panic(err)
+	}
+
+	// Instantiate creates a runnable instance. This module has no imports.
+	inst, err := wago.Instantiate(compiled, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer inst.Close()
+
+	// Invoke uses raw uint64 slots; encode/decode with I32/AsI32/etc.
+	out, err := inst.Invoke("add", wago.I32(2), wago.I32(40))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("add(2, 40) = %d\n", wago.AsI32(out[0]))
+}

--- a/examples/02-runtime-typed/main.go
+++ b/examples/02-runtime-typed/main.go
@@ -1,0 +1,45 @@
+// Example 02: runtime + typed Call.
+//
+// The high-level Runtime wraps compile/instantiate and gives you a typed,
+// context-aware Call where arguments and results are checked against the export's
+// signature. Run:
+//
+//	go run ./examples/02-runtime-typed
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	// rt.Compile returns a *Module (a runtime-aware wrapper over the compiled code).
+	mod, err := rt.Compile(mods.Add())
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	inst, err := rt.Instantiate(ctx, mod)
+	if err != nil {
+		panic(err)
+	}
+	defer inst.Close()
+
+	// Call takes typed Values and returns typed Values — no manual slot encoding.
+	// The context is honored for cancellation.
+	out, err := inst.Call(ctx, "add", wago.ValueI32(2), wago.ValueI32(3))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("add(2, 3) = %d (type %s)\n", out[0].I32(), out[0].Type())
+
+	// Inspect the module.
+	fmt.Println("exports:", mod.Exports())
+}

--- a/examples/03-host-import/main.go
+++ b/examples/03-host-import/main.go
@@ -1,0 +1,42 @@
+// Example 03: host imports.
+//
+// A guest can call back into the host. Host functions use the single, portable
+// stack form wago.HostFunc — it reads params and writes results as raw slots and
+// binds identically on standard Go and TinyGo (no reflection). Run:
+//
+//	go run ./examples/03-host-import
+package main
+
+import (
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	// The module imports host.mul(a, b i32) -> i32 and exports square(x) = mul(x, x).
+	compiled, err := wago.Compile(mods.SquareViaHost())
+	if err != nil {
+		panic(err)
+	}
+
+	// A HostFunc reads its wasm params from params[] and writes results into
+	// results[]. Here: mul(a, b) = a * b.
+	mul := wago.HostFunc(func(_ wago.HostModule, params, results []uint64) {
+		a, b := wago.AsI32(params[0]), wago.AsI32(params[1])
+		results[0] = wago.I32(a * b)
+	})
+
+	inst, err := wago.Instantiate(compiled, wago.Imports{"host.mul": mul})
+	if err != nil {
+		panic(err)
+	}
+	defer inst.Close()
+
+	out, err := inst.Invoke("square", wago.I32(9))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("square(9) = %d\n", wago.AsI32(out[0]))
+}

--- a/examples/04-memory/main.go
+++ b/examples/04-memory/main.go
@@ -1,0 +1,52 @@
+// Example 04: reading guest memory from a host function.
+//
+// The classic host-import pattern is (ptr, len) -> read bytes out of the guest's
+// linear memory. HostModule.Memory() gives the host a view of that memory during
+// the call. Run:
+//
+//	go run ./examples/04-memory
+package main
+
+import (
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	// The module holds "hello from wasm" in its memory and calls
+	// env.write(ptr, len) with the location of that string.
+	compiled, err := wago.Compile(mods.MemWriter("hello from wasm"))
+	if err != nil {
+		panic(err)
+	}
+
+	write := wago.HostFunc(func(m wago.HostModule, params, results []uint64) {
+		ptr, n := uint32(params[0]), uint32(params[1])
+		mem := m.Memory() // a view of the calling instance's linear memory
+		if int(ptr)+int(n) > len(mem) {
+			results[0] = wago.I32(-1) // out of bounds
+			return
+		}
+		fmt.Printf("guest wrote: %q\n", mem[ptr:ptr+n])
+		results[0] = wago.I32(int32(n))
+	})
+
+	inst, err := wago.Instantiate(compiled, wago.Imports{"env.write": write})
+	if err != nil {
+		panic(err)
+	}
+	defer inst.Close()
+
+	out, err := inst.Invoke("run")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("run() wrote %d bytes\n", wago.AsI32(out[0]))
+
+	// You can also read/write the instance's memory directly from the host.
+	inst.WriteUint8(0, 'H')
+	b, _ := inst.ReadUint8(0)
+	fmt.Printf("memory[0] is now %q\n", rune(b))
+}

--- a/examples/05-globals/main.go
+++ b/examples/05-globals/main.go
@@ -1,0 +1,47 @@
+// Example 05: exported globals.
+//
+// Modules can export mutable globals; the host can read and write them by name,
+// typed. Run:
+//
+//	go run ./examples/05-globals
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	// Counter exports a mutable i32 global "count" and inc() -> i32.
+	mod, err := rt.Compile(mods.Counter())
+	if err != nil {
+		panic(err)
+	}
+	ctx := context.Background()
+	inst, err := rt.Instantiate(ctx, mod)
+	if err != nil {
+		panic(err)
+	}
+	defer inst.Close()
+
+	// Each inc() bumps the global.
+	for i := 0; i < 3; i++ {
+		out, _ := inst.Call(ctx, "inc")
+		fmt.Printf("inc() = %d\n", out[0].I32())
+	}
+
+	// Read the global directly, typed.
+	v, _ := inst.GlobalValue("count")
+	fmt.Printf("count global = %d\n", v.I32())
+
+	// Set it from the host, then observe the guest continue from there.
+	_ = inst.SetGlobalValue("count", wago.ValueI32(100))
+	out, _ := inst.Call(ctx, "inc")
+	fmt.Printf("after set to 100, inc() = %d\n", out[0].I32())
+}

--- a/examples/06-plugin-timer/main.go
+++ b/examples/06-plugin-timer/main.go
@@ -1,0 +1,48 @@
+// Example 06: using a built-in plugin (timer).
+//
+// Plugins register host imports into a Runtime under a reserved module namespace.
+// rt.Use(timer.Ext()) makes wago_timer.* available to any guest the runtime runs.
+// Run:
+//
+//	go run ./examples/06-plugin-timer
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+	"github.com/wago-org/wago/plugins/timer"
+)
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	// Enable the timer plugin. Its imports (wago_timer.now_unix_ms, etc.) are now
+	// available to every module this runtime instantiates.
+	if err := rt.Use(timer.Ext()); err != nil {
+		panic(err)
+	}
+
+	// A guest that imports wago_timer.now_unix_ms() -> i64 and re-exports it as now().
+	mod, err := rt.Compile(mods.ImportCaller("wago_timer", "now_unix_ms", "now", []byte{mods.I64}))
+	if err != nil {
+		panic(err)
+	}
+	ctx := context.Background()
+	inst, err := rt.Instantiate(ctx, mod)
+	if err != nil {
+		panic(err)
+	}
+	defer inst.Close()
+
+	out, _ := inst.Call(ctx, "now")
+	fmt.Printf("guest sees wall-clock time: %d ms\n", out[0].I64())
+
+	// Plugins can be inspected.
+	for _, info := range rt.Extensions() {
+		fmt.Printf("loaded plugin: %s %s\n", info.ID, info.Version)
+	}
+}

--- a/examples/07-plugins-log-metrics/main.go
+++ b/examples/07-plugins-log-metrics/main.go
@@ -1,0 +1,50 @@
+// Example 07: combining plugins (log + metrics).
+//
+// A runtime can use many plugins at once. The metrics plugin also exposes a
+// host-side Go API to read back what the guest recorded. Run:
+//
+//	go run ./examples/07-plugins-log-metrics
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+	"github.com/wago-org/wago/plugins/log"
+	"github.com/wago-org/wago/plugins/metrics"
+)
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	// Configure plugins with options: send logs to stdout, keep metrics in memory.
+	m := metrics.Ext() // default in-memory sink, queryable below
+	if err := rt.Use(log.Ext(log.WithWriter(os.Stdout))); err != nil {
+		panic(err)
+	}
+	if err := rt.Use(m); err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+
+	// A guest that logs a line at WARN (level 2).
+	logMod, _ := rt.Compile(mods.LogCaller(2, "hello from the guest"))
+	logInst, _ := rt.Instantiate(ctx, logMod)
+	defer logInst.Close()
+	_, _ = logInst.Call(ctx, "run")
+
+	// A guest that bumps the "requests" counter by 3, called twice.
+	metMod, _ := rt.Compile(mods.MetricsCaller("requests", 3))
+	metInst, _ := rt.Instantiate(ctx, metMod)
+	defer metInst.Close()
+	_, _ = metInst.Call(ctx, "run")
+	_, _ = metInst.Call(ctx, "run")
+
+	// Read the counter back from the host side of the plugin.
+	fmt.Printf("metrics: requests counter = %d\n", m.Counter("requests"))
+}

--- a/examples/08-custom-plugin/main.go
+++ b/examples/08-custom-plugin/main.go
@@ -1,0 +1,72 @@
+// Example 08: writing your own plugin.
+//
+// A plugin is any type implementing wago.Extension: Info() describes it, and
+// Register() declares the host imports and capabilities it contributes. Host
+// functions use the portable stack form. Run:
+//
+//	go run ./examples/08-custom-plugin
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+// randExt is a tiny custom plugin that exposes a deterministic "random" number
+// generator to guests under the wago_rand module. (Deterministic so the example
+// output is stable.)
+type randExt struct{ seed uint64 }
+
+// CapRand is the capability this plugin provides; a policy can allow or deny it.
+const CapRand = wago.Capability("rand.read")
+
+func (e *randExt) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{
+		ID:          "example.rand",
+		Name:        "Rand",
+		Version:     "1.0.0",
+		Description: "A deterministic pseudo-random source for guests.",
+		MinWago:     "0.1.0",
+		Stability:   wago.Experimental,
+	}
+}
+
+func (e *randExt) Register(reg *wago.Registry) error {
+	reg.Capability(CapRand, wago.CapabilityDocs("read pseudo-random numbers"))
+
+	// next() -> i64 advances an xorshift state and returns it.
+	reg.ImportModule("wago_rand").
+		Func("next", func(_ wago.HostModule, _, results []uint64) {
+			e.seed ^= e.seed << 13
+			e.seed ^= e.seed >> 7
+			e.seed ^= e.seed << 17
+			results[0] = e.seed
+		}).
+		Results(wago.ValI64).Capability(CapRand).
+		Docs("advance the RNG and return the next 64-bit value")
+
+	return nil
+}
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	if err := rt.Use(&randExt{seed: 42}); err != nil {
+		panic(err)
+	}
+
+	// A guest importing wago_rand.next() -> i64, re-exported as roll().
+	mod, _ := rt.Compile(mods.ImportCaller("wago_rand", "next", "roll", []byte{mods.I64}))
+	ctx := context.Background()
+	inst, _ := rt.Instantiate(ctx, mod)
+	defer inst.Close()
+
+	for i := 0; i < 3; i++ {
+		out, _ := inst.Call(ctx, "roll")
+		fmt.Printf("roll() = %d\n", uint64(out[0].I64()))
+	}
+}

--- a/examples/09-capabilities-policy/main.go
+++ b/examples/09-capabilities-policy/main.go
@@ -1,0 +1,47 @@
+// Example 09: capabilities and policy.
+//
+// Plugins declare capabilities; a Policy decides which a given instance may use,
+// and can cap resources like memory. A module needing a disallowed capability is
+// rejected before it runs. Run:
+//
+//	go run ./examples/09-capabilities-policy
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+	"github.com/wago-org/wago/plugins/timer"
+)
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+	_ = rt.Use(timer.Ext()) // provides wago_timer.*, requires the timer.read capability
+
+	mod, _ := rt.Compile(mods.ImportCaller("wago_timer", "now_unix_ms", "now", []byte{mods.I64}))
+	fmt.Println("module requires capabilities:", mod.RequiredCapabilities())
+
+	ctx := context.Background()
+
+	// A policy that does NOT allow timer.read rejects the module.
+	_, err := rt.Instantiate(ctx, mod, wago.WithPolicy(wago.Policy{
+		AllowedCapabilities: []wago.Capability{wago.CapMetricsWrite}, // not timer.read
+	}))
+	fmt.Println("denied instantiate:", errors.Is(err, wago.ErrPermissionDenied), "-", err)
+
+	// Allowing timer.read (and bounding memory) lets it run.
+	inst, err := rt.Instantiate(ctx, mod, wago.WithPolicy(wago.Policy{
+		AllowedCapabilities: []wago.Capability{timer.CapRead},
+		MaxMemoryBytes:      16 << 20, // 16 MiB ceiling
+	}))
+	if err != nil {
+		panic(err)
+	}
+	defer inst.Close()
+	out, _ := inst.Call(ctx, "now")
+	fmt.Printf("allowed: now() = %d ms\n", out[0].I64())
+}

--- a/examples/10-hooks/main.go
+++ b/examples/10-hooks/main.go
@@ -1,0 +1,55 @@
+// Example 10: lifecycle hooks (observability).
+//
+// Hooks let a plugin observe compile and invoke without the guest knowing. This
+// is how tracing/metrics auto-instrumentation works: BeforeInvoke/AfterInvoke
+// wrap every Instance.Call. Run:
+//
+//	go run ./examples/10-hooks
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+// tracer is a plugin that times every invocation via invoke hooks.
+type tracer struct{}
+
+func (tracer) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{ID: "example.tracer", Version: "1.0.0", Stability: wago.Experimental}
+}
+
+func (tracer) Register(reg *wago.Registry) error {
+	reg.Hooks().AfterCompile(func(_ *wago.CompileContext, m *wago.Module) error {
+		fmt.Printf("[trace] compiled module, exports=%v\n", m.Exports())
+		return nil
+	})
+	reg.Hooks().BeforeInvoke(func(ic *wago.InvokeContext) error {
+		ic.Metadata["start"] = time.Now()
+		fmt.Printf("[trace] -> %s(%v)\n", ic.Export, ic.Args)
+		return nil
+	})
+	reg.Hooks().AfterInvoke(func(ic *wago.InvokeContext, out []wago.Value, err error) {
+		elapsed := time.Since(ic.Metadata["start"].(time.Time))
+		fmt.Printf("[trace] <- %s => %v (%s, err=%v)\n", ic.Export, out, elapsed.Round(time.Microsecond), err)
+	})
+	return nil
+}
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+	_ = rt.Use(tracer{})
+
+	mod, _ := rt.Compile(mods.Add())
+	ctx := context.Background()
+	inst, _ := rt.Instantiate(ctx, mod)
+	defer inst.Close()
+
+	// Every Call is wrapped by the hooks above.
+	_, _ = inst.Call(ctx, "add", wago.ValueI32(20), wago.ValueI32(22))
+}

--- a/examples/11-class-pool/main.go
+++ b/examples/11-class-pool/main.go
@@ -1,0 +1,50 @@
+// Example 11: Class and instance pooling.
+//
+// A Class is "compile once, spawn many": a module plus a pool of reusable
+// instances. Acquire leases one (reusing a warm instance or creating a new one
+// under the cap); Release resets it to the module's initial state and returns it.
+// Run:
+//
+//	go run ./examples/11-class-pool
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	// Counter has a mutable global; observing it reset between leases proves the
+	// pool hands out fresh state.
+	mod, _ := rt.Compile(mods.Counter())
+	class, err := rt.Class(mod, wago.ClassOptions{
+		Name: "counter",
+		Pool: wago.PoolOptions{MinInstances: 2, MaxInstances: 8, Reset: wago.ResetReinstantiate},
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer class.Close()
+
+	ctx := context.Background()
+
+	// Lease an instance, mutate it, release it.
+	lease, _ := class.Acquire(ctx)
+	out, _ := lease.Instance().Call(ctx, "inc")
+	fmt.Printf("first lease:  inc() = %d\n", out[0].I32())
+	out, _ = lease.Instance().Call(ctx, "inc")
+	fmt.Printf("first lease:  inc() = %d\n", out[0].I32())
+	_ = lease.Release()
+
+	// The next lease starts from a reset state (count back to 0).
+	lease2, _ := class.Acquire(ctx)
+	out, _ = lease2.Instance().Call(ctx, "inc")
+	fmt.Printf("second lease: inc() = %d  (state was reset)\n", out[0].I32())
+	_ = lease2.Release()
+}

--- a/examples/12-actors/main.go
+++ b/examples/12-actors/main.go
@@ -1,0 +1,53 @@
+// Example 12: processes and mailboxes (the actor model).
+//
+// Spawn runs a module on its own goroutine as a process with a mailbox. Send
+// delivers a message; the guest blocks on recv until it arrives. Monitor reports
+// the process's exit. Run:
+//
+//	go run ./examples/12-actors
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	// Worker imports wago_process.self + wago_mailbox.recv; its main() blocks on
+	// recv and returns the recv status code. Spawn injects those imports per-process.
+	mod, _ := rt.Compile(mods.Worker())
+	class, _ := rt.Class(mod, wago.ClassOptions{Pool: wago.PoolOptions{MaxInstances: 16}})
+	defer class.Close()
+
+	ctx := context.Background()
+	pid, err := rt.Spawn(ctx, class, wago.SpawnOptions{Entry: "main"})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("spawned worker as pid %d\n", pid)
+
+	// Watch for the worker's exit.
+	exit, _ := rt.Monitor(ctx, pid)
+
+	// The worker is blocked on recv; sending a message unblocks it and it exits.
+	if err := rt.Send(ctx, pid, []byte("ping")); err != nil {
+		panic(err)
+	}
+
+	ev := <-exit
+	fmt.Printf("worker exited: normal=%v, recv status=%d\n",
+		ev.Reason.Normal, statusOf(ev.Reason.Results))
+}
+
+func statusOf(results []wago.Value) int32 {
+	if len(results) == 0 {
+		return -1
+	}
+	return results[0].I32()
+}

--- a/examples/13-supervisor/main.go
+++ b/examples/13-supervisor/main.go
@@ -1,0 +1,61 @@
+// Example 13: supervision.
+//
+// A supervisor spawns children and restarts them when they exit, per a strategy
+// and a restart-intensity limit. This is the Erlang/OTP "let it crash" model. Run:
+//
+//	go run ./examples/13-supervisor
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	mod, _ := rt.Compile(mods.Worker())
+	class, _ := rt.Class(mod, wago.ClassOptions{Pool: wago.PoolOptions{MaxInstances: 16}})
+	defer class.Close()
+
+	ctx := context.Background()
+
+	// OneForOne: only the child that exits is restarted. Up to 5 restarts / minute.
+	sup, err := rt.Supervise(ctx,
+		wago.SupervisorOptions{Strategy: wago.OneForOne, MaxRestarts: 5, Window: time.Minute},
+		wago.ChildSpec{Name: "worker-a", Class: class, Spawn: wago.SpawnOptions{Entry: "main"}},
+		wago.ChildSpec{Name: "worker-b", Class: class, Spawn: wago.SpawnOptions{Entry: "main"}},
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer sup.Stop()
+
+	before := sup.Children()
+	fmt.Printf("children: %v\n", before)
+
+	// Kill worker-a; the supervisor restarts it with a new pid, leaving b alone.
+	_ = rt.Kill(ctx, before[0], wago.ExitReason{})
+	waitFor(func() bool {
+		c := sup.Children()
+		return c[0] != 0 && c[0] != before[0]
+	})
+	after := sup.Children()
+	fmt.Printf("after killing worker-a: %v (a restarted, b unchanged=%v)\n",
+		after, after[1] == before[1])
+}
+
+func waitFor(cond func() bool) {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}

--- a/examples/14-handles/main.go
+++ b/examples/14-handles/main.go
@@ -1,0 +1,60 @@
+// Example 14: resource handles.
+//
+// Plugins that manage host resources (files, sockets, timers) hand guests opaque
+// integer handles instead of Go pointers. HandleTable tracks them with a
+// generation counter, so a stale handle fails cleanly instead of aliasing a new
+// resource. Run:
+//
+//	go run ./examples/14-handles
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+)
+
+// conn is a stand-in host resource that a guest would refer to by handle.
+type conn struct {
+	name   string
+	closed bool
+}
+
+func (c *conn) Close() error { c.closed = true; return nil }
+
+func main() {
+	table := wago.NewHandleTable()
+
+	// A plugin's "open" host import would insert a resource and return the handle
+	// (as an i64) to the guest.
+	h := table.Insert("conn", &conn{name: "db-1"})
+	fmt.Printf("opened handle = %d, live handles = %d\n", uint64(h), table.Len())
+
+	// A "use" host import looks the handle back up, kind-checked.
+	if r, ok := table.Get(h, "conn"); ok {
+		fmt.Printf("using resource: %s\n", r.(*conn).name)
+	}
+
+	// Wrong kind is rejected.
+	if _, ok := table.Get(h, "socket"); !ok {
+		fmt.Println("Get with wrong kind correctly rejected")
+	}
+
+	// Close releases the resource and invalidates the handle.
+	_ = table.Close(h)
+	if _, ok := table.Get(h, "conn"); !ok {
+		fmt.Println("handle no longer resolves after Close")
+	}
+
+	// A stale handle (slot reused by a new resource) does not alias it.
+	h2 := table.Insert("conn", &conn{name: "db-2"})
+	if _, ok := table.Get(h, "conn"); !ok && h != h2 {
+		fmt.Println("stale handle does not alias the reused slot (generation guard)")
+	}
+
+	// Double-close is reported, not silently ignored.
+	if err := table.Close(h); errors.Is(err, wago.ErrInvalidHandle) {
+		fmt.Println("double-close reported as ErrInvalidHandle")
+	}
+}

--- a/examples/15-config/main.go
+++ b/examples/15-config/main.go
@@ -1,0 +1,38 @@
+// Example 15: runtime configuration.
+//
+// A RuntimeConfig controls feature gating and the bounds-check strategy. Pass it
+// to a Runtime with WithRuntimeConfig, or to the low-level CompileWithConfig. Run:
+//
+//	go run ./examples/15-config
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	// Bounds-check modes: explicit (inline checks) vs signals-based (guard-page).
+	// Here we ask for every access to be bounds-checked (no elision).
+	cfg := wago.NewRuntimeConfig().WithDeferBoundsChecks(false)
+
+	fmt.Println("features:", cfg.CoreFeatures())
+	fmt.Println("bounds checks:", cfg.BoundsChecks())
+
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	defer rt.Close()
+
+	mod, err := rt.Compile(mods.Add())
+	if err != nil {
+		panic(err)
+	}
+	ctx := context.Background()
+	inst, _ := rt.Instantiate(ctx, mod)
+	defer inst.Close()
+
+	out, _ := inst.Call(ctx, "add", wago.ValueI32(1), wago.ValueI32(2))
+	fmt.Printf("add(1, 2) = %d\n", out[0].I32())
+}

--- a/examples/16-serialize/main.go
+++ b/examples/16-serialize/main.go
@@ -1,0 +1,41 @@
+// Example 16: precompiling to a .wago blob.
+//
+// Compilation can be done ahead of time and the result serialized, so startup
+// only pays for instantiation. MarshalBinary produces a portable blob; Load
+// accepts either a .wago blob or raw wasm. Run:
+//
+//	go run ./examples/16-serialize
+package main
+
+import (
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	// Compile once...
+	compiled, err := wago.Compile(mods.Add())
+	if err != nil {
+		panic(err)
+	}
+
+	// ...serialize the precompiled module (write this to disk / cache it).
+	blob, err := compiled.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("precompiled blob: %d bytes, is-wago-blob=%v\n", len(blob), wago.IsCompiled(blob))
+
+	// Later, in a fresh process: Load accepts a blob or raw wasm transparently.
+	loaded, err := wago.Load(blob)
+	if err != nil {
+		panic(err)
+	}
+	inst, _ := wago.Instantiate(loaded, nil)
+	defer inst.Close()
+
+	out, _ := inst.Invoke("add", wago.I32(19), wago.I32(23))
+	fmt.Printf("loaded-from-blob add(19, 23) = %d\n", wago.AsI32(out[0]))
+}

--- a/examples/17-per-call-imports/main.go
+++ b/examples/17-per-call-imports/main.go
@@ -1,0 +1,53 @@
+// Example 17: per-call imports and plugin registry.
+//
+// Beyond plugins registered on the runtime, you can supply extra imports for a
+// single Instantiate with WithImports. You can also resolve plugins by name from
+// the compile-time registry (the mechanism behind `wago run --plugin=...`). Run:
+//
+//	go run ./examples/17-per-call-imports
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+	"github.com/wago-org/wago/plugins/timer"
+)
+
+func init() {
+	// Register a plugin under a short name so it can be enabled by name. Plugins
+	// normally do this in their own init(); the CLI does it for the built-ins.
+	wago.RegisterExtension("timer", func() wago.Extension { return timer.Ext() })
+}
+
+func main() {
+	fmt.Println("plugins compiled in:", wago.RegisteredPluginNames())
+
+	rt := wago.NewRuntime()
+	defer rt.Close()
+
+	// Enable a plugin by name (as a CLI would from --plugin=timer).
+	if err := rt.UsePlugin("timer"); err != nil {
+		panic(err)
+	}
+
+	// A module needing both a plugin import (wago_timer) and an ad-hoc one (host.mul).
+	mod, _ := rt.Compile(mods.SquareViaHost())
+	ctx := context.Background()
+
+	// Supply host.mul just for this instance via WithImports.
+	inst, err := rt.Instantiate(ctx, mod, wago.WithImports(wago.Imports{
+		"host.mul": wago.HostFunc(func(_ wago.HostModule, p, r []uint64) {
+			r[0] = wago.I32(wago.AsI32(p[0]) * wago.AsI32(p[1]))
+		}),
+	}))
+	if err != nil {
+		panic(err)
+	}
+	defer inst.Close()
+
+	out, _ := inst.Call(ctx, "square", wago.ValueI32(7))
+	fmt.Printf("square(7) = %d\n", out[0].I32())
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,107 @@
+# wago examples
+
+Runnable, self-contained examples of the wago API — from running a single module
+to building plugins, actors, and supervised process trees. Each example is a small
+`main.go` you can run directly:
+
+```sh
+go run ./examples/01-hello
+go run ./examples/12-actors
+```
+
+The tiny WebAssembly modules the examples run against are assembled in-process by
+[`internal/mods`](internal/mods/mods.go) so nothing here needs an external wasm
+toolchain — real projects would load `.wasm` files compiled from Rust,
+AssemblyScript, TinyGo, or C instead. The examples are about the **wago Go API**,
+not wasm authoring.
+
+## Go API examples
+
+| # | Example | Shows |
+|---|---------|-------|
+| 01 | [hello](01-hello) | Low-level `Compile` → `Instantiate` → `Invoke` |
+| 02 | [runtime-typed](02-runtime-typed) | `Runtime` + context-aware typed `Call` with `Value` |
+| 03 | [host-import](03-host-import) | Defining a `HostFunc` the guest calls back into |
+| 04 | [memory](04-memory) | Reading/writing guest linear memory from the host |
+| 05 | [globals](05-globals) | Reading and setting exported globals, typed |
+| 06 | [plugin-timer](06-plugin-timer) | Using a built-in plugin (`timer`) |
+| 07 | [plugins-log-metrics](07-plugins-log-metrics) | Combining plugins; reading metrics back host-side |
+| 08 | [custom-plugin](08-custom-plugin) | Writing your own `Extension` |
+| 09 | [capabilities-policy](09-capabilities-policy) | Capability/resource `Policy` enforcement |
+| 10 | [hooks](10-hooks) | Invoke/compile hooks (tracing, auto-instrumentation) |
+| 11 | [class-pool](11-class-pool) | `Class` + instance pool with reset (`Acquire`/`Release`) |
+| 12 | [actors](12-actors) | Processes + mailboxes (`Spawn`/`Send`/`Monitor`) |
+| 13 | [supervisor](13-supervisor) | Supervision trees with restart strategies |
+| 14 | [handles](14-handles) | `HandleTable` resource handles with a generation guard |
+| 15 | [config](15-config) | `RuntimeConfig`: features and bounds-check modes |
+| 16 | [serialize](16-serialize) | Precompiling to a `.wago` blob and loading it |
+| 17 | [per-call-imports](17-per-call-imports) | `WithImports` + the by-name plugin registry |
+
+Run them all:
+
+```sh
+for d in examples/[0-9]*; do echo "== $d =="; go run "./$d"; done
+```
+
+## Host functions are always the stack form
+
+Every host import — whether ad-hoc or provided by a plugin — is a `wago.HostFunc`:
+
+```go
+func(m wago.HostModule, params, results []uint64)
+```
+
+It reads its wasm arguments from `params` (decode with `wago.AsI32`/`AsI64`/…),
+writes results into `results` (encode with `wago.I32`/…), and can reach the
+calling instance's linear memory via `m.Memory()`. This one reflection-free form
+binds identically on standard Go and TinyGo — see
+[03-host-import](03-host-import) and [04-memory](04-memory).
+
+## Writing a plugin
+
+A plugin implements `wago.Extension` (`Info` + `Register`) and declares its host
+imports, capabilities, and optional lifecycle hooks through the `Registry` —
+see [08-custom-plugin](08-custom-plugin) and [10-hooks](10-hooks). Register it on
+a runtime with `rt.Use(myplugin.Ext())`.
+
+## CLI
+
+The `wago` CLI mirrors much of this from the shell.
+
+Run a module and inspect it:
+
+```sh
+wago run add.wasm 2 40                 # compile + execute (typed args)
+wago run -e fib fib.wasm 30            # pick an export
+wago run --plugin timer,log app.wasm   # enable compiled-in plugins
+wago module imports app.wasm           # what a module imports (resolved vs plugins)
+wago module capabilities app.wasm      # capabilities a module requires
+```
+
+Plugins compiled into the binary:
+
+```sh
+wago plugin list                       # plugins available in this binary
+wago plugin inspect timer              # a plugin's imports, signatures, capabilities
+```
+
+Declare plugins for a custom build (a `wago-plugins.json` manifest):
+
+```sh
+wago plugin add timer                                        # a built-in
+wago plugin add github.com/acme/wago-redis --version v0.3.1  # a third-party module
+wago plugin manifest                                         # show the manifest
+```
+
+Version management (nvm-style; ships in every build, network install in full builds):
+
+```sh
+wago --version              # this binary's version
+wago version list           # installed versions
+wago version install 0.5.0  # download + verify (full build)
+wago version use 0.5.0      # switch the active version
+wago env                    # resolved config/cache/data directories
+```
+
+See the repository root for building the CLI (`make build`) and the lean,
+TinyGo-compiled release (`make build-release`).

--- a/examples/internal/mods/mods.go
+++ b/examples/internal/mods/mods.go
@@ -1,0 +1,244 @@
+// Package mods builds the tiny WebAssembly modules the examples run against.
+//
+// Real projects compile guests from Rust, AssemblyScript, TinyGo, or C; these
+// examples assemble a handful of minimal modules in-process so each example is
+// self-contained and needs no external toolchain. The wasm here is deliberately
+// small — the examples are about the wago Go API, not wasm authoring.
+package mods
+
+import "github.com/wago-org/wago/testutil/wasmtest"
+
+// common opcodes
+const (
+	opLocalGet  = 0x20
+	opGlobalGet = 0x23
+	opGlobalSet = 0x24
+	opI32Const  = 0x41
+	opI32Add    = 0x6a
+	opCall      = 0x10
+	opEnd       = 0x0b
+)
+
+// wasm value-type bytes
+const (
+	i32 = 0x7f
+	i64 = 0x7e
+)
+
+// Add is a pure module exporting add(a, b i32) -> i32 = a + b. No imports.
+func Add() []byte {
+	body := []byte{opLocalGet, 0, opLocalGet, 1, opI32Add, opEnd}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(ftype(vt(i32, i32), vt(i32)))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("add", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+}
+
+// Counter exports a mutable i32 global "count" (init 0) and inc() -> i32 that
+// increments it and returns the new value. Fresh instances start at 0.
+func Counter() []byte {
+	glob := []byte{i32, 0x01, opI32Const, 0x00, opEnd} // i32, mutable, i32.const 0
+	body := []byte{
+		opGlobalGet, 0, opI32Const, 0x01, opI32Add, // count + 1
+		opGlobalSet, 0, opGlobalGet, 0, opEnd, // store; return
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(ftype(nil, vt(i32)))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(6, wasmtest.Vec(glob)),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("inc", 0, 0),
+			wasmtest.ExportEntry("count", 3, 0), // export kind 3 = global
+		)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+}
+
+// SquareViaHost imports host.mul(a, b i32) -> i32 and exports square(x) =
+// mul(x, x). A returning host import exercises the synchronous host path.
+func SquareViaHost() []byte {
+	// types: 0 = (i32,i32)->i32 (import), 1 = (i32)->i32 (square)
+	imp := importEntry("host", "mul", 0)
+	// body: local.get 0; local.get 0; call 0; end
+	body := []byte{opLocalGet, 0, opLocalGet, 0, opCall, 0, opEnd}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			ftype(vt(i32, i32), vt(i32)),
+			ftype(vt(i32), vt(i32)),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))), // square uses type 1
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("square", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+}
+
+// MemWriter imports env.write(ptr, len i32) -> i32, holds the bytes msg in an
+// exported memory as active data at offset 0, and exports run() -> i32 =
+// write(0, len(msg)). The host reads the message straight out of guest memory.
+func MemWriter(msg string) []byte {
+	n := len(msg)
+	imp := importEntry("env", "write", 0) // type 0 = (i32,i32)->i32
+	body := []byte{opI32Const, byte(0), opI32Const, byte(n), opCall, 0, opEnd}
+	memType := append([]byte{0x00}, wasmtest.ULEB(1)...) // 1 page, no max
+	data := append([]byte{0x00, opI32Const, 0x00, opEnd}, append(wasmtest.ULEB(uint32(n)), msg...)...)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			ftype(vt(i32, i32), vt(i32)),
+			ftype(nil, vt(i32)),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(5, wasmtest.Vec(memType)),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("run", 0, 1),
+			wasmtest.ExportEntry("memory", 2, 0),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+		wasmtest.Section(11, wasmtest.Vec(data)),
+	)
+}
+
+// ImportCaller builds a module importing one function (module.name) with the
+// given wasm signature and exporting export():()->results whose body just calls
+// the import (pushing no arguments). Handy for wiring plugin imports like
+// wago_timer.now_unix_ms()->i64. params must be empty (the call pushes nothing).
+func ImportCaller(module, name, export string, results []byte) []byte {
+	imp := importEntry(module, name, 0)
+	body := []byte{opCall, 0, opEnd}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			ftype(nil, results), // import type
+			ftype(nil, results), // export type (same results)
+		)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry(export, 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+}
+
+// I64 is the wasm i64 result-type byte, for ImportCaller results (e.g. a timer).
+const I64 = i64
+
+// I32 is the wasm i32 result-type byte.
+const I32 = i32
+
+// LogCaller imports wago_log.write(level, ptr, len i32) -> i32 and exports
+// run() -> i32 that logs msg at the given level from an exported memory.
+func LogCaller(level int, msg string) []byte {
+	n := len(msg)
+	imp := importEntry("wago_log", "write", 0) // (i32,i32,i32)->i32
+	body := []byte{
+		opI32Const, byte(level), // level
+		opI32Const, 0x00, // ptr
+		opI32Const, byte(n), // len
+		opCall, 0x00, opEnd,
+	}
+	memType := append([]byte{0x00}, wasmtest.ULEB(1)...)
+	data := append([]byte{0x00, opI32Const, 0x00, opEnd}, append(wasmtest.ULEB(uint32(n)), msg...)...)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			ftype(vt(i32, i32, i32), vt(i32)),
+			ftype(nil, vt(i32)),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(5, wasmtest.Vec(memType)),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("run", 0, 1),
+			wasmtest.ExportEntry("memory", 2, 0),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+		wasmtest.Section(11, wasmtest.Vec(data)),
+	)
+}
+
+// MetricsCaller imports wago_metrics.counter_add(name_ptr, name_len i32, delta
+// i64) -> i32 and exports run() -> i32 that adds delta to the named counter,
+// reading the counter name from an exported memory.
+func MetricsCaller(name string, delta int) []byte {
+	n := len(name)
+	imp := importEntry("wago_metrics", "counter_add", 0) // (i32,i32,i64)->i32
+	body := []byte{
+		opI32Const, 0x00, // name_ptr
+		opI32Const, byte(n), // name_len
+		0x42, byte(delta), // i64.const delta
+		opCall, 0x00, opEnd,
+	}
+	memType := append([]byte{0x00}, wasmtest.ULEB(1)...)
+	data := append([]byte{0x00, opI32Const, 0x00, opEnd}, append(wasmtest.ULEB(uint32(n)), name...)...)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			ftype(vt(i32, i32, i64), vt(i32)),
+			ftype(nil, vt(i32)),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(5, wasmtest.Vec(memType)),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("run", 0, 1),
+			wasmtest.ExportEntry("memory", 2, 0),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+		wasmtest.Section(11, wasmtest.Vec(data)),
+	)
+}
+
+// Worker imports wago_mailbox.recv(buf_ptr, buf_cap, out_len_ptr, timeout_ms) and
+// wago_process.self(); it exports main() -> i32 that blocks on recv (timeout -1)
+// and returns the recv status. A 1-page memory is exported for the message buffer.
+func Worker() []byte {
+	// types: 0 = recv(i32,i32,i32,i64)->i32, 1 = self()->i64, 2 = main()->i32
+	recvImp := importEntry("wago_mailbox", "recv", 0)
+	selfImp := importEntry("wago_process", "self", 1)
+	// main: i32.const 0; i32.const 64; i32.const 128; i64.const -1; call 0 (recv); end
+	body := []byte{
+		opI32Const, 0x00, // buf_ptr
+		opI32Const, 0x40, // buf_cap = 64
+		opI32Const, byte(0x80), 0x01, // out_len_ptr = 128 (LEB)
+		0x42, 0x7f, // i64.const -1 (block forever)
+		opCall, 0x00, // call recv (import 0)
+		opEnd,
+	}
+	memType := append([]byte{0x00}, wasmtest.ULEB(1)...)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			ftype(vt(i32, i32, i32, i64), vt(i32)),
+			ftype(nil, vt(i64)),
+			ftype(nil, vt(i32)),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(recvImp, selfImp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2))), // main uses type 2
+		wasmtest.Section(5, wasmtest.Vec(memType)),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("main", 0, 2), // func index 2 (after 2 imports)
+			wasmtest.ExportEntry("memory", 2, 0),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+}
+
+// ---- helpers ------------------------------------------------------------
+
+// vt builds a slice of wasm value-type bytes.
+func vt(types ...byte) []byte { return append([]byte(nil), types...) }
+
+// ftype builds a wasm function type: 0x60, param count + bytes, result count + bytes.
+func ftype(params, results []byte) []byte {
+	out := []byte{0x60}
+	out = append(out, wasmtest.ULEB(uint32(len(params)))...)
+	out = append(out, params...)
+	out = append(out, wasmtest.ULEB(uint32(len(results)))...)
+	out = append(out, results...)
+	return out
+}
+
+// importEntry builds a function import entry (module.name -> type index).
+func importEntry(module, name string, typeIdx uint32) []byte {
+	e := append(wasmtest.Name(module), wasmtest.Name(name)...)
+	e = append(e, 0x00) // func import
+	return append(e, wasmtest.ULEB(typeIdx)...)
+}


### PR DESCRIPTION
Adds a comprehensive, **runnable** `examples/` folder — 17 self-contained programs plus a README — covering running modules, host imports, all the built-in and custom plugins, capabilities/policy, hooks, pooling, actors, supervision, handles, config, and serialization.

Each example is `go run ./examples/NN-name` and prints real output. The tiny wasm modules are assembled in-process by `examples/internal/mods` (via the repo's `wasmtest` builder), so nothing needs an external wasm toolchain — the examples focus on the wago Go API.

## Contents
- **01–05 core**: low-level Compile/Instantiate/Invoke; Runtime + typed `Call`; host imports (`HostFunc`); reading guest memory; exported globals.
- **06–08 plugins**: built-in `timer`; combining `log`+`metrics` (with host-side readback); writing your own `Extension`.
- **09–11 control**: capability/resource `Policy` enforcement; invoke/compile hooks (tracing); `Class` + instance pool with reset.
- **12–14 processes**: actors (`Spawn`/`Send`/`Monitor` + mailboxes); supervision trees (OneForOne restart); `HandleTable` resource handles.
- **15–17 misc**: `RuntimeConfig`; precompile → `.wago` blob → `Load`; `WithImports` + the by-name plugin registry.
- **README.md**: an index of all examples, the host-function convention, how to write a plugin, and a CLI cheat-sheet (`wago run --plugin`, `plugin list/inspect/add/manifest`, `module imports/capabilities`, the version manager, `env`).

## Verification
- Every example **builds and runs** with correct output (verified each; e.g. actors spawn→send→exit, supervisor restarts a killed child, policy denies a missing capability).
- `go build ./...`, `go vet ./...`, `gofmt`, `go test ./src/wago ./plugins/...` — all pass with examples in the module graph.
- **`act` locally: Lint & format ✅ (incl. staticcheck over `./...`), Build & test ✅.**
- Facade unchanged (examples add no public symbols); lean TinyGo CLI still builds (examples aren't in that path).