### PR TITLE
bench: add v8 startup latency

### DIFF
--- a/bench/startup/README.md
+++ b/bench/startup/README.md
@@ -29,7 +29,7 @@ for the performance section).
 ```sh
 make bench-startup                 # → bench/startup/startup.json
 # or point at specific binaries:
-WASM3_BIN=… IWASM_BIN=… node bench/startup/run.mjs
+V8_BIN=… WASM3_BIN=… IWASM_BIN=… node bench/startup/run.mjs
 ```
 
 Then regenerate the site from the data (no benchmarking):

--- a/bench/startup/run.mjs
+++ b/bench/startup/run.mjs
@@ -16,7 +16,7 @@
 //   node bench/startup/run.mjs                 # full sweep → bench/out/startup.json
 //   node bench/startup/run.mjs --out x.json    # write elsewhere
 //   WARMUP=5 MINRUNS=30 node bench/startup/run.mjs
-//   WAGO_BIN=/path/to/wago WASM3_BIN=... node bench/startup/run.mjs
+//   WAGO_BIN=/path/to/wago V8_BIN=/path/to/v8 WASM3_BIN=... node bench/startup/run.mjs
 
 import { readFile, writeFile, mkdir, access, rm } from "node:fs/promises";
 import { constants, accessSync } from "node:fs";
@@ -58,7 +58,7 @@ for (const w of cfg.workloads) {
   const args = ["-N", "--warmup", WARMUP, "--min-runs", MINRUNS, "--export-json", jsonTmp];
   for (const name of active) {
     const r = resolved[name];
-    const cmd = [r.bin, ...r.args.map((a) => a.replaceAll("{wasm}", wasm))].join(" ");
+    const cmd = [r.bin, ...r.args.map((a) => a.replaceAll("{repo}", REPO).replaceAll("{wasm}", wasm))].join(" ");
     args.push("-n", name, cmd);
   }
   process.stdout.write(`  ${w.id} … `);

--- a/bench/startup/runtimes.json
+++ b/bench/startup/runtimes.json
@@ -5,6 +5,7 @@
     "wazero",
     "wasmtime",
     "wasmer",
+    "v8",
     "wasm3",
     "wasmi",
     "iwasm",
@@ -48,6 +49,16 @@
         "run",
         "--disable-cache",
         "-s",
+        "{wasm}"
+      ]
+    },
+    "v8": {
+      "tag": "JIT",
+      "bin": "v8",
+      "env": "V8_BIN",
+      "args": [
+        "{repo}/bench/startup/v8-runner.js",
+        "--",
         "{wasm}"
       ]
     },

--- a/bench/startup/startup.json
+++ b/bench/startup/startup.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-05",
+  "generated": "2026-07-06",
   "machine": "AMD Ryzen 7 7800X3D 8-Core Processor, linux/x64",
   "method": "hyperfine -N --warmup 5 --min-runs 30; cold caches (full process, exec→exit)",
   "unit": "ms",
@@ -14,6 +14,9 @@
       "tag": "JIT"
     },
     "wasmer": {
+      "tag": "JIT"
+    },
+    "v8": {
       "tag": "JIT"
     },
     "wasm3": {
@@ -41,7 +44,8 @@
         "wasmer": 11.427,
         "wasm3": 5.569,
         "wasmi": 7.558,
-        "wavm": 289.086
+        "wavm": 289.086,
+        "v8": 15.823
       }
     },
     {
@@ -55,7 +59,8 @@
         "wasmer": 150.906,
         "wasm3": 287.999,
         "wasmi": 363.331,
-        "wavm": 54.563
+        "wavm": 54.563,
+        "v8": 48.241
       }
     },
     {
@@ -69,7 +74,8 @@
         "wasmer": 22.895,
         "wasm3": 22.836,
         "wasmi": 40.037,
-        "wavm": 55.983
+        "wavm": 55.983,
+        "v8": 19.028
       }
     },
     {
@@ -83,7 +89,8 @@
         "wasmer": 21.24,
         "wasm3": 37.69,
         "wasmi": 49.332,
-        "wavm": 145.376
+        "wavm": 145.376,
+        "v8": 21.041
       }
     },
     {
@@ -97,7 +104,8 @@
         "wasmer": 31.474,
         "wasm3": 37.007,
         "wasmi": 56.197,
-        "wavm": 45.478
+        "wavm": 45.478,
+        "v8": 19.735
       }
     },
     {
@@ -111,7 +119,8 @@
         "wasmer": 9.377,
         "wasm3": 6.987,
         "wasmi": 10.5,
-        "wavm": 37.062
+        "wavm": 37.062,
+        "v8": 16.733
       }
     }
   ]

--- a/bench/startup/v8-runner.js
+++ b/bench/startup/v8-runner.js
@@ -1,0 +1,13 @@
+if (arguments.length !== 1) {
+  throw new Error("usage: v8 v8-runner.js -- <module.wasm>");
+}
+
+const bytes = readbuffer(arguments[0]);
+const mod = new WebAssembly.Module(bytes);
+const instance = new WebAssembly.Instance(mod, {});
+
+if (typeof instance.exports._start !== "function") {
+  throw new Error("module does not export _start");
+}
+
+instance.exports._start();


### PR DESCRIPTION
## What

Adds V8 to the startup-latency sweep:

- adds a V8 shell runner for the committed startup twins
- wires `v8`/`V8_BIN` into `bench/startup/runtimes.json`
- records measured V8 startup results for the six workloads
- documents the new override in `bench/startup/README.md`

## Why

The website startup section should compare Wago against V8 alongside the existing runtime set.

## Validation

- `node` JSON parse for `bench/startup/runtimes.json` and `bench/startup/startup.json`
- `V8_BIN=/home/hub/.jsvu/bin/v8 WARMUP=1 MINRUNS=3 node bench/startup/run.mjs --out /tmp/wago-startup-v8-verify.json`
- `hyperfine -N --warmup 5 --min-runs 30` for each V8 workload
