### PR TITLE
fix(wago): persist active-segment store effects when a shared-memory importer's start traps

### DIFF
--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -301,6 +301,20 @@ func (j *JobMemory) SetTableDirPtr(v uintptr) { j.putU64(offTableDirPtr, uint64(
 // TableDirPtr returns the runtime-owned indexed table descriptor directory.
 func (j *JobMemory) TableDirPtr() uintptr { return uintptr(j.getU64(offTableDirPtr)) }
 
+// SnapshotBasedata copies the whole per-instance basedata region (the bytes below
+// the linear-memory base). It lets a transient co-tenant of a shared JobMemory be
+// instantiated and run — installing its own globals/table/funcref/ctx pointers and
+// stack fence — and then rolled back with RestoreBasedata, so the memory owner's
+// basedata is never left aliasing the co-tenant's arena. Linear memory and table
+// storage (positive offsets / separate descriptors) are untouched, so a co-tenant's
+// active-segment store effects still persist.
+func (j *JobMemory) SnapshotBasedata() []byte {
+	return append([]byte(nil), j.mem[:j.linOff]...)
+}
+
+// RestoreBasedata writes back a region previously returned by SnapshotBasedata.
+func (j *JobMemory) RestoreBasedata(saved []byte) { copy(j.mem[:j.linOff], saved) }
+
 // ReserveRange returns the guard-page reservation [base, base+len) for the trap
 // handler's fault-address check (both zero in classic mode).
 func (j *JobMemory) ReserveRange() (base, length uintptr) { return j.reserveBase, j.reserveLen }

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -238,6 +238,12 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 		memObj  *Memory
 		ownsMem bool
 	)
+	// transientSharedImporter marks a shared-memory importer that would install
+	// per-instance basedata into the owner's region: it is run only to apply its
+	// active-segment store effects and its start function, then rolled back via
+	// savedBasedata and never kept live. See the shared-memory guard below.
+	var transientSharedImporter bool
+	var savedBasedata []byte
 	if c.memoryImport != "" {
 		m, ok := imports.memory(c.memoryImport)
 		if !ok {
@@ -292,8 +298,19 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 			hasNativeGlobalState := len(c.Globals) > 0 && len(c.Entry) > 0
 			if hasNativeGlobalState || hasPrivateTableState || len(c.PassiveData) > 0 ||
 				len(c.passiveElems) > 0 || c.needsFuncRefDescs() || hasHostCtx {
-				runtime.ReleaseEngine(eng)
-				return nil, fmt.Errorf("a module importing a shared memory may not install per-instance basedata state (globals, local or multiple tables, funcrefs, host calls, or passive segments) that would alias the shared linear memory owner's region")
+				// A start function's store effects — active data/element segments written
+				// into the shared memory and table — must persist even when start traps
+				// (WebAssembly linking semantics: "the store is modified if the start
+				// function traps"). Run such a module transiently: snapshot the owner's
+				// basedata below, let this module install its own basedata and run start,
+				// then restore the owner's basedata and discard this module (it can never
+				// be kept live without aliasing the owner). A module with no start has no
+				// observable reason to run here, so it is still rejected outright.
+				if !c.HasStart {
+					runtime.ReleaseEngine(eng)
+					return nil, fmt.Errorf("a module importing a shared memory may not install per-instance basedata state (globals, local or multiple tables, funcrefs, host calls, or passive segments) that would alias the shared linear memory owner's region")
+				}
+				transientSharedImporter = true
 			}
 		}
 		if err := m.attachImporter(); err != nil {
@@ -301,6 +318,9 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 			return nil, fmt.Errorf("imported memory %q: %w", c.memoryImport, err)
 		}
 		jm, memObj = m.jobMemory(), m
+		if transientSharedImporter {
+			savedBasedata = jm.SnapshotBasedata()
+		}
 	} else {
 		initialBytes, maxBytes := c.memorySizeBytes()
 		// Restoring from a snapshot: size the fresh mapping to the snapshot's
@@ -850,6 +870,14 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 				startErr = callNative(c, eng, jm, false, startEntry, serArgs, trap, results)
 			}
 			if startErr != nil {
+				// A transient shared-memory importer installed its basedata into the
+				// owner's region only to run this start; restore it now that native
+				// execution is done. Its active data/element writes into the shared
+				// memory and table persist (they live in linear memory and table
+				// storage, not basedata).
+				if transientSharedImporter {
+					jm.RestoreBasedata(savedBasedata)
+				}
 				// Instantiation writes to imported tables are store side effects. If a
 				// local funcref remains installed when start traps, the shared table
 				// becomes the failed instance's lifetime owner. The table prunes roots
@@ -862,6 +890,20 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 				return nil, fmt.Errorf("start function trapped: %w", startErr)
 			}
 		}
+	}
+
+	if transientSharedImporter {
+		// The importer's start did not trap, but it cannot be kept live on the
+		// owner's shared basedata. Its active-segment store effects are already
+		// applied to the shared memory/table; restore the owner's basedata, retain
+		// any table roots it contributed, and report that a live instance of this
+		// shape is unsupported. (The store-modified-on-trap case returns above.)
+		jm.RestoreBasedata(savedBasedata)
+		if retainProducerRootsInImportedTables(in) {
+			success = true
+		}
+		_ = in.Close()
+		return nil, fmt.Errorf("a module importing a shared memory may not be instantiated as a live instance when it installs per-instance basedata state")
 	}
 
 	success = true

