### PR TITLE
feat(railshot): aggressive inlining — memory/global/multi-slot + control-flow leaf callees

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -622,6 +622,16 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool
 	}
 	hasCall := hints.hasCall
 	touchesMemory := hints.touchesMemory
+	// Auto-inlining: collect the callees this caller will splice (before the pin
+	// setup below, which the plan can influence). A spliced memory-touching callee
+	// runs its linear-memory ops in THIS caller's frame, so fold it into
+	// touchesMemory — otherwise the guard-page pin exclusion (which drops R9/R10/R11
+	// from the pool for a memory-touching call-making function) would be skipped for
+	// a caller whose own body never touched memory.
+	inlinedCallees := collectInlinedCallees(c, inlineTargets)
+	if inlinePlanTouchesMemory(inlinedCallees) {
+		touchesMemory = true
+	}
 	regABI := regABIEnabled && sigFitsRegABI(ft)
 	gpPool := gpPinPool(regABI, f.nParams)
 	if f.memSizeReg != regNone {
@@ -715,7 +725,7 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool
 	// nLocals-dependent setup above, so zeroDeclaredLocals/skipFence/lazyZero see the
 	// caller's own locals only). Extends the frame's local arrays with unpinned
 	// scratch; the splice at each call site binds/zeroes them.
-	f.reserveInlineLocals(c, inlineTargets)
+	f.reserveInlineLocals(inlinedCallees, inlineTargets)
 
 	if regABIEnabled && sigFitsRegABI(ft) {
 		internalOff, err := f.emitRegABI(c)

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -156,6 +156,11 @@ type fn struct {
 	inlineTargets map[int]*inlineTarget
 	inlineBase    map[int]int
 	localBase     int
+	// inlineRetFrame is the f.ctrl index of the synthetic block frame standing in
+	// for an inlined control-flow callee's function boundary: `return` inside the
+	// callee branches to it (not the real function frame). 0 when not inside such a
+	// splice (the synthetic frame is always at index >= 1, above ctrl[0]=cfFunc).
+	inlineRetFrame int
 
 	// importBindings, when non-nil, resolves imported-function calls to host
 	// (log-and-replay) or cross-instance (native context-swap) lowering. Set only

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -621,6 +621,23 @@ func (f *fn) opEnd() error {
 	return nil
 }
 
+// branchToFrame emits an unconditional branch edge to control frame fi: converge
+// pinned locals, flush operands, move the branched values into the frame's
+// canonical slots (or merge register), and jump. Shared by opBr's unconditional
+// path and opReturn's inlined-callee routing. The caller sets f.unreachable.
+func (f *fn) branchToFrame(fi int) {
+	fr := &f.ctrl[fi]
+	f.convergeBranchLocals(fr)
+	a, d := fr.branchN, f.depth()
+	f.flush()
+	if fr.regMerge1 {
+		f.branchEdgeToMerge1(fr, d)
+	} else {
+		f.moveBranchValues(fr, d, a)
+	}
+	f.branchJump(fr)
+}
+
 func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 	if f.unreachable {
 		if conditional {
@@ -652,20 +669,15 @@ func (f *fn) opBr(r *wasm.Reader, conditional bool) error {
 	if fi < 0 {
 		return errBadLabel
 	}
+	if !conditional {
+		f.branchToFrame(fi)
+		f.unreachable = true
+		return nil
+	}
 	fr := &f.ctrl[fi]
 	f.convergeBranchLocals(fr)
 	a, d := fr.branchN, f.depth()
 	f.flush()
-	if !conditional {
-		if fr.regMerge1 {
-			f.branchEdgeToMerge1(fr, d)
-		} else {
-			f.moveBranchValues(fr, d, a)
-		}
-		f.branchJump(fr)
-		f.unreachable = true
-		return nil
-	}
 	f.a.TestSelf(creg, false)
 	if cOwned {
 		f.release(creg)
@@ -823,6 +835,14 @@ func (f *fn) opBrTable(r *wasm.Reader) error {
 
 func (f *fn) opReturn() error {
 	if f.unreachable {
+		return nil
+	}
+	if f.inlineRetFrame > 0 {
+		// Inside an inlined control-flow callee: `return` exits the callee, not the
+		// enclosing function — branch to its synthetic boundary frame (its `end`
+		// merge), exactly like a br to that label.
+		f.branchToFrame(f.inlineRetFrame)
+		f.unreachable = true
 		return nil
 	}
 	if f.singleRegResult {

--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -12,8 +12,16 @@ import (
 // Frontend.cpp parseCodeSection opcode switch. Phase 0 covers the integer const/
 // local/ALU subset needed to prove the pipeline end-to-end.
 func (f *fn) body(code []byte) error {
-	r := wasm.NewReader(code)
-	for len(f.ctrl) > 0 {
+	return f.bodyLoop(wasm.NewReader(code), 0)
+}
+
+// bodyLoop drives the opcode switch until the control stack shrinks to minCtrl.
+// The function body runs with minCtrl=0 (until the function frame's end). An
+// inlined callee with control flow runs with minCtrl = the depth just below its
+// synthetic frame, so its terminating `end` (which pops that frame) ends the loop
+// and returns control to the caller's body.
+func (f *fn) bodyLoop(r *wasm.Reader, minCtrl int) error {
+	for len(f.ctrl) > minCtrl {
 		op, err := r.Byte()
 		if err != nil {
 			return err

--- a/src/core/compiler/backend/railshot/inline.go
+++ b/src/core/compiler/backend/railshot/inline.go
@@ -345,6 +345,7 @@ type inlineTarget struct {
 	params     int           // param count (callee locals 0..params-1)
 	nLocals    int           // params + declared locals
 	localTypes []machineType // length nLocals: the callee's local machine types
+	touchesMem bool          // the body has a linear-memory op (drives the caller's guard-page pin exclusion)
 }
 
 // buildInlineTargets returns the straight-line leaf inline candidates keyed by
@@ -366,22 +367,19 @@ func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
 		if err != nil {
 			continue
 		}
-		// The Phase-2 transform class is stricter than the report's candidate class:
-		// straight-line (no control frames), and — conservatively for this first
-		// landing — pure integer compute (no memory or global ops, and int-only
-		// declared locals as well as an int-only signature). Excluding memory/globals
-		// sidesteps the guard-page pin-exclusion and global-coherence interactions;
-		// requiring int declared locals keeps the splice's zero-init/bind on the
-		// simple 8-byte path (a v128 local needs two-slot zeroing). Broadening this is
-		// a measured follow-up.
+		// The transform class: a straight-line (no control frames) leaf with an
+		// int-only reg-ABI signature and a small body. Memory- and global-touching
+		// bodies and multi-slot (v128/float) declared locals are allowed (Phase 3):
+		// the splice binds params through setLocal's typed paths, zero-inits declared
+		// locals across their full slot width, and — for a memory-touching callee —
+		// the caller's guard-page pin exclusion is re-derived to include it (see
+		// compileFuncAttempt). Straight-line-ness is the one hard requirement, so the
+		// splice never needs a synthetic control frame or edge convergence.
 		if ok, _ := inlineClass(facts); !ok || !facts.straightLine() {
 			continue
 		}
-		if facts.touchesMem || facts.touchesGlobal {
-			continue
-		}
 		lt := calleeLocalTypes(m, i)
-		if lt == nil || !allIntLocals(lt) {
+		if lt == nil {
 			continue
 		}
 		if targets == nil {
@@ -393,19 +391,10 @@ func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
 			params:     facts.params,
 			nLocals:    len(lt),
 			localTypes: lt,
+			touchesMem: facts.touchesMem,
 		}
 	}
 	return targets
-}
-
-// allIntLocals reports whether every local machine type is i32 or i64.
-func allIntLocals(lt []machineType) bool {
-	for _, t := range lt {
-		if t != mtI32 && t != mtI64 {
-			return false
-		}
-	}
-	return true
 }
 
 // calleeLocalTypes returns the machine types of a local function's params and
@@ -435,32 +424,13 @@ func calleeLocalTypes(m *wasm.Module, localIdx int) []machineType {
 // locals are appended unpinned. All splice sites of the same callee share one
 // region — inlined bodies never overlap (a straight-line leaf fully completes
 // before the next splice), so the region is safely reused.
-func (f *fn) reserveInlineLocals(caller *wasm.Func, targets map[int]*inlineTarget) {
-	if targets == nil || len(caller.BodyBytes) == 0 {
+func (f *fn) reserveInlineLocals(callees []*inlineTarget, targets map[int]*inlineTarget) {
+	if len(callees) == 0 {
 		return
 	}
-	r := wasm.NewReader(caller.BodyBytes)
-	var imm wasm.InstructionImmediate
-	for r.HasNext() {
-		op, err := r.Byte()
-		if err != nil {
-			return
-		}
-		if err := wasm.ClassifyInstructionImmediateInto(r, op, &imm); err != nil {
-			return
-		}
-		if imm.Kind != wasm.InstrCall {
-			continue
-		}
-		t := targets[int(imm.Index)]
-		if t == nil {
-			continue
-		}
-		if f.inlineBase != nil {
-			if _, done := f.inlineBase[t.globalIdx]; done {
-				continue
-			}
-		}
+	f.inlineTargets = targets
+	f.inlineBase = make(map[int]int, len(callees))
+	for _, t := range callees {
 		base := len(f.localType)
 		for _, lt := range t.localTypes {
 			f.localType = append(f.localType, lt)
@@ -468,12 +438,56 @@ func (f *fn) reserveInlineLocals(caller *wasm.Func, targets map[int]*inlineTarge
 			f.nLocalSlots += lt.stackSlots()
 			f.locals = append(f.locals, localDef{reg: regNone, typ: lt, state: lsMem})
 		}
-		if f.inlineBase == nil {
-			f.inlineBase = map[int]int{}
-		}
 		f.inlineBase[t.globalIdx] = base
-		f.inlineTargets = targets
 	}
+}
+
+// collectInlinedCallees scans the caller body once and returns the distinct
+// inline targets it calls, in first-call order. Computed before frame setup so
+// the caller's guard-page pin exclusion can be re-derived from the callees
+// (whether any touches memory), and reused by reserveInlineLocals.
+func collectInlinedCallees(caller *wasm.Func, targets map[int]*inlineTarget) []*inlineTarget {
+	if targets == nil || len(caller.BodyBytes) == 0 {
+		return nil
+	}
+	var out []*inlineTarget
+	var seen map[int]bool
+	r := wasm.NewReader(caller.BodyBytes)
+	var imm wasm.InstructionImmediate
+	for r.HasNext() {
+		op, err := r.Byte()
+		if err != nil {
+			return out
+		}
+		if err := wasm.ClassifyInstructionImmediateInto(r, op, &imm); err != nil {
+			return out
+		}
+		if imm.Kind != wasm.InstrCall {
+			continue
+		}
+		t := targets[int(imm.Index)]
+		if t == nil || seen[t.globalIdx] {
+			continue
+		}
+		if seen == nil {
+			seen = map[int]bool{}
+		}
+		seen[t.globalIdx] = true
+		out = append(out, t)
+	}
+	return out
+}
+
+// inlinePlanTouchesMemory reports whether any spliced callee touches linear
+// memory — used to extend the caller's touchesMemory for the guard-page pin
+// exclusion, since the spliced memory ops run in the caller's frame.
+func inlinePlanTouchesMemory(callees []*inlineTarget) bool {
+	for _, t := range callees {
+		if t.touchesMem {
+			return true
+		}
+	}
+	return false
 }
 
 // inlineCall splices target t's straight-line body at the current call site: it
@@ -491,12 +505,16 @@ func (f *fn) inlineCall(t *inlineTarget) error {
 		f.setLocal(base+i, false)
 	}
 	// Zero the callee's declared locals (wasm zero-init) — re-done each splice so a
-	// call in a loop, or a second call site, always starts from zero.
+	// call in a loop, or a second call site, always starts from zero. Each local is
+	// zeroed across its full slot width, so a v128 declared local (two slots) has
+	// both halves cleared (matching zeroDeclaredLocals).
 	if t.nLocals > t.params {
 		z := f.allocReg(0)
 		f.a.XorSelf32(z)
 		for i := t.params; i < t.nLocals; i++ {
-			f.a.Store64(RSP, f.localOff(base+i), z)
+			for s := 0; s < t.localTypes[i].stackSlots(); s++ {
+				f.a.Store64(RSP, f.localOff(base+i)+int32(8*s), z)
+			}
 			f.locals[base+i].state = lsMem
 		}
 		f.release(z)

--- a/src/core/compiler/backend/railshot/inline.go
+++ b/src/core/compiler/backend/railshot/inline.go
@@ -25,9 +25,10 @@ import (
 // reason about — an inline of such a body cannot re-enter the inliner.
 
 // inlineMaxBodyBytes is the default encoded-body-size ceiling for a candidate
-// (a proxy for how much code each inline site adds). Overridable for A/B via
+// (a proxy for how much code each inline site adds). Control-flow callees are
+// larger than the tiny straight-line accessors, so this is generous; tune via
 // WAGO_INLINE_MAXBYTES.
-const inlineMaxBodyBytes = 48
+const inlineMaxBodyBytes = 160
 
 // inlineCallSeqBytes is a rough per-call-site machine-code cost for the call
 // sequence an inline removes (arg staging + call + result handling). Used only
@@ -144,6 +145,11 @@ func inlineClass(f inlineFacts) (bool, string) {
 	case f.hasControlCall:
 		return false, "has call_indirect/return_call"
 	case f.calleeCount > 0:
+		// Non-leaf callees (ones that themselves call) are excluded: inlining them
+		// injects a real call into the caller's straight-line region, whose arg
+		// staging interacts with the guard-page pinned-local exclusion and explicit-
+		// mode register pressure in ways that regressed sqlite/bignum. Leaf-only keeps
+		// the transform to bodies that add no call machinery.
 		return false, fmt.Sprintf("non-leaf (%d call(s))", f.calleeCount)
 	case !f.regABIIntOnly:
 		return false, "signature not int-only reg-ABI"
@@ -340,12 +346,15 @@ var inlineEnabled = os.Getenv("WAGO_INLINE") == "1"
 // inlineTarget is a callee that will be spliced at its call sites: a straight-line
 // leaf with an int-only register-ABI signature and a small body.
 type inlineTarget struct {
-	globalIdx  int           // global function index (what a `call` immediate names)
-	body       []byte        // the callee's expression bytecode (ends in the terminating `end`)
-	params     int           // param count (callee locals 0..params-1)
-	nLocals    int           // params + declared locals
-	localTypes []machineType // length nLocals: the callee's local machine types
-	touchesMem bool          // the body has a linear-memory op (drives the caller's guard-page pin exclusion)
+	globalIdx   int           // global function index (what a `call` immediate names)
+	body        []byte        // the callee's expression bytecode (ends in the terminating `end`)
+	params      int           // param count (callee locals 0..params-1)
+	nLocals     int           // params + declared locals
+	localTypes  []machineType // length nLocals: the callee's local machine types
+	resultTypes []machineType // the callee's result machine types
+	res0        machineType   // first result type (mtNone if none) — for the single-result merge
+	touchesMem  bool          // the body has a linear-memory op (drives the caller's guard-page pin exclusion)
+	hasCtrl     bool          // the body has control flow → splice through a synthetic boundary frame
 }
 
 // buildInlineTargets returns the straight-line leaf inline candidates keyed by
@@ -367,31 +376,42 @@ func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
 		if err != nil {
 			continue
 		}
-		// The transform class: a straight-line (no control frames) leaf with an
-		// int-only reg-ABI signature and a small body. Memory- and global-touching
-		// bodies and multi-slot (v128/float) declared locals are allowed (Phase 3):
-		// the splice binds params through setLocal's typed paths, zero-inits declared
-		// locals across their full slot width, and — for a memory-touching callee —
-		// the caller's guard-page pin exclusion is re-derived to include it (see
-		// compileFuncAttempt). Straight-line-ness is the one hard requirement, so the
-		// splice never needs a synthetic control frame or edge convergence.
-		if ok, _ := inlineClass(facts); !ok || !facts.straightLine() {
+		// The transform class: a leaf (no calls, so non-recursive/acyclic) with an
+		// int-only reg-ABI signature and a small body. Memory/global ops and
+		// multi-slot (v128/float) declared locals are allowed. Control flow is
+		// allowed too: such a callee is spliced through a synthetic block frame that
+		// stands in for its function boundary (its `return`/`end` merge there), so
+		// the existing block/br/convergence machinery lowers it. A straight-line
+		// callee skips the frame entirely (the cheaper fast path).
+		if ok, _ := inlineClass(facts); !ok {
 			continue
 		}
 		lt := calleeLocalTypes(m, i)
 		if lt == nil {
 			continue
 		}
+		ft, _ := m.LocalFuncType(i)
+		var rt []machineType
+		res0 := mtNone
+		if ft != nil {
+			rt = typesOfVals(ft.Results)
+			if len(rt) > 0 {
+				res0 = rt[0]
+			}
+		}
 		if targets == nil {
 			targets = map[int]*inlineTarget{}
 		}
 		targets[importedFuncs+i] = &inlineTarget{
-			globalIdx:  importedFuncs + i,
-			body:       body,
-			params:     facts.params,
-			nLocals:    len(lt),
-			localTypes: lt,
-			touchesMem: facts.touchesMem,
+			globalIdx:   importedFuncs + i,
+			body:        body,
+			params:      facts.params,
+			nLocals:     len(lt),
+			localTypes:  lt,
+			resultTypes: rt,
+			res0:        res0,
+			touchesMem:  facts.touchesMem,
+			hasCtrl:     facts.hasControlFlow,
 		}
 	}
 	return targets
@@ -490,24 +510,50 @@ func inlinePlanTouchesMemory(callees []*inlineTarget) bool {
 	return false
 }
 
-// inlineCall splices target t's straight-line body at the current call site: it
-// binds the p argument operands into the callee's param locals, zeroes the
-// callee's declared locals, runs the body with localBase set (remapping the
-// callee's locals onto the reserved region), then decouples the results from the
-// reserved slots so a later splice of the same callee cannot alias them.
+// inlineCall splices target t's body at the current call site: it binds the p
+// argument operands into the callee's param locals, zeroes the callee's declared
+// locals, runs the body with localBase set (remapping the callee's locals onto
+// the reserved region), then decouples the results from the reserved slots so a
+// later splice of the same callee cannot alias them. A straight-line callee runs
+// on the cheap frameless path; a control-flow callee runs under a synthetic
+// boundary frame (inlineBodyCtrl).
 func (f *fn) inlineCall(t *inlineTarget) error {
 	f.stats.call("inline")
 	base := f.inlineBase[t.globalIdx]
+	f.bindInlineParams(t, base)
 
-	// Bind params: the p args are the top operands (deepest = param 0). Pop each into
-	// its param local. setLocal takes the absolute index (localBase is still 0 here).
+	old := f.localBase
+	f.localBase = base
+	var err error
+	if t.hasCtrl {
+		err = f.inlineBodyCtrl(t)
+	} else {
+		err = f.inlineBody(t.body)
+	}
+	f.localBase = old
+	if err != nil {
+		return err
+	}
+
+	// The callee's results sit on the operand stack; a bare `local.get` result is a
+	// lazy stLocalRef into a reserved slot, and a deferred result may read one. A
+	// later splice of the same callee rebinds those slots, so realize any operand
+	// still referencing the reserved region into a register/value now. (The control-
+	// flow path already merged results into canonical slots, so this is a no-op there.)
+	f.realizeInlineRange(base, base+t.nLocals)
+	return nil
+}
+
+// bindInlineParams binds the p argument operands into the callee's param locals
+// and zero-initializes its declared locals (wasm zero-init, re-done each splice
+// so a call in a loop or a second site always starts from zero). Each declared
+// local is cleared across its full slot width (a v128 local clears both halves).
+func (f *fn) bindInlineParams(t *inlineTarget, base int) {
+	// The p args are the top operands (deepest = param 0). Pop each into its param
+	// local. setLocal takes the absolute index (localBase is still 0 here).
 	for i := t.params - 1; i >= 0; i-- {
 		f.setLocal(base+i, false)
 	}
-	// Zero the callee's declared locals (wasm zero-init) — re-done each splice so a
-	// call in a loop, or a second call site, always starts from zero. Each local is
-	// zeroed across its full slot width, so a v128 declared local (two slots) has
-	// both halves cleared (matching zeroDeclaredLocals).
 	if t.nLocals > t.params {
 		z := f.allocReg(0)
 		f.a.XorSelf32(z)
@@ -519,22 +565,36 @@ func (f *fn) inlineCall(t *inlineTarget) error {
 		}
 		f.release(z)
 	}
+}
 
-	// Run the straight-line body with the callee's locals remapped onto the region.
-	old := f.localBase
-	f.localBase = base
-	err := f.inlineBody(t.body)
-	f.localBase = old
-	if err != nil {
-		return err
+// inlineBodyCtrl splices a control-flow callee: it pushes a synthetic block frame
+// standing in for the callee's function boundary (0 params — the args were bound
+// to locals — with the callee's result types), runs the body through the normal
+// opcode driver until that frame's terminating `end` pops it, and routes the
+// callee's `return` to that frame. The callee's own blocks/loops/ifs and its
+// result merge are lowered by the existing control-flow machinery.
+func (f *fn) inlineBodyCtrl(t *inlineTarget) error {
+	minCtrl := len(f.ctrl)
+	rN := len(t.resultTypes)
+	fr := ctrlFrame{
+		kind:        cfBlock,
+		resultN:     rN,
+		branchN:     rN,
+		resultTypes: t.resultTypes,
+		res0:        t.res0,
+		elseSite:    -1,
+		height:      f.depth(),
 	}
+	fr.regMerge1 = f.regMerge && rN == 1 && t.res0 != mtNone && t.res0 != mtV128
+	fr.baseTypes = append([]machineType(nil), f.currentLogicalTypes()...)
+	f.flush()
+	f.ctrl = append(f.ctrl, fr)
 
-	// The callee's results sit on the operand stack; a bare `local.get` result is a
-	// lazy stLocalRef into a reserved slot, and a deferred result may read one. A
-	// later splice of the same callee rebinds those slots, so realize any operand
-	// still referencing the reserved region into a register/value now.
-	f.realizeInlineRange(base, base+t.nLocals)
-	return nil
+	prevRet := f.inlineRetFrame
+	f.inlineRetFrame = len(f.ctrl) - 1
+	err := f.bodyLoop(wasm.NewReader(t.body), minCtrl)
+	f.inlineRetFrame = prevRet
+	return err
 }
 
 // inlineBody runs a straight-line callee body's opcodes on the current operand

--- a/src/core/compiler/backend/railshot/inline_test.go
+++ b/src/core/compiler/backend/railshot/inline_test.go
@@ -183,10 +183,10 @@ func TestInlineExecTwoSites(t *testing.T) {
 	})
 }
 
-// TestInlineExecMemory checks that a memory-touching straight-line leaf is NOT
-// inlined (conservatively excluded from the Phase-2 transform class to avoid the
-// guard-page pin-exclusion interaction) yet still runs correctly via a normal
-// call.
+// TestInlineExecMemory inlines a leaf that does a memory store+load (Phase 3:
+// memory-touching leaves are inlinable; the caller's guard-page pin exclusion is
+// re-derived to include the spliced memory ops), verifying the memory path is
+// correct through a splice.
 func TestInlineExecMemory(t *testing.T) {
 	withInlineEnabled(t, func() {
 		// func 1 (addr,val)->i32 leaf: store val at addr, load it back.
@@ -216,14 +216,14 @@ func TestInlineExecMemory(t *testing.T) {
 			t.Fatalf("decode: %v", err)
 		}
 		if got := runAmd64(t, m); got != 42 {
-			t.Errorf("memory put/get = %d, want 42", got)
+			t.Errorf("inlined memory put/get = %d, want 42", got)
 		}
 		var ms ModuleStats
 		if _, err := CompileModuleWith(m, CompileOptions{Stats: &ms}); err != nil {
 			t.Fatalf("compile: %v", err)
 		}
-		if ms.Funcs[0].Calls["inline"] != 0 {
-			t.Errorf("memory-touching leaf should not be inlined; Calls=%v", ms.Funcs[0].Calls)
+		if ms.Funcs[0].Calls["inline"] != 1 {
+			t.Errorf("memory-touching leaf should be inlined; Calls=%v", ms.Funcs[0].Calls)
 		}
 	})
 }

--- a/src/core/compiler/backend/railshot/inline_test.go
+++ b/src/core/compiler/backend/railshot/inline_test.go
@@ -29,9 +29,10 @@ func TestAnalyzeInlineCandidates(t *testing.T) {
 	leaf := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b}
 	// func 2 (recursive, (i32)->i32): local.get 0; call 2; end
 	recursive := []byte{0x00, 0x20, 0x00, 0x10, 0x02, 0x0b}
-	// func 3 (oversized leaf, ()->i32): 20× (i32.const 0; drop) then i32.const 0; end
+	// func 3 (oversized leaf, ()->i32): many (i32.const 0; drop) exceeding the size
+	// ceiling, then i32.const 0; end
 	big := []byte{0x00}
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 70; i++ {
 		big = append(big, 0x41, 0x00, 0x1a) // i32.const 0; drop
 	}
 	big = append(big, 0x41, 0x00, 0x0b) // i32.const 0; end
@@ -224,6 +225,106 @@ func TestInlineExecMemory(t *testing.T) {
 		}
 		if ms.Funcs[0].Calls["inline"] != 1 {
 			t.Errorf("memory-touching leaf should be inlined; Calls=%v", ms.Funcs[0].Calls)
+		}
+	})
+}
+
+// TestInlineExecIfElse inlines a control-flow leaf `max(a,b)` (if/else), exercising
+// the synthetic boundary frame + merge machinery.
+func TestInlineExecIfElse(t *testing.T) {
+	withInlineEnabled(t, func() {
+		// func 1 (i32,i32)->i32: local.get0; local.get1; i32.gt_s; if(i32) local.get0 else local.get1 end; end
+		leaf := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x4a, 0x04, 0x7f, 0x20, 0x00, 0x05, 0x20, 0x01, 0x0b, 0x0b}
+		// func 0 ()->i32: max(7,3) → 7
+		caller := []byte{0x00, 0x41, 0x07, 0x41, 0x03, 0x10, 0x01, 0x0b}
+		m := modFuncs(t,
+			funcDef{params: nil, results: []wasm.ValType{vI32}, body: caller},
+			funcDef{params: []wasm.ValType{vI32, vI32}, results: []wasm.ValType{vI32}, body: leaf},
+		)
+		if got := runAmd64(t, m); got != 7 {
+			t.Errorf("inlined max(7,3) = %d, want 7", got)
+		}
+		var ms ModuleStats
+		if _, err := CompileModuleWith(m, CompileOptions{Stats: &ms}); err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if ms.Funcs[0].Calls["inline"] != 1 {
+			t.Errorf("control-flow leaf should be inlined; Calls=%v", ms.Funcs[0].Calls)
+		}
+	})
+}
+
+// TestInlineExecIfElseReturn inlines a control-flow leaf that uses an early
+// `return` inside an if, exercising opReturn's routing to the synthetic frame.
+func TestInlineExecIfElseReturn(t *testing.T) {
+	withInlineEnabled(t, func() {
+		// func 1 (i32)->i32: if arg0 != 0 { return 100 }; 200
+		//   local.get0; if(void) i32.const 100; return end; i32.const 200; end
+		//   (i32.const 100 is 0x41 0xe4 0x00 in signed LEB128 — 0x64 alone is -28)
+		leaf := []byte{0x00, 0x20, 0x00, 0x04, 0x40, 0x41, 0xe4, 0x00, 0x0f, 0x0b, 0x41, 0xc8, 0x01, 0x0b}
+		// func 0 ()->i32: f(1) → 100
+		caller := []byte{0x00, 0x41, 0x01, 0x10, 0x01, 0x0b}
+		m := modFuncs(t,
+			funcDef{params: nil, results: []wasm.ValType{vI32}, body: caller},
+			funcDef{params: []wasm.ValType{vI32}, results: []wasm.ValType{vI32}, body: leaf},
+		)
+		if got := runAmd64(t, m); got != 100 {
+			t.Errorf("inlined early-return f(1) = %d, want 100", got)
+		}
+	})
+}
+
+// TestInlineExecReturnBare inlines `{ return arg0 }` — isolates opReturn routing.
+func TestInlineExecReturnBare(t *testing.T) {
+	withInlineEnabled(t, func() {
+		leaf := []byte{0x00, 0x20, 0x00, 0x0f, 0x0b} // local.get0; return; end
+		caller := []byte{0x00, 0x41, 0x2a, 0x10, 0x01, 0x0b}
+		m := modFuncs(t,
+			funcDef{params: nil, results: []wasm.ValType{vI32}, body: caller},
+			funcDef{params: []wasm.ValType{vI32}, results: []wasm.ValType{vI32}, body: leaf},
+		)
+		if got := runAmd64(t, m); got != 42 {
+			t.Errorf("inlined {return arg0}(42) = %d, want 42", got)
+		}
+	})
+}
+
+// TestInlineExecLoop inlines a control-flow leaf with a loop: sum(n) = n+(n-1)+…+1.
+func TestInlineExecLoop(t *testing.T) {
+	withInlineEnabled(t, func() {
+		// func 1 (n)->i32, locals: (acc i32). loop { acc += n; n -= 1; if n>0 continue }
+		//   (local acc)
+		//   loop
+		//     local.get1; local.get0; i32.add; local.set1     ; acc += n
+		//     local.get0; i32.const 1; i32.sub; local.set0     ; n -= 1
+		//     local.get0; i32.const 0; i32.gt_s; br_if 0        ; if n>0 loop
+		//   end
+		//   local.get1                                          ; acc
+		leaf := []byte{
+			0x01, 0x01, 0x7f, // 1 local: acc i32
+			0x03, 0x40, // loop (void)
+			0x20, 0x01, 0x20, 0x00, 0x6a, 0x21, 0x01, // acc += n
+			0x20, 0x00, 0x41, 0x01, 0x6b, 0x21, 0x00, // n -= 1
+			0x20, 0x00, 0x41, 0x00, 0x4a, 0x0d, 0x00, // if n>0 br 0
+			0x0b,       // end loop
+			0x20, 0x01, // local.get acc
+			0x0b, // end func
+		}
+		// func 0 ()->i32: sum(5) = 5+4+3+2+1 = 15
+		caller := []byte{0x00, 0x41, 0x05, 0x10, 0x01, 0x0b}
+		m := modFuncs(t,
+			funcDef{params: nil, results: []wasm.ValType{vI32}, body: caller},
+			funcDef{params: []wasm.ValType{vI32}, results: []wasm.ValType{vI32}, body: leaf},
+		)
+		if got := runAmd64(t, m); got != 15 {
+			t.Errorf("inlined sum(5) = %d, want 15", got)
+		}
+		var ms ModuleStats
+		if _, err := CompileModuleWith(m, CompileOptions{Stats: &ms}); err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if ms.Funcs[0].Calls["inline"] != 1 {
+			t.Errorf("loop leaf should be inlined; Calls=%v", ms.Funcs[0].Calls)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Makes the `WAGO_INLINE` splice transform substantially more aggressive (off by default). Two commits on top of the Phase-2 transform (#190):

1. **Broaden the leaf class** — memory ops, global ops, and multi-slot (v128/float) declared locals are now inlinable (fixes the earlier review's v128 zero-init and guard-page findings via full-slot-width zeroing + a `touchesMemory` re-derivation before pin assignment).
2. **Control flow in callees** — a callee with `block`/`loop`/`if`/`br`/`return` is now inlinable, spliced through a **synthetic block frame** that stands in for its function boundary. Its `return` branches to that frame; its own blocks/loops/ifs and result merge are lowered by the existing control-flow machinery. Straight-line callees keep the cheaper frameless fast path. The size ceiling is raised (48→160B, `WAGO_INLINE_MAXBYTES`) since control-flow bodies are larger.

The one hard requirement is still **leaf** (no calls) — see below.

## Impact

Splice coverage on the corpus jumps dramatically:

| module  | before (straight-line) | after (control flow) |
|---------|-----------------------:|---------------------:|
| lua     | 17                     | **236**              |
| inflate | 4                      | **8**                |

(json-as stays 0 — its functions are all non-leaf; see below.)

## Why leaf-only (non-leaf was tried and dropped)

I prototyped **non-leaf** inlining too (inner calls kept real via an `inSplice` guard, so no recursion/cycles). It was a huge further lever — lua 236→1651, inflate 8→280, **json-as 0→78** — but injecting a real call into the caller's straight-line region regressed **sqlite** (explicit) and **bignum** (guard-page): the arg-staging of the inlined call interacts with the guard-page pinned-local exclusion and explicit-mode register pressure (the #144/num-bigint class). Rather than ship a miscompile, non-leaf is reverted and left as a future effort with proper call-boundary handling.

## Testing

- New exec tests: control-flow `max` (if/else), early-`return` inside an `if`, a `loop` (sum), plus the existing straight-line/memory/multi-slot/region-reuse cases.
- With `WAGO_INLINE=1`: spec suite (15,372 assertions), full repo (both bounds modes), bench corpus differential (both modes), WASI apps — all identical to non-inlined.
- Default off → default builds byte-for-byte unchanged.

## Toward default-on

Still needs a bench-corpus exec-vs-compile measurement and a refined cost model (the raised threshold + control flow make the compile-time cost worth re-measuring). Non-leaf, and broadening past leaf generally, is the remaining large lever once the call-boundary register interactions are handled.