### PR TITLE
compiler: reduce whole-module compile memory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,8 +48,8 @@ backend codegen.
      │
      ▼
  ┌─────────┐   ┌──────────┐   ┌─────────────────────┐   ┌──────────┐
- │ decode  │──▶│ validate │──▶│ compile (Valent-    │──▶│ Compiled │
- │         │   │          │   │ Block x86-64 codegen)│   │ metadata │
+ │ decode  │──▶│ validate │──▶│ compile (Valent-     │──▶│ Compiled │
+ │         │   │          │   │ Block native codegen)│   │ metadata │
  └─────────┘   └──────────┘   └─────────────────────┘   └────┬─────┘
  src/core/compiler/wasm        src/core/compiler/backend/railshot│
                                                               │  (optional: MarshalBinary → .wago blob)
@@ -81,7 +81,10 @@ wago.go                           generated root facade (re-exports src/wago)
 internal/genfacade/               generator for wago.go (+ up-to-date test)
 cli/wago/                         CLI: run; compile/profile/validate are stubs
 src/core/compiler/wasm/           decoder + validator (front end)
-src/core/compiler/backend/railshot/  single-pass x86-64 codegen (Valent-Block)
+src/core/compiler/backend/railshot/  direct native codegen (Valent-Block)
+  amd64/                            x86-64 selection, registers, ABI, encoding
+  arm64/                            AArch64 selection, registers, ABI, encoding
+  shared/                           architecture-neutral policy and metadata
 src/core/runtime/                 mmap, foreign stack, JobMemory, traps
 src/core/runtime/abi/             layout constants shared by codegen + runtime
 tests/spec/                       WebAssembly spec testsuite (submodule, MVP-pinned)
@@ -132,6 +135,11 @@ side-effecting instruction appears (`local.set`, `global.set`, `br_if`, a call,
 a control-flow join), are the deferred operands *condensed* — materialized into
 registers just in time. At control-flow joins the machine state is flushed to
 deterministic frame slots so every incoming edge agrees on register/stack state.
