### PR TITLE
feat(cli): pkg commands default to cwd wago.json, else global set

### DIFF
--- a/cli/wagocli/cmd_pkg.go
+++ b/cli/wagocli/cmd_pkg.go
@@ -7,12 +7,14 @@ package wagocli
 // wagomodule.go). The publish side (publish/unpublish/deprecate) talks to the
 // registry and is build-tagged (registry_net.go vs the lean registry_stub.go).
 func pkgCommand() *Cmd {
-	global := Flag{Name: "global", Short: "g", Bool: true, Help: "operate on the CLI-wide plugin set (~/.wago) instead of this project"}
+	global := Flag{Name: "global", Short: "g", Bool: true, Help: "force the CLI-wide plugin set (~/.wago); default when the cwd has no wago.json"}
+	local := Flag{Name: "local", Short: "l", Bool: true, Help: "force this project's wago.json (create one here if absent)"}
 	force := Flag{Name: "force", Short: "f", Bool: true, Help: "ignore the build cache / fetch the latest version"}
 	verbose := Flag{Name: "verbose", Short: "v", Bool: true, Help: "stream the underlying go output"}
 	opts := func(c *Ctx) pkgOpts {
-		return pkgOpts{global: c.Bool("global"), force: c.Bool("force"), verbose: c.Bool("verbose")}
+		return pkgOpts{global: resolveScope(c.Bool("global"), c.Bool("local")), force: c.Bool("force"), verbose: c.Bool("verbose")}
 	}
+	scope := func(c *Ctx) bool { return resolveScope(c.Bool("global"), c.Bool("local")) }
 	return &Cmd{
 		Name:    "pkg",
 		Summary: "add, build, and publish registry packages",
@@ -21,33 +23,33 @@ func pkgCommand() *Cmd {
 				Name: "add", Aliases: []string{"install", "i"},
 				Summary: "add a plugin dependency (wago.json + go get)",
 				Args:    "<module>[@version]",
-				Flags:   []Flag{global, force, verbose},
+				Flags:   []Flag{global, local, force, verbose},
 				Run:     func(c *Ctx) { pkgAdd(normalizeModuleRef(c.one("<module>[@version]")), opts(c)) },
 			},
 			{
 				Name: "remove", Aliases: []string{"uninstall", "rm"},
 				Summary: "remove a plugin dependency",
 				Args:    "<name>",
-				Flags:   []Flag{global},
-				Run:     func(c *Ctx) { pkgRemove(normalizeModuleRef(c.one("<name>")), c.Bool("global")) },
+				Flags:   []Flag{global, local},
+				Run:     func(c *Ctx) { pkgRemove(normalizeModuleRef(c.one("<name>")), scope(c)) },
 			},
 			{
 				Name: "update", Aliases: []string{"up", "upgrade"},
 				Summary: "update plugin dependencies to their latest versions, then rebuild",
 				Args:    "[module]",
-				Flags:   []Flag{global, verbose},
+				Flags:   []Flag{global, local, verbose},
 				Run:     func(c *Ctx) { pkgUpdate(normalizeModuleRef(c.opt("[module]")), opts(c)) },
 			},
 			{
 				Name: "list", Aliases: []string{"ls"},
 				Summary: "list declared plugin dependencies",
-				Flags:   []Flag{global},
-				Run:     func(c *Ctx) { pkgList(c.Bool("global")) },
+				Flags:   []Flag{global, local},
+				Run:     func(c *Ctx) { pkgList(scope(c)) },
 			},
 			{
 				Name:    "build",
 				Summary: "build a custom wago binary with the declared plugins",
-				Flags:   []Flag{global, force, verbose},
+				Flags:   []Flag{global, local, force, verbose},
 				Run:     func(c *Ctx) { pkgBuild(opts(c)) },
 			},
 			{

--- a/cli/wagocli/scope.go
+++ b/cli/wagocli/scope.go
@@ -1,0 +1,38 @@
+package wagocli
+
+import (
+	"errors"
+	"os"
+)
+
+// scopeGlobal is the pure decision behind the `wago pkg` commands' plugin-set
+// scope: given the explicit --global/--local flags and whether the current
+// directory has a wago.json, report whether to operate on the global set (or an
+// error for conflicting flags). With no flags it mirrors what `wago run` already
+// does (activePluginSet): a wago.json in the cwd selects the local project set,
+// and its absence falls back to the CLI-wide global set.
+func scopeGlobal(explicitGlobal, explicitLocal, cwdHasManifest bool) (bool, error) {
+	switch {
+	case explicitGlobal && explicitLocal:
+		return false, errors.New("choose either --global or --local, not both")
+	case explicitGlobal:
+		return true, nil
+	case explicitLocal:
+		return false, nil
+	case cwdHasManifest:
+		return false, nil // a project manifest is present — use it
+	default:
+		return true, nil // no local manifest — the global set is the default
+	}
+}
+
+// resolveScope applies scopeGlobal against the real filesystem, fataling on
+// conflicting flags. It returns whether to operate on the global plugin set.
+func resolveScope(explicitGlobal, explicitLocal bool) bool {
+	_, statErr := os.Stat(projectManifestPath("."))
+	useGlobal, err := scopeGlobal(explicitGlobal, explicitLocal, statErr == nil)
+	if err != nil {
+		fatal("pkg: %v", err)
+	}
+	return useGlobal
+}

--- a/cli/wagocli/scope_test.go
+++ b/cli/wagocli/scope_test.go
@@ -1,0 +1,34 @@
+package wagocli
+
+import "testing"
+
+func TestScopeGlobal(t *testing.T) {
+	type in struct{ global, local, manifest bool }
+	cases := []struct {
+		in      in
+		want    bool
+		wantErr bool
+	}{
+		// No flags: cwd manifest selects local, absence falls back to global.
+		{in{false, false, true}, false, false},
+		{in{false, false, false}, true, false},
+		// Explicit flags win over the cwd state.
+		{in{true, false, true}, true, false},   // --global in a project dir
+		{in{false, true, false}, false, false}, // --local in an empty dir
+		{in{true, false, false}, true, false},
+		{in{false, true, true}, false, false},
+		// Conflicting flags error.
+		{in{true, true, false}, false, true},
+		{in{true, true, true}, false, true},
+	}
+	for _, tc := range cases {
+		got, err := scopeGlobal(tc.in.global, tc.in.local, tc.in.manifest)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("scopeGlobal(%+v) err=%v, wantErr=%v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if err == nil && got != tc.want {
+			t.Errorf("scopeGlobal(%+v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
**Item 5 of the CLI plugin-UX work.** Stacked on #248 (base is that branch, so this PR shows only item 5's diff; retarget to `main` once #248 lands).

Brings `wago pkg` in line with how `wago run` already resolves its plugin set (`activePluginSet`): with no flag, a `wago.json` in the current directory selects the local project set, and its absence falls back to the CLI-wide global set (`~/.wago`). Previously `pkg` always defaulted to local — so `wago pkg add` in an arbitrary directory created a stray local set instead of updating your global one.

- New **`--local`/`-l`** forces the project set (creating a `wago.json` here if absent), mirroring **`--global`/`-g`** which forces global. Mutually exclusive.
- `scopeGlobal()` is the pure, unit-tested decision; `resolveScope()` applies it against the filesystem. Wired into add/remove/update/list/build.

Adds `TestScopeGlobal`; full `cli/wagocli` suite green; gofmt clean. Interactive/e2e behavior to be validated on hub.