### PR TITLE
feat(cli): every command uses the project's local wago build when wago.json exists

### DIFF
--- a/cli/wagocli/cmd_run.go
+++ b/cli/wagocli/cmd_run.go
@@ -32,8 +32,9 @@ func runCommand() *Cmd {
 }
 
 func runExec(c *Ctx) {
-	// Seamlessly hand off to the custom binary that has this project's plugins
-	// compiled in (building it once, then cached). No-op without a manifest.
+	// Main already handed off to a local project build (usesProjectBuild). Here we
+	// also cover the global set, so `wago run` outside a project still picks up a
+	// globally-installed package set. No-op once inside a handed-off build.
 	maybeReexecForPlugins()
 
 	applyOptFlags(c) // override codegen knobs before any module compiles

--- a/cli/wagocli/main.go
+++ b/cli/wagocli/main.go
@@ -61,6 +61,14 @@ func Main(v string) {
 		printVersion()
 		return
 	}
+	// In a project (a wago.json declaring packages), transparently hand off to the
+	// project's own wago — .wago/bin/wago, built on demand — so every command runs
+	// with the local package set compiled in. With no project it stays on this
+	// (global) wago. Build-management and toolchain/meta commands are skipped so
+	// they don't rebuild circularly or need a project to run.
+	if usesProjectBuild(args) {
+		maybeReexecLocal()
+	}
 	if cmd := root.child(args[0]); cmd != nil {
 		cmd.Dispatch("wago "+cmd.Name, args[1:])
 		return
@@ -74,6 +82,30 @@ func Main(v string) {
 	fmt.Fprintf(os.Stderr, "%s unknown command %q\n\n", red("wago:"), args[0])
 	usage(os.Stderr)
 	os.Exit(2)
+}
+
+// usesProjectBuild reports whether an invocation should hand off to the project's
+// local wago build. Most commands do (run, module, validate, and the pkg
+// introspection commands, so they see the local package set). Commands that
+// build/manage the package set — or are toolchain/meta and don't need packages —
+// stay on the invoked wago, so they neither rebuild circularly nor require a
+// project to run.
+func usesProjectBuild(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	switch args[0] {
+	case "version", "auth", "env", "opts":
+		return false
+	case "pkg", "package":
+		if len(args) >= 2 {
+			switch args[1] {
+			case "install", "i", "uninstall", "rm", "update", "up", "upgrade", "build", "grant":
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // looksLikeRunTarget reports whether s is plausibly a module to run: a .wasm/.wago

--- a/cli/wagocli/plugin_build.go
+++ b/cli/wagocli/plugin_build.go
@@ -287,6 +287,35 @@ func maybeReexecForPlugins() {
 	}
 }
 
+// maybeReexecLocal hands off to the project's local .wago/bin/wago (built on
+// demand) when the current directory has a wago.json declaring packages — so
+// every command runs with the project's packages compiled in. Unlike
+// maybeReexecForPlugins it never falls back to the global set: with no local
+// project it leaves the invoked (global) wago running. No-op inside an already
+// handed-off build (WAGO_PLUGIN_ACTIVE) or under WAGO_BARE.
+func maybeReexecLocal() {
+	if os.Getenv("WAGO_PLUGIN_ACTIVE") != "" || truthyEnv("WAGO_BARE") {
+		return
+	}
+	deps, _ := projectDeps(".")
+	if len(deps) == 0 {
+		return
+	}
+	dir, err := buildDirFor(false)
+	if err != nil {
+		return
+	}
+	bin, _, err := ensureBuiltBinary(dir, deps, false, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s could not build packages (%v); running without them\n", dim("wago:"), err)
+		return
+	}
+	env := append(os.Environ(), "WAGO_PLUGIN_ACTIVE="+buildHash(deps))
+	if err := execProcess(bin, append([]string{bin}, os.Args[1:]...), env); err != nil {
+		fatal("packages: exec %s: %v", bin, err)
+	}
+}
+
 // activePluginSet resolves which plugin set `wago run` uses here, and a scope
 // label ("bare"/"local"/"global"/"plain"). Order:
 //   - WAGO_BARE       → none (run the plain engine)


### PR DESCRIPTION
In a project (a `wago.json` declaring packages), any `wago` command now transparently runs the project's local `.wago/bin/wago` — built on demand — so it sees the project's packages compiled in. Outside a project it stays on the invoked (global) wago.

- Hoists the custom-binary handoff from `wago run` up to `Main`.
- `maybeReexecLocal()`: **local-only** handoff (never the global set) so a stale global `.wago` can't shadow newer commands with 'unknown subcommand'.
- `usesProjectBuild()` skips build-management (`pkg install/uninstall/update/build/grant`) and toolchain/meta (`version/auth/env/opts`) so they don't rebuild circularly or need a project.
- `run` keeps its own handoff so it still picks up a `--global` package set.

Verified end-to-end: in a project `wago pkg compiled` and `wago run` reflect the local build; outside one they stay on the base binary. Full suite green; gofmt/vet clean. Independent of `cli/package-vocab` (different files).