### PR TITLE
railshot: const-fold pack — constant compares/unary/conversions + same-operand compare identities

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -53,6 +53,12 @@ condense engine) with an on-the-fly whole-register-file allocator. Landed, in ro
 - **Algebraic identities + strength reduction** (old P4) — `x±0`, `x&~0`, `x|0`, `x^0`,
   shifts by 0, `x*1`, `x*0`, `x*2ⁿ→shl`, `x*{3,5,9}→lea`, `x/ᵤ2ⁿ→shr`, `x%ᵤ2ⁿ→and`,
   `x-x`/`x^x→0`, `x&x`/`x|x→x` — at `pushBinOp`, before a node exists.
+- **Const-fold pack** (P2.3/P2.4) — extends constant folding past binary arithmetic to
+  relational compares (all i32/i64 signed+unsigned), the unary ops (clz/ctz/popcnt/eqz),
+  and the width conversions (wrap / sign- & zero-extend); plus same-local integer compare
+  identities (`x==x`/`x<=x`/`x>=x→1`, `x!=x`/`x<x`/`x>x→0`) alongside the existing
+  `x-x`/`x&x` ones. All at `pushBinOp`/`pushUnOp`, fire only on compile-time-known inputs
+  (`const-fold` / `same-operand` counters), so no node/SETcc is emitted (`fold.go`).
 - **Scaled-index LEA fusion** — `add(x, shl(y, k≤3))` → `lea [x + y*2ᵏ]` (the
   AssemblyScript array-address shape).
 - **`br_table` jump tables** (old P7) — n≥5 dispatches through a RIP-relative offset
@@ -205,9 +211,9 @@ flat/GC-bound; no further wago-side lever identified.
 ### R7. Adopted from the 2026-07-03 external review (new items; plan §2)
 Codegen, cheap-and-safe first: **alias-aware pending loads** (any store currently
 flushes ALL deferred loads — keep same-base provably-disjoint ones, plan P2.1) ·
