### PR TITLE
feat(wago): snapshot + instance pool API (Capture/Instantiate/Pool)

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -69,13 +69,13 @@ func BenchmarkCompile_wazero(b *testing.B) {
 // caches. Built with -tags wago_guardpage this runs the signals-based
 // (guard-page) path.
 func BenchmarkInstantiate_wago(b *testing.B) {
-	c, err := wago.Compile(fibWasm)
+	c, err := wago.Compile(nil, fibWasm)
 	if err != nil {
 		b.Fatal(err)
 	}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		in, err := wago.Instantiate(c, nil)
+		in, err := wago.Instantiate(c, wago.InstantiateOptions{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -205,13 +205,13 @@ func BenchmarkExecCallOverhead_wazero(b *testing.B) {
 // boundary crossing. Compare against ExecCallOverhead (a plain guest-only call):
 // the difference is the added cost of the host-boundary round trip.
 func BenchmarkExecHostRoundtrip_wago(b *testing.B) {
-	c, err := wago.Compile(hostcallWasm)
+	c, err := wago.Compile(nil, hostcallWasm)
 	if err != nil {
 		b.Fatal(err)
 	}
-	in, err := wago.Instantiate(c, wago.Imports{
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wago.Imports{
 		"env.host": wago.HostFunc(func(_ wago.HostModule, p, r []uint64) { r[0] = p[0] + 1 }),
-	})
+	}})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -256,11 +256,11 @@ func BenchmarkExecHostRoundtrip_wazero(b *testing.B) {
 
 func globalBenchInstance(b *testing.B) (*wago.Instance, func()) {
 	b.Helper()
-	c, err := wago.Compile(globalBenchWasm)
+	c, err := wago.Compile(nil, globalBenchWasm)
 	if err != nil {
 		b.Fatal(err)
 	}
-	in, err := wago.Instantiate(c, nil)
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/bench/cmd/jsonprof/main.go
+++ b/bench/cmd/jsonprof/main.go
@@ -44,12 +44,12 @@ func main() {
 	if len(os.Args) > 2 && os.Args[2] == "guard" {
 		cfg = cfg.WithBoundsChecks(wago.BoundsChecksSignalsBased)
 	}
-	c, err := wago.CompileWithConfig(cfg, b)
+	c, err := wago.Compile(cfg, b)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "compile:", err)
 		os.Exit(1)
 	}
-	in, err := wago.Instantiate(c, wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})})
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})}})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "instantiate:", err)
 		os.Exit(1)

--- a/bench/corpus_differential_test.go
+++ b/bench/corpus_differential_test.go
@@ -51,11 +51,11 @@ func runCorpusDifferentialCase(t *testing.T, mode wago.BoundsCheckMode, file, in
 		t.Fatalf("read %s: %v", file, err)
 	}
 	cfg := wago.NewRuntimeConfig().WithBoundsChecks(mode)
-	comp, err := wago.CompileWithConfig(cfg, b)
+	comp, err := wago.Compile(cfg, b)
 	if err != nil {
 		t.Fatalf("%s compile: %v", file, err)
 	}
-	in, err := wago.Instantiate(comp, wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})})
+	in, err := wago.Instantiate(comp, wago.InstantiateOptions{Imports: wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})}})
 	if err != nil {
 		t.Fatalf("%s instantiate: %v", file, err)
 	}

--- a/bench/inflate_known_bug_test.go
+++ b/bench/inflate_known_bug_test.go
@@ -40,12 +40,12 @@ func TestInflateKnownMiscompile(t *testing.T) {
 	if err != nil {
 		t.Skipf("inflate.wasm not present")
 	}
-	c, err := wago.Compile(src)
+	c, err := wago.Compile(nil, src)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
 	var stdout bytes.Buffer
-	in, err := wago.Instantiate(c, wasi.Imports(wasi.Config{Stdout: &stdout, Args: []string{"inflate.wasm"}}))
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wasi.Imports(wasi.Config{Stdout: &stdout, Args: []string{"inflate.wasm"}})})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}

--- a/bench/inflate_regression_test.go
+++ b/bench/inflate_regression_test.go
@@ -38,12 +38,12 @@ func TestInflateMiscompileRegression(t *testing.T) {
 	if err != nil {
 		t.Skipf("inflate.wasm not present")
 	}
-	c, err := wago.Compile(src)
+	c, err := wago.Compile(nil, src)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
 	var stdout bytes.Buffer
-	in, err := wago.Instantiate(c, wasi.Imports(wasi.Config{Stdout: &stdout, Args: []string{"inflate.wasm"}}))
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wasi.Imports(wasi.Config{Stdout: &stdout, Args: []string{"inflate.wasm"}})})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}

--- a/bench/jsonas_guard_test.go
+++ b/bench/jsonas_guard_test.go
@@ -15,11 +15,11 @@ import (
 // bounds check is elided and out-of-bounds accesses fault into a trap handler.
 func wagoJSONGuard(t *testing.T, wasmBytes []byte) (ser, deser func()) {
 	cfg := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksSignalsBased)
-	c, err := wago.CompileWithConfig(cfg, wasmBytes)
+	c, err := wago.Compile(cfg, wasmBytes)
 	if err != nil {
 		t.Fatalf("compile (guard): %v", err)
 	}
-	in, err := wago.Instantiate(c, wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})})
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})}})
 	if err != nil {
 		t.Fatalf("instantiate (guard): %v", err)
 	}
@@ -51,11 +51,11 @@ func TestJsonAsGuardCorrect(t *testing.T) {
 		if guard {
 			cfg = cfg.WithBoundsChecks(wago.BoundsChecksSignalsBased)
 		}
-		c, err := wago.CompileWithConfig(cfg, b)
+		c, err := wago.Compile(cfg, b)
 		if err != nil {
 			t.Fatalf("compile: %v", err)
 		}
-		in, err := wago.Instantiate(c, wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})})
+		in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})}})
 		if err != nil {
 			t.Fatalf("instantiate: %v", err)
 		}
@@ -111,11 +111,11 @@ func TestMemSumGuard(t *testing.T) {
 		if guard {
 			cfg = cfg.WithBoundsChecks(wago.BoundsChecksSignalsBased)
 		}
-		c, err := wago.CompileWithConfig(cfg, mb)
+		c, err := wago.Compile(cfg, mb)
 		if err != nil {
 			t.Fatalf("compile: %v", err)
 		}
-		in, err := wago.Instantiate(c, nil)
+		in, err := wago.Instantiate(c, wago.InstantiateOptions{})
 		if err != nil {
 			t.Fatalf("instantiate: %v", err)
 		}

--- a/bench/jsonas_test.go
+++ b/bench/jsonas_test.go
@@ -58,11 +58,11 @@ func wagoJSON(tb testing.TB, wasmBytes []byte) (ser, deser func()) {
 	// Force explicit bounds so this baseline is deterministic regardless of the
 	// WAGO_BOUNDS environment default.
 	cfg := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
-	c, err := wago.CompileWithConfig(cfg, wasmBytes)
+	c, err := wago.Compile(cfg, wasmBytes)
 	if err != nil {
 		tb.Fatalf("compile: %v", err)
 	}
-	in, err := wago.Instantiate(c, wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})})
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})}})
 	if err != nil {
 		tb.Fatalf("instantiate: %v", err)
 	}

