### PR TITLE
perf(compile): cut compile latency ~34% and peak memory ~82%

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/allocation_test.go
+++ b/src/core/compiler/backend/railshot/amd64/allocation_test.go
@@ -52,7 +52,12 @@ func TestStackArenaOverflowKeepsExistingPointersStable(t *testing.T) {
 	if s.head.next != first {
 		t.Fatal("first elem is no longer linked after arena overflow")
 	}
-	if cap(s.arena) != defaultStackArenaCap {
-		t.Fatalf("arena cap = %d, want fixed cap %d", cap(s.arena), defaultStackArenaCap)
+	// Growing past the first chunk must advance the arena, never reallocate an
+	// existing chunk (which would invalidate the pointers above).
+	if len(s.chunks) < 2 {
+		t.Fatalf("arena did not advance past the first chunk: %d chunk(s)", len(s.chunks))
+	}
+	if cap(s.chunks[0]) != defaultStackArenaCap {
+		t.Fatalf("first chunk cap = %d, want %d", cap(s.chunks[0]), defaultStackArenaCap)
 	}
 }

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -668,11 +668,7 @@ func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, emitCall func()
 	// owned, pinned registers now (protected from the flush below); const/memory
 	// args are loaded straight into their target register afterward.
 	moves := f.tmpMoves[:0]
-	type deferredArg struct {
-		target Reg
-		root   *elem
-	}
-	var deferred []deferredArg
+	deferred := f.tmpDeferred[:0]
 	for i := 0; i < p; i++ {
 		root := argRoots[i]
 		if root.isDeferred() || (root.kind == ekValue && (root.st.kind == stReg || root.st.kind == stLocalReg || root.st.kind == stGlobReg || root.st.kind == stMemRef)) {
@@ -711,6 +707,7 @@ func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, emitCall func()
 			f.a.Load64(da.target, RSP, f.localOff(da.root.st.idx))
 		}
 	}
+	f.tmpDeferred = deferred[:0]
 
 	// Consume the args; the operand model is now the k below-operands in slots.
 	f.setDepth(d - p)

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 
 	"github.com/wago-org/wago/src/core/compiler/codegen"
@@ -132,6 +133,7 @@ type fn struct {
 	// type table used by existing lowering; locals holds the assigned register and
 	// call-spill state for each local.
 	locals           []localDef
+	pinnedLocals     []int // indices of register-pinned locals (fixed after assignPinnedLocals)
 	pinnedLocalMask  regMask
 	fpinnedLocalMask regMask
 
@@ -244,11 +246,21 @@ type fn struct {
 	// Control-flow state (Phase 3).
 	ctrl        []ctrlFrame // open block/loop/if frames; ctrl[0] is the function frame
 	unreachable bool        // in dead code after an unconditional branch/trap
-	retSites    []int       // forward jmp sites that target the epilogue
 
-	// brFoldSites are the Jcc rel32 offsets of empty-edge `Jcc over; JMP target`
-	// br_if idioms, folded post-assembly into a single inverted Jcc (peephole.go).
-	brFoldSites []int
+	// lsPool recycles []locState merge buffers (length nLocals) whose lifetime is a
+	// control frame's: convergeEdgeTo grabs one, opEnd returns both of a frame's on
+	// pop. Frames are LIFO, so the live-buffer count is bounded by nesting depth
+	// rather than total frame count — collapsing what was one heap slice per frame.
+	lsPool [][]locState
+
+	// sc holds per-function scratch whose backing is reused across the module:
+	// retSites, brFoldSites and trapSites live there so each function rewinds their
+	// lengths (sc.reset) rather than reallocating. See scratch.
+	sc *scratch
+
+	// endsPool recycles frame end-patch []int buffers (frameAddEnd/freeEndsBuf),
+	// bounded by nesting depth like lsPool.
+	endsPool [][]int
 
 	// Loop bounds-check hoisting (WAGO_LOOP_PRECHECK, boundshoist.go). elideBases
 	// holds the loop-invariant address-source locals whose inline bounds check is
@@ -289,11 +301,6 @@ type fn struct {
 	// live. Computed once per module in compileFunc.
 	syncHostCalls bool
 
-	// trapSites[code] lists the branch sites (Jcc/Jmp rel32 placeholders) that
-	// target this function's shared trap stub for `code`; emitTrapStubs emits the
-	// stubs after the epilogue and patches them. See trapIf.
-	trapSites map[uint32][]int
-
 	// stats collects per-function codegen counters (docs/no-ir-plan.md P1). nil
 	// unless the caller requested collection, in which case every counter method
 	// is a no-op — the hot compile path is unaffected. See stats.go.
@@ -301,14 +308,36 @@ type fn struct {
 
 	// Reused compile-time scratch for short-lived stack/type/register/label lists.
 	// These slices must not be stored in ctrlFrame or other persistent metadata.
-	tmpRoots  []*elem
-	tmpTypes  []machineType
-	tmpTypes2 []machineType
-	tmpRegs   []Reg
-	tmpSlots  []int
-	tmpMoves  []regMove
-	tmpLabels []uint32
+	tmpRoots    []*elem
+	tmpTypes    []machineType
+	tmpTypes2   []machineType
+	tmpRegs     []Reg
+	tmpSlots    []int
+	tmpMoves    []regMove
+	tmpLabels   []uint32
+	tmpDeferred []deferredArg
+	tmpBelow    []*elem  // flushBelow scratch (distinct from tmpRoots, which is live as call argRoots)
+	tmpGpCand   []gpCand // assignPinnedLocals GP pin-candidate scratch
 }
+
+// gpCand is a hot int local or global competing for a GP pin register, ranked by
+// loop-weighted access score. See assignPinnedLocals.
+type gpCand struct {
+	global bool
+	idx    int
+	score  int64
+}
+
+// deferredArg is a call argument (const/slot/localRef) staged into its target
+// register after the parallel register-move resolves. See emitRegisterCallVia.
+type deferredArg struct {
+	target Reg
+	root   *elem
+}
+
+// alignPad is a shared zero source for inter-function 16-byte alignment padding,
+// appended via alignPad[:pad] to avoid allocating a temporary per function.
+var alignPad [16]byte
 
 func align16(n int) int { return (n + 15) &^ 15 }
 
@@ -338,6 +367,16 @@ func asmCapForBody(bodyLen int) int {
 type scratch struct {
 	stack *stack     // the valent-block operand stack
 	asm   *amd64.Asm // the x86-64 encoder byte buffer
+
+	// Per-function jump-site accumulators. Held here (not on fn) so their backing
+	// arrays are retained and reused across every function in the module instead of
+	// being reallocated per function; reset() only rewinds their lengths. trapSites
+	// is indexed by trap code (a small dense enum), replacing a per-function map.
+	retSites     []int
+	brFoldSites  []int
+	trapSites    [trapStackFence + 1][]int
+	ctrl         []ctrlFrame // control-frame stack backing; reused across functions
+	pinnedLocals []int       // pinned-local index backing; reused across functions
 }
 
 func newScratch() *scratch {
@@ -347,6 +386,12 @@ func newScratch() *scratch {
 func (sc *scratch) reset() {
 	sc.stack.reset()
 	sc.asm.B = sc.asm.B[:0]
+	sc.retSites = sc.retSites[:0]
+	sc.brFoldSites = sc.brFoldSites[:0]
+	sc.ctrl = sc.ctrl[:0]
+	for i := range sc.trapSites {
+		sc.trapSites[i] = sc.trapSites[i][:0]
+	}
 }
 
 // Frameless layout (WARP-style, RSP-relative). RBP is NOT a frame pointer — it is
@@ -534,9 +579,18 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	// Compile is sequential, so sharing one scratch is safe.
 	// Auto-inlining (WAGO_INLINE): the straight-line leaf callees to splice at their
 	// call sites, keyed by global func index. nil when inlining is disabled.
-	inlineTargets := buildInlineTargets(m)
+	inlineTargets := buildInlineTargets(m, allHints)
 	sc := newScratch()
-	var code []byte
+	// Pre-size the module code buffer to roughly the final machine-code size
+	// (lowering emits ~4-5 native bytes per wasm body byte, matching asmCapForBody).
+	// Without this the buffer grows geometrically, and each reallocation copies the
+	// whole accumulated code — on a 16 MB module that churns hundreds of MB of
+	// garbage. Under-estimating only costs a tail append; it is never incorrect.
+	totalBody := 0
+	for i := range m.Code {
+		totalBody += len(m.Code[i].BodyBytes)
+	}
+	code := make([]byte, 0, totalBody*5+n*16+64)
 	for i := range m.Code {
 		hints := allHints[i]
 		var st *CodegenStats
@@ -548,9 +602,9 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		if err != nil {
 			return nil, fmt.Errorf("amd64: function %d: %w", i, err)
 		}
-		// 16-byte align each function.
+		// 16-byte align each function (append zeros without a temp allocation).
 		if pad := (16 - len(code)%16) % 16; pad != 0 {
-			code = append(code, make([]byte, pad)...)
+			code = append(code, alignPad[:pad]...)
 		}
 		entry[i] = len(code)
 		internalEntry[i] = len(code) + internalOff
@@ -878,7 +932,9 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts, int
 
 	sc.reset()
 	sc.asm.Grow(asmCapForBody(len(c.BodyBytes)))
-	f := &fn{a: sc.asm, s: sc.stack, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stats: stats}
+	f := &fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stats: stats}
+	// Retain the (possibly grown) control-frame backing for the next function.
+	defer func() { sc.ctrl = f.ctrl }()
 	f.syncHostCalls = syncHostCalls || moduleUsesSyncHostCalls(m, importBindings)
 	if !guardMode && len(m.Memories) > 0 {
 		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module
@@ -1073,11 +1129,14 @@ func (f *fn) finalizeStats(codeLen int) {
 // return/br-to-function site to the (current) epilogue position.
 func (f *fn) runBody(c *wasm.Func) error {
 	resultTypes := typesOfVals(f.ft.Results)
-	f.ctrl = []ctrlFrame{{kind: cfFunc, resultN: len(resultTypes), branchN: len(resultTypes), resultTypes: resultTypes}}
+	// Seed the control-frame stack from scratch's retained backing so its
+	// (large-struct) array is reused across functions rather than regrown to peak
+	// nesting depth for every one; sc.ctrl is written back below to keep the cap.
+	f.ctrl = append(f.sc.ctrl[:0], ctrlFrame{kind: cfFunc, resultN: len(resultTypes), branchN: len(resultTypes), resultTypes: resultTypes})
 	if err := f.body(c.BodyBytes); err != nil {
 		return err
 	}
-	for _, s := range f.retSites {
+	for _, s := range f.sc.retSites {
 		f.a.PatchRel32(s, f.a.Len())
 	}
 	return nil
@@ -1163,12 +1222,7 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 	// mutable int accessed inside a loop (score >= one loop level): WARP pins only int
 	// globals as values, and the loop gate ensures the per-iteration memory traffic it
 	// removes outweighs the one-time prologue load + epilogue write-back.
-	type gpCand struct {
-		global bool
-		idx    int
-		score  int64
-	}
-	var gp []gpCand
+	gp := f.tmpGpCand[:0]
 	for i := 0; i < f.nLocals; i++ {
 		if f.localType[i] == mtI32 || f.localType[i] == mtI64 {
 			gp = append(gp, gpCand{idx: i, score: scores[i]})
@@ -1192,14 +1246,21 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 		}
 		gp = append(gp, gpCand{global: true, idx: g, score: globalScores[g]})
 	}
-	sort.SliceStable(gp, func(a, b int) bool {
-		if gp[a].score != gp[b].score {
-			return gp[a].score > gp[b].score
+	f.tmpGpCand = gp
+	slices.SortStableFunc(gp, func(a, b gpCand) int {
+		if a.score != b.score {
+			if a.score > b.score { // descending score
+				return -1
+			}
+			return 1
 		}
-		if gp[a].global != gp[b].global {
-			return !gp[a].global // tie: prefer a local (value) over a global (pointer)
+		if a.global != b.global {
+			if a.global {
+				return 1 // tie: prefer a local (value) over a global (pointer)
+			}
+			return -1
 		}
-		return gp[a].idx < gp[b].idx
+		return a.idx - b.idx
 	})
 	for k, c := range gp {
 		if k >= len(gpPool) {
@@ -1251,6 +1312,17 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 		f.fpinnedLocalMask = f.fpinnedLocalMask.add(pinnedFLocalRegs[k])
 		f.stats.addPinnedLocal()
 	}
+	// Record the pinned-local index list so the per-edge/per-call state loops
+	// iterate only pinned locals rather than scanning every local (the pin set is
+	// fixed for the rest of the function). Backed by scratch so it is not
+	// reallocated per function.
+	f.pinnedLocals = f.sc.pinnedLocals[:0]
+	for x := range f.locals {
+		if f.locals[x].reg != regNone {
+			f.pinnedLocals = append(f.pinnedLocals, x)
+		}
+	}
+	f.sc.pinnedLocals = f.pinnedLocals
 }
 
 // derivePinnedGlobals loads each pinned global's cell pointer into its dedicated

--- a/src/core/compiler/backend/railshot/amd64/control.go
+++ b/src/core/compiler/backend/railshot/amd64/control.go
@@ -369,9 +369,9 @@ func (f *fn) branchJump(fr *ctrlFrame) {
 				f.a.Load64(RAX, RSP, f.spillOff(0))
 			}
 		}
-		f.retSites = append(f.retSites, f.a.JmpPlaceholder())
+		f.sc.retSites = append(f.sc.retSites, f.a.JmpPlaceholder())
 	default:
-		fr.ends = append(fr.ends, f.a.JmpPlaceholder())
+		f.frameAddEnd(fr, f.a.JmpPlaceholder())
 		fr.endReachable = true
 	}
 }
@@ -532,7 +532,7 @@ func (f *fn) opElse() error {
 		} else {
 			f.flush()
 		}
-		fr.ends = append(fr.ends, f.a.JmpPlaceholder())
+		f.frameAddEnd(fr, f.a.JmpPlaceholder())
 		fr.endReachable = true
 	}
 	f.a.PatchRel32(fr.elseSite, f.a.Len())
@@ -633,6 +633,11 @@ func (f *fn) opEnd() error {
 			f.setDepthTypes(f.frameDepthTypes(fr.baseTypes, fr.resultTypes))
 		}
 	}
+	// The frame is popped and its buffers are dead — recycle them for the next
+	// frame pushed at this or a shallower depth.
+	f.freeLocStateBuf(fr.branchState)
+	f.freeLocStateBuf(fr.entryState)
+	f.freeEndsBuf(fr.ends)
 	return nil
 }
 
@@ -863,7 +868,7 @@ func (f *fn) opReturn() error {
 	}
 	if f.singleRegResult {
 		f.placeSingleResult() // result straight to RAX/XMM0; epilogue does not reload
-		f.retSites = append(f.retSites, f.a.JmpPlaceholder())
+		f.sc.retSites = append(f.sc.retSites, f.a.JmpPlaceholder())
 		f.unreachable = true
 		return nil
 	}
@@ -871,7 +876,7 @@ func (f *fn) opReturn() error {
 	a, d := fr.resultN, f.depth()
 	f.flush()
 	f.moveBranchValues(fr, d, a)
-	f.retSites = append(f.retSites, f.a.JmpPlaceholder())
+	f.sc.retSites = append(f.sc.retSites, f.a.JmpPlaceholder())
 	f.unreachable = true
 	return nil
 }

--- a/src/core/compiler/backend/railshot/amd64/ct_bench_test.go
+++ b/src/core/compiler/backend/railshot/amd64/ct_bench_test.go
@@ -1,0 +1,138 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/frontend"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// Compile-throughput corpus benchmarks over real-world modules. Run:
+//
+//	go test ./src/core/compiler/backend/railshot/amd64 -run x -bench 'CTFull' -benchmem
+//	go test ./src/core/compiler/backend/railshot/amd64 -run x -bench 'CTFull/esbuild' -benchmem \
+//	    -cpuprofile cpu.out -memprofile mem.out -benchtime 3x
+//
+// Stages are measured separately so pprof attributes cost to decode / validate /
+// codegen. "Full" is the end-to-end pipeline a caller actually pays for.
+
+func ctCorpusDir() string {
+	// package dir is src/core/compiler/backend/railshot/amd64 → 6 up to repo root.
+	return filepath.Join("..", "..", "..", "..", "..", "..", "bench", "corpus")
+}
+
+// ctModules lists representative corpus files spanning sizes/shapes.
+var ctModules = []string{
+	"ruby.wasm",       // 16MB, huge C module
+	"esbuild.wasm",    // 11MB Go module
+	"sqlite3.wasm",    // 900K C
+	"regexmatch.wasm", // 1.1M
+	"markdown.wasm",   // 320K
+	"lua.wasm",        // 270K
+	"wasm3.wasm",      // 184K
+	"bignum.wasm",     // 110K
+	"blake3sum.wasm",  // 57K SIMD
+	"json-as-simd.wasm",
+}
+
+func ctRead(tb testing.TB, name string) []byte {
+	tb.Helper()
+	data, err := os.ReadFile(filepath.Join(ctCorpusDir(), name))
+	if err != nil {
+		tb.Skipf("corpus %s not present: %v", name, err)
+	}
+	return data
+}
+
+var ctSink any
+
+func BenchmarkCTDecode(b *testing.B) {
+	for _, name := range ctModules {
+		data := ctRead(b, name)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(data)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				m, err := wasm.DecodeModule(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+				ctSink = m
+			}
+		})
+	}
+}
+
+func BenchmarkCTValidate(b *testing.B) {
+	for _, name := range ctModules {
+		data := ctRead(b, name)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(data)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				m, err := wasm.DecodeModule(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := wasm.ValidateModule(m); err != nil {
+					b.Fatal(err)
+				}
+				ctSink = m
+			}
+		})
+	}
+}
+
+func BenchmarkCTCodegen(b *testing.B) {
+	for _, name := range ctModules {
+		data := ctRead(b, name)
+		m, err := frontend.DecodeValidate(data)
+		if err != nil {
+			b.Skipf("%s: %v", name, err)
+		}
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(data)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cm, err := CompileModule(m)
+				if err != nil {
+					b.Fatal(err)
+				}
+				ctSink = cm
+			}
+		})
+	}
+}
+
+func BenchmarkCTFull(b *testing.B) {
+	for _, name := range ctModules {
+		data := ctRead(b, name)
+		if _, err := frontend.DecodeValidate(data); err != nil {
+			b.Logf("skip %s: %v", name, err)
+			continue
+		}
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(data)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				m, err := frontend.DecodeValidate(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+				cm, err := CompileModule(m)
+				if err != nil {
+					b.Fatal(err)
+				}
+				ctSink = cm
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/amd64/fuse.go
+++ b/src/core/compiler/backend/railshot/amd64/fuse.go
@@ -28,10 +28,11 @@ func (f *fn) flushBelow(node *elem) int {
 	f.invalidateGlobalsCache() // a following call would clobber the cached cell-ptr register
 	f.invalidateBoundsCert()   // bounds facts are valid only within a straight-line region
 	base := baseOfValentBlock(node)
-	var below []*elem
+	below := f.tmpBelow[:0]
 	for cur := base.prev; cur != f.s.head; cur = baseOfValentBlock(cur).prev {
 		below = append(below, cur)
 	}
+	f.tmpBelow = below
 	for i, j := 0, len(below)-1; i < j; i, j = i+1, j-1 {
 		below[i], below[j] = below[j], below[i]
 	}

--- a/src/core/compiler/backend/railshot/amd64/hints.go
+++ b/src/core/compiler/backend/railshot/amd64/hints.go
@@ -34,6 +34,14 @@ type funcHints struct {
 	usesBulkMem   bool // memory.copy/fill (rep movs/stos clobber RDI/RSI/RCX)
 	mutatesTable  bool // table.set/init/copy/grow/fill; excludes immutable local-table call_indirect specialization
 
+	// Inline-candidacy signals, gathered in the same pre-scan so buildInlineTargets
+	// needs no second body walk. hasControlFlow matches scanInlineFactsBytes's set
+	// exactly (unreachable/block/loop/if/else/br*/return, NOT try_table); hasLoop is
+	// the loop subset. calleeCount>0/hasControlCall from inlineOK both reduce to
+	// hasCall (an inline candidate is leaf), so no separate call-kind split is kept.
+	hasLoop        bool
+	hasControlFlow bool
+
 	// immutableLocalTable is derived after the one-pass per-function scans have
 	// been aggregated (computeModuleHints). The table must also be private (an
 	// exported table can be mutated by another importing instance). Every non-null
@@ -150,6 +158,15 @@ func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 		sub := false
 		for i := range instrs {
 			in := &instrs[i]
+			// Inline-candidacy control-flow signals (matches scanInlineFactsAST).
+			switch in.Kind {
+			case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf,
+				wasm.InstrBr, wasm.InstrBrIf, wasm.InstrBrTable, wasm.InstrReturn:
+				h.hasControlFlow = true
+				if in.Kind == wasm.InstrLoop {
+					h.hasLoop = true
+				}
+			}
 			switch in.Kind {
 			case wasm.InstrCall, wasm.InstrReturnCall, wasm.InstrCallRef, wasm.InstrReturnCallRef:
 				sub, h.hasCall = true, true
@@ -393,6 +410,16 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 		op, err := s.r.byte()
 		if err != nil {
 			return true, 0, err
+		}
+		// Inline-candidacy signals (folded in so buildInlineTargets needs no second
+		// walk). Exactly scanInlineFactsBytes's control-flow set — try_table (0x1f)
+		// is deliberately excluded to match it.
+		switch op {
+		case 0x00, 0x02, 0x03, 0x04, 0x05, 0x0c, 0x0d, 0x0e, 0x0f:
+			s.h.hasControlFlow = true
+			if op == 0x03 {
+				s.h.hasLoop = true
+			}
 		}
 		switch op {
 		case 0x0b: // end

--- a/src/core/compiler/backend/railshot/amd64/inline.go
+++ b/src/core/compiler/backend/railshot/amd64/inline.go
@@ -147,6 +147,27 @@ func AnalyzeInlineCandidates(m *wasm.Module) (*InlineReport, error) {
 // (independent of how often it is called) and returns the verdict plus a one-line
 // reason. This is what the Phase-2 transform keys off: a call to a class member
 // can be spliced wherever it appears.
+// inlineOK is the boolean verdict of inlineClass without building a reason
+// string. The compile hot path (buildInlineTargets) runs this for every function
+// and discards the reason, so it must not allocate; inlineClass adds the reason
+// only for the opt-in stats report.
+func inlineOK(f inlineFacts) bool {
+	switch {
+	case f.hasControlCall:
+		return false
+	case f.calleeCount > 0:
+		return false
+	case !f.regABIIntOnly:
+		return false
+	case f.hasLoop && !inlineLoopCallees:
+		return false
+	case f.bodyBytes > inlineMaxBytes:
+		return false
+	default:
+		return true
+	}
+}
+
 func inlineClass(f inlineFacts) (bool, string) {
 	switch {
 	case f.hasControlCall:
@@ -390,7 +411,11 @@ type inlineTarget struct {
 // GLOBAL function index, or nil when inlining is disabled. Candidacy here is a
 // property of the callee alone (the call-site count only mattered for the report),
 // so a call to one of these can be spliced wherever it appears.
-func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
+// buildInlineTargets derives the splice set from the per-function hints already
+// gathered by computeModuleHints — no second body walk. inlineFacts is
+// reconstructed from the hints (any call ⇒ not a leaf ⇒ ineligible, so hasCall
+// stands in for both calleeCount>0 and hasControlCall), plus the signature.
+func buildInlineTargets(m *wasm.Module, allHints []funcHints) map[int]*inlineTarget {
 	if !inlineEnabled {
 		return nil
 	}
@@ -401,9 +426,22 @@ func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
 		if len(body) == 0 {
 			continue // AST-only bodies are not spliced (the byte body drives the splice)
 		}
-		facts, err := scanInlineFacts(m, m.Code[i], i, importedFuncs)
-		if err != nil {
+		ft, ok := m.LocalFuncType(i)
+		if !ok || ft == nil {
 			continue
+		}
+		h := allHints[i]
+		facts := inlineFacts{
+			bodyBytes:      len(body),
+			hasLoop:        h.hasLoop,
+			hasControlFlow: h.hasControlFlow,
+			touchesMem:     h.touchesMemory || h.usesBulkMem,
+			params:         len(ft.Params),
+			results:        len(ft.Results),
+			regABIIntOnly:  sigFitsRegABI(ft) && sigIsIntOnly(ft),
+		}
+		if h.hasCall {
+			facts.calleeCount = 1 // any call disqualifies: an inline candidate is a leaf
 		}
 		// The transform class: a leaf (no calls, so non-recursive/acyclic) with an
 		// int-only reg-ABI signature and a small body. Memory/global ops and
@@ -412,21 +450,18 @@ func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
 		// stands in for its function boundary (its `return`/`end` merge there), so
 		// the existing block/br/convergence machinery lowers it. A straight-line
 		// callee skips the frame entirely (the cheaper fast path).
-		if ok, _ := inlineClass(facts); !ok {
+		if !inlineOK(facts) {
 			continue
 		}
 		lt := calleeLocalTypes(m, i)
 		if lt == nil {
 			continue
 		}
-		ft, _ := m.LocalFuncType(i)
 		var rt []machineType
 		res0 := mtNone
-		if ft != nil {
-			rt = typesOfVals(ft.Results)
-			if len(rt) > 0 {
-				res0 = rt[0]
-			}
+		rt = typesOfVals(ft.Results)
+		if len(rt) > 0 {
+			res0 = rt[0]
 		}
 		if targets == nil {
 			targets = map[int]*inlineTarget{}

--- a/src/core/compiler/backend/railshot/amd64/localstate.go
+++ b/src/core/compiler/backend/railshot/amd64/localstate.go
@@ -139,11 +139,8 @@ func (f *fn) markLocalDirty(x int) {
 // pinned locals clobbered (lsMem) — the WARP save-before-call step. No reload
 // follows; the next read recovers lazily. Callers must emit this before a call.
 func (f *fn) spillLocalsForCall() {
-	for x := 0; x < f.nLocals; x++ {
-		reg, isFloat, ok := f.pinReg(x)
-		if !ok {
-			continue
-		}
+	for _, x := range f.pinnedLocals {
+		reg, isFloat := f.locals[x].reg, f.locals[x].isFloat
 		if !f.usesCalls {
 			f.storeLocalReg(x, reg, isFloat) // old model: store all; reloaded after the call
 			continue
@@ -164,10 +161,8 @@ func (f *fn) reloadLocalsForCall() {
 	if f.usesCalls {
 		return
 	}
-	for x := 0; x < f.nLocals; x++ {
-		if reg, isFloat, ok := f.pinReg(x); ok {
-			f.loadLocalReg(x, reg, isFloat)
-		}
+	for _, x := range f.pinnedLocals {
+		f.loadLocalReg(x, f.locals[x].reg, f.locals[x].isFloat)
 	}
 }
 
@@ -181,21 +176,18 @@ func (f *fn) reloadLocalsForCall() {
 func (f *fn) reconcileLocals() {
 	for x := 0; x < f.nLocals; x++ {
 		if f.locals[x].state == lsConstZero {
-			f.materializeZeroLocal(x, true)
-			continue
+			f.materializeZeroLocal(x, true) // leaves pinned locals in lsStackReg
 		}
-		if !f.usesCalls {
-			continue
-		}
-		reg, isFloat, ok := f.pinReg(x)
-		if !ok {
-			continue
-		}
+	}
+	if !f.usesCalls {
+		return
+	}
+	for _, x := range f.pinnedLocals {
 		switch f.locals[x].state {
 		case lsMem:
-			f.loadLocalReg(x, reg, isFloat)
+			f.loadLocalReg(x, f.locals[x].reg, f.locals[x].isFloat)
 		case lsReg:
-			f.storeLocalReg(x, reg, isFloat)
+			f.storeLocalReg(x, f.locals[x].reg, f.locals[x].isFloat)
 		}
 		f.locals[x].state = lsStackReg
 	}
@@ -214,31 +206,69 @@ func (f *fn) reconcileLocals() {
 // recorded) — always safe: the merge assumes only the target. The merge point
 // itself must then install the recorded target as the tracked state
 // (setLocalsState).
+// newLocStateBuf returns a length-nLocals []locState for a frame merge target,
+// recycled from lsPool when available. Callers overwrite every element (both
+// convergeEdgeTo callers do), so the buffer is not zeroed. freeLocStateBuf
+// returns one to the pool when its owning frame is popped.
+func (f *fn) newLocStateBuf() []locState {
+	if n := len(f.lsPool); n > 0 {
+		b := f.lsPool[n-1]
+		f.lsPool[n-1] = nil
+		f.lsPool = f.lsPool[:n-1]
+		return b[:f.nLocals]
+	}
+	return make([]locState, f.nLocals)
+}
+
+func (f *fn) freeLocStateBuf(b []locState) {
+	if cap(b) >= f.nLocals && f.nLocals > 0 {
+		f.lsPool = append(f.lsPool, b[:cap(b)])
+	}
+}
+
+// frameAddEnd appends a forward-jump site to a frame's end-patch list, drawing
+// the backing slice from endsPool on first use. Frames are LIFO, so returning the
+// slice on pop (freeEndsBuf) bounds live buffers by nesting depth rather than
+// total frame count.
+func (f *fn) frameAddEnd(fr *ctrlFrame, site int) {
+	if fr.ends == nil {
+		if n := len(f.endsPool); n > 0 {
+			fr.ends = f.endsPool[n-1][:0]
+			f.endsPool[n-1] = nil
+			f.endsPool = f.endsPool[:n-1]
+		}
+	}
+	fr.ends = append(fr.ends, site)
+}
+
+func (f *fn) freeEndsBuf(b []int) {
+	if cap(b) > 0 {
+		f.endsPool = append(f.endsPool, b[:0])
+	}
+}
+
 func (f *fn) convergeEdgeTo(target *[]locState) {
-	// Dirty registers and lazy zeros always materialize to the slot: every
-	// target guarantees at least "slot is current".
+	// Lazy zeros always materialize to the slot so unpinned declared-zero locals
+	// have a real slot value on every edge (all locals — const-zero ones may be
+	// unpinned). materializeZeroLocal leaves a pinned local in lsStackReg, so the
+	// pinned-spill pass below correctly skips it.
 	for x := 0; x < f.nLocals; x++ {
 		if f.locals[x].state == lsConstZero {
 			f.materializeZeroLocal(x, true)
-			continue
-		}
-		if !f.usesCalls {
-			continue
-		}
-		reg, isFloat, ok := f.pinReg(x)
-		if !ok {
-			continue
-		}
-		if f.locals[x].state == lsReg {
-			f.storeLocalReg(x, reg, isFloat)
-			f.locals[x].state = lsStackReg
 		}
 	}
 	if !f.usesCalls {
 		return
 	}
+	// Dirty pinned registers materialize to the slot too.
+	for _, x := range f.pinnedLocals {
+		if f.locals[x].state == lsReg {
+			f.storeLocalReg(x, f.locals[x].reg, f.locals[x].isFloat)
+			f.locals[x].state = lsStackReg
+		}
+	}
 	if *target == nil { // first edge fixes the frame's merge state
-		t := make([]locState, f.nLocals)
+		t := f.newLocStateBuf()
 		for x := range t {
 			t[x] = f.locals[x].state
 		}
@@ -246,13 +276,9 @@ func (f *fn) convergeEdgeTo(target *[]locState) {
 		return
 	}
 	t := *target
-	for x := 0; x < f.nLocals; x++ {
-		reg, isFloat, ok := f.pinReg(x)
-		if !ok {
-			continue
-		}
+	for _, x := range f.pinnedLocals {
 		if t[x] == lsStackReg && f.locals[x].state == lsMem {
-			f.loadLocalReg(x, reg, isFloat)
+			f.loadLocalReg(x, f.locals[x].reg, f.locals[x].isFloat)
 			f.locals[x].state = lsStackReg
 		}
 	}
@@ -264,9 +290,7 @@ func (f *fn) setLocalsState(t []locState) {
 	if !f.usesCalls || t == nil {
 		return
 	}
-	for x := 0; x < f.nLocals; x++ {
-		if _, _, ok := f.pinReg(x); ok {
-			f.locals[x].state = t[x]
-		}
+	for _, x := range f.pinnedLocals {
+		f.locals[x].state = t[x]
 	}
 }

--- a/src/core/compiler/backend/railshot/amd64/memory.go
+++ b/src/core/compiler/backend/railshot/amd64/memory.go
@@ -98,26 +98,20 @@ func (f *fn) trapIf(cc Cond, code uint32) {
 	if code == trapMemOOB {
 		f.stats.addBoundsCheck() // inline linear-memory OOB check (P6 elides these)
 	}
-	if f.trapSites == nil {
-		f.trapSites = map[uint32][]int{}
-	}
-	f.trapSites[code] = append(f.trapSites[code], f.a.JccPlaceholder(cc))
+	f.sc.trapSites[code] = append(f.sc.trapSites[code], f.a.JccPlaceholder(cc))
 }
 
 // trapAlways is trapIf's unconditional form (`unreachable`): a 5-byte jmp to the
 // shared stub instead of the inline 20-byte trap block.
 func (f *fn) trapAlways(code uint32) {
-	if f.trapSites == nil {
-		f.trapSites = map[uint32][]int{}
-	}
-	f.trapSites[code] = append(f.trapSites[code], f.a.JmpPlaceholder())
+	f.sc.trapSites[code] = append(f.sc.trapSites[code], f.a.JmpPlaceholder())
 }
 
 // emitTrapStubs emits one trap stub per trap code used by this function and
 // patches every recorded site to it. Called once, after the epilogue.
 func (f *fn) emitTrapStubs() {
 	for code := uint32(1); code <= trapStackFence; code++ { // deterministic order
-		sites := f.trapSites[code]
+		sites := f.sc.trapSites[code]
 		if len(sites) == 0 {
 			continue
 		}

--- a/src/core/compiler/backend/railshot/amd64/peephole.go
+++ b/src/core/compiler/backend/railshot/amd64/peephole.go
@@ -24,7 +24,7 @@ func (f *fn) recordBrFold(over int) {
 		return
 	}
 	if b := f.a.B; over+4 < len(b) && b[over+4] == 0xE9 {
-		f.brFoldSites = append(f.brFoldSites, over)
+		f.sc.brFoldSites = append(f.sc.brFoldSites, over)
 	}
 }
 
@@ -43,7 +43,7 @@ func (f *fn) finalizeBranchFolds() {
 		return
 	}
 	b := f.a.B
-	for _, over := range f.brFoldSites {
+	for _, over := range f.sc.brFoldSites {
 		// Idiom: 0F 8x <rel32=5> | E9 <rel32> | over:
 		//   Jcc opcode at over-2..over-1, rel32 at over..over+3 (ends at over+4);
 		//   JMP opcode at over+4, rel32 at over+5..over+8 (ends/over: at over+9).

--- a/src/core/compiler/backend/railshot/amd64/regcopy.go
+++ b/src/core/compiler/backend/railshot/amd64/regcopy.go
@@ -2,6 +2,8 @@
 
 package amd64
 
+import "math/bits"
+
 // Parallel register-move resolution (WARP's RegisterCopyResolver): placing N
 // values, each already live in some register, into their target registers is a
 // *parallel* move — a target may still hold a value another move needs — and the
@@ -15,27 +17,35 @@ type regMove struct{ dst, src Reg }
 // resolveRegMoves emits the moves in a safe order via emitMove (dst = src) and
 // emitSwap (exchange). The move set must be a function from dst to src (each
 // register written at most once), which holds for ABI argument placement.
+//
+// The pending graph is held as a fixed src[dst] array plus a `pending` bitmask
+// of live destinations (every dst is a GP register < 64), so resolution allocates
+// nothing — this runs on every register-ABI call.
 func resolveRegMoves(moves []regMove, emitMove func(dst, src Reg), emitSwap func(a, b Reg)) {
-	pending := make(map[Reg]Reg, len(moves))
+	var src [64]Reg
+	var pending regMask
 	for _, m := range moves {
 		if m.dst != m.src {
-			pending[m.dst] = m.src
+			src[m.dst] = m.src
+			pending = pending.add(m.dst)
 		}
 	}
+	// isSource reports whether r is still needed as some pending move's source.
 	isSource := func(r Reg) bool {
-		for _, s := range pending {
-			if s == r {
+		for d := uint64(pending); d != 0; d &= d - 1 {
+			if src[bits.TrailingZeros64(d)] == r {
 				return true
 			}
 		}
 		return false
 	}
-	for len(pending) > 0 {
+	for pending != 0 {
 		moved := false
-		for dst, src := range pending {
+		for d := uint64(pending); d != 0; d &= d - 1 {
+			dst := Reg(bits.TrailingZeros64(d))
 			if !isSource(dst) {
-				emitMove(dst, src)
-				delete(pending, dst)
+				emitMove(dst, src[dst])
+				pending = pending.remove(dst)
 				moved = true
 				break
 			}
@@ -44,19 +54,18 @@ func resolveRegMoves(moves []regMove, emitMove func(dst, src Reg), emitSwap func
 			continue
 		}
 		// Residual graph is pure cycles; break one with a swap.
-		var dst, src Reg
-		for d, s := range pending {
-			dst, src = d, s
-			break
-		}
-		emitSwap(dst, src)
-		delete(pending, dst)
-		for d, s := range pending {
-			if s == dst {
-				if d == src {
-					delete(pending, d)
+		dst := Reg(bits.TrailingZeros64(uint64(pending)))
+		s := src[dst]
+		emitSwap(dst, s)
+		pending = pending.remove(dst)
+		// Any move still sourcing from dst now reads the swapped-in value s.
+		for d := uint64(pending); d != 0; d &= d - 1 {
+			dd := Reg(bits.TrailingZeros64(d))
+			if src[dd] == dst {
+				if dd == s {
+					pending = pending.remove(dd)
 				} else {
-					pending[d] = src
+					src[dd] = s
 				}
 			}
 		}

--- a/src/core/compiler/backend/railshot/amd64/stack.go
+++ b/src/core/compiler/backend/railshot/amd64/stack.go
@@ -167,17 +167,25 @@ const maxDeferDepth = 6
 // isDeferred reports whether e is an un-emitted operation.
 func (e *elem) isDeferred() bool { return e.kind == ekDeferred }
 
-// stack is the operand stack: a sentinel-terminated doubly-linked list with a
-// bump arena of elems (never freed mid-function; that matches single-pass usage
-// and keeps *elem pointers stable).
+// stack is the operand stack: a sentinel-terminated doubly-linked list backed by
+// a chunked bump arena of elems. Each chunk is a fixed-capacity []elem that is
+// never reallocated once created, so every *elem handed out stays valid for the
+// life of the function even as the arena grows without bound. Chunks grow
+// geometrically (256, 512, … capped) so a huge function costs O(log n) chunk
+// allocations instead of one heap object per node; reset() reuses every chunk
+// across the module compile, so after the largest function is seen the arena
+// allocates nothing further. Nodes are never freed mid-function — that matches
+// single-pass usage.
 type stack struct {
-	arena []elem
-	head  *elem // sentinel (arena[0]); head.next is the bottom, back() is the top
+	chunks [][]elem // each chunk fixed-cap, never moved; chunks[cur] is being filled
+	cur    int      // index of the chunk alloc currently appends to
+	head   *elem    // sentinel (chunks[0][0]); head.next is the bottom, back() is the top
 }
 
 const (
-	defaultStackArenaCap = 256
-	minStackArenaCap     = 16
+	defaultStackArenaCap = 256  // first chunk capacity
+	minStackArenaCap     = 16   // floor for an explicitly-sized first chunk
+	maxStackChunkCap     = 8192 // ceiling on geometric chunk growth
 )
 
 func newStack() *stack { return newStackWithCap(defaultStackArenaCap) }
@@ -186,40 +194,37 @@ func newStackWithCap(capHint int) *stack {
 	if capHint < minStackArenaCap {
 		capHint = minStackArenaCap
 	}
-	if capHint > defaultStackArenaCap {
-		capHint = defaultStackArenaCap
-	}
-	s := &stack{arena: make([]elem, 0, capHint)}
-	s.arena = append(s.arena, elem{}) // sentinel
-	s.head = &s.arena[0]
-	s.head.prev, s.head.next = s.head, s.head
+	s := &stack{chunks: [][]elem{make([]elem, 0, capHint)}}
+	s.initSentinel()
 	return s
 }
 
-// reset rewinds the stack to empty for reuse by the next function in a module
-// compile, preserving the arena's backing capacity so the common case allocates
-// nothing per function. The prior function's nodes are dead by the time this is
-// called (its code is already emitted), so dropping them is safe; standalone
-// spill nodes are simply released to the GC. alloc rezeroes every reused arena
-// slot, so no stale fields survive.
-func (s *stack) reset() {
-	s.arena = s.arena[:0]
-	s.arena = append(s.arena, elem{}) // sentinel
-	s.head = &s.arena[0]
+// initSentinel rewinds to the first chunk and installs the sentinel node.
+func (s *stack) initSentinel() {
+	s.cur = 0
+	c := &s.chunks[0]
+	*c = append((*c)[:0], elem{}) // sentinel (cap already reserved, never reallocates)
+	s.head = &(*c)[0]
 	s.head.prev, s.head.next = s.head, s.head
 }
+
+// reset rewinds the stack to empty for reuse by the next function in a module
+// compile, retaining every chunk's backing array so the common case allocates
+// nothing per function. The prior function's nodes are dead by the time this is
+// called (its code is already emitted), so dropping them is safe; alloc rezeroes
+// every reused slot, so no stale fields survive.
+func (s *stack) reset() { s.initSentinel() }
 
 func stackArenaCapForBody(bodyLen, nLocals int) int {
 	return stackArenaCapForHints(bodyLen, nLocals, 0)
 }
 
 func stackArenaCapForHints(bodyLen, nLocals, nodeHint int) int {
-	// The arena is a per-function bump allocation for all stack nodes created while
-	// walking the bytecode. Historically the hint was one node per body byte; keep
-	// that as a ceiling, but let the pre-scan's opcode-based estimate avoid
-	// reserving nodes for long immediates (notably 16-byte SIMD constants). The
-	// stack still falls back to standalone heap nodes if the estimate is low, so
-	// pointer stability is preserved.
+	// Node-count estimate used to size the first chunk so a typical function fits
+	// without advancing chunks. Historically one node per body byte; the pre-scan's
+	// opcode-based estimate avoids reserving nodes for long immediates (notably
+	// 16-byte SIMD constants). The chunked arena grows past any underestimate while
+	// preserving pointer stability, so this is a hint, not a bound.
 	legacy := bodyLen + nLocals/4 + 1
 	if nodeHint <= 0 {
 		return legacy
@@ -234,16 +239,26 @@ func stackArenaCapForHints(bodyLen, nLocals, nodeHint int) int {
 	return precise
 }
 
-// alloc returns a fresh zeroed node from the arena.
+// alloc returns a fresh zeroed node from the arena. The returned pointer is
+// stable for the life of the function: chunks are never reallocated, and when the
+// current chunk is full alloc advances to (or grows) the next one rather than
+// growing the current backing array in place.
 func (s *stack) alloc() *elem {
-	// Growing the arena may move earlier elems, invalidating pointers — so we
-	// never let it reallocate: reserve generously and, if exceeded, spill to
-	// individually-heap-allocated nodes (still pointer-stable).
-	if len(s.arena) < cap(s.arena) {
-		s.arena = append(s.arena, elem{})
-		return &s.arena[len(s.arena)-1]
+	c := &s.chunks[s.cur]
+	if len(*c) == cap(*c) {
+		s.cur++
+		if s.cur == len(s.chunks) {
+			nextCap := cap(*c) * 2
+			if nextCap > maxStackChunkCap {
+				nextCap = maxStackChunkCap
+			}
+			s.chunks = append(s.chunks, make([]elem, 0, nextCap))
+		}
+		c = &s.chunks[s.cur]
+		*c = (*c)[:0] // reuse a retained chunk from a previous function
 	}
-	return &elem{}
+	*c = append(*c, elem{})
+	return &(*c)[len(*c)-1]
 }
 
 // push appends e as the new top of the stack and returns it.

--- a/src/core/compiler/backend/railshot/amd64/stack_test.go
+++ b/src/core/compiler/backend/railshot/amd64/stack_test.go
@@ -6,12 +6,12 @@ import "testing"
 
 func TestNewStackArenaDefaultCapacity(t *testing.T) {
 	s := newStack()
-	if cap(s.arena) != defaultStackArenaCap {
-		t.Fatalf("stack arena cap = %d, want %d", cap(s.arena), defaultStackArenaCap)
+	if cap(s.chunks[0]) != defaultStackArenaCap {
+		t.Fatalf("first chunk cap = %d, want %d", cap(s.chunks[0]), defaultStackArenaCap)
 	}
 }
 
-func TestNewStackWithCapClamps(t *testing.T) {
+func TestNewStackWithCapSizesFirstChunk(t *testing.T) {
 	for _, tc := range []struct {
 		hint int
 		want int
@@ -19,11 +19,11 @@ func TestNewStackWithCapClamps(t *testing.T) {
 		{0, minStackArenaCap},
 		{minStackArenaCap - 1, minStackArenaCap},
 		{minStackArenaCap + 7, minStackArenaCap + 7},
-		{defaultStackArenaCap + 1, defaultStackArenaCap},
+		{defaultStackArenaCap + 1, defaultStackArenaCap + 1}, // no upper clamp: chunked arena grows freely
 	} {
 		s := newStackWithCap(tc.hint)
-		if cap(s.arena) != tc.want {
-			t.Fatalf("newStackWithCap(%d) cap = %d, want %d", tc.hint, cap(s.arena), tc.want)
+		if cap(s.chunks[0]) != tc.want {
+			t.Fatalf("newStackWithCap(%d) first chunk cap = %d, want %d", tc.hint, cap(s.chunks[0]), tc.want)
 		}
 		if s.head == nil || s.head.next != s.head || s.head.prev != s.head {
 			t.Fatalf("newStackWithCap(%d) did not initialize sentinel links", tc.hint)
@@ -33,8 +33,8 @@ func TestNewStackWithCapClamps(t *testing.T) {
 
 func TestStackArenaCapForBodyTinyFunction(t *testing.T) {
 	s := newStackWithCap(stackArenaCapForBody(0, 0))
-	if cap(s.arena) != minStackArenaCap {
-		t.Fatalf("tiny stack arena cap = %d, want %d", cap(s.arena), minStackArenaCap)
+	if cap(s.chunks[0]) != minStackArenaCap {
+		t.Fatalf("tiny stack first chunk cap = %d, want %d", cap(s.chunks[0]), minStackArenaCap)
 	}
 }
 
@@ -43,15 +43,8 @@ func TestStackArenaCapForBodyMediumFunction(t *testing.T) {
 	const locals = 12
 	want := bodyLen + locals/4 + 1
 	s := newStackWithCap(stackArenaCapForBody(bodyLen, locals))
-	if cap(s.arena) != want {
-		t.Fatalf("medium stack arena cap = %d, want %d", cap(s.arena), want)
-	}
-}
-
-func TestStackArenaCapForBodyLargeFunctionClamp(t *testing.T) {
-	s := newStackWithCap(stackArenaCapForBody(1024, 128))
-	if cap(s.arena) != defaultStackArenaCap {
-		t.Fatalf("large stack arena cap = %d, want clamp %d", cap(s.arena), defaultStackArenaCap)
+	if cap(s.chunks[0]) != want {
+		t.Fatalf("medium stack first chunk cap = %d, want %d", cap(s.chunks[0]), want)
 	}
 }
 
@@ -66,21 +59,54 @@ func TestStackArenaCapForHintsIgnoresLongImmediates(t *testing.T) {
 	}
 }
 
-func TestStackArenaPointerStabilityAcrossArenaAndHeapFallback(t *testing.T) {
+func TestStackArenaPointerStabilityAcrossChunks(t *testing.T) {
 	s := newStackWithCap(minStackArenaCap)
 	first := s.pushValue(storage{kind: stConst, typ: mtI32, cval: 1})
 	var last *elem
-	for i := 2; i < minStackArenaCap; i++ { // fills the fixed arena after the sentinel.
+	// Push far past the first chunk so the arena advances through several
+	// geometrically-grown chunks. Every earlier *elem must stay valid.
+	const total = 4 * minStackArenaCap
+	for i := 2; i <= total; i++ {
 		last = s.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(i)})
 	}
-	// The next allocation exceeds the fixed arena capacity and falls back to a
-	// standalone heap node. Existing arena pointers must remain valid.
-	heap := s.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(minStackArenaCap)})
-	if first.st.cval != 1 || last.st.cval != minStackArenaCap-1 || heap.st.cval != minStackArenaCap {
-		t.Fatalf("stack values changed across heap fallback: %d %d %d", first.st.cval, last.st.cval, heap.st.cval)
+	if len(s.chunks) < 2 {
+		t.Fatalf("expected the arena to advance past the first chunk, got %d chunk(s)", len(s.chunks))
 	}
-	if s.head.next != first || last.next != heap || heap.next != s.head {
-		t.Fatal("stack links changed across heap fallback")
+	if first.st.cval != 1 || last.st.cval != total {
+		t.Fatalf("stack values changed across chunk growth: first=%d last=%d", first.st.cval, last.st.cval)
+	}
+	// Walk the whole physical list and confirm contiguous values 1..total.
+	want := int64(1)
+	for e := s.head.next; e != s.head; e = e.next {
+		if e.st.cval != want {
+			t.Fatalf("list value at position %d = %d, want %d", want, e.st.cval, want)
+		}
+		want++
+	}
+	if want != int64(total)+1 {
+		t.Fatalf("walked %d nodes, want %d", want-1, total)
+	}
+}
+
+func TestStackArenaReusesChunksAcrossReset(t *testing.T) {
+	s := newStackWithCap(minStackArenaCap)
+	for i := 0; i < 4*minStackArenaCap; i++ {
+		s.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(i)})
+	}
+	grown := len(s.chunks)
+	if grown < 2 {
+		t.Fatalf("expected chunk growth, got %d", grown)
+	}
+	s.reset()
+	// After reset the sentinel is back and every chunk is retained for reuse.
+	if s.cur != 0 || len(s.chunks[0]) != 1 || s.head.next != s.head {
+		t.Fatalf("reset did not rewind: cur=%d len0=%d", s.cur, len(s.chunks[0]))
+	}
+	for i := 0; i < 4*minStackArenaCap; i++ {
+		s.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(i)})
+	}
+	if len(s.chunks) != grown {
+		t.Fatalf("reuse allocated new chunks: %d, want %d retained", len(s.chunks), grown)
 	}
 }
 
@@ -137,6 +163,7 @@ func TestAssignPinnedLocalsUsesLocalDefs(t *testing.T) {
 	f := &fn{
 		nLocals:   3,
 		localType: []machineType{mtI32, mtF64, mtI32},
+		sc:        &scratch{},
 	}
 	f.assignPinnedLocals([]int64{1, 10, 5}, nil, nil, pinnedLocalRegs, baseFPPins, false)
 

--- a/src/core/compiler/wasm/types.go
+++ b/src/core/compiler/wasm/types.go
@@ -464,9 +464,12 @@ func (m *Module) ImportedMemCount() int    { return m.importCount(ExternMem) }
 func (m *Module) ImportedGlobalCount() int { return m.importCount(ExternGlobal) }
 func (m *Module) ImportedTagCount() int    { return m.importCount(ExternTag) }
 func (m *Module) importCount(k ExternKind) int {
+	// Index-based iteration: Import is a large struct (~208 bytes), and these
+	// counters are called frequently on the compile hot path, so ranging by value
+	// would copy every import per call (shows up as runtime.duffcopy).
 	n := 0
-	for _, im := range m.Imports {
-		if im.Type.Kind == k {
+	for i := range m.Imports {
+		if m.Imports[i].Type.Kind == k {
 			n++
 		}
 	}

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -258,9 +258,9 @@ func (v *moduleValidator) collectDeclaredFuncsInExpr(expr Expr) {
 		v.constFV = fv
 	}
 	fv.rd.reset(expr.BodyBytes)
+	var op directOp
 	for fv.rd.has() {
-		op, err := fv.decodeDirectOp(&fv.rd, false)
-		if err != nil {
+		if err := fv.decodeDirectOp(&fv.rd, false, &op); err != nil {
 			// The normal const-expression validation path reports malformed bytes;
 			// declaration collection must not change validation error ordering.
 			return
@@ -438,8 +438,8 @@ func (v *moduleValidator) validateMemType(mt MemType) error {
 }
 func (v *moduleValidator) funcType(idx uint32) (*CompType, bool) {
 	n := uint32(0)
-	for _, im := range v.m.Imports {
-		if im.Type.Kind == ExternFunc {
+	for i := range v.m.Imports {
+		if im := &v.m.Imports[i]; im.Type.Kind == ExternFunc {
 			if n == idx {
 				ft := v.funcTypeFromTypeIdx(im.Type.Type)
 				return ft, ft != nil
@@ -454,26 +454,30 @@ func (v *moduleValidator) funcType(idx uint32) (*CompType, bool) {
 	ft := v.funcTypeFromTypeIdx(v.m.FuncTypes[local])
 	return ft, ft != nil
 }
-func (v *moduleValidator) globalType(idx uint32) (GlobalType, bool) {
+
+// globalType returns a pointer to the resolved global's type. Returning a pointer
+// (into the module's stable Imports/Globals slices) rather than a value avoids a
+// per-access struct copy (runtime.duffcopy) on the validation hot path.
+func (v *moduleValidator) globalType(idx uint32) (*GlobalType, bool) {
 	n := uint32(0)
-	for _, im := range v.m.Imports {
-		if im.Type.Kind == ExternGlobal {
+	for i := range v.m.Imports {
+		if im := &v.m.Imports[i]; im.Type.Kind == ExternGlobal {
 			if n == idx {
-				return im.Type.Global, true
+				return &im.Type.Global, true
 			}
 			n++
 		}
 	}
 	local := int(idx - n)
 	if local < 0 || local >= len(v.m.Globals) {
-		return GlobalType{}, false
+		return nil, false
 	}
-	return v.m.Globals[local].Type, true
+	return &v.m.Globals[local].Type, true
 }
 func (v *moduleValidator) tableType(idx uint32) (TableType, bool) {
 	n := uint32(0)
-	for _, im := range v.m.Imports {
-		if im.Type.Kind == ExternTable {
+	for i := range v.m.Imports {
+		if im := &v.m.Imports[i]; im.Type.Kind == ExternTable {
 			if n == idx {
 				return im.Type.Table, true
 			}
@@ -487,21 +491,24 @@ func (v *moduleValidator) tableType(idx uint32) (TableType, bool) {
 	return v.m.Tables[local].Type, true
 }
 
-func (v *moduleValidator) memoryType(idx uint32) (MemType, bool) {
+// memoryType returns a pointer to the resolved memory's type. Pointer return (into
+// the module's stable Imports/Memories slices) avoids a per-memory-op struct copy
+// on the validation hot path — checkMemArg calls this for every load/store.
+func (v *moduleValidator) memoryType(idx uint32) (*MemType, bool) {
 	n := uint32(0)
-	for _, im := range v.m.Imports {
-		if im.Type.Kind == ExternMem {
+	for i := range v.m.Imports {
+		if im := &v.m.Imports[i]; im.Type.Kind == ExternMem {
 			if n == idx {
-				return im.Type.Mem, true
+				return &im.Type.Mem, true
 			}
 			n++
 		}
 	}
 	local := int(idx - n)
 	if local < 0 || local >= len(v.m.Memories) {
-		return MemType{}, false
+		return nil, false
 	}
-	return v.m.Memories[local], true
+	return &v.m.Memories[local], true
 }
 func (v *moduleValidator) validExternIdx(x ExternIdx) bool {
 	switch x.Kind {
@@ -527,7 +534,7 @@ func (v *moduleValidator) validateConstExpr(e Expr, want ValType) error {
 	fv.resetStacks()
 	fv.pushCtrl(ctrlFunc, nil, []ValType{want})
 	for _, in := range e.Instrs {
-		if err := fv.step(in); err != nil {
+		if err := fv.step(&in); err != nil {
 			return err
 		}
 	}
@@ -685,7 +692,7 @@ func (v *funcValidator) validateFunc(fn Func, ft *CompType) error {
 	}
 	v.pushCtrl(ctrlFunc, nil, ft.Results)
 	for _, in := range fn.Body.Instrs {
-		if err := v.step(in); err != nil {
+		if err := v.step(&in); err != nil {
 			return err
 		}
 	}

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -743,6 +743,7 @@ func (v *moduleValidator) validateConstExprDirect(e directConstExpr, want ValTyp
 	fv.pushCtrl(ctrlFunc, nil, []ValType{want})
 	fv.rd.reset(e.body)
 	r := &fv.rd
+	var op directOp // reused across the loop; decodeDirectOp overwrites it each step
 	for {
 		if len(fv.ctrls) == 0 {
 			if r.has() {
@@ -750,14 +751,13 @@ func (v *moduleValidator) validateConstExprDirect(e directConstExpr, want ValTyp
 			}
 			return nil
 		}
-		op, err := fv.decodeDirectOp(r, false)
-		if err != nil {
+		if err := fv.decodeDirectOp(r, false, &op); err != nil {
 			return err
 		}
 		if op.kind != directInstr && op.kind != directEnd {
 			return fv.verr(ErrConstExprRequired, "structured instruction")
 		}
-		if err := fv.stepDirectOp(op); err != nil {
+		if err := fv.stepDirectOp(&op); err != nil {
 			return err
 		}
 	}
@@ -832,6 +832,7 @@ func (v *funcValidator) validateFuncDirect(body directCodeBody, ft *CompType, me
 	v.pushCtrl(ctrlFunc, nil, ft.Results)
 	v.rd.reset(body.body)
 	r := &v.rd
+	var op directOp // reused across the loop; decodeDirectOp overwrites it each step
 	for {
 		if len(v.ctrls) == 0 {
 			if r.has() {
@@ -839,11 +840,10 @@ func (v *funcValidator) validateFuncDirect(body directCodeBody, ft *CompType, me
 			}
 			return nil
 		}
-		op, err := v.decodeDirectOp(r, memarg64)
-		if err != nil {
+		if err := v.decodeDirectOp(r, memarg64, &op); err != nil {
 			return err
 		}
-		if err := v.stepDirectOp(op); err != nil {
+		if err := v.stepDirectOp(&op); err != nil {
 			return err
 		}
 	}
@@ -868,19 +868,22 @@ type directOp struct {
 	catches   []Catch
 }
 
-func (v *funcValidator) decodeDirectOp(r *reader, memarg64 bool) (directOp, error) {
+func (v *funcValidator) decodeDirectOp(r *reader, memarg64 bool, out *directOp) error {
 	op, err := r.byte()
 	if err != nil {
-		return directOp{}, err
+		*out = directOp{}
+		return err
 	}
 	if k := simpleOpcode[op]; k != InstrInvalid {
-		return directOp{kind: directInstr, instr: Instruction{Kind: k}}, nil
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: k}}
+		return nil
 	}
 	switch op {
 	case 0x02, 0x03, 0x04:
 		bt, err := decodeBlockType(r)
 		if err != nil {
-			return directOp{}, err
+			*out = directOp{}
+			return err
 		}
 		k := directBlock
 		if op == 0x03 {
@@ -888,141 +891,187 @@ func (v *funcValidator) decodeDirectOp(r *reader, memarg64 bool) (directOp, erro
 		} else if op == 0x04 {
 			k = directIf
 		}
-		return directOp{kind: k, blockType: bt}, nil
+		*out = directOp{kind: k, blockType: bt}
+		return nil
 	case 0x05:
-		return directOp{kind: directElse}, nil
+		*out = directOp{kind: directElse}
+		return nil
 	case 0x08:
 		in, err := indexInst(r, InstrThrow)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x0b:
-		return directOp{kind: directEnd}, nil
+		*out = directOp{kind: directEnd}
+		return nil
 	case 0x0c:
 		in, err := indexInst(r, InstrBr)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x0d:
 		in, err := indexInst(r, InstrBrIf)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x0e:
 		labels, err := readVec(r, func(r *reader) (uint32, error) { return r.u32() })
 		if err != nil {
-			return directOp{}, err
+			*out = directOp{}
+			return err
 		}
 		def, err := r.u32()
 		v.opExt = instrExt{Indices: labels}
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrBrTable, Index: def, ext: &v.opExt}}, err
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrBrTable, Index: def, ext: &v.opExt}}
+		return err
 	case 0x10:
 		in, err := indexInst(r, InstrCall)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x11:
 		in, err := twoIndexInst(r, InstrCallIndirect)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x12:
 		in, err := indexInst(r, InstrReturnCall)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x13:
 		in, err := twoIndexInst(r, InstrReturnCallIndirect)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x14:
 		in, err := indexInst(r, InstrCallRef)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x15:
 		in, err := indexInst(r, InstrReturnCallRef)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x1c:
 		vts, err := decodeResultType(r)
 		v.opExt = instrExt{ValTypes: vts}
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrSelect, ext: &v.opExt}}, err
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrSelect, ext: &v.opExt}}
+		return err
 	case 0x1f:
 		bt, err := decodeBlockType(r)
 		if err != nil {
-			return directOp{}, err
+			*out = directOp{}
+			return err
 		}
 		catches, err := readVec(r, decodeCatch)
 		if err != nil {
-			return directOp{}, err
+			*out = directOp{}
+			return err
 		}
-		return directOp{kind: directTryTable, blockType: bt, catches: catches}, nil
+		*out = directOp{kind: directTryTable, blockType: bt, catches: catches}
+		return nil
 	case 0x20:
 		in, err := indexInst(r, InstrLocalGet)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x21:
 		in, err := indexInst(r, InstrLocalSet)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x22:
 		in, err := indexInst(r, InstrLocalTee)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x23:
 		in, err := indexInst(r, InstrGlobalGet)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x24:
 		in, err := indexInst(r, InstrGlobalSet)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x25:
 		in, err := indexInst(r, InstrTableGet)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x26:
 		in, err := indexInst(r, InstrTableSet)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e:
 		ma, err := decodeMemArgWithWidth(r, memarg64)
 		v.opExt = instrExt{MemArg: ma}
-		return directOp{kind: directInstr, instr: Instruction{Kind: memOpcodeKind[op], ext: &v.opExt}}, err
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: memOpcodeKind[op], ext: &v.opExt}}
+		return err
 	case 0x3f:
 		in, err := reservedZeroInst(r, InstrMemorySize)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x40:
 		in, err := reservedZeroInst(r, InstrMemoryGrow)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0x41:
 		x, err := r.i32()
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrI32Const, I32: x}}, err
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrI32Const, I32: x}}
+		return err
 	case 0x42:
 		x, err := r.i64()
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrI64Const, I64: x}}, err
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrI64Const, I64: x}}
+		return err
 	case 0x43:
 		x, err := r.le32()
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrF32Const, F32Bits: x}}, err
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrF32Const, F32Bits: x}}
+		return err
 	case 0x44:
 		x, err := r.le64()
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrF64Const, F64Bits: x}}, err
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrF64Const, F64Bits: x}}
+		return err
 	case 0xd0:
 		rt, err := decodeRefTypeForNull(r)
 		v.opExt = instrExt{RefType: rt}
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrRefNull, ext: &v.opExt}}, err
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrRefNull, ext: &v.opExt}}
+		return err
 	case 0xd2:
 		in, err := indexInst(r, InstrRefFunc)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0xd3:
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrRefEq}}, nil
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrRefEq}}
+		return nil
 	case 0xd4:
-		return directOp{kind: directInstr, instr: Instruction{Kind: InstrRefAsNonNull}}, nil
+		*out = directOp{kind: directInstr, instr: Instruction{Kind: InstrRefAsNonNull}}
+		return nil
 	case 0xd5:
 		in, err := indexInst(r, InstrBrOnNull)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0xd6:
 		in, err := indexInst(r, InstrBrOnNonNull)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0xfb:
 		in, err := decodeFB(r)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0xfc:
 		in, err := decodeFC(r)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0xfd:
 		in, err := decodeFDWithMemarg64(r, memarg64)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	case 0xfe:
 		in, err := decodeFEWithMemarg64(r, memarg64)
-		return directOp{kind: directInstr, instr: in}, err
+		*out = directOp{kind: directInstr, instr: in}
+		return err
 	default:
-		return directOp{}, &DecodeError{Code: ErrInvalidInstruction, Offset: r.off() - 1}
+		*out = directOp{}
+		return &DecodeError{Code: ErrInvalidInstruction, Offset: r.off() - 1}
 	}
 }
 
-func (v *funcValidator) stepDirectOp(op directOp) error {
+// stepDirectOp validates one decoded direct op. op is taken by pointer: directOp
+// embeds a ~56-byte Instruction, so a value parameter here is a per-opcode
+// duffcopy on the validator's hot path.
+func (v *funcValidator) stepDirectOp(op *directOp) error {
 	switch op.kind {
 	case directInstr:
-		return v.step(op.instr)
+		return v.step(&op.instr)
 	case directBlock:
 		ins, outs, err := v.blockSig(op.blockType)
 		if err != nil {

--- a/src/core/compiler/wasm/validate_coverage_test.go
+++ b/src/core/compiler/wasm/validate_coverage_test.go
@@ -601,7 +601,7 @@ func coverageFuncValidator(m *Module, results []ValType) *funcValidator {
 
 func expectStepErr(t *testing.T, fv *funcValidator, in Instruction, code ValidationErrorCode) {
 	t.Helper()
-	err := fv.step(in)
+	err := fv.step(&in)
 	var ve *ValidationError
 	if !errors.As(err, &ve) || ve.Code != code {
 		t.Fatalf("expected %v, got %v", code, err)
@@ -1020,7 +1020,7 @@ func TestValidatorRelaxedSIMDTernaryShape(t *testing.T) {
 		InstrI32x4RelaxedDotI8x16I7x16AddS,
 	} {
 		fv := coverageFuncValidatorWithStack(&Module{}, V128, V128, V128)
-		if err := fv.step(Instruction{Kind: kind}); err != nil {
+		if err := fv.step(&Instruction{Kind: kind}); err != nil {
 			t.Fatalf("%s ternary shape: %v", kind, err)
 		}
 		if len(fv.vals) != 1 || fv.vals[0].t != V128 {
@@ -1149,7 +1149,7 @@ func TestValidatorCoverageMoreProposalBranches(t *testing.T) {
 		expectStepErr(t, tv, Instruction{Kind: InstrTryTable, ext: &instrExt{Body: Expr{Instrs: []Instruction{{Kind: InstrI32Const}}}}}, ErrTypeMismatch)
 		expectStepErr(t, coverageFuncValidatorWithStack(m, I32), Instruction{Kind: InstrRefCast, ext: &instrExt{HeapType: AbsHeap(HeapEq)}}, ErrTypeMismatch)
 		expectStepErr(t, coverageFuncValidator(m, nil), Instruction{Kind: InstrRefCastDescEq, ext: &instrExt{HeapType: AbsHeap(HeapEq)}}, ErrTypeMismatch)
-		if err := coverageFuncValidatorWithStack(m, RefVal(Ref(true, IndexedHeap(TypeIdx{Index: 3}), false))).step(Instruction{Kind: InstrRefGetDesc, Index: 3}); err != nil {
+		if err := coverageFuncValidatorWithStack(m, RefVal(Ref(true, IndexedHeap(TypeIdx{Index: 3}), false))).step(&Instruction{Kind: InstrRefGetDesc, Index: 3}); err != nil {
 			t.Fatalf("ref.get_desc success: %v", err)
 		}
 		expectStepErr(t, coverageFuncValidatorWithStack(m, refToType(1, true), I32, I32), Instruction{Kind: InstrArrayFill, Index: 1}, ErrTypeMismatch)
@@ -1227,10 +1227,10 @@ func TestValidatorCoverageFinalTailBranches(t *testing.T) {
 			t.Fatalf("expected atomic fallback error, got %v", err)
 		}
 		gm := &Module{Types: []RecType{arrayType(field(I32, Var)), structType(nil, TypeMetadata{})}, DataCount: ptr(uint32(1)), Data: []Data{{Mode: DataMode{Kind: DataPassive}}}, Elements: []Elem{{Mode: ElemMode{Kind: ElemPassive}, Kind: ElemKind{Kind: ElemFuncExprs, Exprs: []Expr{{Instrs: []Instruction{{Kind: InstrRefNull, ext: &instrExt{RefType: AbsRef(HeapFunc)}}}}}}}}}
-		if err := coverageFuncValidatorWithStack(gm, EqRef).step(Instruction{Kind: InstrRefTest, ext: &instrExt{HeapType: AbsHeap(HeapEq)}}); err != nil {
+		if err := coverageFuncValidatorWithStack(gm, EqRef).step(&Instruction{Kind: InstrRefTest, ext: &instrExt{HeapType: AbsHeap(HeapEq)}}); err != nil {
 			t.Fatalf("ref.test success: %v", err)
 		}
-		if err := coverageFuncValidatorWithStack(gm, EqRef).step(Instruction{Kind: InstrRefCast, ext: &instrExt{HeapType: AbsHeap(HeapEq)}}); err != nil {
+		if err := coverageFuncValidatorWithStack(gm, EqRef).step(&Instruction{Kind: InstrRefCast, ext: &instrExt{HeapType: AbsHeap(HeapEq)}}); err != nil {
 			t.Fatalf("ref.cast success: %v", err)
 		}
 		expectStepErr(t, coverageFuncValidatorWithStack(gm, refToType(0, true), I32), Instruction{Kind: InstrArrayFill, Index: 0}, ErrTypeMismatch)
@@ -1298,7 +1298,7 @@ func TestValidatorCoverageLastPassBranches(t *testing.T) {
 			t.Fatalf("explicit memory shared arg: %v", err)
 		}
 		gm := &Module{Types: []RecType{arrayType(field(I32, Var)), structType([]FieldType{field(I32, Var)}, TypeMetadata{}), ft(nil, nil)}, DataCount: ptr(uint32(1)), Data: []Data{{Mode: DataMode{Kind: DataPassive}}}, Elements: []Elem{{Mode: ElemMode{Kind: ElemPassive}, Kind: ElemKind{Kind: ElemFuncExprs, Exprs: []Expr{{Instrs: []Instruction{{Kind: InstrRefNull, ext: &instrExt{RefType: AbsRef(HeapFunc)}}}}}}}}}
-		if err := coverageFuncValidatorWithStack(gm, I32).step(Instruction{Kind: InstrStructNew, Index: 1}); err != nil {
+		if err := coverageFuncValidatorWithStack(gm, I32).step(&Instruction{Kind: InstrStructNew, Index: 1}); err != nil {
 			t.Fatalf("struct.new success: %v", err)
 		}
 		expectStepErr(t, coverageFuncValidator(gm, nil), Instruction{Kind: InstrArrayFill, Index: 0}, ErrTypeMismatch)
@@ -1309,25 +1309,25 @@ func TestValidatorCoverageLastPassBranches(t *testing.T) {
 		if err := coverageFuncValidator(gm, nil).stepGC(Instruction{Kind: InstrNop}); !isValidationCode(err, ErrUnsupportedValidationOpcode) {
 			t.Fatalf("expected gc fallback error, got %v", err)
 		}
-		if err := coverageFuncValidatorWithStack(gm, I32, I32).step(Instruction{Kind: InstrArrayNew, Index: 0}); err != nil {
+		if err := coverageFuncValidatorWithStack(gm, I32, I32).step(&Instruction{Kind: InstrArrayNew, Index: 0}); err != nil {
 			t.Fatalf("array.new success: %v", err)
 		}
-		if err := coverageFuncValidatorWithStack(gm, I32, I32).step(Instruction{Kind: InstrArrayNewData, Index: 0}); err != nil {
+		if err := coverageFuncValidatorWithStack(gm, I32, I32).step(&Instruction{Kind: InstrArrayNewData, Index: 0}); err != nil {
 			t.Fatalf("array.new_data success: %v", err)
 		}
-		if err := coverageFuncValidatorWithStack(gm, I32, I32).step(Instruction{Kind: InstrArrayNewElem, Index: 0}); err != nil {
+		if err := coverageFuncValidatorWithStack(gm, I32, I32).step(&Instruction{Kind: InstrArrayNewElem, Index: 0}); err != nil {
 			t.Fatalf("array.new_elem success: %v", err)
 		}
 		fv := coverageFuncValidator(&Module{}, nil)
 		_ = fv.pushCtrl(ctrlBlock, nil, []ValType{EqRef})
 		fv.push(AnyRef)
-		if err := fv.step(Instruction{Kind: InstrBrOnCast, Index: 0, Cast: CastOp{SourceNullable: true, TargetNullable: true}, ext: &instrExt{HeapType: AbsHeap(HeapAny), HeapType2: AbsHeap(HeapEq)}}); err != nil {
+		if err := fv.step(&Instruction{Kind: InstrBrOnCast, Index: 0, Cast: CastOp{SourceNullable: true, TargetNullable: true}, ext: &instrExt{HeapType: AbsHeap(HeapAny), HeapType2: AbsHeap(HeapEq)}}); err != nil {
 			t.Fatalf("br_on_cast success: %v", err)
 		}
 		fv = coverageFuncValidator(&Module{}, nil)
 		_ = fv.pushCtrl(ctrlBlock, nil, []ValType{AnyRef})
 		fv.push(AnyRef)
-		if err := fv.step(Instruction{Kind: InstrBrOnCastFail, Index: 0, Cast: CastOp{SourceNullable: true, TargetNullable: true}, ext: &instrExt{HeapType: AbsHeap(HeapAny), HeapType2: AbsHeap(HeapEq)}}); err != nil {
+		if err := fv.step(&Instruction{Kind: InstrBrOnCastFail, Index: 0, Cast: CastOp{SourceNullable: true, TargetNullable: true}, ext: &instrExt{HeapType: AbsHeap(HeapAny), HeapType2: AbsHeap(HeapEq)}}); err != nil {
 			t.Fatalf("br_on_cast_fail success: %v", err)
 		}
 	})
@@ -1337,7 +1337,7 @@ func TestValidatorCoverageRemainingBranches(t *testing.T) {
 	t.Run("core remaining", func(t *testing.T) {
 		fv := coverageFuncValidator(&Module{}, nil)
 		fv.unreachable()
-		if err := fv.step(Instruction{Kind: InstrSelect}); err != nil {
+		if err := fv.step(&Instruction{Kind: InstrSelect}); err != nil {
 			t.Fatalf("polymorphic select: %v", err)
 		}
 		fv = coverageFuncValidator(&Module{Globals: []Global{{Type: GlobalType{Type: I32}}}}, nil)

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -1,6 +1,9 @@
 package wasm
 
-func (v *funcValidator) step(in Instruction) error {
+// step validates one already-decoded instruction. in is taken by pointer: the
+// Instruction struct is ~56 bytes and this is the validator's innermost hot path,
+// so passing a value here shows up as runtime.duffcopy under profiling.
+func (v *funcValidator) step(in *Instruction) error {
 	if v.constOnly && !isConstInstruction(in.Kind) {
 		return v.verr(ErrConstExprRequired, in.Kind.String())
 	}
@@ -46,7 +49,7 @@ func (v *funcValidator) step(in Instruction) error {
 			return err
 		}
 		for _, child := range in.Body().Instrs {
-			if err := v.step(child); err != nil {
+			if err := v.step(&child); err != nil {
 				return err
 			}
 		}
@@ -66,7 +69,7 @@ func (v *funcValidator) step(in Instruction) error {
 			return err
 		}
 		for _, child := range in.Then() {
-			if err := v.step(child); err != nil {
+			if err := v.step(&child); err != nil {
 				return err
 			}
 		}
@@ -82,7 +85,7 @@ func (v *funcValidator) step(in Instruction) error {
 				return err
 			}
 			for _, child := range in.Else() {
-				if err := v.step(child); err != nil {
+				if err := v.step(&child); err != nil {
 					return err
 				}
 			}
@@ -567,7 +570,7 @@ func sameValTypes(a, b []ValType) bool {
 	return true
 }
 
-func (v *funcValidator) stackEffect(in Instruction) error {
+func (v *funcValidator) stackEffect(in *Instruction) error {
 	k := in.Kind
 	if e := opEffects[k]; e.cat != effNone {
 		switch e.cat {
@@ -710,12 +713,12 @@ func (v *funcValidator) checkMemArg(ma MemArg, natural uint32) (ValType, error) 
 		return ValType{}, v.verr(ErrInvalidAlignment, "")
 	}
 	if mt.Limits.Addr64 {
-		return MemoryAddrType(mt), nil
+		return I64, nil
 	}
 	if ma.Offset > uint64(^uint32(0)) {
 		return ValType{}, v.verr(ErrInvalidAlignment, "offset out of range for i32 memory")
 	}
-	return MemoryAddrType(mt), nil
+	return I32, nil
 }
 
 func (v *funcValidator) checkSharedMemArg(ma MemArg, natural uint32) (ValType, error) {
@@ -728,7 +731,7 @@ func (v *funcValidator) checkSharedMemArg(ma MemArg, natural uint32) (ValType, e
 		idx = uint32(*ma.Mem)
 	}
 	mt, _ := v.memoryType(idx) // existence was checked by checkMemArg above.
-	if !mt.Shared {
+	if mt == nil || !mt.Shared {
 		// Atomic memory instructions are valid only for shared memories.
 		return ValType{}, v.verr(ErrInvalidSharedMemory, "atomic memory instruction")
 	}

--- a/src/core/compiler/wasm/validate_proposal.go
+++ b/src/core/compiler/wasm/validate_proposal.go
@@ -1,28 +1,28 @@
 package wasm
 
-func (v *funcValidator) proposalStep(in Instruction) (bool, error) {
+func (v *funcValidator) proposalStep(in *Instruction) (bool, error) {
 	switch in.Kind {
 	case InstrTryTable:
-		return true, v.stepTryTable(in)
+		return true, v.stepTryTable(*in)
 	case InstrCallRef, InstrReturnCallRef:
-		return true, v.stepCallRef(in)
+		return true, v.stepCallRef(*in)
 	case InstrMemoryAtomicNotify, InstrMemoryAtomicWait32, InstrMemoryAtomicWait64, InstrAtomicFence,
 		InstrI32AtomicLoad, InstrI64AtomicLoad, InstrI32AtomicLoad8U, InstrI32AtomicLoad16U,
 		InstrI64AtomicLoad8U, InstrI64AtomicLoad16U, InstrI64AtomicLoad32U,
 		InstrI32AtomicStore, InstrI64AtomicStore, InstrI32AtomicStore8, InstrI32AtomicStore16,
 		InstrI64AtomicStore8, InstrI64AtomicStore16, InstrI64AtomicStore32,
 		InstrAtomicRmw, InstrAtomicCmpxchg:
-		return true, v.stepAtomic(in)
+		return true, v.stepAtomic(*in)
 	case InstrStructNew, InstrStructNewDefault, InstrStructNewDesc, InstrStructNewDefaultDesc,
 		InstrStructGet, InstrStructGetS, InstrStructGetU, InstrStructAtomicGet, InstrStructAtomicGetS, InstrStructAtomicGetU, InstrStructSet,
 		InstrArrayNew, InstrArrayNewDefault, InstrArrayNewFixed, InstrArrayNewData, InstrArrayNewElem,
 		InstrArrayGet, InstrArrayGetS, InstrArrayGetU, InstrArraySet, InstrArrayLen, InstrArrayFill, InstrArrayCopy, InstrArrayInitData, InstrArrayInitElem,
 		InstrRefGetDesc, InstrRefTest, InstrRefCast, InstrRefTestDesc, InstrRefCastDescEq, InstrBrOnCast, InstrBrOnCastFail,
 		InstrAnyConvertExtern, InstrExternConvertAny, InstrRefI31, InstrI31GetS, InstrI31GetU:
-		return true, v.stepGC(in)
+		return true, v.stepGC(*in)
 	}
 	if in.Kind < numInstrKinds && simdEffects[in.Kind].cat != simdNone {
-		return true, v.stepSIMD(in)
+		return true, v.stepSIMD(*in)
 	}
 	return false, nil
 }
@@ -94,7 +94,7 @@ func (v *funcValidator) stepTryTable(in Instruction) error {
 		return err
 	}
 	for _, child := range in.Body().Instrs {
-		if err := v.step(child); err != nil {
+		if err := v.step(&child); err != nil {
 			return err
 		}
 	}
@@ -104,8 +104,8 @@ func (v *funcValidator) stepTryTable(in Instruction) error {
 
 func (v *moduleValidator) tagFuncType(idx uint32) (*CompType, bool) {
 	n := uint32(0)
-	for _, im := range v.m.Imports {
-		if im.Type.Kind == ExternTag {
+	for i := range v.m.Imports {
+		if im := &v.m.Imports[i]; im.Type.Kind == ExternTag {
 			if n == idx {
 				ft := v.funcTypeFromTypeIdx(im.Type.Tag.Type)
 				return ft, ft != nil


### PR DESCRIPTION
Profile-guided compile-throughput and memory work, measured on the real corpus (ruby 16 MB, esbuild 11 MB, …) on linux/amd64.

## Results (ruby, end-to-end decode→validate→codegen)

| Metric | Baseline | This PR | Δ |
|---|---|---|---|
| Time | 1584 ms | 1038 ms | **−34%** |
| Peak bytes | 630 MB | 114 MB | **−82%** |
| Allocations | 4.54 M | 953 K | **−79%** |
| — validation | 580 ms | 273 ms | −53% |
| — codegen | 890 ms | 611 ms | −31% |

Smaller modules improve similarly (e.g. markdown codegen allocs −85%, sqlite3 codegen −11%).

## Memory (now dominated by the machine-code output itself)
- **Pre-size the module code buffer** instead of `append`-growing it — geometric reallocation churned ~256 MB of garbage on ruby.
- **Reuse the control-frame stack** backing across functions (scratch) rather than regrowing the large `ctrlFrame` array per function.
- **Chunked, pointer-stable operand-stack arena** replacing the fixed-256 arena + per-node heap spill (killed ~74% of alloc objects).
- **Pool per-frame/per-op buffers**: `locState` merge buffers, frame end-lists, ret/brFold/trap sites → scratch; `trapSites` map → `[14][]int`; call-arg temps; `resolveRegMoves` map → fixed array + bitmask.

## Latency
- **Validator by-value struct copies** were 24% of total CPU (`runtime.duffcopy`): `step`/`stepDirectOp` take pointers, `decodeDirectOp` fills an out-param, and `memoryType`/`globalType`/`funcType`/`importCount` return pointers and iterate `m.Imports` by index (an `Import` is 208 B).
- **Fold inline-candidate detection into the hints pre-scan** (3 body walks → 2); `buildInlineTargets` derives its decisions from the hints. The inline target set is byte-identical to the old scan across the whole corpus.
- **Pinned-local merge loops** (`convergeEdgeTo` etc.) iterate a precomputed `pinnedLocals` list instead of scanning every local per control edge/call.

## Testing
- spec1 (629 modules / 16026 assertions), spec2 (1600 / 48248), corpus differential-execution suite, and all unit tests: **0 failures**.
- Verified the inline target set is unchanged from the prior scan on every corpus module.
- Adds `ct_bench_test.go`: per-stage compile-throughput benches over the corpus for future profiling.

No generated-code changes: the remaining codegen cost is fundamental (two necessary decode passes + emission + register-allocation quality); nothing here alters what code is emitted.