### PR TITLE
cli: rewrite command dispatch into a small modular framework

### DIFF
--- a/cli/wago/cli.go
+++ b/cli/wago/cli.go
@@ -1,0 +1,246 @@
+package main
+
+// A tiny, zero-dependency command framework. Every wago command is a Cmd
+// declared in a cmd_*.go file and hung off root by buildRoot(). The framework
+// gives every command uniform flag parsing and an automatic `-h`/`--help`, so no
+// command hand-rolls its own argument handling (the old CLI did, inconsistently).
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Flag declares one option a command accepts.
+type Flag struct {
+	Name  string // canonical long name without dashes, e.g. "invoke"
+	Short string // optional one-letter alias without a dash, e.g. "e"; "" if none
+	Bool  bool   // presence-only (--json) vs value-taking (--invoke <name>)
+	Arg   string // value placeholder shown in help, e.g. "<name>"; unused when Bool
+	Help  string // one-line description for per-command help
+}
+
+// Cmd is a command or a group of subcommands. A group has Children (and no Run);
+// a leaf has a Run. buildRoot() wires the whole tree.
+type Cmd struct {
+	Name        string
+	Aliases     []string   // alternate names, e.g. {"ls"} for list
+	Summary     string     // one line for the parent's command list
+	Args        string     // positional synopsis for help, e.g. "<file> [args...]"
+	Group       string     // "" (core) or "registry"; buckets the top-level list
+	Long        string     // optional extra prose appended to per-command help
+	Flags       []Flag     // options this leaf accepts
+	PassThrough bool       // run: stop flag parsing at the first positional (guest argv)
+	Run         func(*Ctx) // leaf action; nil for a pure group
+	Children    []*Cmd     // subcommands; non-empty makes this a group
+	DefaultSub  string     // group invoked with no subcommand runs this child
+}
+
+// Ctx is a parsed invocation handed to a leaf's Run.
+type Ctx struct {
+	Cmd   *Cmd
+	Path  string   // e.g. "wago plugin inspect", for messages
+	Args  []string // positionals after flag parsing (guest argv for run)
+	strs  map[string]string
+	bools map[string]bool
+}
+
+// Str returns the value of a value-flag (empty if unset).
+func (c *Ctx) Str(name string) string { return c.strs[name] }
+
+// Bool reports whether a boolean flag was present.
+func (c *Ctx) Bool(name string) bool { return c.bools[name] }
+
+// one returns the sole positional argument, or fatals with a usage hint naming
+// what was expected (e.g. "<name>").
+func (c *Ctx) one(what string) string {
+	if len(c.Args) != 1 {
+		fatal("%s: need exactly one %s", strings.TrimPrefix(c.Path, "wago "), what)
+	}
+	return c.Args[0]
+}
+
+// child finds a subcommand by name or alias.
+func (c *Cmd) child(name string) *Cmd {
+	for _, ch := range c.Children {
+		if ch.Name == name {
+			return ch
+		}
+		for _, a := range ch.Aliases {
+			if a == name {
+				return ch
+			}
+		}
+	}
+	return nil
+}
+
+// label is the command path without the leading "wago " (for error messages).
+func (c *Cmd) label(path string) string { return strings.TrimPrefix(path, "wago ") }
+
+// Dispatch resolves args against c and runs (or delegates to) the right command.
+// It is the single entry point from main() for every command.
+func (c *Cmd) Dispatch(path string, args []string) {
+	// A group's own -h/--help must precede the subcommand token, so `token create
+	// --help` descends to create rather than printing the group's help. That's the
+	// same "stop at the first positional" rule PassThrough uses.
+	if wantsHelp(args, c.PassThrough || len(c.Children) > 0) {
+		c.printHelp(os.Stdout, path)
+		return
+	}
+	if len(c.Children) > 0 {
+		if len(args) == 0 {
+			if c.DefaultSub != "" {
+				sub := c.child(c.DefaultSub)
+				sub.Dispatch(path+" "+sub.Name, nil)
+				return
+			}
+			c.printHelp(os.Stderr, path)
+			os.Exit(2)
+		}
+		if sub := c.child(args[0]); sub != nil {
+			sub.Dispatch(path+" "+sub.Name, args[1:])
+			return
+		}
+		fmt.Fprintf(os.Stderr, "%s %s: unknown subcommand %q\n\n", red("wago:"), c.label(path), args[0])
+		c.printHelp(os.Stderr, path)
+		os.Exit(2)
+	}
+	ctx, err := c.parse(path, args)
+	if err != nil {
+		fatal("%s: %v", c.label(path), err)
+	}
+	c.Run(ctx)
+}
+
+// wantsHelp reports whether -h/--help appears among the flag tokens. For a
+// PassThrough command it only scans up to the first positional (the .wasm file),
+// so a guest program's own --help is not mistaken for wago's.
+func wantsHelp(args []string, passThrough bool) bool {
+	for _, a := range args {
+		if a == "--" {
+			return false
+		}
+		if a == "-h" || a == "--help" {
+			return true
+		}
+		if passThrough && (a == "" || a[0] != '-') {
+			return false
+		}
+	}
+	return false
+}
+
+// parse turns args into a Ctx using the command's Flags. It accepts "--name val",
+// "--name=val", short "-x val"/"-x=val", bare booleans, and a "--" positional
+// terminator. Unknown flags are an error (this is what makes `--help` work instead
+// of being swallowed as a filename). A PassThrough command stops consuming flags at
+// the first positional, so everything from the .wasm file onward is guest argv.
+func (c *Cmd) parse(path string, args []string) (*Ctx, error) {
+	ctx := &Ctx{Cmd: c, Path: path, strs: map[string]string{}, bools: map[string]bool{}}
+	lookup := map[string]*Flag{}
+	for i := range c.Flags {
+		f := &c.Flags[i]
+		lookup["--"+f.Name] = f
+		if f.Short != "" {
+			lookup["-"+f.Short] = f
+		}
+	}
+	raw := false         // past a "--" terminator: everything is positional
+	passthrough := false // PassThrough and already saw the first positional
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case raw || passthrough:
+			ctx.Args = append(ctx.Args, a)
+			continue
+		case a == "--":
+			raw = true
+			continue
+		case a == "-" || a == "" || a[0] != '-':
+			ctx.Args = append(ctx.Args, a)
+			if c.PassThrough {
+				passthrough = true
+			}
+			continue
+		}
+		name, inline, hasInline := a, "", false
+		if eq := strings.IndexByte(a, '='); eq >= 0 {
+			name, inline, hasInline = a[:eq], a[eq+1:], true
+		}
+		f, ok := lookup[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown flag %s", name)
+		}
+		if f.Bool {
+			if hasInline {
+				return nil, fmt.Errorf("flag --%s takes no value", f.Name)
+			}
+			ctx.bools[f.Name] = true
+			continue
+		}
+		switch {
+		case hasInline:
+			ctx.strs[f.Name] = inline
+		case i+1 < len(args):
+			ctx.strs[f.Name] = args[i+1]
+			i++
+		default:
+			return nil, fmt.Errorf("flag --%s needs a value", f.Name)
+		}
+	}
+	return ctx, nil
+}
+
+// printHelp renders a command's own help: a usage line, its summary, then either
+// its subcommands (for a group) or its flags (for a leaf). -h/--help is always
+// listed.
+func (c *Cmd) printHelp(w *os.File, path string) {
+	var b strings.Builder
+	line := "Usage: " + path
+	if len(c.Children) > 0 {
+		line += " <command>"
+	}
+	if c.Args != "" {
+		line += " " + c.Args
+	}
+	if len(c.Flags) > 0 {
+		line += " [flags]"
+	}
+	fmt.Fprintf(&b, "%s\n", bold(line))
+	if c.Summary != "" {
+		fmt.Fprintf(&b, "\n  %s\n", c.Summary)
+	}
+	if len(c.Children) > 0 {
+		fmt.Fprintf(&b, "\n%s\n", bold("Commands:"))
+		for _, ch := range c.Children {
+			left := ch.Name
+			if ch.Args != "" {
+				left += " " + ch.Args
+			}
+			fmt.Fprintf(&b, "  %-22s %s\n", left, ch.Summary)
+		}
+	}
+	fmt.Fprintf(&b, "\n%s\n", bold("Flags:"))
+	for _, f := range c.Flags {
+		fmt.Fprintf(&b, "  %-22s %s\n", flagLabel(f), f.Help)
+	}
+	fmt.Fprintf(&b, "  %-22s %s\n", "-h, --help", "show this help")
+	if c.Long != "" {
+		fmt.Fprintf(&b, "\n%s\n", strings.TrimRight(c.Long, "\n"))
+	}
+	fmt.Fprint(w, b.String())
+}
+
+// flagLabel renders a flag's left-column help label, e.g. "-e, --invoke <name>".
+func flagLabel(f Flag) string {
+	head := "    "
+	if f.Short != "" {
+		head = "-" + f.Short + ", "
+	}
+	s := head + "--" + f.Name
+	if !f.Bool && f.Arg != "" {
+		s += " " + f.Arg
+	}
+	return s
+}

