### PR TITLE
wasm: cover trunc_sat opcode matrix

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,7 +39,7 @@ Later proposals and engine/platform capabilities beyond the MVP.
 | Feature | Planned | Status |
 |---|:---:|---|
 | Sign-extension ops (`i32.extend8_s`, …) | ✓ | ✅ done (decoder/validator plus railshot runtime/codegen coverage for all five scalar opcodes) |
-| Non-trapping float→int (`trunc_sat`) | ✓ | ✅ done |
+| Non-trapping float→int (`trunc_sat`) | ✓ | ✅ done (decoder/validator plus railshot runtime/codegen coverage for all eight scalar opcodes, including NaN, negative unsigned, and overflow clamp cases) |
 | Multi-value (multiple block/func results) | ✓ | 🚧 partial |
 | Reference types (`funcref`/`externref`, `select t`, `ref.*`, `table.get/set`, multi-table) | ✓ | 🚧 partial (`select t` done) |
 | Bulk memory (`memory.copy`/`fill`/`init`, `data.drop`, `table.*`) | ✓ | 🚧 partial (`memory.copy`/`memory.fill` done; `memory.init`, `data.drop`, `table.*` planned) |

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -868,18 +868,87 @@ func TestAmd64BulkAndSat(t *testing.T) {
 		}
 	})
 
-	// trunc_sat: NaN→0, overflow→clamp
-	t.Run("i32.trunc_sat_f64_s", func(t *testing.T) {
-		m := mod1(t, []wasm.ValType{wasm.F64}, []wasm.ValType{i32}, []byte{0x00,
-			0x20, 0x00, 0xfc, 0x02, 0x0b})
-		for _, tc := range []struct {
-			in   float64
-			want int32
-		}{{3.9, 3}, {-3.9, -3}, {math.NaN(), 0}, {1e300, 0x7FFFFFFF}, {-1e300, -0x80000000}} {
-			got := int32(uint32(runAmd64u(t, m, f64b(tc.in))))
-			if got != tc.want {
-				t.Fatalf("trunc_sat(%v) = %d, want %d", tc.in, got, tc.want)
+	// trunc_sat: all scalar non-trapping conversion opcodes pin NaN→0,
+	// negative unsigned→0, and overflow→clamp semantics.
+	t.Run("trunc_sat_scalar_opcodes", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			param  wasm.ValType
+			result wasm.ValType
+			opcode byte
+			cases  []struct {
+				arg  uint64
+				want uint64
 			}
+		}{
+			{name: "i32.trunc_sat_f32_s", param: wasm.F32, result: i32, opcode: 0x00, cases: []struct {
+				arg  uint64
+				want uint64
+			}{
+				{f32b(3.9), 3}, {f32b(-3.9), 0xfffffffd}, {f32b(float32(math.NaN())), 0},
+				{f32b(float32(math.Inf(1))), 0x7fffffff}, {f32b(float32(math.Inf(-1))), 0x80000000},
+			}},
+			{name: "i32.trunc_sat_f32_u", param: wasm.F32, result: i32, opcode: 0x01, cases: []struct {
+				arg  uint64
+				want uint64
+			}{
+				{f32b(3.9), 3}, {f32b(-1.9), 0}, {f32b(float32(math.NaN())), 0}, {f32b(float32(math.Inf(1))), 0xffffffff},
+			}},
+			{name: "i32.trunc_sat_f64_s", param: wasm.F64, result: i32, opcode: 0x02, cases: []struct {
+				arg  uint64
+				want uint64
+			}{
+				{f64b(3.9), 3}, {f64b(-3.9), 0xfffffffd}, {f64b(math.NaN()), 0},
+				{f64b(math.Inf(1)), 0x7fffffff}, {f64b(math.Inf(-1)), 0x80000000},
+			}},
+			{name: "i32.trunc_sat_f64_u", param: wasm.F64, result: i32, opcode: 0x03, cases: []struct {
+				arg  uint64
+				want uint64
+			}{
+				{f64b(3.9), 3}, {f64b(-1.9), 0}, {f64b(math.NaN()), 0}, {f64b(math.Inf(1)), 0xffffffff},
+			}},
+			{name: "i64.trunc_sat_f32_s", param: wasm.F32, result: i64, opcode: 0x04, cases: []struct {
+				arg  uint64
+				want uint64
+			}{
+				{f32b(3.9), 3}, {f32b(-3.9), u64(-3)}, {f32b(float32(math.NaN())), 0},
+				{f32b(float32(math.Inf(1))), 0x7fffffffffffffff}, {f32b(float32(math.Inf(-1))), 0x8000000000000000},
+			}},
+			{name: "i64.trunc_sat_f32_u", param: wasm.F32, result: i64, opcode: 0x05, cases: []struct {
+				arg  uint64
+				want uint64
+			}{
+				{f32b(3.9), 3}, {f32b(-1.9), 0}, {f32b(float32(math.NaN())), 0}, {f32b(float32(math.Inf(1))), ^uint64(0)},
+			}},
+			{name: "i64.trunc_sat_f64_s", param: wasm.F64, result: i64, opcode: 0x06, cases: []struct {
+				arg  uint64
+				want uint64
+			}{
+				{f64b(3.9), 3}, {f64b(-3.9), u64(-3)}, {f64b(math.NaN()), 0},
+				{f64b(math.Inf(1)), 0x7fffffffffffffff}, {f64b(math.Inf(-1)), 0x8000000000000000},
+			}},
+			{name: "i64.trunc_sat_f64_u", param: wasm.F64, result: i64, opcode: 0x07, cases: []struct {
+				arg  uint64
+				want uint64
+			}{
+				{f64b(3.9), 3}, {f64b(-1.9), 0}, {f64b(math.NaN()), 0}, {f64b(math.Inf(1)), ^uint64(0)},
+			}},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				m := mod1(t, []wasm.ValType{tt.param}, []wasm.ValType{tt.result}, []byte{0x00,
+					0x20, 0x00, 0xfc, tt.opcode, 0x0b})
+				for _, tc := range tt.cases {
+					got := runAmd64u(t, m, tc.arg)
+					if wasm.EqualValType(tt.result, i64) {
+						if got != tc.want {
+							t.Fatalf("%s(%#x) = %#x, want %#x", tt.name, tc.arg, got, tc.want)
+						}
+					} else if uint32(got) != uint32(tc.want) {
+						t.Fatalf("%s(%#x) = %#x, want %#x", tt.name, tc.arg, uint32(got), uint32(tc.want))
+					}
+				}
+			})
 		}
 	})
 }

