### PR TITLE
runtime: guarantee exact-instance plugin cleanup across close and failed start

### DIFF
--- a/docs/plugin-api-v2.md
+++ b/docs/plugin-api-v2.md
@@ -49,7 +49,7 @@ These capabilities authorize Wago integration, not arbitrary Go behavior:
 
 | Capability | Authority |
 |---|---|
-| `host.imports` | Add host functions to Wasm import namespaces. |
+| `host.imports` | Add host functions to Wasm import namespaces and resolve the exact active caller identity. |
 | `host.environment` | Read the host environment explicitly exposed to plugins. |
 | `runtime.lifecycle` | Observe runtime shutdown and release plugin resources. |
 | `module.compile` | Observe or transform runtime module compilation. |
@@ -130,6 +130,122 @@ Each privileged surface also has a capability-specific handle (`HostImports`,
 `ModuleCompiler`, `InstanceInvocation`, and so on), so APIs obtained for one
 grant cannot be used to reach another. Resource-owning capabilities may carry
 core-enforced budgets in the manifest.
+
+## Exact-instance resource lifecycle
+
+A resource-owning plugin should key its private state by the exact
+`*wago.Instance`. Attach state in `AfterInstantiate`, associate host calls with
+that pointer through `CallerResolver`, and retire the state in `BeforeClose`.
+The map belongs to the plugin object; Wago does not maintain or require a
+process-global instance registry.
+
+```go
+type plugin struct {
+    mu      sync.Mutex
+    callers *wago.CallerResolver
+    state   map[*wago.Instance]*resource
+}
+
+func (p *plugin) Register(reg *wago.Registry) error {
+    host, err := reg.HostImports()
+    if err != nil {
+        return err
+    }
+    p.callers = host.CallerResolver()
+    host.Module("acme_resource").
+        Func("open", p.open).
+        Params().Results()
+
+    lifecycle, err := reg.InstanceLifecycle()
+    if err != nil {
+        return err
+    }
+    lifecycle.AfterInstantiate(p.attach)
+    lifecycle.BeforeClose(p.detach)
+    return nil
+}
+
+func (p *plugin) attach(_ *wago.InstantiateContext, in *wago.Instance) error {
+    p.mu.Lock()
+    defer p.mu.Unlock()
+    if p.state == nil {
+        p.state = make(map[*wago.Instance]*resource)
+    }
+    p.state[in] = newResource()
+    return nil
+}
+
+func (p *plugin) open(caller wago.HostModule, _, _ []uint64) {
+    in, err := p.callers.Resolve(caller)
+    if err != nil {
+        panic(err)
+    }
+    p.mu.Lock()
+    resource := p.state[in]
+    p.mu.Unlock()
+    _ = resource
+}
+
+func (p *plugin) detach(ctx *wago.InstanceContext) {
+    p.mu.Lock()
+    resource := p.state[ctx.Instance]
+    delete(p.state, ctx.Instance)
+    p.mu.Unlock()
+    if resource != nil {
+        resource.Close()
+    }
+}
+```
+
+`BeforeClose` is the authoritative disposal event. It receives the same instance
+identity delivered to successful instantiation and active caller resolution,
+plus the owning runtime, compiled module, direct/managed origin, and a metadata
+map shared with `AfterClose`. Hooks run in reverse registration order. Concurrent
+`Instance.Close` calls wait for one close operation; `BeforeClose`, Wago's own
+cleanup, and `AfterClose` each execute once. Each hook panic is recovered
+independently, remaining hooks and internal cleanup continue, and `Close` returns
+an aggregated error rather than silently losing the panic.
+
+`CallerResolver` is deliberately available from the `host.imports` handle. It
+grants identity only and does **not** grant instance creation, invocation, close,
+management, pooling, or worker authority, so `instance.manage` is not required.
+Resolution succeeds only during the synchronous `HostFunc` callback. Retained,
+expired, forged, cross-runtime, low-level, and otherwise incompatible
+`HostModule` values fail closed.
+
+The runtime attaches ownership and origin before imported or local Wasm start
+functions execute. If a start function calls a host import and then traps, exits,
+or otherwise fails, the partially initialized instance runs the normal close
+lifecycle before `Instantiate` returns. An `AfterInstantiate` failure is handled
+the same way. `OnInstantiateError` still observes the failure after cleanup; a
+panic in that observer is reported without replacing the original failure or
+preventing disposal. Original instantiation and cleanup errors remain available
+through `errors.Is`/`errors.As` because Wago joins them.
+
+A trap, context cancellation, `HostExit`/`ExitError`, or exported-function error
+from an ordinary invocation is **not** a disposal event. `AfterInvoke` may observe
+it, but a caller-owned instance remains open until its owner closes it. A
+`HostExit` raised while executing a start function is different: instantiation
+never succeeds, so the partially created instance is closed as failed-start
+cleanup.
+
+Runtime-created direct instances remain caller-owned when `Runtime.Close` runs.
+Managed instances, including forks still owned by an `InstanceManager`, are
+closed by manager/runtime shutdown. Wago's managed API does not logically reset
+or republish an instance: creation and fork paths physically instantiate. A
+plugin that implements its own leases or pooling and owns non-Wasm sockets,
+handles, quotas, registrations, or similar state must close the old physical
+instance through the full lifecycle before publishing another owner, or require
+physical reinstantiation.
+
+The package-level low-level `Compile`/`Instantiate`/`Invoke` APIs remain outside
+the Runtime plugin lifecycle. Their instances do not emit plugin hooks and their
+`HostModule` values cannot be resolved by a runtime `CallerResolver`.
+
+Finally, these guarantees cover controlled in-process Wago lifecycle paths. A
+native host-process crash, `SIGSEGV`, forced termination, or power loss cannot
+reliably execute an in-process close callback; plugins needing crash durability
+must use operating-system or external-service recovery mechanisms.
 
 ## Core-size rule
 

--- a/docs/wago-json.md
+++ b/docs/wago-json.md
@@ -94,7 +94,7 @@ the plan commits.
 
 | Capability | Allows the plugin to |
 |---|---|
-| `host.imports` | Add host functions to Wasm import namespaces. |
+| `host.imports` | Add host functions to Wasm import namespaces and resolve exact active caller identity. |
 | `host.environment` | Read the narrow host environment explicitly exposed by Wago. |
 | `runtime.lifecycle` | Observe runtime shutdown and release plugin resources. |
 | `module.compile` | Transform Wasm bytes before compilation or observe compiled modules. |

--- a/src/wago/access.go
+++ b/src/wago/access.go
@@ -29,6 +29,15 @@ func (a *HostImportAccess) Module(name string) *ImportModuleBuilder {
 	return a.reg.ImportModule(name)
 }
 