+
+The decoded module and complete function bodies remain available throughout
+compilation. Railshot reuses module-scoped scratch arenas between functions and
+pre-sizes retained output, reducing transient heap growth without imposing a
+streaming or borrowed-buffer lifetime on analysis and optimization code.
 
 The net effect: straight-line code emits essentially no per-operation stack
 traffic. `valent_test.go`'s `TestRegisterResident` disassembles a straight-line

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	// A successful Compile takes ownership of src. Keep it immutable and do not
+	// reuse its backing array while mod is alive.
 	inst, err := wago.Instantiate(mod, nil)
 	if err != nil {
 		panic(err)

--- a/docs/codegen-benchmarks.md
+++ b/docs/codegen-benchmarks.md
@@ -9,21 +9,61 @@ clutter the repository root.
 
 ## Stable benchmark runs
 
-Use repeated runs when comparing performance:
+The corpus suite is a separate Go module. Use repeated stage-specific runs when
+comparing performance:
 
 ```sh
-go test ./src/core/compiler/backend/railshot -bench=. -benchmem -count=10 > /tmp/railshot-before.txt
-go test ./src/core/compiler/frontend -bench=. -benchmem -count=10 > /tmp/frontend-before.txt
-go test ./src/core/compiler/wasm -bench=. -benchmem -count=10 > /tmp/wasm-before.txt
+cd bench
+go test . -run '^$' -bench 'BenchmarkCompile/(sqlite3|ruby|esbuild)$' \
+  -benchmem -benchtime=1x -count=5
+go test . -run '^$' -bench 'BenchmarkValidate/(sqlite3|ruby|esbuild)$' \
+  -benchmem -benchtime=1x -count=5
 ```
 
 Optional `benchstat` workflow:
 
 ```sh
-go test ./src/core/compiler/backend/railshot -bench=. -benchmem -count=10 > /tmp/railshot-before.txt
+cd bench
+go test . -run '^$' -bench 'BenchmarkCompile/(sqlite3|ruby|esbuild)$' \
+  -benchmem -benchtime=1x -count=10 > /tmp/railshot-before.txt
 # make changes
-go test ./src/core/compiler/backend/railshot -bench=. -benchmem -count=10 > /tmp/railshot-after.txt
+go test . -run '^$' -bench 'BenchmarkCompile/(sqlite3|ruby|esbuild)$' \
+  -benchmem -benchtime=1x -count=10 > /tmp/railshot-after.txt
 benchstat /tmp/railshot-before.txt /tmp/railshot-after.txt
+```
+
+## Compile-memory reference (2026-07-17)
+
+Apple M4 Max, darwin/arm64, explicit bounds. `main` and the compile-memory
+refactor were measured from prebuilt benchmark binaries with `-benchtime=1x`.
+`B/op` is cumulative allocation; RSS includes the benchmark process and corpus
+loader, so it is a deliberately conservative whole-process measurement.
+
+| stage/corpus | main B/op | refactor B/op | reduction |
+|---|---:|---:|---:|
+| Railshot / sqlite3 | 45,528,608 | 9,177,056 | 79.8% |
+| Railshot / ruby | 558,089,848 | 88,589,296 | 84.1% |
+| Railshot / esbuild | 522,828,072 | 73,553,168 | 85.9% |
+| full compile / sqlite3 | 50,363,176 | 16,049,616 | 68.1% |
+| full compile / ruby | 587,471,976 | 114,503,176 | 80.5% |
+| full compile / esbuild | 572,585,912 | 101,079,816 | 82.3% |
+
+Ruby Railshot peak RSS fell from 209,780,736 to 130,400,256 bytes (37.8%);
+esbuild fell from 190,447,616 to 123,043,840 bytes (35.4%). Adjacent compile
+samples were faster rather than slower; longer execution checks remained
+zero-allocation and within normal run-to-run variation of main.
+
+For compile-memory work, report both cumulative allocation (`B/op`) and peak
+process RSS. They measure different things: reusable scratch can sharply reduce
+allocation traffic while retained corpus bytes and native output still set a
+larger live-memory floor. Build the benchmark binary once before an RSS run so
+the Go build is outside the measurement:
+
+```sh
+cd bench
+go test -c -o /tmp/wago-bench.test .
+/usr/bin/time -l /tmp/wago-bench.test -test.run '^$' \
+  -test.bench '^BenchmarkCompile$/^ruby$' -test.benchtime=1x -test.benchmem
 ```
 
 ## Backend toggles
@@ -48,8 +88,9 @@ candidates.
 Backend railshot compile profiles:
 
 ```sh
-go test ./src/core/compiler/backend/railshot -bench=BenchmarkRailshotCompile -benchmem \
-  -memprofile /tmp/railshot_mem.out -cpuprofile /tmp/railshot_cpu.out
+cd bench
+go test . -run '^$' -bench '^BenchmarkCompile$/^ruby$' -benchtime=1x \
+  -benchmem -memprofile /tmp/railshot_mem.out -cpuprofile /tmp/railshot_cpu.out
 go tool pprof -top /tmp/railshot_mem.out
 go tool pprof -top /tmp/railshot_cpu.out
 ```

--- a/docs/codegen-benchmarks.md
+++ b/docs/codegen-benchmarks.md
@@ -41,15 +41,19 @@ loader, so it is a deliberately conservative whole-process measurement.
 
 | stage/corpus | main B/op | refactor B/op | reduction |
 |---|---:|---:|---:|
-| Railshot / sqlite3 | 45,528,608 | 9,177,056 | 79.8% |
-| Railshot / ruby | 558,089,848 | 88,589,296 | 84.1% |
-| Railshot / esbuild | 522,828,072 | 73,553,168 | 85.9% |
-| full compile / sqlite3 | 50,363,176 | 16,049,616 | 68.1% |
-| full compile / ruby | 587,471,976 | 114,503,176 | 80.5% |
-| full compile / esbuild | 572,585,912 | 101,079,816 | 82.3% |
+| Railshot / sqlite3 | 45,528,608 | 8,042,024 | 82.3% |
+| Railshot / ruby | 558,089,848 | 70,789,544 | 87.3% |
+| Railshot / esbuild | 522,828,072 | 61,481,080 | 88.2% |
+| full compile / sqlite3 | 50,363,176 | 13,972,520 | 72.3% |
+| full compile / ruby | 587,471,976 | 80,459,008 | 86.3% |
+| full compile / esbuild | 572,585,912 | 77,350,592 | 86.5% |
 
-Ruby Railshot peak RSS fell from 209,780,736 to 130,400,256 bytes (37.8%);
-esbuild fell from 190,447,616 to 123,043,840 bytes (35.4%). Adjacent compile
+Ruby Railshot peak RSS initially fell from 209,780,736 to 130,400,256 bytes;
+esbuild fell from 190,447,616 to 123,043,840 bytes. The completed refactor's
+standalone public-Compile harness measured median peak RSS of 101,941,248 bytes
+for Ruby and 93,913,088 bytes for esbuild. Median wall time was 1.11 s and
+0.75 s respectively. The public path uses one late GC checkpoint for sources at
+least 8 MiB; it does not alter process-wide GOGC or GOMEMLIMIT. Adjacent compile
 samples were faster rather than slower; longer execution checks remained
 zero-allocation and within normal run-to-run variation of main.
 

--- a/docs/streaming-singlepass-plan.md
+++ b/docs/streaming-singlepass-plan.md
@@ -1,8 +1,14 @@
 # Streaming and bounded-memory single-pass pipeline
 
-Status: proposed design plan.
+Status: superseded; retained as design history.
 
-## Goal
+Wago does not plan to stream decode, validation, or Railshot compilation. The
+current direction keeps the complete decoded module and function bodies
+available to code generation, while reducing compile memory through reusable
+per-function scratch, compact metadata, and pre-sized retained output. This
+preserves unrestricted lookahead for current and future whole-module analyses.
+
+## Historical goal
 
 Make Wago's direct ("single-pass") compiler pipeline consume WebAssembly in
 chunks and bound its *transient* memory use. The target is not constant total

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -636,15 +636,12 @@ func (f *fn) callInternal(localIdx int, ft *wasm.CompType, resHint int) error {
 // resHint >= 0 fuses a following `local.set resHint`: RAX moves straight into
 // the pinned local's register instead of an allocated result register.
 func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType, resHint int) {
-	f.emitRegisterCallVia(ft, resHint, func() {
-		site := f.a.CallRel32()
-		f.relocs = append(f.relocs, callReloc{at: site, target: localIdx, internal: true})
-	})
+	f.emitRegisterCallVia(ft, resHint, localIdx, regNone)
 }
 
-// emitRegisterCallVia is emitRegisterCall with a pluggable call emitter
-// (direct rel32 or an indirect `call [mem]` for call_indirect).
-func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, emitCall func()) {
+// emitRegisterCallVia emits either a direct internal rel32 call (localIdx >= 0)
+// or an indirect register call. Explicit operands avoid a closure per wasm call.
+func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, localIdx int, indirect Reg) {
 	p, rN := len(ft.Params), len(ft.Results)
 	d := f.depth()
 	f.storePinnedGlobals(false) // spill value-pinned globals to their cells before the call (scratch is free here)
@@ -714,7 +711,12 @@ func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, emitCall func()
 
 	// No environment passing: RBX (linMem) is a whole-module invariant and the
 	// trap cell pointer lives in basedata — the callee inherits both (WARP model).
-	emitCall()
+	if localIdx >= 0 {
+		site := f.a.CallRel32()
+		f.relocs = append(f.relocs, callReloc{at: site, target: localIdx, internal: true})
+	} else {
+		f.a.CallReg(indirect)
+	}
 
 	// Capture the result(s) out of the return registers before the reload
 	// sequence below reuses RAX/RDX as scratch. Single int → RAX; two ints →
@@ -992,7 +994,7 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 		f.release(idxReg)
 		f.pinned = f.pinned.add(code)
 		f.stats.peep("immutable-local-call-indirect")
-		f.emitRegisterCallVia(ft, -1, func() { f.a.CallReg(code) })
+		f.emitRegisterCallVia(ft, -1, -1, code)
 		f.pinned = f.pinned.remove(code)
 		f.release(code)
 		return nil
@@ -1025,7 +1027,7 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 		f.release(tag)
 		wrapper := f.a.JccPlaceholder(condE)
 		f.pinned = f.pinned.remove(home)
-		f.emitRegisterCallVia(ft, -1, func() { f.a.CallReg(code) })
+		f.emitRegisterCallVia(ft, -1, -1, code)
 		f.pinned = f.pinned.remove(code)
 		f.release(code)
 		done := f.a.JmpPlaceholder()

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -790,13 +790,10 @@ func (f *fn) emitMixedRegisterCall(localIdx int, ft *wasm.CompType) {
 	// Register-resident args are materialized into owned, pinned registers now
 	// (per bank), so the flush below cannot spill them; const/slot/local-ref args
 	// are deferred and loaded straight into their target register afterward.
-	type deferredMixedArg struct {
-		target Reg
-		root   *elem
-		float  bool
-	}
-	var gpMoves, fpMoves []regMove
-	var deferred []deferredMixedArg
+	var gpBuf, fpBuf [8]regMove
+	var deferredBuf [16]deferredMixedArg
+	gpMoves, fpMoves := gpBuf[:0], fpBuf[:0]
+	deferred := deferredBuf[:0]
 	gp, fp := 0, 0
 	for i, t := range ft.Params {
 		mt := mtOf(t)

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -330,6 +330,12 @@ type deferredArg struct {
 	root   *elem
 }
 
+type deferredMixedArg struct {
+	target Reg
+	root   *elem
+	float  bool
+}
+
 // alignPad is a shared zero source for inter-function 16-byte alignment padding,
 // appended via alignPad[:pad] to avoid allocating a temporary per function.
 var alignPad [16]byte
@@ -489,6 +495,14 @@ type CompileOptions struct {
 	// native call tree so a running wasm loop is cancelled within one iteration.
 	Interruptible bool
 
+	// MemoryPressure is called once after retained native output reaches
+	// MemoryPressureAt bytes. With a zero threshold it runs at seven-eighths of
+	// the reserved output capacity. Public compilation uses that late checkpoint
+	// for large modules to reclaim dead per-function state without changing global
+	// GC configuration. A nil callback disables it.
+	MemoryPressureAt int
+	MemoryPressure   func()
+
 	// Codegen carries injectable runtime/heap dependencies for future WasmGC
 	// lowering. The current direct backend does not lower WasmGC opcodes yet, but
 	// threading the option here lets that work use the same HeapABI as the IR
@@ -578,7 +592,12 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	for i := range m.Code {
 		totalBody += len(m.Code[i].BodyBytes)
 	}
-	code := make([]byte, 0, shared.ModuleCodeCapacity(totalBody, n, 5))
+	code := make([]byte, 0, shared.TaperedModuleCodeCapacity(totalBody, n, 40, 37, 1<<20))
+	pressureDone := false
+	pressureAt := opts.MemoryPressureAt
+	if opts.MemoryPressure != nil && pressureAt <= 0 {
+		pressureAt = cap(code) * 7 / 8
+	}
 	for i := range m.Code {
 		hints := allHints[i]
 		var st *CodegenStats
@@ -599,6 +618,10 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		internalEntry[i] = len(code) + internalOff
 		relocs[i] = rl
 		code = append(code, fnCode...)
+		if !pressureDone && opts.MemoryPressure != nil && len(code) >= pressureAt {
+			pressureDone = true
+			opts.MemoryPressure()
+		}
 	}
 	// Patch call sites now that every function's entry offsets are known.
 	for i := 0; i < n; i++ {
@@ -668,18 +691,50 @@ func computeFuncHints(m *wasm.Module, funcIdx int, nGlobals int, importedFuncs i
 // immediate-decoding pass per function (the standalone global-scores scan). The
 // standalone computeModuleGlobalScores is retained as the parity oracle in tests.
 func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHints, []int64, error) {
-	allHints := make([]funcHints, len(m.Code))
-	var agg []int64
-	if nGlobals > 0 && len(m.Code) > 0 {
-		agg = make([]int64, nGlobals)
-	}
+	n := len(m.Code)
+	allHints := make([]funcHints, n)
+	localCounts := make([]int, n)
+	totalLocals := 0
 	for i := range m.Code {
-		h, err := computeFuncHints(m, i, nGlobals, importedFuncs)
+		ft, ok := m.LocalFuncType(i)
+		if !ok {
+			return nil, nil, fmt.Errorf("function %d hints: unknown function type", i)
+		}
+		count, err := countLocals(ft.Params, m.Code[i].Locals)
 		if err != nil {
 			return nil, nil, fmt.Errorf("function %d hints: %w", i, err)
 		}
+		if count > int(^uint(0)>>1)-totalLocals {
+			return nil, nil, fmt.Errorf("function hint locals overflow")
+		}
+		localCounts[i] = count
+		totalLocals += count
+	}
+	if nGlobals > 0 && n > int(^uint(0)>>1)/nGlobals {
+		return nil, nil, fmt.Errorf("function hint globals overflow")
+	}
+	localScores := make([]uint32, totalLocals)
+	globalScores := make([]uint32, n*nGlobals)
+	globalEligibility := make([]bool, n*nGlobals)
+	eligibilityTracker := newGlobalEligibilityTracker(nGlobals)
+	var agg []int64
+	if nGlobals > 0 && n > 0 {
+		agg = make([]int64, nGlobals)
+	}
+	localAt := 0
+	for i := range m.Code {
+		nLocals := localCounts[i]
+		globalAt := i * nGlobals
+		h := funcHintsWithStorage(localScores[localAt:localAt+nLocals], globalScores[globalAt:globalAt+nGlobals], globalEligibility[globalAt:globalAt+nGlobals])
+		h.nLocals = nLocals
+		var err error
+		h, err = scanFuncBodyInto(m.Code[i], nLocals, nGlobals, uint32(importedFuncs+i), h, &eligibilityTracker)
+		if err != nil {
+			return nil, nil, fmt.Errorf("function %d hints: %w", i, err)
+		}
+		localAt += nLocals
 		allHints[i] = h
-		for g := 0; g < nGlobals && g < len(h.globalScore); g++ {
+		for g := 0; g < nGlobals; g++ {
 			agg[g] += int64(h.globalScore[g])
 		}
 	}

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/encoder/amd64"
@@ -122,6 +123,7 @@ type fn struct {
 	s  *stack     // the valent-block operand stack
 	m  *wasm.Module
 	ft *wasm.CompType // this function's signature
+	transient
 
 	nParams     int
 	nLocals     int           // params + declared locals
@@ -247,20 +249,10 @@ type fn struct {
 	ctrl        []ctrlFrame // open block/loop/if frames; ctrl[0] is the function frame
 	unreachable bool        // in dead code after an unconditional branch/trap
 
-	// lsPool recycles []locState merge buffers (length nLocals) whose lifetime is a
-	// control frame's: convergeEdgeTo grabs one, opEnd returns both of a frame's on
-	// pop. Frames are LIFO, so the live-buffer count is bounded by nesting depth
-	// rather than total frame count — collapsing what was one heap slice per frame.
-	lsPool [][]locState
-
 	// sc holds per-function scratch whose backing is reused across the module:
 	// retSites, brFoldSites and trapSites live there so each function rewinds their
 	// lengths (sc.reset) rather than reallocating. See scratch.
 	sc *scratch
-
-	// endsPool recycles frame end-patch []int buffers (frameAddEnd/freeEndsBuf),
-	// bounded by nesting depth like lsPool.
-	endsPool [][]int
 
 	// Loop bounds-check hoisting (WAGO_LOOP_PRECHECK, boundshoist.go). elideBases
 	// holds the loop-invariant address-source locals whose inline bounds check is
@@ -305,9 +297,11 @@ type fn struct {
 	// unless the caller requested collection, in which case every counter method
 	// is a no-op — the hot compile path is unaffected. See stats.go.
 	stats *CodegenStats
+}
 
-	// Reused compile-time scratch for short-lived stack/type/register/label lists.
-	// These slices must not be stored in ctrlFrame or other persistent metadata.
+type transient struct {
+	lsPool      [][]locState
+	endsPool    [][]int
 	tmpRoots    []*elem
 	tmpTypes    []machineType
 	tmpTypes2   []machineType
@@ -316,8 +310,9 @@ type fn struct {
 	tmpMoves    []regMove
 	tmpLabels   []uint32
 	tmpDeferred []deferredArg
-	tmpBelow    []*elem  // flushBelow scratch (distinct from tmpRoots, which is live as call argRoots)
-	tmpGpCand   []gpCand // assignPinnedLocals GP pin-candidate scratch
+	tmpBelow    []*elem
+	tmpGpCand   []gpCand
+	tmpInts     []int
 }
 
 // gpCand is a hot int local or global competing for a GP pin register, ranked by
@@ -325,7 +320,7 @@ type fn struct {
 type gpCand struct {
 	global bool
 	idx    int
-	score  int64
+	score  uint32
 }
 
 // deferredArg is a call argument (const/slot/localRef) staged into its target
@@ -377,6 +372,7 @@ type scratch struct {
 	trapSites    [trapStackFence + 1][]int
 	ctrl         []ctrlFrame // control-frame stack backing; reused across functions
 	pinnedLocals []int       // pinned-local index backing; reused across functions
+	transient
 }
 
 func newScratch() *scratch {
@@ -460,16 +456,8 @@ func (f *fn) allLocalsRegisterHomed() bool {
 	return true
 }
 
-// ImportBinding tells the compiler how an imported function is bound at link
-// time, so a cross-instance call can be lowered to a native context-swap into
-// the callee instance. The zero value (CrossInstance false) selects the default
-// host-import log-and-replay lowering. When ImportBindings is supplied it is
-// indexed by imported-function index.
-type ImportBinding struct {
-	CrossInstance bool
-	CalleeLinMem  uint64 // callee instance's linear-memory base pointer
-	CalleeEntry   uint64 // callee function's offset-0 (wrapper-ABI) entry pointer
-}
+// ImportBinding is shared by both Railshot architectures.
+type ImportBinding = shared.ImportBinding
 
 // CompileOptions configures direct wasm-to-amd64 compilation.
 type CompileOptions struct {
@@ -590,7 +578,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	for i := range m.Code {
 		totalBody += len(m.Code[i].BodyBytes)
 	}
-	code := make([]byte, 0, totalBody*5+n*16+64)
+	code := make([]byte, 0, shared.ModuleCodeCapacity(totalBody, n, 5))
 	for i := range m.Code {
 		hints := allHints[i]
 		var st *CodegenStats
@@ -599,6 +587,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 			ms.Funcs[i] = st
 		}
 		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, sc)
+		allHints[i] = funcHints{}
 		if err != nil {
 			return nil, fmt.Errorf("amd64: function %d: %w", i, err)
 		}
@@ -691,7 +680,7 @@ func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHint
 		}
 		allHints[i] = h
 		for g := 0; g < nGlobals && g < len(h.globalScore); g++ {
-			agg[g] += h.globalScore[g]
+			agg[g] += int64(h.globalScore[g])
 		}
 	}
 	// Immutable local-table specialization for call_indirect (mirrors arm64):
@@ -932,9 +921,12 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts, int
 
 	sc.reset()
 	sc.asm.Grow(asmCapForBody(len(c.BodyBytes)))
-	f := &fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stats: stats}
+	f := &fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, transient: sc.transient, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stats: stats}
 	// Retain the (possibly grown) control-frame backing for the next function.
-	defer func() { sc.ctrl = f.ctrl }()
+	defer func() {
+		sc.ctrl = f.ctrl
+		sc.transient = f.transient
+	}()
 	f.syncHostCalls = syncHostCalls || moduleUsesSyncHostCalls(m, importBindings)
 	if !guardMode && len(m.Memories) > 0 {
 		f.memSizeReg = R15 // explicit bounds: R15 = memBytes for the whole module
@@ -1029,7 +1021,7 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts, int
 	// loop do — the spill/reload keeping the cell coherent then lands on the sparse
 	// out-of-loop calls, not per iteration. Non-eligible globals use the per-run
 	// cell-pointer cache (globalCellPtr).
-	var globalScores []int64
+	var globalScores []uint32
 	var globalElig []bool
 	if regABI {
 		globalScores = hints.globalScore
@@ -1199,7 +1191,7 @@ func withoutReg(pool []Reg, r Reg) []Reg {
 	return out
 }
 
-func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool, gpPool []Reg, fpPinLimit int, pinV128 bool) {
+func (f *fn) assignPinnedLocals(scores, globalScores []uint32, globalElig []bool, gpPool []Reg, fpPinLimit int, pinV128 bool) {
 	f.locals = make([]localDef, f.nLocals)
 	for i := range f.locals {
 		f.locals[i] = localDef{reg: regNone, typ: f.localType[i], state: lsReg}
@@ -1228,7 +1220,7 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 			gp = append(gp, gpCand{idx: i, score: scores[i]})
 		}
 	}
-	loopMin := loopWeight(1)
+	loopMin := uint32(loopWeight(1))
 	for g := 0; g < len(globalScores); g++ {
 		if globalScores[g] < loopMin || f.isModuleGlobal(g) {
 			continue
@@ -1285,18 +1277,22 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 	// Float locals use the separate XMM pin pool. Call-free functions also pin hot
 	// v128 locals here (same pool, full 128-bit): every XMM is caller-saved, so a
 	// v128 pin is confined to the call-free class (pinV128).
-	var fc []int
+	fc := f.tmpInts[:0]
 	for i := 0; i < f.nLocals; i++ {
 		if f.localType[i].isFloat() || (pinV128 && f.localType[i] == mtV128) {
 			fc = append(fc, i)
 		}
 	}
-	sort.SliceStable(fc, func(a, b int) bool {
-		if scores[fc[a]] != scores[fc[b]] {
-			return scores[fc[a]] > scores[fc[b]]
+	slices.SortFunc(fc, func(a, b int) int {
+		if scores[a] != scores[b] {
+			if scores[a] > scores[b] {
+				return -1
+			}
+			return 1
 		}
-		return fc[a] < fc[b]
+		return a - b
 	})
+	f.tmpInts = fc
 	if fpPinLimit > len(pinnedFLocalRegs) {
 		fpPinLimit = len(pinnedFLocalRegs)
 	}

--- a/src/core/compiler/backend/railshot/amd64/control.go
+++ b/src/core/compiler/backend/railshot/amd64/control.go
@@ -546,7 +546,9 @@ func (f *fn) opElse() error {
 }
 
 func (f *fn) opEnd() error {
-	fr := f.ctrl[len(f.ctrl)-1]
+	last := len(f.ctrl) - 1
+	fr := f.ctrl[last]
+	f.ctrl[last] = ctrlFrame{}
 	f.ctrl = f.ctrl[:len(f.ctrl)-1]
 
 	if fr.kind == cfFunc {

--- a/src/core/compiler/backend/railshot/amd64/driver.go
+++ b/src/core/compiler/backend/railshot/amd64/driver.go
@@ -14,7 +14,8 @@ import (
 // Frontend.cpp parseCodeSection opcode switch. Phase 0 covers the integer const/
 // local/ALU subset needed to prove the pipeline end-to-end.
 func (f *fn) body(code []byte) error {
-	return f.bodyLoop(wasm.NewReader(code), 0)
+	r := wasm.ReaderFrom(code)
+	return f.bodyLoop(&r, 0)
 }
 
 // bodyLoop drives the opcode switch until the control stack shrinks to minCtrl.

--- a/src/core/compiler/backend/railshot/amd64/hints.go
+++ b/src/core/compiler/backend/railshot/amd64/hints.go
@@ -28,6 +28,7 @@ func loopWeight(depth int) int64 {
 
 // funcHints is everything scanFuncBody yields.
 type funcHints struct {
+	nLocals       int
 	hasCall       bool // any direct or indirect call
 	callsSelf     bool // a direct call to the function's own index
 	touchesMemory bool // any linear-memory op
@@ -73,11 +74,11 @@ type funcHints struct {
 }
 
 func newFuncHints(nLocals, nGlobals int) funcHints {
-	return funcHints{
-		localScore:  make([]uint32, nLocals),
-		globalScore: make([]uint32, nGlobals),
-		globalElig:  make([]bool, nGlobals),
-	}
+	return funcHintsWithStorage(make([]uint32, nLocals), make([]uint32, nGlobals), make([]bool, nGlobals))
+}
+
+func funcHintsWithStorage(localScore, globalScore []uint32, globalElig []bool) funcHints {
+	return funcHints{localScore: localScore, globalScore: globalScore, globalElig: globalElig}
 }
 
 func addHotness(scores []uint32, idx uint32, delta int64) {
@@ -106,6 +107,11 @@ type globalEligibilityFrame struct {
 
 func newGlobalEligibilityTracker(nGlobals int) globalEligibilityTracker {
 	return globalEligibilityTracker{marks: make([]uint32, nGlobals)}
+}
+
+func (t *globalEligibilityTracker) reset() {
+	t.globals = t.globals[:0]
+	t.frames = t.frames[:0]
 }
 
 func (t *globalEligibilityTracker) push() int {
@@ -151,10 +157,16 @@ func (t *globalEligibilityTracker) pop(frame int) {
 // scanFuncBody chooses the byte-backed scanner used for decoded modules, falling
 // back to the AST scanner for tests or callers that construct Func.Body directly.
 func scanFuncBody(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32) (funcHints, error) {
+	h := newFuncHints(nLocals, nGlobals)
+	elig := newGlobalEligibilityTracker(nGlobals)
+	return scanFuncBodyInto(fn, nLocals, nGlobals, selfIdx, h, &elig)
+}
+
+func scanFuncBodyInto(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker) (funcHints, error) {
 	if len(fn.BodyBytes) != 0 {
-		return scanBodyBytes(fn.BodyBytes, nLocals, nGlobals, selfIdx)
+		return scanBodyBytesInto(fn.BodyBytes, nLocals, nGlobals, selfIdx, h, elig)
 	}
-	return scanBody(fn.Body, nLocals, nGlobals, selfIdx), nil
+	return scanBodyInto(fn.Body, nLocals, nGlobals, selfIdx, h, elig), nil
 }
 
 // scanBody performs the AST pre-scan walk. selfIdx is the function's global
@@ -162,6 +174,11 @@ func scanFuncBody(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32) (funcHint
 func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 	h := newFuncHints(nLocals, nGlobals)
 	elig := newGlobalEligibilityTracker(nGlobals)
+	return scanBodyInto(body, nLocals, nGlobals, selfIdx, h, &elig)
+}
+
+func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker) funcHints {
+	elig.reset()
 	// walk returns whether the subtree contains a call. curLoop identifies the
 	// innermost enclosing loop whose globals are being considered for eligibility.
 	var walk func(instrs []wasm.Instruction, depth int, curLoop int) bool
@@ -391,8 +408,15 @@ func (s *globalScoreByteScanner) classifyInstructionInto(op byte, imm *wasm.Inst
 // allocating Instruction trees. body includes the terminating end opcode and
 // excludes local declarations.
 func scanBodyBytes(body []byte, nLocals int, nGlobals int, selfIdx uint32) (funcHints, error) {
+	h := newFuncHints(nLocals, nGlobals)
+	elig := newGlobalEligibilityTracker(nGlobals)
+	return scanBodyBytesInto(body, nLocals, nGlobals, selfIdx, h, &elig)
+}
+
+func scanBodyBytesInto(body []byte, nLocals int, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker) (funcHints, error) {
+	elig.reset()
 	r := wasm.ReaderFrom(body)
-	s := byteBodyScanner{r: byteScanReader{Reader: &r}, h: newFuncHints(nLocals, nGlobals), nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, elig: newGlobalEligibilityTracker(nGlobals)}
+	s := byteBodyScanner{r: byteScanReader{Reader: &r}, h: h, nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, elig: elig}
 	called, term, err := s.scanExpr(0, 0, -1, false)
 	if err != nil {
 		return s.h, err
@@ -412,7 +436,7 @@ type byteBodyScanner struct {
 	nLocals  int
 	nGlobals int
 	selfIdx  uint32
-	elig     globalEligibilityTracker
+	elig     *globalEligibilityTracker
 }
 
 func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAtElse bool) (bool, byte, error) {

--- a/src/core/compiler/backend/railshot/amd64/hints.go
+++ b/src/core/compiler/backend/railshot/amd64/hints.go
@@ -74,7 +74,9 @@ type funcHints struct {
 }
 
 func newFuncHints(nLocals, nGlobals int) funcHints {
-	return funcHintsWithStorage(make([]uint32, nLocals), make([]uint32, nGlobals), make([]bool, nGlobals))
+	h := funcHintsWithStorage(make([]uint32, nLocals), make([]uint32, nGlobals), make([]bool, nGlobals))
+	h.nLocals = nLocals
+	return h
 }
 
 func funcHintsWithStorage(localScore, globalScore []uint32, globalElig []bool) funcHints {

--- a/src/core/compiler/backend/railshot/amd64/hints.go
+++ b/src/core/compiler/backend/railshot/amd64/hints.go
@@ -54,8 +54,8 @@ type funcHints struct {
 
 	// Loop-weighted hotness: local.get/global.get = 1×, set/tee = 2×, ×loopWeight
 	// per enclosing loop level.
-	localScore  []int64
-	globalScore []int64
+	localScore  []uint32
+	globalScore []uint32
 
 	// globalElig[g]: global g is accessed inside a loop whose subtree contains NO
 	// call. Value-pinning such a global in a call-making function is a win: the
@@ -74,9 +74,21 @@ type funcHints struct {
 
 func newFuncHints(nLocals, nGlobals int) funcHints {
 	return funcHints{
-		localScore:  make([]int64, nLocals),
-		globalScore: make([]int64, nGlobals),
+		localScore:  make([]uint32, nLocals),
+		globalScore: make([]uint32, nGlobals),
 		globalElig:  make([]bool, nGlobals),
+	}
+}
+
+func addHotness(scores []uint32, idx uint32, delta int64) {
+	if int(idx) >= len(scores) || delta <= 0 {
+		return
+	}
+	const max = ^uint32(0)
+	if uint64(scores[idx])+uint64(delta) >= uint64(max) {
+		scores[idx] = max
+	} else {
+		scores[idx] += uint32(delta)
 	}
 }
 
@@ -177,18 +189,18 @@ func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 				sub, h.hasCall = true, true
 			case wasm.InstrLocalGet:
 				if int(in.Index) < nLocals {
-					h.localScore[in.Index] += w
+					addHotness(h.localScore, in.Index, w)
 				}
 			case wasm.InstrLocalSet, wasm.InstrLocalTee:
 				if int(in.Index) < nLocals {
-					h.localScore[in.Index] += 2 * w
+					addHotness(h.localScore, in.Index, 2*w)
 				}
 			case wasm.InstrGlobalGet, wasm.InstrGlobalSet:
 				if int(in.Index) < nGlobals {
 					if in.Kind == wasm.InstrGlobalSet {
-						h.globalScore[in.Index] += 2 * w
+						addHotness(h.globalScore, in.Index, 2*w)
 					} else {
-						h.globalScore[in.Index] += w
+						addHotness(h.globalScore, in.Index, w)
 					}
 					elig.add(curLoop, in.Index)
 				}
@@ -267,7 +279,8 @@ func scanBodyGlobalScores(body wasm.Expr, nGlobals int, add func(g uint32, score
 }
 
 func scanBodyBytesGlobalScores(body []byte, nGlobals int, add func(g uint32, score int64)) error {
-	s := globalScoreByteScanner{r: byteScanReader{Reader: wasm.NewReader(body)}, nGlobals: nGlobals, add: add}
+	r := wasm.ReaderFrom(body)
+	s := globalScoreByteScanner{r: byteScanReader{Reader: &r}, nGlobals: nGlobals, add: add}
 	term, err := s.scanExpr(0, 0, false)
 	if err != nil {
 		return err
@@ -378,7 +391,8 @@ func (s *globalScoreByteScanner) classifyInstructionInto(op byte, imm *wasm.Inst
 // allocating Instruction trees. body includes the terminating end opcode and
 // excludes local declarations.
 func scanBodyBytes(body []byte, nLocals int, nGlobals int, selfIdx uint32) (funcHints, error) {
-	s := byteBodyScanner{r: byteScanReader{Reader: wasm.NewReader(body)}, h: newFuncHints(nLocals, nGlobals), nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, elig: newGlobalEligibilityTracker(nGlobals)}
+	r := wasm.ReaderFrom(body)
+	s := byteBodyScanner{r: byteScanReader{Reader: &r}, h: newFuncHints(nLocals, nGlobals), nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, elig: newGlobalEligibilityTracker(nGlobals)}
 	called, term, err := s.scanExpr(0, 0, -1, false)
 	if err != nil {
 		return s.h, err
@@ -509,9 +523,9 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 			idx := imm.Index
 			if int(idx) < s.nLocals {
 				if op == 0x20 {
-					s.h.localScore[idx] += loopWeight(loopDepth)
+					addHotness(s.h.localScore, idx, loopWeight(loopDepth))
 				} else {
-					s.h.localScore[idx] += 2 * loopWeight(loopDepth)
+					addHotness(s.h.localScore, idx, 2*loopWeight(loopDepth))
 				}
 			}
 		case 0x23, 0x24: // global.get/set
@@ -524,9 +538,9 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 			idx := imm.Index
 			if int(idx) < s.nGlobals {
 				if op == 0x24 {
-					s.h.globalScore[idx] += 2 * loopWeight(loopDepth)
+					addHotness(s.h.globalScore, idx, 2*loopWeight(loopDepth))
 				} else {
-					s.h.globalScore[idx] += loopWeight(loopDepth)
+					addHotness(s.h.globalScore, idx, loopWeight(loopDepth))
 				}
 				s.elig.add(curLoop, idx)
 			}

--- a/src/core/compiler/backend/railshot/amd64/hints_test.go
+++ b/src/core/compiler/backend/railshot/amd64/hints_test.go
@@ -267,7 +267,7 @@ func TestModuleGlobalScoreScanMatchesFullHints(t *testing.T) {
 					t.Fatalf("full scan body %x: %v", body, err)
 				}
 				for g, score := range h.globalScore {
-					want[g] += score
+					want[g] += int64(score)
 				}
 			}
 			if len(got) != len(want) {
@@ -303,7 +303,7 @@ func TestModuleGlobalScoreScanSupportsASTBodies(t *testing.T) {
 		t.Fatalf("compute module global scores for ast body: %v", err)
 	}
 	want := scanBody(m.Code[0].Body, 0, 1, 0).globalScore
-	if len(got) != 1 || got[0] != want[0] || got[0] != 30 {
+	if len(got) != 1 || got[0] != int64(want[0]) || got[0] != 30 {
 		t.Fatalf("AST aggregate scores = %v, want %v", got, want)
 	}
 	pins := pickModuleGlobals(m, m.GlobalCount(), got)

--- a/src/core/compiler/backend/railshot/amd64/localstate.go
+++ b/src/core/compiler/backend/railshot/amd64/localstate.go
@@ -211,11 +211,20 @@ func (f *fn) reconcileLocals() {
 // convergeEdgeTo callers do), so the buffer is not zeroed. freeLocStateBuf
 // returns one to the pool when its owning frame is popped.
 func (f *fn) newLocStateBuf() []locState {
-	if n := len(f.lsPool); n > 0 {
-		b := f.lsPool[n-1]
-		f.lsPool[n-1] = nil
-		f.lsPool = f.lsPool[:n-1]
+	for i := len(f.lsPool) - 1; i >= 0; i-- {
+		b := f.lsPool[i]
+		if cap(b) < f.nLocals {
+			continue
+		}
+		last := len(f.lsPool) - 1
+		f.lsPool[i] = f.lsPool[last]
+		f.lsPool[last] = nil
+		f.lsPool = f.lsPool[:last]
 		return b[:f.nLocals]
+	}
+	if last := len(f.lsPool) - 1; last >= 0 {
+		f.lsPool[last] = nil
+		f.lsPool = f.lsPool[:last]
 	}
 	return make([]locState, f.nLocals)
 }

--- a/src/core/compiler/backend/railshot/amd64/pressure_test.go
+++ b/src/core/compiler/backend/railshot/amd64/pressure_test.go
@@ -1,0 +1,16 @@
+//go:build amd64
+
+package amd64
+
+import "testing"
+
+func TestCompileMemoryPressureCheckpointRunsOnce(t *testing.T) {
+	m := benchSmallScalarModule(t)
+	calls := 0
+	if _, err := CompileModuleWith(m, CompileOptions{MemoryPressureAt: 1, MemoryPressure: func() { calls++ }}); err != nil {
+		t.Fatalf("CompileModuleWith: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("memory-pressure calls = %d, want 1", calls)
+	}
+}

--- a/src/core/compiler/backend/railshot/amd64/stack.go
+++ b/src/core/compiler/backend/railshot/amd64/stack.go
@@ -2,6 +2,8 @@
 
 package amd64
 
+import "github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+
 // The operand stack and its element model — ported from WARP's Stack /
 // StackElement / StackType / VariableStorage (warp/src/core/compiler/common/).
 //
@@ -177,9 +179,9 @@ func (e *elem) isDeferred() bool { return e.kind == ekDeferred }
 // allocates nothing further. Nodes are never freed mid-function — that matches
 // single-pass usage.
 type stack struct {
-	chunks [][]elem // each chunk fixed-cap, never moved; chunks[cur] is being filled
-	cur    int      // index of the chunk alloc currently appends to
-	head   *elem    // sentinel (chunks[0][0]); head.next is the bottom, back() is the top
+	chunks [][]elem
+	cur    int
+	head   *elem
 }
 
 const (
@@ -202,9 +204,9 @@ func newStackWithCap(capHint int) *stack {
 // initSentinel rewinds to the first chunk and installs the sentinel node.
 func (s *stack) initSentinel() {
 	s.cur = 0
-	c := &s.chunks[0]
-	*c = append((*c)[:0], elem{}) // sentinel (cap already reserved, never reallocates)
-	s.head = &(*c)[0]
+	chunk := &s.chunks[0]
+	*chunk = append((*chunk)[:0], elem{})
+	s.head = &(*chunk)[0]
 	s.head.prev, s.head.next = s.head, s.head
 }
 
@@ -225,18 +227,7 @@ func stackArenaCapForHints(bodyLen, nLocals, nodeHint int) int {
 	// opcode-based estimate avoids reserving nodes for long immediates (notably
 	// 16-byte SIMD constants). The chunked arena grows past any underestimate while
 	// preserving pointer stability, so this is a hint, not a bound.
-	legacy := bodyLen + nLocals/4 + 1
-	if nodeHint <= 0 {
-		return legacy
-	}
-	precise := nodeHint + nodeHint/2 + nLocals/4 + 1
-	if floor := bodyLen/4 + nLocals/4 + 1; precise < floor {
-		precise = floor
-	}
-	if precise > legacy {
-		precise = legacy
-	}
-	return precise
+	return shared.StackArenaCapacity(bodyLen, nLocals, nodeHint)
 }
 
 // alloc returns a fresh zeroed node from the arena. The returned pointer is
@@ -244,21 +235,21 @@ func stackArenaCapForHints(bodyLen, nLocals, nodeHint int) int {
 // current chunk is full alloc advances to (or grows) the next one rather than
 // growing the current backing array in place.
 func (s *stack) alloc() *elem {
-	c := &s.chunks[s.cur]
-	if len(*c) == cap(*c) {
+	chunk := &s.chunks[s.cur]
+	if len(*chunk) == cap(*chunk) {
 		s.cur++
 		if s.cur == len(s.chunks) {
-			nextCap := cap(*c) * 2
+			nextCap := cap(*chunk) * 2
 			if nextCap > maxStackChunkCap {
 				nextCap = maxStackChunkCap
 			}
 			s.chunks = append(s.chunks, make([]elem, 0, nextCap))
 		}
-		c = &s.chunks[s.cur]
-		*c = (*c)[:0] // reuse a retained chunk from a previous function
+		chunk = &s.chunks[s.cur]
+		*chunk = (*chunk)[:0]
 	}
-	*c = append(*c, elem{})
-	return &(*c)[len(*c)-1]
+	*chunk = append(*chunk, elem{})
+	return &(*chunk)[len(*chunk)-1]
 }
 
 // push appends e as the new top of the stack and returns it.

--- a/src/core/compiler/backend/railshot/amd64/stack_test.go
+++ b/src/core/compiler/backend/railshot/amd64/stack_test.go
@@ -165,7 +165,7 @@ func TestAssignPinnedLocalsUsesLocalDefs(t *testing.T) {
 		localType: []machineType{mtI32, mtF64, mtI32},
 		sc:        &scratch{},
 	}
-	f.assignPinnedLocals([]int64{1, 10, 5}, nil, nil, pinnedLocalRegs, baseFPPins, false)
+	f.assignPinnedLocals([]uint32{1, 10, 5}, nil, nil, pinnedLocalRegs, baseFPPins, false)
 
 	r, isFloat, ok := f.pinReg(1)
 	if !ok || !isFloat || r != pinnedFLocalRegs[0] {

--- a/src/core/compiler/backend/railshot/arm64/allocation_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/allocation_arm64_test.go
@@ -180,10 +180,8 @@ func TestExecBrTableComputedIndexArm64(t *testing.T) {
 }
 
 // TestStackArenaOverflowKeepsExistingPointersStableArm64 checks the operand-stack
-// arena: growing past its fixed capacity must keep already-handed-out element
-// pointers valid and linked (they must not move when the arena "overflows" to
-// heap-allocated elems). Ported from amd64's identically-named test; the stack is
-// architecture-neutral.
+// arena: growing past its first chunk must keep already-handed-out element
+// pointers valid and linked. Ported from amd64's identically-named test.
 func TestStackArenaOverflowKeepsExistingPointersStableArm64(t *testing.T) {
 	s := newStack()
 	first := s.pushValue(storage{kind: stConst, typ: mtI32, cval: 1})
@@ -196,7 +194,7 @@ func TestStackArenaOverflowKeepsExistingPointersStableArm64(t *testing.T) {
 	if s.head.next != first {
 		t.Fatal("first elem is no longer linked after arena overflow")
 	}
-	if cap(s.arena) != defaultStackArenaCap {
-		t.Fatalf("arena cap = %d, want fixed cap %d", cap(s.arena), defaultStackArenaCap)
+	if len(s.chunks) < 2 {
+		t.Fatalf("arena did not grow past its first chunk: %d", len(s.chunks))
 	}
 }

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -642,7 +642,7 @@ func (f *fn) emitCrossInstanceCall(b ImportBinding, ft *wasm.CompType) error {
 func (f *fn) callInternal(localIdx int, ft *wasm.CompType, resHint int) error {
 	if regABIEnabled && sigFitsRegABI(ft) && sigIsIntOnly(ft) {
 		f.stats.call("regabi")
-		f.emitRegisterCall(localIdx, ft, resHint, f.directCalleePreservesPins(localIdx, ft))
+		f.emitRegisterCall(localIdx, ft, resHint, f.directCalleePreservesPins(localIdx))
 		return nil
 	}
 	f.stats.call("wrapper")
@@ -808,18 +808,13 @@ func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, preservesPins b
 	}
 }
 
-// directCalleePreservesPins recomputes the small, validated leaf classification
+// directCalleePreservesPins returns the module-precomputed leaf classification
 // for one direct target. This is compile-time only; execution stays a plain BL.
-func (f *fn) directCalleePreservesPins(localIdx int, ft *wasm.CompType) bool {
-	if localIdx < 0 || localIdx >= len(f.m.Code) {
+func (f *fn) directCalleePreservesPins(localIdx int) bool {
+	if localIdx < 0 || localIdx >= len(f.calleePreservesPins) {
 		return false
 	}
-	nLocals, err := countLocals(ft.Params, f.m.Code[localIdx].Locals)
-	if err != nil {
-		return false
-	}
-	h, err := scanFuncBody(f.m.Code[localIdx], nLocals, f.m.GlobalCount(), uint32(f.m.ImportedFuncCount()+localIdx), f.m.BranchHintsForFunc(uint32(f.m.ImportedFuncCount()+localIdx)))
-	return err == nil && preservesCallerPins(ft, nLocals, h)
+	return f.calleePreservesPins[localIdx]
 }
 
 // emitMixedRegisterCall uses the register ABI for signatures containing floats.
@@ -1051,7 +1046,7 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 		f.pinned = f.pinned.remove(code)
 		f.release(code)
 		f.stats.peep("monomorphic-call-indirect")
-		f.emitRegisterCall(f.monomorphicTarget, ft, -1, f.directCalleePreservesPins(f.monomorphicTarget, ft))
+		f.emitRegisterCall(f.monomorphicTarget, ft, -1, f.directCalleePreservesPins(f.monomorphicTarget))
 		return nil
 	}
 	// NOTE: the polymorphic immutable-local fast path (register-ABI Blr of the

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -659,15 +659,12 @@ func (f *fn) callInternal(localIdx int, ft *wasm.CompType, resHint int) error {
 // resHint >= 0 fuses a following `local.set resHint`: X0 moves straight into
 // the pinned local's register instead of an allocated result register.
 func (f *fn) emitRegisterCall(localIdx int, ft *wasm.CompType, resHint int, preservesPins bool) {
-	f.emitRegisterCallVia(ft, resHint, preservesPins, func() {
-		site := f.a.Bl()
-		f.relocs = append(f.relocs, callReloc{at: site, target: localIdx, internal: true})
-	})
+	f.emitRegisterCallVia(ft, resHint, preservesPins, localIdx, regNone)
 }
 
-// emitRegisterCallVia is emitRegisterCall with a pluggable call emitter
-// (direct BL or an indirect BLR for call_indirect).
-func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, preservesPins bool, emitCall func()) {
+// emitRegisterCallVia emits either a direct internal BL (localIdx >= 0) or an
+// indirect BLR. Explicit operands avoid allocating a closure at every wasm call.
+func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, preservesPins bool, localIdx int, indirect Reg) {
 	p, rN := len(ft.Params), len(ft.Results)
 	d := f.depth()
 	if !preservesPins {
@@ -693,11 +690,7 @@ func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, preservesPins b
 	// owned, pinned registers now (protected from the flush below); const/memory
 	// args are loaded straight into their target register afterward.
 	moves := f.tmpMoves[:0]
-	type deferredArg struct {
-		target Reg
-		root   *elem
-	}
-	var deferred []deferredArg
+	deferred := f.tmpDeferred[:0]
 	for i := 0; i < p; i++ {
 		root := argRoots[i]
 		if root.isDeferred() || (root.kind == ekValue && (root.st.kind == stReg || root.st.kind == stLocalReg || root.st.kind == stGlobReg || root.st.kind == stMemRef)) {
@@ -746,13 +739,19 @@ func (f *fn) emitRegisterCallVia(ft *wasm.CompType, resHint int, preservesPins b
 			f.ld64(da.target, SP, f.localOff(da.root.st.idx))
 		}
 	}
+	f.tmpDeferred = deferred[:0]
 
 	// Consume the args; the operand model is now the k below-operands in slots.
 	f.setDepth(d - p)
 
 	// No environment passing: linMemReg (linMem) is a whole-module invariant and the
 	// trap cell pointer lives in basedata — the callee inherits both (WARP model).
-	emitCall()
+	if localIdx >= 0 {
+		site := f.a.Bl()
+		f.relocs = append(f.relocs, callReloc{at: site, target: localIdx, internal: true})
+	} else {
+		f.a.Blr(indirect)
+	}
 
 	// A pin-preserving callee leaves the caller state untouched, so its result can
 	// remain allocator-owned in X0. Calls that reload state still copy it out first
@@ -1071,7 +1070,7 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 		f.pinned = f.pinned.remove(idxReg).add(code)
 		f.release(idxReg)
 		f.stats.peep("immutable-local-call-indirect")
-		f.emitRegisterCallVia(ft, -1, false, func() { f.a.Blr(code) })
+		f.emitRegisterCallVia(ft, -1, false, -1, code)
 		f.pinned = f.pinned.remove(code)
 		f.release(code)
 		return nil
@@ -1102,7 +1101,7 @@ func (f *fn) callIndirect(r *wasm.Reader) error {
 		f.release(tag)
 		wrapper := f.a.Bcond(condE)
 		f.pinned = f.pinned.remove(home)
-		f.emitRegisterCallVia(ft, -1, false, func() { f.a.Blr(code) })
+		f.emitRegisterCallVia(ft, -1, false, -1, code)
 		done := f.a.Branch()
 		f.a.PatchBranch19(wrapper, f.a.Len())
 		f.locals = savedLocals

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -302,6 +302,10 @@ type fn struct {
 	// is a no-op — the hot compile path is unaffected. See stats.go.
 	stats *CodegenStats
 
+	// calleePreservesPins is computed once from module hints. Direct calls consult
+	// it instead of rescanning and reallocating the callee's hint state per site.
+	calleePreservesPins []bool
+
 	// One-entry linear-memory store forwarding window. The value register is
 	// protected in f.pinned until an exact load consumes it or any non-local.get
 	// opcode invalidates it; address identity is deliberately limited to a local.
@@ -530,6 +534,14 @@ type CompileOptions struct {
 	// callers may leave it off for the smallest standalone code.
 	Interruptible bool
 
+	// MemoryPressure is called once after retained native output reaches
+	// MemoryPressureAt bytes. With a zero threshold it runs at seven-eighths of
+	// the reserved output capacity. Public compilation uses that late checkpoint
+	// for large modules to reclaim dead per-function state without changing global
+	// GC configuration. A nil callback disables it.
+	MemoryPressureAt int
+	MemoryPressure   func()
+
 	// Codegen carries injectable runtime/heap dependencies for future WasmGC
 	// lowering. The current direct backend does not lower WasmGC opcodes yet, but
 	// threading the option here lets that work use the same HeapABI as the IR
@@ -609,6 +621,13 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 	// Auto-inlining (WAGO_INLINE): the straight-line leaf callees to splice at their
 	// call sites, keyed by global func index. nil when inlining is disabled.
 	inlineTargets := buildInlineTargets(m, allHints)
+	calleePreservesPins := make([]bool, n)
+	for i := range allHints {
+		ft, ok := m.LocalFuncType(i)
+		if ok {
+			calleePreservesPins[i] = preservesCallerPins(ft, allHints[i].nLocals, allHints[i])
+		}
+	}
 	sc := newScratch()
 	// AArch64 lowering is close to four native bytes per Wasm opcode plus
 	// adapters/alignment. Reserve once so large modules do not repeatedly copy the
@@ -617,8 +636,13 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 	for i := range m.Code {
 		totalBody += len(m.Code[i].BodyBytes)
 	}
-	code := make([]byte, 0, shared.ModuleCodeCapacity(totalBody, n, 4))
+	code := make([]byte, 0, shared.TaperedModuleCodeCapacity(totalBody, n, 32, 28, 768<<10))
 	var alignPad [16]byte
+	pressureDone := false
+	pressureAt := opts.MemoryPressureAt
+	if opts.MemoryPressure != nil && pressureAt <= 0 {
+		pressureAt = cap(code) * 7 / 8
+	}
 	for i := range m.Code {
 		hints := allHints[i]
 		var st *CodegenStats
@@ -626,7 +650,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 			st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
 			ms.Funcs[i] = st
 		}
-		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, sc)
+		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, calleePreservesPins, sc)
 		allHints[i] = funcHints{}
 		if err != nil {
 			return nil, fmt.Errorf("arm64: function %d: %w", i, err)
@@ -639,6 +663,10 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 		internalEntry[i] = len(code) + internalOff
 		relocs[i] = rl
 		code = append(code, fnCode...)
+		if !pressureDone && opts.MemoryPressure != nil && len(code) >= pressureAt {
+			pressureDone = true
+			opts.MemoryPressure()
+		}
 	}
 	// Patch call sites now that every function's entry offsets are known. Direct
 	// wasm→wasm calls are BL placeholders (imm26, ±128 MiB); wrap the finished code
@@ -713,18 +741,50 @@ func computeFuncHints(m *wasm.Module, funcIdx int, nGlobals int, importedFuncs i
 // immediate-decoding pass per function (the standalone global-scores scan). The
 // standalone computeModuleGlobalScores is retained as the parity oracle in tests.
 func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHints, []int64, error) {
-	allHints := make([]funcHints, len(m.Code))
-	var agg []int64
-	if nGlobals > 0 && len(m.Code) > 0 {
-		agg = make([]int64, nGlobals)
-	}
+	n := len(m.Code)
+	allHints := make([]funcHints, n)
+	localCounts := make([]int, n)
+	totalLocals := 0
 	for i := range m.Code {
-		h, err := computeFuncHints(m, i, nGlobals, importedFuncs)
+		ft, ok := m.LocalFuncType(i)
+		if !ok {
+			return nil, nil, fmt.Errorf("function %d hints: unknown function type", i)
+		}
+		count, err := countLocals(ft.Params, m.Code[i].Locals)
 		if err != nil {
 			return nil, nil, fmt.Errorf("function %d hints: %w", i, err)
 		}
+		if count > int(^uint(0)>>1)-totalLocals {
+			return nil, nil, fmt.Errorf("function hint locals overflow")
+		}
+		localCounts[i] = count
+		totalLocals += count
+	}
+	if nGlobals > 0 && n > int(^uint(0)>>1)/nGlobals {
+		return nil, nil, fmt.Errorf("function hint globals overflow")
+	}
+	localScores := make([]uint32, totalLocals)
+	globalScores := make([]uint32, n*nGlobals)
+	globalEligibility := make([]bool, n*nGlobals)
+	eligibilityTracker := newGlobalEligibilityTracker(nGlobals)
+	var agg []int64
+	if nGlobals > 0 && n > 0 {
+		agg = make([]int64, nGlobals)
+	}
+	localAt := 0
+	for i := range m.Code {
+		nLocals := localCounts[i]
+		globalAt := i * nGlobals
+		h := funcHintsWithStorage(localScores[localAt:localAt+nLocals], globalScores[globalAt:globalAt+nGlobals], globalEligibility[globalAt:globalAt+nGlobals])
+		h.nLocals = nLocals
+		var err error
+		h, err = scanFuncBodyInto(m.Code[i], nLocals, nGlobals, uint32(importedFuncs+i), m.BranchHintsForFunc(uint32(importedFuncs+i)), h, &eligibilityTracker)
+		if err != nil {
+			return nil, nil, fmt.Errorf("function %d hints: %w", i, err)
+		}
+		localAt += nLocals
 		allHints[i] = h
-		for g := 0; g < nGlobals && g < len(h.globalScore); g++ {
+		for g := 0; g < nGlobals; g++ {
 			agg[g] += int64(h.globalScore[g])
 		}
 	}
@@ -927,11 +987,11 @@ var errRegExhausted = errors.New("arm64: no register available to spill")
 // compileFunc compiles one function, retrying with local pinning disabled if the
 // first (pinned) attempt exhausts the register file. Pinning is a pure speed
 // optimization, so the unpinned recompile is always correct.
-func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls bool, stats *CodegenStats, inlineTargets map[int]*inlineTarget, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
-	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, stats, true, inlineTargets, sc)
+func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls bool, stats *CodegenStats, inlineTargets map[int]*inlineTarget, calleePreservesPins []bool, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
+	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, stats, true, inlineTargets, calleePreservesPins, sc)
 	if errors.Is(err, errRegExhausted) {
 		resetFuncStats(stats)
-		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, stats, false, inlineTargets, sc)
+		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, stats, false, inlineTargets, calleePreservesPins, sc)
 		if err == nil {
 			stats.setUnpinnedRetry()
 		}
@@ -939,7 +999,7 @@ func compileFunc(m *wasm.Module, funcIdx int, guardMode, boundsFacts, interrupti
 	return
 }
 
-func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls bool, stats *CodegenStats, pinLocals bool, inlineTargets map[int]*inlineTarget, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls bool, stats *CodegenStats, pinLocals bool, inlineTargets map[int]*inlineTarget, calleePreservesPins []bool, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(regExhausted); ok {
@@ -966,7 +1026,7 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts, int
 	sc.reset()
 	sc.asm.DenseIdxDisp = hints.memOps >= 8
 	sc.asm.Grow(asmCapForBody(len(c.BodyBytes)))
-	f := &fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, transient: sc.transient, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stats: stats, branchHints: m.BranchHintsForFunc(uint32(m.ImportedFuncCount() + funcIdx)), branchHintLocalDecl: c.LocalDeclBytes}
+	f := &fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, transient: sc.transient, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stats: stats, branchHints: m.BranchHintsForFunc(uint32(m.ImportedFuncCount() + funcIdx)), branchHintLocalDecl: c.LocalDeclBytes, calleePreservesPins: calleePreservesPins}
 	defer func() {
 		sc.ctrl = f.ctrl
 		sc.transient = f.transient

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -3,11 +3,14 @@
 package arm64
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	a64 "github.com/wago-org/wago/src/core/encoder/arm64"
@@ -117,8 +120,10 @@ const mergeFReg Reg = 15
 type fn struct {
 	a  *a64.Asm // the (reused) AArch64 encoder
 	s  *stack   // the valent-block operand stack
+	sc *scratch // module-wide reusable compile scratch
 	m  *wasm.Module
 	ft *wasm.CompType // this function's signature
+	transient
 
 	nParams     int
 	nLocals     int           // params + declared locals
@@ -251,8 +256,7 @@ type fn struct {
 	// deeply-nested functions (60% of esbuild's compile). Set on activateLoopPins,
 	// cleared when that frame is popped in opEnd.
 	activeLoopPins []loopPin
-	unreachable    bool  // in dead code after an unconditional branch/trap
-	retSites       []int // forward branch sites that target the epilogue
+	unreachable    bool // in dead code after an unconditional branch/trap
 
 	// Loop bounds-check hoisting (WAGO_LOOP_PRECHECK, boundshoist.go). elideBases
 	// holds the loop-invariant address-source locals whose inline bounds check is
@@ -293,26 +297,10 @@ type fn struct {
 	// live. Computed once per module in compileFunc.
 	syncHostCalls bool
 
-	// trapSites[code] lists the branch sites (Bcond/Branch placeholders) that
-	// target this function's shared trap stub for `code`; emitTrapStubs emits the
-	// stubs after the epilogue and patches them. See trapIf.
-	trapSites map[uint32][]int
-
 	// stats collects per-function codegen counters (docs/no-ir-plan.md P1). nil
 	// unless the caller requested collection, in which case every counter method
 	// is a no-op — the hot compile path is unaffected. See stats.go.
 	stats *CodegenStats
-
-	// Reused compile-time scratch for short-lived stack/type/register/label lists.
-	// These slices must not be stored in ctrlFrame or other persistent metadata.
-	tmpRoots    []*elem
-	tmpTypes    []machineType
-	tmpTypes2   []machineType
-	tmpRegs     []Reg
-	tmpSlots    []int
-	tmpMoves    []regMove
-	tmpLabels   []uint32
-	edgeScratch []byte // relocatable copy of a br_if edge's bytes (opBr non-empty edge)
 
 	// One-entry linear-memory store forwarding window. The value register is
 	// protected in f.pinned until an exact load consumes it or any non-local.get
@@ -322,6 +310,25 @@ type fn struct {
 	storeForwardOK bool
 }
 
+// transient is the per-function workspace handed back to module scratch after
+// each compile. Embedding it keeps hot call sites terse while making ownership
+// and lifetime a single assignment instead of a list of parallel fields.
+type transient struct {
+	lsPool      [][]locState
+	endsPool    [][]int
+	tmpRoots    []*elem
+	tmpTypes    []machineType
+	tmpTypes2   []machineType
+	tmpRegs     []Reg
+	tmpSlots    []int
+	tmpMoves    []regMove
+	tmpLabels   []uint32
+	tmpDeferred []deferredArg
+	tmpGpCand   []gpCand
+	tmpInts     []int
+	edgeScratch []byte
+}
+
 type storeForward struct {
 	valid  bool
 	reg    Reg
@@ -329,6 +336,17 @@ type storeForward struct {
 	local  int
 	offset uint32
 	size   int
+}
+
+type gpCand struct {
+	global bool
+	idx    int
+	score  uint32
+}
+
+type deferredArg struct {
+	target Reg
+	root   *elem
 }
 
 func align16(n int) int { return (n + 15) &^ 15 }
@@ -359,6 +377,21 @@ func asmCapForBody(bodyLen int) int {
 type scratch struct {
 	stack *stack   // the valent-block operand stack
 	asm   *a64.Asm // the AArch64 encoder byte buffer
+
+	retSites      []int
+	ctrl          []ctrlFrame
+	trapSites     [trapStackFence + 1][]int
+	branchTargets map[int]bool
+	transient
+}
+
+// scratchState keeps low-level backend tests able to exercise an isolated fn.
+// Production compilation always installs the module-owned scratch explicitly.
+func (f *fn) scratchState() *scratch {
+	if f.sc == nil {
+		f.sc = &scratch{}
+	}
+	return f.sc
 }
 
 func newScratch() *scratch {
@@ -368,6 +401,12 @@ func newScratch() *scratch {
 func (sc *scratch) reset() {
 	sc.stack.reset()
 	sc.asm.B = sc.asm.B[:0]
+	sc.retSites = sc.retSites[:0]
+	sc.ctrl = sc.ctrl[:0]
+	for i := range sc.trapSites {
+		sc.trapSites[i] = sc.trapSites[i][:0]
+	}
+	clear(sc.branchTargets)
 }
 
 // Frameless layout (WARP-style, SP-relative). X29/FP is only a frame-record anchor
@@ -459,16 +498,8 @@ func (f *fn) patchFrameAdjusts() {
 	f.a.PatchMovImm(f.addRspAt, uint32(size))
 }
 
-// ImportBinding tells the compiler how an imported function is bound at link
-// time, so a cross-instance call can be lowered to a native context-swap into
-// the callee instance. The zero value (CrossInstance false) selects the default
-// host-import log-and-replay lowering. When ImportBindings is supplied it is
-// indexed by imported-function index.
-type ImportBinding struct {
-	CrossInstance bool
-	CalleeLinMem  uint64 // callee instance's linear-memory base pointer
-	CalleeEntry   uint64 // callee function's offset-0 (wrapper-ABI) entry pointer
-}
+// ImportBinding is shared by both Railshot architectures.
+type ImportBinding = shared.ImportBinding
 
 // CompileOptions configures direct wasm-to-arm64 compilation.
 type CompileOptions struct {
@@ -577,9 +608,17 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 	// Compile is sequential, so sharing one scratch is safe.
 	// Auto-inlining (WAGO_INLINE): the straight-line leaf callees to splice at their
 	// call sites, keyed by global func index. nil when inlining is disabled.
-	inlineTargets := buildInlineTargets(m)
+	inlineTargets := buildInlineTargets(m, allHints)
 	sc := newScratch()
-	var code []byte
+	// AArch64 lowering is close to four native bytes per Wasm opcode plus
+	// adapters/alignment. Reserve once so large modules do not repeatedly copy the
+	// accumulated native image as it grows.
+	totalBody := 0
+	for i := range m.Code {
+		totalBody += len(m.Code[i].BodyBytes)
+	}
+	code := make([]byte, 0, shared.ModuleCodeCapacity(totalBody, n, 4))
+	var alignPad [16]byte
 	for i := range m.Code {
 		hints := allHints[i]
 		var st *CodegenStats
@@ -588,12 +627,13 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 			ms.Funcs[i] = st
 		}
 		fnCode, rl, internalOff, err := compileFunc(m, i, guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, st, inlineTargets, sc)
+		allHints[i] = funcHints{}
 		if err != nil {
 			return nil, fmt.Errorf("arm64: function %d: %w", i, err)
 		}
 		// 16-byte align each function.
 		if pad := (16 - len(code)%16) % 16; pad != 0 {
-			code = append(code, make([]byte, pad)...)
+			code = append(code, alignPad[:pad]...)
 		}
 		entry[i] = len(code)
 		internalEntry[i] = len(code) + internalOff
@@ -685,7 +725,7 @@ func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHint
 		}
 		allHints[i] = h
 		for g := 0; g < nGlobals && g < len(h.globalScore); g++ {
-			agg[g] += h.globalScore[g]
+			agg[g] += int64(h.globalScore[g])
 		}
 	}
 	immutableLocalTable := immutableLocalTableEnabled && importedFuncs == 0 &&
@@ -926,7 +966,11 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts, int
 	sc.reset()
 	sc.asm.DenseIdxDisp = hints.memOps >= 8
 	sc.asm.Grow(asmCapForBody(len(c.BodyBytes)))
-	f := &fn{a: sc.asm, s: sc.stack, m: m, ft: ft, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stats: stats, branchHints: m.BranchHintsForFunc(uint32(m.ImportedFuncCount() + funcIdx)), branchHintLocalDecl: c.LocalDeclBytes}
+	f := &fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, transient: sc.transient, nParams: len(ft.Params), nLocals: nLocals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stats: stats, branchHints: m.BranchHintsForFunc(uint32(m.ImportedFuncCount() + funcIdx)), branchHintLocalDecl: c.LocalDeclBytes}
+	defer func() {
+		sc.ctrl = f.ctrl
+		sc.transient = f.transient
+	}()
 	f.storeForwardOK = linearStoreForwardEnabled && len(c.BodyBytes) <= 256 && nLocals <= 8
 	f.syncHostCalls = syncHostCalls || moduleUsesSyncHostCalls(m, importBindings)
 	if !guardMode && len(m.Memories) > 0 {
@@ -1065,7 +1109,7 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, guardMode, boundsFacts, int
 	// loop do — the spill/reload keeping the cell coherent then lands on the sparse
 	// out-of-loop calls, not per iteration. Non-eligible globals use the per-run
 	// cell-pointer cache (globalCellPtr).
-	var globalScores []int64
+	var globalScores []uint32
 	var globalElig []bool
 	if regABI {
 		globalScores = hints.globalScore
@@ -1180,11 +1224,12 @@ func (f *fn) finalizeStats(codeLen int) {
 // return/br-to-function site to the current epilogue position.
 func (f *fn) runBody(c *wasm.Func) error {
 	resultTypes := typesOfVals(f.ft.Results)
-	f.ctrl = []ctrlFrame{{kind: cfFunc, resultN: len(resultTypes), branchN: len(resultTypes), resultTypes: resultTypes}}
+	sc := f.scratchState()
+	f.ctrl = append(sc.ctrl[:0], ctrlFrame{kind: cfFunc, resultN: len(resultTypes), branchN: len(resultTypes), resultTypes: resultTypes})
 	if err := f.body(c.BodyBytes); err != nil {
 		return err
 	}
-	for _, s := range f.retSites {
+	for _, s := range sc.retSites {
 		// return/br-to-function sites are unconditional B placeholders (imm26).
 		f.a.PatchBranch26(s, f.a.Len())
 	}
@@ -1247,7 +1292,7 @@ func withoutReg(pool []Reg, r Reg) []Reg {
 	return out
 }
 
-func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool, gpPool []Reg, hasCall bool) {
+func (f *fn) assignPinnedLocals(scores, globalScores []uint32, globalElig []bool, gpPool []Reg, hasCall bool) {
 	f.locals = make([]localDef, f.nLocals)
 	for i := range f.locals {
 		f.locals[i] = localDef{reg: regNone, typ: f.localType[i], state: lsReg}
@@ -1270,18 +1315,13 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 	// mutable int accessed inside a loop (score >= one loop level): WARP pins only int
 	// globals as values, and the loop gate ensures the per-iteration memory traffic it
 	// removes outweighs the one-time prologue load + epilogue write-back.
-	type gpCand struct {
-		global bool
-		idx    int
-		score  int64
-	}
-	var gp []gpCand
+	gp := f.tmpGpCand[:0]
 	for i := 0; i < f.nLocals; i++ {
 		if f.localType[i] == mtI32 || f.localType[i] == mtI64 {
 			gp = append(gp, gpCand{idx: i, score: scores[i]})
 		}
 	}
-	loopMin := loopWeight(1)
+	loopMin := uint32(loopWeight(1))
 	for g := 0; g < len(globalScores); g++ {
 		if globalScores[g] < loopMin || f.isModuleGlobal(g) {
 			continue
@@ -1299,15 +1339,19 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 		}
 		gp = append(gp, gpCand{global: true, idx: g, score: globalScores[g]})
 	}
-	sort.SliceStable(gp, func(a, b int) bool {
-		if gp[a].score != gp[b].score {
-			return gp[a].score > gp[b].score
+	slices.SortFunc(gp, func(a, b gpCand) int {
+		if a.score != b.score {
+			return cmp.Compare(b.score, a.score)
 		}
-		if gp[a].global != gp[b].global {
-			return !gp[a].global // tie: prefer a local (value) over a global (pointer)
+		if a.global != b.global {
+			if !a.global {
+				return -1 // tie: prefer a local (value) over a global (pointer)
+			}
+			return 1
 		}
-		return gp[a].idx < gp[b].idx
+		return a.idx - b.idx
 	})
+	f.tmpGpCand = gp
 	for k, c := range gp {
 		if k >= len(gpPool) {
 			break
@@ -1332,18 +1376,19 @@ func (f *fn) assignPinnedLocals(scores, globalScores []int64, globalElig []bool,
 	// v128 locals here (same V registers, full 128-bit): a wasm→wasm call would only
 	// preserve the low 64 bits, so a v128 pin is confined to the call-free class.
 	pinV128 := v128LocalPinsEnabled && !hasCall
-	var fc []int
+	fc := f.tmpInts[:0]
 	for i := 0; i < f.nLocals; i++ {
 		if f.localType[i].isFloat() || (pinV128 && f.localType[i] == mtV128) {
 			fc = append(fc, i)
 		}
 	}
-	sort.SliceStable(fc, func(a, b int) bool {
-		if scores[fc[a]] != scores[fc[b]] {
-			return scores[fc[a]] > scores[fc[b]]
+	slices.SortFunc(fc, func(a, b int) int {
+		if scores[a] != scores[b] {
+			return cmp.Compare(scores[b], scores[a])
 		}
-		return fc[a] < fc[b]
+		return a - b
 	})
+	f.tmpInts = fc
 	fpPinLimit := len(pinnedFLocalRegs)
 	if legacyFPPinsEnabled && fpPinLimit > 4 {
 		fpPinLimit = 4

--- a/src/core/compiler/backend/railshot/arm64/control.go
+++ b/src/core/compiler/backend/railshot/arm64/control.go
@@ -458,9 +458,10 @@ func (f *fn) branchJump(fr *ctrlFrame) {
 				f.ld64(X0, SP, f.spillOff(0))
 			}
 		}
-		f.retSites = append(f.retSites, f.a.Branch())
+		sc := f.scratchState()
+		sc.retSites = append(sc.retSites, f.a.Branch())
 	default:
-		fr.ends = append(fr.ends, f.a.Branch())
+		f.appendEndSite(&fr.ends, f.a.Branch())
 		fr.endReachable = true
 	}
 }
@@ -483,7 +484,7 @@ func (f *fn) condBranchJump(fr *ctrlFrame, cc Cond) bool {
 		}
 		return true
 	case cfBlock, cfIf:
-		fr.condEnds = append(fr.condEnds, f.a.Bcond(cc)) // patched to the block end (imm19)
+		f.appendEndSite(&fr.condEnds, f.a.Bcond(cc)) // patched to the block end (imm19)
 		fr.endReachable = true
 		return true
 	}
@@ -777,7 +778,7 @@ func (f *fn) opElse() error {
 		} else {
 			f.flush()
 		}
-		fr.ends = append(fr.ends, f.a.Branch())
+		f.appendEndSite(&fr.ends, f.a.Branch())
 		fr.endReachable = true
 	}
 	f.a.PatchBranch19(fr.elseSite, f.a.Len()) // the false edge is a B.cond (imm19)
@@ -791,7 +792,11 @@ func (f *fn) opElse() error {
 }
 
 func (f *fn) opEnd() error {
-	fr := f.ctrl[len(f.ctrl)-1]
+	last := len(f.ctrl) - 1
+	fr := f.ctrl[last]
+	// ctrl backing is reused across functions. Clear the popped slot so its
+	// variable-sized type and loop-analysis slices do not stay live in scratch.
+	f.ctrl[last] = ctrlFrame{}
 	f.ctrl = f.ctrl[:len(f.ctrl)-1]
 	if len(fr.loopPins) != 0 {
 		f.activeLoopPins = nil // this frame's pins leave scope with the pop
@@ -936,6 +941,12 @@ func (f *fn) opEnd() error {
 			f.setDepthTypes(f.frameDepthTypes(fr.baseTypes, fr.resultTypes))
 		}
 	}
+	// The popped frame no longer owns these temporary buffers. Recycle them for
+	// later frames at the same or a shallower nesting depth.
+	f.freeLocStateBuf(fr.branchState)
+	f.freeLocStateBuf(fr.entryState)
+	f.freeEndsBuf(fr.ends)
+	f.freeEndsBuf(fr.condEnds)
 	return nil
 }
 
@@ -1195,7 +1206,8 @@ func (f *fn) opReturn() error {
 	}
 	if f.singleRegResult {
 		f.placeSingleResult() // result straight to X0/V0; epilogue does not reload
-		f.retSites = append(f.retSites, f.a.Branch())
+		sc := f.scratchState()
+		sc.retSites = append(sc.retSites, f.a.Branch())
 		f.unreachable = true
 		return nil
 	}
@@ -1203,7 +1215,8 @@ func (f *fn) opReturn() error {
 	a, d := fr.resultN, f.depth()
 	f.flush()
 	f.moveBranchValues(fr, d, a)
-	f.retSites = append(f.retSites, f.a.Branch())
+	sc := f.scratchState()
+	sc.retSites = append(sc.retSites, f.a.Branch())
 	f.unreachable = true
 	return nil
 }

--- a/src/core/compiler/backend/railshot/arm64/driver.go
+++ b/src/core/compiler/backend/railshot/arm64/driver.go
@@ -14,7 +14,8 @@ import (
 // Frontend.cpp parseCodeSection opcode switch. Phase 0 covers the integer const/
 // local/ALU subset needed to prove the pipeline end-to-end.
 func (f *fn) body(code []byte) error {
-	return f.bodyLoop(wasm.NewReader(code), 0)
+	r := wasm.ReaderFrom(code)
+	return f.bodyLoop(&r, 0)
 }
 
 // bodyLoop drives the opcode switch until the control stack shrinks to minCtrl.

--- a/src/core/compiler/backend/railshot/arm64/hints.go
+++ b/src/core/compiler/backend/railshot/arm64/hints.go
@@ -78,7 +78,9 @@ type funcHints struct {
 }
 
 func newFuncHints(nLocals, nGlobals int) funcHints {
-	return funcHintsWithStorage(make([]uint32, nLocals), make([]uint32, nGlobals), make([]bool, nGlobals))
+	h := funcHintsWithStorage(make([]uint32, nLocals), make([]uint32, nGlobals), make([]bool, nGlobals))
+	h.nLocals = nLocals
+	return h
 }
 
 func funcHintsWithStorage(localScore, globalScore []uint32, globalElig []bool) funcHints {

--- a/src/core/compiler/backend/railshot/arm64/hints.go
+++ b/src/core/compiler/backend/railshot/arm64/hints.go
@@ -37,6 +37,7 @@ func weightedBranchPath(weight int64) int64 {
 
 // funcHints is everything scanFuncBody yields.
 type funcHints struct {
+	nLocals        int
 	hasCall        bool // any direct or indirect call
 	callsSelf      bool // a direct call to the function's own index
 	hasLoop        bool // structured loop (X12/X13 may be borrowed by loop promotion)
@@ -77,11 +78,11 @@ type funcHints struct {
 }
 
 func newFuncHints(nLocals, nGlobals int) funcHints {
-	return funcHints{
-		localScore:  make([]uint32, nLocals),
-		globalScore: make([]uint32, nGlobals),
-		globalElig:  make([]bool, nGlobals),
-	}
+	return funcHintsWithStorage(make([]uint32, nLocals), make([]uint32, nGlobals), make([]bool, nGlobals))
+}
+
+func funcHintsWithStorage(localScore, globalScore []uint32, globalElig []bool) funcHints {
+	return funcHints{localScore: localScore, globalScore: globalScore, globalElig: globalElig}
 }
 
 func addHotness(scores []uint32, idx uint32, delta int64) {
@@ -110,6 +111,11 @@ type globalEligibilityFrame struct {
 
 func newGlobalEligibilityTracker(nGlobals int) globalEligibilityTracker {
 	return globalEligibilityTracker{marks: make([]uint32, nGlobals)}
+}
+
+func (t *globalEligibilityTracker) reset() {
+	t.globals = t.globals[:0]
+	t.frames = t.frames[:0]
 }
 
 func (t *globalEligibilityTracker) push() int {
@@ -155,10 +161,16 @@ func (t *globalEligibilityTracker) pop(frame int) {
 // scanFuncBody chooses the byte-backed scanner used for decoded modules, falling
 // back to the AST scanner for tests or callers that construct Func.Body directly.
 func scanFuncBody(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, branchHints []wasm.BranchHint) (funcHints, error) {
+	h := newFuncHints(nLocals, nGlobals)
+	elig := newGlobalEligibilityTracker(nGlobals)
+	return scanFuncBodyInto(fn, nLocals, nGlobals, selfIdx, branchHints, h, &elig)
+}
+
+func scanFuncBodyInto(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, branchHints []wasm.BranchHint, h funcHints, elig *globalEligibilityTracker) (funcHints, error) {
 	if len(fn.BodyBytes) != 0 {
-		return scanBodyBytesWithHints(fn.BodyBytes, fn.LocalDeclBytes, nLocals, nGlobals, selfIdx, branchHints)
+		return scanBodyBytesInto(fn.BodyBytes, fn.LocalDeclBytes, nLocals, nGlobals, selfIdx, branchHints, h, elig)
 	}
-	return scanBody(fn.Body, nLocals, nGlobals, selfIdx), nil
+	return scanBodyInto(fn.Body, nLocals, nGlobals, selfIdx, h, elig), nil
 }
 
 // scanBody performs the AST pre-scan walk. selfIdx is the function's global
@@ -166,6 +178,11 @@ func scanFuncBody(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, branchHin
 func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 	h := newFuncHints(nLocals, nGlobals)
 	elig := newGlobalEligibilityTracker(nGlobals)
+	return scanBodyInto(body, nLocals, nGlobals, selfIdx, h, &elig)
+}
+
+func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker) funcHints {
+	elig.reset()
 	// walk returns whether the subtree contains a call. curLoop identifies the
 	// innermost enclosing loop whose globals are being considered for eligibility.
 	var walk func(instrs []wasm.Instruction, depth int, curLoop int) bool
@@ -400,8 +417,15 @@ func scanBodyBytes(body []byte, nLocals int, nGlobals int, selfIdx uint32) (func
 }
 
 func scanBodyBytesWithHints(body []byte, localDeclBytes uint32, nLocals int, nGlobals int, selfIdx uint32, branchHints []wasm.BranchHint) (funcHints, error) {
+	h := newFuncHints(nLocals, nGlobals)
+	elig := newGlobalEligibilityTracker(nGlobals)
+	return scanBodyBytesInto(body, localDeclBytes, nLocals, nGlobals, selfIdx, branchHints, h, &elig)
+}
+
+func scanBodyBytesInto(body []byte, localDeclBytes uint32, nLocals int, nGlobals int, selfIdx uint32, branchHints []wasm.BranchHint, h funcHints, elig *globalEligibilityTracker) (funcHints, error) {
+	elig.reset()
 	r := wasm.ReaderFrom(body)
-	s := byteBodyScanner{r: byteScanReader{Reader: &r}, h: newFuncHints(nLocals, nGlobals), nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, localDeclBytes: localDeclBytes, branchHints: branchHints, elig: newGlobalEligibilityTracker(nGlobals)}
+	s := byteBodyScanner{r: byteScanReader{Reader: &r}, h: h, nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, localDeclBytes: localDeclBytes, branchHints: branchHints, elig: elig}
 	called, term, err := s.scanExpr(0, 0, -1, false, 1)
 	if err != nil {
 		return s.h, err
@@ -423,7 +447,7 @@ type byteBodyScanner struct {
 	selfIdx        uint32
 	localDeclBytes uint32
 	branchHints    []wasm.BranchHint
-	elig           globalEligibilityTracker
+	elig           *globalEligibilityTracker
 }
 
 func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAtElse bool, pathWeight int64) (bool, byte, error) {

--- a/src/core/compiler/backend/railshot/arm64/hints.go
+++ b/src/core/compiler/backend/railshot/arm64/hints.go
@@ -37,13 +37,14 @@ func weightedBranchPath(weight int64) int64 {
 
 // funcHints is everything scanFuncBody yields.
 type funcHints struct {
-	hasCall       bool // any direct or indirect call
-	callsSelf     bool // a direct call to the function's own index
-	hasLoop       bool // structured loop (X12/X13 may be borrowed by loop promotion)
-	touchesMemory bool // any linear-memory op
-	memOps        int  // scalar/vector/bulk linear-memory instructions
-	usesBulkMem   bool // memory.copy/fill (explicit LDRB/STRB copy/fill loop clobbers X16/X17 + call scratch)
-	mutatesTable  bool // table.set/init/copy/grow/fill; excludes immutable local-table call_indirect specialization
+	hasCall        bool // any direct or indirect call
+	callsSelf      bool // a direct call to the function's own index
+	hasLoop        bool // structured loop (X12/X13 may be borrowed by loop promotion)
+	touchesMemory  bool // any linear-memory op
+	memOps         int  // scalar/vector/bulk linear-memory instructions
+	usesBulkMem    bool // memory.copy/fill (explicit LDRB/STRB copy/fill loop clobbers X16/X17 + call scratch)
+	mutatesTable   bool // table.set/init/copy/grow/fill; excludes immutable local-table call_indirect specialization
+	hasControlFlow bool // control opcode relevant to inline splice framing
 
 	// immutableLocalTable is derived after the one-pass per-function scans have
 	// been aggregated. The table must also be private (an exported table can be
@@ -57,8 +58,8 @@ type funcHints struct {
 
 	// Loop-weighted hotness: local.get/global.get = 1×, set/tee = 2×, ×loopWeight
 	// per enclosing loop level.
-	localScore  []int64
-	globalScore []int64
+	localScore  []uint32
+	globalScore []uint32
 
 	// globalElig[g]: global g is accessed inside a loop whose subtree contains NO
 	// call. Value-pinning such a global in a call-making function is a win: the
@@ -77,9 +78,21 @@ type funcHints struct {
 
 func newFuncHints(nLocals, nGlobals int) funcHints {
 	return funcHints{
-		localScore:  make([]int64, nLocals),
-		globalScore: make([]int64, nGlobals),
+		localScore:  make([]uint32, nLocals),
+		globalScore: make([]uint32, nGlobals),
 		globalElig:  make([]bool, nGlobals),
+	}
+}
+
+func addHotness(scores []uint32, idx uint32, delta int64) {
+	if int(idx) >= len(scores) || delta <= 0 {
+		return
+	}
+	const max = ^uint32(0)
+	if uint64(scores[idx])+uint64(delta) >= uint64(max) {
+		scores[idx] = max
+	} else {
+		scores[idx] += uint32(delta)
 	}
 }
 
@@ -162,6 +175,14 @@ func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 		for i := range instrs {
 			in := &instrs[i]
 			switch in.Kind {
+			case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf,
+				wasm.InstrBr, wasm.InstrBrIf, wasm.InstrBrTable, wasm.InstrReturn:
+				h.hasControlFlow = true
+				if in.Kind == wasm.InstrLoop {
+					h.hasLoop = true
+				}
+			}
+			switch in.Kind {
 			case wasm.InstrCall, wasm.InstrReturnCall, wasm.InstrCallRef, wasm.InstrReturnCallRef:
 				sub, h.hasCall = true, true
 				if in.Kind == wasm.InstrCall && in.Index == selfIdx {
@@ -171,18 +192,18 @@ func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 				sub, h.hasCall = true, true
 			case wasm.InstrLocalGet:
 				if int(in.Index) < nLocals {
-					h.localScore[in.Index] += w
+					addHotness(h.localScore, in.Index, w)
 				}
 			case wasm.InstrLocalSet, wasm.InstrLocalTee:
 				if int(in.Index) < nLocals {
-					h.localScore[in.Index] += 2 * w
+					addHotness(h.localScore, in.Index, 2*w)
 				}
 			case wasm.InstrGlobalGet, wasm.InstrGlobalSet:
 				if int(in.Index) < nGlobals {
 					if in.Kind == wasm.InstrGlobalSet {
-						h.globalScore[in.Index] += 2 * w
+						addHotness(h.globalScore, in.Index, 2*w)
 					} else {
-						h.globalScore[in.Index] += w
+						addHotness(h.globalScore, in.Index, w)
 					}
 					elig.add(curLoop, in.Index)
 				}
@@ -263,7 +284,8 @@ func scanBodyGlobalScores(body wasm.Expr, nGlobals int, add func(g uint32, score
 }
 
 func scanBodyBytesGlobalScores(body []byte, nGlobals int, add func(g uint32, score int64)) error {
-	s := globalScoreByteScanner{r: byteScanReader{Reader: wasm.NewReader(body)}, nGlobals: nGlobals, add: add}
+	r := wasm.ReaderFrom(body)
+	s := globalScoreByteScanner{r: byteScanReader{Reader: &r}, nGlobals: nGlobals, add: add}
 	term, err := s.scanExpr(0, 0, false)
 	if err != nil {
 		return err
@@ -378,7 +400,8 @@ func scanBodyBytes(body []byte, nLocals int, nGlobals int, selfIdx uint32) (func
 }
 
 func scanBodyBytesWithHints(body []byte, localDeclBytes uint32, nLocals int, nGlobals int, selfIdx uint32, branchHints []wasm.BranchHint) (funcHints, error) {
-	s := byteBodyScanner{r: byteScanReader{Reader: wasm.NewReader(body)}, h: newFuncHints(nLocals, nGlobals), nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, localDeclBytes: localDeclBytes, branchHints: branchHints, elig: newGlobalEligibilityTracker(nGlobals)}
+	r := wasm.ReaderFrom(body)
+	s := byteBodyScanner{r: byteScanReader{Reader: &r}, h: newFuncHints(nLocals, nGlobals), nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, localDeclBytes: localDeclBytes, branchHints: branchHints, elig: newGlobalEligibilityTracker(nGlobals)}
 	called, term, err := s.scanExpr(0, 0, -1, false, 1)
 	if err != nil {
 		return s.h, err
@@ -412,6 +435,13 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 		op, err := s.r.byte()
 		if err != nil {
 			return true, 0, err
+		}
+		switch op {
+		case 0x00, 0x02, 0x03, 0x04, 0x05, 0x0c, 0x0d, 0x0e, 0x0f:
+			s.h.hasControlFlow = true
+			if op == 0x03 {
+				s.h.hasLoop = true
+			}
 		}
 		switch op {
 		case 0x0b: // end
@@ -511,9 +541,9 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 			idx := imm.Index
 			if int(idx) < s.nLocals {
 				if op == 0x20 {
-					s.h.localScore[idx] += pathWeight * loopWeight(loopDepth)
+					addHotness(s.h.localScore, idx, pathWeight*loopWeight(loopDepth))
 				} else {
-					s.h.localScore[idx] += 2 * pathWeight * loopWeight(loopDepth)
+					addHotness(s.h.localScore, idx, 2*pathWeight*loopWeight(loopDepth))
 				}
 			}
 		case 0x23, 0x24: // global.get/set
@@ -526,9 +556,9 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 			idx := imm.Index
 			if int(idx) < s.nGlobals {
 				if op == 0x24 {
-					s.h.globalScore[idx] += 2 * pathWeight * loopWeight(loopDepth)
+					addHotness(s.h.globalScore, idx, 2*pathWeight*loopWeight(loopDepth))
 				} else {
-					s.h.globalScore[idx] += pathWeight * loopWeight(loopDepth)
+					addHotness(s.h.globalScore, idx, pathWeight*loopWeight(loopDepth))
 				}
 				s.elig.add(curLoop, idx)
 			}

--- a/src/core/compiler/backend/railshot/arm64/hints_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/hints_arm64_test.go
@@ -123,7 +123,7 @@ func TestBranchHintWeightsIfArmLocalScores(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scan likely-then: %v", err)
 	}
-	if got, want := likelyThen.localScore[0], int64(branchHintWeight); got != want {
+	if got, want := likelyThen.localScore[0], uint32(branchHintWeight); got != want {
 		t.Fatalf("likely then local score = %d, want %d", got, want)
 	}
 	if got := likelyThen.localScore[1]; got != 1 {
@@ -133,7 +133,7 @@ func TestBranchHintWeightsIfArmLocalScores(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scan likely-else: %v", err)
 	}
-	if got, want := likelyElse.localScore[1], int64(branchHintWeight); got != want {
+	if got, want := likelyElse.localScore[1], uint32(branchHintWeight); got != want {
 		t.Fatalf("likely else local score = %d, want %d", got, want)
 	}
 }

--- a/src/core/compiler/backend/railshot/arm64/inline.go
+++ b/src/core/compiler/backend/railshot/arm64/inline.go
@@ -177,6 +177,19 @@ func inlineClass(f inlineFacts) (bool, string) {
 	}
 }
 
+func inlineOK(f inlineFacts) bool {
+	switch {
+	case f.hasControlCall, f.calleeCount > 0, !f.regABIIntOnly:
+		return false
+	case f.hasLoop && !inlineLoopCallees:
+		return false
+	case f.bodyBytes > inlineMaxBytes:
+		return false
+	default:
+		return true
+	}
+}
+
 // inlineDecision layers the call-site gate on inlineClass for the report (a
 // class member with no call sites is unused, not inlinable).
 func inlineDecision(f inlineFacts, callSites int) (bool, string) {
@@ -391,7 +404,7 @@ type inlineTarget struct {
 // GLOBAL function index, or nil when inlining is disabled. Candidacy here is a
 // property of the callee alone (the call-site count only mattered for the report),
 // so a call to one of these can be spliced wherever it appears.
-func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
+func buildInlineTargets(m *wasm.Module, allHints []funcHints) map[int]*inlineTarget {
 	if !inlineEnabled {
 		return nil
 	}
@@ -402,9 +415,30 @@ func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
 		if len(body) == 0 {
 			continue // AST-only bodies are not spliced (the byte body drives the splice)
 		}
-		facts, err := scanInlineFacts(m, m.Code[i], i, importedFuncs)
-		if err != nil {
+		ft, ok := m.LocalFuncType(i)
+		if !ok || ft == nil {
 			continue
+		}
+		h := allHints[i]
+		touchesGlobal := false
+		for _, score := range h.globalScore {
+			if score != 0 {
+				touchesGlobal = true
+				break
+			}
+		}
+		facts := inlineFacts{
+			bodyBytes:      len(body),
+			hasLoop:        h.hasLoop,
+			hasControlFlow: h.hasControlFlow,
+			touchesGlobal:  touchesGlobal,
+			touchesMem:     h.touchesMemory || h.usesBulkMem,
+			params:         len(ft.Params),
+			results:        len(ft.Results),
+			regABIIntOnly:  sigFitsRegABI(ft) && sigIsIntOnly(ft),
+		}
+		if h.hasCall {
+			facts.calleeCount = 1
 		}
 		// The transform class: a leaf (no calls, so non-recursive/acyclic) with an
 		// int-only reg-ABI signature and a small body. Memory/global ops and
@@ -413,14 +447,13 @@ func buildInlineTargets(m *wasm.Module) map[int]*inlineTarget {
 		// stands in for its function boundary (its `return`/`end` merge there), so
 		// the existing block/br/convergence machinery lowers it. A straight-line
 		// callee skips the frame entirely (the cheaper fast path).
-		if ok, _ := inlineClass(facts); !ok {
+		if !inlineOK(facts) {
 			continue
 		}
 		lt := calleeLocalTypes(m, i)
 		if lt == nil {
 			continue
 		}
-		ft, _ := m.LocalFuncType(i)
 		var rt []machineType
 		res0 := mtNone
 		if ft != nil {

--- a/src/core/compiler/backend/railshot/arm64/localstate.go
+++ b/src/core/compiler/backend/railshot/arm64/localstate.go
@@ -236,6 +236,51 @@ func (f *fn) reconcileLocals() {
 // recorded) — always safe: the merge assumes only the target. The merge point
 // itself must then install the recorded target as the tracked state
 // (setLocalsState).
+func (f *fn) newLocStateBuf() []locState {
+	for i := len(f.lsPool) - 1; i >= 0; i-- {
+		b := f.lsPool[i]
+		if cap(b) < f.nLocals {
+			continue
+		}
+		last := len(f.lsPool) - 1
+		f.lsPool[i] = f.lsPool[last]
+		f.lsPool[last] = nil
+		f.lsPool = f.lsPool[:last]
+		return b[:f.nLocals]
+	}
+	// No retained buffer is large enough. Drop one undersized entry before
+	// replacing it so the module-wide pool is bounded by maximum simultaneous
+	// control depth, not by the number of different local counts encountered.
+	if last := len(f.lsPool) - 1; last >= 0 {
+		f.lsPool[last] = nil
+		f.lsPool = f.lsPool[:last]
+	}
+	return make([]locState, f.nLocals)
+}
+
+func (f *fn) freeLocStateBuf(b []locState) {
+	if cap(b) >= f.nLocals && f.nLocals > 0 {
+		f.lsPool = append(f.lsPool, b[:cap(b)])
+	}
+}
+
+func (f *fn) appendEndSite(sites *[]int, site int) {
+	if *sites == nil {
+		if n := len(f.endsPool); n > 0 {
+			*sites = f.endsPool[n-1][:0]
+			f.endsPool[n-1] = nil
+			f.endsPool = f.endsPool[:n-1]
+		}
+	}
+	*sites = append(*sites, site)
+}
+
+func (f *fn) freeEndsBuf(b []int) {
+	if cap(b) > 0 {
+		f.endsPool = append(f.endsPool, b[:0])
+	}
+}
+
 func (f *fn) convergeEdgeTo(target *[]locState) {
 	// Dirty registers and lazy zeros always materialize to the slot: every
 	// target guarantees at least "slot is current".
@@ -260,7 +305,7 @@ func (f *fn) convergeEdgeTo(target *[]locState) {
 		return
 	}
 	if *target == nil { // first edge fixes the frame's merge state
-		t := make([]locState, f.nLocals)
+		t := f.newLocStateBuf()
 		for x := range t {
 			t[x] = f.locals[x].state
 		}

--- a/src/core/compiler/backend/railshot/arm64/memory.go
+++ b/src/core/compiler/backend/railshot/arm64/memory.go
@@ -111,12 +111,10 @@ func (f *fn) trapIf(cc Cond, code uint32) {
 	if code == trapMemOOB {
 		f.stats.addBoundsCheck() // inline linear-memory OOB check (P6 elides these)
 	}
-	if f.trapSites == nil {
-		f.trapSites = map[uint32][]int{}
-	}
 	// A B.cond site (imm19, ±1 MiB); bit0 of the site offset is 0 (4-aligned), so
 	// emitTrapStubs uses it to tag Bcond vs Branch patch ranges (§6.2).
-	f.trapSites[code] = append(f.trapSites[code], f.a.Bcond(cc))
+	sc := f.scratchState()
+	sc.trapSites[code] = append(sc.trapSites[code], f.a.Bcond(cc))
 }
 
 // trapAlways is trapIf's unconditional form (`unreachable`): a single B to the
@@ -124,17 +122,15 @@ func (f *fn) trapIf(cc Cond, code uint32) {
 // emitTrapStubs patches it with PatchBranch26 (imm26, ±128 MiB) rather than the
 // PatchBranch19 range a B.cond site uses.
 func (f *fn) trapAlways(code uint32) {
-	if f.trapSites == nil {
-		f.trapSites = map[uint32][]int{}
-	}
-	f.trapSites[code] = append(f.trapSites[code], f.a.Branch()|1)
+	sc := f.scratchState()
+	sc.trapSites[code] = append(sc.trapSites[code], f.a.Branch()|1)
 }
 
 // emitTrapStubs emits one trap stub per trap code used by this function and
 // patches every recorded site to it. Called once, after the epilogue.
 func (f *fn) emitTrapStubs() {
 	for code := uint32(1); code <= trapStackFence; code++ { // deterministic order
-		sites := f.trapSites[code]
+		sites := f.scratchState().trapSites[code]
 		if len(sites) == 0 {
 			continue
 		}

--- a/src/core/compiler/backend/railshot/arm64/peephole.go
+++ b/src/core/compiler/backend/railshot/arm64/peephole.go
@@ -31,16 +31,18 @@ func (f *fn) finalizePeepholes() {
 	if n < 8 {
 		return
 	}
-	var targets map[int]bool
+	sc := f.scratchState()
+	targets := sc.branchTargets
+	if targets == nil {
+		targets = make(map[int]bool, 16)
+		sc.branchTargets = targets
+	}
 	for pc := 0; pc < n; pc += 4 {
 		w := rdWord(b, pc)
 		if isIndirectBranch(w) {
 			return
 		}
 		if t, ok := branchTarget(pc, w); ok {
-			if targets == nil {
-				targets = make(map[int]bool, 16)
-			}
 			targets[t] = true
 		}
 	}

--- a/src/core/compiler/backend/railshot/arm64/pressure_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/pressure_arm64_test.go
@@ -1,0 +1,16 @@
+//go:build arm64
+
+package arm64
+
+import "testing"
+
+func TestCompileMemoryPressureCheckpointRunsOnce(t *testing.T) {
+	m := mod1(t, nil, nil, []byte{0x00, 0x01, 0x0b})
+	calls := 0
+	if _, err := CompileModuleWith(m, CompileOptions{MemoryPressureAt: 1, MemoryPressure: func() { calls++ }}); err != nil {
+		t.Fatalf("CompileModuleWith: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("memory-pressure calls = %d, want 1", calls)
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/regcopy.go
+++ b/src/core/compiler/backend/railshot/arm64/regcopy.go
@@ -2,6 +2,8 @@
 
 package arm64
 
+import "math/bits"
+
 // Parallel register-move resolution (WARP's RegisterCopyResolver): placing N
 // values, each already live in some register, into their target registers is a
 // *parallel* move — a target may still hold a value another move needs — and the
@@ -16,26 +18,29 @@ type regMove struct{ dst, src Reg }
 // emitSwap (exchange). The move set must be a function from dst to src (each
 // register written at most once), which holds for ABI argument placement.
 func resolveRegMoves(moves []regMove, emitMove func(dst, src Reg), emitSwap func(a, b Reg)) {
-	pending := make(map[Reg]Reg, len(moves))
+	var src [64]Reg
+	var pending regMask
 	for _, m := range moves {
 		if m.dst != m.src {
-			pending[m.dst] = m.src
+			src[m.dst] = m.src
+			pending = pending.add(m.dst)
 		}
 	}
 	isSource := func(r Reg) bool {
-		for _, s := range pending {
-			if s == r {
+		for d := uint64(pending); d != 0; d &= d - 1 {
+			if src[bits.TrailingZeros64(d)] == r {
 				return true
 			}
 		}
 		return false
 	}
-	for len(pending) > 0 {
+	for pending != 0 {
 		moved := false
-		for dst, src := range pending {
+		for d := uint64(pending); d != 0; d &= d - 1 {
+			dst := Reg(bits.TrailingZeros64(d))
 			if !isSource(dst) {
-				emitMove(dst, src)
-				delete(pending, dst)
+				emitMove(dst, src[dst])
+				pending = pending.remove(dst)
 				moved = true
 				break
 			}
@@ -44,19 +49,17 @@ func resolveRegMoves(moves []regMove, emitMove func(dst, src Reg), emitSwap func
 			continue
 		}
 		// Residual graph is pure cycles; break one with a swap.
-		var dst, src Reg
-		for d, s := range pending {
-			dst, src = d, s
-			break
-		}
-		emitSwap(dst, src)
-		delete(pending, dst)
-		for d, s := range pending {
-			if s == dst {
-				if d == src {
-					delete(pending, d)
+		dst := Reg(bits.TrailingZeros64(uint64(pending)))
+		s := src[dst]
+		emitSwap(dst, s)
+		pending = pending.remove(dst)
+		for d := uint64(pending); d != 0; d &= d - 1 {
+			dd := Reg(bits.TrailingZeros64(d))
+			if src[dd] == dst {
+				if dd == s {
+					pending = pending.remove(dd)
 				} else {
-					pending[d] = src
+					src[dd] = s
 				}
 			}
 		}

--- a/src/core/compiler/backend/railshot/arm64/stack.go
+++ b/src/core/compiler/backend/railshot/arm64/stack.go
@@ -2,6 +2,8 @@
 
 package arm64
 
+import "github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+
 // The operand stack and its element model — ported from WARP's Stack /
 // StackElement / StackType / VariableStorage (warp/src/core/compiler/common/).
 //
@@ -175,13 +177,15 @@ func (e *elem) isDeferred() bool { return e.kind == ekDeferred }
 // bump arena of elems (never freed mid-function; that matches single-pass usage
 // and keeps *elem pointers stable).
 type stack struct {
-	arena []elem
-	head  *elem // sentinel (arena[0]); head.next is the bottom, back() is the top
+	chunks [][]elem
+	cur    int
+	head   *elem
 }
 
 const (
 	defaultStackArenaCap = 256
 	minStackArenaCap     = 16
+	maxStackChunkCap     = 8192
 )
 
 func newStack() *stack { return newStackWithCap(defaultStackArenaCap) }
@@ -190,27 +194,26 @@ func newStackWithCap(capHint int) *stack {
 	if capHint < minStackArenaCap {
 		capHint = minStackArenaCap
 	}
-	if capHint > defaultStackArenaCap {
-		capHint = defaultStackArenaCap
-	}
-	s := &stack{arena: make([]elem, 0, capHint)}
-	s.arena = append(s.arena, elem{}) // sentinel
-	s.head = &s.arena[0]
-	s.head.prev, s.head.next = s.head, s.head
+	s := &stack{chunks: [][]elem{make([]elem, 0, capHint)}}
+	s.initSentinel()
 	return s
+}
+
+func (s *stack) initSentinel() {
+	s.cur = 0
+	chunk := &s.chunks[0]
+	*chunk = append((*chunk)[:0], elem{})
+	s.head = &(*chunk)[0]
+	s.head.prev, s.head.next = s.head, s.head
 }
 
 // reset rewinds the stack to empty for reuse by the next function in a module
 // compile, preserving the arena's backing capacity so the common case allocates
 // nothing per function. The prior function's nodes are dead by the time this is
-// called (its code is already emitted), so dropping them is safe; standalone
-// spill nodes are simply released to the GC. alloc rezeroes every reused arena
-// slot, so no stale fields survive.
+// called (its code is already emitted). alloc rezeroes every reused chunk slot,
+// so no stale fields survive.
 func (s *stack) reset() {
-	s.arena = s.arena[:0]
-	s.arena = append(s.arena, elem{}) // sentinel
-	s.head = &s.arena[0]
-	s.head.prev, s.head.next = s.head, s.head
+	s.initSentinel()
 }
 
 func stackArenaCapForBody(bodyLen, nLocals int) int {
@@ -222,32 +225,28 @@ func stackArenaCapForHints(bodyLen, nLocals, nodeHint int) int {
 	// walking the bytecode. Historically the hint was one node per body byte; keep
 	// that as a ceiling, but let the pre-scan's opcode-based estimate avoid
 	// reserving nodes for long immediates (notably 16-byte SIMD constants). The
-	// stack still falls back to standalone heap nodes if the estimate is low, so
+	// chunked arena grows past an underestimate without moving prior nodes, so
 	// pointer stability is preserved.
-	legacy := bodyLen + nLocals/4 + 1
-	if nodeHint <= 0 {
-		return legacy
-	}
-	precise := nodeHint + nodeHint/2 + nLocals/4 + 1
-	if floor := bodyLen/4 + nLocals/4 + 1; precise < floor {
-		precise = floor
-	}
-	if precise > legacy {
-		precise = legacy
-	}
-	return precise
+	return shared.StackArenaCapacity(bodyLen, nLocals, nodeHint)
 }
 
 // alloc returns a fresh zeroed node from the arena.
 func (s *stack) alloc() *elem {
-	// Growing the arena may move earlier elems, invalidating pointers — so we
-	// never let it reallocate: reserve generously and, if exceeded, spill to
-	// individually-heap-allocated nodes (still pointer-stable).
-	if len(s.arena) < cap(s.arena) {
-		s.arena = append(s.arena, elem{})
-		return &s.arena[len(s.arena)-1]
+	chunk := &s.chunks[s.cur]
+	if len(*chunk) == cap(*chunk) {
+		s.cur++
+		if s.cur == len(s.chunks) {
+			nextCap := cap(*chunk) * 2
+			if nextCap > maxStackChunkCap {
+				nextCap = maxStackChunkCap
+			}
+			s.chunks = append(s.chunks, make([]elem, 0, nextCap))
+		}
+		chunk = &s.chunks[s.cur]
+		*chunk = (*chunk)[:0]
 	}
-	return &elem{}
+	*chunk = append(*chunk, elem{})
+	return &(*chunk)[len(*chunk)-1]
 }
 
 // push appends e as the new top of the stack and returns it.

--- a/src/core/compiler/backend/railshot/arm64/stack_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/stack_arm64_test.go
@@ -11,12 +11,12 @@ import "testing"
 
 func TestNewStackArenaDefaultCapacityArm64(t *testing.T) {
 	s := newStack()
-	if cap(s.arena) != defaultStackArenaCap {
-		t.Fatalf("stack arena cap = %d, want %d", cap(s.arena), defaultStackArenaCap)
+	if cap(s.chunks[0]) != defaultStackArenaCap {
+		t.Fatalf("stack arena cap = %d, want %d", cap(s.chunks[0]), defaultStackArenaCap)
 	}
 }
 
-func TestNewStackWithCapClampsArm64(t *testing.T) {
+func TestNewStackWithCapSizesFirstChunkArm64(t *testing.T) {
 	for _, tc := range []struct {
 		hint int
 		want int
@@ -24,11 +24,11 @@ func TestNewStackWithCapClampsArm64(t *testing.T) {
 		{0, minStackArenaCap},
 		{minStackArenaCap - 1, minStackArenaCap},
 		{minStackArenaCap + 7, minStackArenaCap + 7},
-		{defaultStackArenaCap + 1, defaultStackArenaCap},
+		{defaultStackArenaCap + 1, defaultStackArenaCap + 1},
 	} {
 		s := newStackWithCap(tc.hint)
-		if cap(s.arena) != tc.want {
-			t.Fatalf("newStackWithCap(%d) cap = %d, want %d", tc.hint, cap(s.arena), tc.want)
+		if cap(s.chunks[0]) != tc.want {
+			t.Fatalf("newStackWithCap(%d) cap = %d, want %d", tc.hint, cap(s.chunks[0]), tc.want)
 		}
 		if s.head == nil || s.head.next != s.head || s.head.prev != s.head {
 			t.Fatalf("newStackWithCap(%d) did not initialize sentinel links", tc.hint)
@@ -38,8 +38,8 @@ func TestNewStackWithCapClampsArm64(t *testing.T) {
 
 func TestStackArenaCapForBodyTinyFunctionArm64(t *testing.T) {
 	s := newStackWithCap(stackArenaCapForBody(0, 0))
-	if cap(s.arena) != minStackArenaCap {
-		t.Fatalf("tiny stack arena cap = %d, want %d", cap(s.arena), minStackArenaCap)
+	if cap(s.chunks[0]) != minStackArenaCap {
+		t.Fatalf("tiny stack arena cap = %d, want %d", cap(s.chunks[0]), minStackArenaCap)
 	}
 }
 
@@ -48,15 +48,16 @@ func TestStackArenaCapForBodyMediumFunctionArm64(t *testing.T) {
 	const locals = 12
 	want := bodyLen + locals/4 + 1
 	s := newStackWithCap(stackArenaCapForBody(bodyLen, locals))
-	if cap(s.arena) != want {
-		t.Fatalf("medium stack arena cap = %d, want %d", cap(s.arena), want)
+	if cap(s.chunks[0]) != want {
+		t.Fatalf("medium stack arena cap = %d, want %d", cap(s.chunks[0]), want)
 	}
 }
 
-func TestStackArenaCapForBodyLargeFunctionClampArm64(t *testing.T) {
+func TestStackArenaCapForBodyLargeFunctionArm64(t *testing.T) {
 	s := newStackWithCap(stackArenaCapForBody(1024, 128))
-	if cap(s.arena) != defaultStackArenaCap {
-		t.Fatalf("large stack arena cap = %d, want clamp %d", cap(s.arena), defaultStackArenaCap)
+	want := stackArenaCapForBody(1024, 128)
+	if cap(s.chunks[0]) != want {
+		t.Fatalf("large stack arena cap = %d, want %d", cap(s.chunks[0]), want)
 	}
 }
 

--- a/src/core/compiler/backend/railshot/shared/binding.go
+++ b/src/core/compiler/backend/railshot/shared/binding.go
@@ -1,0 +1,10 @@
+package shared
+
+// ImportBinding describes a link-time imported-function binding. The zero value
+// selects host-import lowering; CrossInstance supplies the native context and
+// wrapper entry needed by either architecture's direct-call lowering.
+type ImportBinding struct {
+	CrossInstance bool
+	CalleeLinMem  uint64
+	CalleeEntry   uint64
+}

--- a/src/core/compiler/backend/railshot/shared/capacity.go
+++ b/src/core/compiler/backend/railshot/shared/capacity.go
@@ -35,3 +35,29 @@ func ModuleCodeCapacity(bodyBytes, functions, expansion int) int {
 	}
 	return bodyBytes*expansion + overhead
 }
+
+// TaperedModuleCodeCapacity keeps the conservative small-module expansion while
+// capping how much of that headroom a large module can retain. Expansion values
+// are expressed in eighths (32 == 4x, 40 == 5x), avoiding floating point in the
+// compiler and allowing architecture-specific measured ratios.
+func TaperedModuleCodeCapacity(bodyBytes, functions, smallEighths, largeEighths, maxHeadroom int) int {
+	const maxInt = int(^uint(0) >> 1)
+	if bodyBytes < 0 || functions < 0 || largeEighths <= 0 || smallEighths < largeEighths || maxHeadroom < 0 || functions > (maxInt-64)/16 {
+		return 0
+	}
+	overhead := functions*16 + 64
+	body := uint64(bodyBytes)
+	if body > (^uint64(0)-7)/uint64(smallEighths) {
+		return 0
+	}
+	base := (body*uint64(largeEighths) + 7) / 8
+	headroom := (body*uint64(smallEighths-largeEighths) + 7) / 8
+	if headroom > uint64(maxHeadroom) {
+		headroom = uint64(maxHeadroom)
+	}
+	total := base + headroom + uint64(overhead)
+	if total > uint64(maxInt) {
+		return 0
+	}
+	return int(total)
+}

--- a/src/core/compiler/backend/railshot/shared/capacity.go
+++ b/src/core/compiler/backend/railshot/shared/capacity.go
@@ -1,0 +1,37 @@
+// Package shared contains small, architecture-neutral building blocks used by
+// Railshot backends. Instruction selection, registers, ABI details, and native
+// encoding remain in the architecture packages.
+package shared
+
+// StackArenaCapacity estimates operand nodes for one function. An opcode-based
+// hint avoids reserving nodes for immediate bytes while a body-size floor keeps
+// malformed or incomplete hints from causing allocation cliffs.
+func StackArenaCapacity(bodyLen, nLocals, nodeHint int) int {
+	legacy := bodyLen + nLocals/4 + 1
+	if nodeHint <= 0 {
+		return legacy
+	}
+	precise := nodeHint + nodeHint/2 + nLocals/4 + 1
+	if floor := bodyLen/4 + nLocals/4 + 1; precise < floor {
+		precise = floor
+	}
+	if precise > legacy {
+		precise = legacy
+	}
+	return precise
+}
+
+// ModuleCodeCapacity estimates the final native image capacity. Expansion is an
+// architecture-specific upper estimate of native bytes per Wasm body byte;
+// per-function headroom covers alignment and adapters.
+func ModuleCodeCapacity(bodyBytes, functions, expansion int) int {
+	const maxInt = int(^uint(0) >> 1)
+	if bodyBytes < 0 || functions < 0 || expansion <= 0 || functions > (maxInt-64)/16 {
+		return 0
+	}
+	overhead := functions*16 + 64
+	if bodyBytes > (maxInt-overhead)/expansion {
+		return 0
+	}
+	return bodyBytes*expansion + overhead
+}

--- a/src/core/compiler/backend/railshot/shared/capacity_test.go
+++ b/src/core/compiler/backend/railshot/shared/capacity_test.go
@@ -22,3 +22,16 @@ func TestModuleCodeCapacity(t *testing.T) {
 		t.Fatalf("zero expansion capacity = %d, want 0", got)
 	}
 }
+
+func TestTaperedModuleCodeCapacity(t *testing.T) {
+	if got := TaperedModuleCodeCapacity(100, 3, 32, 28, 1<<20); got != 512 {
+		t.Fatalf("small capacity = %d, want 512", got)
+	}
+	wantLarge := (28 << 20) + (512 << 10) + 112
+	if got := TaperedModuleCodeCapacity(8<<20, 3, 32, 28, 512<<10); got != wantLarge {
+		t.Fatalf("large capacity = %d, want %d", got, wantLarge)
+	}
+	if got := TaperedModuleCodeCapacity(100, 3, 27, 28, 1); got != 0 {
+		t.Fatalf("inverted expansion capacity = %d, want 0", got)
+	}
+}

--- a/src/core/compiler/backend/railshot/shared/capacity_test.go
+++ b/src/core/compiler/backend/railshot/shared/capacity_test.go
@@ -1,0 +1,24 @@
+package shared
+
+import "testing"
+
+func TestStackArenaCapacity(t *testing.T) {
+	if got := StackArenaCapacity(64, 0, 12); got != 19 {
+		t.Fatalf("hinted capacity = %d, want 19", got)
+	}
+	if got := StackArenaCapacity(64, 12, 0); got != 68 {
+		t.Fatalf("legacy capacity = %d, want 68", got)
+	}
+}
+
+func TestModuleCodeCapacity(t *testing.T) {
+	if got := ModuleCodeCapacity(100, 3, 5); got != 612 {
+		t.Fatalf("capacity = %d, want 612", got)
+	}
+	if got := ModuleCodeCapacity(-1, 1, 5); got != 0 {
+		t.Fatalf("negative capacity = %d, want 0", got)
+	}
+	if got := ModuleCodeCapacity(100, 3, 0); got != 0 {
+		t.Fatalf("zero expansion capacity = %d, want 0", got)
+	}
+}

--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -615,7 +615,7 @@ func (p supportPass) data() error {
 			if err := p.constExpr(d.Mode.Offset, ""); err != nil {
 				if unsupported, ok := err.(*UnsupportedError); ok {
 					copy := *unsupported
-					copy.Context = fmt.Sprintf("data %d offset", i)
+					copy.Context = fmt.Sprintf("data %d offset%s", i, unsupported.Context)
 					return &copy
 				}
 				return fmt.Errorf("data %d offset: %w", i, err)

--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -606,20 +606,27 @@ func elemKindName(k wasm.ElemKindKind) string {
 
 func (p supportPass) data() error {
 	for i, d := range p.m.Data {
-		ctx := fmt.Sprintf("data %d", i)
 		switch d.Mode.Kind {
 		case wasm.DataActive:
 			if d.Mode.Mem != 0 {
+				ctx := fmt.Sprintf("data %d", i)
 				return p.unsupported("data", fmt.Sprintf("memory index %d", d.Mode.Mem), ctx)
 			}
-			if err := p.constExpr(d.Mode.Offset, ctx+" offset"); err != nil {
-				return err
+			if err := p.constExpr(d.Mode.Offset, ""); err != nil {
+				if unsupported, ok := err.(*UnsupportedError); ok {
+					copy := *unsupported
+					copy.Context = fmt.Sprintf("data %d offset", i)
+					return &copy
+				}
+				return fmt.Errorf("data %d offset: %w", i, err)
 			}
 		case wasm.DataPassive:
 			if !p.feat.BulkMemory {
+				ctx := fmt.Sprintf("data %d", i)
 				return p.unsupported("data", "passive segment (bulk-memory-operations disabled)", ctx)
 			}
 		default:
+			ctx := fmt.Sprintf("data %d", i)
 			return p.unsupported("data", "unknown segment mode", ctx)
 		}
 	}
@@ -1166,7 +1173,7 @@ func (p supportPass) constExpr(e wasm.Expr, context string) error {
 }
 
 func (p supportPass) constExprBytes(body []byte, context string) error {
-	r := wasm.NewReader(body)
+	r := wasm.ReaderFrom(body)
 	op, err := r.Byte()
 	if err != nil {
 		return err
@@ -1218,7 +1225,7 @@ func (p supportPass) constExprBytes(body []byte, context string) error {
 		}
 	case 0xfd:
 		var imm wasm.InstructionImmediate
-		err := wasm.ClassifyInstructionImmediateInto(r, op, &imm)
+		err := wasm.ClassifyInstructionImmediateInto(&r, op, &imm)
 		if err != nil {
 			return err
 		}

--- a/src/core/compiler/wasm/reader_export.go
+++ b/src/core/compiler/wasm/reader_export.go
@@ -12,6 +12,11 @@ type Reader struct {
 
 func NewReader(bytecode []byte) *Reader { return &Reader{data: bytecode} }
 
+// ReaderFrom returns a cursor value for allocation-sensitive callers that keep
+// it on their own stack. NewReader remains convenient when an immediate pointer
+// is required by a decoder helper.
+func ReaderFrom(bytecode []byte) Reader { return Reader{data: bytecode} }
+
 func (r *Reader) Offset() int    { return r.pos }
 func (r *Reader) BytesLeft() int { return len(r.data) - r.pos }
 func (r *Reader) HasNext() bool  { return r.BytesLeft() > 0 }

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -637,6 +637,7 @@ type funcValidator struct {
 	// or deeply nested functions still grow normally and reuse that capacity.
 	valBuf      [2]val
 	ctrlBuf     [1]ctrlFrame
+	constResult [1]ValType
 	localParams []ValType
 	localRuns   []LocalRun
 	localCount  uint64

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -757,7 +757,8 @@ func (v *moduleValidator) validateConstExprDirect(e directConstExpr, want ValTyp
 		v.constFV = fv
 	}
 	fv.resetStacks()
-	fv.pushCtrl(ctrlFunc, nil, []ValType{want})
+	fv.constResult[0] = want
+	fv.pushCtrl(ctrlFunc, nil, fv.constResult[:])
 	fv.rd.reset(e.body)
 	r := &fv.rd
 	var op directOp // reused across the loop; decodeDirectOp overwrites it each step

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -32,6 +32,11 @@ const (
 
 // Compile decodes, validates, and compiles a wasm module to native code.
 //
+// On success ownership of wasmBytes transfers to the returned Compiled. The
+// caller must not mutate or reuse its backing array: active segment metadata and
+// link-time recompilation deliberately retain slices into that storage. This
+// avoids an input-sized copy for modules with function imports.
+//
 // It accepts both the current explicit form:
 //
 //	Compile(cfg, wasmBytes)
@@ -49,8 +54,9 @@ func Compile(args ...any) (*Compiled, error) {
 	return compileWithConfig(cfg, wasmBytes)
 }
 
-// CompileWithConfig is the named compatibility form of Compile(cfg, wasmBytes):
-// the config's feature set gates which modules are accepted and its bounds-check
+// CompileWithConfig is the named compatibility form of Compile(cfg, wasmBytes).
+// It has the same successful-call ownership transfer for wasmBytes. The
+// config's feature set gates which modules are accepted and its bounds-check
 // mode selects the code-generation strategy.
 func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
 	return compileWithConfig(cfg, wasmBytes)
@@ -113,7 +119,8 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	var code []byte
 	var entry, internalEntry []int
 	if !needsLink {
-		cm, err := railshotCompileModuleWith(m, railshotCompileOptions{ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds, SyncHostCalls: syncHostInitial, Interruptible: true})
+		pressureAt, pressure := compileMemoryPressure(len(wasmBytes))
+		cm, err := railshotCompileModuleWith(m, railshotCompileOptions{ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds, SyncHostCalls: syncHostInitial, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
 		if err != nil {
 			return nil, fmt.Errorf("compile: %w", err)
 		}
@@ -132,7 +139,7 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	// Retain the raw module for the link-time recompile whenever an import could be
 	// bound cross-instance (any function import), or codegen was deferred.
 	if needsLink || importedFuncs > 0 {
-		c.wasmBytes = append([]byte(nil), wasmBytes...)
+		c.wasmBytes = wasmBytes
 	}
 	// Any module with function imports may need a host-only sync recompile at
 	// Instantiate (deferred returning/v128 imports, or non-legacy host bindings),
@@ -369,6 +376,16 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	return installCompiledFinalizer(c), nil
 }
 
+func compileMemoryPressure(sourceBytes int) (int, func()) {
+	// One checkpoint is enough to prevent dead per-function state from riding the
+	// GC growth curve to the end of real-world modules. Small modules stay on the
+	// zero-overhead path. runtime.GC does not modify GOGC or GOMEMLIMIT.
+	if sourceBytes < 8<<20 {
+		return 0, nil
+	}
+	return 0, goruntime.GC
+}
+
 // moduleNeedsLink reports whether the module has a returning function import,
 // which the host log-and-replay model cannot satisfy: it must be bound to
 // another instance's function at Instantiate, so codegen is deferred to the
@@ -578,7 +595,8 @@ func (c *Compiled) recompileLinked(imports Imports, bindings []railshotImportBin
 			syncHost = true
 		}
 	}
-	cm, err := railshotCompileModuleWith(m, railshotCompileOptions{ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noDeferBounds, ImportBindings: bindings, SyncHostCalls: syncHost, Interruptible: true})
+	pressureAt, pressure := compileMemoryPressure(len(c.wasmBytes))
+	cm, err := railshotCompileModuleWith(m, railshotCompileOptions{ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noDeferBounds, ImportBindings: bindings, SyncHostCalls: syncHost, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
 	if err != nil {
 		return nil, fmt.Errorf("link: %w", err)
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -342,6 +342,16 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 		// index space. Active slots remain zero-length (dropped).
 		c.PassiveData = make([]PassiveDataInit, dataStateCount)
 	}
+	// Active data dominates metadata in Go-produced modules (esbuild has tens of
+	// thousands of segments). Reserve once instead of geometrically copying the
+	// growing descriptor slice.
+	activeData := 0
+	for i := range m.Data {
+		if m.Data[i].Mode.Kind != wasm.DataPassive {
+			activeData++
+		}
+	}
+	c.Data = make([]DataInit, 0, activeData)
 	for i := range m.Data {
 		d := &m.Data[i]
 		if d.Mode.Kind == wasm.DataPassive {

--- a/src/wago/compile_ownership_test.go
+++ b/src/wago/compile_ownership_test.go
@@ -1,0 +1,26 @@
+package wago
+
+import "testing"
+
+func TestCompileRetainsTransferredSourceWithoutCopy(t *testing.T) {
+	source := returningImportModule([]byte{0x60, 0x00, 0x01, 0x7f}, []byte{0x00, 0x10, 0x00, 0x0b})
+	compiled, err := Compile(nil, source)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if len(compiled.wasmBytes) != len(source) {
+		t.Fatalf("retained source length = %d, want %d", len(compiled.wasmBytes), len(source))
+	}
+	if len(source) > 0 && &compiled.wasmBytes[0] != &source[0] {
+		t.Fatal("Compile copied transferred source")
+	}
+}
+
+func TestCompileMemoryPressureOnlyForLargeSources(t *testing.T) {
+	if at, pressure := compileMemoryPressure((8 << 20) - 1); at != 0 || pressure != nil {
+		t.Fatalf("small source pressure = (%d, %v), want disabled", at, pressure != nil)
+	}
+	if at, pressure := compileMemoryPressure(8 << 20); at != 0 || pressure == nil {
+		t.Fatalf("large source pressure = (%d, %v), want (auto, enabled)", at, pressure != nil)
+	}
+}

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -236,8 +236,10 @@ func (c *RuntimeConfig) DeferBoundsChecks() bool { return !c.noDeferBounds }
 // MemoryLimitPages reports the configured maximum linear-memory size in pages.
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }
 
-// Compile decodes, validates, and compiles wasmBytes under this config. It is the
-// fluent form of Compile(c, wasmBytes):
+// Compile decodes, validates, and compiles wasmBytes under this config. On
+// success the returned Compiled owns the byte slice and the caller must not
+// mutate or reuse its backing array. It is the fluent form of Compile(c,
+// wasmBytes):
 //
 //	mod, err := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksSignalsBased).Compile(b)
 func (c *RuntimeConfig) Compile(wasmBytes []byte) (*Compiled, error) {

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -602,9 +602,10 @@ type Compiled struct {
 	tableImportMax    int
 	tableImportHasMax bool
 
-	// wasmBytes retains the raw module for the link-time recompile that lowers
-	// cross-instance calls (set only when the module has function imports, the
-	// recompile candidates). needsLink marks a module whose codegen was deferred
+	// wasmBytes retains the caller-transferred raw module for the link-time
+	// recompile that lowers cross-instance calls (set only when the module has
+	// function imports, the recompile candidates). needsLink marks a module whose
+	// codegen was deferred
 	// because it has a returning import that must be bound to another instance's
 	// function at Instantiate; its Code/Entry are empty until then.
 	wasmBytes        []byte


### PR DESCRIPTION
## Summary

- keep the frontend and Railshot whole-module rather than introducing a streaming compiler
- reuse per-function compiler scratch and flat hint storage, precompute module-wide call facts, and reduce call/control/stack allocation churn
- move shared backend capacity and import-binding helpers into the Railshot shared package
- taper native-code reservations and run one late memory-pressure checkpoint for source modules at least 8 MiB, without changing process-wide `GOGC` or `GOMEMLIMIT`
- transfer ownership of the input Wasm bytes on successful `Compile`, removing the retained link-time source copy

## Why

Large real-world modules were dominated by geometric native-code growth, repeated per-function hint/call allocations, and a duplicate retained Wasm source. These objects pushed peak RSS substantially above the live native-code and source footprint.

After this change, the main live contributor is the compiled native-code buffer itself, followed by the retained Wasm input.

## Breaking change

A successful `Compile`, `CompileWithConfig`, or `RuntimeConfig.Compile` call now takes ownership of the supplied byte slice. Callers must not mutate or reuse its backing array while the returned `Compiled` object is alive.

## Measurements

Apple M4 Max, darwin/arm64, explicit bounds, one compile per sample:

| corpus/stage | main B/op | this PR B/op | reduction |
|---|---:|---:|---:|
| Railshot / sqlite3 | 45,528,608 | 8,042,024 | 82.3% |
| Railshot / ruby | 558,089,848 | 70,789,544 | 87.3% |
| Railshot / esbuild | 522,828,072 | 61,481,080 | 88.2% |
| full compile / sqlite3 | 50,363,176 | 13,972,520 | 72.3% |
| full compile / ruby | 587,471,976 | 80,459,008 | 86.3% |
| full compile / esbuild | 572,585,912 | 77,350,592 | 86.5% |

Standalone public-`Compile` harness:

- Ruby: median peak RSS 101,941,248 bytes; median wall time 1.11 s
- esbuild: median peak RSS 93,913,088 bytes; median wall time 0.75 s

## Validation

- `make test`
- `WAGO_CORPUS_TIMEOUT=20s make test-corpus`
- `make tinygo-test`
- `tinygo test ./src/core/compiler/codegen ./src/core/compiler/ir ./src/core/encoder/amd64 ./src/core/encoder/arm64`
- Linux/amd64 Railshot test binary cross-compiles
- native ARM64 backend/runtime/public API tests pass

Known baseline issues remain unchanged:

- `make lint` fails because `testing.Chdir` requires Go 1.24 while the module declares Go 1.22
- the combined guard-page snapshot target fails because signals-based compiled modules are intentionally not serializable/snapshot-compatible yet
