### PR TITLE
wago: enable multi-value support

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -40,7 +40,7 @@ Later proposals and engine/platform capabilities beyond the MVP.
 |---|:---:|---|
 | Sign-extension ops (`i32.extend8_s`, …) | ✓ | ✅ done (decoder/validator plus railshot runtime/codegen coverage for all five scalar opcodes) |
 | Non-trapping float→int (`trunc_sat`) | ✓ | ✅ done (decoder/validator plus railshot runtime/codegen coverage for all eight scalar opcodes, including NaN, negative unsigned, and overflow clamp cases) |
-| Multi-value (multiple block/func results) | ✓ | 🚧 partial |
+| Multi-value (multiple block/func results) | ✓ | ✅ done (decoder/validator, block/if/branch/br_if/br_table/function results, direct and cross-instance calls, public `Invoke`/typed `Call`, and `.wago` metadata are executable; optimized multi-result register ABI remains a performance item, not a semantics blocker) |
 | Reference types (`funcref`/`externref`, `select t`, `ref.*`, `table.get/set`, multi-table) | ✓ | 🚧 partial (`select t` done) |
 | Bulk memory (`memory.copy`/`fill`/`init`, `data.drop`, `table.*`) | ✓ | 🚧 partial (`memory.copy`/`memory.fill` done; `memory.init`, `data.drop`, `table.*` planned) |
 | Tail calls (`return_call` / `return_call_indirect`) | ✓ | ⬜ planned |

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -179,12 +179,12 @@ func (f *fn) brIfFused(top *elem, labelIdx uint32) error {
 	f.convergeBranchLocals(fr) // before the compare: loads/stores stay clear of the flags window
 	k := f.flushBelow(top)
 	cc := f.condenseToFlags(top)
-	a, base := fr.branchN, fr.height
+	a := fr.branchN
 	over := f.a.JccPlaceholder(invertCond(cc)) // fall through when the compare is false
 	if fr.regMerge1 {
 		f.branchEdgeToMerge1(fr, k)
 	} else {
-		f.moveSlots(k-a, base, a)
+		f.moveBranchValues(fr, k, a)
 	}
 	f.branchJump(fr)
 	f.a.PatchRel32(over, f.a.Len())

--- a/src/core/compiler/wasm/proposal_decode_edges_test.go
+++ b/src/core/compiler/wasm/proposal_decode_edges_test.go
@@ -162,6 +162,79 @@ func TestScalarTruncSatInstructionDecodeMatrix(t *testing.T) {
 	}
 }
 
