### PR TITLE
amd64: preload float constants

### DIFF
--- a/src/core/compiler/backend/railshot/compile.go
+++ b/src/core/compiler/backend/railshot/compile.go
@@ -68,6 +68,7 @@ type fn struct {
 	// Parallel XMM-register occupancy for float values (Phase 5).
 	fregUser [16]*elem
 	fpinned  regMask
+	fconsts  []floatConstReg
 
 	maxSpill    int  // high-water number of operand spill slots used
 	subRspAt    int  // byte offset of the prologue's SubRsp imm32 (patched with frameSize)
@@ -750,6 +751,7 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts bool
 	}
 
 	f.prologue()
+	f.preloadFloatConsts(c.BodyBytes)
 	if err := f.runBody(c); err != nil {
 		return nil, nil, 0, err
 	}
@@ -1221,6 +1223,7 @@ func (f *fn) emitRegABI(c *wasm.Func) (int, error) {
 		}
 	}
 	f.zeroDeclaredLocals()
+	f.preloadFloatConsts(c.BodyBytes)
 	f.derivePinnedGlobals()
 	if err := f.runBody(c); err != nil {
 		return 0, err

--- a/src/core/compiler/backend/railshot/exec_test.go
+++ b/src/core/compiler/backend/railshot/exec_test.go
@@ -517,6 +517,22 @@ func TestAmd64Phase5Floats(t *testing.T) {
 			t.Fatalf("f32.max(1,NaN) bits = %#x, want NaN", bits)
 		}
 	})
