### PR TITLE
feat(railshot): fuse select onto a compare condition's flags

### DIFF
--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -604,6 +604,13 @@ func (f *fn) popValue() *elem {
 // stack holds a, then b, then cond on top. Lowered to test + cmove (if cond == 0,
 // move b into a). Materialized eagerly (select is a sink for its operands).
 func (f *fn) emitSelect() {
+	// Flags-select: when the condition is a deferred relational/eqz compare and both
+	// branches are integers, emit the compare's CMP and a CMOV on its flags directly
+	// — skipping the SETcc + MOVZX + TEST that materializing the boolean costs. The
+	// compare is condensed last (right before the CMOV), so its flags are live.
+	if top := f.s.back(); isFusableCompare(top) && f.trySelectOnFlags(top) {
+		return
+	}
 	cond := f.popValue()
 	condReg := f.materialize(cond) // condition is i32
 	f.pinned = f.pinned.add(condReg)
@@ -672,6 +679,45 @@ func mtI32OrWide(wide bool) machineType {
 		return mtI64
 	}
 	return mtI32
+}
+
+// trySelectOnFlags lowers `select` on the flags of a fusable compare condition
+// (cond, the top operand). It materializes the two integer branches into owned
+// registers, emits the compare's CMP (which sets the flags last), and CMOVs —
+// no SETcc/TEST. Returns false (leaving the operand stack untouched) when the
+// branches are not both integer (floats/v128 have no CMOV) or the block shape is
+// unexpected, so the caller falls back to the materialized-boolean path.
+func (f *fn) trySelectOnFlags(cond *elem) bool {
+	bRoot := baseOfValentBlock(cond).prev
+	if bRoot == f.s.head {
+		return false
+	}
+	aRoot := baseOfValentBlock(bRoot).prev
+	if aRoot == f.s.head {
+		return false
+	}
+	at, bt := rootMachineType(aRoot), rootMachineType(bRoot)
+	if at.isFloat() || at.isV128() || bt.isFloat() || bt.isV128() {
+		return false
+	}
+	w := at.is64() || bt.is64()
+	// Materialize both branches into owned registers BEFORE the compare: their loads
+	// clobber flags harmlessly (the CMP comes after and sets them cleanly), and they
+	// are pinned so condensing the compare's operands cannot spill them.
+	aReg := f.materialize(aRoot)
+	f.pinned = f.pinned.add(aReg)
+	bReg := f.materialize(bRoot)
+	f.pinned = f.pinned.add(bReg)
+	cc := f.condenseToFlags(cond) // emits the CMP (last flag-affecting insn), consumes cond
+	f.stats.peep("select-flags")
+	f.a.Cmovcc(invertCond(cc), aReg, bReg, w) // cond false → a = b
+	f.pinned = f.pinned.remove(aReg)
+	f.pinned = f.pinned.remove(bReg)
+	f.release(bReg)
+	f.erase(bRoot)
+	f.erase(aRoot)
+	f.pushReg(aReg, mtI32OrWide(w))
+	return true
 }
 
 // setLocal stores the top-of-stack value into local x. For local.tee the value

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -1303,6 +1303,14 @@ func TestAmd64Phase1(t *testing.T) {
 			[]byte{0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0x1b, 0x0b}, []uint64{11, 22, 0}, 22},
 		{"select-i64", []wasm.ValType{i64, i64, i32}, []wasm.ValType{i64},
 			[]byte{0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0x1b, 0x0b}, []uint64{0x700000000, 0x900000000, 0}, 0x900000000},
+		// select on a fusable compare condition (trySelectOnFlags): min(a,b) via
+		// select(a, b, a<b). Exercises the flags path (no materialized boolean).
+		{"select-cmp-true", []wasm.ValType{i32, i32}, []wasm.ValType{i32},
+			[]byte{0x20, 0x00, 0x20, 0x01, 0x20, 0x00, 0x20, 0x01, 0x48, 0x1b, 0x0b}, []uint64{11, 22}, 11}, // 11<22 → a
+		{"select-cmp-false", []wasm.ValType{i32, i32}, []wasm.ValType{i32},
+			[]byte{0x20, 0x00, 0x20, 0x01, 0x20, 0x00, 0x20, 0x01, 0x48, 0x1b, 0x0b}, []uint64{22, 11}, 11}, // 22<11 false → b
+		{"select-cmp-i64", []wasm.ValType{i64, i64}, []wasm.ValType{i64},
+			[]byte{0x20, 0x00, 0x20, 0x01, 0x20, 0x00, 0x20, 0x01, 0x53, 0x1b, 0x0b}, []uint64{0x900000000, 0x700000000}, 0x700000000}, // min i64
 
 		// --- width conversions / sign extension ---
 		{"i32.wrap_i64", []wasm.ValType{i64}, []wasm.ValType{i32},


### PR DESCRIPTION
## Summary

Extends compare→flags fusion to **`select`**. Today a `select` whose condition is a relational/eqz compare materializes the boolean (`cmp; setcc; movzx`), then does `test; cmov`. This lowers it to `cmp; cmov` on the compare's flags directly — dropping the `setcc + movzx + test` per fused select.

Compare→**branch** (`br_if`/`if`) fusion already existed (`condenseToFlags`); `select` was the one common conditional consumer left materializing a boolean. This reuses `condenseToFlags` unchanged: the two integer branches are materialized into owned registers first, then the compare's `CMP` is emitted last (so its flags are live), then `CMOV`. No new storage kind and no flag-clobber tracking — the compare is deferred and emitted adjacent to the `CMOV`.

Integer branches only (there is no float/v128 `CMOV`); float/v128 selects and non-compare conditions keep the existing branch/materialized-boolean path.

## Impact (materialized-boolean `setcc` count drops)

| module  | setcc before | setcc after | selects fused |
|---------|-------------:|------------:|--------------:|
| inflate | 134          | **41**      | 93            |
| lua     | 631          | **436**     | 195           |
| json-as | 130          | **124**     | 6             |

This is a **pure win** (strictly fewer instructions, nothing added), so unlike the inlining work it is on unconditionally.

## Testing

- New exec cases: `select(a, b, a<b)` (min) for i32 both directions and i64.
- spec suite (15,372 assertions), full repo, bench corpus differential, WASI apps — all green in both bounds modes.