### PR TITLE
perf(amd64): fold a commutative float op's memRef left operand as SSE source

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/fcommute_fmem_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/fcommute_fmem_exec_test.go
@@ -1,0 +1,125 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+// TestFloatCommuteMemFold exercises the commutative float memory-fold swap
+// (fbin: foldFloatMem(a) && !foldFloatMem(b) → swap so the load folds as the SSE
+// r/m source). The body stores param a to memory then computes
+//
+//	(f64.load 0) <op> (local.get 1)
+//
+// which places the deferred load on the LEFT of the operator. For add/mul the
+// operands are swapped and the load becomes `addsd/mulsd xmm_b, [mem]`; for
+// sub/div (non-commutative) the swap must NOT fire and the load is materialized.
+// IEEE add/mul are exactly commutative, so Go's a<op>b is the oracle across the
+// full NaN/±inf/±0 grid.
+func TestFloatCommuteMemFold(t *testing.T) {
+	type opc struct {
+		name   string
+		f32Op  byte
+		f64Op  byte
+		fn     func(a, b float64) float64
+		commut bool // true for add/mul (swap expected)
+	}
+	ops := []opc{
+		{"add", 0x92, 0xa0, func(a, b float64) float64 { return a + b }, true},
+		{"mul", 0x94, 0xa2, func(a, b float64) float64 { return a * b }, true},
+		{"sub", 0x93, 0xa1, func(a, b float64) float64 { return a - b }, false},
+		{"div", 0x95, 0xa3, func(a, b float64) float64 { return a / b }, false},
+	}
+	inputs := []struct{ a, b float64 }{
+		{2, 3}, {3, 2}, {-1.5, 4.25}, {0, 5}, {5, 0},
+		{math.NaN(), 1}, {1, math.NaN()},
+		{math.Inf(1), 2}, {2, math.Inf(-1)}, {math.Inf(1), math.Inf(-1)},
+		{math.Copysign(0, -1), 0}, {0, math.Copysign(0, -1)},
+	}
+
+	// body: store a@0, then (load 0) <op> b. align = log2(width).
+	build := func(storeOp, loadOp, arithOp, align byte) []byte {
+		return []byte{0x00, // no locals
+			0x41, 0x00, // i32.const 0  (store addr)
+			0x20, 0x00, // local.get 0  (a)
+			storeOp, align, 0x00, // <f>.store  align off=0
+			0x41, 0x00, // i32.const 0  (load addr)
+			loadOp, align, 0x00, // <f>.load   -> memRef (LEFT operand)
+			0x20, 0x01, // local.get 1  (b)
+			arithOp, // <f>.<op>
+			0x0b}    // end
+	}
+
+	memType := append([]byte{0x00}, wasmtest.ULEB(1)...) // min 1 page, no max
+	modFor := func(t *testing.T, typ wasm.ValType, body []byte) *wasm.Module {
+		t.Helper()
+		entry := append(wasmtest.ULEB(uint32(len(body))), body...)
+		b := wasmtest.Module(
+			wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{typ, typ}, []wasm.ValType{typ}))),
+			wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+			wasmtest.Section(5, wasmtest.Vec(memType)),
+			wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+			wasmtest.Section(10, wasmtest.Vec(entry)),
+		)
+		m, err := wasm.DecodeModule(b)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return m
+	}
+
+	for _, o := range ops {
+		o := o
+		for _, ft := range []struct {
+			name    string
+			typ     wasm.ValType
+			arithOp byte
+			storeOp byte
+			loadOp  byte
+			align   byte
+		}{
+			{"f32", wasm.F32, o.f32Op, 0x38, 0x2a, 0x02},
+			{"f64", wasm.F64, o.f64Op, 0x39, 0x2b, 0x03},
+		} {
+			t.Run(ft.name+"."+o.name, func(t *testing.T) {
+				body := build(ft.storeOp, ft.loadOp, ft.arithOp, ft.align)
+				m := modFor(t, ft.typ, body)
+				for _, in := range inputs {
+					a, b := in.a, in.b
+					var av, bv uint64
+					var want uint64
+					if ft.typ == wasm.F32 {
+						av, bv = f32b(float32(a)), f32b(float32(b))
+						want = f32b(float32(o.fn(float64(float32(a)), float64(float32(b)))))
+					} else {
+						av, bv = f64b(a), f64b(b)
+						want = f64b(o.fn(a, b))
+					}
+					got := runAmd64u(t, m, av, bv)
+					// Compare bit patterns, but treat any NaN as equal to any NaN.
+					if !bitsEqualOrNaN(got, want, ft.typ == wasm.F32) {
+						t.Fatalf("%s.%s(%v,%v) = %#x, want %#x", ft.name, o.name, a, b, got, want)
+					}
+				}
+			})
+		}
+	}
+}
+
+// bitsEqualOrNaN compares result bit patterns, collapsing all NaNs to equal
+// (wasm does not mandate a canonical NaN payload for arithmetic results).
+func bitsEqualOrNaN(got, want uint64, f32 bool) bool {
+	if got == want {
+		return true
+	}
+	if f32 {
+		return math.IsNaN(float64(math.Float32frombits(uint32(got)))) &&
+			math.IsNaN(float64(math.Float32frombits(uint32(want))))
+	}
+	return math.IsNaN(math.Float64frombits(got)) && math.IsNaN(math.Float64frombits(want))
+}