+func TestMultiValueBlockTypeDecodeAndValidation(t *testing.T) {
+	multiResultFuncType := []byte{0x60, 0x00, 0x02, 0x7f, 0x7e} // () -> (i32, i64)
+	typePayload := append([]byte{0x02}, multiResultFuncType...)
+	typePayload = append(typePayload, multiResultFuncType...)
+	moduleWithBody := func(body []byte) []byte {
+		codePayload := append([]byte{0x01}, u32(uint32(len(body)))...)
+		codePayload = append(codePayload, body...)
+		return module(
+			section(secType, typePayload...),
+			section(secFunction, 0x01, 0x01),
+			section(secCode, codePayload...),
+		)
+	}
+
+	validBlockBody := []byte{
+		0x00,       // local decl count
+		0x02, 0x00, // block typeidx 0: () -> (i32, i64)
+		0x41, 0x07, // i32.const 7
+		0x42, 0x09, // i64.const 9
+		0x0b, // end block
+		0x0b, // end func
+	}
+	m, err := DecodeModule(moduleWithBody(validBlockBody))
+	if err != nil {
+		t.Fatalf("DecodeModule multi-value block typeidx: %v", err)
+	}
+	if len(m.Code) != 1 || !sameValTypes(m.Types[0].SubTypes[0].Comp.Results, []ValType{I32, I64}) {
+		t.Fatalf("decoded multi-value function type = %#v", m.Types)
+	}
+	if got, want := m.Code[0].BodyBytes, validBlockBody[1:]; string(got) != string(want) {
+		t.Fatalf("body bytes=%x want %x", got, want)
+	}
+	if err := ValidateModule(m); err != nil {
+		t.Fatalf("ValidateModule multi-value block typeidx: %v", err)
+	}
+
+	validBranchBody := []byte{
+		0x00,       // local decl count
+		0x02, 0x00, // block typeidx 0: () -> (i32, i64)
+		0x41, 0x15, // i32.const 21
+		0x42, 0x16, // i64.const 22
+		0x41, 0x01, // i32.const 1
+		0x0d, 0x00, // br_if 0 carrying both block results
+		0x1a,       // fallthrough: drop i64
+		0x1a,       // fallthrough: drop i32
+		0x41, 0x1f, // i32.const 31
+		0x42, 0x20, // i64.const 32
+		0x0b, // end block
+		0x0b, // end func
+	}
+	m, err = DecodeModule(moduleWithBody(validBranchBody))
+	if err != nil {
+		t.Fatalf("DecodeModule multi-value br_if payload: %v", err)
+	}
+	if err := ValidateModule(m); err != nil {
+		t.Fatalf("ValidateModule multi-value br_if payload: %v", err)
+	}
+
+	invalidBranchBody := []byte{
+		0x00,       // local decl count
+		0x02, 0x00, // block typeidx 0: () -> (i32, i64)
+		0x41, 0x07, // i32.const 7; missing i64 branch payload
+		0x0c, 0x00, // br 0
+		0x0b, // end block
+		0x0b, // end func
+	}
+	m, err = DecodeModule(moduleWithBody(invalidBranchBody))
+	if err != nil {
+		t.Fatalf("DecodeModule invalid multi-value branch payload: %v", err)
+	}
+	expectValidateErr(t, m, ErrTypeMismatch)
+}
+
 func TestSIMDAndRelaxedSIMDDecodeMatrix(t *testing.T) {
 	cases := []struct {
 		sub  uint32

--- a/src/core/compiler/wasm/proposal_decode_edges_test.go
+++ b/src/core/compiler/wasm/proposal_decode_edges_test.go
@@ -164,8 +164,10 @@ func TestScalarTruncSatInstructionDecodeMatrix(t *testing.T) {
 
 func TestMultiValueBlockTypeDecodeAndValidation(t *testing.T) {
 	multiResultFuncType := []byte{0x60, 0x00, 0x02, 0x7f, 0x7e} // () -> (i32, i64)
-	typePayload := append([]byte{0x02}, multiResultFuncType...)
+	singleResultFuncType := []byte{0x60, 0x00, 0x01, 0x7f}      // () -> i32
+	typePayload := append([]byte{0x03}, multiResultFuncType...)
 	typePayload = append(typePayload, multiResultFuncType...)
+	typePayload = append(typePayload, singleResultFuncType...)
 	moduleWithBody := func(body []byte) []byte {
 		codePayload := append([]byte{0x01}, u32(uint32(len(body)))...)
 		codePayload = append(codePayload, body...)
@@ -219,6 +221,48 @@ func TestMultiValueBlockTypeDecodeAndValidation(t *testing.T) {
 	if err := ValidateModule(m); err != nil {
 		t.Fatalf("ValidateModule multi-value br_if payload: %v", err)
 	}
+
+	validBrTableBody := []byte{
+		0x00,       // local decl count
+		0x02, 0x00, // outer block typeidx 0: () -> (i32, i64)
+		0x02, 0x00, // inner block typeidx 0: () -> (i32, i64)
+		0x41, 0x0b, // i32.const 11
+		0x42, 0x0c, // i64.const 12
+		0x41, 0x00, // selector
+		0x0e, 0x01, 0x00, 0x01, // br_table [inner] default outer, carrying both results
+		0x0b,       // end inner
+		0x1a,       // drop i64 payload from the selected inner branch
+		0x1a,       // drop i32 payload from the selected inner branch
+		0x41, 0x0d, // i32.const 13
+		0x42, 0x0e, // i64.const 14
+		0x0b, // end outer
+		0x0b, // end func
+	}
+	m, err = DecodeModule(moduleWithBody(validBrTableBody))
+	if err != nil {
+		t.Fatalf("DecodeModule multi-value br_table payload: %v", err)
+	}
+	if err := ValidateModule(m); err != nil {
+		t.Fatalf("ValidateModule multi-value br_table payload: %v", err)
+	}
+
+	invalidBrTableLabelBody := []byte{
+		0x00,       // local decl count
+		0x02, 0x00, // outer block typeidx 0: () -> (i32, i64)
+		0x02, 0x02, // inner block typeidx 2: () -> i32
+		0x41, 0x0b, // i32.const 11
+		0x42, 0x0c, // i64.const 12
+		0x41, 0x00, // selector
+		0x0e, 0x01, 0x00, 0x01, // target inner has a different label arity than default outer
+		0x0b, // end inner
+		0x0b, // end outer
+		0x0b, // end func
+	}
+	m, err = DecodeModule(moduleWithBody(invalidBrTableLabelBody))
+	if err != nil {
+		t.Fatalf("DecodeModule invalid multi-value br_table labels: %v", err)
+	}
+	expectValidateErr(t, m, ErrTypeMismatch)
 
 	invalidBranchBody := []byte{
 		0x00,       // local decl count

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -48,10 +48,11 @@ const (
 	// coreFeaturesWago is the optional set wago's single-pass backend lowers
 	// today; it is the default and the ceiling WithCoreFeatures is validated
 	// against. Bulk-memory here means the supported subset (memory.copy/fill).
-	// Multi-value, reference-types, and tail-call are not yet fully wired, so
-	// enabling them is rejected up front rather than silently mis-running.
+	// Reference-types and tail-call are not yet fully wired, so enabling them is
+	// rejected up front rather than silently mis-running.
 	coreFeaturesWago = CoreFeatureMutableGlobal |
 		CoreFeatureSignExtensionOps |
+		CoreFeatureMultiValue |
 		CoreFeatureBulkMemoryOperations |
 		CoreFeatureNonTrappingFloatToIntConversion |
 		CoreFeatureSIMD

--- a/src/wago/cross_instance_test.go
+++ b/src/wago/cross_instance_test.go
@@ -3,6 +3,7 @@
 package wago
 
 import (
+	"context"
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -336,6 +337,75 @@ func TestCrossInstanceIndirectCallReloadsModulePinnedGlobal(t *testing.T) {
 	}
 	if got := AsI32(res[0]); got != 77 {
 		t.Fatalf("B.call = %d, want 77 from cross-instance indirect callee", got)
+	}
+}
+
+func TestCrossInstanceCallMultiValueImport(t *testing.T) {
+	wantI64 := int64(0x1020304050607080)
+	wantI32 := int32(0x10203040)
+
+	modA := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(
+			[]wasm.ValType{wasm.I32, wasm.I64},
+			[]wasm.ValType{wasm.I64, wasm.I32},
+		))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("reorder", 0, 0))),
+		// local.get 1; local.get 0; end
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x01, 0x20, 0x00, 0x0b}))),
+	)
+	inA, err := Instantiate(MustCompile(modA), nil)
+	if err != nil {
+		t.Fatalf("instantiate A: %v", err)
+	}
+	defer inA.Close()
+	reorderExport, err := inA.ExportedFunc("reorder")
+	if err != nil {
+		t.Fatalf("export reorder: %v", err)
+	}
+
+	imp := funcImportEntry("env", "reorder", 0)
+	body := []byte{0x41}
+	body = append(body, wasmtest.SLEB32(wantI32)...)
+	body = append(body, 0x42)
+	body = append(body, wasmtest.SLEB64(wantI64)...)
+	body = append(body, 0x10, 0x00, 0x0b) // call imported reorder; end
+	modB := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I64}, []wasm.ValType{wasm.I64, wasm.I32}),
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I64, wasm.I32}),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+	inB, err := Instantiate(MustCompile(modB), Imports{"env.reorder": reorderExport})
+	if err != nil {
+		t.Fatalf("instantiate B: %v", err)
+	}
+	defer inB.Close()
+
+	raw, err := inB.Invoke("call")
+	if err != nil {
+		t.Fatalf("invoke cross-instance multi-value call: %v", err)
+	}
+	if len(raw) != 2 {
+		t.Fatalf("cross-instance call returned %d slot(s), want 2", len(raw))
+	}
+	if got := AsI64(raw[0]); got != wantI64 {
+		t.Fatalf("cross-instance i64 result = %d, want %d", got, wantI64)
+	}
+	if got := AsI32(raw[1]); got != wantI32 {
+		t.Fatalf("cross-instance i32 result = %d, want %d", got, wantI32)
+	}
+
+	out, err := inB.Call(context.Background(), "call")
+	if err != nil {
+		t.Fatalf("typed call cross-instance multi-value: %v", err)
+	}
+	if len(out) != 2 || out[0].Type() != ValI64 || out[0].I64() != wantI64 || out[1].Type() != ValI32 || out[1].I32() != wantI32 {
+		t.Fatalf("typed cross-instance call = %v, want i64(%d), i32(%d)", out, wantI64, wantI32)
 	}
 }
 

