### PR TITLE
fix: installer fetches the plugins/wasi submodule before building

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,6 +107,14 @@ if ! git clone --depth 1 --branch "$version" "$repo_ssh" "$tmp/src" 2>/dev/null;
 	git -C "$tmp/src" checkout -q "$version" 2>/dev/null || die "no such version: $version"
 fi
 
+# The CLI imports the wasi plugin, pinned as a submodule (replace ./plugins/wasi).
+# Fetch it before building. Rewrite its HTTPS URL to SSH so it uses the same key
+# that cloned wago (wago-org/wasi is private too).
+step "fetching plugins ${dim}(wasi)${reset}"
+git -C "$tmp/src" -c url."git@github.com:".insteadOf="https://github.com/" \
+	submodule update --init "plugins/wasi" >/dev/null 2>&1 \
+	|| die "could not fetch the plugins/wasi submodule (need access to wago-org/wasi)"
+
 # The Go module is stdlib-only, so this builds offline without fetching deps.
 stamp=$(git -C "$tmp/src" describe --tags --always 2>/dev/null || echo "$version")
 step "building wago ${dim}($stamp)${reset}"


### PR DESCRIPTION
The `install.sh` bootstrap shallow-clones `wago` and runs `go build ./cli/wago`, but never initializes the **`plugins/wasi`** submodule that `cli/wago/plugins.go` imports (`replace ./plugins/wasi`). A fresh install therefore fails:

```
cli/wago/plugins.go:12:2: github.com/wago-org/wasi@v0.0.0 (replaced by ./plugins/wasi): reading plugins/wasi/go.mod: no such file or directory
```

Adds `git submodule update --init plugins/wasi` after the clone, rewriting the submodule's HTTPS URL to SSH (`url."git@github.com:".insteadOf`) so it reuses the key that cloned wago (wago-org/wasi is private). Only that submodule is fetched — the build doesn't need the others.

Verified: fresh `--depth 1` clone reproduces the failure; with the submodule fetch, `go build ./cli/wago` succeeds. `bash -n` clean.

(Companion fix to the served installer in wago-org/website#12.)
