### PR TITLE
cli: make WASI an optional build tag (wago_wasi), out of default build

### DIFF
--- a/cli/wago/plugins.go
+++ b/cli/wago/plugins.go
@@ -9,28 +9,12 @@ import (
 	"strings"
 
 	"github.com/wago-org/wago"
-	"github.com/wago-org/wasi/p1"
-	"github.com/wago-org/wasi/unstable"
 )
 
-// The built-in plugins compiled into this binary. WASI is the only bundled plugin
-// for now; it lives in its own repo (github.com/wago-org/wasi, vendored as the
-// plugins/wasi submodule). Heavier third-party plugins live in their own modules,
-// wired in via a custom build.
-func init() {
-	// WASI plugins are selected by path: `wasi` is the default (preview1), and a
-	// specific snapshot is `wasi/<version>` (wasi/p1, wasi/unstable). Preview 2
-	// (wasi/p2) is a placeholder and not yet implemented.
-	wago.RegisterExtension("wasi", func() wago.Extension { return p1.Ext(wasiCLIConfig()) })
-	wago.RegisterExtension("wasi/p1", func() wago.Extension { return p1.Ext(wasiCLIConfig()) })
-	wago.RegisterExtension("wasi/unstable", func() wago.Extension { return unstable.Ext(wasiCLIConfig()) })
-}
-
-// wasiCLIConfig is the base WASI config for the CLI: process stdio and env. argv
-// is filled in per run (the run's positional args) by pluginImports.
-func wasiCLIConfig() p1.Config {
-	return p1.Config{Stdout: os.Stdout, Stderr: os.Stderr, Stdin: os.Stdin, Env: os.Environ()}
-}
+// WASI is not bundled into the default binary — it lives in its own (private)
+// repo, github.com/wago-org/wasi, and is compiled in only with the `wago_wasi`
+// build tag (see wasi_on.go / wasi_off.go). The stock installer never fetches it.
+// Third-party plugins live in their own modules, wired in via a custom build.
 
 // pluginCmd dispatches `wago plugin <sub>`.
 func pluginCmd(args []string) {
@@ -349,22 +333,18 @@ func pluginImports(list string, argv []string) wago.Imports {
 	rt := wago.NewRuntime()
 	for _, name := range strings.Split(list, ",") {
 		name = strings.TrimSpace(name)
-		cfg := wasiCLIConfig()
-		cfg.Args = argv
-		switch name {
-		case "":
+		if name == "" {
 			continue
-		case "wasi", "wasi/p1":
-			mergeImports(out, p1.Imports(cfg))
-		case "wasi/unstable":
-			mergeImports(out, unstable.Imports(cfg))
-		case "wasi/p2":
-			fatal("--plugin wasi/p2: WASI preview 2 (component model) is not implemented yet; use wasi (preview1) or wasi/unstable")
-		default:
-			if err := rt.UsePlugin(name); err != nil {
-				fmt.Fprintf(os.Stderr, "%s %v\n", red("wago:"), err)
-				os.Exit(1)
-			}
+		}
+		// WASI names are handled by the build-tagged hook (a no-op stub when the
+		// binary is built without wago_wasi); everything else is a registered plugin.
+		if imp, handled := wasiImports(name, argv); handled {
+			mergeImports(out, imp)
+			continue
+		}
+		if err := rt.UsePlugin(name); err != nil {
+			fmt.Fprintf(os.Stderr, "%s %v\n", red("wago:"), err)
+			os.Exit(1)
 		}
 	}
 	mergeImports(out, rt.HostImports())

--- a/cli/wago/wasi_off.go
+++ b/cli/wago/wasi_off.go
@@ -1,0 +1,21 @@
+//go:build !wago_wasi
+
+// No-WASI stub for the default build. WASI is not compiled in unless the binary
+// is built with `-tags wago_wasi` (see wasi_on.go), so this build imports neither
+// the wago-org/wasi module nor its submodule. A wasi/* plugin name errors with a
+// hint instead of silently doing nothing.
+
+package main
+
+import "github.com/wago-org/wago"
+
+// wasiImports is the no-op counterpart to the wago_wasi build's hook: it reports
+// that WASI is unavailable in this binary. It returns handled=false for non-WASI
+// names so the caller falls through to the plugin registry.
+func wasiImports(name string, _ []string) (wago.Imports, bool) {
+	switch name {
+	case "wasi", "wasi/p1", "wasi/unstable", "wasi/p2":
+		fatal("--plugin %s: this wago build has no WASI support; rebuild with -tags wago_wasi", name)
+	}
+	return nil, false
+}

--- a/cli/wago/wasi_on.go
+++ b/cli/wago/wasi_on.go
@@ -1,0 +1,53 @@
+//go:build wago_wasi
+
+// WASI support, compiled in only with `-tags wago_wasi`. This is the sole file
+// that imports github.com/wago-org/wasi, so a default build needs neither the
+// module nor its plugins/wasi submodule. Build with the tag (and the submodule
+// checked out) to include WASI:
+//
+//	go build -tags wago_wasi ./cli/wago
+
+package main
+
+import (
+	"os"
+
+	"github.com/wago-org/wago"
+	"github.com/wago-org/wasi/p1"
+	"github.com/wago-org/wasi/unstable"
+)
+
+func init() {
+	// WASI plugins are selected by path: `wasi` is the default (preview1), and a
+	// specific snapshot is `wasi/<version>` (wasi/p1, wasi/unstable). Preview 2
+	// (wasi/p2) is a placeholder and not yet implemented.
+	wago.RegisterExtension("wasi", func() wago.Extension { return p1.Ext(wasiCLIConfig()) })
+	wago.RegisterExtension("wasi/p1", func() wago.Extension { return p1.Ext(wasiCLIConfig()) })
+	wago.RegisterExtension("wasi/unstable", func() wago.Extension { return unstable.Ext(wasiCLIConfig()) })
+}
+
+// wasiCLIConfig is the base WASI config for the CLI: process stdio and env. argv
+// is filled in per run (the run's positional args) by wasiImports.
+func wasiCLIConfig() p1.Config {
+	return p1.Config{Stdout: os.Stdout, Stderr: os.Stderr, Stdin: os.Stdin, Env: os.Environ()}
+}
+
+// wasiImports resolves the built-in WASI plugin names to their host imports.
+// handled is false for any non-WASI name, so the caller falls back to the plugin
+// registry.
+func wasiImports(name string, argv []string) (wago.Imports, bool) {
+	cfg := wasiCLIConfig()
+	cfg.Args = argv
+	out := wago.Imports{}
+	switch name {
+	case "wasi", "wasi/p1":
+		mergeImports(out, p1.Imports(cfg))
+	case "wasi/unstable":
+		mergeImports(out, unstable.Imports(cfg))
+	case "wasi/p2":
+		fatal("--plugin wasi/p2: WASI preview 2 (component model) is not implemented yet; use wasi (preview1) or wasi/unstable")
+	default:
+		return nil, false
+	}
+	return out, true
+}


### PR DESCRIPTION
Splits WASI wiring into two build-tagged files so a **default build pulls neither the `github.com/wago-org/wasi` module nor its `plugins/wasi` submodule**:

- `wasi_on.go` (`//go:build wago_wasi`) — the sole importer of the wasi module; registers the `wasi`, `wasi/p1`, `wasi/unstable` extensions and resolves their imports.
- `wasi_off.go` (`//go:build !wago_wasi`) — no-op stub; a `wasi/*` plugin name errors with `rebuild with -tags wago_wasi` instead of silently doing nothing.

`plugins.go` now routes WASI names through the build-tagged `wasiImports` hook. Includes a small `plugins/wasi` submodule version/readme bump.

A step toward splitting built-in plugins into their own repos. Verified: default build compiles without the wasi module and rejects `--plugin wasi` with the hint; `-tags wago_wasi` build resolves WASI imports and runs a module.