### PR TITLE
feat(cli): interactive capability selector + permission review (wago pkg grant)

### DIFF
--- a/cli/wagocli/cmd_pkg.go
+++ b/cli/wagocli/cmd_pkg.go
@@ -51,6 +51,13 @@ func pkgCommand() *Cmd {
 				Run:     func(c *Ctx) { pkgBuild(opts(c)) },
 			},
 			{
+				Name:    "grant",
+				Summary: "review and edit a plugin's granted capabilities",
+				Args:    "<name>",
+				Flags:   []Flag{global},
+				Run:     func(c *Ctx) { pkgGrant(c.one("<name>"), c.Bool("global")) },
+			},
+			{
 				Name: "info", Aliases: []string{"show", "view"},
 				Summary: "show a package's registry info",
 				Args:    "<name>",

--- a/cli/wagocli/plugin_grants.go
+++ b/cli/wagocli/plugin_grants.go
@@ -1,0 +1,51 @@
+package wagocli
+
+import "sort"
+
+// plugin_grants.go reads and writes the per-plugin capability grants in a
+// wago.json — the "plugins" object keyed by GitHub-relative ID (see #246), where
+// each entry carries a "capabilities" array of the privileged APIs that plugin is
+// allowed to use at runtime.
+
+// pluginGrants returns the capabilities currently granted to plugin id in dir's
+// wago.json (nil when the plugin or its capabilities are absent).
+func pluginGrants(dir, id string) []string {
+	m, err := readProjectMap(dir)
+	if err != nil {
+		return nil
+	}
+	plugins, _ := m["plugins"].(map[string]any)
+	entry, _ := plugins[id].(map[string]any)
+	raw, _ := entry["capabilities"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// setPluginGrants replaces the capabilities granted to plugin id in dir's
+// wago.json (sorted for stable diffs), creating the plugin entry if needed while
+// preserving any other fields on it (before/after/config).
+func setPluginGrants(dir, id string, caps []string) error {
+	m, err := readProjectMap(dir)
+	if err != nil {
+		return err
+	}
+	plugins, _ := m["plugins"].(map[string]any)
+	if plugins == nil {
+		plugins = map[string]any{}
+	}
+	entry, _ := plugins[id].(map[string]any)
+	if entry == nil {
+		entry = map[string]any{}
+	}
+	sorted := append([]string(nil), caps...)
+	sort.Strings(sorted)
+	entry["capabilities"] = toAnySlice(sorted)
+	plugins[id] = entry
+	m["plugins"] = plugins
+	return writeProjectMap(dir, m)
+}

--- a/cli/wagocli/plugin_grants_test.go
+++ b/cli/wagocli/plugin_grants_test.go
@@ -1,0 +1,48 @@
+package wagocli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPluginGrantsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	// Seed a wago.json with a plugin entry that has other fields to preserve.
+	seed := `{
+      "dependencies": ["github.com/wago-org/wasi"],
+      "plugins": {"wago-org/wasi": {"capabilities": ["wasi:stdio"], "after": ["x"]}}
+    }`
+	if err := os.WriteFile(filepath.Join(dir, projectFile), []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := pluginGrants(dir, "wago-org/wasi"); !reflect.DeepEqual(got, []string{"wasi:stdio"}) {
+		t.Fatalf("initial grants: %v", got)
+	}
+
+	// Replace grants; unrelated fields must survive, output must be sorted.
+	if err := setPluginGrants(dir, "wago-org/wasi", []string{"wasi:random", "wasi:clock"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := pluginGrants(dir, "wago-org/wasi"); !reflect.DeepEqual(got, []string{"wasi:clock", "wasi:random"}) {
+		t.Fatalf("updated grants: %v", got)
+	}
+	m, _ := readProjectMap(dir)
+	entry := m["plugins"].(map[string]any)["wago-org/wasi"].(map[string]any)
+	if _, ok := entry["after"]; !ok {
+		t.Fatal("setPluginGrants dropped the plugin's other fields (after)")
+	}
+
+	// A plugin with no entry yet: absent grants, then created on set.
+	if got := pluginGrants(dir, "wago-org/new"); len(got) != 0 {
+		t.Fatalf("expected no grants for absent plugin, got %v", got)
+	}
+	if err := setPluginGrants(dir, "wago-org/new", []string{"net:dial"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := pluginGrants(dir, "wago-org/new"); !reflect.DeepEqual(got, []string{"net:dial"}) {
+		t.Fatalf("new plugin grants: %v", got)
+	}
+}

--- a/cli/wagocli/review.go
+++ b/cli/wagocli/review.go
@@ -1,0 +1,92 @@
+package wagocli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/wago-org/wago"
+)
+
+// reviewCapabilities presents a plugin's requestable capabilities and returns the
+// subset the user grants. `required` is the plugin's full requestable set;
+// `granted` is the currently-granted subset (shown pre-checked). It prompts
+// Accept-all / Modify / Reject; Modify opens the interactive selector. Returns
+// (chosen, ok); ok is false when the user rejects or cancels. A plugin that
+// requests nothing returns an empty grant with ok=true.
+//
+// This is shared by `wago pkg grant` and (next) the install-on-demand flow.
+func reviewCapabilities(name string, required, granted []string) (chosen []string, ok bool) {
+	if len(required) == 0 {
+		fmt.Printf("%s requests no capabilities.\n", cyan(name))
+		return nil, true
+	}
+	grantedSet := map[string]bool{}
+	for _, g := range granted {
+		grantedSet[g] = true
+	}
+	fmt.Printf("%s requests these capabilities:\n", cyan(name))
+	for _, c := range required {
+		mark := dim("◦")
+		if grantedSet[c] {
+			mark = cyan("✔")
+		}
+		fmt.Printf("  %s %s\n", mark, c)
+	}
+	fmt.Printf("\n%s ", bold("[A]ccept all  [M]odify  [R]eject:"))
+
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "a", "accept", "y", "yes", "":
+		return append([]string(nil), required...), true
+	case "m", "modify", "e", "edit":
+		items := make([]selItem, len(required))
+		for i, c := range required {
+			// Pre-check current grants; a brand-new plugin (no grants yet) starts
+			// fully selected so "accept all" and "modify" agree by default.
+			items[i] = selItem{label: c, on: len(granted) == 0 || grantedSet[c]}
+		}
+		m := &multiSelect{title: "grant capabilities for " + name, items: items}
+		if cancelled := runSelector(m); cancelled {
+			return nil, false
+		}
+		return m.chosen(), true
+	default: // r, reject, n, no, anything else
+		return nil, false
+	}
+}
+
+// pkgGrant interactively edits which of a compiled-in plugin's requestable
+// capabilities are granted in the active wago.json (local or global per scope).
+func pkgGrant(name string, useGlobal bool) {
+	id := strings.TrimPrefix(strings.TrimSpace(name), "github.com/")
+	ext, ok := wago.NewExtension(id)
+	if !ok {
+		fatal("pkg grant: %q is not compiled into this binary — add it with `wago pkg add` first", name)
+	}
+	required := make([]string, 0, len(ext.Info().RequiresCapabilities))
+	for _, c := range ext.Info().RequiresCapabilities {
+		required = append(required, string(c))
+	}
+	sort.Strings(required)
+
+	src, err := depsSource(useGlobal)
+	if err != nil {
+		fatal("pkg grant: %v", err)
+	}
+	chosen, ok := reviewCapabilities(id, required, pluginGrants(src, id))
+	if !ok {
+		fmt.Println(dim("no changes"))
+		return
+	}
+	if err := setPluginGrants(src, id, chosen); err != nil {
+		fatal("pkg grant: %v", err)
+	}
+	if len(chosen) == 0 {
+		fmt.Printf("%s %s now has no capability grants\n", cyan("✓"), id)
+		return
+	}
+	fmt.Printf("%s granted %s: %s\n", cyan("✓"), id, strings.Join(chosen, ", "))
+}

--- a/cli/wagocli/select.go
+++ b/cli/wagocli/select.go
@@ -1,0 +1,145 @@
+package wagocli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// select.go is a tiny, dependency-free multi-select: a cursor over a list of
+// toggleable rows. The model here is pure (no terminal I/O) so it's fully
+// unit-testable; the raw-mode driver that feeds it keypresses and paints frames
+// lives in select_unix.go / select_windows.go.
+
+// selItem is one toggleable row.
+type selItem struct {
+	label string // machine value, e.g. a capability id "wasi:stdio"
+	desc  string // one-line human description (may be empty)
+	on    bool   // currently selected
+}
+
+// selectKey is a normalized keypress the model understands.
+type selectKey int
+
+const (
+	keyNoop selectKey = iota // unrecognized / intentionally inert (e.g. ← →)
+	keyUp
+	keyDown
+	keyToggle // space
+	keyAll    // a
+	keyClear  // n
+	keyAccept // enter / return
+	keyCancel // esc / q / ctrl-c
+)
+
+// multiSelect is the pure picker state: a list plus a cursor.
+type multiSelect struct {
+	title  string
+	items  []selItem
+	cursor int
+}
+
+// apply advances the model by one key. It reports whether the interaction is
+// finished, and if so whether it was cancelled (esc) rather than accepted
+// (enter). Movement clamps at the ends; ← and → are intentionally inert.
+func (m *multiSelect) apply(k selectKey) (done, cancelled bool) {
+	switch k {
+	case keyUp:
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case keyDown:
+		if m.cursor < len(m.items)-1 {
+			m.cursor++
+		}
+	case keyToggle:
+		if len(m.items) > 0 {
+			m.items[m.cursor].on = !m.items[m.cursor].on
+		}
+	case keyAll:
+		for i := range m.items {
+			m.items[i].on = true
+		}
+	case keyClear:
+		for i := range m.items {
+			m.items[i].on = false
+		}
+	case keyAccept:
+		return true, false
+	case keyCancel:
+		return true, true
+	}
+	return false, false
+}
+
+// chosen returns the labels of the selected rows, in list order.
+func (m *multiSelect) chosen() []string {
+	var out []string
+	for _, it := range m.items {
+		if it.on {
+			out = append(out, it.label)
+		}
+	}
+	return out
+}
+
+// decodeKey maps a raw input chunk (one keypress, possibly a multi-byte escape
+// sequence for arrows) to a selectKey. Kept pure and separate so key handling is
+// testable without a terminal.
+func decodeKey(b []byte) selectKey {
+	switch {
+	case len(b) == 0:
+		return keyNoop
+	case len(b) == 1:
+		switch b[0] {
+		case '\r', '\n':
+			return keyAccept
+		case ' ':
+			return keyToggle
+		case 'a', 'A':
+			return keyAll
+		case 'n', 'N':
+			return keyClear
+		case 'q', 'Q', 3, 27: // q, Ctrl-C, bare ESC
+			return keyCancel
+		case 'k', 'K':
+			return keyUp
+		case 'j', 'J':
+			return keyDown
+		}
+	case len(b) >= 3 && b[0] == 27 && b[1] == '[':
+		switch b[2] {
+		case 'A':
+			return keyUp
+		case 'B':
+			return keyDown
+		case 'C', 'D': // → and ← — intentionally inert for now
+			return keyNoop
+		}
+	}
+	return keyNoop
+}
+
+// frame renders the selector as plain text (the driver repaints it each key).
+func (m *multiSelect) frame() string {
+	var b strings.Builder
+	if m.title != "" {
+		fmt.Fprintf(&b, "%s\n", bold(m.title))
+	}
+	fmt.Fprintf(&b, "%s\n\n", dim("↑/↓ move · space toggle · a all · n none · enter confirm · esc cancel"))
+	for i, it := range m.items {
+		cursor := "  "
+		if i == m.cursor {
+			cursor = cyan("▸ ")
+		}
+		box := "[ ]"
+		if it.on {
+			box = cyan("[x]")
+		}
+		line := fmt.Sprintf("%s%s %s", cursor, box, it.label)
+		if it.desc != "" {
+			line += "  " + dim(it.desc)
+		}
+		fmt.Fprintf(&b, "%s\n", line)
+	}
+	return b.String()
+}

--- a/cli/wagocli/select_test.go
+++ b/cli/wagocli/select_test.go
@@ -1,0 +1,90 @@
+package wagocli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func newTestSelect() *multiSelect {
+	return &multiSelect{
+		title: "pick",
+		items: []selItem{
+			{label: "wasi:stdio", on: true},
+			{label: "wasi:clock", on: false},
+			{label: "env:args", on: true},
+		},
+	}
+}
+
+func TestMultiSelectMovementClamps(t *testing.T) {
+	m := newTestSelect()
+	m.apply(keyUp) // already at top
+	if m.cursor != 0 {
+		t.Fatalf("cursor should clamp at 0, got %d", m.cursor)
+	}
+	m.apply(keyDown)
+	m.apply(keyDown)
+	m.apply(keyDown) // past the end
+	if m.cursor != 2 {
+		t.Fatalf("cursor should clamp at last index 2, got %d", m.cursor)
+	}
+}
+
+func TestMultiSelectToggleAllNone(t *testing.T) {
+	m := newTestSelect()
+	m.apply(keyDown)   // cursor -> wasi:clock
+	m.apply(keyToggle) // turn it on
+	if got := m.chosen(); !reflect.DeepEqual(got, []string{"wasi:stdio", "wasi:clock", "env:args"}) {
+		t.Fatalf("after toggle: %v", got)
+	}
+	m.apply(keyClear)
+	if got := m.chosen(); got != nil {
+		t.Fatalf("keyClear should deselect all, got %v", got)
+	}
+	m.apply(keyAll)
+	if got := m.chosen(); len(got) != 3 {
+		t.Fatalf("keyAll should select all, got %v", got)
+	}
+}
+
+func TestMultiSelectAcceptCancel(t *testing.T) {
+	m := newTestSelect()
+	if done, cancelled := m.apply(keyAccept); !done || cancelled {
+		t.Fatalf("enter => done, not cancelled; got done=%v cancelled=%v", done, cancelled)
+	}
+	if done, cancelled := m.apply(keyCancel); !done || !cancelled {
+		t.Fatalf("esc => done and cancelled; got done=%v cancelled=%v", done, cancelled)
+	}
+	if done, _ := m.apply(keyNoop); done {
+		t.Fatalf("noop must not finish the interaction")
+	}
+}
+
+func TestDecodeKey(t *testing.T) {
+	cases := []struct {
+		in   []byte
+		want selectKey
+	}{
+		{[]byte{'\r'}, keyAccept},
+		{[]byte{'\n'}, keyAccept},
+		{[]byte{' '}, keyToggle},
+		{[]byte{'a'}, keyAll},
+		{[]byte{'n'}, keyClear},
+		{[]byte{'q'}, keyCancel},
+		{[]byte{3}, keyCancel},  // Ctrl-C
+		{[]byte{27}, keyCancel}, // bare ESC
+		{[]byte{'j'}, keyDown},
+		{[]byte{'k'}, keyUp},
+		{[]byte{27, '[', 'A'}, keyUp},
+		{[]byte{27, '[', 'B'}, keyDown},
+		{[]byte{27, '[', 'C'}, keyNoop}, // → inert
+		{[]byte{27, '[', 'D'}, keyNoop}, // ← inert
+		{[]byte{'x'}, keyNoop},
+		{nil, keyNoop},
+	}
+	for _, tc := range cases {
+		if got := decodeKey(tc.in); got != tc.want {
+			t.Errorf("decodeKey(%v) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cli/wagocli/select_unix.go
+++ b/cli/wagocli/select_unix.go
@@ -1,0 +1,90 @@
+//go:build !windows
+
+package wagocli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// runSelector drives the multi-select in raw terminal mode, repainting on each
+// keypress, and returns whether the user cancelled (esc). When stdin isn't an
+// interactive terminal, or raw mode can't be entered, it makes no changes and
+// returns false so the caller keeps the pre-seeded selection.
+//
+// Raw mode is toggled with stty rather than a termios cgo/x-sys dependency, so
+// the CLI stays dependency-free; `stty -g` captures the exact prior settings so
+// they're restored precisely on exit.
+func runSelector(m *multiSelect) (cancelled bool) {
+	if !stdinIsTTY() {
+		return false
+	}
+	restore, err := makeRaw()
+	if err != nil {
+		return false
+	}
+	defer restore()
+
+	in := bufio.NewReader(os.Stdin)
+	prev := 0
+	paint := func() {
+		if prev > 0 {
+			fmt.Fprintf(os.Stderr, "\x1b[%dA\x1b[J", prev) // up over the old frame, clear down
+		}
+		f := m.frame()
+		fmt.Fprint(os.Stderr, strings.ReplaceAll(f, "\n", "\r\n"))
+		prev = strings.Count(f, "\n")
+	}
+	paint()
+
+	buf := make([]byte, 8)
+	for {
+		n, err := in.Read(buf)
+		if err != nil {
+			return true // read failure: treat like cancel
+		}
+		done, cancel := m.apply(decodeKey(buf[:n]))
+		paint()
+		if done {
+			return cancel
+		}
+	}
+}
+
+// stdinIsTTY reports whether standard input is an interactive terminal.
+func stdinIsTTY() bool {
+	fi, err := os.Stdin.Stat()
+	return err == nil && (fi.Mode()&os.ModeCharDevice) != 0
+}
+
+// makeRaw switches the terminal to raw, no-echo mode and returns a restore func
+// that reinstates the captured settings.
+func makeRaw() (func(), error) {
+	saved, err := sttyOutput("-g")
+	if err != nil {
+		return nil, err
+	}
+	if err := stty("raw", "-echo"); err != nil {
+		return nil, err
+	}
+	return func() {
+		_ = stty(strings.Fields(strings.TrimSpace(saved))...)
+		fmt.Fprint(os.Stderr, "\r\n")
+	}, nil
+}
+
+func stty(args ...string) error {
+	cmd := exec.Command("stty", args...)
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
+func sttyOutput(args ...string) (string, error) {
+	cmd := exec.Command("stty", args...)
+	cmd.Stdin = os.Stdin
+	out, err := cmd.Output()
+	return string(out), err
+}

--- a/cli/wagocli/select_windows.go
+++ b/cli/wagocli/select_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package wagocli
+
+// runSelector's interactive raw-mode path is Unix-only (it toggles the terminal
+// with stty). On Windows we skip the interactive picker and keep the caller's
+// pre-seeded selection, returning not-cancelled.
+func runSelector(m *multiSelect) (cancelled bool) {
+	return false
+}


### PR DESCRIPTION
The **< and >** selector plus the permission-review UX (items 3–4 of the plugin install flow), wired into a real, safe command — `wago pkg grant <name>` — that reviews and edits a compiled-in plugin's granted capabilities in `wago.json`. It deliberately does **not** touch the `run` path; the install-on-demand hook (item 2) reuses `reviewCapabilities` next.

**What's here**
- `select.go` — a dependency-free multi-select: a pure, unit-tested model (↑↓ cursor, space toggle, `a`=all / `n`=none, enter/esc) + a raw-mode driver that toggles the terminal via `stty` (no `x/term` dep, per the zero-dependency policy). **← and → are inert** for now (per your call). Windows keeps the seeded selection.
- `review.go` — `reviewCapabilities`: shows a plugin's requestable capabilities and prompts **[A]ccept / [M]odify / [R]eject**; Modify opens the selector.
- `plugin_grants.go` — read/write `plugins[id].capabilities` in `wago.json` (GitHub-relative IDs from #246), preserving other entry fields.

**Verification**
- Unit-tested: `multiSelect` transitions, `decodeKey` (including inert ←/→), grants round-trip. Full `cli/wagocli` suite green; `go vet` clean; gofmt clean; builds on linux + darwin.
- The raw-mode TTY interaction and end-to-end `grant` behavior need a **hub** run — this sandbox can't attach a TTY or execute the built binary.

Independent of #250 (uses the existing `--global` flag). Follow-up: item 2 wires `reviewCapabilities` into `wago run --plugin X` so a missing plugin offers to install + review before building.