### PR TITLE
railshot: enable loop bounds-check precheck by default

### DIFF
--- a/src/core/compiler/backend/railshot/boundshoist.go
+++ b/src/core/compiler/backend/railshot/boundshoist.go
@@ -25,9 +25,9 @@ import (
 // that is what makes hoisting sound here (a plain hoisted check would move the
 // trap earlier, which is observable because a wasm trap leaves partial memory
 // writes visible). Explicit-bounds mode only (guard mode has no inline check to
-// elide). Gated behind WAGO_LOOP_PRECHECK while it proves out.
+// elide). Defaults on; set WAGO_LOOP_PRECHECK=0/off/false to disable it for A/B runs.
 
-var loopPrecheckEnabled = os.Getenv("WAGO_LOOP_PRECHECK") == "1"
+var loopPrecheckEnabled = envDefaultOn(os.Getenv("WAGO_LOOP_PRECHECK"))
 
 // memAccessSize returns the byte width a memarg load/store opcode accesses, or 0
 // if op is not a plain (non-SIMD) linear-memory load/store.

--- a/src/core/compiler/backend/railshot/inline.go
+++ b/src/core/compiler/backend/railshot/inline.go
@@ -342,9 +342,11 @@ func truncName(s string) string {
 // runs regardless. It defaults on because Impart-style AS rules spend real time
 // in tiny string/range helpers where the call sequence dominates; set
 // WAGO_INLINE=0/off/false to disable it for A/B runs.
-var inlineEnabled = inlineEnvEnabled(os.Getenv("WAGO_INLINE"))
+var inlineEnabled = envDefaultOn(os.Getenv("WAGO_INLINE"))
 
-func inlineEnvEnabled(v string) bool {
+// envDefaultOn parses a default-on (opt-out) boolean knob: empty/unset means
+// enabled; 0/false/off/no disables it.
+func envDefaultOn(v string) bool {
 	switch strings.ToLower(strings.TrimSpace(v)) {
 	case "0", "false", "off", "no":
 		return false

--- a/src/core/compiler/backend/railshot/inline_test.go
+++ b/src/core/compiler/backend/railshot/inline_test.go
@@ -144,8 +144,8 @@ func TestInlineEnvEnabledDefaultAndOptOut(t *testing.T) {
 		{"no", false},
 		{" OFF ", false},
 	} {
-		if got := inlineEnvEnabled(tc.env); got != tc.want {
-			t.Fatalf("inlineEnvEnabled(%q) = %v, want %v", tc.env, got, tc.want)
+		if got := envDefaultOn(tc.env); got != tc.want {
+			t.Fatalf("envDefaultOn(%q) = %v, want %v", tc.env, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Flips the last off-by-default optimization knob (`WAGO_LOOP_PRECHECK`) to on, so all railshot optimizations are enabled by default.

- `loopPrecheckEnabled` now defaults on; set `WAGO_LOOP_PRECHECK=0/off/false` to disable for A/B runs — matching the `WAGO_INLINE` opt-out convention.
- Generalized the inline opt-out parser `inlineEnvEnabled` → `envDefaultOn`, now shared by both flags.

Loop precheck was already proven out in #193/#194; it's a branch (not a hoisted trap), so it introduces no spurious traps.

Gates: railshot + core + wago unit tests pass; full spec-suite exec gate green in explicit-bounds mode (16,022 assertions, the mode that actually exercises precheck).