--- a/bench/sqlite_exec_test.go
+++ b/bench/sqlite_exec_test.go
@@ -48,7 +48,7 @@ func sqliteMemLimits(m *wasm.Module) (min, max uint32) {
 
 func BenchmarkSqliteQueryWago(b *testing.B) {
 	src := sqliteBytes(b)
-	c, err := wago.Compile(src)
+	c, err := wago.Compile(nil, src)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func BenchmarkSqliteQueryWago(b *testing.B) {
 	for _, fn := range c.Imports {
 		imp[fn] = wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})
 	}
-	in, err := wago.Instantiate(c, imp)
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: imp})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/bench/suite_test.go
+++ b/bench/suite_test.go
@@ -200,7 +200,7 @@ func BenchmarkCompile(b *testing.B) {
 func BenchmarkCompileFull(b *testing.B) {
 	eachModule(b, "CompileFull", func(b *testing.B, m corpusModule) {
 		for i := 0; i < b.N; i++ {
-			if _, err := wago.Compile(m.bytes); err != nil {
+			if _, err := wago.Compile(nil, m.bytes); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -210,14 +210,14 @@ func BenchmarkCompileFull(b *testing.B) {
 // BenchmarkInstantiate times instance setup for an already-compiled module.
 func BenchmarkInstantiate(b *testing.B) {
 	eachModule(b, "Instantiate", func(b *testing.B, m corpusModule) {
-		c, err := wago.Compile(m.bytes)
+		c, err := wago.Compile(nil, m.bytes)
 		if err != nil {
 			b.Fatal(err)
 		}
 		imports := hostStubs(c)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			in, err := wago.Instantiate(c, imports)
+			in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: imports})
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -233,11 +233,11 @@ func BenchmarkExec(b *testing.B) {
 		if len(m.Exec) == 0 || !m.supports("Exec") {
 			continue
 		}
-		c, err := wago.Compile(m.bytes)
+		c, err := wago.Compile(nil, m.bytes)
 		if err != nil {
 			b.Fatalf("%s compile: %v", m.name(), err)
 		}
-		in, err := wago.Instantiate(c, hostStubs(c))
+		in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: hostStubs(c)})
 		if err != nil {
 			b.Fatalf("%s instantiate: %v", m.name(), err)
 		}

--- a/bench/wasi_differential_test.go
+++ b/bench/wasi_differential_test.go
@@ -48,12 +48,12 @@ func TestWASIAppsDifferential(t *testing.T) {
 func runWASIApp(t *testing.T, src []byte, mode wago.BoundsCheckMode, file string) string {
 	t.Helper()
 	cfg := wago.NewRuntimeConfig().WithBoundsChecks(mode)
-	c, err := wago.CompileWithConfig(cfg, src)
+	c, err := wago.Compile(cfg, src)
 	if err != nil {
 		t.Fatalf("%s (%v) compile: %v", file, mode, err)
 	}
 	var stdout bytes.Buffer
-	in, err := wago.Instantiate(c, wasi.Imports(wasi.Config{Stdout: &stdout, Args: []string{file}}))
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wasi.Imports(wasi.Config{Stdout: &stdout, Args: []string{file}})})
 	if err != nil {
 		t.Fatalf("%s (%v) instantiate: %v", file, mode, err)
 	}

--- a/bench/wasi_instantiate_test.go
+++ b/bench/wasi_instantiate_test.go
@@ -23,14 +23,14 @@ func BenchmarkInstBigWago(b *testing.B) {
 		if err != nil {
 			continue
 		}
-		c, err := wago.Compile(src)
+		c, err := wago.Compile(nil, src)
 		if err != nil {
 			b.Fatalf("%s compile: %v", name, err)
 		}
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				in, err := wago.Instantiate(c, wasi.Imports(wasi.Config{Stdout: io.Discard, Args: []string{name}}))
+				in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wasi.Imports(wasi.Config{Stdout: io.Discard, Args: []string{name}})})
 				if err != nil {
 					b.Fatalf("instantiate: %v", err)
 				}

--- a/bench/wasi_run_test.go
+++ b/bench/wasi_run_test.go
@@ -31,11 +31,11 @@ func BenchmarkRunWago(b *testing.B) {
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				c, err := wago.Compile(src)
+				c, err := wago.Compile(nil, src)
 				if err != nil {
 					b.Fatalf("compile: %v", err)
 				}
-				in, err := wago.Instantiate(c, wasi.Imports(wasi.Config{Stdout: io.Discard, Args: []string{name}}))
+				in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: wasi.Imports(wasi.Config{Stdout: io.Discard, Args: []string{name}})})
 				if err != nil {
 					b.Fatalf("instantiate: %v", err)
 				}

--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -167,7 +167,7 @@ func runCmd(args []string) {
 		for k, v := range pluginImports(plugins, pos) {
 			imports[k] = v
 		}
-		in, err := wago.Instantiate(c, imports)
+		in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: imports})
 		if err != nil {
 			fatal("%v", err)
 		}
@@ -190,7 +190,7 @@ func runCmd(args []string) {
 	for k, v := range pluginImports(plugins, pos) {
 		imports[k] = v
 	}
-	in, err := wago.Instantiate(c, imports)
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: imports})
 	if err != nil {
 		fatal("%v", err)
 	}
@@ -213,7 +213,7 @@ func mustLoad(file string, cfg *wago.RuntimeConfig) *wago.Compiled {
 	if wago.IsCompiled(src) {
 		c, err = wago.Load(src) // precompiled .wago — codegen options baked in already
 	} else {
-		c, err = wago.CompileWithConfig(cfg, src)
+		c, err = wago.Compile(cfg, src)
 	}
 	if err != nil {
 		fatal("%v", err)

--- a/examples/01-hello/main.go
+++ b/examples/01-hello/main.go
@@ -16,13 +16,13 @@ import (
 func main() {
 	// mods.Add() returns the bytes of a module exporting add(a, b i32) -> i32.
 	// In a real project these bytes come from a .wasm file on disk.
-	compiled, err := wago.Compile(mods.Add())
+	compiled, err := wago.Compile(nil, mods.Add())
 	if err != nil {
 		panic(err)
 	}
 
 	// Instantiate creates a runnable instance. This module has no imports.
-	inst, err := wago.Instantiate(compiled, nil)
+	inst, err := wago.Instantiate(compiled, wago.InstantiateOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/examples/03-host-import/main.go
+++ b/examples/03-host-import/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	// The module imports host.mul(a, b i32) -> i32 and exports square(x) = mul(x, x).
-	compiled, err := wago.Compile(mods.SquareViaHost())
+	compiled, err := wago.Compile(nil, mods.SquareViaHost())
 	if err != nil {
 		panic(err)
 	}
@@ -28,7 +28,7 @@ func main() {
 		results[0] = wago.I32(a * b)
 	})
 
-	inst, err := wago.Instantiate(compiled, wago.Imports{"host.mul": mul})
+	inst, err := wago.Instantiate(compiled, wago.InstantiateOptions{Imports: wago.Imports{"host.mul": mul}})
 	if err != nil {
 		panic(err)
 	}

--- a/examples/04-memory/main.go
+++ b/examples/04-memory/main.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	// The module holds "hello from wasm" in its memory and calls
 	// env.write(ptr, len) with the location of that string.
-	compiled, err := wago.Compile(mods.MemWriter("hello from wasm"))
+	compiled, err := wago.Compile(nil, mods.MemWriter("hello from wasm"))
 	if err != nil {
 		panic(err)
 	}
@@ -33,7 +33,7 @@ func main() {
 		results[0] = wago.I32(int32(n))
 	})
 
-	inst, err := wago.Instantiate(compiled, wago.Imports{"env.write": write})
+	inst, err := wago.Instantiate(compiled, wago.InstantiateOptions{Imports: wago.Imports{"env.write": write}})
 	if err != nil {
 		panic(err)
 	}

--- a/examples/16-serialize/main.go
+++ b/examples/16-serialize/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	// Compile once...
-	compiled, err := wago.Compile(mods.Add())
+	compiled, err := wago.Compile(nil, mods.Add())
 	if err != nil {
 		panic(err)
 	}
@@ -33,7 +33,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	inst, _ := wago.Instantiate(loaded, nil)
+	inst, _ := wago.Instantiate(loaded, wago.InstantiateOptions{})
 	defer inst.Close()
 
 	out, _ := inst.Invoke("add", wago.I32(19), wago.I32(23))

--- a/examples/17-snapshot-pool/main.go
+++ b/examples/17-snapshot-pool/main.go
@@ -1,0 +1,69 @@
+// Example 17: snapshots and instance pools.
+//
+// A snapshot captures a module's initialized (or warmed-up) memory + globals so
+// fresh instances can be created in that exact state without re-running init.
+// Snapshots stay in local memory by default and can be serialized to a blob for
+// disk. An InstancePool restored from a snapshot leases instances and resets them
+// to the captured state between uses — the fast path for per-request isolation.
+//
+//	go run ./examples/17-snapshot-pool
+package main
+
+import (
+	"context"
+	"fmt"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/examples/internal/mods"
+)
+
+func main() {
+	// Compile a module with a mutable global `count`, bumped by `inc`.
+	compiled, err := wago.Compile(nil, mods.Counter())
+	if err != nil {
+		panic(err)
+	}
+
+	// Warm snapshot: run `inc` twice at capture time, then snapshot the state.
+	snap, err := wago.Capture(compiled, wago.SnapshotOptions{
+		Kind:     wago.SnapshotWarm,
+		WarmFunc: "inc",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Every instance restored from the snapshot starts warm (count == 1 here,
+	// since the warm func ran once) — no start/init replay.
+	inst, err := wago.Instantiate(snap, wago.InstantiateOptions{})
+	if err != nil {
+		panic(err)
+	}
+	warm, _ := inst.Global("count")
+	fmt.Printf("restored instance starts at count = %d\n", wago.AsI32(warm))
+	inst.Close()
+
+	// Snapshots are self-contained blobs: write to disk, reload elsewhere.
+	blob, _ := snap.MarshalBinary()
+	fmt.Printf("snapshot blob: %d bytes, is-snapshot=%v\n", len(blob), wago.IsSnapshot(blob))
+
+	// A pool leases instances and resets them to the snapshot between uses, so
+	// each Invoke sees the same warm starting state regardless of prior calls.
+	pool, err := wago.Pool(snap, wago.SnapshotPoolOptions{MinIdle: 4, MaxInstances: 32})
+	if err != nil {
+		panic(err)
+	}
+	defer pool.Close()
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		out, err := pool.Invoke(ctx, "inc") // each call: reset -> inc -> returns 2
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("pool.Invoke #%d -> inc returned %d (isolated per lease)\n", i, wago.AsI32(out[0]))
+	}
+
+	st := pool.Stats()
+	fmt.Printf("pool stats: live=%d idle=%d created=%d reused=%d\n", st.Live, st.Idle, st.Created, st.Reused)
+}

--- a/spectest_exec_test.go
+++ b/spectest_exec_test.go
@@ -346,7 +346,7 @@ func (st *specState) instantiate(filename string) (*Instance, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := Compile(data)
+	c, err := Compile(nil, data)
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +434,7 @@ func (st *specState) instantiate(filename string) (*Instance, error) {
 			return nil, fmt.Errorf("cross-instance linking unsupported: table import %q", key)
 		}
 	}
-	in, err := Instantiate(c, imports)
+	in, err := Instantiate(c, InstantiateOptions{Imports: imports})
 	if err != nil {
 		return nil, err
 	}

--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -177,6 +177,31 @@ func (j *JobMemory) reclaimForReuse() error {
 // native code maintains (memory.grow updates it without involving Go).
 func (j *JobMemory) curBytes() int { return int(j.getU32(offActualLinMemByteSize)) }
 
+// RestoreLinear reloads linear memory from data (a full snapshot image whose
+// length is the desired logical size) and resets the size caches to match, so
+// the mapping returns to exactly the captured state for reuse. Any pages the
+// previous tenant grew or dirtied beyond len(data) are zeroed, so a later
+// memory.grow re-exposes them as spec-required zero bytes. Explicit-bounds
+// (non-guarded) mappings only; guard-page reuse would also need a PROT re-arm.
+func (j *JobMemory) RestoreLinear(data []byte) {
+	n := len(data)
+	old := j.curBytes()
+	hi := n
+	if old > hi {
+		hi = old
+	}
+	if hi > j.linLen {
+		hi = j.linLen
+	}
+	lin := j.mem[j.linOff : j.linOff+hi]
+	copy(lin, data)
+	if old > n {
+		clear(lin[n:old]) // drop grown/dirtied tail back to zero
+	}
+	j.putU32(offActualLinMemByteSize, uint32(n))
+	j.putU32(offLinMemWasmSize, uint32(n/65536))
+}
+
 // CurrentBytes returns the host-facing view of linear memory at its current
 // (possibly grown) logical size — what Memory.Bytes exposes.
 func (j *JobMemory) CurrentBytes() []byte {

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -27,16 +27,11 @@ const (
 	GCRuntimeIncrementalMarkSweep = gc.RuntimeIncrementalMarkSweep
 )
 
-// Compile decodes, validates, and compiles a wasm module to native code using
-// the default configuration.
-func Compile(wasmBytes []byte) (*Compiled, error) {
-	return CompileWithConfig(NewRuntimeConfig(), wasmBytes)
-}
-
-// CompileWithConfig is Compile under an explicit RuntimeConfig: the config's
-// feature set gates which modules are accepted and its bounds-check mode selects
-// the code-generation strategy.
-func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
+// Compile decodes, validates, and compiles a wasm module to native code under
+// the given RuntimeConfig: the config's feature set gates which modules are
+// accepted and its bounds-check mode selects the code-generation strategy. Pass
+// nil for the default configuration.
+func Compile(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
 	if cfg == nil {
 		cfg = NewRuntimeConfig()
 	}
@@ -433,10 +428,10 @@ func instrsUseMemoryGrow(instrs []wasm.Instruction) bool {
 	return false
 }
 
-// MustCompile is like Compile but panics on error, for tests, examples, and
-// package-level initialization.
+// MustCompile is like Compile with the default config but panics on error, for
+// tests, examples, and package-level initialization.
 func MustCompile(wasmBytes []byte) *Compiled {
-	c, err := Compile(wasmBytes)
+	c, err := Compile(nil, wasmBytes)
 	if err != nil {
 		panic("wago: MustCompile: " + err.Error())
 	}
@@ -764,7 +759,7 @@ func Load(b []byte) (*Compiled, error) {
 		c := &Compiled{}
 		return c, c.UnmarshalBinary(b)
 	}
-	return Compile(b)
+	return Compile(nil, b)
 }
 
 // Invoke marshals slot-based arguments/results around one native WasmWrapper

--- a/src/wago/bench_test.go
+++ b/src/wago/bench_test.go
@@ -15,7 +15,7 @@ var benchIntSink int32
 
 func benchMustCompile(b *testing.B, mod []byte) *Compiled {
 	b.Helper()
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		b.Fatalf("Compile: %v", err)
 	}
@@ -64,7 +64,7 @@ func BenchmarkCompileSmallScalar(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c, err := Compile(mod)
+		c, err := Compile(nil, mod)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -74,7 +74,7 @@ func BenchmarkCompileSmallScalar(b *testing.B) {
 
 func BenchmarkInvokeAddOne(b *testing.B) {
 	c := benchMustCompile(b, benchAddOneModule())
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}
@@ -96,7 +96,7 @@ func BenchmarkInvokeAddOne(b *testing.B) {
 func BenchmarkInvokeLegacyHostFuncVoid(b *testing.B) {
 	c := benchMustCompile(b, voidI32ImportCallerModule())
 	var calls int32
-	in, err := Instantiate(c, Imports{"env.log": HostFunc(func(_ HostModule, p, _ []uint64) { calls += AsI32(p[0]) & 1 })})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.log": HostFunc(func(_ HostModule, p, _ []uint64) { calls += AsI32(p[0]) & 1 })}})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}
@@ -114,7 +114,7 @@ func BenchmarkInvokeLegacyHostFuncVoid(b *testing.B) {
 
 func BenchmarkInvokeHostFuncDirect(b *testing.B) {
 	c := benchMustCompile(b, benchReturningImportModule())
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] + 1 })})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] + 1 })}})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}
@@ -135,7 +135,7 @@ func BenchmarkInvokeReflectedHostFuncDirect(b *testing.B) {
 		b.Skip("reflected host imports are unavailable under TinyGo")
 	}
 	c := benchMustCompile(b, benchReturningImportModule())
-	in, err := Instantiate(c, Imports{"env.f": func(v int32) int32 { return v + 1 }})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": func(v int32) int32 { return v + 1 }}})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}
@@ -153,7 +153,7 @@ func BenchmarkInvokeReflectedHostFuncDirect(b *testing.B) {
 
 func BenchmarkInvokeHostFuncTableIndirect(b *testing.B) {
 	c := benchMustCompile(b, benchTableReturningImportModule())
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] + 1 })})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] + 1 })}})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}
@@ -172,7 +172,7 @@ func BenchmarkInvokeHostFuncTableIndirect(b *testing.B) {
 func BenchmarkInvokeLegacyHostFuncTableIndirect(b *testing.B) {
 	c := benchMustCompile(b, benchTableVoidImportModule())
 	var calls int32
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, _ []uint64) { calls += AsI32(p[0]) & 1 })})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, _ []uint64) { calls += AsI32(p[0]) & 1 })}})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}
@@ -195,7 +195,7 @@ func BenchmarkInvokeReflectedHostFuncTableIndirect(b *testing.B) {
 		b.Skip("reflected host imports are unavailable under TinyGo")
 	}
 	c := benchMustCompile(b, benchTableReturningImportModule())
-	in, err := Instantiate(c, Imports{"env.f": func(v int32) int32 { return v + 1 }})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": func(v int32) int32 { return v + 1 }}})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}
@@ -218,7 +218,7 @@ func BenchmarkInvokeHostFuncV128TableIndirect(b *testing.B) {
 	c := benchMustCompile(b, benchTableV128ImportModule())
 	inVec := V128{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	lo, hi := hostV128Slots(inVec)
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0], r[1] = p[0]+1, p[1]+1 })})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0], r[1] = p[0]+1, p[1]+1 })}})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}
@@ -240,7 +240,7 @@ func BenchmarkInstantiateImportedStartHostFunc(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		in, err := Instantiate(c, imports)
+		in, err := Instantiate(c, InstantiateOptions{Imports: imports})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -252,7 +252,7 @@ func BenchmarkInstantiateTableHostFuncThunk(b *testing.B) {
 	c := benchMustCompile(b, benchTableReturningImportModule())
 	imports := Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] })}
 	// Warm the host link cache so the benchmark isolates instance wiring and thunk mapping.
-	warm, err := Instantiate(c, imports)
+	warm, err := Instantiate(c, InstantiateOptions{Imports: imports})
 	if err != nil {
 		b.Fatalf("warm Instantiate: %v", err)
 	}