+	t.Run("f64.max-nan", func(t *testing.T) {
+		m := mod1(t, []wasm.ValType{f64, f64}, []wasm.ValType{f64}, []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, 0xa5, 0x0b})
+		bits := runAmd64u(t, m, 0x7ff8000000000001, f64b(1))
+		if !math.IsNaN(math.Float64frombits(bits)) {
+			t.Fatalf("f64.max(NaN,1) bits = %#x, want NaN", bits)
+		}
+	})
+	t.Run("f32.min-signed-zero", func(t *testing.T) {
+		m := mod1(t, []wasm.ValType{f32, f32}, []wasm.ValType{f32}, []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, 0x96, 0x0b})
+		bits := uint32(runAmd64u(t, m, f32b(0), f32b(float32(math.Copysign(0, -1)))))
+		if bits != 0x80000000 {
+			t.Fatalf("f32.min(+0,-0) bits = %#x, want -0", bits)
+		}
+	})
 	t.Run("f64.min-signed-zero", func(t *testing.T) {
 		m := mod1(t, []wasm.ValType{f64, f64}, []wasm.ValType{f64}, []byte{0x00,
 			0x20, 0x00, 0x20, 0x01, 0xa4, 0x0b})

--- a/src/core/compiler/backend/railshot/fp.go
+++ b/src/core/compiler/backend/railshot/fp.go
@@ -37,10 +37,24 @@ func (f *fn) releaseF(r Reg) {
 	}
 }
 
+type floatConstReg struct {
+	typ  machineType
+	bits int64
+	reg  Reg
+}
+
+func (f *fn) fconstMask() regMask {
+	var m regMask
+	for _, c := range f.fconsts {
+		m = m.add(c.reg)
+	}
+	return m
+}
+
 // allocFReg returns a free XMM register, spilling the deepest float-resident stack
 // value if none is free.
 func (f *fn) allocFReg(avoid regMask) Reg {
-	block := avoid.union(f.fpinned).union(f.fpinnedLocalMask)
+	block := avoid.union(f.fpinned).union(f.fpinnedLocalMask).union(f.fconstMask())
 	for r := Reg(0); r < 16; r++ {
 		if f.fregUser[r] == nil && !block.has(r) {
 			return r
@@ -78,6 +92,14 @@ func (f *fn) materializeF(e *elem) Reg {
 	case stReg:
 		return e.st.reg
 	case stConst:
+		if !f.usesCalls {
+			if c, ok := f.floatConstReg(e.st); ok {
+				x := f.allocFReg(maskOf(c))
+				f.a.FMov(x, c, e.st.typ == mtF64)
+				f.occupyF(e, x)
+				return x
+			}
+		}
 		x := f.allocFReg(0)
 		f.loadFConst(x, e.st)
 		f.occupyF(e, x)
@@ -119,7 +141,58 @@ func (f *fn) operandRegF(e *elem) (reg Reg, owned bool) {
 	if e.kind == ekValue && e.st.kind == stLocalReg {
 		return e.st.reg, false
 	}
+	if e.kind == ekValue && e.st.kind == stConst && e.st.typ.isFloat() && !f.usesCalls {
+		if r, ok := f.floatConstReg(e.st); ok {
+			return r, false
+		}
+	}
 	return f.materializeF(e), true
+}
+
+func (f *fn) floatConstReg(st storage) (Reg, bool) {
+	for _, c := range f.fconsts {
+		if c.typ == st.typ && c.bits == st.cval {
+			return c.reg, true
+		}
+	}
+	if len(f.fconsts) >= 2 {
+		return regNone, false
+	}
+	x := f.allocFReg(0)
+	f.loadFConst(x, st)
+	f.fconsts = append(f.fconsts, floatConstReg{typ: st.typ, bits: st.cval, reg: x})
+	return x, true
+}
+
+func (f *fn) preloadFloatConsts(code []byte) {
+	if f.usesCalls {
+		return
+	}
+	r := wasm.NewReader(code)
+	for r.HasNext() && len(f.fconsts) < 2 {
+		op, err := r.Byte()
+		if err != nil {
+			return
+		}
+		switch op {
+		case 0x43: // f32.const
+			bits, err := r.LEU32()
+			if err != nil {
+				return
+			}
+			f.floatConstReg(storage{kind: stConst, typ: mtF32, cval: int64(bits)})
+		case 0x44: // f64.const
+			bits, err := r.LEU64()
+			if err != nil {
+				return
+			}
+			f.floatConstReg(storage{kind: stConst, typ: mtF64, cval: int64(bits)})
+		default:
+			if err := wasm.SkipInstructionImmediate(r, op); err != nil {
+				return
+			}
+		}
+	}
 }
 
 // pushFReg pushes an XMM-resident float value of the given type.

--- a/src/core/compiler/backend/railshot/golden_test.go
+++ b/src/core/compiler/backend/railshot/golden_test.go
@@ -115,6 +115,33 @@ func TestGoldenFloatLocalSink(t *testing.T) {
 	}
 }
 
+func TestGoldenFloatConstPreloadBeforeLoop(t *testing.T) {
+	// acc = 1; loop { acc *= 1.0000001; n-- }; return acc. The multiplier
+	// constant should be materialized before the loop header, not on every trip.
+	m := mod1(t, []wasm.ValType{wasm.I32}, []wasm.ValType{wasm.F64}, []byte{
+		0x01, 0x01, 0x7c,
+		0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, // f64.const 1
+		0x21, 0x01, // local.set 1
+		0x02, 0x40, // block
+		0x03, 0x40, // loop
+		0x20, 0x00, 0x45, 0x0d, 0x01, // br_if break (i32.eqz n)
+		0x20, 0x01,
+		0x44, 0x9b, 0xf2, 0xd7, 0x1a, 0x00, 0x00, 0xf0, 0x3f, // f64.const 1.0000001
+		0xa2,       // f64.mul
+		0x21, 0x01, // local.set 1
+		0x20, 0x00, 0x41, 0x01, 0x6b, 0x21, 0x00, // n--
+		0x0c, 0x00, // br loop
+		0x0b, 0x0b, // end loop/block
+		0x20, 0x01, 0x0b, // local.get 1; end
+	})
+	d := disasm(t, compileCode(t, m, false))
+	c := strings.Index(d, "0x3ff000001ad7f29b")
+	loop := strings.Index(d, "\ttest")
+	if c < 0 || loop < 0 || c > loop {
+		t.Errorf("expected f64 multiplier constant before loop test, got:\n%s", d)
+	}
+}
+
 // mod1Mem builds a one-memory module whose exported function does a single
 // i32.load of its i32 parameter (the guard-vs-explicit bounds shape probe).
 func mod1Mem(t *testing.T) *wasm.Module {


### PR DESCRIPTION
## What

Preloads up to two scalar `f32`/`f64` constants into reserved XMM registers for call-free railshot functions, then reuses those registers for read-only float operands. This keeps loop-invariant float constants out of hot loop bodies without adding a new IR pass.

The PR also adds a golden disassembly regression for the loop shape and broadens scalar min/max edge coverage for NaN and signed-zero cases.

## Why

`bench/corpus/float.wasm` rebuilt its f64 multiplier constant inside the loop on every trip. The emitted loop now uses the preloaded XMM constant directly.

Measured on this machine:

| Benchmark | before | after | note |
|---|---:|---:|---|
| `BenchmarkExec/float.run` | ~10.6 us/op | ~10.1 us/op | 0 B/op, 0 allocs/op |
| `BenchmarkExec/mandelbrot.render` | ~270 us/op | ~264 us/op | 0 B/op, 0 allocs/op |
| wasmtime CLI `run --invoke run float.wasm 2000` | ~3 ms/invoke | n/a | CLI/process path, not in-process apples-to-apples |

Wazero remains faster on `float.run` in the existing in-process comparison, but this closes a real codegen gap and keeps Wago comfortably ahead of the available wasmtime CLI invocation path.

## Validation

- `go test ./...`
- `cd bench && go test ./...`
- `go test -tags wago_guardpage ./src/core/compiler/backend/railshot ./src/core/runtime -count=1`
- `cd bench && go test -tags wago_guardpage ./...`
- `go test -run TestSpecExec -count=1 -v .` (`pass=16592 fail=0 skip=1591`)
- `cd bench && WAGO_BOUNDS= go test -run '^$' -bench '^(BenchmarkExec|BenchmarkWazeroExec)/(float\.run|mandelbrot\.render)$' -benchmem -benchtime=1s -count=3 .`
