### PR TITLE
gc: add roadmap benchmark matrix

### DIFF
--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -1,0 +1,175 @@
+# WasmGC measurement matrix
+
+This document defines the measurement contract for collector changes tracked by
+issue #300. The matrix is intentionally broader than the current implementation:
+it covers the Throughput and Tiny collectors that exist today and the collector
+directions explicitly recorded in issues #302–#321.
+
+The benchmark source is `src/core/runtime/gc/matrix_bench_test.go`. Benchmark
+names and custom metric names are stable machine-facing identifiers. Change them
+only when the represented workload or unit changes.
+
+## Measurement principles
+
+Every result must keep mutator, collector, compiler, and operating-system costs
+distinct. A lower pause is not a win if it comes from substantially more mutator
+barrier work, CPU, memory, or generated code.
+
+Report at least:
+
+- mutator wall time and throughput;
+- collection-cycle and individual-step p50, p90, p95, p99, and maximum latency;
+- total collector CPU and phase time;
+- objects, payload bytes, and reference slots visited, copied, promoted, swept,
+  or evacuated;
+- managed live, committed, free, and reserved bytes;
+- metadata, Go heap, executable JIT, and peak RSS bytes as separate domains;
+- allocation rate, survival by age, full/minor frequency, and time to exhaustion;
+- linked bytes, JIT bytes, compile time, B/op, and allocs/op where code generation
+  participates; and
+- a semantic checksum or expected trap for every timed fixture.
+
+Percentiles are derived from a bounded 64-bucket log2 nanosecond histogram. This
+keeps measurement memory fixed even for long runs. A percentile is the upper
+bound of its bucket; raw `ns/op` remains available for comparison tools.
+
+Deterministic counters (objects, slots, bytes, roots, cards, search steps, and
+semantic checksums) may be compared exactly. Time, CPU counters, page faults,
+RSS, and cache/TLB behavior are host-specific and require repeated interleaved
+A/B runs on an otherwise idle machine.
+
+## Collector-level matrix
+
+`BenchmarkGCCollectionMatrix` crosses:
+
+- collector: Throughput minor, Throughput full, and Tiny full;
+- survival: 0%, 1%, 10%, 50%, and 90%; and
+- layout: pointer-free, sparse-reference struct, dense-reference struct, and
+  dense-reference array.
+
+Allocation and cleanup occur outside the benchmark timer. Each operation checks
+the exact live-object count and every surviving object's type before cleanup.
+This matrix is the primary discriminator for tracing density, promotion cost,
+zero-survivor cleanup, and future age-based tenuring.
+
+`BenchmarkGCSparseRememberedArray` crosses 4K and 256K-element old arrays with
+two distant young writes or 1,024 distributed writes. It is deliberately hostile
+to the current whole-object remembered scan. Future card implementations should
+make the two-write case proportional to dirty regions without hiding dense-scan
+costs.
+
+`BenchmarkGCRootClassMatrix` crosses Throughput and Tiny with 1, 64, and 4,096
+direct, global, or table roots. It isolates root enumeration that the collector
+owns. Frame, token, foreign-instance, exception, and snapshot-temporary roots
+remain runtime-integration fixtures because collapsing them into generic slots
+would hide their actual traversal and synchronization costs.
+
+`BenchmarkGCTinyStepMatrix` scans reference arrays with 16, 4K, and 64K slots.
+Today one Tiny step may scan the whole object. A slot/byte-budgeted implementation
+must keep p99 and maximum step time bounded while increasing `steps/op` with the
+amount of scan work.
+
+## Required companion layers
+
+Collector microbenchmarks cannot observe every cost. Keep the following as
+separate layers instead of folding unrelated setup into collector pause timing.
+
+| Layer | Required dimensions |
+|---|---|
+| Collector | Survival, topology, pointer density, roots, cards, promotion/copy, sweep, fragmentation, Tiny steps |
+| Runtime integration | Frames, globals, tables, public tokens, foreign instances, snapshot temporaries, exceptions, re-entry, cross-instance calls |
+| JIT/compiler | One hot static site versus thousands of sparse sites; native-fast/medium/helper paths; barriers; spills; stubs; trap code; root-map bytes |
+| Product | Compile/load/instantiate time, Go compiler/runtime heaps, managed heap, executable mappings, linked binary, snapshots, RSS |
+
+Future issue work must extend the matrix as follows:
+
+- #302: no-survivor and low-survivor cleanup with high handle counts;
+- #303/#315: 128/256/512-byte cards, sparse/dense writes, root cards, and all
+  reference bulk operations;
+- #304: 64, 65, 128, 256, and 1,024 exact roots plus metadata bytes/safepoint;
+- #308: reserved/committed bytes, backing growth, bytes copied, and page faults;
+- #309: metadata bytes/object, handle-resolution instructions, and cache misses;
+- #310: object lifetimes of zero through five minors, adaptive thresholds,
+  survivor occupancy, copied/promoted bytes, and full-GC frequency;
+- #311: numeric/reference arrays at lengths 0, 1, 4, 32, 256, and 4,096 plus
+  handle/chunk refill and cancellation paths;
+- #312/#313: randomized fragmentation, large spans, occupancy histograms,
+  mark bandwidth, recyclable regions, and selective evacuation;
+- #318/#319: Tiny metadata, size-bin search, giant objects, root churn, mutation
+  during every phase, allocation debt, cycle latency, and minimum mutator
+  utilization; and
+- #321: one, two, four, and available-core collectors only after its prerequisites
+  land, including synchronization and total CPU rather than wall time alone.
+
+## Running the matrix
+
+Do not run the complete matrix casually on a busy development machine. First
+compile without executing benchmarks:
+
+```sh
+go test ./src/core/runtime/gc -run '^$'
+```
+
+For a controlled run, disable frequency scaling/turbo when practical, pin the
+process to one physical CPU, record the CPU/kernel/Go revision, and run multiple
+interleaved samples:
+
+```sh
+taskset -c 2 go test ./src/core/runtime/gc \
+  -run '^$' -bench '^BenchmarkGC' -benchmem -count=10 -timeout=30m \
+  | tee gc-matrix.txt
+```
+
+Go's JSON event stream can be retained alongside ordinary benchmark text:
+
+```sh
+taskset -c 2 go test ./src/core/runtime/gc \
+  -run '^$' -bench '^BenchmarkGC' -benchmem -count=10 -timeout=30m -json \
+  > gc-matrix.json
+```
+
+Compare ordinary output with `benchstat`. Preserve raw files; summaries alone
+discard run order and outliers.
+
+On Linux, collect hardware counters in separate runs because `perf` changes the
+measurement environment:
+
+```sh
+perf stat -r 10 -e \
+instructions,cycles,branches,branch-misses,L1-dcache-loads,L1-dcache-load-misses,\
+LLC-loads,LLC-load-misses,iTLB-loads,iTLB-load-misses,dTLB-loads,dTLB-load-misses,\
+minor-faults,major-faults \
+taskset -c 2 go test ./src/core/runtime/gc \
+  -run '^$' -bench '^BenchmarkGCCollectionMatrix$' -benchtime=1x
+```
+
+Use native hardware for architecture claims. QEMU results are correctness data,
+not ARM64 performance data.
+
+## Research basis
+
+The matrix follows primary and official sources rather than one aggregate
+throughput score:
+
+- Blackburn and McKinley's Immix work measures collection efficiency, space
+  efficiency, mutator locality, fragmentation, line/block occupancy, and
+  opportunistic evacuation: <https://doi.org/10.1145/1375581.1375586>.
+- Bacon, Cheng, and Rajan's Metronome work treats pause bounds, pointer density,
+  object size, fragmentation, heap overhead, and minimum mutator utilization as
+  coupled quantities: <https://research.ibm.com/publications/controlling-fragmentation-and-space-consumption-in-the-metronome-a-real-time-garbage-collector-for-java>.
+- Zhao, Blackburn, and McKinley's LXR evaluation reports tail latency together
+  with throughput and the costs of remembered sets, copying, barriers, and
+  fragmentation: <https://arxiv.org/abs/2210.17175>.
+- Cai et al.'s distilled-cost methodology separates collector cost from the
+  application's intrinsic allocation/reclamation work:
+  <https://arxiv.org/abs/2112.07880>.
+- Go's official runtime metrics separate GC CPU classes, pause distributions,
+  live/goal heap bytes, and scannable heap/stack/global bytes:
+  <https://pkg.go.dev/runtime/metrics>.
+- G1's official tuning documentation exposes root scanning, remembered-set
+  merging, heap-root scanning, object copying, survivor aging, and region/card
+  behavior as distinct phases:
+  <https://docs.oracle.com/en/java/javase/18/gctuning/garbage-first-g1-garbage-collector1.html>.
+
+These sources are guidance for what to measure, not targets for copying JVM heap
+policy into a small no-cgo Wasm runtime.

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -29,8 +29,9 @@ Report at least:
   participates; and
 - a semantic checksum or expected trap for every timed fixture.
 
