### PR TITLE
release: use immutable channel prereleases

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,8 +1,8 @@
 name: Publish canary
 
 # Every canary is built from main itself, never from the branch that happens to
-# manually dispatch this workflow. Every successful target is attached to the
-# rolling canary prerelease with the same asset names as nightly and stable.
+# manually dispatch this workflow. Every successful target is attached to an
+# immutable canary-* prerelease with the same asset names as nightly and stable.
 on:
   push:
     branches: [main]
@@ -26,6 +26,7 @@ jobs:
     outputs:
       sha: ${{ steps.version.outputs.sha }}
       version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +38,7 @@ jobs:
           sha=$(git rev-parse HEAD)
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "version=canary-${sha::7}" >> "$GITHUB_OUTPUT"
+          echo "tag=canary-${sha::7}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build canary (${{ matrix.goos }}/${{ matrix.goarch }})
@@ -156,14 +158,17 @@ jobs:
             test -s "$asset"
             sha256sum --check "$asset.sha256"
           done
-      - name: Publish rolling canary release
+      - name: Publish immutable canary release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
           test "${#assets[@]}" -gt 0
-          gh release delete canary --repo "${{ github.repository }}" --cleanup-tag --yes || true
-          gh release create canary \
+          if gh release view "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "canary release already exists for ${{ needs.prepare.outputs.sha }}"
+            exit 0
+          fi
+          gh release create "${{ needs.prepare.outputs.tag }}" \
             --repo "${{ github.repository }}" \
             --target "${{ needs.prepare.outputs.sha }}" \
             --title "Canary (${{ needs.prepare.outputs.version }})" \

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,8 +1,8 @@
 name: Publish canary
 
 # Every canary is built from main itself, never from the branch that happens to
-# manually dispatch this workflow. The rolling `canary` prerelease therefore
-# always represents a main commit and is directly installable as that channel.
+# manually dispatch this workflow. Every successful target is attached to the
+# rolling canary prerelease with the same asset names as nightly and stable.
 on:
   push:
     branches: [main]
@@ -20,46 +20,153 @@ env:
   TINYGO_VERSION: "0.41.1"
 
 jobs:
-  release:
-    name: Build & publish canary (linux/amd64)
+  prepare:
+    name: Resolve canary source
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.version.outputs.sha }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
-          # Pushes provide the exact main commit; manual runs resolve current main.
           ref: ${{ github.event_name == 'push' && github.sha || 'main' }}
           fetch-depth: 1
