### PR TITLE
Installed wago can build plugins: keep source at ~/.wago/src

### DIFF
--- a/cli/wagocli/wagomodule.go
+++ b/cli/wagocli/wagomodule.go
@@ -149,6 +149,12 @@ func mirroredReplaces(src string) []string {
 			if !filepath.IsAbs(p) {
 				p = filepath.Join(src, p)
 			}
+			// Skip a local replace whose target isn't present — e.g. an installed
+			// wago has no sibling plugin checkout — so the plugin resolves via
+			// `go get` (published) instead of a dangling path.
+			if _, err := os.Stat(p); err != nil {
+				continue
+			}
 			newSpec = filepath.ToSlash(p)
 		} else if r.New.Version != "" {
 			newSpec = r.New.Path + "@" + r.New.Version
@@ -258,18 +264,36 @@ func wagoModuleDir() (string, error) {
 	if d := os.Getenv("WAGO_SRC"); d != "" {
 		return d, nil
 	}
-	out, err := exec.Command("go", "env", "GOMOD").Output()
+	// Inside a wago checkout (e.g. hacking on wago itself)? Use it.
+	if out, err := exec.Command("go", "env", "GOMOD").Output(); err == nil {
+		gomod := strings.TrimSpace(string(out))
+		if gomod != "" && gomod != os.DevNull {
+			if b, err := os.ReadFile(gomod); err == nil && strings.Contains(string(b), "module github.com/wago-org/wago") {
+				return filepath.Dir(gomod), nil
+			}
+		}
+	}
+	// Otherwise the source the installer keeps at ~/.wago/src, so an installed
+	// wago builds plugins with no checkout. (Only needed while wago is unpublished;
+	// once it ships, the .wago module just `go get`s it.)
+	if d := installedWagoSource(); d != "" {
+		return d, nil
+	}
+	return "", fmt.Errorf("no wago source found; set WAGO_SRC to a wago checkout, or reinstall via wago.sh so the source is kept for plugin builds")
+}
+
+// installedWagoSource returns the wago source the installer places at ~/.wago/src,
+// or "" if it isn't a wago checkout.
+func installedWagoSource() string {
+	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("locating wago source: %w (set WAGO_SRC to the wago checkout)", err)
+		return ""
 	}
-	gomod := strings.TrimSpace(string(out))
-	if gomod == "" || gomod == os.DevNull {
-		return "", fmt.Errorf("not inside a Go module; set WAGO_SRC to the wago checkout")
+	dir := filepath.Join(home, ".wago", "src")
+	if b, err := os.ReadFile(filepath.Join(dir, "go.mod")); err == nil && strings.Contains(string(b), "module github.com/wago-org/wago") {
+		return dir
 	}
-	if b, err := os.ReadFile(gomod); err != nil || !strings.Contains(string(b), "module github.com/wago-org/wago") {
-		return "", fmt.Errorf("current module is not github.com/wago-org/wago; set WAGO_SRC to the wago checkout")
-	}
-	return filepath.Dir(gomod), nil
+	return ""
 }
 
 func exeSuffix() string {

--- a/cli/wagocli/wagomodule_test.go
+++ b/cli/wagocli/wagomodule_test.go
@@ -1,0 +1,29 @@
+package wagocli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstalledWagoSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if d := installedWagoSource(); d != "" {
+		t.Fatalf("no source yet: want %q, got %q", "", d)
+	}
+	src := filepath.Join(home, ".wago", "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A non-wago go.mod is ignored.
+	os.WriteFile(filepath.Join(src, "go.mod"), []byte("module example.com/x\n"), 0o644)
+	if d := installedWagoSource(); d != "" {
+		t.Fatalf("non-wago go.mod: want %q, got %q", "", d)
+	}
+	// The wago module is found.
+	os.WriteFile(filepath.Join(src, "go.mod"), []byte("module github.com/wago-org/wago\n\ngo 1.22\n"), 0o644)
+	if d := installedWagoSource(); d != src {
+		t.Fatalf("wago source: want %q, got %q", src, d)
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,9 @@ set -eu
 repo_ssh="git@github.com:wago-org/wago"
 version="${WAGO_VERSION:-main}"
 bin_dir="${WAGO_BIN_DIR:-$HOME/.local/bin}"
+# The wago source is kept here so `wago pkg add` can build plugins while wago is
+# unpublished — the CLI looks for it at ~/.wago/src (see wagoModuleDir).
+src_dir="${WAGO_SRC_DIR:-$HOME/.wago/src}"
 dry_run="${WAGO_DRY_RUN:-0}"
 
 # Accept GitHub's host key non-interactively; ssh still prompts for a key
@@ -92,7 +95,8 @@ have go || die "Go 1.22+ is required to build wago from source"
 go_version_ok || die "Go 1.22 or newer is required"
 
 if [ "$dry_run" = "1" ]; then
-	info "dry run: clone $repo_ssh@$version, then go build ./cli/wago -> $bin_dir/wago"
+	info "dry run: clone $repo_ssh@$version, go build ./cli/wago -> $bin_dir/wago,"
+	info "         and keep the source at $src_dir for plugin builds"
 	exit 0
 fi
 
@@ -108,8 +112,7 @@ if ! git clone --depth 1 --branch "$version" "$repo_ssh" "$tmp/src" 2>/dev/null;
 fi
 
 # No plugins are bundled: wago builds plugin-free (stdlib-only, so this builds
-# offline with no module downloads). Add plugins afterward from the registry —
-# e.g. `wago pkg add github.com/wago-org/wasi && wago pkg build`.
+# offline with no module downloads).
 stamp=$(git -C "$tmp/src" describe --tags --always 2>/dev/null || echo "$version")
 step "building wago ${dim}($stamp)${reset}"
 ( cd "$tmp/src" && go build -trimpath -ldflags "-X main.version=$stamp" -o "$tmp/wago" ./cli/wago ) \
@@ -118,6 +121,15 @@ step "building wago ${dim}($stamp)${reset}"
 mkdir -p "$bin_dir"
 mv "$tmp/wago" "$bin_dir/wago"
 ok "installed $bin_dir/wago"
+
+# Keep the source so `wago pkg add <module> && wago pkg build` can compile a
+# custom binary with plugins (wago is unpublished, so builds need it; the CLI
+# finds it at ~/.wago/src). Swapped in only after a successful build.
+rm -rf "$src_dir"
+mkdir -p "$(dirname "$src_dir")"
+if mv "$tmp/src" "$src_dir" 2>/dev/null; then
+	ok "kept wago source at $src_dir ${dim}(for plugin builds)${reset}"
+fi
 
 "$bin_dir/wago" --version || true
 case ":$PATH:" in


### PR DESCRIPTION
The installer promised `wago pkg add <module> && wago pkg build`, but that couldn't work for installed users: plugin builds need the wago source (wago is unpublished), and the installer cloned to a temp dir and deleted it.

- **install.sh**: after building the binary, keeps the checkout at `~/.wago/src` (override `WAGO_SRC_DIR`), swapped in only on a successful build.
- **wagoModuleDir**: when `WAGO_SRC` is unset and we're not inside a wago checkout, falls back to `~/.wago/src` (`installedWagoSource`). So an installed wago builds plugins with no env setup.
- **mirroredReplaces**: skips a local `replace` whose target is missing — an installed wago has no sibling plugin checkout, so e.g. `wasi => ../wasi` is dropped and the (now public) plugin resolves via `go get` instead of a dangling path.

## Verified
- Dev flow unchanged: with a wago checkout + sibling wasi, `pkg add wasi` mirrors the local replace and `run --plugin wasi` prints "hello from wasi".
- `TestInstalledWagoSource` covers the `~/.wago/src` fallback; cli suite green; `sh -n install.sh` clean.

CI is billing-blocked; validated locally.