### PR TITLE
feat(cli): unified capability review — single selector with Reject All

### DIFF
--- a/cli/wagocli/review.go
+++ b/cli/wagocli/review.go
@@ -1,61 +1,59 @@
 package wagocli
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
 	"github.com/wago-org/wago"
 )
 
-// reviewCapabilities presents a plugin's requestable capabilities and returns the
-// subset the user grants. `required` is the plugin's full requestable set;
-// `granted` is the currently-granted subset (shown pre-checked). It prompts
-// Accept-all / Modify / Reject; Modify opens the interactive selector. Returns
-// (chosen, ok); ok is false when the user rejects or cancels. A plugin that
-// requests nothing returns an empty grant with ok=true.
+// capabilityDocs describes the standard plugin capabilities for the review UI.
+// Unknown capabilities render with no description.
+var capabilityDocs = map[string]string{
+	"host.imports":       "provide host-import functions to guests",
+	"host.environment":   "read the host environment (args, env, clock, fs)",
+	"module.compile":     "hook module compilation",
+	"instance.lifecycle": "hook instance create/destroy",
+	"instance.invoke":    "hook guest invocations",
+	"runtime.lifecycle":  "hook runtime start/stop",
+	"instance.manage":    "create and manage guest instances",
+}
+
+func capabilityDoc(cap string) string { return capabilityDocs[cap] }
+
+// reviewCapabilities presents a plugin's requestable capabilities in an
+// interactive selector — pre-checked, with a trailing "Reject All" row — and
+// returns the subset the user grants. `granted` pre-checks the current grants; a
+// brand-new plugin starts fully checked. Returns (chosen, ok); ok is false when
+// the user rejects (Reject All) or cancels (esc). A plugin that requests nothing
+// returns an empty grant with ok=true. On a non-interactive terminal the driver
+// keeps the pre-seeded (all/granted) selection, i.e. accept.
 //
