### PR TITLE
cli: npm-like pkg commands (force, verbose, update, info, aliases)

### DIFF
--- a/cli/wagocli/cli.go
+++ b/cli/wagocli/cli.go
@@ -59,6 +59,20 @@ func (c *Ctx) one(what string) string {
 	return c.Args[0]
 }
 
+// opt returns an optional sole positional (empty when none), fataling if more
+// than one was given so `what` still documents the single-arg shape.
+func (c *Ctx) opt(what string) string {
+	switch len(c.Args) {
+	case 0:
+		return ""
+	case 1:
+		return c.Args[0]
+	default:
+		fatal("%s: accepts at most one %s", strings.TrimPrefix(c.Path, "wago "), what)
+		return ""
+	}
+}
+
 // child finds a subcommand by name or alias.
 func (c *Cmd) child(name string) *Cmd {
 	for _, ch := range c.Children {

--- a/cli/wagocli/cmd_pkg.go
+++ b/cli/wagocli/cmd_pkg.go
@@ -7,17 +7,22 @@ package wagocli
 // wagomodule.go). The publish side (publish/unpublish/deprecate) talks to the
 // registry and is build-tagged (registry_net.go vs the lean registry_stub.go).
 func pkgCommand() *Cmd {
-	global := Flag{Name: "global", Bool: true, Help: "operate on the CLI-wide plugin set (~/.wago) instead of this project"}
+	global := Flag{Name: "global", Short: "g", Bool: true, Help: "operate on the CLI-wide plugin set (~/.wago) instead of this project"}
+	force := Flag{Name: "force", Short: "f", Bool: true, Help: "ignore the build cache / fetch the latest version"}
+	verbose := Flag{Name: "verbose", Short: "v", Bool: true, Help: "stream the underlying go output"}
+	opts := func(c *Ctx) pkgOpts {
+		return pkgOpts{global: c.Bool("global"), force: c.Bool("force"), verbose: c.Bool("verbose")}
+	}
 	return &Cmd{
 		Name:    "pkg",
 		Summary: "add, build, and publish registry packages",
 		Children: []*Cmd{
 			{
-				Name: "add", Aliases: []string{"install"},
+				Name: "add", Aliases: []string{"install", "i"},
 				Summary: "add a plugin dependency (wago.json + go get)",
-				Args:    "<module>",
-				Flags:   []Flag{global},
-				Run:     func(c *Ctx) { pkgAdd(c.one("<module>"), c.Bool("global")) },
+				Args:    "<module>[@version]",
+				Flags:   []Flag{global, force, verbose},
+				Run:     func(c *Ctx) { pkgAdd(c.one("<module>[@version]"), opts(c)) },
 			},
 			{
 				Name: "remove", Aliases: []string{"uninstall", "rm"},
@@ -25,6 +30,13 @@ func pkgCommand() *Cmd {
 				Args:    "<name>",
 				Flags:   []Flag{global},
 				Run:     func(c *Ctx) { pkgRemove(c.one("<name>"), c.Bool("global")) },
+			},
+			{
+				Name: "update", Aliases: []string{"up", "upgrade"},
+				Summary: "update plugin dependencies to their latest versions, then rebuild",
+				Args:    "[module]",
+				Flags:   []Flag{global, verbose},
+				Run:     func(c *Ctx) { pkgUpdate(c.opt("[module]"), opts(c)) },
 			},
 			{
 				Name: "list", Aliases: []string{"ls"},
@@ -35,8 +47,14 @@ func pkgCommand() *Cmd {
 			{
 				Name:    "build",
 				Summary: "build a custom wago binary with the declared plugins",
-				Flags:   []Flag{global},
-				Run:     func(c *Ctx) { pkgBuild(c.Bool("global")) },
+				Flags:   []Flag{global, force, verbose},
+				Run:     func(c *Ctx) { pkgBuild(opts(c)) },
+			},
+			{
+				Name: "info", Aliases: []string{"show", "view"},
+				Summary: "show a package's registry info",
+				Args:    "<name>",
+				Run:     func(c *Ctx) { pkgInfo(c.one("<name>")) },
 			},
 			{
 				Name:    "status",

--- a/cli/wagocli/plugin_build.go
+++ b/cli/wagocli/plugin_build.go
@@ -9,9 +9,24 @@ import (
 	"strings"
 )
 
+// pkgOpts are the shared flags for the consume-side pkg commands.
+type pkgOpts struct {
+	global  bool // operate on the ~/.wago set instead of the project
+	force   bool // ignore the build cache / fetch latest
+	verbose bool // stream the underlying `go` output
+}
+
+// plural returns "s" unless n == 1.
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
 // pkgAdd declares a plugin dependency: resolve its module path, `go get` it into
 // the .wago build module, and record it in wago.json's dependencies.
-func pkgAdd(modOrName string, global bool) {
+func pkgAdd(modOrName string, o pkgOpts) {
 	module, version := splitModuleVersion(modOrName)
 	if !strings.Contains(module, "/") && !strings.Contains(module, ".") {
 		// A bare name: resolve its Go module path from the registry.
@@ -22,7 +37,7 @@ func pkgAdd(modOrName string, global bool) {
 		module = resolved
 	}
 
-	buildDir, err := buildDirFor(global)
+	buildDir, err := buildDirFor(o.global)
 	if err != nil {
 		fatal("pkg add: %v", err)
 	}
@@ -33,20 +48,27 @@ func pkgAdd(modOrName string, global bool) {
 	if version != "" {
 		getSpec += "@" + version
 	}
-	fmt.Printf("%s %s\n", dim("go get"), getSpec)
-	if err := goGetDep(buildDir, getSpec); err != nil {
+	var getErr error
+	if o.force && version == "" {
+		fmt.Printf("%s %s %s\n", dim("→ fetching"), module, dim("(latest)"))
+		getErr = goUpdate(buildDir, module, o.verbose)
+	} else {
+		fmt.Printf("%s %s\n", dim("→ fetching"), getSpec)
+		getErr = goGetDep(buildDir, getSpec, o.verbose)
+	}
+	if getErr != nil {
 		if _, haveSrc := wagoSourceDir(); !haveSrc {
-			fatal("pkg add: go get %s: %v\n  (during dev, set WAGO_SRC to a wago checkout so sibling plugins resolve locally)", getSpec, err)
+			fatal("pkg add: fetching %s: %v\n  (during dev, set WAGO_SRC to a wago checkout so sibling plugins resolve locally)", getSpec, getErr)
 		}
-		fatal("pkg add: go get %s: %v", getSpec, err)
+		fatal("pkg add: fetching %s: %v", getSpec, getErr)
 	}
 
-	src, _ := depsSource(global)
+	src, _ := depsSource(o.global)
 	newly, err := addProjectDep(src, module)
 	if err != nil {
 		fatal("pkg add: %v", err)
 	}
-	if !global {
+	if !o.global {
 		ensureGitignore(".wago/")
 	}
 	deps, _ := projectDeps(src)
@@ -56,8 +78,8 @@ func pkgAdd(modOrName string, global bool) {
 	if newly {
 		verb = "added"
 	}
-	fmt.Printf("%s %s  %s\n", verb, cyan(deriveName(module)), dim(module))
-	fmt.Printf("  %s\n", dim("run any module and wago rebuilds with it, or: wago pkg build"))
+	fmt.Printf("%s %s  %s\n", cyan(verb), deriveName(module), dim(module))
+	fmt.Printf("  %s\n", dim(fmt.Sprintf("%d plugin%s declared · run any module to rebuild, or: wago pkg build", len(deps), plural(len(deps)))))
 }
 
 // pkgRemove drops a dependency from wago.json (a later build's `go mod tidy`
@@ -104,12 +126,12 @@ func pkgList(global bool) {
 }
 
 // pkgBuild builds (or reuses) the custom wago binary for the declared plugins.
-func pkgBuild(global bool) {
-	buildDir, err := buildDirFor(global)
+func pkgBuild(o pkgOpts) {
+	buildDir, err := buildDirFor(o.global)
 	if err != nil {
 		fatal("pkg build: %v", err)
 	}
-	src, _ := depsSource(global)
+	src, _ := depsSource(o.global)
 	deps, err := projectDeps(src)
 	if err != nil {
 		fatal("pkg build: %v", err)
@@ -117,11 +139,11 @@ func pkgBuild(global bool) {
 	if len(deps) == 0 {
 		fatal("pkg build: no dependencies in %s (add one: wago pkg add <module>)", projectManifestPath(src))
 	}
-	fmt.Printf("%s\n", bold("building a custom wago binary with:"))
+	fmt.Printf("%s\n", bold(fmt.Sprintf("building wago with %d plugin%s:", len(deps), plural(len(deps)))))
 	for _, d := range deps {
 		fmt.Printf("  %s  %s\n", cyan(deriveName(d)), dim(d))
 	}
-	bin, cached, err := ensureBuiltBinary(buildDir, deps)
+	bin, cached, err := ensureBuiltBinary(buildDir, deps, o.force, o.verbose)
 	if err != nil {
 		fatal("pkg build: %v", err)
 	}
@@ -130,6 +152,47 @@ func pkgBuild(global bool) {
 		verb = "up to date"
 	}
 	fmt.Printf("%s %s  %s\n", cyan("✓"), verb, bin)
+}
+
+// pkgUpdate updates dependencies to their latest versions (go get -u) and
+// rebuilds. With a target it updates just that plugin; otherwise all of them.
+func pkgUpdate(target string, o pkgOpts) {
+	buildDir, err := buildDirFor(o.global)
+	if err != nil {
+		fatal("pkg update: %v", err)
+	}
+	if err := ensureBuildModule(buildDir); err != nil {
+		fatal("pkg update: %v", err)
+	}
+	src, _ := depsSource(o.global)
+	deps, err := projectDeps(src)
+	if err != nil {
+		fatal("pkg update: %v", err)
+	}
+	if len(deps) == 0 {
+		fatal("pkg update: no dependencies to update (add one: wago pkg add <module>)")
+	}
+	targets := deps
+	if target != "" {
+		if !strings.Contains(target, "/") && !strings.Contains(target, ".") {
+			if m, err := resolveRegistryModule(target); err == nil {
+				target = m
+			}
+		}
+		targets = []string{target}
+	}
+	for _, t := range targets {
+		fmt.Printf("%s %s %s\n", dim("→ updating"), t, dim("(latest)"))
+		if err := goUpdate(buildDir, t, o.verbose); err != nil {
+			fatal("pkg update: %s: %v", t, err)
+		}
+	}
+	_ = writeBuildMain(buildDir, deps)
+	bin, _, err := ensureBuiltBinary(buildDir, deps, true, o.verbose) // force rebuild after update
+	if err != nil {
+		fatal("pkg update: %v", err)
+	}
+	fmt.Printf("%s updated %d plugin%s  %s\n", cyan("✓"), len(targets), plural(len(targets)), bin)
 }
 
 // maybeReexecForPlugins transparently hands off to a custom wago binary with this
@@ -145,7 +208,7 @@ func maybeReexecForPlugins() {
 	if len(deps) == 0 {
 		return
 	}
-	bin, _, err := ensureBuiltBinary(buildDir, deps)
+	bin, _, err := ensureBuiltBinary(buildDir, deps, false, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s could not build plugins (%v); running without them\n", dim("wago:"), err)
 		return

--- a/cli/wagocli/registry_net.go
+++ b/cli/wagocli/registry_net.go
@@ -791,3 +791,130 @@ func splitCommaList(s string) []string {
 	}
 	return out
 }
+
+// infoPackage is the subset of a registry package GET /api/packages/{name}
+// response that `wago pkg info` renders.
+type infoPackage struct {
+	Name              string   `json:"name"`
+	Short             string   `json:"short"`
+	Description       string   `json:"description"`
+	Category          string   `json:"category"`
+	Tags              []string `json:"tags"`
+	License           string   `json:"license"`
+	Repository        string   `json:"repository"`
+	Homepage          string   `json:"homepage"`
+	OwnerLogin        string   `json:"ownerLogin"`
+	Dependencies      []string `json:"dependencies"`
+	DeprecatedMessage string   `json:"deprecatedMessage"`
+	Stars             int      `json:"stars"`
+	Score             int      `json:"score"`
+	UpdatedAt         string   `json:"updatedAt"`
+	Authors           []struct {
+		Login string `json:"login"`
+		Name  string `json:"name"`
+	} `json:"authors"`
+	Versions []struct {
+		Version     string `json:"version"`
+		PublishedAt string `json:"publishedAt"`
+		Latest      bool   `json:"latest"`
+		Deprecated  bool   `json:"deprecated"`
+	} `json:"versions"`
+}
+
+// pkgInfo prints a package's registry metadata (`wago pkg info <name>`). It
+// accepts a short name or a full module path — both resolve via the same lookup.
+func pkgInfo(name string) {
+	if name == "" {
+		fatal("pkg info: a package name is required")
+	}
+	// A full module path still has a usable short as its last segment.
+	lookup := name
+	if strings.Contains(name, "/") {
+		lookup = name[strings.LastIndexByte(name, '/')+1:]
+	}
+	status, data, err := apiRequest(http.MethodGet, "/api/packages/"+url.PathEscape(lookup), "", nil)
+	if err != nil {
+		fatal("pkg info: %v", err)
+	}
+	if status == http.StatusNotFound {
+		fatal("pkg info: no package %q in the registry", name)
+	}
+	if status != http.StatusOK {
+		fatal("pkg info: %s", apiError(status, data))
+	}
+	var p infoPackage
+	if err := json.Unmarshal(data, &p); err != nil {
+		fatal("pkg info: %v", err)
+	}
+
+	// Latest version + publish date.
+	latest, published := "", ""
+	for _, v := range p.Versions {
+		if v.Latest {
+			latest, published = v.Version, v.PublishedAt
+			break
+		}
+	}
+	if latest == "" && len(p.Versions) > 0 {
+		latest = p.Versions[0].Version
+		published = p.Versions[0].PublishedAt
+	}
+
+	title := p.Short
+	if latest != "" {
+		title += " " + latest
+	}
+	fmt.Printf("%s  %s\n", bold(cyan(title)), dim(p.Name))
+	if p.Description != "" {
+		fmt.Printf("%s\n", p.Description)
+	}
+	fmt.Println()
+
+	row := func(label, val string) {
+		if val != "" {
+			fmt.Printf("  %-10s %s\n", dim(label), val)
+		}
+	}
+	row("license", p.License)
+	row("category", p.Category)
+	if len(p.Tags) > 0 {
+		row("tags", strings.Join(p.Tags, ", "))
+	}
+	row("homepage", p.Homepage)
+	row("repository", p.Repository)
+	if p.OwnerLogin != "" {
+		row("owner", p.OwnerLogin)
+	}
+	if len(p.Authors) > 0 {
+		names := make([]string, 0, len(p.Authors))
+		for _, a := range p.Authors {
+			if a.Login != "" {
+				names = append(names, a.Login)
+			} else if a.Name != "" {
+				names = append(names, a.Name)
+			}
+		}
+		row("authors", strings.Join(names, ", "))
+	}
+	row("stars", fmt.Sprintf("%d", p.Stars))
+	if p.Score > 0 {
+		row("score", fmt.Sprintf("%d", p.Score))
+	}
+
+	if len(p.Dependencies) > 0 {
+		fmt.Printf("\n%s\n", dim("dependencies:"))
+		for _, d := range p.Dependencies {
+			fmt.Printf("  %s  %s\n", cyan(deriveName(d)), dim(d))
+		}
+	}
+
+	fmt.Println()
+	install := "wago pkg add " + p.Short
+	fmt.Printf("%s %s\n", dim("install:"), install)
+	if published != "" {
+		fmt.Printf("%s published %s\n", dim("·"), published)
+	}
+	if p.DeprecatedMessage != "" {
+		fmt.Printf("%s %s\n", red("⚠ deprecated:"), p.DeprecatedMessage)
+	}
+}

--- a/cli/wagocli/registry_stub.go
+++ b/cli/wagocli/registry_stub.go
@@ -23,5 +23,6 @@ func registryLogin(*Ctx)     { leanUnavailable("auth login") }
 func registryLogout(*Ctx)    { leanUnavailable("auth logout") }
 func registryWhoami(*Ctx)    { leanUnavailable("auth whoami") }
 func registryPublish(*Ctx)   { leanUnavailable("pkg publish") }
+func pkgInfo(string)         { leanUnavailable("pkg info") }
 func registryUnpublish(*Ctx) { leanUnavailable("pkg unpublish") }
 func registryDeprecate(*Ctx) { leanUnavailable("pkg deprecate") }

--- a/cli/wagocli/wagomodule.go
+++ b/cli/wagocli/wagomodule.go
@@ -169,13 +169,33 @@ func isFilesystemPath(p string) bool {
 }
 
 // goGetDep runs `go get modspec` in the build module (modspec may be module@ver).
-func goGetDep(dir, modspec string) error {
-	cmd := exec.Command("go", "get", modspec)
+// goRun runs `go <args>` in dir. When verbose, it streams go's output live;
+// otherwise it captures it and only surfaces it on failure (quiet success, like
+// npm). Errors include the tail of go's output for context.
+func goRun(dir string, verbose bool, args ...string) error {
+	cmd := exec.Command("go", args...)
 	cmd.Dir = dir
 	cmd.Env = os.Environ()
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if verbose {
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil && len(out) > 0 {
+		os.Stderr.Write(out)
+	}
+	return err
+}
+
+// goGetDep runs `go get modspec` in the build module (verbose streams output).
+func goGetDep(dir, modspec string, verbose bool) error {
+	return goRun(dir, verbose, "get", modspec)
+}
+
+// goUpdate runs `go get -u target` (update to latest) in the build module.
+func goUpdate(dir, target string, verbose bool) error {
+	return goRun(dir, verbose, "get", "-u", target)
 }
 
 // writeBuildMain generates .wago/main.go: import wago's CLI as a library and
@@ -197,13 +217,15 @@ func writeBuildMain(dir string, deps []string) error {
 
 // ensureBuiltBinary builds (or reuses a cached) custom wago binary at
 // .wago/bin/wago for deps. cached reports a hash hit (deps + toolchain unchanged).
-func ensureBuiltBinary(dir string, deps []string) (bin string, cached bool, err error) {
+func ensureBuiltBinary(dir string, deps []string, force, verbose bool) (bin string, cached bool, err error) {
 	bin = filepath.Join(dir, "bin", "wago"+exeSuffix())
 	hashFile := bin + ".hash"
 	want := buildHash(deps)
-	if b, err := os.ReadFile(hashFile); err == nil && strings.TrimSpace(string(b)) == want {
-		if _, err := os.Stat(bin); err == nil {
-			return bin, true, nil
+	if !force {
+		if b, err := os.ReadFile(hashFile); err == nil && strings.TrimSpace(string(b)) == want {
+			if _, err := os.Stat(bin); err == nil {
+				return bin, true, nil
+			}
 		}
 	}
 	if err := ensureBuildModule(dir); err != nil {
@@ -218,13 +240,14 @@ func ensureBuiltBinary(dir string, deps []string) (bin string, cached bool, err 
 	// Resolve the import graph (fetch any published plugins; local replaces stay
 	// local), then compile.
 	_, haveSrc := wagoSourceDir()
-	for _, step := range [][]string{{"mod", "tidy"}, {"build", "-o", bin, "."}} {
-		cmd := exec.Command("go", step...)
-		cmd.Dir = dir
-		cmd.Env = os.Environ()
-		cmd.Stdout = os.Stderr
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
+	// -buildvcs=false: the generated build module is a local throwaway; VCS
+	// stamping is meaningless and would otherwise fail when .wago sits inside an
+	// unrelated or partial git work tree.
+	for _, step := range [][]string{{"mod", "tidy"}, {"build", "-buildvcs=false", "-o", bin, "."}} {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "%s go %s\n", dim("→"), strings.Join(step, " "))
+		}
+		if err := goRun(dir, verbose, step...); err != nil {
 			if step[0] == "mod" && !haveSrc {
 				return "", false, fmt.Errorf("go mod tidy: %w\n  (wago may not be published yet — set WAGO_SRC to a wago checkout to build from source)", err)
 			}


### PR DESCRIPTION
Makes `wago pkg` more robust and verbose, closer to npm's ergonomics.

**New / changed**
- `-f, --force` on `add`/`build` — ignore the build cache; `add -f` fetches the latest version (`go get -u`).
- `-v, --verbose` on `add`/`build`/`update` — stream the underlying `go` output live; quiet-on-success otherwise (errors still surface `go`'s output).
- `-g` short flag for `--global`.
- `wago pkg update [module]` (aliases `up`, `upgrade`) — `go get -u` all deps (or one), then force-rebuild.
- `wago pkg info <name>` (aliases `show`, `view`) — print a package's registry metadata (version, license, tags, homepage/repo, authors, dependencies, deprecation).
- `i` alias for `add` (npm parity).
- Friendlier output: `→ fetching`, `N plugin(s) declared`, `✓ built` / `up to date`.

**Robustness**
- Build the generated `.wago` module with `-buildvcs=false` — it's a local throwaway; VCS stamping is meaningless and previously failed when `.wago` sat inside an unrelated/partial git work tree.

Verified end-to-end (add → build → cache hit → force → update → remove; run a wasm32-wasip1 module through the plugin-built binary; `info` against the live registry). Both normal and `-tags wago_lean` builds pass; `go test ./cli/...` green.