-**pure-tree `drop` discard** (P2.2) · **const-fold pack** — compares/eqz/clz/ctz/
-popcnt/extensions + narrow-load mask elision (P2.3) · **same-operand int compare
-identities** (P2.4). Then: **limited multi-result register ABI** (RAX,RDX / XMM0,XMM1 —
+**pure-tree `drop` discard** (P2.2) · ~~**const-fold pack** — compares/eqz/clz/ctz/
+popcnt/extensions (P2.3)~~ ✅ DONE (narrow-load mask elision still open) · ~~**same-operand
+int compare identities** (P2.4)~~ ✅ DONE. Then: **limited multi-result register ABI** (RAX,RDX / XMM0,XMM1 —
 unblocks multi-value, with `regMerge2`, P5.3) · **straight-line bounds facts** +
 **hybrid loop precheck** (explicit mode; the TinyGo story, P6.1–.2) · **store
 combining** (explicit-only, cold-path sequential replay for trap semantics, P6.3) ·

--- a/src/core/compiler/backend/railshot/constfold_test.go
+++ b/src/core/compiler/backend/railshot/constfold_test.go
@@ -1,0 +1,228 @@
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// The const-fold pack (docs/no-ir-plan.md P2.3/P2.4): relational compares and the
+// unary ops (clz/ctz/popcnt/eqz + width conversions) fold at compile time when
+// their operands are constant, and integer compares of the same local collapse to
+// a constant. These only fire on compile-time-known inputs, so the fold value is
+// checked against Go's own arithmetic and against end-to-end execution.
+
+func TestFoldCompareUnit(t *testing.T) {
+	cases := []struct {
+		op   wOp
+		a, b int64
+		w    bool
+		want int64
+	}{
+		// i32: signed vs unsigned disagree on the sign bit.
+		{opLtS, -1, 1, false, 1}, // -1 <ₛ 1
+		{opLtU, -1, 1, false, 0}, // 0xffffffff <ᵤ 1 is false
+		{opGtU, -1, 1, false, 1},
+		{opEq, 5, 5, false, 1},
+		{opNe, 5, 5, false, 0},
+		{opLeS, 5, 5, false, 1},
+		{opGeU, 3, 7, false, 0},
+		// i64: full-width signed/unsigned.
+		{opLtS, -1, 1, true, 1},
+		{opLtU, -1, 1, true, 0},
+		{opEq, 1 << 40, 1 << 40, true, 1},
+		{opGtS, 1 << 40, 1<<40 - 1, true, 1},
+	}
+	for _, c := range cases {
+		if got := foldCompare(c.op, c.a, c.b, c.w); got != c.want {
+			t.Errorf("foldCompare(%d, %d, %d, w=%v) = %d, want %d", c.op, c.a, c.b, c.w, got, c.want)
+		}
+	}
+}
+
+func TestFoldUnaryConstUnit(t *testing.T) {
+	cases := []struct {
+		op    wOp
+		a     int64
+		typ   machineType
+		want  int64
+		wantT machineType
+	}{
+		{opEqz, 0, mtI32, 1, mtI32},
+		{opEqz, 7, mtI32, 0, mtI32},
+		{opEqz, 0, mtI64, 1, mtI32},
+		{opClz, 1, mtI32, 31, mtI32},
+		{opClz, 0, mtI32, 32, mtI32},
+		{opClz, 1, mtI64, 63, mtI64},
+		{opCtz, 8, mtI32, 3, mtI32},
+		{opCtz, 0, mtI64, 64, mtI64},
+		{opPopcnt, 6, mtI32, 2, mtI32},   // 0b110
+		{opPopcnt, -1, mtI64, 64, mtI64}, // all bits set
+		{opWrap, int64(0x1_0000_0007), mtI32, 7, mtI32},
+		{opSExt32, int64(int32(-1)), mtI64, -1, mtI64},         // stays -1 (sign-extended)
+		{opZExt32, int64(int32(-1)), mtI64, 0xFFFFFFFF, mtI64}, // zero-extended
+		{opSExt8, 0xFF, mtI32, -1, mtI32},                      // low byte 0xFF → -1
+		{opSExt8, 0xFF, mtI64, -1, mtI64},
+		{opSExt16, 0x8000, mtI32, int64(int32(-32768)), mtI32},
+	}
+	for _, c := range cases {
+		got, gotT, ok := foldUnaryConst(c.op, c.a, c.typ)
+		if !ok {
+			t.Errorf("foldUnaryConst(%d, %d, %v) not ok", c.op, c.a, c.typ)
+			continue
+		}
+		if got != c.want || gotT != c.wantT {
+			t.Errorf("foldUnaryConst(%d, %d, %v) = (%d, %v), want (%d, %v)",
+				c.op, c.a, c.typ, got, gotT, c.want, c.wantT)
+		}
+	}
+	// Non-unary ops are not foldable here.
+	if _, _, ok := foldUnaryConst(opAdd, 1, mtI32); ok {
+		t.Errorf("foldUnaryConst(opAdd) unexpectedly ok")
+	}
+}
+
+// TestConstFoldPackExec runs const-folded bodies end-to-end so the folded value is
+// validated against the real runtime, not just the fold helper.
+func TestConstFoldPackExec(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	i64 := []wasm.ValType{wasm.I64}
+	// i32-result cases: (body without leading local-decl byte / trailing end).
+	i32cases := []struct {
+		name string
+		body []byte
+		want int32
+	}{
+		// i32.const -1; i32.const 1; i32.lt_s → 1
+		{"lt_s", []byte{0x41, 0x7f, 0x41, 0x01, 0x48}, 1},
+		// i32.const -1; i32.const 1; i32.lt_u → 0
+		{"lt_u", []byte{0x41, 0x7f, 0x41, 0x01, 0x49}, 0},
+		// i32.const 5; i32.const 5; i32.eq → 1
+		{"eq", []byte{0x41, 0x05, 0x41, 0x05, 0x46}, 1},
+		// i32.const 0; i32.eqz → 1
+		{"eqz_zero", []byte{0x41, 0x00, 0x45}, 1},
+		// i32.const 1; i32.clz → 31
+		{"clz", []byte{0x41, 0x01, 0x67}, 31},
+		// i32.const 8; i32.ctz → 3
+		{"ctz", []byte{0x41, 0x08, 0x68}, 3},
+		// i32.const 6; i32.popcnt → 2
+		{"popcnt", []byte{0x41, 0x06, 0x69}, 2},
+		// i64.const 7; i32.wrap_i64 → 7
+		{"wrap", []byte{0x42, 0x07, 0xa7}, 7},
+		// i32.const 255; i32.extend8_s → -1
+		{"extend8_s", []byte{0x41, 0xff, 0x01, 0xc0}, -1},
+	}
+	for _, c := range i32cases {
+		t.Run("i32/"+c.name, func(t *testing.T) {
+			body := append(append([]byte{0x00}, c.body...), 0x0b)
+			m := mod1(t, nil, i32, body)
+			if got := runAmd64(t, m); got != c.want {
+				t.Errorf("%s = %d, want %d", c.name, got, c.want)
+			}
+		})
+	}
+
+	// i64-result cases.
+	i64cases := []struct {
+		name string
+		body []byte
+		want uint64
+	}{
+		// i64.const 1; i64.clz → 63
+		{"clz", []byte{0x42, 0x01, 0x79}, 63},
+		// i32.const -1; i64.extend_i32_u → 0xFFFFFFFF
+		{"extend_i32_u", []byte{0x41, 0x7f, 0xad}, 0xFFFFFFFF},
+		// i32.const -1; i64.extend_i32_s → all ones
+		{"extend_i32_s", []byte{0x41, 0x7f, 0xac}, 0xFFFFFFFFFFFFFFFF},
+	}
+	for _, c := range i64cases {
+		t.Run("i64/"+c.name, func(t *testing.T) {
+			body := append(append([]byte{0x00}, c.body...), 0x0b)
+			m := mod1(t, nil, i64, body)
+			if got := runAmd64u(t, m); got != c.want {
+				t.Errorf("%s = %#x, want %#x", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSameOperandCompareExec checks the same-local integer compare identities
+// (x==x→1, x<x→0) fold and execute correctly regardless of the argument value.
+func TestSameOperandCompareExec(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	cases := []struct {
+		name string
+		cmp  byte
+		want int32
+	}{
+		{"eq", 0x46, 1},
+		{"le_s", 0x4c, 1},
+		{"ge_u", 0x4f, 1},
+		{"ne", 0x47, 0},
+		{"lt_s", 0x48, 0},
+		{"gt_u", 0x4b, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// local.get 0; local.get 0; <cmp>
+			body := []byte{0x00, 0x20, 0x00, 0x20, 0x00, c.cmp, 0x0b}
+			m := mod1(t, i32, i32, body)
+			for _, arg := range []int32{0, -1, 7, 1 << 30} {
+				if got := runAmd64(t, m, arg); got != c.want {
+					t.Errorf("%s(%d) = %d, want %d", c.name, arg, got, c.want)
+				}
+			}
+		})
+	}
+}
+
+// TestConstFoldPackPeep proves the fold actually happened: a constant compare
+// bumps "const-fold" (not "compare-setcc", which would mean a runtime SETcc was
+// emitted), a constant unary bumps "const-fold", and a same-local compare bumps
+// "same-operand".
+func TestConstFoldPackPeep(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	cases := []struct {
+		name string
+		in   []wasm.ValType
+		out  []wasm.ValType
+		body []byte
+		peep string
+	}{
+		{
+			// i32.const 5; i32.const 3; i32.lt_s → folded to const 0
+			name: "compare-fold", out: i32,
+			body: []byte{0x00, 0x41, 0x05, 0x41, 0x03, 0x48, 0x0b},
+			peep: "const-fold",
+		},
+		{
+			// i32.const 8; i32.ctz → folded to const 3
+			name: "unary-fold", out: i32,
+			body: []byte{0x00, 0x41, 0x08, 0x68, 0x0b},
+			peep: "const-fold",
+		},
+		{
+			// local.get 0; local.get 0; i32.eq → same-operand → const 1
+			name: "same-operand-compare", in: i32, out: i32,
+			body: []byte{0x00, 0x20, 0x00, 0x20, 0x00, 0x46, 0x0b},
+			peep: "same-operand",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mod1(t, tc.in, tc.out, tc.body)
+			s := compileWithStats(t, m, false).Funcs[0]
+			if got := s.Peephole[tc.peep]; got != 1 {
+				t.Errorf("Peephole[%q] = %d, want 1 (all: %v)", tc.peep, got, s.Peephole)
+			}
+			// A folded compare must NOT have emitted a runtime SETcc.
+			if got := s.Peephole["compare-setcc"]; got != 0 {
+				t.Errorf("compare-setcc = %d, want 0 (fold should have elided it; all: %v)", got, s.Peephole)
+			}
+			// Nothing should have been condensed: the whole body folds to a const.
+			if s.Condenses != 0 {
+				t.Errorf("Condenses = %d, want 0 (body folds to a constant)", s.Condenses)
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/fold.go
+++ b/src/core/compiler/backend/railshot/fold.go
@@ -1,5 +1,7 @@
 package amd64
 
+import "math/bits"
+
 // Constant folding: when both operands of a binary op are constants, compute the
 // result at compile time and push a constant instead of a deferred node (WARP's
 // tryConstantPropagation). Values are kept in an int64; i32 ops operate on the
@@ -81,4 +83,120 @@ func foldable(op wOp) bool {
 		return true
 	}
 	return false
+}
+
+// foldCompare folds a relational compare of two integer constants to its 0/1
+// result. w selects the operand width (i64 else i32); the result is always i32.
+// Signed ops interpret the operands at the operand width, unsigned ops at the
+// same width unsigned — matching wasm's per-width comparison semantics.
+func foldCompare(op wOp, a, b int64, w bool) int64 {
+	var res bool
+	if w {
+		ua, ub := uint64(a), uint64(b)
+		switch op {
+		case opEq:
+			res = a == b
+		case opNe:
+			res = a != b
+		case opLtS:
+			res = a < b
+		case opLtU:
+			res = ua < ub
+		case opGtS:
+			res = a > b
+		case opGtU:
+			res = ua > ub
+		case opLeS:
+			res = a <= b
+		case opLeU:
+			res = ua <= ub
+		case opGeS:
+			res = a >= b
+		case opGeU:
+			res = ua >= ub
+		default:
+			panic("amd64: foldCompare unsupported op")
+		}
+	} else {
+		sa, sb := int32(a), int32(b)
+		ua, ub := uint32(a), uint32(b)
+		switch op {
+		case opEq:
+			res = sa == sb
+		case opNe:
+			res = sa != sb
+		case opLtS:
+			res = sa < sb
+		case opLtU:
+			res = ua < ub
+		case opGtS:
+			res = sa > sb
+		case opGtU:
+			res = ua > ub
+		case opLeS:
+			res = sa <= sb
+		case opLeU:
+			res = ua <= ub
+		case opGeS:
+			res = sa >= sb
+		case opGeU:
+			res = ua >= ub
+		default:
+			panic("amd64: foldCompare unsupported op")
+		}
+	}
+	if res {
+		return 1
+	}
+	return 0
+}
+
+// foldUnaryConst folds a unary op over a constant operand: the counting ops
+// (clz/ctz/popcnt), eqz, and the width conversions (wrap / sign- & zero-extend).
+// typ is the argument pushUnOp received — the operand width for the counting/eqz/
+// extend8/16 forms and the result width for wrap/extend32; foldUnaryConst reads
+// only the bits each op actually consumes, so the distinction is immaterial here.
+// It returns the folded value, its storage type, and ok=false for a non-foldable
+// op (floats never reach this path).
+func foldUnaryConst(op wOp, a int64, typ machineType) (int64, machineType, bool) {
+	w := typ.is64()
+	switch op {
+	case opEqz: // operand width w; result is i32
+		if (w && a == 0) || (!w && uint32(a) == 0) {
+			return 1, mtI32, true
+		}
+		return 0, mtI32, true
+	case opClz:
+		if w {
+			return int64(bits.LeadingZeros64(uint64(a))), mtI64, true
+		}
+		return int64(bits.LeadingZeros32(uint32(a))), mtI32, true
+	case opCtz:
+		if w {
+			return int64(bits.TrailingZeros64(uint64(a))), mtI64, true
+		}
+		return int64(bits.TrailingZeros32(uint32(a))), mtI32, true
+	case opPopcnt:
+		if w {
+			return int64(bits.OnesCount64(uint64(a))), mtI64, true
+		}
+		return int64(bits.OnesCount32(uint32(a))), mtI32, true
+	case opWrap: // i32 <- i64: low 32 bits
+		return int64(int32(a)), mtI32, true
+	case opSExt32: // i64 <- low 32 sign-extended (i64.extend_i32_s / i64.extend32_s)
+		return int64(int32(a)), mtI64, true
+	case opZExt32: // i64 <- low 32 zero-extended (i64.extend_i32_u)
+		return int64(uint32(a)), mtI64, true
+	case opSExt8: // sign-extend low 8, result width = operand width
+		if w {
+			return int64(int8(a)), mtI64, true
+		}
+		return int64(int32(int8(a))), mtI32, true
+	case opSExt16: // sign-extend low 16, result width = operand width
+		if w {
+			return int64(int16(a)), mtI64, true
+		}
+		return int64(int32(int16(a))), mtI32, true
+	}
+	return 0, mtI32, false
 }

--- a/src/core/compiler/backend/railshot/stack.go
+++ b/src/core/compiler/backend/railshot/stack.go
@@ -294,15 +294,25 @@ func (f *fn) pushBinOp(op wOp, typ machineType) {
 	right := f.s.back()
 	left := baseOfValentBlock(right).prev
 	// Constant-fold when both operands are constants (WARP tryConstantPropagation).
-	if foldable(op) &&
-		right.kind == ekValue && right.st.kind == stConst &&
+	if right.kind == ekValue && right.st.kind == stConst &&
 		left.kind == ekValue && left.st.kind == stConst {
-		f.stats.peep("const-fold")
-		v := foldBin(op, left.st.cval, right.st.cval, typ.is64())
-		f.erase(right)
-		f.erase(left)
-		f.pushValue(storage{kind: stConst, typ: typ, cval: v})
-		return
+		if foldable(op) {
+			f.stats.peep("const-fold")
+			v := foldBin(op, left.st.cval, right.st.cval, typ.is64())
+			f.erase(right)
+			f.erase(left)
+			f.pushValue(storage{kind: stConst, typ: typ, cval: v})
+			return
+		}
+		if isCompare(op) {
+			// typ carries the operand width; a compare's result is always i32.
+			f.stats.peep("const-fold")
+			v := foldCompare(op, left.st.cval, right.st.cval, typ.is64())
+			f.erase(right)
+			f.erase(left)
+			f.pushValue(storage{kind: stConst, typ: mtI32, cval: v})
+			return
+		}
 	}
 	// One-constant algebraic simplification + strength reduction (P4): identities
 	// collapse without emitting a node; expensive ops rewrite to cheaper ones.
@@ -432,6 +442,18 @@ func (f *fn) simplifySameOperand(op wOp, typ machineType, left, right *elem) boo
 	case opAnd, opOr:
 		f.erase(right) // x stays
 		return true
+	case opEq, opLeS, opLeU, opGeS, opGeU:
+		// x==x, x<=x, x>=x → 1 (integer compares only; floats go through fp.go).
+		f.erase(right)
+		f.erase(left)
+		f.pushValue(storage{kind: stConst, typ: mtI32, cval: 1})
+		return true
+	case opNe, opLtS, opLtU, opGtS, opGtU:
+		// x!=x, x<x, x>x → 0.
+		f.erase(right)
+		f.erase(left)
+		f.pushValue(storage{kind: stConst, typ: mtI32})
+		return true
 	}
 	return false
 }
@@ -470,6 +492,15 @@ func log2u(v uint64) int {
 // when condensed.
 func (f *fn) pushUnOp(op wOp, typ machineType) {
 	operand := f.s.back()
+	// Constant-fold clz/ctz/popcnt/eqz and the width conversions over a constant.
+	if operand.kind == ekValue && operand.st.kind == stConst {
+		if v, rtyp, ok := foldUnaryConst(op, operand.st.cval, typ); ok {
+			f.stats.peep("const-fold")
+			f.erase(operand)
+			f.pushValue(storage{kind: stConst, typ: rtyp, cval: v})
+			return
+		}
+	}
 	if deferDepthOf(operand) >= maxDeferDepth {
 		f.materialize(operand) // cap deferred-tree height (see pushBinOp)
 	}


### PR DESCRIPTION
## What

Extends the single-pass constant folder past binary arithmetic:

- **Relational compares** on two constants → 0/1 (all i32/i64, signed + unsigned)
- **Unary ops** on a constant — clz / ctz / popcnt / eqz
- **Width conversions** on a constant — wrap / sign-extend / zero-extend
- **Same-local integer compare identities** — `x==x`/`x<=x`/`x>=x → 1`, `x!=x`/`x<x`/`x>x → 0`

All fire at `pushBinOp`/`pushUnOp` on compile-time-known inputs only (`const-fold` / `same-operand` counters), so no node/SETcc is ever emitted — they cannot miscompile.

## Why

The roadmap's "cheap-and-safe first" batch (P2.3/P2.4). Purely additive, zero miscompile risk (only fires on constants or proven same-local reads), and extends the existing `fold.go`. Compounds with inlining, which exposes more constant operands.

## Verification

- New `constfold_test.go`: pure-function unit tests (signed/unsigned boundaries, clz(0), sext vs zext), end-to-end exec through the real runtime, stats tests proving the fold fired (`compare-setcc==0`, `Condenses==0`)
- Spec suite: 16,022 assertions pass
- Full `src/core/...` + `src/wago/...` green
- Local CI via `act`: `lint` + `test` (incl. guard-page `TestCorpusDifferential`) both pass

`OPTIMIZATIONS.md` updated (P2.3/P2.4 marked done).