--- a/src/core/compiler/backend/railshot/amd64/fp.go
+++ b/src/core/compiler/backend/railshot/amd64/fp.go
@@ -276,10 +276,25 @@ func (f *fn) fconst(bits uint64, typ machineType) {
 // operands are read directly (a pinned local is borrowed, never copied), and the
 // result lands in a reused owned-operand register or a fresh one — so no operand is
 // pre-copied to scratch the way legacy 2-operand SSE requires.
+// foldFloatMem reports whether e is a deferred float load of the given width that
+// can be folded directly as an SSE r/m operand (addsd/mulsd/subsd/divsd xmm, [mem]).
+func foldFloatMem(e *elem, f64 bool) bool {
+	return e.kind == ekValue && e.st.kind == stMemRef && e.st.typ.isFloat() && e.st.memSize() == fsize(f64)
+}
+
+// fMemCommutable reports whether an SSE arithmetic memOp is commutative, so its
+// operands may be swapped to expose a foldable memory operand: addss/addsd (0x58)
+// and mulss/mulsd (0x59). subss/subsd and divss/divsd are not.
+func fMemCommutable(memOp byte) bool { return memOp == 0x58 || memOp == 0x59 }
+
 func (f *fn) fbin(vop func(dst, s1, s2 Reg, f64 bool), memOp byte, f64 bool) {
 	b := f.popValue()
 	a := f.popValue()
-	if b.kind == ekValue && b.st.kind == stMemRef && b.st.typ.isFloat() && b.st.memSize() == fsize(f64) {
+	if commuteFMemEnabled && fMemCommutable(memOp) && foldFloatMem(a, f64) && !foldFloatMem(b, f64) {
+		a, b = b, a
+		f.stats.peep("fcommute_mem")
+	}
+	if foldFloatMem(b, f64) {
 		f.fbinMemRight(a, b, memOp, f64)
 		return
 	}
@@ -313,7 +328,11 @@ func (f *fn) fbin(vop func(dst, s1, s2 Reg, f64 bool), memOp byte, f64 bool) {
 func (f *fn) fbinInto(dst Reg, vop func(dst, s1, s2 Reg, f64 bool), memOp byte, f64 bool) {
 	b := f.popValue()
 	a := f.popValue()
-	if b.kind == ekValue && b.st.kind == stMemRef && b.st.typ.isFloat() && b.st.memSize() == fsize(f64) {
+	if commuteFMemEnabled && fMemCommutable(memOp) && foldFloatMem(a, f64) && !foldFloatMem(b, f64) {
+		a, b = b, a
+		f.stats.peep("fcommute_mem")
+	}
+	if foldFloatMem(b, f64) {
 		f.fbinMemRightInto(dst, a, b, memOp, f64)
 		return
 	}

--- a/src/core/compiler/backend/railshot/amd64/stats.go
+++ b/src/core/compiler/backend/railshot/amd64/stats.go
@@ -56,6 +56,13 @@ var (
 	// with an owned-register right, to fold the memory as an r/m operand and
 	// accumulate in the register. WAGO_NO_COMMUTE_MEM=1 is the A/B oracle.
 	commuteMemLeftEnabled = os.Getenv("WAGO_NO_COMMUTE_MEM") != "1"
+
+	// commuteFMemEnabled gates the float analogue: swapping a commutative float
+	// op's (add/mul) memRef left operand with a non-memRef right so the load folds
+	// as the SSE memory source instead of being materialized. IEEE add/mul are
+	// exactly commutative (incl. NaN/±0), so output is bit-identical.
+	// WAGO_NO_COMMUTE_FMEM=1 is the A/B oracle.
+	commuteFMemEnabled = os.Getenv("WAGO_NO_COMMUTE_FMEM") != "1"
 )
 
 func parsePinGlobalK(s string) int {


### PR DESCRIPTION
## What

Completes the float memory-operand folding story. `fbin` already folds a deferred float load into the SSE arithmetic instruction when the load is the **right** operand (`addsd/mulsd/subsd/divsd xmm, [mem]`). This adds the symmetric **left**-operand case: when a commutative float op (`add`/`mul`) has a memRef *left* operand and a non-memRef right, swap them so the load still folds and the right operand accumulates in the register.

It's the float mirror of the integer commutative memory-left reversal landed in #274.

## Why it's safe

IEEE-754 `add` and `mul` are **exactly commutative** — `a+b` and `b+a` (and `a*b`/`b*a`) produce bit-identical results including NaN payload propagation and `+0`/`-0` sign. `sub`/`div` are non-commutative and left untouched. Output is byte-identical to the un-swapped lowering; the swap only changes which operand is the register accumulator vs. the folded memory source.

Gated by `WAGO_NO_COMMUTE_FMEM=1` as the A/B oracle.

## Impact

Fires on real float-heavy modules where the source emits `mem[i] <op> reg` order:

| module | before | after | delta |
|---|---|---|---|
| nbody | 7181 | 7021 | **-160 B (-2.2%)** |
| matmul | 2660 | 2644 | -16 B |

(float/mandelbrot/spectralnorm/raytrace unchanged — loads already right-side.)

## Verification (hub, linux/amd64)

- `spec1`: **629/629 modules, 16026 assertions, 0 fail**
- New `TestFloatCommuteMemFold` exec test: add/mul/sub/div × f32/f64 across the full `{NaN, ±inf, ±0, normals}` input grid, comparing bit patterns against Go's native ops (NaN-collapsed).
- A/B parity: same test passes with `WAGO_NO_COMMUTE_FMEM=1`.
- `go build ./...`, `go vet`, `staticcheck` all clean; full railshot/amd64 suite green.

amd64-only (arm64 has no float memory-source ALU form).