### PR TITLE
chore(wasi): bump plugin submodule to wago-API-migrated commit

### DIFF
--- a/bench/perf_costmodel_test.go
+++ b/bench/perf_costmodel_test.go
@@ -35,11 +35,11 @@ func BenchmarkKernels(b *testing.B) {
 				b.Skipf("no %s", k.file)
 			}
 			cfg := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
-			comp, err := wago.CompileWithConfig(cfg, src)
+			comp, err := wago.Compile(cfg, src)
 			if err != nil {
 				b.Fatalf("compile: %v", err)
 			}
-			in, err := wago.Instantiate(comp, wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})})
+			in, err := wago.Instantiate(comp, wago.InstantiateOptions{Imports: wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})}})
 			if err != nil {
 				b.Fatalf("instantiate: %v", err)
 			}


### PR DESCRIPTION
Bumps the `plugins/wasi` submodule from the stale `118d5d8` to `31d06f7` on wasi `main`.

That wasi commit migrates the p1 test suite to the new `Compile(cfg, wasm)` / `Instantiate(source, opts)` API (from #199) and includes wasi's own intervening `#1` manifest rename. The wasi plugin packages wago compiles in (`p1`, `unstable`, `internal/core`, `wasi.go`) build and test clean against the new API; `go build ./...` (incl. `cli/wago`) passes here.

Note: wasi's `internal/genmanifest` tool has a pre-existing `m.Extensions` leftover from its rename — unrelated to this bump and not compiled by wago.