### PR TITLE
feat(railshot): inline-candidate detection + WAGO_EXPLAIN report

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -343,6 +343,11 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	if ms != nil {
 		ms.Funcs = make([]*CodegenStats, n)
 		ms.ModuleGlobalPins = moduleGlobalPinInfos(modGlobals)
+		// Inline-candidate detection (report only; no codegen change yet). Failure
+		// to analyze is non-fatal — it never blocks a compile.
+		if rep, ierr := AnalyzeInlineCandidates(m); ierr == nil {
+			ms.Inline = rep
+		}
 	}
 	// Compile scratch reused across every function in the module. The operand
 	// stack arena and the occurrence-tracking refs map are per-function scratch

--- a/src/core/compiler/backend/railshot/inline.go
+++ b/src/core/compiler/backend/railshot/inline.go
@@ -1,0 +1,284 @@
+package amd64
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// Inline-candidate detection (analysis + reporting phase). This computes, for
+// every local function, whether it is a good target to splice into its call
+// sites, plus a module-level report surfaced via WAGO_EXPLAIN. It performs NO
+// codegen change — it is the analysis a later transform phase will consume, and
+// it lets us see exactly what (and how much) would inline before touching the
+// register allocator.
+//
+// The conservative candidate class (matching the agreed heuristic) is a small,
+// non-recursive LEAF function with a register-ABI int-only signature: the
+// classic tiny accessor/helper where the call sequence dominates the actual
+// work. Leaf-ness (no calls at all) subsumes non-recursion and rules out
+// call_indirect / return_call cycles, so the whole class is trivially safe to
+// reason about — an inline of such a body cannot re-enter the inliner.
+
+// inlineMaxBodyBytes is the default encoded-body-size ceiling for a candidate
+// (a proxy for how much code each inline site adds). Overridable for A/B via
+// WAGO_INLINE_MAXBYTES.
+const inlineMaxBodyBytes = 48
+
+// inlineCallSeqBytes is a rough per-call-site machine-code cost for the call
+// sequence an inline removes (arg staging + call + result handling). Used only
+// to estimate the saved bytes in the report, so an approximate constant is fine.
+const inlineCallSeqBytes = 24
+
+var inlineMaxBytes = func() int {
+	if v := os.Getenv("WAGO_INLINE_MAXBYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return inlineMaxBodyBytes
+}()
+
+// inlineFacts are the per-function facts the candidacy decision needs.
+type inlineFacts struct {
+	bodyBytes      int      // encoded body size (proxy for inlined code growth)
+	calleeCount    int      // number of direct `call` instructions in the body
+	callees        []uint32 // direct call target func indices (global indexing)
+	hasControlCall bool     // call_indirect / return_call* / call_ref (inline blocker)
+	hasLoop        bool
+	params         int
+	results        int
+	regABIIntOnly  bool // signature fits the int-only register ABI
+}
+
+// InlineCandidateInfo is one local function's entry in the report.
+type InlineCandidateInfo struct {
+	FuncIdx   int    // global function index
+	Name      string // display name (from the name section, or func#N)
+	BodyBytes int    // encoded body size
+	Params    int
+	Results   int
+	CallSites int    // number of direct call sites targeting this function
+	Candidate bool   // meets the conservative inline-candidate class
+	Reason    string // why it is (or is not) a candidate
+}
+
+// InlineReport is the module-level inline-candidate analysis.
+type InlineReport struct {
+	Funcs                   []InlineCandidateInfo // one entry per local function
+	NumCandidates           int
+	TotalInlinableCallSites int // Σ candidate.CallSites
+	EstBytesAdded           int // rough: Σ callSites*bodyBytes over candidates
+	EstBytesSaved           int // rough: Σ callSites*inlineCallSeqBytes over candidates
+	MaxBodyBytes            int // the size ceiling in effect
+}
+
+// AnalyzeInlineCandidates runs the inline-candidate detection over a module's
+// local functions and returns the report. It is pure analysis (no compilation)
+// so it is safe to call independently — e.g. from tooling or tests.
+func AnalyzeInlineCandidates(m *wasm.Module) (*InlineReport, error) {
+	importedFuncs := m.ImportedFuncCount()
+	n := len(m.Code)
+	facts := make([]inlineFacts, n)
+	for i := range m.Code {
+		f, err := scanInlineFacts(m, m.Code[i], i, importedFuncs)
+		if err != nil {
+			return nil, fmt.Errorf("function %d inline scan: %w", i, err)
+		}
+		facts[i] = f
+	}
+
+	// Call-site counts: for every direct call anywhere in the module, tally the
+	// target. Indexed by global function index.
+	callSites := make([]int, importedFuncs+n)
+	for i := range facts {
+		for _, callee := range facts[i].callees {
+			if int(callee) < len(callSites) {
+				callSites[callee]++
+			}
+		}
+	}
+
+	rep := &InlineReport{MaxBodyBytes: inlineMaxBytes}
+	rep.Funcs = make([]InlineCandidateInfo, n)
+	for i := range facts {
+		globalIdx := importedFuncs + i
+		info := InlineCandidateInfo{
+			FuncIdx:   globalIdx,
+			Name:      funcDisplayName(m, i, importedFuncs),
+			BodyBytes: facts[i].bodyBytes,
+			Params:    facts[i].params,
+			Results:   facts[i].results,
+			CallSites: callSites[globalIdx],
+		}
+		info.Candidate, info.Reason = inlineDecision(facts[i], callSites[globalIdx])
+		if info.Candidate {
+			rep.NumCandidates++
+			rep.TotalInlinableCallSites += info.CallSites
+			rep.EstBytesAdded += info.CallSites * facts[i].bodyBytes
+			rep.EstBytesSaved += info.CallSites * inlineCallSeqBytes
+		}
+		rep.Funcs[i] = info
+	}
+	return rep, nil
+}
+
+// inlineDecision applies the conservative candidate class and returns the
+// verdict plus a one-line reason (why, or why not).
+func inlineDecision(f inlineFacts, callSites int) (bool, string) {
+	switch {
+	case f.hasControlCall:
+		return false, "has call_indirect/return_call"
+	case f.calleeCount > 0:
+		return false, fmt.Sprintf("non-leaf (%d call(s))", f.calleeCount)
+	case !f.regABIIntOnly:
+		return false, "signature not int-only reg-ABI"
+	case f.bodyBytes > inlineMaxBytes:
+		return false, fmt.Sprintf("too big (%dB > %dB)", f.bodyBytes, inlineMaxBytes)
+	case callSites == 0:
+		return false, "no call sites"
+	default:
+		loop := ""
+		if f.hasLoop {
+			loop = ", has loop"
+		}
+		return true, fmt.Sprintf("leaf, %dB, %d site(s)%s", f.bodyBytes, callSites, loop)
+	}
+}
+
+// scanInlineFacts collects a single local function's inline facts, from the
+// byte-backed body (the DecodeModule path) or the AST body (frontend/test path).
+func scanInlineFacts(m *wasm.Module, fn wasm.Func, localIdx, importedFuncs int) (inlineFacts, error) {
+	var f inlineFacts
+	if ft, ok := m.LocalFuncType(localIdx); ok {
+		f.params = len(ft.Params)
+		f.results = len(ft.Results)
+		f.regABIIntOnly = sigFitsRegABI(ft) && sigIsIntOnly(ft)
+	}
+	if len(fn.BodyBytes) != 0 {
+		if err := scanInlineFactsBytes(fn.BodyBytes, &f); err != nil {
+			return f, err
+		}
+		return f, nil
+	}
+	scanInlineFactsAST(fn.Body.Instrs, &f)
+	return f, nil
+}
+
+func scanInlineFactsBytes(body []byte, f *inlineFacts) error {
+	f.bodyBytes = len(body)
+	r := wasm.NewReader(body)
+	var imm wasm.InstructionImmediate
+	for r.HasNext() {
+		op, err := r.Byte()
+		if err != nil {
+			return err
+		}
+		if err := wasm.ClassifyInstructionImmediateInto(r, op, &imm); err != nil {
+			return err
+		}
+		switch imm.Kind {
+		case wasm.InstrCall:
+			f.calleeCount++
+			f.callees = append(f.callees, imm.Index)
+		case wasm.InstrCallIndirect, wasm.InstrReturnCall, wasm.InstrReturnCallIndirect,
+			wasm.InstrCallRef, wasm.InstrReturnCallRef:
+			f.hasControlCall = true
+		case wasm.InstrLoop:
+			f.hasLoop = true
+		}
+	}
+	return nil
+}
+
+func scanInlineFactsAST(instrs []wasm.Instruction, f *inlineFacts) {
+	for i := range instrs {
+		in := &instrs[i]
+		switch in.Kind {
+		case wasm.InstrCall:
+			f.calleeCount++
+			f.callees = append(f.callees, in.Index)
+		case wasm.InstrCallIndirect, wasm.InstrReturnCall, wasm.InstrReturnCallIndirect,
+			wasm.InstrCallRef, wasm.InstrReturnCallRef:
+			f.hasControlCall = true
+		case wasm.InstrLoop:
+			f.hasLoop = true
+			scanInlineFactsAST(in.Body().Instrs, f)
+		case wasm.InstrBlock:
+			scanInlineFactsAST(in.Body().Instrs, f)
+		case wasm.InstrIf:
+			scanInlineFactsAST(in.Then(), f)
+			scanInlineFactsAST(in.Else(), f)
+		}
+	}
+}
+
+// String renders the inline-candidate report for WAGO_EXPLAIN. Candidates are
+// listed first (by descending call-site count), then a compact tally of the
+// most common reasons functions were rejected.
+func (r *InlineReport) String() string {
+	if r == nil {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "inline candidates: %d/%d functions, %d inlinable call site(s), ~%dB added / ~%dB call-seq saved (<=%dB bodies)\n",
+		r.NumCandidates, len(r.Funcs), r.TotalInlinableCallSites, r.EstBytesAdded, r.EstBytesSaved, r.MaxBodyBytes)
+
+	cands := make([]InlineCandidateInfo, 0, r.NumCandidates)
+	rejected := make(map[string]int)
+	for _, f := range r.Funcs {
+		if f.Candidate {
+			cands = append(cands, f)
+		} else {
+			rejected[reasonBucket(f.Reason)]++
+		}
+	}
+	sort.SliceStable(cands, func(i, j int) bool { return cands[i].CallSites > cands[j].CallSites })
+	for _, f := range cands {
+		fmt.Fprintf(&b, "  INLINE  %-28s  %d->%d  %s\n", truncName(f.Name), f.Params, f.Results, f.Reason)
+	}
+	if len(rejected) > 0 {
+		buckets := make([]string, 0, len(rejected))
+		for k := range rejected {
+			buckets = append(buckets, k)
+		}
+		sort.SliceStable(buckets, func(i, j int) bool { return rejected[buckets[i]] > rejected[buckets[j]] })
+		b.WriteString("  rejected:")
+		for _, k := range buckets {
+			fmt.Fprintf(&b, " %s=%d", k, rejected[k])
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// reasonBucket collapses a per-function reason to its category (dropping the
+// numeric detail) for the rejected tally.
+func reasonBucket(reason string) string {
+	switch {
+	case strings.HasPrefix(reason, "non-leaf"):
+		return "non-leaf"
+	case strings.HasPrefix(reason, "too big"):
+		return "too-big"
+	case strings.HasPrefix(reason, "has call_indirect"):
+		return "indirect/return-call"
+	case strings.HasPrefix(reason, "signature"):
+		return "non-int-sig"
+	case strings.HasPrefix(reason, "no call sites"):
+		return "unused"
+	default:
+		return reason
+	}
+}
+
+func truncName(s string) string {
+	const max = 28
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}

--- a/src/core/compiler/backend/railshot/inline_test.go
+++ b/src/core/compiler/backend/railshot/inline_test.go
@@ -1,0 +1,144 @@
+package amd64
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+var vI32 = wasm.I32 // shorthand for the hand-built test bodies below
+
+// TestAnalyzeInlineCandidates builds a small module exercising each candidacy
+// outcome: a tiny leaf (candidate, two call sites), a recursive function
+// (non-leaf via a self call), an oversized leaf (too big), and the caller.
+func TestAnalyzeInlineCandidates(t *testing.T) {
+	// func 0 (caller, ()->i32): calls func 1 twice and func 2 once.
+	//   i32.const 1; i32.const 2; call 1; drop
+	//   i32.const 3; i32.const 4; call 1; drop
+	//   i32.const 5; call 2; end
+	caller := []byte{
+		0x00, // no local decls
+		0x41, 0x01, 0x41, 0x02, 0x10, 0x01, 0x1a,
+		0x41, 0x03, 0x41, 0x04, 0x10, 0x01, 0x1a,
+		0x41, 0x05, 0x10, 0x02,
+		0x0b,
+	}
+	// func 1 (leaf, (i32,i32)->i32): local.get 0; local.get 1; i32.add; end
+	leaf := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b}
+	// func 2 (recursive, (i32)->i32): local.get 0; call 2; end
+	recursive := []byte{0x00, 0x20, 0x00, 0x10, 0x02, 0x0b}
+	// func 3 (oversized leaf, ()->i32): 20× (i32.const 0; drop) then i32.const 0; end
+	big := []byte{0x00}
+	for i := 0; i < 20; i++ {
+		big = append(big, 0x41, 0x00, 0x1a) // i32.const 0; drop
+	}
+	big = append(big, 0x41, 0x00, 0x0b) // i32.const 0; end
+
+	m := modFuncs(t,
+		funcDef{params: nil, results: []wasm.ValType{vI32}, body: caller},
+		funcDef{params: []wasm.ValType{vI32, vI32}, results: []wasm.ValType{vI32}, body: leaf},
+		funcDef{params: []wasm.ValType{vI32}, results: []wasm.ValType{vI32}, body: recursive},
+		funcDef{params: nil, results: []wasm.ValType{vI32}, body: big},
+	)
+
+	rep, err := AnalyzeInlineCandidates(m)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(rep.Funcs) != 4 {
+		t.Fatalf("Funcs len = %d, want 4", len(rep.Funcs))
+	}
+
+	// func 1 (leaf) is the only candidate, with two call sites.
+	leafInfo := rep.Funcs[1]
+	if !leafInfo.Candidate {
+		t.Errorf("func 1 (leaf) should be a candidate; reason=%q", leafInfo.Reason)
+	}
+	if leafInfo.CallSites != 2 {
+		t.Errorf("func 1 CallSites = %d, want 2", leafInfo.CallSites)
+	}
+	if leafInfo.Params != 2 || leafInfo.Results != 1 {
+		t.Errorf("func 1 sig = %d->%d, want 2->1", leafInfo.Params, leafInfo.Results)
+	}
+
+	// func 0 (caller) is non-leaf.
+	if rep.Funcs[0].Candidate {
+		t.Errorf("func 0 (caller) should not be a candidate")
+	}
+	// func 2 (recursive) is non-leaf (it calls itself), CallSites==1.
+	if rep.Funcs[2].Candidate {
+		t.Errorf("func 2 (recursive) should not be a candidate; reason=%q", rep.Funcs[2].Reason)
+	}
+	// Two call sites target func 2: the caller's `call 2` and its own self-call.
+	if rep.Funcs[2].CallSites != 2 {
+		t.Errorf("func 2 CallSites = %d, want 2", rep.Funcs[2].CallSites)
+	}
+	// func 3 (oversized leaf) is rejected for size.
+	if rep.Funcs[3].Candidate {
+		t.Errorf("func 3 (big) should not be a candidate; reason=%q", rep.Funcs[3].Reason)
+	}
+	if rep.Funcs[3].BodyBytes <= inlineMaxBytes {
+		t.Errorf("func 3 BodyBytes = %d, expected > %d", rep.Funcs[3].BodyBytes, inlineMaxBytes)
+	}
+
+	if rep.NumCandidates != 1 {
+		t.Errorf("NumCandidates = %d, want 1", rep.NumCandidates)
+	}
+	if rep.TotalInlinableCallSites != 2 {
+		t.Errorf("TotalInlinableCallSites = %d, want 2", rep.TotalInlinableCallSites)
+	}
+	if s := rep.String(); s == "" {
+		t.Error("report String() is empty")
+	}
+}
+
+// TestInlineReportInModuleStats verifies the report is populated on ModuleStats
+// during a real compile and rendered in its String() (the WAGO_EXPLAIN path).
+func TestInlineReportInModuleStats(t *testing.T) {
+	caller := []byte{0x00, 0x41, 0x01, 0x41, 0x02, 0x10, 0x01, 0x0b} // i32.const1;i32.const2;call 1;end
+	leaf := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b}         // (i32,i32)->i32 a+b
+	m := modFuncs(t,
+		funcDef{params: nil, results: []wasm.ValType{vI32}, body: caller},
+		funcDef{params: []wasm.ValType{vI32, vI32}, results: []wasm.ValType{vI32}, body: leaf},
+	)
+	var ms ModuleStats
+	if _, err := CompileModuleWith(m, CompileOptions{Stats: &ms}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if ms.Inline == nil {
+		t.Fatal("ModuleStats.Inline not populated during compile")
+	}
+	if ms.Inline.NumCandidates != 1 {
+		t.Errorf("NumCandidates = %d, want 1", ms.Inline.NumCandidates)
+	}
+	if s := ms.String(); !strings.Contains(s, "inline candidates:") {
+		t.Errorf("ModuleStats.String() missing inline report:\n%s", s)
+	}
+}
+
+// TestAnalyzeInlineCandidatesUnused checks that a leaf with no call sites is
+// reported as unused (not a candidate) rather than inlinable.
+func TestAnalyzeInlineCandidatesUnused(t *testing.T) {
+	// func 0 (exported, ()->i32): i32.const 7; end — never calls func 1.
+	main := []byte{0x00, 0x41, 0x07, 0x0b}
+	// func 1 (leaf, uncalled): i32.const 0; end
+	unused := []byte{0x00, 0x41, 0x00, 0x0b}
+	m := modFuncs(t,
+		funcDef{params: nil, results: []wasm.ValType{vI32}, body: main},
+		funcDef{params: nil, results: []wasm.ValType{vI32}, body: unused},
+	)
+	rep, err := AnalyzeInlineCandidates(m)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if rep.Funcs[1].Candidate {
+		t.Errorf("uncalled leaf should not be a candidate; reason=%q", rep.Funcs[1].Reason)
+	}
+	if rep.Funcs[1].Reason != "no call sites" {
+		t.Errorf("reason = %q, want %q", rep.Funcs[1].Reason, "no call sites")
+	}
+	if rep.NumCandidates != 0 {
+		t.Errorf("NumCandidates = %d, want 0", rep.NumCandidates)
+	}
+}

--- a/src/core/compiler/backend/railshot/stats.go
+++ b/src/core/compiler/backend/railshot/stats.go
@@ -213,6 +213,7 @@ type ModuleGlobalPinInfo struct {
 type ModuleStats struct {
 	Funcs            []*CodegenStats
 	ModuleGlobalPins []ModuleGlobalPinInfo
+	Inline           *InlineReport // inline-candidate detection (nil if not analyzed)
 }
 
 // String renders the explain dump: a module summary line, the module-pinned
@@ -231,6 +232,9 @@ func (ms *ModuleStats) String() string {
 			fmt.Fprintf(&b, " g%d→%s", p.Global, p.Reg)
 		}
 		b.WriteByte('\n')
+	}
+	if ms.Inline != nil {
+		b.WriteString(ms.Inline.String())
 	}
 	for _, s := range ms.Funcs {
 		if s == nil {


### PR DESCRIPTION
## Summary

Phase 1 of auto-inlining: a **module-level inline-candidate detector** for the railshot backend, surfaced via `WAGO_EXPLAIN`. This is **analysis + reporting only — no codegen change**. It lets us see exactly what (and how much) would inline before touching the register allocator, and is the analysis a later transform phase will consume.

## What it does

`AnalyzeInlineCandidates(m)` walks every local function once, builds the module call graph (direct-call target list + per-callee call-site counts), and classifies each function against the agreed **conservative candidate class**:

- **leaf** (no `call`, and no `call_indirect`/`return_call*`/`call_ref`) — subsumes non-recursion and rules out inline cycles, so the class is trivially safe to reason about
- **int-only register-ABI signature** (keeps the eventual splice simple)
- **body ≤ 48 bytes** (`WAGO_INLINE_MAXBYTES` to tune)
- at least one call site

Each function gets a verdict + one-line reason (or rejection bucket: `non-leaf`, `too-big`, `indirect/return-call`, `non-int-sig`, `unused`). The report is attached to `ModuleStats.Inline` and rendered in the `WAGO_EXPLAIN` dump, with rough est. bytes-added / call-sequence-saved.

## Sample output (real corpus)

```
inline candidates: 3/658 functions, 19 inlinable call site(s), ~841B added / ~456B call-seq saved (<=48B bodies)   # lua.wasm
  INLINE  <helper>   2->0  leaf, 48B, 10 site(s)
  ...
  rejected: non-leaf=514 too-big=55 indirect/return-call=43 unused=32 non-int-sig=11
```

## Testing

- New unit tests: candidate/non-candidate classification (leaf vs recursive vs oversized vs unused), call-site counting (incl. self-calls), and the `ModuleStats`/`WAGO_EXPLAIN` integration path.
- Full repo + spec suite (15,372 assertions) green in explicit and guard-page modes — pure analysis, no codegen impact.

## Next (not in this PR)

Phase 2 — the actual splice transform for this candidate class, behind a flag (`WAGO_INLINE`), gated on the corpus differential + spec + wasi corpus, with a conservative size/benefit heuristic governing default-on.