--- a/cli/wago/cmd_meta.go
+++ b/cli/wago/cmd_meta.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/wago-org/wago"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// envCommand prints wago's resolved on-disk directories.
+func envCommand() *Cmd {
+	return &Cmd{
+		Name:    "env",
+		Summary: "print resolved config/cache/data directories",
+		Run: func(*Ctx) {
+			d := wago.DirsFor(versionString())
+			fmt.Printf("%s %s\n", dim("WAGO_VERSION"), d.Version)
+			fmt.Printf("%s %s\n", dim("WAGO_CONFIG  "), d.Config)
+			fmt.Printf("%s %s\n", dim("WAGO_DATA    "), d.Data)
+			fmt.Printf("%s %s\n", dim("WAGO_VERSIONS"), d.Versions)
+			fmt.Printf("%s %s\n", dim("WAGO_CACHE   "), d.Cache)
+		},
+	}
+}
+
+// buildCommand is a placeholder for the not-yet-implemented AOT builder.
+func buildCommand() *Cmd {
+	return &Cmd{
+		Name:    "build",
+		Summary: "not implemented",
+		Run:     func(*Ctx) { fatal("build: not implemented") },
+	}
+}
+
+// validateCommand decodes and validates a module without running it.
+func validateCommand() *Cmd {
+	return &Cmd{
+		Name:    "validate",
+		Summary: "decode and validate a module",
+		Args:    "<file>",
+		Run: func(c *Ctx) {
+			file := singleFileArg("validate", c.Args)
+			src, err := os.ReadFile(file)
+			if err != nil {
+				fatal("%v", err)
+			}
+			if err := validateModuleBytes(src); err != nil {
+				fatal("validate: %v", err)
+			}
+		},
+	}
+}
+
+// singleFileArg returns the sole positional or fatals with a usage hint.
+func singleFileArg(cmd string, args []string) string {
+	if len(args) != 1 {
+		fatal("%s: need exactly one <file>", cmd)
+	}
+	return args[0]
+}
+
+func validateModuleBytes(src []byte) error {
+	m, err := wasm.DecodeModule(src)
+	if err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	if err := wasm.ValidateModule(m); err != nil {
+		return fmt.Errorf("validate: %w", err)
+	}
+	return nil
+}

--- a/cli/wago/cmd_module.go
+++ b/cli/wago/cmd_module.go
@@ -1,0 +1,26 @@
+package main
+
+// moduleCommand is the `wago module` group: inspect a module's imports and the
+// capabilities it requires, resolved against the compiled-in plugins. The leaf
+// actions live in module.go.
+func moduleCommand() *Cmd {
+	return &Cmd{
+		Name:    "module",
+		Aliases: []string{"mod"},
+		Summary: "inspect a module's imports and required capabilities",
+		Children: []*Cmd{
+			{
+				Name:    "imports",
+				Summary: "list a module's imports (resolved vs plugins)",
+				Args:    "<file>",
+				Run:     func(c *Ctx) { moduleImports(c.one("<file>")) },
+			},
+			{
+				Name: "capabilities", Aliases: []string{"caps"},
+				Summary: "list the capabilities a module requires",
+				Args:    "<file>",
+				Run:     func(c *Ctx) { moduleCapabilities(c.one("<file>")) },
+			},
+		},
+	}
+}

--- a/cli/wago/cmd_plugin.go
+++ b/cli/wago/cmd_plugin.go
@@ -1,0 +1,56 @@
+package main
+
+// pluginCommand is the `wago plugin` group: inspect the plugins compiled into this
+// binary and manage the wago-plugins.json manifest for a custom build. The leaf
+// actions (pluginList, pluginInspect, pluginManifest*) live in plugins.go /
+// manifest.go; this file only declares the command surface.
+func pluginCommand() *Cmd {
+	jsonFlag := Flag{Name: "json", Bool: true, Help: "emit machine-readable JSON"}
+	return &Cmd{
+		Name:       "plugin",
+		Aliases:    []string{"plugins"},
+		Summary:    "inspect compiled-in plugins and manage the manifest",
+		DefaultSub: "list",
+		Children: []*Cmd{
+			{
+				Name: "list", Aliases: []string{"ls"},
+				Summary: "list plugins compiled into this binary",
+				Flags:   []Flag{jsonFlag},
+				Run:     func(c *Ctx) { pluginList(c.Bool("json")) },
+			},
+			{
+				Name: "inspect", Aliases: []string{"show"},
+				Summary: "show a plugin's imports and capabilities",
+				Args:    "<name>",
+				Flags:   []Flag{jsonFlag},
+				Run:     func(c *Ctx) { pluginInspect(c.one("<name>"), c.Bool("json")) },
+			},
+			{
+				Name: "add", Aliases: []string{"install"},
+				Summary: "declare a plugin in wago-plugins.json",
+				Args:    "<module>",
+				Flags: []Flag{
+					{Name: "name", Arg: "<name>", Help: "plugin name (defaults to one derived from the module)"},
+					{Name: "version", Arg: "<v>", Help: "pin a module version"},
+				},
+				Run: func(c *Ctx) { pluginManifestAdd(c.one("<module>"), c.Str("name"), c.Str("version")) },
+			},
+			{
+				Name: "remove", Aliases: []string{"uninstall", "rm"},
+				Summary: "remove a plugin from the manifest",
+				Args:    "<name>",
+				Run:     func(c *Ctx) { pluginManifestRemove(c.one("<name>")) },
+			},
+			{
+				Name: "manifest", Aliases: []string{"declared"},
+				Summary: "show declared plugins (for a custom build)",
+				Run:     func(*Ctx) { pluginManifestShow() },
+			},
+			{
+				Name:    "build",
+				Summary: "preview the custom build described by the manifest",
+				Run:     func(*Ctx) { pluginBuild() },
+			},
+		},
+	}
+}