@@ -260,7 +260,7 @@ func BenchmarkInstantiateTableHostFuncThunk(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		in, err := Instantiate(c, imports)
+		in, err := Instantiate(c, InstantiateOptions{Imports: imports})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/src/wago/callargs_test.go
+++ b/src/wago/callargs_test.go
@@ -54,11 +54,11 @@ func TestCallMixedArgKinds(t *testing.T) {
 				(local.get 0)
 				(i32.add (local.get 0) (i32.const 1))
 				(i32.const 4))))`)
-	c, err := Compile(wasm)
+	c, err := Compile(nil, wasm)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}

--- a/src/wago/code_mapping_test.go
+++ b/src/wago/code_mapping_test.go
@@ -9,24 +9,24 @@ import (
 )
 
 func TestCompiledCloseRejectsFutureInstantiate(t *testing.T) {
-	c, err := Compile(fibWasm)
+	c, err := Compile(nil, fibWasm)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
 	if err := c.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if _, err := Instantiate(c, nil); err == nil || !strings.Contains(err.Error(), "closed") {
+	if _, err := Instantiate(c, InstantiateOptions{}); err == nil || !strings.Contains(err.Error(), "closed") {
 		t.Fatalf("Instantiate after Close error = %v, want closed", err)
 	}
 }
 
 func TestCompiledCloseKeepsExistingInstanceAlive(t *testing.T) {
-	c, err := Compile(fibWasm)
+	c, err := Compile(nil, fibWasm)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestCompiledCloseKeepsExistingInstanceAlive(t *testing.T) {
 	if err := c.Close(); err != nil {
 		t.Fatalf("Close with live instance: %v", err)
 	}
-	if _, err := Instantiate(c, nil); err == nil || !strings.Contains(err.Error(), "closed") {
+	if _, err := Instantiate(c, InstantiateOptions{}); err == nil || !strings.Contains(err.Error(), "closed") {
 		t.Fatalf("Instantiate after Close error = %v, want closed", err)
 	}
 	if in.eng != eng || in.jm != jm || in.ar != ar {

--- a/src/wago/codec_hardening_test.go
+++ b/src/wago/codec_hardening_test.go
@@ -26,7 +26,7 @@ func TestMarshalRejectsSyncHostLinkedModule(t *testing.T) {
 	// A void f64 import cannot use the async replay path, so binding it forces the
 	// synchronous host dispatcher.
 	c := MustCompile(voidF64ImportCallerModule())
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(HostModule, []uint64, []uint64) {})})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(HostModule, []uint64, []uint64) {})}})
 	if err != nil {
 		t.Fatalf("instantiate sync host module: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestMarshalGlobalScalarAndV128RoundTrip(t *testing.T) {
 	if err := dec.UnmarshalBinary(blob); err != nil {
 		t.Fatalf("UnmarshalBinary: %v", err)
 	}
-	in, err := Instantiate(&dec, nil)
+	in, err := Instantiate(&dec, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestUnmarshalRejectsSIMDBlobWhenHostUnsupported(t *testing.T) {
 	t.Setenv("WAGO_BOUNDS", "explicit")
 	old := simdHostFeaturesSupported
 	simdHostFeaturesSupported = func() bool { return true }
-	c, err := Compile(codecSIMDModule())
+	c, err := Compile(nil, codecSIMDModule())
 	if err != nil {
 		simdHostFeaturesSupported = old
 		t.Fatalf("Compile SIMD module: %v", err)
@@ -149,7 +149,7 @@ func TestUnmarshalRejectsV128BlockTypeBlobWhenHostUnsupported(t *testing.T) {
 	t.Setenv("WAGO_BOUNDS", "explicit")
 	old := simdHostFeaturesSupported
 	simdHostFeaturesSupported = func() bool { return true }
-	c, err := Compile(codecSIMDBlockTypeModule())
+	c, err := Compile(nil, codecSIMDBlockTypeModule())
 	if err != nil {
 		simdHostFeaturesSupported = old
 		t.Fatalf("Compile SIMD block type module: %v", err)

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -229,16 +229,16 @@ func (c *RuntimeConfig) DeferBoundsChecks() bool { return !c.noDeferBounds }
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }
 
 // Compile decodes, validates, and compiles wasmBytes under this config. It is the
-// fluent form of CompileWithConfig(c, wasmBytes):
+// fluent form of Compile(c, wasmBytes):
 //
 //	mod, err := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksSignalsBased).Compile(b)
 func (c *RuntimeConfig) Compile(wasmBytes []byte) (*Compiled, error) {
-	return CompileWithConfig(c, wasmBytes)
+	return Compile(c, wasmBytes)
 }
 
 // MustCompile is like Compile but panics on error.
 func (c *RuntimeConfig) MustCompile(wasmBytes []byte) *Compiled {
-	m, err := CompileWithConfig(c, wasmBytes)
+	m, err := Compile(c, wasmBytes)
 	if err != nil {
 		panic("wago: MustCompile: " + err.Error())
 	}

--- a/src/wago/config_guardpage_test.go
+++ b/src/wago/config_guardpage_test.go
@@ -25,14 +25,14 @@ func loadModule() []byte {
 // via the signal handler rather than an inline check.
 func TestConfigSignalsBasedEndToEnd(t *testing.T) {
 	cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksSignalsBased)
-	c, err := CompileWithConfig(cfg, loadModule())
+	c, err := Compile(cfg, loadModule())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if c.boundsMode != BoundsChecksSignalsBased {
 		t.Fatal("compiled module did not record signals-based mode")
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -105,28 +105,28 @@ func v128FuncImportModule() []byte {
 }
 
 func TestConfigDefaultAcceptsSupportedFeatures(t *testing.T) {
-	if _, err := Compile(signExtModule()); err != nil {
+	if _, err := Compile(nil, signExtModule()); err != nil {
 		t.Fatalf("default config should accept sign-extension: %v", err)
 	}
 	if hostSupportsSIMD() {
-		if _, err := Compile(simdModule()); err != nil {
+		if _, err := Compile(nil, simdModule()); err != nil {
 			t.Fatalf("default config should accept supported SIMD: %v", err)
 		}
 	}
-	if _, err := CompileWithConfig(nil, signExtModule()); err != nil {
+	if _, err := Compile(nil, signExtModule()); err != nil {
 		t.Fatalf("nil config should use defaults: %v", err)
 	}
 }
 
 func TestConfigFeatureGatingRejects(t *testing.T) {
 	cfg := NewRuntimeConfig().WithCoreFeatures(coreFeaturesWago &^ CoreFeatureSignExtensionOps)
-	_, err := CompileWithConfig(cfg, signExtModule())
+	_, err := Compile(cfg, signExtModule())
 	if err == nil || !strings.Contains(err.Error(), "sign-extension") {
 		t.Fatalf("disabling sign-extension should reject the module, got %v", err)
 	}
 
 	cfg = NewRuntimeConfig().WithCoreFeatures(coreFeaturesWago &^ CoreFeatureSIMD)
-	_, err = CompileWithConfig(cfg, simdModule())
+	_, err = Compile(cfg, simdModule())
 	if err == nil || !strings.Contains(err.Error(), "simd disabled") {
 		t.Fatalf("disabling SIMD should reject the module, got %v", err)
 	}
@@ -134,14 +134,14 @@ func TestConfigFeatureGatingRejects(t *testing.T) {
 
 func TestConfigValidationRejectsUnsupported(t *testing.T) {
 	cfg := NewRuntimeConfig().WithFeature(CoreFeatureTailCall, true)
-	if _, err := CompileWithConfig(cfg, signExtModule()); err == nil {
+	if _, err := Compile(cfg, signExtModule()); err == nil {
 		t.Fatal("enabling unsupported tail-call should error")
 	}
 }
 
 func TestConfigSignalsBasedRequiresBuildTag(t *testing.T) {
 	cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksSignalsBased)
-	_, err := CompileWithConfig(cfg, signExtModule())
+	_, err := Compile(cfg, signExtModule())
 	if guardPageBuilt {
 		if err != nil {
 			t.Fatalf("signals-based should compile under the build tag: %v", err)
@@ -231,10 +231,10 @@ func TestConfigRejectsSIMDWhenHostUnsupported(t *testing.T) {
 	old := simdHostFeaturesSupported
 	simdHostFeaturesSupported = func() bool { return false }
 	defer func() { simdHostFeaturesSupported = old }()
-	if _, err := Compile(signExtModule()); err != nil {
+	if _, err := Compile(nil, signExtModule()); err != nil {
 		t.Fatalf("non-SIMD module should still compile when host SIMD is unavailable: %v", err)
 	}
-	_, err := Compile(simdModule())
+	_, err := Compile(nil, simdModule())
 	if err == nil || !strings.Contains(err.Error(), "simd disabled") {
 		t.Fatalf("SIMD module should be rejected when host SIMD is unavailable, got %v", err)
 	}
@@ -262,7 +262,7 @@ func TestConfigRejectsV128TypesWhenHostUnsupported(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := Compile(tc.mod)
+			_, err := Compile(nil, tc.mod)
 			if err == nil || !strings.Contains(err.Error(), "v128") {
 				t.Fatalf("v128 module should be rejected when host SIMD is unavailable, got %v", err)
 			}

--- a/src/wago/cross_instance_test.go
+++ b/src/wago/cross_instance_test.go
@@ -39,7 +39,7 @@ func TestCrossInstanceMemoryShared(t *testing.T) {
 		// data: offset 10, bytes {1,2,3}
 		wasmtest.Section(11, wasmtest.Vec(append([]byte{0x00, 0x41, 0x0a, 0x0b, 0x03}, 0x01, 0x02, 0x03))),
 	)
-	inA, err := Instantiate(MustCompile(modA), nil)
+	inA, err := Instantiate(MustCompile(modA), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate A: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestCrossInstanceMemoryShared(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x2d, 0x00, 0x00, 0x0b}),             // load8_u
 		)),
 	)
-	inB, err := Instantiate(MustCompile(modB), Imports{"env.mem": memImport})
+	inB, err := Instantiate(MustCompile(modB), InstantiateOptions{Imports: Imports{"env.mem": memImport}})
 	if err != nil {
 		t.Fatalf("instantiate B: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestCrossInstanceGlobalShared(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x24, 0x00, 0x0b}), // local.get 0; global.set 0; end
 		)),
 	)
-	inA, err := Instantiate(MustCompile(modA), nil)
+	inA, err := Instantiate(MustCompile(modA), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate A: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestCrossInstanceGlobalShared(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x24, 0x00, 0x0b}), // local.get 0; global.set 0; end
 		)),
 	)
-	inB, err := Instantiate(MustCompile(modB), Imports{"env.g": gImport})
+	inB, err := Instantiate(MustCompile(modB), InstantiateOptions{Imports: Imports{"env.g": gImport}})
 	if err != nil {
 		t.Fatalf("instantiate B: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestCrossInstanceCallNoArgs(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x2a, 0x0b}))), // i32.const 42; end
 	)
-	inA, err := Instantiate(MustCompile(modA), nil)
+	inA, err := Instantiate(MustCompile(modA), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate A: %v", err)
 	}
@@ -199,14 +199,14 @@ func TestCrossInstanceCallNoArgs(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", 0, 1))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))), // call 0; end
 	)
-	cB, err := Compile(modB)
+	cB, err := Compile(nil, modB)
 	if err != nil {
 		t.Fatalf("compile B: %v", err)
 	}
 	if !cB.needsLink {
 		t.Fatalf("B should need link (returning import)")
 	}
-	inB, err := Instantiate(cB, Imports{"env.f": fExport})
+	inB, err := Instantiate(cB, InstantiateOptions{Imports: Imports{"env.f": fExport}})
 	if err != nil {
 		t.Fatalf("instantiate B: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestCrossInstanceCallArgs(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("add", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b}))), // local.get 0; local.get 1; i32.add; end
 	)
-	inA, err := Instantiate(MustCompile(modA), nil)
+	inA, err := Instantiate(MustCompile(modA), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate A: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestCrossInstanceCallArgs(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("addBoth", 0, 1))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x14, 0x41, 0x16, 0x10, 0x00, 0x0b}))), // i32.const 20; i32.const 22; call 0; end
 	)
-	inB, err := Instantiate(MustCompile(modB), Imports{"env.add": addExport})
+	inB, err := Instantiate(MustCompile(modB), InstantiateOptions{Imports: Imports{"env.add": addExport}})
 	if err != nil {
 		t.Fatalf("instantiate B: %v", err)
 	}
@@ -284,7 +284,7 @@ func TestCrossInstanceIndirectCallReloadsModulePinnedGlobal(t *testing.T) {
 		)),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(set77Body))),
 	)
-	inA, err := Instantiate(MustCompile(modA), nil)
+	inA, err := Instantiate(MustCompile(modA), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate A: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestCrossInstanceIndirectCallReloadsModulePinnedGlobal(t *testing.T) {
 		wasmtest.Section(9, wasmtest.Vec([]byte{0x00, 0x41, 0x00, 0x0b, 0x01, 0x00})), // elem (i32.const 0) [imported set]
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
 	)
-	inB, err := Instantiate(MustCompile(modB), Imports{"env.set": setExport, "env.g": gExport})
+	inB, err := Instantiate(MustCompile(modB), InstantiateOptions{Imports: Imports{"env.set": setExport, "env.g": gExport}})
 	if err != nil {
 		t.Fatalf("instantiate B: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestCrossInstanceCallV128(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("id", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x00, 0x0b}))), // local.get 0; end
 	)
-	inA, err := Instantiate(MustCompile(modA), nil)
+	inA, err := Instantiate(MustCompile(modA), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate A: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestCrossInstanceCallV128(t *testing.T) {
 	if !cB.needsLink {
 		t.Fatal("v128 function import should need link")
 	}
-	inB, err := Instantiate(cB, Imports{"env.id": idExport})
+	inB, err := Instantiate(cB, InstantiateOptions{Imports: Imports{"env.id": idExport}})
 	if err != nil {
 		t.Fatalf("instantiate B: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestCrossInstanceCallV128(t *testing.T) {
 		wasmtest.Section(2, wasmtest.Vec(imp)),
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("id", 0, 0))),
 	)
-	inReexport, err := Instantiate(MustCompile(modReexport), Imports{"env.id": idExport})
+	inReexport, err := Instantiate(MustCompile(modReexport), InstantiateOptions{Imports: Imports{"env.id": idExport}})
 	if err != nil {
 		t.Fatalf("instantiate re-export: %v", err)
 	}

--- a/src/wago/defer_bounds_checks_test.go
+++ b/src/wago/defer_bounds_checks_test.go
@@ -42,11 +42,11 @@ func TestWithDeferBoundsChecks(t *testing.T) {
 
 	// The option reaches codegen through the public API: eliding the redundant
 	// second check shrinks the emitted code.
-	on, err := CompileWithConfig(base, twoLoadModule())
+	on, err := Compile(base, twoLoadModule())
 	if err != nil {
 		t.Fatal(err)
 	}
-	dis, err := CompileWithConfig(off, twoLoadModule())
+	dis, err := Compile(off, twoLoadModule())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/wago/example_test.go
+++ b/src/wago/example_test.go
@@ -23,11 +23,11 @@ func addModule() []byte {
 
 // Compile, instantiate, and invoke — the standard path.
 func Example_compileAndInvoke() {
-	mod, err := wago.Compile(addModule())
+	mod, err := wago.Compile(nil, addModule())
 	if err != nil {
 		panic(err)
 	}
-	inst, err := wago.Instantiate(mod, nil)
+	inst, err := wago.Instantiate(mod, wago.InstantiateOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/src/wago/global_test.go
+++ b/src/wago/global_test.go
@@ -58,7 +58,7 @@ func TestCompileGlobalMetadataNumericInits(t *testing.T) {
 		)),
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("g32", 3, 0), wasmtest.ExportEntry("g64", 3, 1))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,14 +100,14 @@ func TestV128LocalGlobalGetSetAndAPI(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x24, 0x00, 0x0b}), // local.get 0; global.set 0
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile v128 global: %v", err)
 	}
 	if c.Globals[0].V128 != init {
 		t.Fatalf("compiled v128 init = %x, want %x", c.Globals[0].V128, init)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate v128 global: %v", err)
 	}
@@ -156,13 +156,13 @@ func TestV128ImportedGlobalSharedObject(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x24, 0x00, 0x0b}),
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile imported v128 global: %v", err)
 	}
 	g := NewGlobalV128(initial, true)
 	defer g.Close()
-	in, err := Instantiate(c, Imports{"env.g": g})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.g": g}})
 	if err != nil {
 		t.Fatalf("Instantiate imported v128 global: %v", err)
 	}
@@ -197,7 +197,7 @@ func v128FromSlots(slots []uint64) V128 {
 
 func TestCompileRejectsGlobalInitializerTypeMismatch(t *testing.T) {
 	mod := wasmtest.Module(wasmtest.Section(6, wasmtest.Vec(wasmtest.GlobalEntry(wasm.I32, false, []byte{0x42, 0x00, 0x0b}))))
-	if _, err := Compile(mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte("validate")) {
+	if _, err := Compile(nil, mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte("validate")) {
 		t.Fatalf("Compile mismatch error = %v, want validate error", err)
 	}
 }
@@ -221,7 +221,7 @@ func TestCompileRejectsUnsupportedGlobalTypes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := Compile(tt.mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte(tt.want)) {
+			if _, err := Compile(nil, tt.mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte(tt.want)) {
 				t.Fatalf("Compile error = %v, want %q", err, tt.want)
 			}
 		})
@@ -230,7 +230,7 @@ func TestCompileRejectsUnsupportedGlobalTypes(t *testing.T) {
 
 func TestCompileRejectsWasm3DecodedProposalFeatureBeforeLegacyDecode(t *testing.T) {
 	mod := wasmtest.Module(wasmtest.Section(5, wasmtest.Vec([]byte{0x04, 0x00}))) // memory64 min 0
-	if _, err := Compile(mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte("compile: unsupported memory memory64 at memory 0")) {
+	if _, err := Compile(nil, mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte("compile: unsupported memory memory64 at memory 0")) {
 		t.Fatalf("Compile memory64 error = %v, want frontend support-pass rejection", err)
 	}
 }
@@ -242,7 +242,7 @@ func TestCompileAcceptsMemoryGrow(t *testing.T) {
 		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x01, 0x40, 0x00, 0x0b}))), // i32.const 1; memory.grow 0; end
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile memory.grow error = %v, want success", err)
 	}
@@ -258,7 +258,7 @@ func TestCompileCapsNoGrowMemoryAtInitialPages(t *testing.T) {
 		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x3f, 0x00, 0x0b}))), // memory.size 0; end
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile memory.size error = %v", err)
 	}
@@ -286,7 +286,7 @@ func TestCompileRejectsMalformedGlobalConstExpressions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mod := wasmtest.Module(wasmtest.Section(6, wasmtest.Vec(wasmtest.GlobalEntry(wasm.I32, false, tt.init))))
-			if _, err := Compile(mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte(tt.want)) {
+			if _, err := Compile(nil, mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte(tt.want)) {
 				t.Fatalf("Compile error = %v, want %q", err, tt.want)
 			}
 		})
@@ -338,7 +338,7 @@ func TestCompiledValidateRejectsMalformedMetadata(t *testing.T) {
 
 func TestInstantiateRejectsMalformedCompiledBeforeMapping(t *testing.T) {
 	c := &Compiled{Entry: []int{0}, FuncTypeID: []uint32{1}, GlobalExports: map[string]int{"g": 0}}
-	_, err := Instantiate(c, Imports{})
+	_, err := Instantiate(c, InstantiateOptions{Imports: Imports{}})
 	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("Entry length 1 != Funcs length 0")) {
 		t.Fatalf("InstantiateWithImports malformed metadata error = %v, want validate error", err)
 	}
@@ -349,7 +349,7 @@ func TestInstantiateInitializesGlobalSlots(t *testing.T) {
 		{Type: ValI32, Bits: 0x11223344},
 		{Type: ValI64, Mutable: true, Bits: 0x0123456789abcdef},
 	}}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +375,7 @@ func TestInstantiateLateGlobalErrorCleansResources(t *testing.T) {
 		},
 	}
 	for i := 0; i < 5; i++ {
-		if in, err := Instantiate(c, nil); err == nil {
+		if in, err := Instantiate(c, InstantiateOptions{}); err == nil {
 			in.Close()
 			t.Fatal("Instantiate malformed global initializer succeeded, want error")
 		} else if !bytes.Contains([]byte(err.Error()), []byte("initializer references unavailable global")) {
@@ -399,12 +399,12 @@ func procSelfMapsCount(t *testing.T) int {
 
 func TestInstantiateGlobalStorageIsPerInstance(t *testing.T) {
 	c := &Compiled{Globals: []GlobalDef{{Type: ValI32, Mutable: true, Bits: 7}}}
-	in1, err := Instantiate(c, nil)
+	in1, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer in1.Close()
-	in2, err := Instantiate(c, nil)
+	in2, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -426,11 +426,11 @@ func TestGlobalGetSetEndToEnd(t *testing.T) {
 			wasmtest.Code([]byte{0x23, 0x00, 0x20, 0x00, 0x6a, 0x24, 0x00, 0x23, 0x00, 0x0b}),
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +497,7 @@ func TestGlobalValidationCompileAlignment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := Compile(tt.module)
+			_, err := Compile(nil, tt.module)
 			if !tt.wantErr && err != nil {
 				t.Fatalf("Compile error = %v, want nil", err)
 			}
@@ -535,11 +535,11 @@ func TestGlobalNumericRoundTrips(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x24, 0x03, 0x23, 0x03, 0x0b}),
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,11 +561,11 @@ func TestDataOffsetI32ConstUnchanged(t *testing.T) {
 		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
 		wasmtest.Section(11, wasmtest.Vec(seg)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -587,11 +587,11 @@ func TestElementOffsetI32ConstUnchanged(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x11, 0x00, 0x00, 0x0b}),
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -615,7 +615,7 @@ func TestCompileRejectsActiveElementExpressionSegments(t *testing.T) {
 		wasmtest.Section(9, wasmtest.Vec(seg)),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x07, 0x0b}))),
 	)
-	_, err := Compile(mod)
+	_, err := Compile(nil, mod)
 	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("unsupported")) {
 		t.Fatalf("Compile active element expr error = %v, want unsupported", err)
 	}
@@ -632,14 +632,14 @@ func TestZeroLengthTableCallIndirectTraps(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x00, 0x11, 0x00, 0x00, 0x0b}))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !c.HasTable || c.TableSize != 0 {
 		t.Fatalf("compiled table metadata HasTable=%v TableSize=%d, want true/0", c.HasTable, c.TableSize)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -674,11 +674,11 @@ func TestInstantiateRejectsOutOfBoundsActiveDataSegments(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := Compile(tt.mod)
+			c, err := Compile(nil, tt.mod)
 			if err != nil {
 				t.Fatal(err)
 			}
-			in, err := Instantiate(c, tt.imports)
+			in, err := Instantiate(c, InstantiateOptions{Imports: tt.imports})
 			if err == nil {
 				in.Close()
 				t.Fatal("InstantiateWithImports succeeded, want active data out-of-bounds error")
@@ -721,11 +721,11 @@ func TestInstantiateRejectsOutOfBoundsActiveElementSegments(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := Compile(tt.mod)
+			c, err := Compile(nil, tt.mod)
 			if err != nil {
 				t.Fatal(err)
 			}
-			in, err := Instantiate(c, tt.imports)
+			in, err := Instantiate(c, InstantiateOptions{Imports: tt.imports})
 			if err == nil {
 				in.Close()
 				t.Fatal("InstantiateWithImports succeeded, want active element out-of-bounds error")
@@ -744,11 +744,11 @@ func TestDataOffsetCanUseImportedImmutableGlobal(t *testing.T) {
 		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
 		wasmtest.Section(11, wasmtest.Vec(seg)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, Imports{"env.offset": GlobalImport{Type: ValI32, Bits: 9}})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.offset": GlobalImport{Type: ValI32, Bits: 9}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -771,11 +771,11 @@ func TestElementOffsetCanUseImportedImmutableGlobal(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x11, 0x00, 0x00, 0x0b}),
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, Imports{"env.slot": GlobalImport{Type: ValI32, Bits: 1}})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.slot": GlobalImport{Type: ValI32, Bits: 1}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -798,11 +798,11 @@ func TestLocalGlobalInitializedFromImportedImmutableGlobal(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("imported", 0, 0), wasmtest.ExportEntry("local", 0, 1), wasmtest.ExportEntry("seed", 3, 0), wasmtest.ExportEntry("copied", 3, 1))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x23, 0x00, 0x0b}), wasmtest.Code([]byte{0x23, 0x01, 0x0b}))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, Imports{"env.seed": GlobalImport{Type: ValI32, Bits: 77}})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.seed": GlobalImport{Type: ValI32, Bits: 77}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -823,7 +823,7 @@ func TestCompileRejectsLocalInitializerFromMutableImportedGlobal(t *testing.T) {
 		wasmtest.Section(2, wasmtest.Vec(wasmtest.GlobalImportEntry("env", "seed", wasm.I32, true))),
 		wasmtest.Section(6, wasmtest.Vec(wasmtest.GlobalEntry(wasm.I32, false, []byte{0x23, 0x00, 0x0b}))),
 	)
-	if _, err := Compile(mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte("validate")) {
+	if _, err := Compile(nil, mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte("validate")) {
 		t.Fatalf("Compile mutable imported global initializer error = %v, want validate error", err)
 	}
 }
@@ -857,13 +857,13 @@ func TestDuplicateImportedGlobalKeysAliasSameObject(t *testing.T) {
 			wasmtest.Code([]byte{0x23, 0x01, 0x0b}),
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
 	shared := NewGlobalI32(3, true)
 	defer shared.Close()
-	in, err := Instantiate(c, Imports{"env.dup": GlobalImport{Global: shared}})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.dup": GlobalImport{Global: shared}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -887,14 +887,14 @@ func TestImportedMutableGlobalImportAliasesHostObject(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("get", 0, 0), wasmtest.ExportEntry("counter", 3, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x23, 0x00, 0x0b}))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
 	shared := NewGlobalI32(10, true)
 	defer shared.Close()
 	imports := Imports{"env.counter": GlobalImport{Global: shared}}
-	in, err := Instantiate(c, imports)
+	in, err := Instantiate(c, InstantiateOptions{Imports: imports})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -924,11 +924,11 @@ func TestImportedGlobalReadWriteThroughWasm(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("add", 0, 0), wasmtest.ExportEntry("counter", 3, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x23, 0x00, 0x20, 0x00, 0x6a, 0x24, 0x00, 0x23, 0x00, 0x0b}))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, Imports{"env.counter": GlobalImport{Type: ValI32, Mutable: true, Bits: 10}})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.counter": GlobalImport{Type: ValI32, Mutable: true, Bits: 10}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -942,13 +942,13 @@ func TestImportedGlobalReadWriteThroughWasm(t *testing.T) {
 	if got, err := in.Global("counter"); err != nil || AsI32(got) != 15 {
 		t.Fatalf("imported Global after wasm write = %v, %v; want 15", got, err)
 	}
-	if _, err := Instantiate(c, Imports{}); err == nil {
+	if _, err := Instantiate(c, InstantiateOptions{Imports: Imports{}}); err == nil {
 		t.Fatal("InstantiateWithImports missing global succeeded, want error")
 	}
-	if _, err := Instantiate(c, Imports{"env.counter": GlobalImport{Type: ValI64, Mutable: true}}); err == nil {
+	if _, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.counter": GlobalImport{Type: ValI64, Mutable: true}}}); err == nil {
 		t.Fatal("InstantiateWithImports type mismatch succeeded, want error")
 	}
-	if _, err := Instantiate(c, Imports{"env.counter": GlobalImport{Type: ValI32}}); err == nil {
+	if _, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.counter": GlobalImport{Type: ValI32}}}); err == nil {
 		t.Fatal("InstantiateWithImports mutability mismatch succeeded, want error")
 	}
 }
@@ -962,7 +962,7 @@ func TestGlobalSlotBitsCanonicalize32BitValues(t *testing.T) {
 		},
 		GlobalExports: map[string]int{"i": 0, "f": 1},
 	}
-	in, err := Instantiate(c, Imports{"env.i": GlobalImport{Type: ValI32, Bits: 0xffff000012345678}})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.i": GlobalImport{Type: ValI32, Bits: 0xffff000012345678}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -995,11 +995,11 @@ func TestExportedGlobalAccessors(t *testing.T) {
 			wasmtest.Code([]byte{0x23, 0x01, 0x0b}),
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1050,11 +1050,11 @@ func TestGlobalsInteractWithControlFlowAndLocals(t *testing.T) {
 			0x20, 0x00, 0x23, 0x00, 0x6a, 0x0b, // local 0 + global 0
 		}))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1078,11 +1078,11 @@ func TestUnreachableGlobalOpsSkipImmediates(t *testing.T) {
 			wasmtest.Code([]byte{0x00, 0x24, 0x00, 0x0b}),
 		)),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1123,11 +1123,11 @@ func TestGeneratedGlobalWasmFixtures(t *testing.T) {
 			wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("add", 0, 0))),
 			wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x23, 0x00, 0x20, 0x00, 0x6a, 0x24, 0x00, 0x23, 0x00, 0x0b}))),
 		)
-		c, err := Compile(mod)
+		c, err := Compile(nil, mod)
 		if err != nil {
 			t.Fatal(err)
 		}
-		in, err := Instantiate(c, nil)
+		in, err := Instantiate(c, InstantiateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1190,11 +1190,11 @@ func TestGeneratedGlobalWasmFixtures(t *testing.T) {
 			)),
 			wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("imm", 3, 0), wasmtest.ExportEntry("mut", 3, 1))),
 		)
-		c, err := Compile(mod)
+		c, err := Compile(nil, mod)
 		if err != nil {
 			t.Fatal(err)
 		}
-		in, err := Instantiate(c, nil)
+		in, err := Instantiate(c, InstantiateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1222,16 +1222,16 @@ func TestGlobalAPIE2EHelpers(t *testing.T) {
 	if res := runv(t, mod, "add", I32(5)); AsI32(res[0]) != 15 {
 		t.Fatalf("add global = %v; want 15", res)
 	}
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in1, err := Instantiate(c, nil)
+	in1, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer in1.Close()
-	in2, err := Instantiate(c, nil)
+	in2, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1267,16 +1267,16 @@ func TestGlobalsArePerInstanceThroughWasm(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("add", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x23, 0x00, 0x20, 0x00, 0x6a, 0x24, 0x00, 0x23, 0x00, 0x0b}))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in1, err := Instantiate(c, nil)
+	in1, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer in1.Close()
-	in2, err := Instantiate(c, nil)
+	in2, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/wago/hostcall_hardening_test.go
+++ b/src/wago/hostcall_hardening_test.go
@@ -74,12 +74,12 @@ func tableHostImportModuleWithLocal(importSig, localSig []byte, body []byte) []b
 func TestVoidHostFuncImportRunsOnce(t *testing.T) {
 	c := MustCompile(voidI32ImportCallerModule())
 	calls := 0
-	in, err := Instantiate(c, Imports{"env.log": HostFunc(func(_ HostModule, p, _ []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.log": HostFunc(func(_ HostModule, p, _ []uint64) {
 		calls++
 		if AsI32(p[0]) != 123 {
 			t.Fatalf("param = %d, want 123", AsI32(p[0]))
 		}
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -95,12 +95,12 @@ func TestVoidHostFuncImportRunsOnce(t *testing.T) {
 func TestLegacyHostFuncImportStillRuns(t *testing.T) {
 	c := MustCompile(voidI32ImportCallerModule())
 	calls := 0
-	in, err := Instantiate(c, Imports{"env.log": HostFunc(func(_ HostModule, p, _ []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.log": HostFunc(func(_ HostModule, p, _ []uint64) {
 		calls++
 		if v := AsI32(p[0]); v != 77 {
 			t.Fatalf("param = %d, want 77", v)
 		}
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -116,12 +116,12 @@ func TestLegacyHostFuncImportStillRuns(t *testing.T) {
 func TestImportedStartHostFuncRuns(t *testing.T) {
 	c := MustCompile(importedStartModule())
 	calls := 0
-	in, err := Instantiate(c, Imports{"env.start": HostFunc(func(_ HostModule, p, r []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.start": HostFunc(func(_ HostModule, p, r []uint64) {
 		calls++
 		if len(p) != 0 || len(r) != 0 {
 			t.Fatalf("start got params/results len %d/%d, want 0/0", len(p), len(r))
 		}
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestImportedStartBadSignatureErrors(t *testing.T) {
 	c := MustCompile(importedStartModule())
 	// A bare native func is not a HostFunc; binding it is rejected identically on
 	// standard Go and TinyGo (no reflection anywhere).
-	_, err := Instantiate(c, Imports{"env.start": func(int32) {}})
+	_, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.start": func(int32) {}}})
 	want := "must be a wago.HostFunc"
 	if err == nil || !strings.Contains(err.Error(), "env.start") || !strings.Contains(err.Error(), want) {
 		t.Fatalf("want clear start binding error containing %q, got %v", want, err)
@@ -144,7 +144,7 @@ func TestImportedStartBadSignatureErrors(t *testing.T) {
 
 func TestMissingLegacyAsyncHostImportErrors(t *testing.T) {
 	c := MustCompile(voidI32ImportCallerModule())
-	_, err := Instantiate(c, nil)
+	_, err := Instantiate(c, InstantiateOptions{})
 	if err == nil || !strings.Contains(err.Error(), "env.log") || !strings.Contains(err.Error(), "legacy async host calls require wago.HostFunc") {
 		t.Fatalf("want missing legacy host import error, got %v", err)
 	}
@@ -173,12 +173,12 @@ func TestLegacyHostFuncCompatibleImportRoundTrips(t *testing.T) {
 		t.Fatalf("UnmarshalBinary i32 import: %v", err)
 	}
 	calls := 0
-	in, err := Instantiate(&dec, Imports{"env.log": HostFunc(func(_ HostModule, p, _ []uint64) {
+	in, err := Instantiate(&dec, InstantiateOptions{Imports: Imports{"env.log": HostFunc(func(_ HostModule, p, _ []uint64) {
 		calls++
 		if v := AsI32(p[0]); v != 123 {
 			t.Fatalf("param = %d, want 123", v)
 		}
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate round-tripped i32 import: %v", err)
 	}
@@ -196,10 +196,10 @@ func TestSyncHostImportInTableRunsIndirectly(t *testing.T) {
 	body := []byte{0x20, 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x0b} // local.get 0; i32.const 0; call_indirect type 0 table 0; end
 	c := MustCompile(tableHostImportModule(sig, body))
 	calls := 0
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
 		calls++
 		r[0] = p[0] + 1
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -219,12 +219,12 @@ func TestVoidSyncHostImportInTableRunsIndirectly(t *testing.T) {
 	body := []byte{0x20, 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x41, 0x09, 0x0b} // call_indirect; i32.const 9; end
 	c := MustCompile(tableHostImportModuleWithLocal(importSig, localSig, body))
 	calls := 0
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, _ []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, _ []uint64) {
 		calls++
 		if AsI32(p[0]) != 6 {
 			t.Fatalf("param = %d, want 6", AsI32(p[0]))
 		}
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -244,12 +244,12 @@ func TestLegacyHostFuncInTableStillRunsIndirectly(t *testing.T) {
 	body := []byte{0x20, 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x41, 0x07, 0x0b} // call_indirect; i32.const 7; end
 	c := MustCompile(tableHostImportModuleWithLocal(importSig, localSig, body))
 	calls := 0
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, _ []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, _ []uint64) {
 		calls++
 		if v := AsI32(p[0]); v != 5 {
 			t.Fatalf("param = %d", v)
 		}
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -273,13 +273,13 @@ func TestSyncHostImportV128InTableRunsIndirectly(t *testing.T) {
 	body := []byte{0x20, 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x0b} // local.get 0; i32.const 0; call_indirect type 0 table 0; end
 	c := MustCompile(tableHostImportModule(sig, body))
 	calls := 0
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
 		calls++
 		if got := hostV128FromSlots(p[0], p[1]); got != inVec {
 			t.Fatalf("v128 param = % x, want % x", got, inVec)
 		}
 		r[0], r[1] = hostV128Slots(outVec)
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -33,7 +33,7 @@ func TestSyncHostImportSlotForm(t *testing.T) {
 	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
 	body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b} // local.get 0; call 0; end
 	c := MustCompile(returningImportModule(sig, body))
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] * 3 })})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] * 3 })}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestSyncHostImportV128SlotForm(t *testing.T) {
 		t.Fatal("v128 host import should force link-time sync host lowering")
 	}
 	calls := 0
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
 		calls++
 		if len(p) != 4 { // i32 + two v128 slots + i64
 			t.Fatalf("params len = %d, want 4", len(p))
@@ -70,7 +70,7 @@ func TestSyncHostImportV128SlotForm(t *testing.T) {
 		}
 		r[0], r[1] = hostV128Slots(outVec)
 		r[2] = I32(99)
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -109,12 +109,12 @@ func TestSyncHostImportVoidV128UsesSyncPath(t *testing.T) {
 		t.Fatal("void v128 host import should force link-time sync host lowering")
 	}
 	called := false
-	in, err := Instantiate(c, Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
 		called = true
 		if got := hostV128FromSlots(p[0], p[1]); got != vec {
 			t.Fatalf("v128 param = % x, want % x", got, vec)
 		}
-	})})
+	})}})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}

--- a/src/wago/hostlink_test.go
+++ b/src/wago/hostlink_test.go
@@ -16,7 +16,7 @@ func TestHostLinkCached(t *testing.T) {
 	if err != nil {
 		t.Skip("jsonproc.wasm not present")
 	}
-	c, err := Compile(src)
+	c, err := Compile(nil, src)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -2,6 +2,7 @@ package wago
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -34,6 +35,7 @@ type Instance struct {
 	serArgs, results, trap []byte
 	resultVals             []uint64    // reusable Invoke result buffer (valid until the next call)
 	ic                     invokeCache // single-entry export resolution cache
+	closed                 bool        // guards Close against double-release (user defer + pool)
 
 	// rt is set when the instance is created through a Runtime (rt.Instantiate /
 	// Spawn), so Instance.Call can fire the runtime's invoke hooks. It is nil for
@@ -52,21 +54,54 @@ type invokeCache struct {
 	resultWide  []bool // one entry per returned uint64 slot; false means read low 32 bits
 }
 
-// InstantiateOptions configures instance creation.
+// InstantiateOptions configures instance creation from a *Compiled. When
+// instantiating from a *Snapshot both fields are ignored: the snapshot carries
+// the imports and GC config it was created with.
 type InstantiateOptions struct {
 	Imports Imports
 	GC      GCConfig
+
+	// restore, when set, seeds the new instance from a captured Snapshot instead
+	// of the module's declared initial state: linear memory and module-local
+	// globals are loaded from the snapshot, and active data segments plus the
+	// start function are skipped. Set only via the *Snapshot instantiation path;
+	// unexported so it stays an internal instantiation mode.
+	restore *Snapshot
 }
 
-// Instantiate maps code, wires the module's imports (functions, globals, …) from
-// the unified imports namespace, initializes memory/table state, and allocates
-// call buffers. Pass nil for a module with no imports.
-func Instantiate(c *Compiled, imports Imports) (*Instance, error) {
-	return InstantiateWithOptions(c, InstantiateOptions{Imports: imports})
+// Instantiable is the set of sources Instantiate accepts: a compiled module or a
+// captured snapshot. The interface is sealed — only *Compiled and *Snapshot
+// implement it.
+type Instantiable interface {
+	instantiable()
 }
 
-// InstantiateWithOptions maps code and applies explicit instance options.
-func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, error) {
+func (*Compiled) instantiable() {}
+func (*Snapshot) instantiable() {}
+
+// Instantiate creates a live instance from either a *Compiled (wiring the
+// module's imports from opts and running its start function) or a *Snapshot
+// (loading captured memory/globals; opts is ignored — the snapshot supplies its
+// own imports and GC config, and the start function is not re-run).
+func Instantiate(source Instantiable, opts InstantiateOptions) (*Instance, error) {
+	switch s := source.(type) {
+	case *Compiled:
+		return instantiateCore(s, opts)
+	case *Snapshot:
+		if s == nil || s.c == nil {
+			return nil, errors.New("wago: snapshot has no bound module (load it with LoadSnapshot)")
+		}
+		return instantiateCore(s.c, InstantiateOptions{Imports: s.imports, GC: s.gc, restore: s})
+	case nil:
+		return nil, errors.New("wago: Instantiate: nil source")
+	default:
+		return nil, fmt.Errorf("wago: Instantiate: unsupported source %T", source)
+	}
+}
+
+// instantiateCore maps code and applies explicit instance options. It is the
+// shared engine behind Instantiate for both the compiled and snapshot paths.
+func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 	imports := opts.Imports
 	// Resolve cross-instance function imports, recompiling the module with their
 	// bindings when any are present (a no-op for host-only modules).
@@ -144,6 +179,17 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 		}
 	} else {
 		initialBytes, maxBytes := c.memorySizeBytes()
+		// Restoring from a snapshot: size the fresh mapping to the snapshot's
+		// (possibly grown) linear-memory size so the saved bytes fit and memory.size
+		// reports the captured value, not the module's declared minimum.
+		if opts.restore != nil {
+			if rb := int(opts.restore.memPages) * 65536; rb > initialBytes {
+				initialBytes = rb
+				if initialBytes > maxBytes {
+					maxBytes = initialBytes
+				}
+			}
+		}
 		if c.boundsMode == BoundsChecksSignalsBased {
 			jm, err = newGuardedJobMemory(initialBytes, maxBytes)
 		} else {
@@ -257,6 +303,22 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 			globalCells[i] = cell
 			binary.LittleEndian.PutUint64(globals[i*8:], uint64(uintptr(unsafe.Pointer(&cell.cell[0]))))
 		}
+		// Snapshot restore: replace each module-local global's freshly-initialized
+		// value with the captured one. Imported globals (the leading cells) keep the
+		// value of whatever the caller re-imported this time — their state lives in
+		// the host, not in the snapshot.
+		if opts.restore != nil {
+			for i := len(importGlobals); i < len(globalCells) && i < len(opts.restore.globals); i++ {
+				gs := opts.restore.globals[i]
+				if globalCells[i] == nil {
+					continue
+				}
+				writeGlobalObject(globalCells[i], gs.typ, gs.bits)
+				if gs.typ == ValV128 {
+					writeGlobalObjectV128(globalCells[i], gs.vec)
+				}
+			}
+		}
 		jm.SetGlobalsPtr(uintptr(unsafe.Pointer(&globals[0])))
 	}
 
@@ -332,7 +394,17 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 		jm.SetTablePtr(uintptr(unsafe.Pointer(&desc[0])))
 	}
 
-	if len(c.Data) > 0 {
+	if opts.restore != nil {
+		// The snapshot's linear-memory bytes already reflect post-data-init state
+		// plus every mutation up to the capture point, so copy them wholesale and
+		// skip the module's active data segments below.
+		dst := jm.HostBytes()
+		if len(opts.restore.memory) > len(dst) {
+			return nil, fmt.Errorf("snapshot memory (%d bytes) exceeds instance memory (%d bytes)", len(opts.restore.memory), len(dst))
+		}
+		copy(dst, opts.restore.memory)
+	}
+	if len(c.Data) > 0 && opts.restore == nil {
 		lin := jm.CurrentBytes() // active data must fit the initial size, not the reservation
 		for seg, d := range c.Data {
 			off := d.Offset.Base
@@ -371,8 +443,10 @@ func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, er
 	}
 
 	// Run the start function (() -> ()) now that memory, globals, table, and data
-	// are initialized. A trap here aborts instantiation.
-	if c.HasStart {
+	// are initialized. A trap here aborts instantiation. Skip it on a snapshot
+	// restore: start already ran in the instance the snapshot was taken from, and
+	// its effects are baked into the restored memory/globals.
+	if c.HasStart && opts.restore == nil {
 		if c.StartIsImport {
 			// Imported start: run the imported function through the same normalized
 			// binding machinery used by ordinary host imports. Validation guarantees
@@ -474,8 +548,13 @@ func buildHostFuncThunks(c *Compiled, imports Imports) (map[uint32]uint64, []byt
 }
 
 // Close releases the instance's mapped code, engine, and (if instance-owned) its
-// memory. An imported memory is left for the host to Close.
-func (in *Instance) Close() {
+// memory. An imported memory is left for the host to Close. Close is idempotent;
+// the error result is always nil today and exists for forward compatibility.
+func (in *Instance) Close() error {
+	if in == nil || in.closed {
+		return nil
+	}
+	in.closed = true
 	if in.gc != nil {
 		in.gc.Close()
 	}
@@ -491,6 +570,35 @@ func (in *Instance) Close() {
 		in.memory.inUse = false
 	}
 	runtime.ReleaseEngine(in.eng)
+	return nil
+}
+
+// resetToSnapshot returns a live instance to the captured state of s in place —
+// reloading linear memory and module-local globals — without unmapping code or
+// re-acquiring the engine/arena/memory. It backs the snapshot pool's fast
+// between-lease reset. The instance must be one this snapshot's module produced
+// (the pool guarantees it) and must own its memory.
+func (in *Instance) resetToSnapshot(s *Snapshot) error {
+	if in.c != s.c {
+		return errors.New("wago: resetToSnapshot: instance is not from this snapshot's module")
+	}
+	if !in.ownsMem {
+		return errors.New("wago: resetToSnapshot: instance memory is host-imported")
+	}
+	in.jm.RestoreLinear(s.memory)
+	for i := 0; i < len(in.globalCells) && i < len(s.globals); i++ {
+		cell := in.globalCells[i]
+		if cell == nil || i < len(in.c.GlobalImports) {
+			continue // imported globals belong to the host, not the snapshot
+		}
+		gs := s.globals[i]
+		writeGlobalObject(cell, gs.typ, gs.bits)
+		if gs.typ == ValV128 {
+			writeGlobalObjectV128(cell, gs.vec)
+		}
+	}
+	in.ic = invokeCache{} // drop memoized export resolution; state changed underneath
+	return nil
 }
 
 // Memory returns the instance's linear-memory object (instance-owned or the

--- a/src/wago/memory_access_test.go
+++ b/src/wago/memory_access_test.go
@@ -11,11 +11,11 @@ import (
 // instance to exercise the typed accessors without running its functions.
 
 func TestMemoryAccessors(t *testing.T) {
-	c, err := Compile(memprogWasm)
+	c, err := Compile(nil, memprogWasm)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
@@ -102,11 +102,11 @@ func TestMemoryAccessors(t *testing.T) {
 // linear memory (no DCE): a single bounds-checked aligned load/store, ~3-4x
 // faster than the encoding/binary idiom under TinyGo (see docs/tinygo.md).
 func BenchmarkInstanceUint32(b *testing.B) {
-	c, err := Compile(memprogWasm)
+	c, err := Compile(nil, memprogWasm)
 	if err != nil {
 		b.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		b.Fatalf("Instantiate: %v", err)
 	}

--- a/src/wago/memory_grow_guardpage_test.go
+++ b/src/wago/memory_grow_guardpage_test.go
@@ -40,11 +40,11 @@ func growMemModule() []byte {
 func TestMemoryBytesAfterGrowGuardPage(t *testing.T) {
 	const page = 65536
 	cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksSignalsBased)
-	c, err := CompileWithConfig(cfg, growMemModule())
+	c, err := Compile(cfg, growMemModule())
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}

--- a/src/wago/memory_guardpage_test.go
+++ b/src/wago/memory_guardpage_test.go
@@ -16,7 +16,7 @@ import (
 // trap via the signal handler rather than an inline check.
 func TestImportedMemoryGuardPage(t *testing.T) {
 	cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksSignalsBased)
-	c, err := CompileWithConfig(cfg, importMemModule())
+	c, err := Compile(cfg, importMemModule())
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestImportedMemoryGuardPage(t *testing.T) {
 	if !mem.guarded {
 		t.Fatal("NewMemory should be guard-page backed in a wago_guardpage build")
 	}
-	in, err := Instantiate(c, Imports{"env.mem": mem})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.mem": mem}})
 	if err != nil {
 		t.Fatalf("instantiate imported memory under guard-page mode: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestImportedMemoryGuardPageCrossInstance(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b}), // store8
 		)),
 	)
-	inA, err := Instantiate(MustCompile(modA), nil)
+	inA, err := Instantiate(MustCompile(modA), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate A: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestImportedMemoryGuardPageCrossInstance(t *testing.T) {
 			wasmtest.Code([]byte{0x20, 0x00, 0x2d, 0x00, 0x00, 0x0b}),             // load8_u
 		)),
 	)
-	inB, err := Instantiate(MustCompile(modB), Imports{"env.mem": memImport})
+	inB, err := Instantiate(MustCompile(modB), InstantiateOptions{Imports: Imports{"env.mem": memImport}})
 	if err != nil {
 		t.Fatalf("instantiate B on shared guard-page memory: %v", err)
 	}
@@ -143,11 +143,11 @@ func TestImportedMemoryGuardPageRejectsPlainMemory(t *testing.T) {
 		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})), // 1 memory, min 1
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("mem", 2, 0))),
 	)
-	owner, err := CompileWithConfig(explicitCfg, ownerMod)
+	owner, err := Compile(explicitCfg, ownerMod)
 	if err != nil {
 		t.Fatalf("compile owner: %v", err)
 	}
-	inOwner, err := Instantiate(owner, nil)
+	inOwner, err := Instantiate(owner, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate owner: %v", err)
 	}
@@ -162,11 +162,11 @@ func TestImportedMemoryGuardPageRejectsPlainMemory(t *testing.T) {
 
 	// Importer compiled signals-based: it must reject the unguarded memory.
 	sigCfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksSignalsBased)
-	importer, err := CompileWithConfig(sigCfg, importMemModule())
+	importer, err := Compile(sigCfg, importMemModule())
 	if err != nil {
 		t.Fatalf("compile importer: %v", err)
 	}
-	if _, err := Instantiate(importer, Imports{"env.mem": memImport}); err == nil {
+	if _, err := Instantiate(importer, InstantiateOptions{Imports: Imports{"env.mem": memImport}}); err == nil {
 		t.Fatal("signals-based module importing an unguarded memory should be rejected")
 	}
 }

--- a/src/wago/memory_test.go
+++ b/src/wago/memory_test.go
@@ -35,7 +35,7 @@ func importMemModule() []byte {
 
 func TestImportedMemoryShared(t *testing.T) {
 	t.Setenv("WAGO_BOUNDS", "explicit") // pin the explicit-bounds path (guard-page imports are covered in memory_guardpage_test.go)
-	c, err := Compile(importMemModule())
+	c, err := Compile(nil, importMemModule())
 	if err != nil {
 		t.Fatalf("compile (memory import should be accepted now): %v", err)
 	}
@@ -44,7 +44,7 @@ func TestImportedMemoryShared(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mem.Close()
-	in, err := Instantiate(c, Imports{"env.mem": mem})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.mem": mem}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,33 +73,33 @@ func TestImportedMemoryShared(t *testing.T) {
 }
 
 func TestImportedMemoryMissing(t *testing.T) {
-	c, err := Compile(importMemModule())
+	c, err := Compile(nil, importMemModule())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Instantiate(c, nil); err == nil {
+	if _, err := Instantiate(c, InstantiateOptions{}); err == nil {
 		t.Fatal("Instantiate without the imported memory should fail")
 	}
 }
 
 func TestImportedMemorySingleInstance(t *testing.T) {
 	t.Setenv("WAGO_BOUNDS", "explicit") // pin the explicit-bounds path (guard-page imports are covered in memory_guardpage_test.go)
-	c, _ := Compile(importMemModule())
+	c, _ := Compile(nil, importMemModule())
 	mem, _ := NewMemory(1, 1)
 	defer mem.Close()
-	in, err := Instantiate(c, Imports{"env.mem": mem})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.mem": mem}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer in.Close()
-	if _, err := Instantiate(c, Imports{"env.mem": mem}); err == nil {
+	if _, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.mem": mem}}); err == nil {
 		t.Fatal("a second instance importing the same in-use memory should fail")
 	}
 }
 
 func TestImportedMemorySurvivesMarshalLoad(t *testing.T) {
 	t.Setenv("WAGO_BOUNDS", "explicit") // pin explicit: serializing a signals-based module is unsupported (see TestSignalsBasedNotSerializable)
-	c, err := Compile(importMemModule())
+	c, err := Compile(nil, importMemModule())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestImportedMemorySurvivesMarshalLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Instantiate(loaded, nil); err == nil {
+	if _, err := Instantiate(loaded, InstantiateOptions{}); err == nil {
 		t.Fatal("loaded module should still require imported memory")
 	}
 	mem, err := NewMemory(1, 1)
@@ -119,7 +119,7 @@ func TestImportedMemorySurvivesMarshalLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mem.Close()
-	in, err := Instantiate(loaded, Imports{"env.mem": mem})
+	in, err := Instantiate(loaded, InstantiateOptions{Imports: Imports{"env.mem": mem}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/wago/pinnedglobal_test.go
+++ b/src/wago/pinnedglobal_test.go
@@ -50,11 +50,11 @@ func TestPinnedGlobalAccumulateAndPersist(t *testing.T) {
 				(br $lp)))
 			(global.get $g))
 		(func (export "get") (result i64) (global.get $g)))`)
