### PR TITLE
perf: fuse ordered float compares into branches (amd64 + arm64)

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/driver.go
+++ b/src/core/compiler/backend/railshot/amd64/driver.go
@@ -62,6 +62,21 @@ func (f *fn) bodyLoop(r *wasm.Reader, minCtrl int) error {
 	return nil
 }
 
+// fcmpMaybeDefer lowers an ordered float compare (gt/ge/lt/le). It defers the
+// compare as a fusable node only when the very next opcode is if (0x04) or br_if
+// (0x0d), so that consumer condenses it directly to UCOMIS + Jcc; otherwise it
+// emits the eager 0/1 boolean. The node therefore never lingers on the operand
+// stack past its immediate branch consumer.
+func (f *fn) fcmpMaybeDefer(r *wasm.Reader, op wOp, f64 bool) {
+	if fcmpFuseEnabled {
+		if next, ok := r.Peek(); ok && (next == 0x04 || next == 0x0d) {
+			f.pushFCompare(op, f64)
+			return
+		}
+	}
+	f.fcmp(op, f64)
+}
+
 // emitPlain lowers a single non-control opcode (leaves, arithmetic, memory,
 // conversions). Called only when reachable; dead code is skipped by the body loop.
 func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
@@ -421,26 +436,26 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x5c:
 		f.fcmp(opNe, false)
 	case 0x5d:
-		f.fcmp(opLtS, false)
+		f.fcmpMaybeDefer(r, opLtS, false)
 	case 0x5e:
-		f.fcmp(opGtS, false)
+		f.fcmpMaybeDefer(r, opGtS, false)
 	case 0x5f:
-		f.fcmp(opLeS, false)
+		f.fcmpMaybeDefer(r, opLeS, false)
 	case 0x60:
-		f.fcmp(opGeS, false)
+		f.fcmpMaybeDefer(r, opGeS, false)
 	// f64 comparisons
 	case 0x61:
 		f.fcmp(opEq, true)
 	case 0x62:
 		f.fcmp(opNe, true)
 	case 0x63:
-		f.fcmp(opLtS, true)
+		f.fcmpMaybeDefer(r, opLtS, true)
 	case 0x64:
-		f.fcmp(opGtS, true)
+		f.fcmpMaybeDefer(r, opGtS, true)
 	case 0x65:
-		f.fcmp(opLeS, true)
+		f.fcmpMaybeDefer(r, opLeS, true)
 	case 0x66:
-		f.fcmp(opGeS, true)
+		f.fcmpMaybeDefer(r, opGeS, true)
 
 	// f32 unary/binary
 	case 0x8b:
