### PR TITLE
perf(railshot): loop-versioning benefit gate + kernel exec benchmark

### DIFF
--- a/bench/perf_costmodel_test.go
+++ b/bench/perf_costmodel_test.go
@@ -1,0 +1,55 @@
+package wagobench
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wago-org/wago/src/wago"
+)
+
+// perfKernel is one compute kernel invoked in the exec benchmark below.
+type perfKernel struct {
+	file, export string
+	args         []uint64
+}
+
+var perfKernels = []perfKernel{
+	{"nbody.wasm", "step", []uint64{2000}},
+	{"spectralnorm.wasm", "run", []uint64{128}},
+	{"fannkuch.wasm", "run", []uint64{9}},
+	{"matmul.wasm", "run", []uint64{64}},
+	{"quicksort.wasm", "sortN", []uint64{4096}},
+	{"sha256.wasm", "hashN", []uint64{64}},
+	{"raytrace.wasm", "render", []uint64{48}},
+}
+
+// BenchmarkKernels times each compute kernel's exec (compile+instantiate once,
+// then Invoke b.N times). Run with WAGO_INLINE / WAGO_LOOP_PRECHECK on/off to
+// measure the exec win of the gated optimizations against their code-size cost.
+func BenchmarkKernels(b *testing.B) {
+	for _, k := range perfKernels {
+		k := k
+		b.Run(k.export, func(b *testing.B) {
+			src, err := os.ReadFile("corpus/" + k.file)
+			if err != nil {
+				b.Skipf("no %s", k.file)
+			}
+			cfg := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+			comp, err := wago.CompileWithConfig(cfg, src)
+			if err != nil {
+				b.Fatalf("compile: %v", err)
+			}
+			in, err := wago.Instantiate(comp, wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})})
+			if err != nil {
+				b.Fatalf("instantiate: %v", err)
+			}
+			defer in.Close()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := in.Invoke(k.export, k.args...); err != nil {
+					b.Fatalf("invoke: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/boundshoist.go
+++ b/src/core/compiler/backend/railshot/boundshoist.go
@@ -2,6 +2,7 @@ package amd64
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
@@ -53,13 +54,15 @@ type hoistCand struct {
 
 // scanLoopHoistable scans the loop body (reader at the body start, restored on
 // return) for hoistable bases: locals accessed as a direct memory base and never
-// set in the loop. Returns them with each one's max extent, plus whether the loop
-// grows memory (a grower is not versioned in v1). Post-validation, so a decode
-// error just ends the scan with what was found.
-func scanLoopHoistable(r *wasm.Reader) (cands []hoistCand, hasGrow bool) {
+// set in the loop. Returns them with each one's max extent, the total number of
+// per-iteration accesses that would be elided (the check-density benefit signal),
+// and whether the loop grows memory (a grower is not versioned in v1). Post-
+// validation, so a decode error just ends the scan with what was found.
+func scanLoopHoistable(r *wasm.Reader) (cands []hoistCand, elidable int, hasGrow bool) {
 	start := r.Offset()
 	set := map[uint32]bool{}
 	maxExt := map[uint32]int32{}
+	acc := map[uint32]int{}     // direct-access count per base
 	poison := map[uint32]bool{} // bases with a direct access this scan can't size (SIMD)
 	prevGet := int64(-1)        // local index of an immediately-preceding local.get, else -1
 	depth := 0
@@ -126,6 +129,7 @@ scan:
 					break scan
 				}
 				if prevGet >= 0 {
+					acc[uint32(prevGet)]++
 					// The precheck's LEA displacement is int32; an offset near 2^32 would
 					// overflow it and check a wrong (too-small) bound, so poison instead.
 					if ext := int64(off) + int64(size); ext > 0x7FFFFFFF {
@@ -144,10 +148,25 @@ scan:
 	for b, ext := range maxExt {
 		if !set[b] && !poison[b] { // invariant, never set in the loop, all accesses sized
 			cands = append(cands, hoistCand{base: b, extent: ext})
+			elidable += acc[b]
 		}
 	}
-	return cands, hasGrow
+	return cands, elidable, hasGrow
 }
+
+// loopPrecheckMinChecks is the minimum per-iteration elided-check count for a loop
+// to be worth versioning: the fast/slow bodies double the loop code, so a loop
+// that would elide only a check or two is not worth 2× the size. Tunable via
+// WAGO_LP_MINCHECKS. (The gate mainly filters out the many 1–2 check loops; the
+// check-dense loops that carry the exec win are kept.)
+var loopPrecheckMinChecks = func() int {
+	if v := os.Getenv("WAGO_LP_MINCHECKS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			return n
+		}
+	}
+	return 4
+}()
 
 // compileVersionedLoop lowers a versionable void loop: precheck → fast body
 // (invariant-base checks elided) → jump past → slow body (checked). Both bodies

--- a/src/core/compiler/backend/railshot/boundshoist_test.go
+++ b/src/core/compiler/backend/railshot/boundshoist_test.go
@@ -41,13 +41,44 @@ func TestLoopPrecheckSlowTrap(t *testing.T) {
 	})
 }
 
-// withLoopPrecheck runs fn with WAGO_LOOP_PRECHECK force-enabled.
+// withLoopPrecheck runs fn with WAGO_LOOP_PRECHECK force-enabled and the benefit
+// threshold lowered to 1, so the small test loops (one elided check each) still
+// version.
 func withLoopPrecheck(t *testing.T, fn func()) {
 	t.Helper()
-	prev := loopPrecheckEnabled
-	loopPrecheckEnabled = true
-	defer func() { loopPrecheckEnabled = prev }()
+	prevEn, prevK := loopPrecheckEnabled, loopPrecheckMinChecks
+	loopPrecheckEnabled, loopPrecheckMinChecks = true, 1
+	defer func() { loopPrecheckEnabled, loopPrecheckMinChecks = prevEn, prevK }()
 	fn()
+}
+
+// TestLoopPrecheckBenefitGate checks that a loop below the elided-check threshold
+// is NOT versioned (the fast/slow bodies double the loop code, so a loop that
+// would elide too few checks is not worth it).
+func TestLoopPrecheckBenefitGate(t *testing.T) {
+	i32 := wasm.I32
+	m := modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{i32}, readLoopBody) // 1 elided check/iter
+	prevEn, prevK := loopPrecheckEnabled, loopPrecheckMinChecks
+	defer func() { loopPrecheckEnabled, loopPrecheckMinChecks = prevEn, prevK }()
+	loopPrecheckEnabled = true
+
+	loopPrecheckMinChecks = 3 // 1 < 3 → not versioned
+	var ms ModuleStats
+	if _, err := CompileModuleWith(m, CompileOptions{Stats: &ms}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if ms.Funcs[0].Peephole["loop-precheck"] != 0 {
+		t.Errorf("loop with 1 elided check should NOT version at K=3")
+	}
+
+	loopPrecheckMinChecks = 1 // 1 >= 1 → versioned
+	var ms2 ModuleStats
+	if _, err := CompileModuleWith(m, CompileOptions{Stats: &ms2}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if ms2.Funcs[0].Peephole["loop-precheck"] == 0 {
+		t.Errorf("loop should version at K=1")
+	}
 }
 
 // TestLoopPrecheckExec versions a loop that reads mem[$ptr] (a loop-invariant

--- a/src/core/compiler/backend/railshot/control.go
+++ b/src/core/compiler/backend/railshot/control.go
@@ -458,7 +458,7 @@ func (f *fn) opBlock(r *wasm.Reader, op byte) error {
 		// via a precheck + fast/slow bodies. Explicit mode only (guard has no inline
 		// check to elide) and not while already inside a versioned body.
 		if loopPrecheckEnabled && f.memSizeReg != regNone && !f.inVersionedLoop {
-			if cands, hasGrow := scanLoopHoistable(r); len(cands) > 0 && !hasGrow {
+			if cands, elidable, hasGrow := scanLoopHoistable(r); len(cands) > 0 && !hasGrow && elidable >= loopPrecheckMinChecks {
 				if f.compileVersionedLoop(r, paramTypes, resultTypes, res0, cands) {
 					return nil
 				}


### PR DESCRIPTION
## Summary

Two things, both from measuring the gated optimizations (#191 inlining, #193 loop-hoisting) to decide default-on:

1. **A benefit gate for loop versioning** (`WAGO_LOOP_PRECHECK`): only version a loop whose invariant-base accesses would elide **≥ `WAGO_LP_MINCHECKS` (default 4)** bounds checks per iteration. The scan now counts elided-check density; a loop that would save only a check or two isn't worth doubling its body. Correctness-safe (versioning fewer loops can't miscompile) — spec (15,372 assertions) + corpus differential green in both modes; new `TestLoopPrecheckBenefitGate`.

2. **`BenchmarkKernels`** — an exec benchmark over the compute-kernel corpus (nbody, spectralnorm, fannkuch, matmul, quicksort, sha256, raytrace), so the exec win of the gated opts can be measured against their code-size cost.

## Measurement findings (why defaults are NOT flipped)

Both optimizations stay **off by default** — the corpus data doesn't justify turning them on:

- **Inlining**: no statistically-significant exec change on any compute kernel (geomean +2.7%, within noise). Its value is in call-heavy dispatch code (interpreters, etc.), which these kernels don't exercise — so default-on needs a call-heavy benchmark, not this corpus. Code cost is low (lua +7%, inflate +0.2%).
- **Loop-hoisting**: helps **fannkuch −4.9%** (p=0.000) and nothing else measurable; costs ~20% code. The benefit gate can't fix the cost — the check-dense loops that carry the win are also the largest, so versioning where it pays inherently grows code ~18–20%. That's a poor default-on trade for a single-kernel win.

**Conclusion:** both remain opt-in. The gate makes loop-hoisting saner when enabled (no versioning of worthless loops); the benchmark is the harness to revisit default-on for inlining once a call-heavy workload is added.