### PR TITLE
perf(wasm): out-param Into for hot immediate-classification callers

### DIFF
--- a/src/core/compiler/backend/railshot/hints.go
+++ b/src/core/compiler/backend/railshot/hints.go
@@ -269,7 +269,7 @@ func (s *globalScoreByteScanner) scanExpr(depth int, loopDepth int, stopAtElse b
 			}
 			return op, s.r.err(wasm.ErrInvalidInstruction, s.r.off()-1)
 		case 0x02, 0x03, 0x04: // block, loop, if
-			if _, err := s.classifyInstruction(op); err != nil {
+			if err := wasm.SkipInstructionImmediate(s.r.Reader, op); err != nil {
 				return 0, err
 			}
 			switch op {
@@ -305,7 +305,8 @@ func (s *globalScoreByteScanner) scanExpr(depth int, loopDepth int, stopAtElse b
 				}
 			}
 		case 0x23, 0x24: // global.get/set
-			imm, err := s.classifyInstruction(op)
+			var imm wasm.InstructionImmediate
+			err := s.classifyInstructionInto(op, &imm)
 			if err != nil {
 				return 0, err
 			}
@@ -318,7 +319,7 @@ func (s *globalScoreByteScanner) scanExpr(depth int, loopDepth int, stopAtElse b
 				s.add(idx, score)
 			}
 		case 0x1f: // try_table: blocktype, catch vector, body
-			if _, err := s.classifyInstruction(op); err != nil {
+			if err := wasm.SkipInstructionImmediate(s.r.Reader, op); err != nil {
 				return 0, err
 			}
 			term, err := s.scanExpr(depth+1, loopDepth, false)
@@ -329,15 +330,15 @@ func (s *globalScoreByteScanner) scanExpr(depth int, loopDepth int, stopAtElse b
 				return term, s.r.err(wasm.ErrInvalidInstruction, s.r.off()-1)
 			}
 		default:
-			if _, err := s.classifyInstruction(op); err != nil {
+			if err := wasm.SkipInstructionImmediate(s.r.Reader, op); err != nil {
 				return 0, err
 			}
 		}
 	}
 }
 
