### PR TITLE
perf: optimize Impart runtime paths

### DIFF
--- a/src/core/compiler/backend/railshot/driver.go
+++ b/src/core/compiler/backend/railshot/driver.go
@@ -451,12 +451,24 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x91:
 		f.fsqrt(false)
 	case 0x92:
+		if done, err := f.tryFbinLocalSet(r, f.a.VFAdd, 0x58, false); done || err != nil {
+			return err
+		}
 		f.fbin(f.a.VFAdd, 0x58, false)
 	case 0x93:
+		if done, err := f.tryFbinLocalSet(r, f.a.VFSub, 0x5C, false); done || err != nil {
+			return err
+		}
 		f.fbin(f.a.VFSub, 0x5C, false)
 	case 0x94:
+		if done, err := f.tryFbinLocalSet(r, f.a.VFMul, 0x59, false); done || err != nil {
+			return err
+		}
 		f.fbin(f.a.VFMul, 0x59, false)
 	case 0x95:
+		if done, err := f.tryFbinLocalSet(r, f.a.VFDiv, 0x5E, false); done || err != nil {
+			return err
+		}
 		f.fbin(f.a.VFDiv, 0x5E, false)
 	case 0x96:
 		f.fminmax(false, false)
@@ -480,12 +492,24 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x9f:
 		f.fsqrt(true)
 	case 0xa0:
+		if done, err := f.tryFbinLocalSet(r, f.a.VFAdd, 0x58, true); done || err != nil {
+			return err
+		}
 		f.fbin(f.a.VFAdd, 0x58, true)
 	case 0xa1:
+		if done, err := f.tryFbinLocalSet(r, f.a.VFSub, 0x5C, true); done || err != nil {
+			return err
+		}
 		f.fbin(f.a.VFSub, 0x5C, true)
 	case 0xa2:
+		if done, err := f.tryFbinLocalSet(r, f.a.VFMul, 0x59, true); done || err != nil {
+			return err
+		}
 		f.fbin(f.a.VFMul, 0x59, true)
 	case 0xa3:
+		if done, err := f.tryFbinLocalSet(r, f.a.VFDiv, 0x5E, true); done || err != nil {
+			return err
+		}
 		f.fbin(f.a.VFDiv, 0x5E, true)
 	case 0xa4:
 		f.fminmax(true, false)
@@ -598,6 +622,48 @@ func (f *fn) popValue() *elem {
 	}
 	f.erase(e)
 	return e
