### PR TITLE
cli: expose compiler optimization knobs as run flags + wago opts

### DIFF
--- a/cli/wagocli/cmd_run.go
+++ b/cli/wagocli/cmd_run.go
@@ -19,13 +19,14 @@ func runCommand() *Cmd {
 		Summary:     "compile and execute an export   (default)",
 		Args:        "<file> [args...]",
 		PassThrough: true,
-		Flags: []Flag{
+		Flags: append([]Flag{
 			{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
 			{Name: "plugin", Arg: "<names>", Help: "comma-separated plugins to enable (see: wago plugin list)"},
 			{Name: "bounds", Arg: "<mode>", Help: "bounds checks: defer (default) | all"},
-		},
+		}, optKnobFlags()...),
 		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
-			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64",
+			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64\n" +
+			"Optimization knobs (--<knob> / --no-<knob>): see `wago opts`.",
 		Run: runExec,
 	}
 }
@@ -34,6 +35,8 @@ func runExec(c *Ctx) {
 	// Seamlessly hand off to the custom binary that has this project's plugins
 	// compiled in (building it once, then cached). No-op without a manifest.
 	maybeReexecForPlugins()
+
+	applyOptFlags(c) // override codegen knobs before any module compiles
 
 	invoke, bounds, plugins := c.Str("invoke"), c.Str("bounds"), c.Str("plugin")
 	pos := c.Args

--- a/cli/wagocli/main.go
+++ b/cli/wagocli/main.go
@@ -37,6 +37,7 @@ func buildRoot() *Cmd {
 		pluginCommand(),
 		moduleCommand(),
 		envCommand(),
+		optsCommand(),
 		buildCommand(),
 		validateCommand(),
 		versionCommand(),

--- a/cli/wagocli/optflags.go
+++ b/cli/wagocli/optflags.go
@@ -1,0 +1,72 @@
+package wagocli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/wago-org/wago"
+)
+
+// Optimization-knob CLI surface. Every codegen knob the active railshot backend
+// exposes (wago.OptKnobs) gets a `--<name>` / `--no-<name>` flag pair on the run
+// command; `wago opts` lists them. Knobs default from WAGO_* env vars; a flag
+// overrides at runtime (precedence: flag > env > built-in). See `wago opts`.
+
+// optKnobFlags builds the generated flag pair (`--<name>`, `--no-<name>`) for
+// every knob, so parse() accepts them and help lists them.
+func optKnobFlags() []Flag {
+	knobs := wago.OptKnobs()
+	flags := make([]Flag, 0, len(knobs)*2)
+	for _, k := range knobs {
+		flags = append(flags,
+			Flag{Name: k.Name, Bool: true, Help: "enable: " + k.Desc},
+			Flag{Name: "no-" + k.Name, Bool: true, Help: "disable: " + k.Desc},
+		)
+	}
+	return flags
+}
+
+// applyOptFlags applies the knob flags parsed into c before any compilation.
+// `--<name>` forces on, `--no-<name>` forces off; giving both fatals.
+func applyOptFlags(c *Ctx) {
+	for _, k := range wago.OptKnobs() {
+		on, off := c.Bool(k.Name), c.Bool("no-"+k.Name)
+		if on && off {
+			fatal("run: conflicting --%s and --no-%s", k.Name, k.Name)
+		}
+		switch {
+		case on:
+			wago.SetOptKnob(k.Name, true)
+		case off:
+			wago.SetOptKnob(k.Name, false)
+		}
+	}
+}
+
+// optsCommand is `wago opts`: list every optimization knob, its default state,
+// and description. The canonical reference for the run flag pairs.
+func optsCommand() *Cmd {
+	return &Cmd{
+		Name:    "opts",
+		Summary: "list compiler optimization knobs (--<knob> / --no-<knob> on run)",
+		Long: "Each knob is a codegen optimization toggle. On `wago run`, force it with\n" +
+			"--<knob> or --no-<knob>. Defaults come from WAGO_* env vars, overridden by\n" +
+			"the flag. The state shown is the current default on this build.",
+		Run: func(*Ctx) {
+			knobs := wago.OptKnobs()
+			sort.Slice(knobs, func(i, j int) bool { return knobs[i].Name < knobs[j].Name })
+			w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(w, "KNOB\tDEFAULT\tDESCRIPTION")
+			for _, k := range knobs {
+				state := "off"
+				if k.On {
+					state = "on"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\n", k.Name, state, k.Desc)
+			}
+			w.Flush()
+		},
+	}
+}

--- a/src/core/compiler/backend/railshot/amd64/knobs.go
+++ b/src/core/compiler/backend/railshot/amd64/knobs.go
@@ -1,0 +1,84 @@
+//go:build amd64
+
+package amd64
+
+// (registry re-exported to package wago via src/wago/railshot_amd64.go)
+
+// Central registry of the CLI-exposable optimization knobs. Each entry points at
+// a package-level bool whose built-in default is set from a WAGO_* env var at
+// init (env stays the fallback); the CLI overrides it at runtime via SetOptKnob.
+// A knob's public sense is always "on = optimization enabled" — `inverted` flips
+// that for the handful of vars stored as a DISABLE flag (noStackFence etc.).
+
+type optKnob struct {
+	name     string
+	desc     string
+	ptr      *bool
+	inverted bool // ptr is a disable flag: stored value == !enabled
+}
+
+// optKnobRegistry lists every boolean codegen knob. Keep names kebab-case and
+// stable — they are the CLI flag surface (`--<name>` / `--no-<name>`).
+var optKnobRegistry = []optKnob{
+	{"bounds-facts", "straight-line bounds-check elision", &boundsFactsEnabled, false},
+	{"st-flags", "keep comparison results in the flags register", &stFlagsEnabled, false},
+	{"reg-merge", "single-result block values stay in registers across joins", &regMergeEnabled, false},
+	{"tee-sink", "sink local.tee expressions into the local's register", &teeLocalSinkEnabled, false},
+	{"unary-sink", "sink unary/convert local.set expressions in place", &unaryLocalSinkEnabled, false},
+	{"branch-fold", "fold Jcc/JMP pairs into one inverted conditional branch", &branchFoldEnabled, false},
+	{"entry-arg-pins", "pin entry arguments in their incoming registers", &entryArgPinsEnabled, false},
+	{"ext-fp-pins", "pin extra float locals in call-free functions", &extendedFPPinsEnabled, false},
+	{"immutable-table", "specialize calls through never-written tables", &immutableLocalTableEnabled, false},
+	{"immutable-table-type", "skip the type check on immutable-table calls", &immutableTableTypeEnabled, false},
+	{"inline-callfree", "hint call-free callees for inlining", &inlineCallFreeHintsEnabled, false},
+	{"store-forward", "straight-line store to load forwarding", &linearStoreForwardEnabled, false},
+	{"frame-elide", "omit the frame for small single-result functions", &smallFrameElideEnabled, false},
+	{"v128-const-cache", "reserve XMM registers for repeated v128 constants", &v128ConstCacheEnabled, false},
+	{"v128-pins", "pin hot v128 locals in XMM for call-free functions", &v128LocalPinsEnabled, false},
+	{"v128-sink", "sink v128 binary ops into pinned locals (3-operand VEX)", &v128LocalSinkEnabled, false},
+	{"reg-abi", "internal register calling convention", &regABIEnabled, false},
+	{"inline", "inline eligible callees", &inlineEnabled, false},
+	{"inline-loop-callees", "inline callees called from inside a loop", &inlineLoopCallees, false},
+	{"loop-precheck", "hoist a loop-invariant bounds check to a pre-loop check", &loopPrecheckEnabled, false},
+	{"stack-fence", "emit the stack-overflow guard fence", &noStackFence, true},
+	{"stack-reg", "keep the guest stack pointer in a register", &noStackReg, true},
+}
+
+// KnobInfo describes one optimization knob for the CLI: its stable name, a
+// one-line description, and whether it is currently enabled.
+type KnobInfo struct {
+	Name string
+	Desc string
+	On   bool
+}
+
+// OptKnobs returns the current state of every optimization knob (public sense:
+// On == optimization enabled), in registry order.
+func OptKnobs() []KnobInfo {
+	out := make([]KnobInfo, len(optKnobRegistry))
+	for i, k := range optKnobRegistry {
+		on := *k.ptr
+		if k.inverted {
+			on = !on
+		}
+		out[i] = KnobInfo{Name: k.name, Desc: k.desc, On: on}
+	}
+	return out
+}
+
+// SetOptKnob forces knob `name` on or off (public sense). Returns false if no
+// knob has that name.
+func SetOptKnob(name string, on bool) bool {
+	for _, k := range optKnobRegistry {
+		if k.name != name {
+			continue
+		}
+		v := on
+		if k.inverted {
+			v = !v
+		}
+		*k.ptr = v
+		return true
+	}
+	return false
+}

--- a/src/core/compiler/backend/railshot/arm64/knobs.go
+++ b/src/core/compiler/backend/railshot/arm64/knobs.go
@@ -1,0 +1,96 @@
+//go:build arm64
+
+package arm64
+
+// Central registry of the CLI-exposable optimization knobs. Each entry points at
+// a package-level bool whose built-in default is set from a WAGO_* env var at
+// init (env stays the fallback); the CLI overrides it at runtime via SetOptKnob.
+// A knob's public sense is always "on = optimization enabled"; `inverted` flips
+// that for the handful of vars stored as a DISABLE flag (noStackFence etc.).
+// Names are shared with the amd64 registry wherever the concept matches, so a
+// script using `--no-v128-pins` works on either architecture.
+
+type optKnob struct {
+	name     string
+	desc     string
+	ptr      *bool
+	inverted bool // ptr is a disable flag: stored value == !enabled
+}
+
+// optKnobRegistry lists every boolean codegen knob. Keep names kebab-case and
+// stable — they are the CLI flag surface (`--<name>` / `--no-<name>`).
+var optKnobRegistry = []optKnob{
+	{"bounds-facts", "straight-line bounds-check elision", &boundsFactsEnabled, false},
+	{"st-flags", "keep comparison results in the flags register", &stFlagsEnabled, false},
+	{"reg-merge", "single-result block values stay in registers across joins", &regMergeEnabled, false},
+	{"tee-sink", "sink local.tee expressions into the local's register", &teeLocalSinkEnabled, false},
+	{"unary-sink", "sink unary/convert local.set expressions in place", &unaryLocalSinkEnabled, false},
+	{"three-op-sink", "sink binary ops into pinned locals (3-operand form)", &threeOperandSinkEnabled, false},
+	{"olddest-rhs-sink", "reuse an old-dest register as a binary op's RHS", &oldDestRHSSinkEnabled, false},
+	{"branch-fold", "fold branch pairs into one inverted conditional branch", &branchFoldEnabled, false},
+	{"store-load-fwd", "post-assembly store to load forwarding peephole", &storeLoadFwdEnabled, false},
+	{"uxtw-add", "fold a zero-extend into ADD ...,UXTW", &uxtwAddEnabled, false},
+	{"entry-arg-pins", "pin entry arguments in their incoming registers", &entryArgPinsEnabled, false},
+	{"x8-pin", "pin a scratch value in x8 for call-free functions", &callFreeX8PinEnabled, false},
+	{"deep-fp-pins", "pin extra float locals in call-free functions", &deepFPPinsEnabled, false},
+	{"ext-fp-pins", "extend the float pin pool in call-free functions", &extendedFPPinsEnabled, false},
+	{"leaf-scratch-pins", "pin scratch values in leaf functions", &leafScratchPinsEnabled, false},
+	{"immutable-table", "specialize calls through never-written tables", &immutableLocalTableEnabled, false},
+	{"immutable-table-type", "skip the type check on immutable-table calls", &immutableTableTypeEnabled, false},
+	{"inline-callfree", "hint call-free callees for inlining", &inlineCallFreeHintsEnabled, false},
+	{"store-forward", "straight-line store to load forwarding", &linearStoreForwardEnabled, false},
+	{"frame-elide-reghomed", "omit the frame when locals are register-homed", &frameElideRegHomed, false},
+	{"small-frame", "use the small-frame stack adjustment form", &smallFrameAdjustEnabled, false},
+	{"v128-const-cache", "reserve V registers for repeated v128 constants", &v128ConstCacheEnabled, false},
+	{"v128-pins", "pin hot v128 locals in V registers for call-free functions", &v128LocalPinsEnabled, false},
+	{"v128-sink", "sink v128 binary ops into pinned locals", &v128LocalSinkEnabled, false},
+	{"reg-abi", "internal register calling convention", &regABIEnabled, false},
+	{"inline", "inline eligible callees", &inlineEnabled, false},
+	{"inline-loop-callees", "inline callees called from inside a loop", &inlineLoopCallees, false},
+	{"loop-precheck", "hoist a loop-invariant bounds check to a pre-loop check", &loopPrecheckEnabled, false},
+	{"loop-region-pins", "pin loop-carried values across the loop region", &loopRegionPinsEnabled, false},
+	{"immutable-poly-fastpath", "polymorphic fast path for immutable-table calls", &immutableLocalPolyFastPath, false},
+	{"legacy-fp-pins", "legacy float-pin allocation (fallback)", &legacyFPPinsEnabled, false},
+	{"legacy-gp-pins", "legacy integer-pin allocation (fallback)", &legacyGPPinsEnabled, false},
+	{"stack-fence", "emit the stack-overflow guard fence", &noStackFence, true},
+	{"stack-reg", "keep the guest stack pointer in a register", &noStackReg, true},
+}
+
+// KnobInfo describes one optimization knob for the CLI: its stable name, a
+// one-line description, and whether it is currently enabled.
+type KnobInfo struct {
+	Name string
+	Desc string
+	On   bool
+}
+
+// OptKnobs returns the current state of every optimization knob (public sense:
+// On == optimization enabled), in registry order.
+func OptKnobs() []KnobInfo {
+	out := make([]KnobInfo, len(optKnobRegistry))
+	for i, k := range optKnobRegistry {
+		on := *k.ptr
+		if k.inverted {
+			on = !on
+		}
+		out[i] = KnobInfo{Name: k.name, Desc: k.desc, On: on}
+	}
+	return out
+}
+
+// SetOptKnob forces knob `name` on or off (public sense). Returns false if no
+// knob has that name.
+func SetOptKnob(name string, on bool) bool {
+	for _, k := range optKnobRegistry {
+		if k.name != name {
+			continue
+		}
+		v := on
+		if k.inverted {
+			v = !v
+		}
+		*k.ptr = v
+		return true
+	}
+	return false
+}

--- a/src/wago/optknobs.go
+++ b/src/wago/optknobs.go
@@ -1,0 +1,17 @@
+package wago
+
+// Optimization-knob API, re-exported from the active railshot backend
+// (railshot_{amd64,arm64}.go). Knobs default from WAGO_* env vars at init; this
+// API lets an embedder or the CLI override them programmatically before
+// compiling. Public sense: On == optimization enabled.
+
+// OptKnobInfo describes one compiler optimization knob.
+type OptKnobInfo = railshotKnobInfo
+
+// OptKnobs returns every optimization knob and its current state, in a stable
+// order suitable for building a CLI flag surface.
+func OptKnobs() []OptKnobInfo { return railshotOptKnobs() }
+
+// SetOptKnob forces the named knob on or off. Returns false if the name is not a
+// known knob. Call before compiling a module for the setting to take effect.
+func SetOptKnob(name string, on bool) bool { return railshotSetOptKnob(name, on) }

--- a/src/wago/railshot_amd64.go
+++ b/src/wago/railshot_amd64.go
@@ -11,6 +11,10 @@ import (
 type railshotImportBinding = railshot.ImportBinding
 type railshotCompileOptions = railshot.CompileOptions
 type railshotCompiledModule = encoderamd64.CompiledModule
+type railshotKnobInfo = railshot.KnobInfo
+
+func railshotOptKnobs() []railshotKnobInfo         { return railshot.OptKnobs() }
+func railshotSetOptKnob(name string, on bool) bool { return railshot.SetOptKnob(name, on) }
 
 func railshotCompileModuleWith(m *wasm.Module, opts railshotCompileOptions) (*railshotCompiledModule, error) {
 	return railshot.CompileModuleWith(m, opts)

--- a/src/wago/railshot_arm64.go
+++ b/src/wago/railshot_arm64.go
@@ -11,6 +11,10 @@ import (
 type railshotImportBinding = railshot.ImportBinding
 type railshotCompileOptions = railshot.CompileOptions
 type railshotCompiledModule = encoderarm64.CompiledModule
+type railshotKnobInfo = railshot.KnobInfo
+
+func railshotOptKnobs() []railshotKnobInfo         { return railshot.OptKnobs() }
+func railshotSetOptKnob(name string, on bool) bool { return railshot.SetOptKnob(name, on) }
 
 func railshotCompileModuleWith(m *wasm.Module, opts railshotCompileOptions) (*railshotCompiledModule, error) {
 	return railshot.CompileModuleWith(m, opts)

--- a/wago.go
+++ b/wago.go
@@ -77,6 +77,7 @@ type (
 	Module                    = impl.Module
 	ModuleMetadata            = impl.ModuleMetadata
 	OffsetInit                = impl.OffsetInit
+	OptKnobInfo               = impl.OptKnobInfo
 	PassiveDataInit           = impl.PassiveDataInit
 	PluginCapability          = impl.PluginCapability
 	PluginConfig              = impl.PluginConfig
@@ -284,6 +285,8 @@ func NullExternRef() ExternRef { return impl.NullExternRef() }
 
 func NullFuncRef() FuncRef { return impl.NullFuncRef() }
 
+func OptKnobs() []OptKnobInfo { return impl.OptKnobs() }
+
 func ProvideService(reg *Registry, name string, value any) error {
 	return impl.ProvideService(reg, name, value)
 }
@@ -299,6 +302,8 @@ func RequireService(reg *Registry, name string) (*ServiceRef, error) {
 }
 
 func SetGuestArgs(args []string) { impl.SetGuestArgs(args) }
+
+func SetOptKnob(name string, on bool) bool { return impl.SetOptKnob(name, on) }
 
 func SupportedFeatures() CoreFeatures { return impl.SupportedFeatures() }
 


### PR DESCRIPTION
## Summary

Exposes the compiler's optimization knobs as CLI flags on `wago run` instead of only WAGO_* env vars, and adds `wago opts` to list them. Env vars remain the fallback default, so nothing that sets them breaks.

## What

- **Per-backend knob registry** (`knobs.go` for amd64 + arm64): a table pointing at the existing env-defaulted package vars, with a stable kebab-case name and description each. amd64 exposes 22 knobs, arm64 exposes 33 (shared names where the concept matches — `--no-v128-pins` works on either arch). A knob's public sense is always "on = optimization enabled"; the handful stored as disable flags (`noStackFence`) are marked inverted.
- **Re-exported** through the build-constrained `railshot_{amd64,arm64}.go` shims and the generated `wago` facade as `OptKnobs()` / `SetOptKnob()` — so embedders can drive knobs programmatically too.
- **`wago run`** gains a generated `--<knob>` / `--no-<knob>` flag pair per knob, applied before the module compiles. Giving both fatals; unknown knobs are rejected by the normal flag parser.
- **`wago opts`** lists every knob, its current default, and description.

**Precedence: CLI flag > WAGO_* env > built-in default.** Defaults are unchanged — this only adds a control surface. (The default-off experimental/legacy knobs stay off, now CLI-toggleable.)

## Testing

- `wago opts` lists 22 (amd64) / 33 (arm64) knobs with correct defaults; conflict + unknown-flag detection verified.
- **SetOptKnob provably reaches codegen and is reversible**: compiling the corpus with `inline` on vs off differs by ~1.9 MB of generated code (102,873,105 vs 100,986,770), and re-enabling restores the exact byte count.
- amd64 backend + CLI + wago tests green; spec suite 629 modules / 16,026 assertions, 0 fail. Purely additive; no default behavior changed.

## Notes / follow-ups

- Numeric tuning params (`WAGO_INLINE_MAXBYTES`, `WAGO_PIN_GLOBAL_K`, `WAGO_LP_MINCHECKS`) and debug flags (`WAGO_EXPLAIN`) are not yet exposed — they'd be value flags rather than the on/off pairs here. Easy to add if wanted.
- `foldIdxDispEnabled` lives in the arm64 *encoder* package (not the backend), so it's not in the registry yet.
