### PR TITLE
wasm: support funcref table initializers

### DIFF
--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -266,7 +266,12 @@ func (p supportPass) tables() error {
 			return p.unsupported("table", "64-bit limits", ctx)
 		}
 		if t.Init != nil {
-			return p.unsupported("table", "initializer expression", ctx)
+			if !p.feat.ReferenceTypes {
+				return p.unsupported("table", "initializer expression (reference-types disabled)", ctx)
+			}
+			if err := p.elementExpr(*t.Init, ctx+" initializer"); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -201,7 +201,7 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	c.TableSize = tableSize
 	c.TableMax = tableMax
 	if len(m.Tables) > 0 && m.Tables[0].Init != nil {
-		payload, err := elementExprPayload(*m.Tables[0].Init)
+		payload, err := funcrefExprPayload(*m.Tables[0].Init)
 		if err != nil {
 			return nil, fmt.Errorf("table 0 initializer: %w", err)
 		}
@@ -329,7 +329,7 @@ func elementPayloads(e *wasm.Elem) ([]uint32, error) {
 	case wasm.ElemFuncExprs, wasm.ElemTypedExprs:
 		out := make([]uint32, len(e.Kind.Exprs))
 		for i, ex := range e.Kind.Exprs {
-			payload, err := elementExprPayload(ex)
+			payload, err := funcrefExprPayload(ex)
 			if err != nil {
 				return nil, fmt.Errorf("expression %d: %w", i, err)
 			}
@@ -341,7 +341,7 @@ func elementPayloads(e *wasm.Elem) ([]uint32, error) {
 	}
 }
 
-func elementExprPayload(e wasm.Expr) (uint32, error) {
+func funcrefExprPayload(e wasm.Expr) (uint32, error) {
 	payload, err := wasm.ParseFuncrefElementExpr(e)
 	if err != nil {
 		return 0, err

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -735,7 +735,7 @@ func (c *Compiled) validate() error {
 		if c.tableImport != "" {
 			return fmt.Errorf("compiled metadata invalid: table initializer on imported table")
 		}
-		if int(c.TableInitFunc) >= totalFuncs {
+		if uint64(c.TableInitFunc) >= uint64(totalFuncs) {
 			return fmt.Errorf("compiled metadata invalid: table initializer function index %d out of range", c.TableInitFunc)
 		}
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -200,6 +200,16 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	c.HasTable = hasTable
 	c.TableSize = tableSize
 	c.TableMax = tableMax
+	if len(m.Tables) > 0 && m.Tables[0].Init != nil {
+		payload, err := elementExprPayload(*m.Tables[0].Init)
+		if err != nil {
+			return nil, fmt.Errorf("table 0 initializer: %w", err)
+		}
+		if payload != nullFuncRefIndex {
+			c.HasTableInitFunc = true
+			c.TableInitFunc = payload
+		}
+	}
 	if len(m.Memories) > 0 {
 		lim := m.Memories[0].Limits
 		c.HasMemory = true
@@ -718,6 +728,17 @@ func (c *Compiled) validate() error {
 	if len(c.FuncTypeID) != totalFuncs {
 		return fmt.Errorf("compiled metadata invalid: FuncTypeID length %d != function count %d", len(c.FuncTypeID), totalFuncs)
 	}
+	if c.HasTableInitFunc {
+		if !c.HasTable {
+			return fmt.Errorf("compiled metadata invalid: table initializer without table")
+		}
+		if c.tableImport != "" {
+			return fmt.Errorf("compiled metadata invalid: table initializer on imported table")
+		}
+		if int(c.TableInitFunc) >= totalFuncs {
+			return fmt.Errorf("compiled metadata invalid: table initializer function index %d out of range", c.TableInitFunc)
+		}
+	}
 	for name, gfi := range c.Exports {
 		if gfi < 0 || gfi >= totalFuncs {
 			return fmt.Errorf("compiled metadata invalid: function export %q index %d out of range", name, gfi)
@@ -886,10 +907,8 @@ func (c *Compiled) validateDeferredOffsetGlobal(kind string, seg, idx int) error
 
 const wagoMagic = "WAGO"
 
-// Bumped to 16 for the merge of the wasm-2 table-ops codec (passive element
-// descriptors, table metadata) with the memory.init codec (passive data
-// descriptors); the combined blob format is distinct from either branch's.
-const wagoVersion = 16
+// Bumped to 17 to serialize non-null funcref table initializer expressions.
+const wagoVersion = 17
 
 // MarshalBinary serializes the precompiled module to a ".wago" blob.
 //

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -75,6 +75,10 @@ func marshalCompiled(c *Compiled) ([]byte, error) {
 	w.bool(c.HasTable)
 	w.uvar(uint64(c.TableSize))
 	w.uvar(uint64(c.TableMax))
+	w.bool(c.HasTableInitFunc)
+	if c.HasTableInitFunc {
+		w.u32(c.TableInitFunc)
+	}
 	w.u32Slice(c.FuncTypeID)
 	w.elems(c.Elems)
 	w.elems(c.passiveElems)
@@ -365,6 +369,16 @@ func unmarshalCompiled(c *Compiled, data []byte) error {
 		return fmt.Errorf("TableMax overflows int")
 	}
 	c.TableMax = int(n)
+	c.HasTableInitFunc, err = r.bool()
+	if err != nil {
+		return err
+	}
+	if c.HasTableInitFunc {
+		c.TableInitFunc, err = r.u32()
+		if err != nil {
+			return err
+		}
+	}
 	c.FuncTypeID, err = r.u32Slice()
 	if err != nil {
 		return err

--- a/src/wago/codec_count_test.go
+++ b/src/wago/codec_count_test.go
@@ -380,8 +380,9 @@ func TestCompiledReaderRejectsMaliciousCountsBeforeAllocation(t *testing.T) {
 			write: func(w *compiledWriter) {
 				writeCompiledCodecPrefixAfterGlobalExports(t, w)
 				w.bool(false)
-				w.uvar(0) // TableSize.
-				w.uvar(0) // TableMax.
+				w.uvar(0)     // TableSize.
+				w.uvar(0)     // TableMax.
+				w.bool(false) // HasTableInitFunc.
 				w.uvar(huge)
 			},
 		},

--- a/src/wago/codec_test_helpers_test.go
+++ b/src/wago/codec_test_helpers_test.go
@@ -40,8 +40,9 @@ func writeCompiledCodecPrefixAfterFuncTypeIDs(t testing.TB, w *compiledWriter) {
 	t.Helper()
 	writeCompiledCodecPrefixAfterGlobalExports(t, w)
 	w.bool(false)
-	w.uvar(0) // TableSize.
-	w.uvar(0) // TableMax.
+	w.uvar(0)     // TableSize.
+	w.uvar(0)     // TableMax.
+	w.bool(false) // HasTableInitFunc.
 	w.u32Slice(nil)
 }
 

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -248,11 +248,13 @@ type Compiled struct {
 	Globals       []GlobalDef       // global entries in wasm global-index order
 	GlobalExports map[string]int    // exported global name -> global index
 
-	HasTable   bool       // true when table 0 is declared, even with minimum length 0
-	TableSize  int        // initial/current table length
-	TableMax   int        // allocated table capacity/max; zero means TableSize for older hand-built metadata
-	FuncTypeID []uint32   // canonical signature id per global function index
-	Elems      []ElemInit // active element segments
+	HasTable         bool       // true when table 0 is declared, even with minimum length 0
+	TableSize        int        // initial/current table length
+	TableMax         int        // allocated table capacity/max; zero means TableSize for older hand-built metadata
+	HasTableInitFunc bool       // table initializer is a non-null ref.func payload
+	TableInitFunc    uint32     // wasm function index used to prefill local table entries when HasTableInitFunc
+	FuncTypeID       []uint32   // canonical signature id per global function index
+	Elems            []ElemInit // active element segments
 
 	passiveElems []ElemInit // passive element descriptors keyed by original element index for table.init/elem.drop
 

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -459,6 +459,12 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 			}
 			copy(entry, funcRefDescs[payload*runtime.TableEntryBytes:(payload+1)*runtime.TableEntryBytes])
 		}
+		if c.HasTableInitFunc {
+			for slot := 0; slot < size; slot++ {
+				off := 8 + slot*runtime.TableEntryBytes
+				writeTableEntry(desc[off:off+runtime.TableEntryBytes], c.TableInitFunc)
+			}
+		}
 		type resolvedElemInit struct {
 			elem ElemInit
 			base uint32

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -270,6 +270,47 @@ func TestFuncrefTableInitializerExpressionActiveRefNullOverrides(t *testing.T) {
 	}
 }
 
+func TestFuncrefTableInitializerExpressionPassiveTableInitRefNullOverrides(t *testing.T) {
+	mod := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType(nil, nil),
+		)),
+		tableTestFuncSection(0, 1, 2),
+		wasmtest.Section(4, wasmtest.Vec(tableTestTableWithInit(3, 3, tableTestRefFuncExpr(0)))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("callAt", 0, 1),
+			wasmtest.ExportEntry("initNull", 0, 2),
+		)),
+		wasmtest.Section(9, wasmtest.Vec(tableTestPassiveElemExpr(tableTestRefNullFuncExpr()))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code(tableTestBody(tableTestI32Const(42))),
+			wasmtest.Code(tableTestBody(tableTestLocalGet(0), tableTestCallIndirect(0, 0))),
+			wasmtest.Code(tableTestBody(tableTestI32Const(1), tableTestI32Const(0), tableTestI32Const(1), tableTestBulk(12, 0, 0))),
+		)),
+	)
+	inst := tableTestInstantiate(t, mod)
+	defer inst.Close()
+
+	for _, idx := range []int32{0, 1, 2} {
+		if got := tableTestCallI32(t, inst, "callAt", I32(idx)); got != 42 {
+			t.Fatalf("callAt(%d) before initNull = %d, want initializer target 42", idx, got)
+		}
+	}
+	if _, err := inst.Invoke("initNull"); err != nil {
+		t.Fatalf("initNull: %v", err)
+	}
+	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 42 {
+		t.Fatalf("callAt(0) after initNull = %d, want initializer target 42", got)
+	}
+	_, err := inst.Invoke("callAt", I32(1))
+	tableTestExpectTrap(t, err, TrapIndirectOutOfBounds)
+	if got := tableTestCallI32(t, inst, "callAt", I32(2)); got != 42 {
+		t.Fatalf("callAt(2) after initNull = %d, want initializer target 42", got)
+	}
+}
+
 func TestFuncrefTableInitializerExpressionNullLeavesEntriesUninitialized(t *testing.T) {
 	inst := tableTestInstantiate(t, tableInitializerModule(tableTestRefNullFuncExpr()))
 	defer inst.Close()

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -4,6 +4,7 @@ package wago
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -348,9 +349,20 @@ func TestFuncrefTableInitializerExpressionZeroLengthTableDoesNotWrite(t *testing
 }
 
 func TestCompiledValidationRejectsInvalidTableInitializerFunction(t *testing.T) {
-	c := &Compiled{Code: []byte{0}, Entry: []int{0}, Funcs: []FuncSig{{}}, HasTable: true, TableSize: 1, TableMax: 1, HasTableInitFunc: true, TableInitFunc: 1, FuncTypeID: []uint32{0}}
-	if err := c.validate(); err == nil || !strings.Contains(err.Error(), "table initializer function index 1 out of range") {
-		t.Fatalf("validate invalid table initializer = %v, want out-of-range error", err)
+	for _, tc := range []struct {
+		name string
+		idx  uint32
+	}{
+		{name: "at function count", idx: 1},
+		{name: "large uint32", idx: ^uint32(0)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Compiled{Code: []byte{0}, Entry: []int{0}, Funcs: []FuncSig{{}}, HasTable: true, TableSize: 1, TableMax: 1, HasTableInitFunc: true, TableInitFunc: tc.idx, FuncTypeID: []uint32{0}}
+			want := fmt.Sprintf("table initializer function index %d out of range", tc.idx)
+			if err := c.validate(); err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("validate invalid table initializer = %v, want %q", err, want)
+			}
+		})
 	}
 }
 

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -257,6 +257,19 @@ func TestFuncrefTableInitializerExpressionActiveSegmentOverrides(t *testing.T) {
 	}
 }
 
+func TestFuncrefTableInitializerExpressionActiveRefNullOverrides(t *testing.T) {
+	inst := tableTestInstantiate(t, tableInitializerModule(tableTestRefFuncExpr(1), tableTestActiveElemExpr(1, tableTestRefNullFuncExpr())))
+	defer inst.Close()
+	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 42 {
+		t.Fatalf("callAt(0) = %d, want initializer target 42", got)
+	}
+	_, err := inst.Invoke("callAt", I32(1))
+	tableTestExpectTrap(t, err, TrapIndirectOutOfBounds)
+	if got := tableTestCallI32(t, inst, "callAt", I32(2)); got != 42 {
+		t.Fatalf("callAt(2) = %d, want initializer target 42", got)
+	}
+}
+
 func TestFuncrefTableInitializerExpressionNullLeavesEntriesUninitialized(t *testing.T) {
 	inst := tableTestInstantiate(t, tableInitializerModule(tableTestRefNullFuncExpr()))
 	defer inst.Close()

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -195,6 +195,43 @@ func tableInitializerModule(initExpr []byte, activeElems ...[]byte) []byte {
 	return wasmtest.Module(sections...)
 }
 
+func tableInitializerImportModule() []byte {
+	importFunc := append(wasmtest.Name("env"), wasmtest.Name("f")...)
+	importFunc = append(importFunc, 0x00) // import kind func
+	importFunc = append(importFunc, wasmtest.ULEB(0)...)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),                      // 0: () -> i32 imported initializer target
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}), // 1: (i32) -> i32 callAt
+		)),
+		wasmtest.Section(2, wasmtest.Vec(importFunc)),
+		tableTestFuncSection(1),
+		wasmtest.Section(4, wasmtest.Vec(tableTestTableWithInit(2, 2, tableTestRefFuncExpr(0)))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("callAt", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(tableTestBody(tableTestLocalGet(0), tableTestCallIndirect(0, 0))))),
+	)
+}
+
+func tableInitializerZeroLengthModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),                      // 0: () -> i32
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}), // 1: (i32) -> i32
+		)),
+		tableTestFuncSection(0, 0, 1),
+		wasmtest.Section(4, wasmtest.Vec(tableTestTableWithInit(0, 2, tableTestRefFuncExpr(0)))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("size", 0, 1),
+			wasmtest.ExportEntry("callAt", 0, 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code(tableTestBody(tableTestI32Const(11))),
+			wasmtest.Code(tableTestBody(tableTestBulk(16, 0))),
+			wasmtest.Code(tableTestBody(tableTestLocalGet(0), tableTestCallIndirect(0, 0))),
+		)),
+	)
+}
+
 func TestFuncrefTableInitializerExpressionPrefillsTable(t *testing.T) {
 	inst := tableTestInstantiate(t, tableInitializerModule(tableTestRefFuncExpr(1)))
 	defer inst.Close()
@@ -250,6 +287,70 @@ func TestFuncrefTableInitializerExpressionSurvivesCompiledCodec(t *testing.T) {
 	defer inst.Close()
 	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 42 {
 		t.Fatalf("callAt(0) after codec = %d, want table initializer target 42", got)
+	}
+}
+
+func TestFuncrefTableInitializerExpressionRejectsWhenReferenceTypesDisabled(t *testing.T) {
+	cfg := NewRuntimeConfig().WithFeature(CoreFeatureReferenceTypes, false)
+	_, err := Compile(cfg, tableInitializerModule(tableTestRefFuncExpr(1)))
+	if err == nil || !strings.Contains(err.Error(), "initializer expression") || !strings.Contains(err.Error(), "reference-types disabled") {
+		t.Fatalf("Compile with reference-types disabled error = %v, want table initializer rejection", err)
+	}
+}
+
+func TestFuncrefTableInitializerExpressionCanTargetHostImport(t *testing.T) {
+	inst := tableTestInstantiateWithImports(t, tableInitializerImportModule(), Imports{
+		"env.f": HostFunc(func(_ HostModule, _ []uint64, r []uint64) { r[0] = I32(55) }),
+	})
+	defer inst.Close()
+	for _, idx := range []int32{0, 1} {
+		if got := tableTestCallI32(t, inst, "callAt", I32(idx)); got != 55 {
+			t.Fatalf("callAt(%d) = %d, want host import result 55", idx, got)
+		}
+	}
+}
+
+func TestFuncrefTableInitializerExpressionCanTargetCrossInstanceImport(t *testing.T) {
+	producer := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}))),
+		tableTestFuncSection(0),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(tableTestBody(tableTestI32Const(123))))),
+	)
+	prodInst := tableTestInstantiate(t, producer)
+	defer prodInst.Close()
+	export, err := prodInst.ExportedFunc("f")
+	if err != nil {
+		t.Fatalf("export f: %v", err)
+	}
+	consumer, err := Compile(nil, tableInitializerImportModule())
+	if err != nil {
+		t.Fatalf("Compile consumer: %v", err)
+	}
+	consInst, err := Instantiate(consumer, Imports{"env.f": export})
+	if err != nil {
+		t.Fatalf("Instantiate consumer: %v", err)
+	}
+	defer consInst.Close()
+	if got := tableTestCallI32(t, consInst, "callAt", I32(0)); got != 123 {
+		t.Fatalf("cross-instance table initializer call = %d, want 123", got)
+	}
+}
+
+func TestFuncrefTableInitializerExpressionZeroLengthTableDoesNotWrite(t *testing.T) {
+	inst := tableTestInstantiate(t, tableInitializerZeroLengthModule())
+	defer inst.Close()
+	if got := tableTestCallI32(t, inst, "size"); got != 0 {
+		t.Fatalf("initial table.size = %d, want 0", got)
+	}
+	_, err := inst.Invoke("callAt", I32(0))
+	tableTestExpectTrap(t, err, TrapIndirectOutOfBounds)
+}
+
+func TestCompiledValidationRejectsInvalidTableInitializerFunction(t *testing.T) {
+	c := &Compiled{Code: []byte{0}, Entry: []int{0}, Funcs: []FuncSig{{}}, HasTable: true, TableSize: 1, TableMax: 1, HasTableInitFunc: true, TableInitFunc: 1, FuncTypeID: []uint32{0}}
+	if err := c.validate(); err == nil || !strings.Contains(err.Error(), "table initializer function index 1 out of range") {
+		t.Fatalf("validate invalid table initializer = %v, want out-of-range error", err)
 	}
 }
 

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -233,6 +233,29 @@ func tableInitializerZeroLengthModule() []byte {
 	)
 }
 
