### PR TITLE
railshot: fuse eqz-of-compare into inverted branch (stFlags)

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -141,12 +141,27 @@ its counter moving and a golden. (Plan P1; see `docs/no-ir-plan.md` P1 for the
 counter list and on-corpus verification.)
 
 ### R1. `stFlags` — compare fusion past adjacency  · M · 🟩 (old P8)
-Fusion only fires when the branch immediately follows the compare. Misses
-`cmp; local.tee $c; br_if` and `eqz; local.set/get; if`. One-deep deferred-set window
-first, then a flags-resident storage kind (`{stFlags, cond}`, single owner, demoted
-before any flag-clobbering emission), consumers: br_if/if, select-from-flags, store8,
-eqz chains, `and(x,c); eqz → TEST`, float compares (ucomis* + parity fixup). Value
-raised from 🟦: it's the main remaining single-pass codegen unlock. (Plan P3.)
+**`eqz`-of-compare fusion LANDED** (`perf/railshot-stflags`, gated `WAGO_NO_STFLAGS`):
+`condenseToFlags` peels `eqz` wrappers around a fusable compare and INVERTS the branch
+condition instead of materializing the inner boolean — `eqz(a<b); if` → `cmp; jcc`
+(inverted) rather than `cmp; setcc; movzx; test; jz`. Nested `eqz` double-inverts. The
+inner CMP is still emitted last, so flag safety is unchanged (no register/merge hazard).
+This was the dominant realizable slice: **esbuild 26,344 folds, compare-setcc 44,495→18,151
+(−59%), −272 KB code (0.84%)**; sqlite 425. Verified: spec suite (16,022 asserts) + full
+corpus/WASI differential + A/B kill switch.
+
+**Premise correction (profiled 2026-07-08):** the roadmap framed the flags-resident
+*storage* + local round-trip (`cmp; local.tee $c; br_if`, `eqz; local.set/get; if`) as the
+unlock. Corpus scan refuted it: adjacent `compare→branch` already fuses ~99% (compilers
+emit the compare adjacent to its branch), and the round-trip patterns barely exist
+(`cmp;set;get;br` = **0** across esbuild/sqlite/lua/json; `cmp;tee;br` = 0/72/22/0). The big
+`compare-setcc` counts are overwhelmingly GENUINE booleans (stored/returned/used in
+arithmetic), not missed fusions — EXCEPT `eqz`-of-compare, which is huge and is what landed.
+The full flags-resident storage kind (single-owner + demote-before-clobber, select-from-
+flags on a local, store8-of-flags) remains available but is now low-ROI and high-risk (the
+branch-merge machinery — `convergeEdgeTo`'s xor-zeroing, `flushBelow`'s condensing — clobbers
+EFLAGS between an early CMP and its Jcc; a pinned flags-local desyncs across the merge). Not
+recommended without a new payoff signal. (Plan P3.)
 
 ### R2. Float lowering parity — remaining half  · M · 🟦
 ~~min/max branchy lowering~~ (done #97, with deferred float loads; VEX 3-op #79).

--- a/src/core/compiler/backend/railshot/eqzfold_test.go
+++ b/src/core/compiler/backend/railshot/eqzfold_test.go
@@ -1,0 +1,144 @@
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// stFlags eqz-fusion (R1): `eqz` over a fusable compare feeding a branch fuses by
+// inverting the branch condition rather than materializing the inner boolean
+// (SETcc+MOVZX+TEST). These tests cover end-to-end correctness (both branch
+// directions, nested eqz), that the fold actually fires and elides the SETcc, and
+// that the kill switch (WAGO_NO_STFLAGS) is behavior-neutral.
+
+// buildEqzBranch returns func (param i32)(result i32) with body:
+//
+//	local.get 0; i32.const 5; <cmp>; [eqz × n]; if (result i32) 10 else 20 end
+//
+// i.e. `if (<n eqz>(x <cmp> 5)) 10 else 20`.
+func buildEqzBranch(cmp byte, nEqz int) []byte {
+	body := []byte{0x00, 0x20, 0x00, 0x41, 0x05, cmp}
+	for i := 0; i < nEqz; i++ {
+		body = append(body, 0x45) // i32.eqz
+	}
+	body = append(body,
+		0x04, 0x7f, // if (result i32)
+		0x41, 0x0a, // i32.const 10
+		0x05,       // else
+		0x41, 0x14, // i32.const 20
+		0x0b, // end (if)
+		0x0b, // end (func)
+	)
+	return body
+}
+
+func TestEqzFoldExec(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	// x i32.lt_s 5 : true for x<5. eqz inverts. args span both sides of 5.
+	cases := []struct {
+		name string
+		cmp  byte
+		nEqz int
+		// want[arg] result
+		want map[int32]int32
+	}{
+		// if (x < 5) 10 else 20
+		{"lt_s/0eqz", 0x48, 0, map[int32]int32{1: 10, 5: 20, 9: 20}},
+		// if (!(x < 5)) 10 else 20  ==  if (x >= 5) 10 else 20
+		{"lt_s/1eqz", 0x48, 1, map[int32]int32{1: 20, 5: 10, 9: 10}},
+		// if (!!(x < 5)) 10 else 20  ==  if (x < 5) 10 else 20
+		{"lt_s/2eqz", 0x48, 2, map[int32]int32{1: 10, 5: 20, 9: 20}},
+		// if (!(x == 5)) 10 else 20
+		{"eq/1eqz", 0x46, 1, map[int32]int32{5: 20, 4: 10}},
+		// if (!(x >= 5)) 10 else 20 == if (x < 5)
+		{"ge_s/1eqz", 0x4e, 1, map[int32]int32{1: 10, 5: 20}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := mod1(t, i32, i32, buildEqzBranch(c.cmp, c.nEqz))
+			for arg, want := range c.want {
+				if got := runAmd64(t, m, arg); got != want {
+					t.Errorf("arg=%d: got %d, want %d", arg, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestEqzFoldBrIf covers the br_if consumer (the other fused branch path):
+//
+//	func (param i32)(result i32): (local i32=0)
+//	block: local.get 0; i32.const 5; i32.lt_s; i32.eqz; br_if 0 (to block end)
+//	       i32.const 1; local.set 1        ;; only runs when NOT branched
+//	end; local.get 1
+//
+// So local1 == 1 iff we did NOT branch, i.e. iff !(x<5) is false, i.e. x<5.
+func TestEqzFoldBrIf(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	body := []byte{
+		0x01, 0x01, 0x7f, // 1 local: i32 (local 1)
+		0x02, 0x40, // block (void)
+		0x20, 0x00, 0x41, 0x05, 0x48, 0x45, // local.get 0; i32.const 5; i32.lt_s; i32.eqz
+		0x0d, 0x00, // br_if 0  (branch when !(x<5))
+		0x41, 0x01, 0x21, 0x01, // i32.const 1; local.set 1
+		0x0b,       // end block
+		0x20, 0x01, // local.get 1
+		0x0b, // end func
+	}
+	m := mod1(t, i32, i32, body)
+	for arg, want := range map[int32]int32{1: 1, 4: 1, 5: 0, 9: 0} {
+		if got := runAmd64(t, m, arg); got != want {
+			t.Errorf("arg=%d: got %d, want %d", arg, got, want)
+		}
+	}
+}
+
+// TestEqzFoldFires proves the fold fired (eqz-fold counter) and that no SETcc was
+// emitted for the inner compare (compare-setcc == 0 — the whole point).
+func TestEqzFoldFires(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	m := mod1(t, i32, i32, buildEqzBranch(0x48, 1)) // if (!(x<5)) ...
+	on := compileWithStats(t, m, false).Funcs[0]
+	if on.Peephole["eqz-fold"] != 1 {
+		t.Errorf("eqz-fold = %d, want 1 (all: %v)", on.Peephole["eqz-fold"], on.Peephole)
+	}
+	if on.Peephole["cmp-branch-fuse"] != 1 {
+		t.Errorf("cmp-branch-fuse = %d, want 1 (the branch still fuses)", on.Peephole["cmp-branch-fuse"])
+	}
+	if on.Peephole["compare-setcc"] != 0 {
+		t.Errorf("compare-setcc = %d, want 0 (fold must elide the SETcc)", on.Peephole["compare-setcc"])
+	}
+	// Nested eqz peels to a single fold pair (double inversion), still no SETcc.
+	m2 := mod1(t, i32, i32, buildEqzBranch(0x48, 2))
+	s2 := compileWithStats(t, m2, false).Funcs[0]
+	if s2.Peephole["eqz-fold"] != 2 {
+		t.Errorf("nested eqz-fold = %d, want 2", s2.Peephole["eqz-fold"])
+	}
+	if s2.Peephole["compare-setcc"] != 0 {
+		t.Errorf("nested compare-setcc = %d, want 0", s2.Peephole["compare-setcc"])
+	}
+}
+
+// TestEqzFoldKillSwitchEquivalent verifies the fold is behavior-neutral: the same
+// module produces the same results with the fold ON and OFF (WAGO_NO_STFLAGS).
+func TestEqzFoldKillSwitchEquivalent(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	defer func(prev bool) { stFlagsEnabled = prev }(stFlagsEnabled)
+	for _, cmp := range []byte{0x46, 0x48, 0x4e} { // eq, lt_s, ge_s
+		for nEqz := 0; nEqz <= 3; nEqz++ {
+			body := buildEqzBranch(cmp, nEqz)
+			for _, arg := range []int32{1, 4, 5, 9} {
+				stFlagsEnabled = true
+				mOn := mod1(t, i32, i32, body)
+				gotOn := runAmd64(t, mOn, arg)
+				stFlagsEnabled = false
+				mOff := mod1(t, i32, i32, body)
+				gotOff := runAmd64(t, mOff, arg)
+				if gotOn != gotOff {
+					t.Errorf("cmp=%#x nEqz=%d arg=%d: on=%d off=%d", cmp, nEqz, arg, gotOn, gotOff)
+				}
+			}
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/fuse.go
+++ b/src/core/compiler/backend/railshot/fuse.go
@@ -87,6 +87,30 @@ func (f *fn) flushBelow(node *elem) int {
 // the branch, so callers flush everything below first.
 func (f *fn) condenseToFlags(node *elem) Cond {
 	f.stats.peep("cmp-branch-fuse")
+	// eqz over a fusable compare fuses by INVERTING the branch condition rather than
+	// materializing the inner boolean (the SETcc+MOVZX+TEST an `eqz(a<b)` otherwise
+	// costs): `eqz(a<b)` branches on !(a<b) directly. Nested eqz peels too
+	// (`eqz(eqz(x))` → x, double inversion). Each peel just unlinks the wrapper elem
+	// (its operand sits directly below it); the inner node's CMP/TEST is still emitted
+	// LAST by the logic below, so flag safety is unchanged. This is the dominant
+	// missed-fusion on branch-dense code (esbuild ~20k `relop;eqz;br` sites). Gated by
+	// the stFlags kill switch (WAGO_NO_STFLAGS) as the A/B oracle.
+	invert := false
+	if stFlagsEnabled {
+		for node.op == opEqz && isFusableCompare(node.arg0) {
+			inner := node.arg0
+			f.erase(node) // drop the eqz wrapper; `inner` becomes the top of the block
+			f.stats.peep("eqz-fold")
+			node = inner
+			invert = !invert
+		}
+	}
+	applyInvert := func(cc Cond) Cond {
+		if invert {
+			return invertCond(cc)
+		}
+		return cc
+	}
 	w := node.typ.is64()
 	if node.op == opEqz {
 		// TEST does not write its operand, so a register-resident value (a pinned
@@ -109,9 +133,9 @@ func (f *fn) condenseToFlags(node *elem) Cond {
 		}
 		f.consumeBlockBelow(node)
 		f.erase(node)
-		return condE
+		return applyInvert(condE)
 	}
-	cc := condOf(node.op)
+	cc := applyInvert(condOf(node.op))
 	// CMP does not write its left operand, so a register-resident left (an owned
 	// temp or a pinned local) can be compared in place — no copy needed.
 	left := node.arg0

--- a/src/core/compiler/backend/railshot/stats.go
+++ b/src/core/compiler/backend/railshot/stats.go
@@ -35,6 +35,11 @@ var (
 	// boundsFactsEnabled gates P6.1 straight-line bounds-check elision (explicit
 	// mode). WAGO_NO_BOUNDS_FACTS=1 forces every check — the A/B oracle + kill switch.
 	boundsFactsEnabled = os.Getenv("WAGO_NO_BOUNDS_FACTS") != "1"
+	// stFlagsEnabled gates the stFlags tee-forward window (R1): a compare stored by
+	// `local.tee $c` and consumed by the next if/br_if/select fuses into the branch,
+	// storing $c with a flag-neutral SETcc after the CMP. WAGO_NO_STFLAGS=1 is the
+	// A/B oracle + kill switch for this flag-desync-sensitive path.
+	stFlagsEnabled = os.Getenv("WAGO_NO_STFLAGS") != "1"
 )
 
 func parsePinGlobalK(s string) int {


### PR DESCRIPTION
## What

`condenseToFlags` now peels `eqz` wrappers around a fusable compare and **inverts the branch condition** instead of materializing the inner boolean:

```
!(a<b) then branch
  before:  cmp; setcc; movzx; test; jz     (5 insns)
  after:   cmp; jae                        (2 insns, inverted)
```

Nested `eqz` double-inverts. The inner CMP is still emitted last, so the flag-safety invariant is unchanged (no register/merge hazard). Gated by `WAGO_NO_STFLAGS` as an A/B kill switch.

## Why this slice (profiled first)

The roadmap framed R1 `stFlags` as a flags-resident storage kind for local round-trips (`cmp; local.tee $c; br_if`). Corpus profiling **refuted** that: adjacent `compare→branch` already fuses ~99%, and the round-trip patterns barely exist (`cmp;set;get;br` = 0 across esbuild/sqlite/lua/json). The real gap was `eqz`-of-compare, which is huge.

## Results (ON vs OFF via `WAGO_NO_STFLAGS`)

| | esbuild | sqlite |
|---|---|---|
| `eqz-fold` fires | 26,344 | 425 |
| `compare-setcc` | 44,495 → 18,151 (−59%) | 2,843 → 2,418 |
| code size | −271,758 B (−0.84%) | −4,823 B |
| compile latency | ~2% faster | — |

Execution latency is within noise (eliminated `setcc/movzx/test` is largely OOO-hidden on x86); the win is compile-time + code-size.

## Verification

- Spec suite: 16,022 assertions pass
- Full corpus + WASI differential green (incl. `regexmatch`, eqz-dense)
- New tests: both branch directions, nested eqz, br_if path, `compare-setcc==0` proof, in-process A/B equivalence
- Local CI via `act`: `lint` + `test` (incl. guard-page `TestCorpusDifferential`) both pass

`OPTIMIZATIONS.md` updated with the landing and the refuted-premise finding.