### PR TITLE
fix(railshot): emit deferred load before spilling its address register

### DIFF
--- a/src/core/compiler/backend/railshot/regalloc.go
+++ b/src/core/compiler/backend/railshot/regalloc.go
@@ -101,6 +101,36 @@ func (f *fn) spillIfUsed(r Reg) {
 
 // spill evicts the register-resident value elem e to a fresh frame slot.
 func (f *fn) spill(e *elem) {
+	if e.st.kind == stMemRef {
+		// e is a deferred load: e.st.reg holds the effective ADDRESS, not the
+		// loaded value. Emit the load now and spill the value. Storing the address
+		// register directly (and marking e as a plain slot value) would silently
+		// drop the load, so a later reload uses the address as if it were the
+		// loaded value. This mirrors the pending-load eviction in allocReg and the
+		// stMemRef case of materialize(). Reached via spillIfUsed when a deferred
+		// load's owned address register is reclaimed for a fixed role (e.g. RAX/RDX
+		// for div/mul, RCX for a shift count).
+		if e.st.typ.isFloat() {
+			x := f.allocFReg(0)
+			f.loadFMemRef(x, e.st)
+			f.releaseMemRef(e.st)
+			f.occupyF(e, x)
+			f.spillF(e)
+
+			return
+		}
+
+		dst := e.st.reg
+		if e.st.memBorrow() >= 0 {
+			// Borrowed pinned-local address register: never clobber it — load into
+			// a fresh register instead.
+			dst = f.allocReg(maskOf(e.st.reg))
+		}
+		f.loadMemRef(dst, e.st)
+		f.occupy(e, dst)
+		// e is now a plain register value; fall through to spill it.
+	}
+
 	f.stats.addSpill()
 	r := e.st.reg
 	slot := f.allocSpillSlot()

--- a/src/core/compiler/backend/railshot/regalloc_memref_spill_test.go
+++ b/src/core/compiler/backend/railshot/regalloc_memref_spill_test.go
@@ -1,0 +1,48 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestMemRefSpillKeepsLoad is a regression test for a deferred-load (stMemRef)
+// eviction bug in spill(). A deferred integer load holds its effective ADDRESS in
+// a register with the actual mov not yet emitted. When that owned address register
+// was reclaimed by spillIfUsed for a fixed role (RAX/RDX for a div, RCX for a
+// shift), spill() stored the address register and marked the value as a plain
+// slot — silently dropping the load, so a later reload used the address as if it
+// were the loaded value.
+//
+// This miscompiled AssemblyScript's Unicode casemap() (~lib/util/casemap, used by
+// String#toLowerCase): the case-table lookup multiplied a table ADDRESS instead of
+// the loaded byte, producing wrong case mappings and, on some inputs, an infinite
+// loop in the AS module-init path (every AS module that lowercases a string during
+// global init hung on load).
+//
+// The function below is the minimal shape: the load's address (96 / x) is produced
+// by a div so it lands in RAX; the second div (x / 3) reclaims RAX, spilling the
+// still-pending load. For x = 12: mem[8] = 200, addr = 96/12 = 8, load8(8) = 200,
+// x/3 = 4, result = 200 * 4 = 800. The bug multiplied the address 8 instead: 32.
+func TestMemRefSpillKeepsLoad(t *testing.T) {
+	m := modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{i32}, []byte{
+		0x00,       // 0 local decls
+		0x41, 0x08, // i32.const 8
+		0x41, 0xc8, 0x01, // i32.const 200
+		0x3a, 0x00, 0x00, // i32.store8 (mem[8] = 200)
+		0x41, 0xe0, 0x00, // i32.const 96
+		0x20, 0x00, // local.get 0 (x)
+		0x6e,             // i32.div_u  -> 96/x, result in RAX
+		0x2d, 0x00, 0x00, // i32.load8_u [96/x]  (deferred; address owns RAX)
+		0x20, 0x00, // local.get 0 (x)
+		0x41, 0x03, // i32.const 3
+		0x6e, // i32.div_u  -> x/3 (reclaims RAX, spilling the pending load)
+		0x6c, // i32.mul   (loaded byte * (x/3))
+		0x0b, // end
+	})
+	if got := runAmd64(t, m, 12); got != 800 {
+		t.Fatalf("deferred load spilled as its address instead of its value: got %d, want 800", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a register-allocator miscompile in the railshot single-pass backend: a **deferred integer load (`stMemRef`) was spilled as its address instead of its value**, silently dropping the load. Consumers then used the effective *address* where the *loaded byte* was expected.

This is why **no AssemblyScript module that lowercases a string during global init could run on wago** — it hung in `_initialize`.

## Root cause

A `stMemRef` operand-stack entry carries the bounds-checked effective address in a register with the `mov` deferred. `allocReg`'s eviction path and `materialize()` both emit the load before reusing the register — but `spill()` did not:

```go
func (f *fn) spill(e *elem) {
    f.stats.addSpill()
    r := e.st.reg                 // for stMemRef this is the ADDRESS, not the value
    slot := f.allocSpillSlot()
    f.a.Store64(RSP, f.spillOff(slot), r)   // spills the address
    f.regUser[r] = nil
    f.replaceStorage(e, storage{kind: stSlot, ...})  // now a plain value → load lost
}
```

`spill()` is reached for a pending `stMemRef` via `spillIfUsed`, which frees a fixed-role register (`RAX`/`RDX` for `div`/`mul`, `RCX` for a shift count). When a deferred load's owned address register happened to be that register, the load was dropped and the address flowed on as the value.

## Where it bit

AssemblyScript's Unicode `~lib/util/casemap/casemap` (used by `String#toLowerCase`) computes a case-table index roughly as `A + ((C * Dh) >> 11) % 6`, where `C = load8(base + l3/3)`. The load address for `C` lands in `RAX` (built on a prior `div`); the very next `div` (`l3 % 3`) reclaims `RAX` and spilled the pending load. The multiply then used `C`'s **address** instead of its byte, producing:

- wrong case mappings (`casemap('A')` returned `'A'` instead of `'a'`), and
- an **infinite loop** on inputs where the corrupted value drove the case-folding binary search into a non-terminating state.

Verified against a faithful emulator over all inputs `0..2000`: post-fix, 0 mismatches and 0 hangs (pre-fix: many wrong values + 29 hangs in that range).

## Fix

Handle `stMemRef` in `spill()` by emitting the load first (mirroring `allocReg` / `materialize()`), then spilling the loaded value. Integer and float/vector deferred loads are both handled, plus the borrowed pinned-local-address case.

## Test

`TestMemRefSpillKeepsLoad` is a minimal, self-contained regression: `mem[8]=200; return load8(96/x) * (x/3)`. The `96/x` load address lands in `RAX`; the `x/3` div reclaims it, spilling the pending load. For `x=12` the correct result is `200*4 = 800`; the bug produced `8*4 = 32` (address instead of value). Passes with the fix, fails without it.

Full `go test ./...` and the `bench/` wago-vs-wazero differential corpus pass.