-// This is shared by `wago pkg grant` and (next) the install-on-demand flow.
+// Shared by `wago pkg grant` and the install-on-demand flow.
 func reviewCapabilities(name string, required, granted []string) (chosen []string, ok bool) {
 	if len(required) == 0 {
-		fmt.Printf("%s requests no capabilities.\n", cyan(name))
 		return nil, true
 	}
 	grantedSet := map[string]bool{}
 	for _, g := range granted {
 		grantedSet[g] = true
 	}
-	fmt.Printf("%s requests these capabilities:\n", cyan(name))
-	for _, c := range required {
-		mark := dim("◦")
-		if grantedSet[c] {
-			mark = cyan("✔")
-		}
-		fmt.Printf("  %s %s\n", mark, c)
+	items := make([]selItem, len(required))
+	for i, c := range required {
+		items[i] = selItem{label: c, desc: capabilityDoc(c), on: len(granted) == 0 || grantedSet[c]}
 	}
-	fmt.Printf("\n%s ", bold("[A]ccept all  [M]odify  [R]eject:"))
-
-	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
-	switch strings.ToLower(strings.TrimSpace(line)) {
-	case "a", "accept", "y", "yes", "":
-		return append([]string(nil), required...), true
-	case "m", "modify", "e", "edit":
-		items := make([]selItem, len(required))
-		for i, c := range required {
-			// Pre-check current grants; a brand-new plugin (no grants yet) starts
-			// fully selected so "accept all" and "modify" agree by default.
-			items[i] = selItem{label: c, on: len(granted) == 0 || grantedSet[c]}
-		}
-		m := &multiSelect{title: "grant capabilities for " + name, items: items}
-		if cancelled := runSelector(m); cancelled {
-			return nil, false
-		}
-		return m.chosen(), true
-	default: // r, reject, n, no, anything else
+	m := &multiSelect{
+		title:  fmt.Sprintf("Package %s wants to use the following capabilities:", name),
+		prompt: "Use arrow keys and space to select and toggle on and off. Enter to submit.",
+		items:  items,
+		reject: true,
+	}
+	cancelled := runSelector(m)
+	if cancelled || m.rejected {
 		return nil, false
 	}
+	return m.chosen(), true
 }
 
 // pkgGrant interactively edits which of a compiled-in plugin's requestable

--- a/cli/wagocli/select.go
+++ b/cli/wagocli/select.go
@@ -31,15 +31,29 @@ const (
 	keyCancel // esc / q / ctrl-c
 )
 
-// multiSelect is the pure picker state: a list plus a cursor.
+// multiSelect is the pure picker state: a list plus a cursor. When reject is
+// set, a trailing "Reject All" row sits after the items; submitting on it sets
+// rejected. prompt overrides the default footer hint.
 type multiSelect struct {
-	title  string
-	items  []selItem
-	cursor int
+	title    string
+	prompt   string
+	items    []selItem
+	cursor   int
+	reject   bool // show a trailing "Reject All" row
+	rejected bool // submitted while on the Reject All row
+}
+
+// lastRow is the index of the final navigable row (the Reject All row when
+// present, otherwise the last item).
+func (m *multiSelect) lastRow() int {
+	if m.reject {
+		return len(m.items)
+	}
+	return len(m.items) - 1
 }
 
 // apply advances the model by one key. It reports whether the interaction is
-// finished, and if so whether it was cancelled (esc) rather than accepted
+// finished, and if so whether it was cancelled (esc) rather than submitted
 // (enter). Movement clamps at the ends; ← and → are intentionally inert.
 func (m *multiSelect) apply(k selectKey) (done, cancelled bool) {
 	switch k {
@@ -48,11 +62,11 @@ func (m *multiSelect) apply(k selectKey) (done, cancelled bool) {
 			m.cursor--
 		}
 	case keyDown:
-		if m.cursor < len(m.items)-1 {
+		if m.cursor < m.lastRow() {
 			m.cursor++
 		}
 	case keyToggle:
-		if len(m.items) > 0 {
+		if m.cursor < len(m.items) { // no-op on the Reject All row
 			m.items[m.cursor].on = !m.items[m.cursor].on
 		}
 	case keyAll:
@@ -64,6 +78,9 @@ func (m *multiSelect) apply(k selectKey) (done, cancelled bool) {
 			m.items[i].on = false
 		}
 	case keyAccept:
+		if m.reject && m.cursor == len(m.items) {
+			m.rejected = true // submitted on Reject All
+		}
 		return true, false
 	case keyCancel:
 		return true, true
@@ -119,13 +136,21 @@ func decodeKey(b []byte) selectKey {
 	return keyNoop
 }
 
-// frame renders the selector as plain text (the driver repaints it each key).
+// frame renders the selector as plain text (the driver repaints it each key):
+// an optional title, the capability checkboxes, an optional "Reject All" row,
+// and a footer hint.
 func (m *multiSelect) frame() string {
 	var b strings.Builder
 	if m.title != "" {
 		fmt.Fprintf(&b, "%s\n", bold(m.title))
 	}
-	fmt.Fprintf(&b, "%s\n\n", dim("↑/↓ move · space toggle · a all · n none · enter confirm · esc cancel"))
+	// Align descriptions to the widest label so the two columns line up.
+	labelW := 0
+	for _, it := range m.items {
+		if len(it.label) > labelW {
+			labelW = len(it.label)
+		}
+	}
 	for i, it := range m.items {
 		cursor := "  "
 		if i == m.cursor {
@@ -135,11 +160,23 @@ func (m *multiSelect) frame() string {
 		if it.on {
 			box = cyan("[x]")
 		}
-		line := fmt.Sprintf("%s%s %s", cursor, box, it.label)
+		line := fmt.Sprintf("%s%s %-*s", cursor, box, labelW, it.label)
 		if it.desc != "" {
 			line += "  " + dim(it.desc)
 		}
 		fmt.Fprintf(&b, "%s\n", line)
 	}
+	if m.reject {
+		if m.cursor == len(m.items) {
+			fmt.Fprintf(&b, "%s%s\n", cyan("▸ "), cyan("Reject All"))
+		} else {
+			fmt.Fprintf(&b, "  %s\n", dim("Reject All"))
+		}
+	}
+	prompt := m.prompt
+	if prompt == "" {
+		prompt = "↑/↓ move · space toggle · enter submit · esc cancel"
+	}
+	fmt.Fprintf(&b, "%s\n", dim(prompt))
 	return b.String()
 }

--- a/cli/wagocli/select_test.go
+++ b/cli/wagocli/select_test.go
@@ -60,6 +60,44 @@ func TestMultiSelectAcceptCancel(t *testing.T) {
 	}
 }
 
+func TestMultiSelectRejectRow(t *testing.T) {
+	m := &multiSelect{
+		items:  []selItem{{label: "a", on: true}, {label: "b", on: true}},
+		reject: true,
+	}
+	m.apply(keyDown)
+	m.apply(keyDown) // onto the Reject All row (index 2)
+	if m.cursor != 2 {
+		t.Fatalf("cursor should reach the Reject All row (2), got %d", m.cursor)
+	}
+	m.apply(keyDown) // clamps there
+	if m.cursor != 2 {
+		t.Fatalf("cursor should clamp at the Reject All row, got %d", m.cursor)
+	}
+	m.apply(keyToggle) // no-op on the reject row (must not panic or toggle an item)
+	if got := m.chosen(); len(got) != 2 {
+		t.Fatalf("toggle on reject row must not change item state, got %v", got)
+	}
+	done, cancelled := m.apply(keyAccept)
+	if !done || cancelled || !m.rejected {
+		t.Fatalf("enter on Reject All => done, rejected; got done=%v cancelled=%v rejected=%v", done, cancelled, m.rejected)
+	}
+}
+
+func TestMultiSelectSubmitOnItemNotRejected(t *testing.T) {
+	m := &multiSelect{
+		items:  []selItem{{label: "a", on: true}, {label: "b", on: false}},
+		reject: true,
+	}
+	done, cancelled := m.apply(keyAccept) // enter while on an item
+	if !done || cancelled || m.rejected {
+		t.Fatalf("enter on an item => submit; got done=%v cancelled=%v rejected=%v", done, cancelled, m.rejected)
+	}
+	if got := m.chosen(); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("chosen=%v, want [a]", got)
+	}
+}
+
 func TestDecodeKey(t *testing.T) {
 	cases := []struct {
 		in   []byte


### PR DESCRIPTION
Refines the capability review (from #253) to the single interactive selector you sketched, replacing the two-step `[A]ccept/[M]odify/[R]eject` text prompt:

```
Package <pkg> wants to use the following capabilities:
▸ [x] host.imports        provide host-import functions to guests
  [x] host.environment    read the host environment (args, env, clock, fs)
  Reject All
Use arrow keys and space to select and toggle on and off. Enter to submit.
```

- All capabilities **pre-checked**; ↑/↓ move, space toggles, **enter submits** the checked set, **esc cancels**.
- A trailing **Reject All** row — submitting on it rejects (grants nothing).
- Standard capabilities get human descriptions (`capabilityDocs`), aligned into a second column.

Tests: reject-row navigation + submit, submit-on-item (not rejected), plus the existing model/decodeKey coverage. `go vet`/gofmt clean; builds linux+darwin. Raw-mode TTY still hub-verified.

**Remaining (item 2, next):** auto-fire this review during `wago pkg add` — on first install, or when a package's required capabilities change — sourcing the required caps from the freshly-built `.wago/bin/wago`. Composes on top of #254 (auto-rebuild) + #255 (id fix, now on main).