### PR TITLE
compiler: add opt-in parallel function compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ suffix when the default parser is not enough:
 wago run -e hypot tests/testdata/fprog.wasm 3:f64 4:f64
 ```
 
+Compilation is serial by default. Use `-p` for adaptive per-function compile
+parallelism, or specify a worker maximum with the standard separated form or the
+short joined form:
+
+```bash
+wago run -p app.wasm          # adaptive policy
+wago run -p 8 app.wasm        # at most 8 workers
+wago run -p8 app.wasm         # equivalent shorthand
+wago run --parallel=8 app.wasm
+```
+
 Validate without executing:
 
 ```bash
@@ -633,6 +644,8 @@ using TinyGo; see the TinyGo doc for the foreign-stack and GC rationale.
 | `WAGO_NO_BOUNDS_FACTS=1` | Disable deferred bounds-check facts globally. |
 | `RuntimeConfig.WithFeature` | Accept or reject individual wasm feature families. |
 | `RuntimeConfig.WithMemoryLimitPages` | Cap declared linear memory in 64 KiB wasm pages. |
+| `RuntimeConfig.WithCompileWorkers` | Select serial (`1`), adaptive (`0`), or a forced worker maximum. |
+| `wago run -p[workers]` | Enable adaptive compile parallelism (`-p`) or force a maximum (`-p8`, `-p 8`). |
 
 Guard-page mode is faster on memory-heavy modules but installs process-wide signal
 handlers and must be selected deliberately in builds that include it.

--- a/bench/backend_amd64.go
+++ b/bench/backend_amd64.go
@@ -8,7 +8,11 @@ import (
 )
 
 func benchCompileModule(m *wasm.Module) (*benchCompiledModule, error) {
-	cm, err := railshot.CompileModule(m)
+	return benchCompileModuleWorkers(m, 1)
+}
+
+func benchCompileModuleWorkers(m *wasm.Module, workers int) (*benchCompiledModule, error) {
+	cm, err := railshot.CompileModuleWith(m, railshot.CompileOptions{Workers: workers})
 	if err != nil {
 		return nil, err
 	}

--- a/bench/backend_arm64.go
+++ b/bench/backend_arm64.go
@@ -8,7 +8,11 @@ import (
 )
 
 func benchCompileModule(m *wasm.Module) (*benchCompiledModule, error) {
-	cm, err := railshot.CompileModule(m)
+	return benchCompileModuleWorkers(m, 1)
+}
+
+func benchCompileModuleWorkers(m *wasm.Module, workers int) (*benchCompiledModule, error) {
+	cm, err := railshot.CompileModuleWith(m, railshot.CompileOptions{Workers: workers})
 	if err != nil {
 		return nil, err
 	}

--- a/bench/suite_test.go
+++ b/bench/suite_test.go
@@ -8,6 +8,7 @@ package wagobench
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -195,6 +196,47 @@ func BenchmarkCompile(b *testing.B) {
 	})
 }
 
+// BenchmarkCompileWorkers measures the latency of one backend module compile at
+// forced worker counts. Decode and validation happen outside the timed loop.
+// This intentionally does not use b.RunParallel: that would measure independent
+// multi-module throughput rather than intra-module compile latency.
+func BenchmarkCompileWorkers(b *testing.B) {
+	wanted := map[string]bool{
+		"tiny": true, "fib_rec": true, "many_funcs": true,
+		"json-as": true, "blake-as": true, "lua": true,
+		"sqlite3": true, "ruby": true, "esbuild": true,
+	}
+	for _, m := range loadCorpus(b) {
+		if !m.supports("Compile") || !wanted[m.name()] {
+			continue
+		}
+		mod := m.decoded(b)
+		if err := wasm.ValidateModule(mod); err != nil {
+			b.Fatalf("%s validate: %v", m.name(), err)
+		}
+		b.Run(m.name(), func(b *testing.B) {
+			for _, workers := range []int{1, 2, 4, 8} {
+				b.Run(fmt.Sprintf("p%d", workers), func(b *testing.B) {
+					b.ReportAllocs()
+					var cm *benchCompiledModule
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						var err error
+						cm, err = benchCompileModuleWorkers(mod, workers)
+						if err != nil {
+							b.Fatal(err)
+						}
+					}
+					b.StopTimer()
+					if cm != nil {
+						b.ReportMetric(float64(len(cm.Code)), "code-B")
+					}
+				})
+			}
+		})
+	}
+}
+
 // BenchmarkCompileFull times the end-to-end decode+validate+compile entry point.
 func BenchmarkCompileFull(b *testing.B) {
 	eachModule(b, "CompileFull", func(b *testing.B, m corpusModule) {
@@ -204,6 +246,74 @@ func BenchmarkCompileFull(b *testing.B) {
 			}
 		}
 	})
