### PR TITLE
ci: test native OS and architecture matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,26 +158,13 @@ jobs:
           WAGO_CORPUS_TIMEOUT: 20s
         run: make test-corpus
 
-  spec2:
-    name: WebAssembly 2.0 spec
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
+      - name: Fetch SIMD proposal suite
+        if: matrix.runtime
+        run: git submodule update --init tests/spec
 
-      - name: Install wabt (wast2json)
-        run: sudo apt-get update && sudo apt-get install -y wabt
-
-      - name: Fetch pinned WebAssembly 2.0 spec
-        run: git submodule update --init tests/spec-v2
-
-      - name: Run WebAssembly 2.0 core suite
-        run: make spec2
+      - name: SIMD execution suite
+        if: matrix.runtime
+        run: make simd
 
   tinygo:
     name: TinyGo build & test
@@ -240,13 +227,11 @@ jobs:
       - name: Install wabt (wast2json / wat2wasm)
         run: sudo apt-get update && sudo apt-get install -y wabt
 
-      # The spec-suite and WASI-suite card producers replay the WebAssembly
-      # testsuites; fetch only those submodules (not the large C++ warp/ one).
-      - name: Fetch spec + WASI testsuite submodules
-        run: git submodule update --init tests/spec tests/spec-v2 tests/wasi
-
       # Produce the coverage/tests/spec fragments. On PRs, CARD_BASELINE_REF
       # measures main in a worktree for the "Δ vs main" columns, so fetch main.
+      # The spec fragment runs last and initializes its own corpora, keeping
+      # known spec gaps informational instead of feeding them into coverage or
+      # ordinary test counts.
       - name: Produce card fragments
         env:
           CARD_BASELINE_REF: ${{ github.event_name == 'pull_request' && 'origin/main' || '' }}
@@ -340,7 +325,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [changes, lint, platform-test, spec2, tinygo, coverage, size]
+    needs: [changes, lint, platform-test, tinygo, coverage, size]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,10 +167,30 @@ jobs:
         run: make simd
 
   tinygo:
-    name: TinyGo build & test
+    name: TinyGo / ${{ matrix.name }}
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux / amd64
+            runner: ubuntu-24.04
+            runtime: true
+            cli: true
+          - name: Linux / arm64
+            runner: ubuntu-24.04-arm
+            runtime: true
+            cli: true
+          - name: Darwin / amd64
+            runner: macos-15-intel
+            runtime: false
+            cli: false
+          - name: Darwin / arm64
+            runner: macos-15
+            runtime: true
+            cli: false
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -184,22 +204,32 @@ jobs:
       # TinyGo links native linux/amd64 binaries with LLVM lld; the runner needs
       # ld.lld on PATH (otherwise: "ROM segments are non-contiguous").
       - name: Install lld
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y lld
 
       # Compile portability: the whole pipeline (wasm -> amd64 -> runtime ->
       # public API + CLI) must build under TinyGo. A NOTE: the output name must
       # not end in .bin, which TinyGo treats as a firmware image.
       - name: Build CLI with TinyGo
+        if: matrix.cli
         run: make tinygo-build
 
-      # Runtime behavior: this exercises enterNative through the generated
-      # trampoline (trampoline_tinygo_amd64.go). If TinyGo's func-value ABI ever
-      # diverges from the System V assumption it relies on, these fail loudly.
+      # Runtime behavior exercises the generated amd64/arm64 foreign-stack
+      # trampolines and synchronous host-call resume path natively.
       - name: Test (runtime + public API) under TinyGo
+        if: matrix.runtime
         run: make tinygo-test
+
+      # Darwin/amd64 mirrors the Big Go matrix: the native JIT ABI is not yet
+      # implemented, but architecture-neutral compiler and encoder code must
+      # remain buildable and testable under TinyGo.
+      - name: Portable compiler tests under TinyGo
+        if: ${{ !matrix.runtime }}
+        run: tinygo test ./src/core/compiler/codegen ./src/core/compiler/ir ./src/core/encoder/amd64 ./src/core/encoder/arm64
 
       # End-to-end smoke: the TinyGo-built JIT must execute a real module.
       - name: Smoke-run a real module
+        if: matrix.cli
         run: |
           out="$(./wago-tinygo run --invoke fib tests/testdata/fib.wasm 20)"
           echo "$out"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,14 @@ env:
   GO_VERSION: "1.22"
 
 jobs:
