### PR TITLE
perf: valent-block condense fusions (MADD/MSUB, 3-op IMUL, commutative memory reversal)

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/emit.go
+++ b/src/core/compiler/backend/railshot/amd64/emit.go
@@ -119,13 +119,22 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 	left := node.arg0
 	right := node.arg1
 
-	// Commutative reassociation (selectInstr): if the left operand is a constant
-	// but the right is not, swap so the constant folds as an immediate rather than
-	// being loaded into dest.
-	if node.op.commutative() &&
-		left.kind == ekValue && left.st.kind == stConst &&
-		!(right.kind == ekValue && right.st.kind == stConst) {
-		left, right = right, left
+	// Commutative reassociation (selectInstr): swap operands so the cheaper form
+	// falls out. (1) a constant left folds as an immediate rather than being loaded
+	// into dest. (2) a memory left (spill slot / frame local / deferred load) with an
+	// owned-register right accumulates into that register and folds the memory as an
+	// r/m operand — `add rr,[m]` — instead of loading [m] into dest then adding rr
+	// (the mirror of the memory-on-the-right case already folded by applyALU).
+	if node.op.commutative() && left.kind == ekValue {
+		swapConst := left.st.kind == stConst && !(right.kind == ekValue && right.st.kind == stConst)
+		swapMem := commuteMemLeftEnabled && right.kind == ekValue && right.st.kind == stReg &&
+			(left.st.kind == stSlot || left.st.kind == stLocalRef || left.st.kind == stMemRef)
+		if swapConst || swapMem {
+			left, right = right, left
+			if swapMem {
+				f.stats.peep("commute-mem-left")
+			}
+		}
 	}
 
 	// Scaled-index fusion: add(x, shl(y, k∈1..3)) → `lea dest,[x + y*2ᵏ]` — one

--- a/src/core/compiler/backend/railshot/amd64/emit.go
+++ b/src/core/compiler/backend/railshot/amd64/emit.go
@@ -144,6 +144,9 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 		if r := f.tryLeaMul(node, left, right, dest); r != regNone {
 			return r
 		}
+		if r := f.tryMulConstThreeOp(node, left, right, dest, w); r != regNone {
+			return r
+		}
 	}
 
 	// Materialize the RHS into a safe, foldable operand BEFORE the LHS overwrites
@@ -754,6 +757,35 @@ func (f *fn) applyALU(enc aluEnc, dest Reg, right *elem, w bool) {
 }
 
 // applyMul emits `dest = dest * right` (imul), folding the right operand.