--- a/src/wago/example_test.go
+++ b/src/wago/example_test.go
@@ -51,7 +51,7 @@ func ExampleSupportedFeatures() {
 func ExampleRuntimeConfig_WithFeature() {
 	cfg := wago.NewRuntimeConfig().WithFeature(wago.CoreFeatureBulkMemoryOperations, false)
 	fmt.Println(cfg.CoreFeatures())
-	// Output: mutable-global|nontrapping-float-to-int-conversion|sign-extension-ops|simd
+	// Output: multi-value|mutable-global|nontrapping-float-to-int-conversion|sign-extension-ops|simd
 }
 
 func ExampleCoreFeatures_IsEnabled() {

--- a/src/wago/multivalue_test.go
+++ b/src/wago/multivalue_test.go
@@ -1,0 +1,285 @@
+//go:build linux && amd64
+
+package wago
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+func multiValueControlCallModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32, wasm.I64}),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32, wasm.I64}),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(
+			wasmtest.ULEB(0), // pair: () -> (i32, i64)
+			wasmtest.ULEB(1), // choose: (i32) -> (i32, i64)
+		)),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("pair", 0, 0),
+			wasmtest.ExportEntry("choose", 0, 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x12, 0x42, 0x13, 0x0b}),                                                 // i32.const 18; i64.const 19; end
+			wasmtest.Code([]byte{0x20, 0x00, 0x04, 0x00, 0x10, 0x00, 0x05, 0x41, 0x07, 0x42, 0x09, 0x0b, 0x0b}), // local.get 0; if type 0; call pair; else constants; end; end
+		)),
+	)
+}
+
+func multiValueBranchPayloadModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32, wasm.I64}),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32, wasm.I64}),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(
+			wasmtest.ULEB(0), // block_br: () -> (i32, i64)
+			wasmtest.ULEB(1), // br_if_pair: (i32) -> (i32, i64)
+			wasmtest.ULEB(1), // br_table_pair: (i32) -> (i32, i64)
+		)),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("block_br", 0, 0),
+			wasmtest.ExportEntry("br_if_pair", 0, 1),
+			wasmtest.ExportEntry("br_table_pair", 0, 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{
+				0x02, 0x00, // block type 0: () -> (i32, i64)
+				0x41, 0x2a, // i32.const 42
+				0x42, 0x2b, // i64.const 43
+				0x0c, 0x00, // br 0 with both result values
+				0x41, 0x07, // unreachable fallback keeps the block type explicit
+				0x42, 0x09,
+				0x0b, // end block
+				0x0b, // end func
+			}),
+			wasmtest.Code([]byte{
+				0x02, 0x00, // block type 0
+				0x41, 0x15, // i32.const 21
+				0x42, 0x16, // i64.const 22
+				0x20, 0x00, // local.get selector
+				0x0d, 0x00, // br_if 0 carrying both values when selector is non-zero
+				0x1a,       // fallthrough: drop i64 branch payload
+				0x1a,       // fallthrough: drop i32 branch payload
+				0x41, 0x1f, // i32.const 31
+				0x42, 0x20, // i64.const 32
+				0x0b, // end block
+				0x0b, // end func
+			}),
+			wasmtest.Code([]byte{
+				0x02, 0x00, // outer block type 0
+				0x02, 0x00, // inner block type 0
+				0x41, 0x0b, // i32.const 11
+				0x42, 0x0c, // i64.const 12
+				0x20, 0x00, // local.get selector
+				0x0e, 0x01, 0x00, 0x01, // br_table [inner] default outer, carrying both values
+				0x0b, // end inner; selector 0 lands here with the pair still on stack
+				0x0b, // end outer; default exits here directly with the same pair
+				0x0b, // end func
+			}),
+		)),
+	)
+}
+
+func multiValueFusedBrIfV128PayloadModule(takenVec, fallthroughVec V128) []byte {
+	v128Const := func(v V128) []byte { return append([]byte{0xfd, 0x0c}, v[:]...) }
+	body := []byte{
+		0x42, 0x2d, // i64.const 45: preserved result below the block
+		0x02, 0x00, // block type 0: () -> (v128, i32)
+		0x41, 0x11, // extra i32 below the branch payload; must be discarded on taken br_if
+	}
+	body = append(body, v128Const(takenVec)...)
+	body = append(body,
+		0x41, 0x26, // branch payload i32
+		0x20, 0x00, // local.get selector
+		0x41, 0x00, // i32.const 0
+		0x47,       // i32.ne; fused with br_if by railshot
+		0x0d, 0x00, // br_if 0 carrying (v128, i32)
+		0x1a, // fallthrough: drop payload i32
+		0x1a, // fallthrough: drop payload v128
+		0x1a, // fallthrough: drop extra i32
+	)
+	body = append(body, v128Const(fallthroughVec)...)
+	body = append(body,
+		0x41, 0x33, // fallback i32
+		0x0b, // end block
+		0x0b, // end func
+	)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.V128, wasm.I32}),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I64, wasm.V128, wasm.I32}),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+}
+
+func TestMultiValueDefaultConfigControlCallsAndCodec(t *testing.T) {
+	if !SupportedFeatures().IsEnabled(CoreFeatureMultiValue) {
+		t.Fatal("default supported features should include multi-value")
+	}
+
+	cfg := NewRuntimeConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("default config should validate with multi-value enabled: %v", err)
+	}
+
+	c, err := cfg.Compile(multiValueControlCallModule())
+	if err != nil {
+		t.Fatalf("Compile default multi-value module: %v", err)
+	}
+	if cfg.BoundsChecks() != BoundsChecksSignalsBased {
+		blob, err := c.MarshalBinary()
+		if err != nil {
+			t.Fatalf("MarshalBinary: %v", err)
+		}
+		c, err = Load(blob)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+	}
+
+	in, err := Instantiate(c, nil)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+
+	got, err := in.Invoke("choose", I32(0))
+	if err != nil {
+		t.Fatalf("Invoke choose(0): %v", err)
+	}
+	if want := []uint64{I32(7), I64(9)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("choose(0) = %#x, want %#x", got, want)
+	}
+	got, err = in.Invoke("choose", I32(1))
+	if err != nil {
+		t.Fatalf("Invoke choose(1): %v", err)
+	}
+	if want := []uint64{I32(18), I64(19)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("choose(1) = %#x, want %#x", got, want)
+	}
+}
+
+func TestMultiValueFusedBrIfUsesSlotWidths(t *testing.T) {
+	if !hostSupportsSIMD() {
+		t.Skip("host SIMD unavailable")
+	}
+	takenVec := V128{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f}
+	fallthroughVec := V128{0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf}
+	c, err := NewRuntimeConfig().Compile(multiValueFusedBrIfV128PayloadModule(takenVec, fallthroughVec))
+	if err != nil {
+		t.Fatalf("Compile fused br_if multi-value module: %v", err)
+	}
+	in, err := Instantiate(c, nil)
+	if err != nil {
+		t.Fatalf("Instantiate fused br_if multi-value module: %v", err)
+	}
+	defer in.Close()
+
+	for _, tc := range []struct {
+		selector int32
+		vec      V128
+		i32      uint64
+	}{
+		{0, fallthroughVec, I32(0x33)},
+		{1, takenVec, I32(0x26)},
+	} {
+		got, err := in.Invoke("f", I32(tc.selector))
+		if err != nil {
+			t.Fatalf("Invoke f(%d): %v", tc.selector, err)
+		}
+		lo, hi := hostV128Slots(tc.vec)
+		want := []uint64{I64(45), lo, hi, tc.i32}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("f(%d) = %#x, want %#x", tc.selector, got, want)
+		}
+	}
+}
+
+func TestMultiValueBranchPayloadsAndTypedCall(t *testing.T) {
+	cfg := NewRuntimeConfig()
+	c, err := cfg.Compile(multiValueBranchPayloadModule())
+	if err != nil {
+		t.Fatalf("Compile default multi-value module: %v", err)
+	}
+	if cfg.BoundsChecks() != BoundsChecksSignalsBased {
+		blob, err := c.MarshalBinary()
+		if err != nil {
+			t.Fatalf("MarshalBinary: %v", err)
+		}
+		c, err = Load(blob)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+	}
+	in, err := Instantiate(c, nil)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+
+	got, err := in.Invoke("block_br")
+	if err != nil {
+		t.Fatalf("Invoke block_br: %v", err)
+	}
+	if want := []uint64{I32(42), I64(43)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("block_br = %#x, want %#x", got, want)
+	}
+
+	out, err := in.Call(context.Background(), "block_br")
+	if err != nil {
+		t.Fatalf("Call block_br: %v", err)
+	}
+	if len(out) != 2 || out[0].Type() != ValI32 || out[0].I32() != 42 || out[1].Type() != ValI64 || out[1].I64() != 43 {
+		t.Fatalf("Call block_br = %v, want i32(42), i64(43)", out)
+	}
+
+	for _, tc := range []struct {
+		selector int32
+		want     []uint64
+	}{
+		{0, []uint64{I32(31), I64(32)}},
+		{1, []uint64{I32(21), I64(22)}},
+	} {
+		got, err = in.Invoke("br_if_pair", I32(tc.selector))
+		if err != nil {
+			t.Fatalf("Invoke br_if_pair(%d): %v", tc.selector, err)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("br_if_pair(%d) = %#x, want %#x", tc.selector, got, tc.want)
+		}
+		out, err = in.Call(context.Background(), "br_if_pair", ValueI32(tc.selector))
+		if err != nil {
+			t.Fatalf("Call br_if_pair(%d): %v", tc.selector, err)
+		}
+		if len(out) != 2 || out[0].Type() != ValI32 || out[0].I32() != int32(tc.want[0]) || out[1].Type() != ValI64 || out[1].I64() != int64(tc.want[1]) {
+			t.Fatalf("Call br_if_pair(%d) = %v, want i32(%d), i64(%d)", tc.selector, out, int32(tc.want[0]), int64(tc.want[1]))
+		}
+	}
+
+	for _, selector := range []int32{0, 1, 2} {
+		got, err = in.Invoke("br_table_pair", I32(selector))
+		if err != nil {
+			t.Fatalf("Invoke br_table_pair(%d): %v", selector, err)
+		}
+		if want := []uint64{I32(11), I64(12)}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("br_table_pair(%d) = %#x, want %#x", selector, got, want)
+		}
+		out, err = in.Call(context.Background(), "br_table_pair", ValueI32(selector))
+		if err != nil {
+			t.Fatalf("Call br_table_pair(%d): %v", selector, err)
+		}
+		if len(out) != 2 || out[0].Type() != ValI32 || out[0].I32() != 11 || out[1].Type() != ValI64 || out[1].I64() != 12 {
+			t.Fatalf("Call br_table_pair(%d) = %v, want i32(11), i64(12)", selector, out)
+		}
+	}
+}