-  # Decide which parts of CI actually need to run for this change, so we don't
-  # burn minutes on unrelated edits.
-  #   code -> any non-docs source/build/config change (gates the whole matrix)
-  #   arm  -> arm64-specific OR shared code changed, so arm64 behavior may differ
-  # amd64-only edits skip the arm64 job; docs-only edits skip everything but the
-  # gate. See ci-ok below for how this stays compatible with required checks.
+  # Decide whether the change can affect executable code. Docs-only changes skip
+  # the expensive jobs; every code change runs the complete native platform
+  # matrix so architecture and OS interactions cannot hide behind path filters.
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.derive.outputs.code }}
-      arm: ${{ steps.derive.outputs.arm }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -40,42 +36,17 @@ jobs:
               - '**/*.md'
               - 'docs/**'
               - 'LICENSE'
-            amd64:
-              - 'src/core/encoder/amd64/**'
-              - 'src/core/compiler/backend/railshot/amd64/**'
-            arm64:
-              - 'src/core/encoder/arm64/**'
-              - 'src/core/compiler/backend/railshot/arm64/**'
-            # "shared" = anything that isn't docs and isn't arch-specific, i.e. a
-            # change that could affect either architecture's behavior.
-            shared:
+            code:
               - '**'
               - '!**/*.md'
               - '!docs/**'
               - '!LICENSE'
-              - '!src/core/encoder/amd64/**'
-              - '!src/core/encoder/arm64/**'
-              - '!src/core/compiler/backend/railshot/amd64/**'
-              - '!src/core/compiler/backend/railshot/arm64/**'
       - name: Derive job gates
         id: derive
         run: |
-          amd64='${{ steps.filter.outputs.amd64 }}'
-          arm64='${{ steps.filter.outputs.arm64 }}'
-          shared='${{ steps.filter.outputs.shared }}'
-          code=false
-          arm=false
-          if [ "$amd64" = true ] || [ "$arm64" = true ] || [ "$shared" = true ]; then
-            code=true
-          fi
-          # arm64 codegen can be perturbed by shared compiler/runtime changes, so
-          # run the arm64 job whenever arm64-specific OR shared code moved.
-          if [ "$arm64" = true ] || [ "$shared" = true ]; then
-            arm=true
-          fi
+          code='${{ steps.filter.outputs.code }}'
           echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "arm=$arm"   >> "$GITHUB_OUTPUT"
-          echo "gates: code=$code arm=$arm (amd64=$amd64 arm64=$arm64 shared=$shared)"
+          echo "gate: code=$code"
 
   lint:
     name: Lint & format
@@ -101,11 +72,43 @@ jobs:
       - name: Lint
         run: make lint
 
-  test:
-    name: Build & test
+  platform-test:
+    name: ${{ matrix.name }}
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux / amd64
+            runner: ubuntu-24.04
+            goos: linux
+            goarch: amd64
+            runtime: true
+            guard: true
+            corpus: true
+          - name: Linux / arm64
+            runner: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+            runtime: true
+            guard: true
+            corpus: true
+          - name: Darwin / amd64
+            runner: macos-15-intel
+            goos: darwin
+            goarch: amd64
+            runtime: false
+            guard: false
+            corpus: false
+          - name: Darwin / arm64
+            runner: macos-15
+            goos: darwin
+            goarch: arm64
+            runtime: true
+            guard: true
+            corpus: true
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -114,20 +117,46 @@ jobs:
           # No go.sum (stdlib-only module) -> nothing to cache; avoids a warning.
           cache: false
 
-      # The amd64 codegen tests assemble fixtures with wat2wasm and disassemble
-      # with objdump; without wabt those tests t.Skip and silently pass.
-      - name: Install wabt (wat2wasm)
+      # Codegen and corpus tests use wat2wasm. Install it on every platform so
+      # missing tooling cannot turn coverage into a silent skip.
+      - name: Install wabt (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y wabt
+      - name: Install wabt (macOS)
+        if: runner.os == 'macOS'
+        run: brew install wabt
+
+      - name: Verify native runner
+        run: |
+          test "$(go env GOOS)" = "${{ matrix.goos }}"
+          test "$(go env GOARCH)" = "${{ matrix.goarch }}"
+          go version
+          uname -a
 
       - name: Build & test
+        if: matrix.runtime
         run: make test
+
+      # Darwin/amd64 is not yet a supported native runtime target. Keep its
+      # architecture-neutral compiler and encoder surface honest without
+      # implying that the JIT ABI is implemented there.
+      - name: Portable compiler tests
+        if: ${{ !matrix.runtime }}
+        run: go test -count=1 ./internal/... ./src/core/compiler/codegen ./src/core/compiler/ir ./src/core/compiler/wasm ./src/core/encoder/amd64 ./src/core/encoder/arm64
 
       # Guard-page (signals-based) mode is behind a build tag, so `make test`
       # never exercises it — which is how a broken SIGSEGV fault->trap handler
       # stayed CI-invisible. This runs the fault->trap path plus in-bounds
       # differential correctness under the tag.
       - name: Guard-page trap tests
+        if: matrix.guard
         run: make test-guard
+
+      - name: Corpus correctness matrix
+        if: matrix.corpus
+        env:
+          WAGO_CORPUS_TIMEOUT: 20s
+        run: make test-corpus
 
   spec2:
     name: WebAssembly 2.0 spec
@@ -149,38 +178,6 @@ jobs:
 
       - name: Run WebAssembly 2.0 core suite
         run: make spec2
-
-  linux-arm64:
-    name: Linux arm64 runtime
-    needs: changes
-    # Native arm64 coverage on a cheap (~1x) arm runner. Only needed when arm64
-    # or shared code changed; amd64-only and docs-only edits skip it. macOS/arm64
-    # is validated locally (make test-native-arm64), not in CI.
-    if: needs.changes.outputs.arm == 'true'
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
-
-      - name: Verify native runner
-        run: |
-          test "$(go env GOOS)" = "linux"
-          test "$(go env GOARCH)" = "arm64"
-          uname -a
-
-      - name: Native backend/runtime/API tests
-        run: go test ./src/core/encoder/arm64 ./src/core/compiler/backend/railshot/arm64 ./src/core/runtime ./src/wago -count=1
-
-      - name: Guard-page runtime tests
-        run: go test -tags wago_guardpage ./src/core/runtime ./src/wago -count=1 -v
-
-      - name: Corpus correctness matrix
-        env:
-          WAGO_CORPUS_TIMEOUT: 20s
-        run: make test-corpus
 
   tinygo:
     name: TinyGo build & test
@@ -343,7 +340,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [changes, lint, test, spec2, tinygo, linux-arm64, coverage, size]
+    needs: [changes, lint, platform-test, spec2, tinygo, coverage, size]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,9 @@ jobs:
       - uses: acifani/setup-tinygo@v2
         with:
           tinygo-version: "0.41.1"
+          # Native builds do not use Binaryen, whose pinned release has no
+          # Linux/arm64 artifact and otherwise makes setup fail with a 404.
+          install-binaryen: false
 
       # TinyGo links native linux/amd64 binaries with LLVM lld; the runner needs
       # ld.lld on PATH (otherwise: "ROM segments are non-contiguous").

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,10 @@ spec2: ## Run the pinned official WebAssembly 2.0 core suite against x64 (needs 
 spec3: ## Run the WebAssembly 3.0 proposal spec tests against x64 (needs wast2json)
 	$(call run-spec,3.0,$(SPEC3_DIR),i32.wast,tests/spec)
 
+.PHONY: simd
+simd: ## Run the official SIMD proposal execution suite (needs wast2json)
+	$(call run-spec,simd,$(SPEC1_DIR),proposals/simd/simd_address.wast,tests/spec)
+
 .PHONY: spec
 spec: spec1 spec2 spec3 ## Run the WebAssembly spec suite for all versions
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -4,28 +4,30 @@ Pull requests and pushes to `main` run `.github/workflows/ci.yml`. Markdown-only
 changes use the lightweight aggregation gate; every code or build change runs
 the complete native platform matrix:
 
-| Runner | OS | Architecture | Standard suite | Guard pages | Corpus |
-|---|---|---|---:|---:|---:|
-| `ubuntu-24.04` | Linux | amd64 | yes | yes | yes |
-| `ubuntu-24.04-arm` | Linux | arm64 | yes | yes | yes |
-| `macos-15-intel` | Darwin | amd64 | portable compiler/encoder | no | no |
-| `macos-15` | Darwin | arm64 | yes | yes | yes |
+| Runner | OS | Architecture | Standard suite | Guard pages | Corpus | SIMD |
+|---|---|---|---:|---:|---:|---:|
+| `ubuntu-24.04` | Linux | amd64 | yes | yes | yes | yes |
+| `ubuntu-24.04-arm` | Linux | arm64 | yes | yes | yes | yes |
+| `macos-15-intel` | Darwin | amd64 | portable compiler/encoder | no | no | no |
+| `macos-15` | Darwin | arm64 | yes | yes | yes | yes |
 
 Each matrix cell asserts `go env GOOS` and `GOARCH` before testing. WABT is
 installed explicitly so tests that need `wat2wasm` do not silently skip because
 the runner image lacks the tool.
 
 The three supported runtime targets run `make test`, which builds and tests every
-Go package, followed by `make test-corpus` with a bounded per-case timeout. Their
-guard-page cells additionally run `make test-guard`. Darwin/amd64 is a native
-portability check for architecture-neutral compiler and encoder packages; wago
-does not yet implement its JIT ABI or signal-backed guard pages for that target,
-so runtime and corpus execution are deliberately excluded.
+Go package, followed by `make test-corpus` with a bounded per-case timeout and
+`make simd` against the official SIMD proposal corpus. Their guard-page cells
+additionally run `make test-guard`. Darwin/amd64 is a native portability check
+for architecture-neutral compiler and encoder packages; wago does not yet
+implement its JIT ABI or signal-backed guard pages for that target, so runtime,
+corpus, and SIMD execution are deliberately excluded.
 
-Linux/amd64 continues to host architecture-independent lint, WebAssembly 2.0
-conformance, TinyGo, coverage, and binary-size jobs. The final `CI` aggregation
-job is the stable branch-protection check and fails if any required matrix cell
-or supporting job fails.
+Linux/amd64 continues to host architecture-independent lint, TinyGo, coverage,
+and binary-size jobs. The CI card runs the WebAssembly 1.0, 2.0, and 3.0 suites
+for visibility without making their current gaps required checks. The final
+`CI` aggregation job is the stable branch-protection check and fails if any
+required matrix cell or supporting job fails.
 
 For a local native approximation, run:
 
@@ -34,4 +36,5 @@ make lint
 make test
 make test-guard   # only on a supported guard-page target
 WAGO_CORPUS_TIMEOUT=20s make test-corpus
+make simd
 ```

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,37 @@
+# Continuous integration
+
+Pull requests and pushes to `main` run `.github/workflows/ci.yml`. Markdown-only
+changes use the lightweight aggregation gate; every code or build change runs
+the complete native platform matrix:
+
+| Runner | OS | Architecture | Standard suite | Guard pages | Corpus |
+|---|---|---|---:|---:|---:|
+| `ubuntu-24.04` | Linux | amd64 | yes | yes | yes |
+| `ubuntu-24.04-arm` | Linux | arm64 | yes | yes | yes |
+| `macos-15-intel` | Darwin | amd64 | portable compiler/encoder | no | no |
+| `macos-15` | Darwin | arm64 | yes | yes | yes |
+
+Each matrix cell asserts `go env GOOS` and `GOARCH` before testing. WABT is
+installed explicitly so tests that need `wat2wasm` do not silently skip because
+the runner image lacks the tool.
+
+The three supported runtime targets run `make test`, which builds and tests every
+Go package, followed by `make test-corpus` with a bounded per-case timeout. Their
+guard-page cells additionally run `make test-guard`. Darwin/amd64 is a native
+portability check for architecture-neutral compiler and encoder packages; wago
+does not yet implement its JIT ABI or signal-backed guard pages for that target,
+so runtime and corpus execution are deliberately excluded.
+
+Linux/amd64 continues to host architecture-independent lint, WebAssembly 2.0
+conformance, TinyGo, coverage, and binary-size jobs. The final `CI` aggregation
+job is the stable branch-protection check and fails if any required matrix cell
+or supporting job fails.
+
+For a local native approximation, run:
+
+```sh
+make lint
+make test
+make test-guard   # only on a supported guard-page target
+WAGO_CORPUS_TIMEOUT=20s make test-corpus
+```

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -24,7 +24,10 @@ implement its JIT ABI or signal-backed guard pages for that target, so runtime,
 corpus, and SIMD execution are deliberately excluded.
 
 Linux/amd64 continues to host architecture-independent lint, TinyGo, coverage,
-and binary-size jobs. The CI card runs the WebAssembly 1.0, 2.0, and 3.0 suites
+and binary-size jobs. TinyGo mirrors the native matrix: Linux/amd64 and
+Linux/arm64 build, test, and smoke-run the CLI; Darwin/arm64 runs the runtime and
+public API suites; Darwin/amd64 runs the same portable compiler/encoder scope as
+Big Go. The CI card runs the WebAssembly 1.0, 2.0, and 3.0 suites
 for visibility without making their current gaps required checks. The final
 `CI` aggregation job is the stable branch-protection check and fails if any
 required matrix cell or supporting job fails.

--- a/docs/spec-testing.md
+++ b/docs/spec-testing.md
@@ -32,12 +32,16 @@ Install WABT so `wast2json` is on `PATH`, then run:
 ```sh
 make spec1
 make spec2
+make simd
 ```
 
 `make spec2` sets `WAGO_SPECTEST_DIR` to the `tests/spec-v2` checkout and
 `WAGO_SPEC_VERSION=2.0`; the execution harness resolves the tagged repository's
-`test/core` layout. CI provisions WABT, initializes only `tests/spec-v2`, and
-runs this same target in the `WebAssembly 2.0 spec` job.
+`test/core` layout. CI provisions WABT and runs the full release suites for the
+informational CI card. `make simd` is the required native execution gate for the
+focused official SIMD proposal corpus on each supported runtime target; broader
+spec-suite gaps remain visible in the card without failing the aggregate CI
+check.
 
 The validation harness uses the same release discovery and can be run directly:
 

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -177,7 +177,10 @@ checks. Go keeps its ~2× edge only on pure host-side *memory loops* (0.57 vs 1.
   comes from the embedded-fixture tests in `wago_test.go` (which read checked-in
   `.wasm` via `os.ReadFile`, no subprocess). **When adding a new test that uses
   `os/exec` or relies on `t.Skip`/`t.Fatal` aborting, tag it `!tinygo`** or the
-  `make tinygo-test` / CI gate will crash.
+  `make tinygo-test` / CI gate will crash. When only part of an otherwise
+  TinyGo-compatible test file needs WABT, guard those test functions with
+  `requireExternalWAT`; the TinyGo implementation returns before the unavailable
+  helper can run while the rest of the file remains covered.
 
 - **Test suites that probe standard-Go internals.** `stress_test.go` (morestack
   relocation, the `_Grunning` contract, adversarial concurrent `runtime.GC()`)

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -1,9 +1,13 @@
 # Building wago with TinyGo
 
-wago builds and runs under [TinyGo](https://tinygo.org) on `linux/amd64` with **no
-cgo**. The decode → validate → codegen → execute pipeline works end to end: the
-CLI and the public `wago` API run real modules (recursion, i64, floats, linear
-memory, host imports, `call_indirect`) identically to the standard toolchain.
+wago builds and runs under [TinyGo](https://tinygo.org) on `linux/amd64`,
+`linux/arm64`, and `darwin/arm64` with **no cgo**. The decode → validate →
+codegen → execute pipeline works end to end: the public `wago` API runs real
+modules (recursion, i64, floats, linear memory, host imports, `call_indirect`)
+identically to the standard toolchain. The CLI is additionally built and
+smoke-tested on both Linux architectures. TinyGo's Darwin standard library
+cannot currently link the CLI's `os/exec` paths, so Darwin/arm64 gates the
+runtime and public API directly.
 
 ## Why this needs special handling
 
@@ -27,12 +31,14 @@ maps native code, and enters it through an `unsafe` func-value cast:
   The thunk switches `RSP`, `call`s `R8`, and restores the Go context — mirroring
   the assembly trampoline exactly.
 
-The standard (`!tinygo`) build is unchanged and keeps using the assembly
-trampoline; the build tags select the right implementation automatically.
+On arm64, `trampoline_tinygo_arm64.go` generates the corresponding AAPCS64 entry
+and host-call resume thunks with the repository's AArch64 encoder. The standard
+(`!tinygo`) build is unchanged and keeps using the assembly trampolines; build
+tags select the right implementation automatically.
 
 ## Building
 
-TinyGo on `linux/amd64` links with LLVM `lld`. Make sure `ld.lld` is on `PATH`
+TinyGo on Linux links with LLVM `lld`. Make sure `ld.lld` is on `PATH`
 (`apt install lld`, or any LLVM toolchain).
 
 ```bash
@@ -188,4 +194,6 @@ checks. Go keeps its ~2× edge only on pure host-side *memory loops* (0.57 vs 1.
   runtime stress test is build-tagged `!tinygo`, with a TinyGo-appropriate
   counterpart in `stress_tinygo_test.go`.
 
-- **Platform.** `linux/amd64` only, same as the standard build.
+- **Platform.** Native execution is covered on `linux/amd64`, `linux/arm64`, and
+  `darwin/arm64`. Darwin/amd64 is a compiler/encoder portability target until
+  wago gains a native Darwin/amd64 JIT ABI under either Go toolchain.

--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sync"
-	"syscall"
 	"unsafe"
 
 	"github.com/wago-org/wago/src/core/runtime/abi"
@@ -323,10 +322,7 @@ func (j *JobMemory) Close() error {
 		if guardCloseHook != nil {
 			guardCloseHook(j.reserveBase)
 		}
-		if _, _, errno := syscall.Syscall(syscall.SYS_MUNMAP, j.reserveBase, j.reserveLen, 0); errno != 0 {
-			return errno
-		}
-		return nil
+		return munmapRange(j.reserveBase, j.reserveLen)
 	}
 	return munmap(j.mem)
 }

--- a/src/core/runtime/madvise_darwin_arm64.go
+++ b/src/core/runtime/madvise_darwin_arm64.go
@@ -1,0 +1,25 @@
+//go:build darwin && arm64 && !tinygo
+
+package runtime
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const madvZero = 11
+
+func madviseDontNeed(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	if _, _, errno := syscall.Syscall(syscall.SYS_MADVISE,
+		uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)), madvZero); errno == 0 {
+		return nil
+	}
+	if _, _, errno := syscall.Syscall(syscall.SYS_MADVISE,
+		uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)), syscall.MADV_DONTNEED); errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/src/core/runtime/madvise_darwin_arm64_tinygo.go
+++ b/src/core/runtime/madvise_darwin_arm64_tinygo.go
@@ -1,0 +1,10 @@
+//go:build darwin && arm64 && tinygo
+
+package runtime
+
+// TinyGo's Darwin syscall surface does not expose madvise. Clearing preserves
+// the zero-on-reuse contract; it merely forgoes returning those pages to the OS.
+func madviseDontNeed(b []byte) error {
+	clear(b)
+	return nil
+}

