### PR TITLE
fix(arm64): two miscompiles that broke every real Rust/WASI program

### DIFF
--- a/src/core/compiler/backend/railshot/arm64/memexec_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/memexec_arm64_test.go
@@ -18,6 +18,51 @@ import (
 // under qemu, and verifies the value round-trips through linear memory — proving
 // the ported memory codegen (base+index+disp address fold) is correct, not just
 // compiling.
+// TestMemExecConstStoreLargeDisp is a regression test for a StoreImmIdx bug: a
+// constant-value store whose memarg offset exceeds the scaled-immediate range
+// (so the displacement is folded into X16 via addDispX16, which uses X17 as
+// scratch) parked the store value in X17 *before* that fold — so the fold
+// clobbered the value and the store wrote the displacement instead. Loads and
+// register-value stores were unaffected; only const-value stores at large
+// offsets, which is exactly dlmalloc's mparams init — hence every real Rust/WASI
+// program aborted at its first heap allocation.
+func TestMemExecConstStoreLargeDisp(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	// offset 32768 (0x8000) is past the word-scaled imm12 range (0xFFF*4 = 16380),
+	// forcing the large-displacement path. f(addr): mem[addr+32768] = 12345;
+	// return mem[addr+32768].
+	body := []byte{
+		0x00,
+		0x20, 0x00, 0x41, 0xb9, 0xe0, 0x00, 0x36, 0x02, 0x80, 0x80, 0x02, // local.get0; i32.const 12345; i32.store offset=32768
+		0x20, 0x00, 0x28, 0x02, 0x80, 0x80, 0x02, // local.get0; i32.load offset=32768
+		0x0b,
+	}
+	m := modMem(t, 1, i32, i32, body)
+	cm, err := CompileModuleWith(m, CompileOptions{ElideBoundsChecks: true})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	code, err := arm64spike.MapExec(cm.Code)
+	if err != nil {
+		t.Fatalf("map code: %v", err)
+	}
+	const head = 4096
+	buf, err := arm64spike.MapRW(head + 65536)
+	if err != nil {
+		t.Fatalf("map mem: %v", err)
+	}
+	linMem := uintptr(unsafe.Pointer(&buf[head]))
+	entry := uintptr(unsafe.Pointer(&code[cm.InternalEntry[0]]))
+	const addr = 16
+	got := arm64spike.Call3(entry, addr, 0, linMem)
+	if uint32(got) != 12345 {
+		t.Fatalf("returned %d, want 12345 (const store wrote the displacement, not the value)", uint32(got))
+	}
+	if inMem := binary.LittleEndian.Uint32(buf[head+addr+32768:]); inMem != 12345 {
+		t.Fatalf("linear memory at [%d] = %d, want 12345", addr+32768, inMem)
+	}
+}
+
 func TestMemExec(t *testing.T) {
 	i32 := []wasm.ValType{wasm.I32}
 	// f(addr): mem[addr+4] = 12345; return mem[addr+4]

--- a/src/core/encoder/arm64/asm2.go
+++ b/src/core/encoder/arm64/asm2.go
@@ -489,25 +489,31 @@ func (a *Asm) StoreIdx(base, index, src Reg, disp int32, size int) {
 	a.StrIdx(src, X16, XZR, size)
 }
 func (a *Asm) StoreImmIdx(base, index Reg, disp, val int32, size int) {
-	src := Reg(XZR)
-	if val != 0 {
+	// The store value lives in X17 (a nonzero immediate); XZR when zero. X17 is
+	// also the scratch register addDispX16 uses to fold a large displacement, so
+	// the value must be materialized *after* any X17-clobbering address math —
+	// otherwise the store writes the displacement instead of val.
+	immSrc := func() Reg {
+		if val == 0 {
+			return XZR
+		}
 		a.MovImm64(X17, uint64(uint32(val)))
-		src = X17
+		return X17
 	}
 	if disp == 0 {
-		a.StrIdx(src, base, index, size)
+		a.StrIdx(immSrc(), base, index, size)
 		return
 	}
+	a.AddShifted(X16, base, index, 0, false)
 	if foldIdxDispEnabled && a.DenseIdxDisp {
-		a.AddShifted(X16, base, index, 0, false)
-		if a.storeDisp(src, X16, disp, size) {
+		// storeDisp folds disp into a scaled immediate (no X17 use), so the value
+		// may be parked in X17 first.
+		if a.storeDisp(immSrc(), X16, disp, size) {
 			return
 		}
-	} else {
-		a.AddShifted(X16, base, index, 0, false)
 	}
-	a.addDispX16(disp)
-	a.StrIdx(src, X16, XZR, size)
+	a.addDispX16(disp) // clobbers X17
+	a.StrIdx(immSrc(), X16, XZR, size)
 }
 
 // FMov is the amd64-legacy alias for a scalar V→V move.

--- a/src/core/runtime/resume_arm64.s
+++ b/src/core/runtime/resume_arm64.s
@@ -44,7 +44,12 @@ afterResume:
 
 resumeWasm:
 	MOVD R30, R11                  // afterResume continuation PC
-	MOVD R11, -16(R26)
+	// Store the continuation PC at the trap-handler slot (arm64TrapHandlerPtrOffset
+	// = 32), matching enterNative and the backend's offTrapHandlerPtr. Offset 16 is
+	// WRONG here: a u64 there overlaps the max-pages cache at -12, so the PC's high
+	// word clobbers the memory.grow ceiling — every host call would then break the
+	// next memory.grow (and thus heap allocation).
+	MOVD R11, -32(R26)
 	LDP 8(R9), (R19, R20)
 	LDP 24(R9), (R21, R22)
 	LDP 40(R9), (R23, R24)

--- a/src/wago/hostcall_grow_regress_test.go
+++ b/src/wago/hostcall_grow_regress_test.go
@@ -1,0 +1,56 @@
+//go:build (linux && (amd64 || arm64)) || (darwin && arm64)
+
+package wago
+
+import "testing"
+
+// hostCallThenGrowWasm: a module with an imported host function and a memory
+// that grows. _start calls the import, then does memory.grow(1) and stores the
+// result at address 0.
+//
+//	(import "env" "f" (func $f (param i32)))
+//	(memory (export "memory") 18)
+//	(func (export "_start")
+//	  (call $f (i32.const 123))
+//	  i32.const 0 i32.const 1 memory.grow i32.store)
+var hostCallThenGrowWasm = []byte{
+	0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x60,
+	0x01, 0x7f, 0x00, 0x60, 0x00, 0x00, 0x02, 0x09, 0x01, 0x03, 0x65, 0x6e,
+	0x76, 0x01, 0x66, 0x00, 0x00, 0x03, 0x02, 0x01, 0x01, 0x05, 0x03, 0x01,
+	0x00, 0x12, 0x07, 0x13, 0x02, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79,
+	0x02, 0x00, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x01, 0x0a,
+	0x12, 0x01, 0x10, 0x00, 0x41, 0xfb, 0x00, 0x10, 0x00, 0x41, 0x00, 0x41,
+	0x01, 0x40, 0x00, 0x36, 0x02, 0x00, 0x0b,
+}
+
+// TestHostCallThenGrow is a regression test for an arm64 resumeNative bug: it
+// stored the host-call continuation PC at basedata offset -16, whose upper half
+// overlaps the memory.grow max-pages cache at -12, so the PC's high word
+// clobbered the grow ceiling. Every host call then broke the next memory.grow —
+// real Rust/WASI programs, which allocate after their first WASI call, aborted
+// with "memory allocation failed". memory.grow(1) from 18 pages must return the
+// old size (18), not -1.
+func TestHostCallThenGrow(t *testing.T) {
+	c, err := Compile(nil, hostCallThenGrowWasm)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+		"env.f": HostFunc(func(_ HostModule, _, _ []uint64) {}),
+	}})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	if _, err := in.Invoke("_start"); err != nil {
+		t.Fatalf("_start: %v", err)
+	}
+	got, ok := in.ReadUint32Le(0)
+	if !ok {
+		t.Fatal("read mem[0] failed")
+	}
+	if got != 18 {
+		t.Fatalf("memory.grow(1) after a host call returned %d, want 18 (old page count); "+
+			"0xffffffff means the host-call continuation-PC store corrupted the max-pages cache", int32(got))
+	}
+}


### PR DESCRIPTION
## Summary

Two independent arm64 backend bugs each caused real Rust/WASI programs (markdown, serde_json, blake3, base64, crc, rhai, regex, …) to abort. With both fixed, all 8 programs in the wasi plugin's `TestWASIApps` corpus pass on arm64 (they compiled + instantiated fine before, but trapped during execution).

### Bug 1 — `StoreImmIdx` clobbers the value on large-offset const stores
A constant-value store whose memarg offset exceeds the word-scaled imm12 range folds the displacement into `X16` via `addDispX16`, which uses `X17` as scratch — but the store value was already parked in `X17`, so the fold overwrote it and the store wrote the *displacement* instead of the value. This is exactly what dlmalloc's `mparams` init does (store constants at large offsets), so every program aborted at its **first heap allocation**.

Fix: materialize the value into `X17` *after* the `X17`-clobbering address math.

### Bug 2 — `resumeNative` writes the continuation PC over the max-pages cache
`resumeNative` stored the host-call continuation PC at basedata offset `-16`, whose upper u32 overlaps the `memory.grow` max-pages cache at `-12` (`enterNative` and the backend correctly use `-32` = `arm64TrapHandlerPtrOffset`). The PC's high word (`1` for a 4–8 GiB code pointer) clobbered the grow ceiling, so after **any** host call the next `memory.grow` failed. Programs allocate after their first WASI call, so they aborted with `memory allocation failed`.

Fix: store the continuation PC at `-32`, matching `enterNative`.

## How they were found
Enabled the arm64-gated `TestWASIApps`, then instrumented at the WASM level (inject `(call $trace …)` at function entries / around suspect ops via `wasm2wat`/`wat2wasm`, run with a trace host import) to get the trapping call-chain and operand values, and reduced each to a tiny hand-written module.

## Tests
- `TestMemExecConstStoreLargeDisp` (backend) — const store at a large offset round-trips the value; fails on the old code returning the displacement.
- `TestHostCallThenGrow` (src/wago) — `memory.grow(1)` after a host call returns the old page count, not `-1`.

Both were confirmed to fail before their respective fix and pass after.

## Verification
- arm64: all 8 `TestWASIApps` programs pass; arm64 encoder/backend unit tests + corpus green.
- amd64 (linux): build + core runtime/backend/encoder tests green (both fixes are arm64-only files).

## Out of scope
A separate, pre-existing bug: `RunWago/regexmatch` SIGSEGVs on **amd64 under guard-page bounds** (bad jump target, `pc=0xfff38`) — regexmatch runs fine on amd64 in explicit-bounds mode. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)