### PR TITLE
fix(cli): version install re-fetches rolling channels (canary/nightly)

### DIFF
--- a/cli/wagocli/version_common.go
+++ b/cli/wagocli/version_common.go
@@ -125,6 +125,15 @@ func vmUninstall(d wago.Dirs, ver string) {
 	fmt.Printf("uninstalled wago %s\n", ver)
 }
 
+// rollingChannels are version names whose build moves under a fixed name:
+// "canary" tracks the latest main commit, "nightly" the latest nightly release.
+// Installing or updating one always re-fetches, unlike an immutable release.
+var rollingChannels = map[string]bool{"canary": true, "nightly": true}
+
+// isRollingChannel reports whether ver names a rolling release channel rather
+// than a pinned, immutable version.
+func isRollingChannel(ver string) bool { return rollingChannels[ver] }
+
 // updateVersionTarget chooses the version refreshed by `wago version update`.
 // No selector means the active version; explicit channel flags make refreshing a
 // rolling channel convenient without first selecting it.

--- a/cli/wagocli/version_net.go
+++ b/cli/wagocli/version_net.go
@@ -25,9 +25,16 @@ import (
 
 func vmInstall(d wago.Dirs, ver string) {
 	dest := d.VersionBinary(ver)
+	existed := false
 	if fi, err := os.Stat(dest); err == nil && !fi.IsDir() {
-		fmt.Printf("wago %s already installed\n", ver)
-		return
+		// A rolling channel (canary/nightly) re-fetches even when present — the
+		// name is stable but the build behind it moves. Only an immutable release
+		// short-circuits, since re-downloading identical bytes is pointless.
+		if !isRollingChannel(ver) {
+			fmt.Printf("wago %s already installed\n", ver)
+			return
+		}
+		existed = true
 	}
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version install: %v", err)
@@ -35,7 +42,11 @@ func vmInstall(d wago.Dirs, ver string) {
 	if err := downloadBinary(releaseBase(), ver, dest); err != nil {
 		fatal("version install: %v", err)
 	}
-	fmt.Printf("installed wago %s -> %s\n", cyan(ver), dest)
+	verb := "installed"
+	if existed {
+		verb = "refreshed"
+	}
+	fmt.Printf("%s wago %s -> %s\n", verb, cyan(ver), dest)
 }
 
 // vmUpdate fetches a fresh copy even when the version is already installed.

--- a/cli/wagocli/version_rolling_test.go
+++ b/cli/wagocli/version_rolling_test.go
@@ -1,0 +1,16 @@
+package wagocli
+
+import "testing"
+
+func TestIsRollingChannel(t *testing.T) {
+	for _, v := range []string{"canary", "nightly"} {
+		if !isRollingChannel(v) {
+			t.Errorf("%q should be a rolling channel", v)
+		}
+	}
+	for _, v := range []string{"1.2.3", "v1.0.0", "stable", "", "canaryx", "night"} {
+		if isRollingChannel(v) {
+			t.Errorf("%q should not be a rolling channel", v)
+		}
+	}
+}


### PR DESCRIPTION
`wago version install canary` printed "wago canary already installed" and did nothing whenever the binary was on disk — but `canary` tracks the latest `main` commit and `nightly` the latest nightly, so the build behind the name moves. The already-installed short-circuit is only correct for immutable releases.

Now a rolling channel always re-fetches (reporting `refreshed` when it was already present), matching what `wago version update --canary` already does; immutable releases still short-circuit. `isRollingChannel` centralizes the canary/nightly set.

Adds `TestIsRollingChannel`; full + `wago_lean` builds green; gofmt clean.