--- a/cli/wago/cmd_registry.go
+++ b/cli/wago/cmd_registry.go
@@ -1,0 +1,119 @@
+package main
+
+// Registry command surface for the wago registry at pkg.wago.sh. This file is
+// unconditional so `wago publish --help` (and every other registry command's help)
+// works in the lean build too — the Run bodies live in registry_net.go for the
+// full build and registry_stub.go (fatal stubs) for the lean/TinyGo build.
+func registryCommands() []*Cmd {
+	jsonFlag := Flag{Name: "json", Bool: true, Help: "emit machine-readable JSON"}
+	return []*Cmd{
+		{
+			Name: "login", Group: "registry",
+			Summary: "authenticate to the registry (pkg.wago.sh)",
+			Flags: []Flag{
+				{Name: "link", Bool: true, Help: "log in via a browser link on this machine"},
+				{Name: "code", Bool: true, Help: "log in with a one-time code (headless/remote)"},
+				{Name: "token", Arg: "<t>", Help: "use this API token directly"},
+				{Name: "with-token", Bool: true, Help: "read an API token from stdin (for CI)"},
+			},
+			Long: "With no flag, login asks whether to use a browser link or a one-time code.",
+			Run:  registryLogin,
+		},
+		{
+			Name: "logout", Group: "registry",
+			Summary: "remove stored registry credentials",
+			Run:     registryLogout,
+		},
+		{
+			Name: "whoami", Group: "registry",
+			Summary: "print the logged-in registry account",
+			Run:     registryWhoami,
+		},
+		{
+			Name: "search", Group: "registry",
+			Summary: "search packages",
+			Args:    "<query…>",
+			Flags:   []Flag{{Name: "limit", Arg: "<n>", Help: "max rows to show (default 20)"}, jsonFlag},
+			Run:     registrySearch,
+		},
+		{
+			Name: "info", Group: "registry",
+			Summary: "show a package's details",
+			Args:    "<pkg>",
+			Flags:   []Flag{jsonFlag},
+			Run:     registryInfo,
+		},
+		{
+			Name: "versions", Group: "registry",
+			Summary: "list a package's published versions",
+			Args:    "<pkg>",
+			Flags:   []Flag{jsonFlag},
+			Run:     registryVersions,
+		},
+		{
+			Name: "star", Group: "registry",
+			Summary: "star a package",
+			Args:    "<pkg>",
+			Run:     registryStar,
+		},
+		{
+			Name: "unstar", Group: "registry",
+			Summary: "remove a star from a package",
+			Args:    "<pkg>",
+			Run:     registryUnstar,
+		},
+		{
+			Name: "token", Group: "registry",
+			Summary: "manage API tokens",
+			Children: []*Cmd{
+				{
+					Name: "list", Aliases: []string{"ls"},
+					Summary: "list your API tokens",
+					Run:     registryTokenList,
+				},
+				{
+					Name: "create", Aliases: []string{"new"},
+					Summary: "mint a new API token",
+					Flags:   []Flag{{Name: "label", Arg: "<l>", Help: "a label for the token"}},
+					Run:     registryTokenCreate,
+				},
+				{
+					Name: "revoke", Aliases: []string{"rm", "delete"},
+					Summary: "revoke an API token by id",
+					Args:    "<id>",
+					Run:     registryTokenRevoke,
+				},
+			},
+		},
+		{
+			Name: "publish", Group: "registry",
+			Summary: "publish a plugin from wago-plugin.json",
+			Flags: []Flag{
+				{Name: "manifest", Arg: "<p>", Help: "manifest path (default wago-plugin.json)"},
+				{Name: "version", Arg: "<v>", Help: "version to publish (default: newest git tag)"},
+				{Name: "commit", Arg: "<c>", Help: "commit SHA (default: git HEAD)"},
+				{Name: "notes", Arg: "<s>", Help: "release notes"},
+				{Name: "category", Arg: "<c>", Help: "package category"},
+				{Name: "tags", Arg: "<a,b>", Help: "comma-separated tags"},
+			},
+			Run: registryPublish,
+		},
+		{
+			Name: "unpublish", Group: "registry",
+			Summary: "remove a package or one version",
+			Args:    "<name>[@version]",
+			Flags:   []Flag{{Name: "yes", Bool: true, Help: "skip the confirmation prompt"}},
+			Run:     registryUnpublish,
+		},
+		{
+			Name: "deprecate", Group: "registry",
+			Summary: "deprecate a package/version",
+			Args:    "<name>[@version]",
+			Flags: []Flag{
+				{Name: "message", Arg: "<m>", Help: "deprecation notice"},
+				{Name: "undo", Bool: true, Help: "reverse a deprecation"},
+			},
+			Run: registryDeprecate,
+		},
+	}
+}

--- a/cli/wago/cmd_run.go
+++ b/cli/wago/cmd_run.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/wago-org/wago"
+)
+
+// runCommand is `wago run <file> [args...]`: compile and execute an export. It's
+// PassThrough so everything after the .wasm file is handed to the guest verbatim.
+func runCommand() *Cmd {
+	return &Cmd{
+		Name:        "run",
+		Summary:     "compile and execute an export   (default)",
+		Args:        "<file> [args...]",
+		PassThrough: true,
+		Flags: []Flag{
+			{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
+			{Name: "plugin", Arg: "<names>", Help: "comma-separated plugins to enable (see: wago plugin list)"},
+			{Name: "bounds", Arg: "<mode>", Help: "bounds checks: defer (default) | all"},
+		},
+		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
+			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64",
+		Run: runExec,
+	}
+}
+
+func runExec(c *Ctx) {
+	invoke, bounds, plugins := c.Str("invoke"), c.Str("bounds"), c.Str("plugin")
+	pos := c.Args
+	if len(pos) < 1 {
+		fatal("run: need a <file>")
+	}
+	cfg := wago.NewRuntimeConfig()
+	switch bounds {
+	case "", "defer": // default: skip a bounds check a prior one already proved safe
+	case "all": // bounds-check every access
+		cfg = cfg.WithDeferBoundsChecks(false)
+	default:
+		fatal("run: unknown --bounds %q (want: defer, all)", bounds)
+	}
+	comp := mustLoad(pos[0], cfg)
+	export := mustResolveExport(comp, invoke)
+
+	// Program mode: a _start entry point is a command (e.g. a WASI program). Wire
+	// the positional args as guest argv, run _start, and surface proc_exit as the
+	// process exit code. Enable WASI with `--plugin wasi` (or wasi/unstable).
+	if export == "_start" {
+		imports := autoHosts(comp, false)
+		for k, v := range pluginImports(plugins, pos) {
+			imports[k] = v
+		}
+		in, err := wago.Instantiate(comp, wago.InstantiateOptions{Imports: imports})
+		if err != nil {
+			fatal("%v", err)
+		}
+		defer in.Close()
+		if _, err := in.Invoke("_start"); err != nil {
+			var ex *wago.ExitError
+			if errors.As(err, &ex) {
+				in.Close()
+				os.Exit(int(ex.Code))
+			}
+			fatal("%s %s", red("trap:"), trapReason(err))
+		}
+		return
+	}
+
+	// Value mode: a normal exported function, with parsed args and a printed result.
+	params, results, _ := comp.Signature(export)
+	vals := mustParseArgs(pos[1:], params)
+	imports := autoHosts(comp, true)
+	for k, v := range pluginImports(plugins, pos) {
+		imports[k] = v
+	}
+	in, err := wago.Instantiate(comp, wago.InstantiateOptions{Imports: imports})
+	if err != nil {
+		fatal("%v", err)
+	}
+	defer in.Close()
+	res, err := in.Invoke(export, vals...)
+	if err != nil {
+		fatal("%s %s", red("trap:"), trapReason(err))
+	}
+	fmt.Println(format(export, vals, res, params, results))
+}
+
+// ---- loading & imports --------------------------------------------------
+
+func mustLoad(file string, cfg *wago.RuntimeConfig) *wago.Compiled {
+	src, err := os.ReadFile(file)
+	if err != nil {
+		fatal("%v", err)
+	}
+	var c *wago.Compiled
+	if wago.IsCompiled(src) {
+		c, err = wago.Load(src) // precompiled .wago — codegen options baked in already
+	} else {
+		c, err = wago.Compile(cfg, src)
+	}
+	if err != nil {
+		fatal("%v", err)
+	}
+	return c
+}
+
+func mustResolveExport(c *wago.Compiled, invoke string) string {
+	names := c.ExportedFunctions()
+	if invoke != "" {
+		if _, ok := c.Exports[invoke]; !ok {
+			fatal("no exported function %q (have: %s)", invoke, strings.Join(names, ", "))
+		}
+		return invoke
+	}
+	for _, name := range []string{"_start", "main"} {
+		if _, ok := c.Exports[name]; ok {
+			return name
+		}
+	}
+	if len(names) == 1 {
+		return names[0]
+	}
+	fatal("multiple exports; pass -e <name> (have: %s)", strings.Join(names, ", "))
+	return ""
+}
+
+// autoHosts satisfies every function import with a host that echoes the call.
+func autoHosts(c *wago.Compiled, trace bool) wago.Imports {
+	hosts := wago.Imports{}
+	for _, name := range c.Imports {
+		n := name
+		if trace {
+			hosts[n] = wago.HostFunc(func(_ wago.HostModule, params, _ []uint64) {
+				var arg int32
+				if len(params) > 0 {
+					arg = wago.AsI32(params[0])
+				}
+				fmt.Printf("  %s %s(%d)\n", dim("host"), n, arg)
+			})
+		} else {
+			hosts[n] = wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})
+		}
+	}
+	return hosts
+}
+
+// ---- arg parsing & formatting -------------------------------------------
+
+func mustParseArgs(strs []string, params []wago.ValType) []uint64 {
+	if len(strs) != len(params) {
+		fatal("expected %d arg(s), got %d", len(params), len(strs))
+	}
+	vals := make([]uint64, len(strs))
+	for i, s := range strs {
+		t := params[i]
+		valPart := s
+		if idx := strings.LastIndexByte(s, ':'); idx >= 0 {
+			valPart = s[:idx]
+			switch s[idx+1:] {
+			case "i32":
+				t = wago.ValI32
+			case "i64":
+				t = wago.ValI64
+			case "f32":
+				t = wago.ValF32
+			case "f64":
+				t = wago.ValF64
+			default:
+				fatal("arg %d: bad type suffix in %q", i, s)
+			}
+		}
+		v, err := parseVal(valPart, t)
+		if err != nil {
+			fatal("arg %d (%q): %v", i, s, err)
+		}
+		vals[i] = v
+	}
+	return vals
+}
+
+func parseVal(s string, t wago.ValType) (uint64, error) {
+	switch t {
+	case wago.ValI64:
+		if n, err := strconv.ParseInt(s, 0, 64); err == nil {
+			return wago.I64(n), nil
+		}
+		u, err := strconv.ParseUint(s, 0, 64)
+		return wago.I64(int64(u)), err
+	case wago.ValF32:
+		f, err := strconv.ParseFloat(s, 32)
+		return wago.F32(float32(f)), err
+	case wago.ValF64:
+		f, err := strconv.ParseFloat(s, 64)
+		return wago.F64(f), err
+	default: // i32
+		if n, err := strconv.ParseInt(s, 0, 32); err == nil {
+			return wago.I32(int32(n)), nil
+		}
+		u, err := strconv.ParseUint(s, 0, 32)
+		return wago.I32(int32(uint32(u))), err
+	}
+}
+
+func fmtVal(bits uint64, t wago.ValType) string {
+	switch t {
+	case wago.ValI64:
+		return strconv.FormatInt(wago.AsI64(bits), 10)
+	case wago.ValF32:
+		return strconv.FormatFloat(float64(wago.AsF32(bits)), 'g', -1, 32)
+	case wago.ValF64:
+		return strconv.FormatFloat(wago.AsF64(bits), 'g', -1, 64)
+	default:
+		return strconv.FormatInt(int64(wago.AsI32(bits)), 10)
+	}
+}
+
+func format(export string, args, res []uint64, paramTypes, resultTypes []wago.ValType) string {
+	as := make([]string, len(args))
+	for i, v := range args {
+		as[i] = fmtVal(v, paramTypes[i])
+	}
+	call := fmt.Sprintf("%s(%s)", export, strings.Join(as, ", "))
+	if len(res) == 0 {
+		return fmt.Sprintf("%s = %s", call, dim("()"))
+	}
+	rs := make([]string, len(res))
+	for i, v := range res {
+		rs[i] = fmtVal(v, resultTypes[i])
+	}
+	return fmt.Sprintf("%s = %s", call, cyan(strings.Join(rs, ", ")))
+}
+
+// trapReason renders an Invoke error, preferring the typed trap code.
+func trapReason(err error) string {
+	var te *wago.TrapError
+	if errors.As(err, &te) {
+		return te.Code.String()
+	}
+	return err.Error()
+}

