### PR TITLE
feat: context-aware raw invocation (InvokeContext) + interruptible host-call loops

### DIFF
--- a/src/core/runtime/engine_unix.go
+++ b/src/core/runtime/engine_unix.go
@@ -181,9 +181,19 @@ func (e *Engine) CallWithHost(code uintptr, serArgs, linMem, trap, results, ctrl
 }
 
 func (e *Engine) callWithHostLoop(code uintptr, serArgs, linMem, trap, results, ctrl []byte, ctrlPtr uintptr, host HostCall, argBuf, resBuf []uint64) error {
-	const maxReentries = 1 << 20
-	for i := 0; i < maxReentries; i++ {
-		if i == 0 {
+	// The host-call re-entry loop is intentionally unbounded: a single guest
+	// invocation may legitimately make an arbitrary number of host calls (e.g. a
+	// long-running rule that polls Date.now()/Math.random() in a loop). A fixed
+	// re-entry cap would turn such a guest into an opaque hard error *before* its
+	// deadline, pre-empting the cooperative interrupt. The runaway-guest guard is
+	// the trap cell: a cancelled/expired context arms TrapInterrupted, the guest
+	// traps at the next function-entry/loop-header safepoint, and that surfaces
+	// here as `tc != 0` — breaking the loop with the interrupt code rather than a
+	// synthetic "too many host calls" error. A guest with no deadline that spins
+	// on host calls forever is no different from one that spins on compute
+	// forever: both require the caller to arm a timeout, exactly as under wazero.
+	for first := true; ; first = false {
+		if first {
 			enterNative(code, slicePtr(serArgs), slicePtr(linMem), slicePtr(trap), slicePtr(results), e.stackTop)
 		} else {
 			storeTrap(trap, 0) // clear the pending marker before resuming
@@ -220,7 +230,6 @@ func (e *Engine) callWithHostLoop(code uintptr, serArgs, linMem, trap, results, 
 			return nil
 		}
 	}
-	return fmt.Errorf("jit: host re-entry limit exceeded")
 }
 
 func (e *Engine) Close() error { return munmap(e.stack) }

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1,6 +1,7 @@
 package wago
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -1503,6 +1504,35 @@ func Load(b []byte) (*Compiled, error) {
 // only in the Runtime store (or standalone private store) that issued them.
 func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
 	return in.invoke(export, args, nil)
+}
+
+// InvokeContext is like Invoke but honors context cancellation. If ctx is
+// cancelled or its deadline expires while the guest is executing, the call is
+// interrupted at the next native safepoint and returns ctx.Err() (e.g.
+// context.DeadlineExceeded) instead of blocking on a runaway guest.
+//
+// Native cancellation is available on amd64/arm64; on other architectures ctx
+// is only checked before the call begins. A nil or already-cancelled ctx is
+// handled up front; a Background context (Done() == nil) keeps Invoke's
+// zero-goroutine fast path.
+//
+// This is the raw-uint64 sibling of Call, for callers that invoke by slot
+// values rather than typed Values (e.g. AssemblyScript rule dispatch).
+func (in *Instance) InvokeContext(ctx context.Context, export string, args ...uint64) ([]uint64, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	var cancel <-chan struct{}
+	if nativeCancellationSupported() && ctx != nil {
+		cancel = ctx.Done()
+	}
+
+	out, err := in.invoke(export, args, cancel)
+
+	return out, contextInterruptError(ctx, err)
 }
 
 func (in *Instance) invoke(export string, args []uint64, cancel <-chan struct{}) ([]uint64, error) {

--- a/src/wago/cancellation_test.go
+++ b/src/wago/cancellation_test.go
@@ -57,6 +57,58 @@ func TestCallContextInterruptsNativeLoop(t *testing.T) {
 	}
 }
 
+// TestInvokeContextInterruptsHostCallLoop guards the runaway-guest guard itself:
+// a guest that calls a host import on every loop iteration must be interruptible
+// by context, and must not be pre-empted by any fixed host-call re-entry cap. The
+// loop here issues far more than the historical 1<<20 re-entry bound before its
+// deadline; the cooperative trap-cell interrupt — not a "too many host calls"
+// error — is what must break it.
+func TestInvokeContextInterruptsHostCallLoop(t *testing.T) {
+	i32 := []wasm.ValType{wasm.I32}
+	// import env.tick : () -> i32
+	imp := append(append(wasmtest.Name("env"), wasmtest.Name("tick")...), 0x00, 0x00)
+	mod := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, i32), // type 0: () -> i32 (the import)
+			wasmtest.FuncType(nil, nil), // type 1: () -> ()  (spin)
+		)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))), // func 1 (spin) has type 1
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("spin", 0, 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			// spin(): loop { drop(call $tick); br 0 }
+			wasmtest.Code([]byte{0x03, 0x40, 0x10, 0x00, 0x1a, 0x0c, 0x00, 0x0b, 0x0b}),
+		)),
+	)
+	calls := 0
+	c := MustCompile(mod)
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.tick": HostFunc(func(_ HostModule, _, r []uint64) {
+		calls++
+		r[0] = I32(0)
+	})}})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if _, err := in.InvokeContext(ctx, "spin"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("spin error = %v, want context deadline (a re-entry-cap error here is the regression)", err)
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("cancellation took %v, want bounded interruption", elapsed)
+	}
+	// Prove the loop sailed past the historical 1<<20 host-call re-entry cap:
+	// interruption, not a synthetic bound, is what stopped it.
+	if calls <= 1<<20 {
+		t.Fatalf("host calls = %d, want > %d (loop must exceed the old cap to be a real regression guard)", calls, 1<<20)
+	}
+}
+
 func TestInvokeContextInterruptsNativeLoop(t *testing.T) {
 	mod := wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(

--- a/src/wago/cancellation_test.go
+++ b/src/wago/cancellation_test.go
@@ -56,3 +56,48 @@ func TestCallContextInterruptsNativeLoop(t *testing.T) {
 		t.Fatalf("post-cancel value = %v, %v; want 7", out, err)
 	}
 }
+
+func TestInvokeContextInterruptsNativeLoop(t *testing.T) {
+	mod := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, nil),
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("spin", 0, 0),
+			wasmtest.ExportEntry("value", 0, 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b}), // loop { br 0 }
+			wasmtest.Code([]byte{0x41, 0x07, 0x0b}),
+		)),
+	)
+	rt := NewRuntime()
+	defer rt.Close()
+	compiled, err := rt.Compile(mod)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), compiled)
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if _, err := in.InvokeContext(ctx, "spin"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("spin error = %v, want context deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("cancellation took %v, want bounded interruption", elapsed)
+	}
+
+	// The watcher must leave the shared trap cell clean for the next invocation.
+	out, err := in.InvokeContext(context.Background(), "value")
+	if err != nil || len(out) != 1 || out[0] != 7 {
+		t.Fatalf("post-cancel value = %v, %v; want 7", out, err)
+	}
+}


