### PR TITLE
railshot: don't inline loop-carrying leaf callees (−2.9% on Impart libinjection rule)

### DIFF
--- a/bench/sqli_rule_test.go
+++ b/bench/sqli_rule_test.go
@@ -1,0 +1,107 @@
+package wagobench
+
+// Standalone exec bench for Impart's real libinjection SQLi detector
+// (experimental/jack/libinjection/compare-build/sqli.wasm) — scalar AS byte code,
+// the actual "rules" workload. Drives isSQLiBool over a fixed input to A/B wago
+// codegen changes without the asbuilder/node pipeline.
+
+import (
+	"os"
+	"testing"
+
+	wago "github.com/wago-org/wago"
+)
+
+// sqliWasmPath points at Impart's prebuilt libinjection SQLi detector. Override
+// with WAGO_SQLI_WASM; the bench/tests skip if it is not present.
+func sqliWasmPath() string {
+	if p := os.Getenv("WAGO_SQLI_WASM"); p != "" {
+		return p
+	}
+	return "/home/hub/Code/Impart/impart/experimental/jack/libinjection/compare-build/sqli.wasm"
+}
+
+// asStringID is AssemblyScript's idof<string>, calibrated empirically by
+// TestSqliCalibrate.
+var asStringID = uint64(2)
+
+func loadSqli(tb testing.TB) *wago.Instance {
+	src, err := os.ReadFile(sqliWasmPath())
+	if err != nil {
+		tb.Skipf("sqli.wasm not present: %v", err)
+	}
+	c, err := wago.Compile(src)
+	if err != nil {
+		tb.Fatalf("compile: %v", err)
+	}
+	imp := wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})}
+	in, err := wago.Instantiate(c, imp)
+	if err != nil {
+		tb.Fatalf("instantiate: %v", err)
+	}
+	return in
+}
+
+// newASString allocates an AssemblyScript string holding s (ASCII → UTF-16) and
+// returns its pointer.
+func newASString(tb testing.TB, in *wago.Instance, s string) uint64 {
+	r, err := in.Invoke("__new", uint64(len(s)*2), asStringID)
+	if err != nil {
+		tb.Fatalf("__new: %v", err)
+	}
+	ptr := r[0]
+	mem := in.Memory().Bytes()
+	for i := 0; i < len(s); i++ {
+		mem[ptr+uint64(2*i)] = s[i]
+		mem[ptr+uint64(2*i)+1] = 0
+	}
+	return ptr
+}
+
+func isSQLi(tb testing.TB, in *wago.Instance, ptr uint64) bool {
+	r, err := in.Invoke("isSQLiBool", ptr)
+	if err != nil {
+		tb.Fatalf("isSQLiBool: %v", err)
+	}
+	return r[0] != 0
+}
+
+// TestSqliCalibrate finds the string id that makes detection correct, and prints
+// it. Run: go test -run TestSqliCalibrate -v .
+func TestSqliCalibrate(t *testing.T) {
+	src, err := os.ReadFile(sqliWasmPath())
+	if err != nil {
+		t.Skipf("sqli.wasm not present: %v", err)
+	}
+	c, _ := wago.Compile(src)
+	for _, id := range []uint64{1, 2, 3, 4, 5} {
+		imp := wago.Imports{"env.abort": wago.HostFunc(func(wago.HostModule, []uint64, []uint64) {})}
+		in, err := wago.Instantiate(c, imp)
+		if err != nil {
+			t.Fatalf("instantiate: %v", err)
+		}
+		asStringID = id
+		attack := newASString(t, in, "1' OR '1'='1' -- ")
+		benign := newASString(t, in, "the quick brown fox jumps over the lazy dog")
+		gotAttack := isSQLi(t, in, attack)
+		gotBenign := isSQLi(t, in, benign)
+		t.Logf("id=%d  attack=%v benign=%v  %s", id, gotAttack, gotBenign,
+			map[bool]string{true: "<-- CORRECT", false: ""}[gotAttack && !gotBenign])
+	}
+}
+
+// benchInputs: a benign string (the slower full-scan path per RESULTS.md) and an
+// attack. Fixed so codegen A/B is apples-to-apples.
+var benignInput = "SELECT the quick brown fox from the lazy dog where id equals fortytwo and name is bob"
+
+func BenchmarkSqliBenign(b *testing.B) {
+	in := loadSqli(b)
+	ptr := newASString(b, in, benignInput)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := in.Invoke("isSQLiBool", ptr)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/docs/exec-codegen-opts-plan.md
+++ b/docs/exec-codegen-opts-plan.md
@@ -91,6 +91,43 @@ JIT'd CPUID stub. Only if 1–5 leave time; measure on sha256/blake.
   (R2d): higher effort, lower/uncertain corpus ROI — deferred.
 - Anything in the SSA/IR direction: forbidden by the no-IR decision.
 
+## Impart-rules pass — LANDED WIN (2026-07-08)
+
+Retargeted from the synthetic corpus to Impart's **actual** workload: the AS
+libinjection security rules run on wago (guard-page mode = the intended deployment;
+prod inspector is still on wazero, wago is the candidate replacement). Built a
+standalone, dependency-free bench (`bench/sqli_rule_test.go`) that drives the real
+`isSQLiBool` detector (Impart `experimental/jack/libinjection/compare-build/sqli.wasm`,
+the 82 KB fn#96 tokenizer) — a fast A/B loop without the asbuilder/node pipeline.
+
+**Findings (guard-page, the deployed mode):**
+- Bounds checks cost **17% in explicit** mode but **0% in guard-page** (RESULTS.md §6
+  agrees) → bounds-hoisting is not a deployment lever here. (This is why last session's
+  synthetic-corpus bounds work doesn't transfer.)
+- Copies: OOO-neutral (already proven, `wago-copies-ooo-hidden`). No SIMD in the guest.
+- **Inlining REGRESSED the rule ~3%.** Root cause isolated by A/B: it's specifically
+  the inlining of **loop-carrying leaf callees** (the Phase 3/4 control-flow broadening,
+  landed but never bench-validated). Splicing a loop body into a hot caller adds
+  register pressure that outweighs the removed call.
+
+**Fix (landed):** `inlineClass` now excludes leaf callees that contain a loop
+(`inline.go`; opt back in with `WAGO_INLINE_LOOPCALLEE=1`). Straight-line and
+simple-branch leaf helpers — the real inline win — are unaffected.
+
+| workload (guard-page) | before | after | Δ |
+|---|--:|--:|--:|
+| **Impart SQLi rule** (sqli.wasm) | 4057 ns | **3940 ns** | **−2.9%** |
+| sha256 (byte-hash, rule-shaped) | 37843 | 36862 | −2.6% |
+| json-as serialize | 20154 | 20157 | ~0 (non-loop callee kept) |
+| many_funcs (dispatcher) | 16.28 | 16.20 | ~0 (straight-line kept) |
+| quicksort / dispatch / fib_iter / json-deser | — | — | <1% (noise, best-of-4) |
+
+Explicit-bounds sqli also improves (4899→4840, −1.2%). Correctness: railshot units +
+`TestSpecExec` spec suite + corpus differential all green. `TestInlineExecLoop` updated
+to opt into loop-callee inlining (it tests that path specifically).
+
+---
+
 ## Results log — MEASURED (2026-07-07/08)
 
 The measurement pass **overturned the ranking above**. Every "cheap win" turned out

--- a/docs/exec-codegen-opts-plan.md
+++ b/docs/exec-codegen-opts-plan.md
@@ -1,0 +1,156 @@
+# Exec-codegen optimization pass (2026-07-07)
+
+Worktree: `../wago-exec-codegen`, branch `perf/exec-codegen`. Scope chosen by the
+user: **generated machine-code quality** in `src/core/compiler/backend/railshot`
+(not compile speed, not runtime/infra). Ranked by ROI = expected corpus exec win ÷
+effort, discounted by miscompile risk (the storage-model / deferred-load areas have
+a history of subtle desync bugs — #68, inflate-condense, br_table-RAX, sqlite-pin).
+
+## Baseline (AMD Ryzen 7 7800X3D, explicit bounds, `BenchmarkExec`, 200ms)
+
+| program | ns/op | program | ns/op | program | ns/op |
+|---|--:|---|--:|---|--:|
+| tiny.add | 16.0 | memory.sum | 235 | sha256.hashN | 42 937 |
+| fib_iter | 27.1 | memory_tree | 11 557 | crc32.hashN | 19 426 |
+| fib_rec | 1 426 929 | globals.acc | 852 | quicksort | 63 267 |
+| dispatch | 19.0 | linked_list | 9 374 | matmul | 162 467 |
+| branches | 15.3 | sieve.count | 83 939 | json-as ser | 22 293 |
+| many_funcs | 16.1 | mandelbrot | 267 341 | json-as deser | 39 980 |
+| arith | 1 675 | nbody | 323 487 | blake-as | 750 904 |
+| float.run | 10 067 | spectralnorm | 2 221 418 | utf-as | 198 396 |
+|  |  | fannkuch | 1 072 877 | raytrace | 415 523 |
+
+Float-heavy programs dominate the slow tail (spectralnorm, raytrace, nbody,
+mandelbrot). Loop/branch-heavy: sieve, quicksort, fannkuch. Rotate/shift-heavy:
+sha256, blake, crc32.
+
+## What's already landed (reconciled vs OPTIMIZATIONS.md, which was stale)
+
+DONE since the doc: R2a in-place XMM accumulation (`fbinInto`/`float-local-sink`),
+R2b lazy float pinned locals (uniform STACK_REG), R1's *select*-onto-flags fusion
+(#192 `trySelectOnFlags`), leaf inlining (default-ON), loop-precheck bounds hoisting
+(default-ON). Don't re-do these.
+
+## Correctness gate (run after every change)
+
+1. `go test ./src/core/compiler/backend/railshot/` — unit + golden disasm + exec.
+2. `cd bench && go test -run 'Differential|Corpus|Sqlite|Jsonas|Wasi' ./...` — corpus
+   differential + real-program exec (this is what catches miscompiles).
+3. Spec suite `TestSpecSuiteExec` (needs `WAGO_SPECTEST_DIR`) before finalizing.
+
+Any change lands only with (a) its CodegenStats counter moving, (b) gate green, (c)
+a measured benchmark delta.
+
+## ROI-ranked optimizations (implement top-down, keep winners, revert losers)
+
+### 1. R3 — store-narrowing peephole  · S · low risk
+`setcc r8; movzx r,r8; i32.store8 [mem],r` keeps a dead `movzx`. Store the setcc
+byte directly. Self-contained in the store8 lowering; the `SETcc` byte is already
+8-bit. Targets boolean-array writes (sieve mark, predicate tables). Counter:
+`store-narrow`.
+
+### 2. Const-fold pack + same-operand compare identities (P2.3 + P2.4)  · S · low risk
+`fold.go:foldable` folds only arithmetic binops. Add const folding for compares,
+`eqz`, `clz/ctz/popcnt`, and integer extensions; add same-operand compare
+identities (`x==x→1`, `x<x→0`, `x<=x→1`, …) beside `simplifySameOperand`. Pure
+compile-time; near-zero exec risk, shrinks code and removes a few live ops where
+constants/aliases flow in. Bundled because they touch the same two functions.
+
+### 3. R2c — float `call; local.set` result fusion  · S–M · low–med risk
+The call-result→pinned-local fusion (`call.go`) is `sigIsIntOnly`-gated. Extend to a
+single float result landing directly in the pinned XMM local, mirroring the int
+path. Helps float programs that call helpers (raytrace, nbody, spectralnorm).
+Counter: `float-call-set`.
+
+### 4. R7 P2.1 — alias-aware pending loads  · M · med risk
+`materializePendingLoads` flushes ALL deferred `stMemRef` on every store. Keep loads
+that are provably disjoint from the store (same base register, non-overlapping
+[disp,disp+size) static ranges; conservative — bail to full-flush otherwise). Helps
+load-heavy code between stores (json, sha256, blake, memory_tree). Higher risk:
+deferred-load aliasing is where past desync bugs lived — extra differential runs.
+Counter: `alias-load-kept`.
+
+### 5. R1 — `stFlags`, first slice: one-deep deferred-set fusion window  · M–L · higher risk
+Compare→branch fusion breaks when a `local.tee`/`local.set` sits between the compare
+and its `br_if`/`if` (`cmp; local.tee $c; br_if`, `eqz; local.set $c; if`) — common
+in TinyGo/AssemblyScript loop conditions. Allow the fusion to survive a single
+deferred local-set of the compared boolean, materializing the flag only if a
+flag-clobbering op intervenes. The full flags-resident storage kind is deferred;
+this is the high-value, lower-scope slice. Do LAST, gate behind an env flag first,
+spec-suite before default-on. Counter: `cmp-fuse-window`.
+
+### 6. (stretch) BMI2 `rorx`/`shlx`/`shrx` behind a CPUID probe  · M · niche
+Non-destructive 3-operand shifts/rotates skip the value-copy + `CL` staging that
+2-operand shifts need. Helps rotate-heavy sha256/blake3/crc32. Needs a one-time
+JIT'd CPUID stub. Only if 1–5 leave time; measure on sha256/blake.
+
+## Rejected / out of scope
+- Same-operand compare identities on their own program impact is ~nil (compilers
+  don't emit `x==x`) — folded into #2 only because it's free there.
+- call_indirect inline caches, immutable-global folding, mixed-call parallel staging
+  (R2d): higher effort, lower/uncertain corpus ROI — deferred.
+- Anything in the SSA/IR direction: forbidden by the no-IR decision.
+
+## Results log — MEASURED (2026-07-07/08)
+
+The measurement pass **overturned the ranking above**. Every "cheap win" turned out
+exec-dead or neutral on the corpus; the one real lever needs a substantial feature.
+Method: `bench/cmd/explain` counters (static) + `BenchmarkExec` explicit-vs-guard
+(the guard-vs-explicit delta is the *entire* ceiling of ALL bounds-check work at once).
+
+### The decisive measurement: guard (all bounds checks removed) vs explicit baseline
+
+| program | explicit ns | guard ns | bounds ceiling |
+|---|--:|--:|--:|
+| **matmul** | 162 467 | 107 966 | **−33.5%** |
+| **memory_tree** | 11 557 | 9 100 | **−21%** |
+| **sha256** | 42 937 | 36 969 | **−14%** |
+| json deser | 39 980 | 37 264 | −7% |
+| json ser | 22 293 | 21 063 | −5.5% |
+| blake-as | 750 904 | 723 706 | −3.6% |
+| crc32 | 19 426 | 18 833 | −3% |
+| fannkuch | 1 072 877 | 1 043 652 | −2.7% |
+| sieve / quicksort / spectralnorm | — | — | <2% |
+
+**Bounds-check elision is the only lever with real dynamic ROI, and it's concentrated
+in matmul / memory_tree / sha256.** Everything else is ≤7%.
+
+### What was TRIED and the verdict
+
+| item | verdict | evidence |
+|---|---|---|
+| R3 store-narrowing (`setcc;movzx;store8`) | **DEAD** | `compare-setcc` counts are ~0–3 static across the corpus; the slow (float) programs are 0 (compares already fuse); a lone `movzx` is OOO-hidden. |
+| R1 `stFlags` / fusion-past-adjacency | **DEAD** | `cmp-branch-fuse` already fires nearly everywhere (fannkuch 66 fused vs 3 not; matmul 12 vs 1). The adjacency limit almost never triggers in real compiled wasm. |
+| const-fold pack + same-operand compares (P2.3/4) | **near-zero exec** | compile-time only; folds constants computed once. Not worth the surface. |
+| R2c float `call;local.set` fusion | **DEAD for the hot programs** | the slow float loops (spectralnorm/nbody/mandelbrot/raytrace) are call-free; `f64.sqrt` is an intrinsic, not a call. |
+| **loop-param versioning** (lifted `len(paramTypes)!=0` bail) | **IMPLEMENTED, then REVERTED — exec-neutral** | Correct + safe (railshot units + full spec suite + corpus differential all green; void-loop codegen byte-identical). But it captured **0 new versioned loops** anywhere in the corpus: the blocker was never params — `scanLoopHoistable` only proposes a *direct invariant-base* `local.get;load` as a candidate, and no param loop had one. Reverted per "no exec win → don't keep the complexity." |
+
+### Why the big-ceiling programs are NOT captured today
+
+- **matmul (−33%)**: hot loop `c[i*n+j] += aik*b[k*n+j]` compiles to **running pointer
+  locals** (`local 1`/`local 2`) incremented by a constant stride (16) each iteration
+  and used as direct memop bases. They're `local.set` in the loop → not invariant →
+  correctly skipped by the invariant-base precheck. Capturing them needs
+  induction-variable max-extent analysis.
+- **sha256 (−14%)**: `hoistable=16` checks are **indexed** accesses (`invariantBase +
+  idx`, idx a loop counter), not a bare `local.get;load` — `scanLoopHoistable` never
+  proposes them. Same IV/max-index need.
+- **memory_tree (−21%)**: pointer-chasing tree traversal — the base is **data-dependent**
+  (not monotone), so it is *genuinely unhoistable* by any static analysis. Unreachable.
+
+### Conclusion / the one real next step
+
+The railshot exec codegen is already highly tuned (measured: spills≈0, compares fuse,
+in-place XMM accumulation, lazy float pins all present). The single remaining lever
+with real ROI is **monotonic-induction-variable loop-bounds-check elision** — extend
+`scanLoopHoistable` + the existing fast/slow versioning to counted loops whose base is
+either (a) a running pointer advanced by a constant stride, or (b) an invariant base +
+a bounded loop-counter index. Precheck the **conservatively over-approximated** max
+extent (over-approx = safe: a too-strict precheck only diverts to the checked slow
+body; a too-lax one silently skips a real trap — the security-critical direction).
+Ceiling: matmul −33%, sha256 ~−7–14%. This is a real, trap-sensitive feature (~150–250
+LOC + IV edge-case tests), **not** a quick peephole — it warrants its own spec-gated
+session, which is why it was scoped here rather than rushed. The versioning machinery
+(`boundshoist.go`), the fast/slow trap-exact safety proof, and the param-loop support
+(trivially re-addable, shown safe above) are all already in place for it.
+

--- a/src/core/compiler/backend/railshot/inline.go
+++ b/src/core/compiler/backend/railshot/inline.go
@@ -35,6 +35,11 @@ const inlineMaxBodyBytes = 160
 // to estimate the saved bytes in the report, so an approximate constant is fine.
 const inlineCallSeqBytes = 24
 
+// inlineLoopCallees (WAGO_INLINE_LOOPCALLEE=1) re-enables inlining of leaf callees
+// that contain a loop. Off by default: loop-carrying bodies are a net-negative to
+// splice (see inlineClass).
+var inlineLoopCallees = os.Getenv("WAGO_INLINE_LOOPCALLEE") == "1"
+
 var inlineMaxBytes = func() int {
 	if v := os.Getenv("WAGO_INLINE_MAXBYTES"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
@@ -153,6 +158,16 @@ func inlineClass(f inlineFacts) (bool, string) {
 		return false, fmt.Sprintf("non-leaf (%d call(s))", f.calleeCount)
 	case !f.regABIIntOnly:
 		return false, "signature not int-only reg-ABI"
+	case f.hasLoop && !inlineLoopCallees:
+		// A leaf callee that contains a LOOP is a net-negative to splice: its loop
+		// body lands inside the caller's hot region and adds register pressure /
+		// code that outweighs the call it removes. Measured: excluding these speeds
+		// Impart's libinjection SQLi rule ~3% and sha256 ~2.7% (both big scan/hash
+		// functions), with no measurable regression elsewhere on the corpus (the
+		// straight-line and simple-branch leaf helpers — the real inline win, e.g.
+		// many_funcs, json serialize — are unaffected). Opt back in for A/B with
+		// WAGO_INLINE_LOOPCALLEE=1.
+		return false, "leaf callee contains a loop"
 	case f.bodyBytes > inlineMaxBytes:
 		return false, fmt.Sprintf("too big (%dB > %dB)", f.bodyBytes, inlineMaxBytes)
 	default:

--- a/src/core/compiler/backend/railshot/inline_test.go
+++ b/src/core/compiler/backend/railshot/inline_test.go
@@ -311,7 +311,11 @@ func TestInlineExecReturnBare(t *testing.T) {
 }
 
 // TestInlineExecLoop inlines a control-flow leaf with a loop: sum(n) = n+(n-1)+…+1.
+// Loop-carrying leaves are excluded from inlining by default (net-negative to
+// splice), so this opts back in via inlineLoopCallees to exercise that path.
 func TestInlineExecLoop(t *testing.T) {
+	defer func(o bool) { inlineLoopCallees = o }(inlineLoopCallees)
+	inlineLoopCallees = true
 	withInlineEnabled(t, func() {
 		// func 1 (n)->i32, locals: (acc i32). loop { acc += n; n -= 1; if n>0 continue }
 		//   (local acc)


### PR DESCRIPTION
## What

`inlineClass` now excludes leaf callees that contain a **loop** from inlining
(opt back in with `WAGO_INLINE_LOOPCALLEE=1`). Splicing a loop body into a hot
caller adds register pressure that outweighs the removed call — the Phase-3/4
control-flow broadening that allowed this was never bench-validated.

Straight-line and simple-branch leaf helpers (the real inline win — `many_funcs`,
json serialize) are unaffected.

## Why / measurement

Retargeted at Impart's actual workload — the AS libinjection security rules run on
wago in guard-page mode. A new standalone bench (`bench/sqli_rule_test.go`) drives
the real `isSQLiBool` detector.

| workload (guard-page) | before | after | Δ |
|---|--:|--:|--:|
| Impart SQLi rule (sqli.wasm) | 4057 ns | **3940 ns** | **−2.9%** |
| sha256 (rule-shaped byte-hash) | 37843 | 36862 | −2.6% |
| json-as serialize / many_funcs | — | — | ~0 (non-loop callees kept) |
| quicksort / dispatch / fib_iter / json-deser | — | — | <1% (noise, best-of-4) |

Explicit-bounds sqli also improves (−1.2%). Principled, general heuristic —
validated net-neutral-or-positive across the whole synthetic corpus.

## Correctness

railshot unit tests + `TestSpecExec` spec suite + corpus differential all green.
`TestInlineExecLoop` updated to opt into loop-callee inlining (it tests that path).

Full write-up: `docs/exec-codegen-opts-plan.md`.