--- a/cli/wago/cmd_version.go
+++ b/cli/wago/cmd_version.go
@@ -1,0 +1,56 @@
+package main
+
+import "github.com/wago-org/wago"
+
+// versionCommand is the `wago version` manager: list/use/install wago toolchain
+// versions. The binary's own version is printed by `wago --version`. Management
+// (list/use/current/which/uninstall) is net-free; the downloader (install,
+// list-remote) is stubbed in the lean build (version_net.go vs version_net_stub.go).
+func versionCommand() *Cmd {
+	dirs := func() wago.Dirs { return wago.DirsFor(versionString()) }
+	return &Cmd{
+		Name:       "version",
+		Summary:    "manage installed toolchain versions (list, use, install, …)",
+		DefaultSub: "list",
+		Children: []*Cmd{
+			{
+				Name: "list", Aliases: []string{"ls"},
+				Summary: "list installed versions",
+				Run:     func(*Ctx) { vmList(dirs()) },
+			},
+			{
+				Name:    "current",
+				Summary: "print the active version",
+				Run:     func(*Ctx) { vmCurrent(dirs()) },
+			},
+			{
+				Name:    "which",
+				Summary: "print the path to the active binary",
+				Run:     func(*Ctx) { vmWhich(dirs()) },
+			},
+			{
+				Name:    "use",
+				Summary: "select an installed version",
+				Args:    "<version>",
+				Run:     func(c *Ctx) { vmUse(dirs(), c.one("<version>")) },
+			},
+			{
+				Name: "install", Aliases: []string{"add"},
+				Summary: "download and install a version",
+				Args:    "<version>",
+				Run:     func(c *Ctx) { vmInstall(dirs(), c.one("<version>")) },
+			},
+			{
+				Name: "uninstall", Aliases: []string{"remove", "rm"},
+				Summary: "remove an installed version",
+				Args:    "<version>",
+				Run:     func(c *Ctx) { vmUninstall(dirs(), c.one("<version>")) },
+			},
+			{
+				Name: "list-remote", Aliases: []string{"ls-remote"},
+				Summary: "list versions available to download",
+				Run:     func(*Ctx) { vmListRemote() },
+			},
+		},
+	}
+}

--- a/cli/wago/main.go
+++ b/cli/wago/main.go
@@ -2,14 +2,9 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
-
-	"github.com/wago-org/wago"
-	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
 // version is overridden at build time via -ldflags "-X main.version=<tag>" (see
@@ -25,97 +20,81 @@ func versionString() string {
 	return version
 }
 