--- a/src/core/compiler/wasm/proposal_decode_edges_test.go
+++ b/src/core/compiler/wasm/proposal_decode_edges_test.go
@@ -137,6 +137,31 @@ func TestScalarSignExtensionInstructionDecodeMatrix(t *testing.T) {
 	}
 }
 
+func TestScalarTruncSatInstructionDecodeMatrix(t *testing.T) {
+	cases := []struct {
+		name  string
+		bytes []byte
+		kind  InstrKind
+	}{
+		{"i32.trunc_sat_f32_s", []byte{0xfc, 0x00}, InstrI32TruncSatF32S},
+		{"i32.trunc_sat_f32_u", []byte{0xfc, 0x01}, InstrI32TruncSatF32U},
+		{"i32.trunc_sat_f64_s", []byte{0xfc, 0x02}, InstrI32TruncSatF64S},
+		{"i32.trunc_sat_f64_u", []byte{0xfc, 0x03}, InstrI32TruncSatF64U},
+		{"i64.trunc_sat_f32_s", []byte{0xfc, 0x04}, InstrI64TruncSatF32S},
+		{"i64.trunc_sat_f32_u", []byte{0xfc, 0x05}, InstrI64TruncSatF32U},
+		{"i64.trunc_sat_f64_s", []byte{0xfc, 0x06}, InstrI64TruncSatF64S},
+		{"i64.trunc_sat_f64_u", []byte{0xfc, 0x07}, InstrI64TruncSatF64U},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in, err := decodeInstruction(newReader(tc.bytes), 0)
+			if err != nil || in.Kind != tc.kind {
+				t.Fatalf("decode %x = %#v err=%v, want %v", tc.bytes, in.Kind, err, tc.kind)
+			}
+		})
+	}
+}
+
 func TestSIMDAndRelaxedSIMDDecodeMatrix(t *testing.T) {
 	cases := []struct {
 		sub  uint32

--- a/src/core/compiler/wasm/validate_coverage_test.go
+++ b/src/core/compiler/wasm/validate_coverage_test.go
@@ -307,10 +307,14 @@ func TestValidatorCoverageStackEffectCategories(t *testing.T) {
 		{"i64.extend8_s", []Instruction{{Kind: InstrI64Const}, {Kind: InstrI64Extend8S}}, []ValType{I64}},
 		{"i64.extend16_s", []Instruction{{Kind: InstrI64Const}, {Kind: InstrI64Extend16S}}, []ValType{I64}},
 		{"i64.extend32_s", []Instruction{{Kind: InstrI64Const}, {Kind: InstrI64Extend32S}}, []ValType{I64}},
-		{"truncsat-f32-i32", []Instruction{{Kind: InstrF32Const}, {Kind: InstrI32TruncSatF32S}}, []ValType{I32}},
-		{"truncsat-f64-i32", []Instruction{{Kind: InstrF64Const}, {Kind: InstrI32TruncSatF64S}}, []ValType{I32}},
-		{"truncsat-f32-i64", []Instruction{{Kind: InstrF32Const}, {Kind: InstrI64TruncSatF32S}}, []ValType{I64}},
-		{"truncsat-f64-i64", []Instruction{{Kind: InstrF64Const}, {Kind: InstrI64TruncSatF64S}}, []ValType{I64}},
+		{"i32.trunc_sat_f32_s", []Instruction{{Kind: InstrF32Const}, {Kind: InstrI32TruncSatF32S}}, []ValType{I32}},
+		{"i32.trunc_sat_f32_u", []Instruction{{Kind: InstrF32Const}, {Kind: InstrI32TruncSatF32U}}, []ValType{I32}},
+		{"i32.trunc_sat_f64_s", []Instruction{{Kind: InstrF64Const}, {Kind: InstrI32TruncSatF64S}}, []ValType{I32}},
+		{"i32.trunc_sat_f64_u", []Instruction{{Kind: InstrF64Const}, {Kind: InstrI32TruncSatF64U}}, []ValType{I32}},
+		{"i64.trunc_sat_f32_s", []Instruction{{Kind: InstrF32Const}, {Kind: InstrI64TruncSatF32S}}, []ValType{I64}},
+		{"i64.trunc_sat_f32_u", []Instruction{{Kind: InstrF32Const}, {Kind: InstrI64TruncSatF32U}}, []ValType{I64}},
+		{"i64.trunc_sat_f64_s", []Instruction{{Kind: InstrF64Const}, {Kind: InstrI64TruncSatF64S}}, []ValType{I64}},
+		{"i64.trunc_sat_f64_u", []Instruction{{Kind: InstrF64Const}, {Kind: InstrI64TruncSatF64U}}, []ValType{I64}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- split non-trapping float-to-int / `trunc_sat` coverage from `wasm2` onto updated `main`
- pin decode and validator stack effects for all eight scalar `trunc_sat` opcodes
- replace the single railshot smoke test with NaN, negative unsigned, and overflow clamp coverage across the full opcode matrix
- document completed `trunc_sat` coverage in `FEATURES.md`

## Tests
- `go test ./src/core/compiler/wasm -run 'TestScalarTruncSatInstructionDecodeMatrix|TestValidatorCoverageStackEffectCategories' -count=1`\n- `go test ./src/core/compiler/backend/railshot -run TestAmd64BulkAndSat$ -count=1`\n- `go test ./...` fails on updated `main` in `cli/wago`: `registrySearch`, `registryInfo`, `registryVersions`, `registryStar`, `registryUnstar`, and `registryToken` are undefined.