### PR TITLE
wasm: parallelize function validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,10 +108,12 @@ so the public package stays clean.
 - `validate.go` / `validate_ops.go` enforce the wasm type rules: a structured
   operand-stack/control-frame validator that type-checks every opcode and
   rejects malformed or ill-typed modules before any code is emitted.
-- Module declarations and constant expressions validate serially. With function
-  workers enabled, independent bodies use worker-local stacks/readers while
-  sharing a frozen read-only type cache; errors are selected by lowest function
-  index so diagnostics match serial validation.
+- Module declarations and constant expressions, including element initializers,
+  validate serially. With function workers enabled, independent bodies use
+  worker-local stacks/readers. Shared module/element metadata is immutable, the
+  type cache is frozen, and `table.init` reads only the validated element type;
+  errors are selected by lowest function index so diagnostics match serial
+  validation.
 - Unsupported value types and opcodes are rejected explicitly rather than
   silently accepted — correctness and explicit failure come first.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,8 +68,10 @@ backend codegen.
 `Compile` (in `src/wago/api.go`) runs decode → validate → backend codegen and
 returns a `*Compiled`: machine code plus the instantiate-time metadata
 (signatures, imports/exports, globals, element/data segments, table size).
-`Instantiate` turns a `*Compiled` into a runnable `*Instance`. `Invoke` calls an
-exported function.
+Validation and codegen can use the same bounded per-module function-worker policy;
+module-wide analysis remains serial, and final errors/code layout remain ordered by
+function index. `Instantiate` turns a `*Compiled` into a runnable `*Instance`.
+`Invoke` calls an exported function.
 
 ---
 
@@ -79,7 +81,7 @@ exported function.
 src/wago/                         public API implementation (package wago)
 wago.go                           generated root facade (re-exports src/wago)
 internal/genfacade/               generator for wago.go (+ up-to-date test)
-cli/wago/                         CLI: run; compile/profile/validate are stubs
+cli/wago/                         CLI entry point and command implementation
 src/core/compiler/wasm/           decoder + validator (front end)
 src/core/compiler/backend/railshot/  direct native codegen (Valent-Block)
   amd64/                            x86-64 selection, registers, ABI, encoding
@@ -106,6 +108,10 @@ so the public package stays clean.
 - `validate.go` / `validate_ops.go` enforce the wasm type rules: a structured
   operand-stack/control-frame validator that type-checks every opcode and
   rejects malformed or ill-typed modules before any code is emitted.
+- Module declarations and constant expressions validate serially. With function
+  workers enabled, independent bodies use worker-local stacks/readers while
+  sharing a frozen read-only type cache; errors are selected by lowest function
+  index so diagnostics match serial validation.
 - Unsupported value types and opcodes are rejected explicitly rather than
   silently accepted — correctness and explicit failure come first.
 
@@ -137,9 +143,12 @@ registers just in time. At control-flow joins the machine state is flushed to
 deterministic frame slots so every incoming edge agrees on register/stack state.
 
 The decoded module and complete function bodies remain available throughout
-compilation. Railshot reuses module-scoped scratch arenas between functions and
-pre-sizes retained output, reducing transient heap growth without imposing a
-streaming or borrowed-buffer lifetime on analysis and optimization code.
+compilation. Railshot reuses module-scoped scratch arenas between functions on
+the serial path. With function workers enabled, module-wide decisions finish
+first, each worker owns private scratch and an append-only code arena, and the
+results are joined and relocated in original function order. This reduces
+one-module latency without making code layout or serialized output depend on
+scheduling.
 
 The net effect: straight-line code emits essentially no per-operation stack
 traffic. `valent_test.go`'s `TestRegisterResident` disassembles a straight-line

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,8 +141,10 @@ go test -bench .
 
 For changes that affect parsing, validation, codegen, instantiation, memory, or
 host-call logging, also test a larger or more adversarial input than the happy
-path fixture. The goal is to catch behavior that is technically correct on small
-modules but falls over with:
+path fixture. Function-worker changes should include `BenchmarkValidateWorkers`
+and/or `BenchmarkCompileFullWorkers` at fixed `GOMAXPROCS`, with serial and
+parallel allocation counts. The goal is to catch behavior that is technically
+correct on small modules but falls over with:
 
 - many functions, locals, params, results, blocks, or table entries
 - large active data or element segments

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -53,6 +53,7 @@ Later proposals and engine/platform capabilities beyond the MVP.
 | Branch hinting (`metadata.code.branch_hint`) | ✓ | ✅ done: the current code-metadata wire format is decoded strictly (unique/pre-code section, ordered function/offset vectors, one-byte payload, and only `if`/`br_if` targets). ARM64 railshot uses `if` likelihood to weight local/global pinning and defers non-empty unlikely `br_if` reconciliation into cold target fragments. |
 | Threads & atomics | ✓ | ⬜ planned |
 | Synchronous host-import results | ✓ | ✅ done |
+| Bounded function-pipeline parallelism | ✓ | ✅ done: validation and native codegen share one deterministic serial/adaptive/forced worker policy. The default is serial; `WithFunctionWorkers(0)` and CLI `-p` select adaptive mode, while explicit maxima remain capped by `GOMAXPROCS` and local-function count. |
 | Cooperative invocation cancellation | ✓ | 🚧 partial — ARM64 `Instance.Call(ctx, ...)` interrupts native execution at function entries and loop headers; amd64 currently honors cancellation before entry only. |
 | Architectures beyond linux/amd64 (arm64, macOS, Windows) | ✓ | 🚧 partial — Linux/arm64 and Darwin/arm64 have native CI for the encoder, backend, runtime/API, explicit and signal-backed guard-page bounds, and corpus correctness. ARM64 reference globals and heterogeneous indexed tables execute; amd64 cancellation polling and Windows remain planned. |
 | Multi-memory | ✗ | ❌ not planned |

