### PR TITLE
Add tagged process mailboxes

### DIFF
--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -11,25 +12,28 @@ import (
 // PID identifies a spawned process within a Runtime.
 type PID uint64
 
-// Guest-visible mailbox status codes (returned by the injected wago_mailbox.*
-// imports).
+// Guest-visible process/mailbox status codes returned by the injected
+// wago_process, wago_mailbox, and wago_message imports.
 const (
-	statusOK          int32 = 0
-	statusBufTooSmall int32 = 4
-	statusWouldBlock  int32 = 5
-	statusTimeout     int32 = 6
-	statusClosed      int32 = 7
-	statusPending      int32 = 8
-	statusNoMessage    int32 = 9
-	statusSizeMismatch int32 = 10
+	statusOK                int32 = 0
+	statusInvalidMemory     int32 = 1
+	statusNoProcess         int32 = 2
+	statusMailboxFull       int32 = 3
+	statusMailboxClosed     int32 = 4
+	statusWouldBlock        int32 = 5
+	statusTimeout           int32 = 6
+	statusPendingMessage    int32 = 7
+	statusNoPreparedMessage int32 = 8
+	statusSizeMismatch      int32 = 9
 )
 
 // Process-layer sentinel errors (const so the root facade can re-export them;
 // match with errors.Is).
 const (
-	ErrNoProcess     = extErr("wago: no such process")
-	ErrMailboxFull   = extErr("wago: mailbox full")
-	ErrMailboxClosed = extErr("wago: mailbox closed")
+	ErrNoProcess       = extErr("wago: no such process")
+	ErrMailboxFull     = extErr("wago: mailbox full")
+	ErrMailboxClosed   = extErr("wago: mailbox closed")
+	ErrMessageTooLarge = extErr("wago: message too large")
 )
 
 // DefaultMailboxCapacity is the mailbox size used when SpawnOptions.MailboxCapacity
@@ -120,6 +124,9 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 	if err := applyPolicy(class.mod, opts.Policy); err != nil {
 		return 0, err
 	}
+	if err := validateReservedProcessImports(class.mod); err != nil {
+		return 0, err
+	}
 
 	rt.procMu.Lock()
 	if rt.closed {
@@ -158,12 +165,8 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 // the reserved-override and missing-import guards of rt.Instantiate because Spawn
 // is trusted infrastructure providing those reserved modules itself.
 func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, error) {
-	if err := validateProcessImportSignatures(class.mod); err != nil {
-		return nil, err
-	}
-
 	rt.mu.Lock()
-	merged := make(Imports, len(rt.imports)+len(class.imports)+8)
+	merged := make(Imports, len(rt.imports)+len(class.imports)+4)
 	for k, v := range rt.imports {
 		merged[k] = v
 	}
@@ -183,19 +186,13 @@ func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, e
 }
 
 var processImportSigs = map[string]FuncSig{
-	"wago_process.self":             {nil, []ValType{ValI64}},
-	"wago_mailbox.send":             {[]ValType{ValI64, ValI32, ValI32}, []ValType{ValI32}},
-	"wago_mailbox.send_tagged":      {[]ValType{ValI64, ValI64, ValI32, ValI32}, []ValType{ValI32}},
-	"wago_mailbox.recv":             {[]ValType{ValI32, ValI32, ValI32, ValI64}, []ValType{ValI32}},
-	"wago_mailbox.recv_tagged":      {[]ValType{ValI32, ValI32, ValI32, ValI64, ValI64}, []ValType{ValI32}},
-	"wago_mailbox.try_recv":         {[]ValType{ValI32, ValI32, ValI32}, []ValType{ValI32}},
-	"wago_mailbox.try_recv_tagged":  {[]ValType{ValI32, ValI32, ValI32, ValI64}, []ValType{ValI32}},
-	"wago_mailbox.prepare_receive":  {[]ValType{ValI32, ValI64, ValI64}, []ValType{ValI32}},
-	"wago_mailbox.len":              {nil, []ValType{ValI32}},
-	"wago_message.receive":          {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
+	"wago_process.self":            {nil, []ValType{ValI64}},
+	"wago_mailbox.send":            {[]ValType{ValI64, ValI64, ValI32, ValI32}, []ValType{ValI32}},
+	"wago_mailbox.prepare_receive": {[]ValType{ValI32, ValI64, ValI64}, []ValType{ValI32}},
+	"wago_message.receive":         {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
 }
 
-func validateProcessImportSignatures(mod *Module) error {
+func validateReservedProcessImports(mod *Module) error {
 	if mod == nil || mod.c == nil {
 		return fmt.Errorf("wago: process module is nil")
 	}
@@ -235,44 +232,14 @@ func (rt *Runtime) processImports(proc *Process) Imports {
 			res[0] = uint64(proc.PID)
 		}),
 		"wago_mailbox.send": HostFunc(func(m HostModule, p, res []uint64) {
-			pid := PID(p[0])
-			ptr, n := uint32(p[1]), uint32(p[2])
-			mem := m.Memory()
-			if int64(ptr)+int64(n) > int64(len(mem)) {
-				res[0] = I32(statusBufTooSmall)
-				return
-			}
-			if err := rt.Send(context.Background(), pid, mem[ptr:ptr+n]); err != nil {
-				res[0] = I32(statusClosed)
-				return
-			}
-			res[0] = I32(statusOK)
-		}),
-		"wago_mailbox.send_tagged": HostFunc(func(m HostModule, p, res []uint64) {
 			pid, tag := PID(p[0]), p[1]
 			ptr, n := uint32(p[2]), uint32(p[3])
 			mem := m.Memory()
 			if int64(ptr)+int64(n) > int64(len(mem)) {
-				res[0] = I32(statusBufTooSmall)
+				res[0] = I32(statusInvalidMemory)
 				return
 			}
-			if err := rt.SendTagged(context.Background(), pid, tag, mem[ptr:ptr+n]); err != nil {
-				res[0] = I32(statusClosed)
-				return
-			}
-			res[0] = I32(statusOK)
-		}),
-		"wago_mailbox.recv": HostFunc(func(m HostModule, p, res []uint64) {
-			res[0] = I32(mb.receiveIntoTag(m.Memory(), 0, uint32(p[0]), uint32(p[1]), uint32(p[2]), AsI64(p[3])))
-		}),
-		"wago_mailbox.recv_tagged": HostFunc(func(m HostModule, p, res []uint64) {
-			res[0] = I32(mb.receiveIntoTag(m.Memory(), p[3], uint32(p[0]), uint32(p[1]), uint32(p[2]), AsI64(p[4])))
-		}),
-		"wago_mailbox.try_recv": HostFunc(func(m HostModule, p, res []uint64) {
-			res[0] = I32(mb.receiveIntoTag(m.Memory(), 0, uint32(p[0]), uint32(p[1]), uint32(p[2]), 0))
-		}),
-		"wago_mailbox.try_recv_tagged": HostFunc(func(m HostModule, p, res []uint64) {
-			res[0] = I32(mb.receiveIntoTag(m.Memory(), p[3], uint32(p[0]), uint32(p[1]), uint32(p[2]), 0))
+			res[0] = I32(statusFromSendErr(rt.SendTagged(context.Background(), pid, tag, mem[ptr:ptr+n])))
 		}),
 		"wago_mailbox.prepare_receive": HostFunc(func(m HostModule, p, res []uint64) {
 			res[0] = I32(mb.prepareReceive(m.Memory(), uint32(p[0]), p[1], AsI64(p[2])))
@@ -280,9 +247,21 @@ func (rt *Runtime) processImports(proc *Process) Imports {
 		"wago_message.receive": HostFunc(func(m HostModule, p, res []uint64) {
 			res[0] = I32(mb.receivePrepared(m.Memory(), uint32(p[0]), uint32(p[1])))
 		}),
-		"wago_mailbox.len": HostFunc(func(_ HostModule, _, res []uint64) {
-			res[0] = I32(int32(mb.length()))
-		}),
+	}
+}
+
+func statusFromSendErr(err error) int32 {
+	switch {
+	case err == nil:
+		return statusOK
+	case errors.Is(err, ErrNoProcess):
+		return statusNoProcess
+	case errors.Is(err, ErrMailboxFull):
+		return statusMailboxFull
+	case errors.Is(err, ErrMailboxClosed):
+		return statusMailboxClosed
+	default:
+		return statusInvalidMemory
 	}
 }
 
@@ -336,6 +315,9 @@ func (rt *Runtime) SendTagged(ctx context.Context, pid PID, tag uint64, msg []by
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+	}
+	if uint64(len(msg)) > uint64(^uint32(0)) {
+		return ErrMessageTooLarge
 	}
 	rt.procMu.Lock()
 	proc := rt.procs[pid]
@@ -429,6 +411,9 @@ type Mailbox struct {
 }
 
 func newMailbox(capN int) *Mailbox {
+	if capN <= 0 {
+		capN = DefaultMailboxCapacity
+	}
 	return &Mailbox{cap: capN, notify: make(chan struct{}, 1)}
 }
 
@@ -462,39 +447,10 @@ func (m *Mailbox) signal() {
 	}
 }
 
-func (m *Mailbox) length() int {
+func (m *Mailbox) queuedLen() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.q)
-}
-
-// copyTaggedInto copies the first queued message matching tag into guest memory
-// and pops it only after the destination has been validated. It leaves nonmatching
-// messages in FIFO order and reports closedNoMatch when no future matching message
-// can arrive. This powers the legacy one-shot recv imports.
-func (m *Mailbox) copyTaggedInto(mem []byte, tag uint64, bufPtr, bufCap, outLenPtr uint32) (status int32, matched, closedNoMatch bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	for idx, msg := range m.q {
-		if msg.Tag != tag {
-			continue
-		}
-		n := uint32(len(msg.Data))
-		if !writeU32(mem, outLenPtr, n) {
-			return statusBufTooSmall, true, false
-		}
-		if n > bufCap {
-			return statusBufTooSmall, true, false // leave the message queued for a larger buffer
-		}
-		if int64(bufPtr)+int64(n) > int64(len(mem)) {
-			return statusBufTooSmall, true, false
-		}
-		copy(mem[bufPtr:bufPtr+n], msg.Data)
-		m.removeAtLocked(idx)
-		return statusOK, true, false
-	}
-	return 0, false, m.closed
 }
 
 func (m *Mailbox) removeAtLocked(idx int) {
@@ -507,8 +463,8 @@ func (m *Mailbox) removeAtLocked(idx int) {
 // for a matching message, reserves it, and writes its byte length to lenPtr. The
 // guest must then acknowledge exactly that length by passing it to receivePrepared.
 func (m *Mailbox) prepareReceive(mem []byte, lenPtr uint32, tag uint64, timeoutMs int64) int32 {
-	if int64(lenPtr)+4 > int64(len(mem)) {
-		return statusBufTooSmall
+	if !writeU32(mem, lenPtr, 0) {
+		return statusInvalidMemory
 	}
 	var deadline <-chan time.Time
 	if timeoutMs > 0 {
@@ -517,7 +473,7 @@ func (m *Mailbox) prepareReceive(mem []byte, lenPtr uint32, tag uint64, timeoutM
 		deadline = t.C
 	}
 	for {
-		status, done := m.prepareQueued(mem, lenPtr, tag)
+		status, done := m.tryPrepareReceive(mem, lenPtr, tag)
 		if done {
 			return status
 		}
@@ -532,24 +488,26 @@ func (m *Mailbox) prepareReceive(mem []byte, lenPtr uint32, tag uint64, timeoutM
 	}
 }
 
-func (m *Mailbox) prepareQueued(mem []byte, lenPtr uint32, tag uint64) (status int32, done bool) {
+func (m *Mailbox) tryPrepareReceive(mem []byte, lenPtr uint32, tag uint64) (status int32, done bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.hasPending {
-		return statusPending, true
+		return statusPendingMessage, true
 	}
 	for idx, msg := range m.q {
 		if msg.Tag != tag {
 			continue
 		}
-		binary.LittleEndian.PutUint32(mem[lenPtr:], uint32(len(msg.Data)))
+		if !writeU32(mem, lenPtr, uint32(len(msg.Data))) {
+			return statusInvalidMemory, true
+		}
 		m.pending = msg
 		m.hasPending = true
 		m.removeAtLocked(idx)
 		return statusOK, true
 	}
 	if m.closed {
-		return statusClosed, true
+		return statusMailboxClosed, true
 	}
 	return 0, false
 }
@@ -562,55 +520,19 @@ func (m *Mailbox) receivePrepared(mem []byte, ptr, byteLen uint32) int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if !m.hasPending {
-		return statusNoMessage
+		return statusNoPreparedMessage
 	}
 	msg := m.pending
 	if byteLen != uint32(len(msg.Data)) {
 		return statusSizeMismatch
 	}
 	if int64(ptr)+int64(byteLen) > int64(len(mem)) {
-		return statusBufTooSmall
+		return statusInvalidMemory
 	}
 	copy(mem[ptr:ptr+byteLen], msg.Data)
 	m.pending = mailboxMessage{}
 	m.hasPending = false
 	return statusOK
-}
-
-// receiveInto blocks (per timeoutMs: <0 forever, 0 non-blocking, >0 bounded) for an
-// untagged message, then writes it into guest memory at bufPtr (up to bufCap bytes)
-// and the message length at outLenPtr. It returns a guest status code.
-func (m *Mailbox) receiveInto(mem []byte, bufPtr, bufCap, outLenPtr uint32, timeoutMs int64) int32 {
-	return m.receiveIntoTag(mem, 0, bufPtr, bufCap, outLenPtr, timeoutMs)
-}
-
-// receiveIntoTag blocks (per timeoutMs: <0 forever, 0 non-blocking, >0 bounded) for
-// a message with tag, then writes it into guest memory at bufPtr (up to bufCap
-// bytes) and the message length at outLenPtr. It returns a guest status code.
-func (m *Mailbox) receiveIntoTag(mem []byte, tag uint64, bufPtr, bufCap, outLenPtr uint32, timeoutMs int64) int32 {
-	var deadline <-chan time.Time
-	if timeoutMs > 0 {
-		t := time.NewTimer(time.Duration(timeoutMs) * time.Millisecond)
-		defer t.Stop()
-		deadline = t.C
-	}
-	for {
-		status, matched, closedNoMatch := m.copyTaggedInto(mem, tag, bufPtr, bufCap, outLenPtr)
-		if matched {
-			return status
-		}
-		if closedNoMatch {
-			return statusClosed
-		}
-		if timeoutMs == 0 {
-			return statusWouldBlock
-		}
-		select {
-		case <-m.notify:
-		case <-deadline:
-			return statusTimeout
-		}
-	}
 }
 
 // writeU32 writes v little-endian at off, returning false if out of range.

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -19,6 +19,9 @@ const (
 	statusWouldBlock  int32 = 5
 	statusTimeout     int32 = 6
 	statusClosed      int32 = 7
+	statusPending      int32 = 8
+	statusNoMessage    int32 = 9
+	statusSizeMismatch int32 = 10
 )
 
 // Process-layer sentinel errors (const so the root facade can re-export them;
@@ -222,6 +225,12 @@ func (rt *Runtime) processImports(proc *Process) Imports {
 		"wago_mailbox.try_recv_tagged": HostFunc(func(m HostModule, p, res []uint64) {
 			res[0] = I32(mb.receiveIntoTag(m.Memory(), p[3], uint32(p[0]), uint32(p[1]), uint32(p[2]), 0))
 		}),
+		"wago_mailbox.prepare_receive": HostFunc(func(m HostModule, p, res []uint64) {
+			res[0] = I32(mb.prepareReceive(m.Memory(), uint32(p[0]), p[1], AsI64(p[2])))
+		}),
+		"wago_message.receive": HostFunc(func(m HostModule, p, res []uint64) {
+			res[0] = I32(mb.receivePrepared(m.Memory(), uint32(p[0]), uint32(p[1])))
+		}),
 		"wago_mailbox.len": HostFunc(func(_ HostModule, _, res []uint64) {
 			res[0] = I32(int32(mb.length()))
 		}),
@@ -361,11 +370,13 @@ type mailboxMessage struct {
 
 // Mailbox is a bounded FIFO of tagged byte messages delivered to a process.
 type Mailbox struct {
-	mu     sync.Mutex
-	q      []mailboxMessage
-	cap    int
-	closed bool
-	notify chan struct{}
+	mu         sync.Mutex
+	q          []mailboxMessage
+	cap        int
+	closed     bool
+	notify     chan struct{}
+	pending    mailboxMessage
+	hasPending bool
 }
 
 func newMailbox(capN int) *Mailbox {
@@ -408,9 +419,10 @@ func (m *Mailbox) length() int {
 	return len(m.q)
 }
 
-// copyTaggedInto copies the first message matching tag into guest memory and pops it
-// only after the destination has been validated. It leaves nonmatching messages in
-// FIFO order and reports closedNoMatch when no future matching message can arrive.
+// copyTaggedInto copies the first queued message matching tag into guest memory
+// and pops it only after the destination has been validated. It leaves nonmatching
+// messages in FIFO order and reports closedNoMatch when no future matching message
+// can arrive. This powers the legacy one-shot recv imports.
 func (m *Mailbox) copyTaggedInto(mem []byte, tag uint64, bufPtr, bufCap, outLenPtr uint32) (status int32, matched, closedNoMatch bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -430,12 +442,90 @@ func (m *Mailbox) copyTaggedInto(mem []byte, tag uint64, bufPtr, bufCap, outLenP
 			return statusBufTooSmall, true, false
 		}
 		copy(mem[bufPtr:bufPtr+n], msg.Data)
-		copy(m.q[idx:], m.q[idx+1:])
-		m.q[len(m.q)-1] = mailboxMessage{}
-		m.q = m.q[:len(m.q)-1]
+		m.removeAtLocked(idx)
 		return statusOK, true, false
 	}
 	return 0, false, m.closed
+}
+
+func (m *Mailbox) removeAtLocked(idx int) {
+	copy(m.q[idx:], m.q[idx+1:])
+	m.q[len(m.q)-1] = mailboxMessage{}
+	m.q = m.q[:len(m.q)-1]
+}
+
+// prepareReceive blocks (per timeoutMs: <0 forever, 0 non-blocking, >0 bounded)
+// for a matching message, reserves it, and writes its byte length to lenPtr. The
+// guest must then acknowledge exactly that length by passing it to receivePrepared.
+func (m *Mailbox) prepareReceive(mem []byte, lenPtr uint32, tag uint64, timeoutMs int64) int32 {
+	if int64(lenPtr)+4 > int64(len(mem)) {
+		return statusBufTooSmall
+	}
+	var deadline <-chan time.Time
+	if timeoutMs > 0 {
+		t := time.NewTimer(time.Duration(timeoutMs) * time.Millisecond)
+		defer t.Stop()
+		deadline = t.C
+	}
+	for {
+		status, done := m.prepareQueued(mem, lenPtr, tag)
+		if done {
+			return status
+		}
+		if timeoutMs == 0 {
+			return statusWouldBlock
+		}
+		select {
+		case <-m.notify:
+		case <-deadline:
+			return statusTimeout
+		}
+	}
+}
+
+func (m *Mailbox) prepareQueued(mem []byte, lenPtr uint32, tag uint64) (status int32, done bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hasPending {
+		return statusPending, true
+	}
+	for idx, msg := range m.q {
+		if msg.Tag != tag {
+			continue
+		}
+		binary.LittleEndian.PutUint32(mem[lenPtr:], uint32(len(msg.Data)))
+		m.pending = msg
+		m.hasPending = true
+		m.removeAtLocked(idx)
+		return statusOK, true
+	}
+	if m.closed {
+		return statusClosed, true
+	}
+	return 0, false
+}
+
+// receivePrepared copies the message reserved by prepareReceive into guest memory
+// only if byteLen exactly matches the prepared message length. This explicit size
+// acknowledgement catches stale lengths and preserves the pending message for a
+// retry when the acknowledgement or destination buffer is wrong.
+func (m *Mailbox) receivePrepared(mem []byte, ptr, byteLen uint32) int32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.hasPending {
+		return statusNoMessage
+	}
+	msg := m.pending
+	if byteLen != uint32(len(msg.Data)) {
+		return statusSizeMismatch
+	}
+	if int64(ptr)+int64(byteLen) > int64(len(mem)) {
+		return statusBufTooSmall
+	}
+	copy(mem[ptr:ptr+byteLen], msg.Data)
+	m.pending = mailboxMessage{}
+	m.hasPending = false
+	return statusOK
 }
 
 // receiveInto blocks (per timeoutMs: <0 forever, 0 non-blocking, >0 bounded) for an

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -25,20 +25,29 @@ const (
 	statusPendingMessage    int32 = 7
 	statusNoPreparedMessage int32 = 8
 	statusSizeMismatch      int32 = 9
+	statusInvalidName       int32 = 10
+	statusNameTaken         int32 = 11
+	statusNameNotFound      int32 = 12
+	statusPermissionDenied  int32 = 13
 )
 
 // Process-layer sentinel errors (const so the root facade can re-export them;
 // match with errors.Is).
 const (
-	ErrNoProcess       = extErr("wago: no such process")
-	ErrMailboxFull     = extErr("wago: mailbox full")
-	ErrMailboxClosed   = extErr("wago: mailbox closed")
-	ErrMessageTooLarge = extErr("wago: message too large")
+	ErrNoProcess           = extErr("wago: no such process")
+	ErrMailboxFull         = extErr("wago: mailbox full")
+	ErrMailboxClosed       = extErr("wago: mailbox closed")
+	ErrMessageTooLarge     = extErr("wago: message too large")
+	ErrInvalidProcessName  = extErr("wago: invalid process name")
+	ErrProcessNameTaken    = extErr("wago: process name already registered")
+	ErrProcessNameNotFound = extErr("wago: process name not found")
 )
 
 // DefaultMailboxCapacity is the mailbox size used when SpawnOptions.MailboxCapacity
 // is zero.
 const DefaultMailboxCapacity = 1024
+
+const maxProcessNameBytes = 256
 
 // ExitReason describes why a process ended.
 type ExitReason struct {
@@ -71,7 +80,8 @@ type SpawnOptions struct {
 	Entry string
 	// Args are passed to Entry.
 	Args []Value
-	// Name is an optional human label.
+	// Name is an optional registered process name. If set, Spawn atomically binds it
+	// to the new PID before the process starts; the name is released on process exit.
 	Name string
 	// Policy is the capability/resource policy applied to the process instance.
 	Policy Policy
@@ -121,6 +131,11 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 	if capN <= 0 {
 		capN = DefaultMailboxCapacity
 	}
+	if opts.Name != "" {
+		if err := validateProcessName(opts.Name); err != nil {
+			return 0, err
+		}
+	}
 	if err := applyPolicy(class.mod, opts.Policy); err != nil {
 		return 0, err
 	}
@@ -133,16 +148,28 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 		rt.procMu.Unlock()
 		return 0, fmt.Errorf("wago: Spawn on a closed runtime")
 	}
+	if opts.Name != "" {
+		if _, taken := rt.procNames[opts.Name]; taken {
+			rt.procMu.Unlock()
+			return 0, ErrProcessNameTaken
+		}
+	}
 	pid := rt.nextPID
 	rt.nextPID++
 	proc := &Process{PID: pid, Name: opts.Name, Class: class, mailbox: newMailbox(capN), links: map[PID]struct{}{}}
 	rt.procs[pid] = proc
+	if opts.Name != "" {
+		rt.procNames[opts.Name] = pid
+	}
 	rt.procMu.Unlock()
 
 	inst, err := rt.instantiateProcess(class, proc)
 	if err != nil {
 		rt.procMu.Lock()
 		delete(rt.procs, pid)
+		if opts.Name != "" && rt.procNames[opts.Name] == pid {
+			delete(rt.procNames, opts.Name)
+		}
 		rt.procMu.Unlock()
 		return 0, err
 	}
@@ -166,7 +193,7 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 // is trusted infrastructure providing those reserved modules itself.
 func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, error) {
 	rt.mu.Lock()
-	merged := make(Imports, len(rt.imports)+len(class.imports)+4)
+	merged := make(Imports, len(rt.imports)+len(class.imports)+7)
 	for k, v := range rt.imports {
 		merged[k] = v
 	}
@@ -187,6 +214,9 @@ func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, e
 
 var processImportSigs = map[string]FuncSig{
 	"wago_process.self":            {nil, []ValType{ValI64}},
+	"wago_process.register":        {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
+	"wago_process.get":             {[]ValType{ValI32, ValI32, ValI32}, []ValType{ValI32}},
+	"wago_process.unregister":      {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
 	"wago_mailbox.send":            {[]ValType{ValI64, ValI64, ValI32, ValI32}, []ValType{ValI32}},
 	"wago_mailbox.prepare_receive": {[]ValType{ValI32, ValI64, ValI64}, []ValType{ValI32}},
 	"wago_message.receive":         {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
@@ -231,6 +261,40 @@ func (rt *Runtime) processImports(proc *Process) Imports {
 		"wago_process.self": HostFunc(func(_ HostModule, _, res []uint64) {
 			res[0] = uint64(proc.PID)
 		}),
+		"wago_process.register": HostFunc(func(m HostModule, p, res []uint64) {
+			name, status := guestProcessName(m.Memory(), uint32(p[0]), uint32(p[1]))
+			if status != statusOK {
+				res[0] = I32(status)
+				return
+			}
+			res[0] = I32(statusFromRegistryErr(rt.RegisterProcessName(context.Background(), name, proc.PID)))
+		}),
+		"wago_process.get": HostFunc(func(m HostModule, p, res []uint64) {
+			mem := m.Memory()
+			name, status := guestProcessName(mem, uint32(p[0]), uint32(p[1]))
+			if status != statusOK {
+				res[0] = I32(status)
+				return
+			}
+			pid, err := rt.LookupProcessName(context.Background(), name)
+			if err != nil {
+				res[0] = I32(statusFromRegistryErr(err))
+				return
+			}
+			if !writeU64(mem, uint32(p[2]), uint64(pid)) {
+				res[0] = I32(statusInvalidMemory)
+				return
+			}
+			res[0] = I32(statusOK)
+		}),
+		"wago_process.unregister": HostFunc(func(m HostModule, p, res []uint64) {
+			name, status := guestProcessName(m.Memory(), uint32(p[0]), uint32(p[1]))
+			if status != statusOK {
+				res[0] = I32(status)
+				return
+			}
+			res[0] = I32(statusFromRegistryErr(rt.unregisterProcessNameFor(name, proc.PID)))
+		}),
 		"wago_mailbox.send": HostFunc(func(m HostModule, p, res []uint64) {
 			pid, tag := PID(p[0]), p[1]
 			ptr, n := uint32(p[2]), uint32(p[3])
@@ -265,6 +329,154 @@ func statusFromSendErr(err error) int32 {
 	}
 }
 
+func statusFromRegistryErr(err error) int32 {
+	switch {
+	case err == nil:
+		return statusOK
+	case errors.Is(err, ErrNoProcess):
+		return statusNoProcess
+	case errors.Is(err, ErrInvalidProcessName):
+		return statusInvalidName
+	case errors.Is(err, ErrProcessNameTaken):
+		return statusNameTaken
+	case errors.Is(err, ErrProcessNameNotFound):
+		return statusNameNotFound
+	case errors.Is(err, ErrPermissionDenied):
+		return statusPermissionDenied
+	default:
+		return statusInvalidMemory
+	}
+}
+
+func guestProcessName(mem []byte, ptr, n uint32) (string, int32) {
+	if n == 0 || n > maxProcessNameBytes {
+		return "", statusInvalidName
+	}
+	if int64(ptr)+int64(n) > int64(len(mem)) {
+		return "", statusInvalidMemory
+	}
+	name := string(mem[ptr : ptr+n])
+	if err := validateProcessName(name); err != nil {
+		return "", statusFromRegistryErr(err)
+	}
+	return name, statusOK
+}
+
+func validateProcessName(name string) error {
+	if name == "" || len(name) > maxProcessNameBytes {
+		return ErrInvalidProcessName
+	}
+	return nil
+}
+
+// RegisterProcessName binds name to pid in the runtime process registry. Repeating
+// the same name/pid registration is idempotent; binding a live name to a different
+// pid fails with ErrProcessNameTaken.
+func (rt *Runtime) RegisterProcessName(ctx context.Context, name string, pid PID) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if err := validateProcessName(name); err != nil {
+		return err
+	}
+	rt.procMu.Lock()
+	defer rt.procMu.Unlock()
+	proc := rt.procs[pid]
+	if proc == nil {
+		return ErrNoProcess
+	}
+	proc.mu.Lock()
+	exited := proc.exited
+	proc.mu.Unlock()
+	if exited {
+		return ErrNoProcess
+	}
+	if existing, ok := rt.procNames[name]; ok && existing != pid {
+		return ErrProcessNameTaken
+	}
+	rt.procNames[name] = pid
+	return nil
+}
+
+// LookupProcessName resolves name to a live process id.
+func (rt *Runtime) LookupProcessName(ctx context.Context, name string) (PID, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+	}
+	if err := validateProcessName(name); err != nil {
+		return 0, err
+	}
+	rt.procMu.Lock()
+	defer rt.procMu.Unlock()
+	pid, ok := rt.procNames[name]
+	if !ok {
+		return 0, ErrProcessNameNotFound
+	}
+	proc := rt.procs[pid]
+	if proc == nil {
+		delete(rt.procNames, name)
+		return 0, ErrProcessNameNotFound
+	}
+	proc.mu.Lock()
+	exited := proc.exited
+	proc.mu.Unlock()
+	if exited {
+		delete(rt.procNames, name)
+		return 0, ErrProcessNameNotFound
+	}
+	return pid, nil
+}
+
+// UnregisterProcessName removes name from the runtime process registry.
+func (rt *Runtime) UnregisterProcessName(ctx context.Context, name string) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if err := validateProcessName(name); err != nil {
+		return err
+	}
+	rt.procMu.Lock()
+	defer rt.procMu.Unlock()
+	if _, ok := rt.procNames[name]; !ok {
+		return ErrProcessNameNotFound
+	}
+	delete(rt.procNames, name)
+	return nil
+}
+
+func (rt *Runtime) unregisterProcessNameFor(name string, pid PID) error {
+	if err := validateProcessName(name); err != nil {
+		return err
+	}
+	rt.procMu.Lock()
+	defer rt.procMu.Unlock()
+	existing, ok := rt.procNames[name]
+	if !ok {
+		return ErrProcessNameNotFound
+	}
+	if existing != pid {
+		return ErrPermissionDenied
+	}
+	delete(rt.procNames, name)
+	return nil
+}
+
+func (rt *Runtime) unregisterNamesForPID(pid PID) {
+	rt.procMu.Lock()
+	defer rt.procMu.Unlock()
+	for name, mapped := range rt.procNames {
+		if mapped == pid {
+			delete(rt.procNames, name)
+		}
+	}
+}
+
 // finishProcess records a process's exit, closes its instance, notifies monitors,
 // and propagates abnormal exits to linked processes.
 func (rt *Runtime) finishProcess(proc *Process, res []Value, err error) {
@@ -280,6 +492,8 @@ func (rt *Runtime) finishProcess(proc *Process, res []Value, err error) {
 		links = append(links, lp)
 	}
 	proc.mu.Unlock()
+
+	rt.unregisterNamesForPID(proc.PID)
 
 	// Close the mailbox so later sends fail, and retain the exited Process record
 	// (marked exited) so a Monitor that races the exit still finds the real
@@ -541,5 +755,14 @@ func writeU32(mem []byte, off, v uint32) bool {
 		return false
 	}
 	binary.LittleEndian.PutUint32(mem[off:], v)
+	return true
+}
+
+// writeU64 writes v little-endian at off, returning false if out of range.
+func writeU64(mem []byte, off uint32, v uint64) bool {
+	if int64(off)+8 > int64(len(mem)) {
+		return false
+	}
+	binary.LittleEndian.PutUint64(mem[off:], v)
 	return true
 }

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -110,6 +110,11 @@ type Process struct {
 	links    map[PID]struct{}
 }
 
+type processNameEntry struct {
+	PID   PID
+	Owner PID
+}
+
 // Spawn starts a new process from a class: it instantiates a dedicated instance
 // with per-process wago_process/wago_mailbox imports bound to the process, then
 // runs the entry function on its own goroutine. It returns the new PID.
@@ -159,7 +164,7 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 	proc := &Process{PID: pid, Name: opts.Name, Class: class, mailbox: newMailbox(capN), links: map[PID]struct{}{}}
 	rt.procs[pid] = proc
 	if opts.Name != "" {
-		rt.procNames[opts.Name] = pid
+		rt.procNames[opts.Name] = processNameEntry{PID: pid, Owner: pid}
 	}
 	rt.procMu.Unlock()
 
@@ -167,7 +172,7 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 	if err != nil {
 		rt.procMu.Lock()
 		delete(rt.procs, pid)
-		if opts.Name != "" && rt.procNames[opts.Name] == pid {
+		if opts.Name != "" && rt.procNames[opts.Name].PID == pid {
 			delete(rt.procNames, opts.Name)
 		}
 		rt.procMu.Unlock()
@@ -214,7 +219,7 @@ func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, e
 
 var processImportSigs = map[string]FuncSig{
 	"wago_process.self":            {nil, []ValType{ValI64}},
-	"wago_process.register":        {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
+	"wago_process.register":        {[]ValType{ValI64, ValI32, ValI32}, []ValType{ValI32}},
 	"wago_process.get":             {[]ValType{ValI32, ValI32, ValI32}, []ValType{ValI32}},
 	"wago_process.unregister":      {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
 	"wago_mailbox.send":            {[]ValType{ValI64, ValI64, ValI32, ValI32}, []ValType{ValI32}},
@@ -262,12 +267,13 @@ func (rt *Runtime) processImports(proc *Process) Imports {
 			res[0] = uint64(proc.PID)
 		}),
 		"wago_process.register": HostFunc(func(m HostModule, p, res []uint64) {
-			name, status := guestProcessName(m.Memory(), uint32(p[0]), uint32(p[1]))
+			targetPID := PID(p[0])
+			name, status := guestProcessName(m.Memory(), uint32(p[1]), uint32(p[2]))
 			if status != statusOK {
 				res[0] = I32(status)
 				return
 			}
-			res[0] = I32(statusFromRegistryErr(rt.RegisterProcessName(context.Background(), name, proc.PID)))
+			res[0] = I32(statusFromRegistryErr(rt.registerProcessNameFor(name, targetPID, proc.PID)))
 		}),
 		"wago_process.get": HostFunc(func(m HostModule, p, res []uint64) {
 			mem := m.Memory()
@@ -378,6 +384,10 @@ func (rt *Runtime) RegisterProcessName(ctx context.Context, name string, pid PID
 			return err
 		}
 	}
+	return rt.registerProcessNameFor(name, pid, 0)
+}
+
+func (rt *Runtime) registerProcessNameFor(name string, pid, owner PID) error {
 	if err := validateProcessName(name); err != nil {
 		return err
 	}
@@ -393,10 +403,12 @@ func (rt *Runtime) RegisterProcessName(ctx context.Context, name string, pid PID
 	if exited {
 		return ErrNoProcess
 	}
-	if existing, ok := rt.procNames[name]; ok && existing != pid {
+	if existing, ok := rt.procNames[name]; ok && existing.PID != pid {
 		return ErrProcessNameTaken
 	}
-	rt.procNames[name] = pid
+	if _, ok := rt.procNames[name]; !ok {
+		rt.procNames[name] = processNameEntry{PID: pid, Owner: owner}
+	}
 	return nil
 }
 
@@ -412,11 +424,11 @@ func (rt *Runtime) LookupProcessName(ctx context.Context, name string) (PID, err
 	}
 	rt.procMu.Lock()
 	defer rt.procMu.Unlock()
-	pid, ok := rt.procNames[name]
+	entry, ok := rt.procNames[name]
 	if !ok {
 		return 0, ErrProcessNameNotFound
 	}
-	proc := rt.procs[pid]
+	proc := rt.procs[entry.PID]
 	if proc == nil {
 		delete(rt.procNames, name)
 		return 0, ErrProcessNameNotFound
@@ -428,7 +440,7 @@ func (rt *Runtime) LookupProcessName(ctx context.Context, name string) (PID, err
 		delete(rt.procNames, name)
 		return 0, ErrProcessNameNotFound
 	}
-	return pid, nil
+	return entry.PID, nil
 }
 
 // UnregisterProcessName removes name from the runtime process registry.
@@ -450,17 +462,17 @@ func (rt *Runtime) UnregisterProcessName(ctx context.Context, name string) error
 	return nil
 }
 
-func (rt *Runtime) unregisterProcessNameFor(name string, pid PID) error {
+func (rt *Runtime) unregisterProcessNameFor(name string, caller PID) error {
 	if err := validateProcessName(name); err != nil {
 		return err
 	}
 	rt.procMu.Lock()
 	defer rt.procMu.Unlock()
-	existing, ok := rt.procNames[name]
+	entry, ok := rt.procNames[name]
 	if !ok {
 		return ErrProcessNameNotFound
 	}
-	if existing != pid {
+	if entry.PID != caller && entry.Owner != caller {
 		return ErrPermissionDenied
 	}
 	delete(rt.procNames, name)
@@ -470,8 +482,8 @@ func (rt *Runtime) unregisterProcessNameFor(name string, pid PID) error {
 func (rt *Runtime) unregisterNamesForPID(pid PID) {
 	rt.procMu.Lock()
 	defer rt.procMu.Unlock()
-	for name, mapped := range rt.procNames {
-		if mapped == pid {
+	for name, entry := range rt.procNames {
+		if entry.PID == pid {
 			delete(rt.procNames, name)
 		}
 	}

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -158,6 +158,10 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 // the reserved-override and missing-import guards of rt.Instantiate because Spawn
 // is trusted infrastructure providing those reserved modules itself.
 func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, error) {
+	if err := validateProcessImportSignatures(class.mod); err != nil {
+		return nil, err
+	}
+
 	rt.mu.Lock()
 	merged := make(Imports, len(rt.imports)+len(class.imports)+8)
 	for k, v := range rt.imports {
@@ -176,6 +180,51 @@ func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, e
 	}
 	inst.rt = rt // enable Instance.Call invoke hooks for the process body
 	return inst, nil
+}
+
+var processImportSigs = map[string]FuncSig{
+	"wago_process.self":             {nil, []ValType{ValI64}},
+	"wago_mailbox.send":             {[]ValType{ValI64, ValI32, ValI32}, []ValType{ValI32}},
+	"wago_mailbox.send_tagged":      {[]ValType{ValI64, ValI64, ValI32, ValI32}, []ValType{ValI32}},
+	"wago_mailbox.recv":             {[]ValType{ValI32, ValI32, ValI32, ValI64}, []ValType{ValI32}},
+	"wago_mailbox.recv_tagged":      {[]ValType{ValI32, ValI32, ValI32, ValI64, ValI64}, []ValType{ValI32}},
+	"wago_mailbox.try_recv":         {[]ValType{ValI32, ValI32, ValI32}, []ValType{ValI32}},
+	"wago_mailbox.try_recv_tagged":  {[]ValType{ValI32, ValI32, ValI32, ValI64}, []ValType{ValI32}},
+	"wago_mailbox.prepare_receive":  {[]ValType{ValI32, ValI64, ValI64}, []ValType{ValI32}},
+	"wago_mailbox.len":              {nil, []ValType{ValI32}},
+	"wago_message.receive":          {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
+}
+
+func validateProcessImportSignatures(mod *Module) error {
+	if mod == nil || mod.c == nil {
+		return fmt.Errorf("wago: process module is nil")
+	}
+	for idx, key := range mod.c.Imports {
+		want, ok := processImportSigs[key]
+		if !ok {
+			continue
+		}
+		if idx >= len(mod.c.importFuncSigs) {
+			return fmt.Errorf("process import %q missing signature metadata", key)
+		}
+		got := mod.c.importFuncSigs[idx]
+		if !sameValTypes(got.Params, want.Params) || !sameValTypes(got.Results, want.Results) {
+			return fmt.Errorf("process import %q signature mismatch: got params=%v results=%v, want params=%v results=%v", key, got.Params, got.Results, want.Params, want.Results)
+		}
+	}
+	return nil
+}
+
+func sameValTypes(a, b []ValType) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // processImports builds the per-process wago_process/wago_mailbox host bindings.

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -196,11 +196,31 @@ func (rt *Runtime) processImports(proc *Process) Imports {
 			}
 			res[0] = I32(statusOK)
 		}),
+		"wago_mailbox.send_tagged": HostFunc(func(m HostModule, p, res []uint64) {
+			pid, tag := PID(p[0]), p[1]
+			ptr, n := uint32(p[2]), uint32(p[3])
+			mem := m.Memory()
+			if int64(ptr)+int64(n) > int64(len(mem)) {
+				res[0] = I32(statusBufTooSmall)
+				return
+			}
+			if err := rt.SendTagged(context.Background(), pid, tag, mem[ptr:ptr+n]); err != nil {
+				res[0] = I32(statusClosed)
+				return
+			}
+			res[0] = I32(statusOK)
+		}),
 		"wago_mailbox.recv": HostFunc(func(m HostModule, p, res []uint64) {
-			res[0] = I32(mb.receiveInto(m.Memory(), uint32(p[0]), uint32(p[1]), uint32(p[2]), AsI64(p[3])))
+			res[0] = I32(mb.receiveIntoTag(m.Memory(), 0, uint32(p[0]), uint32(p[1]), uint32(p[2]), AsI64(p[3])))
+		}),
+		"wago_mailbox.recv_tagged": HostFunc(func(m HostModule, p, res []uint64) {
+			res[0] = I32(mb.receiveIntoTag(m.Memory(), p[3], uint32(p[0]), uint32(p[1]), uint32(p[2]), AsI64(p[4])))
 		}),
 		"wago_mailbox.try_recv": HostFunc(func(m HostModule, p, res []uint64) {
-			res[0] = I32(mb.receiveInto(m.Memory(), uint32(p[0]), uint32(p[1]), uint32(p[2]), 0))
+			res[0] = I32(mb.receiveIntoTag(m.Memory(), 0, uint32(p[0]), uint32(p[1]), uint32(p[2]), 0))
+		}),
+		"wago_mailbox.try_recv_tagged": HostFunc(func(m HostModule, p, res []uint64) {
+			res[0] = I32(mb.receiveIntoTag(m.Memory(), p[3], uint32(p[0]), uint32(p[1]), uint32(p[2]), 0))
 		}),
 		"wago_mailbox.len": HostFunc(func(_ HostModule, _, res []uint64) {
 			res[0] = I32(int32(mb.length()))
@@ -246,8 +266,14 @@ func (rt *Runtime) finishProcess(proc *Process, res []Value, err error) {
 	}
 }
 
-// Send delivers a message to a process's mailbox. The bytes are copied.
+// Send delivers an untagged message to a process's mailbox. The bytes are copied.
 func (rt *Runtime) Send(ctx context.Context, pid PID, msg []byte) error {
+	return rt.SendTagged(ctx, pid, 0, msg)
+}
+
+// SendTagged delivers a tagged message to a process's mailbox. The bytes are
+// copied. A tag of zero is the untagged mailbox lane.
+func (rt *Runtime) SendTagged(ctx context.Context, pid PID, tag uint64, msg []byte) error {
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -259,7 +285,7 @@ func (rt *Runtime) Send(ctx context.Context, pid PID, msg []byte) error {
 	if proc == nil {
 		return ErrNoProcess
 	}
-	return proc.mailbox.send(msg)
+	return proc.mailbox.send(tag, msg)
 }
 
 // Kill requests termination of a process. It is cooperative: the mailbox is
@@ -327,10 +353,16 @@ func (rt *Runtime) Link(ctx context.Context, a, b PID) error {
 	return nil
 }
 
-// Mailbox is a bounded FIFO of byte messages delivered to a process.
+// mailboxMessage is one process mailbox item. Tag zero is the untagged lane.
+type mailboxMessage struct {
+	Tag  uint64
+	Data []byte
+}
+
+// Mailbox is a bounded FIFO of tagged byte messages delivered to a process.
 type Mailbox struct {
 	mu     sync.Mutex
-	q      [][]byte
+	q      []mailboxMessage
 	cap    int
 	closed bool
 	notify chan struct{}
@@ -340,7 +372,7 @@ func newMailbox(capN int) *Mailbox {
 	return &Mailbox{cap: capN, notify: make(chan struct{}, 1)}
 }
 
-func (m *Mailbox) send(msg []byte) error {
+func (m *Mailbox) send(tag uint64, msg []byte) error {
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
@@ -350,7 +382,7 @@ func (m *Mailbox) send(msg []byte) error {
 		m.mu.Unlock()
 		return ErrMailboxFull
 	}
-	m.q = append(m.q, append([]byte(nil), msg...))
+	m.q = append(m.q, mailboxMessage{Tag: tag, Data: append([]byte(nil), msg...)})
 	m.mu.Unlock()
 	m.signal()
 	return nil
@@ -376,29 +408,47 @@ func (m *Mailbox) length() int {
 	return len(m.q)
 }
 
-// front returns the head message without removing it, plus whether the mailbox is
-// closed and empty.
-func (m *Mailbox) front() (msg []byte, ok, closedEmpty bool) {
+// copyTaggedInto copies the first message matching tag into guest memory and pops it
+// only after the destination has been validated. It leaves nonmatching messages in
+// FIFO order and reports closedNoMatch when no future matching message can arrive.
+func (m *Mailbox) copyTaggedInto(mem []byte, tag uint64, bufPtr, bufCap, outLenPtr uint32) (status int32, matched, closedNoMatch bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m.q) > 0 {
-		return m.q[0], true, false
+
+	for idx, msg := range m.q {
+		if msg.Tag != tag {
+			continue
+		}
+		n := uint32(len(msg.Data))
+		if !writeU32(mem, outLenPtr, n) {
+			return statusBufTooSmall, true, false
+		}
+		if n > bufCap {
+			return statusBufTooSmall, true, false // leave the message queued for a larger buffer
+		}
+		if int64(bufPtr)+int64(n) > int64(len(mem)) {
+			return statusBufTooSmall, true, false
+		}
+		copy(mem[bufPtr:bufPtr+n], msg.Data)
+		copy(m.q[idx:], m.q[idx+1:])
+		m.q[len(m.q)-1] = mailboxMessage{}
+		m.q = m.q[:len(m.q)-1]
+		return statusOK, true, false
 	}
-	return nil, false, m.closed
+	return 0, false, m.closed
 }
 
-func (m *Mailbox) pop() {
-	m.mu.Lock()
-	if len(m.q) > 0 {
-		m.q = m.q[1:]
-	}
-	m.mu.Unlock()
-}
-
-// receiveInto blocks (per timeoutMs: <0 forever, 0 non-blocking, >0 bounded) for a
-// message, then writes it into guest memory at bufPtr (up to bufCap bytes) and the
-// message length at outLenPtr. It returns a guest status code.
+// receiveInto blocks (per timeoutMs: <0 forever, 0 non-blocking, >0 bounded) for an
+// untagged message, then writes it into guest memory at bufPtr (up to bufCap bytes)
+// and the message length at outLenPtr. It returns a guest status code.
 func (m *Mailbox) receiveInto(mem []byte, bufPtr, bufCap, outLenPtr uint32, timeoutMs int64) int32 {
+	return m.receiveIntoTag(mem, 0, bufPtr, bufCap, outLenPtr, timeoutMs)
+}
+
+// receiveIntoTag blocks (per timeoutMs: <0 forever, 0 non-blocking, >0 bounded) for
+// a message with tag, then writes it into guest memory at bufPtr (up to bufCap
+// bytes) and the message length at outLenPtr. It returns a guest status code.
+func (m *Mailbox) receiveIntoTag(mem []byte, tag uint64, bufPtr, bufCap, outLenPtr uint32, timeoutMs int64) int32 {
 	var deadline <-chan time.Time
 	if timeoutMs > 0 {
 		t := time.NewTimer(time.Duration(timeoutMs) * time.Millisecond)
@@ -406,23 +456,11 @@ func (m *Mailbox) receiveInto(mem []byte, bufPtr, bufCap, outLenPtr uint32, time
 		deadline = t.C
 	}
 	for {
-		msg, ok, closedEmpty := m.front()
-		if ok {
-			n := uint32(len(msg))
-			if !writeU32(mem, outLenPtr, n) {
-				return statusBufTooSmall
-			}
-			if n > bufCap {
-				return statusBufTooSmall // leave the message queued for a larger buffer
-			}
-			if int64(bufPtr)+int64(n) > int64(len(mem)) {
-				return statusBufTooSmall
-			}
-			copy(mem[bufPtr:bufPtr+n], msg)
-			m.pop()
-			return statusOK
+		status, matched, closedNoMatch := m.copyTaggedInto(mem, tag, bufPtr, bufCap, outLenPtr)
+		if matched {
+			return status
 		}
-		if closedEmpty {
+		if closedNoMatch {
 			return statusClosed
 		}
 		if timeoutMs == 0 {

--- a/src/wago/process.go
+++ b/src/wago/process.go
@@ -12,8 +12,8 @@ import (
 // PID identifies a spawned process within a Runtime.
 type PID uint64
 
-// Guest-visible process/mailbox status codes returned by the injected
-// wago_process, wago_mailbox, and wago_message imports.
+// Guest-visible process/mailbox/monitor status codes returned by the injected
+// wago_process, wago_mailbox, wago_message, and wago_monitor imports.
 const (
 	statusOK                int32 = 0
 	statusInvalidMemory     int32 = 1
@@ -29,6 +29,12 @@ const (
 	statusNameTaken         int32 = 11
 	statusNameNotFound      int32 = 12
 	statusPermissionDenied  int32 = 13
+)
+
+const (
+	monitorReasonNormal int32 = 0
+	monitorReasonKilled int32 = 1
+	monitorReasonError  int32 = 2
 )
 
 // Process-layer sentinel errors (const so the root facade can re-export them;
@@ -68,7 +74,7 @@ func (r ExitReason) String() string {
 	}
 }
 
-// ExitEvent is delivered to monitors when a process exits.
+// ExitEvent is delivered to host-side monitors when a process exits.
 type ExitEvent struct {
 	PID    PID
 	Reason ExitReason
@@ -106,13 +112,25 @@ type Process struct {
 	exited   bool
 	killed   bool
 	reason   ExitReason
-	monitors []chan ExitEvent
+	monitors []chan ExitEvent // host-side monitors
 	links    map[PID]struct{}
+
+	monitorPIDs       []PID // guest-side process monitors watching this process
+	monitorEvents     []monitorEvent
+	pendingMonitor    monitorEvent
+	hasPendingMonitor bool
+	monitorNotify     chan struct{}
 }
 
 type processNameEntry struct {
 	PID   PID
 	Owner PID
+}
+
+type monitorEvent struct {
+	PID    PID
+	Reason int32
+	Data   []byte
 }
 
 // Spawn starts a new process from a class: it instantiates a dedicated instance
@@ -161,7 +179,7 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 	}
 	pid := rt.nextPID
 	rt.nextPID++
-	proc := &Process{PID: pid, Name: opts.Name, Class: class, mailbox: newMailbox(capN), links: map[PID]struct{}{}}
+	proc := &Process{PID: pid, Name: opts.Name, Class: class, mailbox: newMailbox(capN), links: map[PID]struct{}{}, monitorNotify: make(chan struct{}, 1)}
 	rt.procs[pid] = proc
 	if opts.Name != "" {
 		rt.procNames[opts.Name] = processNameEntry{PID: pid, Owner: pid}
@@ -198,7 +216,7 @@ func (rt *Runtime) Spawn(ctx context.Context, class *Class, opts SpawnOptions) (
 // is trusted infrastructure providing those reserved modules itself.
 func (rt *Runtime) instantiateProcess(class *Class, proc *Process) (*Instance, error) {
 	rt.mu.Lock()
-	merged := make(Imports, len(rt.imports)+len(class.imports)+7)
+	merged := make(Imports, len(rt.imports)+len(class.imports)+10)
 	for k, v := range rt.imports {
 		merged[k] = v
 	}
@@ -222,9 +240,12 @@ var processImportSigs = map[string]FuncSig{
 	"wago_process.register":        {[]ValType{ValI64, ValI32, ValI32}, []ValType{ValI32}},
 	"wago_process.get":             {[]ValType{ValI32, ValI32, ValI32}, []ValType{ValI32}},
 	"wago_process.unregister":      {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
+	"wago_process.monitor":         {[]ValType{ValI64}, []ValType{ValI32}},
 	"wago_mailbox.send":            {[]ValType{ValI64, ValI64, ValI32, ValI32}, []ValType{ValI32}},
 	"wago_mailbox.prepare_receive": {[]ValType{ValI32, ValI64, ValI64}, []ValType{ValI32}},
 	"wago_message.receive":         {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
+	"wago_monitor.prepare":         {[]ValType{ValI32, ValI32, ValI32, ValI64}, []ValType{ValI32}},
+	"wago_monitor.receive":         {[]ValType{ValI32, ValI32}, []ValType{ValI32}},
 }
 
 func validateReservedProcessImports(mod *Module) error {
@@ -301,6 +322,9 @@ func (rt *Runtime) processImports(proc *Process) Imports {
 			}
 			res[0] = I32(statusFromRegistryErr(rt.unregisterProcessNameFor(name, proc.PID)))
 		}),
+		"wago_process.monitor": HostFunc(func(_ HostModule, p, res []uint64) {
+			res[0] = I32(statusFromMonitorErr(rt.MonitorProcess(context.Background(), proc.PID, PID(p[0]))))
+		}),
 		"wago_mailbox.send": HostFunc(func(m HostModule, p, res []uint64) {
 			pid, tag := PID(p[0]), p[1]
 			ptr, n := uint32(p[2]), uint32(p[3])
@@ -316,6 +340,12 @@ func (rt *Runtime) processImports(proc *Process) Imports {
 		}),
 		"wago_message.receive": HostFunc(func(m HostModule, p, res []uint64) {
 			res[0] = I32(mb.receivePrepared(m.Memory(), uint32(p[0]), uint32(p[1])))
+		}),
+		"wago_monitor.prepare": HostFunc(func(m HostModule, p, res []uint64) {
+			res[0] = I32(proc.prepareMonitor(m.Memory(), uint32(p[0]), uint32(p[1]), uint32(p[2]), AsI64(p[3])))
+		}),
+		"wago_monitor.receive": HostFunc(func(m HostModule, p, res []uint64) {
+			res[0] = I32(proc.receiveMonitor(m.Memory(), uint32(p[0]), uint32(p[1])))
 		}),
 	}
 }
@@ -349,6 +379,17 @@ func statusFromRegistryErr(err error) int32 {
 		return statusNameNotFound
 	case errors.Is(err, ErrPermissionDenied):
 		return statusPermissionDenied
+	default:
+		return statusInvalidMemory
+	}
+}
+
+func statusFromMonitorErr(err error) int32 {
+	switch {
+	case err == nil:
+		return statusOK
+	case errors.Is(err, ErrNoProcess):
+		return statusNoProcess
 	default:
 		return statusInvalidMemory
 	}
@@ -489,6 +530,51 @@ func (rt *Runtime) unregisterNamesForPID(pid PID) {
 	}
 }
 
+// MonitorProcess subscribes watcherPID to an exit event for targetPID. If the
+// target already exited, the event is queued immediately for the watcher.
+func (rt *Runtime) MonitorProcess(ctx context.Context, watcherPID, targetPID PID) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	rt.procMu.Lock()
+	watcher := rt.procs[watcherPID]
+	target := rt.procs[targetPID]
+	rt.procMu.Unlock()
+	if watcher == nil || target == nil {
+		return ErrNoProcess
+	}
+
+	target.mu.Lock()
+	if target.exited {
+		ev := monitorEventFromExit(target.PID, target.reason)
+		target.mu.Unlock()
+		watcher.enqueueMonitorEvent(ev)
+		return nil
+	}
+	for _, pid := range target.monitorPIDs {
+		if pid == watcherPID {
+			target.mu.Unlock()
+			return nil
+		}
+	}
+	target.monitorPIDs = append(target.monitorPIDs, watcherPID)
+	target.mu.Unlock()
+	return nil
+}
+
+func monitorEventFromExit(pid PID, reason ExitReason) monitorEvent {
+	switch {
+	case reason.Killed:
+		return monitorEvent{PID: pid, Reason: monitorReasonKilled}
+	case reason.Err != nil:
+		return monitorEvent{PID: pid, Reason: monitorReasonError, Data: []byte(reason.Err.Error())}
+	default:
+		return monitorEvent{PID: pid, Reason: monitorReasonNormal}
+	}
+}
+
 // finishProcess records a process's exit, closes its instance, notifies monitors,
 // and propagates abnormal exits to linked processes.
 func (rt *Runtime) finishProcess(proc *Process, res []Value, err error) {
@@ -499,6 +585,8 @@ func (rt *Runtime) finishProcess(proc *Process, res []Value, err error) {
 	proc.reason = reason
 	monitors := proc.monitors
 	proc.monitors = nil
+	monitorPIDs := append([]PID(nil), proc.monitorPIDs...)
+	proc.monitorPIDs = nil
 	links := make([]PID, 0, len(proc.links))
 	for lp := range proc.links {
 		links = append(links, lp)
@@ -520,6 +608,15 @@ func (rt *Runtime) finishProcess(proc *Process, res []Value, err error) {
 		select {
 		case ch <- ev:
 		default:
+		}
+	}
+	monitorEv := monitorEventFromExit(proc.PID, reason)
+	for _, watcherPID := range monitorPIDs {
+		rt.procMu.Lock()
+		watcher := rt.procs[watcherPID]
+		rt.procMu.Unlock()
+		if watcher != nil {
+			watcher.enqueueMonitorEvent(monitorEv)
 		}
 	}
 	if !reason.Normal {
@@ -617,6 +714,89 @@ func (rt *Runtime) Link(ctx context.Context, a, b PID) error {
 	pb.links[a] = struct{}{}
 	pb.mu.Unlock()
 	return nil
+}
+
+func (p *Process) enqueueMonitorEvent(ev monitorEvent) {
+	p.mu.Lock()
+	if p.monitorNotify == nil {
+		p.monitorNotify = make(chan struct{}, 1)
+	}
+	p.monitorEvents = append(p.monitorEvents, monitorEvent{PID: ev.PID, Reason: ev.Reason, Data: append([]byte(nil), ev.Data...)})
+	notify := p.monitorNotify
+	p.mu.Unlock()
+	select {
+	case notify <- struct{}{}:
+	default:
+	}
+}
+
+func (p *Process) prepareMonitor(mem []byte, pidPtr, reasonPtr, lenPtr uint32, timeoutMs int64) int32 {
+	if !writeU64(mem, pidPtr, 0) || !writeU32(mem, reasonPtr, 0) || !writeU32(mem, lenPtr, 0) {
+		return statusInvalidMemory
+	}
+	var deadline <-chan time.Time
+	if timeoutMs > 0 {
+		t := time.NewTimer(time.Duration(timeoutMs) * time.Millisecond)
+		defer t.Stop()
+		deadline = t.C
+	}
+	for {
+		status, done, notify := p.tryPrepareMonitor(mem, pidPtr, reasonPtr, lenPtr)
+		if done {
+			return status
+		}
+		if timeoutMs == 0 {
+			return statusWouldBlock
+		}
+		select {
+		case <-notify:
+		case <-deadline:
+			return statusTimeout
+		}
+	}
+}
+
+func (p *Process) tryPrepareMonitor(mem []byte, pidPtr, reasonPtr, lenPtr uint32) (status int32, done bool, notify <-chan struct{}) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.monitorNotify == nil {
+		p.monitorNotify = make(chan struct{}, 1)
+	}
+	if p.hasPendingMonitor {
+		return statusPendingMessage, true, p.monitorNotify
+	}
+	if len(p.monitorEvents) == 0 {
+		return 0, false, p.monitorNotify
+	}
+	ev := p.monitorEvents[0]
+	if !writeU64(mem, pidPtr, uint64(ev.PID)) || !writeU32(mem, reasonPtr, uint32(ev.Reason)) || !writeU32(mem, lenPtr, uint32(len(ev.Data))) {
+		return statusInvalidMemory, true, p.monitorNotify
+	}
+	copy(p.monitorEvents[0:], p.monitorEvents[1:])
+	p.monitorEvents[len(p.monitorEvents)-1] = monitorEvent{}
+	p.monitorEvents = p.monitorEvents[:len(p.monitorEvents)-1]
+	p.pendingMonitor = ev
+	p.hasPendingMonitor = true
+	return statusOK, true, p.monitorNotify
+}
+
+func (p *Process) receiveMonitor(mem []byte, ptr, byteLen uint32) int32 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.hasPendingMonitor {
+		return statusNoPreparedMessage
+	}
+	ev := p.pendingMonitor
+	if byteLen != uint32(len(ev.Data)) {
+		return statusSizeMismatch
+	}
+	if int64(ptr)+int64(byteLen) > int64(len(mem)) {
+		return statusInvalidMemory
+	}
+	copy(mem[ptr:ptr+byteLen], ev.Data)
+	p.pendingMonitor = monitorEvent{}
+	p.hasPendingMonitor = false
+	return statusOK
 }
 
 // mailboxMessage is one process mailbox item. Tag zero is the untagged lane.

--- a/src/wago/process_import_signature_test.go
+++ b/src/wago/process_import_signature_test.go
@@ -1,0 +1,39 @@
+package wago
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSpawnRejectsMismatchedProcessImportSignature(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+
+	// Declare recv_tagged with four params instead of the required five. The module
+	// itself is valid because its call site matches the declared import type, but
+	// Spawn must reject it before binding the reserved process host import.
+	body := []byte{0x41, 0x00} // i32.const 0 (buf_ptr)
+	body = append(body, 0x41, 0x00) // i32.const 0 (buf_cap)
+	body = append(body, 0x41, 0x00) // i32.const 0 (out_len_ptr)
+	body = append(body, 0x42, 0x00) // i64.const 0 (tag)
+	body = append(body, 0x10, 0x00, 0x0b) // call 0; end
+
+	mod := procModule(t, []impSpec{{
+		module:  "wago_mailbox",
+		name:    "recv_tagged",
+		params:  []byte{i32b, i32b, i32b, i64b},
+		results: []byte{i32b},
+	}}, 1, []byte{i32b}, body)
+	class := classFor(t, rt, mod)
+	defer class.Close()
+
+	pid, err := rt.Spawn(context.Background(), class, SpawnOptions{Entry: "run"})
+	if err == nil {
+		_ = rt.Kill(context.Background(), pid, ExitReason{})
+		t.Fatal("Spawn succeeded with mismatched reserved process import signature")
+	}
+	if !strings.Contains(err.Error(), "wago_mailbox.recv_tagged") || !strings.Contains(err.Error(), "signature mismatch") {
+		t.Fatalf("Spawn error = %v, want recv_tagged signature mismatch", err)
+	}
+}

--- a/src/wago/process_import_signature_test.go
+++ b/src/wago/process_import_signature_test.go
@@ -10,19 +10,19 @@ func TestSpawnRejectsMismatchedProcessImportSignature(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()
 
-	// Declare recv_tagged with four params instead of the required five. The module
-	// itself is valid because its call site matches the declared import type, but
-	// Spawn must reject it before binding the reserved process host import.
-	body := []byte{0x41, 0x00} // i32.const 0 (buf_ptr)
-	body = append(body, 0x41, 0x00) // i32.const 0 (buf_cap)
-	body = append(body, 0x41, 0x00) // i32.const 0 (out_len_ptr)
-	body = append(body, 0x42, 0x00) // i64.const 0 (tag)
+	// Declare wago_mailbox.send with the old three-parameter shape instead of the
+	// canonical four-parameter envelope (pid, tag, ptr, len). The module itself is
+	// valid because its call site matches the declared import type, but Spawn must
+	// reject it before binding the reserved process host import.
+	body := []byte{0x42, 0x00}       // i64.const 0 (pid)
+	body = append(body, 0x41, 0x00)  // i32.const 0 (ptr)
+	body = append(body, 0x41, 0x00)  // i32.const 0 (len)
 	body = append(body, 0x10, 0x00, 0x0b) // call 0; end
 
 	mod := procModule(t, []impSpec{{
 		module:  "wago_mailbox",
-		name:    "recv_tagged",
-		params:  []byte{i32b, i32b, i32b, i64b},
+		name:    "send",
+		params:  []byte{i64b, i32b, i32b},
 		results: []byte{i32b},
 	}}, 1, []byte{i32b}, body)
 	class := classFor(t, rt, mod)
@@ -33,7 +33,7 @@ func TestSpawnRejectsMismatchedProcessImportSignature(t *testing.T) {
 		_ = rt.Kill(context.Background(), pid, ExitReason{})
 		t.Fatal("Spawn succeeded with mismatched reserved process import signature")
 	}
-	if !strings.Contains(err.Error(), "wago_mailbox.recv_tagged") || !strings.Contains(err.Error(), "signature mismatch") {
-		t.Fatalf("Spawn error = %v, want recv_tagged signature mismatch", err)
+	if !strings.Contains(err.Error(), "wago_mailbox.send") || !strings.Contains(err.Error(), "signature mismatch") {
+		t.Fatalf("Spawn error = %v, want send signature mismatch", err)
 	}
 }

--- a/src/wago/process_monitor_test.go
+++ b/src/wago/process_monitor_test.go
@@ -1,0 +1,171 @@
+package wago
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+func TestGuestMonitorReceivesNormalExit(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	watcher := &Process{PID: 1, mailbox: newMailbox(1)}
+	target := &Process{PID: 2, mailbox: newMailbox(1)}
+	rt.procs[watcher.PID] = watcher
+	rt.procs[target.PID] = target
+
+	imports := rt.processImports(watcher)
+	var res [1]uint64
+	imports["wago_process.monitor"].(HostFunc)(testHostModule{}, []uint64{uint64(target.PID)}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("monitor status = %d, want %d", got, statusOK)
+	}
+
+	rt.finishProcess(target, nil, nil)
+	mem := make([]byte, 64)
+	imports["wago_monitor.prepare"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 8, 12, 0}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("monitor prepare status = %d, want %d", got, statusOK)
+	}
+	if got := PID(binary.LittleEndian.Uint64(mem[0:])); got != target.PID {
+		t.Fatalf("monitor pid = %d, want %d", got, target.PID)
+	}
+	if got := int32(binary.LittleEndian.Uint32(mem[8:])); got != monitorReasonNormal {
+		t.Fatalf("monitor reason = %d, want %d", got, monitorReasonNormal)
+	}
+	if got := binary.LittleEndian.Uint32(mem[12:]); got != 0 {
+		t.Fatalf("monitor payload length = %d, want 0", got)
+	}
+	imports["wago_monitor.receive"].(HostFunc)(testHostModule{mem: mem}, []uint64{16, 0}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("monitor receive status = %d, want %d", got, statusOK)
+	}
+	imports["wago_monitor.receive"].(HostFunc)(testHostModule{mem: mem}, []uint64{16, 0}, res[:])
+	if got := int32(res[0]); got != statusNoPreparedMessage {
+		t.Fatalf("monitor receive after consume = %d, want %d", got, statusNoPreparedMessage)
+	}
+}
+
+func TestGuestMonitorReceivesErrorPayloadAndRetries(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	watcher := &Process{PID: 1, mailbox: newMailbox(1)}
+	target := &Process{PID: 2, mailbox: newMailbox(1)}
+	rt.procs[watcher.PID] = watcher
+	rt.procs[target.PID] = target
+
+	imports := rt.processImports(watcher)
+	var res [1]uint64
+	imports["wago_process.monitor"].(HostFunc)(testHostModule{}, []uint64{uint64(target.PID)}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("monitor status = %d, want %d", got, statusOK)
+	}
+
+	rt.finishProcess(target, nil, errors.New("boom"))
+	mem := make([]byte, 64)
+	imports["wago_monitor.prepare"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 8, 12, 0}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("monitor prepare status = %d, want %d", got, statusOK)
+	}
+	if got := int32(binary.LittleEndian.Uint32(mem[8:])); got != monitorReasonError {
+		t.Fatalf("monitor reason = %d, want %d", got, monitorReasonError)
+	}
+	if got := binary.LittleEndian.Uint32(mem[12:]); got != 4 {
+		t.Fatalf("monitor payload length = %d, want 4", got)
+	}
+	imports["wago_monitor.receive"].(HostFunc)(testHostModule{mem: mem}, []uint64{16, 3}, res[:])
+	if got := int32(res[0]); got != statusSizeMismatch {
+		t.Fatalf("monitor receive wrong size = %d, want %d", got, statusSizeMismatch)
+	}
+	imports["wago_monitor.receive"].(HostFunc)(testHostModule{mem: mem}, []uint64{16, 4}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("monitor receive retry = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+4]); got != "boom" {
+		t.Fatalf("monitor payload = %q, want boom", got)
+	}
+}
+
+func TestGuestMonitorImmediateEventForAlreadyExitedProcess(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	watcher := &Process{PID: 1, mailbox: newMailbox(1)}
+	target := &Process{PID: 2, mailbox: newMailbox(1)}
+	rt.procs[watcher.PID] = watcher
+	rt.procs[target.PID] = target
+	rt.finishProcess(target, nil, nil)
+
+	imports := rt.processImports(watcher)
+	var res [1]uint64
+	imports["wago_process.monitor"].(HostFunc)(testHostModule{}, []uint64{uint64(target.PID)}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("monitor exited process = %d, want %d", got, statusOK)
+	}
+	mem := make([]byte, 64)
+	imports["wago_monitor.prepare"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 8, 12, 0}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("prepare immediate monitor event = %d, want %d", got, statusOK)
+	}
+	if got := PID(binary.LittleEndian.Uint64(mem[0:])); got != target.PID {
+		t.Fatalf("immediate monitor pid = %d, want %d", got, target.PID)
+	}
+}
+
+func TestGuestMonitorPrepareInvalidMemoryKeepsEvent(t *testing.T) {
+	proc := &Process{PID: 1, mailbox: newMailbox(1)}
+	proc.enqueueMonitorEvent(monitorEvent{PID: 2, Reason: monitorReasonKilled})
+
+	shortMem := make([]byte, 8)
+	if got := proc.prepareMonitor(shortMem, 0, 8, 12, 0); got != statusInvalidMemory {
+		t.Fatalf("prepare invalid memory = %d, want %d", got, statusInvalidMemory)
+	}
+	mem := make([]byte, 64)
+	if got := proc.prepareMonitor(mem, 0, 8, 12, 0); got != statusOK {
+		t.Fatalf("prepare after invalid memory = %d, want %d", got, statusOK)
+	}
+	if got := PID(binary.LittleEndian.Uint64(mem[0:])); got != 2 {
+		t.Fatalf("monitor pid after invalid memory = %d, want 2", got)
+	}
+}
+
+func TestGuestMonitorPrepareTimeoutAndWouldBlock(t *testing.T) {
+	proc := &Process{PID: 1, mailbox: newMailbox(1)}
+	mem := make([]byte, 64)
+	if got := proc.prepareMonitor(mem, 0, 8, 12, 0); got != statusWouldBlock {
+		t.Fatalf("monitor prepare nonblocking empty = %d, want %d", got, statusWouldBlock)
+	}
+	if got := proc.prepareMonitor(mem, 0, 8, 12, 1); got != statusTimeout {
+		t.Fatalf("monitor prepare timeout = %d, want %d", got, statusTimeout)
+	}
+}
+
+func TestGuestMonitorUnknownProcess(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	watcher := &Process{PID: 1, mailbox: newMailbox(1)}
+	rt.procs[watcher.PID] = watcher
+	imports := rt.processImports(watcher)
+	var res [1]uint64
+	imports["wago_process.monitor"].(HostFunc)(testHostModule{}, []uint64{999}, res[:])
+	if got := int32(res[0]); got != statusNoProcess {
+		t.Fatalf("monitor unknown process = %d, want %d", got, statusNoProcess)
+	}
+}
+
+func TestMonitorProcessHostAPI(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	watcher := &Process{PID: 1, mailbox: newMailbox(1)}
+	target := &Process{PID: 2, mailbox: newMailbox(1)}
+	rt.procs[watcher.PID] = watcher
+	rt.procs[target.PID] = target
+	if err := rt.MonitorProcess(context.Background(), watcher.PID, target.PID); err != nil {
+		t.Fatalf("MonitorProcess: %v", err)
+	}
+	rt.finishProcess(target, nil, nil)
+	mem := make([]byte, 64)
+	if got := watcher.prepareMonitor(mem, 0, 8, 12, 0); got != statusOK {
+		t.Fatalf("prepare monitor event from host API = %d, want %d", got, statusOK)
+	}
+}

--- a/src/wago/process_name_test.go
+++ b/src/wago/process_name_test.go
@@ -1,0 +1,146 @@
+package wago
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+type testHostModule struct{ mem []byte }
+
+func (m testHostModule) Memory() []byte { return m.mem }
+
+func TestSpawnRegistersAndReleasesName(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	class := classFor(t, rt, blockingReceiveModule(t))
+	defer class.Close()
+
+	pid, err := rt.Spawn(context.Background(), class, SpawnOptions{Entry: "run", Name: "worker"})
+	if err != nil {
+		t.Fatalf("spawn named process: %v", err)
+	}
+	if got, err := rt.LookupProcessName(context.Background(), "worker"); err != nil || got != pid {
+		t.Fatalf("LookupProcessName(worker) = %d, %v; want %d, nil", got, err, pid)
+	}
+	if _, err := rt.Spawn(context.Background(), class, SpawnOptions{Entry: "run", Name: "worker"}); !errors.Is(err, ErrProcessNameTaken) {
+		t.Fatalf("duplicate named spawn = %v, want ErrProcessNameTaken", err)
+	}
+
+	mon := mustMonitor(t, rt, pid)
+	if err := rt.Kill(context.Background(), pid, ExitReason{}); err != nil {
+		t.Fatalf("kill named process: %v", err)
+	}
+	<-mon
+	if _, err := rt.LookupProcessName(context.Background(), "worker"); !errors.Is(err, ErrProcessNameNotFound) {
+		t.Fatalf("LookupProcessName after exit = %v, want ErrProcessNameNotFound", err)
+	}
+}
+
+func TestProcessNameHostRegisterLookupUnregister(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	class := classFor(t, rt, blockingReceiveModule(t))
+	defer class.Close()
+
+	pid, err := rt.Spawn(context.Background(), class, SpawnOptions{Entry: "run"})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer rt.Kill(context.Background(), pid, ExitReason{})
+
+	if err := rt.RegisterProcessName(context.Background(), "alias", pid); err != nil {
+		t.Fatalf("RegisterProcessName: %v", err)
+	}
+	if err := rt.RegisterProcessName(context.Background(), "alias", pid); err != nil {
+		t.Fatalf("idempotent RegisterProcessName: %v", err)
+	}
+	if got, err := rt.LookupProcessName(context.Background(), "alias"); err != nil || got != pid {
+		t.Fatalf("LookupProcessName(alias) = %d, %v; want %d, nil", got, err, pid)
+	}
+	if err := rt.UnregisterProcessName(context.Background(), "alias"); err != nil {
+		t.Fatalf("UnregisterProcessName: %v", err)
+	}
+	if _, err := rt.LookupProcessName(context.Background(), "alias"); !errors.Is(err, ErrProcessNameNotFound) {
+		t.Fatalf("LookupProcessName after unregister = %v, want ErrProcessNameNotFound", err)
+	}
+}
+
+func TestProcessNameGuestImports(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	const pid PID = 77
+	proc := &Process{PID: pid, mailbox: newMailbox(1)}
+	rt.procs[pid] = proc
+
+	mem := make([]byte, 64)
+	copy(mem[0:], "worker")
+	imports := rt.processImports(proc)
+	var res [1]uint64
+
+	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 6}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("guest register status = %d, want %d", got, statusOK)
+	}
+	imports["wago_process.get"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 6, 16}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("guest get status = %d, want %d", got, statusOK)
+	}
+	if got := PID(binary.LittleEndian.Uint64(mem[16:])); got != pid {
+		t.Fatalf("guest get pid = %d, want %d", got, pid)
+	}
+	imports["wago_process.unregister"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 6}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("guest unregister status = %d, want %d", got, statusOK)
+	}
+	imports["wago_process.get"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 6, 16}, res[:])
+	if got := int32(res[0]); got != statusNameNotFound {
+		t.Fatalf("guest get after unregister = %d, want %d", got, statusNameNotFound)
+	}
+}
+
+func TestProcessNameGuestUnregisterRequiresOwnership(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	const owner PID = 1
+	const other PID = 2
+	rt.procs[owner] = &Process{PID: owner, mailbox: newMailbox(1)}
+	otherProc := &Process{PID: other, mailbox: newMailbox(1)}
+	rt.procs[other] = otherProc
+	if err := rt.RegisterProcessName(context.Background(), "owned", owner); err != nil {
+		t.Fatalf("RegisterProcessName: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	copy(mem[0:], "owned")
+	imports := rt.processImports(otherProc)
+	var res [1]uint64
+	imports["wago_process.unregister"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 5}, res[:])
+	if got := int32(res[0]); got != statusPermissionDenied {
+		t.Fatalf("guest unregister by non-owner = %d, want %d", got, statusPermissionDenied)
+	}
+	if got, err := rt.LookupProcessName(context.Background(), "owned"); err != nil || got != owner {
+		t.Fatalf("LookupProcessName after denied unregister = %d, %v; want %d, nil", got, err, owner)
+	}
+}
+
+func TestProcessNameGuestInvalidMemoryAndName(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	const pid PID = 3
+	proc := &Process{PID: pid, mailbox: newMailbox(1)}
+	rt.procs[pid] = proc
+	imports := rt.processImports(proc)
+	var res [1]uint64
+
+	mem := make([]byte, 4)
+	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{2, 4}, res[:])
+	if got := int32(res[0]); got != statusInvalidMemory {
+		t.Fatalf("guest register invalid memory = %d, want %d", got, statusInvalidMemory)
+	}
+	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 0}, res[:])
+	if got := int32(res[0]); got != statusInvalidName {
+		t.Fatalf("guest register empty name = %d, want %d", got, statusInvalidName)
+	}
+}

--- a/src/wago/process_name_test.go
+++ b/src/wago/process_name_test.go
@@ -79,7 +79,7 @@ func TestProcessNameGuestImports(t *testing.T) {
 	imports := rt.processImports(proc)
 	var res [1]uint64
 
-	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 6}, res[:])
+	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{uint64(pid), 0, 6}, res[:])
 	if got := int32(res[0]); got != statusOK {
 		t.Fatalf("guest register status = %d, want %d", got, statusOK)
 	}
@@ -97,6 +97,62 @@ func TestProcessNameGuestImports(t *testing.T) {
 	imports["wago_process.get"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 6, 16}, res[:])
 	if got := int32(res[0]); got != statusNameNotFound {
 		t.Fatalf("guest get after unregister = %d, want %d", got, statusNameNotFound)
+	}
+}
+
+func TestProcessNameGuestSupervisorRegistersServiceProcess(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	const master PID = 10
+	const service PID = 11
+	masterProc := &Process{PID: master, mailbox: newMailbox(1)}
+	rt.procs[master] = masterProc
+	rt.procs[service] = &Process{PID: service, mailbox: newMailbox(1)}
+
+	mem := make([]byte, 64)
+	copy(mem[0:], "service")
+	imports := rt.processImports(masterProc)
+	var res [1]uint64
+
+	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{uint64(service), 0, 7}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("master register service status = %d, want %d", got, statusOK)
+	}
+	imports["wago_process.get"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 7, 16}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("master get service status = %d, want %d", got, statusOK)
+	}
+	if got := PID(binary.LittleEndian.Uint64(mem[16:])); got != service {
+		t.Fatalf("resolved service pid = %d, want %d", got, service)
+	}
+	imports["wago_process.unregister"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 7}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("master unregister service status = %d, want %d", got, statusOK)
+	}
+}
+
+func TestProcessNameGuestTargetCanUnregisterSupervisorRegisteredName(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	const master PID = 10
+	const service PID = 11
+	rt.procs[master] = &Process{PID: master, mailbox: newMailbox(1)}
+	serviceProc := &Process{PID: service, mailbox: newMailbox(1)}
+	rt.procs[service] = serviceProc
+	if err := rt.registerProcessNameFor("service", service, master); err != nil {
+		t.Fatalf("registerProcessNameFor: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	copy(mem[0:], "service")
+	imports := rt.processImports(serviceProc)
+	var res [1]uint64
+	imports["wago_process.unregister"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 7}, res[:])
+	if got := int32(res[0]); got != statusOK {
+		t.Fatalf("service unregister status = %d, want %d", got, statusOK)
+	}
+	if _, err := rt.LookupProcessName(context.Background(), "service"); !errors.Is(err, ErrProcessNameNotFound) {
+		t.Fatalf("LookupProcessName after service unregister = %v, want ErrProcessNameNotFound", err)
 	}
 }
 
@@ -135,11 +191,11 @@ func TestProcessNameGuestInvalidMemoryAndName(t *testing.T) {
 	var res [1]uint64
 
 	mem := make([]byte, 4)
-	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{2, 4}, res[:])
+	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{uint64(pid), 2, 4}, res[:])
 	if got := int32(res[0]); got != statusInvalidMemory {
 		t.Fatalf("guest register invalid memory = %d, want %d", got, statusInvalidMemory)
 	}
-	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{0, 0}, res[:])
+	imports["wago_process.register"].(HostFunc)(testHostModule{mem: mem}, []uint64{uint64(pid), 0, 0}, res[:])
 	if got := int32(res[0]); got != statusInvalidName {
 		t.Fatalf("guest register empty name = %d, want %d", got, statusInvalidName)
 	}

--- a/src/wago/process_tags_test.go
+++ b/src/wago/process_tags_test.go
@@ -1,0 +1,115 @@
+package wago
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+)
+
+func TestMailboxReceiveFiltersByTag(t *testing.T) {
+	mb := newMailbox(4)
+	if err := mb.send(7, []byte("tagged")); err != nil {
+		t.Fatalf("send tagged: %v", err)
+	}
+	if err := mb.send(0, []byte("plain")); err != nil {
+		t.Fatalf("send untagged: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	if got := mb.receiveIntoTag(mem, 0, 16, 16, 4, 0); got != statusOK {
+		t.Fatalf("receive untagged status = %d, want %d", got, statusOK)
+	}
+	if n := binary.LittleEndian.Uint32(mem[4:]); n != 5 {
+		t.Fatalf("untagged length = %d, want 5", n)
+	}
+	if got := string(mem[16 : 16+5]); got != "plain" {
+		t.Fatalf("untagged payload = %q, want plain", got)
+	}
+
+	if got := mb.receiveIntoTag(mem, 7, 16, 16, 4, 0); got != statusOK {
+		t.Fatalf("receive tagged status = %d, want %d", got, statusOK)
+	}
+	if n := binary.LittleEndian.Uint32(mem[4:]); n != 6 {
+		t.Fatalf("tagged length = %d, want 6", n)
+	}
+	if got := string(mem[16 : 16+6]); got != "tagged" {
+		t.Fatalf("tagged payload = %q, want tagged", got)
+	}
+}
+
+func TestMailboxTaggedReceivePreservesMismatchedMessages(t *testing.T) {
+	mb := newMailbox(4)
+	if err := mb.send(9, []byte("nine")); err != nil {
+		t.Fatalf("send tag 9: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	if got := mb.receiveIntoTag(mem, 8, 16, 16, 4, 0); got != statusWouldBlock {
+		t.Fatalf("receive wrong tag status = %d, want %d", got, statusWouldBlock)
+	}
+	if got := mb.length(); got != 1 {
+		t.Fatalf("mailbox length after mismatched receive = %d, want 1", got)
+	}
+
+	if got := mb.receiveIntoTag(mem, 9, 16, 16, 4, 0); got != statusOK {
+		t.Fatalf("receive tag 9 status = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+4]); got != "nine" {
+		t.Fatalf("tag 9 payload = %q, want nine", got)
+	}
+}
+
+func TestMailboxTaggedBufferTooSmallLeavesMessageQueued(t *testing.T) {
+	mb := newMailbox(2)
+	if err := mb.send(3, []byte("payload")); err != nil {
+		t.Fatalf("send tag 3: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	if got := mb.receiveIntoTag(mem, 3, 16, 3, 4, 0); got != statusBufTooSmall {
+		t.Fatalf("short receive status = %d, want %d", got, statusBufTooSmall)
+	}
+	if n := binary.LittleEndian.Uint32(mem[4:]); n != 7 {
+		t.Fatalf("short receive length = %d, want 7", n)
+	}
+	if got := mb.length(); got != 1 {
+		t.Fatalf("mailbox length after short receive = %d, want 1", got)
+	}
+
+	if got := mb.receiveIntoTag(mem, 3, 16, 7, 4, 0); got != statusOK {
+		t.Fatalf("retry receive status = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+7]); got != "payload" {
+		t.Fatalf("retried payload = %q, want payload", got)
+	}
+}
+
+func TestRuntimeSendTagged(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+
+	const pid PID = 42
+	rt.procs[pid] = &Process{PID: pid, mailbox: newMailbox(2)}
+
+	if err := rt.SendTagged(context.Background(), pid, 55, []byte("hello")); err != nil {
+		t.Fatalf("SendTagged: %v", err)
+	}
+	if err := rt.Send(context.Background(), pid, []byte("plain")); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	mb := rt.procs[pid].mailbox
+	if got := mb.receiveIntoTag(mem, 0, 16, 16, 4, 0); got != statusOK {
+		t.Fatalf("receive untagged status = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+5]); got != "plain" {
+		t.Fatalf("untagged payload = %q, want plain", got)
+	}
+	if got := mb.receiveIntoTag(mem, 55, 16, 16, 4, 0); got != statusOK {
+		t.Fatalf("receive tagged status = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+5]); got != "hello" {
+		t.Fatalf("tagged payload = %q, want hello", got)
+	}
+}

--- a/src/wago/process_tags_test.go
+++ b/src/wago/process_tags_test.go
@@ -84,6 +84,70 @@ func TestMailboxTaggedBufferTooSmallLeavesMessageQueued(t *testing.T) {
 	}
 }
 
+func TestMailboxPrepareReceiveRequiresSizeAcknowledgement(t *testing.T) {
+	mb := newMailbox(4)
+	if err := mb.send(7, []byte("payload")); err != nil {
+		t.Fatalf("send tag 7: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	if got := mb.prepareReceive(mem, 4, 7, 0); got != statusOK {
+		t.Fatalf("prepare status = %d, want %d", got, statusOK)
+	}
+	if n := binary.LittleEndian.Uint32(mem[4:]); n != 7 {
+		t.Fatalf("prepared length = %d, want 7", n)
+	}
+	if got := mb.length(); got != 0 {
+		t.Fatalf("mailbox length after prepare = %d, want 0", got)
+	}
+
+	if got := mb.receivePrepared(mem, 16, 6); got != statusSizeMismatch {
+		t.Fatalf("receive with wrong ack size = %d, want %d", got, statusSizeMismatch)
+	}
+	if got := mb.receivePrepared(mem, 16, 7); got != statusOK {
+		t.Fatalf("receive with acked size = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+7]); got != "payload" {
+		t.Fatalf("prepared payload = %q, want payload", got)
+	}
+	if got := mb.receivePrepared(mem, 16, 7); got != statusNoMessage {
+		t.Fatalf("receive after consume = %d, want %d", got, statusNoMessage)
+	}
+}
+
+func TestMailboxPrepareReceiveRejectsSecondPendingMessage(t *testing.T) {
+	mb := newMailbox(4)
+	if err := mb.send(1, []byte("one")); err != nil {
+		t.Fatalf("send tag 1: %v", err)
+	}
+	if err := mb.send(1, []byte("two")); err != nil {
+		t.Fatalf("send tag 1 second: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	if got := mb.prepareReceive(mem, 4, 1, 0); got != statusOK {
+		t.Fatalf("first prepare status = %d, want %d", got, statusOK)
+	}
+	if got := mb.prepareReceive(mem, 4, 1, 0); got != statusPending {
+		t.Fatalf("second prepare status = %d, want %d", got, statusPending)
+	}
+	if got := mb.receivePrepared(mem, 16, 3); got != statusOK {
+		t.Fatalf("receive first pending = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+3]); got != "one" {
+		t.Fatalf("first pending payload = %q, want one", got)
+	}
+	if got := mb.prepareReceive(mem, 4, 1, 0); got != statusOK {
+		t.Fatalf("prepare after consume = %d, want %d", got, statusOK)
+	}
+	if got := mb.receivePrepared(mem, 16, 3); got != statusOK {
+		t.Fatalf("receive second pending = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+3]); got != "two" {
+		t.Fatalf("second pending payload = %q, want two", got)
+	}
+}
+
 func TestRuntimeSendTagged(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()
@@ -106,8 +170,11 @@ func TestRuntimeSendTagged(t *testing.T) {
 	if got := string(mem[16 : 16+5]); got != "plain" {
 		t.Fatalf("untagged payload = %q, want plain", got)
 	}
-	if got := mb.receiveIntoTag(mem, 55, 16, 16, 4, 0); got != statusOK {
-		t.Fatalf("receive tagged status = %d, want %d", got, statusOK)
+	if got := mb.prepareReceive(mem, 4, 55, 0); got != statusOK {
+		t.Fatalf("prepare tagged status = %d, want %d", got, statusOK)
+	}
+	if got := mb.receivePrepared(mem, 16, binary.LittleEndian.Uint32(mem[4:])); got != statusOK {
+		t.Fatalf("receive prepared tagged status = %d, want %d", got, statusOK)
 	}
 	if got := string(mem[16 : 16+5]); got != "hello" {
 		t.Fatalf("tagged payload = %q, want hello", got)

--- a/src/wago/process_tags_test.go
+++ b/src/wago/process_tags_test.go
@@ -3,7 +3,9 @@ package wago
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"testing"
+	"time"
 )
 
 func TestMailboxReceiveFiltersByTag(t *testing.T) {
@@ -115,6 +117,135 @@ func TestMailboxPrepareReceiveRequiresSizeAcknowledgement(t *testing.T) {
 	}
 }
 
+func TestMailboxReceivePreparedBufferTooSmallKeepsPending(t *testing.T) {
+	mb := newMailbox(2)
+	if err := mb.send(12, []byte("message")); err != nil {
+		t.Fatalf("send tag 12: %v", err)
+	}
+
+	mem := make([]byte, 64)
+	if got := mb.prepareReceive(mem, 4, 12, 0); got != statusOK {
+		t.Fatalf("prepare status = %d, want %d", got, statusOK)
+	}
+	if got := mb.receivePrepared(mem, 60, 7); got != statusBufTooSmall {
+		t.Fatalf("too-small destination status = %d, want %d", got, statusBufTooSmall)
+	}
+	if got := mb.receivePrepared(mem, 16, 7); got != statusOK {
+		t.Fatalf("retry receive status = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+7]); got != "message" {
+		t.Fatalf("retried prepared payload = %q, want message", got)
+	}
+}
+
+func TestMailboxPrepareReceiveRejectsBadLengthPointerWithoutConsuming(t *testing.T) {
+	mb := newMailbox(2)
+	if err := mb.send(4, []byte("keep")); err != nil {
+		t.Fatalf("send tag 4: %v", err)
+	}
+
+	shortMem := make([]byte, 4)
+	if got := mb.prepareReceive(shortMem, 1, 4, 0); got != statusBufTooSmall {
+		t.Fatalf("prepare with bad length pointer = %d, want %d", got, statusBufTooSmall)
+	}
+	if got := mb.length(); got != 1 {
+		t.Fatalf("mailbox length after bad length pointer = %d, want 1", got)
+	}
+
+	mem := make([]byte, 64)
+	if got := mb.prepareReceive(mem, 4, 4, 0); got != statusOK {
+		t.Fatalf("prepare after bad pointer = %d, want %d", got, statusOK)
+	}
+	if n := binary.LittleEndian.Uint32(mem[4:]); n != 4 {
+		t.Fatalf("prepared length after bad pointer = %d, want 4", n)
+	}
+	if got := mb.receivePrepared(mem, 16, 4); got != statusOK {
+		t.Fatalf("receive after bad pointer = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+4]); got != "keep" {
+		t.Fatalf("payload after bad pointer = %q, want keep", got)
+	}
+}
+
+func TestMailboxPrepareReceiveZeroLengthMessage(t *testing.T) {
+	mb := newMailbox(1)
+	if err := mb.send(2, nil); err != nil {
+		t.Fatalf("send zero-length message: %v", err)
+	}
+
+	mem := make([]byte, 16)
+	if got := mb.prepareReceive(mem, 4, 2, 0); got != statusOK {
+		t.Fatalf("prepare zero-length status = %d, want %d", got, statusOK)
+	}
+	if n := binary.LittleEndian.Uint32(mem[4:]); n != 0 {
+		t.Fatalf("zero-length prepared length = %d, want 0", n)
+	}
+	if got := mb.receivePrepared(mem, uint32(len(mem)), 0); got != statusOK {
+		t.Fatalf("receive zero-length at end pointer = %d, want %d", got, statusOK)
+	}
+}
+
+func TestMailboxPrepareReceiveRejectsOutOfRangeZeroLengthDestination(t *testing.T) {
+	mb := newMailbox(1)
+	if err := mb.send(2, nil); err != nil {
+		t.Fatalf("send zero-length message: %v", err)
+	}
+
+	mem := make([]byte, 16)
+	if got := mb.prepareReceive(mem, 4, 2, 0); got != statusOK {
+		t.Fatalf("prepare zero-length status = %d, want %d", got, statusOK)
+	}
+	if got := mb.receivePrepared(mem, uint32(len(mem)+1), 0); got != statusBufTooSmall {
+		t.Fatalf("receive zero-length out of range = %d, want %d", got, statusBufTooSmall)
+	}
+	if got := mb.receivePrepared(mem, uint32(len(mem)), 0); got != statusOK {
+		t.Fatalf("retry zero-length receive = %d, want %d", got, statusOK)
+	}
+}
+
+func TestMailboxPrepareReceiveCloseSemantics(t *testing.T) {
+	mb := newMailbox(4)
+	if err := mb.send(1, []byte("one")); err != nil {
+		t.Fatalf("send tag 1: %v", err)
+	}
+	if err := mb.send(2, []byte("two")); err != nil {
+		t.Fatalf("send tag 2: %v", err)
+	}
+	mb.close()
+
+	mem := make([]byte, 64)
+	if got := mb.prepareReceive(mem, 4, 3, 0); got != statusClosed {
+		t.Fatalf("prepare missing tag on closed mailbox = %d, want %d", got, statusClosed)
+	}
+	if got := mb.prepareReceive(mem, 4, 2, 0); got != statusOK {
+		t.Fatalf("prepare queued tag on closed mailbox = %d, want %d", got, statusOK)
+	}
+	if got := mb.receivePrepared(mem, 16, 3); got != statusOK {
+		t.Fatalf("receive queued tag on closed mailbox = %d, want %d", got, statusOK)
+	}
+	if got := string(mem[16 : 16+3]); got != "two" {
+		t.Fatalf("closed queued payload = %q, want two", got)
+	}
+	if got := mb.prepareReceive(mem, 4, 2, 0); got != statusClosed {
+		t.Fatalf("prepare consumed tag on closed mailbox = %d, want %d", got, statusClosed)
+	}
+	if got := mb.prepareReceive(mem, 4, 1, 0); got != statusOK {
+		t.Fatalf("prepare remaining queued tag on closed mailbox = %d, want %d", got, statusOK)
+	}
+}
+
+func TestMailboxPrepareReceiveTimeout(t *testing.T) {
+	mb := newMailbox(1)
+	mem := make([]byte, 64)
+	start := time.Now()
+	if got := mb.prepareReceive(mem, 4, 99, 5); got != statusTimeout {
+		t.Fatalf("prepare timeout status = %d, want %d", got, statusTimeout)
+	}
+	if elapsed := time.Since(start); elapsed <= 0 {
+		t.Fatalf("prepare timeout elapsed = %s, want positive duration", elapsed)
+	}
+}
+
 func TestMailboxPrepareReceiveRejectsSecondPendingMessage(t *testing.T) {
 	mb := newMailbox(4)
 	if err := mb.send(1, []byte("one")); err != nil {
@@ -145,6 +276,20 @@ func TestMailboxPrepareReceiveRejectsSecondPendingMessage(t *testing.T) {
 	}
 	if got := string(mem[16 : 16+3]); got != "two" {
 		t.Fatalf("second pending payload = %q, want two", got)
+	}
+}
+
+func TestMailboxCapacityAndClosedSendErrors(t *testing.T) {
+	mb := newMailbox(1)
+	if err := mb.send(0, []byte("one")); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	if err := mb.send(0, []byte("two")); !errors.Is(err, ErrMailboxFull) {
+		t.Fatalf("second send = %v, want ErrMailboxFull", err)
+	}
+	mb.close()
+	if err := mb.send(0, []byte("three")); !errors.Is(err, ErrMailboxClosed) {
+		t.Fatalf("send after close = %v, want ErrMailboxClosed", err)
 	}
 }
 

--- a/src/wago/process_tags_test.go
+++ b/src/wago/process_tags_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestMailboxReceiveFiltersByTag(t *testing.T) {
+func TestMailboxPrepareReceiveFiltersByTag(t *testing.T) {
 	mb := newMailbox(4)
 	if err := mb.send(7, []byte("tagged")); err != nil {
 		t.Fatalf("send tagged: %v", err)
@@ -18,71 +18,55 @@ func TestMailboxReceiveFiltersByTag(t *testing.T) {
 	}
 
 	mem := make([]byte, 64)
-	if got := mb.receiveIntoTag(mem, 0, 16, 16, 4, 0); got != statusOK {
-		t.Fatalf("receive untagged status = %d, want %d", got, statusOK)
+	if got := mb.prepareReceive(mem, 4, 0, 0); got != statusOK {
+		t.Fatalf("prepare untagged status = %d, want %d", got, statusOK)
 	}
 	if n := binary.LittleEndian.Uint32(mem[4:]); n != 5 {
 		t.Fatalf("untagged length = %d, want 5", n)
+	}
+	if got := mb.receivePrepared(mem, 16, 5); got != statusOK {
+		t.Fatalf("receive untagged status = %d, want %d", got, statusOK)
 	}
 	if got := string(mem[16 : 16+5]); got != "plain" {
 		t.Fatalf("untagged payload = %q, want plain", got)
 	}
 
-	if got := mb.receiveIntoTag(mem, 7, 16, 16, 4, 0); got != statusOK {
-		t.Fatalf("receive tagged status = %d, want %d", got, statusOK)
+	if got := mb.prepareReceive(mem, 4, 7, 0); got != statusOK {
+		t.Fatalf("prepare tagged status = %d, want %d", got, statusOK)
 	}
 	if n := binary.LittleEndian.Uint32(mem[4:]); n != 6 {
 		t.Fatalf("tagged length = %d, want 6", n)
+	}
+	if got := mb.receivePrepared(mem, 16, 6); got != statusOK {
+		t.Fatalf("receive tagged status = %d, want %d", got, statusOK)
 	}
 	if got := string(mem[16 : 16+6]); got != "tagged" {
 		t.Fatalf("tagged payload = %q, want tagged", got)
 	}
 }
 
-func TestMailboxTaggedReceivePreservesMismatchedMessages(t *testing.T) {
+func TestMailboxPrepareReceivePreservesMismatchedMessages(t *testing.T) {
 	mb := newMailbox(4)
 	if err := mb.send(9, []byte("nine")); err != nil {
 		t.Fatalf("send tag 9: %v", err)
 	}
 
 	mem := make([]byte, 64)
-	if got := mb.receiveIntoTag(mem, 8, 16, 16, 4, 0); got != statusWouldBlock {
-		t.Fatalf("receive wrong tag status = %d, want %d", got, statusWouldBlock)
+	if got := mb.prepareReceive(mem, 4, 8, 0); got != statusWouldBlock {
+		t.Fatalf("prepare wrong tag status = %d, want %d", got, statusWouldBlock)
 	}
-	if got := mb.length(); got != 1 {
-		t.Fatalf("mailbox length after mismatched receive = %d, want 1", got)
+	if got := mb.queuedLen(); got != 1 {
+		t.Fatalf("mailbox length after mismatched prepare = %d, want 1", got)
 	}
 
-	if got := mb.receiveIntoTag(mem, 9, 16, 16, 4, 0); got != statusOK {
+	if got := mb.prepareReceive(mem, 4, 9, 0); got != statusOK {
+		t.Fatalf("prepare tag 9 status = %d, want %d", got, statusOK)
+	}
+	if got := mb.receivePrepared(mem, 16, 4); got != statusOK {
 		t.Fatalf("receive tag 9 status = %d, want %d", got, statusOK)
 	}
 	if got := string(mem[16 : 16+4]); got != "nine" {
 		t.Fatalf("tag 9 payload = %q, want nine", got)
-	}
-}
-
-func TestMailboxTaggedBufferTooSmallLeavesMessageQueued(t *testing.T) {
-	mb := newMailbox(2)
-	if err := mb.send(3, []byte("payload")); err != nil {
-		t.Fatalf("send tag 3: %v", err)
-	}
-
-	mem := make([]byte, 64)
-	if got := mb.receiveIntoTag(mem, 3, 16, 3, 4, 0); got != statusBufTooSmall {
-		t.Fatalf("short receive status = %d, want %d", got, statusBufTooSmall)
-	}
-	if n := binary.LittleEndian.Uint32(mem[4:]); n != 7 {
-		t.Fatalf("short receive length = %d, want 7", n)
-	}
-	if got := mb.length(); got != 1 {
-		t.Fatalf("mailbox length after short receive = %d, want 1", got)
-	}
-
-	if got := mb.receiveIntoTag(mem, 3, 16, 7, 4, 0); got != statusOK {
-		t.Fatalf("retry receive status = %d, want %d", got, statusOK)
-	}
-	if got := string(mem[16 : 16+7]); got != "payload" {
-		t.Fatalf("retried payload = %q, want payload", got)
 	}
 }
 
@@ -99,7 +83,7 @@ func TestMailboxPrepareReceiveRequiresSizeAcknowledgement(t *testing.T) {
 	if n := binary.LittleEndian.Uint32(mem[4:]); n != 7 {
 		t.Fatalf("prepared length = %d, want 7", n)
 	}
-	if got := mb.length(); got != 0 {
+	if got := mb.queuedLen(); got != 0 {
 		t.Fatalf("mailbox length after prepare = %d, want 0", got)
 	}
 
@@ -112,12 +96,12 @@ func TestMailboxPrepareReceiveRequiresSizeAcknowledgement(t *testing.T) {
 	if got := string(mem[16 : 16+7]); got != "payload" {
 		t.Fatalf("prepared payload = %q, want payload", got)
 	}
-	if got := mb.receivePrepared(mem, 16, 7); got != statusNoMessage {
-		t.Fatalf("receive after consume = %d, want %d", got, statusNoMessage)
+	if got := mb.receivePrepared(mem, 16, 7); got != statusNoPreparedMessage {
+		t.Fatalf("receive after consume = %d, want %d", got, statusNoPreparedMessage)
 	}
 }
 
-func TestMailboxReceivePreparedBufferTooSmallKeepsPending(t *testing.T) {
+func TestMailboxReceivePreparedInvalidMemoryKeepsPending(t *testing.T) {
 	mb := newMailbox(2)
 	if err := mb.send(12, []byte("message")); err != nil {
 		t.Fatalf("send tag 12: %v", err)
@@ -127,8 +111,8 @@ func TestMailboxReceivePreparedBufferTooSmallKeepsPending(t *testing.T) {
 	if got := mb.prepareReceive(mem, 4, 12, 0); got != statusOK {
 		t.Fatalf("prepare status = %d, want %d", got, statusOK)
 	}
-	if got := mb.receivePrepared(mem, 60, 7); got != statusBufTooSmall {
-		t.Fatalf("too-small destination status = %d, want %d", got, statusBufTooSmall)
+	if got := mb.receivePrepared(mem, 60, 7); got != statusInvalidMemory {
+		t.Fatalf("too-small destination status = %d, want %d", got, statusInvalidMemory)
 	}
 	if got := mb.receivePrepared(mem, 16, 7); got != statusOK {
 		t.Fatalf("retry receive status = %d, want %d", got, statusOK)
@@ -145,10 +129,10 @@ func TestMailboxPrepareReceiveRejectsBadLengthPointerWithoutConsuming(t *testing
 	}
 
 	shortMem := make([]byte, 4)
-	if got := mb.prepareReceive(shortMem, 1, 4, 0); got != statusBufTooSmall {
-		t.Fatalf("prepare with bad length pointer = %d, want %d", got, statusBufTooSmall)
+	if got := mb.prepareReceive(shortMem, 1, 4, 0); got != statusInvalidMemory {
+		t.Fatalf("prepare with bad length pointer = %d, want %d", got, statusInvalidMemory)
 	}
-	if got := mb.length(); got != 1 {
+	if got := mb.queuedLen(); got != 1 {
 		t.Fatalf("mailbox length after bad length pointer = %d, want 1", got)
 	}
 
@@ -195,8 +179,8 @@ func TestMailboxPrepareReceiveRejectsOutOfRangeZeroLengthDestination(t *testing.
 	if got := mb.prepareReceive(mem, 4, 2, 0); got != statusOK {
 		t.Fatalf("prepare zero-length status = %d, want %d", got, statusOK)
 	}
-	if got := mb.receivePrepared(mem, uint32(len(mem)+1), 0); got != statusBufTooSmall {
-		t.Fatalf("receive zero-length out of range = %d, want %d", got, statusBufTooSmall)
+	if got := mb.receivePrepared(mem, uint32(len(mem)+1), 0); got != statusInvalidMemory {
+		t.Fatalf("receive zero-length out of range = %d, want %d", got, statusInvalidMemory)
 	}
 	if got := mb.receivePrepared(mem, uint32(len(mem)), 0); got != statusOK {
 		t.Fatalf("retry zero-length receive = %d, want %d", got, statusOK)
@@ -214,8 +198,8 @@ func TestMailboxPrepareReceiveCloseSemantics(t *testing.T) {
 	mb.close()
 
 	mem := make([]byte, 64)
-	if got := mb.prepareReceive(mem, 4, 3, 0); got != statusClosed {
-		t.Fatalf("prepare missing tag on closed mailbox = %d, want %d", got, statusClosed)
+	if got := mb.prepareReceive(mem, 4, 3, 0); got != statusMailboxClosed {
+		t.Fatalf("prepare missing tag on closed mailbox = %d, want %d", got, statusMailboxClosed)
 	}
 	if got := mb.prepareReceive(mem, 4, 2, 0); got != statusOK {
 		t.Fatalf("prepare queued tag on closed mailbox = %d, want %d", got, statusOK)
@@ -226,8 +210,8 @@ func TestMailboxPrepareReceiveCloseSemantics(t *testing.T) {
 	if got := string(mem[16 : 16+3]); got != "two" {
 		t.Fatalf("closed queued payload = %q, want two", got)
 	}
-	if got := mb.prepareReceive(mem, 4, 2, 0); got != statusClosed {
-		t.Fatalf("prepare consumed tag on closed mailbox = %d, want %d", got, statusClosed)
+	if got := mb.prepareReceive(mem, 4, 2, 0); got != statusMailboxClosed {
+		t.Fatalf("prepare consumed tag on closed mailbox = %d, want %d", got, statusMailboxClosed)
 	}
 	if got := mb.prepareReceive(mem, 4, 1, 0); got != statusOK {
 		t.Fatalf("prepare remaining queued tag on closed mailbox = %d, want %d", got, statusOK)
@@ -259,8 +243,8 @@ func TestMailboxPrepareReceiveRejectsSecondPendingMessage(t *testing.T) {
 	if got := mb.prepareReceive(mem, 4, 1, 0); got != statusOK {
 		t.Fatalf("first prepare status = %d, want %d", got, statusOK)
 	}
-	if got := mb.prepareReceive(mem, 4, 1, 0); got != statusPending {
-		t.Fatalf("second prepare status = %d, want %d", got, statusPending)
+	if got := mb.prepareReceive(mem, 4, 1, 0); got != statusPendingMessage {
+		t.Fatalf("second prepare status = %d, want %d", got, statusPendingMessage)
 	}
 	if got := mb.receivePrepared(mem, 16, 3); got != statusOK {
 		t.Fatalf("receive first pending = %d, want %d", got, statusOK)
@@ -309,7 +293,10 @@ func TestRuntimeSendTagged(t *testing.T) {
 
 	mem := make([]byte, 64)
 	mb := rt.procs[pid].mailbox
-	if got := mb.receiveIntoTag(mem, 0, 16, 16, 4, 0); got != statusOK {
+	if got := mb.prepareReceive(mem, 4, 0, 0); got != statusOK {
+		t.Fatalf("prepare untagged status = %d, want %d", got, statusOK)
+	}
+	if got := mb.receivePrepared(mem, 16, binary.LittleEndian.Uint32(mem[4:])); got != statusOK {
 		t.Fatalf("receive untagged status = %d, want %d", got, statusOK)
 	}
 	if got := string(mem[16 : 16+5]); got != "plain" {

--- a/src/wago/process_test.go
+++ b/src/wago/process_test.go
@@ -99,19 +99,28 @@ func TestSpawnSelfPID(t *testing.T) {
 	}
 }
 
-func TestSpawnRecvMessage(t *testing.T) {
+func TestSpawnPrepareAndReceiveMessage(t *testing.T) {
 	rt := NewRuntime()
-	// run() -> i32 = wago_mailbox.recv(buf=0, cap=256, out_len=256, timeout=-1)
-	body := []byte{0x41, 0x00} // i32.const 0 (buf_ptr)
-	body = append(body, 0x41)
-	body = append(body, wasmtest.SLEB32(256)...) // i32.const 256 (buf_cap)
-	body = append(body, 0x41)
-	body = append(body, wasmtest.SLEB32(256)...) // i32.const 256 (out_len_ptr)
+	// run() -> i32:
+	//   prepare_receive(length_ptr=256, tag=0, timeout=-1)
+	//   drop
+	//   message.receive(ptr=0, len=i32.load(256))
+	body := []byte{0x41}
+	body = append(body, wasmtest.SLEB32(256)...) // i32.const 256 (length_ptr)
+	body = append(body, 0x42, 0x00)             // i64.const 0 (untagged)
 	body = append(body, 0x42)
 	body = append(body, wasmtest.SLEB64(-1)...) // i64.const -1 (timeout: block)
-	body = append(body, 0x10, 0x00, 0x0b)       // call 0; end
-	mod := procModule(t, []impSpec{{"wago_mailbox", "recv", []byte{i32b, i32b, i32b, i64b}, []byte{i32b}}},
-		1, []byte{i32b}, body)
+	body = append(body, 0x10, 0x00)             // call 0 prepare_receive
+	body = append(body, 0x1a)                   // drop status
+	body = append(body, 0x41, 0x00)             // i32.const 0 (message dst)
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(256)...) // i32.const 256
+	body = append(body, 0x28, 0x02, 0x00)        // i32.load align=2 offset=0
+	body = append(body, 0x10, 0x01, 0x0b)        // call 1 message.receive; end
+	mod := procModule(t, []impSpec{
+		{"wago_mailbox", "prepare_receive", []byte{i32b, i64b, i64b}, []byte{i32b}},
+		{"wago_message", "receive", []byte{i32b, i32b}, []byte{i32b}},
+	}, 1, []byte{i32b}, body)
 	class := classFor(t, rt, mod)
 	defer class.Close()
 
@@ -124,7 +133,7 @@ func TestSpawnRecvMessage(t *testing.T) {
 	}
 	ev := <-mustMonitor(t, rt, pid)
 	if !ev.Reason.Normal || len(ev.Reason.Results) != 1 || ev.Reason.Results[0].I32() != statusOK {
-		t.Fatalf("recv exit = %s results=%v, want normal status 0", ev.Reason, ev.Reason.Results)
+		t.Fatalf("receive exit = %s results=%v, want normal status 0", ev.Reason, ev.Reason.Results)
 	}
 	// Sending to the exited process now fails.
 	if err := rt.Send(context.Background(), pid, []byte("x")); err == nil {
@@ -135,23 +144,21 @@ func TestSpawnRecvMessage(t *testing.T) {
 	}
 }
 
-// blockingRecvModule builds run() -> i32 that blocks forever on recv.
-func blockingRecvModule(t *testing.T) *Module {
-	body := []byte{0x41, 0x00}
-	body = append(body, 0x41)
+// blockingReceiveModule builds run() -> i32 that blocks forever on prepare_receive.
+func blockingReceiveModule(t *testing.T) *Module {
+	body := []byte{0x41}
 	body = append(body, wasmtest.SLEB32(256)...)
-	body = append(body, 0x41)
-	body = append(body, wasmtest.SLEB32(256)...)
+	body = append(body, 0x42, 0x00)
 	body = append(body, 0x42)
 	body = append(body, wasmtest.SLEB64(-1)...)
 	body = append(body, 0x10, 0x00, 0x0b)
-	return procModule(t, []impSpec{{"wago_mailbox", "recv", []byte{i32b, i32b, i32b, i64b}, []byte{i32b}}},
+	return procModule(t, []impSpec{{"wago_mailbox", "prepare_receive", []byte{i32b, i64b, i64b}, []byte{i32b}}},
 		1, []byte{i32b}, body)
 }
 
 func TestKillCooperative(t *testing.T) {
 	rt := NewRuntime()
-	class := classFor(t, rt, blockingRecvModule(t))
+	class := classFor(t, rt, blockingReceiveModule(t))
 	defer class.Close()
 
 	pid, err := rt.Spawn(context.Background(), class, SpawnOptions{Entry: "run"})
@@ -174,7 +181,7 @@ func TestKillCooperative(t *testing.T) {
 
 func TestLinkPropagation(t *testing.T) {
 	rt := NewRuntime()
-	class := classFor(t, rt, blockingRecvModule(t))
+	class := classFor(t, rt, blockingReceiveModule(t))
 	defer class.Close()
 
 	a, err := rt.Spawn(context.Background(), class, SpawnOptions{Entry: "run"})

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -48,9 +48,10 @@ type Runtime struct {
 	capOrder    []Capability
 	closed      bool
 
-	procMu  sync.Mutex
-	procs   map[PID]*Process
-	nextPID PID
+	procMu    sync.Mutex
+	procs     map[PID]*Process
+	procNames map[string]PID
+	nextPID   PID
 }
 
 // RuntimeOption configures a Runtime at construction.
@@ -78,6 +79,7 @@ func NewRuntime(opts ...RuntimeOption) *Runtime {
 		moduleOwner: map[string]string{},
 		caps:        map[Capability]string{},
 		procs:       map[PID]*Process{},
+		procNames:   map[string]PID{},
 		nextPID:     1,
 	}
 	for _, opt := range opts {
@@ -368,7 +370,7 @@ func checkCompat(c Compatibility) error {
 	}
 	con, err := semver.ParseConstraint(constraint)
 	if err != nil {
-		return fmt.Errorf("invalid wago version constraint %q: %w", constraint, err)
+		return fmt.Errorf("invalid wago version constraint %q: %w", constraint)
 	}
 	ver, err := semver.Parse(Version)
 	if err != nil {

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -50,7 +50,7 @@ type Runtime struct {
 
 	procMu    sync.Mutex
 	procs     map[PID]*Process
-	procNames map[string]PID
+	procNames map[string]processNameEntry
 	nextPID   PID
 }
 
@@ -79,7 +79,7 @@ func NewRuntime(opts ...RuntimeOption) *Runtime {
 		moduleOwner: map[string]string{},
 		caps:        map[Capability]string{},
 		procs:       map[PID]*Process{},
-		procNames:   map[string]PID{},
+		procNames:   map[string]processNameEntry{},
 		nextPID:     1,
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
## Summary

- Collapse the guest actor mailbox ABI to one canonical tagged send plus the explicit two-step receive handshake.
- Canonical guest imports are now:
  - `wago_process.self() -> i64`
  - `wago_process.register(pid: i64, name_ptr: i32, name_len: i32) -> i32`
  - `wago_process.get(name_ptr: i32, name_len: i32, pid_ptr: i32) -> i32`
  - `wago_process.unregister(name_ptr: i32, name_len: i32) -> i32`
  - `wago_process.monitor(pid: i64) -> i32`
  - `wago_mailbox.send(pid: i64, tag: i64, ptr: i32, len: i32) -> i32`
  - `wago_mailbox.prepare_receive(length_ptr: i32, tag: i64, timeout_ms: i64) -> i32`
  - `wago_message.receive(ptr: i32, byte_len: i32) -> i32`
  - `wago_monitor.prepare(pid_ptr: i32, reason_ptr: i32, len_ptr: i32, timeout_ms: i64) -> i32`
  - `wago_monitor.receive(msg_ptr: i32, msg_len: i32) -> i32`
- Add a separate guest monitor event queue on each process instead of sending lifecycle events through the normal mailbox.
- `wago_process.monitor` subscribes the calling process to another PID's exit; if the target already exited, a monitor event is queued immediately.
- `wago_monitor.prepare` reserves the next monitor event and writes the exited PID, reason kind, and payload length; `wago_monitor.receive` copies the payload and consumes the prepared event.
- Monitor reason kinds distinguish normal exit, killed exit, and error exit. Error exits carry the error string payload; normal/killed exits currently use an empty payload.
- Add a runtime-owned process name registry guarded by the existing process mutex instead of a separate `sync.Map`, so name registration/lookup stays atomic with process table checks and lifecycle cleanup.
- `process.register` accepts an explicit target PID so a master/supervisor process can spawn service processes and publish them by name.
- Registry entries track both the target PID and the registrar PID; `process.unregister` is allowed from either the registered process itself or the registrar that published it.
- Add host APIs:
  - `RegisterProcessName(ctx, name, pid)`
  - `LookupProcessName(ctx, name)`
  - `UnregisterProcessName(ctx, name)`
  - `MonitorProcess(ctx, watcherPID, targetPID)`
- `SpawnOptions.Name` still atomically registers the spawned process name and releases it on process exit.
- Remove the unused/duplicate guest surface from the PR: `send_tagged`, `recv`, `recv_tagged`, `try_recv`, `try_recv_tagged`, and `wago_mailbox.len`.
- Keep Go-side send ergonomics with `Runtime.Send(ctx, pid, msg)` as untagged and `Runtime.SendTagged(ctx, pid, tag, msg)` as tagged.
- `prepare_receive` blocks/selects a matching message, reserves it, and writes its byte length to guest memory.
- `wago_message.receive` requires the guest to acknowledge exactly the prepared byte length before copying and consuming the message.
- Nonmatching tagged messages stay queued; invalid memory or size-mismatched receives leave the prepared message pending for retry.
- Tighten guest status codes to distinguish invalid memory, missing process, full mailbox, closed mailbox, would-block, timeout, pending message, no prepared message, size mismatch, invalid name, name taken, name not found, and permission denied.
- Validate reserved process/mailbox/message/monitor import signatures before PID allocation/binding, so malformed guests are rejected at spawn time instead of panicking during a host callback.

## Tests

- Updated process lifecycle tests to use the canonical `prepare_receive` + `wago_message.receive` flow.
- Added direct mailbox tests for tag filtering, nonmatching preservation, exact size acknowledgement, pending-message protection, retry behavior, bad length pointers, zero-length messages, close behavior with queued/nonmatching tags, timeout behavior, and mailbox capacity/closed-send errors.
- Added process-name tests for `SpawnOptions.Name`, host register/lookup/unregister, guest register/get/unregister imports, master/supervisor registration of another service PID, target-owned unregister of a supervisor-created name, unregister ownership checks, invalid guest memory, and invalid names.
- Added process-monitor tests for normal exit, error payload, receive retry after size mismatch, already-exited target, invalid memory preserving the pending monitor event, would-block/timeout, unknown target PID, and the host `MonitorProcess` API.
- Added `Runtime.SendTagged` coverage alongside existing untagged `Send`.
- Added a regression test that declares `wago_mailbox.send` with the old three-parameter shape and verifies `Spawn` rejects the module with a signature mismatch.

Not run locally in this environment.