### PR TITLE
feat(compiler): erase plugin externref values into registers

### DIFF
--- a/docs/compiler-instruction-plugin-design.md
+++ b/docs/compiler-instruction-plugin-design.md
@@ -124,23 +124,29 @@ but does not interpret the plugin's instructions.
 Instruction module names, operation names, versioning, feature dispatch,
 cross-platform behavior, and machine-code sequences all belong to the plugin.
 
-## Erased `externref` values
+## Registered custom value types
 
 Pointer imports are suitable at the boundary, but a sequence of pointer-based
 vector operations reloads and stores the same values repeatedly. A plugin can
-instead mark selected `externref` parameters and a single `externref` result as
-a compiler-erased virtual type:
+register a custom type once, choose a standard Wasm validation carrier, and use
+the returned opaque token in any number of instructions:
 
 ```go
-v256 := wago.VirtualType{Name: "example.v256", Size: 32}
+compiler := reg.Compiler()
+v256, err := compiler.Type(wago.CustomTypeSpec{
+	Name:    "example.v256",
+	Size:    32,
+	Carrier: wago.WasmExternRef,
+})
+if err != nil {
+	return err
+}
 
-reg.Compiler().Instruction(wago.InstructionSpec{
+return compiler.Instruction(wago.InstructionSpec{
 	Module: "example",
 	Name:   "v256.xor",
-	Input:  []int32{256, 256},
-	Output: []int32{256},
-	Virtual: &wago.VirtualSignature{
-		Inputs: []wago.VirtualType{v256, v256},
+	Custom: &wago.CustomSignature{
+		Inputs: []wago.CustomType{v256, v256},
 		Output: &v256,
 	},
 	AMD64: amd64Xor,
@@ -148,13 +154,23 @@ reg.Compiler().Instruction(wago.InstructionSpec{
 })
 ```
 
-The physical Wasm signature is
-`(externref, externref) -> externref`. `InputVirtual` transfers each input's
-native register bundle to the lowering, and `OutputVirtual` assigns the output
+Wago derives custom input and output bit widths from the registered tokens.
+Mixed signatures retain `Input` entries only for ordinary values; use zero at a
+custom position and Wago fills it from the type.
+
+With `WasmExternRef`, the physical signature is
+`(externref, externref) -> externref`. `InputCustom` transfers each input's
+native register bundle to the lowering, and `OutputCustom` assigns the output
 bundle. The plugin owns the type name, byte size, register chunking, semantics,
 and machine code.
 
-The `externref` is only a validated carrier. Wago does not allocate a host
+The carrier can be `WasmI32`, `WasmI64`, `WasmF32`, `WasmF64`, `WasmV128`,
+`WasmFuncRef`, or `WasmExternRef`. It affects only the module's ordinary physical function
+signature; the registered custom type identity remains distinct inside the
+compiler. This lets any source language emit whichever standard type it can
+represent most naturally, without a custom section or a new binary type code.
+
+An `externref` carrier is only a validation marker. Wago does not allocate a host
 object, enter the runtime reference store, or materialize the value in linear
 memory. A source-language transform can therefore emit a chain such as:
 
@@ -170,13 +186,18 @@ and the native backend keeps the intermediate value in registers. Load and
 store remain ordinary plugin-defined instructions; Wago does not attach memory
 or SIMD meaning to them.
 
-Virtual values are intentionally native-only and currently have expression
+Custom values are intentionally native-only and currently have expression
 lifetime. They may flow directly between plugin calls, be dropped, or be
 consumed by a plugin call, but cannot be stored in Wasm locals, passed to an
 ordinary function, returned from the guest, or carried across control flow.
-Compilation rejects such escapes. A virtual instruction must provide at least
+Compilation rejects such escapes. A custom instruction must provide at least
 one target lowering and must not provide a portable `Handler`; a target without
 that lowering retains a trapping import.
+
+`CompilerRegistry.Type` is the single registration seam. Repeating the same
+name, size, and carrier is idempotent. Reusing a name with a different
+declaration, using an unregistered token, or using a token obtained from another
+registry is rejected before the instruction is installed.
 
 Because general-purpose and vector register numbers overlap on both supported
 architectures, raw lowerings should call `ReleaseGP` or `ReleaseVector`.

--- a/docs/compiler-instruction-plugin-design.md
+++ b/docs/compiler-instruction-plugin-design.md
@@ -2,8 +2,8 @@
 
 Wago compiler plugins can recognize ordinary Wasm function imports and replace
 their calls during native code generation. Any source language that can emit an
-`i32` import can use the mechanism without custom Wasm types, custom sections,
-binary rewriting, or compiler-specific metadata.
+`i32` or `externref` import can use the mechanism without custom Wasm types,
+custom sections, or compiler-specific metadata.
 
 The guest ABI is conventional:
 
@@ -123,3 +123,62 @@ but does not interpret the plugin's instructions.
 
 Instruction module names, operation names, versioning, feature dispatch,
 cross-platform behavior, and machine-code sequences all belong to the plugin.
