### PR TITLE
ci: make every canary/nightly platform build best-effort (pass on per-platform failure)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -53,13 +53,13 @@ jobs:
             goarch: amd64
             asset: wago-linux-amd64
             builder: tinygo
-            best_effort: false
+            best_effort: true
           - runner: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
             asset: wago-linux-arm64
             builder: tinygo
-            best_effort: false
+            best_effort: true
           - runner: macos-15-intel
             goos: darwin
             goarch: amd64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,13 +77,13 @@ jobs:
             goarch: amd64
             asset: wago-linux-amd64
             builder: tinygo
-            best_effort: false
+            best_effort: true
           - runner: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
             asset: wago-linux-arm64
             builder: tinygo
-            best_effort: false
+            best_effort: true
           - runner: macos-15-intel
             goos: darwin
             goarch: amd64


### PR DESCRIPTION
Canary and nightly no longer fail the whole run when a single platform build fails.

The `build` matrix already gated failure on `continue-on-error: ${{ matrix.best_effort }}`, but the Linux amd64/arm64 targets were the only cells with `best_effort: false` — so a failure on either one failed the entire workflow, even though the `publish` job already assembles a release from whatever platforms did build ("Includes every successful platform build; unsupported targets are omitted").

This sets `best_effort: true` for **all** targets in both workflows. A failed platform build is now non-fatal: the run publishes every platform that succeeded and omits the ones that didn't. Publish behavior is unchanged — it still requires at least one asset, so a total build failure still surfaces.

- `.github/workflows/canary.yml`: linux amd64 + arm64 → `best_effort: true`
- `.github/workflows/nightly.yml`: linux amd64 + arm64 → `best_effort: true`

(Darwin and Windows targets were already best-effort, so the mechanism is proven.)