### PR TITLE
fix(arm64): wrap float-bearing internal calls

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -29,7 +29,7 @@ measure() {
 	END {
 		for (k in seen) {
 			f=k; sub(/:[0-9]+\.[0-9]+,[0-9]+\.[0-9]+$/, "", f)
-			p=f; sub(/\/[^/]+\.go$/, "", p); sub(/^github.com\/wago-org\/wago\/?/, "./", p)
+			p=f; sub("/[^/]+\\.go$", "", p); sub(/^github.com\/wago-org\/wago\/?/, "./", p)
 			if (p == "") p = "./"
 			tot[p]+=stmts[k]; if (max[k]>0) cov[p]+=stmts[k]; T+=stmts[k]; if (max[k]>0) C+=stmts[k]
 		}

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -640,14 +640,9 @@ func (f *fn) emitCrossInstanceCall(b ImportBinding, ft *wasm.CompType) error {
 // callees use the fast register ABI (args/result in registers); others go
 // through the wrapper (sp-buffer) ABI.
 func (f *fn) callInternal(localIdx int, ft *wasm.CompType, resHint int) error {
-	if regABIEnabled && sigFitsRegABI(ft) {
-		if sigIsIntOnly(ft) {
-			f.stats.call("regabi")
-			f.emitRegisterCall(localIdx, ft, resHint, f.directCalleePreservesPins(localIdx, ft))
-		} else {
-			f.stats.call("mixed")
-			f.emitMixedRegisterCall(localIdx, ft)
-		}
+	if regABIEnabled && sigFitsRegABI(ft) && sigIsIntOnly(ft) {
+		f.stats.call("regabi")
+		f.emitRegisterCall(localIdx, ft, resHint, f.directCalleePreservesPins(localIdx, ft))
 		return nil
 	}
 	f.stats.call("wrapper")

--- a/src/core/compiler/backend/railshot/arm64/callexec_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/callexec_arm64_test.go
@@ -81,7 +81,7 @@ func TestLeafCallResultStaysInX0(t *testing.T) {
 	}
 }
 
-func TestMixedCallRegisterArgsExec(t *testing.T) {
+func TestMixedCallWrapperArgsExec(t *testing.T) {
 	i32 := []wasm.ValType{wasm.I32}
 	m := modFuncs(t,
 		// f(x) = trunc(g(float(x), x)); both call operands are register-resident.
@@ -90,8 +90,8 @@ func TestMixedCallRegisterArgsExec(t *testing.T) {
 		funcDef{[]wasm.ValType{wasm.F64, wasm.I32}, []wasm.ValType{wasm.F64}, []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0xb7, 0xa0, 0x0b}},
 	)
 	stats := compileWithStats(t, m, false).Funcs[0]
-	if got := stats.Peephole["mixed-call-reg-arg"]; got != 2 {
-		t.Fatalf("mixed-call-reg-arg = %d, want 2 (all: %v)", got, stats.Peephole)
+	if got := stats.Calls["wrapper"]; got != 1 {
+		t.Fatalf("wrapper calls = %d, want 1 (all: %v)", got, stats.Calls)
 	}
 	cm, err := CompileModule(m)
 	if err != nil {


### PR DESCRIPTION
## Summary

Route float-bearing direct internal calls through the wrapper ABI on ARM64.

The mixed GP/FP register ABI miscompiled the f64 assertion path used by `as-test`. Integer-only calls retain the register ABI fast path.

## Validation

- Focused ARM64 call compiler tests
- Wago-enabled `as-test` mode without `--no-reg-abi`: 20 files passed, 1 skipped