--- a/src/core/runtime/mem_darwin_arm64.go
+++ b/src/core/runtime/mem_darwin_arm64.go
@@ -5,27 +5,9 @@ package runtime
 import (
 	"sync"
 	"syscall"
-	"unsafe"
 )
 
 const pageSize = 16 << 10
-
-const madvZero = 11
-
-func madviseDontNeed(b []byte) error {
-	if len(b) == 0 {
-		return nil
-	}
-	if _, _, errno := syscall.Syscall(syscall.SYS_MADVISE,
-		uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)), madvZero); errno == 0 {
-		return nil
-	}
-	if _, _, errno := syscall.Syscall(syscall.SYS_MADVISE,
-		uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)), syscall.MADV_DONTNEED); errno != 0 {
-		return errno
-	}
-	return nil
-}
 
 func roundUpPage(n int) int {
 	if n <= 0 {

--- a/src/core/runtime/munmap_range.go
+++ b/src/core/runtime/munmap_range.go
@@ -1,0 +1,12 @@
+//go:build (linux && (amd64 || arm64)) || (darwin && arm64 && !tinygo)
+
+package runtime
+
+import "syscall"
+
+func munmapRange(base, length uintptr) error {
+	if _, _, errno := syscall.Syscall(syscall.SYS_MUNMAP, base, length, 0); errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/src/core/runtime/munmap_range_darwin_arm64_tinygo.go
+++ b/src/core/runtime/munmap_range_darwin_arm64_tinygo.go
@@ -1,0 +1,9 @@
+//go:build darwin && arm64 && tinygo
+
+package runtime
+
+import "unsafe"
+
+func munmapRange(base, length uintptr) error {
+	return munmap(unsafe.Slice((*byte)(unsafe.Pointer(base)), int(length)))
+}

--- a/src/core/runtime/trampoline_tinygo_arm64.go
+++ b/src/core/runtime/trampoline_tinygo_arm64.go
@@ -1,0 +1,159 @@
+//go:build (linux || darwin) && arm64 && tinygo
+
+package runtime
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	a64 "github.com/wago-org/wago/src/core/encoder/arm64"
+)
+
+// TinyGo cannot assemble the Plan9 arm64 trampolines. Its indirect func calls
+// use AAPCS64: X0-X3 carry the four explicit wrapper arguments and the func
+// value context follows in X4. Generated thunks use that context as the native
+// code pointer, switch to the engine's foreign stack, and preserve the AAPCS64
+// callee-saved Go state around native execution.
+
+type tinygoARM64FuncValue struct {
+	context uintptr
+	fnptr   uintptr
+}
+
+type tinygoARM64ThunkRef struct {
+	top   uintptr
+	entry uintptr
+}
+
+var (
+	tinygoARM64LastThunk atomic.Pointer[tinygoARM64ThunkRef]
+	tinygoARM64ThunkMu   sync.Mutex
+	tinygoARM64Thunks    = map[uintptr]uintptr{}
+)
+
+func tinygoARM64Store(a *a64.Asm, src, base a64.Reg, off uint32) {
+	if !a.Store64(src, base, off) {
+		panic("wago: arm64 TinyGo trampoline store is not encodable")
+	}
+}
+
+func tinygoARM64Load(a *a64.Asm, dst, base a64.Reg, off uint32) {
+	if !a.Load64(dst, base, off) {
+		panic("wago: arm64 TinyGo trampoline load is not encodable")
+	}
+}
+
+func tinygoARM64SaveGoContext(a *a64.Asm, top a64.Reg) {
+	a.SubImm64(top, top, 176)
+	a.AddImm64(a64.X11, a64.SP, 0)
+	tinygoARM64Store(a, a64.X11, top, 0)
+	for reg, off := a64.X19, uint32(8); reg <= a64.LR; reg, off = reg+1, off+8 {
+		tinygoARM64Store(a, reg, top, off)
+	}
+}
+
+func tinygoARM64RestoreGoContext(a *a64.Asm) {
+	for reg, off := a64.X19, uint32(8); reg <= a64.LR; reg, off = reg+1, off+8 {
+		tinygoARM64Load(a, reg, a64.SP, off)
+	}
+	tinygoARM64Load(a, a64.X11, a64.SP, 0)
+	a.AddImm64(a64.SP, a64.X11, 0)
+	a.Ret()
+}
+
+func tinygoARM64EntryCode(foreignStackTop uintptr) []byte {
+	var a a64.Asm
+	a.MovImm64(a64.X10, uint64(foreignStackTop))
+	tinygoARM64SaveGoContext(&a, a64.X10)
+	a.AddImm64(a64.SP, a64.X10, 0)
+	a.MovImm64(a64.FP, 0)
+	a.Stur64(a64.X10, a64.X1, -offTrapStackReentry)
+	continuation := a.Adr(a64.X11)
+	a.Stur64(a64.X11, a64.X1, -arm64TrapHandlerPtrOffset)
+	a.Blr(a64.X4)
+	epilogue := a.Len()
+	if !a.PatchAdr(continuation, epilogue) {
+		panic("wago: arm64 TinyGo trampoline continuation is out of range")
+	}
+	tinygoARM64RestoreGoContext(&a)
+	return a.B
+}
+
+func tinygoARM64ThunkFor(foreignStackTop uintptr) uintptr {
+	if ref := tinygoARM64LastThunk.Load(); ref != nil && ref.top == foreignStackTop {
+		return ref.entry
+	}
+	tinygoARM64ThunkMu.Lock()
+	entry, ok := tinygoARM64Thunks[foreignStackTop]
+	if !ok {
+		mem, err := mmapExec(tinygoARM64EntryCode(foreignStackTop))
+		if err != nil {
+			tinygoARM64ThunkMu.Unlock()
+			panic("wago: cannot map arm64 TinyGo trampoline: " + err.Error())
+		}
+		entry = uintptr(unsafe.Pointer(&mem[0]))
+		tinygoARM64Thunks[foreignStackTop] = entry
+	}
+	tinygoARM64ThunkMu.Unlock()
+	tinygoARM64LastThunk.Store(&tinygoARM64ThunkRef{top: foreignStackTop, entry: entry})
+	return entry
+}
+
+func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr) {
+	fv := tinygoARM64FuncValue{context: code, fnptr: tinygoARM64ThunkFor(foreignStackTop)}
+	call := *(*func(a, b, c, d uintptr))(unsafe.Pointer(&fv))
+	call(serArgs, linMem, trap, results)
+}
+
+var (
+	tinygoARM64ResumeOnce  sync.Once
+	tinygoARM64ResumeEntry uintptr
+)
+
+func tinygoARM64ResumeCode() []byte {
+	var a a64.Asm
+	a.MovReg64(a64.X9, a64.X0)
+	a.MovReg64(a64.X10, a64.X1)
+	tinygoARM64SaveGoContext(&a, a64.X10)
+	tinygoARM64Load(&a, a64.X26, a64.X9, hcSavedLinMem)
+	a.Stur64(a64.X10, a64.X26, -offTrapStackReentry)
+	continuation := a.Adr(a64.X11)
+	a.Stur64(a64.X11, a64.X26, -arm64TrapHandlerPtrOffset)
+
+	for reg, off := a64.X19, uint32(hcSavedX19); reg <= a64.X27; reg, off = reg+1, off+8 {
+		tinygoARM64Load(&a, reg, a64.X9, off)
+	}
+	tinygoARM64Load(&a, a64.FP, a64.X9, hcSavedFP)
+	tinygoARM64Load(&a, a64.LR, a64.X9, hcSavedLR)
+	for reg, off := a64.Reg(8), int32(hcSavedV8); reg <= a64.Reg(15); reg, off = reg+1, off+8 {
+		a.FLoadDisp(reg, a64.X9, off, true)
+	}
+	tinygoARM64Load(&a, a64.X11, a64.X9, hcSavedSP)
+	a.AddImm64(a64.SP, a64.X11, 0)
+	a.Br(a64.LR)
+
+	epilogue := a.Len()
+	if !a.PatchAdr(continuation, epilogue) {
+		panic("wago: arm64 TinyGo resume continuation is out of range")
+	}
+	tinygoARM64RestoreGoContext(&a)
+	return a.B
+}
+
+func tinygoARM64ResumePtr() uintptr {
+	tinygoARM64ResumeOnce.Do(func() {
+		mem, err := mmapExec(tinygoARM64ResumeCode())
+		if err != nil {
+			panic("wago: cannot map arm64 TinyGo resume trampoline: " + err.Error())
+		}
+		tinygoARM64ResumeEntry = uintptr(unsafe.Pointer(&mem[0]))
+	})
+	return tinygoARM64ResumeEntry
+}
+
+func resumeNative(ctrl, foreignStackTop uintptr) {
+	fv := tinygoARM64FuncValue{fnptr: tinygoARM64ResumePtr()}
+	call := *(*func(a, b uintptr))(unsafe.Pointer(&fv))
+	call(ctrl, foreignStackTop)
+}

--- a/src/wago/bulk_memory_test.go
+++ b/src/wago/bulk_memory_test.go
@@ -5,34 +5,7 @@ package wago
 import (
 	"strings"
 	"testing"
-
-	"github.com/wago-org/wago/src/core/compiler/wasm"
-	"github.com/wago-org/wago/testutil/wasmtest"
 )
-
-func passiveDataModule() []byte {
-	// (func $init (param i32 i32 i32) local.get 0; local.get 1; local.get 2; memory.init 0 0)
-	initBody := []byte{0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfc, 0x08, 0x00, 0x00, 0x0b}
-	// (func $drop data.drop 0)
-	dropBody := []byte{0xfc, 0x09, 0x00, 0x0b}
-
-	return wasmtest.Module(
-		wasmtest.Section(1, wasmtest.Vec(
-			wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32, wasm.I32}, nil),
-			wasmtest.FuncType(nil, nil),
-		)),
-		wasmtest.Section(3, append(wasmtest.ULEB(2), 0x00, 0x01)),
-		wasmtest.Section(5, []byte{0x01, 0x00, 0x01}), // one min-1-page memory
-		wasmtest.Section(7, wasmtest.Vec(
-			wasmtest.ExportEntry("init", 0, 0),
-			wasmtest.ExportEntry("drop", 0, 1),
-			wasmtest.ExportEntry("mem", 2, 0),
-		)),
-		wasmtest.Section(12, wasmtest.ULEB(1)),
-		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(initBody), wasmtest.Code(dropBody))),
-		wasmtest.Section(11, wasmtest.Vec(append([]byte{0x01}, append(wasmtest.ULEB(5), []byte("hello")...)...))),
-	)
-}
 
 func TestPassiveDataMemoryInitAndDrop(t *testing.T) {
 	c, err := Compile(passiveDataModule())

--- a/src/wago/callargs_test.go
+++ b/src/wago/callargs_test.go
@@ -9,34 +9,8 @@
 package wago
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 )
-
-// watToWasmCA assembles a .wat module to wasm via wat2wasm (skips if absent).
-func watToWasmCA(t *testing.T, wat string) []byte {
-	t.Helper()
-	w2w, err := exec.LookPath("wat2wasm")
-	if err != nil {
-		t.Skip("wat2wasm (wabt) not on PATH")
-	}
-	dir := t.TempDir()
-	src := filepath.Join(dir, "m.wat")
-	out := filepath.Join(dir, "m.wasm")
-	if err := os.WriteFile(src, []byte(wat), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if o, err := exec.Command(w2w, src, "-o", out).CombinedOutput(); err != nil {
-		t.Fatalf("wat2wasm: %v\n%s", err, o)
-	}
-	b, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return b
-}
 
 // TestCallMixedArgKinds guards the direct-arg-write call path: a call whose
 // arguments mix constants, locals, and a value computed into a scratch register

--- a/src/wago/cross_instance_test.go
+++ b/src/wago/cross_instance_test.go
@@ -4,11 +4,20 @@ package wago
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/testutil/wasmtest"
 )
