### PR TITLE
perf: enable railshot inlining by default

### DIFF
--- a/docs/codegen-benchmarks.md
+++ b/docs/codegen-benchmarks.md
@@ -26,6 +26,23 @@ go test ./src/core/compiler/backend/railshot -bench=. -benchmem -count=10 > /tmp
 benchstat /tmp/railshot-before.txt /tmp/railshot-after.txt
 ```
 
+## Backend toggles
+
+Railshot inlines small leaf wasm functions by default. This is part of the
+normal execution configuration because real AssemblyScript rules often rotate
+through tiny string and range helpers where the call sequence is a large part of
+the cost.
+
+For A/B runs, disable the transform explicitly:
+
+```sh
+WAGO_INLINE=0 go test ./bench -run '^$' -bench BenchmarkCorpusExec -benchmem
+WAGO_INLINE=0 go test ./src/core/compiler/backend/railshot -bench=. -benchmem
+```
+
+`WAGO_INLINE_MAXBYTES` still controls the encoded-body-size ceiling for inline
+candidates.
+
 ## Targeted profiles
 
 Backend railshot compile profiles:

--- a/src/core/compiler/backend/railshot/inline.go
+++ b/src/core/compiler/backend/railshot/inline.go
@@ -338,10 +338,20 @@ func truncName(s string) string {
 
 // --- Phase 2: the inline transform (WAGO_INLINE) ---
 
-// inlineEnabled gates the actual splice transform. Detection/reporting above runs
-// regardless; only the codegen change is gated (off by default until proven a net
-// win on the bench corpus).
-var inlineEnabled = os.Getenv("WAGO_INLINE") == "1"
+// inlineEnabled gates the actual splice transform. Detection/reporting above
+// runs regardless. It defaults on because Impart-style AS rules spend real time
+// in tiny string/range helpers where the call sequence dominates; set
+// WAGO_INLINE=0/off/false to disable it for A/B runs.
+var inlineEnabled = inlineEnvEnabled(os.Getenv("WAGO_INLINE"))
+
+func inlineEnvEnabled(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "0", "false", "off", "no":
+		return false
+	default:
+		return true
+	}
+}
 
 // inlineTarget is a callee that will be spliced at its call sites: a straight-line
 // leaf with an int-only register-ABI signature and a small body.

--- a/src/core/compiler/backend/railshot/inline_test.go
+++ b/src/core/compiler/backend/railshot/inline_test.go
@@ -129,6 +129,27 @@ func withInlineEnabled(t *testing.T, fn func()) {
 	fn()
 }
 
+func TestInlineEnvEnabledDefaultAndOptOut(t *testing.T) {
+	for _, tc := range []struct {
+		env  string
+		want bool
+	}{
+		{"", true},
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"0", false},
+		{"false", false},
+		{"off", false},
+		{"no", false},
+		{" OFF ", false},
+	} {
+		if got := inlineEnvEnabled(tc.env); got != tc.want {
+			t.Fatalf("inlineEnvEnabled(%q) = %v, want %v", tc.env, got, tc.want)
+		}
+	}
+}
+
 // TestInlineExecAdd inlines a straight-line leaf `add(a,b)=a+b` at a single call
 // site and checks the spliced result is correct and that it was actually spliced
 // (not called).


### PR DESCRIPTION
## Summary
- make railshot's existing small leaf-function inliner default-on
- keep `WAGO_INLINE=0/off/false/no` as an explicit A/B/debug escape hatch
- document the default and benchmark toggle in `docs/codegen-benchmarks.md`

## Why
I profiled Impart's WAF benchmark path with `WAGO_PROFILE=1 WAGO_PERFMAP=1 perf record`. The hot guest-side functions were mostly tiny AssemblyScript helpers in the actual execution path:

| Hot guest function | Flat profile share |
| --- | ---: |
| `Range.isPrint` | 4.35% |
| `JsonParserV2#scan` | 2.05% |
| `String#codePointAt` | 1.97% |
| `String#get:length` | 1.71% |
| `String#charCodeAt` | 1.45% |
| `Matcher#containsCISlice` | 1.14% |

Those are exactly the class of helpers where the existing inliner removes meaningful call sequence overhead.

## Measurements

Impart WAF `wago-compare`, 800 iterations, guard-page build:

| Mode | Wago msg/s | vs wazero | vs wasmtime |
| --- | ---: | ---: | ---: |
| default inline | 5,475 | 1.59x | 1.23x |
| `WAGO_INLINE=0` | 4,583 | 1.34x | 1.02x |

That is roughly a 19% Wago execution improvement in the target Impart WAF run.

The curated corpus was broadly neutral with default-on inlining; the gain is concentrated in the AS helper-heavy Impart path.

## Validation
- `go test ./src/core/compiler/backend/railshot -run 'TestInline|TestCodegenStatsPeepholes' -count=1`
- `go test ./...`
- `go test -tags wago_guardpage ./src/wago ./src/core/compiler/backend/railshot -count=1`
- `make tinygo-test`
- `make tinygo-build`
- Impart WAF `wago-compare` default vs `WAGO_INLINE=0`
- Impart corpus executor default vs `WAGO_INLINE=1` on the curated set