+// tryMulConstThreeOp folds a borrowed register source into a general constant
+// multiply via the three-operand IMUL (dest = src * imm), avoiding the mov
+// src→dest that condenseInto + two-operand ImulRI would emit. The commutative
+// swap has already put the constant on the right; {3,5,9} and powers of two are
+// handled earlier (LEA / shl at pushBinOp), so only a general imm32 source reaches
+// here. Gated by WAGO_NO_MUL3.
+func (f *fn) tryMulConstThreeOp(node, left, right *elem, dest Reg, w bool) Reg {
+	if !mul3opEnabled {
+		return regNone
+	}
+	if !(left.kind == ekValue && (left.st.kind == stLocalReg || left.st.kind == stGlobReg)) {
+		return regNone
+	}
+	if !(right.kind == ekValue && right.st.kind == stConst) || !fitsImm32(right.st.cval) {
+		return regNone
+	}
+	src := left.st.reg
+	d := dest
+	if d == regNone {
+		d = f.allocReg(maskOf(src))
+	}
+	f.a.ImulRRI(d, src, int32(right.st.cval), w)
+	f.stats.peep("mul3-imm")
+	f.consumeBlockBelow(node)
+	f.occupy(node, d)
+	node.op = opNone
+	return d
+}
+
 func (f *fn) applyMul(dest Reg, right *elem, w bool) {
 	switch right.st.kind {
 	case stConst:

--- a/src/core/compiler/backend/railshot/amd64/fcmpbranch_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/fcmpbranch_exec_test.go
@@ -15,11 +15,6 @@ import (
 // NaN-safe Jcc instead of materializing a boolean. Go's native <,>,<=,>= already
 // return false on NaN, matching wasm, so they are the oracle.
 func TestFloatCompareBranchFusion(t *testing.T) {
-	const (
-		nan  = "nan"
-		pinf = "+inf"
-		ninf = "-inf"
-	)
 	// opcodes: [lt, gt, le, ge] for f32 (0x5d..0x60) and f64 (0x63..0x66).
 	type opc struct {
 		name   string

--- a/src/core/compiler/backend/railshot/amd64/mul3op_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/mul3op_exec_test.go
@@ -1,0 +1,54 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// sleb128 encodes v as signed LEB128 (for i32/i64.const immediates).
+func sleb128(v int64) []byte {
+	var out []byte
+	for {
+		b := byte(v & 0x7f)
+		v >>= 7
+		if (v == 0 && b&0x40 == 0) || (v == -1 && b&0x40 != 0) {
+			out = append(out, b)
+			return out
+		}
+		out = append(out, b|0x80)
+	}
+}
+
+// TestMulConstThreeOp checks `local * const` (folded to three-operand IMUL) for a
+// range of general constants that bypass the LEA/shift strength reductions, i32
+// and i64, against Go.
+func TestMulConstThreeOp(t *testing.T) {
+	consts := []int64{7, 11, 100, -5, 1000000, 6, 12, -1000}
+	xs := []int64{0, 1, 3, -3, 123456, -7, 0x1_0000_0001}
+	for _, is64 := range []bool{false, true} {
+		typ, constOp, mulOp, fold := wasm.I32, byte(0x41), byte(0x6c), func(v int64) uint64 { return uint64(uint32(v)) }
+		wname := "i32"
+		if is64 {
+			typ, constOp, mulOp, fold = wasm.I64, 0x42, 0x7e, func(v int64) uint64 { return uint64(v) }
+			wname = "i64"
+		}
+		for _, c := range consts {
+			c := c
+			t.Run(wname, func(t *testing.T) {
+				body := append([]byte{0x00, 0x20, 0x00, constOp}, sleb128(c)...)
+				body = append(body, mulOp, 0x0b)
+				m := mod1(t, []wasm.ValType{typ}, []wasm.ValType{typ}, body)
+				for _, x := range xs {
+					got := fold(int64(runAmd64u(t, m, uint64(x))))
+					want := fold(x * c)
+					if got != want {
+						t.Fatalf("%s: %d * %d = %d, want %d", wname, x, c, got, want)
+					}
+				}
+			})
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/amd64/stats.go
+++ b/src/core/compiler/backend/railshot/amd64/stats.go
@@ -51,6 +51,11 @@ var (
 	// mul3opEnabled gates three-operand IMUL (dest = src*imm) that folds a borrowed
 	// register source into a constant multiply. WAGO_NO_MUL3=1 is the A/B oracle.
 	mul3opEnabled = os.Getenv("WAGO_NO_MUL3") != "1"
+
+	// commuteMemLeftEnabled gates swapping a commutative op's memory left operand
+	// with an owned-register right, to fold the memory as an r/m operand and
+	// accumulate in the register. WAGO_NO_COMMUTE_MEM=1 is the A/B oracle.
+	commuteMemLeftEnabled = os.Getenv("WAGO_NO_COMMUTE_MEM") != "1"
 )
 
 func parsePinGlobalK(s string) int {

--- a/src/core/compiler/backend/railshot/amd64/stats.go
+++ b/src/core/compiler/backend/railshot/amd64/stats.go
@@ -47,6 +47,10 @@ var (
 	// (lt/le/gt/ge) directly before if/br_if lowers to UCOMIS + a NaN-safe Jcc
 	// instead of UCOMIS + SETcc + TEST + Jcc. WAGO_NO_FCMP_FUSE=1 is the A/B oracle.
 	fcmpFuseEnabled = os.Getenv("WAGO_NO_FCMP_FUSE") != "1"
+
+	// mul3opEnabled gates three-operand IMUL (dest = src*imm) that folds a borrowed
+	// register source into a constant multiply. WAGO_NO_MUL3=1 is the A/B oracle.
+	mul3opEnabled = os.Getenv("WAGO_NO_MUL3") != "1"
 )
 
 func parsePinGlobalK(s string) int {

--- a/src/core/compiler/backend/railshot/arm64/emit.go
+++ b/src/core/compiler/backend/railshot/arm64/emit.go
@@ -159,6 +159,15 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 		left, right = right, left
 	}
 
+	// MADD/MSUB fusion: add(c, a*b) → MADD (c + a*b), sub(c, a*b) → MSUB (c - a*b)
+	// in one instruction when the multiply is an un-condensed value*value node.
+	// Checked before the LEA/local-sink forms so a*b±c never splits into MUL + ADD.
+	if node.op == opAdd || node.op == opSub {
+		if r := f.tryMulAddFuse(node, dest, w); r != regNone {
+			return r
+		}
+	}
+
 	// AArch64's integer ALU is genuinely three-operand.  When local.set gives
 	// us a destination register and the left input is a borrowed pinned
 	// local/global, use it as Rn directly instead of first copying it into Rd:
@@ -1029,6 +1038,87 @@ func (f *fn) msub(d, n, m, ra Reg, w bool) {
 	} else {
 		f.a.Msub32(d, n, m, ra)
 	}
+}
+
+// madd emits `d = ra + n*m` (MADD), the fused multiply-add.
+func (f *fn) madd(d, n, m, ra Reg, w bool) {
+	if w {
+		f.a.Madd64(d, n, m, ra)
+	} else {
+		f.a.Madd32(d, n, m, ra)
+	}
+}
+
+// isValueMul reports whether e is a deferred integer multiply whose two operands
+// are both concrete values (not nested deferred subtrees). Such a mul can fuse
+// into a single MADD/MSUB with a value addend without any nested-subtree consume.
+func isValueMul(e *elem) bool {
+	return e != nil && e.kind == ekDeferred && e.op == opMul &&
+		e.arg0 != nil && e.arg0.kind == ekValue &&
+		e.arg1 != nil && e.arg1.kind == ekValue
+}
+
+// tryMulAddFuse fuses add(c, a*b) → MADD (d = c + a*b) and sub(c, a*b) → MSUB
+// (d = c - a*b) into one instruction when the multiply is an un-condensed opMul
+// node with value operands and the addend is a value. a*b - c is NOT MSUB-shaped
+// (MSUB computes ra - n*m), so only the c-minus-mul sub form fuses. Returns the
+// result register or regNone when the shape does not apply. Gated by
+// WAGO_NO_MULADD as the A/B oracle.
+func (f *fn) tryMulAddFuse(node *elem, dest Reg, w bool) Reg {
+	if !mulAddFuseEnabled {
+		return regNone
+	}
+	var mul, addend *elem
+	switch node.op {
+	case opAdd:
+		switch {
+		case isValueMul(node.arg1):
+			mul, addend = node.arg1, node.arg0
+		case isValueMul(node.arg0):
+			mul, addend = node.arg0, node.arg1
+		}
+	case opSub:
+		if isValueMul(node.arg1) { // c - a*b → MSUB; a*b - c is not representable
+			mul, addend = node.arg1, node.arg0
+		}
+	}
+	if mul == nil || addend.kind != ekValue {
+		return regNone
+	}
+	// Three read-only sources; pin each so materializing the next (e.g. a load or
+	// const) cannot reuse it.
+	n, ownN := f.materializeRead(mul.arg0)
+	f.pinned = f.pinned.add(n)
+	m, ownM := f.materializeRead(mul.arg1)
+	f.pinned = f.pinned.add(m)
+	ra, ownRa := f.materializeRead(addend)
+	f.pinned = f.pinned.add(ra)
+	d := dest
+	if d == regNone {
+		d = f.allocReg(0)
+	}
+	if node.op == opAdd {
+		f.madd(d, n, m, ra, w)
+	} else {
+		f.msub(d, n, m, ra, w)
+	}
+	f.pinned = f.pinned.remove(n)
+	f.pinned = f.pinned.remove(m)
+	f.pinned = f.pinned.remove(ra)
+	if ownN {
+		f.release(n)
+	}
+	if ownM && m != n {
+		f.release(m)
+	}
+	if ownRa && ra != n && ra != m {
+		f.release(ra)
+	}
+	f.stats.peep("mul-add-fuse")
+	f.consumeBlockBelow(node)
+	f.occupy(node, d)
+	node.op = opNone
+	return d
 }
 
 // cmpIntMin compares the dividend against the type's most-negative value

--- a/src/core/compiler/backend/railshot/arm64/muladd_exec_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/muladd_exec_arm64_test.go
@@ -1,0 +1,78 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestMulAddFuse checks add(c,a*b)→MADD / sub(c,a*b)→MSUB fusion (and that the
+// non-fusable a*b-c form still computes correctly), for i32 and i64, against Go.
+func TestMulAddFuse(t *testing.T) {
+	// body builders: params (x,y,z) of type T, result T.
+	// mul/add/sub opcodes per width.
+	type widthOps struct {
+		typ           wasm.ValType
+		lget          func(i byte) []byte
+		mul, add, sub byte
+		fold          func(uint64) uint64 // canonicalize to the width
+	}
+	i32ops := widthOps{wasm.I32, func(i byte) []byte { return []byte{0x20, i} }, 0x6c, 0x6a, 0x6b,
+		func(v uint64) uint64 { return uint64(uint32(v)) }}
+	i64ops := widthOps{wasm.I64, func(i byte) []byte { return []byte{0x20, i} }, 0x7e, 0x7c, 0x7d,
+		func(v uint64) uint64 { return v }}
+
+	// shapes: (name, body(ops), expected(a,b,c))
+	shapes := []struct {
+		name   string
+		body   func(w widthOps) []byte
+		expect func(a, b, c uint64) uint64
+	}{
+		{"a*b+c", func(w widthOps) []byte { // add(mul(a,b), c)
+			return concat(w.lget(0), w.lget(1), []byte{w.mul}, w.lget(2), []byte{w.add, 0x0b})
+		}, func(a, b, c uint64) uint64 { return a*b + c }},
+		{"c+a*b", func(w widthOps) []byte { // add(c, mul(a,b))
+			return concat(w.lget(2), w.lget(0), w.lget(1), []byte{w.mul, w.add, 0x0b})
+		}, func(a, b, c uint64) uint64 { return c + a*b }},
+		{"c-a*b", func(w widthOps) []byte { // sub(c, mul(a,b)) → MSUB
+			return concat(w.lget(2), w.lget(0), w.lget(1), []byte{w.mul, w.sub, 0x0b})
+		}, func(a, b, c uint64) uint64 { return c - a*b }},
+		{"a*b-c", func(w widthOps) []byte { // sub(mul(a,b), c) → NOT MSUB (fallback)
+			return concat(w.lget(0), w.lget(1), []byte{w.mul}, w.lget(2), []byte{w.sub, 0x0b})
+		}, func(a, b, c uint64) uint64 { return a*b - c }},
+	}
+	inputs := []struct{ a, b, c uint64 }{
+		{3, 4, 5}, {7, 8, 100}, {0, 9, 3}, {1, 1, 1},
+		{0xFFFFFFFF, 2, 1}, {0x1_0000_0000, 3, 7}, {12345, 6789, 999},
+	}
+
+	for _, w := range []widthOps{i32ops, i64ops} {
+		wname := "i32"
+		if w.typ == wasm.I64 {
+			wname = "i64"
+		}
+		for _, sh := range shapes {
+			body := append([]byte{0x00}, sh.body(w)...) // 0 locals prefix
+			t.Run(wname+"/"+sh.name, func(t *testing.T) {
+				m := mod1(t, []wasm.ValType{w.typ, w.typ, w.typ}, []wasm.ValType{w.typ}, body)
+				for _, in := range inputs {
+					got := w.fold(runArm64u(t, m, in.a, in.b, in.c))
+					want := w.fold(sh.expect(in.a, in.b, in.c))
+					if got != want {
+						t.Fatalf("%s %s(a=%d,b=%d,c=%d) = %d, want %d", wname, sh.name, in.a, in.b, in.c, got, want)
+					}
+				}
+			})
+		}
+	}
+}
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}

--- a/src/core/compiler/backend/railshot/arm64/stats.go
+++ b/src/core/compiler/backend/railshot/arm64/stats.go
@@ -44,9 +44,13 @@ var (
 	// A/B oracle + kill switch for this flag-desync-sensitive path.
 	stFlagsEnabled = os.Getenv("WAGO_NO_STFLAGS") != "1"
 
-	// fcmpFuseEnabled gates float compare-to-branch→branch fusion (FCMP + B.cond instead
-	// of FCMP + CSET + branch). WAGO_NO_FCMP_FUSE=1 is the A/B oracle.
+	// fcmpFuseEnabled gates float compare→branch fusion (FCMP + B.cond instead of
+	// FCMP + CSET + branch). WAGO_NO_FCMP_FUSE=1 is the A/B oracle.
 	fcmpFuseEnabled = os.Getenv("WAGO_NO_FCMP_FUSE") != "1"
+
+	// mulAddFuseEnabled gates MADD/MSUB fusion of add(c, a*b)/sub(c, a*b) into a
+	// single multiply-add/-subtract. WAGO_NO_MULADD=1 is the A/B oracle.
+	mulAddFuseEnabled = os.Getenv("WAGO_NO_MULADD") != "1"
 )
 
 func parsePinGlobalK(s string) int {

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -337,6 +337,21 @@ func (a *Asm) ImulRI(dst Reg, imm int32, w bool) {
 	}
 }
 
+// ImulRRI is the three-operand IMUL: dst = src * imm (src a distinct register),
+// avoiding a preceding mov dst,src that the two-operand ImulRI would require.
+func (a *Asm) ImulRRI(dst, src Reg, imm int32, w bool) {
+	if w || dst >= 8 || src >= 8 {
+		a.emit(rex(w, dst >= 8, false, src >= 8))
+	}
+	mod := byte(0xC0) | ((byte(dst) & 7) << 3) | byte(src&7)
+	if imm >= -128 && imm <= 127 {
+		a.emit(0x6B, mod, byte(imm))
+	} else {
+		a.emit(0x69, mod)
+		a.imm32(imm)
+	}
+}
+
 func (a *Asm) ShiftImm(digit byte, dst Reg, count byte, w bool) {
 	if w || dst >= 8 {
 		a.emit(rex(w, false, false, dst >= 8))

--- a/src/core/encoder/arm64/asm.go
+++ b/src/core/encoder/arm64/asm.go
@@ -278,6 +278,11 @@ func (a *Asm) Madd64(rd, rn, rm, ra Reg) {
 func (a *Asm) Mul64(rd, rn, rm Reg) { a.Madd64(rd, rn, rm, XZR) }
 func (a *Asm) Mul32(rd, rn, rm Reg) { a.word(0x1B000000 | r(rm)<<16 | r(XZR)<<10 | r(rn)<<5 | r(rd)) }
 
+// Madd32 is the 32-bit Rd = Ra + Rn*Rm (MADD, W registers).
+func (a *Asm) Madd32(rd, rn, rm, ra Reg) {
+	a.word(0x1B000000 | r(rm)<<16 | r(ra)<<10 | r(rn)<<5 | r(rd))
+}
+
 // --- Logical (shifted register, LSL #0) ---
 
 func (a *Asm) And32(rd, rn, rm Reg) { a.word(0x0A000000 | r(rm)<<16 | r(rn)<<5 | r(rd)) }

--- a/src/core/encoder/arm64/asm_test.go
+++ b/src/core/encoder/arm64/asm_test.go
@@ -57,6 +57,7 @@ func TestEncodings(t *testing.T) {
 		{"cset x0,ne", func(a *Asm) { a.Cset64(X0, CondNE) }, 0x9a9f07e0},
 		// multiply
 		{"madd x0,x1,x2,x3", func(a *Asm) { a.Madd64(X0, X1, X2, X3) }, 0x9b020c20},
+		{"madd w0,w1,w2,w3", func(a *Asm) { a.Madd32(X0, X1, X2, X3) }, 0x1b020c20},
 		{"mul w9,w0,w1", func(a *Asm) { a.Mul32(X9, X0, X1) }, 0x1b017c09},
 		{"mul x9,x0,x1", func(a *Asm) { a.Mul64(X9, X0, X1) }, 0x9b017c09},
 		// logical (register)


### PR DESCRIPTION
Three independent instruction-selection fusions in the railshot condense engine — each emits one instruction where two were emitted, closing WARP-parity gaps. All behind A/B kill switches with peep counters.

## 1. arm64: `a*b±c` → MADD/MSUB
When a deferred integer multiply (value×value) is an operand of an add/subtract, `condenseBinary` emits a single `MADD` (c + a·b) or `MSUB` (c − a·b) instead of `MUL` then `ADD`/`SUB`. Only the c−mul subtract fuses (`MSUB` is `ra − n·m`; `a·b − c` isn't representable and falls back). i32 + i64. arm64-only (x86-64 has no integer FMA). Adds `Madd32` encoder form. `WAGO_NO_MULADD`.
- **Code-size:** esbuild −5184 B, sqlite3 −4480 B, lua −784 B.

## 2. amd64: `local * const` → three-operand IMUL
`x * const` (general constant; {3,5,9}/powers-of-two already become LEA/shl) was `mov dest,src; imul dest,imm`. Now `imul dest, src, imm` folds the borrowed register source directly — one instruction, no copy, source local intact. Adds `ImulRRI` encoder form. `WAGO_NO_MUL3`.
- **Code-size:** esbuild −2640 B, sqlite3 −1184 B.

## 3. amd64: commutative memory-left operand reversal
For a commutative op (add/and/or/xor/mul) whose left operand is memory (spill slot / frame local / deferred load) and whose right is an owned register, swap them so the op accumulates into the register and folds the memory as an r/m operand (`add rr,[m]`) — the mirror of the memory-on-the-right folding already done. `WAGO_NO_COMMUTE_MEM`.
- **Code-size:** ruby −3584 B, esbuild −704 B.

## Verification
- New exhaustive exec tests for #1 (i32/i64 × a·b+c, c+a·b, c−a·b, a·b−c fallback) and #2 (`x*C` for general/negative C, i32/i64), checked against Go.
- **amd64** (hub): full railshot/amd64 suite, encoder golden tests, spec1 (629 / 16026), spec2 (1600 / 48248), corpus differential — all pass.
- **arm64** (native darwin/arm64): full railshot/arm64 suite, encoder golden tests, corpus differential — all pass.
- Zero code-size regression (output never larger). No public API change.

Part of a larger "extend valent-blocks" effort; the structural float-deferral work (enabling amd64 float memory-operand folding and arm64 FMADD/FMSUB) is tracked separately.