-func (s *globalScoreByteScanner) classifyInstruction(op byte) (wasm.InstructionImmediate, error) {
-	return wasm.ClassifyInstructionImmediate(s.r.Reader, op)
+func (s *globalScoreByteScanner) classifyInstructionInto(op byte, imm *wasm.InstructionImmediate) error {
+	return wasm.ClassifyInstructionImmediateInto(s.r.Reader, op, imm)
 }
 
 // scanBodyBytes performs the same pre-scan over raw expression bytecode without
@@ -389,7 +390,7 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 			return true, op, s.r.err(wasm.ErrInvalidInstruction, s.r.off()-1)
 		case 0x02, 0x03, 0x04: // block, loop, if
 			s.h.stackArenaNodes += 2 // entry flush/rebuild allowance.
-			if _, err := s.classifyInstruction(op); err != nil {
+			if err := wasm.SkipInstructionImmediate(s.r.Reader, op); err != nil {
 				return true, 0, err
 			}
 			switch op {
@@ -437,28 +438,31 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				subHasCall = subHasCall || callsThen || callsElse
 			}
 		case 0x10, 0x12: // call, return_call
-			imm, err := s.classifyInstruction(op)
+			var imm wasm.InstructionImmediate
+			err := s.classifyInstructionInto(op, &imm)
 			if err != nil {
 				return true, 0, err
 			}
-			s.noteStackArenaOp(op, imm)
+			s.noteStackArenaOp(op, &imm)
 			s.h.hasCall, subHasCall = true, true
 			if op == 0x10 && imm.Index == s.selfIdx {
 				s.h.callsSelf = true
 			}
 		case 0x11, 0x13, 0x14, 0x15: // indirect/ref calls
-			imm, err := s.classifyInstruction(op)
+			var imm wasm.InstructionImmediate
+			err := s.classifyInstructionInto(op, &imm)
 			if err != nil {
 				return true, 0, err
 			}
-			s.noteStackArenaOp(op, imm)
+			s.noteStackArenaOp(op, &imm)
 			s.h.hasCall, subHasCall = true, true
 		case 0x20, 0x21, 0x22: // local.get/set/tee
-			imm, err := s.classifyInstruction(op)
+			var imm wasm.InstructionImmediate
+			err := s.classifyInstructionInto(op, &imm)
 			if err != nil {
 				return true, 0, err
 			}
-			s.noteStackArenaOp(op, imm)
+			s.noteStackArenaOp(op, &imm)
 			idx := imm.Index
 			if int(idx) < s.nLocals {
 				if op == 0x20 {
@@ -468,11 +472,12 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				}
 			}
 		case 0x23, 0x24: // global.get/set
-			imm, err := s.classifyInstruction(op)
+			var imm wasm.InstructionImmediate
+			err := s.classifyInstructionInto(op, &imm)
 			if err != nil {
 				return true, 0, err
 			}
-			s.noteStackArenaOp(op, imm)
+			s.noteStackArenaOp(op, &imm)
 			idx := imm.Index
 			if int(idx) < s.nGlobals {
 				if op == 0x24 {
@@ -483,11 +488,12 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				s.elig.add(curLoop, idx)
 			}
 		case 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40, 0xfc, 0xfd, 0xfe, 0xfb:
-			imm, err := s.classifyInstruction(op)
+			var imm wasm.InstructionImmediate
+			err := s.classifyInstructionInto(op, &imm)
 			if err != nil {
 				return true, 0, err
 			}
-			s.noteStackArenaOp(op, imm)
+			s.noteStackArenaOp(op, &imm)
 			if imm.TouchesMemory {
 				s.h.touchesMemory = true
 			}
@@ -496,7 +502,7 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 			}
 		case 0x1f: // try_table: blocktype, catch vector, body
 			s.h.stackArenaNodes += 2 // entry flush/rebuild allowance.
-			if _, err := s.classifyInstruction(op); err != nil {
+			if err := wasm.SkipInstructionImmediate(s.r.Reader, op); err != nil {
 				return true, 0, err
 			}
 			calls, term, err := s.scanExpr(depth+1, loopDepth, curLoop, false)
@@ -508,11 +514,12 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 			}
 			subHasCall = subHasCall || calls
 		default:
-			imm, err := s.classifyInstruction(op)
+			var imm wasm.InstructionImmediate
+			err := s.classifyInstructionInto(op, &imm)
 			if err != nil {
 				return true, 0, err
 			}
-			s.noteStackArenaOp(op, imm)
+			s.noteStackArenaOp(op, &imm)
 			if imm.TouchesMemory {
 				s.h.touchesMemory = true
 			}
@@ -523,17 +530,17 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 	}
 }
 