+}
+
+func (f *fn) tryFbinLocalSet(r *wasm.Reader, vop func(dst, s1, s2 Reg, f64 bool), memOp byte, f64 bool) (bool, error) {
+	save := r.Offset()
+	op, ok := r.Peek()
+	if !ok || (op != 0x21 && op != 0x22) {
+		return false, nil
+	}
+	if _, err := r.Byte(); err != nil {
+		return false, err
+	}
+	x32, err := r.U32()
+	if err != nil {
+		return false, err
+	}
+	x := int(x32) + f.localBase
+	pr, isFloat, pinned := f.pinReg(x)
+	if !pinned || !isFloat || x < 0 || x >= len(f.localType) || f.localType[x] != mtOf2(f64) {
+		if err := r.JumpTo(save); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if f.bcKind == 1 && f.bcIdx == uint32(x) {
+		f.invalidateBoundsCert()
+	}
+	right := f.s.back()
+	if right == nil {
+		if err := r.JumpTo(save); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	left := baseOfValentBlock(right).prev
+	f.realizeLocalRefs(x, left)
+	f.fbinInto(pr, vop, memOp, f64)
+	f.markLocalDirty(x)
+	f.stats.peep("float-local-sink")
+	if op == 0x22 {
+		f.pushValue(storage{kind: stLocalReg, typ: f.localType[x], reg: pr, idx: x})
+	}
+	return true, nil
 }
 
 // emitSelect lowers `select`: result = cond != 0 ? a : b, where the operand

--- a/src/core/compiler/backend/railshot/fp.go
+++ b/src/core/compiler/backend/railshot/fp.go
@@ -216,6 +216,26 @@ func (f *fn) fbin(vop func(dst, s1, s2 Reg, f64 bool), memOp byte, f64 bool) {
 	f.pushFReg(dst, mtOf2(f64))
 }
 
+func (f *fn) fbinInto(dst Reg, vop func(dst, s1, s2 Reg, f64 bool), memOp byte, f64 bool) {
+	b := f.popValue()
+	a := f.popValue()
+	if b.kind == ekValue && b.st.kind == stMemRef && b.st.typ.isFloat() && b.st.memSize() == fsize(f64) {
+		f.fbinMemRightInto(dst, a, b, memOp, f64)
+		return
+	}
+	s1, o1 := f.operandRegF(a)
+	f.fpinned = f.fpinned.add(s1)
+	s2, o2 := f.operandRegF(b)
+	f.fpinned = f.fpinned.remove(s1)
+	vop(dst, s1, s2, f64)
+	if o1 && dst != s1 {
+		f.releaseF(s1)
+	}
+	if o2 && dst != s2 {
+		f.releaseF(s2)
+	}
+}
+
 func (f *fn) fbinMemRight(a, b *elem, memOp byte, f64 bool) {
 	src, owned := f.operandRegF(a)
 	dst := src
@@ -226,6 +246,18 @@ func (f *fn) fbinMemRight(a, b *elem, memOp byte, f64 bool) {
 	f.a.SseIdx(scalarFloatPrefix(f64), memOp, dst, RBX, b.st.reg, b.st.memDisp())
 	f.releaseMemRef(b.st)
 	f.pushFReg(dst, mtOf2(f64))
+}
+
+func (f *fn) fbinMemRightInto(dst Reg, a, b *elem, memOp byte, f64 bool) {
+	src, owned := f.operandRegF(a)
+	if dst != src {
+		f.a.FMov(dst, src, f64)
+	}
+	f.a.SseIdx(scalarFloatPrefix(f64), memOp, dst, RBX, b.st.reg, b.st.memDisp())
+	f.releaseMemRef(b.st)
+	if owned && dst != src {
+		f.releaseF(src)
+	}
 }
 
 // scalarFMinMaxInto implements wasm min/max for one scalar lane, which x86

--- a/src/core/compiler/backend/railshot/golden_test.go
+++ b/src/core/compiler/backend/railshot/golden_test.go
@@ -101,6 +101,20 @@ func TestGoldenMemoryCopyRepMovs(t *testing.T) {
 	}
 }
 
+func TestGoldenFloatLocalSink(t *testing.T) {
+	// local.get 0; local.get 1; f64.add; local.set 0; local.get 0
+	m := mod1(t, []wasm.ValType{wasm.F64, wasm.F64}, []wasm.ValType{wasm.F64},
+		[]byte{0x00, 0x20, 0x00, 0x20, 0x01, 0xa0, 0x21, 0x00, 0x20, 0x00, 0x0b})
+	d := disasm(t, compileCode(t, m, false))
+	if !strings.Contains(d, "vaddsd xmm12,xmm12,xmm13") {
+		t.Errorf("expected fused `vaddsd xmm12,xmm12,xmm13`, got:\n%s", d)
+	}
+	afterAdd := d[strings.Index(d, "vaddsd xmm12,xmm12,xmm13"):]
+	if strings.Contains(afterAdd, "movsd  xmm12") || strings.Contains(afterAdd, "movsd xmm12") {
+		t.Errorf("fused float local update should not move a scratch result back into xmm12:\n%s", d)
+	}
+}
+
 // mod1Mem builds a one-memory module whose exported function does a single
 // i32.load of its i32 parameter (the guard-vs-explicit bounds shape probe).
 func mod1Mem(t *testing.T) *wasm.Module {

--- a/src/core/compiler/backend/railshot/stats_test.go
+++ b/src/core/compiler/backend/railshot/stats_test.go
@@ -69,6 +69,14 @@ func TestCodegenStatsPeepholes(t *testing.T) {
 			body: []byte{0x00, 0x20, 0x00, 0x41, 0x05, 0x48, 0x0b},
 			peep: "compare-setcc",
 		},
+		{
+			// local.get 0; local.get 1; f64.add; local.set 0 sinks the result straight
+			// into local 0's pinned XMM register instead of producing a scratch result
+			// and moving it back in local.set.
+			name: "float-local-sink", in: []wasm.ValType{wasm.F64, wasm.F64}, out: []wasm.ValType{wasm.F64},
+			body: []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0xa0, 0x21, 0x00, 0x20, 0x00, 0x0b},
+			peep: "float-local-sink",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/src/core/compiler/wasm/validate_coverage_test.go
+++ b/src/core/compiler/wasm/validate_coverage_test.go
@@ -151,6 +151,23 @@ func TestValidatorCoverageSIMDOpcodeFamilies(t *testing.T) {
 	}
 }
 
+func TestSIMDEffectTableMatchesAdmissionSet(t *testing.T) {
+	for k := range simdAll {
+		if simdEffects[k].cat == simdNone {
+			t.Fatalf("%s is admitted by simdAll but has no validation effect", k)
+		}
+	}
+	for k, eff := range simdEffects {
+		if eff.cat == simdNone {
+			continue
+		}
+		kind := InstrKind(k)
+		if _, ok := simdAll[kind]; !ok {
+			t.Fatalf("%s has validation effect but is missing from simdAll", kind)
+		}
+	}
+}
+
 func TestValidatorProposalCoverageArrayNewForms(t *testing.T) {
 	arrayMod := func(kind InstrKind, body ...Instruction) *Module {
 		m := &Module{

--- a/src/core/compiler/wasm/validate_proposal.go
+++ b/src/core/compiler/wasm/validate_proposal.go
@@ -21,7 +21,7 @@ func (v *funcValidator) proposalStep(in Instruction) (bool, error) {
 		InstrAnyConvertExtern, InstrExternConvertAny, InstrRefI31, InstrI31GetS, InstrI31GetU:
 		return true, v.stepGC(in)
 	}
-	if _, ok := simdAll[in.Kind]; ok {
+	if in.Kind < numInstrKinds && simdEffects[in.Kind].cat != simdNone {
 		return true, v.stepSIMD(in)
 	}
 	return false, nil
@@ -664,11 +664,13 @@ var simdAll = func() map[InstrKind]struct{} {
 }()
 
 func (v *funcValidator) stepSIMD(in Instruction) error {
-	if limit, ok := simdLaneLimits[in.Kind]; ok && in.Lane >= limit {
+	e := simdEffects[in.Kind]
+	if e.laneLimit != 0 && in.Lane >= e.laneLimit {
 		return v.verr(ErrTypeMismatch, "simd lane out of range")
 	}
-	if eff, ok := simdLoads[in.Kind]; ok {
-		addr, err := v.checkMemArg(in.MemArg(), eff.align)
+	switch e.cat {
+	case simdEffLoad:
+		addr, err := v.checkMemArg(in.MemArg(), e.align)
 		if err != nil {
 			return err
 		}
@@ -677,8 +679,7 @@ func (v *funcValidator) stepSIMD(in Instruction) error {
 		}
 		v.push(V128)
 		return nil
-	}
-	if in.Kind == InstrV128Store {
+	case simdEffStore:
 		addr, err := v.checkMemArg(in.MemArg(), 4)
 		if err != nil {
 			return err
@@ -687,17 +688,10 @@ func (v *funcValidator) stepSIMD(in Instruction) error {
 			return err
 		}
 		return v.popExpect(addr)
-	}
-	if eff, ok := simdMemLane[in.Kind]; ok {
-		addr, err := v.checkMemArg(in.MemArg(), eff.align)
+	case simdEffMemLoadLane:
+		addr, err := v.checkMemArg(in.MemArg(), e.align)
 		if err != nil {
 			return err
-		}
-		if in.Kind >= InstrV128Store8Lane && in.Kind <= InstrV128Store64Lane {
-			if err := v.popExpect(V128); err != nil {
-				return err
-			}
-			return v.popExpect(addr)
 		}
 		if err := v.popExpect(V128); err != nil {
 			return err
@@ -707,33 +701,29 @@ func (v *funcValidator) stepSIMD(in Instruction) error {
 		}
 		v.push(V128)
 		return nil
-	}
-	if scalar, ok := simdSplat[in.Kind]; ok {
-		if err := v.popExpect(scalar); err != nil {
+	case simdEffMemStoreLane:
+		addr, err := v.checkMemArg(in.MemArg(), e.align)
+		if err != nil {
+			return err
+		}
+		if err := v.popExpect(V128); err != nil {
+			return err
+		}
+		return v.popExpect(addr)
+	case simdEffSplat:
+		if err := v.popExpect(e.scalar); err != nil {
 			return err
 		}
 		v.push(V128)
 		return nil
-	}
-	if scalar, ok := simdExtract[in.Kind]; ok {
+	case simdEffExtract:
 		if err := v.popExpect(V128); err != nil {
 			return err
 		}
-		v.push(scalar)
+		v.push(e.scalar)
 		return nil
-	}
-	if scalar, ok := simdReplace[in.Kind]; ok {
-		if err := v.popExpect(scalar); err != nil {
-			return err
-		}
-		if err := v.popExpect(V128); err != nil {
-			return err
-		}
-		v.push(V128)
-		return nil
-	}
-	if in.Kind == InstrI8x16Swizzle {
-		if err := v.popExpect(V128); err != nil {
+	case simdEffReplace:
+		if err := v.popExpect(e.scalar); err != nil {
 			return err
 		}
 		if err := v.popExpect(V128); err != nil {
@@ -741,8 +731,7 @@ func (v *funcValidator) stepSIMD(in Instruction) error {
 		}
 		v.push(V128)
 		return nil
-	}
-	if _, ok := simdShift[in.Kind]; ok {
+	case simdEffShift:
 		if err := v.popExpect(I32); err != nil {
 			return err
 		}
@@ -751,15 +740,13 @@ func (v *funcValidator) stepSIMD(in Instruction) error {
 		}
 		v.push(V128)
 		return nil
-	}
-	if _, ok := simdUnary[in.Kind]; ok {
+	case simdEffUnary:
 		if err := v.popExpect(V128); err != nil {
 			return err
 		}
 		v.push(V128)
 		return nil
-	}
-	if _, ok := simdBinary[in.Kind]; ok {
+	case simdEffBinary:
 		if err := v.popExpect(V128); err != nil {
 			return err
 		}
@@ -768,8 +755,7 @@ func (v *funcValidator) stepSIMD(in Instruction) error {
 		}
 		v.push(V128)
 		return nil
-	}
-	if _, ok := simdTernary[in.Kind]; ok {
+	case simdEffTernary:
 		if err := v.popExpect(V128); err != nil {
 			return err
 		}
@@ -781,15 +767,13 @@ func (v *funcValidator) stepSIMD(in Instruction) error {
 		}
 		v.push(V128)
 		return nil
-	}
-	if in.Kind == InstrV128AnyTrue || in.Kind == InstrI8x16AllTrue || in.Kind == InstrI16x8AllTrue || in.Kind == InstrI32x4AllTrue || in.Kind == InstrI64x2AllTrue || in.Kind == InstrI8x16Bitmask || in.Kind == InstrI16x8Bitmask || in.Kind == InstrI32x4Bitmask || in.Kind == InstrI64x2Bitmask {
+	case simdPopV128PushI32:
 		if err := v.popExpect(V128); err != nil {
 			return err
 		}
 		v.push(I32)
 		return nil
-	}
-	if in.Kind == InstrV128Bitselect || in.Kind == InstrI8x16RelaxedLaneselect || in.Kind == InstrI16x8RelaxedLaneselect || in.Kind == InstrI32x4RelaxedLaneselect || in.Kind == InstrI64x2RelaxedLaneselect {
+	case simdBitselect:
 		if err := v.popExpect(V128); err != nil {
 			return err
 		}
@@ -801,13 +785,41 @@ func (v *funcValidator) stepSIMD(in Instruction) error {
 		}
 		v.push(V128)
 		return nil
-	}
-	if in.Kind == InstrV128Const {
+	case simdConst:
 		v.push(V128)
 		return nil
 	}
 	return v.verr(ErrUnsupportedValidationOpcode, in.Kind.String())
 }
+
+type simdEffectCat uint8
+
+const (
+	simdNone simdEffectCat = iota
+	simdEffLoad
+	simdEffStore
+	simdEffMemLoadLane
+	simdEffMemStoreLane
+	simdEffSplat
+	simdEffExtract
+	simdEffReplace
+	simdEffShift
+	simdEffUnary
+	simdEffBinary
+	simdEffTernary
+	simdPopV128PushI32
+	simdBitselect
+	simdConst
+)
+
+type simdEffect struct {
+	cat       simdEffectCat
+	scalar    ValType
+	align     uint32
+	laneLimit LaneIdx
+}
+
+var simdEffects [numInstrKinds]simdEffect
 
 var simdLoads = map[InstrKind]memeff{InstrV128Load: {V128, 4}, InstrV128Load8x8S: {V128, 3}, InstrV128Load8x8U: {V128, 3}, InstrV128Load16x4S: {V128, 3}, InstrV128Load16x4U: {V128, 3}, InstrV128Load32x2S: {V128, 3}, InstrV128Load32x2U: {V128, 3}, InstrV128Load8Splat: {V128, 0}, InstrV128Load16Splat: {V128, 1}, InstrV128Load32Splat: {V128, 2}, InstrV128Load64Splat: {V128, 3}, InstrV128Load32Zero: {V128, 2}, InstrV128Load64Zero: {V128, 3}}
 var simdMemLane = map[InstrKind]memeff{InstrV128Load8Lane: {V128, 0}, InstrV128Load16Lane: {V128, 1}, InstrV128Load32Lane: {V128, 2}, InstrV128Load64Lane: {V128, 3}, InstrV128Store8Lane: {V128, 0}, InstrV128Store16Lane: {V128, 1}, InstrV128Store32Lane: {V128, 2}, InstrV128Store64Lane: {V128, 3}}
@@ -832,6 +844,64 @@ var simdShift = map[InstrKind]struct{}{InstrI8x16Shl: {}, InstrI8x16ShrS: {}, In
 var simdUnary = map[InstrKind]struct{}{InstrI8x16Swizzle: {}, InstrV128Not: {}, InstrF32x4DemoteF64x2Zero: {}, InstrF64x2PromoteLowF32x4: {}, InstrI8x16Abs: {}, InstrI8x16Neg: {}, InstrI8x16Popcnt: {}, InstrI16x8ExtaddPairwiseI8x16S: {}, InstrI16x8ExtaddPairwiseI8x16U: {}, InstrI32x4ExtaddPairwiseI16x8S: {}, InstrI32x4ExtaddPairwiseI16x8U: {}, InstrF32x4Ceil: {}, InstrF32x4Floor: {}, InstrF32x4Trunc: {}, InstrF32x4Nearest: {}, InstrF64x2Ceil: {}, InstrF64x2Floor: {}, InstrF64x2Trunc: {}, InstrF64x2Nearest: {}, InstrI16x8Abs: {}, InstrI16x8Neg: {}, InstrI32x4Abs: {}, InstrI32x4Neg: {}, InstrI64x2Abs: {}, InstrI64x2Neg: {}, InstrI64x2ExtendLowI32x4S: {}, InstrI64x2ExtendHighI32x4S: {}, InstrI64x2ExtendLowI32x4U: {}, InstrI64x2ExtendHighI32x4U: {}, InstrF32x4Abs: {}, InstrF32x4Neg: {}, InstrF32x4Sqrt: {}, InstrF64x2Abs: {}, InstrF64x2Neg: {}, InstrF64x2Sqrt: {}, InstrI32x4TruncSatF32x4S: {}, InstrI32x4TruncSatF32x4U: {}, InstrF32x4ConvertI32x4S: {}, InstrF32x4ConvertI32x4U: {}, InstrI32x4TruncSatF64x2SZero: {}, InstrI32x4TruncSatF64x2UZero: {}, InstrF64x2ConvertLowI32x4S: {}, InstrF64x2ConvertLowI32x4U: {}, InstrI32x4RelaxedTruncF32x4S: {}, InstrI32x4RelaxedTruncF32x4U: {}, InstrI32x4RelaxedTruncZeroF64x2S: {}, InstrI32x4RelaxedTruncZeroF64x2U: {}, InstrI16x8ExtendLowI8x16S: {}, InstrI16x8ExtendHighI8x16S: {}, InstrI16x8ExtendLowI8x16U: {}, InstrI16x8ExtendHighI8x16U: {}, InstrI32x4ExtendLowI16x8S: {}, InstrI32x4ExtendHighI16x8S: {}, InstrI32x4ExtendLowI16x8U: {}, InstrI32x4ExtendHighI16x8U: {}}
 var simdBinary = map[InstrKind]struct{}{InstrI8x16Shuffle: {}, InstrI8x16RelaxedSwizzle: {}, InstrV128And: {}, InstrV128Andnot: {}, InstrV128Or: {}, InstrV128Xor: {}, InstrI8x16Eq: {}, InstrI8x16Ne: {}, InstrI8x16LtS: {}, InstrI8x16LtU: {}, InstrI8x16GtS: {}, InstrI8x16GtU: {}, InstrI8x16LeS: {}, InstrI8x16LeU: {}, InstrI8x16GeS: {}, InstrI8x16GeU: {}, InstrI16x8Eq: {}, InstrI16x8Ne: {}, InstrI16x8LtS: {}, InstrI16x8LtU: {}, InstrI16x8GtS: {}, InstrI16x8GtU: {}, InstrI16x8LeS: {}, InstrI16x8LeU: {}, InstrI16x8GeS: {}, InstrI16x8GeU: {}, InstrI32x4Eq: {}, InstrI32x4Ne: {}, InstrI32x4LtS: {}, InstrI32x4LtU: {}, InstrI32x4GtS: {}, InstrI32x4GtU: {}, InstrI32x4LeS: {}, InstrI32x4LeU: {}, InstrI32x4GeS: {}, InstrI32x4GeU: {}, InstrF32x4Eq: {}, InstrF32x4Ne: {}, InstrF32x4Lt: {}, InstrF32x4Gt: {}, InstrF32x4Le: {}, InstrF32x4Ge: {}, InstrF64x2Eq: {}, InstrF64x2Ne: {}, InstrF64x2Lt: {}, InstrF64x2Gt: {}, InstrF64x2Le: {}, InstrF64x2Ge: {}, InstrI8x16NarrowI16x8S: {}, InstrI8x16NarrowI16x8U: {}, InstrI8x16Shl: {}, InstrI8x16ShrS: {}, InstrI8x16ShrU: {}, InstrI8x16Add: {}, InstrI8x16AddSatS: {}, InstrI8x16AddSatU: {}, InstrI8x16Sub: {}, InstrI8x16SubSatS: {}, InstrI8x16SubSatU: {}, InstrI8x16MinS: {}, InstrI8x16MinU: {}, InstrI8x16MaxS: {}, InstrI8x16MaxU: {}, InstrI8x16AvgrU: {}, InstrI16x8Q15mulrSatS: {}, InstrI16x8NarrowI32x4S: {}, InstrI16x8NarrowI32x4U: {}, InstrI16x8Shl: {}, InstrI16x8ShrS: {}, InstrI16x8ShrU: {}, InstrI16x8Add: {}, InstrI16x8AddSatS: {}, InstrI16x8AddSatU: {}, InstrI16x8Sub: {}, InstrI16x8SubSatS: {}, InstrI16x8SubSatU: {}, InstrI16x8Mul: {}, InstrI16x8MinS: {}, InstrI16x8MinU: {}, InstrI16x8MaxS: {}, InstrI16x8MaxU: {}, InstrI16x8AvgrU: {}, InstrI16x8ExtmulLowI8x16S: {}, InstrI16x8ExtmulHighI8x16S: {}, InstrI16x8ExtmulLowI8x16U: {}, InstrI16x8ExtmulHighI8x16U: {}, InstrI32x4Add: {}, InstrI32x4Sub: {}, InstrI32x4Mul: {}, InstrI32x4MinS: {}, InstrI32x4MinU: {}, InstrI32x4MaxS: {}, InstrI32x4MaxU: {}, InstrI32x4DotI16x8S: {}, InstrI32x4ExtmulLowI16x8S: {}, InstrI32x4ExtmulHighI16x8S: {}, InstrI32x4ExtmulLowI16x8U: {}, InstrI32x4ExtmulHighI16x8U: {}, InstrI64x2Add: {}, InstrI64x2Sub: {}, InstrI64x2Mul: {}, InstrI64x2ExtmulLowI32x4S: {}, InstrI64x2ExtmulHighI32x4S: {}, InstrI64x2ExtmulLowI32x4U: {}, InstrI64x2ExtmulHighI32x4U: {}, InstrI64x2Eq: {}, InstrI64x2Ne: {}, InstrI64x2LtS: {}, InstrI64x2GtS: {}, InstrI64x2LeS: {}, InstrI64x2GeS: {}, InstrF32x4Add: {}, InstrF32x4Sub: {}, InstrF32x4Mul: {}, InstrF32x4Div: {}, InstrF32x4Min: {}, InstrF32x4Max: {}, InstrF32x4Pmin: {}, InstrF32x4Pmax: {}, InstrF64x2Add: {}, InstrF64x2Sub: {}, InstrF64x2Mul: {}, InstrF64x2Div: {}, InstrF64x2Min: {}, InstrF64x2Max: {}, InstrF64x2Pmin: {}, InstrF64x2Pmax: {}, InstrF32x4RelaxedMin: {}, InstrF32x4RelaxedMax: {}, InstrF64x2RelaxedMin: {}, InstrF64x2RelaxedMax: {}, InstrI16x8RelaxedQ15mulrS: {}, InstrI16x8RelaxedDotI8x16I7x16S: {}}
 var simdTernary = map[InstrKind]struct{}{InstrF32x4RelaxedMadd: {}, InstrF32x4RelaxedNmadd: {}, InstrF64x2RelaxedMadd: {}, InstrF64x2RelaxedNmadd: {}, InstrI32x4RelaxedDotI8x16I7x16AddS: {}}
+
+func init() {
+	for k, eff := range simdLoads {
+		simdEffects[k] = simdEffect{cat: simdEffLoad, align: eff.align}
+	}
+	simdEffects[InstrV128Store] = simdEffect{cat: simdEffStore}
+	for k, eff := range simdMemLane {
+		cat := simdEffMemLoadLane
+		if k >= InstrV128Store8Lane && k <= InstrV128Store64Lane {
+			cat = simdEffMemStoreLane
+		}
+		simdEffects[k] = simdEffect{cat: cat, align: eff.align}
+	}
+	for k, scalar := range simdSplat {
+		simdEffects[k] = simdEffect{cat: simdEffSplat, scalar: scalar}
+	}
+	for k, scalar := range simdExtract {
+		simdEffects[k] = simdEffect{cat: simdEffExtract, scalar: scalar}
+	}
+	for k, scalar := range simdReplace {
+		simdEffects[k] = simdEffect{cat: simdEffReplace, scalar: scalar}
+	}
+	for k := range simdShift {
+		simdEffects[k] = simdEffect{cat: simdEffShift}
+	}
+	for k := range simdUnary {
+		simdEffects[k] = simdEffect{cat: simdEffUnary}
+	}
+	simdEffects[InstrI8x16Swizzle] = simdEffect{cat: simdEffBinary}
+	for k := range simdBinary {
+		if _, isShift := simdShift[k]; isShift {
+			continue
+		}
+		simdEffects[k] = simdEffect{cat: simdEffBinary}
+	}
+	for k := range simdTernary {
+		simdEffects[k] = simdEffect{cat: simdEffTernary}
+	}
+	for _, k := range [...]InstrKind{
+		InstrV128AnyTrue,
+		InstrI8x16AllTrue, InstrI16x8AllTrue, InstrI32x4AllTrue, InstrI64x2AllTrue,
+		InstrI8x16Bitmask, InstrI16x8Bitmask, InstrI32x4Bitmask, InstrI64x2Bitmask,
+	} {
+		simdEffects[k] = simdEffect{cat: simdPopV128PushI32}
+	}
+	for _, k := range [...]InstrKind{
+		InstrV128Bitselect,
+		InstrI8x16RelaxedLaneselect, InstrI16x8RelaxedLaneselect, InstrI32x4RelaxedLaneselect, InstrI64x2RelaxedLaneselect,
+	} {
+		simdEffects[k] = simdEffect{cat: simdBitselect}
+	}
+	simdEffects[InstrV128Const] = simdEffect{cat: simdConst}
+	for k, limit := range simdLaneLimits {
+		eff := simdEffects[k]
+		eff.laneLimit = limit
+		simdEffects[k] = eff
+	}
+}
 
 // SIMDValidationInstructionKinds returns an immutable snapshot of the SIMD
 // instruction kinds admitted by wasm validation. It is intended for downstream

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -27,11 +27,60 @@ const (
 	GCRuntimeIncrementalMarkSweep = gc.RuntimeIncrementalMarkSweep
 )
 
-// Compile decodes, validates, and compiles a wasm module to native code under
-// the given RuntimeConfig: the config's feature set gates which modules are
-// accepted and its bounds-check mode selects the code-generation strategy. Pass
-// nil for the default configuration.
-func Compile(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
+// Compile decodes, validates, and compiles a wasm module to native code.
+//
+// It accepts both the current explicit form:
+//
+//	Compile(cfg, wasmBytes)
+//
+// and the original default-config shorthand:
+//
+//	Compile(wasmBytes)
+//
+// Pass nil as cfg, or omit it, to use NewRuntimeConfig.
+func Compile(args ...any) (*Compiled, error) {
+	cfg, wasmBytes, err := compileArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	return compileWithConfig(cfg, wasmBytes)
+}
+
+// CompileWithConfig is the named compatibility form of Compile(cfg, wasmBytes):
+// the config's feature set gates which modules are accepted and its bounds-check
+// mode selects the code-generation strategy.
+func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
+	return compileWithConfig(cfg, wasmBytes)
+}
+
+func compileArgs(args []any) (*RuntimeConfig, []byte, error) {
+	switch len(args) {
+	case 1:
+		wasmBytes, ok := args[0].([]byte)
+		if !ok {
+			return nil, nil, fmt.Errorf("wago: Compile expects []byte or (*RuntimeConfig, []byte), got %T", args[0])
+		}
+		return nil, wasmBytes, nil
+	case 2:
+		var cfg *RuntimeConfig
+		if args[0] != nil {
+			var ok bool
+			cfg, ok = args[0].(*RuntimeConfig)
+			if !ok {
+				return nil, nil, fmt.Errorf("wago: Compile config must be *RuntimeConfig or nil, got %T", args[0])
+			}
+		}
+		wasmBytes, ok := args[1].([]byte)
+		if !ok {
+			return nil, nil, fmt.Errorf("wago: Compile wasm bytes must be []byte, got %T", args[1])
+		}
+		return cfg, wasmBytes, nil
+	default:
+		return nil, nil, fmt.Errorf("wago: Compile expects []byte or (*RuntimeConfig, []byte), got %d arguments", len(args))
+	}
+}
+
+func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
 	if cfg == nil {
 		cfg = NewRuntimeConfig()
 	}
@@ -770,8 +819,11 @@ func Load(b []byte) (*Compiled, error) {
 // I32/I64/F32/F64 and AsI32/AsI64/AsF32/AsF64). A v128 occupies two adjacent
 // little-endian uint64 slots in the argument and result slices.
 func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
-	if !in.ic.valid || in.ic.export != export {
-		if err := in.fillInvokeCache(export); err != nil {
+	ic := in.findInvokeCache(export)
+	if ic == nil {
+		var err error
+		ic, err = in.fillInvokeCache(export)
+		if err != nil {
 			// A re-exported import (the export names an imported function) is
 			// invoked by calling through to whatever satisfies that import — for a
 			// cross-instance binding, the other instance's function.
@@ -783,15 +835,15 @@ func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
 			return nil, err
 		}
 	}
-	li := in.ic.li
-	if len(args) != in.ic.paramSlots {
-		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, in.ic.paramSlots, len(args))
+	li := ic.li
+	if len(args) != ic.paramSlots {
+		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
 	}
 	if len(args) > len(in.serArgs)/8 {
 		return nil, fmt.Errorf("%s requires %d arg slot(s), instance buffer has %d", export, len(args), len(in.serArgs)/8)
 	}
-	if in.ic.resultSlots > len(in.results)/8 {
-		return nil, fmt.Errorf("%s requires %d result slot(s), instance buffer has %d", export, in.ic.resultSlots, len(in.results)/8)
+	if ic.resultSlots > len(in.results)/8 {
+		return nil, fmt.Errorf("%s requires %d result slot(s), instance buffer has %d", export, ic.resultSlots, len(in.results)/8)
 	}
 	for i, a := range args {
 		binary.LittleEndian.PutUint64(in.serArgs[i*8:], a)
@@ -810,8 +862,8 @@ func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
 		}
 		in.replayHostLog()
 	}
-	out := in.resultVals[:in.ic.resultSlots]
-	for i, wide := range in.ic.resultWide {
+	out := in.resultVals[:ic.resultSlots]
+	for i, wide := range ic.resultWide {
 		off := i * 8
 		if off+8 > len(in.results) {
 			return nil, fmt.Errorf("%s result slot %d exceeds instance result buffer", export, i)
@@ -921,24 +973,23 @@ func (in *Instance) replayHostLog() {
 
 // fillInvokeCache resolves export to its local function index and memoizes it so
 // subsequent Invokes on the same export skip the exports map probe.
-func (in *Instance) fillInvokeCache(export string) error {
+func (in *Instance) fillInvokeCache(export string) (*invokeCache, error) {
 	li, err := in.c.localIndex(export)
 	if err != nil {
-		in.ic.valid = false
-		return err
+		return nil, err
 	}
 	sig := in.c.Funcs[li]
 	paramSlots, err := valTypesSlots(sig.Params)
 	if err != nil {
-		in.ic.valid = false
-		return fmt.Errorf("%s parameter slots: %w", export, err)
+		return nil, fmt.Errorf("%s parameter slots: %w", export, err)
 	}
 	resultSlots, err := valTypesSlots(sig.Results)
 	if err != nil {
-		in.ic.valid = false
-		return fmt.Errorf("%s result slots: %w", export, err)
+		return nil, fmt.Errorf("%s result slots: %w", export, err)
 	}
-	rw := in.ic.resultWide[:0]
+	slot := &in.ic[int(in.icNext)%len(in.ic)]
+	in.icNext++
+	rw := slot.resultWide[:0]
 	if cap(rw) < resultSlots {
 		rw = make([]bool, 0, resultSlots)
 	}
@@ -949,7 +1000,16 @@ func (in *Instance) fillInvokeCache(export string) error {
 			rw = append(rw, r == ValI64 || r == ValF64)
 		}
 	}
-	in.ic = invokeCache{export: export, valid: true, li: li, paramSlots: paramSlots, resultSlots: resultSlots, resultWide: rw}
+	*slot = invokeCache{export: export, valid: true, li: li, paramSlots: paramSlots, resultSlots: resultSlots, resultWide: rw}
+	return slot, nil
+}
+
+func (in *Instance) findInvokeCache(export string) *invokeCache {
+	for i := range in.ic {
+		if in.ic[i].valid && in.ic[i].export == export {
+			return &in.ic[i]
+		}
+	}
 	return nil
 }
 

--- a/src/wago/api_compat_test.go
+++ b/src/wago/api_compat_test.go
@@ -1,0 +1,101 @@
+package wago
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+func TestPublicAPICompatibilityForms(t *testing.T) {
+	c, err := Compile(signExtModule())
+	if err != nil {
+		t.Fatalf("Compile([]byte): %v", err)
+	}
+	in, err := Instantiate(c, Imports{})
+	if err != nil {
+		t.Fatalf("Instantiate(compiled, Imports): %v", err)
+	}
+	in.Close()
+	in, err = Instantiate(c, nil)
+	if err != nil {
+		t.Fatalf("Instantiate(compiled, nil): %v", err)
+	}
+	in.Close()
+
+	cfg := NewRuntimeConfig().WithDeferBoundsChecks(true)
+	if _, err := CompileWithConfig(cfg, signExtModule()); err != nil {
+		t.Fatalf("CompileWithConfig: %v", err)
+	}
+}
+
+func TestInvokeCacheKeepsAlternatingExports(t *testing.T) {
+	c := MustCompile(alternatingExportsModule())
+	in, err := Instantiate(c)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+
+	for i := int32(0); i < 8; i++ {
+		f, err := in.Invoke("f", I32(i))
+		if err != nil {
+			t.Fatalf("Invoke f: %v", err)
+		}
+		if got := AsI32(f[0]); got != i+1 {
+			t.Fatalf("f(%d) = %d, want %d", i, got, i+1)
+		}
+		g, err := in.Invoke("g", I32(i))
+		if err != nil {
+			t.Fatalf("Invoke g: %v", err)
+		}
+		if got := AsI32(g[0]); got != i+2 {
+			t.Fatalf("g(%d) = %d, want %d", i, got, i+2)
+		}
+		if _, err := in.Invoke("__collect"); err != nil {
+			t.Fatalf("Invoke __collect: %v", err)
+		}
+	}
+}
+
+func BenchmarkInvokeAlternatingExports(b *testing.B) {
+	c := MustCompile(alternatingExportsModule())
+	in, err := Instantiate(c)
+	if err != nil {
+		b.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+	x := I32(7)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := in.Invoke("f", x); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := in.Invoke("g", x); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := in.Invoke("__collect"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func alternatingExportsModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType(nil, nil),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("f", 0, 0),
+			wasmtest.ExportEntry("g", 0, 1),
+			wasmtest.ExportEntry("__collect", 0, 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x20, 0x00, 0x41, 0x01, 0x6a, 0x0b}), // local.get 0; i32.const 1; i32.add
+			wasmtest.Code([]byte{0x20, 0x00, 0x41, 0x02, 0x6a, 0x0b}), // local.get 0; i32.const 2; i32.add
+			wasmtest.Code([]byte{0x0b}),
+		)),
+	)
+}

--- a/src/wago/doc.go
+++ b/src/wago/doc.go
@@ -15,7 +15,8 @@
 //
 // RuntimeConfig tunes compilation, modeled on wazero's config: it is immutable,
 // so every WithXxx returns a copy and a base config can be shared safely. Compile
-// under a config with the fluent Compile method or CompileWithConfig:
+// under a config with the fluent Compile method, CompileWithConfig, or
+// Compile(cfg, wasmBytes):
 //
 //	cfg := wago.NewRuntimeConfig().
 //		WithFeature(wago.CoreFeatureBulkMemoryOperations, false) // reject memory.copy/fill
@@ -29,18 +30,16 @@
 // # Guard-page bounds checks
 //
 // WithBoundsChecks selects how out-of-bounds memory accesses are caught. The
-// default, BoundsChecksExplicit, emits an inline check per access.
-// BoundsChecksSignalsBased instead elides the checks and relies on a guard-page
-// mapping plus a signal handler (≈25% faster on memory-heavy code); it requires a
-// binary built with -tags wago_guardpage and is reported by GuardPageSupported:
+// default is the fastest mode available in the current binary:
+// BoundsChecksSignalsBased when built with -tags wago_guardpage, otherwise
+// BoundsChecksExplicit. Signals-based mode elides inline checks and relies on a
+// guard-page mapping plus a signal handler; GuardPageSupported reports whether
+// the current binary can use it:
 //
 //	cfg := wago.NewRuntimeConfig()
-//	if wago.GuardPageSupported() {
-//		cfg = cfg.WithBoundsChecks(wago.BoundsChecksSignalsBased)
-//	}
-//	mod, err := cfg.Compile(wasmBytes) // GuardPageUnavailableError if unsupported
+//	mod, err := cfg.Compile(wasmBytes)
 //
 // See docs/guardpage-spike.md for the mechanism and its limitations. Benchmarks
-// and other default-config entry points can select the same mode with
-// WAGO_BOUNDS=signals when the binary is built with -tags wago_guardpage.
+// and other default-config entry points can be pinned with WAGO_BOUNDS=explicit
+// or WAGO_BOUNDS=signals.
 package wago

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -33,9 +33,10 @@ type Instance struct {
 	thunkMem               []byte        // executable mapping for host-func-in-table log thunks (nil if none)
 	gc                     *gc.Collector // nil for modules with no Wasm GC descriptors/runtime use
 	serArgs, results, trap []byte
-	resultVals             []uint64    // reusable Invoke result buffer (valid until the next call)
-	ic                     invokeCache // single-entry export resolution cache
-	closed                 bool        // guards Close against double-release (user defer + pool)
+	resultVals             []uint64       // reusable Invoke result buffer (valid until the next call)
+	ic                     [4]invokeCache // tiny fixed export resolution cache
+	icNext                 uint8          // round-robin replacement cursor
+	closed                 bool           // guards Close against double-release (user defer + pool)
 
 	// rt is set when the instance is created through a Runtime (rt.Instantiate /
 	// Spawn), so Instance.Call can fire the runtime's invoke hooks. It is nil for
@@ -43,8 +44,10 @@ type Instance struct {
 	rt *Runtime
 }
 
-// invokeCache memoizes per-export work so a hot Invoke loop on one export skips
-// the exports map probe and the fat ValType width comparisons on every call.
+// invokeCache memoizes per-export work so hot Invoke loops skip the exports map
+// probe and the fat ValType width comparisons on every call. Instance keeps a
+// few fixed slots because real AS loops commonly interleave the business export
+// with __collect, __pin, or paired request/response exports.
 type invokeCache struct {
 	export      string
 	valid       bool
@@ -83,10 +86,18 @@ func (*Snapshot) instantiable() {}
 // module's imports from opts and running its start function) or a *Snapshot
 // (loading captured memory/globals; opts is ignored — the snapshot supplies its
 // own imports and GC config, and the start function is not re-run).
-func Instantiate(source Instantiable, opts InstantiateOptions) (*Instance, error) {
+//
+// It accepts InstantiateOptions, Imports, nil, or no second argument. The Imports
+// form keeps older callers source-compatible while the options struct remains the
+// extensible form for newer code.
+func Instantiate(source Instantiable, opts ...any) (*Instance, error) {
+	instOpts, err := instantiateArgs(opts)
+	if err != nil {
+		return nil, err
+	}
 	switch s := source.(type) {
 	case *Compiled:
-		return instantiateCore(s, opts)
+		return instantiateCore(s, instOpts)
 	case *Snapshot:
 		if s == nil || s.c == nil {
 			return nil, errors.New("wago: snapshot has no bound module (load it with LoadSnapshot)")
@@ -96,6 +107,31 @@ func Instantiate(source Instantiable, opts InstantiateOptions) (*Instance, error
 		return nil, errors.New("wago: Instantiate: nil source")
 	default:
 		return nil, fmt.Errorf("wago: Instantiate: unsupported source %T", source)
+	}
+}
+
+func instantiateArgs(args []any) (InstantiateOptions, error) {
+	switch len(args) {
+	case 0:
+		return InstantiateOptions{}, nil
+	case 1:
+		switch v := args[0].(type) {
+		case nil:
+			return InstantiateOptions{}, nil
+		case InstantiateOptions:
+			return v, nil
+		case *InstantiateOptions:
+			if v == nil {
+				return InstantiateOptions{}, nil
+			}
+			return *v, nil
+		case Imports:
+			return InstantiateOptions{Imports: v}, nil
+		default:
+			return InstantiateOptions{}, fmt.Errorf("wago: Instantiate options must be InstantiateOptions, Imports, or nil, got %T", args[0])
+		}
+	default:
+		return InstantiateOptions{}, fmt.Errorf("wago: Instantiate expects at most one options argument, got %d", len(args))
 	}
 }
 
@@ -597,7 +633,8 @@ func (in *Instance) resetToSnapshot(s *Snapshot) error {
 			writeGlobalObjectV128(cell, gs.vec)
 		}
 	}
-	in.ic = invokeCache{} // drop memoized export resolution; state changed underneath
+	in.ic = [4]invokeCache{} // drop memoized export resolution; state changed underneath
+	in.icNext = 0
 	return nil
 }
 

--- a/wago.go
+++ b/wago.go
@@ -195,8 +195,10 @@ func CapabilityDocs(docs string) CapabilityOption { return impl.CapabilityDocs(d
 
 func Capture(c *Compiled, opts SnapshotOptions) (*Snapshot, error) { return impl.Capture(c, opts) }
 
-func Compile(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
-	return impl.Compile(cfg, wasmBytes)
+func Compile(args ...any) (*Compiled, error) { return impl.Compile(args...) }
+
+func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
+	return impl.CompileWithConfig(cfg, wasmBytes)
 }
 
 func DirsFor(version string) Dirs { return impl.DirsFor(version) }
@@ -211,8 +213,8 @@ func I32(v int32) uint64 { return impl.I32(v) }
 
 func I64(v int64) uint64 { return impl.I64(v) }
 
-func Instantiate(source Instantiable, opts InstantiateOptions) (*Instance, error) {
-	return impl.Instantiate(source, opts)
+func Instantiate(source Instantiable, opts ...any) (*Instance, error) {
+	return impl.Instantiate(source, opts...)
 }
 
 func IsCompiled(b []byte) bool { return impl.IsCompiled(b) }


### PR DESCRIPTION
## Summary
- precompute SIMD validation effects so SIMD-heavy decode/validate avoids repeated map/switch classification
- sink f32/f64 binary ops directly into pinned float locals when followed by local.set/local.tee
- expand Instance.Invoke export resolution from a single-entry cache to a four-entry fixed cache for Impart-style AS loops
- restore source-compatible `Compile([]byte)`, `CompileWithConfig`, and `Instantiate(compiled, Imports)` forms while keeping the newer config/options forms
- update package docs for the current fastest-available bounds default

## Measurements

| Workload | Baseline | This branch | Delta |
| --- | ---: | ---: | ---: |
| `BenchmarkDecodeValidateSIMDHeavy` median | 6,796.5 ns/op | 5,015.5 ns/op | 26.2% faster |
| `isa_f64.add` | 60,507.5 ns/op | 45,380.5 ns/op | 25.0% faster |
| `isa_f64.mul` | 60,422.5 ns/op | 45,314.5 ns/op | 25.0% faster |
| `isa_f32.add` | 61,298 ns/op | 45,462 ns/op | 25.8% faster |
| `isa_f32.mul` | 60,073 ns/op | 45,358 ns/op | 24.5% faster |
| Impart WAF `wago-compare` | wago 4,366 msg/s | wago 4,460 msg/s | 1.32x wazero, 1.07x wasmtime in latest run |
| `BenchmarkInvokeAlternatingExports` | n/a | 50-54 ns/op, 0 allocs/op | new guard benchmark |

Impart corpus subset with default `wago.Compile(src)` stayed effectively unchanged on one-export loops, as expected: `json-as` deserialize moved 40.91µs -> 40.28µs, serialize 22.21µs -> 22.19µs, `utf-as` 189.52µs -> 189.73µs.

## Validation
- `go test ./src/core/compiler/backend/railshot -count=1`
- `go test ./src/core/compiler/wasm`
- `go test ./src/core/compiler/...`
- `go test ./src/wago -run 'TestPublicAPICompatibilityForms|TestInvokeCacheKeepsAlternatingExports' -bench BenchmarkInvokeAlternatingExports -benchmem -count=8`
- `go test -tags wago_guardpage ./src/wago -run 'TestConfigSignalsBasedEndToEnd|TestSignalsBasedNotSerializable|TestPublicAPICompatibilityForms|TestInvokeCacheKeepsAlternatingExports' -count=1`
- `go test ./...`
- Impart `wago-compare` WAF fixture with `-tags wago_guardpage`, 400 iterations
- Impart `corpus-exec --only json-as,blake-as,utf-as,sha256` with `-tags wago_guardpage`

Docs: `src/wago/doc.go` updated for default bounds behavior and compatible compile forms.