-Percentiles are derived from a bounded 64-bucket log2 nanosecond histogram. This
-keeps measurement memory fixed even for long runs. A percentile is the upper
+Percentiles are derived from a bounded histogram with 16 linear sub-buckets per
+power-of-two nanosecond interval. Relative bucket width is at most 6.25%, and
+measurement memory stays fixed even for long runs. A percentile is the upper
 bound of its bucket; raw `ns/op` remains available for comparison tools.
 
 Deterministic counters (objects, slots, bytes, roots, cards, search steps, and
@@ -49,6 +50,9 @@ A/B runs on an otherwise idle machine.
 
 Allocation and cleanup occur outside the benchmark timer. Each operation checks
 the exact live-object count and every surviving object's type before cleanup.
+Reference-bearing fixtures store non-null self edges in every traced slot and
+validate them after collection; they therefore exercise traversal rather than
+only iterating null slots.
 This matrix is the primary discriminator for tracing density, promotion cost,
 zero-survivor cleanup, and future age-based tenuring.
 
@@ -108,6 +112,19 @@ compile without executing benchmarks:
 
 ```sh
 go test ./src/core/runtime/gc -run '^$'
+```
+
+Ordinary `TestGC*WorkloadSmoke` tests execute one correctness cycle through
+every benchmark family, including the largest sparse array and Tiny scan, without
+invoking Go's adaptive benchmark runner.
+
+To validate timing plumbing cheaply, select exact sub-benchmarks and force a
+fixed iteration count. For example:
+
+```sh
+go test ./src/core/runtime/gc -run '^$' \
+  -bench '^BenchmarkGCCollectionMatrix/throughput-minor/dense-array-refs/survival=50$' \
+  -benchtime=2x
 ```
 
 For a controlled run, disable frequency scaling/turbo when practical, pin the

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -7,6 +7,9 @@ than a non-goal. The current implementation is an initial foundation under
 descriptors, a byte-slice heap skeleton, exact scanning, roots, barriers, stress
 knobs, and tests.
 
+The decision-grade collector measurement contract and roadmap-aligned benchmark
+matrix are documented in [gc-benchmarks.md](gc-benchmarks.md).
+
 ## Current generated-payload boundary
 
 The mandatory pinned Core 3 corpus is complete, but that result is narrower than

--- a/src/core/runtime/gc/matrix_bench_test.go
+++ b/src/core/runtime/gc/matrix_bench_test.go
@@ -1,0 +1,421 @@
+package gc
+
+import (
+	"fmt"
+	"math/bits"
+	"testing"
+	"time"
+)
+
+// pauseHistogram is a bounded, allocation-free log2 nanosecond histogram. It
+// deliberately trades sub-bucket precision for stable memory use across long
+// benchmark runs. The reported percentile is the upper bound of its bucket.
+type pauseHistogram struct {
+	buckets [64]uint64
+	count   uint64
+	maxNS   uint64
+}
+
+func (h *pauseHistogram) record(d time.Duration) {
+	ns := uint64(d)
+	h.buckets[bits.Len64(ns)]++
+	h.count++
+	if ns > h.maxNS {
+		h.maxNS = ns
+	}
+}
+
+func (h *pauseHistogram) percentile(numerator, denominator uint64) uint64 {
+	if h.count == 0 {
+		return 0
+	}
+	target := (h.count*numerator + denominator - 1) / denominator
+	var seen uint64
+	for i, n := range h.buckets {
+		seen += n
+		if seen >= target {
+			if i == 0 {
+				return 0
+			}
+			upper := (uint64(1) << i) - 1
+			if upper > h.maxNS {
+				return h.maxNS
+			}
+			return upper
+		}
+	}
+	return h.maxNS
+}
+
+func (h *pauseHistogram) report(b *testing.B, prefix string) {
+	b.ReportMetric(float64(h.percentile(50, 100)), prefix+"-p50-ns")
+	b.ReportMetric(float64(h.percentile(90, 100)), prefix+"-p90-ns")
+	b.ReportMetric(float64(h.percentile(95, 100)), prefix+"-p95-ns")
+	b.ReportMetric(float64(h.percentile(99, 100)), prefix+"-p99-ns")
+	b.ReportMetric(float64(h.maxNS), prefix+"-max-ns")
+}
+
+func TestGCPauseHistogram(t *testing.T) {
+	var h pauseHistogram
+	for _, ns := range []time.Duration{0, 1, 2, 3, 4, 8, 16, 32, 64, 128} {
+		h.record(ns * time.Nanosecond)
+	}
+	if got := h.percentile(50, 100); got != 7 {
+		t.Fatalf("p50 = %d ns, want bucket upper bound 7", got)
+	}
+	if got := h.percentile(90, 100); got != 127 {
+		t.Fatalf("p90 = %d ns, want bucket upper bound 127", got)
+	}
+	if got := h.percentile(99, 100); got != 128 {
+		t.Fatalf("p99 = %d ns, want bucket upper bound 128", got)
+	}
+	if h.maxNS != 128 || h.count != 10 {
+		t.Fatalf("histogram max/count = %d/%d, want 128/10", h.maxNS, h.count)
+	}
+}
+
+type gcMatrixLayout struct {
+	name   string
+	typeID TypeID
+	alloc  func(*Collector) (Ref, error)
+}
+
+func gcMatrixTypes(tb testing.TB) ([]TypeDesc, []gcMatrixLayout) {
+	tb.Helper()
+	pointerFree, err := NewStructDesc(0, []StorageKind{
+		StorageI64, StorageI64, StorageI64, StorageI64,
+		StorageI64, StorageI64, StorageI64, StorageI64,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	sparseFields := make([]StorageKind, 16)
+	for i := range sparseFields {
+		sparseFields[i] = StorageI64
+	}
+	sparseFields[8] = StorageRefNull
+	sparse, err := NewStructDesc(1, sparseFields)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	denseFields := make([]StorageKind, 16)
+	for i := range denseFields {
+		denseFields[i] = StorageRefNull
+	}
+	dense, err := NewStructDesc(2, denseFields)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	denseArray, err := NewArrayDesc(3, StorageRefNull)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	types := []TypeDesc{pointerFree, sparse, dense, denseArray}
+	return types, []gcMatrixLayout{
+		{name: "pointer-free", typeID: 0, alloc: func(c *Collector) (Ref, error) { return c.NewStructDefault(0) }},
+		{name: "sparse-struct-refs", typeID: 1, alloc: func(c *Collector) (Ref, error) { return c.NewStructDefault(1) }},
+		{name: "dense-struct-refs", typeID: 2, alloc: func(c *Collector) (Ref, error) { return c.NewStructDefault(2) }},
+		{name: "dense-array-refs", typeID: 3, alloc: func(c *Collector) (Ref, error) { return c.NewArrayDefault(3, 16) }},
+	}
+}
+
+func gcMatrixConfig(profile Profile) Config {
+	if profile == ProfileTiny {
+		return Config{Profile: ProfileTiny, TinyHeapBytes: 16 << 20, TinyBlockBytes: 16}
+	}
+	return Config{NurseryBytes: 1 << 20, ThroughputHeapBytes: 64 << 20, ThroughputPageBytes: 64 << 10}
+}
+
+// BenchmarkGCCollectionMatrix isolates collector pause work across the object
+// layouts and survival ratios called out by issue #300. Allocation and cleanup
+// are outside the benchmark timer. Every operation validates the surviving
+// object count and type, so a fast but semantically wrong collector cannot win.
+func BenchmarkGCCollectionMatrix(b *testing.B) {
+	types, layouts := gcMatrixTypes(b)
+	profiles := []struct {
+		name       string
+		profile    Profile
+		collection string
+	}{
+		{name: "throughput-minor", profile: ProfileThroughput, collection: "minor"},
+		{name: "throughput-full", profile: ProfileThroughput, collection: "full"},
+		{name: "tiny-full", profile: ProfileTiny, collection: "full"},
+	}
+	for _, profile := range profiles {
+		for _, layout := range layouts {
+			for _, survival := range []int{0, 1, 10, 50, 90} {
+				name := fmt.Sprintf("%s/%s/survival=%d", profile.name, layout.name, survival)
+				b.Run(name, func(b *testing.B) {
+					c, err := NewCollector(gcMatrixConfig(profile.profile), types)
+					if err != nil {
+						b.Fatal(err)
+					}
+					b.Cleanup(c.Close)
+					rootValues := make([]Root, survival)
+					roots := make(Slots, survival)
+					for i := range rootValues {
+						roots[i] = &rootValues[i]
+					}
+					var pauses pauseHistogram
+					var checksum uint64
+					b.ReportAllocs()
+					b.ReportMetric(100, "objects/op")
+					b.ReportMetric(float64(survival), "survival-percent")
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						b.StopTimer()
+						for j := 0; j < 100; j++ {
+							r, err := layout.alloc(c)
+							if err != nil {
+								b.Fatal(err)
+							}
+							if j < survival {
+								rootValues[j] = Root(r)
+							}
+						}
+						b.StartTimer()
+						start := time.Now()
+						if profile.collection == "minor" {
+							err = c.CollectMinor(roots)
+						} else {
+							err = c.CollectFull(roots)
+						}
+						pauses.record(time.Since(start))
+						b.StopTimer()
+						if err != nil {
+							b.Fatal(err)
+						}
+						if got := c.Stats().LiveObjects; got != uint32(survival) {
+							b.Fatalf("live objects = %d, want %d", got, survival)
+						}
+						for j := range rootValues {
+							typeID, err := c.ObjectType(Ref(rootValues[j]))
+							if err != nil || typeID != layout.typeID {
+								b.Fatalf("survivor type = %d, %v; want %d", typeID, err, layout.typeID)
+							}
+							checksum += uint64(typeID) + uint64(j) + 1
+							rootValues[j] = Root(Null())
+						}
+						if err := c.CollectFull(nil); err != nil {
+							b.Fatal(err)
+						}
+						if got := c.Stats().LiveObjects; got != 0 {
+							b.Fatalf("cleanup live objects = %d, want 0", got)
+						}
+						b.StartTimer()
+					}
+					b.StopTimer()
+					if survival != 0 && checksum == 0 {
+						b.Fatal("semantic checksum is zero")
+					}
+					pauses.report(b, "pause")
+				})
+			}
+		}
+	}
+}
+
+// BenchmarkGCSparseRememberedArray is the future card-table discriminator: an
+// old reference array receives either two distant young writes or dense writes.
+// Today's collector scans the whole remembered array; card-driven collection
+// should make the sparse case proportional to dirty regions instead.
+func BenchmarkGCSparseRememberedArray(b *testing.B) {
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	refs, err := NewArrayDesc(1, StorageRefNull)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, length := range []uint32{4 << 10, 256 << 10} {
+		for _, writes := range []int{2, 1024} {
+			b.Run(fmt.Sprintf("elements=%d/writes=%d", length, writes), func(b *testing.B) {
+				c, err := NewCollector(Config{NurseryBytes: 1 << 20, ThroughputHeapBytes: 64 << 20}, []TypeDesc{leaf, refs})
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.Cleanup(c.Close)
+				array, err := c.NewArrayDefault(1, length)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := c.ForcePromote(array); err != nil {
+					b.Fatal(err)
+				}
+				arrayRoot := Root(array)
+				roots := Slots{&arrayRoot}
+				children := make([]Ref, writes)
+				var pauses pauseHistogram
+				var checksum uint64
+				b.ReportAllocs()
+				b.ReportMetric(float64(length), "array-elements")
+				b.ReportMetric(float64(writes), "dirty-writes/op")
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					for j := range children {
+						children[j], err = c.NewStructDefault(0)
+						if err != nil {
+							b.Fatal(err)
+						}
+						index := uint32(uint64(j) * uint64(length-1) / uint64(max(1, writes-1)))
+						if err := c.ArraySet(array, index, RefValue(children[j])); err != nil {
+							b.Fatal(err)
+						}
+					}
+					before := c.Stats()
+					b.StartTimer()
+					start := time.Now()
+					err = c.CollectMinor(roots)
+					pauses.record(time.Since(start))
+					b.StopTimer()
+					if err != nil {
+						b.Fatal(err)
+					}
+					after := c.Stats()
+					checksum += after.MinorRememberedScanned - before.MinorRememberedScanned
+					for j := range children {
+						index := uint32(uint64(j) * uint64(length-1) / uint64(max(1, writes-1)))
+						v, err := c.ArrayGet(array, index)
+						if err != nil || v.Ref != children[j] {
+							b.Fatalf("array[%d] = %v, %v; want %v", index, v.Ref, err, children[j])
+						}
+						if err := c.ArraySet(array, index, RefValue(Null())); err != nil {
+							b.Fatal(err)
+						}
+					}
+					if err := c.CollectFull(roots); err != nil {
+						b.Fatal(err)
+					}
+					b.StartTimer()
+				}
+				b.StopTimer()
+				if checksum == 0 {
+					b.Fatal("remembered-set semantic checksum is zero")
+				}
+				pauses.report(b, "minor-pause")
+			})
+		}
+	}
+}
+
+// BenchmarkGCRootClassMatrix isolates root enumeration owned directly by the
+// collector. Native frames, public tokens, foreign instances, and snapshot
+// temporaries are integration-layer roots and belong in product fixtures.
+func BenchmarkGCRootClassMatrix(b *testing.B) {
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	profiles := []struct {
+		name    string
+		profile Profile
+	}{
+		{name: "throughput", profile: ProfileThroughput},
+		{name: "tiny", profile: ProfileTiny},
+	}
+	for _, profile := range profiles {
+		for _, rootClass := range []string{"direct", "global", "table"} {
+			for _, rootCount := range []int{1, 64, 4096} {
+				b.Run(fmt.Sprintf("%s/%s/count=%d", profile.name, rootClass, rootCount), func(b *testing.B) {
+					c, err := NewCollector(gcMatrixConfig(profile.profile), []TypeDesc{leaf})
+					if err != nil {
+						b.Fatal(err)
+					}
+					b.Cleanup(c.Close)
+					object, err := c.NewStructDefault(0)
+					if err != nil {
+						b.Fatal(err)
+					}
+					var roots RootSet
+					switch rootClass {
+					case "direct":
+						values := make([]Root, rootCount)
+						slots := make(Slots, rootCount)
+						for i := range values {
+							values[i] = Root(object)
+							slots[i] = &values[i]
+						}
+						roots = slots
+					case "global":
+						for i := 0; i < rootCount; i++ {
+							c.NewGlobalSlot(object)
+						}
+					case "table":
+						for i := 0; i < rootCount; i++ {
+							c.NewTableSlot(object)
+						}
+					}
+					var pauses pauseHistogram
+					var checksum uint64
+					b.ReportAllocs()
+					b.ReportMetric(float64(rootCount), "roots/op")
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						start := time.Now()
+						if err := c.CollectFull(roots); err != nil {
+							b.Fatal(err)
+						}
+						pauses.record(time.Since(start))
+						checksum += uint64(c.Stats().LiveObjects)
+					}
+					b.StopTimer()
+					if checksum != uint64(b.N) {
+						b.Fatalf("live checksum = %d, want %d", checksum, b.N)
+					}
+					pauses.report(b, "full-pause")
+				})
+			}
+		}
+	}
+}
+
+// BenchmarkGCTinyStepMatrix exposes the unbounded-object problem tracked by
+// #319. A future slot-budgeted scanner should increase steps with array length
+// while keeping p99/max step latency bounded.
+func BenchmarkGCTinyStepMatrix(b *testing.B) {
+	refs, err := NewArrayDesc(0, StorageRefNull)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, length := range []uint32{16, 4 << 10, 64 << 10} {
+		b.Run(fmt.Sprintf("reference-elements=%d", length), func(b *testing.B) {
+			c, err := NewCollector(Config{Profile: ProfileTiny, TinyHeapBytes: 8 << 20, TinyBlockBytes: 16}, []TypeDesc{refs})
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(c.Close)
+			array, err := c.NewArrayDefault(0, length)
+			if err != nil {
+				b.Fatal(err)
+			}
+			root := Root(array)
+			roots := Slots{&root}
+			var steps uint64
+			var stepPauses pauseHistogram
+			b.ReportAllocs()
+			b.ReportMetric(float64(length), "reference-slots")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for {
+					start := time.Now()
+					if err := c.Step(roots); err != nil {
+						b.Fatal(err)
+					}
+					stepPauses.record(time.Since(start))
+					steps++
+					if c.tinyGC.state == tinyIdle {
+						break
+					}
+				}
+			}
+			b.StopTimer()
+			if c.Stats().LiveObjects != 1 {
+				b.Fatalf("live objects = %d, want 1", c.Stats().LiveObjects)
+			}
+			b.ReportMetric(float64(steps)/float64(b.N), "steps/op")
+			stepPauses.report(b, "step")
+		})
+	}
+}

