### PR TITLE
ci: gate canary releases on main CI

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,10 +1,13 @@
 name: Publish canary
 
-# Every canary is built from main itself, never from the branch that happens to
-# manually dispatch this workflow. Every successful target is attached to an
-# immutable canary-* prerelease with the same asset names as nightly and stable.
+# A push to main publishes a canary only after that commit's CI run succeeds.
+# Manual dispatches build the current main tip. Every successful target is
+# attached to a uniquely tagged canary-* prerelease with the same asset names
+# as nightly and stable.
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -22,6 +25,12 @@ env:
 jobs:
   prepare:
     name: Resolve canary source
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.version.outputs.sha }}
@@ -30,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'push' && github.sha || 'main' }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}
           fetch-depth: 1
       - name: Resolve version
         id: version
@@ -158,7 +167,7 @@ jobs:
             test -s "$asset"
             sha256sum --check "$asset.sha256"
           done
-      - name: Publish immutable canary release
+      - name: Publish uniquely tagged canary release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,6 @@
 name: Publish nightly
 
-# Builds the CLI once a day from main and publishes an immutable nightly
+# Builds the CLI once a day from main and publishes a uniquely tagged nightly
 # prerelease. The CLI resolves the newest nightly-* release tag at install time.
 on:
   schedule:
@@ -193,9 +193,9 @@ jobs:
             sha256sum --check "$asset.sha256"
           done
 
-      # Immutable release rules forbid retargeting a rolling tag. Each nightly
-      # gets a unique tag; the CLI resolves the newest nightly-* prerelease.
-      - name: Publish immutable nightly release
+      # Each nightly gets a unique, never-retargeted tag; the CLI resolves the
+      # newest nightly-* prerelease.
+      - name: Publish uniquely tagged nightly release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ downloads.
 ### Toolchain channels
 
 The CLI can install stable versions and the moving release channels. Each
-nightly and canary is an immutable prerelease; the channel name resolves to its
-newest published release at install time:
+nightly and canary has a unique, never-retargeted prerelease tag; the channel
+name resolves to its newest published release at install time:
 
 ```bash
 wago version install 0.1.0
 wago version install nightly  # latest successful nightly release
-wago version install canary   # most recent build of main
+wago version install canary   # most recent successful-CI build of main
 ```
 
 `wago version update` refreshes the active version, while a version argument or

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -34,14 +34,17 @@ required matrix cell or supporting job fails.
 
 Nightly, canary, and tagged release workflows attempt Linux, Darwin, and Windows
 CLI builds for both amd64 and arm64, then publish every successful binary with
-its SHA-256 checksum. Nightly and canary use unique immutable prerelease tags;
-the CLI resolves the newest `nightly-*` or `canary-*` tag when a channel is
-installed. Linux builds use native size-focused TinyGo runners;
-Darwin uses standard Go because TinyGo cannot link the CLI's `os/exec` paths
-there, and Windows uses standard-Go cross-compilation from a Windows amd64
-runner for arm64. Unsupported native JIT targets are best-effort: a failed
-target is omitted and does not block the release. Every channel uses the same
-asset names: `wago-<goos>-<goarch>` (for example, `wago-linux-arm64`).
+its SHA-256 checksum. A push to `main` becomes a canary only after that commit's
+`CI` workflow succeeds; failed or cancelled CI runs do not publish a canary.
+Manual canary runs build the current `main` tip. Nightly and canary use unique
+never-retargeted prerelease tags; the CLI resolves the newest `nightly-*` or
+`canary-*` tag when a channel is installed. Linux builds use native
+size-focused TinyGo runners; Darwin uses standard Go because TinyGo cannot link
+the CLI's `os/exec` paths there, and Windows uses standard-Go cross-compilation
+from a Windows amd64 runner for arm64. Unsupported native JIT targets are
+best-effort: a failed target is omitted and does not block the release. Every
+channel uses the same asset names: `wago-<goos>-<goarch>` (for example,
+`wago-linux-arm64`).
 
 For a local native approximation, run:
 


### PR DESCRIPTION
## Summary

- publish canaries only after the triggering `main` push passes the `CI` workflow
- check out the exact tested commit while keeping manual builds pinned to current `main`
- retain 7-character SHA suffixes for unique canary/nightly tags
- document the successful-CI channel contract and never-retargeted release tags

## Root cause

The canary workflow listened directly to `push`, so it raced the required CI workflow. A canary could be published before CI finished; commit `0ec0418` produced a canary even though its corresponding main CI run later failed.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/canary.yml .github/workflows/nightly.yml .github/workflows/release.yml .github/workflows/ci.yml`
- `git diff --check`

## Notes

Unsupported native JIT targets remain best-effort and are omitted from channel releases when their build fails.