+}
+
+// BenchmarkCompileFullWorkers measures the real public compile pipeline at
+// forced worker maxima and in adaptive mode, including decode, validation,
+// frontend checks, and backend codegen when the module is not link-deferred.
+func BenchmarkCompileFullWorkers(b *testing.B) {
+	wanted := map[string]bool{
+		"tiny": true, "fib_rec": true, "many_funcs": true,
+		"json-as": true, "blake-as": true, "lua": true,
+		"sqlite3": true, "ruby": true, "esbuild": true,
+	}
+	for _, m := range loadCorpus(b) {
+		if !m.supports("CompileFull") || !wanted[m.name()] {
+			continue
+		}
+		b.Run(m.name(), func(b *testing.B) {
+			for _, mode := range []struct {
+				name    string
+				workers int
+			}{{"p1", 1}, {"p2", 2}, {"p4", 4}, {"p8", 8}, {"auto", 0}} {
+				b.Run(mode.name, func(b *testing.B) {
+					b.ReportAllocs()
+					cfg := wago.NewRuntimeConfig().WithCompileWorkers(mode.workers)
+					var cm *wago.Compiled
+					for i := 0; i < b.N; i++ {
+						var err error
+						cm, err = wago.Compile(cfg, m.bytes)
+						if err != nil {
+							b.Fatal(err)
+						}
+					}
+					if cm != nil {
+						b.ReportMetric(float64(len(cm.Code)), "code-B")
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkCompileMultiModuleThroughput explicitly measures several independent
+// full module compilations in parallel. Unlike BenchmarkCompileWorkers, this is
+// a server-throughput/oversubscription benchmark, not single-module latency.
+func BenchmarkCompileMultiModuleThroughput(b *testing.B) {
+	wanted := map[string]bool{"many_funcs": true, "json-as": true, "esbuild": true}
+	for _, m := range loadCorpus(b) {
+		if !m.supports("CompileFull") || !wanted[m.name()] {
+			continue
+		}
+		b.Run(m.name(), func(b *testing.B) {
+			for _, mode := range []struct {
+				name    string
+				workers int
+			}{{"p1", 1}, {"auto", 0}} {
+				b.Run(mode.name, func(b *testing.B) {
+					b.ReportAllocs()
+					cfg := wago.NewRuntimeConfig().WithCompileWorkers(mode.workers)
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							if _, err := wago.Compile(cfg, m.bytes); err != nil {
+								b.Fatal(err)
+							}
+						}
+					})
+				})
+			}
+		})
+	}
 }
 
 // BenchmarkInstantiate times instance setup for an already-compiled module.

--- a/cli/wagocli/cli.go
+++ b/cli/wagocli/cli.go
@@ -24,14 +24,15 @@ type Flag struct {
 // a leaf has a Run. buildRoot() wires the whole tree.
 type Cmd struct {
 	Name        string
-	Aliases     []string   // alternate names, e.g. {"ls"} for list
-	Summary     string     // one line for the parent's command list
-	Args        string     // positional synopsis for help, e.g. "<file> [args...]"
-	Long        string     // optional extra prose appended to per-command help
-	Flags       []Flag     // options this leaf accepts
-	PassThrough bool       // run: stop flag parsing at the first positional (guest argv)
-	Run         func(*Ctx) // leaf action; nil for a pure group
-	Children    []*Cmd     // subcommands; non-empty makes this a group
+	Aliases     []string                         // alternate names, e.g. {"ls"} for list
+	Summary     string                           // one line for the parent's command list
+	Args        string                           // positional synopsis for help, e.g. "<file> [args...]"
+	Long        string                           // optional extra prose appended to per-command help
+	Flags       []Flag                           // options this leaf accepts
+	PassThrough bool                             // run: stop flag parsing at the first positional (guest argv)
+	Normalize   func([]string) ([]string, error) // optional pre-parse argument normalization
+	Run         func(*Ctx)                       // leaf action; nil for a pure group
+	Children    []*Cmd                           // subcommands; non-empty makes this a group
 }
 
 // Ctx is a parsed invocation handed to a leaf's Run.
@@ -114,6 +115,13 @@ func (c *Cmd) Dispatch(path string, args []string) {
 		fmt.Fprintf(os.Stderr, "%s %s: unknown subcommand %q\n\n", red("wago:"), c.label(path), args[0])
 		c.printHelp(os.Stderr, path)
 		os.Exit(2)
+	}
+	if c.Normalize != nil {
+		var err error
+		args, err = c.Normalize(args)
+		if err != nil {
+			fatal("%s: %v", c.label(path), err)
+		}
 	}
 	ctx, err := c.parse(path, args)
 	if err != nil {

--- a/cli/wagocli/cli.go
+++ b/cli/wagocli/cli.go
@@ -94,14 +94,14 @@ func (c *Cmd) label(path string) string { return strings.TrimPrefix(path, "wago 
 // Dispatch resolves args against c and runs (or delegates to) the right command.
 // It is the single entry point from main() for every command.
 func (c *Cmd) Dispatch(path string, args []string) {
-	// A group's own -h/--help must precede the subcommand token, so `token create
-	// --help` descends to create rather than printing the group's help. That's the
-	// same "stop at the first positional" rule PassThrough uses.
-	if wantsHelp(args, c.PassThrough || len(c.Children) > 0) {
-		c.printHelp(os.Stdout, path)
-		return
-	}
 	if len(c.Children) > 0 {
+		// A group's own -h/--help must precede the subcommand token, so `token create
+		// --help` descends to create rather than printing the group's help. That's the
+		// same "stop at the first positional" rule PassThrough uses.
+		if wantsHelp(args, true, c.Flags) {
+			c.printHelp(os.Stdout, path)
+			return
+		}
 		if len(args) == 0 {
 			// A bare group invocation (e.g. `wago plugin`) shows its help — every
 			// group behaves the same, so there's always a discoverable menu.
@@ -123,6 +123,10 @@ func (c *Cmd) Dispatch(path string, args []string) {
 			fatal("%s: %v", c.label(path), err)
 		}
 	}
+	if wantsHelp(args, c.PassThrough, c.Flags) {
+		c.printHelp(os.Stdout, path)
+		return
+	}
 	ctx, err := c.parse(path, args)
 	if err != nil {
 		fatal("%s: %v", c.label(path), err)
@@ -130,11 +134,21 @@ func (c *Cmd) Dispatch(path string, args []string) {
 	c.Run(ctx)
 }
 
-// wantsHelp reports whether -h/--help appears among the flag tokens. For a
-// PassThrough command it only scans up to the first positional (the .wasm file),
-// so a guest program's own --help is not mistaken for wago's.
-func wantsHelp(args []string, passThrough bool) bool {
-	for _, a := range args {
+// wantsHelp reports whether -h/--help appears among the flag tokens. Values of
+// known value-taking flags are skipped, matching parse: a value such as
+// `--output --help` is not command help. For a PassThrough command scanning stops
+// at the first positional (the .wasm file), so a guest's own --help is untouched.
+func wantsHelp(args []string, passThrough bool, flags []Flag) bool {
+	lookup := make(map[string]*Flag, len(flags)*2)
+	for i := range flags {
+		f := &flags[i]
+		lookup["--"+f.Name] = f
+		if f.Short != "" {
+			lookup["-"+f.Short] = f
+		}
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
 		if a == "--" {
 			return false
 		}
@@ -143,6 +157,13 @@ func wantsHelp(args []string, passThrough bool) bool {
 		}
 		if passThrough && (a == "" || a[0] != '-') {
 			return false
+		}
+		name, hasInline := a, false
+		if eq := strings.IndexByte(a, '='); eq >= 0 {
+			name, hasInline = a[:eq], true
+		}
+		if f := lookup[name]; f != nil && !f.Bool && !hasInline && i+1 < len(args) {
+			i++
 		}
 	}
 	return false

--- a/cli/wagocli/cmd_run.go
+++ b/cli/wagocli/cmd_run.go
@@ -19,16 +19,77 @@ func runCommand() *Cmd {
 		Summary:     "compile and execute an export   (default)",
 		Args:        "<file> [args...]",
 		PassThrough: true,
+		Normalize:   normalizeRunParallelArgs,
 		Flags: append([]Flag{
 			{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
 			{Name: "plugin", Arg: "<names>", Help: "comma-separated extra plugins to enable, on top of wago.json (see: wago plugin list)"},
 			{Name: "bounds", Arg: "<mode>", Help: "bounds checks: defer (default) | all"},
+			{Name: "parallel", Short: "p", Arg: "[workers]", Help: "parallel function compilation; omit workers for adaptive mode"},
 		}, optKnobFlags()...),
 		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
 			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64\n" +
-			"Optimization knobs (--<knob> / --no-<knob>): see `wago opts`.",
+			"Use -p for adaptive compile parallelism, or -p8 / -p 8 / --parallel=8 to\n" +
+			"force a worker maximum. Optimization knobs: see `wago opts`.",
 		Run: runExec,
 	}
+}
+
+// normalizeRunParallelArgs accepts the standard separated/equal forms plus the
+// convenient joined form requested by the CLI: -p, -p8, -p 8, -p=8,
+// --parallel, and --parallel=8. Bare -p/--parallel means adaptive mode. Parsing
+// stops at the wasm file so a guest's own -p argument remains untouched.
+func normalizeRunParallelArgs(args []string) ([]string, error) {
+	out := make([]string, 0, len(args)+1)
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" || a == "-" || a == "" || a[0] != '-' {
+			out = append(out, args[i:]...)
+			return out, nil
+		}
+		switch a {
+		case "-p", "--parallel":
+			value := "auto"
+			if i+1 < len(args) {
+				if _, err := strconv.Atoi(args[i+1]); err == nil {
+					value = args[i+1]
+					i++
+				}
+			}
+			out = append(out, "--parallel="+value)
+			continue
+		}
+		if strings.HasPrefix(a, "-p") && !strings.HasPrefix(a, "-p=") && len(a) > 2 {
+			if _, err := strconv.Atoi(a[2:]); err == nil {
+				out = append(out, "--parallel="+a[2:])
+				continue
+			}
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+func runConfig(bounds, parallel string) (*wago.RuntimeConfig, error) {
+	cfg := wago.NewRuntimeConfig()
+	switch bounds {
+	case "", "defer": // default: skip a bounds check a prior one already proved safe
+	case "all": // bounds-check every access
+		cfg = cfg.WithDeferBoundsChecks(false)
+	default:
+		return nil, fmt.Errorf("unknown --bounds %q (want: defer, all)", bounds)
+	}
+	switch parallel {
+	case "": // default remains serial
+	case "auto":
+		cfg = cfg.WithCompileWorkers(0)
+	default:
+		workers, err := strconv.Atoi(parallel)
+		if err != nil || workers < 0 {
+			return nil, fmt.Errorf("invalid parallelism %q (want: -p, or a non-negative worker count)", parallel)
+		}
+		cfg = cfg.WithCompileWorkers(workers)
+	}
+	return cfg, nil
 }
 
 func runExec(c *Ctx) {
@@ -46,13 +107,9 @@ func runExec(c *Ctx) {
 	}
 	// Publish the guest argv so host-import plugins can read it.
 	wago.SetGuestArgs(pos)
-	cfg := wago.NewRuntimeConfig()
-	switch bounds {
-	case "", "defer": // default: skip a bounds check a prior one already proved safe
-	case "all": // bounds-check every access
-		cfg = cfg.WithDeferBoundsChecks(false)
-	default:
-		fatal("run: unknown --bounds %q (want: defer, all)", bounds)
+	cfg, err := runConfig(bounds, c.Str("parallel"))
+	if err != nil {
+		fatal("run: %v", err)
 	}
 	rt := loadPluginRuntime(cfg, plugins)
 	defer rt.Close()

--- a/cli/wagocli/cmd_run.go
+++ b/cli/wagocli/cmd_run.go
@@ -14,18 +14,21 @@ import (
 // runCommand is `wago run <file> [args...]`: compile and execute an export. It's
 // PassThrough so everything after the .wasm file is handed to the guest verbatim.
 func runCommand() *Cmd {
+	flags := append([]Flag{
+		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
+		{Name: "plugin", Arg: "<names>", Help: "comma-separated extra plugins to enable, on top of wago.json (see: wago plugin list)"},
+		{Name: "bounds", Arg: "<mode>", Help: "bounds checks: defer (default) | all"},
+		{Name: "parallel", Short: "p", Arg: "[workers]", Help: "parallel function compilation; omit workers for adaptive mode"},
+	}, optKnobFlags()...)
 	return &Cmd{
 		Name:        "run",
 		Summary:     "compile and execute an export   (default)",
 		Args:        "<file> [args...]",
 		PassThrough: true,
-		Normalize:   normalizeRunParallelArgs,
-		Flags: append([]Flag{
-			{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
-			{Name: "plugin", Arg: "<names>", Help: "comma-separated extra plugins to enable, on top of wago.json (see: wago plugin list)"},
-			{Name: "bounds", Arg: "<mode>", Help: "bounds checks: defer (default) | all"},
-			{Name: "parallel", Short: "p", Arg: "[workers]", Help: "parallel function compilation; omit workers for adaptive mode"},
-		}, optKnobFlags()...),
+		Normalize: func(args []string) ([]string, error) {
+			return normalizeRunParallelArgs(args, flags)
+		},
+		Flags: flags,
 		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
 			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64\n" +
 			"Use -p for adaptive compile parallelism, or -p8 / -p 8 / --parallel=8 to\n" +
@@ -37,8 +40,21 @@ func runCommand() *Cmd {
 // normalizeRunParallelArgs accepts the standard separated/equal forms plus the
 // convenient joined form requested by the CLI: -p, -p8, -p 8, -p=8,
 // --parallel, and --parallel=8. Bare -p/--parallel means adaptive mode. Parsing
-// stops at the wasm file so a guest's own -p argument remains untouched.
-func normalizeRunParallelArgs(args []string) ([]string, error) {
+// stops at the wasm file so a guest's own -p argument remains untouched. Values
+// belonging to earlier value-taking flags are skipped according to the same Flag
+// table used by parse, so they cannot be mistaken for the file boundary.
+func normalizeRunParallelArgs(args []string, flags []Flag) ([]string, error) {
+	valueFlags := make(map[string]struct{}, len(flags)*2)
+	for _, flag := range flags {
+		if flag.Bool || flag.Name == "parallel" {
+			continue
+		}
+		valueFlags["--"+flag.Name] = struct{}{}
+		if flag.Short != "" {
+			valueFlags["-"+flag.Short] = struct{}{}
+		}
+	}
+
 	out := make([]string, 0, len(args)+1)
 	for i := 0; i < len(args); i++ {
 		a := args[i]
@@ -64,7 +80,16 @@ func normalizeRunParallelArgs(args []string) ([]string, error) {
 				continue
 			}
 		}
+
+		name, inline := a, false
+		if eq := strings.IndexByte(a, '='); eq >= 0 {
+			name, inline = a[:eq], true
+		}
 		out = append(out, a)
+		if _, ok := valueFlags[name]; ok && !inline && i+1 < len(args) {
+			i++
+			out = append(out, args[i])
+		}
 	}
 	return out, nil
 }

--- a/cli/wagocli/cmd_run_test.go
+++ b/cli/wagocli/cmd_run_test.go
@@ -67,16 +67,23 @@ func TestLoadModuleAndResolveExport(t *testing.T) {
 func TestRunParallelFlagForms(t *testing.T) {
 	cmd := runCommand()
 	for _, tc := range []struct {
-		name string
-		args []string
-		want string
+		name         string
+		args         []string
+		wantParallel string
+		wantInvoke   string
+		wantBounds   string
+		wantPlugin   string
 	}{
-		{"bare short", []string{"-p", "module.wasm"}, "auto"},
-		{"joined short", []string{"-p8", "module.wasm"}, "8"},
-		{"separated short", []string{"-p", "8", "module.wasm"}, "8"},
-		{"equal short", []string{"-p=8", "module.wasm"}, "8"},
-		{"bare long", []string{"--parallel", "module.wasm"}, "auto"},
-		{"equal long", []string{"--parallel=8", "module.wasm"}, "8"},
+		{name: "bare short", args: []string{"-p", "module.wasm"}, wantParallel: "auto"},
+		{name: "joined short", args: []string{"-p8", "module.wasm"}, wantParallel: "8"},
+		{name: "separated short", args: []string{"-p", "8", "module.wasm"}, wantParallel: "8"},
+		{name: "equal short", args: []string{"-p=8", "module.wasm"}, wantParallel: "8"},
+		{name: "bare long", args: []string{"--parallel", "module.wasm"}, wantParallel: "auto"},
+		{name: "equal long", args: []string{"--parallel=8", "module.wasm"}, wantParallel: "8"},
+		{name: "after separated invoke", args: []string{"-e", "add", "-p8", "module.wasm"}, wantParallel: "8", wantInvoke: "add"},
+		{name: "after separated bounds", args: []string{"--bounds", "all", "-p", "module.wasm"}, wantParallel: "auto", wantBounds: "all"},
+		{name: "after separated plugin", args: []string{"--plugin", "wasi", "--parallel=4", "module.wasm"}, wantParallel: "4", wantPlugin: "wasi"},
+		{name: "parallel-looking invoke value", args: []string{"-e", "-p8", "module.wasm"}, wantInvoke: "-p8"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			args, err := cmd.Normalize(tc.args)
@@ -87,8 +94,17 @@ func TestRunParallelFlagForms(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := ctx.Str("parallel"); got != tc.want {
-				t.Fatalf("parallel = %q, want %q (normalized %v)", got, tc.want, args)
+			if got := ctx.Str("parallel"); got != tc.wantParallel {
+				t.Fatalf("parallel = %q, want %q (normalized %v)", got, tc.wantParallel, args)
+			}
+			if got := ctx.Str("invoke"); got != tc.wantInvoke {
+				t.Fatalf("invoke = %q, want %q (normalized %v)", got, tc.wantInvoke, args)
+			}
+			if got := ctx.Str("bounds"); got != tc.wantBounds {
+				t.Fatalf("bounds = %q, want %q (normalized %v)", got, tc.wantBounds, args)
+			}
+			if got := ctx.Str("plugin"); got != tc.wantPlugin {
+				t.Fatalf("plugin = %q, want %q (normalized %v)", got, tc.wantPlugin, args)
 			}
 			if len(ctx.Args) != 1 || ctx.Args[0] != "module.wasm" {
 				t.Fatalf("positionals = %v", ctx.Args)

--- a/cli/wagocli/cmd_run_test.go
+++ b/cli/wagocli/cmd_run_test.go
@@ -64,6 +64,81 @@ func TestLoadModuleAndResolveExport(t *testing.T) {
 	}
 }
 
+func TestRunParallelFlagForms(t *testing.T) {
+	cmd := runCommand()
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"bare short", []string{"-p", "module.wasm"}, "auto"},
+		{"joined short", []string{"-p8", "module.wasm"}, "8"},
+		{"separated short", []string{"-p", "8", "module.wasm"}, "8"},
+		{"equal short", []string{"-p=8", "module.wasm"}, "8"},
+		{"bare long", []string{"--parallel", "module.wasm"}, "auto"},
+		{"equal long", []string{"--parallel=8", "module.wasm"}, "8"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := cmd.Normalize(tc.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, err := cmd.parse("wago run", args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := ctx.Str("parallel"); got != tc.want {
+				t.Fatalf("parallel = %q, want %q (normalized %v)", got, tc.want, args)
+			}
+			if len(ctx.Args) != 1 || ctx.Args[0] != "module.wasm" {
+				t.Fatalf("positionals = %v", ctx.Args)
+			}
+		})
+	}
+
+	args, err := cmd.Normalize([]string{"module.wasm", "-p8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, err := cmd.parse("wago run", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.Str("parallel") != "" || len(ctx.Args) != 2 || ctx.Args[1] != "-p8" {
+		t.Fatalf("guest -p8 was consumed: parallel=%q args=%v", ctx.Str("parallel"), ctx.Args)
+	}
+}
+
+func TestRunConfigParallelism(t *testing.T) {
+	for _, tc := range []struct {
+		parallel string
+		want     int
+	}{
+		{"", 1},
+		{"auto", 0},
+		{"0", 0},
+		{"1", 1},
+		{"8", 8},
+	} {
+		cfg, err := runConfig("", tc.parallel)
+		if err != nil {
+			t.Fatalf("parallel %q: %v", tc.parallel, err)
+		}
+		if got := cfg.CompileWorkers(); got != tc.want {
+			t.Fatalf("parallel %q workers = %d, want %d", tc.parallel, got, tc.want)
+		}
+	}
+	for _, value := range []string{"-1", "many"} {
+		if _, err := runConfig("", value); err == nil {
+			t.Fatalf("parallel %q accepted", value)
+		}
+	}
+	cfg, err := runConfig("all", "8")
+	if err != nil || cfg.DeferBoundsChecks() {
+		t.Fatalf("combined config = %v, %v", cfg, err)
+	}
+}
+
 func TestRunExecValueMode(t *testing.T) {
 	t.Setenv("WAGO_BARE", "1") // exercise the CLI execution path without project/global plugin handoff.
 	wasm := []byte{'\x00', 'a', 's', 'm', 1, 0, 0, 0,

--- a/cli/wagocli/main_test.go
+++ b/cli/wagocli/main_test.go
@@ -168,8 +168,12 @@ func TestRunHelpCollapsesBooleanPairs(t *testing.T) {
 	runCommand().printHelp(f, "wago run")
 	f.Close()
 	b, _ := os.ReadFile(f.Name())
-	if !strings.Contains(string(b), "--<no->st-flags") || strings.Contains(string(b), "enable: keep comparison results") {
+	text := string(b)
+	if !strings.Contains(text, "--<no->st-flags") || strings.Contains(text, "enable: keep comparison results") {
 		t.Fatalf("run help did not collapse optimization pair:\n%s", b)
+	}
+	if !strings.Contains(text, "--parallel, -p [workers]") || !strings.Contains(text, "-p8 / -p 8 / --parallel=8") {
+		t.Fatalf("run help did not document compile parallelism:\n%s", b)
 	}
 }
 

--- a/cli/wagocli/main_test.go
+++ b/cli/wagocli/main_test.go
@@ -206,11 +206,22 @@ func TestCmdParseAndHelpRecognition(t *testing.T) {
 		t.Fatal("boolean inline value accepted")
 	}
 
-	if wantsHelp([]string{"module.wasm", "--help"}, true) {
+	if wantsHelp([]string{"module.wasm", "--help"}, true, leaf.Flags) {
 		t.Fatal("guest --help treated as command help")
 	}
-	if !wantsHelp([]string{"--help", "module.wasm"}, true) || wantsHelp([]string{"--", "--help"}, false) {
+	if !wantsHelp([]string{"--help", "module.wasm"}, true, leaf.Flags) || wantsHelp([]string{"--", "--help"}, false, leaf.Flags) {
 		t.Fatal("help recognition mismatch")
+	}
+	if !wantsHelp([]string{"-o", "result", "--help"}, true, leaf.Flags) {
+		t.Fatal("help after a separated flag value was missed")
+	}
+	if wantsHelp([]string{"-o", "--help", "module.wasm"}, true, leaf.Flags) {
+		t.Fatal("a value equal to --help was treated as command help")
+	}
+	run := runCommand()
+	normalized, err := run.Normalize([]string{"-p", "8", "--help"})
+	if err != nil || !wantsHelp(normalized, run.PassThrough, run.Flags) {
+		t.Fatalf("help after separated parallelism was missed: normalized=%v err=%v", normalized, err)
 	}
 	group := &Cmd{Name: "root", Children: []*Cmd{{Name: "child", Aliases: []string{"c"}}}}
 	if group.child("child") == nil || group.child("c") == nil || group.child("missing") != nil {

--- a/docs/parallel-function-compilation-report.md
+++ b/docs/parallel-function-compilation-report.md
@@ -11,8 +11,8 @@ Baseline commit: `e774b93849df0fd66d0c4ad8def0c73a8ed7ec82`
 **Ship the bounded worker implementation and public configuration, but keep the
 default serial.** Applications that prioritize one-module compile latency can opt
 into the measured adaptive policy with `WithCompileWorkers(0)` or force a maximum
-with `WithCompileWorkers(N)`. `NewRuntimeConfig`, `Compile(nil, ...)`, and `Load`
-of wasm remain serial by default.
+with `WithCompileWorkers(N)`. The defaults used by `NewRuntimeConfig`,
+`Compile(nil, ...)`, and `Load` when given raw wasm remain serial.
 
 Enabling parallel compilation globally by default is not justified:
 
@@ -49,8 +49,9 @@ Function count alone is insufficient: `many_funcs` has 301 functions but only
   `/tmp/wago-parallel-func-comp-20260717T151140Z/`
 
 Generated logs and profiles remain under `/tmp`, consistent with
-`docs/codegen-benchmarks.md`. The important final files are listed in
-[Raw data](#raw-data).
+`docs/codegen-benchmarks.md`. These paths are author-local and are not committed;
+the reproduction commands below regenerate equivalent data. The important final
+files are listed in [Raw data](#raw-data).
 
 ## Implementation
 
@@ -217,8 +218,9 @@ Completed gates:
 - arm64 backend and public-package cross-compilation before CI;
 - WebAssembly 1.0: 629 modules and 16,026 assertions passed;
 - WebAssembly 2.0: 1,600 modules and 48,248 assertions passed;
-- WebAssembly 3.0 proposal run completed with only the repository's documented
-  unsupported/toolchain gaps (62 modules and 742 assertions skipped, zero failures).
+- WebAssembly 3.0 proposal run completed with zero failures; only the repository's
+  documented unsupported/toolchain gaps were skipped. Exact skip counts vary with
+  the proposal corpus/toolchain snapshot, so the hosted CI summary is authoritative.
 
 The first `make test` run caught a 16-byte `Compiled` footprint increase from an
 `int` policy field. The field was changed to a capped `uint16` placed in existing

--- a/docs/parallel-function-compilation-report.md
+++ b/docs/parallel-function-compilation-report.md
@@ -1,0 +1,305 @@
+# Parallel function compilation experiment
+
+Date: 2026-07-17
+
+Branch: `parallel-func-comp`
+
+Baseline commit: `e774b93849df0fd66d0c4ad8def0c73a8ed7ec82`
+
+## Decision
+
+**Ship the bounded worker implementation and public configuration, but keep the
+default serial.** Applications that prioritize one-module compile latency can opt
+into the measured adaptive policy with `WithCompileWorkers(0)` or force a maximum
+with `WithCompileWorkers(N)`. `NewRuntimeConfig`, `Compile(nil, ...)`, and `Load`
+of wasm remain serial by default.
+
+Enabling parallel compilation globally by default is not justified:
+
+- single-module backend latency improves substantially on medium and large modules;
+- end-to-end latency improves where backend codegen is a material part of the public
+  pipeline;
+- allocations increase by roughly 43–93% at four workers on representative modules;
+- compile-once peak RSS for esbuild rises from about 147 MiB to 190 MiB at four
+  workers;
+- independent-module throughput does not reliably improve, and esbuild throughput
+  regressed 16.5% under the adaptive four-worker policy at `GOMAXPROCS=8`;
+- eight workers improve backend-only latency further on the largest modules, but
+  add enough allocation/CPU/RSS cost that they are not suitable for auto mode.
+
+The adaptive policy is therefore deliberately conservative:
+
+```text
+score = total wasm function-body bytes + 64 * local function count
+score < 16 KiB: serial
+otherwise:       at most 4 workers
+always cap by GOMAXPROCS and local function count
+```
+
+Function count alone is insufficient: `many_funcs` has 301 functions but only
+2,053 body bytes, while esbuild has 4,148 functions and 8,471,854 body bytes.
+
+## Environment
+
+- Go 1.24.4, linux/amd64
+- AMD Ryzen 7 8845HS, 8 physical / 16 logical cores
+- initial `GOMAXPROCS=16`; worker matrices explicitly used 1, 2, 4, and 8
+- no `WAGO_*` environment overrides
+- raw run directory:
+  `/tmp/wago-parallel-func-comp-20260717T151140Z/`
+
+Generated logs and profiles remain under `/tmp`, consistent with
+`docs/codegen-benchmarks.md`. The important final files are listed in
+[Raw data](#raw-data).
+
+## Implementation
+
+The amd64 and arm64 direct backends now accept `CompileOptions.Workers`.
+
+- `Workers <= 1` uses a distinct serial path with the original allocation shape:
+  one reusable scratch object, no worker metadata, atomics, goroutines, channels,
+  or intermediate code arena.
+- `Workers > 1` is capped by `GOMAXPROCS` and local-function count.
+- Module-wide analyses and decisions remain serial and complete before workers
+  start.
+- Each worker owns one compiler scratch object and one append-only machine-code
+  arena.
+- A fixed-size pool takes function indexes from an atomic counter.
+- Results retain arena offsets, relocation metadata, internal-entry offsets, and
+  deterministic per-function stats destinations.
+- Final code is joined in original function order, aligned identically, and then
+  relocated using the original ordered layout.
+- Errors are selected by the lowest function index, not completion order.
+- The parallel implementation is in a separate helper so its goroutine closure
+  does not escape into or add allocations to the serial path.
+
+Parallel testing exposed pre-existing output nondeterminism in loop bounds-hoist
+candidate ordering. Both backends now sort candidates by base local with the
+generic `slices.SortFunc`, avoiding the allocation that `sort.Slice` would add to
+the serial path.
+
+Public integration:
+
+- `WithCompileWorkers(0)`: adaptive, opt-in;
+- `WithCompileWorkers(1)`: serial;
+- `WithCompileWorkers(N)`, `N > 1`: forced maximum;
+- `wago run -p`: adaptive CLI mode;
+- `wago run -p8`, `wago run -p 8`, or `wago run --parallel=8`: forced CLI maximum;
+- negative values fail `RuntimeConfig.Validate`;
+- initial compilation and link-time recompilation use the same policy;
+- the link policy is retained in a `uint16` non-serialized metadata slot, preserving
+  the existing 632-byte `Compiled` footprint;
+- serialized output is independent of worker policy, and deserialization does not
+  restore process-local compile policy.
+
+## Corpus shape
+
+| module | local funcs | body bytes | maximum body |
+|---|---:|---:|---:|
+| tiny | 2 | 9 | 6 |
+| fib_rec | 1 | 28 | 28 |
+| many_funcs | 301 | 2,053 | 17 |
+| json-as | 43 | 16,651 | 2,445 |
+| blake-as | 6 | 4,474 | 3,532 |
+| lua | 658 | 234,408 | 22,018 |
+| sqlite3 | 2,831 | 798,392 | 39,188 |
+| ruby | 17,452 | 11,143,998 | 100,238 |
+| esbuild | 4,148 | 8,471,854 | 216,489 |
+
+## Backend latency
+
+Decode and validation were outside the timed loop. Values are medians from eight
+runs at `-benchtime=3x`; `p4`/`p8` are effective maxima after the `GOMAXPROCS`
+cap. The complete distributions and benchstat confidence tests are in the raw
+files.
+
+### `GOMAXPROCS=4`
+
+| module | p1 | p2 | p4 | p8 | best versus p1 |
+|---|---:|---:|---:|---:|---:|
+| tiny | 5.6 us | 19.0 us | 15.9 us | 16.2 us | serial |
+| fib_rec | 7.0 us | 6.8 us | 6.8 us | 6.3 us | noisy / effectively serial work |
+| many_funcs | 255.6 us | 218.8 us | 167.6 us | 152.6 us | -40.3% |
+| json-as | 1.006 ms | 641.4 us | 439.9 us | 395.2 us | -60.7% |
+| blake-as | 209.1 us | 169.8 us | 169.2 us | 190.2 us | -19.1% at p4 |
+| lua | 18.181 ms | 11.215 ms | 9.048 ms | 8.994 ms | -50.5% |
+| sqlite3 | 56.445 ms | 34.353 ms | 22.718 ms | 22.567 ms | -60.0% |
+| ruby | 611.153 ms | 382.929 ms | 257.990 ms | 248.788 ms | -59.3% |
+| esbuild | 416.895 ms | 259.706 ms | 175.881 ms | 183.189 ms | -57.8% at p4 |
+
+At `GOMAXPROCS=8`, p8 reached -64.6% on sqlite3, -68.9% on ruby, and
+-66.1% on esbuild. This is a backend-only result; the full-pipeline and memory
+results below are why auto mode stops at four.
+
+## Full public pipeline
+
+`BenchmarkCompileFullWorkers` includes decode, validation, frontend checks, and
+backend codegen when codegen is not link-deferred. At `GOMAXPROCS=8`, adaptive
+versus serial medians were:
+
+| module | serial | adaptive | change | allocation ratio |
+|---|---:|---:|---:|---:|
+| many_funcs | 0.474 ms | 0.357 ms | -24.6% | 1.57x |
+| json-as | 2.072 ms | 1.629 ms | -21.4% | 1.74x |
+| esbuild | 878.327 ms | 632.513 ms | -28.0% | 1.44x |
+
+`lua`, `sqlite3`, and `ruby` have returning imports, so public `Compile` defers
+backend codegen until linking; their compile-only full-pipeline rows correctly
+show no worker benefit. A separate generated returning-import benchmark forces
+fresh link-time codegen each iteration. At `GOMAXPROCS=8`, adaptive link-pipeline
+latency improved 8.6% (54.26 ms to 49.60 ms), while allocations rose 70.6%.
+Forced p8 improved 14.4% but raised allocations 76.0%.
+
+## Allocation, CPU, and RSS cost
+
+At `GOMAXPROCS=8`, backend allocation changes for p4 versus p1 were:
+
+| module | p1 B/op | p4 B/op | change |
+|---|---:|---:|---:|
+| many_funcs | 182.0 KiB | 305.9 KiB | +68.0% |
+| json-as | 362.6 KiB | 701.5 KiB | +93.4% |
+| lua | 5.934 MiB | 9.339 MiB | +57.4% |
+| sqlite3 | 15.88 MiB | 26.98 MiB | +69.8% |
+| ruby | 103.3 MiB | 174.5 MiB | +69.0% |
+| esbuild | 97.78 MiB | 161.34 MiB | +65.0% |
+
+Compile-once esbuild measurements used a fresh benchmark process per sample and
+Python `resource.getrusage(RUSAGE_CHILDREN)`; values below are medians of five
+runs at `GOMAXPROCS=8`.
+
+| mode | backend latency | child user CPU | peak RSS |
+|---|---:|---:|---:|
+| p1 | 481.7 ms | 0.974 s | 147.4 MiB |
+| p2 | 292.1 ms | 0.987 s | 176.9 MiB |
+| p4 | 190.2 ms | 1.037 s | 190.4 MiB |
+| p8 | 161.6 ms | 1.173 s | 189.9 MiB |
+
+The p8 RSS median happened to be slightly below p4 in this five-process sample,
+but p8 allocated 178.83 MiB/op versus 161.34 MiB/op for p4 in the repeated
+backend benchmark and consumed more user CPU. It is not a lower-footprint mode.
+
+CPU profiles confirm useful parallelism rather than one new serialized hotspot:
+five esbuild backend compiles took 480.7 ms/op at p1 and 162.8 ms/op at p8, while
+total sampled CPU increased from 3.60 s over 3.71 s wall time to 4.87 s over
+1.74 s wall time. The same parsing, bounds-hoist, instruction classification, and
+encoder routines remain dominant.
+
+## Oversubscription
+
+`BenchmarkCompileMultiModuleThroughput` uses `b.RunParallel` and is explicitly a
+throughput benchmark, not a one-module latency benchmark. Adaptive versus p1:
+
+| `GOMAXPROCS` | many_funcs | json-as | esbuild |
+|---:|---:|---:|---:|
+| 2 | no significant change | no significant change | +1.0% slower |
+| 4 | no significant change | +6.5% slower | +2.2% slower |
+| 8 | -7.7% faster | -6.0% faster | **+16.5% slower** |
+
+The mixed result means a library cannot infer whether the caller values one-module
+latency or aggregate server throughput. Keeping serial as the default is the
+predictable choice; concurrent hosts can leave it serial, while CLI/build-style
+callers can explicitly request adaptive compilation.
+
+## Correctness and validation
+
+Completed gates:
+
+- byte-for-byte p1/p2/p4/p8 equality for code, `Entry`, `InternalEntry`, lengths,
+  relocations, and per-function stats across repeated targeted modules;
+- whole selected corpus parity including lua, sqlite3, ruby, and esbuild;
+- deterministic lowest-index error behavior by construction;
+- link-time serial/parallel output equality and policy propagation;
+- serialized p1/p8 artifact equality and non-serialization of policy;
+- targeted race runs for backend corpus parity and public/link paths;
+- `make test`;
+- `make test-corpus` in explicit and guard-page builds;
+- arm64 backend cross-compilation;
+- WebAssembly 1.0: 629 modules and 16,026 assertions passed;
+- WebAssembly 2.0: 1,600 modules and 48,248 assertions passed;
+- WebAssembly 3.0 proposal run completed with only the repository's documented
+  unsupported/toolchain gaps (62 modules and 742 assertions skipped, zero failures).
+
+The first `make test` run caught a 16-byte `Compiled` footprint increase from an
+`int` policy field. The field was changed to a capped `uint16` placed in existing
+padding; the 632-byte footprint tests now pass.
+
+A side-by-side interleaved baseline/current serial run found no statistically
+significant change for tiny, many_funcs, json-as, blake-as, sqlite3, ruby, or
+esbuild. Lua measured +3.1% in that noisy `3x` sample. Serial allocation counts
+are restored exactly (for example tiny remains 35 allocs/op), and the serial code
+path has no parallel helper closure or worker bookkeeping.
+
+## Reproduction
+
+Representative backend matrix:
+
+```sh
+cd bench
+for gp in 1 2 4 8; do
+  GOMAXPROCS=$gp go test -run '^$' \
+    -bench '^BenchmarkCompileWorkers/(tiny|fib_rec|many_funcs|json-as|blake-as|lua|sqlite3|ruby|esbuild)/' \
+    -benchtime=3x -count=8 -benchmem -timeout=0 . \
+    > /tmp/final-workers-all-gomaxprocs${gp}.txt
+done
+```
+
+Public full pipeline:
+
+```sh
+GOMAXPROCS=8 go test -run '^$' \
+  -bench '^BenchmarkCompileFullWorkers/.*/(p1|auto)$' \
+  -benchtime=3x -count=8 -benchmem -timeout=0 ./bench
+```
+
+Link-time path:
+
+```sh
+GOMAXPROCS=8 go test ./src/wago -run '^$' \
+  -bench '^BenchmarkCompileLinkWorkers/' \
+  -benchtime=3x -count=8 -benchmem -timeout=0
+```
+
+Race and correctness:
+
+```sh
+go test -race ./src/core/compiler/backend/railshot/amd64 \
+  -run 'TestCompileWorkers(Deterministic|CorpusParity)' -count=1 -timeout=0
+go test -race ./src/wago \
+  -run 'TestCompileWorkers(LinkPathAndSerialization|ForModulePolicy)' -count=1
+make test
+make test-corpus
+PATH="$PWD/.tools/wabt-1.0.41-linux-x64/bin:$PATH" make spec
+```
+
+## Raw data
+
+All raw data is under:
+
+```text
+/tmp/wago-parallel-func-comp-20260717T151140Z/
+```
+
+Key files:
+
+- `environment.txt`, `module-metrics.txt`
+- `baseline-backend-small.txt`, `baseline-compile-large.txt`
+- `final-workers-all-gomaxprocs{1,2,4,8}.txt`
+- `final-benchstat-workers-gomaxprocs{1,2,4,8}.txt`
+- `full-auto-all-gomaxprocs{1,2,4,8}.txt`
+- `benchstat-full-auto-gomaxprocs{1,2,4,8}.txt`
+- `final-link-workers-gomaxprocs{1,2,4,8}.txt`
+- `final-benchstat-link-workers-gomaxprocs{1,2,4,8}.txt`
+- `oversub-small-gomaxprocs{2,4,8}.txt`
+- `oversub-esbuild-auto4-gomaxprocs{2,4,8}.txt`
+- `benchstat-oversub-gomaxprocs{2,4,8}.txt`
+- `benchstat-oversub-esbuild-auto4-gomaxprocs{2,4,8}.txt`
+- `final-compile-once-rss-esbuild.txt`
+- `final-compile-once-rss-esbuild-summary.txt`
+- `final-cpu-backend-esbuild-p{1,8}.pprof`
+- `final-mem-backend-esbuild-p{1,8}.pprof`
+- `final-profile-backend-esbuild-p{1,8}-top.txt`
+- `final-profile-backend-esbuild-p{1,8}-alloc-top.txt`
+- `final-benchstat-interleaved-base-vs-serial.txt`
+- `final-race-backend-workers.txt`, `final-race-public-workers.txt`
+- `final-make-test-complete.txt`, `final-test-corpus.txt`, `final-spec.txt`
+- `raw-manifest.txt`, `SHA256SUMS.txt`

--- a/docs/parallel-function-compilation-report.md
+++ b/docs/parallel-function-compilation-report.md
@@ -213,7 +213,8 @@ Completed gates:
 - targeted race runs for backend corpus parity and public/link paths;
 - `make test`;
 - `make test-corpus` in explicit and guard-page builds;
-- arm64 backend cross-compilation;
+- native Linux/arm64 and Darwin/arm64 CI, including TinyGo on both hosts;
+- arm64 backend and public-package cross-compilation before CI;
 - WebAssembly 1.0: 629 modules and 16,026 assertions passed;
 - WebAssembly 2.0: 1,600 modules and 48,248 assertions passed;
 - WebAssembly 3.0 proposal run completed with only the repository's documented

--- a/examples/15-config/main.go
+++ b/examples/15-config/main.go
@@ -1,7 +1,8 @@
 // Example 15: runtime configuration.
 //
-// A RuntimeConfig controls feature gating and the bounds-check strategy. Pass it
-// to a Runtime with WithRuntimeConfig, or to the low-level CompileWithConfig. Run:
+// A RuntimeConfig controls feature gating, bounds checks, and compile-worker
+// policy. Pass it to a Runtime with WithRuntimeConfig, or to the low-level
+// CompileWithConfig. Run:
 //
 //	go run ./examples/15-config
 package main
@@ -17,10 +18,16 @@ import (
 func main() {
 	// Bounds-check modes: explicit (inline checks) vs signals-based (guard-page).
 	// Here we ask for every access to be bounds-checked (no elision).
-	cfg := wago.NewRuntimeConfig().WithDeferBoundsChecks(false)
+	// Compile workers are serial by default. Zero opts into the adaptive policy;
+	// one forces serial compilation, and values above one are worker maxima. The
+	// effective count is still capped by GOMAXPROCS and the local-function count.
+	cfg := wago.NewRuntimeConfig().
+		WithDeferBoundsChecks(false).
+		WithCompileWorkers(0)
 
 	fmt.Println("features:", cfg.CoreFeatures())
 	fmt.Println("bounds checks:", cfg.BoundsChecks())
+	fmt.Println("compile workers:", cfg.CompileWorkers())
 
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
 	defer rt.Close()

--- a/src/core/compiler/backend/railshot/amd64/allocation_test.go
+++ b/src/core/compiler/backend/railshot/amd64/allocation_test.go
@@ -2,7 +2,11 @@
 
 package amd64
 
-import "testing"
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
 
 func TestCompileSmallScalarAllocationBudget(t *testing.T) {
 	m := benchSmallScalarModule(t)
@@ -37,6 +41,45 @@ func TestCompileSIMDHeavyAllocationBudget(t *testing.T) {
 	const budget = 80.0
 	if allocs > budget {
 		t.Fatalf("allocations = %.1f, budget = %.1f", allocs, budget)
+	}
+}
+
+func TestCompileParallelAllocationBudget(t *testing.T) {
+	m := readParallelTestModule(t, filepath.Join("..", "..", "..", "..", "..", "..", "bench", "corpus", "json-as.wasm"))
+	oldProcs := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	allocs := func(workers int) float64 {
+		return testing.AllocsPerRun(10, func() {
+			cm, err := CompileModuleWith(m, CompileOptions{Workers: workers})
+			if err != nil {
+				t.Fatalf("CompileModuleWith workers=%d: %v", workers, err)
+			}
+			benchCompiledSink = cm
+		})
+	}
+	serial := allocs(1)
+	parallel := allocs(4)
+	t.Logf("json-as backend allocations: p1=%.1f p4=%.1f", serial, parallel)
+
+	// Measured locally on linux/amd64 Go 1.24.4: p1=1,286 and p4=1,286
+	// allocations/op. The p4 path intentionally allocates more bytes (the worker
+	// report measured about 363 KiB/op at p1 and 702 KiB/op at p4), even though the
+	// allocation-event count is currently equal. These ceilings leave broad Go/CI
+	// margin while catching per-instruction allocation or recreating all function
+	// metadata independently in every worker.
+	const (
+		serialBudget   = 5000.0
+		parallelBudget = 8000.0
+	)
+	if serial > serialBudget {
+		t.Fatalf("serial allocations = %.1f, budget = %.1f", serial, serialBudget)
+	}
+	if parallel > parallelBudget {
+		t.Fatalf("p4 allocations = %.1f, budget = %.1f (serial %.1f)", parallel, parallelBudget, serial)
+	}
+	if absurd := serial*3 + 512; parallel > absurd {
+		t.Fatalf("p4 allocations = %.1f, serial = %.1f, absurd-multiplier ceiling = %.1f", parallel, serial, absurd)
 	}
 }
 

--- a/src/core/compiler/backend/railshot/amd64/boundshoist.go
+++ b/src/core/compiler/backend/railshot/amd64/boundshoist.go
@@ -3,7 +3,9 @@
 package amd64
 
 import (
+	"cmp"
 	"os"
+	"slices"
 	"strconv"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -153,6 +155,10 @@ scan:
 			elidable += acc[b]
 		}
 	}
+	// Map iteration order must not choose precheck/register order: parallel
+	// function compilation creates these maps on different goroutines and exposed
+	// the latent nondeterminism as byte-different code for the same function.
+	slices.SortFunc(cands, func(a, b hoistCand) int { return cmp.Compare(a.base, b.base) })
 	return cands, elidable, hasGrow
 }
 

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"slices"
 	"sort"
+	"sync"
+	"sync/atomic"
 
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/codegen"
@@ -396,6 +399,26 @@ func (sc *scratch) reset() {
 	}
 }
 
+// workerState owns every mutable buffer used by one parallel compiler worker.
+// arena is append-only until all workers join. Results retain offsets into it,
+// never slices, because a later append may reallocate the arena.
+type workerState struct {
+	scratch *scratch
+	arena   []byte
+}
+
+// funcResult is one independently compiled local function. worker/start/end
+// identify its owned bytes after the worker pool joins; relocs is independently
+// owned by the fn compiler state (it is not backed by scratch).
+type funcResult struct {
+	worker      int
+	start       int
+	end         int
+	internalOff int
+	relocs      []callReloc
+	err         error
+}
+
 // Frameless layout (WARP-style, RSP-relative). RBP is NOT a frame pointer — it is
 // a general allocatable register — so the frame is a single `sub rsp,frameSize`
 // with everything addressed at non-negative offsets from RSP, which stays put for
@@ -467,6 +490,11 @@ type ImportBinding = shared.ImportBinding
 
 // CompileOptions configures direct wasm-to-amd64 compilation.
 type CompileOptions struct {
+	// Workers forces the maximum number of per-function compiler workers.
+	// Values <= 1 retain the exact serial fast path. Values > 1 are capped by
+	// runtime.GOMAXPROCS(0) and the module's local-function count.
+	Workers int
+
 	// ElideBoundsChecks omits inline linear-memory bounds checks, relying on
 	// a guard-page mapping + SIGSEGV handler (see runtime/sigtrap_linux_amd64.go).
 	// EXPERIMENTAL: only sound when the memory is backed by runtime guard pages.
@@ -582,7 +610,6 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	// Auto-inlining (WAGO_INLINE): the straight-line leaf callees to splice at their
 	// call sites, keyed by global func index. nil when inlining is disabled.
 	inlineTargets := buildInlineTargets(m, allHints)
-	sc := newScratch()
 	// Pre-size the module code buffer to roughly the final machine-code size
 	// (lowering emits ~4-5 native bytes per wasm body byte, matching asmCapForBody).
 	// Without this the buffer grows geometrically, and each reallocation copies the
@@ -592,38 +619,146 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	for i := range m.Code {
 		totalBody += len(m.Code[i].BodyBytes)
 	}
-	code := make([]byte, 0, shared.TaperedModuleCodeCapacity(totalBody, n, 40, 37, 1<<20))
-	pressureDone := false
+	codeCap := shared.TaperedModuleCodeCapacity(totalBody, n, 40, 37, 1<<20)
+	workers := opts.Workers
+	if workers > 1 {
+		if max := runtime.GOMAXPROCS(0); workers > max {
+			workers = max
+		}
+		if workers > n {
+			workers = n
+		}
+	}
+	if workers <= 1 {
+		// Keep the serial compiler as a distinct fast path: one reusable scratch,
+		// no goroutines, channels, atomics, worker metadata, or intermediate arena.
+		sc := newScratch()
+		code := make([]byte, 0, codeCap)
+		pressureDone := false
+		pressureAt := opts.MemoryPressureAt
+		if opts.MemoryPressure != nil && pressureAt <= 0 {
+			pressureAt = cap(code) * 7 / 8
+		}
+		for i := range m.Code {
+			hints := allHints[i]
+			var st *CodegenStats
+			if ms != nil {
+				st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
+				ms.Funcs[i] = st
+			}
+			fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, sc)
+			allHints[i] = funcHints{}
+			if err != nil {
+				return nil, fmt.Errorf("amd64: function %d: %w", i, err)
+			}
+			// 16-byte align each function (append zeros without a temp allocation).
+			if pad := (16 - len(code)%16) % 16; pad != 0 {
+				code = append(code, alignPad[:pad]...)
+			}
+			entry[i] = len(code)
+			internalEntry[i] = len(code) + internalOff
+			relocs[i] = rl
+			code = append(code, fnCode...)
+			if !pressureDone && opts.MemoryPressure != nil && len(code) >= pressureAt {
+				pressureDone = true
+				opts.MemoryPressure()
+			}
+		}
+		// Patch call sites now that every function's entry offsets are known.
+		for i := 0; i < n; i++ {
+			for _, rl := range relocs[i] {
+				site := entry[i] + rl.at
+				target := entry[rl.target]
+				if rl.internal {
+					target = internalEntry[rl.target]
+				}
+				binary.LittleEndian.PutUint32(code[site:], uint32(int32(target-(site+4))))
+			}
+		}
+		if explainEnabled && ms != nil {
+			fmt.Fprint(os.Stderr, ms.String())
+		}
+		return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
+	}
+
+	return compileModuleParallel(m, opts, workers, codeCap, entry, internalEntry, relocs, allHints, modGlobals, inlineTargets, ms, guardMode, boundsFacts, importedFuncs)
+}
+
+// compileModuleParallel is split from CompileModuleWith so the goroutine closure
+// and its captured state cannot escape into or add allocations to the serial path.
+func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap int, entry, internalEntry []int, relocs [][]callReloc, allHints []funcHints, modGlobals []moduleGlobalPin, inlineTargets map[int]*inlineTarget, ms *ModuleStats, guardMode, boundsFacts bool, importedFuncs int) (*amd64.CompiledModule, error) {
+	n := len(m.Code)
+	// Parallel codegen starts only after every module-wide decision is complete.
+	// Each function has a deterministic stats destination, and each worker owns all
+	// mutable compiler state plus an append-only arena for completed function code.
+	if ms != nil {
+		for i := range m.Code {
+			ms.Funcs[i] = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
+		}
+	}
+	states := make([]workerState, workers)
+	arenaCap := (codeCap + workers - 1) / workers
 	pressureAt := opts.MemoryPressureAt
 	if opts.MemoryPressure != nil && pressureAt <= 0 {
-		pressureAt = cap(code) * 7 / 8
+		pressureAt = codeCap * 7 / 8
 	}
-	for i := range m.Code {
-		hints := allHints[i]
-		var st *CodegenStats
-		if ms != nil {
-			st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
-			ms.Funcs[i] = st
-		}
-		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, sc)
-		allHints[i] = funcHints{}
-		if err != nil {
-			return nil, fmt.Errorf("amd64: function %d: %w", i, err)
-		}
-		// 16-byte align each function (append zeros without a temp allocation).
+	var pressureBytes atomic.Int64
+	var pressureOnce sync.Once
+	for i := range states {
+		states[i] = workerState{scratch: newScratch(), arena: make([]byte, 0, arenaCap)}
+	}
+	results := make([]funcResult, n)
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for workerID := range states {
+		go func(workerID int) {
+			defer wg.Done()
+			ws := &states[workerID]
+			for {
+				i := int(next.Add(1) - 1)
+				if i >= n {
+					return
+				}
+				var st *CodegenStats
+				if ms != nil {
+					st = ms.Funcs[i]
+				}
+				fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, allHints[i], opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, ws.scratch)
+				allHints[i] = funcHints{}
+				if err != nil {
+					results[i].err = err
+					continue
+				}
+				start := len(ws.arena)
+				ws.arena = append(ws.arena, fnCode...)
+				results[i] = funcResult{worker: workerID, start: start, end: len(ws.arena), internalOff: internalOff, relocs: rl}
+				if opts.MemoryPressure != nil && pressureBytes.Add(int64(len(fnCode))) >= int64(pressureAt) {
+					pressureOnce.Do(opts.MemoryPressure)
+				}
+			}
+		}(workerID)
+	}
+	wg.Wait()
+
+	// Error selection is by function index, never by wall-clock completion order.
+	if i, err := firstFuncError(results); err != nil {
+		return nil, fmt.Errorf("amd64: function %d: %w", i, err)
+	}
+
+	// Join in original function order so layout, alignment, entry metadata, and
+	// relocation patching are byte-for-byte identical to the serial compiler.
+	code := make([]byte, 0, codeCap)
+	for i := range results {
+		r := &results[i]
 		if pad := (16 - len(code)%16) % 16; pad != 0 {
 			code = append(code, alignPad[:pad]...)
 		}
 		entry[i] = len(code)
-		internalEntry[i] = len(code) + internalOff
-		relocs[i] = rl
-		code = append(code, fnCode...)
-		if !pressureDone && opts.MemoryPressure != nil && len(code) >= pressureAt {
-			pressureDone = true
-			opts.MemoryPressure()
-		}
+		internalEntry[i] = len(code) + r.internalOff
+		relocs[i] = r.relocs
+		code = append(code, states[r.worker].arena[r.start:r.end]...)
 	}
-	// Patch call sites now that every function's entry offsets are known.
 	for i := 0; i < n; i++ {
 		for _, rl := range relocs[i] {
 			site := entry[i] + rl.at
@@ -638,6 +773,15 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		fmt.Fprint(os.Stderr, ms.String())
 	}
 	return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
+}
+
+func firstFuncError(results []funcResult) (int, error) {
+	for i := range results {
+		if results[i].err != nil {
+			return i, results[i].err
+		}
+	}
+	return 0, nil
 }
 
 // moduleGlobalPinInfos converts the internal module-global pin assignments to the

--- a/src/core/compiler/backend/railshot/amd64/parallel_compile_test.go
+++ b/src/core/compiler/backend/railshot/amd64/parallel_compile_test.go
@@ -1,0 +1,123 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/frontend"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	encoder "github.com/wago-org/wago/src/core/encoder/amd64"
+)
+
+func TestCompileWorkersDeterministic(t *testing.T) {
+	corpus := filepath.Join("..", "..", "..", "..", "..", "..", "bench", "corpus")
+	for _, name := range []string{
+		"tiny.wasm",
+		"fib_rec.wasm",      // recursion and direct-call relocations
+		"dispatch.wasm",     // call_indirect
+		"many_funcs.wasm",   // enough functions to exercise every worker
+		"globals.wasm",      // mutable globals
+		"memory_tree.wasm",  // memory plus recursion
+		"branches.wasm",     // structured control flow
+		"json-as-simd.wasm", // SIMD, memory, globals, calls, and auto-inlining
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := readParallelTestModule(t, filepath.Join(corpus, name))
+			want, wantStats := compileWorkerTestModule(t, m, 1)
+			for _, workers := range []int{2, 4, 8} {
+				for repeat := 0; repeat < 5; repeat++ {
+					got, gotStats := compileWorkerTestModule(t, m, workers)
+					assertCompiledModuleEqual(t, got, want)
+					if !reflect.DeepEqual(gotStats, wantStats) {
+						t.Fatalf("workers=%d repeat=%d: stats differ\n got: %#v\nwant: %#v", workers, repeat, gotStats, wantStats)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCompileWorkersLowestIndexError(t *testing.T) {
+	results := make([]funcResult, 8)
+	results[7].err = errors.New("late index")
+	results[2].err = errors.New("first index")
+	idx, err := firstFuncError(results)
+	if idx != 2 || err == nil || err.Error() != "first index" {
+		t.Fatalf("firstFuncError = (%d, %v), want (2, first index)", idx, err)
+	}
+}
+
+func TestCompileWorkersCorpusParity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping whole-corpus compiler parity in short mode")
+	}
+	corpus := filepath.Join("..", "..", "..", "..", "..", "..", "bench", "corpus")
+	for _, name := range []string{
+		"tiny.wasm", "fib_rec.wasm", "many_funcs.wasm",
+		"json-as.wasm", "blake-as.wasm", "lua.wasm", "sqlite3.wasm",
+		"ruby.wasm", "esbuild.wasm",
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := readParallelTestModule(t, filepath.Join(corpus, name))
+			serial, err := CompileModuleWith(m, CompileOptions{Workers: 1})
+			if err != nil {
+				t.Fatalf("serial compile: %v", err)
+			}
+			parallel, err := CompileModuleWith(m, CompileOptions{Workers: 8})
+			if err != nil {
+				t.Fatalf("parallel compile: %v", err)
+			}
+			assertCompiledModuleEqual(t, parallel, serial)
+		})
+	}
+}
+
+func readParallelTestModule(t *testing.T, path string) *wasm.Module {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := frontend.DecodeValidate(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func compileWorkerTestModule(t *testing.T, m *wasm.Module, workers int) (*encoder.CompiledModule, *ModuleStats) {
+	t.Helper()
+	stats := &ModuleStats{}
+	cm, err := CompileModuleWith(m, CompileOptions{Workers: workers, Stats: stats})
+	if err != nil {
+		t.Fatalf("workers=%d: compile: %v", workers, err)
+	}
+	return cm, stats
+}
+
+func assertCompiledModuleEqual(t *testing.T, got, want *encoder.CompiledModule) {
+	t.Helper()
+	if len(got.Code) != len(want.Code) {
+		t.Fatalf("code length = %d, want %d", len(got.Code), len(want.Code))
+	}
+	if !bytes.Equal(got.Code, want.Code) {
+		for i := range got.Code {
+			if got.Code[i] != want.Code[i] {
+				t.Fatalf("code differs at byte %d: got %#02x want %#02x", i, got.Code[i], want.Code[i])
+			}
+		}
+		t.Fatal("code differs")
+	}
+	if !reflect.DeepEqual(got.Entry, want.Entry) {
+		t.Fatalf("Entry differs\n got: %v\nwant: %v", got.Entry, want.Entry)
+	}
+	if !reflect.DeepEqual(got.InternalEntry, want.InternalEntry) {
+		t.Fatalf("InternalEntry differs\n got: %v\nwant: %v", got.InternalEntry, want.InternalEntry)
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/boundshoist.go
+++ b/src/core/compiler/backend/railshot/arm64/boundshoist.go
@@ -3,7 +3,9 @@
 package arm64
 
 import (
+	"cmp"
 	"os"
+	"slices"
 	"strconv"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -153,6 +155,9 @@ scan:
 			elidable += acc[b]
 		}
 	}
+	// Map iteration order must not choose precheck/register order. Keep output
+	// deterministic when different functions are compiled by different workers.
+	slices.SortFunc(cands, func(a, b hoistCand) int { return cmp.Compare(a.base, b.base) })
 	return cands, elidable, hasGrow
 }
 

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"slices"
 	"sort"
+	"sync"
+	"sync/atomic"
 
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/codegen"
@@ -353,6 +356,8 @@ type deferredArg struct {
 	root   *elem
 }
 
+var alignPad [16]byte
+
 func align16(n int) int { return (n + 15) &^ 15 }
 
 func asmCapForBody(bodyLen int) int {
@@ -411,6 +416,26 @@ func (sc *scratch) reset() {
 		sc.trapSites[i] = sc.trapSites[i][:0]
 	}
 	clear(sc.branchTargets)
+}
+
+// workerState owns every mutable buffer used by one parallel compiler worker.
+// arena is append-only until all workers join. Results retain offsets into it,
+// never slices, because a later append may reallocate the arena.
+type workerState struct {
+	scratch *scratch
+	arena   []byte
+}
+
+// funcResult is one independently compiled local function. worker/start/end
+// identify its owned bytes after the worker pool joins; relocs is independently
+// owned by the fn compiler state (it is not backed by scratch).
+type funcResult struct {
+	worker      int
+	start       int
+	end         int
+	internalOff int
+	relocs      []callReloc
+	err         error
 }
 
 // Frameless layout (WARP-style, SP-relative). X29/FP is only a frame-record anchor
@@ -507,6 +532,11 @@ type ImportBinding = shared.ImportBinding
 
 // CompileOptions configures direct wasm-to-arm64 compilation.
 type CompileOptions struct {
+	// Workers forces the maximum number of per-function compiler workers.
+	// Values <= 1 retain the exact serial fast path. Values > 1 are capped by
+	// runtime.GOMAXPROCS(0) and the module's local-function count.
+	Workers int
+
 	// ElideBoundsChecks omits inline linear-memory bounds checks, relying on
 	// a guard-page mapping + SIGSEGV handler (see runtime/sigtrap_linux_arm64.go).
 	// EXPERIMENTAL: only sound when the memory is backed by runtime guard pages.
@@ -628,7 +658,6 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 			calleePreservesPins[i] = preservesCallerPins(ft, allHints[i].nLocals, allHints[i])
 		}
 	}
-	sc := newScratch()
 	// AArch64 lowering is close to four native bytes per Wasm opcode plus
 	// adapters/alignment. Reserve once so large modules do not repeatedly copy the
 	// accumulated native image as it grows.
@@ -636,41 +665,139 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 	for i := range m.Code {
 		totalBody += len(m.Code[i].BodyBytes)
 	}
-	code := make([]byte, 0, shared.TaperedModuleCodeCapacity(totalBody, n, 32, 28, 768<<10))
-	var alignPad [16]byte
-	pressureDone := false
+	codeCap := shared.TaperedModuleCodeCapacity(totalBody, n, 32, 28, 768<<10)
+	workers := opts.Workers
+	if workers > 1 {
+		if max := runtime.GOMAXPROCS(0); workers > max {
+			workers = max
+		}
+		if workers > n {
+			workers = n
+		}
+	}
+	if workers <= 1 {
+		// Keep the serial compiler as a distinct fast path: one reusable scratch,
+		// no goroutines, channels, atomics, worker metadata, or intermediate arena.
+		sc := newScratch()
+		code := make([]byte, 0, codeCap)
+		pressureDone := false
+		pressureAt := opts.MemoryPressureAt
+		if opts.MemoryPressure != nil && pressureAt <= 0 {
+			pressureAt = cap(code) * 7 / 8
+		}
+		for i := range m.Code {
+			hints := allHints[i]
+			var st *CodegenStats
+			if ms != nil {
+				st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
+				ms.Funcs[i] = st
+			}
+			fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, calleePreservesPins, sc)
+			allHints[i] = funcHints{}
+			if err != nil {
+				return nil, fmt.Errorf("arm64: function %d: %w", i, err)
+			}
+			if pad := (16 - len(code)%16) % 16; pad != 0 {
+				code = append(code, alignPad[:pad]...)
+			}
+			entry[i] = len(code)
+			internalEntry[i] = len(code) + internalOff
+			relocs[i] = rl
+			code = append(code, fnCode...)
+			if !pressureDone && opts.MemoryPressure != nil && len(code) >= pressureAt {
+				pressureDone = true
+				opts.MemoryPressure()
+			}
+		}
+		asm := &a64.Asm{B: code}
+		for i := 0; i < n; i++ {
+			for _, rl := range relocs[i] {
+				site := entry[i] + rl.at
+				target := entry[rl.target]
+				if rl.internal {
+					target = internalEntry[rl.target]
+				}
+				asm.PatchBranch26(site, target)
+			}
+		}
+		code = asm.B
+		if explainEnabled && ms != nil {
+			fmt.Fprint(os.Stderr, ms.String())
+		}
+		return &a64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
+	}
+
+	return compileModuleParallel(m, opts, workers, codeCap, entry, internalEntry, relocs, allHints, modGlobals, inlineTargets, calleePreservesPins, ms, guardMode, boundsFacts, importedFuncs)
+}
+
+// compileModuleParallel is split from CompileModuleWith so the goroutine closure
+// and its captured state cannot escape into or add allocations to the serial path.
+func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap int, entry, internalEntry []int, relocs [][]callReloc, allHints []funcHints, modGlobals []moduleGlobalPin, inlineTargets map[int]*inlineTarget, calleePreservesPins []bool, ms *ModuleStats, guardMode, boundsFacts bool, importedFuncs int) (*a64.CompiledModule, error) {
+	n := len(m.Code)
+	if ms != nil {
+		for i := range m.Code {
+			ms.Funcs[i] = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
+		}
+	}
+	states := make([]workerState, workers)
+	arenaCap := (codeCap + workers - 1) / workers
 	pressureAt := opts.MemoryPressureAt
 	if opts.MemoryPressure != nil && pressureAt <= 0 {
-		pressureAt = cap(code) * 7 / 8
+		pressureAt = codeCap * 7 / 8
 	}
-	for i := range m.Code {
-		hints := allHints[i]
-		var st *CodegenStats
-		if ms != nil {
-			st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
-			ms.Funcs[i] = st
-		}
-		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, calleePreservesPins, sc)
-		allHints[i] = funcHints{}
-		if err != nil {
-			return nil, fmt.Errorf("arm64: function %d: %w", i, err)
-		}
-		// 16-byte align each function.
+	var pressureBytes atomic.Int64
+	var pressureOnce sync.Once
+	for i := range states {
+		states[i] = workerState{scratch: newScratch(), arena: make([]byte, 0, arenaCap)}
+	}
+	results := make([]funcResult, n)
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for workerID := range states {
+		go func(workerID int) {
+			defer wg.Done()
+			ws := &states[workerID]
+			for {
+				i := int(next.Add(1) - 1)
+				if i >= n {
+					return
+				}
+				var st *CodegenStats
+				if ms != nil {
+					st = ms.Funcs[i]
+				}
+				fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, allHints[i], opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, calleePreservesPins, ws.scratch)
+				allHints[i] = funcHints{}
+				if err != nil {
+					results[i].err = err
+					continue
+				}
+				start := len(ws.arena)
+				ws.arena = append(ws.arena, fnCode...)
+				results[i] = funcResult{worker: workerID, start: start, end: len(ws.arena), internalOff: internalOff, relocs: rl}
+				if opts.MemoryPressure != nil && pressureBytes.Add(int64(len(fnCode))) >= int64(pressureAt) {
+					pressureOnce.Do(opts.MemoryPressure)
+				}
+			}
+		}(workerID)
+	}
+	wg.Wait()
+	if i, err := firstFuncError(results); err != nil {
+		return nil, fmt.Errorf("arm64: function %d: %w", i, err)
+	}
+
+	code := make([]byte, 0, codeCap)
+	for i := range results {
+		r := &results[i]
 		if pad := (16 - len(code)%16) % 16; pad != 0 {
 			code = append(code, alignPad[:pad]...)
 		}
 		entry[i] = len(code)
-		internalEntry[i] = len(code) + internalOff
-		relocs[i] = rl
-		code = append(code, fnCode...)
-		if !pressureDone && opts.MemoryPressure != nil && len(code) >= pressureAt {
-			pressureDone = true
-			opts.MemoryPressure()
-		}
+		internalEntry[i] = len(code) + r.internalOff
+		relocs[i] = r.relocs
+		code = append(code, states[r.worker].arena[r.start:r.end]...)
 	}
-	// Patch call sites now that every function's entry offsets are known. Direct
-	// wasm→wasm calls are BL placeholders (imm26, ±128 MiB); wrap the finished code
-	// slice in an Asm so PatchBranch26 can fill each site's displacement.
 	asm := &a64.Asm{B: code}
 	for i := 0; i < n; i++ {
 		for _, rl := range relocs[i] {
@@ -687,6 +814,15 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 		fmt.Fprint(os.Stderr, ms.String())
 	}
 	return &a64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
+}
+
+func firstFuncError(results []funcResult) (int, error) {
+	for i := range results {
+		if results[i].err != nil {
+			return i, results[i].err
+		}
+	}
+	return 0, nil
 }
 
 // moduleGlobalPinInfos converts the internal module-global pin assignments to the

--- a/src/core/compiler/backend/railshot/arm64/parallel_compile_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/parallel_compile_arm64_test.go
@@ -1,0 +1,98 @@
+//go:build (linux || darwin) && arm64
+
+package arm64
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/frontend"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	encoder "github.com/wago-org/wago/src/core/encoder/arm64"
+)
+
+func TestCompileWorkersDeterministicArm64(t *testing.T) {
+	corpus := filepath.Join("..", "..", "..", "..", "..", "..", "bench", "corpus")
+	for _, name := range []string{
+		"tiny.wasm",
+		"fib_rec.wasm",      // recursion and direct-call relocations
+		"dispatch.wasm",     // call_indirect
+		"many_funcs.wasm",   // enough functions to exercise every worker
+		"globals.wasm",      // mutable globals
+		"memory_tree.wasm",  // memory plus recursion
+		"branches.wasm",     // structured control flow
+		"json-as-simd.wasm", // SIMD, memory, globals, calls, and auto-inlining
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := readParallelTestModuleArm64(t, filepath.Join(corpus, name))
+			want, wantStats := compileWorkerTestModuleArm64(t, m, 1)
+			for _, workers := range []int{2, 4, 8} {
+				for repeat := 0; repeat < 5; repeat++ {
+					got, gotStats := compileWorkerTestModuleArm64(t, m, workers)
+					assertCompiledModuleEqualArm64(t, got, want)
+					if !reflect.DeepEqual(gotStats, wantStats) {
+						t.Fatalf("workers=%d repeat=%d: stats differ\n got: %#v\nwant: %#v", workers, repeat, gotStats, wantStats)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCompileWorkersLowestIndexErrorArm64(t *testing.T) {
+	results := make([]funcResult, 8)
+	results[7].err = errors.New("late index")
+	results[2].err = errors.New("first index")
+	idx, err := firstFuncError(results)
+	if idx != 2 || err == nil || err.Error() != "first index" {
+		t.Fatalf("firstFuncError = (%d, %v), want (2, first index)", idx, err)
+	}
+}
+
+func readParallelTestModuleArm64(t *testing.T, path string) *wasm.Module {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := frontend.DecodeValidate(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func compileWorkerTestModuleArm64(t *testing.T, m *wasm.Module, workers int) (*encoder.CompiledModule, *ModuleStats) {
+	t.Helper()
+	stats := &ModuleStats{}
+	cm, err := CompileModuleWith(m, CompileOptions{Workers: workers, Stats: stats})
+	if err != nil {
+		t.Fatalf("workers=%d: compile: %v", workers, err)
+	}
+	return cm, stats
+}
+
+func assertCompiledModuleEqualArm64(t *testing.T, got, want *encoder.CompiledModule) {
+	t.Helper()
+	if len(got.Code) != len(want.Code) {
+		t.Fatalf("code length = %d, want %d", len(got.Code), len(want.Code))
+	}
+	if !bytes.Equal(got.Code, want.Code) {
+		for i := range got.Code {
+			if got.Code[i] != want.Code[i] {
+				t.Fatalf("code differs at byte %d: got %#02x want %#02x", i, got.Code[i], want.Code[i])
+			}
+		}
+		t.Fatal("code differs")
+	}
+	if !reflect.DeepEqual(got.Entry, want.Entry) {
+		t.Fatalf("Entry differs\n got: %v\nwant: %v", got.Entry, want.Entry)
+	}
+	if !reflect.DeepEqual(got.InternalEntry, want.InternalEntry) {
+		t.Fatalf("InternalEntry differs\n got: %v\nwant: %v", got.InternalEntry, want.InternalEntry)
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/regcopy.go
+++ b/src/core/compiler/backend/railshot/arm64/regcopy.go
@@ -17,6 +17,11 @@ type regMove struct{ dst, src Reg }
 // resolveRegMoves emits the moves in a safe order via emitMove (dst = src) and
 // emitSwap (exchange). The move set must be a function from dst to src (each
 // register written at most once), which holds for ABI argument placement.
+//
+// The pending graph is held as a fixed src[dst] array plus a `pending` bitmask.
+// Besides avoiding a hot-path map allocation, walking destinations by increasing
+// register number keeps emitted code independent of Go map iteration order and
+// therefore identical between serial and parallel function compilation.
 func resolveRegMoves(moves []regMove, emitMove func(dst, src Reg), emitSwap func(a, b Reg)) {
 	var src [64]Reg
 	var pending regMask
@@ -48,7 +53,7 @@ func resolveRegMoves(moves []regMove, emitMove func(dst, src Reg), emitSwap func
 		if moved {
 			continue
 		}
-		// Residual graph is pure cycles; break one with a swap.
+		// Residual graph is pure cycles; break the lowest-destination cycle.
 		dst := Reg(bits.TrailingZeros64(uint64(pending)))
 		s := src[dst]
 		emitSwap(dst, s)

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -89,6 +89,52 @@ func compileArgs(args []any) (*RuntimeConfig, []byte, error) {
 	}
 }
 
+// storedCompileWorkers keeps link-time policy in existing Compiled padding.
+// Values above uint16 still mean "at least every practical GOMAXPROCS" and are
+// therefore equivalent after the backend cap.
+func storedCompileWorkers(policy int) uint16 {
+	if policy > int(^uint16(0)) {
+		return ^uint16(0)
+	}
+	return uint16(policy)
+}
+
+// compileWorkersForModule resolves a public compile-worker policy to a forced
+// backend worker count. Positive policies are explicit maxima. Auto mode uses a
+// measured work score that distinguishes hundreds of tiny functions from a few
+// substantial bodies while retaining the exact serial fast path below 16 KiB.
+// Four workers won consistently from that crossover. Eight improved backend-only
+// latency on the largest modules, but not end-to-end latency enough to justify its
+// additional allocation and peak-RSS cost, so auto mode deliberately caps at four.
+func compileWorkersForModule(m *wasm.Module, policy int) int {
+	workers := policy
+	if workers == 0 {
+		const (
+			perFunctionWeight = 64
+			parallelThreshold = 16 << 10
+		)
+		totalBody := 0
+		for i := range m.Code {
+			totalBody += len(m.Code[i].BodyBytes)
+		}
+		if score := totalBody + perFunctionWeight*len(m.Code); score < parallelThreshold {
+			workers = 1
+		} else {
+			workers = 4
+		}
+	}
+	if max := goruntime.GOMAXPROCS(0); workers > max {
+		workers = max
+	}
+	if workers > len(m.Code) {
+		workers = len(m.Code)
+	}
+	if workers <= 1 {
+		return 1
+	}
+	return workers
+}
+
 func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
 	if cfg == nil {
 		cfg = NewRuntimeConfig()
@@ -120,14 +166,14 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	var entry, internalEntry []int
 	if !needsLink {
 		pressureAt, pressure := compileMemoryPressure(len(wasmBytes))
-		cm, err := railshotCompileModuleWith(m, railshotCompileOptions{ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds, SyncHostCalls: syncHostInitial, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
+		cm, err := railshotCompileModuleWith(m, railshotCompileOptions{Workers: compileWorkersForModule(m, cfg.compileWorkers), ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds, SyncHostCalls: syncHostInitial, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
 		if err != nil {
 			return nil, fmt.Errorf("compile: %w", err)
 		}
 		code, entry, internalEntry = cm.Code, cm.Entry, cm.InternalEntry
 	}
 
-	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs, needsLink: needsLink, boundsElide: elide, noDeferBounds: cfg.noDeferBounds, requiredFeatures: uint8(moduleRequiredFeatures(m)), syncHostImports: syncHostInitial}
+	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs, needsLink: needsLink, boundsElide: elide, noDeferBounds: cfg.noDeferBounds, compileWorkers: storedCompileWorkers(cfg.compileWorkers), requiredFeatures: uint8(moduleRequiredFeatures(m)), syncHostImports: syncHostInitial}
 	if importedFuncs > 0 {
 		c.importFuncSigs = make([]FuncSig, importedFuncs)
 		for i := 0; i < importedFuncs; i++ {
@@ -596,7 +642,7 @@ func (c *Compiled) recompileLinked(imports Imports, bindings []railshotImportBin
 		}
 	}
 	pressureAt, pressure := compileMemoryPressure(len(c.wasmBytes))
-	cm, err := railshotCompileModuleWith(m, railshotCompileOptions{ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noDeferBounds, ImportBindings: bindings, SyncHostCalls: syncHost, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
+	cm, err := railshotCompileModuleWith(m, railshotCompileOptions{Workers: compileWorkersForModule(m, int(c.compileWorkers)), ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noDeferBounds, ImportBindings: bindings, SyncHostCalls: syncHost, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
 	if err != nil {
 		return nil, fmt.Errorf("link: %w", err)
 	}

--- a/src/wago/bench_test.go
+++ b/src/wago/bench_test.go
@@ -72,6 +72,31 @@ func benchReturningImportModule() []byte {
 	return returningImportModule(returningI32Sig(), []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b}) // local.get 0; call 0; end
 }
 
+// benchParallelLinkModule builds a link-deferred module with enough independent
+// local functions to measure worker policy propagation through link-time codegen.
+func benchParallelLinkModule(funcs, adds int) []byte {
+	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	imp := append(append(wasmtest.Name("env"), wasmtest.Name("f")...), 0x00, 0x00) // func, type 0
+	funcTypes := make([][]byte, funcs)
+	codes := make([][]byte, funcs)
+	for i := range funcTypes {
+		funcTypes[i] = wasmtest.ULEB(0)
+		body := []byte{0x20, 0x00, 0x10, 0x00} // local.get 0; call import 0
+		for j := 0; j < adds; j++ {
+			body = append(body, 0x41, 0x01, 0x6a) // i32.const 1; i32.add
+		}
+		body = append(body, 0x0b)
+		codes[i] = wasmtest.Code(body)
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(sig)),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(3, wasmtest.Vec(funcTypes...)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f0", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(codes...)),
+	)
+}
+
 func benchTableReturningImportModule() []byte {
 	return tableHostImportModule(returningI32Sig(), []byte{0x20, 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x0b}) // local.get 0; i32.const 0; call_indirect type 0 table 0; end
 }
@@ -277,6 +302,38 @@ func BenchmarkCompileSmallScalar(b *testing.B) {
 			b.Fatal(err)
 		}
 		benchCompiledSink = c
+	}
+}
+
+// BenchmarkCompileLinkWorkers measures the public decode+validate plus deferred
+// host-link codegen path. A fresh Compiled is used per iteration so the host-link
+// cache cannot hide recompilation.
+func BenchmarkCompileLinkWorkers(b *testing.B) {
+	mod := benchParallelLinkModule(1600, 128)
+	imports := Imports{"env.f": HostFunc(func(_ HostModule, params, results []uint64) { results[0] = params[0] })}
+	for _, mode := range []struct {
+		name    string
+		workers int
+	}{{"p1", 1}, {"p2", 2}, {"p4", 4}, {"p8", 8}, {"auto", 0}} {
+		b.Run(mode.name, func(b *testing.B) {
+			cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(mode.workers)
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c, err := Compile(cfg, mod)
+				if err != nil {
+					b.Fatal(err)
+				}
+				linked, err := c.linkModule(imports, nil)
+				if err != nil {
+					_ = c.Close()
+					b.Fatal(err)
+				}
+				benchCompiledSink = linked
+				if err := c.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -138,14 +138,15 @@ type RuntimeConfig struct {
 	maxMemoryPages uint32
 	boundsChecks   BoundsCheckMode
 	noDeferBounds  bool // disable skipping of provably-redundant bounds checks (default: enabled)
+	compileWorkers int  // 0 adaptive; 1 serial; >1 forced maximum
 }
 
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
 
 // NewRuntimeConfig returns the default configuration: wago's supported feature
-// set, and the fastest available bounds-check mode — signals-based (guard-page)
-// when the binary was built with -tags wago_guardpage, explicit otherwise.
-// WAGO_BOUNDS overrides either way ("explicit" / "signals").
+// set, serial function compilation, and the fastest available bounds-check mode —
+// signals-based (guard-page) when the binary was built with -tags wago_guardpage,
+// explicit otherwise. WAGO_BOUNDS overrides either way ("explicit" / "signals").
 func NewRuntimeConfig() *RuntimeConfig {
 	bounds := BoundsChecksExplicit
 	if guardPageBuilt {
@@ -161,6 +162,7 @@ func NewRuntimeConfig() *RuntimeConfig {
 		features:       coreFeaturesWago,
 		maxMemoryPages: defaultMaxMemoryPages,
 		boundsChecks:   bounds,
+		compileWorkers: 1,
 	}
 }
 
@@ -223,6 +225,16 @@ func (c *RuntimeConfig) WithDeferBoundsChecks(enabled bool) *RuntimeConfig {
 	return &n
 }
 
+// WithCompileWorkers sets the per-module function-codegen policy. Zero selects
+// the measured adaptive policy, one forces the serial fast path, and N > 1
+// forces at most N workers (still capped by GOMAXPROCS and local-function count).
+// Negative values are rejected by Validate.
+func (c *RuntimeConfig) WithCompileWorkers(workers int) *RuntimeConfig {
+	n := *c
+	n.compileWorkers = workers
+	return &n
+}
+
 // CoreFeatures reports the configured feature set.
 func (c *RuntimeConfig) CoreFeatures() CoreFeatures { return c.features }
 
@@ -235,6 +247,10 @@ func (c *RuntimeConfig) DeferBoundsChecks() bool { return !c.noDeferBounds }
 
 // MemoryLimitPages reports the configured maximum linear-memory size in pages.
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }
+
+// CompileWorkers reports the configured compile-worker policy: zero adaptive,
+// one serial, or a positive forced maximum.
+func (c *RuntimeConfig) CompileWorkers() int { return c.compileWorkers }
 
 // Compile decodes, validates, and compiles wasmBytes under this config. On
 // success the returned Compiled owns the byte slice and the caller must not
@@ -256,8 +272,8 @@ func (c *RuntimeConfig) MustCompile(wasmBytes []byte) *Compiled {
 }
 
 func (c *RuntimeConfig) String() string {
-	return fmt.Sprintf("RuntimeConfig{features: %s, bounds: %s, maxMemoryPages: %d}",
-		c.features, c.boundsChecks, c.maxMemoryPages)
+	return fmt.Sprintf("RuntimeConfig{features: %s, bounds: %s, maxMemoryPages: %d, compileWorkers: %d}",
+		c.features, c.boundsChecks, c.maxMemoryPages, c.compileWorkers)
 }
 
 // SupportedFeatures reports the WebAssembly feature set this wago build can
@@ -328,6 +344,9 @@ func (c *RuntimeConfig) frontendFeatures() frontend.Features {
 // surfacing a bad config early (e.g. at startup). A feature flag is never a
 // silent no-op.
 func (c *RuntimeConfig) Validate() error {
+	if c.compileWorkers < 0 {
+		return fmt.Errorf("wago: compile workers must be non-negative, got %d", c.compileWorkers)
+	}
 	if unsupported := c.features &^ coreFeaturesWago; unsupported != 0 {
 		return &UnsupportedFeatureError{Requested: unsupported, Supported: coreFeaturesWago}
 	}

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -299,8 +299,18 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 }
 
 func TestCompileWorkersLinkPathAndSerialization(t *testing.T) {
+	producer, err := Instantiate(MustCompile(benchAddOneModule()), InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate link producer: %v", err)
+	}
+	defer producer.Close()
+	f, err := producer.ExportedFunc("f")
+	if err != nil {
+		t.Fatalf("export link producer function: %v", err)
+	}
+
 	mod := benchParallelLinkModule(64, 16)
-	imports := Imports{"env.f": HostFunc(func(_ HostModule, params, results []uint64) { results[0] = params[0] })}
+	imports := Imports{"env.f": f}
 	compileLinked := func(workers int) (*Compiled, *Compiled) {
 		t.Helper()
 		cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(workers)
@@ -308,24 +318,26 @@ func TestCompileWorkersLinkPathAndSerialization(t *testing.T) {
 		if err != nil {
 			t.Fatalf("workers=%d compile: %v", workers, err)
 		}
-		if int(c.compileWorkers) != workers || !c.needsLink {
-			t.Fatalf("workers=%d metadata policy=%d needsLink=%v", workers, c.compileWorkers, c.needsLink)
+		if int(c.compileWorkers) != workers || len(c.wasmBytes) == 0 {
+			t.Fatalf("workers=%d metadata policy=%d retainedSource=%d", workers, c.compileWorkers, len(c.wasmBytes))
 		}
 		linked, err := c.linkModule(imports, nil)
 		if err != nil {
 			_ = c.Close()
 			t.Fatalf("workers=%d link: %v", workers, err)
 		}
-		if int(linked.compileWorkers) != workers {
+		if linked == c || int(linked.compileWorkers) != workers {
 			_ = c.Close()
-			t.Fatalf("workers=%d linked policy=%d", workers, linked.compileWorkers)
+			t.Fatalf("workers=%d linked=%p owner=%p policy=%d", workers, linked, c, linked.compileWorkers)
 		}
 		return c, linked
 	}
 	serialOwner, serial := compileLinked(1)
 	defer serialOwner.Close()
+	defer serial.Close()
 	parallelOwner, parallel := compileLinked(8)
 	defer parallelOwner.Close()
+	defer parallel.Close()
 	if !bytes.Equal(parallel.Code, serial.Code) || !bytes.Equal(intSliceBytes(parallel.Entry), intSliceBytes(serial.Entry)) || !bytes.Equal(intSliceBytes(parallel.InternalEntry), intSliceBytes(serial.InternalEntry)) {
 		t.Fatal("link-time parallel codegen differs from serial output")
 	}

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -3,8 +3,10 @@
 package wago
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -272,6 +274,13 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	if err := NewRuntimeConfig().Validate(); err != nil {
 		t.Fatalf("default config should validate: %v", err)
 	}
+	if err := NewRuntimeConfig().WithCompileWorkers(-1).Validate(); err == nil || !strings.Contains(err.Error(), "non-negative") {
+		t.Fatalf("negative compile workers should fail validation, got %v", err)
+	}
+	workers := NewRuntimeConfig().WithCompileWorkers(4)
+	if workers.CompileWorkers() != 4 || NewRuntimeConfig().CompileWorkers() != 1 {
+		t.Fatal("WithCompileWorkers must be immutable and observable; default must remain serial")
+	}
 	wantFeatures := coreFeaturesWago
 	if !hostSupportsSIMD() {
 		wantFeatures &^= CoreFeatureSIMD
@@ -284,8 +293,121 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	}
 	// String is non-empty / informative. The default bounds mode depends on the
 	// build tag (explicit normally, signals-based under wago_guardpage).
-	if s := NewRuntimeConfig().String(); !strings.Contains(s, "explicit") && !strings.Contains(s, "signals-based") {
-		t.Fatalf("config String missing bounds mode: %q", s)
+	if s := NewRuntimeConfig().String(); (!strings.Contains(s, "explicit") && !strings.Contains(s, "signals-based")) || !strings.Contains(s, "compileWorkers: 1") {
+		t.Fatalf("config String missing bounds mode or serial default policy: %q", s)
+	}
+}
+
+func TestCompileWorkersLinkPathAndSerialization(t *testing.T) {
+	mod := benchParallelLinkModule(64, 16)
+	imports := Imports{"env.f": HostFunc(func(_ HostModule, params, results []uint64) { results[0] = params[0] })}
+	compileLinked := func(workers int) (*Compiled, *Compiled) {
+		t.Helper()
+		cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(workers)
+		c, err := Compile(cfg, mod)
+		if err != nil {
+			t.Fatalf("workers=%d compile: %v", workers, err)
+		}
+		if int(c.compileWorkers) != workers || !c.needsLink {
+			t.Fatalf("workers=%d metadata policy=%d needsLink=%v", workers, c.compileWorkers, c.needsLink)
+		}
+		linked, err := c.linkModule(imports, nil)
+		if err != nil {
+			_ = c.Close()
+			t.Fatalf("workers=%d link: %v", workers, err)
+		}
+		if int(linked.compileWorkers) != workers {
+			_ = c.Close()
+			t.Fatalf("workers=%d linked policy=%d", workers, linked.compileWorkers)
+		}
+		return c, linked
+	}
+	serialOwner, serial := compileLinked(1)
+	defer serialOwner.Close()
+	parallelOwner, parallel := compileLinked(8)
+	defer parallelOwner.Close()
+	if !bytes.Equal(parallel.Code, serial.Code) || !bytes.Equal(intSliceBytes(parallel.Entry), intSliceBytes(serial.Entry)) || !bytes.Equal(intSliceBytes(parallel.InternalEntry), intSliceBytes(serial.InternalEntry)) {
+		t.Fatal("link-time parallel codegen differs from serial output")
+	}
+
+	serialArtifact, err := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(1).Compile(benchAddOneModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serialArtifact.Close()
+	parallelArtifact, err := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(8).Compile(benchAddOneModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parallelArtifact.Close()
+	serialBlob, err := serialArtifact.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parallelBlob, err := parallelArtifact.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(parallelBlob, serialBlob) {
+		t.Fatal("compile-worker policy changed serialized output")
+	}
+	var loaded Compiled
+	if err := loaded.UnmarshalBinary(parallelBlob); err != nil {
+		t.Fatal(err)
+	}
+	if loaded.compileWorkers != 0 {
+		t.Fatalf("deserialized compile policy = %d, want zero/non-serialized", loaded.compileWorkers)
+	}
+}
+
+func intSliceBytes(v []int) []byte {
+	out := make([]byte, 8*len(v))
+	for i, x := range v {
+		binary.LittleEndian.PutUint64(out[8*i:], uint64(x))
+	}
+	return out
+}
+
+func TestCompileWorkersForModulePolicy(t *testing.T) {
+	module := func(funcs, bodyBytes int) *wasm.Module {
+		m := &wasm.Module{Code: make([]wasm.Func, funcs)}
+		remaining := bodyBytes
+		for i := range m.Code {
+			n := 0
+			if left := funcs - i; left > 0 {
+				n = remaining / left
+			}
+			m.Code[i].BodyBytes = make([]byte, n)
+			remaining -= n
+		}
+		return m
+	}
+	capWant := func(w, funcs int) int {
+		if w > runtime.GOMAXPROCS(0) {
+			w = runtime.GOMAXPROCS(0)
+		}
+		if w > funcs {
+			w = funcs
+		}
+		if w <= 1 {
+			return 1
+		}
+		return w
+	}
+	if got := compileWorkersForModule(module(2, 9), 0); got != 1 {
+		t.Fatalf("tiny auto workers = %d, want serial", got)
+	}
+	if got, want := compileWorkersForModule(module(301, 2053), 0), capWant(4, 301); got != want {
+		t.Fatalf("many-functions auto workers = %d, want %d", got, want)
+	}
+	if got, want := compileWorkersForModule(module(658, 234408), 0), capWant(4, 658); got != want {
+		t.Fatalf("lua-tier auto workers = %d, want %d", got, want)
+	}
+	if got, want := compileWorkersForModule(module(2831, 798392), 0), capWant(4, 2831); got != want {
+		t.Fatalf("sqlite-tier auto workers = %d, want %d", got, want)
+	}
+	if got, want := compileWorkersForModule(module(10, 10), 3), capWant(3, 10); got != want {
+		t.Fatalf("forced maximum workers = %d, want %d", got, want)
 	}
 }
 

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -610,9 +610,10 @@ type Compiled struct {
 	// function at Instantiate; its Code/Entry are empty until then.
 	wasmBytes        []byte
 	needsLink        bool
-	boundsElide      bool  // cached ElideBoundsChecks decision, for the link-time recompile
-	noDeferBounds    bool  // cached DeferBoundsChecks=false decision, for the link-time recompile
-	requiredFeatures uint8 // exact optional core-feature bits required by code/metadata
+	boundsElide      bool   // cached ElideBoundsChecks decision, for the link-time recompile
+	noDeferBounds    bool   // cached DeferBoundsChecks=false decision, for the link-time recompile
+	compileWorkers   uint16 // capped compile policy for link-time recompilation; never serialized
+	requiredFeatures uint8  // exact optional core-feature bits required by code/metadata
 
 	// hostLink caches the host-only link recompile. A needsLink module (returning
 	// import) defers codegen to Instantiate; when every import binds to a host


### PR DESCRIPTION
## Summary

This PR adds deterministic, bounded per-function compilation parallelism to the amd64 and arm64 railshot backends, wires it through initial and link-time compilation, and exposes it in the CLI:

```sh
wago run -p app.wasm             # adaptive policy
wago run -p8 app.wasm            # at most 8 workers
wago run -p 8 app.wasm           # standard separated form
wago run --parallel=8 app.wasm
```

The default remains serial. This is intentional: single-module latency improves substantially, but parallel compilation increases transient memory and does not reliably improve already-concurrent multi-module throughput.

The full methodology, benchmark distributions, profile paths, RSS methodology, and reproduction commands are in [`docs/parallel-function-compilation-report.md`](../blob/parallel-func-comp/docs/parallel-function-compilation-report.md).

## Policy

Public API:

- `WithCompileWorkers(1)`: serial fast path
- `WithCompileWorkers(0)`: measured adaptive policy
- `WithCompileWorkers(N)`: force at most N workers
- all worker counts are capped by `GOMAXPROCS` and local function count
- negative values fail config validation

Adaptive policy:

```text
score = total wasm function-body bytes + 64 * local function count
score < 16 KiB: serial
otherwise:       at most 4 workers
```

Four workers capture most of the end-to-end latency gain without adopting p8's additional allocation and CPU costs. Callers can still force p8.

## Implementation

- module-wide analyses and decisions finish before workers start
- fixed bounded worker pool, one compiler scratch and append-only code arena per worker
- functions are claimed through an atomic index
- final machine code is joined in original function order
- alignment, `Entry`, `InternalEntry`, relocations, and stats remain deterministic
- errors are reported for the lowest function index, independent of completion order
- the parallel helper is split from the serial path so its goroutine closure cannot add serial-path allocations
- `Workers <= 1` retains one scratch, no goroutines, no atomics, no worker result metadata, and no intermediate arena
- link-time recompilation receives the same policy
- policy metadata is non-serialized and fits existing `Compiled` padding; the 632-byte footprint is unchanged

Parallel testing exposed latent map-order nondeterminism in bounds-hoist candidate order. Both backends now sort candidates by base local with `slices.SortFunc`; this is required for byte-identical output and does not add the `sort.Slice` interface allocation to serial compilation.

## Benchmark environment

- Go 1.24.4
- linux/amd64
- AMD Ryzen 7 8845HS, 8 physical / 16 logical cores
- worker matrices at `GOMAXPROCS=1,2,4,8`
- eight repeated samples, generally `-benchtime=3x -benchmem`
- decode and validation excluded from backend-only benchmarks

Corpus shape:

| module | local funcs | body bytes | max body |
|---|---:|---:|---:|
| tiny | 2 | 9 | 6 |
| fib_rec | 1 | 28 | 28 |
| many_funcs | 301 | 2,053 | 17 |
| json-as | 43 | 16,651 | 2,445 |
| blake-as | 6 | 4,474 | 3,532 |
| lua | 658 | 234,408 | 22,018 |
| sqlite3 | 2,831 | 798,392 | 39,188 |
| ruby | 17,452 | 11,143,998 | 100,238 |
| esbuild | 4,148 | 8,471,854 | 216,489 |

## Backend latency: `GOMAXPROCS=4`

Negative percentages are latency reductions. Speedup is `serial / parallel`.

| module | p1 | p2 | p4 | selected reduction | speedup |
|---|---:|---:|---:|---:|---:|
| many_funcs | 255.6 us | 218.8 us | 167.6 us | -34.4% | 1.53x |
| json-as | 1.006 ms | 641.4 us | 439.9 us | -56.3% | 2.29x |
| blake-as | 209.1 us | 169.8 us | 169.2 us | -19.1% | 1.24x |
| lua | 18.181 ms | 11.215 ms | 9.048 ms | -50.2% | 2.01x |
| sqlite3 | 56.445 ms | 34.353 ms | 22.718 ms | -59.8% | 2.48x |
| ruby | 611.153 ms | 382.929 ms | 257.990 ms | -57.8% | 2.37x |
| esbuild | 416.895 ms | 259.706 ms | 175.881 ms | -57.8% | 2.37x |

Tiny modules remain serial in auto mode: worker startup/join overhead makes p4 roughly 2.8x slower for the 9-byte `tiny` workload.

## Backend latency: `GOMAXPROCS=8`, forced p8

| module | p1 | p8 | latency reduction | speedup |
|---|---:|---:|---:|---:|
| lua | 18.017 ms | 8.338 ms | -53.7% | 2.16x |
| sqlite3 | 55.799 ms | 19.738 ms | -64.6% | 2.83x |
| ruby | 596.245 ms | 185.408 ms | -68.9% | 3.22x |
| esbuild | 416.285 ms | 141.013 ms | -66.1% | 2.95x |

This proves the backend work scales beyond p4 on sufficiently large modules, while the following full-pipeline and footprint data explain the conservative auto cap.

## Full public pipeline

At `GOMAXPROCS=8`, adaptive versus serial:

| module | serial | adaptive | latency reduction | speedup | allocation ratio |
|---|---:|---:|---:|---:|---:|
| many_funcs | 0.474 ms | 0.357 ms | -24.6% | 1.33x | 1.57x |
| json-as | 2.072 ms | 1.629 ms | -21.4% | 1.27x | 1.74x |
| esbuild | 878.327 ms | 632.513 ms | -28.0% | 1.39x | 1.44x |

Lua, sqlite3, and ruby defer backend codegen because of returning imports, so initial public `Compile` correctly shows no worker gain. A fresh host-link benchmark exercises that path:

| mode, `GOMAXPROCS=8` | latency | change | allocation change |
|---|---:|---:|---:|
| p1 | 54.26 ms | baseline | baseline |
| adaptive/p4 | 49.60 ms | -8.6% | +70.6% |
| p8 | 46.47 ms | -14.4% | +76.0% |

## Allocation and peak RSS cost

At `GOMAXPROCS=8`, p4 backend allocations versus p1:

| module | p1 B/op | p4 B/op | change |
|---|---:|---:|---:|
| many_funcs | 182.0 KiB | 305.9 KiB | +68.0% |
| json-as | 362.6 KiB | 701.5 KiB | +93.4% |
| lua | 5.934 MiB | 9.339 MiB | +57.4% |
| sqlite3 | 15.88 MiB | 26.98 MiB | +69.8% |
| ruby | 103.3 MiB | 174.5 MiB | +69.0% |
| esbuild | 97.78 MiB | 161.34 MiB | +65.0% |

Compile-once esbuild, median of five fresh processes at `GOMAXPROCS=8`:

| mode | backend latency | user CPU | peak RSS |
|---|---:|---:|---:|
| p1 | 481.7 ms | 0.974 s | 147.4 MiB |
| p2 | 292.1 ms | 0.987 s | 176.9 MiB |
| p4 | 190.2 ms | 1.037 s | 190.4 MiB |
| p8 | 161.6 ms | 1.173 s | 189.9 MiB |

p8's RSS median happened to be slightly below p4 in this five-process sample, but repeated B/op was higher (178.83 MiB versus 161.34 MiB), CPU was higher, and individual p8 RSS samples reached about 199 MiB.

## Oversubscription / independent-module throughput

Adaptive versus serial under `b.RunParallel`:

| `GOMAXPROCS` | many_funcs | json-as | esbuild |
|---:|---:|---:|---:|
| 2 | no significant change | no significant change | 1.0% slower |
| 4 | no significant change | 6.5% slower | 2.2% slower |
| 8 | 7.7% faster | 6.0% faster | **16.5% slower** |

This is why the PR does not silently change the library default. CLI/build users can request lower single-module latency with `-p`; concurrent servers and low-memory devices retain predictable serial behavior.

## Determinism and correctness

- repeated p1/p2/p4/p8 byte equality for machine code
- identical `Entry`, `InternalEntry`, code lengths, relocations, and per-function stats
- selected whole-corpus parity including lua, sqlite3, ruby, and esbuild
- deterministic lowest-index error selection
- link-time serial/parallel output equality
- serialized p1/p8 artifact equality
- compile policy deliberately absent after deserialization
- targeted race detector runs for backend corpus parity and public/link paths

## Validation

Passed:

- `make test`
- `go vet ./...`
- `go generate ./...` with no generated diff
- `make test-corpus` in explicit and guard-page modes
- targeted race tests
- amd64 selected corpus parity
- native Linux/arm64 and Darwin/arm64 CI, including TinyGo on both hosts
- arm64 backend and public package cross-compilation
- WebAssembly 1.0: 629 modules / 16,026 assertions, zero failures
- WebAssembly 2.0: 1,600 modules / 48,248 assertions, zero failures
- WebAssembly 3.0 proposal run: zero failures, only documented unsupported/toolchain gaps
- CLI execution smoke tests for `-p`, `-p8`, and `-p 8`

CI's **Lint & format** job passes, including staticcheck. Locally, `make lint`'s repository-wide gofmt stage could not complete because this checkout contains pre-existing untracked `.git/tools/go1.22.12` negative syntax fixtures and `.validation` helper programs; scoped gofmt, `go vet`, and generation checks all pass.

## Recommendation

Ship the worker implementation, API, benchmarks, report, and CLI flag. Keep serial as the library/CLI default; make adaptive mode an explicit `-p` / `WithCompileWorkers(0)` choice.