+func tableInitializerGrowModule(growValue []byte) []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),                      // 0: () -> i32
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}), // 1: (i32) -> i32
+		)),
+		tableTestFuncSection(0, 0, 0, 1, 0),
+		wasmtest.Section(4, wasmtest.Vec(tableTestTableWithInit(1, 2, tableTestRefFuncExpr(0)))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("grow", 0, 2),
+			wasmtest.ExportEntry("callAt", 0, 3),
+			wasmtest.ExportEntry("size", 0, 4),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code(tableTestBody(tableTestI32Const(11))),
+			wasmtest.Code(tableTestBody(tableTestI32Const(22))),
+			wasmtest.Code(tableTestBody(growValue, tableTestI32Const(1), tableTestBulk(15, 0))),
+			wasmtest.Code(tableTestBody(tableTestLocalGet(0), tableTestCallIndirect(0, 0))),
+			wasmtest.Code(tableTestBody(tableTestBulk(16, 0))),
+		)),
+	)
+}
+
 func TestFuncrefTableInitializerExpressionPrefillsTable(t *testing.T) {
 	inst := tableTestInstantiate(t, tableInitializerModule(tableTestRefFuncExpr(1)))
 	defer inst.Close()
@@ -400,6 +423,45 @@ func TestFuncrefTableInitializerExpressionZeroLengthTableDoesNotWrite(t *testing
 	}
 	_, err := inst.Invoke("callAt", I32(0))
 	tableTestExpectTrap(t, err, TrapIndirectOutOfBounds)
+}
+
+func TestFuncrefTableInitializerExpressionGrowWithRefNullUsesOperand(t *testing.T) {
+	inst := tableTestInstantiate(t, tableInitializerGrowModule(tableTestRefNullFuncExpr()))
+	defer inst.Close()
+	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 11 {
+		t.Fatalf("callAt(0) before grow = %d, want initializer target 11", got)
+	}
+	if got := tableTestCallI32(t, inst, "grow"); got != 1 {
+		t.Fatalf("table.grow = %d, want old size 1", got)
+	}
+	if got := tableTestCallI32(t, inst, "size"); got != 2 {
+		t.Fatalf("table.size after grow = %d, want 2", got)
+	}
+	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 11 {
+		t.Fatalf("callAt(0) after grow = %d, want initializer target 11", got)
+	}
+	_, err := inst.Invoke("callAt", I32(1))
+	tableTestExpectTrap(t, err, TrapIndirectOutOfBounds)
+}
+
+func TestFuncrefTableInitializerExpressionGrowWithRefFuncUsesOperand(t *testing.T) {
+	inst := tableTestInstantiate(t, tableInitializerGrowModule(tableTestRefFuncExpr(1)))
+	defer inst.Close()
+	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 11 {
+		t.Fatalf("callAt(0) before grow = %d, want initializer target 11", got)
+	}
+	if got := tableTestCallI32(t, inst, "grow"); got != 1 {
+		t.Fatalf("table.grow = %d, want old size 1", got)
+	}
+	if got := tableTestCallI32(t, inst, "size"); got != 2 {
+		t.Fatalf("table.size after grow = %d, want 2", got)
+	}
+	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 11 {
+		t.Fatalf("callAt(0) after grow = %d, want initializer target 11", got)
+	}
+	if got := tableTestCallI32(t, inst, "callAt", I32(1)); got != 22 {
+		t.Fatalf("callAt(1) after grow = %d, want grow operand target 22", got)
+	}
 }
 
 func TestCompiledValidationRejectsInvalidTableInitializerFunction(t *testing.T) {

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -70,6 +70,20 @@ func tableTestImportTable(module, name string, min, max uint32) []byte {
 	return out
 }
 
+func tableTestTableWithInit(min, max uint32, expr []byte) []byte {
+	out := []byte{0x40, 0x00, 0x70} // table with initializer, funcref table type
+	if max != 0 {
+		out = append(out, 0x01) // limits: min + max
+		out = append(out, wasmtest.ULEB(min)...)
+		out = append(out, wasmtest.ULEB(max)...)
+	} else {
+		out = append(out, 0x00) // limits: min only
+		out = append(out, wasmtest.ULEB(min)...)
+	}
+	out = append(out, expr...)
+	return append(out, 0x0b)
+}
+
 func tableTestFuncIdxVec(funcs ...uint32) []byte {
 	out := wasmtest.ULEB(uint32(len(funcs)))
 	for _, f := range funcs {
@@ -157,6 +171,85 @@ func tableTestExpectTrap(t *testing.T, err error, code TrapCode) {
 	var trap *TrapError
 	if !errors.As(err, &trap) || trap.Code != code {
 		t.Fatalf("error = %v, want trap %v", err, code)
+	}
+}
+
+func tableInitializerModule(initExpr []byte, activeElems ...[]byte) []byte {
+	sections := [][]byte{
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),                      // 0: () -> i32
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}), // 1: (i32) -> i32
+		)),
+		tableTestFuncSection(0, 0, 1),
+		wasmtest.Section(4, wasmtest.Vec(tableTestTableWithInit(3, 3, initExpr))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("callAt", 0, 2))),
+	}
+	if len(activeElems) != 0 {
+		sections = append(sections, wasmtest.Section(9, wasmtest.Vec(activeElems...)))
+	}
+	sections = append(sections, wasmtest.Section(10, wasmtest.Vec(
+		wasmtest.Code(tableTestBody(tableTestI32Const(7))),
+		wasmtest.Code(tableTestBody(tableTestI32Const(42))),
+		wasmtest.Code(tableTestBody(tableTestLocalGet(0), tableTestCallIndirect(0, 0))),
+	)))
+	return wasmtest.Module(sections...)
+}
+
+func TestFuncrefTableInitializerExpressionPrefillsTable(t *testing.T) {
+	inst := tableTestInstantiate(t, tableInitializerModule(tableTestRefFuncExpr(1)))
+	defer inst.Close()
+	for _, idx := range []int32{0, 1, 2} {
+		if got := tableTestCallI32(t, inst, "callAt", I32(idx)); got != 42 {
+			t.Fatalf("callAt(%d) = %d, want table initializer target 42", idx, got)
+		}
+	}
+}
+
+func TestFuncrefTableInitializerExpressionActiveSegmentOverrides(t *testing.T) {
+	inst := tableTestInstantiate(t, tableInitializerModule(tableTestRefFuncExpr(1), tableTestActiveElem(1, 0)))
+	defer inst.Close()
+	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 42 {
+		t.Fatalf("callAt(0) = %d, want initializer target 42", got)
+	}
+	if got := tableTestCallI32(t, inst, "callAt", I32(1)); got != 7 {
+		t.Fatalf("callAt(1) = %d, want active element target 7", got)
+	}
+	if got := tableTestCallI32(t, inst, "callAt", I32(2)); got != 42 {
+		t.Fatalf("callAt(2) = %d, want initializer target 42", got)
+	}
+}
+
+func TestFuncrefTableInitializerExpressionNullLeavesEntriesUninitialized(t *testing.T) {
+	inst := tableTestInstantiate(t, tableInitializerModule(tableTestRefNullFuncExpr()))
+	defer inst.Close()
+	_, err := inst.Invoke("callAt", I32(0))
+	tableTestExpectTrap(t, err, TrapIndirectOutOfBounds)
+}
+
+func TestFuncrefTableInitializerExpressionSurvivesCompiledCodec(t *testing.T) {
+	tableTestForceExplicitBounds(t)
+	c, err := Compile(nil, tableInitializerModule(tableTestRefFuncExpr(1)))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	loaded, err := Load(blob)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !loaded.HasTableInitFunc || loaded.TableInitFunc != 1 {
+		t.Fatalf("loaded table initializer = enabled %v func %d, want enabled func 1", loaded.HasTableInitFunc, loaded.TableInitFunc)
+	}
+	inst, err := Instantiate(loaded)
+	if err != nil {
+		t.Fatalf("Instantiate loaded: %v", err)
+	}
+	defer inst.Close()
+	if got := tableTestCallI32(t, inst, "callAt", I32(0)); got != 42 {
+		t.Fatalf("callAt(0) after codec = %d, want table initializer target 42", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- admit funcref table initializer expressions under the reference-types feature gate
- prefill local tables from non-null ref.func initializers before active element segments apply
- serialize initializer metadata in .wago blobs and add runtime/codec coverage

## Tests
- go test ./...

Docs unchanged: internal wasm feature implementation with no developer/agent workflow impact.

Note: agent-todo.md remains untracked locally per request.