+
+func crossInstanceTrapCode(err error) TrapCode {
+	var trap *TrapError
+	if errors.As(err, &trap) {
+		return trap.Code
+	}
+	return TrapNone
+}
 
 func funcImportEntry(module, name string, typeIdx uint32) []byte {
 	out := append(wasmtest.Name(module), wasmtest.Name(name)...)
@@ -225,7 +234,7 @@ func TestCrossInstanceCallNoArgs(t *testing.T) {
 	if AsI32(r[0]) != 42 {
 		t.Fatalf("cross-instance call returned %d, want 42", AsI32(r[0]))
 	}
-	if _, err := inA.Invoke("trap"); trapCode(err) != TrapUnreachable {
+	if _, err := inA.Invoke("trap"); crossInstanceTrapCode(err) != TrapUnreachable {
 		t.Fatalf("producer trap after cross-instance entry = %v, want unreachable", err)
 	}
 	preparedTrap, err := inA.PrepareFunction("trap")
@@ -235,7 +244,7 @@ func TestCrossInstanceCallNoArgs(t *testing.T) {
 	if _, err := inB.Invoke("call"); err != nil {
 		t.Fatalf("second cross-instance call: %v", err)
 	}
-	if _, err := preparedTrap.Invoke(); trapCode(err) != TrapUnreachable {
+	if _, err := preparedTrap.Invoke(); crossInstanceTrapCode(err) != TrapUnreachable {
 		t.Fatalf("prepared producer trap after cross-instance entry = %v, want unreachable", err)
 	}
 }

--- a/src/wago/darwin_arm64_test_helpers_test.go
+++ b/src/wago/darwin_arm64_test_helpers_test.go
@@ -3,61 +3,9 @@
 package wago
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
-	"testing"
-
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/testutil/wasmtest"
 )
-
-func watToWasm(t testing.TB, wat string) []byte {
-	t.Helper()
-	w2w, err := exec.LookPath("wat2wasm")
-	if err != nil {
-		t.Skip("wat2wasm (wabt) not on PATH")
-	}
-	dir := t.TempDir()
-	src, out := filepath.Join(dir, "m.wat"), filepath.Join(dir, "m.wasm")
-	if err := os.WriteFile(src, []byte(wat), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if output, err := exec.Command(w2w, src, "-o", out).CombinedOutput(); err != nil {
-		t.Fatalf("wat2wasm: %v\n%s", err, output)
-	}
-	b, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return b
-}
-
-func passiveDataModule() []byte {
-	initBody := []byte{0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfc, 0x08, 0x00, 0x00, 0x0b}
-	dropBody := []byte{0xfc, 0x09, 0x00, 0x0b}
-	return wasmtest.Module(
-		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32, wasm.I32}, nil), wasmtest.FuncType(nil, nil))),
-		wasmtest.Section(3, append(wasmtest.ULEB(2), 0x00, 0x01)),
-		wasmtest.Section(5, []byte{0x01, 0x00, 0x01}),
-		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("init", 0, 0), wasmtest.ExportEntry("drop", 0, 1), wasmtest.ExportEntry("mem", 2, 0))),
-		wasmtest.Section(12, wasmtest.ULEB(1)),
-		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(initBody), wasmtest.Code(dropBody))),
-		wasmtest.Section(11, wasmtest.Vec(append([]byte{0x01}, append(wasmtest.ULEB(5), []byte("hello")...)...))),
-	)
-}
-
-func multiValueControlCallModule() []byte {
-	return wasmtest.Module(
-		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, []wasm.ValType{wasm.I32, wasm.I64}), wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32, wasm.I64}))),
-		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
-		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("pair", 0, 0), wasmtest.ExportEntry("choose", 0, 1))),
-		wasmtest.Section(10, wasmtest.Vec(
-			wasmtest.Code([]byte{0x41, 0x12, 0x42, 0x13, 0x0b}),
-			wasmtest.Code([]byte{0x20, 0x00, 0x04, 0x00, 0x10, 0x00, 0x05, 0x41, 0x07, 0x42, 0x09, 0x0b, 0x0b}),
-		)),
-	)
-}
 
 // signExtModule exports f(i32)->i32 = i32.extend8_s(local0).
 func signExtModule() []byte {

--- a/src/wago/externref_global_test.go
+++ b/src/wago/externref_global_test.go
@@ -172,6 +172,9 @@ func TestLocalExternrefGlobalsRemainOutOfSerializedState(t *testing.T) {
 }
 
 func TestRelease2ExternrefGlobalSourceGuard(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		return
+	}
 	sites := []struct {
 		file string
 		text []string

--- a/src/wago/externref_table_test.go
+++ b/src/wago/externref_table_test.go
@@ -188,6 +188,7 @@ func TestExternrefTableStructFootprintsRemainBounded(t *testing.T) {
 }
 
 func TestLocalExternrefTablesRespectFeatureStoreAndPersistenceBoundaries(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit")
 	wasmBytes := watToWasm(t, `(module
 		(table 1 2 externref)
 		(func (export "get") (param i32) (result externref) (table.get 0 (local.get 0)))

--- a/src/wago/externref_test.go
+++ b/src/wago/externref_test.go
@@ -340,6 +340,9 @@ func TestExternrefCodecCarriesStructureButNoStoreIdentity(t *testing.T) {
 }
 
 func TestExternrefFeatureGateAndOfficialSourceSites(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		return
+	}
 	cfg := NewRuntimeConfig().WithFeature(CoreFeatureReferenceTypes, false)
 	if _, err := Compile(cfg, externrefControlModule()); err == nil || !strings.Contains(err.Error(), "reference-types disabled") || !strings.Contains(err.Error(), "externref") {
 		t.Fatalf("Compile with reference types disabled = %v, want externref feature gate", err)

--- a/src/wago/funcref_boundary_test.go
+++ b/src/wago/funcref_boundary_test.go
@@ -315,6 +315,9 @@ func TestRuntimeImportedFuncrefRejectsForeignOrCorruptCanonicalDescriptor(t *tes
 }
 
 func TestFuncrefReferenceStoreStructFootprint(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		return
+	}
 	if got := unsafe.Sizeof(Instance{}); got != 776 {
 		t.Fatalf("Instance size = %d, want 776 bytes", got)
 	}

--- a/src/wago/funcref_global_test.go
+++ b/src/wago/funcref_global_test.go
@@ -272,6 +272,9 @@ func TestNullableLocalFuncrefGlobalsRemainOutOfSerializedState(t *testing.T) {
 }
 
 func TestRelease2NullableFuncrefGlobalSourceGuard(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		return
+	}
 	path := filepath.Clean("../../tests/spec-v2/test/core/linking.wast")
 	b, err := os.ReadFile(path)
 	if err != nil {

--- a/src/wago/host_funcref_global_test.go
+++ b/src/wago/host_funcref_global_test.go
@@ -210,6 +210,7 @@ func TestHostCreatedFuncRefGlobalNullAndOwnerBoundaries(t *testing.T) {
 }
 
 func TestHostCreatedFuncRefGlobalPersistenceAndLayoutsStayFailClosed(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit")
 	if got := unsafe.Sizeof(Global{}); got != 40 {
 		t.Fatalf("Global size = %d, want 40", got)
 	}

--- a/src/wago/hostcall_hardening_test.go
+++ b/src/wago/hostcall_hardening_test.go
@@ -166,6 +166,9 @@ func TestBindHostImportRejectsNilSlotForms(t *testing.T) {
 }
 
 func TestLegacyHostFuncCompatibleImportRoundTrips(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		return
+	}
 	if forceSyncHostImports {
 		t.Skip("legacy async host import serialization unavailable on this architecture")
 	}

--- a/src/wago/imported_externref_table_test.go
+++ b/src/wago/imported_externref_table_test.go
@@ -269,6 +269,7 @@ func TestStoreBoundExternrefTableKeepsRootsUntilRuntimeAndTableClose(t *testing.
 }
 
 func TestImportedExternrefTablePersistenceAndFootprintBoundaries(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit")
 	compiled, err := Compile(nil, watToWasm(t, `(module
 		(import "env" "t" (table 1 2 externref))
 		(export "t" (table 0))

--- a/src/wago/imported_reference_global_test.go
+++ b/src/wago/imported_reference_global_test.go
@@ -327,6 +327,9 @@ func TestReferenceGlobalCloseOrderingAliasesAndStoreRoots(t *testing.T) {
 }
 
 func TestReferenceGlobalPersistenceAndFootprintsStayBounded(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		return
+	}
 	if got := unsafe.Sizeof(Global{}); got != 40 {
 		t.Fatalf("Global size = %d, want 40", got)
 	}
@@ -350,6 +353,9 @@ func TestReferenceGlobalPersistenceAndFootprintsStayBounded(t *testing.T) {
 }
 
 func TestRelease2ImportedReferenceGlobalSourceGuard(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		return
+	}
 	raw, err := os.ReadFile(filepath.Clean("../../tests/spec-v2/test/core/linking.wast"))
 	if err != nil {
 		t.Skipf("Release 2 linking.wast unavailable: %v", err)

--- a/src/wago/memory_test.go
+++ b/src/wago/memory_test.go
@@ -145,6 +145,9 @@ func TestImportedMemorySingleInstance(t *testing.T) {
 }
 
 func TestMemoryOwnershipSidecarPreservesScalarHandleFootprint(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		return
+	}
 	if got := unsafe.Sizeof(Memory{}); got != 16 {
 		t.Fatalf("Memory size = %d, want 16 bytes", got)
 	}

--- a/src/wago/multitable_arm64_test.go
+++ b/src/wago/multitable_arm64_test.go
@@ -32,6 +32,9 @@ func arm64TableWasm(t *testing.T, wat string) []byte {
 }
 
 func TestARM64IndexedTableOperations(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	rt := NewRuntime()
 	defer rt.Close()
 	mod, err := rt.Compile(arm64TableWasm(t, `(module

--- a/src/wago/multivalue_test.go
+++ b/src/wago/multivalue_test.go
@@ -11,27 +11,6 @@ import (
 	"github.com/wago-org/wago/testutil/wasmtest"
 )
 
-func multiValueControlCallModule() []byte {
-	return wasmtest.Module(
-		wasmtest.Section(1, wasmtest.Vec(
-			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32, wasm.I64}),
-			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32, wasm.I64}),
-		)),
-		wasmtest.Section(3, wasmtest.Vec(
-			wasmtest.ULEB(0), // pair: () -> (i32, i64)
-			wasmtest.ULEB(1), // choose: (i32) -> (i32, i64)
-		)),
-		wasmtest.Section(7, wasmtest.Vec(
-			wasmtest.ExportEntry("pair", 0, 0),
-			wasmtest.ExportEntry("choose", 0, 1),
-		)),
-		wasmtest.Section(10, wasmtest.Vec(
-			wasmtest.Code([]byte{0x41, 0x12, 0x42, 0x13, 0x0b}),                                                 // i32.const 18; i64.const 19; end
-			wasmtest.Code([]byte{0x20, 0x00, 0x04, 0x00, 0x10, 0x00, 0x05, 0x41, 0x07, 0x42, 0x09, 0x0b, 0x0b}), // local.get 0; if type 0; call pair; else constants; end; end
-		)),
-	)
-}
-
 func multiValueBranchPayloadModule() []byte {
 	return wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(

--- a/src/wago/pinnedglobal_test.go
+++ b/src/wago/pinnedglobal_test.go
@@ -7,34 +7,8 @@
 package wago
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 )
-
-// watToWasm assembles a .wat module to wasm bytes via wat2wasm (skips if absent).
-func watToWasm(t testing.TB, wat string) []byte {
-	t.Helper()
-	w2w, err := exec.LookPath("wat2wasm")
-	if err != nil {
-		t.Skip("wat2wasm (wabt) not on PATH")
-	}
-	dir := t.TempDir()
-	src := filepath.Join(dir, "m.wat")
-	out := filepath.Join(dir, "m.wasm")
-	if err := os.WriteFile(src, []byte(wat), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if o, err := exec.Command(w2w, src, "-o", out).CombinedOutput(); err != nil {
-		t.Fatalf("wat2wasm: %v\n%s", err, o)
-	}
-	b, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return b
-}
 
 // TestPinnedGlobalAccumulateAndPersist exercises a mutable i64 global pinned in
 // a register: the get/add/set loop, the trailing read, write-back to the cell at

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -1270,6 +1270,7 @@ func TestMultipleLocalTableExportsResolveByName(t *testing.T) {
 }
 
 func TestImportedThenLocalFuncrefTablesExecuteAndExportExactly(t *testing.T) {
+	tableTestForceExplicitBounds(t)
 	if !requireExternalWAT(t) {
 		return
 	}
@@ -1410,6 +1411,7 @@ func TestImportedThenLocalFuncrefTablesExecuteAndExportExactly(t *testing.T) {
 }
 
 func TestMultipleImportedFuncrefTablesExecuteAndExportExactly(t *testing.T) {
+	tableTestForceExplicitBounds(t)
 	if !requireExternalWAT(t) {
 		return
 	}
@@ -3191,6 +3193,7 @@ func TestMultipleImportedTableArenaFootprintIsBounded(t *testing.T) {
 }
 
 func TestCompileRejectsUnsupportedTableIndexes(t *testing.T) {
+	tableTestForceExplicitBounds(t)
 	compileErrContains := func(t *testing.T, mod []byte, want string) {
 		t.Helper()
 		_, err := Compile(nil, mod)

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -1270,6 +1270,9 @@ func TestMultipleLocalTableExportsResolveByName(t *testing.T) {
 }
 
 func TestImportedThenLocalFuncrefTablesExecuteAndExportExactly(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	ownerCompiled := MustCompile(watToWasmCA(t, `(module
 		(type $ret (func (result i32)))
 		(table $first (export "first") 1 1 funcref)
@@ -1407,6 +1410,9 @@ func TestImportedThenLocalFuncrefTablesExecuteAndExportExactly(t *testing.T) {
 }
 
 func TestMultipleImportedFuncrefTablesExecuteAndExportExactly(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	newOwner := func(name string, value int32) (*Instance, *Table) {
 		t.Helper()
 		compiled, err := Compile(nil, watToWasmCA(t, fmt.Sprintf(`(module
@@ -1571,6 +1577,9 @@ func TestMultipleImportedFuncrefTablesExecuteAndExportExactly(t *testing.T) {
 }
 
 func TestMultipleImportedFuncrefTablesMayAliasOneHandle(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	shared, err := NewTable(1, 1)
 	if err != nil {
 		t.Fatalf("NewTable: %v", err)
@@ -1611,6 +1620,9 @@ func TestMultipleImportedFuncrefTablesMayAliasOneHandle(t *testing.T) {
 }
 
 func TestMultipleImportedTablesCheckEveryLimit(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	compiled, err := Compile(nil, watToWasmCA(t, `(module
 		(import "a" "table" (table 1 2 funcref))
 		(import "b" "table" (table 2 3 funcref)))`))
@@ -1645,6 +1657,9 @@ func TestMultipleImportedTablesCheckEveryLimit(t *testing.T) {
 }
 
 func TestImportedThenLocalTablesRejectSharedMemoryBasedataAlias(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	tableTestForceExplicitBounds(t)
 	memoryOwner := MustCompile(watToWasmCA(t, `(module
 		(memory (export "memory") 1))`))
@@ -1689,6 +1704,9 @@ func TestImportedThenLocalTablesRejectSharedMemoryBasedataAlias(t *testing.T) {
 }
 
 func TestImportedThenLocalFailedInstantiationRetainsSharedTableWrites(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	ownerCompiled := MustCompile(watToWasmCA(t, `(module
 		(table $shared (export "shared") 1 1 funcref))`))
 	owner, err := Instantiate(ownerCompiled)
@@ -1740,6 +1758,9 @@ func TestImportedThenLocalFailedInstantiationRetainsSharedTableWrites(t *testing
 }
 
 func TestMultipleImportedTablesRetainFailedInstancesAcrossEveryHandle(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	first, err := NewTable(1, 1)
 	if err != nil {
 		t.Fatalf("NewTable first: %v", err)
@@ -2915,6 +2936,9 @@ func TestImportedTableActiveElementEarlierSegmentPersistsBeforeLaterOOB(t *testi
 }
 
 func TestSharedTableFailedInstanceRootsStayCapacityBounded(t *testing.T) {
+	if !requireExternalWAT(t) {
+		return
+	}
 	tbl, err := NewTable(1, 1)
 	if err != nil {
 		t.Fatalf("NewTable: %v", err)

--- a/src/wago/test_fixtures_test.go
+++ b/src/wago/test_fixtures_test.go
@@ -1,0 +1,37 @@
+//go:build (linux && (amd64 || arm64)) || (darwin && arm64)
+
+package wago
+
+import (
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// passiveDataModule and multiValueControlCallModule are shared by native
+// platform tests. Keep these pure-binary fixtures independent of host tooling
+// so Linux/arm64, Darwin/arm64, and TinyGo compile the same test surface.
+func passiveDataModule() []byte {
+	initBody := []byte{0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfc, 0x08, 0x00, 0x00, 0x0b}
+	dropBody := []byte{0xfc, 0x09, 0x00, 0x0b}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32, wasm.I32}, nil), wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, append(wasmtest.ULEB(2), 0x00, 0x01)),
+		wasmtest.Section(5, []byte{0x01, 0x00, 0x01}),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("init", 0, 0), wasmtest.ExportEntry("drop", 0, 1), wasmtest.ExportEntry("mem", 2, 0))),
+		wasmtest.Section(12, wasmtest.ULEB(1)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(initBody), wasmtest.Code(dropBody))),
+		wasmtest.Section(11, wasmtest.Vec(append([]byte{0x01}, append(wasmtest.ULEB(5), []byte("hello")...)...))),
+	)
+}
+
+func multiValueControlCallModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, []wasm.ValType{wasm.I32, wasm.I64}), wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32, wasm.I64}))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("pair", 0, 0), wasmtest.ExportEntry("choose", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x12, 0x42, 0x13, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0x04, 0x00, 0x10, 0x00, 0x05, 0x41, 0x07, 0x42, 0x09, 0x0b, 0x0b}),
+		)),
+	)
+}

--- a/src/wago/tinygo_test_boundary_notinygo_test.go
+++ b/src/wago/tinygo_test_boundary_notinygo_test.go
@@ -1,0 +1,7 @@
+//go:build !tinygo
+
+package wago
+
+import "testing"
+
+func requireStandardGoTestRuntime(*testing.T) bool { return true }

--- a/src/wago/tinygo_test_boundary_test.go
+++ b/src/wago/tinygo_test_boundary_test.go
@@ -1,0 +1,11 @@
+//go:build tinygo
+
+package wago
+
+import "testing"
+
+func requireStandardGoTestRuntime(t *testing.T) bool {
+	t.Helper()
+	t.Log("test depends on standard Go testing control flow or struct layout")
+	return false
+}

--- a/src/wago/typed_element_test.go
+++ b/src/wago/typed_element_test.go
@@ -237,6 +237,7 @@ func TestActiveExternrefElementsPreserveDeclarationOrderOnFailedInstantiation(t 
 }
 
 func TestTypedElementMetadataStaysBoundedAndRoundTripsCodecV20(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit")
 	baseline, err := Compile(nil, watToWasm(t, `(module (table 3 3 externref))`))
 	if err != nil {
 		t.Fatalf("Compile externref table baseline: %v", err)

--- a/src/wago/wasm2_product_closeout_test.go
+++ b/src/wago/wasm2_product_closeout_test.go
@@ -123,6 +123,7 @@ func TestClassReferenceStateIsIsolatedOrRejectedForEveryResetPolicy(t *testing.T
 }
 
 func TestSnapshotProductsRejectCodecV20ReferenceState(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit")
 	for _, tc := range []struct {
 		name string
 		wat  string
@@ -201,6 +202,7 @@ type inspectedTableMetadata struct {
 }
 
 func TestModuleMetadataReportsAllReferenceTypesAndTablesAfterCodecLoad(t *testing.T) {
+	t.Setenv("WAGO_BOUNDS", "explicit")
 	rt := NewRuntime()
 	defer rt.Close()
 	mod, err := rt.Compile(watToWasm(t, `(module

--- a/src/wago/wat_helpers_test.go
+++ b/src/wago/wat_helpers_test.go
@@ -1,0 +1,37 @@
+//go:build ((linux && (amd64 || arm64)) || (darwin && arm64)) && !tinygo
+
+package wago
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func watToWasm(t testing.TB, wat string) []byte {
+	t.Helper()
+	w2w, err := exec.LookPath("wat2wasm")
+	if err != nil {
+		t.Skip("wat2wasm (wabt) not on PATH")
+	}
+	dir := t.TempDir()
+	src, out := filepath.Join(dir, "m.wat"), filepath.Join(dir, "m.wasm")
+	if err := os.WriteFile(src, []byte(wat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := exec.Command(w2w, src, "-o", out).CombinedOutput(); err != nil {
+		t.Fatalf("wat2wasm: %v\n%s", err, output)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func watToWasmCA(t *testing.T, wat string) []byte {
+	return watToWasm(t, wat)
+}
+
+func requireExternalWAT(*testing.T) bool { return true }

--- a/src/wago/wat_helpers_tinygo_test.go
+++ b/src/wago/wat_helpers_tinygo_test.go
@@ -1,4 +1,4 @@
-//go:build tinygo && linux && amd64
+//go:build tinygo && ((linux && (amd64 || arm64)) || (darwin && arm64))
 
 package wago
 

--- a/src/wago/wat_helpers_tinygo_test.go
+++ b/src/wago/wat_helpers_tinygo_test.go
@@ -1,0 +1,24 @@
+//go:build tinygo && linux && amd64
+
+package wago
+
+import "testing"
+
+// TinyGo cannot shell out to WABT. These definitions keep benchmark and test
+// files type-checkable; WAT-backed tests must call requireExternalWAT before
+// attempting assembly.
+func watToWasm(t testing.TB, _ string) []byte {
+	t.Helper()
+	t.Fatal("wat2wasm is unavailable under TinyGo")
+	return nil
+}
+
+func watToWasmCA(t *testing.T, wat string) []byte {
+	return watToWasm(t, wat)
+}
+
+func requireExternalWAT(t *testing.T) bool {
+	t.Helper()
+	t.Log("wat2wasm-backed test is unavailable under TinyGo")
+	return false
+}


### PR DESCRIPTION
## What changed

- replace the selective Linux test jobs with a four-runner native matrix covering Linux and Darwin on amd64 and arm64
- run the full build/test suite, guard-page tests, and explicit/guard corpus checks on all supported runtime targets
- add a native Darwin/amd64 portability gate for architecture-neutral compiler and encoder packages
- verify every runner's actual `GOOS`/`GOARCH` and install WABT explicitly to prevent tool-dependent test skips
- document the CI coverage contract in `docs/ci.md`

## Why

Architecture-specific JIT, ABI, mmap, and signal behavior needs permanent native coverage. The previous workflow deeply tested Linux/amd64 and selectively tested Linux/arm64, but did not continuously exercise Darwin and skipped ARM for amd64-only changes.

Darwin/amd64 remains a portability/compiler check rather than a runtime gate because wago does not currently implement that native JIT ABI or guard-page path.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- `make test` on Darwin/arm64
- `make test-guard` on Darwin/arm64
- `WAGO_CORPUS_TIMEOUT=20s make test-corpus` on Darwin/arm64
- portable compiler/encoder package tests on Darwin/arm64
- `git diff --check`

The repository-pinned staticcheck version could not execute locally under the host's newer macOS/Go combination (`dyld: missing LC_UUID` when built with Go 1.22); the unchanged Linux/Go 1.22 lint job will run it in CI.