### PR DESCRIPTION
Adds full context-based interruption support for the raw-uint64 invocation path, so callers can enforce an invocation deadline / kill a runaway guest — including guests that spin while calling host imports.

## 1. `Instance.InvokeContext` — context-aware raw invocation

`Instance.Call(ctx, ...)` already interrupts a runaway native guest on context cancellation (arms `startCancellationWatch`, guest traps `TrapInterrupted`, `contextInterruptError` maps it to `ctx.Err()`). The raw-uint64 `Instance.Invoke` path — used by callers that invoke by slot values rather than typed `Value`s — had no context-aware sibling and always passed a `nil` cancel channel, so a cancelled/expired context could not interrupt the guest.

`InvokeContext(ctx, export, args ...uint64) ([]uint64, error)` is the raw-uint64 sibling of `Call`: it checks `ctx` up front, arms native cancellation from `ctx.Done()` (amd64/arm64), invokes through the **existing** `in.invoke(cancel)` path, and maps `TrapInterrupted` → `ctx.Err()`. No new machinery.

## 2. Unbounded host-call re-entry loop so interrupts actually win

The synchronous host-call trampoline (`callWithHostLoop`) capped re-entries at `1<<20` and returned `jit: host re-entry limit exceeded` past that. A single guest invocation can legitimately make an unbounded number of host calls — e.g. a rule that polls `Date.now()`/`Math.random()` in a loop. Such a guest hits the cap (~1M calls, well under a second) **before** its deadline, converting an interruptible timeout into an opaque hard error and defeating the cooperative-interrupt path.

The count cap is the wrong runaway-guest guard; the trap cell is the right one. The loop is now unbounded and the interrupt breaks it (guest traps at the next safepoint → `TrapError` → `ctx.Err()`). A deadline-less guest that spins on host calls is no different from one that spins on compute — both require the caller to arm a timeout.

## Tests

- `TestInvokeContextInterruptsNativeLoop` — pure `loop { br 0 }` interrupted within a 20ms deadline; trap cell left clean for reuse.
- `TestInvokeContextInterruptsHostCallLoop` — guest calls a host import every iteration, issues **> 1<<20** calls before a 500ms deadline, and is interrupted with `context.DeadlineExceeded` (not a re-entry-cap error).

```
--- PASS: TestCallContextInterruptsNativeLoop (0.02s)
--- PASS: TestInvokeContextInterruptsNativeLoop (0.02s)
--- PASS: TestInvokeContextInterruptsHostCallLoop (0.50s)
ok  github.com/wago-org/wago/src/core/runtime
ok  github.com/wago-org/wago/src/wago
```