+// CallerResolver returns a runtime-scoped, identity-only resolver for HostModule
+// values passed to this plugin's host imports. It requires host.imports authority
+// only; instance.manage is not required.
+func (a *HostImportAccess) CallerResolver() *CallerResolver {
+	resolver := &CallerResolver{}
+	a.reg.activate = append(a.reg.activate, resolver.activate)
+	return resolver
+}
+
 type RuntimeHookAccess struct{ hooks *HookRegistry }
 
 func (r *Registry) RuntimeLifecycle() (*RuntimeHookAccess, error) {

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -449,19 +449,24 @@ func asyncReplayable(sig FuncSig) bool {
 		(len(sig.Params) == 0 || sig.Params[0] == ValI32)
 }
 
-// linkModule resolves the module's function imports against the provided imports
-// and, when any resolve to another instance's function (cross-instance linking),
-// recompiles the module with those bindings so the calls lower to a native
-// context-swap. It returns c unchanged when no linking is needed (host-only
-// modules keep their prebuilt fast-path code). The returned *Compiled is
-// instance-specific: its code bakes the callee instances' addresses.
+// linkModule resolves imports using the module's normal host-call mode.
 func (c *Compiled) linkModule(imports Imports, store *referenceStore) (*Compiled, error) {
+	return c.linkModuleMode(imports, store, false)
+}
+
+// linkModuleMode resolves the module's function imports and, when necessary,
+// recompiles them for native cross-instance calls or synchronous host callbacks.
+// forceSyncHost is used by Runtime caller resolution so a host callback happens
+// at the actual Wasm call site, including before a later start-function trap.
+func (c *Compiled) linkModuleMode(imports Imports, store *referenceStore, forceSyncHost bool) (*Compiled, error) {
 	bindings := make([]railshotImportBinding, len(c.Imports))
 	anyCross := false
-	forceSyncHost := false
+	requestSyncHost := forceSyncHost
+	forceSyncHost = false
 	for i, key := range c.Imports {
 		ex, ok := imports[key].(*InstanceExport)
 		if !ok {
+			forceSyncHost = forceSyncHost || requestSyncHost
 			switch imports[key].(type) {
 			case *HostFuncRef:
 				if i >= len(c.importFuncSigs) {
@@ -511,8 +516,8 @@ func (c *Compiled) linkModule(imports Imports, store *referenceStore) (*Compiled
 		}
 		anyCross = true
 	}
-	if !c.needsLink && !anyCross && !forceSyncHost {
-		return c, nil // host-only legacy void imports: use the prebuilt async code
+	if !c.needsLink && !anyCross && (!forceSyncHost || c.syncHostImports) {
+		return c, nil // existing code already has the required host-call mode
 	}
 	// Host-only link (deferred codegen, no cross-instance binding): the recompiled
 	// code does not depend on which host functions are supplied, so produce it once
@@ -520,7 +525,11 @@ func (c *Compiled) linkModule(imports Imports, store *referenceStore) (*Compiled
 	// shares the one executable mapping. (bindings here are all zero-value.)
 	if !anyCross {
 		if hl := c.hostLink; hl != nil {
-			hl.once.Do(func() { hl.c, hl.err = c.recompileLinked(nil, bindings, forceSyncHost) })
+			if forceSyncHost {
+				hl.syncOnce.Do(func() { hl.syncC, hl.syncErr = c.recompileLinked(nil, bindings, true) })
+				return hl.syncC, hl.syncErr
+			}
+			hl.once.Do(func() { hl.c, hl.err = c.recompileLinked(nil, bindings, false) })
 			return hl.c, hl.err
 		}
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1743,7 +1743,7 @@ func (in *Instance) replayHostLog() (err error) {
 		if int(imp) < len(in.c.Imports) {
 			if fn := in.hosts[in.c.Imports[imp]]; fn != nil {
 				params[0] = uint64(uint32(arg))
-				if in.rt == nil || !in.rt.managedActive.Load() {
+				if in.rt == nil || !in.rt.scopedHostCalls() {
 					fn(staticHostModule{in: in}, params[:], nil)
 					continue
 				}

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -81,8 +81,13 @@ func (c *Compiled) Close() error {
 	// Release the memoized host-only linked module's mapping too (its finalizer
 	// would eventually, but a caller closing c wants the code freed promptly). Live
 	// instances keep it mapped via the code refcount until they close.
-	if hl := c.hostLink; hl != nil && hl.c != nil {
-		_ = hl.c.Close()
+	if hl := c.hostLink; hl != nil {
+		if hl.c != nil {
+			_ = hl.c.Close()
+		}
+		if hl.syncC != nil && hl.syncC != hl.c {
+			_ = hl.syncC.Close()
+		}
 	}
 	c.ensureCodeCache()
 	cc := c.codeCache

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -625,8 +625,9 @@ type Compiled struct {
 	// modules with no function imports (or hand-built/deserialized).
 	hostLink *hostLinkCache
 
-	// syncHostImports is set by linkModule when the module has a returning host
-	// import: all its host calls use the synchronous control frame and Invoke
+	// syncHostImports is set by linkModule when the module has a returning/v128
+	// host import or exact caller resolution requires call-site callbacks: all host
+	// calls then use the synchronous control frame and Invoke
 	// drives the CallWithHost re-entry loop. importFuncSigs holds the function
 	// imports' signatures (imports first), needed to bind host functions and to
 	// keep legacy HostFunc validation sound after compiled-code serialization.
@@ -659,13 +660,17 @@ type validateMemo struct {
 	err  error
 }
 
-// hostLinkCache memoizes the host-only link recompile of a needsLink module (see
-// Compiled.hostLink). once guards the single recompile; c/err hold its result,
-// shared by every subsequent host Instantiate.
+// hostLinkCache memoizes host-only link recompiles of a needsLink module (see
+// Compiled.hostLink). Normal and forced-synchronous host modes are cached
+// separately so caller-resolution authority cannot reuse async replay code.
 type hostLinkCache struct {
 	once sync.Once
 	c    *Compiled
 	err  error
+
+	syncOnce sync.Once
+	syncC    *Compiled
+	syncErr  error
 }
 
 // validateCached returns the metadata-validation result, running the full check

--- a/src/wago/hooks.go
+++ b/src/wago/hooks.go
@@ -1,6 +1,10 @@
 package wago
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 // HookRegistry collects lifecycle callbacks contributed by extensions: runtime
 // close, compile, instantiate, instance close, and invoke. Hooks fire on the
@@ -58,14 +62,16 @@ func (h *HookRegistry) OnInstantiateError(fns ...func(*InstantiateContext, error
 
 // BeforeClose registers a callback run immediately before a Runtime-created
 // instance releases its resources. Close hooks run in reverse registration order
-// and do not fire for low-level package-level Instantiate instances.
+// and do not fire for low-level package-level Instantiate instances. Each panic
+// is isolated, reported from Instance.Close, and does not skip later cleanup.
 func (h *HookRegistry) BeforeClose(fns ...func(*InstanceContext)) {
 	h.beforeClose = append(h.beforeClose, fns...)
 }
 
 // AfterClose registers a callback run after a Runtime-created instance releases
 // its resources. It shares Metadata with BeforeClose and runs in reverse
-// registration order. Instance.Close is idempotent, so these hooks fire once.
+// registration order. Instance.Close is concurrent-safe and idempotent, so these
+// hooks fire once; panics are isolated and returned as close errors.
 func (h *HookRegistry) AfterClose(fns ...func(*InstanceContext)) {
 	h.afterClose = append(h.afterClose, fns...)
 }
@@ -116,8 +122,9 @@ type InstantiateContext struct {
 	Metadata map[string]any
 }
 
-// InstanceContext is passed to instance-close hooks. Metadata is shared from
-// BeforeClose to AfterClose for one Close call.
+// InstanceContext is passed to instance-close hooks. Instance is the exact
+// Runtime-owned pointer being disposed. Metadata is shared from BeforeClose to
+// AfterClose for that one close operation.
 type InstanceContext struct {
 	Runtime  *Runtime
 	Compiled *Compiled
@@ -163,6 +170,40 @@ func (h *HookRegistry) appendFrom(src *HookRegistry) {
 	h.afterClose = append(h.afterClose, src.afterClose...)
 	h.beforeInvoke = append(h.beforeInvoke, src.beforeInvoke...)
 	h.afterInvoke = append(h.afterInvoke, src.afterInvoke...)
+}
+
+func callHookSafely(phase string, fn func()) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if panicErr, ok := recovered.(error); ok {
+				err = fmt.Errorf("wago: %s hook panicked: %w", phase, panicErr)
+			} else {
+				err = fmt.Errorf("wago: %s hook panicked: %v", phase, recovered)
+			}
+		}
+	}()
+	fn()
+	return nil
+}
+
+func joinPrimary(primary error, additional ...error) error {
+	joined := make([]error, 0, len(additional)+1)
+	if primary != nil {
+		joined = append(joined, primary)
+	}
+	for _, err := range additional {
+		if err != nil {
+			joined = append(joined, err)
+		}
+	}
+	switch len(joined) {
+	case 0:
+		return nil
+	case 1:
+		return joined[0]
+	default:
+		return errors.Join(joined...)
+	}
 }
 
 func (h *HookRegistry) requiredPluginCapabilities() []PluginCapability {

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -40,6 +40,39 @@ type ExternRefHostModule interface {
 // under standard Go and TinyGo — with no reflection anywhere on the path.
 type HostFunc func(m HostModule, params, results []uint64)
 
+// CallerResolver resolves the exact Runtime-owned instance making an active
+// synchronous host call. Its authority is identity-only: it cannot create,
+// invoke, close, manage, pool, or otherwise control instances.
+//
+// Resolve succeeds only while the HostFunc callback is active. Retaining the
+// HostModule and resolving it after the callback returns fails closed.
+type CallerResolver struct {
+	rt atomic.Pointer[Runtime]
+}
+
+func (r *CallerResolver) activate(rt *Runtime) {
+	if r == nil || rt == nil {
+		return
+	}
+	r.rt.Store(rt)
+	rt.callerResolverActive.Store(true)
+}
+
+// Resolve returns the exact instance making caller's active synchronous host
+// call. Forged, expired, cross-runtime, and low-level HostModule values are
+// rejected.
+func (r *CallerResolver) Resolve(caller HostModule) (*Instance, error) {
+	if r == nil {
+		return nil, fmt.Errorf("wago: nil caller resolver: %w", ErrPermissionDenied)
+	}
+	rt := r.rt.Load()
+	h, ok := caller.(instanceHostModule)
+	if rt == nil || !ok || !h.valid() || h.in == nil || h.in.rt != rt {
+		return nil, fmt.Errorf("wago: caller identity requires an active host call from the owning runtime: %w", ErrPermissionDenied)
+	}
+	return h.in, nil
+}
+
 // hostCallScope authorizes one synchronous use of an instanceHostModule.
 type hostCallScope struct {
 	next   uint64
@@ -54,8 +87,14 @@ type hostCallWaiter struct {
 
 type instancePluginState struct {
 	hostScope hostCallScope
+	close     atomic.Pointer[instanceCloseState]
 	gcConfig  *GCConfig
 	origin    InstantiateOrigin
+}
+
+type instanceCloseState struct {
+	done   chan struct{}
+	result error
 }
 
 func (in *Instance) instantiateOrigin() InstantiateOrigin {
@@ -467,7 +506,7 @@ func (in *Instance) newHostDispatch() runtime.HostCall {
 			panic(invalidHostReference{err: fmt.Errorf("host import %d: %w", importIdx, err)})
 		}
 		var mod HostModule
-		if in.rt == nil || !in.rt.managedActive.Load() {
+		if in.rt == nil || !in.rt.scopedHostCalls() {
 			mod = staticHostModule{in: in}
 		} else {
 			caller := in.beginHostCallScope()

--- a/src/wago/hostlink_test.go
+++ b/src/wago/hostlink_test.go
@@ -7,6 +7,31 @@ import (
 	"testing"
 )
 
+func TestCallerResolverSyncLinkCacheClosesWithCompiled(t *testing.T) {
+	c := MustCompile(voidImportCallModule())
+	imports := Imports{"env.f": HostFunc(func(HostModule, []uint64, []uint64) {})}
+	linked, err := c.linkModuleMode(imports, nil, true)
+	if err != nil {
+		t.Fatalf("forced synchronous link: %v", err)
+	}
+	if linked == c || !linked.syncHostImports {
+		t.Fatalf("forced link = %p sync=%v, want distinct synchronous module", linked, linked.syncHostImports)
+	}
+	if c.hostLink == nil || c.hostLink.syncC != linked {
+		t.Fatal("forced synchronous link was not memoized")
+	}
+	linked.ensureCodeCache()
+	if err := c.Close(); err != nil {
+		t.Fatalf("Compiled.Close: %v", err)
+	}
+	linked.codeCache.mu.Lock()
+	closed := linked.codeCache.closed
+	linked.codeCache.mu.Unlock()
+	if !closed {
+		t.Fatal("Compiled.Close left forced synchronous linked code open")
+	}
+}
+
 // TestHostLinkCached verifies the host-only link recompile is memoized: a
 // needsLink module (returning imports) links once and every later host
 // Instantiate reuses that linked module + its code mapping instead of re-running

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -94,7 +94,10 @@ type InstantiateOptions struct {
 	// start function are skipped. Table modules are rejected by Capture until
 	// table state is snapshotted too. Set only via the *Snapshot instantiation path;
 	// unexported so it stays an internal instantiation mode.
-	restore *Snapshot
+	restore  *Snapshot
+	runtime  *Runtime
+	origin   InstantiateOrigin
+	pluginGC *GCConfig
 }
 
 // Instantiable is the set of sources Instantiate accepts: a compiled module or a
@@ -165,11 +168,11 @@ func instantiateArgs(args []any) (InstantiateOptions, error) {
 
 // instantiateCore maps code and applies explicit instance options. It is the
 // shared engine behind Instantiate for both the compiled and snapshot paths.
-func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
+func instantiateCore(c *Compiled, opts InstantiateOptions) (result *Instance, err error) {
 	imports := opts.Imports
 	// Resolve cross-instance function imports, recompiling the module with their
 	// bindings when any are present (a no-op for host-only modules).
-	c, err := c.linkModule(imports, opts.store)
+	c, err = c.linkModule(imports, opts.store)
 	if err != nil {
 		return nil, err
 	}
@@ -812,9 +815,36 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 	}
 	in := &Instance{
 		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, hosts: imports.hostFuncs(), imports: imports, hostLog: hostLog, syncMode: syncMode, ctrl: ctrl, syncHosts: syncHosts, globals: globals, globalCells: globalCells, tableDescPtr: tableDescPtr, tableDescLen: len(tableDesc), funcRefDescs: funcRefDescs, passiveDataDesc: passiveDataDesc, thunkMem: thunkMem, gc: collector,
-		serArgs: serArgs, results: results, trap: trap, resultVals: make([]uint64, c.maxResultSlots),
+		serArgs: serArgs, results: results, trap: trap, resultVals: make([]uint64, c.maxResultSlots), rt: opts.runtime,
 	}
 	registeredInstance = in
+	if opts.origin != InstantiateDirect || opts.pluginGC != nil {
+		state := in.ensurePluginState()
+		state.origin = opts.origin
+		if opts.pluginGC != nil {
+			cfg := *opts.pluginGC
+			state.gcConfig = &cfg
+		}
+	}
+	if opts.runtime != nil {
+		// Once a Runtime-owned Instance exists, every later failure must dispose it
+		// through the normal lifecycle before the instantiation error escapes.
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				result = nil
+				if panicErr, ok := recovered.(error); ok {
+					err = fmt.Errorf("wago: instantiation panicked after instance creation: %w", panicErr)
+				} else {
+					err = fmt.Errorf("wago: instantiation panicked after instance creation: %v", recovered)
+				}
+			}
+			if success {
+				return
+			}
+			success = true // the normal Close path now owns all instance resources
+			err = joinPrimary(err, in.Close())
+		}()
+	}
 	if opts.store != nil {
 		if err := opts.store.registerInstance(in); err != nil {
 			return nil, err
@@ -826,7 +856,7 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 	}
 
 	if initErr != nil {
-		if retainProducerRootsInImportedTables(in) {
+		if opts.runtime == nil && retainProducerRootsInImportedTables(in) {
 			success = true
 			_ = in.Close()
 		}
@@ -854,10 +884,9 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 				return nil, fmt.Errorf("start function %q: %w", key, err)
 			}
 			caller := in.beginHostCallScope()
-			func() {
-				defer caller.scope.end(caller.generation)
-				fn(caller, nil, nil)
-			}()
+			if err := callImportedStart(fn, caller); err != nil {
+				return nil, fmt.Errorf("start function %q: %w", key, err)
+			}
 		} else {
 			if c.StartLocalFunc < 0 || c.StartLocalFunc >= len(c.Entry) {
 				return nil, fmt.Errorf("start function index %d out of range", c.StartLocalFunc)
@@ -883,7 +912,7 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 				// becomes the failed instance's lifetime owner. The table prunes roots
 				// no longer present in any slot, so retention stays bounded by its
 				// descriptor capacity rather than by failed-instantiation count.
-				if retainProducerRootsInImportedTables(in) {
+				if opts.runtime == nil && retainProducerRootsInImportedTables(in) {
 					success = true
 					_ = in.Close()
 				}
@@ -899,15 +928,41 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 		// any table roots it contributed, and report that a live instance of this
 		// shape is unsupported. (The store-modified-on-trap case returns above.)
 		jm.RestoreBasedata(savedBasedata)
-		if retainProducerRootsInImportedTables(in) {
-			success = true
+		if opts.runtime == nil {
+			if retainProducerRootsInImportedTables(in) {
+				success = true
+			}
+			_ = in.Close()
 		}
-		_ = in.Close()
 		return nil, fmt.Errorf("a module importing a shared memory may not be instantiated as a live instance when it installs per-instance basedata state")
 	}
 
 	success = true
 	return in, nil
+}
+
+func callImportedStart(fn HostFunc, caller instanceHostModule) (err error) {
+	defer caller.scope.end(caller.generation)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			switch value := recovered.(type) {
+			case HostExit:
+				err = &ExitError{Code: value.Code}
+			case *HostExit:
+				if value == nil {
+					err = fmt.Errorf("host start panicked with a nil *HostExit")
+				} else {
+					err = &ExitError{Code: value.Code}
+				}
+			case error:
+				err = fmt.Errorf("host start panicked: %w", value)
+			default:
+				err = fmt.Errorf("host start panicked: %v", value)
+			}
+		}
+	}()
+	fn(caller, nil, nil)
+	return nil
 }
 
 func (c *Compiled) needsPublicFuncrefHostReentry() bool {
@@ -1010,21 +1065,63 @@ func buildHostFuncThunks(c *Compiled, imports Imports) (map[uint32]uint64, []byt
 }
 
 // Close releases the instance's mapped code, engine, and (if instance-owned) its
-// memory. An imported memory is left for the host to Close. Close is idempotent;
-// the error result is always nil today and exists for forward compatibility.
-func (in *Instance) Close() error {
+// memory. An imported memory is left for the host to Close. Close is idempotent.
+// Concurrent callers wait for the active close operation and receive its same
+// completed, possibly aggregated, error result.
+func (in *Instance) Close() (err error) {
 	if in == nil {
 		return nil
 	}
+	state, owner := in.beginClose()
+	if !owner {
+		<-state.done
+		return state.result
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if panicErr, ok := recovered.(error); ok {
+				err = joinPrimary(err, fmt.Errorf("wago: instance close panicked: %w", panicErr))
+			} else {
+				err = joinPrimary(err, fmt.Errorf("wago: instance close panicked: %v", recovered))
+			}
+		}
+		state.result = err
+		close(state.done)
+	}()
+	return in.closeOnce()
+}
+
+func (in *Instance) beginClose() (*instanceCloseState, bool) {
+	state := in.ensurePluginState()
+	if active := state.close.Load(); active != nil {
+		return active, false
+	}
+	candidate := &instanceCloseState{done: make(chan struct{})}
+	if state.close.CompareAndSwap(nil, candidate) {
+		return candidate, true
+	}
+	return state.close.Load(), false
+}
+
+func (in *Instance) closeOnce() error {
+	var errs []error
+	appendStep := func(phase string, fn func()) {
+		if err := callHookSafely(phase, fn); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
 	in.lifeMu.Lock()
 	alreadyClosed := in.closed
 	in.lifeMu.Unlock()
 	if alreadyClosed {
 		return nil
 	}
+
 	if in.rt != nil {
 		for i := len(in.rt.hooks.internalBeforeClose) - 1; i >= 0; i-- {
-			in.rt.hooks.internalBeforeClose[i](in)
+			fn := in.rt.hooks.internalBeforeClose[i]
+			appendStep("internal BeforeClose", func() { fn(in) })
 		}
 	}
 
@@ -1034,7 +1131,8 @@ func (in *Instance) Close() error {
 			Runtime: in.rt, Compiled: in.c, Instance: in, Origin: in.instantiateOrigin(), Metadata: map[string]any{},
 		}
 		for i := len(in.rt.hooks.beforeClose) - 1; i >= 0; i-- {
-			in.rt.hooks.beforeClose[i](hctx)
+			fn := in.rt.hooks.beforeClose[i]
+			appendStep("BeforeClose", func() { fn(hctx) })
 		}
 	}
 
@@ -1045,34 +1143,31 @@ func (in *Instance) Close() error {
 	// the write for other importers that later read it. retainResourceRoot refuses
 	// a closed instance, so this runs before in.closed is set; the container drops
 	// the root when the descriptor is overwritten or the container closes.
-	retainProducerRootsInImportedTables(in)
-	retainProducerRootsInImportedGlobals(in)
+	appendStep("retain imported table roots", func() { retainProducerRootsInImportedTables(in) })
+	appendStep("retain imported global roots", func() { retainProducerRootsInImportedGlobals(in) })
 
 	in.lifeMu.Lock()
-	if in.closed {
-		in.lifeMu.Unlock()
-		return nil
-	}
 	in.closed = true
 	shouldRelease := in.resourceRefs == 0
 	store := in.refStore
 	in.lifeMu.Unlock()
 
-	detachImportedHostFuncRefs(in)
-	detachImportedGlobals(in)
-	detachImportedTables(in)
+	appendStep("detach imported host functions", func() { detachImportedHostFuncRefs(in) })
+	appendStep("detach imported globals", func() { detachImportedGlobals(in) })
+	appendStep("detach imported tables", func() { detachImportedTables(in) })
 	if store != nil {
-		store.instanceClosed(in)
+		appendStep("close reference store instance", func() { store.instanceClosed(in) })
 	}
 	if shouldRelease {
-		in.releaseResources()
+		appendStep("release instance resources", in.releaseResources)
 	}
 	if hctx != nil {
 		for i := len(in.rt.hooks.afterClose) - 1; i >= 0; i-- {
-			in.rt.hooks.afterClose[i](hctx)
+			fn := in.rt.hooks.afterClose[i]
+			appendStep("AfterClose", func() { fn(hctx) })
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (in *Instance) releaseResources() {

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -94,10 +94,11 @@ type InstantiateOptions struct {
 	// start function are skipped. Table modules are rejected by Capture until
 	// table state is snapshotted too. Set only via the *Snapshot instantiation path;
 	// unexported so it stays an internal instantiation mode.
-	restore  *Snapshot
-	runtime  *Runtime
-	origin   InstantiateOrigin
-	pluginGC *GCConfig
+	restore       *Snapshot
+	runtime       *Runtime
+	origin        InstantiateOrigin
+	pluginGC      *GCConfig
+	forceSyncHost bool
 }
 
 // Instantiable is the set of sources Instantiate accepts: a compiled module or a
@@ -172,7 +173,7 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (result *Instance, er
 	imports := opts.Imports
 	// Resolve cross-instance function imports, recompiling the module with their
 	// bindings when any are present (a no-op for host-only modules).
-	c, err = c.linkModule(imports, opts.store)
+	c, err = c.linkModuleMode(imports, opts.store, opts.forceSyncHost)
 	if err != nil {
 		return nil, err
 	}

--- a/src/wago/lifecycle_disposal_test.go
+++ b/src/wago/lifecycle_disposal_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/testutil/wasmtest"
 )
 
@@ -94,14 +93,11 @@ func voidImportCallModule() []byte {
 
 func failingLocalStartModule() []byte {
 	return wasmtest.Module(
-		wasmtest.Section(1, wasmtest.Vec(
-			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
-			wasmtest.FuncType(nil, nil),
-		)),
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
 		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "f", 0, 0))),
-		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
 		wasmtest.Section(8, wasmtest.ULEB(1)),
-		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x1a, 0x00, 0x0b}))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x00, 0x0b}))),
 	)
 }
 
@@ -228,6 +224,117 @@ func TestExactInstanceLifecycleManagedExplicitAndRuntimeClose(t *testing.T) {
 	defer mu.Unlock()
 	if closed[firstIn] != 1 || closed[secondIn] != 1 {
 		t.Fatalf("managed close counts = %d/%d, want 1/1", closed[firstIn], closed[secondIn])
+	}
+}
+
+func TestRuntimeCloseWaitsForActiveManagedClose(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var before, after atomic.Int32
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.managed-close-race",
+		requires: []PluginCapability{PluginInstanceHooks, PluginManagedInstances},
+		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			if ctx.Origin != InstantiateManaged {
+				t.Errorf("origin = %v, want managed", ctx.Origin)
+			}
+			before.Add(1)
+			close(entered)
+			<-release
+		}},
+		afterClose: []func(*InstanceContext){func(*InstanceContext) { after.Add(1) }},
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks, PluginManagedInstances)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(wasmtest.Module())
+	managed, err := p.manager.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	managedDone := make(chan error, 1)
+	go func() { managedDone <- managed.Close() }()
+	<-entered
+	runtimeDone := make(chan error, 1)
+	go func() { runtimeDone <- rt.Close() }()
+	select {
+	case err := <-runtimeDone:
+		t.Fatalf("Runtime.Close returned before active managed close: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(release)
+	if err := <-managedDone; err != nil {
+		t.Fatalf("ManagedInstance.Close: %v", err)
+	}
+	if err := <-runtimeDone; err != nil {
+		t.Fatalf("Runtime.Close: %v", err)
+	}
+	if before.Load() != 1 || after.Load() != 1 {
+		t.Fatalf("hook counts = %d/%d, want 1/1", before.Load(), after.Load())
+	}
+}
+
+func TestRuntimeCloseWaitsForPendingManagedInstantiation(t *testing.T) {
+	startEntered := make(chan struct{})
+	releaseStart := make(chan struct{})
+	var resolved, closed *Instance
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.managed-pending-close",
+		requires: []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances},
+		hostName: "start",
+		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			closed = ctx.Instance
+			if ctx.Origin != InstantiateManaged {
+				t.Errorf("origin = %v, want managed", ctx.Origin)
+			}
+		}},
+	}
+	p.hostFn = func(caller HostModule, _, _ []uint64) {
+		var err error
+		resolved, err = p.resolver.Resolve(caller)
+		if err != nil {
+			panic(err)
+		}
+		close(startEntered)
+		<-releaseStart
+	}
+	rt := NewRuntime()
+	grants := []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances}
+	if err := rt.Use(p, WithPluginGrants(grants...)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, err := rt.Compile(importedStartModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	type instantiateResult struct {
+		managed *ManagedInstance
+		err     error
+	}
+	instantiateDone := make(chan instantiateResult, 1)
+	go func() {
+		managed, err := p.manager.Instantiate(context.Background(), mod)
+		instantiateDone <- instantiateResult{managed: managed, err: err}
+	}()
+	<-startEntered
+	runtimeDone := make(chan error, 1)
+	go func() { runtimeDone <- rt.Close() }()
+	select {
+	case err := <-runtimeDone:
+		t.Fatalf("Runtime.Close returned before pending managed instantiation cleanup: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(releaseStart)
+	result := <-instantiateDone
+	if result.managed != nil || result.err == nil {
+		t.Fatalf("pending Instantiate = %v, %v; want nil, error", result.managed, result.err)
+	}
+	if err := <-runtimeDone; err != nil {
+		t.Fatalf("Runtime.Close: %v", err)
+	}
+	if resolved == nil || closed != resolved {
+		t.Fatalf("resolved/closed instances = %p/%p", resolved, closed)
 	}
 }
 
@@ -401,21 +508,19 @@ func TestFailedLocalStartResolvesAndClosesExactInstance(t *testing.T) {
 	var resolved, closed *Instance
 	state := map[*Instance]struct{}{}
 	p := &disposalTestPlugin{
-		id:          "test.lifecycle.local-start",
-		requires:    []PluginCapability{PluginHostImports, PluginInstanceHooks},
-		hostResults: []ValType{ValI32},
+		id:       "test.lifecycle.local-start",
+		requires: []PluginCapability{PluginHostImports, PluginInstanceHooks},
 		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
 			closed = ctx.Instance
 			delete(state, ctx.Instance)
 		}},
 	}
-	p.hostFn = func(caller HostModule, _ []uint64, results []uint64) {
+	p.hostFn = func(caller HostModule, _, _ []uint64) {
 		var err error
 		resolved, err = p.resolver.Resolve(caller)
 		if err != nil {
 			panic(err)
 		}
-		results[0] = I32(1)
 		state[resolved] = struct{}{}
 	}
 	rt := NewRuntime()
@@ -611,9 +716,8 @@ func TestCallerResolverManagedInstance(t *testing.T) {
 func TestManagedFailedStartUsesManagedOriginAndCleansUp(t *testing.T) {
 	var resolved, closed *Instance
 	p := &disposalTestPlugin{
-		id:          "test.lifecycle.managed-failed-start",
-		requires:    []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances},
-		hostResults: []ValType{ValI32},
+		id:       "test.lifecycle.managed-failed-start",
+		requires: []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances},
 		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
 			closed = ctx.Instance
 			if ctx.Origin != InstantiateManaged {
@@ -621,13 +725,12 @@ func TestManagedFailedStartUsesManagedOriginAndCleansUp(t *testing.T) {
 			}
 		}},
 	}
-	p.hostFn = func(caller HostModule, _ []uint64, results []uint64) {
+	p.hostFn = func(caller HostModule, _, _ []uint64) {
 		var err error
 		resolved, err = p.resolver.Resolve(caller)
 		if err != nil {
 			panic(err)
 		}
-		results[0] = I32(1)
 	}
 	rt := NewRuntime()
 	grants := []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances}

--- a/src/wago/lifecycle_disposal_test.go
+++ b/src/wago/lifecycle_disposal_test.go
@@ -1,0 +1,748 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+type disposalTestPlugin struct {
+	id          string
+	requires    []PluginCapability
+	hostFn      HostFunc
+	hostName    string
+	hostParams  []ValType
+	hostResults []ValType
+	resolver    *CallerResolver
+	manager     *InstanceManager
+	afterInst   []func(*InstantiateContext, *Instance) error
+	onInstErr   []func(*InstantiateContext, error)
+	beforeClose []func(*InstanceContext)
+	afterClose  []func(*InstanceContext)
+	afterInvoke []func(*InvokeContext, []Value, error)
+}
+
+func (p *disposalTestPlugin) Info() ExtensionInfo {
+	return ExtensionInfo{ID: p.id, Version: "1.0.0", Stability: Stable, RequiresCapabilities: p.requires}
+}
+
+func (p *disposalTestPlugin) Register(reg *Registry) error {
+	if p.hostFn != nil {
+		host, err := reg.HostImports()
+		if err != nil {
+			return err
+		}
+		p.resolver = host.CallerResolver()
+		name := p.hostName
+		if name == "" {
+			name = "f"
+		}
+		host.Module("env").Func(name, p.hostFn).Params(p.hostParams...).Results(p.hostResults...)
+	}
+	if len(p.afterInst)+len(p.onInstErr)+len(p.beforeClose)+len(p.afterClose) != 0 {
+		lifecycle, err := reg.InstanceLifecycle()
+		if err != nil {
+			return err
+		}
+		lifecycle.AfterInstantiate(p.afterInst...)
+		lifecycle.OnInstantiateError(p.onInstErr...)
+		lifecycle.BeforeClose(p.beforeClose...)
+		lifecycle.AfterClose(p.afterClose...)
+	}
+	if len(p.afterInvoke) != 0 {
+		invocation, err := reg.InstanceInvocation()
+		if err != nil {
+			return err
+		}
+		invocation.After(p.afterInvoke...)
+	}
+	if hasPluginCapability(p.requires, PluginManagedInstances) {
+		var err error
+		p.manager, err = reg.ManagedInstances()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasPluginCapability(caps []PluginCapability, want PluginCapability) bool {
+	for _, cap := range caps {
+		if cap == want {
+			return true
+		}
+	}
+	return false
+}
+
+func voidImportCallModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "f", 0, 0))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+	)
+}
+
+func failingLocalStartModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType(nil, nil),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "f", 0, 0))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(8, wasmtest.ULEB(1)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x1a, 0x00, 0x0b}))),
+	)
+}
+
+func trapExportModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("boom", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x00, 0x0b}))),
+	)
+}
+
+func TestExactInstanceLifecycleDirect(t *testing.T) {
+	var afterInstance, beforeInstance, afterCloseInstance *Instance
+	var beforeCount, afterCount int
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.direct",
+		requires: []PluginCapability{PluginInstanceHooks},
+		afterInst: []func(*InstantiateContext, *Instance) error{func(ctx *InstantiateContext, in *Instance) error {
+			if ctx.Origin != InstantiateDirect {
+				t.Fatalf("AfterInstantiate origin = %v, want direct", ctx.Origin)
+			}
+			afterInstance = in
+			return nil
+		}},
+		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			beforeCount++
+			beforeInstance = ctx.Instance
+			if ctx.Origin != InstantiateDirect || ctx.Runtime == nil || ctx.Compiled == nil {
+				t.Fatalf("BeforeClose context = %+v", ctx)
+			}
+			ctx.Metadata["shared"] = "yes"
+		}},
+		afterClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			afterCount++
+			afterCloseInstance = ctx.Instance
+			if ctx.Metadata["shared"] != "yes" {
+				t.Fatalf("close metadata was not shared: %v", ctx.Metadata)
+			}
+		}},
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if afterInstance != in {
+		t.Fatalf("AfterInstantiate instance = %p, want %p", afterInstance, in)
+	}
+	if err := in.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := in.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if beforeInstance != in || afterCloseInstance != in {
+		t.Fatalf("close pointers = %p/%p, want %p", beforeInstance, afterCloseInstance, in)
+	}
+	if beforeCount != 1 || afterCount != 1 {
+		t.Fatalf("close hook counts = %d/%d, want 1/1", beforeCount, afterCount)
+	}
+}
+
+func TestExactInstanceLifecycleManagedExplicitAndRuntimeClose(t *testing.T) {
+	var mu sync.Mutex
+	origins := map[*Instance]InstantiateOrigin{}
+	closed := map[*Instance]int{}
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.managed",
+		requires: []PluginCapability{PluginInstanceHooks, PluginManagedInstances},
+		afterInst: []func(*InstantiateContext, *Instance) error{func(ctx *InstantiateContext, in *Instance) error {
+			mu.Lock()
+			origins[in] = ctx.Origin
+			mu.Unlock()
+			return nil
+		}},
+		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			mu.Lock()
+			closed[ctx.Instance]++
+			if ctx.Origin != InstantiateManaged {
+				t.Errorf("managed close origin = %v, want managed", ctx.Origin)
+			}
+			mu.Unlock()
+		}},
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks, PluginManagedInstances)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	first, err := p.manager.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("managed Instantiate: %v", err)
+	}
+	firstIn := first.Instance()
+	if origins[firstIn] != InstantiateManaged {
+		t.Fatalf("managed AfterInstantiate origin = %v", origins[firstIn])
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("managed Close: %v", err)
+	}
+	second, err := p.manager.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("second managed Instantiate: %v", err)
+	}
+	secondIn := second.Instance()
+	if err := rt.Close(); err != nil {
+		t.Fatalf("Runtime.Close: %v", err)
+	}
+	if second.Instance() != nil {
+		t.Fatal("runtime close retained managed instance")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if closed[firstIn] != 1 || closed[secondIn] != 1 {
+		t.Fatalf("managed close counts = %d/%d, want 1/1", closed[firstIn], closed[secondIn])
+	}
+}
+
+func TestConcurrentInstanceCloseWaitsAndRunsOnce(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	closePanic := errors.New("concurrent close hook panic")
+	var before, after atomic.Int32
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.concurrent-close",
+		requires: []PluginCapability{PluginInstanceHooks},
+		beforeClose: []func(*InstanceContext){func(*InstanceContext) {
+			before.Add(1)
+			close(entered)
+			<-release
+			panic(closePanic)
+		}},
+		afterClose: []func(*InstanceContext){func(*InstanceContext) { after.Add(1) }},
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(wasmtest.Module())
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	const callers = 32
+	start := make(chan struct{})
+	results := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			<-start
+			results <- in.Close()
+		}()
+	}
+	close(start)
+	<-entered
+	select {
+	case err := <-results:
+		t.Fatalf("Close returned before lifecycle completion: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(release)
+	var first error
+	for i := 0; i < callers; i++ {
+		err := <-results
+		if !errors.Is(err, closePanic) {
+			t.Fatalf("Close[%d] = %v, want close hook panic", i, err)
+		}
+		if i == 0 {
+			first = err
+		} else if err != first {
+			t.Fatalf("Close[%d] result identity differs: %v != %v", i, err, first)
+		}
+	}
+	if before.Load() != 1 || after.Load() != 1 {
+		t.Fatalf("hook counts = %d/%d, want 1/1", before.Load(), after.Load())
+	}
+}
+
+func TestPanickingCloseHookDoesNotSkipCleanup(t *testing.T) {
+	panicErr := errors.New("close hook exploded")
+	var mu sync.Mutex
+	var events []string
+	record := func(event string) {
+		mu.Lock()
+		events = append(events, event)
+		mu.Unlock()
+	}
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.panic-close",
+		requires: []PluginCapability{PluginInstanceHooks},
+		beforeClose: []func(*InstanceContext){
+			func(*InstanceContext) { record("before-first") },
+			func(*InstanceContext) { record("before-panic"); panic(panicErr) },
+			func(*InstanceContext) { record("before-last") },
+		},
+		afterClose: []func(*InstanceContext){
+			func(*InstanceContext) { record("after-first") },
+			func(*InstanceContext) { record("after-last") },
+		},
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(wasmtest.Module())
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	closeErr := in.Close()
+	if !errors.Is(closeErr, panicErr) {
+		t.Fatalf("Close error = %v, want panic error", closeErr)
+	}
+	if second := in.Close(); second != closeErr {
+		t.Fatalf("second Close error identity = %v, want same %v", second, closeErr)
+	}
+	in.lifeMu.Lock()
+	closed, resourcesClosed := in.closed, in.resourcesClosed
+	in.lifeMu.Unlock()
+	if !closed || !resourcesClosed {
+		t.Fatalf("internal cleanup closed=%v resourcesClosed=%v, want true/true", closed, resourcesClosed)
+	}
+	want := "[before-last before-panic before-first after-last after-first]"
+	if got := fmt.Sprint(events); got != want {
+		t.Fatalf("events = %s, want %s", got, want)
+	}
+}
+
+func TestFailedImportedStartResolvesAndClosesExactInstance(t *testing.T) {
+	var mu sync.Mutex
+	state := map[*Instance]bool{}
+	var resolved, closed *Instance
+	var observed error
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.imported-start",
+		requires: []PluginCapability{PluginHostImports, PluginInstanceHooks},
+		hostName: "start",
+		onInstErr: []func(*InstantiateContext, error){func(_ *InstantiateContext, err error) {
+			observed = err
+		}},
+		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			closed = ctx.Instance
+			mu.Lock()
+			delete(state, ctx.Instance)
+			mu.Unlock()
+		}},
+	}
+	p.hostFn = func(caller HostModule, _, _ []uint64) {
+		in, err := p.resolver.Resolve(caller)
+		if err != nil {
+			panic(err)
+		}
+		resolved = in
+		mu.Lock()
+		state[in] = true
+		mu.Unlock()
+		panic(HostExit{Code: 17})
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginHostImports, PluginInstanceHooks)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, err := rt.Compile(importedStartModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	_, err = rt.Instantiate(context.Background(), mod)
+	var exit *ExitError
+	if !errors.As(err, &exit) || exit.Code != 17 {
+		t.Fatalf("Instantiate error = %v, want ExitError(17)", err)
+	}
+	if observed == nil || !errors.As(observed, &exit) {
+		t.Fatalf("OnInstantiateError = %v, want original exit", observed)
+	}
+	if resolved == nil || closed != resolved {
+		t.Fatalf("resolved/closed instances = %p/%p", resolved, closed)
+	}
+	mu.Lock()
+	remaining := len(state)
+	mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("plugin state retained %d failed-start instance(s)", remaining)
+	}
+}
+
+func TestFailedLocalStartResolvesAndClosesExactInstance(t *testing.T) {
+	var resolved, closed *Instance
+	state := map[*Instance]struct{}{}
+	p := &disposalTestPlugin{
+		id:          "test.lifecycle.local-start",
+		requires:    []PluginCapability{PluginHostImports, PluginInstanceHooks},
+		hostResults: []ValType{ValI32},
+		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			closed = ctx.Instance
+			delete(state, ctx.Instance)
+		}},
+	}
+	p.hostFn = func(caller HostModule, _ []uint64, results []uint64) {
+		var err error
+		resolved, err = p.resolver.Resolve(caller)
+		if err != nil {
+			panic(err)
+		}
+		results[0] = I32(1)
+		state[resolved] = struct{}{}
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginHostImports, PluginInstanceHooks)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, err := rt.Compile(failingLocalStartModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	_, err = rt.Instantiate(context.Background(), mod)
+	var trap *TrapError
+	if !errors.As(err, &trap) || trap.Code != TrapUnreachable {
+		t.Fatalf("Instantiate error = %v, want unreachable trap", err)
+	}
+	if resolved == nil || closed != resolved || len(state) != 0 {
+		t.Fatalf("resolved=%p closed=%p state=%d", resolved, closed, len(state))
+	}
+}
+
+func TestAfterInstantiateFailureClosesAndJoinsCleanupError(t *testing.T) {
+	instantiateErr := errors.New("attach failed")
+	cleanupErr := errors.New("detach panicked")
+	var before, after int
+	var observed error
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.after-instantiate-failure",
+		requires: []PluginCapability{PluginInstanceHooks},
+		afterInst: []func(*InstantiateContext, *Instance) error{func(*InstantiateContext, *Instance) error {
+			return instantiateErr
+		}},
+		onInstErr: []func(*InstantiateContext, error){func(_ *InstantiateContext, err error) { observed = err }},
+		beforeClose: []func(*InstanceContext){func(*InstanceContext) {
+			before++
+			panic(cleanupErr)
+		}},
+		afterClose: []func(*InstanceContext){func(*InstanceContext) { after++ }},
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(wasmtest.Module())
+	in, err := rt.Instantiate(context.Background(), mod)
+	if in != nil {
+		t.Fatalf("Instantiate returned failed instance %p", in)
+	}
+	if !errors.Is(err, instantiateErr) || !errors.Is(err, cleanupErr) {
+		t.Fatalf("Instantiate error = %v, want original and cleanup errors", err)
+	}
+	if !errors.Is(observed, instantiateErr) || !errors.Is(observed, cleanupErr) {
+		t.Fatalf("OnInstantiateError = %v, want original and cleanup errors", observed)
+	}
+	if before != 1 || after != 1 {
+		t.Fatalf("close hook counts = %d/%d, want 1/1", before, after)
+	}
+}
+
+func TestPanickingOnInstantiateErrorPreservesFailureAndCleanup(t *testing.T) {
+	instantiateErr := errors.New("attach failed")
+	observerPanic := errors.New("observer panicked")
+	var closed int
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.on-error-panic",
+		requires: []PluginCapability{PluginInstanceHooks},
+		afterInst: []func(*InstantiateContext, *Instance) error{func(*InstantiateContext, *Instance) error {
+			return instantiateErr
+		}},
+		onInstErr:   []func(*InstantiateContext, error){func(*InstantiateContext, error) { panic(observerPanic) }},
+		beforeClose: []func(*InstanceContext){func(*InstanceContext) { closed++ }},
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(wasmtest.Module())
+	_, err := rt.Instantiate(context.Background(), mod)
+	if !errors.Is(err, instantiateErr) {
+		t.Fatalf("Instantiate error = %v, want original failure", err)
+	}
+	if !errors.Is(err, observerPanic) {
+		t.Fatalf("Instantiate error = %v, want reported observer panic", err)
+	}
+	if closed != 1 {
+		t.Fatalf("cleanup count = %d, want 1", closed)
+	}
+}
+
+type forgedHostModule struct{}
+
+func (forgedHostModule) Memory() []byte { return nil }
+
+func TestCallerResolverAuthorityAndExpiry(t *testing.T) {
+	var resolved *Instance
+	var resolveErr error
+	var retained HostModule
+	p := &disposalTestPlugin{id: "test.caller.direct", requires: []PluginCapability{PluginHostImports}}
+	p.hostFn = func(caller HostModule, _, _ []uint64) {
+		retained = caller
+		resolved, resolveErr = p.resolver.Resolve(caller)
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginHostImports)); err != nil {
+		t.Fatalf("host.imports-only Use: %v", err)
+	}
+	mod, err := rt.Compile(voidImportCallModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+	if _, err := in.Call(context.Background(), "call"); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resolveErr != nil || resolved != in {
+		t.Fatalf("Resolve = %p, %v; want %p, nil", resolved, resolveErr, in)
+	}
+	if _, err := p.resolver.Resolve(retained); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("expired Resolve error = %v, want permission denied", err)
+	}
+	if _, err := p.resolver.Resolve(forgedHostModule{}); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("forged Resolve error = %v, want permission denied", err)
+	}
+
+	var crossErr error
+	cross := &disposalTestPlugin{id: "test.caller.cross-runtime", requires: []PluginCapability{PluginHostImports}}
+	cross.hostFn = func(caller HostModule, _, _ []uint64) {
+		_, crossErr = p.resolver.Resolve(caller)
+	}
+	rt2 := NewRuntime()
+	if err := rt2.Use(cross, WithPluginGrants(PluginHostImports)); err != nil {
+		t.Fatalf("cross Use: %v", err)
+	}
+	mod2, _ := rt2.Compile(voidImportCallModule())
+	in2, err := rt2.Instantiate(context.Background(), mod2)
+	if err != nil {
+		t.Fatalf("cross Instantiate: %v", err)
+	}
+	if _, err := in2.Call(context.Background(), "call"); err != nil {
+		t.Fatalf("cross Call: %v", err)
+	}
+	_ = in2.Close()
+	if !errors.Is(crossErr, ErrPermissionDenied) {
+		t.Fatalf("cross-runtime Resolve error = %v, want permission denied", crossErr)
+	}
+
+	resolved, resolveErr = nil, nil
+	low, err := Instantiate(mod.Compiled(), InstantiateOptions{Imports: rt.HostImports()})
+	if err != nil {
+		t.Fatalf("low-level Instantiate: %v", err)
+	}
+	if _, err := low.Invoke("call"); err != nil {
+		t.Fatalf("low-level Invoke: %v", err)
+	}
+	_ = low.Close()
+	if resolved != nil || !errors.Is(resolveErr, ErrPermissionDenied) {
+		t.Fatalf("low-level Resolve = %p, %v; want nil, permission denied", resolved, resolveErr)
+	}
+}
+
+func TestCallerResolverManagedInstance(t *testing.T) {
+	var resolved *Instance
+	var resolveErr error
+	p := &disposalTestPlugin{
+		id:       "test.caller.managed",
+		requires: []PluginCapability{PluginHostImports, PluginManagedInstances},
+	}
+	p.hostFn = func(caller HostModule, _, _ []uint64) {
+		resolved, resolveErr = p.resolver.Resolve(caller)
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginHostImports, PluginManagedInstances)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(voidImportCallModule())
+	managed, err := p.manager.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("managed Instantiate: %v", err)
+	}
+	in := managed.Instance()
+	if _, err := in.Call(context.Background(), "call"); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resolveErr != nil || resolved != in {
+		t.Fatalf("Resolve = %p, %v; want %p, nil", resolved, resolveErr, in)
+	}
+	_ = managed.Close()
+}
+
+func TestManagedFailedStartUsesManagedOriginAndCleansUp(t *testing.T) {
+	var resolved, closed *Instance
+	p := &disposalTestPlugin{
+		id:          "test.lifecycle.managed-failed-start",
+		requires:    []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances},
+		hostResults: []ValType{ValI32},
+		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			closed = ctx.Instance
+			if ctx.Origin != InstantiateManaged {
+				t.Errorf("failed managed start origin = %v, want managed", ctx.Origin)
+			}
+		}},
+	}
+	p.hostFn = func(caller HostModule, _ []uint64, results []uint64) {
+		var err error
+		resolved, err = p.resolver.Resolve(caller)
+		if err != nil {
+			panic(err)
+		}
+		results[0] = I32(1)
+	}
+	rt := NewRuntime()
+	grants := []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances}
+	if err := rt.Use(p, WithPluginGrants(grants...)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(failingLocalStartModule())
+	managed, err := p.manager.Instantiate(context.Background(), mod)
+	if managed != nil || err == nil {
+		t.Fatalf("managed failed-start result = %v, %v", managed, err)
+	}
+	if resolved == nil || closed != resolved {
+		t.Fatalf("resolved/closed = %p/%p", resolved, closed)
+	}
+}
+
+func TestManagedForkLifecycleAndRuntimeOwnership(t *testing.T) {
+	var child *ManagedInstance
+	var childCreateErr error
+	var mu sync.Mutex
+	origin := map[*Instance]InstantiateOrigin{}
+	closed := map[*Instance]int{}
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.managed-fork",
+		requires: []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances},
+		afterInst: []func(*InstantiateContext, *Instance) error{func(ctx *InstantiateContext, in *Instance) error {
+			mu.Lock()
+			origin[in] = ctx.Origin
+			mu.Unlock()
+			return nil
+		}},
+		beforeClose: []func(*InstanceContext){func(ctx *InstanceContext) {
+			mu.Lock()
+			closed[ctx.Instance]++
+			mu.Unlock()
+		}},
+	}
+	p.hostFn = func(caller HostModule, _, _ []uint64) {
+		child, childCreateErr = p.manager.Fork(context.Background(), caller)
+	}
+	rt := NewRuntime()
+	grants := []PluginCapability{PluginHostImports, PluginInstanceHooks, PluginManagedInstances}
+	if err := rt.Use(p, WithPluginGrants(grants...)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(voidImportCallModule())
+	parent, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("parent Instantiate: %v", err)
+	}
+	if _, err := parent.Call(context.Background(), "call"); err != nil {
+		t.Fatalf("parent Call: %v", err)
+	}
+	if childCreateErr != nil || child == nil || child.Instance() == nil {
+		t.Fatalf("Fork = %v, %v", child, childCreateErr)
+	}
+	childIn := child.Instance()
+	mu.Lock()
+	childOrigin := origin[childIn]
+	mu.Unlock()
+	if childOrigin != InstantiateManaged {
+		t.Fatalf("forked origin = %v, want managed", childOrigin)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatalf("Runtime.Close: %v", err)
+	}
+	if child.Instance() != nil {
+		t.Fatal("runtime close retained forked managed instance")
+	}
+	mu.Lock()
+	childClosed, parentClosed := closed[childIn], closed[parent]
+	mu.Unlock()
+	if childClosed != 1 || parentClosed != 0 {
+		t.Fatalf("runtime close child/parent counts = %d/%d, want 1/0", childClosed, parentClosed)
+	}
+	if err := parent.Close(); err != nil {
+		t.Fatalf("caller-owned parent Close: %v", err)
+	}
+}
+
+func TestTrapReportsAfterInvokeButDoesNotClose(t *testing.T) {
+	var invokeErr error
+	var closed int
+	p := &disposalTestPlugin{
+		id:       "test.lifecycle.trap-not-close",
+		requires: []PluginCapability{PluginInstanceHooks, PluginInvokeHooks},
+		beforeClose: []func(*InstanceContext){func(*InstanceContext) {
+			closed++
+		}},
+		afterInvoke: []func(*InvokeContext, []Value, error){func(_ *InvokeContext, _ []Value, err error) {
+			invokeErr = err
+		}},
+	}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks, PluginInvokeHooks)); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	mod, _ := rt.Compile(trapExportModule())
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if _, err := in.Call(context.Background(), "boom"); err == nil {
+		t.Fatal("trapping Call returned nil error")
+	}
+	if invokeErr == nil {
+		t.Fatal("AfterInvoke did not observe trap")
+	}
+	if closed != 0 {
+		t.Fatalf("trap emitted %d close hook(s), want 0", closed)
+	}
+	if err := in.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("explicit close emitted %d hook(s), want 1", closed)
+	}
+}

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -36,6 +37,8 @@ type ManagedInstance struct {
 	manager *InstanceManager
 	value   *Instance
 	closed  bool
+	done    chan struct{}
+	err     error
 }
 
 var voidFuncType = wasm.CompType{Kind: wasm.CompFunc}
