### PR TITLE
cli: compact paired boolean help

### DIFF
--- a/cli/wagocli/cli.go
+++ b/cli/wagocli/cli.go
@@ -236,7 +236,14 @@ func (c *Cmd) printHelp(w *os.File, path string) {
 	// to the widest label so descriptions align.
 	labels := make([]string, 0, len(c.Flags)+1)
 	helps := make([]string, 0, len(c.Flags)+1)
-	for _, f := range c.Flags {
+	for i := 0; i < len(c.Flags); i++ {
+		f := c.Flags[i]
+		if f.Bool && i+1 < len(c.Flags) && c.Flags[i+1].Name == "no-"+f.Name && c.Flags[i+1].Bool {
+			labels = append(labels, "--<no->"+f.Name)
+			helps = append(helps, f.Help)
+			i++
+			continue
+		}
 		labels = append(labels, flagLabel(f))
 		helps = append(helps, f.Help)
 	}

--- a/cli/wagocli/main_test.go
+++ b/cli/wagocli/main_test.go
@@ -67,3 +67,16 @@ func TestUsageDoesNotAdvertiseValidateDirect(t *testing.T) {
 		t.Fatalf("usage should not mention removed validate alias:\n%s", b)
 	}
 }
+
+func TestRunHelpCollapsesBooleanPairs(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "help-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCommand().printHelp(f, "wago run")
+	f.Close()
+	b, _ := os.ReadFile(f.Name())
+	if !strings.Contains(string(b), "--<no->st-flags") || strings.Contains(string(b), "enable: keep comparison results") {
+		t.Fatalf("run help did not collapse optimization pair:\n%s", b)
+	}
+}

--- a/cli/wagocli/optflags.go
+++ b/cli/wagocli/optflags.go
@@ -20,9 +20,13 @@ func optKnobFlags() []Flag {
 	knobs := wago.OptKnobs()
 	flags := make([]Flag, 0, len(knobs)*2)
 	for _, k := range knobs {
+		state := "off"
+		if k.On {
+			state = "on"
+		}
 		flags = append(flags,
-			Flag{Name: k.Name, Bool: true, Help: "enable: " + k.Desc},
-			Flag{Name: "no-" + k.Name, Bool: true, Help: "disable: " + k.Desc},
+			Flag{Name: k.Name, Bool: true, Help: fmt.Sprintf("(default: %s) %s", state, k.Desc)},
+			Flag{Name: "no-" + k.Name, Bool: true},
 		)
 	}
 	return flags


### PR DESCRIPTION
Collapse paired boolean optimization flags in `wago run -h` and show each knob’s current default.