@@ -705,7 +720,7 @@ func (f *fn) emitSelect() {
 	// branches are integers, emit the compare's CMP and a CMOV on its flags directly
 	// — skipping the SETcc + MOVZX + TEST that materializing the boolean costs. The
 	// compare is condensed last (right before the CMOV), so its flags are live.
-	if top := f.s.back(); isFusableCompare(top) && f.trySelectOnFlags(top) {
+	if top := f.s.back(); isFusableCompare(top) && !top.typ.isFloat() && f.trySelectOnFlags(top) {
 		return
 	}
 	cond := f.popValue()

--- a/src/core/compiler/backend/railshot/amd64/emit.go
+++ b/src/core/compiler/backend/railshot/amd64/emit.go
@@ -449,6 +449,9 @@ func (f *fn) condenseShift(node *elem, dest Reg) Reg {
 // producing a 0/1 i32 result. (Fusing compares directly into branches is a later
 // optimization; Phase 1 materializes the boolean.)
 func (f *fn) condenseCompare(node *elem, dest Reg) Reg {
+	if node.typ.isFloat() { // deferred ordered float compare materialized as a value
+		return f.condenseFCompareValue(node, dest)
+	}
 	w := node.typ.is64()
 	left := node.arg0
 

--- a/src/core/compiler/backend/railshot/amd64/fcmpbranch_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/fcmpbranch_exec_test.go
@@ -1,0 +1,110 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestFloatCompareBranchFusion exercises the fused float-compare→branch path
+// (fcmpMaybeDefer → condenseFCompareToFlags): an ordered float relation
+// (lt/le/gt/ge) placed directly before `if` or `br_if` lowers to UCOMIS + a
+// NaN-safe Jcc instead of materializing a boolean. Go's native <,>,<=,>= already
+// return false on NaN, matching wasm, so they are the oracle.
+func TestFloatCompareBranchFusion(t *testing.T) {
+	const (
+		nan  = "nan"
+		pinf = "+inf"
+		ninf = "-inf"
+	)
+	// opcodes: [lt, gt, le, ge] for f32 (0x5d..0x60) and f64 (0x63..0x66).
+	type opc struct {
+		name   string
+		f32Op  byte
+		f64Op  byte
+		predFn func(a, b float64) bool
+	}
+	ops := []opc{
+		{"lt", 0x5d, 0x63, func(a, b float64) bool { return a < b }},
+		{"gt", 0x5e, 0x64, func(a, b float64) bool { return a > b }},
+		{"le", 0x5f, 0x65, func(a, b float64) bool { return a <= b }},
+		{"ge", 0x60, 0x66, func(a, b float64) bool { return a >= b }},
+	}
+	inputs := []struct{ a, b float64 }{
+		{1, 2}, {2, 1}, {1, 1}, {-1, 1}, {1, -1},
+		{math.NaN(), 1}, {1, math.NaN()}, {math.NaN(), math.NaN()},
+		{math.Inf(1), 1}, {1, math.Inf(1)}, {math.Inf(-1), math.Inf(1)},
+		{math.Copysign(0, -1), 0}, // -0.0 vs +0.0 (equal in IEEE)
+	}
+
+	// ifBody / brIfBody wrap opcode `op` (of the given float type) as
+	//   (if (result i32) (<cmp> p0 p1) (then 1) (else 0))
+	// and the br_if analogue, so the compare is the immediate branch predicate.
+	ifBody := func(op byte) []byte {
+		return []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, op, // local.get 0, local.get 1, <cmp>
+			0x04, 0x7f, // if (result i32)
+			0x41, 0x01, // i32.const 1
+			0x05,       // else
+			0x41, 0x00, // i32.const 0
+			0x0b, // end if
+			0x0b} // end func
+	}
+	brIfBody := func(op byte) []byte {
+		return []byte{0x00,
+			0x02, 0x7f, // block (result i32)
+			0x41, 0x01, // i32.const 1 (value carried on branch)
+			0x20, 0x00, 0x20, 0x01, op, // local.get 0, local.get 1, <cmp>
+			0x0d, 0x00, // br_if 0
+			0x1a,       // drop
+			0x41, 0x00, // i32.const 0 (fall-through value)
+			0x0b, // end block
+			0x0b} // end func
+	}
+
+	run := func(t *testing.T, typ wasm.ValType, op byte, body []byte, a, b float64) uint32 {
+		m := mod1(t, []wasm.ValType{typ, typ}, []wasm.ValType{i32}, body)
+		var av, bv uint64
+		if typ == wasm.F32 {
+			av, bv = f32b(float32(a)), f32b(float32(b))
+		} else {
+			av, bv = f64b(a), f64b(b)
+		}
+		return uint32(runAmd64u(t, m, av, bv))
+	}
+
+	for _, o := range ops {
+		o := o
+		for _, form := range []struct {
+			tag  string
+			body func(byte) []byte
+		}{{"if", ifBody}, {"br_if", brIfBody}} {
+			for _, ft := range []struct {
+				name string
+				typ  wasm.ValType
+				code byte
+			}{{"f32", wasm.F32, o.f32Op}, {"f64", wasm.F64, o.f64Op}} {
+				t.Run(ft.name+"."+o.name+"/"+form.tag, func(t *testing.T) {
+					body := form.body(ft.code)
+					for _, in := range inputs {
+						a, b := in.a, in.b
+						if ft.typ == wasm.F32 {
+							a, b = float64(float32(a)), float64(float32(b))
+						}
+						want := uint32(0)
+						if o.predFn(a, b) {
+							want = 1
+						}
+						got := run(t, ft.typ, ft.code, body, in.a, in.b)
+						if got != want {
+							t.Fatalf("%s.%s/%s(%v,%v) = %d, want %d", ft.name, o.name, form.tag, in.a, in.b, got, want)
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/amd64/fp.go
+++ b/src/core/compiler/backend/railshot/amd64/fp.go
@@ -491,6 +491,22 @@ func (f *fn) fcmp(kind wOp, f64 bool) {
 	xb, xbOwned := f.operandRegF(b) // read-only: only compared
 	f.fpinned = f.fpinned.remove(xa)
 	dst := f.allocReg(0)
+	f.emitFCmpSetcc(kind, xa, xb, f64, dst)
+	if xaOwned {
+		f.releaseF(xa)
+	}
+	if xbOwned {
+		f.releaseF(xb)
+	}
+	f.pushReg(dst, mtI32)
+}
+
+// emitFCmpSetcc emits UCOMIS(S/D) plus the NaN-correct SETcc sequence for a float
+// relational op, landing a 0/1 i32 boolean in dst. The ordered ops (gt/ge/lt/le)
+// use the CF-clear `above`/`above-equal` forms (via operand swap for lt/le) so
+// unordered (NaN) yields false; eq/ne combine the equal/parity bits. Shared by
+// fcmp (eager boolean) and condenseFCompareValue (deferred-node fallback).
+func (f *fn) emitFCmpSetcc(kind wOp, xa, xb Reg, f64 bool, dst Reg) {
 	switch kind {
 	case opEq:
 		f.a.Ucomis(xa, xb, f64)
@@ -519,13 +535,95 @@ func (f *fn) fcmp(kind wOp, f64 bool) {
 		f.a.Ucomis(xb, xa, f64)
 		f.a.SetccReg(condAE, dst)
 	}
+}
+
+// pushFCompare pushes a DEFERRED float relational op (gt/ge/lt/le only) instead
+// of materializing a boolean, so the immediately-following if/br_if can fuse it
+// into UCOMIS + Jcc via condenseFCompareToFlags. The driver only defers when the
+// next opcode is if/br_if, so the node never lingers past its consumer. eq/ne are
+// never deferred (their branch form needs two Jccs), so they stay eager in fcmp.
+func (f *fn) pushFCompare(op wOp, f64 bool) {
+	typ := mtF32
+	if f64 {
+		typ = mtF64
+	}
+	right := f.s.back()
+	left := baseOfValentBlock(right).prev
+	node := f.s.alloc()
+	node.kind, node.op, node.typ = ekDeferred, op, typ
+	node.arg0, node.arg1 = left, right
+	node.deferDepth = 1 + max16(deferDepthOf(left), deferDepthOf(right))
+	f.s.push(node)
+}
+
+// condenseFCompareToFlags lowers a deferred float relational node to UCOMIS (no
+// SETcc), consumes the node and its operands, and returns the branch condition
+// that is true when the comparison holds. Mirrors emitFCmpSetcc's operand
+// ordering. invert (from an eqz peel) flips the condition; that stays NaN-correct
+// because wasm's eqz(float-cmp) and the x86 CF/ZF-inverted condition both include
+// the unordered case on the negated side.
+func (f *fn) condenseFCompareToFlags(node *elem, invert bool) Cond {
+	f64 := node.typ == mtF64
+	xa, xaOwned := f.operandRegF(node.arg0)
+	f.fpinned = f.fpinned.add(xa)
+	xb, xbOwned := f.operandRegF(node.arg1)
+	f.fpinned = f.fpinned.remove(xa)
+	var cc Cond
+	switch node.op {
+	case opGtS:
+		f.a.Ucomis(xa, xb, f64)
+		cc = condA
+	case opGeS:
+		f.a.Ucomis(xa, xb, f64)
+		cc = condAE
+	case opLtS:
+		f.a.Ucomis(xb, xa, f64)
+		cc = condA
+	case opLeS:
+		f.a.Ucomis(xb, xa, f64)
+		cc = condAE
+	}
 	if xaOwned {
 		f.releaseF(xa)
 	}
 	if xbOwned {
 		f.releaseF(xb)
 	}
-	f.pushReg(dst, mtI32)
+	if invert {
+		cc = invertCond(cc)
+	}
+	f.consumeBlockBelow(node)
+	f.erase(node)
+	return cc
+}
+
+// condenseFCompareValue materializes a deferred float relational node to a 0/1
+// boolean (the fcmp path applied to the node's operands). Defensive: the driver
+// only defers a float compare directly before its if/br_if consumer, so this is
+// normally unreachable, but it keeps a deferred float node correct on any path
+// that condenses it as a value rather than a branch.
+func (f *fn) condenseFCompareValue(node *elem, dest Reg) Reg {
+	f64 := node.typ == mtF64
+	xa, xaOwned := f.operandRegF(node.arg0)
+	f.fpinned = f.fpinned.add(xa)
+	xb, xbOwned := f.operandRegF(node.arg1)
+	f.fpinned = f.fpinned.remove(xa)
+	result := dest
+	if result == regNone {
+		result = f.allocReg(0)
+	}
+	f.emitFCmpSetcc(node.op, xa, xb, f64, result)
+	if xaOwned {
+		f.releaseF(xa)
+	}
+	if xbOwned {
+		f.releaseF(xb)
+	}
+	f.consumeBlockBelow(node)
+	f.occupy(node, result)
+	node.st.typ = mtI32
+	node.op = opNone
+	return result
 }
 
 // i2f converts a signed integer to float. srcWide selects an i64 source.

--- a/src/core/compiler/backend/railshot/amd64/fp.go
+++ b/src/core/compiler/backend/railshot/amd64/fp.go
@@ -563,6 +563,7 @@ func (f *fn) pushFCompare(op wOp, f64 bool) {
 // because wasm's eqz(float-cmp) and the x86 CF/ZF-inverted condition both include
 // the unordered case on the negated side.
 func (f *fn) condenseFCompareToFlags(node *elem, invert bool) Cond {
+	f.stats.peep("fcmp-branch-fuse")
 	f64 := node.typ == mtF64
 	xa, xaOwned := f.operandRegF(node.arg0)
 	f.fpinned = f.fpinned.add(xa)
@@ -603,6 +604,7 @@ func (f *fn) condenseFCompareToFlags(node *elem, invert bool) Cond {
 // normally unreachable, but it keeps a deferred float node correct on any path
 // that condenses it as a value rather than a branch.
 func (f *fn) condenseFCompareValue(node *elem, dest Reg) Reg {
+	f.stats.peep("fcmp-value-fallback")
 	f64 := node.typ == mtF64
 	xa, xaOwned := f.operandRegF(node.arg0)
 	f.fpinned = f.fpinned.add(xa)

--- a/src/core/compiler/backend/railshot/amd64/fuse.go
+++ b/src/core/compiler/backend/railshot/amd64/fuse.go
@@ -108,6 +108,11 @@ func (f *fn) condenseToFlags(node *elem) Cond {
 			invert = !invert
 		}
 	}
+	// Ordered float relational nodes (gt/ge/lt/le) lower to UCOMIS + a NaN-safe
+	// condition instead of a materialized boolean. eq/ne are never deferred here.
+	if node.typ.isFloat() {
+		return f.condenseFCompareToFlags(node, invert)
+	}
 	applyInvert := func(cc Cond) Cond {
 		if invert {
 			return invertCond(cc)

--- a/src/core/compiler/backend/railshot/amd64/stats.go
+++ b/src/core/compiler/backend/railshot/amd64/stats.go
@@ -42,6 +42,11 @@ var (
 	// storing $c with a flag-neutral SETcc after the CMP. WAGO_NO_STFLAGS=1 is the
 	// A/B oracle + kill switch for this flag-desync-sensitive path.
 	stFlagsEnabled = os.Getenv("WAGO_NO_STFLAGS") != "1"
+
+	// fcmpFuseEnabled gates float compare→branch fusion: an ordered float relation
+	// (lt/le/gt/ge) directly before if/br_if lowers to UCOMIS + a NaN-safe Jcc
+	// instead of UCOMIS + SETcc + TEST + Jcc. WAGO_NO_FCMP_FUSE=1 is the A/B oracle.
+	fcmpFuseEnabled = os.Getenv("WAGO_NO_FCMP_FUSE") != "1"
 )
 
 func parsePinGlobalK(s string) int {

--- a/src/core/compiler/backend/railshot/arm64/driver.go
+++ b/src/core/compiler/backend/railshot/arm64/driver.go
@@ -62,6 +62,21 @@ func (f *fn) bodyLoop(r *wasm.Reader, minCtrl int) error {
 	return nil
 }
 
+// fcmpMaybeDefer lowers an ordered float compare (gt/ge/lt/le). It defers the
+// compare as a fusable node only when the very next opcode is if (0x04) or br_if
+// (0x0d), so that consumer condenses it directly to FCMP + B.cond; otherwise it
+// emits the eager 0/1 boolean. The node therefore never lingers on the operand
+// stack past its immediate branch consumer.
+func (f *fn) fcmpMaybeDefer(r *wasm.Reader, op wOp, f64 bool) {
+	if fcmpFuseEnabled {
+		if next, ok := r.Peek(); ok && (next == 0x04 || next == 0x0d) {
+			f.pushFCompare(op, f64)
+			return
+		}
+	}
+	f.fcmp(op, f64)
+}
+
 // emitPlain lowers a single non-control opcode (leaves, arithmetic, memory,
 // conversions). Called only when reachable; dead code is skipped by the body loop.
 func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
@@ -432,26 +447,26 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x5c:
 		f.fcmp(opNe, false)
 	case 0x5d:
-		f.fcmp(opLtS, false)
+		f.fcmpMaybeDefer(r, opLtS, false)
 	case 0x5e:
-		f.fcmp(opGtS, false)
+		f.fcmpMaybeDefer(r, opGtS, false)
 	case 0x5f:
-		f.fcmp(opLeS, false)
+		f.fcmpMaybeDefer(r, opLeS, false)
 	case 0x60:
-		f.fcmp(opGeS, false)
+		f.fcmpMaybeDefer(r, opGeS, false)
 	// f64 comparisons
 	case 0x61:
 		f.fcmp(opEq, true)
 	case 0x62:
 		f.fcmp(opNe, true)
 	case 0x63:
-		f.fcmp(opLtS, true)
+		f.fcmpMaybeDefer(r, opLtS, true)
 	case 0x64:
-		f.fcmp(opGtS, true)
+		f.fcmpMaybeDefer(r, opGtS, true)
 	case 0x65:
-		f.fcmp(opLeS, true)
+		f.fcmpMaybeDefer(r, opLeS, true)
 	case 0x66:
-		f.fcmp(opGeS, true)
+		f.fcmpMaybeDefer(r, opGeS, true)
 
 	// f32 unary/binary
 	case 0x8b:
@@ -912,7 +927,7 @@ func (f *fn) emitSelect() {
 	// branches are integers, emit the compare's CMP and a CSEL on its flags directly
 	// — skipping the Cset + TEST that materializing the boolean costs. The compare is
 	// condensed last (right before the CSEL), so its NZCV flags are live.
-	if top := f.s.back(); isFusableCompare(top) && f.trySelectOnFlags(top) {
+	if top := f.s.back(); isFusableCompare(top) && !top.typ.isFloat() && f.trySelectOnFlags(top) {
 		return
 	}
 	cond := f.popValue()

--- a/src/core/compiler/backend/railshot/arm64/emit.go
+++ b/src/core/compiler/backend/railshot/arm64/emit.go
@@ -780,6 +780,9 @@ func (f *fn) rorv(d, n, m Reg, w bool) {
 // boolean.) AArch64 has no memory operands, so a slot/local-ref/mem-ref right
 // operand is loaded into a register and compared register-register.
 func (f *fn) condenseCompare(node *elem, dest Reg) Reg {
+	if node.typ.isFloat() { // deferred ordered float compare materialized as a value
+		return f.condenseFCompareValue(node, dest)
+	}
 	w := node.typ.is64()
 	left := node.arg0
 

--- a/src/core/compiler/backend/railshot/arm64/fcmpbranch_exec_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/fcmpbranch_exec_arm64_test.go
@@ -1,0 +1,89 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestFloatCompareBranchFusion exercises the fused float-compare→branch path
+// (fcmpMaybeDefer → condenseFCompareToFlags): an ordered float relation
+// (lt/le/gt/ge) directly before `if` or `br_if` lowers to FCMP + a NaN-safe
+// B.cond instead of materializing a boolean. Go's native <,>,<=,>= return false
+// on NaN, matching wasm, so they are the oracle.
+func TestFloatCompareBranchFusion(t *testing.T) {
+	fbits32 := func(v float32) uint64 { return uint64(math.Float32bits(v)) }
+	fbits64 := func(v float64) uint64 { return math.Float64bits(v) }
+
+	type opc struct {
+		name         string
+		f32Op, f64Op byte
+		predFn       func(a, b float64) bool
+	}
+	ops := []opc{
+		{"lt", 0x5d, 0x63, func(a, b float64) bool { return a < b }},
+		{"gt", 0x5e, 0x64, func(a, b float64) bool { return a > b }},
+		{"le", 0x5f, 0x65, func(a, b float64) bool { return a <= b }},
+		{"ge", 0x60, 0x66, func(a, b float64) bool { return a >= b }},
+	}
+	inputs := []struct{ a, b float64 }{
+		{1, 2}, {2, 1}, {1, 1}, {-1, 1}, {1, -1},
+		{math.NaN(), 1}, {1, math.NaN()}, {math.NaN(), math.NaN()},
+		{math.Inf(1), 1}, {1, math.Inf(1)}, {math.Inf(-1), math.Inf(1)},
+		{math.Copysign(0, -1), 0},
+	}
+	ifBody := func(op byte) []byte {
+		return []byte{0x00,
+			0x20, 0x00, 0x20, 0x01, op,
+			0x04, 0x7f, 0x41, 0x01, 0x05, 0x41, 0x00, 0x0b, 0x0b}
+	}
+	brIfBody := func(op byte) []byte {
+		return []byte{0x00,
+			0x02, 0x7f, 0x41, 0x01, 0x20, 0x00, 0x20, 0x01, op,
+			0x0d, 0x00, 0x1a, 0x41, 0x00, 0x0b, 0x0b}
+	}
+	run := func(t *testing.T, typ wasm.ValType, body []byte, a, b float64) uint32 {
+		m := mod1(t, []wasm.ValType{typ, typ}, []wasm.ValType{wasm.I32}, body)
+		var av, bv uint64
+		if typ == wasm.F32 {
+			av, bv = fbits32(float32(a)), fbits32(float32(b))
+		} else {
+			av, bv = fbits64(a), fbits64(b)
+		}
+		return uint32(runArm64u(t, m, av, bv))
+	}
+
+	for _, o := range ops {
+		o := o
+		for _, form := range []struct {
+			tag  string
+			body func(byte) []byte
+		}{{"if", ifBody}, {"br_if", brIfBody}} {
+			for _, ft := range []struct {
+				name string
+				typ  wasm.ValType
+				code byte
+			}{{"f32", wasm.F32, o.f32Op}, {"f64", wasm.F64, o.f64Op}} {
+				body := form.body(ft.code)
+				t.Run(ft.name+"."+o.name+"/"+form.tag, func(t *testing.T) {
+					for _, in := range inputs {
+						a, b := in.a, in.b
+						if ft.typ == wasm.F32 {
+							a, b = float64(float32(a)), float64(float32(b))
+						}
+						want := uint32(0)
+						if o.predFn(a, b) {
+							want = 1
+						}
+						if got := run(t, ft.typ, body, in.a, in.b); got != want {
+							t.Fatalf("%s.%s/%s(%v,%v) = %d, want %d", ft.name, o.name, form.tag, in.a, in.b, got, want)
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/fp.go
+++ b/src/core/compiler/backend/railshot/arm64/fp.go
@@ -459,6 +459,21 @@ func (f *fn) fcmp(kind wOp, f64 bool) {
 	xb, xbOwned := f.operandRegF(b) // read-only: only compared
 	f.fpinned = f.fpinned.remove(xa)
 	dst := f.allocReg(0)
+	f.emitFCmpCset(kind, xa, xb, f64, dst)
+	if xaOwned {
+		f.releaseF(xa)
+	}
+	if xbOwned {
+		f.releaseF(xb)
+	}
+	f.pushReg(dst, mtI32)
+}
+
+// emitFCmpCset emits FCMP plus the NaN-correct CSET for a float relational op,
+// landing a 0/1 i32 boolean in dst. The ordered ops (gt/ge/lt/le) use GT/GE
+// (unordered clears N=V, so NaN yields false); lt/le swap the operands. Shared by
+// fcmp (eager boolean) and condenseFCompareValue (deferred-node fallback).
+func (f *fn) emitFCmpCset(kind wOp, xa, xb Reg, f64 bool, dst Reg) {
 	switch kind {
 	case opEq: // ordered equal: EQ requires Z=1, which unordered does not set
 		f.a.Fcmp(xa, xb, f64)
@@ -479,13 +494,96 @@ func (f *fn) fcmp(kind wOp, f64 bool) {
 		f.a.Fcmp(xb, xa, f64)
 		f.a.Cset32(dst, a64.CondGE)
 	}
+}
+
+// pushFCompare pushes a DEFERRED float relational op (gt/ge/lt/le only) instead
+// of materializing a boolean, so the immediately-following if/br_if can fuse it
+// into FCMP + B.cond via condenseFCompareToFlags. The driver only defers when the
+// next opcode is if/br_if, so the node never lingers past its consumer. eq/ne are
+// never deferred (their branch form needs two conditional branches).
+func (f *fn) pushFCompare(op wOp, f64 bool) {
+	typ := mtF32
+	if f64 {
+		typ = mtF64
+	}
+	right := f.s.back()
+	left := baseOfValentBlock(right).prev
+	node := f.s.alloc()
+	node.kind, node.op, node.typ = ekDeferred, op, typ
+	node.arg0, node.arg1 = left, right
+	node.deferDepth = 1 + max16(deferDepthOf(left), deferDepthOf(right))
+	f.s.push(node)
+}
+
+// condenseFCompareToFlags lowers a deferred float relational node to FCMP (no
+// CSET), consumes the node and its operands, and returns the branch condition
+// that is true when the comparison holds. Mirrors emitFCmpCset's operand
+// ordering. invert (from an eqz peel) flips the condition; that stays NaN-correct
+// because wasm's eqz(float-cmp) and the inverted arm64 condition both include the
+// unordered case on the negated side (GT↔LE, GE↔LT).
+func (f *fn) condenseFCompareToFlags(node *elem, invert bool) Cond {
+	f.stats.peep("fcmp-branch-fuse")
+	f64 := node.typ == mtF64
+	xa, xaOwned := f.operandRegF(node.arg0)
+	f.fpinned = f.fpinned.add(xa)
+	xb, xbOwned := f.operandRegF(node.arg1)
+	f.fpinned = f.fpinned.remove(xa)
+	var cc Cond
+	switch node.op {
+	case opGtS:
+		f.a.Fcmp(xa, xb, f64)
+		cc = a64.CondGT
+	case opGeS:
+		f.a.Fcmp(xa, xb, f64)
+		cc = a64.CondGE
+	case opLtS:
+		f.a.Fcmp(xb, xa, f64)
+		cc = a64.CondGT
+	case opLeS:
+		f.a.Fcmp(xb, xa, f64)
+		cc = a64.CondGE
+	}
 	if xaOwned {
 		f.releaseF(xa)
 	}
 	if xbOwned {
 		f.releaseF(xb)
 	}
-	f.pushReg(dst, mtI32)
+	if invert {
+		cc = invertCond(cc)
+	}
+	f.consumeBlockBelow(node)
+	f.erase(node)
+	return cc
+}
+
+// condenseFCompareValue materializes a deferred float relational node to a 0/1
+// boolean. Defensive: the driver only defers a float compare directly before its
+// if/br_if consumer, so this is normally unreachable, but it keeps a deferred
+// float node correct on any path that condenses it as a value.
+func (f *fn) condenseFCompareValue(node *elem, dest Reg) Reg {
+	f.stats.peep("fcmp-value-fallback")
+	f64 := node.typ == mtF64
+	xa, xaOwned := f.operandRegF(node.arg0)
+	f.fpinned = f.fpinned.add(xa)
+	xb, xbOwned := f.operandRegF(node.arg1)
+	f.fpinned = f.fpinned.remove(xa)
+	result := dest
+	if result == regNone {
+		result = f.allocReg(0)
+	}
+	f.emitFCmpCset(node.op, xa, xb, f64, result)
+	if xaOwned {
+		f.releaseF(xa)
+	}
+	if xbOwned {
+		f.releaseF(xb)
+	}
+	f.consumeBlockBelow(node)
+	f.occupy(node, result)
+	node.st.typ = mtI32
+	node.op = opNone
+	return result
 }
 
 // i2f converts a signed integer to float. srcWide selects an i64 source.

--- a/src/core/compiler/backend/railshot/arm64/fuse.go
+++ b/src/core/compiler/backend/railshot/arm64/fuse.go
@@ -108,6 +108,11 @@ func (f *fn) condenseToFlags(node *elem) Cond {
 			invert = !invert
 		}
 	}
+	// Ordered float relational nodes (gt/ge/lt/le) lower to FCMP + a NaN-safe
+	// condition instead of a materialized boolean. eq/ne are never deferred here.
+	if node.typ.isFloat() {
+		return f.condenseFCompareToFlags(node, invert)
+	}
 	applyInvert := func(cc Cond) Cond {
 		if invert {
 			return invertCond(cc)

--- a/src/core/compiler/backend/railshot/arm64/stats.go
+++ b/src/core/compiler/backend/railshot/arm64/stats.go
@@ -4,7 +4,7 @@ package arm64
 
 // CodegenStats is the railshot "explain" dashboard: per-function counters that
 // make every later optimization prove itself (docs/no-ir-plan.md P1). Collection
-// is opt-in — a *CodegenStats is threaded through the fn only when the caller asks
+// is opt-in â a *CodegenStats is threaded through the fn only when the caller asks
 // (CompileOptions.Stats) or WAGO_EXPLAIN=1 is set. When off, the field is nil and
 // every counter method is a no-op (nil-receiver methods), so the hot compile path
 // pays nothing.
@@ -36,13 +36,17 @@ var (
 	// pickModuleGlobals heuristic), 0..len(moduleGlobalRegs) = force that many.
 	pinGlobalK = parsePinGlobalK(os.Getenv("WAGO_PIN_GLOBAL_K"))
 	// boundsFactsEnabled gates P6.1 straight-line bounds-check elision (explicit
-	// mode). WAGO_NO_BOUNDS_FACTS=1 forces every check — the A/B oracle + kill switch.
+	// mode). WAGO_NO_BOUNDS_FACTS=1 forces every check â the A/B oracle + kill switch.
 	boundsFactsEnabled = os.Getenv("WAGO_NO_BOUNDS_FACTS") != "1"
 	// stFlagsEnabled gates the stFlags tee-forward window (R1): a compare stored by
 	// `local.tee $c` and consumed by the next if/br_if/select fuses into the branch,
 	// storing $c with a flag-neutral Cset after the CMP. WAGO_NO_STFLAGS=1 is the
 	// A/B oracle + kill switch for this flag-desync-sensitive path.
 	stFlagsEnabled = os.Getenv("WAGO_NO_STFLAGS") != "1"
+
+	// fcmpFuseEnabled gates float compare-to-branch→branch fusion (FCMP + B.cond instead
+	// of FCMP + CSET + branch). WAGO_NO_FCMP_FUSE=1 is the A/B oracle.
+	fcmpFuseEnabled = os.Getenv("WAGO_NO_FCMP_FUSE") != "1"
 )
 
 func parsePinGlobalK(s string) int {
@@ -81,15 +85,15 @@ type CodegenStats struct {
 	CallFlushes          int // full/partial operand flushes emitted for a register-ABI call
 	LocalSetDeferred     int // local.set/tee whose source was a deferred Valent block
 	Condenses            int // deferred-tree condensations to a register
-	Spills               int // register→slot evictions under pressure
-	Reloads              int // slot→register reloads of a spilled value
+	Spills               int // registerâslot evictions under pressure
+	Reloads              int // slotâregister reloads of a spilled value
 	MemRefsForcedByStore int // deferred loads forced out by a store (P2.1 target)
 
 	// Bounds / traps.
 	BoundsChecks          int // inline memory-OOB checks emitted (P6 elides these)
 	BoundsChecksElidable  int // subset of BoundsChecks a straight-line certificate covers (P6.1 sizing; count-only)
 	BoundsChecksInLoop    int // subset emitted inside a loop on a keyable base (P6.2 loop-precheck ceiling; count-only)
-	BoundsChecksHoistable int // subset on a loop-INVARIANT local base (not set in the loop) — the P6.2 hoistable target; count-only
+	BoundsChecksHoistable int // subset on a loop-INVARIANT local base (not set in the loop) â the P6.2 hoistable target; count-only
 	TrapStubs             int // shared cold trap stubs emitted (one per trap code used)
 
 	// Calls, by lowering kind: regabi / mixed / wrapper / host / indirect /
@@ -102,7 +106,7 @@ type CodegenStats struct {
 
 	// UnpinnedRetry is set when the pinned compile exhausted the register file
 	// (a pathologically deep expression tree) and the function was recompiled with
-	// local pinning disabled — a diagnostic flag for such register-heavy functions.
+	// local pinning disabled â a diagnostic flag for such register-heavy functions.
 	UnpinnedRetry bool
 
 	// Peephole/instruction-selection rewrites that fired, by stable name.
@@ -242,7 +246,7 @@ func (s *CodegenStats) peep(name string) {
 	s.Peephole[name]++
 }
 
-// ModuleGlobalPinInfo describes one module-wide global→register reservation.
+// ModuleGlobalPinInfo describes one module-wide globalâregister reservation.
 type ModuleGlobalPinInfo struct {
 	Global uint32
 	Reg    string
@@ -269,7 +273,7 @@ func (ms *ModuleStats) String() string {
 	} else {
 		fmt.Fprintf(&b, "module-pinned globals (K=%d):", len(ms.ModuleGlobalPins))
 		for _, p := range ms.ModuleGlobalPins {
-			fmt.Fprintf(&b, " g%d→%s", p.Global, p.Reg)
+			fmt.Fprintf(&b, " g%dâ%s", p.Global, p.Reg)
 		}
 		b.WriteByte('\n')
 	}


### PR DESCRIPTION
An ordered float relation (`f32`/`f64` `lt`/`le`/`gt`/`ge`) placed directly before `if` or `br_if` now lowers to a single compare + NaN-safe conditional branch, instead of materializing a 0/1 boolean and then branching on it. This closes a valent-block condense gap versus WARP, whose `emitBranch` lowers float conditions the same way; Wago previously deferred only integer compares into the flags path and always spilled float compares to a boolean.

| | before | after |
|---|---|---|
| amd64 | `UCOMIS + SETcc + TEST + Jcc` | `UCOMIS + Jcc` |
| arm64 | `FCMP + CSET + CBNZ` | `FCMP + B.cond` |

## Design
- **Lookahead-gated deferral** (`fcmpMaybeDefer`): the compare is deferred as a fusable node *only* when the very next opcode is `if`/`br_if`, so it is condensed immediately by that consumer and never lingers on the operand stack (avoids any spilled-XMM/-NEON-operand hazard). Every other float-compare use keeps the eager boolean path (`fcmp`).
- **`eq`/`ne` stay eager** — their NaN-correct branch form needs two conditional branches, which does not fit the single-condition sink contract.
- **NaN correctness**: `condenseFCompareToFlags` reuses `fcmp`'s exact operand ordering (swap for `lt`/`le`) and the CF-clear / `GT`/`GE` conditions, so unordered (NaN) yields false. The `eqz`-invert path stays NaN-consistent because wasm's `eqz(float-cmp)` and the inverted machine condition both put the unordered case on the negated side (amd64 `condA↔condBE`; arm64 `GT↔LE`, `GE↔LT` via `invertCond`).
- Defensive `condenseFCompareValue` guard keeps a deferred float node correct on any value-materialization path (normally unreachable given the lookahead).
- `WAGO_NO_FCMP_FUSE=1` is the A/B kill switch; adds an `fcmp-branch-fuse` / `fcmp-value-fallback` peephole counter on both backends.

## Verification
- New exhaustive exec test on **both** arches: all 4 ordered ops × `f32`/`f64` × `if`/`br_if`, with `NaN`/`±inf`/`-0` inputs, checked against Go's native comparison (which matches wasm NaN semantics).
- **amd64** (hub, linux/amd64): spec1 (629 modules / 16026 assertions) + spec2 (1600 / 48248) zero-fail; corpus differential execution clean.
- **arm64** (native darwin/arm64): full railshot/arm64 package suite + corpus differential (executing compiled arm64 code) pass.
- **Zero code-size regression** (output never larger). Code-size A/B via the kill switch (cache-busted): esbuild −528 B, lua −800 B, sqlite3 −752 B; amd64 esbuild −672 B. On-corpus impact is modest because the corpus is integer-heavy — the win lands on float-branch-dense code (numeric kernels, comparators), the paper's target.

No behavior change to any non-branch float compare; no public API change.