--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -80,7 +80,11 @@ truncation + trunc_sat, start function, multi-value, imported/mutable globals.
 `scanBody` instruction walk is used only for programmatically constructed modules that
 provide decoded instructions; normal decoded modules use BodyBytes and first-N pinning.
 Validation is byte-backed and no-body too (#96: type-cache + validator/reader reuse,
-validation allocs −90%).
+validation allocs −90%). The opt-in [function-worker policy](docs/function-workers.md)
+now applies to both validation and codegen: module-wide work remains serial, function
+bodies fan out with worker-local state, and results/errors rejoin deterministically.
+At p4, validation improved 58–72% on the representative medium/large corpus while
+keeping serial allocation counts unchanged.
 
 **Landed since the #87/#88 sweep (2026-07-02 → 07-03)**
 - **Borrowed reads for value-pinned globals** (`stGlobReg`, #93) and

--- a/README.md
+++ b/README.md
@@ -644,8 +644,8 @@ using TinyGo; see the TinyGo doc for the foreign-stack and GC rationale.
 | `WAGO_NO_BOUNDS_FACTS=1` | Disable deferred bounds-check facts globally. |
 | `RuntimeConfig.WithFeature` | Accept or reject individual wasm feature families. |
 | `RuntimeConfig.WithMemoryLimitPages` | Cap declared linear memory in 64 KiB wasm pages. |
-| `RuntimeConfig.WithCompileWorkers` | Select serial (`1`), adaptive (`0`), or a forced worker maximum. |
-| `wago run -p[workers]` | Enable adaptive compile parallelism (`-p`) or force a maximum (`-p8`, `-p 8`). |
+| `RuntimeConfig.WithCompileWorkers` | Select serial (`1`), adaptive (`0`), or a forced worker maximum for function validation and codegen. |
+| `wago run -p[workers]` | Enable adaptive validation/compile parallelism (`-p`) or force a maximum (`-p8`, `-p 8`). |
 
 Guard-page mode is faster on memory-heavy modules but installs process-wide signal
 handlers and must be selected deliberately in builds that include it.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [Startup latency](#startup-latency)
   - [Binary size](#binary-size)
   - [Performance tuning](#performance-tuning)
+  - [Function workers](#function-workers)
   - [Running benchmarks locally](#running-benchmarks-locally)
 - [Configuration](#configuration)
 - [Debugging](#debugging)
@@ -115,6 +116,7 @@ The high-level project docs live in this repo:
 - [OPTIMIZATIONS.md](OPTIMIZATIONS.md) — current and planned codegen work.
 - [docs/plugin-api-v2.md](docs/plugin-api-v2.md) — capability-based plugin architecture.
 - [docs/wago-json.md](docs/wago-json.md) — manifest and schema reference.
+- [docs/function-workers.md](docs/function-workers.md) — parallel validation/codegen policy and tradeoffs.
 - [examples/README.md](examples/README.md) — runnable Go API examples.
 - [bench/README.md](bench/README.md) — benchmark corpus and publishing flow.
 
@@ -138,9 +140,9 @@ suffix when the default parser is not enough:
 wago run -e hypot tests/testdata/fprog.wasm 3:f64 4:f64
 ```
 
-Compilation is serial by default. Use `-p` for adaptive per-function compile
-parallelism, or specify a worker maximum with the standard separated form or the
-short joined form:
+Function validation and codegen are serial by default. Use `-p` for adaptive
+per-function parallelism, or specify a worker maximum with the standard
+separated form or the short joined form:
 
 ```bash
 wago run -p app.wasm          # adaptive policy
@@ -149,10 +151,11 @@ wago run -p8 app.wasm         # equivalent shorthand
 wago run --parallel=8 app.wasm
 ```
 
-Validate without executing:
+Validate without executing; the same worker flag is available:
 
 ```bash
 wago validate tests/testdata/fib.wasm
+wago validate -p tests/testdata/large.wasm
 ```
 
 `wago build` is reserved for the future `.wago` product path and currently
@@ -644,11 +647,27 @@ using TinyGo; see the TinyGo doc for the foreign-stack and GC rationale.
 | `WAGO_NO_BOUNDS_FACTS=1` | Disable deferred bounds-check facts globally. |
 | `RuntimeConfig.WithFeature` | Accept or reject individual wasm feature families. |
 | `RuntimeConfig.WithMemoryLimitPages` | Cap declared linear memory in 64 KiB wasm pages. |
-| `RuntimeConfig.WithCompileWorkers` | Select serial (`1`), adaptive (`0`), or a forced worker maximum for function validation and codegen. |
+| `RuntimeConfig.WithFunctionWorkers` | Select serial (`1`), adaptive (`0`), or a forced worker maximum for function validation and codegen. |
 | `wago run -p[workers]` | Enable adaptive validation/compile parallelism (`-p`) or force a maximum (`-p8`, `-p 8`). |
+| `wago validate -p[workers]` | Apply the same worker policy to validation-only workflows. |
 
 Guard-page mode is faster on memory-heavy modules but installs process-wide signal
 handlers and must be selected deliberately in builds that include it.
+
+### Function workers
+
+Function workers parallelize independent wasm function validation and native
+code generation while keeping module-level analysis serial and deterministic.
+The default is one worker. Use `WithFunctionWorkers(0)` or CLI `-p` for the
+measured adaptive policy; forced values are capped by `GOMAXPROCS` and the local
+function count. Adaptive mode keeps small modules serial and uses at most four
+workers for larger modules.
+
+Parallelism trades bounded transient memory and CPU for lower one-module startup
+latency. It is best suited to CLI/build-style workloads; memory-constrained or
+highly concurrent services should retain the serial default unless benchmarks
+justify otherwise. See [docs/function-workers.md](docs/function-workers.md) for
+policy, determinism, CLI forms, and measurements.
 
 ### Running benchmarks locally
 
@@ -701,7 +720,8 @@ Wago's runtime config is immutable. Every `WithXxx` method returns a copy:
 ```go
 cfg := wago.NewRuntimeConfig().
 	WithFeature(wago.CoreFeatureBulkMemoryOperations, false).
-	WithMemoryLimitPages(256)
+	WithMemoryLimitPages(256).
+	WithFunctionWorkers(0) // adaptive validation + codegen
 
 if wago.GuardPageSupported() {
 	cfg = cfg.WithBoundsChecks(wago.BoundsChecksSignalsBased)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,8 @@ in full — 57/57 applicable files, 0 failing assertions (see [SPECTEST.md](SPEC
 - [x] Binary decoder for all sections; byte-backed `DecodeModule` (function bodies
   stay raw bytes, not materialized AST)
 - [x] Full validator (operand/control stack typing), byte-backed and differential-tested
-  against the official spec testsuite
+  against the official spec testsuite; independent function bodies support bounded,
+  deterministic parallel validation through the function-worker policy
 
 **Compiler backend (`src/core/compiler/backend/railshot`)**
 - [x] Single-pass x86-64 codegen with the WARP Valent-Block register allocator
@@ -45,6 +46,8 @@ in full — 57/57 applicable files, 0 failing assertions (see [SPECTEST.md](SPEC
   `HostFunc` replay, host functions usable as table funcrefs)
 - [x] `select` / `select t`; active element and data segment initialization; `start`
 - [x] Hotness-aware local pinning + value-pinned/module-pinned hot globals
+- [x] Bounded parallel function codegen with worker-local scratch/arenas and
+  deterministic ordered assembly, sharing one policy with function validation
 
 **Runtime (`src/core/runtime`)**
 - [x] No-cgo execution: W^X `mmap`, foreign-stack trampoline, `g` preservation,
@@ -55,11 +58,14 @@ in full — 57/57 applicable files, 0 failing assertions (see [SPECTEST.md](SPEC
 
 **Tooling**
 - [x] `wago` CLI: `run` / `validate` / `version`, typed args
-- [x] Public API: `Run`/`RunValues`, `Compile`/`Compiled`, `Instance`
+- [x] Public API: `Run`/`RunValues`, `Compile`/`Compiled`, `Instance`, plus
+  opt-in serial/adaptive/forced function-worker policy for validation and codegen
 - [x] Workers plugin: the separate `github.com/wago-org/workers` extension
   owns a transactional worker service with bounded copied tagged delivery,
   cooperative kill, neutral exit events, and creator-authorized lifetime links;
   actor/PID/mailbox/supervisor policy remains plugin-owned
+- [x] `wago run` and `wago validate` expose adaptive/forced function workers via
+  `-p`, with serial defaults for predictable memory use
 - [x] Benchmarks vs wazero (compile ~34× faster; wago wins fib_rec, sieve, memory_tree,
   linked_list, dispatch, branches, json deserialize; loses on json serialize, blake)
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -16,6 +16,8 @@ complementary suites live here:
 go test -bench . -benchmem                  # everything, raw numbers
 go test -bench '^BenchmarkCompile$' -benchmem   # one stage across the corpus
 go test -bench 'Decode|Exec' -benchmem      # a couple of stages
+go test -bench '^BenchmarkValidateWorkers' -benchmem  # validation p1/p2/p4/p8 matrix
+go test -bench '^BenchmarkCompileFullWorkers' -benchmem # public pipeline worker matrix
 go test -bench . -benchmem -wago.bench.isa  # include generated ISA micro-suite
 WAGO_BOUNDS=signals go test -tags wago_guardpage -bench '^BenchmarkExec/memory_tree\.run$' -benchmem
 make bench BENCHTIME=1x BENCH_ISA=1         # all corpora once; uses guard-page only on supported hosts
@@ -35,7 +37,8 @@ results read as `Stage/<module>`:
 | Stage | Times |
 |---|---|
 | `Decode` | wasm bytes → byte-backed `*Module` (function locals + raw BodyBytes, no production function-body AST) |
-| `Validate` | type-check a decoded module |
+| `Validate` | type-check a decoded module serially |
+| `ValidateWorkers` | type-check function bodies at forced p1/p2/p4/p8 worker counts |
 | `Compile` | native codegen for a decoded+validated module |
 | `CompileFull` | end-to-end `wago.Compile` (decode+validate+compile) |
 | `Instantiate` | instance setup for a compiled module |
@@ -161,8 +164,9 @@ go run ./cmd/validatestats -runs 30 -warmup 5         # full corpus
 go run ./cmd/validatestats -file ../tests/testdata/fib.wasm
 ```
 
-The measured path is the CLI-equivalent `wago validate <file>` flow:
-byte-backed `DecodeModule` + `ValidateModule`. It does not build or verify IR.
+The measured path is the default serial `wago validate <file>` flow:
+byte-backed `DecodeModule` + `ValidateModule`. Use `BenchmarkValidateWorkers` for
+parallel validation measurements. Neither path builds or verifies IR.
 
 `cmd/benchpub` runs the stage suite, records a **versioned** JSON run
 (`git describe` + commit + date + cpu), appends it to a rolling `history.json`,

--- a/bench/suite_test.go
+++ b/bench/suite_test.go
@@ -298,7 +298,7 @@ func BenchmarkCompileFullWorkers(b *testing.B) {
 			}{{"p1", 1}, {"p2", 2}, {"p4", 4}, {"p8", 8}, {"auto", 0}} {
 				b.Run(mode.name, func(b *testing.B) {
 					b.ReportAllocs()
-					cfg := wago.NewRuntimeConfig().WithCompileWorkers(mode.workers)
+					cfg := wago.NewRuntimeConfig().WithFunctionWorkers(mode.workers)
 					var cm *wago.Compiled
 					for i := 0; i < b.N; i++ {
 						var err error
@@ -332,7 +332,7 @@ func BenchmarkCompileMultiModuleThroughput(b *testing.B) {
 			}{{"p1", 1}, {"auto", 0}} {
 				b.Run(mode.name, func(b *testing.B) {
 					b.ReportAllocs()
-					cfg := wago.NewRuntimeConfig().WithCompileWorkers(mode.workers)
+					cfg := wago.NewRuntimeConfig().WithFunctionWorkers(mode.workers)
 					b.RunParallel(func(pb *testing.PB) {
 						for pb.Next() {
 							if _, err := wago.Compile(cfg, m.bytes); err != nil {

--- a/bench/suite_test.go
+++ b/bench/suite_test.go
@@ -180,6 +180,36 @@ func BenchmarkValidate(b *testing.B) {
 	})
 }
 
+// BenchmarkValidateWorkers measures one decoded module's validation latency at
+// forced function-worker counts. Module-level validation remains serial; only
+// independent function bodies fan out. As with BenchmarkCompileWorkers, this is
+// intra-module latency rather than multi-module throughput.
+func BenchmarkValidateWorkers(b *testing.B) {
+	wanted := map[string]bool{
+		"tiny": true, "many_funcs": true, "json-as": true,
+		"lua": true, "sqlite3": true, "ruby": true, "esbuild": true,
+	}
+	for _, m := range loadCorpus(b) {
+		if !m.supports("Validate") || !wanted[m.name()] {
+			continue
+		}
+		mod := m.decoded(b)
+		b.Run(m.name(), func(b *testing.B) {
+			for _, workers := range []int{1, 2, 4, 8} {
+				b.Run(fmt.Sprintf("p%d", workers), func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if err := wasm.ValidateModuleWithWorkers(mod, workers); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
 // BenchmarkCompile times native codegen for an already decoded+validated module.
 func BenchmarkCompile(b *testing.B) {
 	eachModule(b, "Compile", func(b *testing.B, m corpusModule) {

--- a/cli/wagocli/cmd_meta.go
+++ b/cli/wagocli/cmd_meta.go
@@ -42,7 +42,7 @@ func validateCommand() *Cmd {
 		Summary:   "decode and validate a module",
 		Args:      "<file>",
 		Flags:     flags,
-		Normalize: func(args []string) ([]string, error) { return normalizeParallelArgs(args, flags) },
+		Normalize: func(args []string) ([]string, error) { return normalizeParallelArgs(args, flags, false) },
 		Long:      "Use -p for adaptive parallel function validation, or -p8 / -p 8 / --parallel=8 to force a worker maximum.",
 		Run: func(c *Ctx) {
 			file := singleFileArg("validate", c.Args)

--- a/cli/wagocli/cmd_meta.go
+++ b/cli/wagocli/cmd_meta.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/wago-org/wago"
+	"github.com/wago-org/wago/internal/functionworkers"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
@@ -35,18 +36,26 @@ func buildCommand() *Cmd {
 
 // validateCommand decodes and validates a module without running it.
 func validateCommand() *Cmd {
+	flags := []Flag{parallelFlag()}
 	return &Cmd{
-		Name:    "validate",
-		Summary: "decode and validate a module",
-		Args:    "<file>",
+		Name:      "validate",
+		Summary:   "decode and validate a module",
+		Args:      "<file>",
+		Flags:     flags,
+		Normalize: func(args []string) ([]string, error) { return normalizeParallelArgs(args, flags) },
+		Long:      "Use -p for adaptive parallel function validation, or -p8 / -p 8 / --parallel=8 to force a worker maximum.",
 		Run: func(c *Ctx) {
 			file := singleFileArg("validate", c.Args)
 			src, err := os.ReadFile(file)
 			if err != nil {
 				fatal("%v", err)
 			}
-			if err := validateModuleBytes(src); err != nil {
+			policy, err := parallelPolicy(c.Str("parallel"))
+			if err != nil {
 				fatal("validate: %v", err)
+			}
+			if err := validateModuleBytesWithPolicy(src, policy); err != nil {
+				fatal("%v", err)
 			}
 		},
 	}
@@ -61,11 +70,20 @@ func singleFileArg(cmd string, args []string) string {
 }
 
 func validateModuleBytes(src []byte) error {
+	return validateModuleBytesWithPolicy(src, 1)
+}
+
+func validateModuleBytesWithPolicy(src []byte, policy int) error {
 	m, err := wasm.DecodeModule(src)
 	if err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
-	if err := wasm.ValidateModule(m); err != nil {
+	bodyBytes := 0
+	for i := range m.Code {
+		bodyBytes += len(m.Code[i].BodyBytes)
+	}
+	workers := functionworkers.Resolve(policy, len(m.Code), bodyBytes)
+	if err := wasm.ValidateModuleWithWorkers(m, workers); err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}
 	return nil

--- a/cli/wagocli/cmd_run.go
+++ b/cli/wagocli/cmd_run.go
@@ -18,7 +18,7 @@ func runCommand() *Cmd {
 		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
 		{Name: "plugin", Arg: "<names>", Help: "comma-separated extra plugins to enable, on top of wago.json (see: wago plugin list)"},
 		{Name: "bounds", Arg: "<mode>", Help: "bounds checks: defer (default) | all"},
-		{Name: "parallel", Short: "p", Arg: "[workers]", Help: "parallel function validation and compilation; omit workers for adaptive mode"},
+		parallelFlag(),
 	}, optKnobFlags()...)
 	return &Cmd{
 		Name:        "run",
@@ -26,7 +26,7 @@ func runCommand() *Cmd {
 		Args:        "<file> [args...]",
 		PassThrough: true,
 		Normalize: func(args []string) ([]string, error) {
-			return normalizeRunParallelArgs(args, flags)
+			return normalizeParallelArgs(args, flags)
 		},
 		Flags: flags,
 		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
@@ -37,13 +37,16 @@ func runCommand() *Cmd {
 	}
 }
 
-// normalizeRunParallelArgs accepts the standard separated/equal forms plus the
-// convenient joined form requested by the CLI: -p, -p8, -p 8, -p=8,
-// --parallel, and --parallel=8. Bare -p/--parallel means adaptive mode. Parsing
-// stops at the wasm file so a guest's own -p argument remains untouched. Values
-// belonging to earlier value-taking flags are skipped according to the same Flag
-// table used by parse, so they cannot be mistaken for the file boundary.
-func normalizeRunParallelArgs(args []string, flags []Flag) ([]string, error) {
+func parallelFlag() Flag {
+	return Flag{Name: "parallel", Short: "p", Arg: "[workers]", Help: "parallel function validation and compilation; omit workers for adaptive mode"}
+}
+
+// normalizeParallelArgs accepts -p, -p8, -p 8, -p=8, --parallel, and
+// --parallel=8. Bare -p/--parallel means adaptive mode. Parsing stops at the
+// first positional so run can pass later flags to the guest and validate can
+// treat the module path as the end of options. Values belonging to earlier
+// value-taking flags are skipped according to the same Flag table used by parse.
+func normalizeParallelArgs(args []string, flags []Flag) ([]string, error) {
 	valueFlags := make(map[string]struct{}, len(flags)*2)
 	for _, flag := range flags {
 		if flag.Bool || flag.Name == "parallel" {
@@ -103,18 +106,26 @@ func runConfig(bounds, parallel string) (*wago.RuntimeConfig, error) {
 	default:
 		return nil, fmt.Errorf("unknown --bounds %q (want: defer, all)", bounds)
 	}
+	workers, err := parallelPolicy(parallel)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.WithFunctionWorkers(workers), nil
+}
+
+func parallelPolicy(parallel string) (int, error) {
 	switch parallel {
-	case "": // default remains serial
+	case "":
+		return 1, nil
 	case "auto":
-		cfg = cfg.WithCompileWorkers(0)
+		return 0, nil
 	default:
 		workers, err := strconv.Atoi(parallel)
 		if err != nil || workers < 0 {
-			return nil, fmt.Errorf("invalid parallelism %q (want: -p, or a non-negative worker count)", parallel)
+			return 0, fmt.Errorf("invalid parallelism %q (want: -p, or a non-negative worker count)", parallel)
 		}
-		cfg = cfg.WithCompileWorkers(workers)
+		return workers, nil
 	}
-	return cfg, nil
 }
 
 func runExec(c *Ctx) {

--- a/cli/wagocli/cmd_run.go
+++ b/cli/wagocli/cmd_run.go
@@ -18,7 +18,7 @@ func runCommand() *Cmd {
 		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
 		{Name: "plugin", Arg: "<names>", Help: "comma-separated extra plugins to enable, on top of wago.json (see: wago plugin list)"},
 		{Name: "bounds", Arg: "<mode>", Help: "bounds checks: defer (default) | all"},
-		{Name: "parallel", Short: "p", Arg: "[workers]", Help: "parallel function compilation; omit workers for adaptive mode"},
+		{Name: "parallel", Short: "p", Arg: "[workers]", Help: "parallel function validation and compilation; omit workers for adaptive mode"},
 	}, optKnobFlags()...)
 	return &Cmd{
 		Name:        "run",
@@ -31,7 +31,7 @@ func runCommand() *Cmd {
 		Flags: flags,
 		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
 			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64\n" +
-			"Use -p for adaptive compile parallelism, or -p8 / -p 8 / --parallel=8 to\n" +
+			"Use -p for adaptive validation/compile parallelism, or -p8 / -p 8 / --parallel=8 to\n" +
 			"force a worker maximum. Optimization knobs: see `wago opts`.",
 		Run: runExec,
 	}

--- a/cli/wagocli/cmd_run.go
+++ b/cli/wagocli/cmd_run.go
@@ -26,7 +26,7 @@ func runCommand() *Cmd {
 		Args:        "<file> [args...]",
 		PassThrough: true,
 		Normalize: func(args []string) ([]string, error) {
-			return normalizeParallelArgs(args, flags)
+			return normalizeParallelArgs(args, flags, true)
 		},
 		Flags: flags,
 		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
@@ -42,11 +42,12 @@ func parallelFlag() Flag {
 }
 
 // normalizeParallelArgs accepts -p, -p8, -p 8, -p=8, --parallel, and
-// --parallel=8. Bare -p/--parallel means adaptive mode. Parsing stops at the
-// first positional so run can pass later flags to the guest and validate can
-// treat the module path as the end of options. Values belonging to earlier
-// value-taking flags are skipped according to the same Flag table used by parse.
-func normalizeParallelArgs(args []string, flags []Flag) ([]string, error) {
+// --parallel=8. Bare -p/--parallel means adaptive mode. Run stops at the first
+// positional so later flags reach the guest; validate scans after its module
+// path because ordinary command flags may follow positionals. A -- terminator
+// always stops normalization. Values belonging to earlier value-taking flags
+// are skipped according to the same Flag table used by parse.
+func normalizeParallelArgs(args []string, flags []Flag, stopAtPositional bool) ([]string, error) {
 	valueFlags := make(map[string]struct{}, len(flags)*2)
 	for _, flag := range flags {
 		if flag.Bool || flag.Name == "parallel" {
@@ -61,9 +62,17 @@ func normalizeParallelArgs(args []string, flags []Flag) ([]string, error) {
 	out := make([]string, 0, len(args)+1)
 	for i := 0; i < len(args); i++ {
 		a := args[i]
-		if a == "--" || a == "-" || a == "" || a[0] != '-' {
+		if a == "--" {
 			out = append(out, args[i:]...)
 			return out, nil
+		}
+		if a == "-" || a == "" || a[0] != '-' {
+			out = append(out, a)
+			if stopAtPositional {
+				out = append(out, args[i+1:]...)
+				return out, nil
+			}
+			continue
 		}
 		switch a {
 		case "-p", "--parallel":

--- a/cli/wagocli/cmd_run_test.go
+++ b/cli/wagocli/cmd_run_test.go
@@ -128,29 +128,49 @@ func TestRunParallelFlagForms(t *testing.T) {
 func TestValidateParallelFlagForms(t *testing.T) {
 	cmd := validateCommand()
 	for _, tc := range []struct {
+		name string
 		args []string
 		want string
 	}{
-		{args: []string{"module.wasm"}},
-		{args: []string{"-p", "module.wasm"}, want: "auto"},
-		{args: []string{"-p8", "module.wasm"}, want: "8"},
-		{args: []string{"-p", "8", "module.wasm"}, want: "8"},
-		{args: []string{"--parallel=4", "module.wasm"}, want: "4"},
+		{name: "none", args: []string{"module.wasm"}},
+		{name: "bare before", args: []string{"-p", "module.wasm"}, want: "auto"},
+		{name: "joined before", args: []string{"-p8", "module.wasm"}, want: "8"},
+		{name: "separated before", args: []string{"-p", "8", "module.wasm"}, want: "8"},
+		{name: "long before", args: []string{"--parallel=4", "module.wasm"}, want: "4"},
+		{name: "bare after", args: []string{"module.wasm", "-p"}, want: "auto"},
+		{name: "joined after", args: []string{"module.wasm", "-p8"}, want: "8"},
+		{name: "separated after", args: []string{"module.wasm", "-p", "8"}, want: "8"},
+		{name: "long bare after", args: []string{"module.wasm", "--parallel"}, want: "auto"},
+		{name: "long after", args: []string{"module.wasm", "--parallel=4"}, want: "4"},
 	} {
-		args, err := cmd.Normalize(tc.args)
-		if err != nil {
-			t.Fatal(err)
-		}
-		ctx, err := cmd.parse("wago validate", args)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got := ctx.Str("parallel"); got != tc.want {
-			t.Fatalf("args=%v parallel=%q, want %q", tc.args, got, tc.want)
-		}
-		if len(ctx.Args) != 1 || ctx.Args[0] != "module.wasm" {
-			t.Fatalf("args=%v positionals=%v", tc.args, ctx.Args)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := cmd.Normalize(tc.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, err := cmd.parse("wago validate", args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := ctx.Str("parallel"); got != tc.want {
+				t.Fatalf("args=%v parallel=%q, want %q", tc.args, got, tc.want)
+			}
+			if len(ctx.Args) != 1 || ctx.Args[0] != "module.wasm" {
+				t.Fatalf("args=%v positionals=%v", tc.args, ctx.Args)
+			}
+		})
+	}
+
+	args, err := cmd.Normalize([]string{"module.wasm", "--", "-p8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, err := cmd.parse("wago validate", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.Str("parallel") != "" || len(ctx.Args) != 2 || ctx.Args[1] != "-p8" {
+		t.Fatalf("terminator did not preserve -p8: parallel=%q args=%v", ctx.Str("parallel"), ctx.Args)
 	}
 }
 

--- a/cli/wagocli/cmd_run_test.go
+++ b/cli/wagocli/cmd_run_test.go
@@ -125,6 +125,35 @@ func TestRunParallelFlagForms(t *testing.T) {
 	}
 }
 
+func TestValidateParallelFlagForms(t *testing.T) {
+	cmd := validateCommand()
+	for _, tc := range []struct {
+		args []string
+		want string
+	}{
+		{args: []string{"module.wasm"}},
+		{args: []string{"-p", "module.wasm"}, want: "auto"},
+		{args: []string{"-p8", "module.wasm"}, want: "8"},
+		{args: []string{"-p", "8", "module.wasm"}, want: "8"},
+		{args: []string{"--parallel=4", "module.wasm"}, want: "4"},
+	} {
+		args, err := cmd.Normalize(tc.args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, err := cmd.parse("wago validate", args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := ctx.Str("parallel"); got != tc.want {
+			t.Fatalf("args=%v parallel=%q, want %q", tc.args, got, tc.want)
+		}
+		if len(ctx.Args) != 1 || ctx.Args[0] != "module.wasm" {
+			t.Fatalf("args=%v positionals=%v", tc.args, ctx.Args)
+		}
+	}
+}
+
 func TestRunConfigParallelism(t *testing.T) {
 	for _, tc := range []struct {
 		parallel string
@@ -140,7 +169,7 @@ func TestRunConfigParallelism(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parallel %q: %v", tc.parallel, err)
 		}
-		if got := cfg.CompileWorkers(); got != tc.want {
+		if got := cfg.FunctionWorkers(); got != tc.want {
 			t.Fatalf("parallel %q workers = %d, want %d", tc.parallel, got, tc.want)
 		}
 	}

--- a/cli/wagocli/main_test.go
+++ b/cli/wagocli/main_test.go
@@ -173,7 +173,19 @@ func TestRunHelpCollapsesBooleanPairs(t *testing.T) {
 		t.Fatalf("run help did not collapse optimization pair:\n%s", b)
 	}
 	if !strings.Contains(text, "--parallel, -p [workers]") || !strings.Contains(text, "-p8 / -p 8 / --parallel=8") {
-		t.Fatalf("run help did not document compile parallelism:\n%s", b)
+		t.Fatalf("run help did not document function parallelism:\n%s", b)
+	}
+
+	f, err = os.CreateTemp(t.TempDir(), "validate-help-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateCommand().printHelp(f, "wago validate")
+	f.Close()
+	b, _ = os.ReadFile(f.Name())
+	text = string(b)
+	if !strings.Contains(text, "--parallel, -p [workers]") || !strings.Contains(text, "parallel function validation") {
+		t.Fatalf("validate help did not document function parallelism:\n%s", b)
 	}
 }
 

--- a/docs/function-workers.md
+++ b/docs/function-workers.md
@@ -1,0 +1,105 @@
+# Function workers
+
+Wago can validate and compile independent WebAssembly functions concurrently.
+The feature is opt-in: the default remains one worker so library users get the
+smallest and most predictable memory footprint.
+
+## Go API
+
+Configure the policy on `RuntimeConfig`:
+
+```go
+cfg := wago.NewRuntimeConfig().WithFunctionWorkers(0) // adaptive
+compiled, err := cfg.Compile(wasmBytes)
+```
+
+The policy values are:
+
+| Value | Behavior |
+|---:|---|
+| `0` | Adaptive: serial for small modules, up to four workers for larger modules. |
+| `1` | Serial validation and code generation; this is the default. |
+| `N > 1` | Force a maximum of N workers. |
+
+The effective count is always capped by `GOMAXPROCS` and the number of locally
+defined functions. `FunctionWorkers()` reports the configured policy, not the
+effective count for a particular module.
+
+`WithCompileWorkers` and `CompileWorkers` remain as deprecated source-compatible
+aliases. New code should use `WithFunctionWorkers` and `FunctionWorkers`, because
+the policy covers validation as well as native code generation.
+
+## CLI
+
+Both compilation through `run` and validation-only workflows accept the same
+flag forms:
+
+```sh
+wago run -p module.wasm                 # adaptive
+wago run -p8 module.wasm                # force at most 8
+wago run -p 8 module.wasm
+wago run --parallel=8 module.wasm
+
+wago validate -p module.wasm
+wago validate -p4 module.wasm
+```
+
+Flags after the module passed to `wago run` remain guest arguments and are not
+consumed by Wago.
+
+## Adaptive policy
+
+Adaptive mode uses a bounded work score:
+
+```text
+score = total function-body bytes + 64 * local function count
+score < 16 KiB: serial
+otherwise:       at most 4 workers
+```
+
+This keeps tiny modules on the allocation-minimal serial path. Four workers are
+the adaptive ceiling because eight workers improve latency further on the
+largest modules but consume more CPU and transient memory without consistently
+improving end-to-end or multi-module throughput.
+
+## Execution model
+
+Module declarations are validated serially before workers start. This includes
+types, imports, tables, memories, globals, constant expressions, exports,
+elements, data segments, and the start declaration. Only function bodies fan
+out.
+
+Each validation worker owns its operand/control stacks, byte reader, and decoded
+immediate scratch. The module's resolved type cache is populated and frozen
+before parallel validation, so workers only read shared state. If multiple
+functions are invalid, Wago reports the lowest function index, matching serial
+validation regardless of completion order.
+
+Code generation follows the same bounded-worker policy. Module-wide analyses
+finish first; workers compile functions into private arenas; final machine code
+is joined in original function order. Generated output and serialized `.wago`
+artifacts are independent of worker count.
+
+Modules whose code generation is deferred until import linking still benefit
+from parallel validation during initial compilation. Their retained worker
+policy is also reused for link-time code generation.
+
+## Performance and memory
+
+On the benchmark machine documented in
+[the validation experiment](parallel-function-validation-report.md), four-worker
+function validation reduced validation latency by 58-72% on representative
+medium and large modules, and by 34% on the 301-function `many_funcs` fixture.
+The full public compile pipeline improved by another 8-24% compared with
+parallel code generation alone.
+
+Parallel workers add bounded transient allocations for worker-local stacks and
+scratch state. Keep the default serial policy for memory-constrained or
+multi-module-throughput services unless measurements justify parallelism. Use
+adaptive mode for CLI/build-style workloads where one-module startup latency is
+the priority.
+
+Detailed measurements and reproduction commands:
+
+- [parallel function compilation experiment](parallel-function-compilation-report.md)
+- [parallel function validation experiment](parallel-function-validation-report.md)

--- a/docs/function-workers.md
+++ b/docs/function-workers.md
@@ -66,14 +66,19 @@ improving end-to-end or multi-module throughput.
 
 Module declarations are validated serially before workers start. This includes
 types, imports, tables, memories, globals, constant expressions, exports,
-elements, data segments, and the start declaration. Only function bodies fan
-out.
+elements, data segments, and the start declaration. Element initializer
+expressions are fully validated in this phase. A later function-body `table.init`
+check reads only the already-validated element segment reference type; it does
+not re-run those expressions. Only function bodies fan out.
 
 Each validation worker owns its operand/control stacks, byte reader, and decoded
-immediate scratch. The module's resolved type cache is populated and frozen
-before parallel validation, so workers only read shared state. If multiple
-functions are invalid, Wago reports the lowest function index, matching serial
-validation regardless of completion order.
+immediate scratch. Shared module and byte-backed metadata plus the declared-
+function set are immutable by worker startup. The resolved type cache is
+populated and frozen before parallel validation, and workers cannot reach the
+serial module-level constant-expression validator. Consequently every state
+accessed by workers is worker-local, immutable, or frozen. If multiple functions
+are invalid, Wago reports the lowest function index, matching serial validation
+regardless of completion order.
 
 Code generation follows the same bounded-worker policy. Module-wide analyses
 finish first; workers compile functions into private arenas; final machine code

--- a/docs/parallel-function-compilation-report.md
+++ b/docs/parallel-function-compilation-report.md
@@ -6,6 +6,10 @@ Branch: `parallel-func-comp`
 
 Baseline commit: `e774b93849df0fd66d0c4ad8def0c73a8ed7ec82`
 
+Follow-up: [Parallel function validation experiment](parallel-function-validation-report.md)
+extends the same opt-in worker policy to validation and records the additional
+end-to-end latency improvement.
+
 ## Decision
 
 **Ship the bounded worker implementation and public configuration, but keep the

--- a/docs/parallel-function-compilation-report.md
+++ b/docs/parallel-function-compilation-report.md
@@ -14,8 +14,8 @@ end-to-end latency improvement.
 
 **Ship the bounded worker implementation and public configuration, but keep the
 default serial.** Applications that prioritize one-module compile latency can opt
-into the measured adaptive policy with `WithCompileWorkers(0)` or force a maximum
-with `WithCompileWorkers(N)`. The defaults used by `NewRuntimeConfig`,
+into the measured adaptive policy with `WithFunctionWorkers(0)` or force a maximum
+with `WithFunctionWorkers(N)`. The defaults used by `NewRuntimeConfig`,
 `Compile(nil, ...)`, and `Load` when given raw wasm remain serial.
 
 Enabling parallel compilation globally by default is not justified:
@@ -83,11 +83,13 @@ candidate ordering. Both backends now sort candidates by base local with the
 generic `slices.SortFunc`, avoiding the allocation that `sort.Slice` would add to
 the serial path.
 
-Public integration:
+Public integration (renamed to the broader function-worker terminology when
+validation joined the same policy):
 
-- `WithCompileWorkers(0)`: adaptive, opt-in;
-- `WithCompileWorkers(1)`: serial;
-- `WithCompileWorkers(N)`, `N > 1`: forced maximum;
+- `WithFunctionWorkers(0)`: adaptive, opt-in;
+- `WithFunctionWorkers(1)`: serial;
+- `WithFunctionWorkers(N)`, `N > 1`: forced maximum;
+- `WithCompileWorkers` remains a deprecated source-compatible alias;
 - `wago run -p`: adaptive CLI mode;
 - `wago run -p8`, `wago run -p 8`, or `wago run --parallel=8`: forced CLI maximum;
 - negative values fail `RuntimeConfig.Validate`;
@@ -272,7 +274,7 @@ Race and correctness:
 go test -race ./src/core/compiler/backend/railshot/amd64 \
   -run 'TestCompileWorkers(Deterministic|CorpusParity)' -count=1 -timeout=0
 go test -race ./src/wago \
-  -run 'TestCompileWorkers(LinkPathAndSerialization|ForModulePolicy)' -count=1
+  -run 'TestFunctionWorkers(LinkPathAndSerialization|ForModulePolicy)' -count=1
 make test
 make test-corpus
 PATH="$PWD/.tools/wabt-1.0.41-linux-x64/bin:$PATH" make spec

--- a/docs/parallel-function-validation-report.md
+++ b/docs/parallel-function-validation-report.md
@@ -1,0 +1,166 @@
+# Parallel function validation experiment
+
+Date: 2026-07-17
+
+Branch: `experiment/parallel-function-validation`
+
+Baseline commit: `145aec3471792d8307a7f91288b38f86dd9ed730`
+
+## Decision
+
+Use the existing opt-in function-worker policy for validation as well as native
+code generation. `WithCompileWorkers(1)` and the default configuration retain the
+serial validator. `WithCompileWorkers(0)` / `wago run -p` use the existing
+adaptive module-size policy, and forced values such as `-p4` or `-p8` apply the
+same bounded worker maximum to validation and codegen.
+
+The existing adaptive threshold remains appropriate:
+
+```text
+score = total wasm function-body bytes + 64 * local function count
+score < 16 KiB: serial
+otherwise:       at most 4 workers
+always cap by GOMAXPROCS and local function count
+```
+
+Forced parallelism is intentionally not profitable for tiny modules: the tiny
+corpus module grows from about 0.82 us serial to 3.28 us with workers. Adaptive
+mode keeps that module serial. At four workers, validation itself improves 58-72%
+on the representative medium/large modules and 34% on the 301-function
+`many_funcs` scale fixture.
+
+## Environment and method
+
+- Go 1.24.4, linux/amd64
+- AMD Ryzen 7 8845HS, 8 physical / 16 logical cores
+- `GOMAXPROCS=8`
+- baseline and implementation from the same checkout and corpus
+- validation matrix: `-benchtime=500ms -count=8 -benchmem`
+- full public pipeline: `-benchtime=3x -count=6 -benchmem`
+- reported values are medians
+
+Raw captures for this experiment were written to
+`.validation/parallel-validation-2026-07-17/` and are intentionally not tracked.
+
+## Implementation
+
+Module-level validation remains serial. It validates types, imports, globals,
+constant expressions, elements, data, exports, and the start declaration before
+any worker starts. Function bodies then use a bounded worker pool:
+
+- `workers <= 1` uses the original reusable-validator serial path;
+- worker counts are capped by the local-function count (the public config also
+  caps them by `GOMAXPROCS`);
+- each worker owns one `funcValidator`, including its operand/control stacks,
+  byte reader, and decoded-immediate scratch;
+- workers claim function indexes from an atomic counter, which balances modules
+  containing a mixture of tiny wrappers and very large functions;
+- one result slot is owned by each function index;
+- errors are scanned in original function order after the join, preserving the
+  serial validator's lowest-function-index result regardless of scheduling;
+- the parallel helper is separate from the serial path, so goroutine closure and
+  worker bookkeeping do not escape into serial validation.
+
+The module validator's resolved component-type cache was the one shared mutable
+object on the body-validation path. Before workers start, every valid flat type
+index is resolved and the cache is frozen. Workers then perform concurrent
+read-only lookups. A malformed body that names an invalid type index computes the
+miss without inserting it, keeping invalid-module validation race-free.
+
+The worker-aware entry points are:
+
+- `wasm.ValidateModuleWithWorkers`;
+- `wasm.ValidateByteBackedModuleWithWorkers`;
+- `wasm.ValidateDecodedByteBackedModuleWithWorkers`.
+
+The existing serial entry points delegate with one worker.
+
+## Validation latency
+
+| module | baseline serial | p1 after | p2 | p4 | p8 | p4 vs baseline | p8 vs baseline |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| tiny | 0.816 us | 0.818 us | 3.279 us | 3.276 us | 3.296 us | +301.4% | +303.9% |
+| many_funcs | 46.984 us | 48.018 us | 39.979 us | 30.929 us | 34.172 us | -34.2% | -27.3% |
+| json-as | 0.312 ms | 0.314 ms | 0.184 ms | 0.130 ms | 0.120 ms | -58.2% | -61.6% |
+| lua | 4.771 ms | 4.897 ms | 2.555 ms | 1.541 ms | 1.197 ms | -67.7% | -74.9% |
+| sqlite3 | 17.778 ms | 18.246 ms | 9.360 ms | 5.222 ms | 3.433 ms | -70.6% | -80.7% |
+| ruby | 231.500 ms | 234.055 ms | 118.994 ms | 64.702 ms | 42.981 ms | -72.1% | -81.4% |
+| esbuild | 152.371 ms | 156.582 ms | 83.583 ms | 48.214 ms | 34.470 ms | -68.4% | -77.4% |
+
+The baseline/p1 latency differences are run-to-run noise at these sample counts;
+serial allocation counts are exactly unchanged for every row.
+
+## Allocation cost
+
+| module | serial B/op | p4 B/op | p8 B/op | serial allocs/op | p4 allocs/op | p8 allocs/op |
+|---|---:|---:|---:|---:|---:|---:|
+| tiny | 1,794 | 2,912 | 2,912 | 12 | 18 | 18 |
+| many_funcs | 1,777 | 9,680 | 13,584 | 11 | 21 | 29 |
+| json-as | 10,208 | 20,812 | 31,178 | 50 | 75 | 100 |
+| lua | 78,944 | 114,510 | 141,246 | 382 | 415 | 450 |
+| sqlite3 | 189,072 | 317,294 | 360,044 | 649 | 687 | 729 |
+| ruby | 447,248 | 966,139 | 1,157,548 | 3,938 | 3,982 | 4,032 |
+| esbuild | 2,080,360 | 4,094,304 | 5,620,550 | 4,117 | 4,173 | 4,236 |
+
+The absolute worker overhead is bounded by the worker count and stack capacity
+needed by the functions each worker encounters. It is a good latency trade for
+explicit/adaptive compile-once workloads, but it reinforces keeping serial as
+the library default and four workers as the adaptive cap.
+
+## Full public compile pipeline
+
+`BenchmarkCompileFullWorkers` includes decode, validation, frontend support
+checks, metadata construction, and codegen when codegen is not link-deferred.
+The table compares p4 before this change (parallel codegen only) with p4 after
+this change (parallel validation plus codegen).
+
+| module | old p4 | new p4 | improvement from validation | new p4 vs new p1 |
+|---|---:|---:|---:|---:|
+| many_funcs | 0.342 ms | 0.314 ms | -8.2% | -33.0% |
+| json-as | 1.610 ms | 1.318 ms | -18.1% | -33.0% |
+| lua | 15.009 ms | 12.287 ms | -18.1% | -22.9% |
+| sqlite3 | 50.361 ms | 38.841 ms | -22.9% | -27.0% |
+| ruby | 684.196 ms | 518.094 ms | -24.3% | -28.8% |
+| esbuild | 631.591 ms | 513.108 ms | -18.8% | -42.4% |
+
+`lua`, `sqlite3`, and `ruby` defer backend codegen because of returning imports.
+They previously received no initial-compile benefit from `-p`; parallel validation
+now reduces their public compile latency without changing link behavior.
+
+## Correctness properties and tests
+
+Targeted tests cover:
+
+- successful serial/p2/p4/p8 parity on a 256-function byte-backed module;
+- worker counts above the function count;
+- deterministic lowest-function-index errors over repeated parallel runs;
+- the explicit decoded-byte-backed validation API;
+- public config/CLI tests using the same worker policy for validation and codegen;
+- race testing of the wasm validator and public compile packages.
+
+## Reproduction
+
+Validation worker matrix:
+
+```sh
+cd bench
+GOMAXPROCS=8 go test . -run '^$' \
+  -bench '^BenchmarkValidateWorkers/(tiny|many_funcs|json-as|lua|sqlite3|ruby|esbuild)/(p1|p2|p4|p8)$' \
+  -benchmem -count=8 -benchtime=500ms
+```
+
+Full public pipeline:
+
+```sh
+cd bench
+GOMAXPROCS=8 go test . -run '^$' \
+  -bench '^BenchmarkCompileFullWorkers/(many_funcs|json-as|lua|sqlite3|ruby|esbuild)/(p1|p4)$' \
+  -benchmem -count=6 -benchtime=3x
+```
+
+Correctness and race checks:
+
+```sh
+go test ./src/core/compiler/wasm ./src/wago ./cli/wagocli
+go test -race ./src/core/compiler/wasm ./src/wago
+```

--- a/docs/parallel-function-validation-report.md
+++ b/docs/parallel-function-validation-report.md
@@ -9,10 +9,11 @@ Baseline commit: `145aec3471792d8307a7f91288b38f86dd9ed730`
 ## Decision
 
 Use the existing opt-in function-worker policy for validation as well as native
-code generation. `WithCompileWorkers(1)` and the default configuration retain the
-serial validator. `WithCompileWorkers(0)` / `wago run -p` use the existing
-adaptive module-size policy, and forced values such as `-p4` or `-p8` apply the
-same bounded worker maximum to validation and codegen.
+code generation. `WithFunctionWorkers(1)` and the default configuration retain
+the serial validator. `WithFunctionWorkers(0)` / `wago run -p` use the adaptive
+module-size policy, and forced values such as `-p4` or `-p8` apply the same
+bounded worker maximum to validation and codegen. The earlier
+`WithCompileWorkers` name remains as a deprecated source-compatible alias.
 
 The existing adaptive threshold remains appropriate:
 
@@ -67,7 +68,7 @@ index is resolved and the cache is frozen. Workers then perform concurrent
 read-only lookups. A malformed body that names an invalid type index computes the
 miss without inserting it, keeping invalid-module validation race-free.
 
-The worker-aware entry points are:
+The low-level worker-aware entry points are:
 
 - `wasm.ValidateModuleWithWorkers`;
 - `wasm.ValidateByteBackedModuleWithWorkers`;
@@ -132,10 +133,13 @@ now reduces their public compile latency without changing link behavior.
 Targeted tests cover:
 
 - successful serial/p2/p4/p8 parity on a 256-function byte-backed module;
+- serial/p2/p4/p8 parity across tiny, many-functions, scalar/SIMD real-world,
+  interpreter, database, Ruby, and esbuild corpus modules;
 - worker counts above the function count;
 - deterministic lowest-function-index errors over repeated parallel runs;
 - the explicit decoded-byte-backed validation API;
-- public config/CLI tests using the same worker policy for validation and codegen;
+- public config plus `wago run`/`wago validate` CLI plumbing using the same
+  worker policy for validation and codegen;
 - race testing of the wasm validator and public compile packages.
 
 ## Reproduction

--- a/docs/parallel-function-validation-report.md
+++ b/docs/parallel-function-validation-report.md
@@ -62,11 +62,29 @@ any worker starts. Function bodies then use a bounded worker pool:
 - the parallel helper is separate from the serial path, so goroutine closure and
   worker bookkeeping do not escape into serial validation.
 
-The module validator's resolved component-type cache was the one shared mutable
-object on the body-validation path. Before workers start, every valid flat type
-index is resolved and the cache is frozen. Workers then perform concurrent
-read-only lookups. A malformed body that names an invalid type index computes the
-miss without inserting it, keeping invalid-module validation race-free.
+A shared-state audit classifies the worker-visible module context as follows:
+
+- decoded module metadata, direct byte-backed metadata, and declared-function
+  bits are immutable after serial module validation;
+- each worker's operand/control stacks, byte reader, result slot, locals, and
+  decoded-immediate scratch are worker-local;
+- the resolved component-type cache is the one lookup structure that is mutable
+  while module validation runs, so every valid flat index is resolved and the
+  cache is frozen before workers start; malformed misses are computed without
+  insertion;
+- `moduleValidator.constFV` is mutable serial scratch for module-level constant
+  expressions and is not reachable from function-body validation.
+
+The final point required a correction during review. `table.init` originally
+called the full element-payload validator from each function body. For expression-
+based segments that redundantly revalidated initializer bytes through the shared
+`constFV`, racing its stacks, reader, result slot, and decode scratch; the race
+reproduced under `go test -race` and could panic in `popCtrl`. Element expressions
+already validate serially before body workers start, so `table.init` now performs
+a read-only element reference-type lookup: `ElemFuncs` and `ElemFuncExprs` map to
+`funcref`, while `ElemTypedExprs` uses its declared reference type. The direct
+byte-backed path performs the equivalent lookup from `directElem`. Defensive
+index and unknown-kind errors remain, without revisiting initializer expressions.
 
 The low-level worker-aware entry points are:
 
@@ -108,6 +126,33 @@ needed by the functions each worker encounters. It is a good latency trade for
 explicit/adaptive compile-once workloads, but it reinforces keeping serial as
 the library default and four workers as the adaptive cap.
 
+### `table.init` race-fix regression check
+
+The required p1/p4 matrix was repeated immediately before and after the read-only
+element-type fix with `GOMAXPROCS=8`, `-benchtime=500ms`, `-count=5`, and
+`-benchmem`. Values below are medians. Latency changes are within run noise (the
+pre-fix Ruby p1 samples ranged from 228.5-255.4 ms); serial B/op and allocs/op are
+exactly unchanged on every module. Parallel allocation counts are also unchanged;
+minor p4 B/op variation reflects worker scheduling and retained stack capacity.
+
+| module | workers | before | after | latency delta | B/op before / after | allocs/op before / after |
+|---|---:|---:|---:|---:|---:|---:|
+| many_funcs | 1 | 47.018 us | 46.376 us | -1.4% | 1,777 / 1,777 | 11 / 11 |
+| many_funcs | 4 | 30.375 us | 30.860 us | +1.6% | 9,680 / 9,680 | 21 / 21 |
+| json-as | 1 | 0.309 ms | 0.312 ms | +0.9% | 10,208 / 10,208 | 50 / 50 |
+| json-as | 4 | 0.122 ms | 0.123 ms | +0.9% | 20,834 / 20,828 | 75 / 75 |
+| lua | 1 | 4.714 ms | 4.701 ms | -0.3% | 78,944 / 78,944 | 382 / 382 |
+| lua | 4 | 1.453 ms | 1.456 ms | +0.2% | 114,413 / 114,448 | 415 / 415 |
+| sqlite3 | 1 | 17.709 ms | 17.648 ms | -0.3% | 189,072 / 189,072 | 649 / 649 |
+| sqlite3 | 4 | 4.909 ms | 4.857 ms | -1.1% | 317,118 / 317,372 | 687 / 687 |
+| ruby | 1 | 244.858 ms | 222.880 ms | -9.0% | 447,248 / 447,248 | 3,938 / 3,938 |
+| ruby | 4 | 62.955 ms | 62.612 ms | -0.5% | 994,412 / 994,412 | 3,982 / 3,982 |
+| esbuild | 1 | 152.559 ms | 150.263 ms | -1.5% | 2,080,360 / 2,080,360 | 4,117 / 4,117 |
+| esbuild | 4 | 46.893 ms | 45.659 ms | -2.6% | 4,109,376 / 4,154,165 | 4,173 / 4,173 |
+
+No meaningful regression was observed, and removing repeated element-expression
+validation makes `table.init` body checking strictly less work.
+
 ## Full public compile pipeline
 
 `BenchmarkCompileFullWorkers` includes decode, validation, frontend support
@@ -137,10 +182,21 @@ Targeted tests cover:
   interpreter, database, Ruby, and esbuild corpus modules;
 - worker counts above the function count;
 - deterministic lowest-function-index errors over repeated parallel runs;
+- concurrent `table.init` validation over raw `ref.null` / `ref.func`
+  expression-based elements in both materialized and direct byte-backed forms;
+- exact serial/p2/p4/p8 parity for valid and table/element-type-invalid modules;
+- module-phase initializer rejection plus structural checks that the function
+  phase does not revisit initializer expressions;
 - the explicit decoded-byte-backed validation API;
 - public config plus `wago run`/`wago validate` CLI plumbing using the same
   worker policy for validation and codegen;
 - race testing of the wasm validator and public compile packages.
+
+The `table.init` correction was verified with the focused tests at race-detector
+count 20, the complete validator/config/CLI race set, `make test`, both explicit
+and guard-page `make test-corpus` runs, `go vet ./...`, Go 1.22 Staticcheck
+2024.1.1 through mise, and 20 repetitions of the existing worker-validation test
+set. All completed successfully.
 
 ## Reproduction
 
@@ -166,5 +222,7 @@ Correctness and race checks:
 
 ```sh
 go test ./src/core/compiler/wasm ./src/wago ./cli/wagocli
+go test -race ./src/core/compiler/wasm \
+  -run 'TestValidate.*TableInit.*' -count=20
 go test -race ./src/core/compiler/wasm ./src/wago
 ```

--- a/docs/streaming-singlepass-plan.md
+++ b/docs/streaming-singlepass-plan.md
@@ -29,12 +29,14 @@ expressions, and active data are slices of the source buffer. The compile path
 then performs separate decode, validation, support, hint, and code-generation
 walks.
 
-The backend compiles functions sequentially, but it first retains a
-module-wide hint for every function. Those hints contain per-local and
-per-global arrays, so their retained cost can be O(functions * globals).
-Forward inlining, module-global pinning, and immutable-table specialization
-also depend on future bodies. The emitted module code grows in a heap `[]byte`,
-then the first instantiation copies it into an RX mapping.
+The default backend path compiles functions sequentially; the opt-in function-
+worker policy can instead compile independent bodies with bounded worker-local
+scratch and code arenas. Both paths first retain a module-wide hint for every
+function. Those hints contain per-local and per-global arrays, so their retained
+cost can be O(functions * globals). Forward inlining, module-global pinning, and
+immutable-table specialization also depend on future bodies. The emitted module
+code grows in a heap `[]byte`, then the first instantiation copies it into an RX
+mapping.
 
 Function imports add a separate whole-source dependency: link-time recompiling
 currently copies, re-decodes, and re-lowers the original wasm in order to bake
@@ -52,8 +54,10 @@ cross-instance call addresses into code.
   including trailing data/custom sections, are accepted.
 - Keep local wasm-to-wasm calls direct on the hot path. Do not replace them with
   a universal dispatch table merely to simplify streaming.
-- Keep compilation sequential initially. Parallel compilation increases the
-  peak working set and is not needed for the first bounded-memory result.
+- The historical streaming design would have kept compilation sequential at
+  first. Production Wago now offers opt-in bounded function workers; any future
+  streaming mode must preserve an explicit serial policy for its lowest-memory
+  configuration.
 - Make every budget explicit: input window, body/spool policy, validation
   workspace, metadata, native code, and retained segment bytes. Exceeding a
   configured budget must return a clear resource-limit error.

--- a/examples/15-config/main.go
+++ b/examples/15-config/main.go
@@ -24,11 +24,11 @@ func main() {
 	// function count.
 	cfg := wago.NewRuntimeConfig().
 		WithDeferBoundsChecks(false).
-		WithCompileWorkers(0)
+		WithFunctionWorkers(0)
 
 	fmt.Println("features:", cfg.CoreFeatures())
 	fmt.Println("bounds checks:", cfg.BoundsChecks())
-	fmt.Println("compile workers:", cfg.CompileWorkers())
+	fmt.Println("function workers:", cfg.FunctionWorkers())
 
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
 	defer rt.Close()

--- a/examples/15-config/main.go
+++ b/examples/15-config/main.go
@@ -1,7 +1,7 @@
 // Example 15: runtime configuration.
 //
-// A RuntimeConfig controls feature gating, bounds checks, and compile-worker
-// policy. Pass it to a Runtime with WithRuntimeConfig, or to the low-level
+// A RuntimeConfig controls feature gating, bounds checks, and function-pipeline
+// worker policy. Pass it to a Runtime with WithRuntimeConfig, or to the low-level
 // CompileWithConfig. Run:
 //
 //	go run ./examples/15-config
@@ -18,9 +18,10 @@ import (
 func main() {
 	// Bounds-check modes: explicit (inline checks) vs signals-based (guard-page).
 	// Here we ask for every access to be bounds-checked (no elision).
-	// Compile workers are serial by default. Zero opts into the adaptive policy;
-	// one forces serial compilation, and values above one are worker maxima. The
-	// effective count is still capped by GOMAXPROCS and the local-function count.
+	// Function validation/codegen workers are serial by default. Zero opts into
+	// the adaptive policy; one forces serial work, and values above one are worker
+	// maxima. The effective count is still capped by GOMAXPROCS and the local-
+	// function count.
 	cfg := wago.NewRuntimeConfig().
 		WithDeferBoundsChecks(false).
 		WithCompileWorkers(0)

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ not wasm authoring.
 | 08 | [custom-plugin](08-custom-plugin) | Writing your own `Extension` |
 | 10 | [hooks](10-hooks) | Invoke/compile hooks (tracing, auto-instrumentation) |
 | 14 | [handles](14-handles) | `HandleTable` resource handles with a generation guard |
-| 15 | [config](15-config) | `RuntimeConfig`: features and bounds-check modes |
+| 15 | [config](15-config) | `RuntimeConfig`: features, bounds checks, and function workers |
 | 16 | [serialize](16-serialize) | Precompiling to a `.wago` blob and loading it |
 
 Run them all:

--- a/internal/functionworkers/policy.go
+++ b/internal/functionworkers/policy.go
@@ -1,0 +1,49 @@
+// Package functionworkers resolves Wago's bounded per-module function worker
+// policy for validation and native code generation.
+package functionworkers
+
+import "runtime"
+
+const (
+	perFunctionWeight = 64
+	parallelThreshold = 16 << 10
+	autoWorkerLimit   = 4
+)
+
+// Resolve converts a configured policy into an effective worker count. Zero is
+// adaptive, one is serial, and values above one are forced maxima. The result is
+// always between one and the local-function count, capped by GOMAXPROCS.
+func Resolve(policy, functions, bodyBytes int) int {
+	if functions <= 1 {
+		return 1
+	}
+	if bodyBytes < 0 {
+		bodyBytes = parallelThreshold
+	}
+	workers := policy
+	if workers == 0 {
+		// Avoid an overflowing score for defensive/programmatic module shapes.
+		// For decoded modules bodyBytes is bounded by the source allocation.
+		if bodyBytes < parallelThreshold {
+			remaining := parallelThreshold - bodyBytes
+			neededFunctions := (remaining + perFunctionWeight - 1) / perFunctionWeight
+			if functions < neededFunctions {
+				return 1
+			}
+		}
+		workers = autoWorkerLimit
+	}
+	if workers < 1 {
+		return 1
+	}
+	if max := runtime.GOMAXPROCS(0); workers > max {
+		workers = max
+	}
+	if workers > functions {
+		workers = functions
+	}
+	if workers <= 1 {
+		return 1
+	}
+	return workers
+}

--- a/internal/functionworkers/policy_test.go
+++ b/internal/functionworkers/policy_test.go
@@ -1,0 +1,37 @@
+package functionworkers
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	old := runtime.GOMAXPROCS(8)
+	defer runtime.GOMAXPROCS(old)
+
+	for _, tc := range []struct {
+		name                 string
+		policy, funcs, bytes int
+		want                 int
+	}{
+		{name: "empty", policy: 8, funcs: 0, want: 1},
+		{name: "single", policy: 8, funcs: 1, bytes: 1 << 20, want: 1},
+		{name: "auto tiny", funcs: 2, bytes: 9, want: 1},
+		{name: "auto below threshold", funcs: 255, want: 1},
+		{name: "auto at threshold", funcs: 256, want: 4},
+		{name: "auto body threshold", funcs: 2, bytes: parallelThreshold, want: 2},
+		{name: "auto many funcs", funcs: 301, bytes: 2053, want: 4},
+		{name: "auto large bodies", funcs: 10, bytes: 1 << 20, want: 4},
+		{name: "serial", policy: 1, funcs: 100, bytes: 1 << 20, want: 1},
+		{name: "forced", policy: 3, funcs: 10, want: 3},
+		{name: "function cap", policy: 8, funcs: 3, want: 3},
+		{name: "gomaxprocs cap", policy: 32, funcs: 100, want: 8},
+		{name: "invalid defensive", policy: -1, funcs: 100, want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Resolve(tc.policy, tc.funcs, tc.bytes); got != tc.want {
+				t.Fatalf("Resolve(%d, %d, %d) = %d, want %d", tc.policy, tc.funcs, tc.bytes, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -1,38 +1,117 @@
 package wasm
 
+import (
+	"sync"
+	"sync/atomic"
+)
+
 // ValidateModule validates module-level indexes and typechecks function bodies.
 // The default path consumes raw BodyBytes produced by DecodeModule instead of a
 // structured function-body instruction tree. Programmatically constructed tests
 // may still supply Func.Body instructions when BodyBytes is empty.
 func ValidateModule(m *Module) error {
-	v := &moduleValidator{m: m, funcIndex: -1}
+	return validateModuleWithWorkers(m, nil, 1)
+}
+
+// ValidateModuleWithWorkers is ValidateModule with bounded function-body
+// parallelism. Module-level declarations and constant expressions are validated
+// serially first. workers <= 1 retains the allocation-minimal serial path; larger
+// values are capped by the local-function count. If multiple functions are
+// invalid, the lowest function index wins regardless of completion order.
+func ValidateModuleWithWorkers(m *Module, workers int) error {
+	return validateModuleWithWorkers(m, nil, workers)
+}
+
+func validateModuleWithWorkers(m *Module, direct *directValidationEnv, workers int) error {
+	v := &moduleValidator{m: m, funcIndex: -1, direct: direct}
 	if err := v.validateModule(); err != nil {
 		return err
 	}
-	importedFuncs := m.ImportedFuncCount()
-	memarg64 := moduleMemargOffset64(m)
+	return v.validateFunctions(workers)
+}
+
+func (v *moduleValidator) validateFunctions(workers int) error {
+	if workers <= 1 || len(v.m.Code) <= 1 {
+		return v.validateFunctionsSerial()
+	}
+	if workers > len(v.m.Code) {
+		workers = len(v.m.Code)
+	}
+	v.freezeCompCache()
+	return v.validateFunctionsParallel(workers)
+}
+
+func (v *moduleValidator) validateFunctionsSerial() error {
+	importedFuncs := v.m.ImportedFuncCount()
+	memarg64 := moduleMemargOffset64(v.m)
 	fv := &funcValidator{moduleValidator: v}
-	for i, fn := range m.Code {
-		abs := importedFuncs + i
-		if i >= len(m.FuncTypes) {
-			return v.err(ErrUnknownFunc, "code without function type")
-		}
-		ft, ok := v.funcType(uint32(abs))
-		if !ok {
-			return v.err(ErrUnknownType, "function type")
-		}
-		fv.beginFunc(abs)
-		if len(fn.BodyBytes) != 0 {
-			if err := fv.validateFuncDirect(directCodeBody{locals: fn.Locals, body: fn.BodyBytes}, ft, memarg64); err != nil {
-				return err
-			}
-			continue
-		}
-		if err := fv.validateFunc(fn, ft); err != nil {
+	for i := range v.m.Code {
+		if err := v.validateFunction(fv, i, importedFuncs, memarg64); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (v *moduleValidator) validateFunction(fv *funcValidator, localIndex, importedFuncs int, memarg64 bool) error {
+	fn := &v.m.Code[localIndex]
+	abs := importedFuncs + localIndex
+	if localIndex >= len(v.m.FuncTypes) {
+		return v.err(ErrUnknownFunc, "code without function type")
+	}
+	ft, ok := v.funcType(uint32(abs))
+	if !ok {
+		return v.err(ErrUnknownType, "function type")
+	}
+	fv.beginFunc(abs)
+	if len(fn.BodyBytes) != 0 {
+		return fv.validateFuncDirect(directCodeBody{locals: fn.Locals, body: fn.BodyBytes}, ft, memarg64)
+	}
+	return fv.validateFunc(*fn, ft)
+}
+
+// validateFunctionsParallel is split from the serial path so its goroutine
+// closure and worker bookkeeping cannot escape into or allocate on serial
+// validation. Each worker owns one funcValidator; the module context and its
+// frozen component-type cache are read-only after module validation completes.
+func (v *moduleValidator) validateFunctionsParallel(workers int) error {
+	importedFuncs := v.m.ImportedFuncCount()
+	memarg64 := moduleMemargOffset64(v.m)
+	errs := make([]error, len(v.m.Code))
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func() {
+			defer wg.Done()
+			fv := funcValidator{moduleValidator: v}
+			for {
+				i := int(next.Add(1) - 1)
+				if i >= len(v.m.Code) {
+					return
+				}
+				errs[i] = v.validateFunction(&fv, i, importedFuncs, memarg64)
+			}
+		}()
+	}
+	wg.Wait()
+	for i := range errs {
+		if errs[i] != nil {
+			return errs[i]
+		}
+	}
+	return nil
+}
+
+// freezeCompCache resolves every valid flat type index before workers start.
+// Function validation then performs concurrent read-only map lookups. Invalid
+// body immediates may still miss the cache; resolvedCompType computes those
+// without mutating the frozen map so malformed modules remain race-free.
+func (v *moduleValidator) freezeCompCache() {
+	for i := 0; i < v.m.flattenedTypeCount(); i++ {
+		_, _ = v.resolvedCompType(TypeIdx{Index: uint32(i)})
+	}
+	v.compCacheFrozen = true
 }
 
 type moduleValidator struct {
@@ -52,7 +131,8 @@ type moduleValidator struct {
 	// compTypeFromTypeIdx are called once per block/call/call_indirect, and
 	// re-resolving allocated fresh Params/Results slices plus a CompType each
 	// time; caching returns a shared read-only pointer instead.
-	compCache map[uint32]compCacheEntry
+	compCache       map[uint32]compCacheEntry
+	compCacheFrozen bool
 
 	// constFV is reused across the module's const-expression checks (global/table/
 	// data offsets, element expressions) to avoid a fresh validator + reader per

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -14,10 +14,11 @@ func ValidateModule(m *Module) error {
 }
 
 // ValidateModuleWithWorkers is ValidateModule with bounded function-body
-// parallelism. Module-level declarations and constant expressions are validated
-// serially first. workers <= 1 retains the allocation-minimal serial path; larger
-// values are capped by the local-function count. If multiple functions are
-// invalid, the lowest function index wins regardless of completion order.
+// parallelism. Module-level declarations, element initializer expressions, and
+// other constant expressions are validated serially first. workers <= 1 retains
+// the allocation-minimal serial path; larger values are capped by the local-
+// function count. If multiple functions are invalid, the lowest function index
+// wins regardless of completion order.
 func ValidateModuleWithWorkers(m *Module, workers int) error {
 	return validateModuleWithWorkers(m, nil, workers)
 }
@@ -72,8 +73,9 @@ func (v *moduleValidator) validateFunction(fv *funcValidator, localIndex, import
 
 // validateFunctionsParallel is split from the serial path so its goroutine
 // closure and worker bookkeeping cannot escape into or allocate on serial
-// validation. Each worker owns one funcValidator; the module context and its
-// frozen component-type cache are read-only after module validation completes.
+// validation. Each worker owns one funcValidator. The module/direct metadata and
+// declared-function bits are immutable, the component-type cache is frozen, and
+// the serial const-expression validator is no longer reachable from body checks.
 func (v *moduleValidator) validateFunctionsParallel(workers int) error {
 	importedFuncs := v.m.ImportedFuncCount()
 	memarg64 := moduleMemargOffset64(v.m)
@@ -134,9 +136,9 @@ type moduleValidator struct {
 	compCache       map[uint32]compCacheEntry
 	compCacheFrozen bool
 
-	// constFV is reused across the module's const-expression checks (global/table/
-	// data offsets, element expressions) to avoid a fresh validator + reader per
-	// expression.
+	// constFV is serial module-validation scratch for global/table/data offsets
+	// and element initializer expressions. Function-body validation never reaches
+	// it: table.init reads the element type metadata validated in this phase.
 	constFV *funcValidator
 }
 
@@ -680,6 +682,9 @@ func (v *moduleValidator) validateElemPayload(e Elem) (RefType, error) {
 	}
 }
 
+// elemRefType returns previously validated element metadata for table.init.
+// It deliberately does not revisit initializer expressions: those are checked
+// serially by validateElem before any function worker can start.
 func (v *funcValidator) elemRefType(index uint32) (RefType, error) {
 	if v.direct != nil {
 		return v.directElemRefType(index)

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -680,6 +680,24 @@ func (v *moduleValidator) validateElemPayload(e Elem) (RefType, error) {
 	}
 }
 
+func (v *funcValidator) elemRefType(index uint32) (RefType, error) {
+	if v.direct != nil {
+		return v.directElemRefType(index)
+	}
+	if uint64(index) >= uint64(len(v.m.Elements)) {
+		return RefType{}, v.verr(ErrUnknownTable, "table.init elem")
+	}
+	e := &v.m.Elements[index]
+	switch e.Kind.Kind {
+	case ElemFuncs, ElemFuncExprs:
+		return FuncRef.Ref, nil
+	case ElemTypedExprs:
+		return e.Kind.Ref, nil
+	default:
+		return RefType{}, v.verr(ErrTypeMismatch, "unknown element kind")
+	}
+}
+
 type val struct {
 	t       ValType
 	unknown bool

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -55,11 +55,17 @@ type DecodedByteBackedModule struct {
 // path. It is a convenience for benchmarks and internal tests that need a
 // single call around explicit decode then validate phases.
 func ValidateByteBackedModule(data []byte) error {
+	return ValidateByteBackedModuleWithWorkers(data, 1)
+}
+
+// ValidateByteBackedModuleWithWorkers is ValidateByteBackedModule with bounded
+// parallel function-body validation. workers <= 1 retains serial behavior.
+func ValidateByteBackedModuleWithWorkers(data []byte, workers int) error {
 	dm, err := DecodeModuleByteBacked(data)
 	if err != nil {
 		return err
 	}
-	return ValidateDecodedByteBackedModule(dm)
+	return ValidateDecodedByteBackedModuleWithWorkers(dm, workers)
 }
 
 // DecodeModuleByteBacked decodes data without materializing the structured
@@ -82,32 +88,17 @@ func DecodeModuleByteBacked(data []byte) (*DecodedByteBackedModule, error) {
 // DecodeModuleByteBacked without requiring a structured function-body
 // instruction tree.
 func ValidateDecodedByteBackedModule(dm *DecodedByteBackedModule) error {
+	return ValidateDecodedByteBackedModuleWithWorkers(dm, 1)
+}
+
+// ValidateDecodedByteBackedModuleWithWorkers is
+// ValidateDecodedByteBackedModule with bounded parallel function-body
+// validation. Errors remain ordered by function index.
+func ValidateDecodedByteBackedModuleWithWorkers(dm *DecodedByteBackedModule, workers int) error {
 	if dm == nil || dm.Module == nil {
 		return &ValidationError{Code: ErrTypeMismatch, Func: -1, Detail: "nil byte-backed module"}
 	}
-	v := &moduleValidator{m: dm.Module, funcIndex: -1, direct: &dm.direct}
-	if err := v.validateModule(); err != nil {
-		return err
-	}
-	importedFuncs := dm.Module.ImportedFuncCount()
-	memarg64 := moduleMemargOffset64(dm.Module)
-	fv := &funcValidator{moduleValidator: v}
-	for i, fn := range dm.Module.Code {
-		abs := importedFuncs + i
-		if i >= len(dm.Module.FuncTypes) {
-			return v.err(ErrUnknownFunc, "code without function type")
-		}
-		ft, ok := v.funcType(uint32(abs))
-		if !ok {
-			return v.err(ErrUnknownType, "function type")
-		}
-		fv.beginFunc(abs)
-		body := directCodeBody{locals: fn.Locals, body: fn.BodyBytes}
-		if err := fv.validateFuncDirect(body, ft, memarg64); err != nil {
-			return err
-		}
-	}
-	return nil
+	return validateModuleWithWorkers(dm.Module, &dm.direct, workers)
 }
 
 func (dm *directModule) populateCodeBodies() {

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -825,6 +825,21 @@ func (v *moduleValidator) validateDirectElemPayload(e directElem) (RefType, erro
 	}
 }
 
+func (v *funcValidator) directElemRefType(index uint32) (RefType, error) {
+	if uint64(index) >= uint64(len(v.direct.elements)) {
+		return RefType{}, v.verr(ErrUnknownTable, "table.init elem")
+	}
+	e := &v.direct.elements[index]
+	switch e.kind {
+	case ElemFuncs, ElemFuncExprs:
+		return FuncRef.Ref, nil
+	case ElemTypedExprs:
+		return e.ref, nil
+	default:
+		return RefType{}, v.verr(ErrTypeMismatch, "unknown element kind")
+	}
+}
+
 func (v *funcValidator) validateFuncDirect(body directCodeBody, ft *CompType, memarg64 bool) error {
 	v.localParams = ft.Params
 	v.localRuns = body.locals.Runs

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -825,6 +825,8 @@ func (v *moduleValidator) validateDirectElemPayload(e directElem) (RefType, erro
 	}
 }
 
+// directElemRefType is the byte-backed table.init metadata lookup. Direct
+// initializer bytes were already validated serially by validateDirectElem.
 func (v *funcValidator) directElemRefType(index uint32) (RefType, error) {
 	if uint64(index) >= uint64(len(v.direct.elements)) {
 		return RefType{}, v.verr(ErrUnknownTable, "table.init elem")

--- a/src/core/compiler/wasm/validate_gc_helpers.go
+++ b/src/core/compiler/wasm/validate_gc_helpers.go
@@ -154,10 +154,12 @@ func (v *moduleValidator) resolvedCompType(idx TypeIdx) (*CompType, bool) {
 		ct := v.resolveCompTypeRecIndexes(st.Comp, recGroup)
 		entry.ct = &ct
 	}
-	if v.compCache == nil {
-		v.compCache = make(map[uint32]compCacheEntry)
+	if !v.compCacheFrozen {
+		if v.compCache == nil {
+			v.compCache = make(map[uint32]compCacheEntry)
+		}
+		v.compCache[idx.Index] = entry
 	}
-	v.compCache[idx.Index] = entry
 	return entry.ct, entry.ok
 }
 

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -444,27 +444,9 @@ func (v *funcValidator) step(in *Instruction) error {
 			return err
 		}
 	case InstrTableInit:
-		var elemRef RefType
-		if v.direct != nil {
-			if int(in.Index) >= len(v.direct.elements) {
-				return v.verr(ErrUnknownTable, "table.init elem")
-			}
-			elem := v.direct.elements[in.Index]
-			var err error
-			elemRef, err = v.validateDirectElemPayload(elem)
-			if err != nil {
-				return err
-			}
-		} else {
-			if int(in.Index) >= len(v.m.Elements) {
-				return v.verr(ErrUnknownTable, "table.init elem")
-			}
-			elem := v.m.Elements[in.Index]
-			var err error
-			elemRef, err = v.validateElemPayload(elem)
-			if err != nil {
-				return err
-			}
+		elemRef, err := v.elemRefType(in.Index)
+		if err != nil {
+			return err
 		}
 		tt, ok := v.tableType(in.Index2)
 		if !ok {

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -444,6 +444,8 @@ func (v *funcValidator) step(in *Instruction) error {
 			return err
 		}
 	case InstrTableInit:
+		// Element expressions were validated during the serial module phase. The
+		// body check needs only their immutable declared/result reference type.
 		elemRef, err := v.elemRefType(in.Index)
 		if err != nil {
 			return err

--- a/src/core/compiler/wasm/validate_parallel_test.go
+++ b/src/core/compiler/wasm/validate_parallel_test.go
@@ -121,3 +121,247 @@ func TestValidateDecodedByteBackedModuleWithWorkers(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateModuleWithWorkersTableInitElementExprRace(t *testing.T) {
+	t.Run("valid func and typed expressions", func(t *testing.T) {
+		m := tableInitExprModule(AbsRef(HeapFunc), false)
+		assertTableInitWorkerParity(t, func(workers int) error {
+			return ValidateModuleWithWorkers(m, workers)
+		}, false)
+	})
+
+	t.Run("deterministic type mismatch", func(t *testing.T) {
+		m := tableInitExprModule(AbsRef(HeapExtern), false)
+		validate := func(workers int) error { return ValidateModuleWithWorkers(m, workers) }
+		assertTableInitWorkerParity(t, validate, true)
+		var verr *ValidationError
+		if err := validate(1); !errors.As(err, &verr) || verr.Func != 0 || verr.Code != ErrTypeMismatch {
+			t.Fatalf("table/element mismatch error = %v, want function 0 type mismatch", err)
+		}
+	})
+
+	t.Run("initializer still validates at module level", func(t *testing.T) {
+		m := tableInitExprModule(AbsRef(HeapFunc), true)
+		assertTableInitWorkerParity(t, func(workers int) error {
+			return ValidateModuleWithWorkers(m, workers)
+		}, true)
+		var verr *ValidationError
+		if err := ValidateModuleWithWorkers(m, 8); !errors.As(err, &verr) || verr.Func != -1 || verr.Code != ErrTypeMismatch {
+			t.Fatalf("initializer error = %v, want module-level type mismatch", err)
+		}
+	})
+
+	t.Run("function phase does not revalidate initializers", func(t *testing.T) {
+		m := tableInitExprModule(AbsRef(HeapFunc), false)
+		v := &moduleValidator{m: m, funcIndex: -1}
+		if err := v.validateModule(); err != nil {
+			t.Fatalf("module validation: %v", err)
+		}
+		for i := range m.Elements {
+			m.Elements[i].Kind.Exprs[0].BodyBytes = []byte{0x41, 0x00, 0x0b}
+		}
+		if err := v.validateFunctions(8); err != nil {
+			t.Fatalf("function validation re-read initializer expressions: %v", err)
+		}
+	})
+
+	t.Run("defensive metadata errors", func(t *testing.T) {
+		m := tableInitExprModule(AbsRef(HeapFunc), false)
+		fv := funcValidator{moduleValidator: &moduleValidator{m: m}, funcIndex: 7}
+		if _, err := fv.elemRefType(uint32(len(m.Elements))); !isValidationCode(err, ErrUnknownTable) {
+			t.Fatalf("out-of-range element error = %v", err)
+		}
+		m.Elements[0].Kind.Kind = ElemKindKind(0xff)
+		if _, err := fv.elemRefType(0); !isValidationCode(err, ErrTypeMismatch) {
+			t.Fatalf("unknown element kind error = %v", err)
+		}
+	})
+}
+
+func TestValidateDecodedByteBackedModuleWithWorkersTableInitElementExprRace(t *testing.T) {
+	t.Run("valid func and typed expressions", func(t *testing.T) {
+		dm, err := DecodeModuleByteBacked(tableInitExprModuleBytes(0x70, true, false))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		assertTableInitWorkerParity(t, func(workers int) error {
+			return ValidateDecodedByteBackedModuleWithWorkers(dm, workers)
+		}, false)
+	})
+
+	t.Run("deterministic type mismatch", func(t *testing.T) {
+		dm, err := DecodeModuleByteBacked(tableInitExprModuleBytes(0x6f, false, false))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		validate := func(workers int) error {
+			return ValidateDecodedByteBackedModuleWithWorkers(dm, workers)
+		}
+		assertTableInitWorkerParity(t, validate, true)
+		var verr *ValidationError
+		if err := validate(1); !errors.As(err, &verr) || verr.Func != 0 || verr.Code != ErrTypeMismatch {
+			t.Fatalf("table/element mismatch error = %v, want function 0 type mismatch", err)
+		}
+	})
+
+	t.Run("initializer still validates at module level", func(t *testing.T) {
+		dm, err := DecodeModuleByteBacked(tableInitExprModuleBytes(0x70, false, true))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		assertTableInitWorkerParity(t, func(workers int) error {
+			return ValidateDecodedByteBackedModuleWithWorkers(dm, workers)
+		}, true)
+		var verr *ValidationError
+		if err := ValidateDecodedByteBackedModuleWithWorkers(dm, 8); !errors.As(err, &verr) || verr.Func != -1 || verr.Code != ErrTypeMismatch {
+			t.Fatalf("initializer error = %v, want module-level type mismatch", err)
+		}
+	})
+
+	t.Run("function phase does not revalidate initializers", func(t *testing.T) {
+		dm, err := DecodeModuleByteBacked(tableInitExprModuleBytes(0x70, true, false))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		v := &moduleValidator{m: dm.Module, funcIndex: -1, direct: &dm.direct}
+		if err := v.validateModule(); err != nil {
+			t.Fatalf("module validation: %v", err)
+		}
+		for i := range dm.direct.elements {
+			dm.direct.elements[i].exprs[0].body = []byte{0x41, 0x00, 0x0b}
+		}
+		if err := v.validateFunctions(8); err != nil {
+			t.Fatalf("function validation re-read direct initializer expressions: %v", err)
+		}
+	})
+
+	t.Run("defensive metadata errors", func(t *testing.T) {
+		direct := &directValidationEnv{elements: []directElem{{kind: ElemKindKind(0xff)}}}
+		fv := funcValidator{moduleValidator: &moduleValidator{m: &Module{}, direct: direct}, funcIndex: 7}
+		if _, err := fv.directElemRefType(1); !isValidationCode(err, ErrUnknownTable) {
+			t.Fatalf("out-of-range direct element error = %v", err)
+		}
+		if _, err := fv.directElemRefType(0); !isValidationCode(err, ErrTypeMismatch) {
+			t.Fatalf("unknown direct element kind error = %v", err)
+		}
+	})
+}
+
+func assertTableInitWorkerParity(t *testing.T, validate func(int) error, wantError bool) {
+	t.Helper()
+	want := validate(1)
+	if wantError && want == nil {
+		t.Fatal("serial validation unexpectedly succeeded")
+	}
+	if !wantError && want != nil {
+		t.Fatalf("serial validation: %v", want)
+	}
+	if wantError {
+		var verr *ValidationError
+		if !errors.As(want, &verr) {
+			t.Fatalf("serial error = %T %v, want ValidationError", want, want)
+		}
+	}
+	for _, workers := range []int{2, 4, 8} {
+		for run := 0; run < 10; run++ {
+			got := validate(workers)
+			if !sameValidationResult(got, want) {
+				t.Fatalf("workers=%d run=%d error = %v, want %v", workers, run, got, want)
+			}
+		}
+	}
+}
+
+func sameValidationResult(got, want error) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	var gotValidation, wantValidation *ValidationError
+	if errors.As(got, &gotValidation) && errors.As(want, &wantValidation) {
+		return *gotValidation == *wantValidation
+	}
+	return got.Error() == want.Error()
+}
+
+func tableInitExprModule(tableRef RefType, badInitializer bool) *Module {
+	const funcs = 64
+	firstExpr := []byte{0xd0, 0x70, 0x0b} // ref.null func
+	if badInitializer {
+		firstExpr = []byte{0x41, 0x00, 0x0b} // i32.const 0, not funcref
+	}
+	m := &Module{
+		Types:     []RecType{ft(nil, nil)},
+		FuncTypes: make([]TypeIdx, funcs),
+		Code:      make([]Func, funcs),
+		Tables:    []Table{{Type: TableType{Ref: tableRef, Limits: Limits{Min: 1}}}},
+		Elements: []Elem{
+			{
+				Mode: ElemMode{Kind: ElemPassive},
+				Kind: ElemKind{Kind: ElemFuncExprs, Exprs: []Expr{{BodyBytes: firstExpr}}},
+			},
+			{
+				Mode: ElemMode{Kind: ElemPassive},
+				Kind: ElemKind{Kind: ElemTypedExprs, Ref: AbsRef(HeapFunc), Exprs: []Expr{{BodyBytes: []byte{0xd2, 0x00, 0x0b}}}}, // ref.func 0
+			},
+		},
+	}
+	body := tableInitExprBody(0, 1)
+	for i := range m.Code {
+		m.Code[i].BodyBytes = body
+	}
+	return m
+}
+
+func tableInitExprModuleBytes(tableType byte, bothElementKinds, badInitializer bool) []byte {
+	const funcs = 64
+	funcTypes := append([]byte{}, u32(funcs)...)
+	funcTypes = append(funcTypes, make([]byte, funcs)...)
+
+	elemPayload := u32(1)
+	firstExpr := []byte{0xd0, 0x70, 0x0b} // ref.null func
+	if badInitializer {
+		firstExpr = []byte{0x41, 0x00, 0x0b} // i32.const 0, not funcref
+	}
+	// flags=5: passive typed expression segment, declared funcref.
+	elemPayload = append(elemPayload, 0x05, 0x70, 0x01)
+	elemPayload = append(elemPayload, firstExpr...)
+	indexes := []uint32{0}
+	if bothElementKinds {
+		elemPayload[0] = 0x02
+		// flags=4: active implicit-table function-expression segment. This covers
+		// the direct ElemFuncExprs representation with a raw ref.func initializer.
+		elemPayload = append(elemPayload, 0x04, 0x41, 0x00, 0x0b, 0x01, 0xd2, 0x00, 0x0b)
+		indexes = append(indexes, 1)
+	}
+
+	bodyExpr := tableInitExprBody(indexes...)
+	funcBody := append([]byte{0x00}, bodyExpr...) // zero local declarations
+	codePayload := append([]byte{}, u32(funcs)...)
+	for range funcs {
+		codePayload = append(codePayload, u32(uint32(len(funcBody)))...)
+		codePayload = append(codePayload, funcBody...)
+	}
+
+	return module(
+		section(secType, 0x01, 0x60, 0x00, 0x00),
+		section(secFunction, funcTypes...),
+		section(secTable, 0x01, tableType, 0x00, 0x01),
+		section(secElement, elemPayload...),
+		section(secCode, codePayload...),
+	)
+}
+
+func tableInitExprBody(elementIndexes ...uint32) []byte {
+	body := make([]byte, 0, len(elementIndexes)*10+1)
+	for _, index := range elementIndexes {
+		body = append(body,
+			0x41, 0x00, // destination table offset
+			0x41, 0x00, // source element offset
+			0x41, 0x00, // length
+			0xfc, 0x0c, // table.init
+		)
+		body = append(body, u32(index)...)
+		body = append(body, 0x00) // table index 0
+	}
+	return append(body, 0x0b)
+}

--- a/src/core/compiler/wasm/validate_parallel_test.go
+++ b/src/core/compiler/wasm/validate_parallel_test.go
@@ -1,0 +1,91 @@
+package wasm
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateModuleWithWorkersParity(t *testing.T) {
+	data := benchmarkDecodeValidateModule(256)
+	m, err := DecodeModule(data)
+	if err != nil {
+		t.Fatalf("DecodeModule: %v", err)
+	}
+	if err := ValidateModule(m); err != nil {
+		t.Fatalf("serial validation: %v", err)
+	}
+	for _, workers := range []int{0, 1, 2, 4, 8, 512} {
+		for run := 0; run < 10; run++ {
+			if err := ValidateModuleWithWorkers(m, workers); err != nil {
+				t.Fatalf("workers=%d run=%d: %v", workers, run, err)
+			}
+		}
+	}
+}
+
+func TestValidateModuleWithWorkersLowestFunctionError(t *testing.T) {
+	const funcs = 16
+	m := &Module{
+		Types:     []RecType{ft(nil, nil)},
+		FuncTypes: make([]TypeIdx, funcs),
+		Code:      make([]Func, funcs),
+	}
+	m.Code[3].Body.Instrs = []Instruction{{Kind: InstrLocalGet, Index: 0}}
+	m.Code[11].Body.Instrs = []Instruction{{Kind: InstrCall, Index: 99}}
+
+	want := ValidateModule(m)
+	var wantValidation *ValidationError
+	if !errors.As(want, &wantValidation) {
+		t.Fatalf("serial error = %T %v, want ValidationError", want, want)
+	}
+	if wantValidation.Func != 3 || wantValidation.Code != ErrUnknownLocal {
+		t.Fatalf("serial error = %+v, want function 3 unknown local", wantValidation)
+	}
+
+	for _, workers := range []int{2, 4, 8, 32} {
+		for run := 0; run < 100; run++ {
+			got := ValidateModuleWithWorkers(m, workers)
+			var gotValidation *ValidationError
+			if !errors.As(got, &gotValidation) {
+				t.Fatalf("workers=%d run=%d error = %T %v, want ValidationError", workers, run, got, got)
+			}
+			if *gotValidation != *wantValidation {
+				t.Fatalf("workers=%d run=%d error = %+v, want %+v", workers, run, gotValidation, wantValidation)
+			}
+		}
+	}
+}
+
+func TestValidateModuleWithWorkersInvalidTypeCacheMiss(t *testing.T) {
+	m, err := DecodeModule(benchmarkDecodeValidateModule(64))
+	if err != nil {
+		t.Fatalf("DecodeModule: %v", err)
+	}
+	// call_indirect type 127 misses the frozen valid-type cache. Every fourth
+	// function uses it so several workers can hit the malformed index together.
+	for i := 0; i < len(m.Code); i += 4 {
+		m.Code[i].BodyBytes = []byte{0x11, 0x7f, 0x00, 0x0b}
+	}
+	want := ValidateModule(m)
+	if want == nil {
+		t.Fatal("serial validation unexpectedly accepted invalid type index")
+	}
+	for run := 0; run < 100; run++ {
+		got := ValidateModuleWithWorkers(m, 8)
+		if got == nil || got.Error() != want.Error() {
+			t.Fatalf("run=%d parallel error = %v, want %v", run, got, want)
+		}
+	}
+}
+
+func TestValidateDecodedByteBackedModuleWithWorkers(t *testing.T) {
+	dm, err := DecodeModuleByteBacked(benchmarkDecodeValidateModule(256))
+	if err != nil {
+		t.Fatalf("DecodeModuleByteBacked: %v", err)
+	}
+	for _, workers := range []int{1, 2, 4, 8} {
+		if err := ValidateDecodedByteBackedModuleWithWorkers(dm, workers); err != nil {
+			t.Fatalf("workers=%d: %v", workers, err)
+		}
+	}
+}

--- a/src/core/compiler/wasm/validate_parallel_test.go
+++ b/src/core/compiler/wasm/validate_parallel_test.go
@@ -2,6 +2,8 @@ package wasm
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -20,6 +22,36 @@ func TestValidateModuleWithWorkersParity(t *testing.T) {
 				t.Fatalf("workers=%d run=%d: %v", workers, run, err)
 			}
 		}
+	}
+}
+
+func TestValidateModuleWithWorkersCorpusParity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large validation corpus parity in short mode")
+	}
+	corpus := filepath.Join("..", "..", "..", "..", "bench", "corpus")
+	for _, name := range []string{
+		"tiny.wasm", "many_funcs.wasm", "json-as.wasm", "json-as-simd.wasm",
+		"lua.wasm", "sqlite3.wasm", "ruby.wasm", "esbuild.wasm",
+	} {
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(corpus, name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			m, err := DecodeModule(data)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if err := ValidateModule(m); err != nil {
+				t.Fatalf("serial: %v", err)
+			}
+			for _, workers := range []int{2, 4, 8} {
+				if err := ValidateModuleWithWorkers(m, workers); err != nil {
+					t.Fatalf("p%d: %v", workers, err)
+				}
+			}
+		})
 	}
 }
 

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	"github.com/wago-org/wago/internal/functionworkers"
 	"github.com/wago-org/wago/src/core/compiler/frontend"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	wruntime "github.com/wago-org/wago/src/core/runtime"
@@ -89,51 +90,24 @@ func compileArgs(args []any) (*RuntimeConfig, []byte, error) {
 	}
 }
 
-// storedCompileWorkers keeps link-time policy in existing Compiled padding.
+// storedFunctionWorkers keeps link-time policy in existing Compiled padding.
 // Values above uint16 still mean "at least every practical GOMAXPROCS" and are
-// therefore equivalent after the backend cap.
-func storedCompileWorkers(policy int) uint16 {
+// therefore equivalent after the worker cap.
+func storedFunctionWorkers(policy int) uint16 {
 	if policy > int(^uint16(0)) {
 		return ^uint16(0)
 	}
 	return uint16(policy)
 }
 
-// compileWorkersForModule resolves a public compile-worker policy to a forced
-// function-pipeline worker count used by validation and backend codegen. Positive
-// policies are explicit maxima. Auto mode uses a measured work score that
-// distinguishes hundreds of tiny functions from a few substantial bodies while
-// retaining the exact serial fast path below 16 KiB. Four workers won consistently
-// from that crossover. Eight improved the largest modules, but not end-to-end
-// latency enough to justify its additional allocation and peak-RSS cost, so auto
-// mode deliberately caps at four.
-func compileWorkersForModule(m *wasm.Module, policy int) int {
-	workers := policy
-	if workers == 0 {
-		const (
-			perFunctionWeight = 64
-			parallelThreshold = 16 << 10
-		)
-		totalBody := 0
-		for i := range m.Code {
-			totalBody += len(m.Code[i].BodyBytes)
-		}
-		if score := totalBody + perFunctionWeight*len(m.Code); score < parallelThreshold {
-			workers = 1
-		} else {
-			workers = 4
-		}
+// functionWorkersForModule resolves the configured policy once so validation
+// and codegen use the same bounded worker count for a module.
+func functionWorkersForModule(m *wasm.Module, policy int) int {
+	totalBody := 0
+	for i := range m.Code {
+		totalBody += len(m.Code[i].BodyBytes)
 	}
-	if max := goruntime.GOMAXPROCS(0); workers > max {
-		workers = max
-	}
-	if workers > len(m.Code) {
-		workers = len(m.Code)
-	}
-	if workers <= 1 {
-		return 1
-	}
-	return workers
+	return functionworkers.Resolve(policy, len(m.Code), totalBody)
 }
 
 func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
@@ -147,7 +121,7 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	if err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
-	workers := compileWorkersForModule(m, cfg.compileWorkers)
+	workers := functionWorkersForModule(m, cfg.functionWorkers)
 	if err := wasm.ValidateModuleWithWorkers(m, workers); err != nil {
 		return nil, fmt.Errorf("validate: %w", err)
 	}
@@ -175,7 +149,7 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 		code, entry, internalEntry = cm.Code, cm.Entry, cm.InternalEntry
 	}
 
-	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs, needsLink: needsLink, boundsElide: elide, noDeferBounds: cfg.noDeferBounds, compileWorkers: storedCompileWorkers(cfg.compileWorkers), requiredFeatures: uint8(moduleRequiredFeatures(m)), syncHostImports: syncHostInitial}
+	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, boundsMode: cfg.boundsChecks, GCTypeDescs: gcDescs, needsLink: needsLink, boundsElide: elide, noDeferBounds: cfg.noDeferBounds, functionWorkers: storedFunctionWorkers(cfg.functionWorkers), requiredFeatures: uint8(moduleRequiredFeatures(m)), syncHostImports: syncHostInitial}
 	if importedFuncs > 0 {
 		c.importFuncSigs = make([]FuncSig, importedFuncs)
 		for i := 0; i < importedFuncs; i++ {
@@ -644,7 +618,7 @@ func (c *Compiled) recompileLinked(imports Imports, bindings []railshotImportBin
 		}
 	}
 	pressureAt, pressure := compileMemoryPressure(len(c.wasmBytes))
-	cm, err := railshotCompileModuleWith(m, railshotCompileOptions{Workers: compileWorkersForModule(m, int(c.compileWorkers)), ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noDeferBounds, ImportBindings: bindings, SyncHostCalls: syncHost, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
+	cm, err := railshotCompileModuleWith(m, railshotCompileOptions{Workers: functionWorkersForModule(m, int(c.functionWorkers)), ElideBoundsChecks: c.boundsElide, NoBoundsFacts: c.noDeferBounds, ImportBindings: bindings, SyncHostCalls: syncHost, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
 	if err != nil {
 		return nil, fmt.Errorf("link: %w", err)
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -100,12 +100,13 @@ func storedCompileWorkers(policy int) uint16 {
 }
 
 // compileWorkersForModule resolves a public compile-worker policy to a forced
-// backend worker count. Positive policies are explicit maxima. Auto mode uses a
-// measured work score that distinguishes hundreds of tiny functions from a few
-// substantial bodies while retaining the exact serial fast path below 16 KiB.
-// Four workers won consistently from that crossover. Eight improved backend-only
-// latency on the largest modules, but not end-to-end latency enough to justify its
-// additional allocation and peak-RSS cost, so auto mode deliberately caps at four.
+// function-pipeline worker count used by validation and backend codegen. Positive
+// policies are explicit maxima. Auto mode uses a measured work score that
+// distinguishes hundreds of tiny functions from a few substantial bodies while
+// retaining the exact serial fast path below 16 KiB. Four workers won consistently
+// from that crossover. Eight improved the largest modules, but not end-to-end
+// latency enough to justify its additional allocation and peak-RSS cost, so auto
+// mode deliberately caps at four.
 func compileWorkersForModule(m *wasm.Module, policy int) int {
 	workers := policy
 	if workers == 0 {
@@ -146,7 +147,8 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	if err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
-	if err := wasm.ValidateModule(m); err != nil {
+	workers := compileWorkersForModule(m, cfg.compileWorkers)
+	if err := wasm.ValidateModuleWithWorkers(m, workers); err != nil {
 		return nil, fmt.Errorf("validate: %w", err)
 	}
 	gcDescs, err := frontend.BuildGCTypeDescs(m)
@@ -166,7 +168,7 @@ func compileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) 
 	var entry, internalEntry []int
 	if !needsLink {
 		pressureAt, pressure := compileMemoryPressure(len(wasmBytes))
-		cm, err := railshotCompileModuleWith(m, railshotCompileOptions{Workers: compileWorkersForModule(m, cfg.compileWorkers), ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds, SyncHostCalls: syncHostInitial, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
+		cm, err := railshotCompileModuleWith(m, railshotCompileOptions{Workers: workers, ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds, SyncHostCalls: syncHostInitial, Interruptible: true, MemoryPressureAt: pressureAt, MemoryPressure: pressure})
 		if err != nil {
 			return nil, fmt.Errorf("compile: %w", err)
 		}

--- a/src/wago/bench_test.go
+++ b/src/wago/bench_test.go
@@ -316,7 +316,7 @@ func BenchmarkCompileLinkWorkers(b *testing.B) {
 		workers int
 	}{{"p1", 1}, {"p2", 2}, {"p4", 4}, {"p8", 8}, {"auto", 0}} {
 		b.Run(mode.name, func(b *testing.B) {
-			cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(mode.workers)
+			cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(mode.workers)
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				c, err := Compile(cfg, mod)

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -134,18 +134,18 @@ func (m BoundsCheckMode) String() string {
 // config can be shared and specialised safely. wago-specific knobs (e.g.
 // WithBoundsChecks) extend the wazero-style surface.
 type RuntimeConfig struct {
-	features       CoreFeatures
-	maxMemoryPages uint32
-	boundsChecks   BoundsCheckMode
-	noDeferBounds  bool // disable skipping of provably-redundant bounds checks (default: enabled)
-	compileWorkers int  // function validation/codegen: 0 adaptive; 1 serial; >1 forced maximum
+	features        CoreFeatures
+	maxMemoryPages  uint32
+	boundsChecks    BoundsCheckMode
+	noDeferBounds   bool // disable skipping of provably-redundant bounds checks (default: enabled)
+	functionWorkers int  // function validation/codegen: 0 adaptive; 1 serial; >1 forced maximum
 }
 
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
 
 // NewRuntimeConfig returns the default configuration: wago's supported feature
-// set, serial function validation/codegen, and the fastest available bounds-check mode —
-// signals-based (guard-page) when the binary was built with -tags wago_guardpage,
+// set, serial function validation/codegen, and the fastest available bounds-check
+// mode — signals-based (guard-page) when built with -tags wago_guardpage,
 // explicit otherwise. WAGO_BOUNDS overrides either way ("explicit" / "signals").
 func NewRuntimeConfig() *RuntimeConfig {
 	bounds := BoundsChecksExplicit
@@ -159,10 +159,10 @@ func NewRuntimeConfig() *RuntimeConfig {
 		bounds = BoundsChecksExplicit
 	}
 	return &RuntimeConfig{
-		features:       coreFeaturesWago,
-		maxMemoryPages: defaultMaxMemoryPages,
-		boundsChecks:   bounds,
-		compileWorkers: 1,
+		features:        coreFeaturesWago,
+		maxMemoryPages:  defaultMaxMemoryPages,
+		boundsChecks:    bounds,
+		functionWorkers: 1,
 	}
 }
 
@@ -225,14 +225,20 @@ func (c *RuntimeConfig) WithDeferBoundsChecks(enabled bool) *RuntimeConfig {
 	return &n
 }
 
-// WithCompileWorkers sets the per-module function validation/codegen policy.
+// WithFunctionWorkers sets the per-module function validation/codegen policy.
 // Zero selects the measured adaptive policy, one forces the serial fast path,
 // and N > 1 forces at most N workers (still capped by GOMAXPROCS and local-
 // function count). Negative values are rejected by Validate.
-func (c *RuntimeConfig) WithCompileWorkers(workers int) *RuntimeConfig {
+func (c *RuntimeConfig) WithFunctionWorkers(workers int) *RuntimeConfig {
 	n := *c
-	n.compileWorkers = workers
+	n.functionWorkers = workers
 	return &n
+}
+
+// WithCompileWorkers is retained for source compatibility.
+// Deprecated: use WithFunctionWorkers.
+func (c *RuntimeConfig) WithCompileWorkers(workers int) *RuntimeConfig {
+	return c.WithFunctionWorkers(workers)
 }
 
 // CoreFeatures reports the configured feature set.
@@ -248,9 +254,13 @@ func (c *RuntimeConfig) DeferBoundsChecks() bool { return !c.noDeferBounds }
 // MemoryLimitPages reports the configured maximum linear-memory size in pages.
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }
 
-// CompileWorkers reports the configured function-pipeline worker policy: zero
+// FunctionWorkers reports the configured function-pipeline worker policy: zero
 // adaptive, one serial, or a positive forced maximum.
-func (c *RuntimeConfig) CompileWorkers() int { return c.compileWorkers }
+func (c *RuntimeConfig) FunctionWorkers() int { return c.functionWorkers }
+
+// CompileWorkers is retained for source compatibility.
+// Deprecated: use FunctionWorkers.
+func (c *RuntimeConfig) CompileWorkers() int { return c.FunctionWorkers() }
 
 // Compile decodes, validates, and compiles wasmBytes under this config. On
 // success the returned Compiled owns the byte slice and the caller must not
@@ -272,8 +282,8 @@ func (c *RuntimeConfig) MustCompile(wasmBytes []byte) *Compiled {
 }
 
 func (c *RuntimeConfig) String() string {
-	return fmt.Sprintf("RuntimeConfig{features: %s, bounds: %s, maxMemoryPages: %d, compileWorkers: %d}",
-		c.features, c.boundsChecks, c.maxMemoryPages, c.compileWorkers)
+	return fmt.Sprintf("RuntimeConfig{features: %s, bounds: %s, maxMemoryPages: %d, functionWorkers: %d}",
+		c.features, c.boundsChecks, c.maxMemoryPages, c.functionWorkers)
 }
 
 // SupportedFeatures reports the WebAssembly feature set this wago build can
@@ -344,8 +354,8 @@ func (c *RuntimeConfig) frontendFeatures() frontend.Features {
 // surfacing a bad config early (e.g. at startup). A feature flag is never a
 // silent no-op.
 func (c *RuntimeConfig) Validate() error {
-	if c.compileWorkers < 0 {
-		return fmt.Errorf("wago: compile workers must be non-negative, got %d", c.compileWorkers)
+	if c.functionWorkers < 0 {
+		return fmt.Errorf("wago: function workers must be non-negative, got %d", c.functionWorkers)
 	}
 	if unsupported := c.features &^ coreFeaturesWago; unsupported != 0 {
 		return &UnsupportedFeatureError{Requested: unsupported, Supported: coreFeaturesWago}

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -138,13 +138,13 @@ type RuntimeConfig struct {
 	maxMemoryPages uint32
 	boundsChecks   BoundsCheckMode
 	noDeferBounds  bool // disable skipping of provably-redundant bounds checks (default: enabled)
-	compileWorkers int  // 0 adaptive; 1 serial; >1 forced maximum
+	compileWorkers int  // function validation/codegen: 0 adaptive; 1 serial; >1 forced maximum
 }
 
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
 
 // NewRuntimeConfig returns the default configuration: wago's supported feature
-// set, serial function compilation, and the fastest available bounds-check mode —
+// set, serial function validation/codegen, and the fastest available bounds-check mode —
 // signals-based (guard-page) when the binary was built with -tags wago_guardpage,
 // explicit otherwise. WAGO_BOUNDS overrides either way ("explicit" / "signals").
 func NewRuntimeConfig() *RuntimeConfig {
@@ -225,10 +225,10 @@ func (c *RuntimeConfig) WithDeferBoundsChecks(enabled bool) *RuntimeConfig {
 	return &n
 }
 
-// WithCompileWorkers sets the per-module function-codegen policy. Zero selects
-// the measured adaptive policy, one forces the serial fast path, and N > 1
-// forces at most N workers (still capped by GOMAXPROCS and local-function count).
-// Negative values are rejected by Validate.
+// WithCompileWorkers sets the per-module function validation/codegen policy.
+// Zero selects the measured adaptive policy, one forces the serial fast path,
+// and N > 1 forces at most N workers (still capped by GOMAXPROCS and local-
+// function count). Negative values are rejected by Validate.
 func (c *RuntimeConfig) WithCompileWorkers(workers int) *RuntimeConfig {
 	n := *c
 	n.compileWorkers = workers
@@ -248,8 +248,8 @@ func (c *RuntimeConfig) DeferBoundsChecks() bool { return !c.noDeferBounds }
 // MemoryLimitPages reports the configured maximum linear-memory size in pages.
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }
 
-// CompileWorkers reports the configured compile-worker policy: zero adaptive,
-// one serial, or a positive forced maximum.
+// CompileWorkers reports the configured function-pipeline worker policy: zero
+// adaptive, one serial, or a positive forced maximum.
 func (c *RuntimeConfig) CompileWorkers() int { return c.compileWorkers }
 
 // Compile decodes, validates, and compiles wasmBytes under this config. On

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -274,12 +274,15 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	if err := NewRuntimeConfig().Validate(); err != nil {
 		t.Fatalf("default config should validate: %v", err)
 	}
-	if err := NewRuntimeConfig().WithCompileWorkers(-1).Validate(); err == nil || !strings.Contains(err.Error(), "non-negative") {
-		t.Fatalf("negative compile workers should fail validation, got %v", err)
+	if err := NewRuntimeConfig().WithFunctionWorkers(-1).Validate(); err == nil || !strings.Contains(err.Error(), "non-negative") {
+		t.Fatalf("negative function workers should fail validation, got %v", err)
 	}
-	workers := NewRuntimeConfig().WithCompileWorkers(4)
-	if workers.CompileWorkers() != 4 || NewRuntimeConfig().CompileWorkers() != 1 {
-		t.Fatal("WithCompileWorkers must be immutable and observable; default must remain serial")
+	workers := NewRuntimeConfig().WithFunctionWorkers(4)
+	if workers.FunctionWorkers() != 4 || NewRuntimeConfig().FunctionWorkers() != 1 {
+		t.Fatal("WithFunctionWorkers must be immutable and observable; default must remain serial")
+	}
+	if got := NewRuntimeConfig().WithCompileWorkers(3); got.CompileWorkers() != 3 || got.FunctionWorkers() != 3 {
+		t.Fatal("deprecated compile-worker aliases must preserve the function-worker policy")
 	}
 	wantFeatures := coreFeaturesWago
 	if !hostSupportsSIMD() {
@@ -293,12 +296,12 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	}
 	// String is non-empty / informative. The default bounds mode depends on the
 	// build tag (explicit normally, signals-based under wago_guardpage).
-	if s := NewRuntimeConfig().String(); (!strings.Contains(s, "explicit") && !strings.Contains(s, "signals-based")) || !strings.Contains(s, "compileWorkers: 1") {
+	if s := NewRuntimeConfig().String(); (!strings.Contains(s, "explicit") && !strings.Contains(s, "signals-based")) || !strings.Contains(s, "functionWorkers: 1") {
 		t.Fatalf("config String missing bounds mode or serial default policy: %q", s)
 	}
 }
 
-func TestCompileWorkersLinkPathAndSerialization(t *testing.T) {
+func TestFunctionWorkersLinkPathAndSerialization(t *testing.T) {
 	producer, err := Instantiate(MustCompile(benchAddOneModule()), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate link producer: %v", err)
@@ -313,22 +316,22 @@ func TestCompileWorkersLinkPathAndSerialization(t *testing.T) {
 	imports := Imports{"env.f": f}
 	compileLinked := func(workers int) (*Compiled, *Compiled) {
 		t.Helper()
-		cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(workers)
+		cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(workers)
 		c, err := Compile(cfg, mod)
 		if err != nil {
 			t.Fatalf("workers=%d compile: %v", workers, err)
 		}
-		if int(c.compileWorkers) != workers || len(c.wasmBytes) == 0 {
-			t.Fatalf("workers=%d metadata policy=%d retainedSource=%d", workers, c.compileWorkers, len(c.wasmBytes))
+		if int(c.functionWorkers) != workers || len(c.wasmBytes) == 0 {
+			t.Fatalf("workers=%d metadata policy=%d retainedSource=%d", workers, c.functionWorkers, len(c.wasmBytes))
 		}
 		linked, err := c.linkModule(imports, nil)
 		if err != nil {
 			_ = c.Close()
 			t.Fatalf("workers=%d link: %v", workers, err)
 		}
-		if linked == c || int(linked.compileWorkers) != workers {
+		if linked == c || int(linked.functionWorkers) != workers {
 			_ = c.Close()
-			t.Fatalf("workers=%d linked=%p owner=%p policy=%d", workers, linked, c, linked.compileWorkers)
+			t.Fatalf("workers=%d linked=%p owner=%p policy=%d", workers, linked, c, linked.functionWorkers)
 		}
 		return c, linked
 	}
@@ -342,12 +345,12 @@ func TestCompileWorkersLinkPathAndSerialization(t *testing.T) {
 		t.Fatal("link-time parallel codegen differs from serial output")
 	}
 
-	serialArtifact, err := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(1).Compile(benchAddOneModule())
+	serialArtifact, err := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(1).Compile(benchAddOneModule())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer serialArtifact.Close()
-	parallelArtifact, err := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithCompileWorkers(8).Compile(benchAddOneModule())
+	parallelArtifact, err := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(8).Compile(benchAddOneModule())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,14 +364,14 @@ func TestCompileWorkersLinkPathAndSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(parallelBlob, serialBlob) {
-		t.Fatal("compile-worker policy changed serialized output")
+		t.Fatal("function-worker policy changed serialized output")
 	}
 	var loaded Compiled
 	if err := loaded.UnmarshalBinary(parallelBlob); err != nil {
 		t.Fatal(err)
 	}
-	if loaded.compileWorkers != 0 {
-		t.Fatalf("deserialized compile policy = %d, want zero/non-serialized", loaded.compileWorkers)
+	if loaded.functionWorkers != 0 {
+		t.Fatalf("deserialized function policy = %d, want zero/non-serialized", loaded.functionWorkers)
 	}
 }
 
@@ -380,7 +383,7 @@ func intSliceBytes(v []int) []byte {
 	return out
 }
 
-func TestCompileWorkersForModulePolicy(t *testing.T) {
+func TestFunctionWorkersForModulePolicy(t *testing.T) {
 	module := func(funcs, bodyBytes int) *wasm.Module {
 		m := &wasm.Module{Code: make([]wasm.Func, funcs)}
 		remaining := bodyBytes
@@ -406,19 +409,19 @@ func TestCompileWorkersForModulePolicy(t *testing.T) {
 		}
 		return w
 	}
-	if got := compileWorkersForModule(module(2, 9), 0); got != 1 {
+	if got := functionWorkersForModule(module(2, 9), 0); got != 1 {
 		t.Fatalf("tiny auto workers = %d, want serial", got)
 	}
-	if got, want := compileWorkersForModule(module(301, 2053), 0), capWant(4, 301); got != want {
+	if got, want := functionWorkersForModule(module(301, 2053), 0), capWant(4, 301); got != want {
 		t.Fatalf("many-functions auto workers = %d, want %d", got, want)
 	}
-	if got, want := compileWorkersForModule(module(658, 234408), 0), capWant(4, 658); got != want {
+	if got, want := functionWorkersForModule(module(658, 234408), 0), capWant(4, 658); got != want {
 		t.Fatalf("lua-tier auto workers = %d, want %d", got, want)
 	}
-	if got, want := compileWorkersForModule(module(2831, 798392), 0), capWant(4, 2831); got != want {
+	if got, want := functionWorkersForModule(module(2831, 798392), 0), capWant(4, 2831); got != want {
 		t.Fatalf("sqlite-tier auto workers = %d, want %d", got, want)
 	}
-	if got, want := compileWorkersForModule(module(10, 10), 3), capWant(3, 10); got != want {
+	if got, want := functionWorkersForModule(module(10, 10), 3), capWant(3, 10); got != want {
 		t.Fatalf("forced maximum workers = %d, want %d", got, want)
 	}
 }

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -612,7 +612,7 @@ type Compiled struct {
 	needsLink        bool
 	boundsElide      bool   // cached ElideBoundsChecks decision, for the link-time recompile
 	noDeferBounds    bool   // cached DeferBoundsChecks=false decision, for the link-time recompile
-	compileWorkers   uint16 // capped compile policy for link-time recompilation; never serialized
+	functionWorkers  uint16 // capped function-worker policy for link-time recompilation; never serialized
 	requiredFeatures uint8  // exact optional core-feature bits required by code/metadata
 
 	// hostLink caches the host-only link recompile. A needsLink module (returning


### PR DESCRIPTION
## Summary

- parallelize independent wasm function-body validation under the existing bounded worker policy
- use one effective worker count for validation and native codegen while keeping module-wide work serial
- preserve deterministic lowest-function-index validation errors and serial allocation behavior
- add canonical `WithFunctionWorkers` / `FunctionWorkers` APIs, retaining the compile-worker names as deprecated aliases
- expose the same `-p[workers]` forms on both `wago run` and `wago validate`
- document policy, memory tradeoffs, architecture, benchmarks, and reproduction steps

## Design

Module declarations, types, imports, globals, constant expressions, elements, data, exports, and start validation finish serially before function workers start. Each validation worker owns its operand/control stacks, byte reader, and immediate scratch.

The resolved component-type cache is populated and frozen before workers run. Valid type lookups are then read-only; malformed type-index misses are computed without mutating the cache. Results are stored by function index and scanned in order after the join, so diagnostics match serial validation regardless of scheduling.

A review audit found that `table.init` was redundantly revalidating expression-based element payloads from function workers through shared `moduleValidator.constFV` scratch. This was reproducible as race-detector reports and a `popCtrl` panic. The function-body path now reads only the element reference type already validated during the serial module phase (`funcref` for function/function-expression segments, the declared type for typed-expression segments). The direct byte-backed representation has the equivalent read-only lookup. Workers therefore cannot reach the mutable module-level const-expression validator.

The adaptive policy remains deliberately conservative:

```text
score = total function-body bytes + 64 * local function count
score < 16 KiB: serial
otherwise:       at most 4 workers
```

The effective count is capped by `GOMAXPROCS` and local-function count. The default remains serial.

## Benchmarks

Go 1.24.4, linux/amd64, AMD Ryzen 7 8845HS, `GOMAXPROCS=8`; validation medians from `-benchtime=500ms -count=8 -benchmem`.

### Validation p4 versus baseline serial

| module | change |
|---|---:|
| many_funcs | -34.2% |
| json-as | -58.2% |
| lua | -67.7% |
| sqlite3 | -70.6% |
| ruby | -72.1% |
| esbuild | -68.4% |

Tiny grows from about 0.82 us to 3.28 us when parallelism is forced; adaptive mode keeps it serial. Serial B/op and allocs/op are unchanged on every measured module.

### Full pipeline: new p4 versus codegen-only p4

| module | additional improvement |
|---|---:|
| many_funcs | -8.2% |
| json-as | -18.1% |
| lua | -18.1% |
| sqlite3 | -22.9% |
| ruby | -24.3% |
| esbuild | -18.8% |

The initial compile path for lua/sqlite/ruby previously got no `-p` benefit because codegen is link-deferred; parallel validation now improves that path too.

The p1/p4 validation matrix was repeated before and after the `table.init` fix with `-count=5 -benchtime=500ms -benchmem`. No meaningful latency regression was observed; serial B/op and allocs/op remained exactly unchanged across all six measured modules, as did p4 allocs/op. Full distributions, allocations, environment, and reproduction commands are in `docs/parallel-function-validation-report.md`. The supported feature guide is `docs/function-workers.md`.

## Verification

- `make test`
- `(cd bench && go test ./...)`
- `go test -race ./src/core/compiler/wasm -run 'TestValidate.*TableInit.*' -count=20`
- `go test -race ./internal/functionworkers ./src/core/compiler/wasm ./src/wago ./cli/wagocli`
- `make test-corpus` (explicit and guard-page corpus runs)
- `go vet ./...`
- `mise x go@1.22 staticcheck@2024.1.1 -- make lint-staticcheck`
- generated facade up-to-date
- all tracked Go files gofmt-clean
- serial/p2/p4/p8 validation parity across synthetic, scalar/SIMD, Lua, SQLite, Ruby, and esbuild corpus modules
- focused materialized/direct `table.init` expression-element parity, deterministic invalid cases, and no-revalidation structural tests
- focused post-productization validation and full-pipeline p1/p4 benchmark reruns

Staticcheck passed under the same Go 1.22 / Staticcheck 2024.1.1 versions used by CI.

## AI assistance

AI assistance was used to explore the validator concurrency boundary, draft tests and documentation, run the benchmark matrix, and review the final patch. Every changed path was exercised through the verification listed above.