-func (s *byteBodyScanner) classifyInstruction(op byte) (wasm.InstructionImmediate, error) {
-	return wasm.ClassifyInstructionImmediate(s.r.Reader, op)
+func (s *byteBodyScanner) classifyInstructionInto(op byte, imm *wasm.InstructionImmediate) error {
+	return wasm.ClassifyInstructionImmediateInto(s.r.Reader, op, imm)
 }
 
-func (s *byteBodyScanner) noteStackArenaOp(op byte, imm wasm.InstructionImmediate) {
+func (s *byteBodyScanner) noteStackArenaOp(op byte, imm *wasm.InstructionImmediate) {
 	if stackArenaOpAllocates(op, imm) {
 		s.h.stackArenaNodes++
 	}
 }
 
-func stackArenaOpAllocates(op byte, imm wasm.InstructionImmediate) bool {
+func stackArenaOpAllocates(op byte, imm *wasm.InstructionImmediate) bool {
 	switch op {
 	case 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // calls: conservatively allow one result node.
 		0x1b, 0x1c, // select

--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -541,10 +541,11 @@ func (p supportPass) instrByte(r *wasm.Reader, op byte, context string, instr in
 	case 0x02, 0x03, 0x04:
 		return false, skipBlockType()
 	case 0x0c, 0x0d, 0x10, 0x20, 0x21, 0x22, 0x23, 0x24, 0x0e:
-		_, err := wasm.ClassifyInstructionImmediate(r, op)
+		err := wasm.SkipInstructionImmediate(r, op)
 		return false, err
 	case 0x11:
-		imm, err := wasm.ClassifyInstructionImmediate(r, op)
+		var imm wasm.InstructionImmediate
+		err := wasm.ClassifyInstructionImmediateInto(r, op, &imm)
 		if err != nil {
 			return false, err
 		}
@@ -566,7 +567,8 @@ func (p supportPass) instrByte(r *wasm.Reader, op byte, context string, instr in
 	case 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32,
 		0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d,
 		0x3e:
-		imm, err := wasm.ClassifyInstructionImmediate(r, op)
+		var imm wasm.InstructionImmediate
+		err := wasm.ClassifyInstructionImmediateInto(r, op, &imm)
 		if err != nil {
 			return false, err
 		}
@@ -575,7 +577,8 @@ func (p supportPass) instrByte(r *wasm.Reader, op byte, context string, instr in
 		}
 		return false, nil
 	case 0x3f, 0x40:
-		imm, err := wasm.ClassifyInstructionImmediate(r, op)
+		var imm wasm.InstructionImmediate
+		err := wasm.ClassifyInstructionImmediateInto(r, op, &imm)
 		if err != nil {
 			return false, err
 		}
@@ -584,7 +587,7 @@ func (p supportPass) instrByte(r *wasm.Reader, op byte, context string, instr in
 		}
 		return false, nil
 	case 0x41, 0x42, 0x43, 0x44:
-		_, err := wasm.ClassifyInstructionImmediate(r, op)
+		err := wasm.SkipInstructionImmediate(r, op)
 		return false, err
 	case 0xc0, 0xc1, 0xc2, 0xc3, 0xc4:
 		if !p.feat.SignExtension {
@@ -592,12 +595,13 @@ func (p supportPass) instrByte(r *wasm.Reader, op byte, context string, instr in
 		}
 		return false, nil
 	case 0xd0:
-		if _, err := wasm.ClassifyInstructionImmediate(r, op); err != nil {
+		if err := wasm.SkipInstructionImmediate(r, op); err != nil {
 			return false, err
 		}
 		return false, p.unsupported("reference instruction", "RefNull", ctx())
 	case 0xfd:
-		imm, err := wasm.ClassifyInstructionImmediate(r, op)
+		var imm wasm.InstructionImmediate
+		err := wasm.ClassifyInstructionImmediateInto(r, op, &imm)
 		if err != nil {
 			return false, err
 		}
@@ -612,7 +616,7 @@ func (p supportPass) instrByte(r *wasm.Reader, op byte, context string, instr in
 		}
 		return false, nil
 	case 0xfb, 0xfe:
-		if _, err := wasm.ClassifyInstructionImmediate(r, op); err != nil {
+		if err := wasm.SkipInstructionImmediate(r, op); err != nil {
 			return false, err
 		}
 		return false, p.unsupported("instruction", fmt.Sprintf("opcode 0x%02x", op), ctx())
@@ -688,7 +692,8 @@ func supportedSIMDInstruction(imm wasm.InstructionImmediate) bool {
 }
 
 func (p supportPass) fcInstrByte(r *wasm.Reader, context func() string) error {
-	imm, err := wasm.ClassifyInstructionImmediate(r, 0xfc)
+	var imm wasm.InstructionImmediate
+	err := wasm.ClassifyInstructionImmediateInto(r, 0xfc, &imm)
 	if err != nil {
 		return err
 	}
@@ -769,7 +774,8 @@ func (p supportPass) constExprBytes(body []byte, context string) error {
 			return err
 		}
 	case 0xfd:
-		imm, err := wasm.ClassifyInstructionImmediate(r, op)
+		var imm wasm.InstructionImmediate
+		err := wasm.ClassifyInstructionImmediateInto(r, op, &imm)
 		if err != nil {
 			return err
 		}

--- a/src/core/compiler/wasm/bytecode_walk.go
+++ b/src/core/compiler/wasm/bytecode_walk.go
@@ -20,10 +20,19 @@ type InstructionImmediate struct {
 // immediates without allocating decoded Instruction payloads.
 func ClassifyInstructionImmediate(r *Reader, op byte) (InstructionImmediate, error) {
 	var imm InstructionImmediate
-	ir := &reader{data: r.data, pos: r.pos}
-	_, err := classifyExprOpAfterOpcode(ir, op, &imm)
-	r.pos = ir.pos
+	err := ClassifyInstructionImmediateInto(r, op, &imm)
 	return imm, err
+}
+
+// ClassifyInstructionImmediateInto is ClassifyInstructionImmediate with a
+// caller-provided out-param, avoiding the return-value copy on hot compile paths.
+// It zeroes *imm first, so the buffer may be reused across calls.
+func ClassifyInstructionImmediateInto(r *Reader, op byte, imm *InstructionImmediate) error {
+	*imm = InstructionImmediate{}
+	ir := &reader{data: r.data, pos: r.pos}
+	_, err := classifyExprOpAfterOpcode(ir, op, imm)
+	r.pos = ir.pos
+	return err
 }
 
 // SkipInstructionImmediate consumes the immediates for op from r. The opcode
@@ -32,6 +41,6 @@ func ClassifyInstructionImmediate(r *Reader, op byte) (InstructionImmediate, err
 // Structural opcodes (block/loop/if/else/end/try_table) are accepted and only
 // their inline immediates are consumed.
 func SkipInstructionImmediate(r *Reader, op byte) error {
-	_, err := ClassifyInstructionImmediate(r, op)
-	return err
+	var scratch InstructionImmediate
+	return ClassifyInstructionImmediateInto(r, op, &scratch)
 }


### PR DESCRIPTION
Follow-up to #181. That PR removed the *internal* copy but the public `ClassifyInstructionImmediate` still returned the 28-byte struct by value, leaving a caller-side `runtime.duffcopy` as the new #1 hotspot. Profiling attributed it to two hot loops: frontend `supportPass.instrByte` (60%) and railshot `byteBodyScanner.classifyInstruction` (34%).

## Change
- Add `ClassifyInstructionImmediateInto(r, op, *imm) error` — the out-param form (zeroes `*imm`, so buffers may be reused). `ClassifyInstructionImmediate` now wraps it; `SkipInstructionImmediate` routes through it with a scratch (no return copy).
- **frontend `supportPass.instrByte`**: discard sites → `SkipInstructionImmediate`; value sites → a fresh `var imm` + `…Into`.
- **railshot `byteBodyScanner` / `globalScoreByteScanner`**: `classifyInstruction` wrappers become `classifyInstructionInto` out-params; `noteStackArenaOp`/`stackArenaOpAllocates` take `*InstructionImmediate` (read-only), so `imm` is no longer copied a second time per instruction.

## Result
- **esbuild `CompileFull`: 1.11 s → 1.02 s** (~8% more), i.e. **~17% cumulative** vs. the pre-#181 baseline of 1.23 s. Allocations unchanged.
- `ClassifyInstructionImmediate(Into)` cumulative dropped to ~7% (from ~19% originally). The remaining `duffcopy` is now entirely in the **validator's** own struct returns (`memoryType`/`globalType`/`validateFuncDirect`) — a distinct hotspot for a future PR.

## Verification
- `go test ./src/core/compiler/... ./src/wago` — PASS (immediate classification covered by `bytecode_walk_test`/`frontend_test` + every real-module compile). Real programs run correctly.
- `go build ./...`, `go vet`, `gofmt` clean. **`act`: Build & test ✅, Lint & format ✅ (incl. staticcheck).**