--- a/src/core/runtime/gc/matrix_bench_test.go
+++ b/src/core/runtime/gc/matrix_bench_test.go
@@ -7,22 +7,56 @@ import (
 	"time"
 )
 
-// pauseHistogram is a bounded, allocation-free log2 nanosecond histogram. It
-// deliberately trades sub-bucket precision for stable memory use across long
-// benchmark runs. The reported percentile is the upper bound of its bucket.
+const pauseSubBuckets = 16
+
+// pauseHistogram is a bounded, allocation-free nanosecond histogram with 16
+// linear sub-buckets per power-of-two interval. Its relative bucket width is at
+// most 6.25%, while memory remains fixed across arbitrarily long benchmark runs.
+// The reported percentile is the upper bound of its bucket.
 type pauseHistogram struct {
-	buckets [64]uint64
+	buckets [1 + 63*pauseSubBuckets]uint64
 	count   uint64
 	maxNS   uint64
 }
 
 func (h *pauseHistogram) record(d time.Duration) {
 	ns := uint64(d)
-	h.buckets[bits.Len64(ns)]++
+	h.buckets[pauseBucket(ns)]++
 	h.count++
 	if ns > h.maxNS {
 		h.maxNS = ns
 	}
+}
+
+func pauseBucket(ns uint64) int {
+	if ns == 0 {
+		return 0
+	}
+	exponent := bits.Len64(ns) - 1
+	base := uint64(1) << exponent
+	width := base / pauseSubBuckets
+	if width == 0 {
+		width = 1
+	}
+	sub := int((ns - base) / width)
+	if sub >= pauseSubBuckets {
+		sub = pauseSubBuckets - 1
+	}
+	return 1 + exponent*pauseSubBuckets + sub
+}
+
+func pauseBucketUpper(index int) uint64 {
+	if index == 0 {
+		return 0
+	}
+	index--
+	exponent, sub := index/pauseSubBuckets, index%pauseSubBuckets
+	base := uint64(1) << exponent
+	width := base / pauseSubBuckets
+	if width == 0 {
+		width = 1
+	}
+	return base + uint64(sub+1)*width - 1
 }
 
 func (h *pauseHistogram) percentile(numerator, denominator uint64) uint64 {
@@ -34,10 +68,7 @@ func (h *pauseHistogram) percentile(numerator, denominator uint64) uint64 {
 	for i, n := range h.buckets {
 		seen += n
 		if seen >= target {
-			if i == 0 {
-				return 0
-			}
-			upper := (uint64(1) << i) - 1
+			upper := pauseBucketUpper(i)
 			if upper > h.maxNS {
 				return h.maxNS
 			}
@@ -60,11 +91,11 @@ func TestGCPauseHistogram(t *testing.T) {
 	for _, ns := range []time.Duration{0, 1, 2, 3, 4, 8, 16, 32, 64, 128} {
 		h.record(ns * time.Nanosecond)
 	}
-	if got := h.percentile(50, 100); got != 7 {
-		t.Fatalf("p50 = %d ns, want bucket upper bound 7", got)
+	if got := h.percentile(50, 100); got != 4 {
+		t.Fatalf("p50 = %d ns, want bucket upper bound 4", got)
 	}
-	if got := h.percentile(90, 100); got != 127 {
-		t.Fatalf("p90 = %d ns, want bucket upper bound 127", got)
+	if got := h.percentile(90, 100); got != 67 {
+		t.Fatalf("p90 = %d ns, want bucket upper bound 67", got)
 	}
 	if got := h.percentile(99, 100); got != 128 {
 		t.Fatalf("p99 = %d ns, want bucket upper bound 128", got)
@@ -72,6 +103,58 @@ func TestGCPauseHistogram(t *testing.T) {
 	if h.maxNS != 128 || h.count != 10 {
 		t.Fatalf("histogram max/count = %d/%d, want 128/10", h.maxNS, h.count)
 	}
+}
+
+func populateGCMatrixObject(c *Collector, layout gcMatrixLayout, r Ref) error {
+	d := c.types[c.typeIndex[layout.typeID]]
+	if !d.HasRefs {
+		return nil
+	}
+	if d.Kind == KindStruct {
+		for i, field := range d.Fields {
+			if isCollectorRefKind(field.Kind) {
+				if err := c.StructSet(r, uint32(i), RefValue(r)); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	for i := uint32(0); i < c.header(r).Aux; i++ {
+		if err := c.ArraySet(r, i, RefValue(r)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateGCMatrixObject(c *Collector, layout gcMatrixLayout, r Ref) (uint64, error) {
+	d := c.types[c.typeIndex[layout.typeID]]
+	if !d.HasRefs {
+		return uint64(layout.typeID) + 1, nil
+	}
+	var checksum uint64
+	if d.Kind == KindStruct {
+		for i, field := range d.Fields {
+			if !isCollectorRefKind(field.Kind) {
+				continue
+			}
+			v, err := c.StructGet(r, uint32(i))
+			if err != nil || v.Ref != r {
+				return 0, fmt.Errorf("self reference field %d = %v, %v; want %v", i, v.Ref, err, r)
+			}
+			checksum += uint64(v.Ref)
+		}
+		return checksum, nil
+	}
+	for i := uint32(0); i < c.header(r).Aux; i++ {
+		v, err := c.ArrayGet(r, i)
+		if err != nil || v.Ref != r {
+			return 0, fmt.Errorf("self reference element %d = %v, %v; want %v", i, v.Ref, err, r)
+		}
+		checksum += uint64(v.Ref)
+	}
+	return checksum, nil
 }
 
 type gcMatrixLayout struct {
@@ -169,6 +252,9 @@ func BenchmarkGCCollectionMatrix(b *testing.B) {
 							if err != nil {
 								b.Fatal(err)
 							}
+							if err := populateGCMatrixObject(c, layout, r); err != nil {
+								b.Fatal(err)
+							}
 							if j < survival {
 								rootValues[j] = Root(r)
 							}
@@ -180,8 +266,9 @@ func BenchmarkGCCollectionMatrix(b *testing.B) {
 						} else {
 							err = c.CollectFull(roots)
 						}
-						pauses.record(time.Since(start))
+						elapsed := time.Since(start)
 						b.StopTimer()
+						pauses.record(elapsed)
 						if err != nil {
 							b.Fatal(err)
 						}
@@ -193,7 +280,11 @@ func BenchmarkGCCollectionMatrix(b *testing.B) {
 							if err != nil || typeID != layout.typeID {
 								b.Fatalf("survivor type = %d, %v; want %d", typeID, err, layout.typeID)
 							}
-							checksum += uint64(typeID) + uint64(j) + 1
+							objectChecksum, err := validateGCMatrixObject(c, layout, Ref(rootValues[j]))
+							if err != nil {
+								b.Fatal(err)
+							}
+							checksum += objectChecksum + uint64(typeID) + uint64(j) + 1
 							rootValues[j] = Root(Null())
 						}
 						if err := c.CollectFull(nil); err != nil {
@@ -268,8 +359,9 @@ func BenchmarkGCSparseRememberedArray(b *testing.B) {
 					b.StartTimer()
 					start := time.Now()
 					err = c.CollectMinor(roots)
-					pauses.record(time.Since(start))
+					elapsed := time.Since(start)
 					b.StopTimer()
+					pauses.record(elapsed)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -357,8 +449,11 @@ func BenchmarkGCRootClassMatrix(b *testing.B) {
 						if err := c.CollectFull(roots); err != nil {
 							b.Fatal(err)
 						}
-						pauses.record(time.Since(start))
+						elapsed := time.Since(start)
+						b.StopTimer()
+						pauses.record(elapsed)
 						checksum += uint64(c.Stats().LiveObjects)
+						b.StartTimer()
 					}
 					b.StopTimer()
 					if checksum != uint64(b.N) {
@@ -403,9 +498,13 @@ func BenchmarkGCTinyStepMatrix(b *testing.B) {
 					if err := c.Step(roots); err != nil {
 						b.Fatal(err)
 					}
-					stepPauses.record(time.Since(start))
+					elapsed := time.Since(start)
+					b.StopTimer()
+					stepPauses.record(elapsed)
 					steps++
-					if c.tinyGC.state == tinyIdle {
+					idle := c.tinyGC.state == tinyIdle
+					b.StartTimer()
+					if idle {
 						break
 					}
 				}
@@ -417,5 +516,181 @@ func BenchmarkGCTinyStepMatrix(b *testing.B) {
 			b.ReportMetric(float64(steps)/float64(b.N), "steps/op")
 			stepPauses.report(b, "step")
 		})
+	}
+}
+
+func TestGCMatrixWorkloadSmoke(t *testing.T) {
+	types, layouts := gcMatrixTypes(t)
+	collections := []struct {
+		name       string
+		profile    Profile
+		collection string
+	}{
+		{name: "throughput-minor", profile: ProfileThroughput, collection: "minor"},
+		{name: "throughput-full", profile: ProfileThroughput, collection: "full"},
+		{name: "tiny-full", profile: ProfileTiny, collection: "full"},
+	}
+	for _, collection := range collections {
+		for _, layout := range layouts {
+			t.Run(collection.name+"/"+layout.name, func(t *testing.T) {
+				c, err := NewCollector(gcMatrixConfig(collection.profile), types)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer c.Close()
+				var root Root
+				for i := 0; i < 10; i++ {
+					r, err := layout.alloc(c)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := populateGCMatrixObject(c, layout, r); err != nil {
+						t.Fatal(err)
+					}
+					if i == 0 {
+						root = Root(r)
+					}
+				}
+				roots := Slots{&root}
+				if collection.collection == "minor" {
+					err = c.CollectMinor(roots)
+				} else {
+					err = c.CollectFull(roots)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := c.Stats().LiveObjects; got != 1 {
+					t.Fatalf("live objects = %d, want 1", got)
+				}
+				if _, err := validateGCMatrixObject(c, layout, Ref(root)); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
+	}
+}
+
+func TestGCSparseRememberedArrayWorkloadSmoke(t *testing.T) {
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs, err := NewArrayDesc(1, StorageRefNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		length uint32
+		writes int
+	}{{length: 256 << 10, writes: 2}, {length: 4 << 10, writes: 1024}} {
+		t.Run(fmt.Sprintf("elements=%d/writes=%d", tc.length, tc.writes), func(t *testing.T) {
+			c, err := NewCollector(Config{NurseryBytes: 1 << 20, ThroughputHeapBytes: 64 << 20}, []TypeDesc{leaf, refs})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			array, err := c.NewArrayDefault(1, tc.length)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := c.ForcePromote(array); err != nil {
+				t.Fatal(err)
+			}
+			root := Root(array)
+			for i := 0; i < tc.writes; i++ {
+				child, err := c.NewStructDefault(0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				index := uint32(uint64(i) * uint64(tc.length-1) / uint64(max(1, tc.writes-1)))
+				if err := c.ArraySet(array, index, RefValue(child)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := c.CollectMinor(Slots{&root}); err != nil {
+				t.Fatal(err)
+			}
+			if got := c.Stats().LiveObjects; got != uint32(tc.writes+1) {
+				t.Fatalf("live objects = %d, want %d", got, tc.writes+1)
+			}
+		})
+	}
+}
+
+func TestGCRootClassWorkloadSmoke(t *testing.T) {
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, profile := range []Profile{ProfileThroughput, ProfileTiny} {
+		for _, rootClass := range []string{"direct", "global", "table"} {
+			t.Run(fmt.Sprintf("profile=%d/%s", profile, rootClass), func(t *testing.T) {
+				c, err := NewCollector(gcMatrixConfig(profile), []TypeDesc{leaf})
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer c.Close()
+				object, err := c.NewStructDefault(0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var roots RootSet
+				switch rootClass {
+				case "direct":
+					values := make([]Root, 64)
+					slots := make(Slots, len(values))
+					for i := range values {
+						values[i], slots[i] = Root(object), &values[i]
+					}
+					roots = slots
+				case "global":
+					for i := 0; i < 64; i++ {
+						c.NewGlobalSlot(object)
+					}
+				case "table":
+					for i := 0; i < 64; i++ {
+						c.NewTableSlot(object)
+					}
+				}
+				if err := c.CollectFull(roots); err != nil {
+					t.Fatal(err)
+				}
+				if got := c.Stats().LiveObjects; got != 1 {
+					t.Fatalf("live objects = %d, want 1", got)
+				}
+			})
+		}
+	}
+}
+
+func TestGCTinyStepWorkloadSmoke(t *testing.T) {
+	refs, err := NewArrayDesc(0, StorageRefNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewCollector(Config{Profile: ProfileTiny, TinyHeapBytes: 8 << 20, TinyBlockBytes: 16}, []TypeDesc{refs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	array, err := c.NewArrayDefault(0, 64<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := Root(array)
+	for steps := 0; ; steps++ {
+		if steps > len(c.handles)+8 {
+			t.Fatal("Tiny cycle did not finish within bounded state/handle steps")
+		}
+		if err := c.Step(Slots{&root}); err != nil {
+			t.Fatal(err)
+		}
+		if c.tinyGC.state == tinyIdle {
+			break
+		}
+	}
+	if got := c.Stats().LiveObjects; got != 1 {
+		t.Fatalf("live objects = %d, want 1", got)
 	}
 }


### PR DESCRIPTION
## Summary

- add 85 roadmap-aligned benchmark cases for Wago's Throughput and Tiny collectors
- cross collection mode, survival ratio, pointer density, root class, remembered-array density, and Tiny reference-slot count
- report bounded p50, p90, p95, p99, and maximum pause/step distributions with fixed-memory, 16-sub-bucket resolution
- populate and verify non-null traced edges, and require semantic live-count, object-type, remembered-set, and graph checks
- add ordinary smoke tests for every benchmark family and document cheap exact-case validation
- document deterministic versus host-specific metrics, controlled-run procedures, hardware counters, and the future #302–#321 measurement ledger

## Why

Issue #300 requires decision-grade collector evidence before Wago changes promotion, cards, old-space layout, Tiny pacing, or concurrency. Existing benchmarks cover useful individual paths, but they do not provide one consistent matrix across survival, topology, root shape, sparse remembered sets, and incremental step size.

The matrix keeps collector microbenchmarks separate from runtime/JIT/product fixtures so results do not accidentally mix collection pauses with compilation, native code generation, or executable mapping. Allocation, validation, checksumming, and pause-histogram bookkeeping are outside the benchmark timer.

## Matrix

- Throughput minor, Throughput full, and Tiny full
- 0%, 1%, 10%, 50%, and 90% survival
- pointer-free, sparse-reference struct, dense-reference struct, and dense-reference array layouts
- direct, global, and table roots at 1, 64, and 4,096 roots
- 4K and 256K-element old arrays with two distant or 1,024 distributed young writes
- Tiny incremental scanning at 16, 4K, and 64K reference slots

## Validation

- `go test ./src/core/runtime/gc -run '^(TestGCPauseHistogram|TestGCMatrixWorkloadSmoke|TestGCSparseRememberedArrayWorkloadSmoke|TestGCRootClassWorkloadSmoke|TestGCTinyStepWorkloadSmoke)$'`
- `go test ./src/core/runtime/... -run '^Test'`
- `go vet ./src/core/runtime/gc`
- four exact representative sub-benchmarks, each with `-benchtime=2x -count=1`

The full benchmark suite was not run. The bounded invocations validated collection, sparse remembered arrays, root scanning, and Tiny stepping without an adaptive or full-matrix run.

This is the first atomic slice of #300. Production phase telemetry, four-domain memory accounting, and JIT/product attribution remain follow-up slices defined by the new measurement contract.