+      - name: Resolve version
+        id: version
+        run: |
+          sha=$(git rev-parse HEAD)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "version=canary-${sha::7}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build canary (${{ matrix.goos }}/${{ matrix.goarch }})
+    needs: prepare
+    continue-on-error: ${{ matrix.best_effort }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            goos: linux
+            goarch: amd64
+            asset: wago-linux-amd64
+            builder: tinygo
+            best_effort: false
+          - runner: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+            asset: wago-linux-arm64
+            builder: tinygo
+            best_effort: false
+          - runner: macos-15-intel
+            goos: darwin
+            goarch: amd64
+            asset: wago-darwin-amd64
+            builder: go
+            best_effort: true
+          - runner: macos-15
+            goos: darwin
+            goarch: arm64
+            asset: wago-darwin-arm64
+            builder: go
+            best_effort: true
+          - runner: windows-2022
+            goos: windows
+            goarch: amd64
+            asset: wago-windows-amd64
+            builder: go
+            best_effort: true
+          - runner: windows-2022
+            goos: windows
+            goarch: arm64
+            asset: wago-windows-arm64
+            builder: go
+            best_effort: true
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - uses: acifani/setup-tinygo@v2
+        if: matrix.builder == 'tinygo'
         with:
           tinygo-version: ${{ env.TINYGO_VERSION }}
+          install-binaryen: false
       - name: Install lld
+        if: matrix.builder == 'tinygo'
         run: sudo apt-get update && sudo apt-get install -y lld
-      - name: Resolve version
-        id: ver
+      - name: Build TinyGo canary binary
+        if: matrix.builder == 'tinygo'
+        run: make build-release WAGO_VERSION="${{ needs.prepare.outputs.version }}"
+      - name: Build standard-Go canary binary
+        if: matrix.builder == 'go'
+        shell: bash
         run: |
-          sha=$(git rev-parse HEAD)
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "version=canary-${sha::7}" >> "$GITHUB_OUTPUT"
-      - name: Build canary binary
-        run: make build-release WAGO_VERSION="${{ steps.ver.outputs.version }}"
-      - name: Package + checksum
+          CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
+            go build -trimpath -ldflags="-s -w -X main.version=${{ needs.prepare.outputs.version }}" \
+            -o wago ./cli/wago
+      - name: Package + checksum (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
-          mv wago wago-linux-amd64
-          ./wago-linux-amd64 version
-          sha256sum wago-linux-amd64 | tee wago-linux-amd64.sha256
+          mv wago "${{ matrix.asset }}"
+          ./${{ matrix.asset }} version
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${{ matrix.asset }}" | tee "${{ matrix.asset }}.sha256"
+          else
+            shasum -a 256 "${{ matrix.asset }}" | tee "${{ matrix.asset }}.sha256"
+          fi
+      - name: Package + checksum (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Move-Item wago "${{ matrix.asset }}"
+          $hash = (Get-FileHash -Algorithm SHA256 "${{ matrix.asset }}").Hash.ToLower()
+          "$hash  ${{ matrix.asset }}" | Set-Content -NoNewline -Encoding ascii "${{ matrix.asset }}.sha256"
+      - name: Upload release files
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-${{ matrix.asset }}
+          path: |
+            ${{ matrix.asset }}
+            ${{ matrix.asset }}.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish canary release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: canary-wago-*
+          merge-multiple: true
+          path: release
+      - name: Verify available release files
+        working-directory: release
+        run: |
+          mapfile -t assets < <(find . -maxdepth 1 -type f -name 'wago-*' ! -name '*.sha256' -printf '%f\n' | sort)
+          test "${#assets[@]}" -gt 0
+          for asset in "${assets[@]}"; do
+            test -s "$asset"
+            sha256sum --check "$asset.sha256"
+          done
       - name: Publish rolling canary release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
+          test "${#assets[@]}" -gt 0
           gh release delete canary --repo "${{ github.repository }}" --cleanup-tag --yes || true
           gh release create canary \
             --repo "${{ github.repository }}" \
-            --target "${{ steps.ver.outputs.sha }}" \
-            --title "Canary (${{ steps.ver.outputs.version }})" \
-            --notes "Automated canary build of main at \`${{ steps.ver.outputs.sha }}\`. Unstable — may break without notice." \
+            --target "${{ needs.prepare.outputs.sha }}" \
+            --title "Canary (${{ needs.prepare.outputs.version }})" \
+            --notes "Automated canary build of main at \`${{ needs.prepare.outputs.sha }}\`. Includes every successful platform build; unsupported targets are omitted. Unstable — may break without notice." \
             --prerelease \
-            wago-linux-amd64 wago-linux-amd64.sha256
+            "${assets[@]}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,8 @@
 name: Publish nightly
 
 # Builds the TinyGo CLI once a day from main and publishes it to the rolling
-# `nightly` prerelease. The tag is always the last successful nightly release.
+# `nightly` prerelease. Every supported CLI target is built on a native runner;
+# the tag is always the last successful nightly release.
 on:
   schedule:
     # 06:00 UTC daily (after most contributors' work has landed on main).
@@ -10,6 +11,12 @@ on:
 
 permissions:
   contents: write
+
+concurrency:
+  # Publishing replaces the rolling release, so never let two runs delete or
+  # recreate it concurrently. Queued runs publish in commit order.
+  group: publish-nightly
+  cancel-in-progress: false
 
 env:
   GO_VERSION: "1.22"
@@ -24,6 +31,7 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
       sha: ${{ steps.main.outputs.sha }}
+      version: ${{ steps.main.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,7 +39,10 @@ jobs:
           fetch-depth: 1
       - name: Resolve main
         id: main
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          sha=$(git rev-parse HEAD)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-$(date -u +%Y%m%d)-${sha::7}" >> "$GITHUB_OUTPUT"
       - name: Compare HEAD to the current nightly release
         id: decide
         env:
@@ -53,11 +64,59 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
 
-  release:
-    name: Build & publish nightly (linux/amd64)
+  build:
+    name: Build nightly (${{ matrix.goos }}/${{ matrix.goarch }})
     needs: check
     if: needs.check.outputs.run == 'true'
-    runs-on: ubuntu-latest
+    # A missing native JIT port must not prevent the supported targets from
+    # reaching nightly. Successful matrix cells still upload their assets.
+    continue-on-error: ${{ matrix.best_effort }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux release binaries use the size-minimized TinyGo build. The
+          # other targets use standard Go: TinyGo cannot link the CLI's
+          # os/exec paths on Darwin, and no TinyGo Windows CLI is available.
+          - runner: ubuntu-24.04
+            goos: linux
+            goarch: amd64
+            asset: wago-linux-amd64
+            builder: tinygo
+            best_effort: false
+          - runner: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+            asset: wago-linux-arm64
+            builder: tinygo
+            best_effort: false
+          - runner: macos-15-intel
+            goos: darwin
+            goarch: amd64
+            asset: wago-darwin-amd64
+            builder: go
+            best_effort: true
+          - runner: macos-15
+            goos: darwin
+            goarch: arm64
+            asset: wago-darwin-arm64
+            builder: go
+            best_effort: true
+          - runner: windows-2022
+            goos: windows
+            goarch: amd64
+            asset: wago-windows-amd64
+            builder: go
+            best_effort: true
+          # GitHub does not provide a generally available Windows/arm64 hosted
+          # runner, so compile this target from the Windows amd64 runner.
+          - runner: windows-2022
+            goos: windows
+            goarch: arm64
+            asset: wago-windows-arm64
+            builder: go
+            best_effort: true
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,37 +126,94 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - uses: acifani/setup-tinygo@v2
+        if: matrix.builder == 'tinygo'
         with:
           tinygo-version: ${{ env.TINYGO_VERSION }}
+          # Release builds do not use Binaryen. Its pinned package has no
+          # Linux/arm64 artifact, which would otherwise fail setup.
+          install-binaryen: false
       - name: Install lld
+        if: matrix.builder == 'tinygo'
         run: sudo apt-get update && sudo apt-get install -y lld
-      - name: Stamp version
-        id: ver
-        run: |
-          sha="${{ needs.check.outputs.sha }}"
-          echo "version=nightly-$(date -u +%Y%m%d)-${sha::7}" >> "$GITHUB_OUTPUT"
 
       # The TinyGo build delegates HTTPS downloads to the host curl executable.
       - name: Build release binary
-        run: make build-release WAGO_VERSION="${{ steps.ver.outputs.version }}"
-
-      - name: Package + checksum
+        if: matrix.builder == 'tinygo'
+        run: make build-release WAGO_VERSION="${{ needs.check.outputs.version }}"
+      - name: Build standard-Go release binary
+        if: matrix.builder == 'go'
+        shell: bash
         run: |
-          mv wago wago-linux-amd64
-          ./wago-linux-amd64 version
-          sha256sum wago-linux-amd64 | tee wago-linux-amd64.sha256
+          CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
+            go build -trimpath -ldflags="-s -w -X main.version=${{ needs.check.outputs.version }}" \
+            -o wago ./cli/wago
 
-      # Move the rolling `nightly` tag to this commit and refresh its release.
+      - name: Package + checksum (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mv wago "${{ matrix.asset }}"
+          ./${{ matrix.asset }} version
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${{ matrix.asset }}" | tee "${{ matrix.asset }}.sha256"
+          else
+            shasum -a 256 "${{ matrix.asset }}" | tee "${{ matrix.asset }}.sha256"
+          fi
+      - name: Package + checksum (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Move-Item wago "${{ matrix.asset }}"
+          $hash = (Get-FileHash -Algorithm SHA256 "${{ matrix.asset }}").Hash.ToLower()
+          "$hash  ${{ matrix.asset }}" | Set-Content -NoNewline -Encoding ascii "${{ matrix.asset }}.sha256"
+
+      - name: Upload release files
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-${{ matrix.asset }}
+          path: |
+            ${{ matrix.asset }}
+            ${{ matrix.asset }}.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish nightly release
+    needs: [check, build]
+    if: needs.check.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-wago-*
+          merge-multiple: true
+          path: release
+      - name: Verify available release files
+        working-directory: release
+        run: |
+          mapfile -t assets < <(find . -maxdepth 1 -type f -name 'wago-*' ! -name '*.sha256' -printf '%f\n' | sort)
+          test "${#assets[@]}" -gt 0
+          for asset in "${assets[@]}"; do
+            # Artifact upload/download does not preserve executable bits.
+            test -s "$asset"
+            sha256sum --check "$asset.sha256"
+          done
+
+      # Move the rolling `nightly` tag to this commit and refresh its release
+      # after checksumming every target that built successfully. Unsupported
+      # best-effort targets are omitted rather than blocking the release.
       # Deleting first (with the tag) is what lets `create --target` retarget it.
       - name: Publish rolling nightly release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
+          test "${#assets[@]}" -gt 0
           gh release delete nightly --repo "${{ github.repository }}" --cleanup-tag --yes || true
           gh release create nightly \
             --repo "${{ github.repository }}" \
             --target "${{ needs.check.outputs.sha }}" \
             --title "Nightly ($(date -u +%Y-%m-%d))" \
-            --notes "Automated nightly build of \`${{ needs.check.outputs.sha }}\` (${{ steps.ver.outputs.version }}), $(date -u +%Y-%m-%dT%H:%M:%SZ). Prerelease — unstable, may break without notice." \
+            --notes "Automated nightly build of \`${{ needs.check.outputs.sha }}\` (${{ needs.check.outputs.version }}), $(date -u +%Y-%m-%dT%H:%M:%SZ). Includes every successful platform build; unsupported targets are omitted. Prerelease — unstable, may break without notice." \
             --prerelease \
-            wago-linux-amd64 wago-linux-amd64.sha256
+            "${assets[@]}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,7 @@
 name: Publish nightly
 
-# Builds the TinyGo CLI once a day from main and publishes it to the rolling
-# `nightly` prerelease. Every supported CLI target is built on a native runner;
-# the tag is always the last successful nightly release.
+# Builds the CLI once a day from main and publishes an immutable nightly
+# prerelease. The CLI resolves the newest nightly-* release tag at install time.
 on:
   schedule:
     # 06:00 UTC daily (after most contributors' work has landed on main).
@@ -13,8 +12,6 @@ permissions:
   contents: write
 
 concurrency:
-  # Publishing replaces the rolling release, so never let two runs delete or
-  # recreate it concurrently. Queued runs publish in commit order.
   group: publish-nightly
   cancel-in-progress: false
 
@@ -32,6 +29,7 @@ jobs:
       run: ${{ steps.decide.outputs.run }}
       sha: ${{ steps.main.outputs.sha }}
       version: ${{ steps.main.outputs.version }}
+      tag: ${{ steps.main.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,21 +41,17 @@ jobs:
           sha=$(git rev-parse HEAD)
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "version=nightly-$(date -u +%Y%m%d)-${sha::7}" >> "$GITHUB_OUTPUT"
-      - name: Compare HEAD to the current nightly release
+          echo "tag=nightly-$(date -u +%Y%m%d)-${sha::7}" >> "$GITHUB_OUTPUT"
+      - name: Compare HEAD to the newest nightly release
         id: decide
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "manual run: building"
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          last=$(gh release view nightly \
-            --repo "${{ github.repository }}" \
-            --json targetCommitish -q .targetCommitish 2>/dev/null || true)
+          last=$(gh api "repos/${{ github.repository }}/releases?per_page=100" \
+            --jq '.[] | select(.tag_name | startswith("nightly-")) | .target_commitish' \
+            2>/dev/null | head -1 || true)
           if [ "$last" = "${{ steps.main.outputs.sha }}" ]; then
-            echo "nightly already points at ${{ steps.main.outputs.sha }}; skipping"
+            echo "newest nightly already targets ${{ steps.main.outputs.sha }}; skipping"
             echo "run=false" >> "$GITHUB_OUTPUT"
           else
             echo "main moved ($last -> ${{ steps.main.outputs.sha }}); building"
@@ -199,18 +193,15 @@ jobs:
             sha256sum --check "$asset.sha256"
           done
 
-      # Move the rolling `nightly` tag to this commit and refresh its release
-      # after checksumming every target that built successfully. Unsupported
-      # best-effort targets are omitted rather than blocking the release.
-      # Deleting first (with the tag) is what lets `create --target` retarget it.
-      - name: Publish rolling nightly release
+      # Immutable release rules forbid retargeting a rolling tag. Each nightly
+      # gets a unique tag; the CLI resolves the newest nightly-* prerelease.
+      - name: Publish immutable nightly release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
           test "${#assets[@]}" -gt 0
-          gh release delete nightly --repo "${{ github.repository }}" --cleanup-tag --yes || true
-          gh release create nightly \
+          gh release create "${{ needs.check.outputs.tag }}" \
             --repo "${{ github.repository }}" \
             --target "${{ needs.check.outputs.sha }}" \
             --title "Nightly ($(date -u +%Y-%m-%d))" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Publish release
 
-# Builds the size-minimized TinyGo CLI (no cgo; see docs/tinygo.md) and, on a
-# version tag, publishes it to the GitHub Release. The version downloader uses
-# the host curl executable for HTTPS and redirect handling.
+# Version tags publish every successfully built CLI target. Linux uses TinyGo;
+# other targets use standard Go and remain best-effort until their native JIT
+# ports are complete.
 on:
   push:
     tags: ["v*"]
@@ -20,9 +20,50 @@ env:
   TINYGO_VERSION: "0.41.1"
 
 jobs:
-  release:
-    name: Build & publish (linux/amd64)
-    runs-on: ubuntu-latest
+  build:
+    name: Build release (${{ matrix.goos }}/${{ matrix.goarch }})
+    continue-on-error: ${{ matrix.best_effort }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            goos: linux
+            goarch: amd64
+            asset: wago-linux-amd64
+            builder: tinygo
+            best_effort: false
+          - runner: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+            asset: wago-linux-arm64
+            builder: tinygo
+            best_effort: false
+          - runner: macos-15-intel
+            goos: darwin
+            goarch: amd64
+            asset: wago-darwin-amd64
+            builder: go
+            best_effort: true
+          - runner: macos-15
+            goos: darwin
+            goarch: arm64
+            asset: wago-darwin-arm64
+            builder: go
+            best_effort: true
+          - runner: windows-2022
+            goos: windows
+            goarch: amd64
+            asset: wago-windows-amd64
+            builder: go
+            best_effort: true
+          - runner: windows-2022
+            goos: windows
+            goarch: arm64
+            asset: wago-windows-arm64
+            builder: go
+            best_effort: true
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -30,46 +71,85 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - uses: acifani/setup-tinygo@v2
+        if: matrix.builder == 'tinygo'
         with:
           tinygo-version: ${{ env.TINYGO_VERSION }}
+          install-binaryen: false
       - name: Install lld
+        if: matrix.builder == 'tinygo'
         run: sudo apt-get update && sudo apt-get install -y lld
-      - name: Resolve version
-        id: ver
+      - name: Build TinyGo release binary
+        if: matrix.builder == 'tinygo'
+        run: make build-release WAGO_VERSION="${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}"
+      - name: Build standard-Go release binary
+        if: matrix.builder == 'go'
+        shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
-            v="${{ inputs.version }}"
+          CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
+            go build -trimpath -ldflags="-s -w -X main.version=${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}" \
+            -o wago ./cli/wago
+      - name: Package + checksum (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mv wago "${{ matrix.asset }}"
+          ./${{ matrix.asset }} version
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${{ matrix.asset }}" | tee "${{ matrix.asset }}.sha256"
           else
-            v="${{ github.ref_name }}"
+            shasum -a 256 "${{ matrix.asset }}" | tee "${{ matrix.asset }}.sha256"
           fi
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-
-      # Produces ./wago with the network-backed version manager enabled.
-      - name: Build release binary
-        run: make build-release WAGO_VERSION="${{ steps.ver.outputs.version }}"
-
-      - name: Package + checksum
+      - name: Package + checksum (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          mv wago wago-linux-amd64
-          ./wago-linux-amd64 version
-          sha256sum wago-linux-amd64 | tee wago-linux-amd64.sha256
-
-      # On a tag push, attach the binary to the (auto-created) GitHub Release.
-      - name: Publish to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            wago-linux-amd64
-            wago-linux-amd64.sha256
-          fail_on_unmatched_files: true
-
-      # For manual runs (no tag), keep the binary as a downloadable artifact.
-      - name: Upload build artifact
+          Move-Item wago "${{ matrix.asset }}"
+          $hash = (Get-FileHash -Algorithm SHA256 "${{ matrix.asset }}").Hash.ToLower()
+          "$hash  ${{ matrix.asset }}" | Set-Content -NoNewline -Encoding ascii "${{ matrix.asset }}.sha256"
+      - name: Upload release files
         uses: actions/upload-artifact@v4
         with:
-          name: wago-linux-amd64
+          name: release-${{ matrix.asset }}
           path: |
-            wago-linux-amd64
-            wago-linux-amd64.sha256
+            ${{ matrix.asset }}
+            ${{ matrix.asset }}.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish release files
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-wago-*
+          merge-multiple: true
+          path: release
+      - name: Verify available release files
+        working-directory: release
+        run: |
+          mapfile -t assets < <(find . -maxdepth 1 -type f -name 'wago-*' ! -name '*.sha256' -printf '%f\n' | sort)
+          test "${#assets[@]}" -gt 0
+          for asset in "${assets[@]}"; do
+            test -s "$asset"
+            sha256sum --check "$asset.sha256"
+          done
+      - name: Publish tagged GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
+          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release upload "${{ github.ref_name }}" --repo "${{ github.repository }}" --clobber "${assets[@]}"
+          else
+            gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --verify-tag --generate-notes "${assets[@]}"
+          fi
+      - name: Upload manual build artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: wago-release-files
+          path: release
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ For library use:
 go get github.com/wago-org/wago
 ```
 
-Current target: **linux/amd64**. Published binaries use the size-focused,
-no-cgo TinyGo build. `wago version install` and `wago version update` require
-the host's `curl` executable for HTTPS downloads.
+Nightly attempts binaries for Linux, macOS, and Windows on both amd64 and arm64.
+Every build that succeeds is published as `wago-<goos>-<goarch>` with a SHA-256
+checksum; targets without a native JIT port are omitted rather than blocking the
+nightly. Linux releases use the size-focused, no-cgo TinyGo build. `wago version
+install` and `wago version update` require the host's `curl` executable for HTTPS
+downloads.
 
 ### Toolchain channels
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ downloads.
 
 ### Toolchain channels
 
-The CLI can install stable versions and the rolling release channels:
+The CLI can install stable versions and the moving release channels. Each
+nightly and canary is an immutable prerelease; the channel name resolves to its
+newest published release at install time:
 
 ```bash
 wago version install 0.1.0

--- a/cli/wagocli/cmd_version.go
+++ b/cli/wagocli/cmd_version.go
@@ -45,7 +45,7 @@ func versionCommand() *Cmd {
 				Name: "install", Aliases: []string{"add"},
 				Summary: "install a pinned version, release channel, or latest",
 				Args:    "[version]",
-				Flags:   []Flag{{Name: "latest", Bool: true, Help: "install the latest release"}, {Name: "nightly", Bool: true, Help: "install nightly"}, {Name: "canary", Bool: true, Help: "build Canary from main"}},
+				Flags:   []Flag{{Name: "latest", Bool: true, Help: "install the latest release"}, {Name: "nightly", Bool: true, Help: "install nightly"}, {Name: "canary", Bool: true, Help: "install the latest canary"}},
 				Run: func(c *Ctx) {
 					vmInstallRequested(dirs(), c.Args, c.Bool("latest"), c.Bool("nightly"), c.Bool("canary"))
 				},

--- a/cli/wagocli/version_common.go
+++ b/cli/wagocli/version_common.go
@@ -151,6 +151,46 @@ var rollingChannels = map[string]bool{"canary": true, "nightly": true}
 // than a pinned, immutable version.
 func isRollingChannel(ver string) bool { return rollingChannels[ver] }
 
+// channelRelease returns the moving channel represented by an immutable
+// prerelease tag, if any. Release APIs return newest-first, so callers keep the
+// first tag seen for each channel.
+func channelRelease(tag string) string {
+	for channel := range rollingChannels {
+		if strings.HasPrefix(tag, channel+"-") {
+			return channel
+		}
+	}
+	return ""
+}
+
+func stableReleaseNames(tags []string) []string {
+	names := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if tag != "" && channelRelease(tag) == "" {
+			names = append(names, strings.TrimPrefix(tag, "v"))
+		}
+	}
+	return names
+}
+
+func remoteVersionNames(tags []string) []string {
+	names := make([]string, 0, len(tags)+len(rollingChannels))
+	seen := make(map[string]bool, len(rollingChannels))
+	for _, tag := range tags {
+		if channel := channelRelease(tag); channel != "" {
+			if !seen[channel] {
+				names = append(names, channel)
+				seen[channel] = true
+			}
+			continue
+		}
+		if tag != "" {
+			names = append(names, strings.TrimPrefix(tag, "v"))
+		}
+	}
+	return names
+}
+
 // updateVersionTarget chooses the version refreshed by `wago version update`.
 // No selector means the active version; explicit channel flags make refreshing a
 // rolling channel convenient without first selecting it.

--- a/cli/wagocli/version_common_test.go
+++ b/cli/wagocli/version_common_test.go
@@ -3,6 +3,7 @@ package wagocli
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -103,5 +104,15 @@ func TestUpdateVersionTarget(t *testing.T) {
 				t.Fatalf("updateVersionTarget() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRemoteVersionNamesHideImmutableChannelTags(t *testing.T) {
+	tags := []string{"nightly-20260712-deadbee", "canary-cafef00", "nightly-20260711-abcdef0", "v0.2.0"}
+	if got, want := remoteVersionNames(tags), []string{"nightly", "canary", "0.2.0"}; !slices.Equal(got, want) {
+		t.Fatalf("remoteVersionNames = %v, want %v", got, want)
+	}
+	if got, want := stableReleaseNames(tags), []string{"0.2.0"}; !slices.Equal(got, want) {
+		t.Fatalf("stableReleaseNames = %v, want %v", got, want)
 	}
 }

--- a/cli/wagocli/version_net.go
+++ b/cli/wagocli/version_net.go
@@ -212,7 +212,7 @@ func vmListRemote() {
 	}
 }
 
-// downloadBinary fetches the linux/amd64 wago binary for ver from baseURL,
+// downloadBinary fetches the host-platform wago binary for ver from baseURL,
 // verifies its SHA-256 against the sibling ".sha256" file, and writes it to dest
 // (0755). It writes nothing on a checksum mismatch.
 func downloadBinary(baseURL, ver, dest string) error {

--- a/cli/wagocli/version_net.go
+++ b/cli/wagocli/version_net.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -41,14 +40,8 @@ func vmInstall(d wago.Dirs, ver string) {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version install: %v", err)
 	}
-	var installErr error
-	if ver == "canary" {
-		installErr = buildCanary(dest)
-	} else {
-		installErr = downloadBinary(releaseBase(), ver, dest)
-	}
-	if installErr != nil {
-		fatal("version install: %v", installErr)
+	if err := downloadBinary(releaseBase(), releaseDownloadVersion(ver), dest); err != nil {
+		fatal("version install: %v", err)
 	}
 	verb := "installed"
 	if existed {
@@ -139,53 +132,10 @@ func vmUpdate(d wago.Dirs, ver string) {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version update: %v", err)
 	}
-	if ver == "canary" {
-		if err := buildCanary(dest); err != nil {
-			fatal("version update: %v", err)
-		}
-		fmt.Printf("updated wago %s -> %s\n", cyan(ver), dest)
-		return
-	}
-	if err := downloadBinary(releaseBase(), ver, dest); err != nil {
+	if err := downloadBinary(releaseBase(), releaseDownloadVersion(ver), dest); err != nil {
 		fatal("version update: %v", err)
 	}
 	fmt.Printf("updated wago %s -> %s\n", cyan(ver), dest)
-}
-
-// buildCanary clones main and builds the full CLI locally. Canary is deliberately
-// not a release artifact: it is the current source tree, compiled with the
-// caller's Go toolchain for the caller's platform.
-func buildCanary(dest string) error {
-	work, err := os.MkdirTemp("", "wago-canary-")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(work)
-
-	repo := filepath.Join(work, "wago")
-	clone := exec.Command("git", "clone", "--depth=1", "--branch", "main", canaryRepo(), repo)
-	if out, err := clone.CombinedOutput(); err != nil {
-		return fmt.Errorf("clone main: %w\n%s", err, strings.TrimSpace(string(out)))
-	}
-
-	tmp := dest + ".tmp"
-	defer os.Remove(tmp)
-	build := exec.Command("go", "build", "-o", tmp, "./cli/wago")
-	build.Dir = repo
-	if out, err := build.CombinedOutput(); err != nil {
-		return fmt.Errorf("build canary: %w\n%s", err, strings.TrimSpace(string(out)))
-	}
-	if err := os.Chmod(tmp, 0o755); err != nil {
-		return err
-	}
-	return os.Rename(tmp, dest)
-}
-
-func canaryRepo() string {
-	if v := strings.TrimSpace(os.Getenv("WAGO_CANARY_REPO")); v != "" {
-		return v
-	}
-	return "https://github.com/wago-org/wago.git"
 }
 
 func vmListRemote() {
@@ -210,6 +160,43 @@ func vmListRemote() {
 	for _, r := range releases {
 		fmt.Println(strings.TrimPrefix(r.TagName, "v"))
 	}
+}
+
+// releaseDownloadVersion resolves a rolling channel to its newest immutable
+// prerelease tag. Stable versions are already immutable release tags.
+func releaseDownloadVersion(ver string) string {
+	if !isRollingChannel(ver) {
+		return ver
+	}
+	tag, err := latestChannelRelease(ver)
+	if err != nil {
+		fatal("version %s: %v", ver, err)
+	}
+	return tag
+}
+
+func latestChannelRelease(channel string) (string, error) {
+	resp, err := http.Get(releaseAPI() + "/repos/wago-org/wago/releases?per_page=100")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub returned %s", resp.Status)
+	}
+	var releases []struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return "", err
+	}
+	prefix := channel + "-"
+	for _, release := range releases {
+		if strings.HasPrefix(release.TagName, prefix) {
+			return release.TagName, nil
+		}
+	}
+	return "", fmt.Errorf("no published %s release", channel)
 }
 
 // downloadBinary fetches the host-platform wago binary for ver from baseURL,

--- a/cli/wagocli/version_net.go
+++ b/cli/wagocli/version_net.go
@@ -104,11 +104,11 @@ func vmBrowse(d wago.Dirs) {
 		fatal("version browse: unable to fetch releases")
 	}
 	choices := []string{"latest", "nightly", "canary"}
+	tags := make([]string, 0, len(releases))
 	for _, r := range releases {
-		if r.TagName != "" {
-			choices = append(choices, strings.TrimPrefix(r.TagName, "v"))
-		}
+		tags = append(tags, r.TagName)
 	}
+	choices = append(choices, stableReleaseNames(tags)...)
 	for i, v := range choices {
 		fmt.Printf("  %d) %s\n", i+1, v)
 	}
@@ -157,8 +157,12 @@ func vmListRemote() {
 		fmt.Println(dim("no releases published"))
 		return
 	}
+	tags := make([]string, 0, len(releases))
 	for _, r := range releases {
-		fmt.Println(strings.TrimPrefix(r.TagName, "v"))
+		tags = append(tags, r.TagName)
+	}
+	for _, name := range remoteVersionNames(tags) {
+		fmt.Println(name)
 	}
 }
 

--- a/cli/wagocli/version_net_stub.go
+++ b/cli/wagocli/version_net_stub.go
@@ -140,7 +140,7 @@ func vmListRemote() {
 
 // downloadBinary verifies the sibling SHA-256 before atomically replacing dest.
 func downloadBinary(baseURL, ver, dest string) error {
-	asset := "wago-" + runtime.GOOS + "-" + runtime.GOARCH
+	asset := versionAsset()
 	url := fmt.Sprintf("%s/%s/%s", strings.TrimRight(baseURL, "/"), ver, asset)
 	body, err := curlGetBytes(url)
 	if err != nil {
@@ -164,6 +164,8 @@ func downloadBinary(baseURL, ver, dest string) error {
 	}
 	return os.Rename(tmp, dest)
 }
+
+func versionAsset() string { return "wago-" + runtime.GOOS + "-" + runtime.GOARCH }
 
 // curlGetBytes runs curl without a shell: URL text is always one argument, so a
 // requested version cannot become an option or command. --location follows the

--- a/cli/wagocli/version_net_stub.go
+++ b/cli/wagocli/version_net_stub.go
@@ -30,7 +30,7 @@ func vmInstall(d wago.Dirs, ver string) {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version install: %v", err)
 	}
-	if err := downloadBinary(releaseBase(), ver, dest); err != nil {
+	if err := downloadBinary(releaseBase(), releaseDownloadVersion(ver), dest); err != nil {
 		fatal("version install: %v", err)
 	}
 	fmt.Printf("installed wago %s -> %s\n", cyan(ver), dest)
@@ -112,7 +112,7 @@ func vmUpdate(d wago.Dirs, ver string) {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version update: %v", err)
 	}
-	if err := downloadBinary(releaseBase(), ver, dest); err != nil {
+	if err := downloadBinary(releaseBase(), releaseDownloadVersion(ver), dest); err != nil {
 		fatal("version update: %v", err)
 	}
 	fmt.Printf("updated wago %s -> %s\n", cyan(ver), dest)
@@ -136,6 +136,39 @@ func vmListRemote() {
 	for _, r := range releases {
 		fmt.Println(strings.TrimPrefix(r.TagName, "v"))
 	}
+}
+
+// releaseDownloadVersion resolves a rolling channel to its newest immutable
+// prerelease tag. Stable versions are already immutable release tags.
+func releaseDownloadVersion(ver string) string {
+	if !isRollingChannel(ver) {
+		return ver
+	}
+	tag, err := latestChannelRelease(ver)
+	if err != nil {
+		fatal("version %s: %v", ver, err)
+	}
+	return tag
+}
+
+func latestChannelRelease(channel string) (string, error) {
+	body, err := curlGetBytes(releaseAPI() + "/repos/wago-org/wago/releases?per_page=100")
+	if err != nil {
+		return "", err
+	}
+	var releases []struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return "", err
+	}
+	prefix := channel + "-"
+	for _, release := range releases {
+		if strings.HasPrefix(release.TagName, prefix) {
+			return release.TagName, nil
+		}
+	}
+	return "", fmt.Errorf("no published %s release", channel)
 }
 
 // downloadBinary verifies the sibling SHA-256 before atomically replacing dest.

--- a/cli/wagocli/version_net_stub.go
+++ b/cli/wagocli/version_net_stub.go
@@ -23,9 +23,13 @@ import (
 
 func vmInstall(d wago.Dirs, ver string) {
 	dest := d.VersionBinary(ver)
+	existed := false
 	if fi, err := os.Stat(dest); err == nil && !fi.IsDir() {
-		fmt.Printf("wago %s already installed\n", ver)
-		return
+		if !isRollingChannel(ver) {
+			fmt.Printf("wago %s already installed\n", ver)
+			return
+		}
+		existed = true
 	}
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version install: %v", err)
@@ -33,7 +37,11 @@ func vmInstall(d wago.Dirs, ver string) {
 	if err := downloadBinary(releaseBase(), releaseDownloadVersion(ver), dest); err != nil {
 		fatal("version install: %v", err)
 	}
-	fmt.Printf("installed wago %s -> %s\n", cyan(ver), dest)
+	verb := "installed"
+	if existed {
+		verb = "refreshed"
+	}
+	fmt.Printf("%s wago %s -> %s\n", verb, cyan(ver), dest)
 }
 
 // vmInstallRequested keeps the lean/TinyGo command surface aligned with the
@@ -87,11 +95,11 @@ func vmBrowse(d wago.Dirs) {
 		fatal("version browse: unable to fetch releases")
 	}
 	choices := []string{"latest", "nightly", "canary"}
+	tags := make([]string, 0, len(releases))
 	for _, r := range releases {
-		if r.TagName != "" {
-			choices = append(choices, strings.TrimPrefix(r.TagName, "v"))
-		}
+		tags = append(tags, r.TagName)
 	}
+	choices = append(choices, stableReleaseNames(tags)...)
 	for i, v := range choices {
 		fmt.Printf("  %d) %s\n", i+1, v)
 	}
@@ -133,8 +141,12 @@ func vmListRemote() {
 		fmt.Println(dim("no releases published"))
 		return
 	}
+	tags := make([]string, 0, len(releases))
 	for _, r := range releases {
-		fmt.Println(strings.TrimPrefix(r.TagName, "v"))
+		tags = append(tags, r.TagName)
+	}
+	for _, name := range remoteVersionNames(tags) {
+		fmt.Println(name)
 	}
 }
 

--- a/cli/wagocli/version_net_stub.go
+++ b/cli/wagocli/version_net_stub.go
@@ -36,6 +36,77 @@ func vmInstall(d wago.Dirs, ver string) {
 	fmt.Printf("installed wago %s -> %s\n", cyan(ver), dest)
 }
 
+// vmInstallRequested keeps the lean/TinyGo command surface aligned with the
+// standard downloader without retaining net/http in the release binary.
+func vmInstallRequested(d wago.Dirs, args []string, latest, nightly, canary bool) {
+	if len(args) > 1 || (len(args) == 1 && (latest || nightly || canary)) || (latest && (nightly || canary)) || (nightly && canary) {
+		fatal("version install: choose one version or channel")
+	}
+	if len(args) == 0 && !latest && !nightly && !canary {
+		vmBrowse(d)
+		return
+	}
+	if latest {
+		vmInstall(d, latestRelease())
+		return
+	}
+	if nightly {
+		vmInstall(d, "nightly")
+		return
+	}
+	if canary {
+		vmInstall(d, "canary")
+		return
+	}
+	vmInstall(d, args[0])
+}
+
+func latestRelease() string {
+	body, err := curlGetBytes(releaseAPI() + "/repos/wago-org/wago/releases/latest")
+	if err != nil {
+		fatal("version latest: %v", err)
+	}
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &release); err != nil || release.TagName == "" {
+		fatal("version latest: invalid GitHub response")
+	}
+	return strings.TrimPrefix(release.TagName, "v")
+}
+
+func vmBrowse(d wago.Dirs) {
+	body, err := curlGetBytes(releaseAPI() + "/repos/wago-org/wago/releases")
+	if err != nil {
+		fatal("version browse: %v", err)
+	}
+	var releases []struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &releases); err != nil {
+		fatal("version browse: unable to fetch releases")
+	}
+	choices := []string{"latest", "nightly", "canary"}
+	for _, r := range releases {
+		if r.TagName != "" {
+			choices = append(choices, strings.TrimPrefix(r.TagName, "v"))
+		}
+	}
+	for i, v := range choices {
+		fmt.Printf("  %d) %s\n", i+1, v)
+	}
+	fmt.Print("Install version: ")
+	var n int
+	if _, err := fmt.Fscan(os.Stdin, &n); err != nil || n < 1 || n > len(choices) {
+		fatal("version browse: invalid selection")
+	}
+	if choices[n-1] == "latest" {
+		vmInstall(d, latestRelease())
+		return
+	}
+	vmInstall(d, choices[n-1])
+}
+
 func vmUpdate(d wago.Dirs, ver string) {
 	dest := d.VersionBinary(ver)
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {

--- a/cli/wagocli/version_net_stub_test.go
+++ b/cli/wagocli/version_net_stub_test.go
@@ -28,6 +28,23 @@ func TestCurlGetBytes(t *testing.T) {
 	}
 }
 
+func TestLeanLatestChannelRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/wago-org/wago/releases" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`[{"tag_name":"canary-cafef00"},{"tag_name":"nightly-20260712-deadbee"}]`))
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	got, err := latestChannelRelease("nightly")
+	if err != nil || got != "nightly-20260712-deadbee" {
+		t.Fatalf("latestChannelRelease(nightly) = %q, %v", got, err)
+	}
+}
+
 func TestLeanDownloadNightlyUsesHostAsset(t *testing.T) {
 	payload := []byte("fake nightly binary")
 	sum := sha256.Sum256(payload)

--- a/cli/wagocli/version_net_stub_test.go
+++ b/cli/wagocli/version_net_stub_test.go
@@ -3,6 +3,10 @@
 package wagocli
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,5 +25,32 @@ func TestCurlGetBytes(t *testing.T) {
 	}
 	if string(got) != "test-response" {
 		t.Fatalf("curlGetBytes = %q, want test-response", got)
+	}
+}
+
+func TestLeanDownloadNightlyUsesHostAsset(t *testing.T) {
+	payload := []byte("fake nightly binary")
+	sum := sha256.Sum256(payload)
+	asset := versionAsset()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nightly/" + asset:
+			_, _ = w.Write(payload)
+		case "/nightly/" + asset + ".sha256":
+			_, _ = w.Write([]byte(hex.EncodeToString(sum[:]) + "  " + asset + "\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "wago")
+	if err := downloadBinary(srv.URL, "nightly", dest); err != nil {
+		t.Fatalf("downloadBinary(nightly): %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil || string(got) != string(payload) {
+		t.Fatalf("downloaded nightly content = %q, %v; want %q, nil", got, err, payload)
 	}
 }

--- a/cli/wagocli/version_net_test.go
+++ b/cli/wagocli/version_net_test.go
@@ -13,6 +13,23 @@ import (
 	"testing"
 )
 
+func TestLatestChannelRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/wago-org/wago/releases" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`[{"tag_name":"nightly-20260712-deadbee"},{"tag_name":"canary-cafef00"}]`))
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	got, err := latestChannelRelease("nightly")
+	if err != nil || got != "nightly-20260712-deadbee" {
+		t.Fatalf("latestChannelRelease(nightly) = %q, %v", got, err)
+	}
+}
+
 func TestDownloadBinaryChecksum(t *testing.T) {
 	payload := []byte("fake wago binary bytes")
 	sum := sha256.Sum256(payload)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -34,7 +34,9 @@ required matrix cell or supporting job fails.
 
 Nightly, canary, and tagged release workflows attempt Linux, Darwin, and Windows
 CLI builds for both amd64 and arm64, then publish every successful binary with
-its SHA-256 checksum. Linux builds use native size-focused TinyGo runners;
+its SHA-256 checksum. Nightly and canary use unique immutable prerelease tags;
+the CLI resolves the newest `nightly-*` or `canary-*` tag when a channel is
+installed. Linux builds use native size-focused TinyGo runners;
 Darwin uses standard Go because TinyGo cannot link the CLI's `os/exec` paths
 there, and Windows uses standard-Go cross-compilation from a Windows amd64
 runner for arm64. Unsupported native JIT targets are best-effort: a failed

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -32,15 +32,14 @@ for visibility without making their current gaps required checks. The final
 `CI` aggregation job is the stable branch-protection check and fails if any
 required matrix cell or supporting job fails.
 
-The scheduled nightly workflow attempts Linux, Darwin, and Windows CLI builds
-for both amd64 and arm64, then publishes one rolling `nightly` prerelease with
-every successful binary and its SHA-256 checksum. Linux builds use native
-size-focused TinyGo runners; Darwin uses standard Go because TinyGo cannot link
-the CLI's `os/exec` paths there, and Windows uses standard-Go cross-compilation
-from a Windows amd64 runner for arm64. Unsupported native JIT targets are
-best-effort: a failed target is omitted and does not block the nightly release.
-Release asset names follow `wago-<goos>-<goarch>` (for example,
-`wago-linux-arm64`).
+Nightly, canary, and tagged release workflows attempt Linux, Darwin, and Windows
+CLI builds for both amd64 and arm64, then publish every successful binary with
+its SHA-256 checksum. Linux builds use native size-focused TinyGo runners;
+Darwin uses standard Go because TinyGo cannot link the CLI's `os/exec` paths
+there, and Windows uses standard-Go cross-compilation from a Windows amd64
+runner for arm64. Unsupported native JIT targets are best-effort: a failed
+target is omitted and does not block the release. Every channel uses the same
+asset names: `wago-<goos>-<goarch>` (for example, `wago-linux-arm64`).
 
 For a local native approximation, run:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -32,6 +32,16 @@ for visibility without making their current gaps required checks. The final
 `CI` aggregation job is the stable branch-protection check and fails if any
 required matrix cell or supporting job fails.
 
+The scheduled nightly workflow attempts Linux, Darwin, and Windows CLI builds
+for both amd64 and arm64, then publishes one rolling `nightly` prerelease with
+every successful binary and its SHA-256 checksum. Linux builds use native
+size-focused TinyGo runners; Darwin uses standard Go because TinyGo cannot link
+the CLI's `os/exec` paths there, and Windows uses standard-Go cross-compilation
+from a Windows amd64 runner for arm64. Unsupported native JIT targets are
+best-effort: a failed target is omitted and does not block the nightly release.
+Release asset names follow `wago-<goos>-<goarch>` (for example,
+`wago-linux-arm64`).
+
 For a local native approximation, run:
 
 ```sh


### PR DESCRIPTION
## What changed

- Publish unique immutable `nightly-*` and `canary-*` prereleases instead of deleting/recreating rolling tags.
- Resolve `wago version install nightly` and `canary` through the Releases API to the newest matching immutable tag before downloading the host asset.
- Keep the shared multi-platform release asset format and document the channel behavior.

## Why

Repository rules reject recreating rolling release tags, which left the nightly channel unpublished after a successful build.

## Validation

- `go test ./cli/wagocli`
- `go test -tags wago_lean ./cli/wagocli`
- YAML validation for nightly, canary, and stable release workflows