### PR TITLE
feat(cli): rebuild wago automatically after pkg add

### DIFF
--- a/cli/wagocli/plugin_build.go
+++ b/cli/wagocli/plugin_build.go
@@ -79,7 +79,9 @@ func pkgAdd(modOrName string, o pkgOpts) {
 		verb = "added"
 	}
 	fmt.Printf("%s %s\n", cyan(verb), dim(module))
-	fmt.Printf("  %s\n", dim(fmt.Sprintf("%d plugin%s declared · run any module to rebuild, or: wago pkg build", len(deps), plural(len(deps)))))
+	// Rebuild the custom binary right away so the new plugin is usable without a
+	// separate `wago pkg build` step.
+	buildPlugins(buildDir, deps, o)
 }
 
 // pkgRemove drops a dependency from wago.json (a later build's `go mod tidy`
@@ -139,6 +141,12 @@ func pkgBuild(o pkgOpts) {
 	if len(deps) == 0 {
 		fatal("pkg build: no dependencies in %s (add one: wago pkg add <module>)", projectManifestPath(src))
 	}
+	buildPlugins(buildDir, deps, o)
+}
+
+// buildPlugins compiles (or reuses) the custom wago binary for deps, printing
+// progress. Shared by pkg build and the auto-rebuild after pkg add.
+func buildPlugins(buildDir string, deps []string, o pkgOpts) {
 	fmt.Printf("%s\n", bold(fmt.Sprintf("building wago with %d plugin%s:", len(deps), plural(len(deps)))))
 	for _, d := range deps {
 		fmt.Printf("  %s\n", dim(d))


### PR DESCRIPTION
`wago pkg add` now rebuilds the custom binary immediately (shared `buildPlugins` helper, also used by `pkg build`) instead of printing "run any module to rebuild, or: wago pkg build" and leaving the plugin uncompiled.

full `cli/wagocli` suite green; vet + gofmt clean. e2e build verified on hub.

Note: this does **not** fix the separate `wago run --plugin wago-org/wasi` → "not compiled into this binary" issue in your transcript — that's an ID-match problem at `src/wago/plugin_plan.go:44` (the name you pass vs the name the plugin registered under via `RegisterExtension`), not a build problem. See PR discussion.