### PR TITLE
fix(plugins): canonicalize plugin ids so full-path and short forms match

### DIFF
--- a/src/wago/plugins.go
+++ b/src/wago/plugins.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -47,27 +48,40 @@ func GuestArgs() []string {
 	return guestArgs
 }
 
-// RegisterExtension registers a plugin factory under a short, stable name (e.g.
-// "timer"). Call it from an init() in the binary that compiles the plugin in. It
-// panics on an empty name, a nil factory, or a duplicate name — all build-time
-// programming errors.
+// canonicalPluginID normalizes a plugin identifier to its GitHub-relative form
+// by dropping a leading "github.com/", so a plugin registered under its full
+// module path ("github.com/wago-org/wasi") and one referenced by the short
+// "owner/repo" id that wago.json and `--plugin` use ("wago-org/wasi") resolve to
+// the same entry. Identifiers without that prefix are returned unchanged.
+func canonicalPluginID(name string) string {
+	return strings.TrimPrefix(name, "github.com/")
+}
+
+// RegisterExtension registers a plugin factory under a stable name. The name is
+// canonicalized to its GitHub-relative form (see canonicalPluginID), so a plugin
+// registering under a full module path is found by its short id. Call it from an
+// init() in the binary that compiles the plugin in. It panics on an empty name,
+// a nil factory, or a duplicate name — all build-time programming errors.
 func RegisterExtension(name string, factory ExtensionFactory) {
 	if name == "" || factory == nil {
 		panic("wago: RegisterExtension: empty name or nil factory")
 	}
+	id := canonicalPluginID(name)
 	pluginMu.Lock()
 	defer pluginMu.Unlock()
-	if _, dup := pluginReg[name]; dup {
-		panic("wago: RegisterExtension: duplicate plugin " + name)
+	if _, dup := pluginReg[id]; dup {
+		panic("wago: RegisterExtension: duplicate plugin " + id)
 	}
-	pluginReg[name] = factory
+	pluginReg[id] = factory
 }
 
-// NewExtension constructs a registered plugin by name. The boolean is false for
-// an unregistered name.
+// NewExtension constructs a registered plugin by name, matching on the
+// canonicalized (GitHub-relative) id so the full-path and short forms are
+// interchangeable. The boolean is false for an unregistered name.
 func NewExtension(name string) (Extension, bool) {
+	id := canonicalPluginID(name)
 	pluginMu.Lock()
-	f := pluginReg[name]
+	f := pluginReg[id]
 	pluginMu.Unlock()
 	if f == nil {
 		return nil, false

--- a/src/wago/plugins_canonical_test.go
+++ b/src/wago/plugins_canonical_test.go
@@ -1,0 +1,52 @@
+package wago
+
+import "testing"
+
+func TestCanonicalPluginID(t *testing.T) {
+	cases := map[string]string{
+		"github.com/wago-org/wasi": "wago-org/wasi",
+		"wago-org/wasi":            "wago-org/wasi",
+		"github.com/a/b/c":         "a/b/c",
+		"timer":                    "timer",
+		"gitlab.com/x/y":           "gitlab.com/x/y", // only github.com is stripped
+	}
+	for in, want := range cases {
+		if got := canonicalPluginID(in); got != want {
+			t.Errorf("canonicalPluginID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestRegisterLookupInterchangeable reproduces the reported bug: a plugin that
+// registers under its full module path must be found by the short GitHub-relative
+// id that wago.json and `--plugin` use (and vice-versa), and it must list under
+// the canonical id.
+func TestRegisterLookupInterchangeable(t *testing.T) {
+	const full = "github.com/wago-org/canon-test"
+	const short = "wago-org/canon-test"
+	RegisterExtension(full, func() Extension { return tripleExt{} })
+	t.Cleanup(func() {
+		pluginMu.Lock()
+		delete(pluginReg, short)
+		pluginMu.Unlock()
+	})
+
+	for _, q := range []string{full, short} {
+		if _, ok := NewExtension(q); !ok {
+			t.Errorf("NewExtension(%q) not found; registration/lookup ids disagree", q)
+		}
+	}
+
+	found := false
+	for _, n := range RegisteredPluginNames() {
+		if n == short {
+			found = true
+		}
+		if n == full {
+			t.Errorf("RegisteredPluginNames returned the full path %q; want canonical %q", full, short)
+		}
+	}
+	if !found {
+		t.Errorf("RegisteredPluginNames missing canonical id %q", short)
+	}
+}


### PR DESCRIPTION
**Root cause of `wago run --plugin wago-org/wasi` → "not compiled into this binary".**

#246 moved `wago.json` and `--plugin` to GitHub-relative plugin ids (`wago-org/wasi`) but didn't touch the engine's registry. Plugins register under their full module path:
```go
// github.com/wago-org/wasi/register/register.go
wago.RegisterExtension("github.com/wago-org/wasi", ...)
```
So the lookup for `wago-org/wasi` missed and errored — and rebuilding never helped, because it was never a build problem.

**Fix:** canonicalize ids (strip a leading `github.com/`) at both `RegisterExtension` and `NewExtension` — the choke point every lookup (`LoadPlugins`, `UsePlugin`, `plugin inspect`) goes through. Full-path and short forms are now interchangeable, and `wago plugin list` reports the canonical id, matching `wago.json`.

Tests: `TestCanonicalPluginID`, `TestRegisterLookupInterchangeable` (reproduces the exact bug). Full `src/wago` + `cli/wagocli` suites green; gofmt clean.

**To pick this up locally** (the custom binary builds against `~/.wago/src`): merge → `wago version update --canary` → `wago pkg build --force` (or just re-run; the toolchain hash change triggers a rebuild). Then `--plugin wago-org/wasi` resolves.