### PR TITLE
feat(cli): registry login/publish/unpublish/deprecate commands

### DIFF
--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -44,6 +44,18 @@ func main() {
 		envCmd()
 	case "validate":
 		validateCmd(a[1:])
+	case "login":
+		registryLogin(a[1:])
+	case "logout":
+		registryLogout(a[1:])
+	case "whoami":
+		registryWhoami(a[1:])
+	case "publish":
+		registryPublish(a[1:])
+	case "unpublish":
+		registryUnpublish(a[1:])
+	case "deprecate":
+		registryDeprecate(a[1:])
 	case "--version", "-v":
 		printVersion()
 	case "version":
@@ -75,6 +87,17 @@ func usage(w *os.File) {
   version [sub]             manage installed versions (list, use, install, …)
 
 %s
+  login                     authenticate to the registry (pkg.wago.sh)
+                            --token <t> use a token; --with-token read it from stdin
+  logout                    remove stored registry credentials
+  whoami                    print the logged-in registry account
+  publish                   publish a plugin from wago-plugin.json
+                            --manifest <p> --version <v> --commit <c> --notes <s>
+                            --category <c> --tags <a,b>
+  unpublish <name>[@ver]    remove a package or one version   (--yes to skip prompt)
+  deprecate <name>[@ver]    deprecate a package/version (--message <m>, --undo)
+
+%s
   -v, --version             print version and supported features
   -e, --invoke <name>       export to call
       --plugin <names>      comma-separated plugins to enable (see: wago plugin list)
@@ -89,7 +112,7 @@ func usage(w *os.File) {
 
 For run, <file> is raw .wasm or a precompiled .wago. run args are typed by
 the signature; override per-arg with a suffix:  42   7:i64   3.5:f64
-`, bold("wago"), bold("Usage:"), bold("Commands:"), bold("Flags:"), bold("Examples:"))
+`, bold("wago"), bold("Usage:"), bold("Commands:"), bold("Registry:"), bold("Flags:"), bold("Examples:"))
 }
 
 func notImplemented(cmd string) { fatal("%s: not implemented", cmd) }

--- a/cli/wago/registry_config.go
+++ b/cli/wago/registry_config.go
@@ -1,0 +1,145 @@
+package main
+
+// Credentials store for the wago registry (pkg.wago.sh). This file is net-free
+// (no net/http) so it compiles into both the full and the size-optimized
+// (-tags wago_lean) builds; the actual HTTP calls live in registry_net.go.
+//
+// Credentials are keyed by registry base URL so several registries can coexist.
+// They are stored at $XDG_CONFIG_HOME/wago/credentials.json (else
+// $HOME/.config/wago/credentials.json).
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// defaultRegistry is the public registry API base used when WAGO_REGISTRY is unset.
+const defaultRegistry = "https://api.pkg.wago.sh"
+
+// credential is one registry's stored token and the login it belongs to.
+type credential struct {
+	Token string `json:"token"`
+	Login string `json:"login"`
+}
+
+// registryBase returns the registry API base URL: the WAGO_REGISTRY env var if
+// set (trailing slash trimmed), else the public default.
+func registryBase() string {
+	if v := strings.TrimSpace(os.Getenv("WAGO_REGISTRY")); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return defaultRegistry
+}
+
+// frontendBase derives the website base URL (for package-page links) from the
+// registry API base by dropping a leading "api." host label — e.g.
+// https://api.pkg.wago.sh -> https://pkg.wago.sh. A base with no "api." host
+// (like a localhost dev server) is returned unchanged.
+func frontendBase() string {
+	base := registryBase()
+	for _, scheme := range []string{"https://", "http://"} {
+		if strings.HasPrefix(base, scheme) {
+			rest := base[len(scheme):]
+			if strings.HasPrefix(rest, "api.") {
+				return scheme + rest[len("api."):]
+			}
+			return base
+		}
+	}
+	return base
+}
+
+// shortFromModule derives a package short id from a module path: the last path
+// element with a leading "wago-" or "wago_" stripped. This mirrors the registry
+// server so CLI-printed package-page URLs match.
+func shortFromModule(module string) string {
+	short := module
+	if i := strings.LastIndex(short, "/"); i >= 0 {
+		short = short[i+1:]
+	}
+	short = strings.TrimPrefix(short, "wago-")
+	short = strings.TrimPrefix(short, "wago_")
+	return short
+}
+
+// credentialsPath returns the path to the credentials file.
+func credentialsPath() string {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		dir = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+	return filepath.Join(dir, "wago", "credentials.json")
+}
+
+// loadCredentials reads the registry->credential map. A missing file yields an
+// empty map (not an error); a malformed file yields an error.
+func loadCredentials() (map[string]credential, error) {
+	data, err := os.ReadFile(credentialsPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]credential{}, nil
+		}
+		return nil, err
+	}
+	creds := map[string]credential{}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return creds, nil
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, err
+	}
+	return creds, nil
+}
+
+// saveCredentials records token+login for base, preserving other registries'
+// entries, and writes the file with 0600 permissions.
+func saveCredentials(base, token, login string) error {
+	creds, err := loadCredentials()
+	if err != nil {
+		return err
+	}
+	creds[base] = credential{Token: token, Login: login}
+	return writeCredentials(creds)
+}
+
+// deleteCredentials removes the stored entry for base (a no-op if none exists).
+func deleteCredentials(base string) error {
+	creds, err := loadCredentials()
+	if err != nil {
+		return err
+	}
+	if _, ok := creds[base]; !ok {
+		return nil
+	}
+	delete(creds, base)
+	return writeCredentials(creds)
+}
+
+// writeCredentials serializes the credential map to disk (0600), creating the
+// parent directory if needed.
+func writeCredentials(creds map[string]credential) error {
+	path := credentialsPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+// resolveToken returns the API token for the current registry: WAGO_TOKEN wins,
+// else the stored token for the current base. Returns "" when there is none.
+func resolveToken() string {
+	if v := strings.TrimSpace(os.Getenv("WAGO_TOKEN")); v != "" {
+		return v
+	}
+	creds, err := loadCredentials()
+	if err != nil {
+		return ""
+	}
+	return creds[registryBase()].Token
+}

--- a/cli/wago/registry_net.go
+++ b/cli/wago/registry_net.go
@@ -1,0 +1,478 @@
+//go:build !wago_lean
+
+// Registry commands (login/logout/whoami/publish/unpublish/deprecate) for the
+// wago registry at pkg.wago.sh. This file imports net/http (and net, os/exec for
+// the browser login flow), so it is excluded from the size-optimized/TinyGo build
+// (-tags wago_lean); that build gets the fatal() stubs in registry_stub.go.
+//
+// The credential store and URL helpers live in registry_config.go, which is
+// net-free and shared by both builds.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// errUnauthorized marks a 401 from the registry (used to distinguish "not logged
+// in" from a genuine transport/server error).
+var errUnauthorized = errors.New("unauthorized")
+
+// meResponse is the shape of GET /api/me.
+type meResponse struct {
+	ID     string `json:"id"`
+	Login  string `json:"login"`
+	Name   string `json:"name"`
+	Email  string `json:"email"`
+	Avatar string `json:"avatarUrl"`
+}
+
+// apiRequest performs an HTTP request to the current registry base with the
+// bearer token (when non-empty) and an optional JSON body, returning the status
+// code and raw response bytes.
+func apiRequest(method, path, token string, body any) (int, []byte, error) {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, err
+		}
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, registryBase()+path, reader)
+	if err != nil {
+		return 0, nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, data, nil
+}
+
+// apiError extracts the {"error":...} message from a response body, falling back
+// to the status code.
+func apiError(status int, data []byte) string {
+	var e struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(data, &e) == nil && e.Error != "" {
+		return e.Error
+	}
+	return fmt.Sprintf("server returned status %d", status)
+}
+
+// fetchMe calls GET /api/me and returns the user, or errUnauthorized on a 401.
+func fetchMe(token string) (meResponse, error) {
+	status, data, err := apiRequest(http.MethodGet, "/api/me", token, nil)
+	if err != nil {
+		return meResponse{}, err
+	}
+	if status == http.StatusUnauthorized {
+		return meResponse{}, errUnauthorized
+	}
+	if status != http.StatusOK {
+		return meResponse{}, errors.New(apiError(status, data))
+	}
+	var me meResponse
+	if err := json.Unmarshal(data, &me); err != nil {
+		return meResponse{}, err
+	}
+	return me, nil
+}
+
+// registryLogin obtains an API token and stores it for the current registry.
+// Default is an interactive browser flow; --token <t> uses a token directly and
+// --with-token reads one from stdin (for CI).
+func registryLogin(args []string) {
+	withToken, args := hasFlag(args, "--with-token")
+	var token string
+	if _, err := extractOpts(args, map[string]*string{"--token": &token}); err != nil {
+		fatal("login: %v", err)
+	}
+	base := registryBase()
+	switch {
+	case token != "":
+		// use the provided token directly
+	case withToken:
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fatal("login: reading token from stdin: %v", err)
+		}
+		token = strings.TrimSpace(string(b))
+		if token == "" {
+			fatal("login: no token on stdin")
+		}
+	default:
+		token = browserLogin(base)
+	}
+	me, err := fetchMe(token)
+	if err != nil {
+		if errors.Is(err, errUnauthorized) {
+			fatal("login: the registry rejected that token")
+		}
+		fatal("login: %v", err)
+	}
+	if err := saveCredentials(base, token, me.Login); err != nil {
+		fatal("login: saving credentials: %v", err)
+	}
+	fmt.Printf("%s Logged in as %s\n", cyan("✓"), bold(me.Login))
+}
+
+// browserLogin runs the loopback OAuth flow: it listens on a free localhost port,
+// opens the browser to the registry's CLI-login endpoint, and waits for the
+// /callback redirect carrying the plaintext token. It fatals on error or timeout.
+func browserLogin(base string) string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fatal("login: cannot open a loopback listener: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	state, err := randomState()
+	if err != nil {
+		fatal("login: %v", err)
+	}
+
+	type result struct {
+		token string
+		err   error
+	}
+	resCh := make(chan result, 1)
+	mux := http.NewServeMux()
+	srv := &http.Server{Handler: mux}
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("state") != state {
+			http.Error(w, "state mismatch — login aborted", http.StatusBadRequest)
+			resCh <- result{err: errors.New("state mismatch — login aborted (possible CSRF)")}
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, loginSuccessHTML)
+		resCh <- result{token: q.Get("token")}
+	})
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	loginURL := fmt.Sprintf("%s/auth/cli/login?port=%d&state=%s", base, port, url.QueryEscape(state))
+	if err := openBrowser(loginURL); err != nil {
+		fmt.Printf("Open this URL in your browser to log in:\n\n  %s\n\n", cyan(loginURL))
+	} else {
+		fmt.Printf("%s Opening your browser to log in…\n", dim("→"))
+		fmt.Printf("  %s\n  %s\n", dim("if it doesn't open, visit:"), cyan(loginURL))
+	}
+
+	select {
+	case res := <-resCh:
+		if res.err != nil {
+			fatal("login: %v", res.err)
+		}
+		if res.token == "" {
+			fatal("login: no token received from the registry")
+		}
+		return res.token
+	case <-time.After(2 * time.Minute):
+		fatal("login: timed out waiting for the browser callback")
+		return ""
+	}
+}
+
+// loginSuccessHTML is the page shown in the browser after a successful login.
+const loginSuccessHTML = `<!doctype html><html><head><meta charset="utf-8">` +
+	`<title>wago — logged in</title></head>` +
+	`<body style="font-family:system-ui,sans-serif;text-align:center;padding:4rem">` +
+	`<h1>You're logged in ✓</h1><p>You can close this tab and return to your terminal.</p>` +
+	`</body></html>`
+
+// openBrowser opens url in the user's default browser (platform-specific).
+func openBrowser(target string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+	return cmd.Start()
+}
+
+// randomState returns a random hex string for the login CSRF state parameter.
+func randomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// registryLogout deletes stored credentials for the current registry.
+func registryLogout(args []string) {
+	base := registryBase()
+	creds, _ := loadCredentials()
+	if _, ok := creds[base]; !ok {
+		fmt.Printf("%s Not logged in to %s\n", dim("·"), base)
+		return
+	}
+	if err := deleteCredentials(base); err != nil {
+		fatal("logout: %v", err)
+	}
+	fmt.Printf("%s Logged out of %s\n", cyan("✓"), base)
+}
+
+// registryWhoami prints the login of the current token, or a friendly hint when
+// there is no valid session.
+func registryWhoami(args []string) {
+	token := resolveToken()
+	if token == "" {
+		fmt.Println("not logged in (run: wago login)")
+		return
+	}
+	me, err := fetchMe(token)
+	if err != nil {
+		if errors.Is(err, errUnauthorized) {
+			fmt.Println("not logged in (run: wago login)")
+			return
+		}
+		fatal("whoami: %v", err)
+	}
+	fmt.Println(me.Login)
+}
+
+// registryPublish reads a wago-plugin.json manifest and POSTs it to /api/publish
+// along with a version, commit, and optional metadata.
+func registryPublish(args []string) {
+	var manifestPath, ver, commit, notes, category, tags string
+	if _, err := extractOpts(args, map[string]*string{
+		"--manifest": &manifestPath,
+		"--version":  &ver,
+		"--commit":   &commit,
+		"--notes":    &notes,
+		"--category": &category,
+		"--tags":     &tags,
+	}); err != nil {
+		fatal("publish: %v", err)
+	}
+	token := resolveToken()
+	if token == "" {
+		fatal("publish: not logged in (run: wago login)")
+	}
+	if manifestPath == "" {
+		manifestPath = "wago-plugin.json"
+	}
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		fatal("publish: reading manifest: %v", err)
+	}
+	var mf struct {
+		Schema string `json:"schema"`
+		Module string `json:"module"`
+	}
+	if err := json.Unmarshal(raw, &mf); err != nil {
+		fatal("publish: parsing %s: %v", manifestPath, err)
+	}
+	if strings.TrimSpace(mf.Module) == "" {
+		fatal("publish: %s has no \"module\" field", manifestPath)
+	}
+
+	if ver == "" {
+		ver = strings.TrimSpace(gitOutput("describe", "--tags", "--abbrev=0"))
+		if ver == "" {
+			fatal("publish: no --version given and `git describe --tags` found no tag; pass --version <v>")
+		}
+	}
+	if commit == "" {
+		commit = strings.TrimSpace(gitOutput("rev-parse", "HEAD")) // best-effort; "" if not a repo
+	}
+
+	body := map[string]any{
+		"manifest": json.RawMessage(raw),
+		"version":  ver,
+		"commit":   commit,
+		"notes":    notes,
+		"category": category,
+	}
+	if t := splitCommaList(tags); len(t) > 0 {
+		body["tags"] = t
+	}
+
+	status, data, err := apiRequest(http.MethodPost, "/api/publish", token, body)
+	if err != nil {
+		fatal("publish: %v", err)
+	}
+	switch status {
+	case http.StatusOK:
+		fmt.Printf("%s Published %s %s\n", cyan("✓"), bold(mf.Module), ver)
+		fmt.Printf("  %s\n", dim(frontendBase()+"/#/p/"+shortFromModule(mf.Module)))
+	case http.StatusConflict:
+		fatal("publish: version %s is already published", ver)
+	case http.StatusForbidden:
+		fatal("publish: you are not the owner of %s", mf.Module)
+	case http.StatusUnauthorized:
+		fatal("publish: not logged in (run: wago login)")
+	default:
+		fatal("publish: %s", apiError(status, data))
+	}
+}
+
+// registryUnpublish removes a whole package, or a single version when the
+// argument carries an @version suffix. It confirms first unless --yes is given.
+func registryUnpublish(args []string) {
+	yes, args := hasFlag(args, "--yes")
+	pos, err := extractOpts(args, map[string]*string{})
+	if err != nil {
+		fatal("unpublish: %v", err)
+	}
+	if len(pos) != 1 {
+		fatal("unpublish: need <module-or-short>[@version]")
+	}
+	token := resolveToken()
+	if token == "" {
+		fatal("unpublish: not logged in (run: wago login)")
+	}
+	name, ver := splitAtVersion(pos[0])
+	target := name
+	if ver != "" {
+		target = name + "@" + ver
+	}
+	if !yes && !confirm(fmt.Sprintf("Unpublish %s? This cannot be undone.", target)) {
+		fmt.Println("aborted")
+		return
+	}
+
+	path := "/api/packages/" + url.PathEscape(name)
+	if ver != "" {
+		path += "/versions/" + url.PathEscape(ver)
+	}
+	status, data, err := apiRequest(http.MethodDelete, path, token, nil)
+	if err != nil {
+		fatal("unpublish: %v", err)
+	}
+	switch status {
+	case http.StatusOK:
+		fmt.Printf("%s Unpublished %s\n", cyan("✓"), target)
+	case http.StatusForbidden:
+		fatal("unpublish: you are not the owner of %s", name)
+	case http.StatusNotFound:
+		fatal("unpublish: %s not found", target)
+	case http.StatusUnauthorized:
+		fatal("unpublish: not logged in (run: wago login)")
+	default:
+		fatal("unpublish: %s", apiError(status, data))
+	}
+}
+
+// registryDeprecate marks a package (or a specific @version) deprecated, or
+// reverses it with --undo. --message sets the deprecation notice.
+func registryDeprecate(args []string) {
+	undo, args := hasFlag(args, "--undo")
+	var message string
+	pos, err := extractOpts(args, map[string]*string{"--message": &message})
+	if err != nil {
+		fatal("deprecate: %v", err)
+	}
+	if len(pos) != 1 {
+		fatal("deprecate: need <module-or-short>[@version]")
+	}
+	token := resolveToken()
+	if token == "" {
+		fatal("deprecate: not logged in (run: wago login)")
+	}
+	name, ver := splitAtVersion(pos[0])
+	target := name
+	if ver != "" {
+		target = name + "@" + ver
+	}
+
+	body := map[string]any{"message": message, "version": ver, "undo": undo}
+	path := "/api/packages/" + url.PathEscape(name) + "/deprecate"
+	status, data, err := apiRequest(http.MethodPost, path, token, body)
+	if err != nil {
+		fatal("deprecate: %v", err)
+	}
+	switch status {
+	case http.StatusOK:
+		if undo {
+			fmt.Printf("%s Un-deprecated %s\n", cyan("✓"), target)
+		} else {
+			fmt.Printf("%s Deprecated %s\n", cyan("✓"), target)
+		}
+	case http.StatusForbidden:
+		fatal("deprecate: you are not the owner of %s", name)
+	case http.StatusNotFound:
+		fatal("deprecate: %s not found", target)
+	case http.StatusUnauthorized:
+		fatal("deprecate: not logged in (run: wago login)")
+	default:
+		fatal("deprecate: %s", apiError(status, data))
+	}
+}
+
+// gitOutput runs `git <args...>` and returns stdout, or "" on any error (so
+// callers can treat git as best-effort).
+func gitOutput(args ...string) string {
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// confirm prompts on stderr and reads a yes/no answer from stdin (default no).
+func confirm(prompt string) bool {
+	fmt.Printf("%s [y/N] ", prompt)
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	switch strings.TrimSpace(strings.ToLower(line)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// splitAtVersion splits "name@version" into its parts; the version is "" when
+// there is no @ (module paths never contain @).
+func splitAtVersion(s string) (name, version string) {
+	if i := strings.LastIndexByte(s, '@'); i >= 0 {
+		return s[:i], s[i+1:]
+	}
+	return s, ""
+}
+
+// splitCommaList splits a comma-separated string into trimmed, non-empty items.
+func splitCommaList(s string) []string {
+	var out []string
+	for _, t := range strings.Split(s, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/cli/wago/registry_stub.go
+++ b/cli/wago/registry_stub.go
@@ -1,0 +1,32 @@
+//go:build wago_lean
+
+// Lean/TinyGo build: TinyGo cannot link net/http, so the registry commands are
+// stubbed. Use a full wago binary to authenticate and publish to the registry.
+// The credential store (registry_config.go) is net-free and still compiles here,
+// but nothing in this build reads or writes it.
+
+package main
+
+func registryLogin(args []string) {
+	fatal("login: registry commands need a full wago binary (this lean build cannot link net/http)")
+}
+
+func registryLogout(args []string) {
+	fatal("logout: registry commands need a full wago binary (this lean build cannot link net/http)")
+}
+
+func registryWhoami(args []string) {
+	fatal("whoami: registry commands need a full wago binary (this lean build cannot link net/http)")
+}
+
+func registryPublish(args []string) {
+	fatal("publish: registry commands need a full wago binary (this lean build cannot link net/http)")
+}
+
+func registryUnpublish(args []string) {
+	fatal("unpublish: registry commands need a full wago binary (this lean build cannot link net/http)")
+}
+
+func registryDeprecate(args []string) {
+	fatal("deprecate: registry commands need a full wago binary (this lean build cannot link net/http)")
+}


### PR DESCRIPTION
Adds registry commands to the `wago` CLI so users can authenticate and publish plugins to the wago registry (pkg.wago.sh). These consume the token/publish/unpublish/deprecate endpoints added to the registry backend.

## Commands
- `wago login` — browser loopback OAuth (spins up a localhost listener, opens the browser to `/auth/cli/login`, captures the returned token). `--token <t>` uses a token directly; `--with-token` reads one from stdin (CI). Stores it in `~/.config/wago/credentials.json` (keyed by registry URL, 0600).
- `wago logout`, `wago whoami`.
- `wago publish` — reads `wago-plugin.json` (`--manifest` override), version from `--version` (else `git describe --tags --abbrev=0`), commit from `git rev-parse HEAD`; POSTs with the bearer token. Prints the package-page URL; maps 409→"already published", 403→"not the owner", 401→"run: wago login".
- `wago unpublish <module>[@version] [--yes]` — remove a package or a single version.
- `wago deprecate <module>[@version] [--message …] [--undo]`.

## Build-tag split
The CLI has a size-optimized/TinyGo build (`-tags wago_lean`) that can't link `net/http`. Mirroring `version_net.go`/`version_net_stub.go`:
- `registry_config.go` — net-free credentials store (both builds).
- `registry_net.go` (`//go:build !wago_lean`) — the HTTP client + real command impls.
- `registry_stub.go` (`//go:build wago_lean`) — same signatures, each `fatal`-ing that registry commands need a full binary.

Config: registry base from `WAGO_REGISTRY` (default `https://api.pkg.wago.sh`); token from `WAGO_TOKEN` (else stored).

## Verification
- `go build ./cli/wago` and `go build -tags wago_lean ./cli/wago` both pass; `go vet` + `gofmt` clean.
- End-to-end against a live registry backend: `whoami`, `publish` v0.1.0/v0.2.0, duplicate → 409 message, `deprecate`, `unpublish …@version` then whole package, and `login --with-token` → `whoami` → `logout` all worked.

Depends on the registry-side endpoints (separate PR in `wago-org/registry`). The manifest `extensions`→`subpackages` rename in `plugins/wasi` is its own PR.
