### PR TITLE
feat(railshot): loop bounds-check hoisting via precheck + fast/slow versioning

### DIFF
--- a/src/core/compiler/backend/railshot/boundshoist.go
+++ b/src/core/compiler/backend/railshot/boundshoist.go
@@ -1,0 +1,254 @@
+package amd64
+
+import (
+	"os"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// Loop bounds-check hoisting via loop versioning (P6.2, "hybrid loop precheck").
+//
+// A memory access `mem[$b + off]` inside a loop, where $b is a LOOP-INVARIANT
+// local (never set in the loop body), re-checks `$b + off + size <= memBytes`
+// every iteration even though $b and (since memBytes only ever grows) the bound
+// are loop-invariant. This emits, before the loop, a one-time PRECHECK of the max
+// extent on each such base, and compiles the loop body TWICE:
+//
+//   - the FAST body, run when every precheck passes, with those bases' inline
+//     checks elided (they are provably in bounds — memBytes is monotone);
+//   - the SLOW body, run otherwise, with the normal per-access checks, preserving
+//     exact trap timing (0-iteration / early-exit / a genuinely-OOB access all
+//     behave as the spec requires).
+//
+// The precheck is a BRANCH, not a trap, so it never introduces a spurious trap —
+// that is what makes hoisting sound here (a plain hoisted check would move the
+// trap earlier, which is observable because a wasm trap leaves partial memory
+// writes visible). Explicit-bounds mode only (guard mode has no inline check to
+// elide). Gated behind WAGO_LOOP_PRECHECK while it proves out.
+
+var loopPrecheckEnabled = os.Getenv("WAGO_LOOP_PRECHECK") == "1"
+
+// memAccessSize returns the byte width a memarg load/store opcode accesses, or 0
+// if op is not a plain (non-SIMD) linear-memory load/store.
+func memAccessSize(op byte) int {
+	switch op {
+	case 0x2c, 0x2d, 0x30, 0x31, 0x3a, 0x3c: // i32/i64.load8_*, i32/i64.store8
+		return 1
+	case 0x2e, 0x2f, 0x32, 0x33, 0x3b, 0x3d: // load16_* / store16
+		return 2
+	case 0x28, 0x2a, 0x34, 0x35, 0x36, 0x38, 0x3e: // i32/f32.load, i64.load32_*, i32/f32.store, i64.store32
+		return 4
+	case 0x29, 0x2b, 0x37, 0x39: // i64/f64.load, i64/f64.store
+		return 8
+	}
+	return 0
+}
+
+// hoistCand is one loop-invariant base local and the max access extent (off+size)
+// seen on a DIRECT `local.get $base; <memop>` in the loop body.
+type hoistCand struct {
+	base   uint32
+	extent int32
+}
+
+// scanLoopHoistable scans the loop body (reader at the body start, restored on
+// return) for hoistable bases: locals accessed as a direct memory base and never
+// set in the loop. Returns them with each one's max extent, plus whether the loop
+// grows memory (a grower is not versioned in v1). Post-validation, so a decode
+// error just ends the scan with what was found.
+func scanLoopHoistable(r *wasm.Reader) (cands []hoistCand, hasGrow bool) {
+	start := r.Offset()
+	set := map[uint32]bool{}
+	maxExt := map[uint32]int32{}
+	poison := map[uint32]bool{} // bases with a direct access this scan can't size (SIMD)
+	prevGet := int64(-1)        // local index of an immediately-preceding local.get, else -1
+	depth := 0
+scan:
+	for {
+		op, err := r.Byte()
+		if err != nil {
+			break
+		}
+		curGet := int64(-1)
+		switch op {
+		case 0x02, 0x03, 0x04: // block / loop / if
+			if _, err := r.S33(); err != nil {
+				break scan
+			}
+			depth++
+		case 0x0b: // end
+			if depth == 0 {
+				break scan
+			}
+			depth--
+		case 0x20: // local.get
+			idx, err := r.U32()
+			if err != nil {
+				break scan
+			}
+			curGet = int64(idx)
+		case 0x21, 0x22: // local.set / local.tee
+			idx, err := r.U32()
+			if err != nil {
+				break scan
+			}
+			set[idx] = true
+		case 0x40: // memory.grow
+			if _, err := r.U32(); err != nil {
+				break scan
+			}
+			hasGrow = true
+		case 0x0e: // br_table
+			n, err := r.U32()
+			if err != nil {
+				break scan
+			}
+			if err := r.SkipU32N(n + 1); err != nil {
+				break scan
+			}
+		case 0xfd: // SIMD prefix — a v128 load/store also goes through memAddr (and so
+			// through the elide) but this scan can't size it; poison the base so it is
+			// never hoisted with an under-covered extent.
+			if prevGet >= 0 {
+				poison[uint32(prevGet)] = true
+			}
+			if err := skipImmediates(r, op); err != nil {
+				break scan
+			}
+		default:
+			if size := memAccessSize(op); size != 0 {
+				// memarg: align, offset. A direct base is a local.get immediately before.
+				if _, err := r.U32(); err != nil { // align
+					break scan
+				}
+				off, err := r.U32()
+				if err != nil {
+					break scan
+				}
+				if prevGet >= 0 {
+					// The precheck's LEA displacement is int32; an offset near 2^32 would
+					// overflow it and check a wrong (too-small) bound, so poison instead.
+					if ext := int64(off) + int64(size); ext > 0x7FFFFFFF {
+						poison[uint32(prevGet)] = true
+					} else if int32(ext) > maxExt[uint32(prevGet)] {
+						maxExt[uint32(prevGet)] = int32(ext)
+					}
+				}
+			} else if err := skipImmediates(r, op); err != nil {
+				break scan
+			}
+		}
+		prevGet = curGet
+	}
+	r.JumpTo(start)
+	for b, ext := range maxExt {
+		if !set[b] && !poison[b] { // invariant, never set in the loop, all accesses sized
+			cands = append(cands, hoistCand{base: b, extent: ext})
+		}
+	}
+	return cands, hasGrow
+}
+
+// compileVersionedLoop lowers a versionable void loop: precheck → fast body
+// (invariant-base checks elided) → jump past → slow body (checked). Both bodies
+// are compiled from the same bytecode via bodyLoop; the reader ends past the
+// loop's `end`. Returns false if the loop shape is not versioned here (caller
+// falls back to the normal loop lowering).
+func (f *fn) compileVersionedLoop(r *wasm.Reader, paramTypes, resultTypes []machineType, res0 machineType, cands []hoistCand) bool {
+	// v1 scope: void loops only (no params to stage across the two entries), and
+	// never nest a versioned loop inside another (bounds code growth to 2×).
+	if len(paramTypes) != 0 || f.inVersionedLoop {
+		return false
+	}
+	bodyStart := r.Offset()
+	preLoopCtrl := len(f.ctrl)
+
+	// Canonicalize the loop-entry state so both versions start identically, and
+	// snapshot it for restoring before the slow body.
+	f.reconcileLocals()
+	f.flush()
+	entryTypes := append([]machineType(nil), f.currentLogicalTypes()...)
+	var entryLocals []locState
+	if f.usesCalls {
+		entryLocals = make([]locState, f.nLocals)
+		for x := range entryLocals {
+			entryLocals[x] = f.locals[x].state
+		}
+	}
+
+	// Precheck: for each invariant base, trap-free compare of base+extent to
+	// memBytes; any failure branches to the slow body. Scratch only (post-flush).
+	failSites := make([]int, 0, len(cands))
+	for _, c := range cands {
+		base := f.allocReg(0)
+		f.loadLocalValue(base, c.base)
+		t := f.allocReg(maskOf(base))
+		f.a.LeaDisp(t, base, c.extent) // t = base + off + size
+		f.a.Cmp64(t, f.memSizeReg)
+		failSites = append(failSites, f.a.JccPlaceholder(condA)) // base+ext > memBytes → slow
+		f.release(t)
+		f.release(base)
+	}
+	f.stats.peep("loop-precheck")
+
+	elide := make(map[uint32]bool, len(cands))
+	for _, c := range cands {
+		elide[c.base] = true
+	}
+
+	// FAST body: invariant-base checks elided.
+	f.inVersionedLoop = true
+	f.elideBases = elide
+	f.enterLoopFrame(resultTypes, res0)
+	if err := f.bodyLoop(r, preLoopCtrl); err != nil {
+		panic(err) // decode/lowering error inside the fast body
+	}
+	f.elideBases = nil
+	doneSite := f.a.JmpPlaceholder()
+
+	// SLOW body: normal per-access checks. Re-read the body from the start and
+	// restore the canonical loop-entry state first.
+	for _, s := range failSites {
+		f.a.PatchRel32(s, f.a.Len())
+	}
+	if err := r.JumpTo(bodyStart); err != nil {
+		panic(err)
+	}
+	f.setDepthTypes(entryTypes)
+	f.setLocalsState(entryLocals)
+	f.unreachable = false
+	f.enterLoopFrame(resultTypes, res0)
+	if err := f.bodyLoop(r, preLoopCtrl); err != nil {
+		panic(err)
+	}
+	f.inVersionedLoop = false
+	f.a.PatchRel32(doneSite, f.a.Len())
+	return true
+}
+
+// enterLoopFrame replicates opBlock's cfLoop header for a versioned body: fix the
+// frame's base/height from the (already-flushed) entry, converge locals eagerly,
+// align the loop top, and push the frame.
+func (f *fn) enterLoopFrame(resultTypes []machineType, res0 machineType) {
+	rN := len(resultTypes)
+	fr := ctrlFrame{kind: cfLoop, resultN: rN, branchN: 0, elseSite: -1, res0: res0, resultTypes: resultTypes}
+	fr.height = f.depth()
+	fr.baseTypes = append([]machineType(nil), f.currentLogicalTypes()...)
+	f.reconcileLocals()
+	f.convergeEdgeTo(&fr.branchState)
+	f.flush()
+	f.a.Align16()
+	fr.loopStart = f.a.Len()
+	f.ctrl = append(f.ctrl, fr)
+}
+
+// loadLocalValue loads local x's current value into reg (from its pinned register
+// or its frame slot). Used by the precheck, which runs right after the entry
+// flush (so a pinned local is clean in both its register and slot).
+func (f *fn) loadLocalValue(reg Reg, x uint32) {
+	if pr, isFloat, ok := f.pinReg(int(x)); ok && !isFloat {
+		f.a.MovReg64(reg, pr)
+		return
+	}
+	f.a.Load64(reg, RSP, f.localOff(int(x)))
+}

--- a/src/core/compiler/backend/railshot/boundshoist_test.go
+++ b/src/core/compiler/backend/railshot/boundshoist_test.go
@@ -1,0 +1,87 @@
+package amd64
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// readLoopBody is a loop that accumulates mem[$ptr] (invariant base) 4 times and
+// returns the sum: (param $ptr) (local $i $sum). Used to exercise both the fast
+// (in-bounds → elided) and slow (OOB → checked, traps) versioned paths.
+var readLoopBody = []byte{
+	0x01, 0x02, 0x7f, // 2 i32 locals
+	0x03, 0x40, // loop void
+	0x20, 0x02, 0x20, 0x00, 0x28, 0x02, 0x00, 0x6a, 0x21, 0x02, // $sum += mem[$ptr]
+	0x20, 0x01, 0x41, 0x01, 0x6a, 0x21, 0x01, // $i++
+	0x20, 0x01, 0x41, 0x04, 0x48, 0x0d, 0x00, // if $i<4 br 0
+	0x0b, 0x20, 0x02, 0x0b, // end loop; local.get $sum; end
+}
+
+// TestLoopPrecheckSlowTrap: an out-of-bounds invariant base fails the precheck and
+// runs the SLOW (checked) body, which must trap at the access — preserving exact
+// trap semantics (a hoisted check would have trapped before the loop regardless).
+func TestLoopPrecheckSlowTrap(t *testing.T) {
+	withLoopPrecheck(t, func() {
+		i32 := wasm.I32
+		m := modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{i32}, readLoopBody)
+		// In bounds: precheck passes, fast body, sum = 4 * mem[16].
+		got, _, err := runMemAmd64(t, m, func(lin []byte) { binary.LittleEndian.PutUint32(lin[16:], 7) }, 16)
+		if err != nil {
+			t.Fatalf("in-bounds read trapped: %v", err)
+		}
+		if uint32(got) != 28 {
+			t.Errorf("in-bounds sum = %d, want 28", uint32(got))
+		}
+		// Out of bounds (ptr beyond the 64 KiB page): precheck fails, slow body traps.
+		if _, _, err := runMemAmd64(t, m, nil, 100000); err == nil {
+			t.Errorf("OOB invariant base did not trap (slow path missing its check)")
+		}
+	})
+}
+
+// withLoopPrecheck runs fn with WAGO_LOOP_PRECHECK force-enabled.
+func withLoopPrecheck(t *testing.T, fn func()) {
+	t.Helper()
+	prev := loopPrecheckEnabled
+	loopPrecheckEnabled = true
+	defer func() { loopPrecheckEnabled = prev }()
+	fn()
+}
+
+// TestLoopPrecheckExec versions a loop that reads mem[$ptr] (a loop-invariant
+// base local) each iteration: it stores 10 at $ptr, then loops 4× accumulating
+// mem[$ptr], returning 40. Exercises the precheck + fast (elided) body.
+func TestLoopPrecheckExec(t *testing.T) {
+	withLoopPrecheck(t, func() {
+		i32 := wasm.I32
+		// (param $ptr) (local $i $sum):
+		//   mem[$ptr] = 10
+		//   loop { $sum += mem[$ptr]; $i++; if $i<4 continue }
+		//   return $sum
+		body := []byte{
+			0x01, 0x02, 0x7f, // 2 i32 locals ($i=1, $sum=2)
+			0x20, 0x00, 0x41, 0x0a, 0x36, 0x02, 0x00, // mem[$ptr] = 10
+			0x03, 0x40, // loop void
+			0x20, 0x02, 0x20, 0x00, 0x28, 0x02, 0x00, 0x6a, 0x21, 0x02, // $sum += mem[$ptr]
+			0x20, 0x01, 0x41, 0x01, 0x6a, 0x21, 0x01, // $i++
+			0x20, 0x01, 0x41, 0x04, 0x48, 0x0d, 0x00, // if $i<4 br 0
+			0x0b,       // end loop
+			0x20, 0x02, // local.get $sum
+			0x0b, // end func
+		}
+		m := modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{i32}, body)
+		if got := runAmd64(t, m, 16); got != 40 {
+			t.Errorf("versioned loop sum = %d, want 40", got)
+		}
+		// Confirm it actually versioned (precheck emitted).
+		var ms ModuleStats
+		if _, err := CompileModuleWith(m, CompileOptions{Stats: &ms}); err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if ms.Funcs[0].Peephole["loop-precheck"] == 0 {
+			t.Errorf("loop was not versioned (no loop-precheck peep); peeps=%v", ms.Funcs[0].Peephole)
+		}
+	})
+}