--- a/src/wago/spectest_exec_test.go
+++ b/src/wago/spectest_exec_test.go
@@ -461,13 +461,7 @@ func runRelease2File(t *testing.T, base string) specExecStats {
 
 func TestRelease2InstantiateGapInventory(t *testing.T) {
 	var stats specExecStats
-	// TODO: "linking" is temporarily excluded. The shared-memory + imported-table
-	// cross-instance importer path in instantiate.go corrupts imported memory/table
-	// state (linking.wast: get memory[0]() reads 0 instead of 104, table[0] traps
-	// out of bounds). It is a layout-sensitive memory-safety bug in that path; the
-	// real fix separates linear-memory backing from per-instance basedata. Re-add
-	// "linking" once that is resolved.
-	for _, base := range []string{"binary-leb128", "data", "func_ptrs", "imports", "names", "start", "tokens"} {
+	for _, base := range []string{"binary-leb128", "data", "func_ptrs", "imports", "linking", "names", "start", "tokens"} {
 		stats.add(runRelease2File(t, base))
 	}
 	got := stats.instantiateGaps[:stats.instantiateGapSiteCount]
@@ -792,13 +786,6 @@ func TestRelease2RefFuncGlobalExecution(t *testing.T) {
 }
 
 func TestRelease2LinkingHasNoImportedFunctionReexportGaps(t *testing.T) {
-	// TODO: temporarily skipped. Running the full linking.wast exercises the
-	// shared-memory + imported-table cross-instance importer in instantiate.go,
-	// which corrupts imported memory/table state (get memory[0]() reads 0 instead
-	// of 104, table[0] traps out of bounds). It is a layout-sensitive memory-safety
-	// bug in that path; the fix separates linear-memory backing from per-instance
-	// basedata. Re-enable once that is resolved.
-	t.Skip("known memory-safety bug in the shared-memory + imported-table importer (instantiate.go); see TODO")
 	wast := filepath.Clean("../../tests/spec-v2/test/core/linking.wast")
 	if _, err := os.Stat(wast); err != nil {
 		t.Skipf("Release 2 linking fixture unavailable: %v", err)


### PR DESCRIPTION
## Summary

Fixes a memory-safety / conformance bug in cross-instance shared-memory linking (surfaced as the suppressed linking tests from #232).

When a module imports another instance's memory + table, writes active `data`/`elem` segments into them, and then traps in its `start` function, the WebAssembly spec requires those store writes to **persist** ("the store is modified if the start function traps"). Our shared-memory importer guard rejected any such module outright (it would install per-instance basedata — a funcref table here), so the writes never happened: the owner `Ms` read `memory[0]=0` instead of `104` and `table[0]` trapped out of bounds.

## Root cause

Basedata (globals/table/funcref/ctx pointers) lives at negative offsets from the **shared** linear-memory base, so an importer that installs its own basedata aliases — and later dangles — the memory owner's region. The guard correctly refuses to keep such an importer live. But it refused too early: the active-segment writes are store side effects that must happen regardless.

## Fix

Run such a module **transiently** when it has a start function: snapshot the owner's basedata, let the importer install its basedata and run start, then restore the owner's basedata and discard the importer (never kept live). The active-segment writes persist (they live in linear memory / table storage, not basedata), and contributed table roots are kept alive via the existing `retainProducerRootsInImportedTables` path. Modules with no start are still rejected.

- `src/core/runtime/basedata.go`: `SnapshotBasedata`/`RestoreBasedata`.
- `src/wago/instantiate.go`: transient shared-memory importer path.
- `src/wago/spectest_exec_test.go`: re-enables the two Release 2 linking tests skipped in #232.

## Verification (linux/amd64, hub)

- Linking tests now pass **deterministically** (were 5/5 fail).
- `go test ./...` (0 fail), `go test -race ./src/wago`, `go vet`, full build, TinyGo — all pass; full `src/wago` stressed 15× clean.

## Note on CI coverage

These linking tests require the `tests/spec-v2` submodule, which **CI does not initialize** (only `tests/spec`/`tests/wasi`), so they still `t.Skip` on CI runners — the bug was never CI-visible and this fix is not yet CI-guarded. Options: init `tests/spec-v2` in the coverage job, or add a `wasmtest`-built regression test that needs no fixture. Happy to do either — flagging rather than expanding scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)