-	c, err := Compile(wasm)
+	c, err := Compile(nil, wasm)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
@@ -88,11 +88,11 @@ func TestPinnedGlobalAcrossCall(t *testing.T) {
 			(global.set $g (i64.const 5))
 			(call $bump)
 			(global.get $g)))`)
-	c, err := Compile(wasm)
+	c, err := Compile(nil, wasm)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
@@ -111,11 +111,11 @@ func TestPinnedGlobalAliasCapture(t *testing.T) {
 			global.get $g
 			i64.const 100 global.set $g
 			global.get $g i64.add))`)
-	c, err := Compile(wasm)
+	c, err := Compile(nil, wasm)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}

--- a/src/wago/pool.go
+++ b/src/wago/pool.go
@@ -1,0 +1,248 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+// SnapshotPoolOptions configures an InstancePool. (Named to avoid colliding with
+// the Runtime Class system's PoolOptions, which pools instances differently.)
+type SnapshotPoolOptions struct {
+	// MinIdle instances are created up front (warm start). Must be <= MaxInstances.
+	MinIdle int
+	// MaxIdle caps how many idle instances are retained; instances released beyond
+	// it are discarded. Zero means retain up to MaxInstances.
+	MaxIdle int
+	// MaxInstances is the hard cap on live instances (idle + leased). Required > 0.
+	MaxInstances int
+}
+
+// InstancePool is a concurrency-safe pool of instances restored from a single
+// Snapshot. Acquiring leases an instance; releasing resets it back to the
+// snapshot state and returns it for reuse, which is far cheaper than a fresh
+// instantiation. Discarding drops an instance whose state can't be trusted
+// (typically after a trap).
+type InstancePool struct {
+	snap    *Snapshot
+	idle    chan *Instance
+	sem     chan struct{} // one token per live instance; cap == MaxInstances
+	maxIdle int
+
+	closed atomic.Bool
+
+	created   atomic.Uint64
+	reused    atomic.Uint64
+	discarded atomic.Uint64
+	traps     atomic.Uint64
+
+	closeOnce sync.Once
+}
+
+// PoolStats is a point-in-time view of an InstancePool.
+type PoolStats struct {
+	Idle  int // instances ready for reuse
+	InUse int // instances currently leased out
+	Live  int // Idle + InUse
+
+	Created   uint64 // instances instantiated from the snapshot
+	Reused    uint64 // Acquire calls served from an idle instance
+	Discarded uint64 // instances torn down (over MaxIdle, or Discard/trap)
+	Traps     uint64 // Invoke calls that returned an error
+}
+
+// Pool creates an InstancePool over snapshot. MinIdle instances are instantiated
+// immediately; the rest are created lazily up to MaxInstances.
+func Pool(snapshot *Snapshot, opts SnapshotPoolOptions) (*InstancePool, error) {
+	if snapshot == nil || snapshot.c == nil {
+		return nil, errors.New("wago: Pool: nil or unbound snapshot")
+	}
+	if opts.MaxInstances <= 0 {
+		return nil, errors.New("wago: Pool requires MaxInstances > 0")
+	}
+	if opts.MinIdle < 0 || opts.MinIdle > opts.MaxInstances {
+		return nil, fmt.Errorf("wago: Pool MinIdle (%d) must be in [0, MaxInstances=%d]", opts.MinIdle, opts.MaxInstances)
+	}
+	maxIdle := opts.MaxIdle
+	if maxIdle <= 0 || maxIdle > opts.MaxInstances {
+		maxIdle = opts.MaxInstances
+	}
+	if maxIdle < opts.MinIdle {
+		maxIdle = opts.MinIdle // never retain fewer than the warm-start set
+	}
+	p := &InstancePool{
+		snap: snapshot,
+		// idle is sized to maxIdle so a return past the retain cap can't be parked
+		// (the default branch in returnClean fires and discards it instead); sem is
+		// sized to MaxInstances to bound total live (idle + leased) instances.
+		idle:    make(chan *Instance, maxIdle),
+		sem:     make(chan struct{}, opts.MaxInstances),
+		maxIdle: maxIdle,
+	}
+	// Warm start: pre-instantiate MinIdle instances, each holding a live-slot token.
+	for i := 0; i < opts.MinIdle; i++ {
+		p.sem <- struct{}{}
+		in, err := p.newInstance()
+		if err != nil {
+			<-p.sem
+			p.Close()
+			return nil, fmt.Errorf("wago: Pool warm start: %w", err)
+		}
+		p.idle <- in
+	}
+	return p, nil
+}
+
+// newInstance restores a fresh instance from the snapshot. The caller must hold a
+// live-slot token before calling.
+func (p *InstancePool) newInstance() (*Instance, error) {
+	in, err := Instantiate(p.snap, InstantiateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	p.created.Add(1)
+	return in, nil
+}
+
+// Acquire leases an instance, blocking until one is available or ctx is done. It
+// reuses an idle instance when one exists, otherwise instantiates a new one up to
+// MaxInstances.
+func (p *InstancePool) Acquire(ctx context.Context) (*SnapshotLease, error) {
+	if p.closed.Load() {
+		return nil, errors.New("wago: Acquire on closed pool")
+	}
+	// Prefer an already-warm idle instance.
+	select {
+	case in := <-p.idle:
+		p.reused.Add(1)
+		return &SnapshotLease{Instance: in, pool: p}, nil
+	default:
+	}
+	// Otherwise wait for whichever comes first: an idle instance is returned, a
+	// live slot frees up (so we can create one), or ctx is cancelled.
+	select {
+	case in := <-p.idle:
+		p.reused.Add(1)
+		return &SnapshotLease{Instance: in, pool: p}, nil
+	case p.sem <- struct{}{}:
+		in, err := p.newInstance()
+		if err != nil {
+			<-p.sem
+			return nil, err
+		}
+		return &SnapshotLease{Instance: in, pool: p}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Invoke leases an instance, calls export, and releases it — resetting the
+// instance to the snapshot state afterwards so successive calls don't share
+// state. On error the instance is discarded (its state is untrusted) and the
+// trap counter is bumped.
+func (p *InstancePool) Invoke(ctx context.Context, export string, args ...uint64) ([]uint64, error) {
+	lease, err := p.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out, err := lease.Instance.Invoke(export, args...)
+	if err != nil {
+		p.traps.Add(1)
+		lease.Discard()
+		return nil, err
+	}
+	// Copy results before Release resets the instance's buffers.
+	cp := append([]uint64(nil), out...)
+	lease.Release()
+	return cp, nil
+}
+
+// Close discards every idle instance and marks the pool closed. Leased instances
+// are the holder's responsibility (Release/Discard); doing so after Close tears
+// them down rather than returning them.
+func (p *InstancePool) Close() error {
+	p.closeOnce.Do(func() {
+		p.closed.Store(true)
+		for {
+			select {
+			case in := <-p.idle:
+				in.Close()
+				<-p.sem
+			default:
+				return
+			}
+		}
+	})
+	return nil
+}
+
+// Stats returns a snapshot of pool counters and occupancy.
+func (p *InstancePool) Stats() PoolStats {
+	idle := len(p.idle)
+	live := len(p.sem)
+	return PoolStats{
+		Idle:      idle,
+		InUse:     live - idle,
+		Live:      live,
+		Created:   p.created.Load(),
+		Reused:    p.reused.Load(),
+		Discarded: p.discarded.Load(),
+		Traps:     p.traps.Load(),
+	}
+}
+
+// returnClean resets in to the snapshot state and parks it as idle, or discards
+// it if the idle cache is full or the reset fails.
+func (p *InstancePool) returnClean(in *Instance) {
+	if p.closed.Load() {
+		p.discard(in)
+		return
+	}
+	if err := in.resetToSnapshot(p.snap); err != nil {
+		p.discard(in)
+		return
+	}
+	select {
+	case p.idle <- in:
+	default:
+		p.discard(in) // idle cache full (over MaxIdle): tear this one down
+	}
+}
+
+// discard tears down in and frees its live slot.
+func (p *InstancePool) discard(in *Instance) {
+	in.Close()
+	p.discarded.Add(1)
+	select {
+	case <-p.sem:
+	default:
+	}
+}
+
+// SnapshotLease is a borrowed instance from an InstancePool. Access it via
+// Instance; return it with Release (reset + reuse) or Discard (tear down).
+type SnapshotLease struct {
+	Instance *Instance
+	pool     *InstancePool
+	done     atomic.Bool
+}
+
+// Release returns the instance to its pool, resetting it to the snapshot state
+// for reuse. It is a no-op if the lease was already released or discarded.
+func (l *SnapshotLease) Release() {
+	if l == nil || l.done.Swap(true) {
+		return
+	}
+	l.pool.returnClean(l.Instance)
+}
+
+// Discard tears the leased instance down instead of returning it — use it after
+// a trap or any state the pool shouldn't reuse. No-op if already returned.
+func (l *SnapshotLease) Discard() {
+	if l == nil || l.done.Swap(true) {
+		return
+	}
+	l.pool.discard(l.Instance)
+}

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -167,7 +167,7 @@ func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, e
 	for k, v := range rt.processImports(proc) {
 		merged[k] = v // per-process imports take precedence
 	}
-	inst, err := InstantiateWithOptions(class.mod.c, InstantiateOptions{Imports: merged})
+	inst, err := instantiateCore(class.mod.c, InstantiateOptions{Imports: merged})
 	if err != nil {
 		return nil, err
 	}

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -163,7 +163,7 @@ func (rt *Runtime) Use(ext Extension, _ ...UseOption) error {
 // as a *Module, resolving its imports against the registered extensions and
 // running any AfterCompile hooks.
 func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
-	c, err := CompileWithConfig(rt.cfg, wasmBytes)
+	c, err := Compile(rt.cfg, wasmBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...Instant
 	if cfg.hasGC {
 		iopts.GC = cfg.gc
 	}
-	inst, err := InstantiateWithOptions(mod.c, iopts)
+	inst, err := instantiateCore(mod.c, iopts)
 	if err != nil {
 		return nil, err
 	}

--- a/src/wago/snapshot.go
+++ b/src/wago/snapshot.go
@@ -1,0 +1,311 @@
+package wago
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// SnapshotKind selects what state a Snapshot captures.
+type SnapshotKind uint8
+
+const (
+	// SnapshotInit captures the module immediately after instantiation: initialized
+	// memory, globals, and table, with the start function (if any) already run. No
+	// additional warm function is executed.
+	SnapshotInit SnapshotKind = iota
+	// SnapshotWarm additionally runs a warm-up function before capturing, so the
+	// snapshot reflects post-warm state (e.g. a runtime that lazily builds tables on
+	// first entry). See SnapshotOptions.WarmFunc for resolution.
+	SnapshotWarm
+)
+
+// SnapshotOptions configures Snapshot.
+type SnapshotOptions struct {
+	// Kind selects init vs warm capture. The zero value is SnapshotInit.
+	Kind SnapshotKind
+
+	// Imports available while creating the snapshot. They are retained on the
+	// snapshot and re-applied to every instance restored from it (including pooled
+	// instances), so restore takes no imports of its own.
+	Imports Imports
+
+	// GC configuration used while creating the snapshot and reused on restore.
+	GC GCConfig
+
+	// WarmFunc names the export to run for SnapshotWarm. If empty, Snapshot tries
+	// "_start" then "_instantiate" and uses the first that is exported. Ignored for
+	// SnapshotInit.
+	WarmFunc string
+
+	// WarmArgs are passed to WarmFunc (raw uint64 slots, per the export's signature).
+	WarmArgs []uint64
+}
+
+// defaultWarmFuncs is the resolution order when SnapshotOptions.WarmFunc is empty.
+var defaultWarmFuncs = []string{"_start", "_instantiate"}
+
+// Snapshot is a captured runtime state of a module — linear memory plus global
+// values — from which fresh instances can be created in that exact state without
+// re-running data-segment init or the start function. It also carries the imports
+// and GC config used at capture, so restored instances need none of their own.
+//
+// The default representation lives in local memory (Instance-independent heap
+// copies). MarshalBinary/WriteFile convert it to a self-contained blob (embedding
+// the compiled module) for storage on disk; LoadSnapshot/ReadSnapshotFile bring
+// one back. A Snapshot is safe for concurrent use by Instantiate and Pool: it is
+// read-only after creation.
+//
+// Scope of this prototype: linear memory (current, possibly grown size) and all
+// module-local globals are captured. Imported globals are not — their state is
+// the host's. Table contents are reconstructed from the module's element segments
+// at restore, so runtime table.set mutations are not preserved. Only
+// explicit-bounds modules are supported; signals-based (guard-page) instances are
+// rejected, matching Compiled.MarshalBinary.
+type Snapshot struct {
+	// c is the module the snapshot restores against, kept for the in-memory path.
+	// After a disk round-trip LoadSnapshot rebuilds it from the embedded blob.
+	c *Compiled
+
+	imports Imports  // re-applied to every restored instance
+	gc      GCConfig // reused on restore
+	kind    SnapshotKind
+
+	memPages uint32       // linear-memory size at capture, in 64 KiB wasm pages
+	memory   []byte       // full linear-memory image (length == memPages*65536)
+	globals  []globalSnap // one entry per global cell, indexed by wasm global index
+}
+
+type globalSnap struct {
+	typ  ValType
+	bits uint64
+	vec  V128
+}
+
+// Snapshot instantiates c under opts, optionally runs a warm function, and
+// captures the resulting memory and globals into a reusable Snapshot. The
+// temporary capture instance is closed before returning; the snapshot is
+// independent of it.
+func Capture(c *Compiled, opts SnapshotOptions) (*Snapshot, error) {
+	if c == nil {
+		return nil, errors.New("wago: Snapshot: nil compiled module")
+	}
+	if c.boundsMode == BoundsChecksSignalsBased {
+		return nil, errors.New("wago: signals-based (guard-page) modules cannot be snapshotted yet")
+	}
+	in, err := instantiateCore(c, InstantiateOptions{Imports: opts.Imports, GC: opts.GC})
+	if err != nil {
+		return nil, err
+	}
+	defer in.Close()
+	if !in.ownsMem {
+		return nil, errors.New("wago: cannot snapshot a module whose memory is host-imported or shared")
+	}
+
+	if opts.Kind == SnapshotWarm {
+		if err := runWarm(in, opts); err != nil {
+			return nil, err
+		}
+	}
+
+	// linkModule may return a specialized *Compiled (import-bound); capture against
+	// the instance's actual module so restore recompiles identically.
+	s := &Snapshot{
+		c:       in.c,
+		imports: opts.Imports,
+		gc:      opts.GC,
+		kind:    opts.Kind,
+	}
+	live := in.memory.Bytes()
+	s.memory = make([]byte, len(live))
+	copy(s.memory, live)
+	s.memPages = uint32(len(live) / 65536)
+	s.globals = make([]globalSnap, len(in.globalCells))
+	for i, g := range in.globalCells {
+		if g == nil {
+			continue
+		}
+		s.globals[i] = globalSnap{typ: g.Type, bits: readGlobalObject(g, g.Type), vec: readGlobalObjectV128(g)}
+	}
+	return s, nil
+}
+
+// runWarm resolves and invokes the warm-up function for a SnapshotWarm capture.
+func runWarm(in *Instance, opts SnapshotOptions) error {
+	name := opts.WarmFunc
+	if name == "" {
+		for _, cand := range defaultWarmFuncs {
+			if _, ok := in.c.Exports[cand]; ok {
+				name = cand
+				break
+			}
+		}
+		if name == "" {
+			return fmt.Errorf("wago: warm snapshot: no WarmFunc set and none of %v are exported", defaultWarmFuncs)
+		}
+	}
+	if _, err := in.Invoke(name, opts.WarmArgs...); err != nil {
+		return fmt.Errorf("wago: warm function %q: %w", name, err)
+	}
+	return nil
+}
+
+// Module returns the compiled module this snapshot restores against.
+func (s *Snapshot) Module() *Compiled { return s.c }
+
+// Kind reports whether this is an init or warm snapshot.
+func (s *Snapshot) Kind() SnapshotKind { return s.kind }
+
+const snapshotMagic = "WGSN"
+const snapshotVersion = 1
+
+// MarshalBinary encodes the snapshot to a self-contained blob: the compiled
+// module followed by the captured memory and globals. Trailing zero bytes of
+// linear memory are trimmed (restore re-zeroes the tail), so a snapshot of a
+// program that only touched the low end of a large heap stays small.
+func (s *Snapshot) MarshalBinary() ([]byte, error) {
+	if s == nil || s.c == nil {
+		return nil, errors.New("wago: cannot marshal a snapshot with no bound module")
+	}
+	cb, err := s.c.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("wago: snapshot module: %w", err)
+	}
+
+	mem := s.memory
+	n := len(mem)
+	for n > 0 && mem[n-1] == 0 {
+		n--
+	}
+	mem = mem[:n]
+
+	out := make([]byte, 0, len(snapshotMagic)+2+len(cb)+len(mem)+len(s.globals)*17+32)
+	out = append(out, snapshotMagic...)
+	out = append(out, snapshotVersion, byte(s.kind))
+	out = binary.AppendUvarint(out, uint64(len(cb)))
+	out = append(out, cb...)
+	out = binary.AppendUvarint(out, uint64(s.memPages))
+	out = binary.AppendUvarint(out, uint64(len(mem)))
+	out = append(out, mem...)
+	out = binary.AppendUvarint(out, uint64(len(s.globals)))
+	for _, g := range s.globals {
+		out = append(out, byte(g.typ))
+		if g.typ == ValV128 {
+			out = append(out, g.vec[:]...)
+		} else {
+			var b [16]byte
+			binary.LittleEndian.PutUint64(b[:8], g.bits)
+			out = append(out, b[:]...)
+		}
+	}
+	return out, nil
+}
+
+// IsSnapshot reports whether b is a wago snapshot blob (vs a compiled module or
+// raw wasm).
+func IsSnapshot(b []byte) bool {
+	return len(b) >= len(snapshotMagic)+2 && string(b[:len(snapshotMagic)]) == snapshotMagic
+}
+
+// LoadSnapshot decodes a blob produced by MarshalBinary, rebuilding the embedded
+// compiled module so the snapshot is ready to Instantiate or Pool. Restored
+// instances take no imports (the snapshot's disk form cannot carry host function
+// closures); attach them by re-creating the snapshot in-process if needed.
+func LoadSnapshot(b []byte) (*Snapshot, error) {
+	if !IsSnapshot(b) {
+		return nil, errors.New("wago: not a snapshot blob")
+	}
+	p := b[len(snapshotMagic):]
+	if p[0] != snapshotVersion {
+		return nil, fmt.Errorf("wago: snapshot version %d unsupported (want %d)", p[0], snapshotVersion)
+	}
+	kind := SnapshotKind(p[1])
+	rd := &snapReader{buf: p[2:]}
+
+	cb := rd.bytes(int(rd.uvarint()))
+	memPages := rd.uvarint()
+	memStored := rd.bytes(int(rd.uvarint()))
+	globals := make([]globalSnap, rd.uvarint())
+	for i := range globals {
+		t := ValType(rd.byte())
+		raw := rd.bytes(16)
+		g := globalSnap{typ: t}
+		if t == ValV128 {
+			copy(g.vec[:], raw)
+		} else if len(raw) == 16 {
+			g.bits = binary.LittleEndian.Uint64(raw)
+		}
+		globals[i] = g
+	}
+	if rd.err != nil {
+		return nil, fmt.Errorf("wago: truncated snapshot: %w", rd.err)
+	}
+
+	c, err := Load(cb)
+	if err != nil {
+		return nil, fmt.Errorf("wago: snapshot module: %w", err)
+	}
+	mem := make([]byte, int(memPages)*65536)
+	copy(mem, memStored)
+	return &Snapshot{c: c, kind: kind, memPages: uint32(memPages), memory: mem, globals: globals}, nil
+}
+
+// WriteFile marshals the snapshot and writes it to path.
+func (s *Snapshot) WriteFile(path string) error {
+	b, err := s.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}
+
+// ReadSnapshotFile reads and decodes a snapshot blob from path.
+func ReadSnapshotFile(path string) (*Snapshot, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return LoadSnapshot(b)
+}
+
+// snapReader is a tiny fail-slow byte cursor: once a read runs past the end it
+// latches an error and later reads return zero, so callers check err once.
+type snapReader struct {
+	buf []byte
+	err error
+}
+
+func (r *snapReader) uvarint() uint64 {
+	if r.err != nil {
+		return 0
+	}
+	v, n := binary.Uvarint(r.buf)
+	if n <= 0 {
+		r.err = errors.New("bad uvarint")
+		return 0
+	}
+	r.buf = r.buf[n:]
+	return v
+}
+
+func (r *snapReader) bytes(n int) []byte {
+	if r.err != nil {
+		return nil
+	}
+	if n < 0 || n > len(r.buf) {
+		r.err = fmt.Errorf("want %d bytes, have %d", n, len(r.buf))
+		return nil
+	}
+	b := r.buf[:n]
+	r.buf = r.buf[n:]
+	return b
+}
+
+func (r *snapReader) byte() byte {
+	b := r.bytes(1)
+	if b == nil {
+		return 0
+	}
+	return b[0]
+}

--- a/src/wago/snapshot_pool_test.go
+++ b/src/wago/snapshot_pool_test.go
@@ -1,0 +1,314 @@
+//go:build linux && amd64 && !tinygo && !wago_guardpage
+
+// Snapshots are explicit-bounds only (Capture rejects signals-based modules), so
+// this suite is excluded from the guard-page build, where the default config is
+// signals-based. See Snapshot's doc comment for the scope.
+
+package wago
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// counterWAT: a mutable global "counter" and a linear memory. bump(n) adds n and
+// mirrors the total to memory[0]; get() returns the counter. Enough mutable state
+// to exercise snapshot capture, restore, and pool reset.
+const counterWAT = `(module
+  (memory (export "mem") 1)
+  (global $counter (export "counter") (mut i32) (i32.const 0))
+  (func (export "bump") (param $n i32) (result i32)
+    (global.set $counter (i32.add (global.get $counter) (local.get $n)))
+    (i32.store (i32.const 0) (global.get $counter))
+    (global.get $counter))
+  (func (export "get") (result i32) (global.get $counter)))`
+
+func compileCounter(t *testing.T) *Compiled {
+	t.Helper()
+	c, err := Compile(nil, watToWasmCA(t, counterWAT))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return c
+}
+
+// Capture(SnapshotInit) then Instantiate reproduces initial state (counter 0) and
+// runs forward from there.
+func TestCaptureInitAndInstantiate(t *testing.T) {
+	c := compileCounter(t)
+	snap, err := Capture(c, SnapshotOptions{Kind: SnapshotInit})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	in, err := Instantiate(snap, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	if g, _ := in.Global("counter"); g != 0 {
+		t.Fatalf("counter = %d, want 0", g)
+	}
+	if out, _ := in.Invoke("bump", 7); out[0] != 7 {
+		t.Fatalf("bump = %d, want 7", out[0])
+	}
+}
+
+// A warm snapshot runs the warm function before capturing, so restored instances
+// start from post-warm state. Here "bump" is the warm func with arg 100.
+func TestCaptureWarmExplicitFunc(t *testing.T) {
+	c := compileCounter(t)
+	snap, err := Capture(c, SnapshotOptions{Kind: SnapshotWarm, WarmFunc: "bump", WarmArgs: []uint64{100}})
+	if err != nil {
+		t.Fatalf("capture warm: %v", err)
+	}
+	in, err := Instantiate(snap, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	if g, _ := in.Global("counter"); g != 100 {
+		t.Fatalf("warm counter = %d, want 100", g)
+	}
+	if got := in.Memory().Bytes()[0]; got != 100 {
+		t.Fatalf("warm memory[0] = %d, want 100", got)
+	}
+}
+
+// Default warm-func resolution: no WarmFunc set, module exports _start.
+func TestCaptureWarmDefaultStart(t *testing.T) {
+	wat := `(module
+      (global $g (export "counter") (mut i32) (i32.const 0))
+      (func (export "_start") (global.set $g (i32.const 55)))
+      (func (export "get") (result i32) (global.get $g)))`
+	c, err := Compile(nil, watToWasmCA(t, wat))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	snap, err := Capture(c, SnapshotOptions{Kind: SnapshotWarm}) // resolves _start
+	if err != nil {
+		t.Fatalf("capture warm: %v", err)
+	}
+	in, err := Instantiate(snap, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	if g, _ := in.Global("counter"); g != 55 {
+		t.Fatalf("counter = %d, want 55 (_start ran once at capture)", g)
+	}
+}
+
+// Blob round-trip through a file, plus IsSnapshot detection.
+func TestSnapshotBlobFile(t *testing.T) {
+	c := compileCounter(t)
+	snap, err := Capture(c, SnapshotOptions{Kind: SnapshotWarm, WarmFunc: "bump", WarmArgs: []uint64{9}})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	blob, err := snap.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !IsSnapshot(blob) || IsCompiled(blob) {
+		t.Fatalf("IsSnapshot=%v IsCompiled=%v, want true/false", IsSnapshot(blob), IsCompiled(blob))
+	}
+	path := filepath.Join(t.TempDir(), "s.wgsnap")
+	if err := snap.WriteFile(path); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	loaded, err := ReadSnapshotFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	in, err := Instantiate(loaded, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate loaded: %v", err)
+	}
+	defer in.Close()
+	if g, _ := in.Global("counter"); g != 9 {
+		t.Fatalf("loaded counter = %d, want 9", g)
+	}
+}
+
+// Instantiate still dispatches correctly on a *Compiled with imports/GC options.
+func TestInstantiateCompiledDispatch(t *testing.T) {
+	c := compileCounter(t)
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate compiled: %v", err)
+	}
+	defer in.Close()
+	if out, _ := in.Invoke("bump", 3); out[0] != 3 {
+		t.Fatalf("bump = %d, want 3", out[0])
+	}
+}
+
+// Pool.Invoke must isolate state between calls: each call starts from the
+// snapshot, so two bump(5) calls both return 5 (no accumulation).
+func TestPoolInvokeIsolation(t *testing.T) {
+	c := compileCounter(t)
+	snap, err := Capture(c, SnapshotOptions{})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pool, err := Pool(snap, SnapshotPoolOptions{MinIdle: 2, MaxInstances: 4})
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		out, err := pool.Invoke(ctx, "bump", 5)
+		if err != nil {
+			t.Fatalf("invoke %d: %v", i, err)
+		}
+		if out[0] != 5 {
+			t.Fatalf("invoke %d bump = %d, want 5 (state must reset each lease)", i, out[0])
+		}
+	}
+	if st := pool.Stats(); st.Reused == 0 {
+		t.Fatalf("expected some idle reuse, Stats=%+v", st)
+	}
+}
+
+// Manual lease: mutate through the lease, release (which resets), re-acquire and
+// confirm the next tenant sees clean state.
+func TestPoolLeaseResetsBetweenTenants(t *testing.T) {
+	c := compileCounter(t)
+	snap, err := Capture(c, SnapshotOptions{})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pool, err := Pool(snap, SnapshotPoolOptions{MinIdle: 1, MaxInstances: 1}) // force reuse of the one instance
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+	ctx := context.Background()
+
+	l1, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire1: %v", err)
+	}
+	if _, err := l1.Instance.Invoke("bump", 40); err != nil {
+		t.Fatalf("bump: %v", err)
+	}
+	if _, err := l1.Instance.Invoke("bump", 2); err != nil { // counter now 42
+		t.Fatalf("bump: %v", err)
+	}
+	l1.Release() // resets to snapshot
+
+	l2, err := pool.Acquire(ctx) // same underlying instance (MaxInstances=1)
+	if err != nil {
+		t.Fatalf("acquire2: %v", err)
+	}
+	defer l2.Release()
+	if g, _ := l2.Instance.Global("counter"); g != 0 {
+		t.Fatalf("reused instance counter = %d, want 0 (reset on release)", g)
+	}
+}
+
+// MaxInstances caps concurrent leases; an Acquire past the cap blocks until a
+// release, and honors context cancellation.
+func TestPoolMaxInstancesBlocksAndCancels(t *testing.T) {
+	c := compileCounter(t)
+	snap, err := Capture(c, SnapshotOptions{})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pool, err := Pool(snap, SnapshotPoolOptions{MaxInstances: 1})
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	l1, err := pool.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire1: %v", err)
+	}
+	// Second acquire must block (cap reached); ctx cancellation unblocks it.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := pool.Acquire(ctx); err == nil {
+		t.Fatalf("acquire2 should have failed on cancelled ctx")
+	}
+	if st := pool.Stats(); st.Live != 1 || st.InUse != 1 {
+		t.Fatalf("Stats=%+v, want Live=1 InUse=1", st)
+	}
+	l1.Release()
+	// Now capacity is free again.
+	l2, err := pool.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire3: %v", err)
+	}
+	l2.Release()
+}
+
+// Discard tears the instance down instead of reusing it; Stats.Discarded reflects it.
+func TestPoolDiscard(t *testing.T) {
+	c := compileCounter(t)
+	snap, err := Capture(c, SnapshotOptions{})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pool, err := Pool(snap, SnapshotPoolOptions{MaxInstances: 2})
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+	l, err := pool.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	l.Discard()
+	if st := pool.Stats(); st.Discarded != 1 || st.Live != 0 {
+		t.Fatalf("Stats=%+v, want Discarded=1 Live=0", st)
+	}
+	// Double Release/Discard is a no-op.
+	l.Release()
+	l.Discard()
+	if st := pool.Stats(); st.Discarded != 1 {
+		t.Fatalf("Stats=%+v, double-return should not change counters", st)
+	}
+}
+
+// Concurrent pool usage — run under `go test -race` to catch data races in the
+// acquire/release/reset paths.
+func TestPoolConcurrent(t *testing.T) {
+	c := compileCounter(t)
+	snap, err := Capture(c, SnapshotOptions{})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pool, err := Pool(snap, SnapshotPoolOptions{MinIdle: 4, MaxIdle: 8, MaxInstances: 16})
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	for g := 0; g < 32; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 20; i++ {
+				out, err := pool.Invoke(ctx, "bump", 1)
+				if err != nil {
+					t.Errorf("invoke: %v", err)
+					return
+				}
+				if out[0] != 1 { // isolation: always starts from snapshot
+					t.Errorf("bump = %d, want 1", out[0])
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if st := pool.Stats(); st.Live > 16 {
+		t.Fatalf("Live=%d exceeded MaxInstances=16", st.Live)
+	}
+}

--- a/src/wago/spectest_exec_test.go
+++ b/src/wago/spectest_exec_test.go
@@ -593,12 +593,12 @@ func runSpecExecFile(t *testing.T, base, tmp string, sf specExecFile) (pass, ski
 			if err != nil {
 				continue
 			}
-			compiled, err := wago.CompileWithConfig(cfg, data)
+			compiled, err := wago.Compile(cfg, data)
 			if err != nil {
 				skipMod++
 				continue // unsupported module (feature out of scope) — not a miscompile
 			}
-			in, err := wago.Instantiate(compiled, spectestImports())
+			in, err := wago.Instantiate(compiled, wago.InstantiateOptions{Imports: spectestImports()})
 			if err != nil {
 				skipMod++
 				continue // needs imports / unsupported instantiate — out of scope

--- a/src/wago/sqlite_regression_test.go
+++ b/src/wago/sqlite_regression_test.go
@@ -22,7 +22,7 @@ func TestSyncSQLiteQuery(t *testing.T) {
 	if err != nil {
 		t.Skip("bench/corpus/sqlite3.wasm not present")
 	}
-	c, err := Compile(src)
+	c, err := Compile(nil, src)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestSyncSQLiteQuery(t *testing.T) {
 	for _, fn := range c.Imports { // no-op stubs for the emscripten env.* / wasi imports
 		imp[fn] = HostFunc(func(HostModule, []uint64, []uint64) {})
 	}
-	in, err := Instantiate(c, imp)
+	in, err := Instantiate(c, InstantiateOptions{Imports: imp})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}

--- a/src/wago/start_test.go
+++ b/src/wago/start_test.go
@@ -12,11 +12,11 @@ func TestStartFunctionRuns(t *testing.T) {
 		(func $init (i32.store8 (i32.const 0) (i32.const 42)))
 		(start $init)
 		(func (export "get") (result i32) (i32.load8_u (i32.const 0))))`)
-	c, err := Compile(bin)
+	c, err := Compile(nil, bin)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -33,11 +33,11 @@ func TestStartFunctionRuns(t *testing.T) {
 // A trap in the start function aborts instantiation.
 func TestStartFunctionTrapAbortsInstantiate(t *testing.T) {
 	bin := watToWasmCA(t, `(module (func $boom unreachable) (start $boom))`)
-	c, err := Compile(bin)
+	c, err := Compile(nil, bin)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	if _, err := Instantiate(c, nil); err == nil {
+	if _, err := Instantiate(c, InstantiateOptions{}); err == nil {
 		t.Fatal("trapping start should abort instantiation")
 	}
 }

--- a/src/wago/trap_test.go
+++ b/src/wago/trap_test.go
@@ -17,7 +17,7 @@ func TestInvokeTrapError(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("boom", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x00, 0x0b}))), // unreachable; end
 	)
-	in, err := Instantiate(MustCompile(mod), nil)
+	in, err := Instantiate(MustCompile(mod), InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestRecursiveStackExhaustionTrapsCleanly(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("recurse", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))), // call self; end
 	)
-	in, err := Instantiate(MustCompile(mod), nil)
+	in, err := Instantiate(MustCompile(mod), InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/wago/wago_test.go
+++ b/src/wago/wago_test.go
@@ -52,7 +52,7 @@ func TestCompileWithConfigDoesNotGateOnIRLowering(t *testing.T) {
 			0x0b,
 		}))),
 	)
-	if _, err := CompileWithConfig(NewRuntimeConfig(), mod); err != nil {
+	if _, err := Compile(NewRuntimeConfig(), mod); err != nil {
 		t.Fatalf("CompileWithConfig should use direct backend without IR gate: %v", err)
 	}
 }
@@ -68,11 +68,11 @@ func TestInvokeDynamicallySizesArgBuffer(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x40, 0x0b}))), // local.get 64
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, Imports{})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{}})
 	if err != nil {
 		t.Fatalf("InstantiateWithImports: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestInvokeV128UsesTwoPublicSlots(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestInvokeV128UsesTwoPublicSlots(t *testing.T) {
 	if !reflect.DeepEqual(params, []ValType{ValI32, ValV128, ValI32}) || !reflect.DeepEqual(results, []ValType{ValV128, ValI32}) {
 		t.Fatalf("Signature = (%v) -> (%v), want (i32 v128 i32) -> (v128 i32)", params, results)
 	}
-	in, err := Instantiate(c, Imports{})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{}})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
@@ -145,11 +145,11 @@ func TestInvokeDynamicallySizesResultBuffer(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	in, err := Instantiate(c, Imports{})
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{}})
 	if err != nil {
 		t.Fatalf("InstantiateWithImports: %v", err)
 	}
@@ -192,11 +192,11 @@ func run1(t *testing.T, wasm []byte, export string, args ...int32) int32 {
 // pipeline for one-shot runs that need host functions or imported globals.
 func runImports(t *testing.T, wasm []byte, imports Imports, export string, args ...uint64) []uint64 {
 	t.Helper()
-	c, err := Compile(wasm)
+	c, err := Compile(nil, wasm)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	in, err := Instantiate(c, imports)
+	in, err := Instantiate(c, InstantiateOptions{Imports: imports})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestAssemblyScriptFloat(t *testing.T) {
 
 func TestCompiledRoundtrip(t *testing.T) {
 	t.Setenv("WAGO_BOUNDS", "explicit") // signals-based modules can't be serialized (the guard-tag default)
-	c, err := Compile(fibWasm)
+	c, err := Compile(nil, fibWasm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ func TestCompiledRoundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c2, nil)
+	in, err := Instantiate(c2, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -442,7 +442,7 @@ func TestCompiledRoundtripPreservesDebugNames(t *testing.T) {
 		)),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x2a, 0x0b}))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
@@ -615,11 +615,11 @@ func TestCompiledValidateGCTypeDescFailures(t *testing.T) {
 }
 
 func TestInstantiateGCCollectorLifecycle(t *testing.T) {
-	c, err := Compile(fibWasm)
+	c, err := Compile(nil, fibWasm)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -630,7 +630,7 @@ func TestInstantiateGCCollectorLifecycle(t *testing.T) {
 
 	funcOnly := *c
 	funcOnly.GCTypeDescs = []gc.TypeDesc{{ID: 0, Kind: gc.KindFunc}}
-	in, err = Instantiate(&funcOnly, nil)
+	in, err = Instantiate(&funcOnly, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +640,7 @@ func TestInstantiateGCCollectorLifecycle(t *testing.T) {
 	in.Close()
 
 	c.GCTypeDescs = representativeGCTypeDescs(t)
-	in, err = Instantiate(c, nil)
+	in, err = Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -651,12 +651,12 @@ func TestInstantiateGCCollectorLifecycle(t *testing.T) {
 }
 
 func TestInstantiateWithOptionsGCConfig(t *testing.T) {
-	c, err := Compile(fibWasm)
+	c, err := Compile(nil, fibWasm)
 	if err != nil {
 		t.Fatal(err)
 	}
 	c.GCTypeDescs = representativeGCTypeDescs(t)
-	in, err := InstantiateWithOptions(c, InstantiateOptions{GC: gc.Config{Profile: gc.ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}})
+	in, err := Instantiate(c, InstantiateOptions{GC: gc.Config{Profile: gc.ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -670,7 +670,7 @@ func TestInstantiateWithOptionsGCConfig(t *testing.T) {
 
 	funcOnly := *c
 	funcOnly.GCTypeDescs = []gc.TypeDesc{{ID: 0, Kind: gc.KindFunc}}
-	in, err = InstantiateWithOptions(&funcOnly, InstantiateOptions{GC: gc.Config{Profile: gc.ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}})
+	in, err = Instantiate(&funcOnly, InstantiateOptions{GC: gc.Config{Profile: gc.ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,14 +703,14 @@ func TestCallIndirectZeroLengthTableTrapsOOB(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x00, 0x11, 0x00, 0x00, 0x0b}))),
 	)
-	c, err := Compile(mod)
+	c, err := Compile(nil, mod)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
 	if !c.HasTable || c.TableSize != 0 {
 		t.Fatalf("compiled table shape = HasTable %v, TableSize %d; want true, 0", c.HasTable, c.TableSize)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
@@ -723,11 +723,11 @@ func TestCallIndirectZeroLengthTableTrapsOOB(t *testing.T) {
 }
 
 func TestCallIndirect(t *testing.T) {
-	c, err := Compile(indirectWasm)
+	c, err := Compile(nil, indirectWasm)
 	if err != nil {
 		t.Fatal(err)
 	}
-	in, err := Instantiate(c, nil)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -758,8 +758,8 @@ var dispatchWasm = testdata("dispatch.wasm")
 // Real AssemblyScript using indirect calls (function pointers), select, and data
 // segments (the function-ref objects live in linear memory).
 func TestAssemblyScriptDispatch(t *testing.T) {
-	c, _ := Compile(dispatchWasm)
-	in, err := Instantiate(c, nil)
+	c, _ := Compile(nil, dispatchWasm)
+	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wago.go
+++ b/wago.go
@@ -55,6 +55,8 @@ type (
 	Imports                   = impl.Imports
 	Instance                  = impl.Instance
 	InstanceExport            = impl.InstanceExport
+	InstancePool              = impl.InstancePool
+	Instantiable              = impl.Instantiable
 	InstantiateContext        = impl.InstantiateContext
 	InstantiateOption         = impl.InstantiateOption
 	InstantiateOptions        = impl.InstantiateOptions
@@ -68,6 +70,7 @@ type (
 	PID                       = impl.PID
 	Policy                    = impl.Policy
 	PoolOptions               = impl.PoolOptions
+	PoolStats                 = impl.PoolStats
 	Process                   = impl.Process
 	Registry                  = impl.Registry
 	ResetPolicy               = impl.ResetPolicy
@@ -78,6 +81,11 @@ type (
 	RuntimeConfig             = impl.RuntimeConfig
 	RuntimeContext            = impl.RuntimeContext
 	RuntimeOption             = impl.RuntimeOption
+	Snapshot                  = impl.Snapshot
+	SnapshotKind              = impl.SnapshotKind
+	SnapshotLease             = impl.SnapshotLease
+	SnapshotOptions           = impl.SnapshotOptions
+	SnapshotPoolOptions       = impl.SnapshotPoolOptions
 	SpawnOptions              = impl.SpawnOptions
 	Stability                 = impl.Stability
 	Supervisor                = impl.Supervisor
@@ -149,6 +157,8 @@ const (
 	RestartPermanent                           = impl.RestartPermanent
 	RestartTemporary                           = impl.RestartTemporary
 	RestartTransient                           = impl.RestartTransient
+	SnapshotInit                               = impl.SnapshotInit
+	SnapshotWarm                               = impl.SnapshotWarm
 	Stable                                     = impl.Stable
 	TrapBuiltin                                = impl.TrapBuiltin
 	TrapCalledFnNotLinked                      = impl.TrapCalledFnNotLinked
@@ -183,10 +193,10 @@ func AsI64(b uint64) int64 { return impl.AsI64(b) }
 
 func CapabilityDocs(docs string) CapabilityOption { return impl.CapabilityDocs(docs) }
 
-func Compile(wasmBytes []byte) (*Compiled, error) { return impl.Compile(wasmBytes) }
+func Capture(c *Compiled, opts SnapshotOptions) (*Snapshot, error) { return impl.Capture(c, opts) }
 
-func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
-	return impl.CompileWithConfig(cfg, wasmBytes)
+func Compile(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
+	return impl.Compile(cfg, wasmBytes)
 }
 
 func DirsFor(version string) Dirs { return impl.DirsFor(version) }
@@ -201,19 +211,19 @@ func I32(v int32) uint64 { return impl.I32(v) }
 
 func I64(v int64) uint64 { return impl.I64(v) }
 
-func Instantiate(c *Compiled, imports Imports) (*Instance, error) {
-	return impl.Instantiate(c, imports)
-}
-
-func InstantiateWithOptions(c *Compiled, opts InstantiateOptions) (*Instance, error) {
-	return impl.InstantiateWithOptions(c, opts)
+func Instantiate(source Instantiable, opts InstantiateOptions) (*Instance, error) {
+	return impl.Instantiate(source, opts)
 }
 
 func IsCompiled(b []byte) bool { return impl.IsCompiled(b) }
 
 func IsGuardPageUnavailable(err error) bool { return impl.IsGuardPageUnavailable(err) }
 
+func IsSnapshot(b []byte) bool { return impl.IsSnapshot(b) }
+
 func Load(b []byte) (*Compiled, error) { return impl.Load(b) }
+
+func LoadSnapshot(b []byte) (*Snapshot, error) { return impl.LoadSnapshot(b) }
 
 func MustCompile(wasmBytes []byte) *Compiled { return impl.MustCompile(wasmBytes) }
 
@@ -240,6 +250,12 @@ func NewRuntime(opts ...RuntimeOption) *Runtime { return impl.NewRuntime(opts...
 func NewRuntimeConfig() *RuntimeConfig { return impl.NewRuntimeConfig() }
 
 func NewTable(minSize uint32, maxSize uint32) (*Table, error) { return impl.NewTable(minSize, maxSize) }
+
+func Pool(snapshot *Snapshot, opts SnapshotPoolOptions) (*InstancePool, error) {
+	return impl.Pool(snapshot, opts)
+}
+
+func ReadSnapshotFile(path string) (*Snapshot, error) { return impl.ReadSnapshotFile(path) }
 
 func RegisterExtension(name string, factory ExtensionFactory) { impl.RegisterExtension(name, factory) }
 


### PR DESCRIPTION
Adds a snapshot + instance-pool layer to the low-level API.

## New surface
- `Compile(cfg *RuntimeConfig, wasm) → *Compiled` — config is now the first arg (folds in the old `CompileWithConfig`; pass `nil` for defaults).
- `Capture(c *Compiled, SnapshotOptions) → *Snapshot` — capture an **init** or **warm** snapshot (memory + globals). Warm resolves `WarmFunc`, else `_start`/`_instantiate`.
- `Instantiate(source Instantiable, InstantiateOptions)` — unified entry over a sealed `Instantiable` (`*Compiled | *Snapshot`). Restoring a snapshot skips data-init and the start function.
- `Pool(*Snapshot, SnapshotPoolOptions) → *InstancePool` — `Acquire`/`Invoke`/`Close`/`Stats`; `SnapshotLease{Instance}` with `Release` (fast in-place reset to the snapshot) / `Discard`. `PoolStats` counters.
- Snapshot blobs: `MarshalBinary`/`WriteFile` (self-contained, embeds the module, trailing-zero-trimmed) + `LoadSnapshot`/`ReadSnapshotFile`/`IsSnapshot`. Default is in-memory; disk is opt-in.

Between-lease reset reloads memory + globals and shrinks grown pages back to zero (`JobMemory.RestoreLinear`) instead of re-instantiating.

## Naming decisions (Go constraints)
- Constructor is `Capture`, not `Snapshot` — a func and type can't share a name (cf. `regexp.Compile → *regexp.Regexp`).
- Pool types are namespaced `SnapshotPoolOptions` / `SnapshotLease` to avoid colliding with the Class system's existing `PoolOptions`/`Lease`.
- `RuntimeConfig` stays the existing `*RuntimeConfig` builder (`nil` = defaults) rather than a value struct.

## Scope (documented on `Snapshot`)
Explicit-bounds modules only (guard-page rejected, same as `Compiled.MarshalBinary`); imported globals not captured (host-owned); table reconstructed from element segments at restore (runtime `table.set` not yet preserved).

## Tests
14 new tests (init/warm capture, blob file round-trip, dispatch, pool isolation/reset/cap/discard/stats) + a concurrent pool test that passes under `-race`. Existing call sites migrated to the new signatures; `go build ./... && go vet ./...` clean. Example: `examples/17-snapshot-pool`.

Note: `plugins/wasi` (separate module) also needs its call sites migrated — handled in its own repo, not part of this PR.