@@ -111,7 +114,7 @@ func (m *InstanceManager) Instantiate(ctx context.Context, mod *Module, opts ...
 	}
 	m.live++
 	m.mu.Unlock()
-	in, err := rt.Instantiate(ctx, mod, opts...)
+	in, err := rt.instantiateOrigin(ctx, mod, InstantiateManaged, opts...)
 	if err != nil {
 		m.mu.Lock()
 		m.live--
@@ -338,11 +341,19 @@ func (m *ManagedInstance) Close() error {
 	}
 	m.mu.Lock()
 	if m.closed {
+		done := m.done
 		m.mu.Unlock()
-		return nil
+		if done != nil {
+			<-done
+		}
+		m.mu.Lock()
+		err := m.err
+		m.mu.Unlock()
+		return err
 	}
 	m.closed = true
-	in, manager := m.value, m.manager
+	m.done = make(chan struct{})
+	in, manager, done := m.value, m.manager, m.done
 	m.value, m.manager = nil, nil
 	m.mu.Unlock()
 	if manager != nil {
@@ -354,10 +365,15 @@ func (m *ManagedInstance) Close() error {
 		}
 		manager.mu.Unlock()
 	}
+	var err error
 	if in != nil {
-		return in.Close()
+		err = in.Close()
 	}
-	return nil
+	m.mu.Lock()
+	m.err = err
+	close(done)
+	m.mu.Unlock()
+	return err
 }
 
 func (m *InstanceManager) close() error {
@@ -373,20 +389,20 @@ func (m *InstanceManager) close() error {
 	}
 	m.instances = nil
 	m.mu.Unlock()
-	var first error
+	var errs []error
 	for _, owned := range list {
-		if err := owned.Close(); err != nil && first == nil {
-			first = err
+		if err := owned.Close(); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	m.dispatchMu.Lock()
 	if m.dispatchCode != nil {
-		if err := m.dispatchCode.Close(); err != nil && first == nil {
-			first = err
+		if err := m.dispatchCode.Close(); err != nil {
+			errs = append(errs, err)
 		}
 		m.dispatchCode.releaseCode()
 		m.dispatchCode, m.dispatchBase = nil, 0
 	}
 	m.dispatchMu.Unlock()
-	return first
+	return errors.Join(errs...)
 }

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -27,6 +27,7 @@ type InstanceManager struct {
 	dispatchMu   sync.Mutex
 	dispatchCode *Compiled
 	dispatchBase uintptr
+	pending      sync.WaitGroup
 }
 
 // ManagedInstance is one instance whose lifetime is owned by an
@@ -113,7 +114,9 @@ func (m *InstanceManager) Instantiate(ctx context.Context, mod *Module, opts ...
 		return nil, fmt.Errorf("wago: plugin %s module memory exceeds managed budget %d: %w", m.owner, m.budget.MaxMemoryBytes, ErrPermissionDenied)
 	}
 	m.live++
+	m.pending.Add(1)
 	m.mu.Unlock()
+	defer m.pending.Done()
 	in, err := rt.instantiateOrigin(ctx, mod, InstantiateManaged, opts...)
 	if err != nil {
 		m.mu.Lock()
@@ -132,8 +135,8 @@ func (m *InstanceManager) adopt(in *Instance) (*ManagedInstance, error) {
 			m.live--
 		}
 		m.mu.Unlock()
-		_ = in.Close()
-		return nil, fmt.Errorf("wago: instance manager closed during instantiation")
+		closeErr := in.Close()
+		return nil, joinPrimary(fmt.Errorf("wago: instance manager closed during instantiation"), closeErr)
 	}
 	m.instances[owned] = struct{}{}
 	m.byInstance[in] = owned
@@ -163,8 +166,10 @@ func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*Managed
 		return nil, fmt.Errorf("wago: plugin %s managed-instance limit %d reached: %w", m.owner, m.budget.MaxInstances, ErrPermissionDenied)
 	}
 	m.live++
+	m.pending.Add(1)
 	rt := m.rt
 	m.mu.Unlock()
+	defer m.pending.Done()
 	state := parent.pluginState.Load()
 	var gc GCConfig
 	hasGC := state != nil && state.gcConfig != nil
@@ -356,6 +361,10 @@ func (m *ManagedInstance) Close() error {
 	in, manager, done := m.value, m.manager, m.done
 	m.value, m.manager = nil, nil
 	m.mu.Unlock()
+	var err error
+	if in != nil {
+		err = in.Close()
+	}
 	if manager != nil {
 		manager.mu.Lock()
 		delete(manager.instances, m)
@@ -364,10 +373,6 @@ func (m *ManagedInstance) Close() error {
 			manager.live--
 		}
 		manager.mu.Unlock()
-	}
-	var err error
-	if in != nil {
-		err = in.Close()
 	}
 	m.mu.Lock()
 	m.err = err
@@ -389,6 +394,9 @@ func (m *InstanceManager) close() error {
 	}
 	m.instances = nil
 	m.mu.Unlock()
+	// No new creation can increment pending after closed is set under m.mu.
+	// Wait for in-flight creations to either fail or close themselves in adopt.
+	m.pending.Wait()
 	var errs []error
 	for _, owned := range list {
 		if err := owned.Close(); err != nil {

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -382,15 +382,13 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	return rt.instantiateWithHooksOrigin(mod, merged, cfg.gc, cfg.hasGC, origin)
 }
 
-// instantiateWithHooks runs a direct Runtime-aware instantiation.
-func (rt *Runtime) instantiateWithHooks(mod *Module, imports Imports, gc GCConfig, hasGC bool) (*Instance, error) {
-	return rt.instantiateWithHooksOrigin(mod, imports, gc, hasGC, InstantiateDirect)
-}
-
 // instantiateWithHooksOrigin runs the Runtime-aware instantiation path and emits
 // plugin lifecycle callbacks around the low-level instantiator.
 func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc GCConfig, hasGC bool, origin InstantiateOrigin) (*Instance, error) {
-	iopts := InstantiateOptions{Imports: imports, store: rt.refStore, runtime: rt, origin: origin}
+	iopts := InstantiateOptions{
+		Imports: imports, store: rt.refStore, runtime: rt, origin: origin,
+		forceSyncHost: rt.callerResolverActive.Load(),
+	}
 	if hasGC {
 		iopts.GC = gc
 		iopts.pluginGC = &gc

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -37,12 +37,13 @@ var reservedModules = map[string]struct{}{
 // host imports into it, and it threads those through Compile/Instantiate. The
 // package-level Compile/Instantiate remain available as the low-level API.
 type Runtime struct {
-	mu             sync.Mutex
-	cfg            *RuntimeConfig
-	overridePolicy ImportOverridePolicy
-	managedActive  atomic.Bool
-	hooks          *HookRegistry
-	refStore       *referenceStore
+	mu                   sync.Mutex
+	cfg                  *RuntimeConfig
+	overridePolicy       ImportOverridePolicy
+	managedActive        atomic.Bool
+	callerResolverActive atomic.Bool
+	hooks                *HookRegistry
+	refStore             *referenceStore
 
 	exts        []ExtensionInfo
 	extensions  map[string]Extension
@@ -318,9 +319,16 @@ func WithGC(gc GCConfig) InstantiateOption {
 
 // Instantiate instantiates a module, wiring the runtime's extension imports plus
 // any per-call imports. ctx is honored for cancellation before the (synchronous)
-// instantiate work begins. A function import that no extension or per-call import
-// provides is reported with a hint rather than a downstream binding failure.
+// instantiate work begins. Runtime ownership is attached before start executes;
+// a failed start or AfterInstantiate hook closes the partial instance through the
+// normal lifecycle before returning its joined failure. A function import that no
+// extension or per-call import provides is reported with a hint rather than a
+// downstream binding failure.
 func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...InstantiateOption) (*Instance, error) {
+	return rt.instantiateOrigin(ctx, mod, InstantiateDirect, opts...)
+}
+
+func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin InstantiateOrigin, opts ...InstantiateOption) (*Instance, error) {
 	if mod == nil {
 		return nil, fmt.Errorf("wago: Instantiate: nil module")
 	}
@@ -371,7 +379,7 @@ func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...Instant
 		}
 	}
 
-	return rt.instantiateWithHooks(mod, merged, cfg.gc, cfg.hasGC)
+	return rt.instantiateWithHooksOrigin(mod, merged, cfg.gc, cfg.hasGC, origin)
 }
 
 // instantiateWithHooks runs a direct Runtime-aware instantiation.
@@ -382,62 +390,48 @@ func (rt *Runtime) instantiateWithHooks(mod *Module, imports Imports, gc GCConfi
 // instantiateWithHooksOrigin runs the Runtime-aware instantiation path and emits
 // plugin lifecycle callbacks around the low-level instantiator.
 func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc GCConfig, hasGC bool, origin InstantiateOrigin) (*Instance, error) {
-	iopts := InstantiateOptions{Imports: imports, store: rt.refStore}
+	iopts := InstantiateOptions{Imports: imports, store: rt.refStore, runtime: rt, origin: origin}
 	if hasGC {
 		iopts.GC = gc
+		iopts.pluginGC = &gc
 	}
 
 	// Keep the no-lifecycle-hook path allocation-free. The instance still retains
 	// rt so invoke/close hooks registered before later calls can be observed.
 	if len(rt.hooks.beforeInstantiate) == 0 && len(rt.hooks.afterInstantiate) == 0 && len(rt.hooks.onInstantiateError) == 0 {
-		inst, err := instantiateCore(mod.c, iopts)
-		if err != nil {
-			return nil, err
-		}
-		inst.rt = rt
-		if hasGC && rt.managedActive.Load() {
-			cfg := gc
-			inst.ensurePluginState().gcConfig = &cfg
-		}
-		if origin != InstantiateDirect {
-			inst.ensurePluginState().origin = origin
-		}
-		return inst, nil
+		return instantiateCore(mod.c, iopts)
 	}
 
 	hctx := &InstantiateContext{Runtime: rt, Module: mod, Compiled: mod.c, Imports: imports, Origin: origin, Metadata: map[string]any{}}
-	emitError := func(err error) {
+	emitError := func(original error) error {
+		var hookErrs []error
 		for _, fn := range rt.hooks.onInstantiateError {
-			fn(hctx, err)
+			if panicErr := callHookSafely("OnInstantiateError", func() { fn(hctx, original) }); panicErr != nil {
+				hookErrs = append(hookErrs, panicErr)
+			}
 		}
+		return joinPrimary(original, hookErrs...)
 	}
 
 	for _, fn := range rt.hooks.beforeInstantiate {
-		if err := fn(hctx); err != nil {
-			emitError(err)
-			return nil, err
+		var hookErr error
+		panicErr := callHookSafely("BeforeInstantiate", func() { hookErr = fn(hctx) })
+		if err := joinPrimary(hookErr, panicErr); err != nil {
+			return nil, emitError(err)
 		}
 	}
 	iopts.Imports = hctx.Imports
 
 	inst, err := instantiateCore(mod.c, iopts)
 	if err != nil {
-		emitError(err)
-		return nil, err
-	}
-	inst.rt = rt // enable invoke and close hooks
-	if hasGC && rt.managedActive.Load() {
-		cfg := gc
-		inst.ensurePluginState().gcConfig = &cfg
-	}
-	if origin != InstantiateDirect {
-		inst.ensurePluginState().origin = origin
+		return nil, emitError(err)
 	}
 	for _, fn := range rt.hooks.afterInstantiate {
-		if err := fn(hctx, inst); err != nil {
-			emitError(err)
-			_ = inst.Close()
-			return nil, err
+		var hookErr error
+		panicErr := callHookSafely("AfterInstantiate", func() { hookErr = fn(hctx, inst) })
+		if err := joinPrimary(hookErr, panicErr); err != nil {
+			failed := joinPrimary(err, inst.Close())
+			return nil, emitError(failed)
 		}
 	}
 	return inst, nil
@@ -508,6 +502,10 @@ func importModule(key string) string {
 		}
 	}
 	return key
+}
+
+func (rt *Runtime) scopedHostCalls() bool {
+	return rt != nil && (rt.managedActive.Load() || rt.callerResolverActive.Load())
 }
 
 func isReserved(module string) bool {

--- a/wago.go
+++ b/wago.go
@@ -12,6 +12,7 @@ import impl "github.com/wago-org/wago/src/wago"
 
 type (
 	BoundsCheckMode           = impl.BoundsCheckMode
+	CallerResolver            = impl.CallerResolver
 	Capability                = impl.Capability
 	CapabilityBudget          = impl.CapabilityBudget
 	CapabilityOption          = impl.CapabilityOption


### PR DESCRIPTION
## Summary

Guarantee exact-instance plugin cleanup across successful close, failed Wasm start functions, and failed `AfterInstantiate` hooks without adding a competing lifecycle API.

This hardens the existing `InstanceLifecycle`, `BeforeClose`, `AfterClose`, `AfterInstantiate`, `OnInstantiateError`, and `AfterInvoke` surfaces and adds least-authority caller identity under `host.imports`.

Base used for this PR:

- commit: `aef75ef043cb12077b038af8415443ef1235e2dc`
- tree: `a8f010daabedfebd519bf9b82ec692685afd781b`

## What changed

### Exact caller identity

- Add `(*HostImportAccess).CallerResolver() *CallerResolver`.
- Add `(*CallerResolver).Resolve(HostModule) (*Instance, error)`.
- Resolution returns the exact active Runtime-owned `*Instance` for direct and managed synchronous host calls.
- Retained/expired, forged, cross-runtime, and low-level callers fail closed.
- Identity requires `host.imports`, not `instance.manage`, and grants no management or invocation authority.
- Preserve the existing `HostModule` interface and `HostFunc func(HostModule, []uint64, []uint64)` ABI.

### Start-time ownership and failed-instantiation cleanup

- Attach Runtime ownership and direct/managed origin before imported or local start functions run.
- Route every failure after an Instance exists through normal `Instance.Close` lifecycle cleanup.
- Preserve start/instantiation failures and cleanup failures with joined errors.
- Close the instance before returning an `AfterInstantiate` error.
- Isolate `OnInstantiateError` panics so cleanup completes and the original failure remains observable.
- Correct `InstanceManager.Instantiate` to report managed origin from start time onward.

### Deterministic close

- Serialize close with an optional instance sidecar; `Instance` size is unchanged.
- Concurrent callers wait for the active close and receive the same completed error result.
- Run `BeforeClose`, internal cleanup, and `AfterClose` exactly once.
- Preserve reverse hook registration order and shared close metadata.
- Recover every close hook panic independently, continue remaining hooks and internal cleanup, and aggregate errors.
- Apply equivalent waiting/result behavior to `ManagedInstance.Close` and aggregate manager shutdown errors.

### Ownership boundaries

- Runtime shutdown still does not close caller-owned direct instances.
- Managed instances and managed forks are closed on manager/runtime shutdown.
- Invocation traps remain observable through `AfterInvoke` but do not dispose the instance.
- Package-level low-level instances remain lifecycle-hook-free and cannot be resolved by a Runtime caller resolver.
- No process-global instance registry was added.

## Public API additions

```go
type CallerResolver struct { /* unexported fields */ }

func (a *HostImportAccess) CallerResolver() *CallerResolver
func (r *CallerResolver) Resolve(caller HostModule) (*Instance, error)
```

No public API was removed. `HostModule`, `HostFunc`, Wasm guest ABI, numeric trap/status behavior, and TinyGo compatibility are unchanged.

## Tests

Added focused tests for:

- direct exact pointer identity and exactly-once lifecycle;
- managed explicit close and runtime shutdown origin/identity;
- concurrent close waiting, exactly-once hooks, and identical error results;
- panic-isolated close hooks with internal cleanup and `AfterClose` continuation;
- imported and local failed starts resolving and retiring the exact instance;
- failed managed start cleanup with managed origin;
- failing `AfterInstantiate` with joined cleanup errors;
- panicking `OnInstantiateError`;
- direct/managed active caller resolution plus expired, forged, cross-runtime, and low-level rejection;
- managed fork ownership and runtime shutdown;
- trap reporting without automatic disposal;
- the existing low-level hook-free boundary.

Validation:

```text
GOWORK=off go test ./src/wago -count=1
GOWORK=off go test -race ./src/wago -count=1
GOWORK=off go test ./internal/genfacade -count=1
GOWORK=off tinygo test ./src/wago
GOWORK=off go vet ./src/wago ./internal/genfacade
GOWORK=off go test . -count=1
```

All pass.

## Performance and footprint

- `Instance` layout is unchanged; existing 784/864-byte supported footprint tests pass.
- Close coordination is allocated lazily in the existing optional plugin sidecar on first close.
- Direct host calls only enable expiring caller scopes when a caller resolver or managed-instance service is active.
- No global registry, goroutine, or unbounded cache was added.

## Documentation and limits

The plugin API docs now show a plugin-local map keyed by `*wago.Instance`, explain why `BeforeClose` is authoritative, cover failed starts, traps/HostExit, managed ownership, reuse safety, and the low-level API boundary.

This PR guarantees controlled in-process Wago lifecycle cleanup. It does not claim that callbacks run after a native process crash, `SIGSEGV`, forced termination, or power loss.

No networking-specific dependency or `github.com/wago-org/net` production reference is introduced.