+// root is the command tree, assembled once at startup. usage() and main() both
+// read it, and it's built at package init so it's populated even when a test
+// calls usage() directly.
+var root = buildRoot()
+
+// buildRoot wires every command onto the root. Core commands come first, then the
+// registry group; the order here is the order shown by `wago --help`.
+func buildRoot() *Cmd {
+	r := &Cmd{Name: "wago"}
+	r.Children = append(r.Children,
+		runCommand(),
+		pluginCommand(),
+		moduleCommand(),
+		envCommand(),
+		buildCommand(),
+		validateCommand(),
+		versionCommand(),
+	)
+	r.Children = append(r.Children, registryCommands()...)
+	return r
+}
+
 func main() {
-	a := os.Args[1:]
-	if len(a) == 0 {
+	args := os.Args[1:]
+	if len(args) == 0 {
 		usage(os.Stderr)
 		os.Exit(2)
 	}
-	switch a[0] {
-	case "run":
-		runCmd(a[1:])
-	case "build":
-		notImplemented("build")
-	case "plugin", "plugins":
-		pluginCmd(a[1:])
-	case "module", "mod":
-		moduleCmd(a[1:])
-	case "env":
-		envCmd()
-	case "validate":
-		validateCmd(a[1:])
-	case "login":
-		registryLogin(a[1:])
-	case "logout":
-		registryLogout(a[1:])
-	case "whoami":
-		registryWhoami(a[1:])
-	case "publish":
-		registryPublish(a[1:])
-	case "unpublish":
-		registryUnpublish(a[1:])
-	case "deprecate":
-		registryDeprecate(a[1:])
-	case "search":
-		registrySearch(a[1:])
-	case "info":
-		registryInfo(a[1:])
-	case "versions":
-		registryVersions(a[1:])
-	case "star":
-		registryStar(a[1:])
-	case "unstar":
-		registryUnstar(a[1:])
-	case "token":
-		registryToken(a[1:])
-	case "--version", "-v":
-		printVersion()
-	case "version":
-		versionCmd(a[1:])
+	switch args[0] {
 	case "help", "-h", "--help":
 		usage(os.Stdout)
-	default:
-		runCmd(a) // `wago <file> [args...]` defaults to run
+		return
+	case "-v", "--version":
+		printVersion()
+		return
 	}
+	if cmd := root.child(args[0]); cmd != nil {
+		cmd.Dispatch("wago "+cmd.Name, args[1:])
+		return
+	}
+	// Not a known command. A file path (or a leading flag) is an implicit `run`;
+	// anything else is an unknown command rather than a mystery file-open.
+	if looksLikeRunTarget(args[0]) || strings.HasPrefix(args[0], "-") {
+		root.child("run").Dispatch("wago run", args)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s unknown command %q\n\n", red("wago:"), args[0])
+	usage(os.Stderr)
+	os.Exit(2)
 }
 
+// looksLikeRunTarget reports whether s is plausibly a module to run: a .wasm/.wago
+// name, or an existing file. It keeps `wago app.wasm 2 3` working without letting
+// a mistyped command silently become a failed file open.
+func looksLikeRunTarget(s string) bool {
+	if strings.HasSuffix(s, ".wasm") || strings.HasSuffix(s, ".wago") {
+		return true
+	}
+	fi, err := os.Stat(s)
+	return err == nil && !fi.IsDir()
+}
+
+// usage prints the top-level help: the two command groups (rendered from the
+// registry so a new command shows up automatically), then the run flags and
+// examples. The command list uses a fixed 26-column left field.
 func usage(w *os.File) {
-	fmt.Fprintf(w, `%s — a pure-Go (no cgo) WebAssembly engine
+	fmt.Fprintf(w, "%s — a pure-Go (no cgo) WebAssembly engine\n\n", bold("wago"))
+	fmt.Fprintf(w, "%s wago [run] <file> [args...]\n\n", bold("Usage:"))
 
-%s wago [run] <file> [args...]
+	fmt.Fprintf(w, "%s\n", bold("Commands:"))
+	writeCommandList(w, "")
+	fmt.Fprintf(w, "\n%s\n", bold("Registry:"))
+	writeCommandList(w, "registry")
 
-%s
-  run <file> [args...]      compile and execute an export   (default)
-  plugin list               list plugins compiled into this binary
-  plugin inspect <name>     show a plugin's imports and capabilities
-  plugin add <module>       declare a plugin in wago-plugins.json
-  plugin remove <name>      remove a plugin from the manifest
-  plugin manifest           show declared plugins (for a custom build)
-  module imports <file>     list a module's imports (resolved vs plugins)
-  module capabilities <f>   list the capabilities a module requires
-  env                       print resolved config/cache/data directories
-  build                     not implemented
-  validate <file>           decode and validate a module
-  version [sub]             manage installed versions (list, use, install, …)
-
-%s
-  login                     authenticate to the registry (pkg.wago.sh)
-                            prompts for link vs code; --link or --code to pick one
-                            (--code suits headless/remote machines with no localhost);
-                            --token <t> use a token; --with-token read it from stdin
-  logout                    remove stored registry credentials
-  whoami                    print the logged-in registry account
-  search <query…>           search packages (--limit N, --json)
-  info <pkg>                show a package's details (--json)
-  versions <pkg>            list a package's published versions (--json)
-  star <pkg>                star a package  ·  unstar <pkg> removes it
-  token <list|create|revoke>  manage API tokens (create: --label <l>)
-  publish                   publish a plugin from wago-plugin.json
-                            --manifest <p> --version <v> --commit <c> --notes <s>
-                            --category <c> --tags <a,b>
-  unpublish <name>[@ver]    remove a package or one version   (--yes to skip prompt)
-  deprecate <name>[@ver]    deprecate a package/version (--message <m>, --undo)
-
+	fmt.Fprintf(w, `
 %s
   -v, --version             print version and supported features
   -e, --invoke <name>       export to call
@@ -127,275 +106,26 @@ func usage(w *os.File) {
 %s
   wago add.wasm 2 3
   wago run -e fib fib.wasm 30
-  wago run --plugin timer,log app.wasm
+  wago run --plugin wasi app.wasm
 
 For run, <file> is raw .wasm or a precompiled .wago. run args are typed by
 the signature; override per-arg with a suffix:  42   7:i64   3.5:f64
-`, bold("wago"), bold("Usage:"), bold("Commands:"), bold("Registry:"), bold("Flags:"), bold("Examples:"))
+`, bold("Flags:"), bold("Examples:"))
 }
 
-func notImplemented(cmd string) { fatal("%s: not implemented", cmd) }
-
-// envCmd prints wago's resolved on-disk directories.
-func envCmd() {
-	d := wago.DirsFor(versionString())
-	fmt.Printf("%s %s\n", dim("WAGO_VERSION"), d.Version)
-	fmt.Printf("%s %s\n", dim("WAGO_CONFIG  "), d.Config)
-	fmt.Printf("%s %s\n", dim("WAGO_DATA    "), d.Data)
-	fmt.Printf("%s %s\n", dim("WAGO_VERSIONS"), d.Versions)
-	fmt.Printf("%s %s\n", dim("WAGO_CACHE   "), d.Cache)
-}
-
-// ---- validate -----------------------------------------------------------
-
-func validateCmd(args []string) {
-	file := singleFileArg("validate", args)
-	src, err := os.ReadFile(file)
-	if err != nil {
-		fatal("%v", err)
-	}
-	if err := validateModuleBytes(src); err != nil {
-		fatal("validate: %v", err)
-	}
-}
-
-func singleFileArg(cmd string, args []string) string {
-	if len(args) != 1 {
-		fatal("%s: need exactly one <file>", cmd)
-	}
-	return args[0]
-}
-
-func validateModuleBytes(src []byte) error {
-	m, err := wasm.DecodeModule(src)
-	if err != nil {
-		return fmt.Errorf("decode: %w", err)
-	}
-	if err := wasm.ValidateModule(m); err != nil {
-		return fmt.Errorf("validate: %w", err)
-	}
-	return nil
-}
-
-// ---- run ----------------------------------------------------------------
-
-func runCmd(args []string) {
-	var invoke, bounds, plugins string
-	pos, err := extractOpts(args, map[string]*string{
-		"-e": &invoke, "--invoke": &invoke, "--bounds": &bounds, "--plugin": &plugins,
-	})
-	if err != nil {
-		fatal("run: %v", err)
-	}
-	if len(pos) < 1 {
-		fatal("run: need a <file>")
-	}
-	cfg := wago.NewRuntimeConfig()
-	switch bounds {
-	case "", "defer": // default: skip a bounds check a prior one already proved safe
-	case "all": // bounds-check every access
-		cfg = cfg.WithDeferBoundsChecks(false)
-	default:
-		fatal("run: unknown --bounds %q (want: defer, all)", bounds)
-	}
-	c := mustLoad(pos[0], cfg)
-	export := mustResolveExport(c, invoke)
-
-	// Program mode: a _start entry point is a command (e.g. a WASI program). Wire
-	// the positional args as guest argv, run _start, and surface proc_exit as the
-	// process exit code. Enable WASI with `--plugin wasi` (or `wasi-unstable`).
-	if export == "_start" {
-		imports := autoHosts(c, false)
-		for k, v := range pluginImports(plugins, pos) {
-			imports[k] = v
+// writeCommandList prints the commands in one group as aligned "name  summary"
+// rows. The 26-column left field reproduces the historical layout.
+func writeCommandList(w *os.File, group string) {
+	for _, c := range root.Children {
+		if c.Group != group {
+			continue
 		}
-		in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: imports})
-		if err != nil {
-			fatal("%v", err)
+		left := c.Name
+		if c.Args != "" {
+			left += " " + c.Args
 		}
-		defer in.Close()
-		if _, err := in.Invoke("_start"); err != nil {
-			var ex *wago.ExitError
-			if errors.As(err, &ex) {
-				in.Close()
-				os.Exit(int(ex.Code))
-			}
-			fatal("%s %s", red("trap:"), trapReason(err))
-		}
-		return
+		fmt.Fprintf(w, "  %-26s%s\n", left, c.Summary)
 	}
-
-	// Value mode: a normal exported function, with parsed args and a printed result.
-	params, results, _ := c.Signature(export)
-	vals := mustParseArgs(pos[1:], params)
-	imports := autoHosts(c, true)
-	for k, v := range pluginImports(plugins, pos) {
-		imports[k] = v
-	}
-	in, err := wago.Instantiate(c, wago.InstantiateOptions{Imports: imports})
-	if err != nil {
-		fatal("%v", err)
-	}
-	defer in.Close()
-	res, err := in.Invoke(export, vals...)
-	if err != nil {
-		fatal("%s %s", red("trap:"), trapReason(err))
-	}
-	fmt.Println(format(export, vals, res, params, results))
-}
-
-// ---- loading & imports --------------------------------------------------
-
-func mustLoad(file string, cfg *wago.RuntimeConfig) *wago.Compiled {
-	src, err := os.ReadFile(file)
-	if err != nil {
-		fatal("%v", err)
-	}
-	var c *wago.Compiled
-	if wago.IsCompiled(src) {
-		c, err = wago.Load(src) // precompiled .wago — codegen options baked in already
-	} else {
-		c, err = wago.Compile(cfg, src)
-	}
-	if err != nil {
-		fatal("%v", err)
-	}
-	return c
-}
-
-func mustResolveExport(c *wago.Compiled, invoke string) string {
-	names := c.ExportedFunctions()
-	if invoke != "" {
-		if _, ok := c.Exports[invoke]; !ok {
-			fatal("no exported function %q (have: %s)", invoke, strings.Join(names, ", "))
-		}
-		return invoke
-	}
-	for _, name := range []string{"_start", "main"} {
-		if _, ok := c.Exports[name]; ok {
-			return name
-		}
-	}
-	if len(names) == 1 {
-		return names[0]
-	}
-	fatal("multiple exports; pass -e <name> (have: %s)", strings.Join(names, ", "))
-	return ""
-}
-
-// autoHosts satisfies every function import with a host that echoes the call.
-func autoHosts(c *wago.Compiled, trace bool) wago.Imports {
-	hosts := wago.Imports{}
-	for _, name := range c.Imports {
-		n := name
-		if trace {
-			hosts[n] = wago.HostFunc(func(_ wago.HostModule, params, _ []uint64) {
-				var arg int32
-				if len(params) > 0 {
-					arg = wago.AsI32(params[0])
-				}
-				fmt.Printf("  %s %s(%d)\n", dim("host"), n, arg)
-			})
-		} else {
-			hosts[n] = wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})
-		}
-	}
-	return hosts
-}
-
-// ---- arg parsing & formatting -------------------------------------------
-
-func mustParseArgs(strs []string, params []wago.ValType) []uint64 {
-	if len(strs) != len(params) {
-		fatal("expected %d arg(s), got %d", len(params), len(strs))
-	}
-	vals := make([]uint64, len(strs))
-	for i, s := range strs {
-		t := params[i]
-		valPart := s
-		if idx := strings.LastIndexByte(s, ':'); idx >= 0 {
-			valPart = s[:idx]
-			switch s[idx+1:] {
-			case "i32":
-				t = wago.ValI32
-			case "i64":
-				t = wago.ValI64
-			case "f32":
-				t = wago.ValF32
-			case "f64":
-				t = wago.ValF64
-			default:
-				fatal("arg %d: bad type suffix in %q", i, s)
-			}
-		}
-		v, err := parseVal(valPart, t)
-		if err != nil {
-			fatal("arg %d (%q): %v", i, s, err)
-		}
-		vals[i] = v
-	}
-	return vals
-}
-
-func parseVal(s string, t wago.ValType) (uint64, error) {
-	switch t {
-	case wago.ValI64:
-		if n, err := strconv.ParseInt(s, 0, 64); err == nil {
-			return wago.I64(n), nil
-		}
-		u, err := strconv.ParseUint(s, 0, 64)
-		return wago.I64(int64(u)), err
-	case wago.ValF32:
-		f, err := strconv.ParseFloat(s, 32)
-		return wago.F32(float32(f)), err
-	case wago.ValF64:
-		f, err := strconv.ParseFloat(s, 64)
-		return wago.F64(f), err
-	default: // i32
-		if n, err := strconv.ParseInt(s, 0, 32); err == nil {
-			return wago.I32(int32(n)), nil
-		}
-		u, err := strconv.ParseUint(s, 0, 32)
-		return wago.I32(int32(uint32(u))), err
-	}
-}
-
-func fmtVal(bits uint64, t wago.ValType) string {
-	switch t {
-	case wago.ValI64:
-		return strconv.FormatInt(wago.AsI64(bits), 10)
-	case wago.ValF32:
-		return strconv.FormatFloat(float64(wago.AsF32(bits)), 'g', -1, 32)
-	case wago.ValF64:
-		return strconv.FormatFloat(wago.AsF64(bits), 'g', -1, 64)
-	default:
-		return strconv.FormatInt(int64(wago.AsI32(bits)), 10)
-	}
-}
-
-func format(export string, args, res []uint64, paramTypes, resultTypes []wago.ValType) string {
-	as := make([]string, len(args))
-	for i, v := range args {
-		as[i] = fmtVal(v, paramTypes[i])
-	}
-	call := fmt.Sprintf("%s(%s)", export, strings.Join(as, ", "))
-	if len(res) == 0 {
-		return fmt.Sprintf("%s = %s", call, dim("()"))
-	}
-	rs := make([]string, len(res))
-	for i, v := range res {
-		rs[i] = fmtVal(v, resultTypes[i])
-	}
-	return fmt.Sprintf("%s = %s", call, cyan(strings.Join(rs, ", ")))
-}
-
-// trapReason renders an Invoke error, preferring the typed trap code.
-func trapReason(err error) string {
-	var te *wago.TrapError
-	if errors.As(err, &te) {
-		return te.Code.String()
-	}
-	return err.Error()
 }
 
 // ---- output helpers -----------------------------------------------------
@@ -426,32 +156,3 @@ func bold(s string) string { return paint("1", s) }
 func dim(s string) string  { return paint("2", s) }
 func red(s string) string  { return paint("31", s) }
 func cyan(s string) string { return paint("36", s) }
-
-// extractOpts accepts "-x val", "--x val", and "-x=val" value forms anywhere in
-// args; everything else is returned as positional.
-func extractOpts(args []string, opts map[string]*string) ([]string, error) {
-	var pos []string
-	for i := 0; i < len(args); i++ {
-		a := args[i]
-		name, inline, hasInline := a, "", false
-		if strings.HasPrefix(a, "-") {
-			if eq := strings.IndexByte(a, '='); eq >= 0 {
-				name, inline, hasInline = a[:eq], a[eq+1:], true
-			}
-		}
-		dst, ok := opts[name]
-		if !ok {
-			pos = append(pos, a)
-			continue
-		}
-		if hasInline {
-			*dst = inline
-		} else if i+1 < len(args) {
-			*dst = args[i+1]
-			i++
-		} else {
-			return nil, fmt.Errorf("option %s needs a value", name)
-		}
-	}
-	return pos, nil
-}

--- a/cli/wago/manifest.go
+++ b/cli/wago/manifest.go
@@ -156,23 +156,10 @@ func pluginManifestAdd(modOrName, name, version string) {
 	fmt.Printf("%s %s (%s) in %s\n", verb, cyan(e.Name), e.Module, path)
 }
 
-// pluginAddCmd parses `plugin add <module> [--name x] [--version v]`.
-func pluginAddCmd(args []string) {
-	var name, version string
-	pos, err := extractOpts(args, map[string]*string{"--name": &name, "--version": &version})
-	if err != nil {
-		fatal("plugin add: %v", err)
-	}
-	if len(pos) != 1 {
-		fatal("plugin add: need exactly one <module-or-name>")
-	}
-	pluginManifestAdd(pos[0], name, version)
-}
-
 // pluginBuild previews the custom build described by the manifest. The codegen +
 // `go build` step is implemented in a follow-up; for now it reports what would be
 // built so the manifest can be validated.
-func pluginBuild(_ []string) {
+func pluginBuild() {
 	path := manifestPath()
 	m, err := loadManifest(path)
 	if err != nil {

--- a/cli/wago/module.go
+++ b/cli/wago/module.go
@@ -7,23 +7,6 @@ import (
 	"github.com/wago-org/wago"
 )
 
-// moduleCmd dispatches `wago module <sub> <file>`: inspection of a wasm module's
-// imports and required capabilities, resolved against the built-in plugins.
-func moduleCmd(args []string) {
-	if len(args) < 1 {
-		fatal("module: need a subcommand (imports, capabilities)")
-	}
-	sub := args[0]
-	switch sub {
-	case "imports":
-		moduleImports(singleFileArg("module imports", args[1:]))
-	case "capabilities", "caps":
-		moduleCapabilities(singleFileArg("module capabilities", args[1:]))
-	default:
-		fatal("module: unknown subcommand %q (have: imports, capabilities)", sub)
-	}
-}
-
 // runtimeWithAllPlugins builds a runtime with every compiled-in plugin registered,
 // so a module's imports resolve to their providing plugin's signatures and caps.
 func runtimeWithAllPlugins() *wago.Runtime {

--- a/cli/wago/plugins.go
+++ b/cli/wago/plugins.go
@@ -16,40 +16,8 @@ import (
 // build tag (see wasi_on.go / wasi_off.go). The stock installer never fetches it.
 // Third-party plugins live in their own modules, wired in via a custom build.
 
-// pluginCmd dispatches `wago plugin <sub>`.
-func pluginCmd(args []string) {
-	sub := "list"
-	if len(args) > 0 {
-		sub = args[0]
-	}
-	switch sub {
-	case "list", "ls":
-		asJSON, _ := hasFlag(args[1:], "--json")
-		pluginList(asJSON)
-	case "inspect", "show":
-		asJSON, rest := hasFlag(args[1:], "--json")
-		if len(rest) < 1 {
-			fatal("plugin inspect: need a <name> (see: wago plugin list)")
-		}
-		pluginInspect(rest[0], asJSON)
-	case "add", "install":
-		pluginAddCmd(args[1:])
-	case "remove", "uninstall", "rm":
-		if len(args) < 2 {
-			fatal("plugin %s: need a <name>", sub)
-		}
-		pluginManifestRemove(args[1])
-	case "manifest", "declared":
-		pluginManifestShow()
-	case "build":
-		pluginBuild(args[1:])
-	default:
-		fatal("plugin: unknown subcommand %q (have: list, inspect, add, remove, manifest, build)", sub)
-	}
-}
-
-// hasFlag removes flag from args, reporting whether it was present. Used for bare
-// boolean flags like --json that extractOpts (value flags) does not handle.
+// hasFlag removes flag from args, reporting whether it was present. The Cmd
+// framework (cli.go) parses flags now; this is retained only for its unit test.
 func hasFlag(args []string, flag string) (bool, []string) {
 	found := false
 	rest := make([]string, 0, len(args))

--- a/cli/wago/registry_net.go
+++ b/cli/wago/registry_net.go
@@ -114,14 +114,11 @@ func fetchMe(token string) (meResponse, error) {
 // a one-time code (device flow, for headless/remote machines); --link and --code
 // pick one without prompting. --token <t> uses a token directly and --with-token
 // reads one from stdin (for CI).
-func registryLogin(args []string) {
-	withToken, args := hasFlag(args, "--with-token")
-	code, args := hasFlag(args, "--code")
-	link, args := hasFlag(args, "--link")
-	var token string
-	if _, err := extractOpts(args, map[string]*string{"--token": &token}); err != nil {
-		fatal("login: %v", err)
-	}
+func registryLogin(c *Ctx) {
+	withToken := c.Bool("with-token")
+	code := c.Bool("code")
+	link := c.Bool("link")
+	token := c.Str("token")
 	if code && link {
 		fatal("login: choose either --code or --link, not both")
 	}
@@ -417,7 +414,7 @@ func randomState() (string, error) {
 }
 
 // registryLogout deletes stored credentials for the current registry.
-func registryLogout(args []string) {
+func registryLogout(_ *Ctx) {
 	base := registryBase()
 	creds, _ := loadCredentials()
 	if _, ok := creds[base]; !ok {
@@ -432,7 +429,7 @@ func registryLogout(args []string) {
 
 // registryWhoami prints the login of the current token, or a friendly hint when
 // there is no valid session.
-func registryWhoami(args []string) {
+func registryWhoami(_ *Ctx) {
 	token := resolveToken()
 	if token == "" {
 		fmt.Println("not logged in (run: wago login)")
@@ -451,18 +448,13 @@ func registryWhoami(args []string) {
 
 // registryPublish reads a wago-plugin.json manifest and POSTs it to /api/publish
 // along with a version, commit, and optional metadata.
-func registryPublish(args []string) {
-	var manifestPath, ver, commit, notes, category, tags string
-	if _, err := extractOpts(args, map[string]*string{
-		"--manifest": &manifestPath,
-		"--version":  &ver,
-		"--commit":   &commit,
-		"--notes":    &notes,
-		"--category": &category,
-		"--tags":     &tags,
-	}); err != nil {
-		fatal("publish: %v", err)
-	}
+func registryPublish(c *Ctx) {
+	manifestPath := c.Str("manifest")
+	ver := c.Str("version")
+	commit := c.Str("commit")
+	notes := c.Str("notes")
+	category := c.Str("category")
+	tags := c.Str("tags")
 	token := resolveToken()
 	if token == "" {
 		fatal("publish: not logged in (run: wago login)")
@@ -527,12 +519,9 @@ func registryPublish(args []string) {
 
 // registryUnpublish removes a whole package, or a single version when the
 // argument carries an @version suffix. It confirms first unless --yes is given.
-func registryUnpublish(args []string) {
-	yes, args := hasFlag(args, "--yes")
-	pos, err := extractOpts(args, map[string]*string{})
-	if err != nil {
-		fatal("unpublish: %v", err)
-	}
+func registryUnpublish(c *Ctx) {
+	yes := c.Bool("yes")
+	pos := c.Args
 	if len(pos) != 1 {
 		fatal("unpublish: need <module-or-short>[@version]")
 	}
@@ -574,13 +563,10 @@ func registryUnpublish(args []string) {
 
 // registryDeprecate marks a package (or a specific @version) deprecated, or
 // reverses it with --undo. --message sets the deprecation notice.
-func registryDeprecate(args []string) {
-	undo, args := hasFlag(args, "--undo")
-	var message string
-	pos, err := extractOpts(args, map[string]*string{"--message": &message})
-	if err != nil {
-		fatal("deprecate: %v", err)
-	}
+func registryDeprecate(c *Ctx) {
+	undo := c.Bool("undo")
+	message := c.Str("message")
+	pos := c.Args
 	if len(pos) != 1 {
 		fatal("deprecate: need <module-or-short>[@version]")
 	}
@@ -700,13 +686,10 @@ type subpkg struct {
 
 // registrySearch queries /api/packages and prints an aligned table of matches
 // (or the raw JSON with --json). No auth. --limit caps the rows shown.
-func registrySearch(args []string) {
-	var limit string
-	jsonOut, args := hasFlag(args, "--json")
-	pos, err := extractOpts(args, map[string]*string{"--limit": &limit})
-	if err != nil {
-		fatal("search: %v", err)
-	}
+func registrySearch(c *Ctx) {
+	limit := c.Str("limit")
+	jsonOut := c.Bool("json")
+	pos := c.Args
 	if len(pos) == 0 {
 		fatal("search: need a <query>")
 	}
@@ -763,8 +746,8 @@ func registrySearch(args []string) {
 
 // registryInfo prints a single package's details from /api/packages/{name}, or
 // the raw JSON with --json. No auth. A 404 is reported as "no such package".
-func registryInfo(args []string) {
-	jsonOut, pos := hasFlag(args, "--json")
+func registryInfo(c *Ctx) {
+	jsonOut, pos := c.Bool("json"), c.Args
 	if len(pos) != 1 {
 		fatal("info: need exactly one <pkg>")
 	}
@@ -832,8 +815,8 @@ func registryInfo(args []string) {
 
 // registryVersions lists a package's published versions from
 // /api/packages/{name}/versions, or the raw JSON with --json. No auth.
-func registryVersions(args []string) {
-	jsonOut, pos := hasFlag(args, "--json")
+func registryVersions(c *Ctx) {
+	jsonOut, pos := c.Bool("json"), c.Args
 	if len(pos) != 1 {
 		fatal("versions: need exactly one <pkg>")
 	}
@@ -890,18 +873,15 @@ func registryVersions(args []string) {
 // ---- star / unstar (auth) -----------------------------------------------
 
 // registryStar stars a package via POST /api/packages/{name}/star.
-func registryStar(args []string) { setStar(args, http.MethodPost, "star") }
+func registryStar(c *Ctx) { setStar(c, http.MethodPost, "star") }
 
 // registryUnstar removes a star via DELETE /api/packages/{name}/star.
-func registryUnstar(args []string) { setStar(args, http.MethodDelete, "unstar") }
+func registryUnstar(c *Ctx) { setStar(c, http.MethodDelete, "unstar") }
 
 // setStar toggles the caller's star on a package and prints the new count. The
 // verb is only used to shape command name and messages.
-func setStar(args []string, method, verb string) {
-	pos, err := extractOpts(args, map[string]*string{})
-	if err != nil {
-		fatal("%s: %v", verb, err)
-	}
+func setStar(c *Ctx, method, verb string) {
+	pos := c.Args
 	if len(pos) != 1 {
 		fatal("%s: need exactly one <pkg>", verb)
 	}
@@ -936,25 +916,8 @@ func setStar(args []string, method, verb string) {
 
 // ---- tokens (auth) ------------------------------------------------------
 
-// registryToken dispatches the token sub-commands: list, create, revoke.
-func registryToken(args []string) {
-	if len(args) == 0 {
-		fatal("token: need a sub-command (list, create, revoke)")
-	}
-	switch args[0] {
-	case "list", "ls":
-		registryTokenList(args[1:])
-	case "create", "new":
-		registryTokenCreate(args[1:])
-	case "revoke", "rm", "delete":
-		registryTokenRevoke(args[1:])
-	default:
-		fatal("token: unknown sub-command %q (want: list, create, revoke)", args[0])
-	}
-}
-
 // registryTokenList prints the caller's API tokens from GET /api/tokens.
-func registryTokenList(args []string) {
+func registryTokenList(_ *Ctx) {
 	token := resolveToken()
 	if token == "" {
 		fatal("token list: not logged in (run: wago login)")
@@ -1003,11 +966,8 @@ func registryTokenList(args []string) {
 
 // registryTokenCreate mints a new API token via POST /api/tokens and prints the
 // plaintext value once — it cannot be retrieved again.
-func registryTokenCreate(args []string) {
-	var label string
-	if _, err := extractOpts(args, map[string]*string{"--label": &label}); err != nil {
-		fatal("token create: %v", err)
-	}
+func registryTokenCreate(c *Ctx) {
+	label := c.Str("label")
 	token := resolveToken()
 	if token == "" {
 		fatal("token create: not logged in (run: wago login)")
@@ -1041,11 +1001,8 @@ func registryTokenCreate(args []string) {
 }
 
 // registryTokenRevoke deletes an API token by id via DELETE /api/tokens/{id}.
-func registryTokenRevoke(args []string) {
-	pos, err := extractOpts(args, map[string]*string{})
-	if err != nil {
-		fatal("token revoke: %v", err)
-	}
+func registryTokenRevoke(c *Ctx) {
+	pos := c.Args
 	if len(pos) != 1 {
 		fatal("token revoke: need exactly one <id>")
 	}

--- a/cli/wago/registry_stub.go
+++ b/cli/wago/registry_stub.go
@@ -2,55 +2,27 @@
 
 // Lean/TinyGo build: TinyGo cannot link net/http, so the registry commands are
 // stubbed. Use a full wago binary to authenticate and publish to the registry.
-// The credential store (registry_config.go) is net-free and still compiles here,
-// but nothing in this build reads or writes it.
+// The command surface (names, flags, --help) is declared in cmd_registry.go and
+// works here; only these Run bodies are unavailable. The credential store
+// (registry_config.go) is net-free and still compiles, but nothing here reads it.
 
 package main
 
-func registryLogin(args []string) {
-	fatal("login: registry commands need a full wago binary (this lean build cannot link net/http)")
+func leanUnavailable(cmd string) {
+	fatal("%s: registry commands need a full wago binary (this lean build cannot link net/http)", cmd)
 }
 
-func registryLogout(args []string) {
-	fatal("logout: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryWhoami(args []string) {
-	fatal("whoami: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryPublish(args []string) {
-	fatal("publish: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryUnpublish(args []string) {
-	fatal("unpublish: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryDeprecate(args []string) {
-	fatal("deprecate: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registrySearch(args []string) {
-	fatal("search: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryInfo(args []string) {
-	fatal("info: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryVersions(args []string) {
-	fatal("versions: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryStar(args []string) {
-	fatal("star: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryUnstar(args []string) {
-	fatal("unstar: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
-
-func registryToken(args []string) {
-	fatal("token: registry commands need a full wago binary (this lean build cannot link net/http)")
-}
+func registryLogin(*Ctx)       { leanUnavailable("login") }
+func registryLogout(*Ctx)      { leanUnavailable("logout") }
+func registryWhoami(*Ctx)      { leanUnavailable("whoami") }
+func registryPublish(*Ctx)     { leanUnavailable("publish") }
+func registryUnpublish(*Ctx)   { leanUnavailable("unpublish") }
+func registryDeprecate(*Ctx)   { leanUnavailable("deprecate") }
+func registrySearch(*Ctx)      { leanUnavailable("search") }
+func registryInfo(*Ctx)        { leanUnavailable("info") }
+func registryVersions(*Ctx)    { leanUnavailable("versions") }
+func registryStar(*Ctx)        { leanUnavailable("star") }
+func registryUnstar(*Ctx)      { leanUnavailable("unstar") }
+func registryTokenList(*Ctx)   { leanUnavailable("token list") }
+func registryTokenCreate(*Ctx) { leanUnavailable("token create") }
+func registryTokenRevoke(*Ctx) { leanUnavailable("token revoke") }

--- a/cli/wago/version_common.go
+++ b/cli/wago/version_common.go
@@ -19,44 +19,6 @@ func printVersion() {
 	}
 }
 
-// versionCmd is the version manager (`wago version list|use|install|...`). The
-// binary's own version is printed by `wago --version` / `wago -v`. Version
-// management (list/use/current/which/uninstall) is net-free and ships in every
-// build; only the downloader (install/list-remote) requires the full build, since
-// TinyGo cannot link net/http (see version_net.go vs version_net_stub.go).
-func versionCmd(args []string) {
-	d := wago.DirsFor(versionString())
-	if len(args) == 0 {
-		vmList(d)
-		return
-	}
-	switch args[0] {
-	case "list", "ls":
-		vmList(d)
-	case "current":
-		vmCurrent(d)
-	case "which":
-		vmWhich(d)
-	case "use":
-		vmUse(d, versionArg("use", args[1:]))
-	case "uninstall", "remove", "rm":
-		vmUninstall(d, versionArg("uninstall", args[1:]))
-	case "install", "add":
-		vmInstall(d, versionArg("install", args[1:]))
-	case "list-remote", "ls-remote":
-		vmListRemote()
-	default:
-		fatal("version: unknown subcommand %q (have: list, current, which, use, install, uninstall, list-remote)", args[0])
-	}
-}
-
-func versionArg(sub string, args []string) string {
-	if len(args) != 1 || args[0] == "" {
-		fatal("version %s: need a <version>", sub)
-	}
-	return args[0]
-}
-
 // ---- installed-version state (net-free) ---------------------------------
 
 // installedVersions returns the versions that have an installed binary, sorted


### PR DESCRIPTION
Rewrites the `wago` CLI from a 25-case `switch` in `main()` (every command hand-rolling its own arg parsing) into a tiny, zero-dependency command framework. Pure stdlib — stays TinyGo/`wago_lean` compatible.

## Fixes real breakage
- **No per-command `--help`.** Before: `wago run --help` tried to open a file named `--help`; `wago login --help` launched the interactive login; `wago plugin --help` said "unknown subcommand". Now every command (and subcommand) has auto-generated `-h`/`--help`.
- **`wago plugin` panicked** (`slice bounds out of range`). Now prints the plugin list / group help.
- **Unknown commands silently became implicit-run** (`wago badcmd` → "open badcmd: no such file"). Now: "unknown command" + top-level help, exit 2. Implicit-run of an actual file (`wago app.wasm 2 3`) still works.
- **Dead references removed**: usage text/example advertised `timer,log` plugins that don't exist — WASI is the only bundled plugin (and it's `-tags wago_wasi` gated). Example now uses `--plugin wasi`.

## The framework (`cli.go`, ~250 lines)
A `Cmd` struct (name, aliases, summary, args, flags, children, `Run`) with a single `Dispatch` and a uniform flag parser (`--name val`, `--name=val`, `-e val`, bare bools, `--` terminator; unknown flags are an error). `run` is `PassThrough`: flags are parsed up to the `.wasm` file, everything after is guest argv. Per-command help is generated from the struct; the top-level `usage()` renders its two command groups from the registry (so new commands show up automatically) and keeps the historical column layout the tests pin.

## Layout
Each command is now a small self-registering module: `cmd_run.go`, `cmd_meta.go` (env/validate/build), `cmd_plugin.go`, `cmd_module.go`, `cmd_version.go`, `cmd_registry.go`. Business logic (registry HTTP, version management, manifest, plugin inspection) is unchanged — only the dispatch/parsing wrappers were replaced.

Registry commands migrated fully to the framework: `cmd_registry.go` declares the command surface unconditionally (so `wago publish --help` works even in the lean build), while the `Run` bodies stay build-tagged in `registry_net.go` (real) / `registry_stub.go` (fatal stubs).

## Verification
- Builds clean in all three variants: default, `-tags wago_lean` (TinyGo), `-tags wago_wasi`.
- `go test` + `go vet` green under all three tags; `gofmt` clean.
- Smoke-tested: every command's `--help`, `wago plugin` (no panic), `wago badcmd` (unknown command, exit 2), implicit run, `wago run -e add add.wasm 2 3` → `add(2, 3) = 5`, guest-arg pass-through, and the WASI hint in the default build vs. resolved WASI imports in the `wago_wasi` build.