### PR TITLE
installer: restore prompt flow details

### DIFF
--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -285,7 +285,21 @@ func (i *installer) chooseReinstallMode() (string, bool, error) {
 		{"Partial", "Reset Wago but keep global plugins for reinstall", "partial", ""},
 		{"Minimal", "Replace binaries and keep existing state", "minimal", ""},
 	}, 2)
+	if ok {
+		fmt.Fprintf(i.out, "Reinstall mode: %s\n\n", reinstallLabel(value))
+	}
 	return value, ok, nil
+}
+
+func reinstallLabel(mode string) string {
+	switch mode {
+	case "full":
+		return "Full"
+	case "partial":
+		return "Partial"
+	default:
+		return "Minimal"
+	}
 }
 
 func (i *installer) downloadManager(target string) error {
@@ -612,19 +626,16 @@ func (i *installer) verify(commandPath string) error {
 }
 
 func (i *installer) offerPathSetup() (bool, string) {
-	if pathContains(i.binDir) {
-		return true, ""
-	}
 	if i.noModifyPath {
-		return false, ""
+		return pathContains(i.binDir), ""
 	}
 	targets := pathTargets(i.home)
 	if len(targets) == 0 {
-		return false, ""
+		return pathContains(i.binDir), ""
 	}
 	choice := os.Getenv("WAGO_PATH_SETUP")
 	if choice == "" && i.noTUI {
-		return false, ""
+		return pathContains(i.binDir), ""
 	}
 	if choice == "" {
 		items := make([]radioItem, 0, len(targets)+1)
@@ -636,24 +647,30 @@ func (i *installer) offerPathSetup() (bool, string) {
 			items = append(items, radioItem{target.label, target.description, strconv.Itoa(index), status})
 		}
 		items = append(items, radioItem{"Not now", "", "none", ""})
-		value, selected := radio("Add Wago to your PATH?", items, 0)
+		value, selected := radio(pathSetupQuestion(), items, 0)
 		if !selected {
-			return false, ""
+			return pathContains(i.binDir), ""
 		}
 		choice = value
 	}
 	if strings.EqualFold(choice, "no") || strings.EqualFold(choice, "n") || choice == "none" {
-		return false, ""
+		fmt.Fprintln(i.out, "PATH setup: skipped")
+		fmt.Fprintln(i.out)
+		return pathContains(i.binDir), ""
 	}
 	selectedIndex := 0
 	if !strings.EqualFold(choice, "yes") && !strings.EqualFold(choice, "y") {
 		parsed, err := strconv.Atoi(choice)
 		if err != nil || parsed < 0 || parsed >= len(targets) {
-			return false, ""
+			return pathContains(i.binDir), ""
 		}
 		selectedIndex = parsed
 	}
 	target := targets[selectedIndex]
+	if message := pathSetupTargetMessage(target, i.home); message != "" {
+		fmt.Fprintln(i.out, message)
+		fmt.Fprintln(i.out)
+	}
 	already, err := addPath(i.binDir, target.configFile, target.shell)
 	if err != nil {
 		i.retry("Could not add Wago to PATH")
@@ -679,7 +696,12 @@ func (i *installer) offerCompletions(installed, configFile string) {
 		{"Yes", "Enable command completion", "yes", ""},
 		{"No", "", "no", ""},
 	}, 0)
-	if !ok || value != "yes" {
+	if !ok {
+		return
+	}
+	if value != "yes" {
+		fmt.Fprintln(i.out, "Completions: skipped")
+		fmt.Fprintln(i.out)
 		return
 	}
 	if err := exec.Command(installed, "config", "completions", shellName, "--install", "--rc", configFile).Run(); err != nil {
@@ -691,6 +713,7 @@ func (i *installer) offerCompletions(installed, configFile string) {
 
 func (i *installer) next(pathReady bool, configFile string) {
 	s := colors()
+	pathReady = pathReady || pathContains(i.binDir)
 	fmt.Fprintf(i.out, "\n%sNext%s\n", s.bold, s.reset)
 	if pathReady && configFile != "" && !pathContains(i.binDir) {
 		fmt.Fprintln(i.out, "  Open a new shell, or run:")

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -160,6 +160,58 @@ func TestInstallerScriptedInstallDirectoryAndReinstallMode(t *testing.T) {
 	}
 }
 
+func TestInstallerScriptedPathSetupKeepsStatusDetails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell startup details are Unix-specific")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ZDOTDIR", home)
+	t.Setenv("SHELL", filepath.Join(string(os.PathSeparator), "bin", "zsh"))
+	t.Setenv("PATH", "")
+	t.Setenv("WAGO_PATH_SETUP", "0")
+	t.Setenv("NO_COLOR", "1")
+	var output bytes.Buffer
+	installer, err := newInstaller(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ready, configFile := installer.offerPathSetup()
+	if !ready || configFile != filepath.Join(home, ".zshrc") {
+		t.Fatalf("PATH setup = %v, %q", ready, configFile)
+	}
+	want := "Adding to PATH: ~/.zshrc\n\n✓ Added Wago to PATH\n"
+	if got := output.String(); got != want {
+		t.Fatalf("PATH setup output = %q, want %q", got, want)
+	}
+
+	output.Reset()
+	t.Setenv("WAGO_PATH_SETUP", "none")
+	installer, err = newInstaller(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installer.offerPathSetup()
+	if got, want := output.String(), "PATH setup: skipped\n\n"; got != want {
+		t.Fatalf("skipped PATH output = %q, want %q", got, want)
+	}
+}
+
+func TestInstallerPromptWordingMatchesLegacyFlow(t *testing.T) {
+	want := "Add Wago to your PATH?"
+	if runtime.GOOS == "windows" {
+		want = "Add Wago to your user PATH?"
+	}
+	if got := pathSetupQuestion(); got != want {
+		t.Fatalf("PATH prompt = %q, want %q", got, want)
+	}
+	for mode, want := range map[string]string{"full": "Full", "partial": "Partial", "minimal": "Minimal"} {
+		if got := reinstallLabel(mode); got != want {
+			t.Fatalf("reinstall label %q = %q, want %q", mode, got, want)
+		}
+	}
+}
+
 func TestUnixPartialAndFullCleanupSemantics(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell startup cleanup is Unix-specific")

--- a/cli/installer/install_unix.go
+++ b/cli/installer/install_unix.go
@@ -80,6 +80,12 @@ func pathTargets(home string) []pathTarget {
 	return targets
 }
 
+func pathSetupQuestion() string { return "Add Wago to your PATH?" }
+
+func pathSetupTargetMessage(target pathTarget, home string) string {
+	return "Adding to PATH: " + displayPath(target.configFile, home)
+}
+
 func addPath(binDir, configFile, shellName string) (bool, error) {
 	marker := "# Wago PATH: " + binDir
 	if data, err := os.ReadFile(configFile); err == nil && strings.Contains(string(data), marker) {

--- a/cli/installer/install_windows.go
+++ b/cli/installer/install_windows.go
@@ -22,6 +22,10 @@ func pathTargets(home string) []pathTarget {
 	return []pathTarget{{label: "Command Prompt", description: "User PATH", shell: "cmd", current: true}}
 }
 
+func pathSetupQuestion() string { return "Add Wago to your user PATH?" }
+
+func pathSetupTargetMessage(target pathTarget, home string) string { return "" }
+
 func addPath(binDir, configFile, shellName string) (bool, error) {
 	userPath, pathType := os.Getenv("WAGO_TEST_USER_PATH"), "REG_EXPAND_SZ"
 	if userPath == "" {

--- a/cli/installer/install_windows_test.go
+++ b/cli/installer/install_windows_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,5 +29,25 @@ func TestWindowsPathSetupUsesUserPathWithoutShellFiles(t *testing.T) {
 	targets := pathTargets(t.TempDir())
 	if len(targets) != 1 || targets[0].label != "Command Prompt" || targets[0].description != "User PATH" {
 		t.Fatalf("Windows PATH targets = %#v", targets)
+	}
+}
+
+func TestWindowsPathPromptMatchesLegacyInstaller(t *testing.T) {
+	if got, want := pathSetupQuestion(), "Add Wago to your user PATH?"; got != want {
+		t.Fatalf("PATH prompt = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsSkippedPathSetupKeepsStatus(t *testing.T) {
+	t.Setenv("WAGO_PATH_SETUP", "none")
+	t.Setenv("WAGO_TEST_USER_PATH", `C:\Windows\System32`)
+	var output bytes.Buffer
+	installer, err := newInstaller(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installer.offerPathSetup()
+	if got, want := output.String(), "PATH setup: skipped\n\n"; got != want {
+		t.Fatalf("skipped PATH output = %q, want %q", got, want)
 	}
 }

--- a/cli/installer/main.go
+++ b/cli/installer/main.go
@@ -96,7 +96,7 @@ func main() {
 			{"Minimal", "Replace binaries and keep existing state", "minimal", ""},
 		}, 2)
 	case "path":
-		value, ok = radio("Add Wago to your PATH?", []radioItem{
+		value, ok = radio(pathSetupQuestion(), []radioItem{
 			{"Command Prompt", "User PATH", "yes", "current"},
 			{"Not now", "", "none", ""},
 		}, 0)
@@ -205,7 +205,7 @@ func clear(lines int) {
 func radio(title string, items []radioItem, cursor int) (string, bool) {
 	c, interactive := openConsole()
 	if !interactive {
-		if title == "Add Wago to your PATH?" {
+		if title == pathSetupQuestion() {
 			return "", false
 		}
 		return items[cursor].value, true


### PR DESCRIPTION
## What changed

- restores the original install, reinstall, PATH, and completion decision flow around the polished native UI
- reports selected reinstall mode, PATH target, skipped PATH setup, and skipped completions again
- keeps offering PATH setup when the current process already inherited the directory
- restores Windows' original `Add Wago to your user PATH?` wording

## Why

The native installer kept the underlying choices but removed useful confirmation and skip messages, making the flow feel less complete than the previous installer.

## Validation

- `go test ./cli/installer`
- `go test .`
- Windows installer test binary under Wine 11.0
- interactive Unix PTY walkthrough through install location, reinstall mode, PATH, and completions

Docs unchanged: this restores user-visible behavior without changing developer workflow.