+
+## Erased `externref` values
+
+Pointer imports are suitable at the boundary, but a sequence of pointer-based
+vector operations reloads and stores the same values repeatedly. A plugin can
+instead mark selected `externref` parameters and a single `externref` result as
+a compiler-erased virtual type:
+
+```go
+v256 := wago.VirtualType{Name: "example.v256", Size: 32}
+
+reg.Compiler().Instruction(wago.InstructionSpec{
+	Module: "example",
+	Name:   "v256.xor",
+	Input:  []int32{256, 256},
+	Output: []int32{256},
+	Virtual: &wago.VirtualSignature{
+		Inputs: []wago.VirtualType{v256, v256},
+		Output: &v256,
+	},
+	AMD64: amd64Xor,
+	ARM64: arm64Xor,
+})
+```
+
+The physical Wasm signature is
+`(externref, externref) -> externref`. `InputVirtual` transfers each input's
+native register bundle to the lowering, and `OutputVirtual` assigns the output
+bundle. The plugin owns the type name, byte size, register chunking, semantics,
+and machine code.
+
+The `externref` is only a validated carrier. Wago does not allocate a host
+object, enter the runtime reference store, or materialize the value in linear
+memory. A source-language transform can therefore emit a chain such as:
+
+```wat
+(call $v256.store
+  (call $v256.xor
+    (call $v256.load (i32.const 32))
+    (call $v256.load (i32.const 64)))
+  (i32.const 0))
+```
+
+and the native backend keeps the intermediate value in registers. Load and
+store remain ordinary plugin-defined instructions; Wago does not attach memory
+or SIMD meaning to them.
+
+Virtual values are intentionally native-only and currently have expression
+lifetime. They may flow directly between plugin calls, be dropped, or be
+consumed by a plugin call, but cannot be stored in Wasm locals, passed to an
+ordinary function, returned from the guest, or carried across control flow.
+Compilation rejects such escapes. A virtual instruction must provide at least
+one target lowering and must not provide a portable `Handler`; a target without
+that lowering retains a trapping import.
+
+Because general-purpose and vector register numbers overlap on both supported
+architectures, raw lowerings should call `ReleaseGP` or `ReleaseVector`.
+`Release` remains as a compatibility convenience when the register class is
+unambiguous.

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -164,7 +164,7 @@ func (f *fn) callOp(r *wasm.Reader) error {
 
 func (f *fn) emitCustomInstruction(custom CustomInstruction, ft *wasm.CompType) error {
 	if custom.AMD64 != nil {
-		return f.emitPluginAMD64(custom.AMD64, custom.InputWidths, custom.ResultWidth, len(ft.Results), custom.VirtualInputs, custom.VirtualOutput)
+		return f.emitPluginAMD64(custom.AMD64, custom.InputWidths, custom.ResultWidth, len(ft.Results), custom.CustomInputs, custom.CustomOutput)
 	}
 	if len(ft.Results) != 1 || !wasm.EqualValType(ft.Results[0], wasm.I32) {
 		return fmt.Errorf("custom instruction %d must return one i32", f.globalIdx)

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -164,7 +164,7 @@ func (f *fn) callOp(r *wasm.Reader) error {
 
 func (f *fn) emitCustomInstruction(custom CustomInstruction, ft *wasm.CompType) error {
 	if custom.AMD64 != nil {
-		return f.emitPluginAMD64(custom.AMD64, custom.InputWidths, custom.ResultWidth, len(ft.Results))
+		return f.emitPluginAMD64(custom.AMD64, custom.InputWidths, custom.ResultWidth, len(ft.Results), custom.VirtualInputs, custom.VirtualOutput)
 	}
 	if len(ft.Results) != 1 || !wasm.EqualValType(ft.Results[0], wasm.I32) {
 		return fmt.Errorf("custom instruction %d must return one i32", f.globalIdx)

--- a/src/core/compiler/backend/railshot/amd64/control.go
+++ b/src/core/compiler/backend/railshot/amd64/control.go
@@ -156,6 +156,9 @@ func (f *fn) flush() {
 	slot := 0
 	for _, root := range roots {
 		typ := rootMachineType(root)
+		if typ == mtVirtual {
+			panic("virtual externref cannot cross a control-flow or ordinary call boundary")
+		}
 		types = append(types, typ)
 		if root.kind == ekValue && root.st.kind == stSlot && root.st.slot == slot && root.st.typ == typ {
 			slot += typ.stackSlots()

--- a/src/core/compiler/backend/railshot/amd64/control.go
+++ b/src/core/compiler/backend/railshot/amd64/control.go
@@ -156,8 +156,8 @@ func (f *fn) flush() {
 	slot := 0
 	for _, root := range roots {
 		typ := rootMachineType(root)
-		if typ == mtVirtual {
-			panic("virtual externref cannot cross a control-flow or ordinary call boundary")
+		if typ == mtCustom {
+			panic("custom value cannot cross a control-flow or ordinary call boundary")
 		}
 		types = append(types, typ)
 		if root.kind == ekValue && root.st.kind == stSlot && root.st.slot == slot && root.st.typ == typ {

--- a/src/core/compiler/backend/railshot/amd64/driver.go
+++ b/src/core/compiler/backend/railshot/amd64/driver.go
@@ -91,7 +91,11 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 		e := f.popValue()
 		switch e.st.kind {
 		case stReg:
-			if e.st.typ.isXMM() {
+			if e.st.typ == mtVirtual {
+				for _, reg := range e.st.vregs[:e.st.vcount] {
+					f.releaseF(reg)
+				}
+			} else if e.st.typ.isXMM() {
 				f.releaseF(e.st.reg)
 			} else {
 				f.release(e.st.reg)
@@ -885,6 +889,9 @@ func (f *fn) setLocal(x int, tee bool) {
 		f.invalidateBoundsCert() // the certified base local changed value
 	}
 	e := f.s.back()
+	if e != nil && e.kind == ekValue && e.st.typ == mtVirtual {
+		panic("virtual externref cannot be stored in a Wasm local")
+	}
 	// In-place self-update `local.set $x (op (local.get $x) …)`: let condenseInto
 	// consume the top expression straight into x's register instead of pre-copying
 	// its (local.get $x) operand. The condense paths (binary, shift, unary, convert)

--- a/src/core/compiler/backend/railshot/amd64/driver.go
+++ b/src/core/compiler/backend/railshot/amd64/driver.go
@@ -91,8 +91,8 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 		e := f.popValue()
 		switch e.st.kind {
 		case stReg:
-			if e.st.typ == mtVirtual {
-				for _, reg := range e.st.vregs[:e.st.vcount] {
+			if e.st.typ == mtCustom {
+				for _, reg := range e.st.vregs {
 					f.releaseF(reg)
 				}
 			} else if e.st.typ.isXMM() {
@@ -889,8 +889,8 @@ func (f *fn) setLocal(x int, tee bool) {
 		f.invalidateBoundsCert() // the certified base local changed value
 	}
 	e := f.s.back()
-	if e != nil && e.kind == ekValue && e.st.typ == mtVirtual {
-		panic("virtual externref cannot be stored in a Wasm local")
+	if e != nil && e.kind == ekValue && e.st.typ == mtCustom {
+		panic("custom value cannot be stored in a Wasm local")
 	}
 	// In-place self-update `local.set $x (op (local.get $x) …)`: let condenseInto
 	// consume the top expression straight into x's register instead of pre-copying

--- a/src/core/compiler/backend/railshot/amd64/fp.go
+++ b/src/core/compiler/backend/railshot/amd64/fp.go
@@ -76,14 +76,14 @@ func (f *fn) allocFReg(avoid regMask) Reg {
 // spillF evicts an XMM-resident float/vector value to a fresh frame slot.
 func (f *fn) spillF(e *elem) {
 	r := e.st.reg
-	if e.st.typ == mtVirtual {
-		slot := f.allocSpillSlots(int(e.st.virtual.Size / 8))
-		for i := 0; i < int(e.st.vcount); i++ {
-			reg := e.st.vregs[i]
+	if e.st.typ == mtCustom {
+		chunks := int((e.st.custom.Size() + 31) / 32)
+		slot := f.allocSpillSlots(chunks * 4)
+		for i, reg := range e.st.vregs {
 			f.a.YMovdquStoreDisp(RSP, f.spillOff(slot+i*4), reg)
 			f.fregUser[reg] = nil
 		}
-		f.replaceStorage(e, storage{kind: stSlot, typ: mtVirtual, slot: slot, virtual: e.st.virtual})
+		f.replaceStorage(e, storage{kind: stSlot, typ: mtCustom, slot: slot, custom: e.st.custom})
 		return
 	}
 	if e.st.typ == mtV128 {

--- a/src/core/compiler/backend/railshot/amd64/fp.go
+++ b/src/core/compiler/backend/railshot/amd64/fp.go
@@ -76,6 +76,16 @@ func (f *fn) allocFReg(avoid regMask) Reg {
 // spillF evicts an XMM-resident float/vector value to a fresh frame slot.
 func (f *fn) spillF(e *elem) {
 	r := e.st.reg
+	if e.st.typ == mtVirtual {
+		slot := f.allocSpillSlots(int(e.st.virtual.Size / 8))
+		for i := 0; i < int(e.st.vcount); i++ {
+			reg := e.st.vregs[i]
+			f.a.YMovdquStoreDisp(RSP, f.spillOff(slot+i*4), reg)
+			f.fregUser[reg] = nil
+		}
+		f.replaceStorage(e, storage{kind: stSlot, typ: mtVirtual, slot: slot, virtual: e.st.virtual})
+		return
+	}
 	if e.st.typ == mtV128 {
 		slot := f.allocSpillSlots(2)
 		f.a.VMovdquStoreDisp(RSP, f.spillOff(slot), r)

--- a/src/core/compiler/backend/railshot/amd64/plugin_machine.go
+++ b/src/core/compiler/backend/railshot/amd64/plugin_machine.go
@@ -11,17 +11,17 @@ import (
 )
 
 type pluginAMD64Context struct {
-	f             *fn
-	paramSlots    []int
-	paramWidth    []int32
-	paramElems    []*elem
-	paramVirtual  []coreplugins.VirtualType
-	virtualRead   []bool
-	gp, ymm       regMask
-	output        Reg
-	outputSet     bool
-	virtualOutput *coreplugins.VirtualType
-	virtualRegs   []Reg
+	f            *fn
+	paramSlots   []int
+	paramWidth   []int32
+	paramElems   []*elem
+	paramCustom  []coreplugins.CustomType
+	customRead   []bool
+	gp, ymm      regMask
+	output       Reg
+	outputSet    bool
+	customOutput *coreplugins.CustomType
+	customRegs   []Reg
 }
 
 func (c *pluginAMD64Context) Encoder() *x86.Asm { return c.f.a }
@@ -38,24 +38,24 @@ func (c *pluginAMD64Context) InputI32(index int) (x86.Reg, error) {
 	return r, nil
 }
 
-func (c *pluginAMD64Context) InputVirtual(index int) ([]x86.Reg, error) {
-	if index < 0 || index >= len(c.paramElems) || index >= len(c.paramVirtual) || c.paramVirtual[index] == (coreplugins.VirtualType{}) {
-		return nil, fmt.Errorf("amd64 plugin virtual input %d out of range", index)
+func (c *pluginAMD64Context) InputCustom(index int) ([]x86.Reg, error) {
+	if index < 0 || index >= len(c.paramElems) || index >= len(c.paramCustom) || c.paramCustom[index].IsZero() {
+		return nil, fmt.Errorf("amd64 plugin custom input %d out of range", index)
 	}
 	e := c.paramElems[index]
-	want := c.paramVirtual[index]
-	if e.kind != ekValue || e.st.typ != mtVirtual || e.st.virtual == nil || !e.st.virtual.Equal(want) {
-		return nil, fmt.Errorf("amd64 plugin virtual input %d has incompatible erased externref type", index)
+	want := c.paramCustom[index]
+	if e.kind != ekValue || e.st.typ != mtCustom || e.st.custom == nil || !e.st.custom.Equal(want) {
+		return nil, fmt.Errorf("amd64 plugin custom input %d has incompatible custom type", index)
 	}
-	regs := c.f.materializePluginVirtual(e)
+	regs := c.f.materializePluginCustom(e)
 	out := append([]Reg(nil), regs...)
 	for _, reg := range out {
 		c.f.fregUser[reg] = nil
 		c.f.fpinned = c.f.fpinned.add(reg)
 		c.ymm = c.ymm.add(reg)
 	}
-	e.st.vcount = 0
-	c.virtualRead[index] = true
+	e.st.vregs = nil
+	c.customRead[index] = true
 	return out, nil
 }
 
@@ -186,7 +186,7 @@ func (c *pluginAMD64Context) ReleaseGP(reg x86.Reg) {
 }
 
 func (c *pluginAMD64Context) ReleaseVector(reg x86.Reg) {
-	for _, output := range c.virtualRegs {
+	for _, output := range c.customRegs {
 		if reg == output {
 			return
 		}
@@ -217,8 +217,8 @@ func (c *pluginAMD64Context) CheckedMemory(input int, offset uint32, size int) (
 }
 
 func (c *pluginAMD64Context) OutputI32(reg x86.Reg) error {
-	if c.virtualOutput != nil {
-		return fmt.Errorf("amd64 plugin virtual instruction cannot set an i32 output")
+	if c.customOutput != nil {
+		return fmt.Errorf("amd64 plugin custom instruction cannot set an i32 output")
 	}
 	if !c.gp.has(reg) {
 		return fmt.Errorf("amd64 plugin output register %d is not owned by the lowering", reg)
@@ -230,37 +230,37 @@ func (c *pluginAMD64Context) OutputI32(reg x86.Reg) error {
 	return nil
 }
 
-func (c *pluginAMD64Context) OutputVirtual(regs ...x86.Reg) error {
-	if c.virtualOutput == nil {
-		return fmt.Errorf("amd64 plugin instruction has no virtual output")
+func (c *pluginAMD64Context) OutputCustom(regs ...x86.Reg) error {
+	if c.customOutput == nil {
+		return fmt.Errorf("amd64 plugin instruction has no custom output")
 	}
-	want := int(c.virtualOutput.Size / 32)
+	want := int((c.customOutput.Size() + 31) / 32)
 	if len(regs) != want {
-		return fmt.Errorf("amd64 plugin virtual output has %d register(s), want %d", len(regs), want)
+		return fmt.Errorf("amd64 plugin custom output has %d register(s), want %d", len(regs), want)
 	}
-	if c.outputSet || len(c.virtualRegs) != 0 {
+	if c.outputSet || len(c.customRegs) != 0 {
 		return fmt.Errorf("amd64 plugin output already assigned")
 	}
 	seen := regMask(0)
 	for _, reg := range regs {
 		if !c.ymm.has(reg) || seen.has(reg) {
-			return fmt.Errorf("amd64 plugin virtual output register %d is not uniquely owned by the lowering", reg)
+			return fmt.Errorf("amd64 plugin custom output register %d is not uniquely owned by the lowering", reg)
 		}
 		seen = seen.add(reg)
 	}
-	c.virtualRegs = append([]Reg(nil), regs...)
+	c.customRegs = append([]Reg(nil), regs...)
 	return nil
 }
 
-func (f *fn) materializePluginVirtual(e *elem) []Reg {
+func (f *fn) materializePluginCustom(e *elem) []Reg {
 	if e.st.kind == stReg {
-		return e.st.vregs[:e.st.vcount]
+		return e.st.vregs
 	}
-	if e.st.kind != stSlot || e.st.virtual == nil {
-		panic("amd64: cannot materialize virtual plugin value")
+	if e.st.kind != stSlot || e.st.custom == nil {
+		panic("amd64: cannot materialize custom plugin value")
 	}
-	count := int(e.st.virtual.Size / 32)
-	var regs [4]Reg
+	count := int((e.st.custom.Size() + 31) / 32)
+	regs := make([]Reg, count)
 	var avoid regMask
 	for i := 0; i < count; i++ {
 		reg := f.allocFReg(avoid)
@@ -273,9 +273,9 @@ func (f *fn) materializePluginVirtual(e *elem) []Reg {
 		f.fpinned = f.fpinned.remove(regs[i])
 		f.fregUser[regs[i]] = e
 	}
-	e.st.kind, e.st.typ, e.st.reg = stReg, mtVirtual, regs[0]
-	e.st.vregs, e.st.vcount = regs, uint8(count)
-	return e.st.vregs[:count]
+	e.st.kind, e.st.typ, e.st.reg = stReg, mtCustom, regs[0]
+	e.st.vregs = regs
+	return e.st.vregs
 }
 
 func (c *pluginAMD64Context) finish(resultWidth int32) {
@@ -300,9 +300,9 @@ func (c *pluginAMD64Context) finish(resultWidth int32) {
 	}
 }
 
-func (f *fn) emitPluginAMD64(lowering *machinecode.AMD64Lowering, inputWidths []int32, resultWidth int32, resultCount int, virtualInputs []coreplugins.VirtualType, virtualOutput *coreplugins.VirtualType) error {
-	if len(virtualInputs) != 0 || virtualOutput != nil {
-		return f.emitPluginAMD64Virtual(lowering, inputWidths, resultCount, virtualInputs, virtualOutput)
+func (f *fn) emitPluginAMD64(lowering *machinecode.AMD64Lowering, inputWidths []int32, resultWidth int32, resultCount int, customInputs []coreplugins.CustomType, customOutput *coreplugins.CustomType) error {
+	if len(customInputs) != 0 || customOutput != nil {
+		return f.emitPluginAMD64Custom(lowering, inputWidths, resultCount, customInputs, customOutput)
 	}
 	paramCount := len(inputWidths)
 	types := f.currentLogicalTypes()
@@ -347,10 +347,10 @@ func (f *fn) emitPluginAMD64(lowering *machinecode.AMD64Lowering, inputWidths []
 	return nil
 }
 
-func (f *fn) emitPluginAMD64Virtual(lowering *machinecode.AMD64Lowering, inputWidths []int32, resultCount int, virtualInputs []coreplugins.VirtualType, virtualOutput *coreplugins.VirtualType) error {
+func (f *fn) emitPluginAMD64Custom(lowering *machinecode.AMD64Lowering, inputWidths []int32, resultCount int, customInputs []coreplugins.CustomType, customOutput *coreplugins.CustomType) error {
 	paramCount := len(inputWidths)
-	if len(virtualInputs) != paramCount {
-		return fmt.Errorf("amd64 plugin virtual signature has %d inputs, want %d", len(virtualInputs), paramCount)
+	if len(customInputs) != paramCount {
+		return fmt.Errorf("amd64 plugin custom signature has %d inputs, want %d", len(customInputs), paramCount)
 	}
 	roots := append([]*elem(nil), f.rootsBottomToTop()...)
 	if len(roots) < paramCount {
@@ -359,14 +359,14 @@ func (f *fn) emitPluginAMD64Virtual(lowering *machinecode.AMD64Lowering, inputWi
 	base := len(roots) - paramCount
 	ctx := &pluginAMD64Context{
 		f: f, paramSlots: make([]int, paramCount), paramWidth: inputWidths,
-		paramElems: roots[base:], paramVirtual: virtualInputs, virtualRead: make([]bool, paramCount),
-		output: regNone, virtualOutput: virtualOutput,
+		paramElems: roots[base:], paramCustom: customInputs, customRead: make([]bool, paramCount),
+		output: regNone, customOutput: customOutput,
 	}
-	for i, typ := range virtualInputs {
+	for i, typ := range customInputs {
 		e := ctx.paramElems[i]
-		if typ != (coreplugins.VirtualType{}) {
-			if e.kind != ekValue || e.st.typ != mtVirtual || e.st.virtual == nil || !e.st.virtual.Equal(typ) {
-				return fmt.Errorf("amd64 plugin virtual input %d has incompatible erased externref type", i)
+		if !typ.IsZero() {
+			if e.kind != ekValue || e.st.typ != mtCustom || e.st.custom == nil || !e.st.custom.Equal(typ) {
+				return fmt.Errorf("amd64 plugin custom input %d has incompatible custom type", i)
 			}
 			continue
 		}
@@ -390,20 +390,20 @@ func (f *fn) emitPluginAMD64Virtual(lowering *machinecode.AMD64Lowering, inputWi
 	default:
 		return fmt.Errorf("unsupported amd64 plugin compatibility mode %d", lowering.Compatibility)
 	}
-	for i, typ := range virtualInputs {
-		if typ != (coreplugins.VirtualType{}) && !ctx.virtualRead[i] {
-			return fmt.Errorf("amd64 plugin lowering did not consume virtual input %d", i)
+	for i, typ := range customInputs {
+		if !typ.IsZero() && !ctx.customRead[i] {
+			return fmt.Errorf("amd64 plugin lowering did not consume custom input %d", i)
 		}
 	}
-	if virtualOutput != nil {
-		if resultCount != 1 || len(ctx.virtualRegs) == 0 {
-			return fmt.Errorf("amd64 plugin lowering did not set its virtual output")
+	if customOutput != nil {
+		if resultCount != 1 || len(ctx.customRegs) == 0 {
+			return fmt.Errorf("amd64 plugin lowering did not set its custom output")
 		}
-	} else if resultCount != 0 || len(ctx.virtualRegs) != 0 || ctx.outputSet {
-		return fmt.Errorf("amd64 virtual plugin lowering has an invalid physical output")
+	} else if resultCount != 0 || len(ctx.customRegs) != 0 || ctx.outputSet {
+		return fmt.Errorf("amd64 custom plugin lowering has an invalid physical output")
 	}
-	outputs := make(map[Reg]bool, len(ctx.virtualRegs))
-	for _, reg := range ctx.virtualRegs {
+	outputs := make(map[Reg]bool, len(ctx.customRegs))
+	for _, reg := range ctx.customRegs {
 		outputs[reg] = true
 	}
 	for reg := Reg(0); reg < 16; reg++ {
@@ -415,18 +415,17 @@ func (f *fn) emitPluginAMD64Virtual(lowering *machinecode.AMD64Lowering, inputWi
 		}
 	}
 	for _, root := range ctx.paramElems {
-		if root.st.typ == mtVirtual && root.st.vcount != 0 {
-			for _, reg := range root.st.vregs[:root.st.vcount] {
+		if root.st.typ == mtCustom {
+			for _, reg := range root.st.vregs {
 				f.releaseF(reg)
 			}
 		}
 		f.erase(root)
 	}
-	if virtualOutput != nil {
-		st := storage{kind: stReg, typ: mtVirtual, reg: ctx.virtualRegs[0], virtual: virtualOutput, vcount: uint8(len(ctx.virtualRegs))}
-		copy(st.vregs[:], ctx.virtualRegs)
+	if customOutput != nil {
+		st := storage{kind: stReg, typ: mtCustom, reg: ctx.customRegs[0], custom: customOutput, vregs: append([]Reg(nil), ctx.customRegs...)}
 		e := f.pushValue(st)
-		for _, reg := range ctx.virtualRegs {
+		for _, reg := range ctx.customRegs {
 			ctx.ymm = ctx.ymm.remove(reg)
 			f.fpinned = f.fpinned.remove(reg)
 			f.fregUser[reg] = e
@@ -435,6 +434,6 @@ func (f *fn) emitPluginAMD64Virtual(lowering *machinecode.AMD64Lowering, inputWi
 	if lowering.Features&(machinecode.AMD64FeatureAVX2|machinecode.AMD64FeatureAVX512) != 0 {
 		f.usesWide = true
 	}
-	f.stats.call("custom-machine-code-virtual")
+	f.stats.call("custom-machine-code-custom")
 	return nil
 }

--- a/src/core/compiler/backend/railshot/amd64/plugin_machine.go
+++ b/src/core/compiler/backend/railshot/amd64/plugin_machine.go
@@ -7,15 +7,21 @@ import (
 
 	"github.com/wago-org/wago/src/core/compiler/machinecode"
 	x86 "github.com/wago-org/wago/src/core/encoder/amd64"
+	coreplugins "github.com/wago-org/wago/src/core/plugins"
 )
 
 type pluginAMD64Context struct {
-	f          *fn
-	paramSlots []int
-	paramWidth []int32
-	gp, ymm    regMask
-	output     Reg
-	outputSet  bool
+	f             *fn
+	paramSlots    []int
+	paramWidth    []int32
+	paramElems    []*elem
+	paramVirtual  []coreplugins.VirtualType
+	virtualRead   []bool
+	gp, ymm       regMask
+	output        Reg
+	outputSet     bool
+	virtualOutput *coreplugins.VirtualType
+	virtualRegs   []Reg
 }
 
 func (c *pluginAMD64Context) Encoder() *x86.Asm { return c.f.a }
@@ -30,6 +36,27 @@ func (c *pluginAMD64Context) InputI32(index int) (x86.Reg, error) {
 		c.f.a.AluRI(4, r, int32((uint64(1)<<uint(width))-1), false)
 	}
 	return r, nil
+}
+
+func (c *pluginAMD64Context) InputVirtual(index int) ([]x86.Reg, error) {
+	if index < 0 || index >= len(c.paramElems) || index >= len(c.paramVirtual) || c.paramVirtual[index] == (coreplugins.VirtualType{}) {
+		return nil, fmt.Errorf("amd64 plugin virtual input %d out of range", index)
+	}
+	e := c.paramElems[index]
+	want := c.paramVirtual[index]
+	if e.kind != ekValue || e.st.typ != mtVirtual || e.st.virtual == nil || !e.st.virtual.Equal(want) {
+		return nil, fmt.Errorf("amd64 plugin virtual input %d has incompatible erased externref type", index)
+	}
+	regs := c.f.materializePluginVirtual(e)
+	out := append([]Reg(nil), regs...)
+	for _, reg := range out {
+		c.f.fregUser[reg] = nil
+		c.f.fpinned = c.f.fpinned.add(reg)
+		c.ymm = c.ymm.add(reg)
+	}
+	e.st.vcount = 0
+	c.virtualRead[index] = true
+	return out, nil
 }
 
 func exclusionMask(regs []x86.Reg) regMask {
@@ -73,7 +100,7 @@ func (c *pluginAMD64Context) LoadYMM(input int, offset uint32) (x86.Reg, error) 
 	}
 	x := c.AllocYMM()
 	c.f.a.YMovdquLoadIdx(x, base, index, disp)
-	c.Release(index)
+	c.ReleaseGP(index)
 	return x, nil
 }
 
@@ -86,7 +113,7 @@ func (c *pluginAMD64Context) StoreYMM(input int, offset uint32, value x86.Reg) e
 		return err
 	}
 	c.f.a.YMovdquStoreIdx(base, index, value, disp)
-	c.Release(index)
+	c.ReleaseGP(index)
 	return nil
 }
 
@@ -97,7 +124,7 @@ func (c *pluginAMD64Context) LoadZMM(input int, offset uint32) (x86.Reg, error) 
 	}
 	x := c.AllocYMM()
 	c.f.a.ZMovdqu64LoadIdx(x, base, index, disp)
-	c.Release(index)
+	c.ReleaseGP(index)
 	return x, nil
 }
 
@@ -110,7 +137,7 @@ func (c *pluginAMD64Context) StoreZMM(input int, offset uint32, value x86.Reg) e
 		return err
 	}
 	c.f.a.ZMovdqu64StoreIdx(base, index, value, disp)
-	c.Release(index)
+	c.ReleaseGP(index)
 	return nil
 }
 
@@ -143,6 +170,11 @@ func (c *pluginAMD64Context) ReserveYMM(reg x86.Reg) error {
 }
 
 func (c *pluginAMD64Context) Release(reg x86.Reg) {
+	c.ReleaseGP(reg)
+	c.ReleaseVector(reg)
+}
+
+func (c *pluginAMD64Context) ReleaseGP(reg x86.Reg) {
 	if c.outputSet && reg == c.output {
 		return
 	}
@@ -150,6 +182,14 @@ func (c *pluginAMD64Context) Release(reg x86.Reg) {
 		c.gp = c.gp.remove(reg)
 		c.f.pinned = c.f.pinned.remove(reg)
 		c.f.release(reg)
+	}
+}
+
+func (c *pluginAMD64Context) ReleaseVector(reg x86.Reg) {
+	for _, output := range c.virtualRegs {
+		if reg == output {
+			return
+		}
 	}
 	if c.ymm.has(reg) {
 		c.ymm = c.ymm.remove(reg)
@@ -177,6 +217,9 @@ func (c *pluginAMD64Context) CheckedMemory(input int, offset uint32, size int) (
 }
 
 func (c *pluginAMD64Context) OutputI32(reg x86.Reg) error {
+	if c.virtualOutput != nil {
+		return fmt.Errorf("amd64 plugin virtual instruction cannot set an i32 output")
+	}
 	if !c.gp.has(reg) {
 		return fmt.Errorf("amd64 plugin output register %d is not owned by the lowering", reg)
 	}
@@ -187,13 +230,61 @@ func (c *pluginAMD64Context) OutputI32(reg x86.Reg) error {
 	return nil
 }
 
+func (c *pluginAMD64Context) OutputVirtual(regs ...x86.Reg) error {
+	if c.virtualOutput == nil {
+		return fmt.Errorf("amd64 plugin instruction has no virtual output")
+	}
+	want := int(c.virtualOutput.Size / 32)
+	if len(regs) != want {
+		return fmt.Errorf("amd64 plugin virtual output has %d register(s), want %d", len(regs), want)
+	}
+	if c.outputSet || len(c.virtualRegs) != 0 {
+		return fmt.Errorf("amd64 plugin output already assigned")
+	}
+	seen := regMask(0)
+	for _, reg := range regs {
+		if !c.ymm.has(reg) || seen.has(reg) {
+			return fmt.Errorf("amd64 plugin virtual output register %d is not uniquely owned by the lowering", reg)
+		}
+		seen = seen.add(reg)
+	}
+	c.virtualRegs = append([]Reg(nil), regs...)
+	return nil
+}
+
+func (f *fn) materializePluginVirtual(e *elem) []Reg {
+	if e.st.kind == stReg {
+		return e.st.vregs[:e.st.vcount]
+	}
+	if e.st.kind != stSlot || e.st.virtual == nil {
+		panic("amd64: cannot materialize virtual plugin value")
+	}
+	count := int(e.st.virtual.Size / 32)
+	var regs [4]Reg
+	var avoid regMask
+	for i := 0; i < count; i++ {
+		reg := f.allocFReg(avoid)
+		avoid = avoid.add(reg)
+		f.fpinned = f.fpinned.add(reg)
+		regs[i] = reg
+		f.a.YMovdquLoadDisp(reg, RSP, f.spillOff(e.st.slot+i*4))
+	}
+	for i := 0; i < count; i++ {
+		f.fpinned = f.fpinned.remove(regs[i])
+		f.fregUser[regs[i]] = e
+	}
+	e.st.kind, e.st.typ, e.st.reg = stReg, mtVirtual, regs[0]
+	e.st.vregs, e.st.vcount = regs, uint8(count)
+	return e.st.vregs[:count]
+}
+
 func (c *pluginAMD64Context) finish(resultWidth int32) {
 	for r := Reg(0); r < 16; r++ {
 		if c.gp.has(r) && (!c.outputSet || r != c.output) {
-			c.Release(r)
+			c.ReleaseGP(r)
 		}
 		if c.ymm.has(r) {
-			c.Release(r)
+			c.ReleaseVector(r)
 		}
 	}
 	if !c.outputSet {
@@ -209,7 +300,10 @@ func (c *pluginAMD64Context) finish(resultWidth int32) {
 	}
 }
 
-func (f *fn) emitPluginAMD64(lowering *machinecode.AMD64Lowering, inputWidths []int32, resultWidth int32, resultCount int) error {
+func (f *fn) emitPluginAMD64(lowering *machinecode.AMD64Lowering, inputWidths []int32, resultWidth int32, resultCount int, virtualInputs []coreplugins.VirtualType, virtualOutput *coreplugins.VirtualType) error {
+	if len(virtualInputs) != 0 || virtualOutput != nil {
+		return f.emitPluginAMD64Virtual(lowering, inputWidths, resultCount, virtualInputs, virtualOutput)
+	}
 	paramCount := len(inputWidths)
 	types := f.currentLogicalTypes()
 	if len(types) < paramCount {
@@ -250,5 +344,97 @@ func (f *fn) emitPluginAMD64(lowering *machinecode.AMD64Lowering, inputWidths []
 		f.usesWide = true
 	}
 	f.stats.call("custom-machine-code")
+	return nil
+}
+
+func (f *fn) emitPluginAMD64Virtual(lowering *machinecode.AMD64Lowering, inputWidths []int32, resultCount int, virtualInputs []coreplugins.VirtualType, virtualOutput *coreplugins.VirtualType) error {
+	paramCount := len(inputWidths)
+	if len(virtualInputs) != paramCount {
+		return fmt.Errorf("amd64 plugin virtual signature has %d inputs, want %d", len(virtualInputs), paramCount)
+	}
+	roots := append([]*elem(nil), f.rootsBottomToTop()...)
+	if len(roots) < paramCount {
+		return fmt.Errorf("amd64 plugin lowering has %d stack argument(s), want %d", len(roots), paramCount)
+	}
+	base := len(roots) - paramCount
+	ctx := &pluginAMD64Context{
+		f: f, paramSlots: make([]int, paramCount), paramWidth: inputWidths,
+		paramElems: roots[base:], paramVirtual: virtualInputs, virtualRead: make([]bool, paramCount),
+		output: regNone, virtualOutput: virtualOutput,
+	}
+	for i, typ := range virtualInputs {
+		e := ctx.paramElems[i]
+		if typ != (coreplugins.VirtualType{}) {
+			if e.kind != ekValue || e.st.typ != mtVirtual || e.st.virtual == nil || !e.st.virtual.Equal(typ) {
+				return fmt.Errorf("amd64 plugin virtual input %d has incompatible erased externref type", i)
+			}
+			continue
+		}
+		if e.kind != ekValue || e.st.typ != mtI32 {
+			return fmt.Errorf("amd64 plugin input %d is not i32", i)
+		}
+		r := f.materialize(e)
+		f.spill(e)
+		f.release(r)
+		ctx.paramSlots[i] = e.st.slot
+	}
+	switch lowering.Compatibility {
+	case machinecode.AMD64CompatibilityManaged:
+		if err := lowering.Managed(ctx); err != nil {
+			return err
+		}
+	case machinecode.AMD64CompatibilityFullAccess:
+		if err := lowering.Emit(ctx); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported amd64 plugin compatibility mode %d", lowering.Compatibility)
+	}
+	for i, typ := range virtualInputs {
+		if typ != (coreplugins.VirtualType{}) && !ctx.virtualRead[i] {
+			return fmt.Errorf("amd64 plugin lowering did not consume virtual input %d", i)
+		}
+	}
+	if virtualOutput != nil {
+		if resultCount != 1 || len(ctx.virtualRegs) == 0 {
+			return fmt.Errorf("amd64 plugin lowering did not set its virtual output")
+		}
+	} else if resultCount != 0 || len(ctx.virtualRegs) != 0 || ctx.outputSet {
+		return fmt.Errorf("amd64 virtual plugin lowering has an invalid physical output")
+	}
+	outputs := make(map[Reg]bool, len(ctx.virtualRegs))
+	for _, reg := range ctx.virtualRegs {
+		outputs[reg] = true
+	}
+	for reg := Reg(0); reg < 16; reg++ {
+		if ctx.gp.has(reg) {
+			ctx.ReleaseGP(reg)
+		}
+		if ctx.ymm.has(reg) && !outputs[reg] {
+			ctx.ReleaseVector(reg)
+		}
+	}
+	for _, root := range ctx.paramElems {
+		if root.st.typ == mtVirtual && root.st.vcount != 0 {
+			for _, reg := range root.st.vregs[:root.st.vcount] {
+				f.releaseF(reg)
+			}
+		}
+		f.erase(root)
+	}
+	if virtualOutput != nil {
+		st := storage{kind: stReg, typ: mtVirtual, reg: ctx.virtualRegs[0], virtual: virtualOutput, vcount: uint8(len(ctx.virtualRegs))}
+		copy(st.vregs[:], ctx.virtualRegs)
+		e := f.pushValue(st)
+		for _, reg := range ctx.virtualRegs {
+			ctx.ymm = ctx.ymm.remove(reg)
+			f.fpinned = f.fpinned.remove(reg)
+			f.fregUser[reg] = e
+		}
+	}
+	if lowering.Features&(machinecode.AMD64FeatureAVX2|machinecode.AMD64FeatureAVX512) != 0 {
+		f.usesWide = true
+	}
+	f.stats.call("custom-machine-code-virtual")
 	return nil
 }

--- a/src/core/compiler/backend/railshot/amd64/regalloc.go
+++ b/src/core/compiler/backend/railshot/amd64/regalloc.go
@@ -171,6 +171,9 @@ func (f *fn) curSpillSlot() int {
 // materialize ensures value elem e lives in a register and returns it. A deferred
 // node is condensed; a constant/local/slot value is loaded/moved into a fresh reg.
 func (f *fn) materialize(e *elem) Reg {
+	if e.st.typ == mtVirtual {
+		panic("virtual externref escaped to an ordinary Wasm instruction")
+	}
 	if e.isDeferred() {
 		return f.condense(e, regNone)
 	}

--- a/src/core/compiler/backend/railshot/amd64/regalloc.go
+++ b/src/core/compiler/backend/railshot/amd64/regalloc.go
@@ -171,8 +171,8 @@ func (f *fn) curSpillSlot() int {
 // materialize ensures value elem e lives in a register and returns it. A deferred
 // node is condensed; a constant/local/slot value is loaded/moved into a fresh reg.
 func (f *fn) materialize(e *elem) Reg {
-	if e.st.typ == mtVirtual {
-		panic("virtual externref escaped to an ordinary Wasm instruction")
+	if e.st.typ == mtCustom {
+		panic("custom value escaped to an ordinary Wasm instruction")
 	}
 	if e.isDeferred() {
 		return f.condense(e, regNone)

--- a/src/core/compiler/backend/railshot/amd64/stack.go
+++ b/src/core/compiler/backend/railshot/amd64/stack.go
@@ -2,7 +2,10 @@
 
 package amd64
 
-import "github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+import (
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+	coreplugins "github.com/wago-org/wago/src/core/plugins"
+)
 
 // The operand stack and its element model — ported from WARP's Stack /
 // StackElement / StackType / VariableStorage (warp/src/core/compiler/common/).
@@ -29,12 +32,13 @@ const (
 	mtF32
 	mtF64
 	mtV128
+	mtVirtual
 )
 
 func (t machineType) is64() bool    { return t == mtI64 || t == mtF64 }
 func (t machineType) isFloat() bool { return t == mtF32 || t == mtF64 }
 func (t machineType) isV128() bool  { return t == mtV128 }
-func (t machineType) isXMM() bool   { return t.isFloat() || t.isV128() }
+func (t machineType) isXMM() bool   { return t.isFloat() || t.isV128() || t == mtVirtual }
 func (t machineType) stackSlots() int {
 	if t == mtV128 {
 		return 2
@@ -110,6 +114,11 @@ type storage struct {
 	slot int
 	idx  int   // local/global index for stLocalRef/stGlobalRef
 	cval int64 // constant value/bits for stConst
+	// virtual is non-nil only for compiler-erased externref values. vregs holds
+	// one YMM per 32-byte chunk; reg aliases vregs[0] for allocator scans.
+	virtual *coreplugins.VirtualType
+	vregs   [4]Reg
+	vcount  uint8
 }
 
 // elemKind tags a stack node.

--- a/src/core/compiler/backend/railshot/amd64/stack.go
+++ b/src/core/compiler/backend/railshot/amd64/stack.go
@@ -32,13 +32,13 @@ const (
 	mtF32
 	mtF64
 	mtV128
-	mtVirtual
+	mtCustom
 )
 
 func (t machineType) is64() bool    { return t == mtI64 || t == mtF64 }
 func (t machineType) isFloat() bool { return t == mtF32 || t == mtF64 }
 func (t machineType) isV128() bool  { return t == mtV128 }
-func (t machineType) isXMM() bool   { return t.isFloat() || t.isV128() || t == mtVirtual }
+func (t machineType) isXMM() bool   { return t.isFloat() || t.isV128() || t == mtCustom }
 func (t machineType) stackSlots() int {
 	if t == mtV128 {
 		return 2
@@ -114,11 +114,10 @@ type storage struct {
 	slot int
 	idx  int   // local/global index for stLocalRef/stGlobalRef
 	cval int64 // constant value/bits for stConst
-	// virtual is non-nil only for compiler-erased externref values. vregs holds
+	// custom is non-nil only for compiler-erased custom values. vregs holds
 	// one YMM per 32-byte chunk; reg aliases vregs[0] for allocator scans.
-	virtual *coreplugins.VirtualType
-	vregs   [4]Reg
-	vcount  uint8
+	custom *coreplugins.CustomType
+	vregs  []Reg
 }
 
 // elemKind tags a stack node.

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -172,7 +172,7 @@ func (f *fn) callOp(r *wasm.Reader) error {
 }
 
 func (f *fn) emitCustomInstruction(custom railcore.CustomInstruction, ft *wasm.CompType) error {
-	return f.emitPluginARM64(custom.ARM64, custom.InputWidths, custom.ResultWidth, len(ft.Results), custom.VirtualInputs, custom.VirtualOutput)
+	return f.emitPluginARM64(custom.ARM64, custom.InputWidths, custom.ResultWidth, len(ft.Results), custom.CustomInputs, custom.CustomOutput)
 }
 
 // inCallSiteLoop reports whether the current call site is nested in a Wasm loop.

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -172,7 +172,7 @@ func (f *fn) callOp(r *wasm.Reader) error {
 }
 
 func (f *fn) emitCustomInstruction(custom railcore.CustomInstruction, ft *wasm.CompType) error {
-	return f.emitPluginARM64(custom.ARM64, custom.InputWidths, custom.ResultWidth, len(ft.Results))
+	return f.emitPluginARM64(custom.ARM64, custom.InputWidths, custom.ResultWidth, len(ft.Results), custom.VirtualInputs, custom.VirtualOutput)
 }
 
 // inCallSiteLoop reports whether the current call site is nested in a Wasm loop.

--- a/src/core/compiler/backend/railshot/arm64/control.go
+++ b/src/core/compiler/backend/railshot/arm64/control.go
@@ -242,6 +242,9 @@ func (f *fn) flush() {
 	slot := 0
 	for _, root := range roots {
 		typ := rootMachineType(root)
+		if typ == mtVirtual {
+			panic("virtual externref cannot cross a control-flow or ordinary call boundary")
+		}
 		f.stats.addFlushRoot(root.kind == ekDeferred)
 		types = append(types, typ)
 		if root.kind == ekValue && root.st.kind == stSlot && root.st.slot == slot && root.st.typ == typ {

--- a/src/core/compiler/backend/railshot/arm64/control.go
+++ b/src/core/compiler/backend/railshot/arm64/control.go
@@ -242,8 +242,8 @@ func (f *fn) flush() {
 	slot := 0
 	for _, root := range roots {
 		typ := rootMachineType(root)
-		if typ == mtVirtual {
-			panic("virtual externref cannot cross a control-flow or ordinary call boundary")
+		if typ == mtCustom {
+			panic("custom value cannot cross a control-flow or ordinary call boundary")
 		}
 		f.stats.addFlushRoot(root.kind == ekDeferred)
 		types = append(types, typ)

--- a/src/core/compiler/backend/railshot/arm64/driver.go
+++ b/src/core/compiler/backend/railshot/arm64/driver.go
@@ -104,8 +104,8 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 		e := f.popValue()
 		switch e.st.kind {
 		case stReg:
-			if e.st.typ == mtVirtual {
-				for _, reg := range e.st.vregs[:e.st.vcount] {
+			if e.st.typ == mtCustom {
+				for _, reg := range e.st.vregs {
 					f.releaseF(reg)
 				}
 			} else if e.st.typ.isXMM() {
@@ -1108,8 +1108,8 @@ func (f *fn) setLocal(x int, tee bool) {
 		f.invalidateBoundsCert() // the certified base local changed value
 	}
 	e := f.s.back()
-	if e != nil && e.kind == ekValue && e.st.typ == mtVirtual {
-		panic("virtual externref cannot be stored in a Wasm local")
+	if e != nil && e.kind == ekValue && e.st.typ == mtCustom {
+		panic("custom value cannot be stored in a Wasm local")
 	}
 	if e != nil && e.isDeferred() {
 		f.stats.addLocalSetDeferred()

--- a/src/core/compiler/backend/railshot/arm64/driver.go
+++ b/src/core/compiler/backend/railshot/arm64/driver.go
@@ -104,7 +104,11 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 		e := f.popValue()
 		switch e.st.kind {
 		case stReg:
-			if e.st.typ.isXMM() {
+			if e.st.typ == mtVirtual {
+				for _, reg := range e.st.vregs[:e.st.vcount] {
+					f.releaseF(reg)
+				}
+			} else if e.st.typ.isXMM() {
 				f.releaseF(e.st.reg)
 			} else {
 				f.release(e.st.reg)
@@ -1104,6 +1108,9 @@ func (f *fn) setLocal(x int, tee bool) {
 		f.invalidateBoundsCert() // the certified base local changed value
 	}
 	e := f.s.back()
+	if e != nil && e.kind == ekValue && e.st.typ == mtVirtual {
+		panic("virtual externref cannot be stored in a Wasm local")
+	}
 	if e != nil && e.isDeferred() {
 		f.stats.addLocalSetDeferred()
 	}

--- a/src/core/compiler/backend/railshot/arm64/fp.go
+++ b/src/core/compiler/backend/railshot/arm64/fp.go
@@ -77,6 +77,16 @@ func (f *fn) allocFReg(avoid regMask) Reg {
 // spillF evicts a V-resident float/vector value to a fresh frame slot.
 func (f *fn) spillF(e *elem) {
 	r := e.st.reg
+	if e.st.typ == mtVirtual {
+		slot := f.allocSpillSlots(int(e.st.virtual.Size / 8))
+		for i := 0; i < int(e.st.vcount); i++ {
+			reg := e.st.vregs[i]
+			f.a.StrQ(SP, f.spillOff(slot+i*2), reg)
+			f.fregUser[reg] = nil
+		}
+		f.replaceStorage(e, storage{kind: stSlot, typ: mtVirtual, slot: slot, virtual: e.st.virtual})
+		return
+	}
 	if e.st.typ == mtV128 {
 		slot := f.allocSpillSlots(2)
 		f.a.StrQ(a64.SP, f.spillOff(slot), r)

--- a/src/core/compiler/backend/railshot/arm64/fp.go
+++ b/src/core/compiler/backend/railshot/arm64/fp.go
@@ -77,14 +77,13 @@ func (f *fn) allocFReg(avoid regMask) Reg {
 // spillF evicts a V-resident float/vector value to a fresh frame slot.
 func (f *fn) spillF(e *elem) {
 	r := e.st.reg
-	if e.st.typ == mtVirtual {
-		slot := f.allocSpillSlots(int(e.st.virtual.Size / 8))
-		for i := 0; i < int(e.st.vcount); i++ {
-			reg := e.st.vregs[i]
+	if e.st.typ == mtCustom {
+		slot := f.allocSpillSlots(int(e.st.custom.Size() / 8))
+		for i, reg := range e.st.vregs {
 			f.a.StrQ(SP, f.spillOff(slot+i*2), reg)
 			f.fregUser[reg] = nil
 		}
-		f.replaceStorage(e, storage{kind: stSlot, typ: mtVirtual, slot: slot, virtual: e.st.virtual})
+		f.replaceStorage(e, storage{kind: stSlot, typ: mtCustom, slot: slot, custom: e.st.custom})
 		return
 	}
 	if e.st.typ == mtV128 {

--- a/src/core/compiler/backend/railshot/arm64/plugin_machine.go
+++ b/src/core/compiler/backend/railshot/arm64/plugin_machine.go
@@ -7,15 +7,21 @@ import (
 
 	"github.com/wago-org/wago/src/core/compiler/machinecode"
 	a64 "github.com/wago-org/wago/src/core/encoder/arm64"
+	coreplugins "github.com/wago-org/wago/src/core/plugins"
 )
 
 type pluginARM64Context struct {
-	f          *fn
-	paramSlots []int
-	paramWidth []int32
-	gp, vector regMask
-	output     Reg
-	outputSet  bool
+	f             *fn
+	paramSlots    []int
+	paramWidth    []int32
+	paramElems    []*elem
+	paramVirtual  []coreplugins.VirtualType
+	virtualRead   []bool
+	gp, vector    regMask
+	output        Reg
+	outputSet     bool
+	virtualOutput *coreplugins.VirtualType
+	virtualRegs   []Reg
 }
 
 func (c *pluginARM64Context) Encoder() *a64.Asm { return c.f.a }
@@ -32,10 +38,31 @@ func (c *pluginARM64Context) InputI32(index int) (a64.Reg, error) {
 			tmp := c.AllocGP(r)
 			c.f.a.MovImm64(tmp, uint64(mask))
 			c.f.a.And32(r, r, tmp)
-			c.Release(tmp)
+			c.ReleaseGP(tmp)
 		}
 	}
 	return r, nil
+}
+
+func (c *pluginARM64Context) InputVirtual(index int) ([]a64.Reg, error) {
+	if index < 0 || index >= len(c.paramElems) || index >= len(c.paramVirtual) || c.paramVirtual[index] == (coreplugins.VirtualType{}) {
+		return nil, fmt.Errorf("arm64 plugin virtual input %d out of range", index)
+	}
+	e := c.paramElems[index]
+	want := c.paramVirtual[index]
+	if e.kind != ekValue || e.st.typ != mtVirtual || e.st.virtual == nil || !e.st.virtual.Equal(want) {
+		return nil, fmt.Errorf("arm64 plugin virtual input %d has incompatible erased externref type", index)
+	}
+	regs := c.f.materializePluginVirtual(e)
+	out := append([]Reg(nil), regs...)
+	for _, reg := range out {
+		c.f.fregUser[reg] = nil
+		c.f.fpinned = c.f.fpinned.add(reg)
+		c.vector = c.vector.add(reg)
+	}
+	e.st.vcount = 0
+	c.virtualRead[index] = true
+	return out, nil
 }
 
 func arm64ExclusionMask(regs []a64.Reg) regMask { return maskOf(regs...) }
@@ -83,6 +110,11 @@ func (c *pluginARM64Context) ReserveVector(reg a64.Reg) error {
 }
 
 func (c *pluginARM64Context) Release(reg a64.Reg) {
+	c.ReleaseGP(reg)
+	c.ReleaseVector(reg)
+}
+
+func (c *pluginARM64Context) ReleaseGP(reg a64.Reg) {
 	if c.outputSet && reg == c.output {
 		return
 	}
@@ -90,6 +122,14 @@ func (c *pluginARM64Context) Release(reg a64.Reg) {
 		c.gp = c.gp.remove(reg)
 		c.f.pinned = c.f.pinned.remove(reg)
 		c.f.release(reg)
+	}
+}
+
+func (c *pluginARM64Context) ReleaseVector(reg a64.Reg) {
+	for _, output := range c.virtualRegs {
+		if reg == output {
+			return
+		}
 	}
 	if c.vector.has(reg) {
 		c.vector = c.vector.remove(reg)
@@ -117,6 +157,9 @@ func (c *pluginARM64Context) CheckedMemory(input int, offset uint32, size int) (
 }
 
 func (c *pluginARM64Context) OutputI32(reg a64.Reg) error {
+	if c.virtualOutput != nil {
+		return fmt.Errorf("arm64 plugin virtual instruction cannot set an i32 output")
+	}
 	if !c.gp.has(reg) {
 		return fmt.Errorf("arm64 plugin output register %d is not owned by the lowering", reg)
 	}
@@ -127,13 +170,64 @@ func (c *pluginARM64Context) OutputI32(reg a64.Reg) error {
 	return nil
 }
 
+func (c *pluginARM64Context) OutputVirtual(regs ...a64.Reg) error {
+	if c.virtualOutput == nil {
+		return fmt.Errorf("arm64 plugin instruction has no virtual output")
+	}
+	want := int(c.virtualOutput.Size / 16)
+	if len(regs) != want {
+		return fmt.Errorf("arm64 plugin virtual output has %d register(s), want %d", len(regs), want)
+	}
+	if c.outputSet || len(c.virtualRegs) != 0 {
+		return fmt.Errorf("arm64 plugin output already assigned")
+	}
+	seen := regMask(0)
+	for _, reg := range regs {
+		if !c.vector.has(reg) {
+			return fmt.Errorf("arm64 plugin virtual output register %d is not owned by the lowering (bundle %v)", reg, regs)
+		}
+		if seen.has(reg) {
+			return fmt.Errorf("arm64 plugin virtual output register %d is duplicated (bundle %v)", reg, regs)
+		}
+		seen = seen.add(reg)
+	}
+	c.virtualRegs = append([]Reg(nil), regs...)
+	return nil
+}
+
+func (f *fn) materializePluginVirtual(e *elem) []Reg {
+	if e.st.kind == stReg {
+		return e.st.vregs[:e.st.vcount]
+	}
+	if e.st.kind != stSlot || e.st.virtual == nil {
+		panic("arm64: cannot materialize virtual plugin value")
+	}
+	count := int(e.st.virtual.Size / 16)
+	var regs [4]Reg
+	var avoid regMask
+	for i := 0; i < count; i++ {
+		reg := f.allocFReg(avoid)
+		avoid = avoid.add(reg)
+		f.fpinned = f.fpinned.add(reg)
+		regs[i] = reg
+		f.a.LdrQ(reg, SP, f.spillOff(e.st.slot+i*2))
+	}
+	for i := 0; i < count; i++ {
+		f.fpinned = f.fpinned.remove(regs[i])
+		f.fregUser[regs[i]] = e
+	}
+	e.st.kind, e.st.typ, e.st.reg = stReg, mtVirtual, regs[0]
+	e.st.vregs, e.st.vcount = regs, uint8(count)
+	return e.st.vregs[:count]
+}
+
 func (c *pluginARM64Context) finish(resultWidth int32) {
 	for r := Reg(0); r < 32; r++ {
 		if c.gp.has(r) && (!c.outputSet || r != c.output) {
-			c.Release(r)
+			c.ReleaseGP(r)
 		}
 		if c.vector.has(r) {
-			c.Release(r)
+			c.ReleaseVector(r)
 		}
 	}
 	if !c.outputSet {
@@ -154,7 +248,10 @@ func (c *pluginARM64Context) finish(resultWidth int32) {
 	}
 }
 
-func (f *fn) emitPluginARM64(lowering *machinecode.ARM64Lowering, inputWidths []int32, resultWidth int32, resultCount int) error {
+func (f *fn) emitPluginARM64(lowering *machinecode.ARM64Lowering, inputWidths []int32, resultWidth int32, resultCount int, virtualInputs []coreplugins.VirtualType, virtualOutput *coreplugins.VirtualType) error {
+	if len(virtualInputs) != 0 || virtualOutput != nil {
+		return f.emitPluginARM64Virtual(lowering, inputWidths, resultCount, virtualInputs, virtualOutput)
+	}
 	paramCount := len(inputWidths)
 	types := f.currentLogicalTypes()
 	if len(types) < paramCount {
@@ -192,5 +289,94 @@ func (f *fn) emitPluginARM64(lowering *machinecode.ARM64Lowering, inputWidths []
 	f.setDepthTypes(types[:base])
 	ctx.finish(resultWidth)
 	f.stats.call("custom-machine-code")
+	return nil
+}
+
+func (f *fn) emitPluginARM64Virtual(lowering *machinecode.ARM64Lowering, inputWidths []int32, resultCount int, virtualInputs []coreplugins.VirtualType, virtualOutput *coreplugins.VirtualType) error {
+	paramCount := len(inputWidths)
+	if len(virtualInputs) != paramCount {
+		return fmt.Errorf("arm64 plugin virtual signature has %d inputs, want %d", len(virtualInputs), paramCount)
+	}
+	roots := append([]*elem(nil), f.rootsBottomToTop()...)
+	if len(roots) < paramCount {
+		return fmt.Errorf("arm64 plugin lowering has %d stack argument(s), want %d", len(roots), paramCount)
+	}
+	base := len(roots) - paramCount
+	ctx := &pluginARM64Context{
+		f: f, paramSlots: make([]int, paramCount), paramWidth: inputWidths,
+		paramElems: roots[base:], paramVirtual: virtualInputs, virtualRead: make([]bool, paramCount),
+		output: regNone, virtualOutput: virtualOutput,
+	}
+	for i, typ := range virtualInputs {
+		e := ctx.paramElems[i]
+		if typ != (coreplugins.VirtualType{}) {
+			if e.kind != ekValue || e.st.typ != mtVirtual || e.st.virtual == nil || !e.st.virtual.Equal(typ) {
+				return fmt.Errorf("arm64 plugin virtual input %d has incompatible erased externref type", i)
+			}
+			continue
+		}
+		if e.kind != ekValue || e.st.typ != mtI32 {
+			return fmt.Errorf("arm64 plugin input %d is not i32", i)
+		}
+		r := f.materialize(e)
+		f.spill(e)
+		f.release(r)
+		ctx.paramSlots[i] = e.st.slot
+	}
+	switch lowering.Compatibility {
+	case machinecode.ARM64CompatibilityManaged:
+		if err := lowering.Managed(ctx); err != nil {
+			return err
+		}
+	case machinecode.ARM64CompatibilityFullAccess:
+		if err := lowering.Emit(ctx); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported arm64 plugin compatibility mode %d", lowering.Compatibility)
+	}
+	for i, typ := range virtualInputs {
+		if typ != (coreplugins.VirtualType{}) && !ctx.virtualRead[i] {
+			return fmt.Errorf("arm64 plugin lowering did not consume virtual input %d", i)
+		}
+	}
+	if virtualOutput != nil {
+		if resultCount != 1 || len(ctx.virtualRegs) == 0 {
+			return fmt.Errorf("arm64 plugin lowering did not set its virtual output")
+		}
+	} else if resultCount != 0 || len(ctx.virtualRegs) != 0 || ctx.outputSet {
+		return fmt.Errorf("arm64 virtual plugin lowering has an invalid physical output")
+	}
+	outputs := make(map[Reg]bool, len(ctx.virtualRegs))
+	for _, reg := range ctx.virtualRegs {
+		outputs[reg] = true
+	}
+	for reg := Reg(0); reg < 32; reg++ {
+		if ctx.gp.has(reg) {
+			ctx.ReleaseGP(reg)
+		}
+		if ctx.vector.has(reg) && !outputs[reg] {
+			ctx.ReleaseVector(reg)
+		}
+	}
+	for _, root := range ctx.paramElems {
+		if root.st.typ == mtVirtual && root.st.vcount != 0 {
+			for _, reg := range root.st.vregs[:root.st.vcount] {
+				f.releaseF(reg)
+			}
+		}
+		f.erase(root)
+	}
+	if virtualOutput != nil {
+		st := storage{kind: stReg, typ: mtVirtual, reg: ctx.virtualRegs[0], virtual: virtualOutput, vcount: uint8(len(ctx.virtualRegs))}
+		copy(st.vregs[:], ctx.virtualRegs)
+		e := f.pushValue(st)
+		for _, reg := range ctx.virtualRegs {
+			ctx.vector = ctx.vector.remove(reg)
+			f.fpinned = f.fpinned.remove(reg)
+			f.fregUser[reg] = e
+		}
+	}
+	f.stats.call("custom-machine-code-virtual")
 	return nil
 }

--- a/src/core/compiler/backend/railshot/arm64/plugin_machine.go
+++ b/src/core/compiler/backend/railshot/arm64/plugin_machine.go
@@ -11,17 +11,17 @@ import (
 )
 
 type pluginARM64Context struct {
-	f             *fn
-	paramSlots    []int
-	paramWidth    []int32
-	paramElems    []*elem
-	paramVirtual  []coreplugins.VirtualType
-	virtualRead   []bool
-	gp, vector    regMask
-	output        Reg
-	outputSet     bool
-	virtualOutput *coreplugins.VirtualType
-	virtualRegs   []Reg
+	f            *fn
+	paramSlots   []int
+	paramWidth   []int32
+	paramElems   []*elem
+	paramCustom  []coreplugins.CustomType
+	customRead   []bool
+	gp, vector   regMask
+	output       Reg
+	outputSet    bool
+	customOutput *coreplugins.CustomType
+	customRegs   []Reg
 }
 
 func (c *pluginARM64Context) Encoder() *a64.Asm { return c.f.a }
@@ -44,24 +44,24 @@ func (c *pluginARM64Context) InputI32(index int) (a64.Reg, error) {
 	return r, nil
 }
 
-func (c *pluginARM64Context) InputVirtual(index int) ([]a64.Reg, error) {
-	if index < 0 || index >= len(c.paramElems) || index >= len(c.paramVirtual) || c.paramVirtual[index] == (coreplugins.VirtualType{}) {
-		return nil, fmt.Errorf("arm64 plugin virtual input %d out of range", index)
+func (c *pluginARM64Context) InputCustom(index int) ([]a64.Reg, error) {
+	if index < 0 || index >= len(c.paramElems) || index >= len(c.paramCustom) || c.paramCustom[index].IsZero() {
+		return nil, fmt.Errorf("arm64 plugin custom input %d out of range", index)
 	}
 	e := c.paramElems[index]
-	want := c.paramVirtual[index]
-	if e.kind != ekValue || e.st.typ != mtVirtual || e.st.virtual == nil || !e.st.virtual.Equal(want) {
-		return nil, fmt.Errorf("arm64 plugin virtual input %d has incompatible erased externref type", index)
+	want := c.paramCustom[index]
+	if e.kind != ekValue || e.st.typ != mtCustom || e.st.custom == nil || !e.st.custom.Equal(want) {
+		return nil, fmt.Errorf("arm64 plugin custom input %d has incompatible custom type", index)
 	}
-	regs := c.f.materializePluginVirtual(e)
+	regs := c.f.materializePluginCustom(e)
 	out := append([]Reg(nil), regs...)
 	for _, reg := range out {
 		c.f.fregUser[reg] = nil
 		c.f.fpinned = c.f.fpinned.add(reg)
 		c.vector = c.vector.add(reg)
 	}
-	e.st.vcount = 0
-	c.virtualRead[index] = true
+	e.st.vregs = nil
+	c.customRead[index] = true
 	return out, nil
 }
 
@@ -126,7 +126,7 @@ func (c *pluginARM64Context) ReleaseGP(reg a64.Reg) {
 }
 
 func (c *pluginARM64Context) ReleaseVector(reg a64.Reg) {
-	for _, output := range c.virtualRegs {
+	for _, output := range c.customRegs {
 		if reg == output {
 			return
 		}
@@ -157,8 +157,8 @@ func (c *pluginARM64Context) CheckedMemory(input int, offset uint32, size int) (
 }
 
 func (c *pluginARM64Context) OutputI32(reg a64.Reg) error {
-	if c.virtualOutput != nil {
-		return fmt.Errorf("arm64 plugin virtual instruction cannot set an i32 output")
+	if c.customOutput != nil {
+		return fmt.Errorf("arm64 plugin custom instruction cannot set an i32 output")
 	}
 	if !c.gp.has(reg) {
 		return fmt.Errorf("arm64 plugin output register %d is not owned by the lowering", reg)
@@ -170,40 +170,40 @@ func (c *pluginARM64Context) OutputI32(reg a64.Reg) error {
 	return nil
 }
 
-func (c *pluginARM64Context) OutputVirtual(regs ...a64.Reg) error {
-	if c.virtualOutput == nil {
-		return fmt.Errorf("arm64 plugin instruction has no virtual output")
+func (c *pluginARM64Context) OutputCustom(regs ...a64.Reg) error {
+	if c.customOutput == nil {
+		return fmt.Errorf("arm64 plugin instruction has no custom output")
 	}
-	want := int(c.virtualOutput.Size / 16)
+	want := int(c.customOutput.Size() / 16)
 	if len(regs) != want {
-		return fmt.Errorf("arm64 plugin virtual output has %d register(s), want %d", len(regs), want)
+		return fmt.Errorf("arm64 plugin custom output has %d register(s), want %d", len(regs), want)
 	}
-	if c.outputSet || len(c.virtualRegs) != 0 {
+	if c.outputSet || len(c.customRegs) != 0 {
 		return fmt.Errorf("arm64 plugin output already assigned")
 	}
 	seen := regMask(0)
 	for _, reg := range regs {
 		if !c.vector.has(reg) {
-			return fmt.Errorf("arm64 plugin virtual output register %d is not owned by the lowering (bundle %v)", reg, regs)
+			return fmt.Errorf("arm64 plugin custom output register %d is not owned by the lowering (bundle %v)", reg, regs)
 		}
 		if seen.has(reg) {
-			return fmt.Errorf("arm64 plugin virtual output register %d is duplicated (bundle %v)", reg, regs)
+			return fmt.Errorf("arm64 plugin custom output register %d is duplicated (bundle %v)", reg, regs)
 		}
 		seen = seen.add(reg)
 	}
-	c.virtualRegs = append([]Reg(nil), regs...)
+	c.customRegs = append([]Reg(nil), regs...)
 	return nil
 }
 
-func (f *fn) materializePluginVirtual(e *elem) []Reg {
+func (f *fn) materializePluginCustom(e *elem) []Reg {
 	if e.st.kind == stReg {
-		return e.st.vregs[:e.st.vcount]
+		return e.st.vregs
 	}
-	if e.st.kind != stSlot || e.st.virtual == nil {
-		panic("arm64: cannot materialize virtual plugin value")
+	if e.st.kind != stSlot || e.st.custom == nil {
+		panic("arm64: cannot materialize custom plugin value")
 	}
-	count := int(e.st.virtual.Size / 16)
-	var regs [4]Reg
+	count := int(e.st.custom.Size() / 16)
+	regs := make([]Reg, count)
 	var avoid regMask
 	for i := 0; i < count; i++ {
 		reg := f.allocFReg(avoid)
@@ -216,9 +216,9 @@ func (f *fn) materializePluginVirtual(e *elem) []Reg {
 		f.fpinned = f.fpinned.remove(regs[i])
 		f.fregUser[regs[i]] = e
 	}
-	e.st.kind, e.st.typ, e.st.reg = stReg, mtVirtual, regs[0]
-	e.st.vregs, e.st.vcount = regs, uint8(count)
-	return e.st.vregs[:count]
+	e.st.kind, e.st.typ, e.st.reg = stReg, mtCustom, regs[0]
+	e.st.vregs = regs
+	return e.st.vregs
 }
 
 func (c *pluginARM64Context) finish(resultWidth int32) {
@@ -248,9 +248,9 @@ func (c *pluginARM64Context) finish(resultWidth int32) {
 	}
 }
 
-func (f *fn) emitPluginARM64(lowering *machinecode.ARM64Lowering, inputWidths []int32, resultWidth int32, resultCount int, virtualInputs []coreplugins.VirtualType, virtualOutput *coreplugins.VirtualType) error {
-	if len(virtualInputs) != 0 || virtualOutput != nil {
-		return f.emitPluginARM64Virtual(lowering, inputWidths, resultCount, virtualInputs, virtualOutput)
+func (f *fn) emitPluginARM64(lowering *machinecode.ARM64Lowering, inputWidths []int32, resultWidth int32, resultCount int, customInputs []coreplugins.CustomType, customOutput *coreplugins.CustomType) error {
+	if len(customInputs) != 0 || customOutput != nil {
+		return f.emitPluginARM64Custom(lowering, inputWidths, resultCount, customInputs, customOutput)
 	}
 	paramCount := len(inputWidths)
 	types := f.currentLogicalTypes()
@@ -292,10 +292,10 @@ func (f *fn) emitPluginARM64(lowering *machinecode.ARM64Lowering, inputWidths []
 	return nil
 }
 
-func (f *fn) emitPluginARM64Virtual(lowering *machinecode.ARM64Lowering, inputWidths []int32, resultCount int, virtualInputs []coreplugins.VirtualType, virtualOutput *coreplugins.VirtualType) error {
+func (f *fn) emitPluginARM64Custom(lowering *machinecode.ARM64Lowering, inputWidths []int32, resultCount int, customInputs []coreplugins.CustomType, customOutput *coreplugins.CustomType) error {
 	paramCount := len(inputWidths)
-	if len(virtualInputs) != paramCount {
-		return fmt.Errorf("arm64 plugin virtual signature has %d inputs, want %d", len(virtualInputs), paramCount)
+	if len(customInputs) != paramCount {
+		return fmt.Errorf("arm64 plugin custom signature has %d inputs, want %d", len(customInputs), paramCount)
 	}
 	roots := append([]*elem(nil), f.rootsBottomToTop()...)
 	if len(roots) < paramCount {
@@ -304,14 +304,14 @@ func (f *fn) emitPluginARM64Virtual(lowering *machinecode.ARM64Lowering, inputWi
 	base := len(roots) - paramCount
 	ctx := &pluginARM64Context{
 		f: f, paramSlots: make([]int, paramCount), paramWidth: inputWidths,
-		paramElems: roots[base:], paramVirtual: virtualInputs, virtualRead: make([]bool, paramCount),
-		output: regNone, virtualOutput: virtualOutput,
+		paramElems: roots[base:], paramCustom: customInputs, customRead: make([]bool, paramCount),
+		output: regNone, customOutput: customOutput,
 	}
-	for i, typ := range virtualInputs {
+	for i, typ := range customInputs {
 		e := ctx.paramElems[i]
-		if typ != (coreplugins.VirtualType{}) {
-			if e.kind != ekValue || e.st.typ != mtVirtual || e.st.virtual == nil || !e.st.virtual.Equal(typ) {
-				return fmt.Errorf("arm64 plugin virtual input %d has incompatible erased externref type", i)
+		if !typ.IsZero() {
+			if e.kind != ekValue || e.st.typ != mtCustom || e.st.custom == nil || !e.st.custom.Equal(typ) {
+				return fmt.Errorf("arm64 plugin custom input %d has incompatible custom type", i)
 			}
 			continue
 		}
@@ -335,20 +335,20 @@ func (f *fn) emitPluginARM64Virtual(lowering *machinecode.ARM64Lowering, inputWi
 	default:
 		return fmt.Errorf("unsupported arm64 plugin compatibility mode %d", lowering.Compatibility)
 	}
-	for i, typ := range virtualInputs {
-		if typ != (coreplugins.VirtualType{}) && !ctx.virtualRead[i] {
-			return fmt.Errorf("arm64 plugin lowering did not consume virtual input %d", i)
+	for i, typ := range customInputs {
+		if !typ.IsZero() && !ctx.customRead[i] {
+			return fmt.Errorf("arm64 plugin lowering did not consume custom input %d", i)
 		}
 	}
-	if virtualOutput != nil {
-		if resultCount != 1 || len(ctx.virtualRegs) == 0 {
-			return fmt.Errorf("arm64 plugin lowering did not set its virtual output")
+	if customOutput != nil {
+		if resultCount != 1 || len(ctx.customRegs) == 0 {
+			return fmt.Errorf("arm64 plugin lowering did not set its custom output")
 		}
-	} else if resultCount != 0 || len(ctx.virtualRegs) != 0 || ctx.outputSet {
-		return fmt.Errorf("arm64 virtual plugin lowering has an invalid physical output")
+	} else if resultCount != 0 || len(ctx.customRegs) != 0 || ctx.outputSet {
+		return fmt.Errorf("arm64 custom plugin lowering has an invalid physical output")
 	}
-	outputs := make(map[Reg]bool, len(ctx.virtualRegs))
-	for _, reg := range ctx.virtualRegs {
+	outputs := make(map[Reg]bool, len(ctx.customRegs))
+	for _, reg := range ctx.customRegs {
 		outputs[reg] = true
 	}
 	for reg := Reg(0); reg < 32; reg++ {
@@ -360,23 +360,22 @@ func (f *fn) emitPluginARM64Virtual(lowering *machinecode.ARM64Lowering, inputWi
 		}
 	}
 	for _, root := range ctx.paramElems {
-		if root.st.typ == mtVirtual && root.st.vcount != 0 {
-			for _, reg := range root.st.vregs[:root.st.vcount] {
+		if root.st.typ == mtCustom {
+			for _, reg := range root.st.vregs {
 				f.releaseF(reg)
 			}
 		}
 		f.erase(root)
 	}
-	if virtualOutput != nil {
-		st := storage{kind: stReg, typ: mtVirtual, reg: ctx.virtualRegs[0], virtual: virtualOutput, vcount: uint8(len(ctx.virtualRegs))}
-		copy(st.vregs[:], ctx.virtualRegs)
+	if customOutput != nil {
+		st := storage{kind: stReg, typ: mtCustom, reg: ctx.customRegs[0], custom: customOutput, vregs: append([]Reg(nil), ctx.customRegs...)}
 		e := f.pushValue(st)
-		for _, reg := range ctx.virtualRegs {
+		for _, reg := range ctx.customRegs {
 			ctx.vector = ctx.vector.remove(reg)
 			f.fpinned = f.fpinned.remove(reg)
 			f.fregUser[reg] = e
 		}
 	}
-	f.stats.call("custom-machine-code-virtual")
+	f.stats.call("custom-machine-code-custom")
 	return nil
 }

--- a/src/core/compiler/backend/railshot/arm64/regalloc.go
+++ b/src/core/compiler/backend/railshot/arm64/regalloc.go
@@ -173,8 +173,8 @@ func (f *fn) curSpillSlot() int {
 // materialize ensures value elem e lives in a register and returns it. A deferred
 // node is condensed; a constant/local/slot value is loaded/moved into a fresh reg.
 func (f *fn) materialize(e *elem) Reg {
-	if e.st.typ == mtVirtual {
-		panic("virtual externref escaped to an ordinary Wasm instruction")
+	if e.st.typ == mtCustom {
+		panic("custom value escaped to an ordinary Wasm instruction")
 	}
 	if e.isDeferred() {
 		return f.condense(e, regNone)

--- a/src/core/compiler/backend/railshot/arm64/regalloc.go
+++ b/src/core/compiler/backend/railshot/arm64/regalloc.go
@@ -173,6 +173,9 @@ func (f *fn) curSpillSlot() int {
 // materialize ensures value elem e lives in a register and returns it. A deferred
 // node is condensed; a constant/local/slot value is loaded/moved into a fresh reg.
 func (f *fn) materialize(e *elem) Reg {
+	if e.st.typ == mtVirtual {
+		panic("virtual externref escaped to an ordinary Wasm instruction")
+	}
 	if e.isDeferred() {
 		return f.condense(e, regNone)
 	}

--- a/src/core/compiler/backend/railshot/arm64/stack.go
+++ b/src/core/compiler/backend/railshot/arm64/stack.go
@@ -38,7 +38,7 @@ const (
 	mtF32
 	mtF64
 	mtV128
-	mtVirtual
+	mtCustom
 )
 
 func (t machineType) is64() bool    { return t == mtI64 || t == mtF64 }
@@ -48,7 +48,7 @@ func (t machineType) isV128() bool  { return t == mtV128 }
 // isXMM reports whether the value lives in the SIMD/FP register file (V0–V31 on
 // arm64 — the analog of x86's XMM registers). Name kept per the port contract's
 // type/method-name-parity rule so the sibling emit files read like the originals.
-func (t machineType) isXMM() bool { return t.isFloat() || t.isV128() || t == mtVirtual }
+func (t machineType) isXMM() bool { return t.isFloat() || t.isV128() || t == mtCustom }
 func (t machineType) stackSlots() int {
 	if t == mtV128 {
 		return 2
@@ -112,15 +112,14 @@ func (st storage) memBorrow() int { return int(st.cval) - 1 }
 
 // storage records where a value lives and its machine type.
 type storage struct {
-	kind    storageKind
-	typ     machineType
-	reg     Reg
-	slot    int
-	idx     int   // local/global index for stLocalRef/stGlobalRef
-	cval    int64 // constant value/bits for stConst
-	virtual *coreplugins.VirtualType
-	vregs   [4]Reg
-	vcount  uint8
+	kind   storageKind
+	typ    machineType
+	reg    Reg
+	slot   int
+	idx    int   // local/global index for stLocalRef/stGlobalRef
+	cval   int64 // constant value/bits for stConst
+	custom *coreplugins.CustomType
+	vregs  []Reg
 }
 
 // elemKind tags a stack node.

--- a/src/core/compiler/backend/railshot/arm64/stack.go
+++ b/src/core/compiler/backend/railshot/arm64/stack.go
@@ -2,7 +2,10 @@
 
 package arm64
 
-import "github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+import (
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+	coreplugins "github.com/wago-org/wago/src/core/plugins"
+)
 
 // The operand stack and its element model — ported from WARP's Stack /
 // StackElement / StackType / VariableStorage (warp/src/core/compiler/common/).
@@ -35,6 +38,7 @@ const (
 	mtF32
 	mtF64
 	mtV128
+	mtVirtual
 )
 
 func (t machineType) is64() bool    { return t == mtI64 || t == mtF64 }
@@ -44,7 +48,7 @@ func (t machineType) isV128() bool  { return t == mtV128 }
 // isXMM reports whether the value lives in the SIMD/FP register file (V0–V31 on
 // arm64 — the analog of x86's XMM registers). Name kept per the port contract's
 // type/method-name-parity rule so the sibling emit files read like the originals.
-func (t machineType) isXMM() bool { return t.isFloat() || t.isV128() }
+func (t machineType) isXMM() bool { return t.isFloat() || t.isV128() || t == mtVirtual }
 func (t machineType) stackSlots() int {
 	if t == mtV128 {
 		return 2
@@ -108,12 +112,15 @@ func (st storage) memBorrow() int { return int(st.cval) - 1 }
 
 // storage records where a value lives and its machine type.
 type storage struct {
-	kind storageKind
-	typ  machineType
-	reg  Reg
-	slot int
-	idx  int   // local/global index for stLocalRef/stGlobalRef
-	cval int64 // constant value/bits for stConst
+	kind    storageKind
+	typ     machineType
+	reg     Reg
+	slot    int
+	idx     int   // local/global index for stLocalRef/stGlobalRef
+	cval    int64 // constant value/bits for stConst
+	virtual *coreplugins.VirtualType
+	vregs   [4]Reg
+	vcount  uint8
 }
 
 // elemKind tags a stack node.

--- a/src/core/compiler/machinecode/amd64.go
+++ b/src/core/compiler/machinecode/amd64.go
@@ -38,9 +38,9 @@ type AMD64Lowering struct {
 // to the plugin.
 type AMD64ManagedContext interface {
 	InputI32(index int) (x86.Reg, error)
-	// InputVirtual transfers an erased externref input's native register bundle
+	// InputCustom transfers an erased custom input's native register bundle
 	// to the lowering. Registers are ordered from the lowest-address chunk.
-	InputVirtual(index int) ([]x86.Reg, error)
+	InputCustom(index int) ([]x86.Reg, error)
 	Release(reg x86.Reg)
 	ReleaseGP(reg x86.Reg)
 	ReleaseVector(reg x86.Reg)
@@ -50,9 +50,9 @@ type AMD64ManagedContext interface {
 	LoadZMM(input int, offset uint32) (x86.Reg, error)
 	StoreZMM(input int, offset uint32, value x86.Reg) error
 	OutputI32(reg x86.Reg) error
-	// OutputVirtual assigns the erased externref result. Every register must be
-	// owned by this lowering and the bundle must match the declared virtual size.
-	OutputVirtual(regs ...x86.Reg) error
+	// OutputCustom assigns the erased custom result. Every register must be
+	// owned by this lowering and the bundle must match the declared custom size.
+	OutputCustom(regs ...x86.Reg) error
 }
 
 // AMD64Context exposes Wago's real encoder and managed access to the surrounding

--- a/src/core/compiler/machinecode/amd64.go
+++ b/src/core/compiler/machinecode/amd64.go
@@ -38,13 +38,21 @@ type AMD64Lowering struct {
 // to the plugin.
 type AMD64ManagedContext interface {
 	InputI32(index int) (x86.Reg, error)
+	// InputVirtual transfers an erased externref input's native register bundle
+	// to the lowering. Registers are ordered from the lowest-address chunk.
+	InputVirtual(index int) ([]x86.Reg, error)
 	Release(reg x86.Reg)
+	ReleaseGP(reg x86.Reg)
+	ReleaseVector(reg x86.Reg)
 	ConstYMMRepeated128(lo, hi uint64) x86.Reg
 	LoadYMM(input int, offset uint32) (x86.Reg, error)
 	StoreYMM(input int, offset uint32, value x86.Reg) error
 	LoadZMM(input int, offset uint32) (x86.Reg, error)
 	StoreZMM(input int, offset uint32, value x86.Reg) error
 	OutputI32(reg x86.Reg) error
+	// OutputVirtual assigns the erased externref result. Every register must be
+	// owned by this lowering and the bundle must match the declared virtual size.
+	OutputVirtual(regs ...x86.Reg) error
 }
 
 // AMD64Context exposes Wago's real encoder and managed access to the surrounding

--- a/src/core/compiler/machinecode/arm64.go
+++ b/src/core/compiler/machinecode/arm64.go
@@ -26,8 +26,12 @@ type ARM64Lowering struct {
 // cross-platform semantic operations.
 type ARM64ManagedContext interface {
 	InputI32(index int) (a64.Reg, error)
+	InputVirtual(index int) ([]a64.Reg, error)
 	Release(reg a64.Reg)
+	ReleaseGP(reg a64.Reg)
+	ReleaseVector(reg a64.Reg)
 	OutputI32(reg a64.Reg) error
+	OutputVirtual(regs ...a64.Reg) error
 }
 
 // ARM64Context exposes Wago's raw AArch64 encoder. Encoder().B is public, so a

--- a/src/core/compiler/machinecode/arm64.go
+++ b/src/core/compiler/machinecode/arm64.go
@@ -26,12 +26,12 @@ type ARM64Lowering struct {
 // cross-platform semantic operations.
 type ARM64ManagedContext interface {
 	InputI32(index int) (a64.Reg, error)
-	InputVirtual(index int) ([]a64.Reg, error)
+	InputCustom(index int) ([]a64.Reg, error)
 	Release(reg a64.Reg)
 	ReleaseGP(reg a64.Reg)
 	ReleaseVector(reg a64.Reg)
 	OutputI32(reg a64.Reg) error
-	OutputVirtual(regs ...a64.Reg) error
+	OutputCustom(regs ...a64.Reg) error
 }
 
 // ARM64Context exposes Wago's raw AArch64 encoder. Encoder().B is public, so a

--- a/src/core/plugins/instruction.go
+++ b/src/core/plugins/instruction.go
@@ -10,11 +10,35 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/machinecode"
 )
 
+// VirtualType describes a compiler-erased value carried through Wasm as an
+// externref. Name supplies plugin-owned type identity; Size is its native spill
+// size in bytes. Virtual values never enter the runtime reference store.
+type VirtualType struct {
+	Name string
+	Size int32
+}
+
+func (v VirtualType) valid() bool {
+	return v.Name != "" && v.Size > 0 && v.Size%16 == 0
+}
+
+func (v VirtualType) Equal(other VirtualType) bool {
+	return v.Name == other.Name && v.Size == other.Size
+}
+
+// VirtualSignature overlays compiler-erased externref carriers on selected
+// logical inputs and the optional single output. Inputs, when non-nil, must
+// have the same length as InstructionSpec.Input; a zero VirtualType leaves that
+// parameter as the ordinary i32 carrier.
+type VirtualSignature struct {
+	Inputs []VirtualType
+	Output *VirtualType
+}
+
 // InstructionSpec describes a language-neutral custom instruction. Input and
-// Output contain logical value widths in bits. Its physical Wasm signature is
-// derived entirely from those slices: every input is i32, and the result is
-// void for no outputs or one i32 otherwise. With multiple logical outputs that
-// i32 is a result-pack handle projected through wago:abi.result.get.
+// Output contain logical value widths in bits. Ordinary values use the existing
+// i32/handle ABI. Virtual-selected values physically use externref and are
+// erased into plugin-owned native register bundles during compilation.
 type InstructionSpec struct {
 	Module  string
 	Name    string
@@ -22,6 +46,7 @@ type InstructionSpec struct {
 	Output  []int32
 	Handler InstructionHandler
 	Lower   InstructionLowerer
+	Virtual *VirtualSignature
 	// AMD64 is an explicitly unsafe, fully trusted machine-code lowering. It may
 	// use Wago's real encoder or append arbitrary bytes through Encoder().B.
 	AMD64 *machinecode.AMD64Lowering
@@ -341,6 +366,8 @@ type Instruction struct {
 	ARM64           *machinecode.ARM64Lowering
 	InputWidths     []int32
 	ResultWidth     int32
+	VirtualInputs   []VirtualType
+	VirtualOutput   *VirtualType
 }
 
 // Definition is a validated plugin instruction. It owns detached copies of the
@@ -357,6 +384,13 @@ type Definition struct {
 // portable Handler.
 func (d Definition) Native() (Instruction, bool) {
 	native := Instruction{InputWidths: append([]int32(nil), d.Spec.Input...)}
+	if d.Spec.Virtual != nil {
+		native.VirtualInputs = append([]VirtualType(nil), d.Spec.Virtual.Inputs...)
+		if d.Spec.Virtual.Output != nil {
+			out := *d.Spec.Virtual.Output
+			native.VirtualOutput = &out
+		}
+	}
 	if d.amd64 != nil {
 		copy := *d.amd64
 		native.AMD64 = &copy
@@ -464,7 +498,7 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 	if spec.Module == "" || spec.Name == "" {
 		return Definition{}, fmt.Errorf("wago: instruction requires Module and Name")
 	}
-	if spec.Handler == nil {
+	if spec.Handler == nil && spec.Virtual == nil {
 		return Definition{}, fmt.Errorf("wago: instruction %q.%q requires Handler", spec.Module, spec.Name)
 	}
 	for _, widths := range [][]int32{spec.Input, spec.Output} {
@@ -472,6 +506,39 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 			if w <= 0 {
 				return Definition{}, fmt.Errorf("wago: instruction %q.%q has non-positive width %d", spec.Module, spec.Name, w)
 			}
+		}
+	}
+	if spec.Virtual != nil {
+		if len(spec.Virtual.Inputs) != len(spec.Input) {
+			return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual input metadata has %d entries, want %d", spec.Module, spec.Name, len(spec.Virtual.Inputs), len(spec.Input))
+		}
+		for i, typ := range spec.Virtual.Inputs {
+			if typ == (VirtualType{}) {
+				continue
+			}
+			if !typ.valid() {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual input %d requires a name and a positive 16-byte-aligned size", spec.Module, spec.Name, i)
+			}
+			if spec.Input[i] != typ.Size*8 {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual input %d is %d bits but type %q is %d bytes", spec.Module, spec.Name, i, spec.Input[i], typ.Name, typ.Size)
+			}
+		}
+		if spec.Virtual.Output != nil {
+			if len(spec.Output) != 1 {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual output requires exactly one logical output", spec.Module, spec.Name)
+			}
+			if !spec.Virtual.Output.valid() {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual output requires a name and a positive 16-byte-aligned size", spec.Module, spec.Name)
+			}
+			if spec.Output[0] != spec.Virtual.Output.Size*8 {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual output is %d bits but type %q is %d bytes", spec.Module, spec.Name, spec.Output[0], spec.Virtual.Output.Name, spec.Virtual.Output.Size)
+			}
+		}
+		if spec.Handler != nil {
+			return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual values are native-only and forbid Handler", spec.Module, spec.Name)
+		}
+		if spec.AMD64 == nil && spec.ARM64 == nil {
+			return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual values require a native lowering", spec.Module, spec.Name)
 		}
 	}
 	recipe, err := buildInstructionRecipe(spec)
@@ -499,8 +566,13 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 		if len(spec.Output) > 1 {
 			return Definition{}, fmt.Errorf("wago: instruction %q.%q amd64 lowering supports at most one direct output", spec.Module, spec.Name)
 		}
-		for _, width := range append(append([]int32(nil), spec.Input...), spec.Output...) {
-			if width > 32 {
+		for i, width := range spec.Input {
+			if width > 32 && (spec.Virtual == nil || spec.Virtual.Inputs[i] == (VirtualType{})) {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q amd64 lowering only supports direct values up to 32 bits", spec.Module, spec.Name)
+			}
+		}
+		for _, width := range spec.Output {
+			if width > 32 && (spec.Virtual == nil || spec.Virtual.Output == nil) {
 				return Definition{}, fmt.Errorf("wago: instruction %q.%q amd64 lowering only supports direct values up to 32 bits", spec.Module, spec.Name)
 			}
 		}
@@ -523,8 +595,13 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 		if len(spec.Output) > 1 {
 			return Definition{}, fmt.Errorf("wago: instruction %q.%q arm64 lowering supports at most one direct output", spec.Module, spec.Name)
 		}
-		for _, width := range append(append([]int32(nil), spec.Input...), spec.Output...) {
-			if width > 32 {
+		for i, width := range spec.Input {
+			if width > 32 && (spec.Virtual == nil || spec.Virtual.Inputs[i] == (VirtualType{})) {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q arm64 lowering only supports direct values up to 32 bits", spec.Module, spec.Name)
+			}
+		}
+		for _, width := range spec.Output {
+			if width > 32 && (spec.Virtual == nil || spec.Virtual.Output == nil) {
 				return Definition{}, fmt.Errorf("wago: instruction %q.%q arm64 lowering only supports direct values up to 32 bits", spec.Module, spec.Name)
 			}
 		}
@@ -533,6 +610,14 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 	}
 	spec.Input = append([]int32(nil), spec.Input...)
 	spec.Output = append([]int32(nil), spec.Output...)
+	if spec.Virtual != nil {
+		virtual := &VirtualSignature{Inputs: append([]VirtualType(nil), spec.Virtual.Inputs...)}
+		if spec.Virtual.Output != nil {
+			out := *spec.Virtual.Output
+			virtual.Output = &out
+		}
+		spec.Virtual = virtual
+	}
 	spec.AMD64 = amd64Lowering
 	spec.ARM64 = arm64Lowering
 	return Definition{Spec: spec, recipe: recipe, amd64: amd64Lowering, arm64: arm64Lowering}, nil

--- a/src/core/plugins/instruction.go
+++ b/src/core/plugins/instruction.go
@@ -10,35 +10,74 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/machinecode"
 )
 
-// VirtualType describes a compiler-erased value carried through Wasm as an
-// externref. Name supplies plugin-owned type identity; Size is its native spill
-// size in bytes. Virtual values never enter the runtime reference store.
-type VirtualType struct {
-	Name string
-	Size int32
+// WasmType is a standard physical WebAssembly value type used to carry a
+// compiler-erased custom value through validation. It does not describe the
+// custom value's native representation.
+type WasmType uint8
+
+const (
+	WasmI32 WasmType = iota + 1
+	WasmI64
+	WasmF32
+	WasmF64
+	WasmV128
+	WasmFuncRef
+	WasmExternRef
+)
+
+func (t WasmType) valid() bool { return t >= WasmI32 && t <= WasmExternRef }
+
+// CustomTypeSpec declares one plugin-owned logical type. Carrier is the
+// standard Wasm type in the guest signature; Size is the erased native value's
+// byte width and must be 16-byte aligned.
+type CustomTypeSpec struct {
+	Name    string
+	Size    int32
+	Carrier WasmType
 }
 
-func (v VirtualType) valid() bool {
-	return v.Name != "" && v.Size > 0 && v.Size%16 == 0
+// CustomType is an opaque token returned by CompilerRegistry.Type. Plugins use
+// the token in instruction signatures; they cannot forge registered types.
+type CustomType struct {
+	name    string
+	size    int32
+	carrier WasmType
 }
 
-func (v VirtualType) Equal(other VirtualType) bool {
-	return v.Name == other.Name && v.Size == other.Size
+func PrepareCustomType(spec CustomTypeSpec) (CustomType, error) {
+	if spec.Name == "" {
+		return CustomType{}, fmt.Errorf("wago: custom type requires Name")
+	}
+	if spec.Size <= 0 || spec.Size%16 != 0 {
+		return CustomType{}, fmt.Errorf("wago: custom type %q requires a positive 16-byte-aligned Size", spec.Name)
+	}
+	if !spec.Carrier.valid() {
+		return CustomType{}, fmt.Errorf("wago: custom type %q has unsupported Wasm carrier %d", spec.Name, spec.Carrier)
+	}
+	return CustomType{name: spec.Name, size: spec.Size, carrier: spec.Carrier}, nil
 }
 
-// VirtualSignature overlays compiler-erased externref carriers on selected
-// logical inputs and the optional single output. Inputs, when non-nil, must
-// have the same length as InstructionSpec.Input; a zero VirtualType leaves that
-// parameter as the ordinary i32 carrier.
-type VirtualSignature struct {
-	Inputs []VirtualType
-	Output *VirtualType
+func (t CustomType) Name() string            { return t.name }
+func (t CustomType) Size() int32             { return t.size }
+func (t CustomType) Bits() int32             { return t.size * 8 }
+func (t CustomType) Carrier() WasmType       { return t.carrier }
+func (t CustomType) IsZero() bool            { return t == (CustomType{}) }
+func (t CustomType) Valid() bool             { return t.name != "" && t.size > 0 && t.carrier.valid() }
+func (t CustomType) Equal(o CustomType) bool { return t == o }
+
+// CustomSignature assigns registered custom types to selected logical inputs
+// and the optional single output. Inputs must have the same length as
+// InstructionSpec.Input; a zero CustomType leaves that parameter on the
+// ordinary i32/handle ABI.
+type CustomSignature struct {
+	Inputs []CustomType
+	Output *CustomType
 }
 
 // InstructionSpec describes a language-neutral custom instruction. Input and
 // Output contain logical value widths in bits. Ordinary values use the existing
-// i32/handle ABI. Virtual-selected values physically use externref and are
-// erased into plugin-owned native register bundles during compilation.
+// i32/handle ABI. Custom values physically use their registered standard Wasm
+// carrier and are erased into plugin-owned native register bundles.
 type InstructionSpec struct {
 	Module  string
 	Name    string
@@ -46,7 +85,7 @@ type InstructionSpec struct {
 	Output  []int32
 	Handler InstructionHandler
 	Lower   InstructionLowerer
-	Virtual *VirtualSignature
+	Custom  *CustomSignature
 	// AMD64 is an explicitly unsafe, fully trusted machine-code lowering. It may
 	// use Wago's real encoder or append arbitrary bytes through Encoder().B.
 	AMD64 *machinecode.AMD64Lowering
@@ -366,8 +405,8 @@ type Instruction struct {
 	ARM64           *machinecode.ARM64Lowering
 	InputWidths     []int32
 	ResultWidth     int32
-	VirtualInputs   []VirtualType
-	VirtualOutput   *VirtualType
+	CustomInputs    []CustomType
+	CustomOutput    *CustomType
 }
 
 // Definition is a validated plugin instruction. It owns detached copies of the
@@ -384,11 +423,11 @@ type Definition struct {
 // portable Handler.
 func (d Definition) Native() (Instruction, bool) {
 	native := Instruction{InputWidths: append([]int32(nil), d.Spec.Input...)}
-	if d.Spec.Virtual != nil {
-		native.VirtualInputs = append([]VirtualType(nil), d.Spec.Virtual.Inputs...)
-		if d.Spec.Virtual.Output != nil {
-			out := *d.Spec.Virtual.Output
-			native.VirtualOutput = &out
+	if d.Spec.Custom != nil {
+		native.CustomInputs = append([]CustomType(nil), d.Spec.Custom.Inputs...)
+		if d.Spec.Custom.Output != nil {
+			out := *d.Spec.Custom.Output
+			native.CustomOutput = &out
 		}
 	}
 	if d.amd64 != nil {
@@ -498,7 +537,22 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 	if spec.Module == "" || spec.Name == "" {
 		return Definition{}, fmt.Errorf("wago: instruction requires Module and Name")
 	}
-	if spec.Handler == nil && spec.Virtual == nil {
+	if spec.Custom != nil {
+		if len(spec.Input) == 0 && len(spec.Custom.Inputs) != 0 {
+			spec.Input = make([]int32, len(spec.Custom.Inputs))
+		}
+		if len(spec.Custom.Inputs) == len(spec.Input) {
+			for i, typ := range spec.Custom.Inputs {
+				if spec.Input[i] == 0 && typ.Valid() {
+					spec.Input[i] = typ.Bits()
+				}
+			}
+		}
+		if len(spec.Output) == 0 && spec.Custom.Output != nil && spec.Custom.Output.Valid() {
+			spec.Output = []int32{spec.Custom.Output.Bits()}
+		}
+	}
+	if spec.Handler == nil && spec.Custom == nil {
 		return Definition{}, fmt.Errorf("wago: instruction %q.%q requires Handler", spec.Module, spec.Name)
 	}
 	for _, widths := range [][]int32{spec.Input, spec.Output} {
@@ -508,37 +562,43 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 			}
 		}
 	}
-	if spec.Virtual != nil {
-		if len(spec.Virtual.Inputs) != len(spec.Input) {
-			return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual input metadata has %d entries, want %d", spec.Module, spec.Name, len(spec.Virtual.Inputs), len(spec.Input))
+	if spec.Custom != nil {
+		if len(spec.Custom.Inputs) != len(spec.Input) {
+			return Definition{}, fmt.Errorf("wago: instruction %q.%q custom input metadata has %d entries, want %d", spec.Module, spec.Name, len(spec.Custom.Inputs), len(spec.Input))
 		}
-		for i, typ := range spec.Virtual.Inputs {
-			if typ == (VirtualType{}) {
+		hasCustom := false
+		for i, typ := range spec.Custom.Inputs {
+			if typ.IsZero() {
 				continue
 			}
-			if !typ.valid() {
-				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual input %d requires a name and a positive 16-byte-aligned size", spec.Module, spec.Name, i)
+			hasCustom = true
+			if !typ.Valid() {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q custom input %d is not a registered type", spec.Module, spec.Name, i)
 			}
-			if spec.Input[i] != typ.Size*8 {
-				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual input %d is %d bits but type %q is %d bytes", spec.Module, spec.Name, i, spec.Input[i], typ.Name, typ.Size)
+			if spec.Input[i] != typ.Size()*8 {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q custom input %d is %d bits but type %q is %d bytes", spec.Module, spec.Name, i, spec.Input[i], typ.Name(), typ.Size())
 			}
 		}
-		if spec.Virtual.Output != nil {
+		if spec.Custom.Output != nil {
+			hasCustom = true
 			if len(spec.Output) != 1 {
-				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual output requires exactly one logical output", spec.Module, spec.Name)
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q custom output requires exactly one logical output", spec.Module, spec.Name)
 			}
-			if !spec.Virtual.Output.valid() {
-				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual output requires a name and a positive 16-byte-aligned size", spec.Module, spec.Name)
+			if !spec.Custom.Output.Valid() {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q custom output is not a registered type", spec.Module, spec.Name)
 			}
-			if spec.Output[0] != spec.Virtual.Output.Size*8 {
-				return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual output is %d bits but type %q is %d bytes", spec.Module, spec.Name, spec.Output[0], spec.Virtual.Output.Name, spec.Virtual.Output.Size)
+			if spec.Output[0] != spec.Custom.Output.Size()*8 {
+				return Definition{}, fmt.Errorf("wago: instruction %q.%q custom output is %d bits but type %q is %d bytes", spec.Module, spec.Name, spec.Output[0], spec.Custom.Output.Name(), spec.Custom.Output.Size())
 			}
+		}
+		if !hasCustom {
+			return Definition{}, fmt.Errorf("wago: instruction %q.%q custom signature contains no custom values", spec.Module, spec.Name)
 		}
 		if spec.Handler != nil {
-			return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual values are native-only and forbid Handler", spec.Module, spec.Name)
+			return Definition{}, fmt.Errorf("wago: instruction %q.%q custom values are native-only and forbid Handler", spec.Module, spec.Name)
 		}
 		if spec.AMD64 == nil && spec.ARM64 == nil {
-			return Definition{}, fmt.Errorf("wago: instruction %q.%q virtual values require a native lowering", spec.Module, spec.Name)
+			return Definition{}, fmt.Errorf("wago: instruction %q.%q custom values require a native lowering", spec.Module, spec.Name)
 		}
 	}
 	recipe, err := buildInstructionRecipe(spec)
@@ -567,12 +627,12 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 			return Definition{}, fmt.Errorf("wago: instruction %q.%q amd64 lowering supports at most one direct output", spec.Module, spec.Name)
 		}
 		for i, width := range spec.Input {
-			if width > 32 && (spec.Virtual == nil || spec.Virtual.Inputs[i] == (VirtualType{})) {
+			if width > 32 && (spec.Custom == nil || spec.Custom.Inputs[i].IsZero()) {
 				return Definition{}, fmt.Errorf("wago: instruction %q.%q amd64 lowering only supports direct values up to 32 bits", spec.Module, spec.Name)
 			}
 		}
 		for _, width := range spec.Output {
-			if width > 32 && (spec.Virtual == nil || spec.Virtual.Output == nil) {
+			if width > 32 && (spec.Custom == nil || spec.Custom.Output == nil) {
 				return Definition{}, fmt.Errorf("wago: instruction %q.%q amd64 lowering only supports direct values up to 32 bits", spec.Module, spec.Name)
 			}
 		}
@@ -596,12 +656,12 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 			return Definition{}, fmt.Errorf("wago: instruction %q.%q arm64 lowering supports at most one direct output", spec.Module, spec.Name)
 		}
 		for i, width := range spec.Input {
-			if width > 32 && (spec.Virtual == nil || spec.Virtual.Inputs[i] == (VirtualType{})) {
+			if width > 32 && (spec.Custom == nil || spec.Custom.Inputs[i].IsZero()) {
 				return Definition{}, fmt.Errorf("wago: instruction %q.%q arm64 lowering only supports direct values up to 32 bits", spec.Module, spec.Name)
 			}
 		}
 		for _, width := range spec.Output {
-			if width > 32 && (spec.Virtual == nil || spec.Virtual.Output == nil) {
+			if width > 32 && (spec.Custom == nil || spec.Custom.Output == nil) {
 				return Definition{}, fmt.Errorf("wago: instruction %q.%q arm64 lowering only supports direct values up to 32 bits", spec.Module, spec.Name)
 			}
 		}
@@ -610,13 +670,13 @@ func Prepare(spec InstructionSpec) (Definition, error) {
 	}
 	spec.Input = append([]int32(nil), spec.Input...)
 	spec.Output = append([]int32(nil), spec.Output...)
-	if spec.Virtual != nil {
-		virtual := &VirtualSignature{Inputs: append([]VirtualType(nil), spec.Virtual.Inputs...)}
-		if spec.Virtual.Output != nil {
-			out := *spec.Virtual.Output
-			virtual.Output = &out
+	if spec.Custom != nil {
+		custom := &CustomSignature{Inputs: append([]CustomType(nil), spec.Custom.Inputs...)}
+		if spec.Custom.Output != nil {
+			out := *spec.Custom.Output
+			custom.Output = &out
 		}
-		spec.Virtual = virtual
+		spec.Custom = custom
 	}
 	spec.AMD64 = amd64Lowering
 	spec.ARM64 = arm64Lowering

--- a/src/core/plugins/instruction_test.go
+++ b/src/core/plugins/instruction_test.go
@@ -12,6 +12,27 @@ func portableAdd(_ InstructionContext, args []Bits) ([]Bits, error) {
 	return []Bits{sum}, err
 }
 
+func TestPrepareCustomTypeSupportsStandardCarriers(t *testing.T) {
+	for _, carrier := range []WasmType{WasmI32, WasmI64, WasmF32, WasmF64, WasmV128, WasmFuncRef, WasmExternRef} {
+		typ, err := PrepareCustomType(CustomTypeSpec{Name: "example.value", Size: 16, Carrier: carrier})
+		if err != nil {
+			t.Fatalf("carrier %d: %v", carrier, err)
+		}
+		if typ.Name() != "example.value" || typ.Size() != 16 || typ.Carrier() != carrier || !typ.Valid() {
+			t.Fatalf("carrier %d produced %+v", carrier, typ)
+		}
+	}
+	for _, spec := range []CustomTypeSpec{
+		{Size: 16, Carrier: WasmI32},
+		{Name: "bad", Size: 15, Carrier: WasmI32},
+		{Name: "bad", Size: 16, Carrier: WasmType(255)},
+	} {
+		if _, err := PrepareCustomType(spec); err == nil {
+			t.Fatalf("invalid custom type accepted: %+v", spec)
+		}
+	}
+}
+
 func TestPrepareBuildsNativeInstruction(t *testing.T) {
 	input := []int32{4, 4}
 	output := []int32{4}
@@ -83,13 +104,16 @@ func TestPrepareBuildsIndependentTargetLowerings(t *testing.T) {
 	}
 }
 
-func TestPrepareBuildsVirtualInstruction(t *testing.T) {
-	vector := VirtualType{Name: "example.v256", Size: 32}
-	inputs := []VirtualType{vector, vector}
+func TestPrepareBuildsCustomInstruction(t *testing.T) {
+	vector, err := PrepareCustomType(CustomTypeSpec{Name: "example.v256", Size: 32, Carrier: WasmExternRef})
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := vector
+	inputs := []CustomType{vector, vector}
 	def, err := Prepare(InstructionSpec{
 		Module: "example", Name: "v256.xor",
-		Input: []int32{256, 256}, Output: []int32{256},
-		Virtual: &VirtualSignature{Inputs: inputs, Output: &vector},
+		Custom: &CustomSignature{Inputs: inputs, Output: &output},
 		AMD64: &machinecode.AMD64Lowering{
 			Compatibility: machinecode.AMD64CompatibilityFullAccess,
 			Emit:          func(machinecode.AMD64Context) error { return nil },
@@ -100,23 +124,30 @@ func TestPrepareBuildsVirtualInstruction(t *testing.T) {
 	}
 
 	// Registration snapshots both the signature slices and pointed-to result.
-	inputs[0] = VirtualType{Name: "mutated", Size: 16}
-	vector.Name = "mutated"
+	inputs[0] = CustomType{}
+	output = CustomType{}
 	native, ok := def.Native()
 	if !ok {
-		t.Fatal("virtual instruction should have a native lowering")
+		t.Fatal("custom instruction should have a native lowering")
 	}
-	if len(native.VirtualInputs) != 2 || native.VirtualInputs[0].Name != "example.v256" ||
-		native.VirtualOutput == nil || native.VirtualOutput.Name != "example.v256" {
-		t.Fatalf("virtual signature was not detached: %+v", native)
+	if len(native.CustomInputs) != 2 || native.CustomInputs[0].Name() != "example.v256" ||
+		native.CustomOutput == nil || native.CustomOutput.Name() != "example.v256" {
+		t.Fatalf("custom signature was not detached: %+v", native)
 	}
 	if native.ResultWidth != 256 || native.StackCompatible {
-		t.Fatalf("unexpected virtual lowering: %+v", native)
+		t.Fatalf("unexpected custom lowering: %+v", native)
+	}
+	if got := def.Spec.Input; len(got) != 2 || got[0] != 256 || got[1] != 256 {
+		t.Fatalf("derived custom input widths=%v", got)
 	}
 }
 
 func TestPrepareRejectsInvalidDefinitions(t *testing.T) {
-	virtualAMD64 := &machinecode.AMD64Lowering{
+	vector, err := PrepareCustomType(CustomTypeSpec{Name: "example.v256", Size: 32, Carrier: WasmExternRef})
+	if err != nil {
+		t.Fatal(err)
+	}
+	customAMD64 := &machinecode.AMD64Lowering{
 		Compatibility: machinecode.AMD64CompatibilityFullAccess,
 		Emit:          func(machinecode.AMD64Context) error { return nil },
 	}
@@ -148,37 +179,37 @@ func TestPrepareRejectsInvalidDefinitions(t *testing.T) {
 			want: "did not set output",
 		},
 		{
-			name: "virtual metadata length",
+			name: "custom metadata length",
 			spec: InstructionSpec{
 				Module: "example", Name: "bad", Input: []int32{256},
-				Virtual: &VirtualSignature{}, AMD64: virtualAMD64,
+				Custom: &CustomSignature{}, AMD64: customAMD64,
 			},
-			want: "virtual input metadata has 0 entries, want 1",
+			want: "custom input metadata has 0 entries, want 1",
 		},
 		{
-			name: "virtual width mismatch",
+			name: "custom width mismatch",
 			spec: InstructionSpec{
 				Module: "example", Name: "bad", Input: []int32{128},
-				Virtual: &VirtualSignature{Inputs: []VirtualType{{Name: "example.v256", Size: 32}}},
-				AMD64:   virtualAMD64,
+				Custom: &CustomSignature{Inputs: []CustomType{vector}},
+				AMD64:  customAMD64,
 			},
 			want: "is 128 bits",
 		},
 		{
-			name: "virtual handler",
+			name: "custom handler",
 			spec: InstructionSpec{
 				Module: "example", Name: "bad", Input: []int32{256},
-				Virtual: &VirtualSignature{Inputs: []VirtualType{{Name: "example.v256", Size: 32}}},
+				Custom:  &CustomSignature{Inputs: []CustomType{vector}},
 				Handler: func(InstructionContext, []Bits) ([]Bits, error) { return nil, nil },
-				AMD64:   virtualAMD64,
+				AMD64:   customAMD64,
 			},
 			want: "native-only and forbid Handler",
 		},
 		{
-			name: "virtual without lowering",
+			name: "custom without lowering",
 			spec: InstructionSpec{
 				Module: "example", Name: "bad", Input: []int32{256},
-				Virtual: &VirtualSignature{Inputs: []VirtualType{{Name: "example.v256", Size: 32}}},
+				Custom: &CustomSignature{Inputs: []CustomType{vector}},
 			},
 			want: "require a native lowering",
 		},

--- a/src/core/plugins/instruction_test.go
+++ b/src/core/plugins/instruction_test.go
@@ -83,7 +83,43 @@ func TestPrepareBuildsIndependentTargetLowerings(t *testing.T) {
 	}
 }
 
+func TestPrepareBuildsVirtualInstruction(t *testing.T) {
+	vector := VirtualType{Name: "example.v256", Size: 32}
+	inputs := []VirtualType{vector, vector}
+	def, err := Prepare(InstructionSpec{
+		Module: "example", Name: "v256.xor",
+		Input: []int32{256, 256}, Output: []int32{256},
+		Virtual: &VirtualSignature{Inputs: inputs, Output: &vector},
+		AMD64: &machinecode.AMD64Lowering{
+			Compatibility: machinecode.AMD64CompatibilityFullAccess,
+			Emit:          func(machinecode.AMD64Context) error { return nil },
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Registration snapshots both the signature slices and pointed-to result.
+	inputs[0] = VirtualType{Name: "mutated", Size: 16}
+	vector.Name = "mutated"
+	native, ok := def.Native()
+	if !ok {
+		t.Fatal("virtual instruction should have a native lowering")
+	}
+	if len(native.VirtualInputs) != 2 || native.VirtualInputs[0].Name != "example.v256" ||
+		native.VirtualOutput == nil || native.VirtualOutput.Name != "example.v256" {
+		t.Fatalf("virtual signature was not detached: %+v", native)
+	}
+	if native.ResultWidth != 256 || native.StackCompatible {
+		t.Fatalf("unexpected virtual lowering: %+v", native)
+	}
+}
+
 func TestPrepareRejectsInvalidDefinitions(t *testing.T) {
+	virtualAMD64 := &machinecode.AMD64Lowering{
+		Compatibility: machinecode.AMD64CompatibilityFullAccess,
+		Emit:          func(machinecode.AMD64Context) error { return nil },
+	}
 	tests := []struct {
 		name string
 		spec InstructionSpec
@@ -110,6 +146,41 @@ func TestPrepareRejectsInvalidDefinitions(t *testing.T) {
 				Lower:   func(LoweringContext) error { return nil },
 			},
 			want: "did not set output",
+		},
+		{
+			name: "virtual metadata length",
+			spec: InstructionSpec{
+				Module: "example", Name: "bad", Input: []int32{256},
+				Virtual: &VirtualSignature{}, AMD64: virtualAMD64,
+			},
+			want: "virtual input metadata has 0 entries, want 1",
+		},
+		{
+			name: "virtual width mismatch",
+			spec: InstructionSpec{
+				Module: "example", Name: "bad", Input: []int32{128},
+				Virtual: &VirtualSignature{Inputs: []VirtualType{{Name: "example.v256", Size: 32}}},
+				AMD64:   virtualAMD64,
+			},
+			want: "is 128 bits",
+		},
+		{
+			name: "virtual handler",
+			spec: InstructionSpec{
+				Module: "example", Name: "bad", Input: []int32{256},
+				Virtual: &VirtualSignature{Inputs: []VirtualType{{Name: "example.v256", Size: 32}}},
+				Handler: func(InstructionContext, []Bits) ([]Bits, error) { return nil, nil },
+				AMD64:   virtualAMD64,
+			},
+			want: "native-only and forbid Handler",
+		},
+		{
+			name: "virtual without lowering",
+			spec: InstructionSpec{
+				Module: "example", Name: "bad", Input: []int32{256},
+				Virtual: &VirtualSignature{Inputs: []VirtualType{{Name: "example.v256", Size: 32}}},
+			},
+			want: "require a native lowering",
 		},
 	}
 

--- a/src/wago/custom_type_test.go
+++ b/src/wago/custom_type_test.go
@@ -88,7 +88,40 @@ func (customCarrierExtension) Register(reg *Registry) error {
 			return err
 		}
 	}
-	return nil
+	alias, err := compiler.Type(CustomTypeSpec{Name: "test.value.alias", Size: 32, Carrier: WasmI32})
+	if err != nil {
+		return err
+	}
+	return compiler.Instruction(InstructionSpec{
+		Module: "test:custom", Name: "test.value.alias.drop",
+		Custom: &CustomSignature{Inputs: []CustomType{alias}},
+		AMD64: &AMD64InstructionLowering{
+			Compatibility: AMD64CompatibilityFullAccess,
+			Emit: func(ctx AMD64LoweringContext) error {
+				regs, err := ctx.InputCustom(0)
+				if err != nil {
+					return err
+				}
+				for _, reg := range regs {
+					ctx.ReleaseVector(reg)
+				}
+				return nil
+			},
+		},
+		ARM64: &ARM64InstructionLowering{
+			Compatibility: ARM64CompatibilityFullAccess,
+			Emit: func(ctx ARM64LoweringContext) error {
+				regs, err := ctx.InputCustom(0)
+				if err != nil {
+					return err
+				}
+				for _, reg := range regs {
+					ctx.ReleaseVector(reg)
+				}
+				return nil
+			},
+		},
+	})
 }
 
 func TestCustomTypeCarriersCompileAndExecuteAsErasedValues(t *testing.T) {
@@ -142,6 +175,17 @@ func TestCustomTypeCarriersDeterminePhysicalSignatures(t *testing.T) {
 	}
 }
 
+func TestCustomTypeIdentityIsStrongerThanPhysicalCarrier(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(customCarrierExtension{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := rt.Compile(customCarrierChainModule("test.value.0", "test.value.alias.drop", 0x7f))
+	if err == nil || !strings.Contains(err.Error(), "incompatible custom type") {
+		t.Fatalf("compile error = %v, want incompatible custom type", err)
+	}
+}
+
 func TestCustomTypeRegistrationRejectsConflictsAndForeignTokens(t *testing.T) {
 	first := (&Registry{}).Compiler()
 	typ, err := first.Type(CustomTypeSpec{Name: "test.value", Size: 32, Carrier: WasmI32})
@@ -166,6 +210,10 @@ func TestCustomTypeRegistrationRejectsConflictsAndForeignTokens(t *testing.T) {
 }
 
 func customCarrierModule(name string, carrier byte) []byte {
+	return customCarrierChainModule(name, name+".drop", carrier)
+}
+
+func customCarrierChainModule(producer, consumer string, carrier byte) []byte {
 	produce := []byte{0x60, 0, 1, carrier}
 	consume := []byte{0x60, 1, carrier, 0}
 	run := wasmtest.FuncType(nil, nil)
@@ -176,7 +224,7 @@ func customCarrierModule(name string, carrier byte) []byte {
 	}
 	return wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(produce, consume, run)),
-		wasmtest.Section(2, wasmtest.Vec(importFunc(name, 0), importFunc(name+".drop", 1))),
+		wasmtest.Section(2, wasmtest.Vec(importFunc(producer, 0), importFunc(consumer, 1))),
 		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2))),
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", byte(wasm.ExternFunc), 2))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0, 0x10, 1, 0x0b}))),

--- a/src/wago/custom_type_test.go
+++ b/src/wago/custom_type_test.go
@@ -1,0 +1,184 @@
+//go:build !tinygo
+
+package wago
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/testutil/wasmtest"
+)
+
+type customCarrierExtension struct{}
+
+func (customCarrierExtension) Info() ExtensionInfo {
+	return ExtensionInfo{ID: "test.custom-carriers", Version: "1.0.0", Stability: Experimental}
+}
+
+func (customCarrierExtension) Register(reg *Registry) error {
+	reg.Capability(CapCompilerCodegen)
+	compiler := reg.Compiler()
+	for i, carrier := range []WasmType{WasmI32, WasmI64, WasmF32, WasmF64, WasmV128, WasmFuncRef, WasmExternRef} {
+		name := fmt.Sprintf("test.value.%d", i)
+		typ, err := compiler.Type(CustomTypeSpec{Name: name, Size: 32, Carrier: carrier})
+		if err != nil {
+			return err
+		}
+		again, err := compiler.Type(CustomTypeSpec{Name: name, Size: 32, Carrier: carrier})
+		if err != nil || !again.Equal(typ) {
+			return fmt.Errorf("idempotent registration for %s failed: %w", name, err)
+		}
+		if err := compiler.Instruction(InstructionSpec{
+			Module: "test:custom", Name: name, Output: []int32{256},
+			Custom: &CustomSignature{Output: &typ},
+			AMD64: &AMD64InstructionLowering{
+				Compatibility: AMD64CompatibilityFullAccess,
+				Emit: func(ctx AMD64LoweringContext) error {
+					reg := ctx.AllocYMM()
+					ctx.Encoder().YPxor(reg, reg, reg)
+					return ctx.OutputCustom(reg)
+				},
+			},
+			ARM64: &ARM64InstructionLowering{
+				Compatibility: ARM64CompatibilityFullAccess,
+				Emit: func(ctx ARM64LoweringContext) error {
+					a, b := ctx.AllocVector(), ctx.AllocVector()
+					ctx.Encoder().Eor16b(a, a, a)
+					ctx.Encoder().Eor16b(b, b, b)
+					return ctx.OutputCustom(a, b)
+				},
+			},
+		}); err != nil {
+			return err
+		}
+		if err := compiler.Instruction(InstructionSpec{
+			Module: "test:custom", Name: name + ".drop", Input: []int32{256},
+			Custom: &CustomSignature{Inputs: []CustomType{typ}},
+			AMD64: &AMD64InstructionLowering{
+				Compatibility: AMD64CompatibilityFullAccess,
+				Emit: func(ctx AMD64LoweringContext) error {
+					regs, err := ctx.InputCustom(0)
+					if err != nil {
+						return err
+					}
+					for _, reg := range regs {
+						ctx.ReleaseVector(reg)
+					}
+					return nil
+				},
+			},
+			ARM64: &ARM64InstructionLowering{
+				Compatibility: ARM64CompatibilityFullAccess,
+				Emit: func(ctx ARM64LoweringContext) error {
+					regs, err := ctx.InputCustom(0)
+					if err != nil {
+						return err
+					}
+					for _, reg := range regs {
+						ctx.ReleaseVector(reg)
+					}
+					return nil
+				},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestCustomTypeCarriersCompileAndExecuteAsErasedValues(t *testing.T) {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		t.Skip("custom machine-code lowering is available on amd64 and arm64")
+	}
+	rt := NewRuntime()
+	if err := rt.Use(customCarrierExtension{}); err != nil {
+		t.Fatal(err)
+	}
+	carriers := []byte{0x7f, 0x7e, 0x7d, 0x7c, 0x7b, 0x70, 0x6f}
+	for i, carrier := range carriers {
+		t.Run(fmt.Sprintf("carrier-%x", carrier), func(t *testing.T) {
+			mod, err := rt.Compile(customCarrierModule(fmt.Sprintf("test.value.%d", i), carrier))
+			if err != nil {
+				t.Fatal(err)
+			}
+			in, err := rt.Instantiate(context.Background(), mod)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			if _, err := in.Invoke("run"); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCustomTypeCarriersDeterminePhysicalSignatures(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Use(customCarrierExtension{}); err != nil {
+		t.Fatal(err)
+	}
+	want := []ValType{ValI32, ValI64, ValF32, ValF64, ValV128, ValFuncRef, ValExternRef}
+	seen := make(map[string]ValType)
+	for _, provided := range rt.ProvidedImports() {
+		if provided.Module != "test:custom" || strings.HasSuffix(provided.Name, ".drop") {
+			continue
+		}
+		if len(provided.Params) != 0 || len(provided.Results) != 1 {
+			t.Fatalf("%s has signature %v -> %v", provided.Name, provided.Params, provided.Results)
+		}
+		seen[provided.Name] = provided.Results[0]
+	}
+	for i, carrier := range want {
+		name := fmt.Sprintf("test.value.%d", i)
+		if got, ok := seen[name]; !ok || got != carrier {
+			t.Fatalf("%s carrier=%v, want %v", name, got, carrier)
+		}
+	}
+}
+
+func TestCustomTypeRegistrationRejectsConflictsAndForeignTokens(t *testing.T) {
+	first := (&Registry{}).Compiler()
+	typ, err := first.Type(CustomTypeSpec{Name: "test.value", Size: 32, Carrier: WasmI32})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.Type(CustomTypeSpec{Name: "test.value", Size: 32, Carrier: WasmI64}); err == nil {
+		t.Fatal("conflicting carrier accepted")
+	}
+
+	second := (&Registry{}).Compiler()
+	if err := second.Instruction(InstructionSpec{
+		Module: "test", Name: "foreign", Output: []int32{256},
+		Custom: &CustomSignature{Output: &typ},
+		AMD64: &AMD64InstructionLowering{
+			Compatibility: AMD64CompatibilityFullAccess,
+			Emit:          func(AMD64LoweringContext) error { return nil },
+		},
+	}); err == nil {
+		t.Fatal("custom type token from another registry accepted")
+	}
+}
+
+func customCarrierModule(name string, carrier byte) []byte {
+	produce := []byte{0x60, 0, 1, carrier}
+	consume := []byte{0x60, 1, carrier, 0}
+	run := wasmtest.FuncType(nil, nil)
+	importFunc := func(importName string, typeIndex uint32) []byte {
+		out := append(wasmtest.Name("test:custom"), wasmtest.Name(importName)...)
+		out = append(out, 0)
+		return append(out, wasmtest.ULEB(typeIndex)...)
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(produce, consume, run)),
+		wasmtest.Section(2, wasmtest.Vec(importFunc(name, 0), importFunc(name+".drop", 1))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", byte(wasm.ExternFunc), 2))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0, 0x10, 1, 0x0b}))),
+	)
+}

--- a/src/wago/instruction.go
+++ b/src/wago/instruction.go
@@ -30,6 +30,8 @@ type Bits = coreplugins.Bits
 type LowerValue = coreplugins.LowerValue
 type InstructionLowerer = coreplugins.InstructionLowerer
 type LoweringContext = coreplugins.LoweringContext
+type VirtualType = coreplugins.VirtualType
+type VirtualSignature = coreplugins.VirtualSignature
 
 const (
 	AMD64FeatureAVX2             = machinecode.AMD64FeatureAVX2

--- a/src/wago/instruction.go
+++ b/src/wago/instruction.go
@@ -30,10 +30,20 @@ type Bits = coreplugins.Bits
 type LowerValue = coreplugins.LowerValue
 type InstructionLowerer = coreplugins.InstructionLowerer
 type LoweringContext = coreplugins.LoweringContext
-type VirtualType = coreplugins.VirtualType
-type VirtualSignature = coreplugins.VirtualSignature
+type WasmType = coreplugins.WasmType
+type CustomTypeSpec = coreplugins.CustomTypeSpec
+type CustomType = coreplugins.CustomType
+type CustomSignature = coreplugins.CustomSignature
 
 const (
+	WasmI32       = coreplugins.WasmI32
+	WasmI64       = coreplugins.WasmI64
+	WasmF32       = coreplugins.WasmF32
+	WasmF64       = coreplugins.WasmF64
+	WasmV128      = coreplugins.WasmV128
+	WasmFuncRef   = coreplugins.WasmFuncRef
+	WasmExternRef = coreplugins.WasmExternRef
+
 	AMD64FeatureAVX2             = machinecode.AMD64FeatureAVX2
 	AMD64FeatureAVX512           = machinecode.AMD64FeatureAVX512
 	AMD64CompatibilityManaged    = machinecode.AMD64CompatibilityManaged
@@ -53,6 +63,55 @@ func BitsFromUint32(width int32, value uint32) (Bits, error) {
 type registeredInstruction struct {
 	spec       InstructionSpec
 	definition coreplugins.Definition
+}
+
+// Type registers a plugin-owned logical value type and returns its opaque
+// identity token. Repeating an identical declaration is idempotent; reusing a
+// name with a different size or carrier is rejected.
+func (r *CompilerRegistry) Type(spec CustomTypeSpec) (CustomType, error) {
+	if r == nil || r.reg == nil {
+		return CustomType{}, fmt.Errorf("wago: nil compiler registry")
+	}
+	typ, err := coreplugins.PrepareCustomType(spec)
+	if err != nil {
+		return CustomType{}, err
+	}
+	if r.reg.customTypes == nil {
+		r.reg.customTypes = make(map[string]CustomType)
+	}
+	if existing, ok := r.reg.customTypes[typ.Name()]; ok {
+		if !existing.Equal(typ) {
+			return CustomType{}, fmt.Errorf("wago: custom type %q conflicts with its previous registration", typ.Name())
+		}
+		return existing, nil
+	}
+	r.reg.customTypes[typ.Name()] = typ
+	return typ, nil
+}
+
+func (r *CompilerRegistry) validateCustomSignature(sig *CustomSignature) error {
+	if sig == nil {
+		return nil
+	}
+	check := func(typ CustomType) error {
+		if typ.IsZero() {
+			return nil
+		}
+		registered, ok := r.reg.customTypes[typ.Name()]
+		if !ok || !registered.Equal(typ) {
+			return fmt.Errorf("wago: custom type %q was not registered with this compiler registry", typ.Name())
+		}
+		return nil
+	}
+	for _, typ := range sig.Inputs {
+		if err := check(typ); err != nil {
+			return err
+		}
+	}
+	if sig.Output != nil {
+		return check(*sig.Output)
+	}
+	return nil
 }
 
 func resolveInstructionLowerings(m *wasm.Module, registered map[string]*registeredInstruction) map[uint32]coreplugins.Instruction {
@@ -84,6 +143,9 @@ func resolveInstructionLowerings(m *wasm.Module, registered map[string]*register
 func (r *CompilerRegistry) Instruction(spec InstructionSpec) error {
 	if r == nil || r.reg == nil {
 		return fmt.Errorf("wago: nil compiler registry")
+	}
+	if err := r.validateCustomSignature(spec.Custom); err != nil {
+		return err
 	}
 	definition, err := coreplugins.Prepare(spec)
 	if err != nil {

--- a/src/wago/instruction_runtime.go
+++ b/src/wago/instruction_runtime.go
@@ -62,12 +62,21 @@ func instructionImport(ins *registeredInstruction) *registeredImport {
 	params := make([]ValType, len(ins.spec.Input))
 	for i := range params {
 		params[i] = ValI32
+		if ins.spec.Virtual != nil && ins.spec.Virtual.Inputs[i] != (VirtualType{}) {
+			params[i] = ValExternRef
+		}
 	}
 	var results []ValType
 	if len(ins.spec.Output) > 0 {
 		results = []ValType{ValI32}
+		if ins.spec.Virtual != nil && ins.spec.Virtual.Output != nil {
+			results[0] = ValExternRef
+		}
 	}
 	fn := instructionHostFunc(func(m HostModule, raw, result []uint64) {
+		if ins.spec.Virtual != nil {
+			panic(instructionTrap{fmt.Errorf("wago: virtual instruction %s.%s requires native lowering", ins.spec.Module, ins.spec.Name)})
+		}
 		in, ok := instructionCallingInstance(m)
 		if !ok {
 			panic(instructionTrap{fmt.Errorf("wago: instruction called without an instance")})
@@ -167,6 +176,9 @@ func validateInstructionSignature(key string, spec InstructionSpec, sig FuncSig)
 	params := make([]ValType, len(spec.Input))
 	for i := range params {
 		params[i] = ValI32
+		if spec.Virtual != nil && spec.Virtual.Inputs[i] != (VirtualType{}) {
+			params[i] = ValExternRef
+		}
 	}
 	wantResults := 0
 	if len(spec.Output) > 0 {
@@ -175,6 +187,9 @@ func validateInstructionSignature(key string, spec InstructionSpec, sig FuncSig)
 	results := make([]ValType, wantResults)
 	if wantResults != 0 {
 		results[0] = ValI32
+		if spec.Virtual != nil && spec.Virtual.Output != nil {
+			results[0] = ValExternRef
+		}
 	}
 	return validatePhysicalImportSignature(key, params, results, sig)
 }

--- a/src/wago/instruction_runtime.go
+++ b/src/wago/instruction_runtime.go
@@ -58,24 +58,43 @@ func (s *instructionState) allocID() uint32 {
 	return s.next
 }
 
+func customCarrierType(typ CustomType) ValType {
+	switch typ.Carrier() {
+	case WasmI64:
+		return ValI64
+	case WasmF32:
+		return ValF32
+	case WasmF64:
+		return ValF64
+	case WasmV128:
+		return ValV128
+	case WasmFuncRef:
+		return ValFuncRef
+	case WasmExternRef:
+		return ValExternRef
+	default:
+		return ValI32
+	}
+}
+
 func instructionImport(ins *registeredInstruction) *registeredImport {
 	params := make([]ValType, len(ins.spec.Input))
 	for i := range params {
 		params[i] = ValI32
-		if ins.spec.Virtual != nil && ins.spec.Virtual.Inputs[i] != (VirtualType{}) {
-			params[i] = ValExternRef
+		if ins.spec.Custom != nil && !ins.spec.Custom.Inputs[i].IsZero() {
+			params[i] = customCarrierType(ins.spec.Custom.Inputs[i])
 		}
 	}
 	var results []ValType
 	if len(ins.spec.Output) > 0 {
 		results = []ValType{ValI32}
-		if ins.spec.Virtual != nil && ins.spec.Virtual.Output != nil {
-			results[0] = ValExternRef
+		if ins.spec.Custom != nil && ins.spec.Custom.Output != nil {
+			results[0] = customCarrierType(*ins.spec.Custom.Output)
 		}
 	}
 	fn := instructionHostFunc(func(m HostModule, raw, result []uint64) {
-		if ins.spec.Virtual != nil {
-			panic(instructionTrap{fmt.Errorf("wago: virtual instruction %s.%s requires native lowering", ins.spec.Module, ins.spec.Name)})
+		if ins.spec.Custom != nil {
+			panic(instructionTrap{fmt.Errorf("wago: custom instruction %s.%s requires native lowering", ins.spec.Module, ins.spec.Name)})
 		}
 		in, ok := instructionCallingInstance(m)
 		if !ok {
@@ -176,8 +195,8 @@ func validateInstructionSignature(key string, spec InstructionSpec, sig FuncSig)
 	params := make([]ValType, len(spec.Input))
 	for i := range params {
 		params[i] = ValI32
-		if spec.Virtual != nil && spec.Virtual.Inputs[i] != (VirtualType{}) {
-			params[i] = ValExternRef
+		if spec.Custom != nil && !spec.Custom.Inputs[i].IsZero() {
+			params[i] = customCarrierType(spec.Custom.Inputs[i])
 		}
 	}
 	wantResults := 0
@@ -187,8 +206,8 @@ func validateInstructionSignature(key string, spec InstructionSpec, sig FuncSig)
 	results := make([]ValType, wantResults)
 	if wantResults != 0 {
 		results[0] = ValI32
-		if spec.Virtual != nil && spec.Virtual.Output != nil {
-			results[0] = ValExternRef
+		if spec.Custom != nil && spec.Custom.Output != nil {
+			results[0] = customCarrierType(*spec.Custom.Output)
 		}
 	}
 	return validatePhysicalImportSignature(key, params, results, sig)

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -21,6 +21,7 @@ type Registry struct {
 	used         map[PluginCapability]struct{}
 	config       json.RawMessage
 	compiler     *CompilerRegistry
+	customTypes  map[string]CustomType
 	instructions []*registeredInstruction
 }
 

--- a/wago.go
+++ b/wago.go
@@ -33,6 +33,9 @@ type (
 	CompilerRegistry            = impl.CompilerRegistry
 	ConfigSchemaProvider        = impl.ConfigSchemaProvider
 	CoreFeatures                = impl.CoreFeatures
+	CustomSignature             = impl.CustomSignature
+	CustomType                  = impl.CustomType
+	CustomTypeSpec              = impl.CustomTypeSpec
 	DataInit                    = impl.DataInit
 	Dirs                        = impl.Dirs
 	ElemInit                    = impl.ElemInit
@@ -130,8 +133,7 @@ type (
 	V128                        = impl.V128
 	ValType                     = impl.ValType
 	Value                       = impl.Value
-	VirtualSignature            = impl.VirtualSignature
-	VirtualType                 = impl.VirtualType
+	WasmType                    = impl.WasmType
 )
 
 const (
@@ -225,6 +227,13 @@ const (
 	ValI64                                     = impl.ValI64
 	ValV128                                    = impl.ValV128
 	Version                                    = impl.Version
+	WasmExternRef                              = impl.WasmExternRef
+	WasmF32                                    = impl.WasmF32
+	WasmF64                                    = impl.WasmF64
+	WasmFuncRef                                = impl.WasmFuncRef
+	WasmI32                                    = impl.WasmI32
+	WasmI64                                    = impl.WasmI64
+	WasmV128                                   = impl.WasmV128
 )
 
 func AsF32(b uint64) float32 { return impl.AsF32(b) }

--- a/wago.go
+++ b/wago.go
@@ -130,6 +130,8 @@ type (
 	V128                        = impl.V128
 	ValType                     = impl.ValType
 	Value                       = impl.Value
+	VirtualSignature            = impl.VirtualSignature
+	VirtualType                 = impl.VirtualType
 )
 
 const (


### PR DESCRIPTION
## Summary

- add generic plugin-owned virtual value signatures carried physically as standard Wasm externref
- erase those carriers into native register bundles across straight-line plugin expression chains
- expose typed GP/vector release and virtual input/output ownership APIs on AMD64 and ARM64
- reject virtual values that escape into locals, ordinary calls, returns, or control flow
- document the language-neutral ABI and ownership boundary

## Validation

- `go test $(go list ./... | rg -v '/cli/wagocli$')`\n- `go vet ./src/core/plugins ./src/core/compiler/backend/railshot/amd64 ./src/core/compiler/backend/railshot/arm64 ./src/wago`\n- Wide plugin full catalog on amd64 and arm64/QEMU\n\nThe full `go test ./...` currently also reaches an unrelated existing `cli/wagocli` go.mod helper failure in this checkout; all other packages pass.