--- a/src/wago/multivalue_test.go
+++ b/src/wago/multivalue_test.go
@@ -79,8 +79,12 @@ func multiValueBranchPayloadModule() []byte {
 				0x42, 0x0c, // i64.const 12
 				0x20, 0x00, // local.get selector
 				0x0e, 0x01, 0x00, 0x01, // br_table [inner] default outer, carrying both values
-				0x0b, // end inner; selector 0 lands here with the pair still on stack
-				0x0b, // end outer; default exits here directly with the same pair
+				0x0b,       // end inner; selector 0 lands here with the pair still on stack
+				0x1a,       // selector 0: drop i64 branch payload before returning a distinct pair
+				0x1a,       // selector 0: drop i32 branch payload
+				0x41, 0x0d, // i32.const 13
+				0x42, 0x0e, // i64.const 14
+				0x0b, // end outer; default exits here directly with the original pair
 				0x0b, // end func
 			}),
 		)),
@@ -266,20 +270,27 @@ func TestMultiValueBranchPayloadsAndTypedCall(t *testing.T) {
 		}
 	}
 
-	for _, selector := range []int32{0, 1, 2} {
-		got, err = in.Invoke("br_table_pair", I32(selector))
+	for _, tc := range []struct {
+		selector int32
+		want     []uint64
+	}{
+		{0, []uint64{I32(13), I64(14)}},
+		{1, []uint64{I32(11), I64(12)}},
+		{2, []uint64{I32(11), I64(12)}},
+	} {
+		got, err = in.Invoke("br_table_pair", I32(tc.selector))
 		if err != nil {
-			t.Fatalf("Invoke br_table_pair(%d): %v", selector, err)
+			t.Fatalf("Invoke br_table_pair(%d): %v", tc.selector, err)
 		}
-		if want := []uint64{I32(11), I64(12)}; !reflect.DeepEqual(got, want) {
-			t.Fatalf("br_table_pair(%d) = %#x, want %#x", selector, got, want)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("br_table_pair(%d) = %#x, want %#x", tc.selector, got, tc.want)
 		}
-		out, err = in.Call(context.Background(), "br_table_pair", ValueI32(selector))
+		out, err = in.Call(context.Background(), "br_table_pair", ValueI32(tc.selector))
 		if err != nil {
-			t.Fatalf("Call br_table_pair(%d): %v", selector, err)
+			t.Fatalf("Call br_table_pair(%d): %v", tc.selector, err)
 		}
-		if len(out) != 2 || out[0].Type() != ValI32 || out[0].I32() != 11 || out[1].Type() != ValI64 || out[1].I64() != 12 {
-			t.Fatalf("Call br_table_pair(%d) = %v, want i32(11), i64(12)", selector, out)
+		if len(out) != 2 || out[0].Type() != ValI32 || out[0].I32() != int32(tc.want[0]) || out[1].Type() != ValI64 || out[1].I64() != int64(tc.want[1]) {
+			t.Fatalf("Call br_table_pair(%d) = %v, want i32(%d), i64(%d)", tc.selector, out, int32(tc.want[0]), int64(tc.want[1]))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- split multi-value support from `wasm2` onto updated `main`
- enable `CoreFeatureMultiValue` in the supported/default feature set while keeping reference-types and tail-call rejected
- add decoder/validator coverage for multi-result block type indexes and branch payloads
- add runtime/API coverage for multi-result if, br, br_if, br_table, typed `Call`, raw `Invoke`, compiled-blob roundtrip, and cross-instance imported calls
- update `FEATURES.md` and example output for the new default feature set

## Tests
- `go test ./src/core/compiler/wasm -run TestMultiValueBlockTypeDecodeAndValidation -count=1`
- `go test ./src/core/compiler/frontend -count=1`
- `go test ./src/wago -run 'TestMultiValue|TestCrossInstanceCallMultiValueImport' -count=1`\n- `go test ./...` fails on updated `main` in `cli/wago`: `registrySearch`, `registryInfo`, `registryVersions`, `registryStar`, `registryUnstar`, and `registryToken` are undefined.