### PR TITLE
installer: make setup feel welcoming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ test: ## Build and run the test suite (host)
 	go test -count=1 ./...
 	go test -count=1 -tags wago_runtime ./cli/...
 
+.PHONY: install-local
+install-local: ## Run the installer from this checkout
+	@go run ./cli/installer install
+
 .PHONY: test-starshine
 test-starshine: ## Compile/link/instantiate a MoonBit Starshine wasm-gc artifact (STARSHINE_WASM=/path/cmd.wasm)
 	@test -n "$(STARSHINE_WASM)" || { echo "set STARSHINE_WASM=/path/to/cmd.wasm"; exit 1; }

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -44,6 +44,7 @@ type installer struct {
 	managerFromRelease  bool
 	sourceMethod        string
 	progressActive      bool
+	pathAdded           bool
 }
 
 type release struct {
@@ -176,23 +177,22 @@ func (i *installer) run() error {
 	if stamp == "" {
 		stamp = i.version
 	}
-	fmt.Fprintln(i.out)
-	i.done("Wago " + stamp + " is ready")
-	i.detail("Command", displayPath(installed, i.home))
-	i.next(pathReady, configFile)
+	i.finish(stamp, installed, pathReady, configFile)
 	return nil
 }
 
 func (i *installer) welcome() {
 	s := colors()
-	fmt.Fprintf(i.out, "%s%sWago%s\n", s.bold, s.cyan, s.reset)
-	fmt.Fprintf(i.out, "%sA fast, extensible WebAssembly JIT for Go.%s\n\n", s.dim, s.reset)
+	fmt.Fprintf(i.out, "%s%sWelcome to wago!%s Let's get you set up!\n\n", s.bold, s.cyan, s.reset)
 }
 
 func (i *installer) installLocation() {
+	i.answer("Where should Wago be installed?", displayPath(i.binDir, i.home))
+}
+
+func (i *installer) answer(question, answer string) {
 	s := colors()
-	fmt.Fprintf(i.out, "%sInstall location%s\n", s.bold, s.reset)
-	fmt.Fprintf(i.out, "  %s%s%s\n\n", s.cyan, displayPath(i.binDir, i.home), s.reset)
+	fmt.Fprintf(i.out, "%s%s%s %s%s%s\n\n", s.bold, question, s.reset, s.cyan, answer, s.reset)
 }
 
 func (i *installer) plan() {
@@ -286,7 +286,7 @@ func (i *installer) chooseReinstallMode() (string, bool, error) {
 		{"Minimal", "Replace binaries and keep existing state", "minimal", ""},
 	}, 2)
 	if ok {
-		fmt.Fprintf(i.out, "Reinstall mode: %s\n\n", reinstallLabel(value))
+		i.answer("How should it be reinstalled?", reinstallLabel(value))
 	}
 	return value, ok, nil
 }
@@ -654,8 +654,7 @@ func (i *installer) offerPathSetup() (bool, string) {
 		choice = value
 	}
 	if strings.EqualFold(choice, "no") || strings.EqualFold(choice, "n") || choice == "none" {
-		fmt.Fprintln(i.out, "PATH setup: skipped")
-		fmt.Fprintln(i.out)
+		i.answer(pathSetupQuestion(), "Not now")
 		return pathContains(i.binDir), ""
 	}
 	selectedIndex := 0
@@ -667,10 +666,7 @@ func (i *installer) offerPathSetup() (bool, string) {
 		selectedIndex = parsed
 	}
 	target := targets[selectedIndex]