--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -142,6 +142,14 @@ type fn struct {
 	unreachable bool        // in dead code after an unconditional branch/trap
 	retSites    []int       // forward jmp sites that target the epilogue
 
+	// Loop bounds-check hoisting (WAGO_LOOP_PRECHECK, boundshoist.go). elideBases
+	// holds the loop-invariant address-source locals whose inline bounds check is
+	// elided while the FAST version of a versioned loop body is being compiled
+	// (nil otherwise). inVersionedLoop guards against nesting a versioned loop
+	// inside another (v1 caps code growth at 2×).
+	elideBases      map[uint32]bool
+	inVersionedLoop bool
+
 	// Call state (Phase 4).
 	relocs []callReloc // CallRel32 sites to patch at module layout
 

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -454,6 +454,16 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 	fr.regMerge1 = f.regMerge && (kind == cfBlock || kind == cfIf) && rN == 1 && res0 != mtNone && res0 != mtV128
 	if kind == cfLoop && !f.unreachable {
 		fr.loopSetLocals, fr.loopHasGrow = scanLoopBody(r) // P6.2 foundation (reader restored)
+		// P6.2 loop versioning: hoist invariant-base bounds checks out of the loop
+		// via a precheck + fast/slow bodies. Explicit mode only (guard has no inline
+		// check to elide) and not while already inside a versioned body.
+		if loopPrecheckEnabled && f.memSizeReg != regNone && !f.inVersionedLoop {
+			if cands, hasGrow := scanLoopHoistable(r); len(cands) > 0 && !hasGrow {
+				if f.compileVersionedLoop(r, paramTypes, resultTypes, res0, cands) {
+					return nil
+				}
+			}
+		}
 	}
 	if f.unreachable {
 		f.ctrl = append(f.ctrl, fr)

--- a/src/core/compiler/backend/railshot/memory.go
+++ b/src/core/compiler/backend/railshot/memory.go
@@ -147,6 +147,13 @@ func (f *fn) memAddr(off uint32, size int, aliasPinned bool) (ea Reg, eaOwned bo
 	if f.guardMode {
 		return ea, eaOwned, borrow, disp
 	}
+	// Loop-precheck fast body: a loop-invariant base local proven in bounds by the
+	// pre-loop check needs no per-access check (memBytes only grows). See
+	// boundshoist.go.
+	if f.elideBases != nil && bcKind == 1 && f.elideBases[bcIdx] {
+		f.stats.addBoundsHoistable()
+		return ea, eaOwned, borrow, disp
+	}
 	// P6.1 straight-line bounds-check elision: skip the check when a prior
 	// same-source check in this straight-line region already proved this access
 	// in-bounds. Sound because linear memory only grows and the certificate is


### PR DESCRIPTION
## Summary

Implements **P6.2 loop-invariant bounds-check hoisting** via loop versioning, gated behind `WAGO_LOOP_PRECHECK` (off by default). A memory access `mem[$b + off]` inside a loop where `$b` is a loop-invariant local re-checks `$b + off + size ≤ memBytes` every iteration, even though `$b` and (since memBytes only grows) the bound are loop-invariant.

For each such base, this emits a one-time **precheck** of the max extent before the loop, and compiles the loop body **twice**:
- **fast** body (run when every precheck passes): the invariant bases' inline checks are elided — provably in bounds;
- **slow** body (otherwise): normal per-access checks, preserving exact trap timing.

The precheck is a **branch, not a trap**, which is what makes this sound: a plain hoisted check would move the trap earlier, and a wasm trap leaves partial memory writes observable. The fast body is only entered when all covered accesses provably fit; 0-iteration / early-exit / genuinely-OOB cases all fall to the slow body and behave exactly as spec.

## Impact (loops versioned / checks elided in fast bodies)

| module  | loops versioned | checks elided |
|---------|----------------:|--------------:|
| lua     | 215             | 4563          |
| inflate | 16              | 970           |
| json-as | 0               | 0             |

json-as = 0 as expected — its loop bases are computed (`base + index`), not direct invariant locals; this targets compute/compression kernels (nbody, fannkuch, sha256, inflate) that thread arrays through an invariant pointer.

## Soundness details

- **Explicit-bounds mode only** (guard mode has no inline check to elide; `f.memSizeReg == regNone` there → never versioned).
- **SIMD `v128` accesses** on a base *poison* that base (they go through `memAddr`/the elide but the scan can't size them → would under-cover the precheck extent).
- **Huge memarg offsets** (extent > 2³¹) poison the base (the precheck LEA displacement is int32).
- **memory.grow in the loop** and **non-void loops** are conservatively not versioned in v1.
- Nested versioning is disabled (`inVersionedLoop`) so code growth is bounded to 2× per versioned loop.

## Testing

- New exec tests: fast path (in-bounds invariant base → elided, correct sum) and **slow path** (OOB base → precheck fails → checked body traps) — the slow path isn't exercised by in-bounds corpus programs, so it's covered directly.
- With `WAGO_LOOP_PRECHECK=1`: spec suite (15,372 assertions), full repo, bench corpus differential — all identical to non-versioned in both bounds modes (the differential compares explicit-versioned vs guard-unversioned, so any fast/slow miscompile fails it).
- Default off → default builds byte-for-byte unchanged.

## Toward default-on

Needs a bench-corpus exec-vs-code-size measurement (versioning doubles each versioned loop's body — 215 in lua). The win is concentrated in hot compute kernels; the cost is code size on cold loops, so a size/benefit gate (or profiling) should precede flipping it on.