### PR TITLE
feat(railshot): constant-divisor magic division + redundant zero-extend elimination

### DIFF
--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -532,6 +532,13 @@ func (f *fn) condenseDivRem(node *elem, dest Reg) Reg {
 	left := node.arg0
 	right := node.arg1
 
+	// Constant divisor: strength-reduce to shifts / multiply-high, avoiding idiv.
+	if right.kind == ekValue && right.st.kind == stConst {
+		if r, ok := f.tryDivByConst(node, dest, right.st.cval); ok {
+			return r
+		}
+	}
+
 	// Reserve RAX (dividend/quotient) and RDX (high half/remainder).
 	f.spillIfUsed(RAX)
 	f.spillIfUsed(RDX)

--- a/src/core/compiler/backend/railshot/emit.go
+++ b/src/core/compiler/backend/railshot/emit.go
@@ -53,15 +53,45 @@ func (f *fn) condense(node *elem, dest Reg) Reg {
 // condenseConvert lowers the integer width conversions (wrap / sign- & zero-
 // extend). Each reads the source register and writes the converted value; the
 // source register can be reused when there is no target hint.
+// producesCleanI32 reports whether an i32-typed deferred op materializes into a
+// register whose upper 32 bits are guaranteed zero. All of these lower to 32-bit
+// instructions (ALU/shift/mul/div, bit counts) or a 0/1 setcc, and a 32-bit write
+// clears the upper half on x86-64. Loads and local/global reads are excluded:
+// they can surface dirty upper bits (garbage-padded params, sign-extending loads).
+func producesCleanI32(op wOp) bool {
+	switch op {
+	case opAdd, opSub, opAnd, opOr, opXor,
+		opShl, opShrU, opShrS, opRotl, opRotr,
+		opMul, opDivU, opDivS, opRemU, opRemS,
+		opClz, opCtz, opPopcnt,
+		opEq, opNe, opLtS, opLtU, opGtS, opGtU, opLeS, opLeU, opGeS, opGeU, opEqz,
+		opWrap, opZExt32:
+		return true
+	}
+	return false
+}
+
 func (f *fn) condenseConvert(node *elem, dest Reg) Reg {
+	// Redundant zero-extend elimination: i64.extend_i32_u of a value already in
+	// clean zero-upper form (an i32 produced by a 32-bit instruction, which zeroes
+	// the upper 32 bits on x86-64) is a no-op. Captured before materialize consumes
+	// the deferred node. NOT applied to i32 locals/params or sign-extending loads,
+	// which can carry dirty upper bits — hence the producer-op whitelist.
+	cleanZExt := node.op == opZExt32 && node.arg0.kind == ekDeferred &&
+		node.arg0.typ == mtI32 && producesCleanI32(node.arg0.op)
 	src := f.materialize(node.arg0)
 	result := src
 	if dest != regNone && dest != src {
 		result = dest
 	}
 	switch node.op {
-	case opWrap, opZExt32:
-		// 32-bit mov zero-extends into the full 64-bit register.
+	case opZExt32:
+		if cleanZExt && result == src {
+			f.stats.peep("ext-elim") // upper 32 already zero; the mov would be a no-op
+			break
+		}
+		f.a.MovRegReg32(result, src) // 32-bit mov zero-extends into the full register
+	case opWrap:
 		f.a.MovRegReg32(result, src)
 	case opSExt32:
 		f.a.Movsxd(result, src)

--- a/src/core/compiler/backend/railshot/extelim_test.go
+++ b/src/core/compiler/backend/railshot/extelim_test.go
@@ -1,0 +1,46 @@
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestExtendElimZeroExtends checks that eliminating the redundant zero-extend of a
+// clean i32 op preserves i64.extend_i32_u semantics (upper 32 bits zero, never
+// sign-extended) and that the elimination actually fires. Body, one i64 param n:
+//
+//	n + i64.extend_i32_u( (i32.wrap_i64 n) + 1 )
+//
+// The extend feeds the outer i64.add as its RHS, so it is condensed with no dest
+// hint (result == src) — the case where dropping the redundant mov is a real win.
+func TestExtendElimZeroExtends(t *testing.T) {
+	body := []byte{
+		0x00,       // 0 locals
+		0x20, 0x00, // local.get 0        (i64 n)
+		0x20, 0x00, // local.get 0
+		0xa7,       // i32.wrap_i64       (low32 n)
+		0x41, 0x01, // i32.const 1
+		0x6a, // i32.add            (low32(n)+1, 32-bit → clean upper)
+		0xad, // i64.extend_i32_u   (redundant zero-extend → elided)
+		0x7c, // i64.add
+		0x0b, // end
+	}
+	m := mod1(t, []wasm.ValType{wasm.I64}, []wasm.ValType{wasm.I64}, body)
+	call, done := divInvoker(t, m)
+	defer done()
+	for _, n := range []uint64{0, 1, 0x7fffffff, 0x80000000, 0xffffffff,
+		0x1_0000_0000, 0x7fffffff_ffffffff, 0xffffffff_ffffffff, 0xdead_beef_cafe_babe} {
+		want := n + uint64(uint32(n)+1) // extend_i32_u zero-extends the 32-bit sum
+		if got := call(n); got != want {
+			t.Errorf("n=%#x: got %#x want %#x", n, got, want)
+		}
+	}
+	var ms ModuleStats
+	if _, err := CompileModuleWith(m, CompileOptions{Stats: &ms}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if ms.Funcs[0].Peephole["ext-elim"] == 0 {
+		t.Errorf("ext-elim peep did not fire; peeps=%v", ms.Funcs[0].Peephole)
+	}
+}

--- a/src/core/compiler/backend/railshot/magicdiv.go
+++ b/src/core/compiler/backend/railshot/magicdiv.go
@@ -1,0 +1,285 @@
+package amd64
+
+// Constant-divisor strength reduction. A div/rem by a constant is replaced with
+// cheap shifts (power-of-2 divisors) or a multiply-high + shift (the Granlund–
+// Montgomery "magic number" method, added on top of this), avoiding the ~20–40-
+// cycle idiv. Correctness is checked exhaustively against idiv in the tests.
+
+// tryDivByConst lowers node (a div/rem whose divisor arg1 is the constant c) via
+// strength reduction, returning (resultReg, true) on success or (regNone, false)
+// to fall back to the general idiv path (e.g. c == 0, which must trap).
+func (f *fn) tryDivByConst(node *elem, dest Reg, c int64) (Reg, bool) {
+	if c == 0 {
+		return regNone, false // div/rem by zero traps — leave it to the idiv path
+	}
+	w := node.typ.is64()
+	signed := node.op == opDivS || node.op == opRemS
+	wantRem := node.op == opRemU || node.op == opRemS
+
+	// Decide whether we can handle this divisor before emitting anything, so a
+	// bail-out leaves the operand stack untouched for the idiv fallback.
+	if !strengthReducible(c, w, signed) {
+		return regNone, false
+	}
+
+	// Compute the dividend into an owned result register (kept clear of RAX/RDX so
+	// a magic multiply-high can use them without disturbing it).
+	res := f.allocReg(maskOf(RAX, RDX))
+	f.pinned = f.pinned.add(res)
+	f.condenseInto(node.arg0, res) // res = n (dividend)
+
+	if signed {
+		f.divConstSigned(res, c, w, wantRem)
+	} else {
+		ud := uint64(c)
+		if !w {
+			ud = uint64(uint32(c))
+		}
+		f.divConstUnsigned(res, ud, w, wantRem)
+	}
+	f.pinned = f.pinned.remove(res)
+
+	result := res
+	if dest != regNone && dest != res {
+		f.a.MovReg64(dest, res)
+		f.release(res)
+		result = dest
+	}
+	f.consumeBlockBelow(node)
+	f.occupy(node, result)
+	node.op = opNone
+	f.stats.peep("div-by-const")
+	return result, true
+}
+
+// magicDivEnabled / magicDivSignedEnabled gate the multiply-high path for non-
+// power-of-2 divisors (power-of-2 shifts are always used). Signed magic is a
+// separate flag so it can be disabled independently.
+var (
+	magicDivEnabled       = true
+	magicDivSignedEnabled = true
+)
+
+// strengthReducible reports whether div/rem by the constant c is lowered here
+// rather than via idiv. Signed ±1 stay on idiv (it handles the INT_MIN/-1 trap
+// and x%±1). Power-of-2 divisors are always reducible; non-power-of-2 needs the
+// (gated) magic path.
+func strengthReducible(c int64, w, signed bool) bool {
+	if c == 0 {
+		return false
+	}
+	var ad uint64 // divisor magnitude, as an unsigned W-bit value
+	if signed {
+		if c == 1 || c == -1 {
+			return false
+		}
+		if c < 0 {
+			ad = uint64(-c)
+		} else {
+			ad = uint64(c)
+		}
+	} else {
+		ad = uint64(c)
+		if !w {
+			ad = uint64(uint32(c))
+		}
+	}
+	if ad&(ad-1) == 0 {
+		return true // power of two (or, unsigned, d == 1)
+	}
+	if signed {
+		return magicDivSignedEnabled
+	}
+	return magicDivEnabled
+}
+
+// divConstUnsigned rewrites res (holding the W-bit dividend) to res / d or res % d
+// (unsigned) in place.
+func (f *fn) divConstUnsigned(res Reg, d uint64, w, wantRem bool) {
+	if d == 1 {
+		if wantRem {
+			f.a.XorSelf32(res) // x % 1 == 0
+		}
+		return
+	}
+	if d&(d-1) == 0 { // power of two
+		k := log2u(d)
+		if wantRem {
+			f.andImm(res, int64(d-1), w) // x % 2^k == x & (2^k - 1)
+		} else {
+			f.a.ShiftImm(5, res, byte(k), w) // shr res, k
+		}
+		return
+	}
+	f.divConstUnsignedMagic(res, d, w, wantRem)
+}
+
+// divConstSigned rewrites res (holding the W-bit dividend) to res / d or res % d
+// (signed, truncating toward zero) in place. Only called for |d| >= 2.
+func (f *fn) divConstSigned(res Reg, d int64, w, wantRem bool) {
+	W := uint(32)
+	if w {
+		W = 64
+	}
+	ad := d
+	neg := d < 0
+	if neg {
+		ad = -d
+	}
+	if ad&(ad-1) == 0 { // |d| is a power of two
+		k := log2u(uint64(ad))
+		// Bias the dividend toward zero before an arithmetic shift: add (2^k - 1)
+		// when it is negative. bias = (res >>s (W-1)) >>u (W-k) is 2^k-1 for res<0,
+		// else 0.
+		bias := f.signBias(res, k, W, w)
+		if wantRem {
+			// r = ((res + bias) & (2^k-1)) - bias — sign follows the dividend and is
+			// independent of d's sign (wasm: x % d == x % -d). AluRR store-form
+			// opcodes (0x01 add, 0x29 sub, 0x21 and) take dst first: dst op= src.
+			f.a.AluRR(0x01, res, bias, w) // res += bias
+			f.andImm(res, int64(uint64(ad)-1), w)
+			f.a.AluRR(0x29, res, bias, w) // res -= bias
+		} else {
+			f.a.AluRR(0x01, res, bias, w)    // res += bias
+			f.a.ShiftImm(7, res, byte(k), w) // sar res, k
+			if neg {
+				f.a.Neg(res, w)
+			}
+		}
+		f.pinned = f.pinned.remove(bias)
+		return
+	}
+	f.divConstSignedMagic(res, d, w, wantRem)
+}
+
+// signBias returns an owned register holding (2^k - 1) when res is negative, else
+// 0 — the round-toward-zero bias for a signed power-of-2 divide.
+func (f *fn) signBias(res Reg, k int, W uint, w bool) Reg {
+	t := f.allocReg(maskOf(res))
+	f.pinned = f.pinned.add(t) // pinned so a later andImm scratch can't clobber it
+	f.a.MovReg64(t, res)
+	f.a.ShiftImm(7, t, byte(W-1), w)      // sar t, W-1  → 0 or -1
+	f.a.ShiftImm(5, t, byte(int(W)-k), w) // shr t, W-k  → 0 or (2^k - 1)
+	return t
+}
+
+// andImm emits `and reg, imm`. The mask fits imm32 for k <= 31 (i32, and the
+// common i64 case); a wider i64 mask is loaded into a scratch first.
+func (f *fn) andImm(reg Reg, imm int64, w bool) {
+	if imm >= -1<<31 && imm < 1<<31 {
+		f.a.AluRI(4, reg, int32(imm), w) // and reg, imm32
+		return
+	}
+	t := f.allocReg(maskOf(reg))
+	f.a.MovImm64(t, uint64(imm))
+	f.a.AluRR(0x21, reg, t, w) // reg &= t
+	f.release(t)
+}
+
+// --- magic multiply-high path (non-power-of-2 divisors) ---
+
+// divConstUnsignedMagic rewrites res (the W-bit dividend) to res / d or res % d
+// (unsigned, d not a power of two) via a multiply-high + shift.
+func (f *fn) divConstUnsignedMagic(res Reg, d uint64, w, wantRem bool) {
+	W := uint(32)
+	if w {
+		W = 64
+	}
+	magic, shift, add := magicU(d, W)
+	q := f.magicMulHigh(res, magic, w, false) // q = high(res * magic), pinned
+	if add {
+		// q = ((n - q) >> 1) + q  (an overflow-free way to add n before the shift).
+		t := f.allocReg(maskOf(res, q))
+		f.pinned = f.pinned.add(t)
+		f.a.MovReg64(t, res)
+		f.a.AluRR(0x29, t, q, w) // t -= q  (= n - q)
+		f.a.ShiftImm(5, t, 1, w) // t >>= 1
+		f.a.AluRR(0x01, t, q, w) // t += q
+		f.a.MovReg64(q, t)
+		f.pinned = f.pinned.remove(t)
+	}
+	if shift > 0 {
+		f.a.ShiftImm(5, q, byte(shift), w) // q >>= shift (logical)
+	}
+	if wantRem {
+		f.remFromQuot(res, q, int64(d), w) // res = n - q*d
+	} else {
+		f.a.MovReg64(res, q)
+	}
+	f.pinned = f.pinned.remove(q)
+}
+
+// divConstSignedMagic rewrites res (the W-bit dividend) to res / d or res % d
+// (signed, |d| not a power of two) via a signed multiply-high + shift.
+func (f *fn) divConstSignedMagic(res Reg, d int64, w, wantRem bool) {
+	W := uint(32)
+	if w {
+		W = 64
+	}
+	ad := uint64(d)
+	neg := d < 0
+	if neg {
+		ad = uint64(-d)
+	}
+	magic, shift, addN := magicS(ad, W)
+	q := f.magicMulHigh(res, uint64(magic), w, true) // signed high(res * magic), pinned
+	if addN {
+		f.a.AluRR(0x01, q, res, w) // q += n
+	}
+	if shift > 0 {
+		f.a.ShiftImm(7, q, byte(shift), w) // q >>= shift (arithmetic)
+	}
+	// Turn floor toward negative infinity into truncation toward zero: q += (q>>W-1).
+	sign := f.allocReg(maskOf(res, q))
+	f.pinned = f.pinned.add(sign)
+	f.a.MovReg64(sign, q)
+	f.a.ShiftImm(5, sign, byte(W-1), w) // sign = 1 if q<0 else 0
+	f.a.AluRR(0x01, q, sign, w)         // q += sign
+	f.pinned = f.pinned.remove(sign)
+	if neg {
+		f.a.Neg(q, w) // divisor was negative: negate the quotient
+	}
+	if wantRem {
+		f.remFromQuot(res, q, d, w) // res = n - q*d (d carries its sign; rem sign = dividend's)
+	} else {
+		f.a.MovReg64(res, q)
+	}
+	f.pinned = f.pinned.remove(q)
+}
+
+// magicMulHigh returns a pinned register holding the high W bits of res*magic
+// (signed iff signed). It uses RAX/RDX (spilling their occupants) but leaves res
+// untouched, since the caller keeps res out of RAX/RDX. The caller unpins.
+func (f *fn) magicMulHigh(res Reg, magic uint64, w, signed bool) Reg {
+	f.spillIfUsed(RAX)
+	f.spillIfUsed(RDX)
+	f.pinned = f.pinned.add(RAX)
+	f.pinned = f.pinned.add(RDX)
+	mr := f.allocReg(maskOf(RAX, RDX, res))
+	f.pinned = f.pinned.add(mr)
+	f.a.MovImm64(mr, magic)
+	f.a.MovReg64(RAX, res)
+	if signed {
+		f.a.IMulHigh(mr, w)
+	} else {
+		f.a.Mul(mr, w)
+	}
+	f.pinned = f.pinned.remove(mr)
+	f.pinned = f.pinned.remove(RAX)
+	f.pinned = f.pinned.remove(RDX)
+	hi := f.allocReg(maskOf(res)) // RAX/RDX are free again; avoid clobbering res
+	f.pinned = f.pinned.add(hi)
+	f.a.MovReg64(hi, RDX) // high half of the product
+	return hi
+}
+
+// remFromQuot rewrites nreg (holding the dividend n) to n - q*d — the remainder,
+// given the already-computed quotient q. Low-W bits of q*d suffice (mod 2^W).
+func (f *fn) remFromQuot(nreg, q Reg, d int64, w bool) {
+	t := f.allocReg(maskOf(nreg, q))
+	f.pinned = f.pinned.add(t)
+	f.a.MovImm64(t, uint64(d))
+	f.a.IMul(t, q, w)           // t = d * q
+	f.a.AluRR(0x29, nreg, t, w) // nreg -= t
+	f.pinned = f.pinned.remove(t)
+}

--- a/src/core/compiler/backend/railshot/magicdiv_test.go
+++ b/src/core/compiler/backend/railshot/magicdiv_test.go
@@ -1,0 +1,239 @@
+package amd64
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/src/core/runtime"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// divInvoker compiles a one-arg one-result function once and returns a closure to
+// invoke it repeatedly (avoiding a recompile+mmap per test vector) plus cleanup.
+func divInvoker(t *testing.T, m *wasm.Module) (call func(uint64) uint64, done func()) {
+	t.Helper()
+	cm, err := CompileModule(m)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	eng, err := runtime.NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jm, err := runtime.NewJobMemory(65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ar, err := runtime.NewArena(4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem, entry, err := runtime.MapCode(cm.Code)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	serArgs := ar.Alloc(256)
+	results := ar.Alloc(256)
+	trap := ar.Alloc(8)
+	call = func(arg uint64) uint64 {
+		binary.LittleEndian.PutUint64(serArgs, arg)
+		if err := eng.Call(entry+uintptr(cm.Entry[0]), serArgs, jm.LinearMemory(), trap, results); err != nil {
+			t.Fatalf("call(%#x): %v", arg, err)
+		}
+		return binary.LittleEndian.Uint64(results)
+	}
+	done = func() {
+		runtime.Unmap(mem)
+		ar.Close()
+		jm.Close()
+		eng.Close()
+	}
+	return
+}
+
+// divOp is one wasm division/remainder opcode for a given width.
+type divOp struct {
+	name   string
+	opcode byte
+	signed bool
+	rem    bool
+}
+
+func divOps(w64 bool) []divOp {
+	if w64 {
+		return []divOp{
+			{"i64.div_s", 0x7f, true, false},
+			{"i64.div_u", 0x80, false, false},
+			{"i64.rem_s", 0x81, true, true},
+			{"i64.rem_u", 0x82, false, true},
+		}
+	}
+	return []divOp{
+		{"i32.div_s", 0x6d, true, false},
+		{"i32.div_u", 0x6e, false, false},
+		{"i32.rem_s", 0x6f, true, true},
+		{"i32.rem_u", 0x70, false, true},
+	}
+}
+
+// divConstMod builds (param T)(result T){ local.get 0; T.const d; op } for the
+// given width and divisor bit pattern.
+func divConstMod(t *testing.T, w64 bool, op divOp, d uint64) *wasm.Module {
+	body := []byte{0x00, 0x20, 0x00} // 0 locals; local.get 0
+	if w64 {
+		body = append(body, 0x42)
+		body = append(body, wasmtest.SLEB64(int64(d))...)
+	} else {
+		body = append(body, 0x41)
+		body = append(body, wasmtest.SLEB32(int32(uint32(d)))...)
+	}
+	body = append(body, op.opcode, 0x0b)
+	vt := wasm.I32
+	if w64 {
+		vt = wasm.I64
+	}
+	return mod1(t, []wasm.ValType{vt}, []wasm.ValType{vt}, body)
+}
+
+// refDivRem is the reference (wasm-semantics) result of op(n, d).
+func refDivRem(op divOp, w64 bool, n, d uint64) uint64 {
+	if w64 {
+		if op.signed {
+			a, b := int64(n), int64(d)
+			if op.rem {
+				return uint64(a % b)
+			}
+			return uint64(a / b)
+		}
+		if op.rem {
+			return n % d
+		}
+		return n / d
+	}
+	if op.signed {
+		a, b := int32(uint32(n)), int32(uint32(d))
+		if op.rem {
+			return uint64(uint32(a % b))
+		}
+		return uint64(uint32(a / b))
+	}
+	a, b := uint32(n), uint32(d)
+	if op.rem {
+		return uint64(a % b)
+	}
+	return uint64(a / b)
+}
+
+// TestDivByConstFallback covers the cases that stay on the idiv path: a constant
+// zero divisor (must trap) and signed ±1 (x/-1 == -x with an INT_MIN/-1 trap,
+// x%±1 == 0). Strength reduction must not swallow these.
+func TestDivByConstFallback(t *testing.T) {
+	// div by constant 0 traps.
+	for _, w64 := range []bool{false, true} {
+		for _, op := range divOps(w64) {
+			if _, _, err := runMemAmd64(t, modMem(t, 1, funcParams(w64), funcParams(w64), divBody(w64, op, 0)), nil, 5); err == nil {
+				t.Errorf("%s by const 0 did not trap", op.name)
+			}
+		}
+	}
+	// signed div by -1: x/-1 == -x, and INT_MIN/-1 traps; rem by ±1 == 0.
+	i32 := wasm.I32
+	m := mod1(t, []wasm.ValType{i32}, []wasm.ValType{i32}, divBody(false, divOp{"", 0x6d, true, false}, uint64(^uint32(0))))
+	call, done := divInvoker(t, m)
+	if got := int32(uint32(call(7))); got != -7 {
+		t.Errorf("i32.div_s 7/-1 = %d, want -7", got)
+	}
+	done()
+	// INT_MIN / -1 must trap.
+	if _, _, err := runMemAmd64(t, modMem(t, 1, []wasm.ValType{i32}, []wasm.ValType{i32}, divBody(false, divOp{"", 0x6d, true, false}, uint64(^uint32(0)))), nil, 0x80000000); err == nil {
+		t.Errorf("i32.div_s INT_MIN/-1 did not trap")
+	}
+}
+
+func funcParams(w64 bool) []wasm.ValType {
+	if w64 {
+		return []wasm.ValType{wasm.I64}
+	}
+	return []wasm.ValType{wasm.I32}
+}
+
+// divBody is divConstMod's body without wrapping it in a module.
+func divBody(w64 bool, op divOp, d uint64) []byte {
+	body := []byte{0x00, 0x20, 0x00}
+	if w64 {
+		body = append(body, 0x42)
+		body = append(body, wasmtest.SLEB64(int64(d))...)
+	} else {
+		body = append(body, 0x41)
+		body = append(body, wasmtest.SLEB32(int32(uint32(d)))...)
+	}
+	return append(body, op.opcode, 0x0b)
+}
+
+// TestDivByConstExhaustive checks constant-divisor strength reduction (power-of-2
+// and magic multiply, signed and unsigned, i32 and i64, div and rem) against the
+// idiv reference for a broad set of divisor × dividend pairs.
+func TestDivByConstExhaustive(t *testing.T) {
+	// Dividends: sign boundaries, small magnitudes, and assorted bit patterns.
+	dividends := []uint64{
+		0, 1, 2, 3, 6, 7, 10, 99, 100, 127, 128, 255, 256, 1000, 65535, 65536,
+		0x7fffffff, 0x80000000, 0x80000001, 0xfffffffe, 0xffffffff,
+		0x100000000, 0x123456789a, 0x7fffffffffffffff, 0x8000000000000000,
+		0x8000000000000001, 0xfffffffffffffffe, 0xffffffffffffffff,
+		0xdeadbeef, 0xcafebabecafebabe, 12345678901234567,
+	}
+	// Divisors covering: powers of two (+/-), the add-variant triggers (3,7,...),
+	// small odds/evens, large values, and high-bit unsigned divisors.
+	posDivs := []uint64{
+		2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 25, 100, 1000, 1024,
+		0x10000, 0x7fffffff, 0x80000000, 0xffffffff, 3000000000,
+		0x100000000, 0x123456789, 0x7fffffffffffffff, 0x8000000000000000,
+		0xffffffffffffffff, 0xaaaaaaaaaaaaaaab,
+	}
+	// Signed divisors: |d| >= 2 (±1 use the idiv path), both signs.
+	signedDivs := []int64{
+		2, -2, 3, -3, 4, -4, 5, -5, 7, -7, 8, -8, 10, -10, 100, -100,
+		1024, -1024, 0x7fffffff, -0x7fffffff, 1000000, -1000000,
+		0x100000000, -0x100000000, 0x7fffffffffffffff, -0x7fffffffffffffff,
+		-0x8000000000000000,
+	}
+
+	for _, w64 := range []bool{false, true} {
+		for _, op := range divOps(w64) {
+			divs := posDivs
+			if op.signed {
+				divs = nil
+				for _, d := range signedDivs {
+					divs = append(divs, uint64(d))
+				}
+			}
+			for _, d := range divs {
+				// Skip divisors out of range for the narrower width.
+				if !w64 {
+					if op.signed {
+						sd := int64(int32(uint32(d)))
+						if uint64(sd) != d {
+							continue
+						}
+					} else if d > 0xffffffff {
+						continue
+					}
+				}
+				call, done := divInvoker(t, divConstMod(t, w64, op, d))
+				for _, n := range dividends {
+					want := refDivRem(op, w64, n, d)
+					got := call(n)
+					if !w64 {
+						want &= 0xffffffff
+						got &= 0xffffffff
+					}
+					if got != want {
+						t.Errorf("%s n=%#x d=%#x: got %#x want %#x", op.name, n, d, got, want)
+					}
+				}
+				done()
+			}
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/magicnum.go
+++ b/src/core/compiler/backend/railshot/magicnum.go
@@ -1,0 +1,86 @@
+package amd64
+
+import (
+	"math/big"
+	"math/bits"
+)
+
+// Magic-number derivation for constant division, computed exactly with math/big
+// (no fixed-width overflow to reason about). This is the libdivide / Granlund–
+// Montgomery construction; it runs once per div-by-const at compile time.
+
+// magicU returns (magic, shift, add) for unsigned W-bit division by d, where d is
+// not a power of two and 2 <= d < 2^W. The quotient of n is:
+//
+//	q = MULHU(magic, n)
+//	if add: q = ((n - q) >> 1) + q
+//	q >>= shift
+func magicU(d uint64, W uint) (magic uint64, shift uint, add bool) {
+	one := big.NewInt(1)
+	fl := uint(bits.Len64(d)) - 1 // floor(log2 d)
+	D := new(big.Int).SetUint64(d)
+	// proposed = floor(2^(W+fl) / d), rem = 2^(W+fl) mod d.
+	num := new(big.Int).Lsh(one, W+fl)
+	pm, rem := new(big.Int), new(big.Int)
+	pm.DivMod(num, D, rem)
+	e := new(big.Int).Sub(D, rem) // e = d - rem
+	if e.Cmp(new(big.Int).Lsh(one, fl)) < 0 {
+		pm.Add(pm, one) // magic fits in W bits, no add correction
+		return truncW(pm, W), fl, false
+	}
+	pm.Lsh(pm, 1) // 2*proposed
+	if new(big.Int).Lsh(rem, 1).Cmp(D) >= 0 {
+		pm.Add(pm, one)
+	}
+	pm.Add(pm, one)
+	return truncW(pm, W), fl, true
+}
+
+// magicS returns (magic, shift, addN) for signed W-bit division by the positive
+// magnitude ad (2 <= ad < 2^(W-1), not a power of two). The quotient of n is:
+//
+//	q = MULHS(magic, n)   // signed high half
+//	if addN: q += n
+//	q >>= shift           // arithmetic
+//	q += (unsigned)q >> (W-1)
+//
+// magic is returned as its signed W-bit reinterpretation (may be negative).
+func magicS(ad uint64, W uint) (magic int64, shift uint, addN bool) {
+	one := big.NewInt(1)
+	fl := uint(bits.Len64(ad)) - 1 // floor(log2 ad)
+	D := new(big.Int).SetUint64(ad)
+	// proposed = floor(2^(W-1+fl) / ad), rem = 2^(W-1+fl) mod ad.
+	num := new(big.Int).Lsh(one, W-1+fl)
+	pm, rem := new(big.Int), new(big.Int)
+	pm.DivMod(num, D, rem)
+	e := new(big.Int).Sub(D, rem)
+	if e.Cmp(new(big.Int).Lsh(one, fl)) < 0 {
+		pm.Add(pm, one)
+		return signW(truncW(pm, W), W), fl - 1, false
+	}
+	pm.Lsh(pm, 1)
+	if new(big.Int).Lsh(rem, 1).Cmp(D) >= 0 {
+		pm.Add(pm, one)
+	}
+	pm.Add(pm, one)
+	return signW(truncW(pm, W), W), fl, true
+}
+
+// truncW returns the low W bits of v as a uint64.
+func truncW(v *big.Int, W uint) uint64 {
+	if W >= 64 {
+		return v.Uint64()
+	}
+	return v.Uint64() & ((uint64(1) << W) - 1)
+}
+
+// signW reinterprets the low W bits of m as a signed W-bit value.
+func signW(m uint64, W uint) int64 {
+	if W >= 64 {
+		return int64(m)
+	}
+	if m&(uint64(1)<<(W-1)) != 0 {
+		return int64(m) - (int64(1) << W)
+	}
+	return int64(m)
+}

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -517,6 +517,23 @@ func (a *Asm) Div(r Reg, w bool) {
 	a.emit(0xF7, 0xF0|byte(r&7)) // 0xF7 /6
 }
 
+// Mul computes RDX:RAX = RAX * r (unsigned); the high half lands in RDX. Used by
+// magic division to take the high half of a widening multiply.
+func (a *Asm) Mul(r Reg, w bool) {
+	if w || r >= 8 {
+		a.emit(rex(w, false, false, r >= 8))
+	}
+	a.emit(0xF7, 0xE0|byte(r&7)) // 0xF7 /4
+}
+
+// IMulHigh computes RDX:RAX = RAX * r (signed); the high half lands in RDX.
+func (a *Asm) IMulHigh(r Reg, w bool) {
+	if w || r >= 8 {
+		a.emit(rex(w, false, false, r >= 8))
+	}
+	a.emit(0xF7, 0xE8|byte(r&7)) // 0xF7 /5
+}
+
 // XorSelf32 zeroes r and clears the upper 32 bits.
 func (a *Asm) XorSelf32(r Reg) { a.alu(0x31, r, r, false) }
 


### PR DESCRIPTION
Two constant-folding codegen optimizations for the railshot x86-64 backend.

## Magic-number division (`div-by-const`)
Replaces `div`/`rem` by a **constant** divisor with cheap shifts (power-of-2) or a multiply-high + shift (Granlund–Montgomery magic numbers), avoiding the ~20–40-cycle `idiv`. Covers i32/i64, signed/unsigned, div and rem, negative divisors, and the add-correction magic variant. `c == 0` and signed `±1` stay on the `idiv` path (which owns the div-by-zero and INT_MIN/-1 traps).

- Magic numbers are derived at compile time with `math/big` (exact — no fixed-width overflow to reason about).
- `TestDivByConstExhaustive` checks every op × a broad divisor × dividend grid against the `idiv` reference; `TestDivByConstFallback` covers the trap/±1 fallbacks.
- ~1.9× faster on a div-heavy loop (57.5µs → 29.7µs).

## Redundant zero-extend elimination (`ext-elim`)
`i64.extend_i32_u` of an i32 value produced by a 32-bit instruction is a no-op — a 32-bit write already zeroes the upper half on x86-64. Elides the redundant `mov` when the value stays in place. Whitelisted to provably-clean producers (i32 ALU/shift/mul/div, bit counts, compares, wrap, zext); i32 locals/params and sign-extending loads are excluded (they can carry dirty upper bits).

## Firing on real programs
sqlite3: 217 div-by-const / 202 ext-elim · esbuild: 69 / 72 · lua: 63 / 1323 · bignum: 31 / 48.

## Validation
Spec suite (explicit + guard-page), corpus differential (14 programs), WASI apps differential (4 Rust programs), sqlite regression — all green.