-	if message := pathSetupTargetMessage(target, i.home); message != "" {
-		fmt.Fprintln(i.out, message)
-		fmt.Fprintln(i.out)
-	}
+	i.answer(pathSetupQuestion(), pathSetupAnswer(target, i.home))
 	already, err := addPath(i.binDir, target.configFile, target.shell)
 	if err != nil {
 		i.retry("Could not add Wago to PATH")
@@ -679,6 +675,7 @@ func (i *installer) offerPathSetup() (bool, string) {
 	if already {
 		i.done("Wago is already on PATH")
 	} else {
+		i.pathAdded = true
 		i.done("Added Wago to PATH")
 	}
 	return true, target.configFile
@@ -699,9 +696,12 @@ func (i *installer) offerCompletions(installed, configFile string) {
 	if !ok {
 		return
 	}
+	answer := "No"
+	if value == "yes" {
+		answer = "Yes"
+	}
+	i.answer("Enable Wago completions for "+shellName+"?", answer)
 	if value != "yes" {
-		fmt.Fprintln(i.out, "Completions: skipped")
-		fmt.Fprintln(i.out)
 		return
 	}
 	if err := exec.Command(installed, "config", "completions", shellName, "--install", "--rc", configFile).Run(); err != nil {
@@ -711,21 +711,26 @@ func (i *installer) offerCompletions(installed, configFile string) {
 	i.done("Enabled completions for " + shellName)
 }
 
-func (i *installer) next(pathReady bool, configFile string) {
+func (i *installer) finish(stamp, installed string, pathReady bool, configFile string) {
 	s := colors()
 	pathReady = pathReady || pathContains(i.binDir)
-	fmt.Fprintf(i.out, "\n%sNext%s\n", s.bold, s.reset)
-	if pathReady && configFile != "" && !pathContains(i.binDir) {
-		fmt.Fprintln(i.out, "  Open a new shell, or run:")
-		fmt.Fprintf(i.out, "    %s%s%s\n", s.cyan, sourceCommand(configFile)+" && wago version install", s.reset)
-		return
+	fmt.Fprintf(i.out, "\n%sSweet, we've installed Wago %s at %s%s\n", s.bold, stamp, displayPath(installed, i.home), s.reset)
+	if i.pathAdded {
+		if command := sourceCommand(configFile); command != "" {
+			fmt.Fprintln(i.out, "Since we added it to your PATH just now, please run")
+			fmt.Fprintf(i.out, "\n%s%s%s\n", s.cyan, command, s.reset)
+		} else {
+			fmt.Fprintln(i.out, "Since we added it to your PATH just now, open a new terminal.")
+		}
+	} else if pathReady && configFile != "" && !pathContains(i.binDir) {
+		fmt.Fprintln(i.out, "Wago is already configured in your PATH. Please run")
+		fmt.Fprintf(i.out, "\n%s%s%s\n", s.cyan, sourceCommand(configFile), s.reset)
+	} else if !pathReady {
+		fmt.Fprintf(i.out, "Before you continue, add %s to your PATH.\n", displayPath(i.binDir, i.home))
 	}
-	if pathReady {
-		fmt.Fprintf(i.out, "  %swago version install%s\n", s.cyan, s.reset)
-		return
-	}
-	fmt.Fprintf(i.out, "  Add %s to PATH, then run:\n", displayPath(i.binDir, i.home))
-	fmt.Fprintf(i.out, "    %swago version install%s\n", s.cyan, s.reset)
+	fmt.Fprintln(i.out, "\nAnd then, go ahead and install a version of your choice with,")
+	fmt.Fprintf(i.out, "\n%s%s%s\n", s.cyan, "wago version install", s.reset)
+	fmt.Fprintln(i.out, "\nHave fun!")
 }
 
 func executableName(name string) string {

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -31,9 +31,8 @@ func TestInstallerDryRunPresentation(t *testing.T) {
 		t.Fatal(err)
 	}
 	separator := string(os.PathSeparator)
-	want := "Wago\n" +
-		"A fast, extensible WebAssembly JIT for Go.\n\n" +
-		"Install location\n  ~" + separator + ".wago" + separator + "bin\n\n" +
+	want := "Welcome to wago! Let's get you set up!\n\n" +
+		"Where should Wago be installed? ~" + separator + ".wago" + separator + "bin\n\n" +
 		"Plan\n  Version  canary\n  Command  ~" + separator + ".wago" + separator + "bin" + separator + executableName("wago") + "\n  Source   ~" + separator + ".wago" + separator + "src\n\n" +
 		"Dry run · no changes made.\n"
 	if got := output.String(); got != want {
@@ -180,7 +179,7 @@ func TestInstallerScriptedPathSetupKeepsStatusDetails(t *testing.T) {
 	if !ready || configFile != filepath.Join(home, ".zshrc") {
 		t.Fatalf("PATH setup = %v, %q", ready, configFile)
 	}
-	want := "Adding to PATH: ~/.zshrc\n\n✓ Added Wago to PATH\n"
+	want := "Want to add Wago to PATH? ~/.zshrc\n\n✓ Added Wago to PATH\n"
 	if got := output.String(); got != want {
 		t.Fatalf("PATH setup output = %q, want %q", got, want)
 	}
@@ -192,16 +191,13 @@ func TestInstallerScriptedPathSetupKeepsStatusDetails(t *testing.T) {
 		t.Fatal(err)
 	}
 	installer.offerPathSetup()
-	if got, want := output.String(), "PATH setup: skipped\n\n"; got != want {
+	if got, want := output.String(), "Want to add Wago to PATH? Not now\n\n"; got != want {
 		t.Fatalf("skipped PATH output = %q, want %q", got, want)
 	}
 }
 
-func TestInstallerPromptWordingMatchesLegacyFlow(t *testing.T) {
-	want := "Add Wago to your PATH?"
-	if runtime.GOOS == "windows" {
-		want = "Add Wago to your user PATH?"
-	}
+func TestInstallerPromptWordingMatchesWarmFlow(t *testing.T) {
+	want := "Want to add Wago to PATH?"
 	if got := pathSetupQuestion(); got != want {
 		t.Fatalf("PATH prompt = %q, want %q", got, want)
 	}
@@ -209,6 +205,33 @@ func TestInstallerPromptWordingMatchesLegacyFlow(t *testing.T) {
 		if got := reinstallLabel(mode); got != want {
 			t.Fatalf("reinstall label %q = %q, want %q", mode, got, want)
 		}
+	}
+}
+
+func TestInstallerWarmFinishAfterPathSetup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell activation command is Unix-specific")
+	}
+	home := filepath.Join(string(os.PathSeparator), "home", "wago")
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+	t.Setenv("NO_COLOR", "1")
+	var output bytes.Buffer
+	installer, err := newInstaller(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installer.pathAdded = true
+	installed := filepath.Join(home, ".wago", "bin", "wago")
+	installer.finish("canary-deadbee", installed, true, filepath.Join(home, ".zshrc"))
+	want := "\nSweet, we've installed Wago canary-deadbee at ~/.wago/bin/wago\n" +
+		"Since we added it to your PATH just now, please run\n\n" +
+		"source ~/.zshrc\n\n" +
+		"And then, go ahead and install a version of your choice with,\n\n" +
+		"wago version install\n\n" +
+		"Have fun!\n"
+	if got := output.String(); got != want {
+		t.Fatalf("warm finish:\n--- got ---\n%s--- want ---\n%s", got, want)
 	}
 }
 

--- a/cli/installer/install_unix.go
+++ b/cli/installer/install_unix.go
@@ -80,10 +80,10 @@ func pathTargets(home string) []pathTarget {
 	return targets
 }
 
-func pathSetupQuestion() string { return "Add Wago to your PATH?" }
+func pathSetupQuestion() string { return "Want to add Wago to PATH?" }
 
-func pathSetupTargetMessage(target pathTarget, home string) string {
-	return "Adding to PATH: " + displayPath(target.configFile, home)
+func pathSetupAnswer(target pathTarget, home string) string {
+	return displayPath(target.configFile, home)
 }
 
 func addPath(binDir, configFile, shellName string) (bool, error) {

--- a/cli/installer/install_windows.go
+++ b/cli/installer/install_windows.go
@@ -22,9 +22,9 @@ func pathTargets(home string) []pathTarget {
 	return []pathTarget{{label: "Command Prompt", description: "User PATH", shell: "cmd", current: true}}
 }
 
-func pathSetupQuestion() string { return "Add Wago to your user PATH?" }
+func pathSetupQuestion() string { return "Want to add Wago to PATH?" }
 
-func pathSetupTargetMessage(target pathTarget, home string) string { return "" }
+func pathSetupAnswer(target pathTarget, home string) string { return target.description }
 
 func addPath(binDir, configFile, shellName string) (bool, error) {
 	userPath, pathType := os.Getenv("WAGO_TEST_USER_PATH"), "REG_EXPAND_SZ"

--- a/cli/installer/install_windows_test.go
+++ b/cli/installer/install_windows_test.go
@@ -32,8 +32,8 @@ func TestWindowsPathSetupUsesUserPathWithoutShellFiles(t *testing.T) {
 	}
 }
 
-func TestWindowsPathPromptMatchesLegacyInstaller(t *testing.T) {
-	if got, want := pathSetupQuestion(), "Add Wago to your user PATH?"; got != want {
+func TestWindowsPathPromptMatchesWarmInstaller(t *testing.T) {
+	if got, want := pathSetupQuestion(), "Want to add Wago to PATH?"; got != want {
 		t.Fatalf("PATH prompt = %q, want %q", got, want)
 	}
 }
@@ -47,7 +47,33 @@ func TestWindowsSkippedPathSetupKeepsStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 	installer.offerPathSetup()
-	if got, want := output.String(), "PATH setup: skipped\n\n"; got != want {
+	if got, want := output.String(), "Want to add Wago to PATH? Not now\n\n"; got != want {
 		t.Fatalf("skipped PATH output = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsWarmFinishAfterPathSetup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("NO_COLOR", "1")
+	var output bytes.Buffer
+	installer, err := newInstaller(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installer.pathAdded = true
+	installed := filepath.Join(home, ".wago", "bin", "wago.exe")
+	installer.finish("canary-deadbee", installed, true, "")
+	text := output.String()
+	for _, fragment := range []string{
+		"Sweet, we've installed Wago canary-deadbee at ~\\.wago\\bin\\wago.exe",
+		"Since we added it to your PATH just now, open a new terminal.",
+		"wago version install",
+		"Have fun!",
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("warm finish missing %q:\n%s", fragment, text)
+		}
 	}
 }

--- a/install_test.go
+++ b/install_test.go
@@ -181,7 +181,7 @@ func TestWineCmdBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Wine CMD download bootstrap: %v\n%s", err, output)
 	}
-	if text := strings.ReplaceAll(string(output), "\r", ""); !strings.Contains(text, "Install location") || !strings.Contains(text, "Dry run · no changes made.") {
+	if text := strings.ReplaceAll(string(output), "\r", ""); !strings.Contains(text, "Where should Wago be installed? ROOT\\bin") || !strings.Contains(text, "Dry run · no changes made.") {
 		t.Fatalf("Wine CMD download bootstrap output:\n%s", text)
 	}
 }
@@ -241,7 +241,9 @@ func TestWineInstallerCompletesNativeInstallFlow(t *testing.T) {
 		"Downloaded Wago manager " + tag,
 		"Fetched Wago source archive",
 		"Verified installation",
-		"Wago " + tag + " is ready",
+		"Sweet, we've installed Wago " + tag,
+		"wago version install",
+		"Have fun!",
 	} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("Wine install output missing %q:\n%s", fragment, text)

--- a/install_windows_test.go
+++ b/install_windows_test.go
@@ -47,7 +47,7 @@ func TestCmdBootstrapExecutesNativeInstaller(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CMD bootstrap: %v\n%s", err, output)
 	}
-	for _, fragment := range []string{"Wago", "Install location", "Plan", "Dry run"} {
+	for _, fragment := range []string{"Welcome to wago!", "Where should Wago be installed? ROOT\\bin", "Plan", "Dry run"} {
 		if !strings.Contains(string(output), fragment) {
 			t.Fatalf("CMD bootstrap output missing %q:\n%s", fragment, output)
 		}


### PR DESCRIPTION
## What changed

- opens with the requested warm welcome instead of a product tagline
- keeps install, reinstall, PATH, and completion questions visible with their selected answers
- replaces the terse success block with a friendly PATH activation and version-install handoff
- gives Windows the same voice while using its real next step: opening a new terminal instead of sourcing a shell file

## Why

The installer was visually clean but still read like a build log. This makes it feel like Wago is helping the user through setup while retaining the concise progress information and every existing choice.

## Validation

- `go test ./cli/installer`
- `go test .`
- Windows AMD64 installer tests under Wine 11.0
- interactive Unix PTY happy path through location, PATH, and completions
- Wine PATH-setup walkthrough

Docs unchanged: this is user-facing copy and presentation behavior, not a developer workflow change.
