### PR TITLE
fix(cli): print canonical /{owner}/{short} publish URL

### DIFF
--- a/cli/wagocli/registry_config.go
+++ b/cli/wagocli/registry_config.go
@@ -64,6 +64,31 @@ func shortFromModule(module string) string {
 	return short
 }
 
+// ownerFromModule extracts the GitHub owner from a module path, e.g.
+// "github.com/wago-org/wasi" -> "wago-org". Empty when not a github path.
+func ownerFromModule(module string) string {
+	const host = "github.com/"
+	i := strings.Index(module, host)
+	if i < 0 {
+		return ""
+	}
+	rest := module[i+len(host):]
+	if j := strings.Index(rest, "/"); j >= 0 {
+		return rest[:j]
+	}
+	return ""
+}
+
+// packageURL builds the canonical registry page URL for a module:
+// {frontend}/{owner}/{short}.
+func packageURL(module string) string {
+	owner := ownerFromModule(module)
+	if owner == "" {
+		owner = "packages"
+	}
+	return frontendBase() + "/" + owner + "/" + shortFromModule(module)
+}
+
 // credentialsPath returns the path to the credentials file.
 func credentialsPath() string {
 	dir := os.Getenv("XDG_CONFIG_HOME")

--- a/cli/wagocli/registry_net.go
+++ b/cli/wagocli/registry_net.go
@@ -595,7 +595,7 @@ func registryPublish(c *Ctx) {
 	switch status {
 	case http.StatusOK:
 		fmt.Printf("%s Published %s %s\n", cyan("✓"), bold(mf.Module), ver)
-		fmt.Printf("  %s\n", dim(frontendBase()+"/#/p/"+shortFromModule(mf.Module)))
+		fmt.Printf("  %s\n", dim(packageURL(mf.Module)))
 	case http.StatusConflict:
 		fatal("publish: version %s is already published", ver)
 	case http.StatusForbidden:


### PR DESCRIPTION
The publish success line printed the legacy hash URL (`https://pkg.wago.sh/#/p/{short}`); the site now uses path routing. Emit `https://pkg.wago.sh/{owner}/{short}`, deriving the owner from the module path (falling back to `packages` for non-github modules).

Isolated to `registry_config.go` (new `ownerFromModule`/`packageURL` helpers) + one line in `registry_net.go`. CLI builds clean.