### PR TITLE
cli: build Canary from main

### DIFF
--- a/cli/wagocli/cmd_version.go
+++ b/cli/wagocli/cmd_version.go
@@ -29,7 +29,8 @@ func versionCommand() *Cmd {
 				Run:     func(*Ctx) { vmWhich(dirs()) },
 			},
 			{
-				Name:    "use",
+				Name:    "switch",
+				Aliases: []string{"swap"},
 				Summary: "select an installed version (interactive with no argument)",
 				Args:    "[version]",
 				Run: func(c *Ctx) {
@@ -49,7 +50,6 @@ func versionCommand() *Cmd {
 					vmInstallRequested(dirs(), c.Args, c.Bool("latest"), c.Bool("nightly"), c.Bool("canary"))
 				},
 			},
-			{Name: "browse", Summary: "browse releases and install one interactively", Run: func(*Ctx) { vmBrowse(dirs()) }},
 			{
 				Name:    "update",
 				Summary: "refresh an installed version or release channel",

--- a/cli/wagocli/cmd_version.go
+++ b/cli/wagocli/cmd_version.go
@@ -30,16 +30,26 @@ func versionCommand() *Cmd {
 			},
 			{
 				Name:    "use",
-				Summary: "select an installed version",
-				Args:    "<version>",
-				Run:     func(c *Ctx) { vmUse(dirs(), c.one("<version>")) },
+				Summary: "select an installed version (interactive with no argument)",
+				Args:    "[version]",
+				Run: func(c *Ctx) {
+					if len(c.Args) == 0 {
+						vmChooseInstalled(dirs())
+						return
+					}
+					vmUse(dirs(), c.one("[version]"))
+				},
 			},
 			{
 				Name: "install", Aliases: []string{"add"},
-				Summary: "download and install a version",
-				Args:    "<version>",
-				Run:     func(c *Ctx) { vmInstall(dirs(), c.one("<version>")) },
+				Summary: "install a pinned version, release channel, or latest",
+				Args:    "[version]",
+				Flags:   []Flag{{Name: "latest", Bool: true, Help: "install the latest release"}, {Name: "nightly", Bool: true, Help: "install nightly"}, {Name: "canary", Bool: true, Help: "build Canary from main"}},
+				Run: func(c *Ctx) {
+					vmInstallRequested(dirs(), c.Args, c.Bool("latest"), c.Bool("nightly"), c.Bool("canary"))
+				},
 			},
+			{Name: "browse", Summary: "browse releases and install one interactively", Run: func(*Ctx) { vmBrowse(dirs()) }},
 			{
 				Name:    "update",
 				Summary: "refresh an installed version or release channel",

--- a/cli/wagocli/version_common.go
+++ b/cli/wagocli/version_common.go
@@ -171,10 +171,16 @@ func updateVersionTarget(active string, args []string, nightly, canary bool) (st
 		return "canary", nil
 	}
 	if len(args) == 1 {
+		if !isRollingChannel(args[0]) {
+			return "", fmt.Errorf("%s is pinned; update only refreshes canary or nightly", args[0])
+		}
 		return args[0], nil
 	}
 	if active == "" {
 		return "", fmt.Errorf("no active version; use `wago version update <version>` or select --nightly/--canary")
+	}
+	if !isRollingChannel(active) {
+		return "", fmt.Errorf("active version %s is pinned; switch to canary or nightly to update", active)
 	}
 	return active, nil
 }

--- a/cli/wagocli/version_common.go
+++ b/cli/wagocli/version_common.go
@@ -1,6 +1,7 @@
 package wagocli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -109,6 +110,22 @@ func vmUse(d wago.Dirs, ver string) {
 		fatal("version use: %v", err)
 	}
 	fmt.Printf("now using wago %s\n", cyan(ver))
+}
+
+func vmChooseInstalled(d wago.Dirs) {
+	vers := installedVersions(d)
+	if len(vers) == 0 {
+		fatal("version use: no installed versions")
+	}
+	for i, v := range vers {
+		fmt.Printf("  %d) %s\n", i+1, v)
+	}
+	fmt.Print("Select version: ")
+	var n int
+	if _, err := fmt.Fscan(bufio.NewReader(os.Stdin), &n); err != nil || n < 1 || n > len(vers) {
+		fatal("version use: invalid selection")
+	}
+	vmUse(d, vers[n-1])
 }
 
 func vmUninstall(d wago.Dirs, ver string) {

--- a/cli/wagocli/version_common_test.go
+++ b/cli/wagocli/version_common_test.go
@@ -76,8 +76,10 @@ func TestUpdateVersionTarget(t *testing.T) {
 		want            string
 		wantErr         string
 	}{
-		{name: "active", active: "0.5.0", want: "0.5.0"},
-		{name: "named", active: "0.5.0", args: []string{"0.6.0"}, want: "0.6.0"},
+		{name: "active canary", active: "canary", want: "canary"},
+		{name: "named nightly", active: "0.5.0", args: []string{"nightly"}, want: "nightly"},
+		{name: "active pinned", active: "0.5.0", wantErr: "is pinned"},
+		{name: "named pinned", active: "0.5.0", args: []string{"0.6.0"}, wantErr: "is pinned"},
 		{name: "nightly", active: "0.5.0", nightly: true, want: "nightly"},
 		{name: "canary", active: "0.5.0", canary: true, want: "canary"},
 		{name: "missing active", wantErr: "no active version"},

--- a/cli/wagocli/version_net.go
+++ b/cli/wagocli/version_net.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/wago-org/wago"
@@ -215,7 +216,7 @@ func vmListRemote() {
 // verifies its SHA-256 against the sibling ".sha256" file, and writes it to dest
 // (0755). It writes nothing on a checksum mismatch.
 func downloadBinary(baseURL, ver, dest string) error {
-	asset := "wago-linux-amd64"
+	asset := versionAsset()
 	url := fmt.Sprintf("%s/%s/%s", strings.TrimRight(baseURL, "/"), ver, asset)
 
 	body, err := httpGetBytes(url)
@@ -240,6 +241,8 @@ func downloadBinary(baseURL, ver, dest string) error {
 	}
 	return os.Rename(tmp, dest)
 }
+
+func versionAsset() string { return "wago-" + runtime.GOOS + "-" + runtime.GOARCH }
 
 func httpGetBytes(url string) ([]byte, error) {
 	resp, err := http.Get(url)

--- a/cli/wagocli/version_net.go
+++ b/cli/wagocli/version_net.go
@@ -40,14 +40,94 @@ func vmInstall(d wago.Dirs, ver string) {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version install: %v", err)
 	}
-	if err := downloadBinary(releaseBase(), ver, dest); err != nil {
-		fatal("version install: %v", err)
+	var installErr error
+	if ver == "canary" {
+		installErr = buildCanary(dest)
+	} else {
+		installErr = downloadBinary(releaseBase(), ver, dest)
+	}
+	if installErr != nil {
+		fatal("version install: %v", installErr)
 	}
 	verb := "installed"
 	if existed {
 		verb = "refreshed"
 	}
 	fmt.Printf("%s wago %s -> %s\n", verb, cyan(ver), dest)
+}
+
+func vmInstallRequested(d wago.Dirs, args []string, latest, nightly, canary bool) {
+	if len(args) > 1 || (len(args) == 1 && (latest || nightly || canary)) || (latest && (nightly || canary)) || (nightly && canary) {
+		fatal("version install: choose one version or channel")
+	}
+	if len(args) == 0 && !latest && !nightly && !canary {
+		vmBrowse(d)
+		return
+	}
+	if latest {
+		vmInstall(d, latestRelease())
+		return
+	}
+	if nightly {
+		vmInstall(d, "nightly")
+		return
+	}
+	if canary {
+		vmInstall(d, "canary")
+		return
+	}
+	vmInstall(d, args[0])
+}
+
+func latestRelease() string {
+	resp, err := http.Get(releaseAPI() + "/repos/wago-org/wago/releases/latest")
+	if err != nil {
+		fatal("version latest: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fatal("version latest: GitHub returned %s", resp.Status)
+	}
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil || release.TagName == "" {
+		fatal("version latest: invalid GitHub response")
+	}
+	return strings.TrimPrefix(release.TagName, "v")
+}
+
+func vmBrowse(d wago.Dirs) {
+	resp, err := http.Get(releaseAPI() + "/repos/wago-org/wago/releases")
+	if err != nil {
+		fatal("version browse: %v", err)
+	}
+	defer resp.Body.Close()
+	var releases []struct {
+		TagName string `json:"tag_name"`
+	}
+	if resp.StatusCode != http.StatusOK || json.NewDecoder(resp.Body).Decode(&releases) != nil {
+		fatal("version browse: unable to fetch releases")
+	}
+	choices := []string{"latest", "nightly", "canary"}
+	for _, r := range releases {
+		if r.TagName != "" {
+			choices = append(choices, strings.TrimPrefix(r.TagName, "v"))
+		}
+	}
+	for i, v := range choices {
+		fmt.Printf("  %d) %s\n", i+1, v)
+	}
+	fmt.Print("Install version: ")
+	var n int
+	if _, err := fmt.Fscan(os.Stdin, &n); err != nil || n < 1 || n > len(choices) {
+		fatal("version browse: invalid selection")
+	}
+	if choices[n-1] == "latest" {
+		vmInstall(d, latestRelease())
+		return
+	}
+	vmInstall(d, choices[n-1])
 }
 
 // vmUpdate fetches a fresh copy even when the version is already installed.

--- a/cli/wagocli/version_net.go
+++ b/cli/wagocli/version_net.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -57,10 +58,53 @@ func vmUpdate(d wago.Dirs, ver string) {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version update: %v", err)
 	}
+	if ver == "canary" {
+		if err := buildCanary(dest); err != nil {
+			fatal("version update: %v", err)
+		}
+		fmt.Printf("updated wago %s -> %s\n", cyan(ver), dest)
+		return
+	}
 	if err := downloadBinary(releaseBase(), ver, dest); err != nil {
 		fatal("version update: %v", err)
 	}
 	fmt.Printf("updated wago %s -> %s\n", cyan(ver), dest)
+}
+
+// buildCanary clones main and builds the full CLI locally. Canary is deliberately
+// not a release artifact: it is the current source tree, compiled with the
+// caller's Go toolchain for the caller's platform.
+func buildCanary(dest string) error {
+	work, err := os.MkdirTemp("", "wago-canary-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(work)
+
+	repo := filepath.Join(work, "wago")
+	clone := exec.Command("git", "clone", "--depth=1", "--branch", "main", canaryRepo(), repo)
+	if out, err := clone.CombinedOutput(); err != nil {
+		return fmt.Errorf("clone main: %w\n%s", err, strings.TrimSpace(string(out)))
+	}
+
+	tmp := dest + ".tmp"
+	defer os.Remove(tmp)
+	build := exec.Command("go", "build", "-o", tmp, "./cli/wago")
+	build.Dir = repo
+	if out, err := build.CombinedOutput(); err != nil {
+		return fmt.Errorf("build canary: %w\n%s", err, strings.TrimSpace(string(out)))
+	}
+	if err := os.Chmod(tmp, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(tmp, dest)
+}
+
+func canaryRepo() string {
+	if v := strings.TrimSpace(os.Getenv("WAGO_CANARY_REPO")); v != "" {
+		return v
+	}
+	return "https://github.com/wago-org/wago.git"
 }
 
 func vmListRemote() {

--- a/cli/wagocli/version_net_stub.go
+++ b/cli/wagocli/version_net_stub.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/wago-org/wago"
@@ -68,7 +69,7 @@ func vmListRemote() {
 
 // downloadBinary verifies the sibling SHA-256 before atomically replacing dest.
 func downloadBinary(baseURL, ver, dest string) error {
-	asset := "wago-linux-amd64"
+	asset := "wago-" + runtime.GOOS + "-" + runtime.GOARCH
 	url := fmt.Sprintf("%s/%s/%s", strings.TrimRight(baseURL, "/"), ver, asset)
 	body, err := curlGetBytes(url)
 	if err != nil {

--- a/cli/wagocli/version_net_test.go
+++ b/cli/wagocli/version_net_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -16,17 +17,18 @@ func TestDownloadBinaryChecksum(t *testing.T) {
 	payload := []byte("fake wago binary bytes")
 	sum := sha256.Sum256(payload)
 	hexsum := hex.EncodeToString(sum[:])
+	asset := "wago-" + runtime.GOOS + "-" + runtime.GOARCH
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/0.9.0/wago-linux-amd64", "/nightly/wago-linux-amd64", "/canary/wago-linux-amd64":
+		case "/0.9.0/" + asset, "/nightly/" + asset, "/canary/" + asset:
 			w.Write(payload)
-		case "/0.9.0/wago-linux-amd64.sha256", "/nightly/wago-linux-amd64.sha256", "/canary/wago-linux-amd64.sha256":
-			w.Write([]byte(hexsum + "  wago-linux-amd64\n"))
-		case "/bad/wago-linux-amd64":
+		case "/0.9.0/" + asset + ".sha256", "/nightly/" + asset + ".sha256", "/canary/" + asset + ".sha256":
+			w.Write([]byte(hexsum + "  " + asset + "\n"))
+		case "/bad/" + asset:
 			w.Write(payload)
-		case "/bad/wago-linux-amd64.sha256":
-			w.Write([]byte("deadbeef  wago-linux-amd64\n"))
+		case "/bad/" + asset + ".sha256":
+			w.Write([]byte("deadbeef  " + asset + "\n"))
 		default:
 			http.NotFound(w, r)
 		}

--- a/cli/wagocli/wagomodule.go
+++ b/cli/wagocli/wagomodule.go
@@ -17,20 +17,19 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+
+	"github.com/wago-org/wago"
 )
 
 // buildModuleName is the generated module's path. It never leaves the machine.
 const buildModuleName = "wago.local/build"
 
 // buildDirFor returns the .wago build directory: <cwd>/.wago by default, or
-// <home>/.wago with --global (a single CLI-wide plugin set).
+// a version-scoped directory with --global. This keeps globally installed
+// plugins and their generated binaries isolated between toolchain versions.
 func buildDirFor(global bool) (string, error) {
 	if global {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".wago"), nil
+		return filepath.Join(wago.DirsFor(versionString()).Versions, versionString(), "plugins"), nil
 	}
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## What changed

`wago version update --canary` now shallow-clones `wago-org/wago` at `main`, builds `./cli/wago` locally, chmods the result executable, and atomically installs it as the Canary binary.

## Why

Canary tracks source main; it is not a release asset that can be downloaded from the releases endpoint.

## Validation

- `go test ./cli/wagocli`
- End-to-end `WAGO_HOME=<temp> go run ./cli/wago version update --canary`
- Verified the resulting `versions/canary/wago` is executable