### PR TITLE
cli: adopt rolling v0 plugin schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The high-level project docs live in this repo:
 - [ROADMAP.md](ROADMAP.md) — near-term engine and product roadmap.
 - [ARCHITECTURE.md](ARCHITECTURE.md) — pipeline, runtime, ABI, and design notes.
 - [OPTIMIZATIONS.md](OPTIMIZATIONS.md) — current and planned codegen work.
-- [docs/plugin-api-v2.md](docs/plugin-api-v2.md) — capability-based plugin architecture.
+- [docs/plugin-api.md](docs/plugin-api.md) — capability-based plugin architecture.
 - [docs/plugin-scopes.md](docs/plugin-scopes.md) — local/global plugin intent and toolchain-isolated builds.
 - [docs/compiler-instruction-plugin-design.md](docs/compiler-instruction-plugin-design.md) — language-neutral custom instructions and native lowering.
 - [docs/wago-json.md](docs/wago-json.md) — manifest and schema reference.
@@ -263,25 +263,22 @@ wago module capabilities app.wasm
 wago version list
 ```
 
-The standard CLI contains no plugins. Project dependencies are compiled into a
-custom binary, while `plugins` entries activate them and grant their Wago host
-capabilities:
+The standard CLI contains no plugins. Each `plugins` entry is both a
+version-constrained build dependency and a runtime activation. Reviewed
+capabilities and plugin-owned config are resolved into `wago-lock.json`:
 
 ```json
 {
-  "$schema": "https://wago.sh/schema.json",
-  "schema": "wago/v1",
-  "dependencies": ["github.com/acme/wago-metrics"],
-  "plugins": [{
-    "name": "acme/wago-metrics",
-    "capabilities": ["host.imports"]
-  }]
+  "$schema": "https://wago.sh/v0/schema.json",
+  "plugins": {
+    "acme/wago-metrics": "^0.0.0"
+  }
 }
 ```
 
 Load order is dependency-aware and deterministic; missing grants and cycles fail
 before any plugin contribution is committed. See
-[docs/plugin-api-v2.md](docs/plugin-api-v2.md).
+[docs/plugin-api.md](docs/plugin-api.md).
 The full manifest reference and editor schema are in
 [docs/wago-json.md](docs/wago-json.md) and [`schema.json`](schema.json).
 
@@ -532,11 +529,11 @@ func (randExt) Info() wago.ExtensionInfo {
 	return wago.ExtensionInfo{
 		ID:          "example.rand",
 		Name:        "Rand",
-		Version:     "1.0.0",
+		Version:     "0.0.0",
 		Description: "Pseudo-random numbers for guests.",
 		Stability:   wago.Experimental,
 		Compat: wago.Compatibility{
-			Engines: map[string]string{"wago": ">=0.1.0"},
+			Engines: map[string]string{"wago": "0.0.0"},
 		},
 	}
 }
@@ -626,7 +623,7 @@ for the listed subset. [FEATURES.md](FEATURES.md) is the source of truth.
 | Bounds checks | Explicit checks by default; signals/guard-page mode behind `-tags wago_guardpage` and `WAGO_BOUNDS=signals`. |
 | Runtime config | Done: immutable wazero-style `RuntimeConfig`, feature gating, memory page limit, bounds mode, deferred bounds-check facts. |
 | Synchronous host calls | Done: host imports can return results, including `v128`. |
-| Plugins | Done: open-source provenance, manifest-granted host capabilities, deterministic dependency/load ordering, transactional registration, host imports, hooks, and CLI inspection. |
+| Plugins | Done: open-source provenance, lockfile-recorded host capabilities, deterministic dependency/load ordering, transactional registration, host imports, hooks, and CLI inspection. |
 | Policy | Partial: capability allow/deny plus memory/table limits are enforced; invoke duration is reserved. |
 | Instance pools | Plugin-owned: pooling policy and idle-instance retention are intentionally absent from core. |
 | Actor/process layer | Plugin-owned: core provides only capability-gated managed instances; workers, PIDs, guest mailboxes, signals, monitoring, and supervision live outside the runtime. |

--- a/cli/wago/main_manager_test.go
+++ b/cli/wago/main_manager_test.go
@@ -245,7 +245,9 @@ func TestManagerOwnsInitWithoutSelectedRunner(t *testing.T) {
 		t.Fatalf("manager init output = %q", output)
 	}
 	manifest, err := os.ReadFile(filepath.Join(project, "wago.json"))
-	if err != nil || !strings.Contains(string(manifest), `"schema": "wago/v1"`) {
+	if err != nil ||
+		!strings.Contains(string(manifest), `"$schema": "https://wago.sh/v0/schema.json"`) ||
+		strings.Contains(string(manifest), `"schema":`) {
 		t.Fatalf("manager init manifest = %q, %v", manifest, err)
 	}
 }

--- a/cli/wagocli/cmd_pkg.go
+++ b/cli/wagocli/cmd_pkg.go
@@ -4,7 +4,7 @@ package wagocli
 
 // The plugin command surface: top-level `wago add`/`wago rm` for the common
 // install/remove, and `wago plugin` for the rest (list, inspect, grant, update,
-// publish). The consume side records dependencies in wago.json, `go get`s them
+// publish). The consume side records plugin constraints in wago.json, `go get`s them
 // into a generated .wago build module, and compiles a custom wago (see
 // plugin_build.go / wagomodule.go). The publish side talks to the registry and is
 // build-tagged (registry_net.go vs the lean registry_stub.go).

--- a/cli/wagocli/deps.go
+++ b/cli/wagocli/deps.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -37,55 +38,82 @@ func normalizeModuleRef(ref string) string {
 	return path + ver
 }
 
-type projectPlugin struct {
-	Name         string          `json:"name"`
-	Capabilities json.RawMessage `json:"capabilities,omitempty"`
-	Before       []string        `json:"before,omitempty"`
-	After        []string        `json:"after,omitempty"`
-	Config       json.RawMessage `json:"config,omitempty"`
+type projectPluginRequirement struct {
+	ID         string
+	Module     string
+	Constraint string
 }
 
-// projectPlugins reads the manifest's enabled plugin plan. Dependencies decide
-// what is compiled into the custom binary; plugins decide what is activated and
-// exactly which privileged Wago APIs each one may exercise.
-func projectPlugins(dir string) ([]wago.PluginConfig, error) {
-	m, err := readProjectMap(dir)
-	if err != nil {
-		return nil, err
+var (
+	pluginIDPattern         = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$`)
+	pluginConstraintPattern = regexp.MustCompile(`^(?:\*|[~^]?v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$`)
+)
+
+// projectPluginRequirements reads the manifest's plugin version constraints.
+// Plugin IDs are GitHub-relative; their module paths are used as build inputs.
+func projectPluginRequirements(m map[string]any, dir string) ([]projectPluginRequirement, error) {
+	if _, legacy := m["schema"]; legacy {
+		return nil, fmt.Errorf("%s: schema was removed; use $schema with %q for editor tooling", projectManifestDisplayPath(dir), manifestSchemaURI)
+	}
+	if _, legacy := m["dependencies"]; legacy {
+		return nil, fmt.Errorf("%s: dependencies was removed; declare versioned entries under plugins", projectManifestDisplayPath(dir))
 	}
 	raw, ok := m["plugins"]
 	if !ok {
 		return nil, nil
 	}
-	if _, ok := raw.([]any); !ok {
-		return nil, fmt.Errorf("%s: plugins must be an array of plugin objects", projectManifestDisplayPath(dir))
+	values, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: plugins must be an object mapping plugin IDs to version constraints", projectManifestDisplayPath(dir))
 	}
-	b, err := json.Marshal(raw)
+	out := make([]projectPluginRequirement, 0, len(values))
+	for id, rawConstraint := range values {
+		id = strings.TrimSpace(id)
+		if !pluginIDPattern.MatchString(id) {
+			return nil, fmt.Errorf("%s: plugin ID %q must be GitHub-relative, such as wago-org/wasi", projectManifestDisplayPath(dir), id)
+		}
+		constraint, ok := rawConstraint.(string)
+		if !ok || !pluginConstraintPattern.MatchString(strings.TrimSpace(constraint)) {
+			return nil, fmt.Errorf("%s: plugin %q has invalid version constraint %q", projectManifestDisplayPath(dir), id, rawConstraint)
+		}
+		out = append(out, projectPluginRequirement{
+			ID:         id,
+			Module:     "github.com/" + id,
+			Constraint: strings.TrimSpace(constraint),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// projectPlugins combines wago.json's selected plugins with the resolved
+// authority and opaque configuration recorded in wago-lock.json.
+func projectPlugins(dir string) ([]wago.PluginConfig, error) {
+	m, err := readProjectMap(dir)
 	if err != nil {
-		return nil, fmt.Errorf("%s: plugins: %w", projectManifestDisplayPath(dir), err)
+		return nil, err
 	}
-	var entries []projectPlugin
-	decoder := json.NewDecoder(bytes.NewReader(b))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&entries); err != nil {
-		return nil, fmt.Errorf("%s: invalid plugins array: %w", projectManifestDisplayPath(dir), err)
+	requirements, err := projectPluginRequirements(m, dir)
+	if err != nil {
+		return nil, err
 	}
-	out := make([]wago.PluginConfig, 0, len(entries))
-	seen := make(map[string]struct{}, len(entries))
-	for _, entry := range entries {
-		name := strings.TrimSpace(entry.Name)
-		if name == "" {
-			return nil, fmt.Errorf("%s: plugin name is empty", projectManifestDisplayPath(dir))
-		}
-		if _, duplicate := seen[name]; duplicate {
-			return nil, fmt.Errorf("%s: plugin %q is listed more than once", projectManifestDisplayPath(dir), name)
-		}
-		seen[name] = struct{}{}
-		caps, budgets, err := parsePluginCapabilities(name, entry.Capabilities)
+	lock, err := readLock(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]wago.PluginConfig, 0, len(requirements))
+	for _, requirement := range requirements {
+		entry := lock.Packages[requirement.ID]
+		caps, budgets, err := parsePluginCapabilities(requirement.ID, entry.Capabilities)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", projectManifestDisplayPath(dir), err)
 		}
-		out = append(out, wago.PluginConfig{Name: name, Capabilities: caps, Budgets: budgets, Before: entry.Before, After: entry.After, Config: entry.Config})
+		out = append(out, wago.PluginConfig{
+			Name:         requirement.ID,
+			Capabilities: caps,
+			Budgets:      budgets,
+			Config:       append(json.RawMessage(nil), entry.Config...),
+		})
 	}
 	return out, nil
 }
@@ -136,53 +164,49 @@ func parsePluginCapabilities(name string, raw json.RawMessage) ([]wago.PluginCap
 	return caps, budgets, nil
 }
 
-// depsFromMap extracts the module paths under "dependencies".
-func depsFromMap(m map[string]any) []string {
-	raw, _ := m["dependencies"].([]any)
-	out := make([]string, 0, len(raw))
-	for _, v := range raw {
-		if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
-			out = append(out, s)
-		}
-	}
-	return out
-}
-
-// projectDeps returns the module paths declared under "dependencies" in dir's
-// wago.json (empty when there is no file or no dependencies).
+// projectDeps returns module paths derived from the plugin IDs in wago.json.
 func projectDeps(dir string) ([]string, error) {
 	m, err := readProjectMap(dir)
 	if err != nil {
 		return nil, err
 	}
-	return depsFromMap(m), nil
+	requirements, err := projectPluginRequirements(m, dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, len(requirements))
+	for i := range requirements {
+		out[i] = requirements[i].Module
+	}
+	return out, nil
 }
 
-// addProjectDep adds module to wago.json's dependencies (idempotent), creating the
-// file if absent. Returns whether it was newly added.
-func addProjectDep(dir, module string) (bool, error) {
+// addProjectDep adds or updates a plugin version constraint in wago.json.
+func addProjectDep(dir, module, constraint string) (bool, error) {
+	if !strings.HasPrefix(module, "github.com/") {
+		return false, fmt.Errorf("plugin module %q must be hosted on github.com", module)
+	}
+	if !pluginConstraintPattern.MatchString(constraint) {
+		return false, fmt.Errorf("plugin %q has invalid version constraint %q", strings.TrimPrefix(module, "github.com/"), constraint)
+	}
 	m, err := readProjectMap(dir)
 	if err != nil {
 		return false, err
 	}
 	ensureProjectMetadata(m)
-	deps := depsFromMap(m)
-	for _, d := range deps {
-		if d == module {
-			return false, nil
-		}
+	raw, ok := m["plugins"]
+	if !ok {
+		raw = map[string]any{}
 	}
-	deps = append(deps, module)
-	sort.Strings(deps)
-	m["dependencies"] = toAnySlice(deps)
+	plugins, ok := raw.(map[string]any)
+	if !ok {
+		return false, fmt.Errorf("%s: plugins must be an object mapping plugin IDs to version constraints", projectManifestDisplayPath(dir))
+	}
 	name := strings.TrimPrefix(module, "github.com/")
-	plugins, err := projectPluginMaps(m, dir)
-	if err != nil {
-		return false, err
+	if current, exists := plugins[name]; exists && current == constraint {
+		return false, nil
 	}
-	if projectPluginMap(plugins, name) == nil {
-		plugins = append(plugins, map[string]any{"name": name, "capabilities": []any{}})
-	}
+	plugins[name] = constraint
 	m["plugins"] = plugins
 	return true, writeProjectMap(dir, m)
 }
@@ -193,64 +217,34 @@ func removeProjectDep(dir, name string) (removed bool, module string, err error)
 	if err != nil {
 		return false, "", err
 	}
-	deps := depsFromMap(m)
-	for i, d := range deps {
-		if d == name {
-			deps = append(append([]string{}, deps[:i]...), deps[i+1:]...)
-			m["dependencies"] = toAnySlice(deps)
-			plugins, pluginErr := projectPluginMaps(m, dir)
-			if pluginErr != nil {
-				return false, "", pluginErr
-			}
-			id := strings.TrimPrefix(d, "github.com/")
-			for j, entry := range plugins {
-				if entry["name"] == id {
-					plugins = append(plugins[:j], plugins[j+1:]...)
-					break
-				}
-			}
-			m["plugins"] = plugins
-			return true, d, writeProjectMap(dir, m)
+	requirements, err := projectPluginRequirements(m, dir)
+	if err != nil {
+		return false, "", err
+	}
+	id := strings.TrimPrefix(name, "github.com/")
+	var matchedModule string
+	for _, requirement := range requirements {
+		if requirement.ID == id || requirement.Module == name {
+			matchedModule = requirement.Module
+			break
 		}
 	}
-	return false, "", nil
-}
-
-func projectPluginMaps(m map[string]any, dir string) ([]map[string]any, error) {
-	raw, ok := m["plugins"]
-	if !ok {
-		return []map[string]any{}, nil
+	if matchedModule == "" {
+		return false, "", nil
 	}
-	values, ok := raw.([]any)
-	if !ok {
-		return nil, fmt.Errorf("%s: plugins must be an array of plugin objects", projectManifestDisplayPath(dir))
+	delete(m["plugins"].(map[string]any), id)
+	if err := writeProjectMap(dir, m); err != nil {
+		return false, "", err
 	}
-	entries := make([]map[string]any, 0, len(values))
-	for i, value := range values {
-		entry, ok := value.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("%s: plugins[%d] must be an object", projectManifestDisplayPath(dir), i)
-		}
-		entries = append(entries, entry)
+	lock, lockErr := readLock(dir)
+	if lockErr != nil {
+		return false, "", lockErr
 	}
-	return entries, nil
-}
-
-func projectPluginMap(entries []map[string]any, id string) map[string]any {
-	for _, entry := range entries {
-		if entry["name"] == id {
-			return entry
-		}
+	delete(lock.Packages, id)
+	if err := writeLock(dir, lock); err != nil {
+		return false, "", err
 	}
-	return nil
-}
-
-func toAnySlice(ss []string) []any {
-	out := make([]any, len(ss))
-	for i, s := range ss {
-		out[i] = s
-	}
-	return out
+	return true, matchedModule, nil
 }
 
 // deriveName is retained for registry display plumbing; plugin identities are

--- a/cli/wagocli/deps_plugins_test.go
+++ b/cli/wagocli/deps_plugins_test.go
@@ -1,6 +1,7 @@
 package wagocli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,15 +13,22 @@ import (
 func TestProjectPluginsParsesCapabilitiesAndOrdering(t *testing.T) {
 	dir := t.TempDir()
 	manifest := `{
-  "dependencies": ["github.com/wago-org/workers"],
-  "plugins": [{
-    "name": "wago-org/workers",
-    "capabilities": ["instance.manage", "runtime.lifecycle"],
-    "after": ["github.com/acme/wago-metrics"],
-    "config": {"maxWorkers": 4}
-  }]
+  "plugins": {
+    "wago-org/workers": "^0.0.0"
+  }
 }`
 	if err := os.WriteFile(filepath.Join(dir, projectFile), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lock := lockDoc{Packages: map[string]lockEntry{
+		"wago-org/workers": {
+			Version:              "0.0.0",
+			RequiredCapabilities: []string{"instance.manage", "runtime.lifecycle"},
+			Capabilities:         json.RawMessage(`["instance.manage","runtime.lifecycle"]`),
+			Config:               json.RawMessage(`{"maxWorkers":4}`),
+		},
+	}}
+	if err := writeLock(dir, lock); err != nil {
 		t.Fatal(err)
 	}
 	got, err := projectPlugins(dir)
@@ -28,21 +36,29 @@ func TestProjectPluginsParsesCapabilitiesAndOrdering(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantCaps := []wago.PluginCapability{wago.PluginManagedInstances, wago.PluginRuntimeHooks}
-	if len(got) != 1 || got[0].Name != "wago-org/workers" || !reflect.DeepEqual(got[0].Capabilities, wantCaps) || !reflect.DeepEqual(got[0].After, []string{"github.com/acme/wago-metrics"}) {
+	if len(got) != 1 || got[0].Name != "wago-org/workers" || !reflect.DeepEqual(got[0].Capabilities, wantCaps) {
 		t.Fatalf("projectPlugins = %#v", got)
 	}
-	if string(got[0].Config) != `{"maxWorkers":4}` {
+	if !json.Valid(got[0].Config) || !reflect.DeepEqual(decodeJSON(t, got[0].Config), map[string]any{"maxWorkers": float64(4)}) {
 		t.Fatalf("config = %s", got[0].Config)
 	}
 }
 
-func TestProjectPluginsParsesDocumentedArrayShape(t *testing.T) {
+func decodeJSON(t *testing.T, raw []byte) any {
+	t.Helper()
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func TestProjectPluginsParsesDocumentedVersionMap(t *testing.T) {
 	dir := t.TempDir()
 	manifest := `{
-  "plugins": [{
-    "name": "wago-org/wasi",
-    "capabilities": ["host.imports"]
-  }]
+  "plugins": {
+    "wago-org/wasi": "^0.0.0"
+  }
 }`
 	if err := os.WriteFile(filepath.Join(dir, projectFile), []byte(manifest), 0o644); err != nil {
 		t.Fatal(err)
@@ -56,10 +72,35 @@ func TestProjectPluginsParsesDocumentedArrayShape(t *testing.T) {
 	}
 }
 
+func TestProjectPluginsRejectsLegacyManifestShape(t *testing.T) {
+	for _, manifest := range []string{
+		`{"schema":"wago/other","plugins":[]}`,
+		`{"dependencies":["github.com/wago-org/wasi"],"plugins":{"wago-org/wasi":"^0.0.0"}}`,
+		`{"plugins":[{"name":"wago-org/wasi","capabilities":[]}]}`,
+		`{"plugins":{"wago-org/wasi":"newest"}}`,
+	} {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, projectFile), []byte(manifest), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := projectPlugins(dir); err == nil {
+			t.Fatalf("projectPlugins accepted legacy/invalid manifest: %s", manifest)
+		}
+	}
+}
+
 func TestProjectPluginsParsesCapabilityBudgets(t *testing.T) {
 	dir := t.TempDir()
-	manifest := `{"plugins":[{"name":"wago-org/workers","capabilities":{"runtime.lifecycle":true,"instance.manage":{"maxInstances":3,"maxMemoryBytes":131072}}}]}`
+	manifest := `{"plugins":{"wago-org/workers":"^0.0.0"}}`
 	if err := os.WriteFile(filepath.Join(dir, projectFile), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lock := lockDoc{Packages: map[string]lockEntry{
+		"wago-org/workers": {
+			Capabilities: json.RawMessage(`{"runtime.lifecycle":true,"instance.manage":{"maxInstances":3,"maxMemoryBytes":131072}}`),
+		},
+	}}
+	if err := writeLock(dir, lock); err != nil {
 		t.Fatal(err)
 	}
 	got, err := projectPlugins(dir)
@@ -86,10 +127,13 @@ func TestInitializeProjectCreatesMinimalManifestAndPreservesFields(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if m["$schema"] != manifestSchemaURI || m["schema"] != manifestVersion {
+	if m["$schema"] != manifestSchemaURI {
 		t.Fatalf("initialized metadata = %#v", m)
 	}
-	if deps := depsFromMap(m); len(deps) != 0 {
+	if _, exists := m["schema"]; exists {
+		t.Fatalf("initialized manifest contains removed schema version: %#v", m)
+	}
+	if deps, err := projectDeps(dir); err != nil || len(deps) != 0 {
 		t.Fatalf("initialized dependencies = %v", deps)
 	}
 	m["name"] = "example"

--- a/cli/wagocli/deps_test.go
+++ b/cli/wagocli/deps_test.go
@@ -32,15 +32,15 @@ func TestProjectDepsRoundTrip(t *testing.T) {
 	}
 
 	// Add creates the file and records the module.
-	newly, err := addProjectDep(dir, "github.com/acme/wago-timer")
+	newly, err := addProjectDep(dir, "github.com/acme/wago-timer", "^0.0.0")
 	if err != nil || !newly {
 		t.Fatalf("addProjectDep = %v, %v (want true, nil)", newly, err)
 	}
 	// Adding again is idempotent.
-	if newly, _ := addProjectDep(dir, "github.com/acme/wago-timer"); newly {
+	if newly, _ := addProjectDep(dir, "github.com/acme/wago-timer", "^0.0.0"); newly {
 		t.Fatal("second addProjectDep reported newly-added")
 	}
-	addProjectDep(dir, "github.com/acme/wago-redis")
+	addProjectDep(dir, "github.com/acme/wago-redis", "^0.0.0")
 
 	deps, err := projectDeps(dir)
 	if err != nil {
@@ -64,11 +64,11 @@ func TestProjectDepsRoundTrip(t *testing.T) {
 // Adding a dependency preserves unrelated wago.json fields (publish metadata).
 func TestAddProjectDepPreservesFields(t *testing.T) {
 	dir := t.TempDir()
-	seed := `{"schema":"wago-plugin/v1","module":"github.com/me/thing","version":"1.2.3"}`
+	seed := `{"module":"github.com/me/thing","version":"0.0.0"}`
 	if err := os.WriteFile(filepath.Join(dir, projectFile), []byte(seed), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := addProjectDep(dir, "github.com/acme/wago-timer"); err != nil {
+	if _, err := addProjectDep(dir, "github.com/acme/wago-timer", "^0.0.0"); err != nil {
 		t.Fatal(err)
 	}
 	b, _ := os.ReadFile(filepath.Join(dir, projectFile))
@@ -76,17 +76,17 @@ func TestAddProjectDepPreservesFields(t *testing.T) {
 	if err := json.Unmarshal(b, &m); err != nil {
 		t.Fatal(err)
 	}
-	if m["module"] != "github.com/me/thing" || m["version"] != "1.2.3" || m["schema"] != "wago-plugin/v1" {
+	if m["module"] != "github.com/me/thing" || m["version"] != "0.0.0" {
 		t.Fatalf("publish fields not preserved: %v", m)
 	}
-	if deps := depsFromMap(m); len(deps) != 1 || deps[0] != "github.com/acme/wago-timer" {
+	if deps, err := projectDeps(dir); err != nil || len(deps) != 1 || deps[0] != "github.com/acme/wago-timer" {
 		t.Fatalf("dependency not added: %v", deps)
 	}
 	if m["$schema"] != manifestSchemaURI {
 		t.Fatalf("schema URI = %v, want %s", m["$schema"], manifestSchemaURI)
 	}
-	plugins, err := projectPluginMaps(m, dir)
-	if err != nil || projectPluginMap(plugins, "acme/wago-timer") == nil {
+	plugins, ok := m["plugins"].(map[string]any)
+	if !ok || plugins["acme/wago-timer"] != "^0.0.0" {
 		t.Fatalf("plugin authority scaffold not added: %v", m["plugins"])
 	}
 }

--- a/cli/wagocli/lockfile.go
+++ b/cli/wagocli/lockfile.go
@@ -3,24 +3,26 @@
 package wagocli
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 )
 
-// lockfile.go maintains wago-lock.json, a record — next to wago.json — of what
-// each installed package required and was granted the last time it was installed.
-// It lets `wago add` decide when to (re)run the capability review: on a
-// first install, or when a package's required capabilities change.
+// lockfile.go maintains wago-lock.json, the resolved plugin state next to
+// wago.json. Version constraints remain user intent in the manifest; exact
+// versions, authority grants, and opaque plugin config live here.
 
 const lockFileName = "wago-lock.json"
 
 // lockEntry is a package's recorded state.
 type lockEntry struct {
-	Version              string   `json:"version,omitempty"`
-	RequiredCapabilities []string `json:"requiredCapabilities"`
-	GrantedCapabilities  []string `json:"grantedCapabilities"`
+	Version              string          `json:"version,omitempty"`
+	RequiredCapabilities []string        `json:"requiredCapabilities"`
+	Capabilities         json.RawMessage `json:"capabilities"`
+	Config               json.RawMessage `json:"config,omitempty"`
 }
 
 // lockDoc is the whole wago-lock.json document, keyed by canonical package id.
@@ -30,18 +32,26 @@ type lockDoc struct {
 
 func lockPath(dir string) string { return filepath.Join(dir, lockFileName) }
 
-// readLock loads dir's wago-lock.json, returning an empty (non-nil) doc when it's
-// absent or unreadable.
-func readLock(dir string) lockDoc {
+// readLock loads dir's wago-lock.json. Absence means no resolved state; malformed
+// authority-bearing state is rejected rather than silently disabling grants.
+func readLock(dir string) (lockDoc, error) {
 	d := lockDoc{Packages: map[string]lockEntry{}}
 	b, err := os.ReadFile(lockPath(dir))
+	if os.IsNotExist(err) {
+		return d, nil
+	}
 	if err != nil {
-		return d
+		return d, err
 	}
-	if json.Unmarshal(b, &d) != nil || d.Packages == nil {
-		return lockDoc{Packages: map[string]lockEntry{}}
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&d); err != nil {
+		return lockDoc{}, fmt.Errorf("%s: %w", displayPath(lockPath(dir)), err)
 	}
-	return d
+	if d.Packages == nil {
+		d.Packages = map[string]lockEntry{}
+	}
+	return d, nil
 }
 
 // writeLock writes dir's wago-lock.json with stable, sorted output.

--- a/cli/wagocli/lockfile_test.go
+++ b/cli/wagocli/lockfile_test.go
@@ -1,6 +1,8 @@
 package wagocli
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -10,7 +12,7 @@ func TestLockRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 
 	// Absent lockfile reads as empty (non-nil).
-	if got := readLock(dir); got.Packages == nil || len(got.Packages) != 0 {
+	if got, err := readLock(dir); err != nil || got.Packages == nil || len(got.Packages) != 0 {
 		t.Fatalf("empty read: %+v", got)
 	}
 
@@ -18,7 +20,8 @@ func TestLockRoundTrip(t *testing.T) {
 		"wago-org/wasi": {
 			Version:              "v0.0.0-x",
 			RequiredCapabilities: []string{"host.imports", "host.environment"},
-			GrantedCapabilities:  []string{"host.imports"},
+			Capabilities:         json.RawMessage(`["host.imports"]`),
+			Config:               json.RawMessage(`{"dir":"/tmp"}`),
 		},
 	}}
 	if err := writeLock(dir, d); err != nil {
@@ -27,9 +30,25 @@ func TestLockRoundTrip(t *testing.T) {
 	if _, err := filepath.Abs(lockPath(dir)); err != nil {
 		t.Fatal(err)
 	}
-	got := readLock(dir)
-	if !reflect.DeepEqual(got, d) {
+	got, err := readLock(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Packages["wago-org/wasi"].Version != d.Packages["wago-org/wasi"].Version ||
+		!reflect.DeepEqual(got.Packages["wago-org/wasi"].RequiredCapabilities, d.Packages["wago-org/wasi"].RequiredCapabilities) ||
+		!reflect.DeepEqual(decodeJSON(t, got.Packages["wago-org/wasi"].Capabilities), decodeJSON(t, d.Packages["wago-org/wasi"].Capabilities)) ||
+		!reflect.DeepEqual(decodeJSON(t, got.Packages["wago-org/wasi"].Config), decodeJSON(t, d.Packages["wago-org/wasi"].Config)) {
 		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", got, d)
+	}
+}
+
+func TestReadLockRejectsMalformedAuthorityState(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(lockPath(dir), []byte(`{"plugins":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readLock(dir); err == nil {
+		t.Fatal("readLock accepted a non-object plugins field")
 	}
 }
 

--- a/cli/wagocli/plugin_build.go
+++ b/cli/wagocli/plugin_build.go
@@ -1,8 +1,9 @@
 //go:build !wago_manager
 
-// The consume side of `wago add` / `wago plugin`: declaring plugin dependencies in wago.json,
-// pulling them in with `go get`, and building/running a custom wago that has them
-// compiled in. The build machinery itself lives in wagomodule.go.
+// The consume side of `wago add` / `wago plugin`: declaring version-constrained
+// plugins in wago.json, resolving them with Go modules, and building/running a
+// custom Wago that has them compiled in. The build machinery lives in
+// wagomodule.go.
 package wagocli
 
 import (
@@ -11,6 +12,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -27,6 +29,7 @@ type packageInstall struct {
 	module    string
 	requested string
 	resolved  string
+	exact     string
 }
 
 // handoffPluginProcess is the process-replacement boundary used after resolving
@@ -107,8 +110,10 @@ func pkgAddMany(specs []string, o pkgOpts) {
 			fatal("add: %v", err)
 		}
 	}
-	for _, pkg := range packages {
-		if _, err := addProjectDep(src, pkg.module); err != nil {
+	for i := range packages {
+		packages[i].exact = installedModuleExactVersion(buildDir, packages[i].module, packages[i].requested)
+		packages[i].resolved = displayModuleVersion(packages[i].exact)
+		if _, err := addProjectDep(src, packages[i].module, "^"+packages[i].resolved); err != nil {
 			progress.fail("Package setup failed")
 			fatal("add: %v", err)
 		}
@@ -128,9 +133,6 @@ func pkgAddMany(specs []string, o pkgOpts) {
 		fatal("build: %v", err)
 	}
 	elapsed := time.Since(started)
-	for i := range packages {
-		packages[i].resolved = installedModuleVersion(buildDir, packages[i].module, packages[i].requested)
-	}
 	if cached {
 		progress.finish(fmt.Sprintf("Reused Wago build with %d package%s", len(packages), plural(len(packages))))
 	} else {
@@ -142,7 +144,7 @@ func pkgAddMany(specs []string, o pkgOpts) {
 	// Then review capabilities — on a first install, or when the package's
 	// required capabilities have changed since the lockfile recorded them.
 	for _, pkg := range packages {
-		reviewInstalledCapabilities(src, bin, pkg.module, pkg.resolved)
+		reviewInstalledCapabilities(src, bin, pkg.module, pkg.exact)
 	}
 	printPackageInstallSummary(os.Stdout, packages, elapsed)
 }
@@ -186,13 +188,24 @@ func reviewInstalledCapabilities(src, bin, module, version string) {
 	if err != nil {
 		return // the package exposes no inspectable plugin, or inspect failed — skip
 	}
-	lock := readLock(src)
+	lock, err := readLock(src)
+	if err != nil {
+		fatal("add: reading plugin lock: %v", err)
+	}
 	entry, existed := lock.Packages[id]
 	if existed && sameStringSet(entry.RequiredCapabilities, required) {
+		entry.Version = version
+		lock.Packages[id] = entry
+		_ = writeLock(src, lock)
 		return // already reviewed this exact capability set
 	}
 	if len(required) == 0 {
-		lock.Packages[id] = lockEntry{Version: version} // record that it needs nothing
+		lock.Packages[id] = lockEntry{
+			Version:              version,
+			RequiredCapabilities: []string{},
+			Capabilities:         json.RawMessage("[]"),
+			Config:               entry.Config,
+		}
 		_ = writeLock(src, lock)
 		return
 	}
@@ -202,10 +215,16 @@ func reviewInstalledCapabilities(src, bin, module, version string) {
 		fmt.Printf("%s capability review skipped — set them anytime: wago plugin grant %s\n", dim("!"), id)
 		return
 	}
-	if err := setPluginGrants(src, id, chosen); err != nil {
+	capabilities, err := json.Marshal(chosen)
+	if err != nil {
 		fatal("add: recording capability grants: %v", err)
 	}
-	lock.Packages[id] = lockEntry{Version: version, RequiredCapabilities: required, GrantedCapabilities: chosen}
+	lock.Packages[id] = lockEntry{
+		Version:              version,
+		RequiredCapabilities: required,
+		Capabilities:         capabilities,
+		Config:               entry.Config,
+	}
 	_ = writeLock(src, lock)
 	if len(chosen) == 0 {
 		fmt.Printf("%s no capabilities granted — %s may not function; grant later: wago plugin grant %s\n", dim("!"), id, id)
@@ -254,7 +273,7 @@ func pkgRemove(name string, global bool) {
 }
 
 // buildPlugins compiles (or reuses) the custom wago binary for deps, printing
-// progress. Shared by pkg build and the auto-rebuild after pkg install.
+// progress after an add transaction has already resolved the requested modules.
 func buildPlugins(buildDir string, deps []string, o pkgOpts) (string, bool, error) {
 	if o.verbose {
 		fmt.Printf("%s\n", bold(fmt.Sprintf("building wago with %d plugin%s:", len(deps), plural(len(deps)))))
@@ -276,18 +295,25 @@ func buildPlugins(buildDir string, deps []string, o pkgOpts) (string, bool, erro
 	return bin, cached, nil
 }
 
-func installedModuleVersion(buildDir, module, requested string) string {
+func installedModuleExactVersion(buildDir, module, requested string) string {
+	if version, ok := currentModuleExactVersion(buildDir, module); ok {
+		return version
+	}
+	if requested != "" {
+		return requested
+	}
+	return "v0.0.0"
+}
+
+func currentModuleExactVersion(buildDir, module string) (string, bool) {
 	cmd := exec.Command("go", "list", "-m", "-f={{.Version}}", module)
 	cmd.Dir = buildDir
 	if output, err := cmd.Output(); err == nil {
 		if version := strings.TrimSpace(string(output)); version != "" {
-			return displayModuleVersion(version)
+			return version, true
 		}
 	}
-	if requested != "" {
-		return displayModuleVersion(requested)
-	}
-	return "0.0.0"
+	return "", false
 }
 
 func displayModuleVersion(version string) string {
@@ -296,6 +322,54 @@ func displayModuleVersion(version string) string {
 		return "0.0.0"
 	}
 	return version
+}
+
+// syncLockedPluginVersions restores the exact module versions captured in the
+// lockfile before a generated build is reused or rebuilt. A manifest without a
+// lockfile remains unresolved and is left for the Go module solver.
+func syncLockedPluginVersions(buildDir, manifestDir string, verbose bool) (bool, error) {
+	if err := ensureBuildModule(buildDir); err != nil {
+		return false, err
+	}
+	m, err := readProjectMap(manifestDir)
+	if err != nil {
+		return false, err
+	}
+	requirements, err := projectPluginRequirements(m, manifestDir)
+	if err != nil {
+		return false, err
+	}
+	lock, err := readLock(manifestDir)
+	if err != nil {
+		return false, err
+	}
+	changed := false
+	for _, requirement := range requirements {
+		version := strings.TrimSpace(lock.Packages[requirement.ID].Version)
+		if version == "" {
+			if _, ok := currentModuleExactVersion(buildDir, requirement.Module); ok {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(buildDir, "bin", "wago"+exeSuffix())); err == nil {
+				continue
+			}
+			version = strings.TrimLeft(requirement.Constraint, "^~")
+			if version == "*" {
+				continue
+			}
+		}
+		if !strings.HasPrefix(version, "v") {
+			version = "v" + version
+		}
+		if current, ok := currentModuleExactVersion(buildDir, requirement.Module); ok && current == version {
+			continue
+		}
+		if err := goGetDep(buildDir, requirement.Module+"@"+version, verbose); err != nil {
+			return false, fmt.Errorf("restore %s@%s: %w", requirement.Module, version, err)
+		}
+		changed = true
+	}
+	return changed, nil
 }
 
 func packageInstallDuration(elapsed time.Duration) string {
@@ -315,7 +389,7 @@ func printPackageInstallSummary(out io.Writer, packages []packageInstall, elapse
 		len(packages), plural(len(packages)), packageInstallDuration(elapsed))
 }
 
-// pkgUpdate updates dependencies to their latest versions (go get -u) and
+// pkgUpdate updates plugins to their latest versions (go get -u) and
 // rebuilds. With a target it updates just that plugin; otherwise all of them.
 func pkgUpdate(target string, o pkgOpts) {
 	buildDir, err := buildDirFor(o.global)
@@ -342,6 +416,8 @@ func pkgUpdate(target string, o pkgOpts) {
 			if m, err := resolveRegistryModule(target); err == nil {
 				target = m
 			}
+		} else {
+			target, _ = splitModuleVersion(normalizeModuleRef(target))
 		}
 		targets = []string{target}
 	}
@@ -349,6 +425,21 @@ func pkgUpdate(target string, o pkgOpts) {
 		fmt.Printf("%s %s %s\n", dim("→ updating"), t, dim("(latest)"))
 		if err := goUpdate(buildDir, t, o.verbose); err != nil {
 			fatal("plugin update: %s: %v", t, err)
+		}
+		exact := installedModuleExactVersion(buildDir, t, "")
+		if _, err := addProjectDep(src, t, "^"+displayModuleVersion(exact)); err != nil {
+			fatal("plugin update: recording %s: %v", t, err)
+		}
+		lock, err := readLock(src)
+		if err != nil {
+			fatal("plugin update: %v", err)
+		}
+		id := strings.TrimPrefix(t, "github.com/")
+		entry := lock.Packages[id]
+		entry.Version = exact
+		lock.Packages[id] = entry
+		if err := writeLock(src, lock); err != nil {
+			fatal("plugin update: %v", err)
 		}
 	}
 	_ = writeBuildMain(buildDir, deps)
@@ -376,7 +467,11 @@ func maybeReexecForPlugins() {
 	if len(environment.dependencies) == 0 {
 		return
 	}
-	bin, _, err := ensureBuiltBinary(environment.buildDir, environment.dependencies, false, false)
+	changed, err := syncLockedPluginVersions(environment.buildDir, environment.manifestDir, false)
+	if err != nil {
+		fatal("plugins: %v", err)
+	}
+	bin, _, err := ensureBuiltBinary(environment.buildDir, environment.dependencies, changed, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s could not build plugins (%v); running without them\n", dim("wago:"), err)
 		return

--- a/cli/wagocli/plugin_build_test.go
+++ b/cli/wagocli/plugin_build_test.go
@@ -42,7 +42,7 @@ func TestPluginListHandsOffToGlobalPluginRuntime(t *testing.T) {
 		t.Fatal(err)
 	}
 	const plugin = "github.com/wago-org/wasi"
-	if _, err := addProjectDep(manifestDir, plugin); err != nil {
+	if _, err := addProjectDep(manifestDir, plugin, "^0.0.0"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -112,7 +112,7 @@ func TestRunLoadsGlobalPluginConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 	const plugin = "github.com/wago-org/wasi"
-	if _, err := addProjectDep(manifestDir, plugin); err != nil {
+	if _, err := addProjectDep(manifestDir, plugin, "^0.0.0"); err != nil {
 		t.Fatal(err)
 	}
 	if err := setPluginGrants(manifestDir, "wago-org/wasi", []string{"wasi"}); err != nil {

--- a/cli/wagocli/plugin_environment_test.go
+++ b/cli/wagocli/plugin_environment_test.go
@@ -32,7 +32,7 @@ func TestPluginEnvironmentUsesSharedGlobalIntentAndToolchainBuild(t *testing.T) 
 	if err := os.MkdirAll(dirs.Data, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := addProjectDep(dirs.Data, "github.com/wago-org/wasi"); err != nil {
+	if _, err := addProjectDep(dirs.Data, "github.com/wago-org/wasi", "^0.0.0"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,7 +69,7 @@ func TestPluginEnvironmentKeepsLocalAndGlobalIsolated(t *testing.T) {
 	if err := os.MkdirAll(dirs.Data, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := addProjectDep(dirs.Data, "github.com/wago-org/wasi"); err != nil {
+	if _, err := addProjectDep(dirs.Data, "github.com/wago-org/wasi", "^0.0.0"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := initializeProject("."); err != nil {

--- a/cli/wagocli/plugin_grants.go
+++ b/cli/wagocli/plugin_grants.go
@@ -2,54 +2,41 @@
 
 package wagocli
 
-import "sort"
+import (
+	"encoding/json"
+	"sort"
+)
 
-// plugin_grants.go reads and writes the per-plugin capability grants in a
-// wago.json. Each entry in the "plugins" array has a GitHub-relative name and a
-// "capabilities" array of the privileged APIs that plugin may use at runtime.
+// plugin_grants.go reads and writes reviewed capability grants in wago-lock.json.
 
 // pluginGrants returns the capabilities currently granted to plugin id in dir's
-// wago.json (nil when the plugin or its capabilities are absent).
+// wago-lock.json (nil when the plugin or its capabilities are absent).
 func pluginGrants(dir, id string) []string {
-	m, err := readProjectMap(dir)
+	lock, err := readLock(dir)
 	if err != nil {
 		return nil
 	}
-	plugins, err := projectPluginMaps(m, dir)
-	if err != nil {
-		return nil
-	}
-	entry := projectPluginMap(plugins, id)
-	raw, _ := entry["capabilities"].([]any)
-	out := make([]string, 0, len(raw))
-	for _, v := range raw {
-		if s, ok := v.(string); ok {
-			out = append(out, s)
-		}
-	}
+	var out []string
+	_ = json.Unmarshal(lock.Packages[id].Capabilities, &out)
 	return out
 }
 
 // setPluginGrants replaces the capabilities granted to plugin id in dir's
-// wago.json (sorted for stable diffs), creating the plugin entry if needed while
-// preserving any other fields on it (before/after/config).
+// wago-lock.json (sorted for stable diffs), preserving version, required
+// capabilities, and opaque plugin config.
 func setPluginGrants(dir, id string, caps []string) error {
-	m, err := readProjectMap(dir)
+	lock, err := readLock(dir)
 	if err != nil {
 		return err
-	}
-	plugins, err := projectPluginMaps(m, dir)
-	if err != nil {
-		return err
-	}
-	entry := projectPluginMap(plugins, id)
-	if entry == nil {
-		entry = map[string]any{"name": id}
-		plugins = append(plugins, entry)
 	}
 	sorted := append([]string(nil), caps...)
 	sort.Strings(sorted)
-	entry["capabilities"] = toAnySlice(sorted)
-	m["plugins"] = plugins
-	return writeProjectMap(dir, m)
+	raw, err := json.Marshal(sorted)
+	if err != nil {
+		return err
+	}
+	entry := lock.Packages[id]
+	entry.Capabilities = raw
+	lock.Packages[id] = entry
+	return writeLock(dir, lock)
 }

--- a/cli/wagocli/plugin_grants_test.go
+++ b/cli/wagocli/plugin_grants_test.go
@@ -1,6 +1,7 @@
 package wagocli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -9,12 +10,18 @@ import (
 
 func TestPluginGrantsRoundTrip(t *testing.T) {
 	dir := t.TempDir()
-	// Seed a wago.json with a plugin entry that has other fields to preserve.
-	seed := `{
-      "dependencies": ["github.com/wago-org/wasi"],
-      "plugins": [{"name": "wago-org/wasi", "capabilities": ["wasi:stdio"], "after": ["x"]}]
-    }`
+	seed := `{"plugins":{"wago-org/wasi":"^0.0.0","wago-org/new":"^0.0.0"}}`
 	if err := os.WriteFile(filepath.Join(dir, projectFile), []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lock := lockDoc{Packages: map[string]lockEntry{
+		"wago-org/wasi": {
+			Version:      "0.0.0",
+			Capabilities: json.RawMessage(`["wasi:stdio"]`),
+			Config:       json.RawMessage(`{"dir":"/tmp"}`),
+		},
+	}}
+	if err := writeLock(dir, lock); err != nil {
 		t.Fatal(err)
 	}
 
@@ -29,14 +36,13 @@ func TestPluginGrantsRoundTrip(t *testing.T) {
 	if got := pluginGrants(dir, "wago-org/wasi"); !reflect.DeepEqual(got, []string{"wasi:clock", "wasi:random"}) {
 		t.Fatalf("updated grants: %v", got)
 	}
-	m, _ := readProjectMap(dir)
-	plugins, err := projectPluginMaps(m, dir)
+	updated, err := readLock(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	entry := projectPluginMap(plugins, "wago-org/wasi")
-	if _, ok := entry["after"]; !ok {
-		t.Fatal("setPluginGrants dropped the plugin's other fields (after)")
+	entry := updated.Packages["wago-org/wasi"]
+	if entry.Version != "0.0.0" || !reflect.DeepEqual(decodeJSON(t, entry.Config), map[string]any{"dir": "/tmp"}) {
+		t.Fatal("setPluginGrants dropped the plugin's resolved version or config")
 	}
 
 	// A plugin with no entry yet: absent grants, then created on set.

--- a/cli/wagocli/plugins.go
+++ b/cli/wagocli/plugins.go
@@ -13,7 +13,7 @@ import (
 )
 
 // No plugin is bundled into the default binary. Plugins live in their own modules
-// and are compiled into a custom binary from wago.json's dependencies via `wago add
+// and are compiled into a custom binary from wago.json's plugin map via `wago add
 // build`; each self-registers through its `register` package. There is no
 // per-plugin code or build tag here.
 
@@ -358,9 +358,9 @@ func loadPluginRuntime(cfg *wago.RuntimeConfig, list string) *wago.Runtime {
 	if err != nil {
 		fatal("plugins: %v", err)
 	}
-	// Start with the active package set's manifest (local wago.json when present,
-	// otherwise the version-scoped global manifest), including its configured
-	// capabilities. --plugin adds extras rather than replacing the manifest;
+	// Start with the active package set (local wago.json when present, otherwise
+	// the version-scoped global manifest), including authority/config resolved
+	// from its lockfile. --plugin adds extras rather than replacing the manifest;
 	// names are matched canonically and de-duplicated against it.
 	selected := append([]wago.PluginConfig(nil), manifest...)
 	have := make(map[string]bool, len(manifest))

--- a/cli/wagocli/project_init.go
+++ b/cli/wagocli/project_init.go
@@ -10,8 +10,7 @@ import (
 
 const (
 	projectFile       = "wago.json"
-	manifestSchemaURI = "https://wago.sh/schema.json"
-	manifestVersion   = "wago/v1"
+	manifestSchemaURI = "https://wago.sh/v0/schema.json"
 )
 
 func projectManifestPath(dir string) string { return filepath.Join(dir, projectFile) }
@@ -57,11 +56,8 @@ func initializeProject(dir string) (bool, error) {
 		return false, err
 	}
 	ensureProjectMetadata(m)
-	if _, ok := m["dependencies"]; !ok {
-		m["dependencies"] = []any{}
-	}
 	if _, ok := m["plugins"]; !ok {
-		m["plugins"] = []any{}
+		m["plugins"] = map[string]any{}
 	}
 	return created, writeProjectMap(dir, m)
 }
@@ -69,9 +65,6 @@ func initializeProject(dir string) (bool, error) {
 func ensureProjectMetadata(m map[string]any) {
 	if _, ok := m["$schema"]; !ok {
 		m["$schema"] = manifestSchemaURI
-	}
-	if _, ok := m["schema"]; !ok {
-		m["schema"] = manifestVersion
 	}
 }
 

--- a/cli/wagocli/registry_net.go
+++ b/cli/wagocli/registry_net.go
@@ -596,7 +596,6 @@ func registryPublish(c *Ctx) {
 		fatal("publish: resolving subpackage refs in %s: %v", manifestPath, err)
 	}
 	var mf struct {
-		Schema  string `json:"schema"`
 		Module  string `json:"module"`
 		Version string `json:"version"`
 	}

--- a/cli/wagocli/review.go
+++ b/cli/wagocli/review.go
@@ -3,6 +3,7 @@
 package wagocli
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -57,7 +58,7 @@ func reviewCapabilities(name string, required, granted []string) (chosen []strin
 }
 
 // pkgGrant interactively edits which of a compiled-in plugin's requestable
-// capabilities are granted in the active wago.json (local or global per scope).
+// capabilities are granted in the active wago-lock.json (local or global per scope).
 func pkgGrant(name string, useGlobal bool) {
 	id := strings.TrimPrefix(strings.TrimSpace(name), "github.com/")
 	src, err := depsSource(useGlobal)
@@ -75,7 +76,11 @@ func pkgGrant(name string, useGlobal bool) {
 	if err != nil {
 		fatal("plugin grant: %v", err)
 	}
-	bin, _, err := ensureBuiltBinary(buildDir, deps, false, false)
+	changed, err := syncLockedPluginVersions(buildDir, src, false)
+	if err != nil {
+		fatal("plugin grant: %v", err)
+	}
+	bin, _, err := ensureBuiltBinary(buildDir, deps, changed, false)
 	if err != nil {
 		fatal("plugin grant: %v", err)
 	}
@@ -88,16 +93,21 @@ func pkgGrant(name string, useGlobal bool) {
 		fmt.Println(dim("no changes"))
 		return
 	}
-	if err := setPluginGrants(src, id, chosen); err != nil {
+	// Keep the lockfile snapshot in sync so a later install doesn't re-prompt.
+	lock, err := readLock(src)
+	if err != nil {
 		fatal("plugin grant: %v", err)
 	}
-	// Keep the lockfile snapshot in sync so a later install doesn't re-prompt.
-	lock := readLock(src)
 	entry := lock.Packages[id]
 	entry.RequiredCapabilities = required
-	entry.GrantedCapabilities = chosen
+	entry.Capabilities, err = json.Marshal(chosen)
+	if err != nil {
+		fatal("plugin grant: %v", err)
+	}
 	lock.Packages[id] = entry
-	_ = writeLock(src, lock)
+	if err := writeLock(src, lock); err != nil {
+		fatal("plugin grant: %v", err)
+	}
 	if len(chosen) == 0 {
 		fmt.Printf("%s %s now has no capability grants\n", cyan("✓"), id)
 		return

--- a/cli/wagocli/schema_test.go
+++ b/cli/wagocli/schema_test.go
@@ -4,23 +4,17 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
-	"sort"
 	"testing"
-
-	"github.com/wago-org/wago"
 )
 
-func TestWagoSchemaTracksPluginCapabilities(t *testing.T) {
+func TestWagoSchemaTracksPluginManifest(t *testing.T) {
 	b, err := os.ReadFile(filepath.Join("..", "..", "schema.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var schema struct {
-		ID   string `json:"$id"`
-		Defs map[string]struct {
-			Enum []string `json:"enum"`
-		} `json:"$defs"`
+		ID         string                     `json:"$id"`
+		Properties map[string]json.RawMessage `json:"properties"`
 	}
 	if err := json.Unmarshal(b, &schema); err != nil {
 		t.Fatalf("invalid schema.json: %v", err)
@@ -28,19 +22,13 @@ func TestWagoSchemaTracksPluginCapabilities(t *testing.T) {
 	if schema.ID != manifestSchemaURI {
 		t.Fatalf("schema $id = %q", schema.ID)
 	}
-	got := append([]string(nil), schema.Defs["pluginCapability"].Enum...)
-	want := []string{
-		string(wago.PluginHostImports),
-		string(wago.PluginHostEnvironment),
-		string(wago.PluginRuntimeHooks),
-		string(wago.PluginCompileHooks),
-		string(wago.PluginInstanceHooks),
-		string(wago.PluginInvokeHooks),
-		string(wago.PluginManagedInstances),
+	if _, exists := schema.Properties["schema"]; exists {
+		t.Fatal("schema.json still exposes the removed manifest schema version field")
 	}
-	sort.Strings(got)
-	sort.Strings(want)
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("schema capabilities = %v, runtime capabilities = %v", got, want)
+	var plugins struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(schema.Properties["plugins"], &plugins); err != nil || plugins.Type != "object" {
+		t.Fatalf("plugins type = %q, %v; want object", plugins.Type, err)
 	}
 }

--- a/cli/wagocli/version_common_test.go
+++ b/cli/wagocli/version_common_test.go
@@ -227,8 +227,8 @@ func TestLegacyGlobalPluginsMigrateToSharedIntent(t *testing.T) {
 	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	manifest := []byte(`{"dependencies":["github.com/wago-org/wasi"],"plugins":[{"name":"wago-org/wasi","capabilities":["host.environment"]}]}`)
-	lock := []byte(`{"plugins":{"wago-org/wasi":{"grantedCapabilities":["host.environment"]}}}`)
+	manifest := []byte(`{"$schema":"https://wago.sh/v0/schema.json","plugins":{"wago-org/wasi":"^0.0.0"}}`)
+	lock := []byte(`{"plugins":{"wago-org/wasi":{"version":"0.0.0","requiredCapabilities":["host.environment"],"capabilities":["host.environment"]}}}`)
 	if err := os.WriteFile(filepath.Join(sourceDir, versionPluginManifest), manifest, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cli/wagocli/wagomodule.go
+++ b/cli/wagocli/wagomodule.go
@@ -37,8 +37,8 @@ func buildDirFor(global bool) (string, error) {
 	return localPluginBuildDir()
 }
 
-// depsSource returns the directory whose wago.json holds the dependency list for a
-// build: the current directory locally, or shared Wago data with --global.
+// depsSource returns the directory whose wago.json holds the plugin requirements
+// for a build: the current directory locally, or shared Wago data with --global.
 func depsSource(global bool) (string, error) {
 	if global {
 		dirs := wago.DirsFor(versionString())

--- a/docs/plugin-api-plan.md
+++ b/docs/plugin-api-plan.md
@@ -2,7 +2,7 @@
 
 The pre-release plugin API was redesigned around explicit host capabilities.
 The current contract, manifest schema, load ordering, provenance rules, and
-core-size boundary are documented in [plugin-api-v2.md](plugin-api-v2.md).
+core-size boundary are documented in [plugin-api.md](plugin-api.md).
 
 The separate [`wago-org/workers`](https://github.com/wago-org/workers) plugin is
 the first consumer of the managed-instance capability. Pooling policy has been removed from the

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -4,41 +4,30 @@ Wago plugins are open-source Go modules compiled into the host binary. A plugin
 can run ordinary Go code; Wago does not pretend to sandbox that code. Instead,
 the plugin API controls which privileged Wago integration surfaces the plugin
 may use. Consumers review the source dependency and grant only the integration
-powers they accept in `wago.json`.
+powers they accept. Grants are recorded in `wago-lock.json`.
 
 ## Manifest model
 
-`dependencies` controls what source modules are compiled into the custom Wago
-binary. `plugins` controls what is activated at runtime:
+`plugins` is the single source of package intent: its keys are GitHub-relative
+plugin IDs and its values are semantic-version constraints. Each entry is
+compiled into the custom Wago binary and activated at runtime:
 
 ```json
 {
-  "dependencies": [
-    "github.com/wago-org/workers",
-    "github.com/acme/wago-metrics"
-  ],
-  "plugins": [
-    {
-      "name": "acme/wago-metrics",
-      "capabilities": ["host.imports", "instance.invoke"],
-      "before": ["wago-org/workers"],
-      "config": {"sampleRate": 0.1}
-    },
-    {
-      "name": "wago-org/workers",
-      "capabilities": ["instance.manage"]
-    }
-  ]
+  "plugins": {
+    "acme/wago-metrics": "^0.0.0",
+    "wago-org/workers": "^0.0.0"
+  }
 }
 ```
 
-Compiling a dependency does not activate it. Activating a plugin does not grant
-it a capability. A plugin that exercises an ungranted API fails registration,
-and the complete plan commits nothing.
+Activation does not grant authority. Exact resolved versions, reviewed
+capabilities, and opaque plugin config live in `wago-lock.json`. A plugin that
+exercises an ungranted API fails registration, and the complete plan commits
+nothing.
 
-`wago pkg add` adds both the source dependency and a disabled-by-authority
-plugin entry with an empty capability list. The consumer must review the plugin
-and fill in its grants.
+`wago pkg add` adds the version-constrained plugin entry, resolves its exact
+version, reviews requested capabilities, and writes the result to the lockfile.
 
 The complete manifest field reference and JSON Schema are documented in
 [`wago-json.md`](wago-json.md).
@@ -68,8 +57,7 @@ a module may exercise them.
 ## Load order
 
 Each plugin may declare mandatory `requires` dependencies plus optional
-`before`/`after` constraints. A project's plugin entry may add `before` and
-`after` edges for local integration needs.
+`before`/`after` constraints in its package metadata.
 
 The runtime builds one directed graph:
 
@@ -95,9 +83,10 @@ instance.
 ## Open-source provenance
 
 Manifest-loaded plugins must declare an absolute HTTPS source repository and an
-SPDX license identifier. `Private` plugins are rejected. The Go module fetched
-under `dependencies` is the build input, so consumers can pin, mirror, audit,
-and reproduce the exact source compiled into their host.
+SPDX license identifier. `Private` plugins are rejected. The plugin key expands
+to its GitHub module path for the build, while the lockfile records the exact
+resolved version so consumers can pin, mirror, audit, and reproduce the source
+compiled into their host.
 
 Wago does not claim that provenance metadata is a security sandbox. A host that
 does not trust a plugin's Go source must not compile that plugin.
@@ -129,7 +118,7 @@ validates it without starting plugins.
 Each privileged surface also has a capability-specific handle (`HostImports`,
 `ModuleCompiler`, `InstanceInvocation`, and so on), so APIs obtained for one
 grant cannot be used to reach another. Resource-owning capabilities may carry
-core-enforced budgets in the manifest.
+core-enforced budgets in the lockfile.
 
 ## Exact-instance resource lifecycle
 

--- a/docs/plugin-scopes.md
+++ b/docs/plugin-scopes.md
@@ -2,8 +2,9 @@
 
 Wago separates plugin **intent** from compiled plugin **artifacts**.
 
-- A manifest says which packages are dependencies, which plugin registrations
-  are enabled, and which capabilities they receive.
+- A manifest maps enabled plugin IDs to version constraints.
+- `wago-lock.json` records exact versions, reviewed capabilities, and plugin
+  configuration.
 - A generated plugin runtime is a cache for one exact Wago
   version/profile/build. It is never reused by another toolchain.
 

--- a/docs/wago-json.md
+++ b/docs/wago-json.md
@@ -8,14 +8,12 @@ detection:
 
 ```json
 {
-  "$schema": "https://wago.sh/schema.json",
-  "schema": "wago/v1"
+  "$schema": "https://wago.sh/v0/schema.json"
 }
 ```
 
 The canonical schema is also committed as [`schema.json`](../schema.json).
-It uses JSON Schema draft 2020-12 and rejects unknown fields. Plugin-owned
-`config` is the deliberate exception: its shape belongs to that plugin.
+It uses JSON Schema draft 2020-12 and rejects unknown fields.
 
 Validate a manifest in CI with any draft-2020-12 validator. For example:
 
@@ -25,70 +23,64 @@ npx --yes --package ajv-cli@5 --package ajv-formats@3 \
   -s schema.json -d wago.json
 ```
 
-## Dependencies versus plugins
+## Plugin requirements
 
-These are intentionally separate:
-
-- `dependencies` lists public Go modules compiled into the generated Wago host.
-- `plugins` lists the compiled plugin registrations activated at runtime.
-- `plugins[].capabilities` grants privileged access to Wago integration APIs.
-
-Compiling code does not activate it, and activation does not grant authority.
+`plugins` maps GitHub-relative plugin IDs to semantic-version constraints. A
+single entry declares the Go module build dependency and activates its
+registration at runtime:
 
 ```json
 {
-  "$schema": "https://wago.sh/schema.json",
-  "schema": "wago/v1",
-  "dependencies": [
-    "github.com/wago-org/workers"
-  ],
-  "plugins": [
-    {
-      "name": "wago-org/workers",
-      "capabilities": ["instance.manage"]
-    }
-  ]
+  "$schema": "https://wago.sh/v0/schema.json",
+  "plugins": {
+    "wago-org/wasi": "^0.0.0",
+    "wago-org/workers": "^0.0.0"
+  }
 }
 ```
 
-`wago pkg add <module>` adds the module dependency and scaffolds a plugin entry
-with an empty capability list. Review the plugin source, then grant only the
-capabilities it needs.
+Wago expands `wago-org/wasi` to `github.com/wago-org/wasi` for the Go module
+build. `wago add <module>` resolves the installed version and writes a compatible
+caret constraint. Exact resolution and runtime authority are kept out of the
+manifest.
 
-## Plugin entries
+## `wago-lock.json`
 
-Each plugin entry supports:
-
-| Field | Required | Meaning |
-|---|:---:|---|
-| `name` | yes | GitHub-relative plugin ID, such as `wago-org/workers`. |
-| `capabilities` | yes | Explicit Wago host-integration grants. May be empty. |
-| `before` | no | Load this plugin before the named selected plugins. |
-| `after` | no | Load this plugin after the named selected plugins. |
-| `config` | no | Arbitrary plugin-owned JSON passed through `Registry.Config`. |
-
-Simple grants use an array. An object form attaches core-enforced limits to
-resource-owning capabilities while using `true` for unlimited grants:
+The lockfile records exact versions, the capabilities declared by the package,
+the subset reviewed and granted by the user, and opaque plugin configuration:
 
 ```json
 {
-  "name": "wago-org/workers",
-  "capabilities": {
-    "instance.manage": {
-      "maxInstances": 8,
-      "maxMemoryBytes": 4194304
+  "plugins": {
+    "wago-org/workers": {
+      "version": "0.0.0",
+      "requiredCapabilities": [
+        "instance.manage"
+      ],
+      "capabilities": {
+        "instance.manage": {
+          "maxInstances": 8,
+          "maxMemoryBytes": 4194304
+        }
+      },
+      "config": {
+        "maxWorkers": 8,
+        "maxQueueBytes": 1048576
+      }
     }
   }
 }
 ```
 
+Simple grants use a string array. The object form attaches core-enforced limits
+to resource-owning capabilities while using `true` for an unlimited grant.
 `maxInstances` limits simultaneously live managed instances.
 `maxMemoryBytes` rejects modules whose declared maximum memory exceeds the
 per-instance limit.
 
-Duplicate plugin names, duplicate capabilities, missing mandatory plugin
-dependencies, unknown capabilities, and load-order cycles are rejected before
-the plan commits.
+The lockfile is authority-bearing and parsed strictly. A malformed lockfile is
+an error instead of being silently ignored. Lock entries not selected by
+`wago.json` are ignored.
 
 ### Host-integration capabilities
 
@@ -112,24 +104,8 @@ module may use them.
 
 ## Load ordering
 
-Plugin packages may declare mandatory dependencies and default ordering. A
-project may add `before` and `after` constraints:
-
-```json
-{
-  "plugins": [
-    {
-      "name": "acme/wago-tracing",
-      "capabilities": ["instance.invoke"],
-      "before": ["acme/wago-metrics"]
-    },
-    {
-      "name": "acme/wago-metrics",
-      "capabilities": ["instance.invoke"]
-    }
-  ]
-}
-```
+Plugin packages declare mandatory dependencies and default `before`/`after`
+ordering in their compiled metadata.
 
 Wago resolves one directed acyclic graph. Mandatory dependencies must be
 selected. Missing optional `before`/`after` targets are ignored. Unrelated ready
@@ -138,23 +114,10 @@ run in reverse resolved order.
 
 ## Plugin configuration
 
-Wago does not interpret `config`:
-
-```json
-{
-  "name": "wago-org/workers",
-  "capabilities": ["instance.manage"],
-  "config": {
-    "maxWorkers": 8,
-    "maxQueueBytes": 1048576
-  }
-}
-```
-
-The plugin decodes this value through `Registry.Config`. Plugins may expose a
-schema through `ConfigSchemaProvider`; `wago plugin plan --json` includes it. A
-plugin must still reject invalid configuration during transactional
-registration.
+Wago does not interpret a lock entry's `config`. The plugin decodes it through
+`Registry.Config`. Plugins may expose a schema through `ConfigSchemaProvider`;
+`wago plugin plan --json` includes it. A plugin must still reject invalid
+configuration during transactional registration.
 
 Use `wago plugin check` in CI to validate compiled availability, provenance,
 grants, configuration registration, service dependencies, and load order. Use
@@ -162,15 +125,14 @@ grants, configuration registration, service dependencies, and load order. Use
 
 ## Publishing an open-source package
 
-When `module` is present, the schema also requires `schema`, `license`, and an
-HTTPS `repository`:
+When `module` is present, the schema also requires `license` and an HTTPS
+`repository`:
 
 ```json
 {
-  "$schema": "https://wago.sh/schema.json",
-  "schema": "wago/v1",
+  "$schema": "https://wago.sh/v0/schema.json",
   "module": "github.com/acme/wago-observability",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "name": "Wago Observability",
   "short": "observability",
   "description": "Tracing and metrics plugins for Wago hosts.",
@@ -202,9 +164,7 @@ plugin planning.
 | Field | Purpose |
 |---|---|
 | `$schema` | Editor-facing JSON Schema URI. |
-| `schema` | Wago manifest format, currently `wago/v1`. |
-| `dependencies` | Go modules compiled into the custom host. |
-| `plugins` | Runtime plugin activation, grants, ordering, and config. |
+| `plugins` | GitHub-relative plugin IDs mapped to version constraints. |
 | `module` | Canonical Go module path for publishing. |
 | `version` | Semantic package version. |
 | `name`, `short`, `description` | Registry display and discovery metadata. |

--- a/schema.json
+++ b/schema.json
@@ -1,34 +1,22 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://wago.sh/schema.json",
+  "$id": "https://wago.sh/v0/schema.json",
   "title": "Wago project and plugin manifest",
-  "description": "Configures the Go modules compiled into a Wago host, the plugins activated at runtime, their explicitly granted Wago integration capabilities, and optional open-source package metadata.",
+  "description": "Declares version-constrained plugins compiled into and activated by a Wago host, plus optional open-source package metadata. Resolved versions, capabilities, and plugin config live in wago-lock.json.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string",
       "format": "uri-reference",
-      "description": "JSON Schema URI used by editors. Recommended: https://wago.sh/schema.json."
-    },
-    "schema": {
-      "type": "string",
-      "enum": ["wago/v1", "wago-plugin/v1"],
-      "description": "Wago manifest format version. wago-plugin/v1 is accepted for compatibility; new manifests should use wago/v1."
-    },
-    "dependencies": {
-      "type": "array",
-      "description": "Open-source Go module paths compiled into the generated Wago host. Compilation does not activate or authorize a plugin.",
-      "items": { "$ref": "#/$defs/modulePath" },
-      "uniqueItems": true,
-      "default": []
+      "description": "JSON Schema URI used by editors. Recommended: https://wago.sh/v0/schema.json."
     },
     "plugins": {
-      "type": "array",
-      "description": "Plugins activated at runtime and their explicit capability grants.",
-      "items": { "$ref": "#/$defs/plugin" },
-      "uniqueItems": true,
-      "default": []
+      "type": "object",
+      "description": "GitHub-relative plugin IDs mapped to semantic-version constraints. Each key is also the plugin's build dependency and runtime activation.",
+      "propertyNames": { "$ref": "#/$defs/pluginName" },
+      "additionalProperties": { "$ref": "#/$defs/versionConstraint" },
+      "default": {}
     },
     "module": {
       "$ref": "#/$defs/modulePath",
@@ -142,10 +130,9 @@
   "allOf": [
     {
       "if": {
-        "required": ["schema", "module"],
-        "properties": { "schema": { "const": "wago/v1" } }
+        "required": ["module"]
       },
-      "then": { "required": ["schema", "license", "repository"] }
+      "then": { "required": ["license", "repository"] }
     }
   ],
   "$defs": {
@@ -156,83 +143,13 @@
     },
     "pluginName": {
       "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9._/-]*$",
+      "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
       "maxLength": 100
     },
-    "pluginCapability": {
+    "versionConstraint": {
       "type": "string",
-      "enum": [
-        "host.imports",
-        "host.environment",
-        "runtime.lifecycle",
-        "module.compile",
-        "instance.lifecycle",
-        "instance.invoke",
-        "instance.manage"
-      ]
-    },
-    "capabilityBudget": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "maxInstances": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 4294967295,
-          "description": "Maximum number of simultaneously live instances owned through this capability."
-        },
-        "maxMemoryBytes": {
-          "type": "integer",
-          "minimum": 65536,
-          "description": "Maximum declared WebAssembly memory size per managed instance, in bytes."
-        }
-      }
-    },
-    "plugin": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "capabilities"],
-      "properties": {
-        "name": {
-          "$ref": "#/$defs/pluginName",
-          "description": "GitHub-relative plugin ID, such as wago-org/wasi."
-        },
-        "capabilities": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": { "$ref": "#/$defs/pluginCapability" },
-              "uniqueItems": true
-            },
-            {
-              "type": "object",
-              "propertyNames": { "$ref": "#/$defs/pluginCapability" },
-              "additionalProperties": {
-                "oneOf": [
-                  { "const": true },
-                  { "$ref": "#/$defs/capabilityBudget" }
-                ]
-              }
-            }
-          ],
-          "description": "Privileged Wago API surfaces granted to this plugin. Use an array for simple grants or an object to attach core-enforced resource budgets."
-        },
-        "before": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/pluginName" },
-          "uniqueItems": true,
-          "description": "Optional ordering constraints. This plugin loads before selected targets; missing targets are ignored."
-        },
-        "after": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/pluginName" },
-          "uniqueItems": true,
-          "description": "Optional ordering constraints. This plugin loads after selected targets; missing targets are ignored."
-        },
-        "config": {
-          "description": "Plugin-owned JSON configuration. Wago preserves and passes it to Registry.Config without interpreting its shape."
-        }
-      }
+      "pattern": "^(?:\\*|[~^]?v?[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?)$",
+      "description": "Semantic-version constraint. Pre-release Wago plugins currently use ^0.0.0."
     },
     "author": {
       "type": "object",
@@ -268,7 +185,6 @@
       "additionalProperties": false,
       "required": ["module", "name"],
       "properties": {
-        "schema": { "type": "string", "enum": ["wago/v1", "wago-plugin/v1"] },
         "module": { "$ref": "#/$defs/modulePath" },
         "version": { "type": "string", "pattern": "^v?[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$" },
         "name": { "type": "string", "minLength": 1, "maxLength": 100 },
@@ -285,8 +201,11 @@
         "engines": { "$ref": "#/$defs/engines" },
         "platforms": { "$ref": "#/$defs/platforms" },
         "private": { "const": false },
-        "dependencies": { "type": "array", "items": { "$ref": "#/$defs/modulePath" }, "uniqueItems": true },
-        "plugins": { "type": "array", "items": { "$ref": "#/$defs/plugin" }, "uniqueItems": true },
+        "plugins": {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/pluginName" },
+          "additionalProperties": { "$ref": "#/$defs/versionConstraint" }
+        },
         "subpackages": {
           "type": "array",
           "items": {
@@ -302,16 +221,10 @@
   },
   "examples": [
     {
-      "$schema": "https://wago.sh/schema.json",
-      "schema": "wago/v1",
-      "dependencies": ["github.com/wago-org/workers"],
-      "plugins": [
-        {
-          "name": "wago-org/workers",
-          "capabilities": ["instance.manage"],
-          "config": { "maxWorkers": 8 }
-        }
-      ]
+      "$schema": "https://wago.sh/v0/schema.json",
+      "plugins": {
+        "wago-org/workers": "^0.0.0"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- replace the split `dependencies` plus plugin-object array with a single prerelease `plugins` version map
- use `https://wago.sh/v0/schema.json` as the sole editor/schema marker; remove the redundant manifest `schema` version field
- keep plugin examples at `^0.0.0` / `0.0.0`
- move exact resolved versions, reviewed capabilities, capability budgets, and opaque plugin config into `wago-lock.json`
- strictly reject old manifest shapes and malformed authority-bearing lockfiles
- restore locked Go module versions for reproducible generated plugin runtimes
- update add, remove, update, grant, global migration, schema, tests, and documentation
- rename the prerelease API document from `plugin-api-v2.md` to the versionless `plugin-api.md`

## Impact

This is intentionally breaking. Existing manifests using `dependencies`, a `plugins` array, or the removed `schema` field must be rewritten as:

```json
{
  "$schema": "https://wago.sh/v0/schema.json",
  "plugins": {
    "wago-org/wasi": "^0.0.0"
  }
}
```

Capabilities and plugin-owned configuration now live in `wago-lock.json` rather than `wago.json`. The `/v0/schema.json` document remains a rolling prerelease contract until Wago stabilizes it.

## Validation

- `go test ./...`
- `go test -tags wago_manager ./cli/wago`
- `jq empty schema.json`
- `git diff --check`