### PR TITLE
gc: make successful minor cleanup nursery-bounded

### DIFF
--- a/src/core/runtime/gc/barrier.go
+++ b/src/core/runtime/gc/barrier.go
@@ -265,6 +265,19 @@ func (c *Collector) pruneRemembered() {
 	clear(c.remembered[len(out):])
 	c.remembered = out
 }
+
+// clearRememberedMetadata is valid after complete nursery evacuation: without
+// nursery objects, no old-to-nursery edge can remain. It clears the dense-list
+// metadata without rescanning the payload of every remembered parent.
+func (c *Collector) clearRememberedMetadata() {
+	for _, h := range c.remembered {
+		if h != 0 && int(h) < len(c.handles) {
+			c.handles[h].remembered = false
+		}
+	}
+	clear(c.remembered)
+	c.remembered = c.remembered[:0]
+}
 func (c *Collector) isNurseryRef(r Ref) bool {
 	if !r.IsObj() || !c.validObjectRef(r) {
 		return false

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -96,15 +96,6 @@ func (c *Collector) sweepAll() {
 	c.compactNurseryHandles()
 	c.compactNurseryBump()
 }
-func (c *Collector) sweepNurseryDead() {
-	for _, h := range c.nurseryHandles {
-		if h != 0 && int(h) < len(c.handles) && c.handles[h].space == spaceNursery && !c.mark[h] {
-			c.free(h)
-		}
-	}
-	c.compactNurseryHandles()
-	c.compactNurseryBump()
-}
 
 // finishMinorEvacuation commits the destructive half of a successful minor
 // collection. promoteMarkedNursery has moved every live nursery object before

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -54,6 +54,11 @@ func (c *Collector) CollectMinor(roots RootSet) error {
 	// by the remembered set, while global/table slots are scanned as roots.
 	c.clearNurseryMarks()
 	c.markNurseryRoots(roots)
+	if c.cfg.VerifyAfterCollect {
+		if err := c.verifyRememberedShadow(); err != nil {
+			return err
+		}
+	}
 	for _, h := range c.remembered {
 		if int(h) < len(c.handles) && (c.handles[h].space == spaceOld || c.handles[h].space == spaceLarge) {
 			c.stats.MinorRememberedScanned++
@@ -66,6 +71,11 @@ func (c *Collector) CollectMinor(roots RootSet) error {
 	}
 	c.finishMinorEvacuation()
 	c.clearCardMetadata() // cards are verification scaffolding, not collection inputs
+	if c.cfg.VerifyAfterCollect {
+		if err := c.verifyNurseryEvacuated(); err != nil {
+			return err
+		}
+	}
 	if c.cfg.ForceMajorEveryMinor {
 		if err := c.CollectFull(roots); err != nil {
 			return err

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -64,8 +64,7 @@ func (c *Collector) CollectMinor(roots RootSet) error {
 	if err := c.promoteMarkedNursery(); err != nil {
 		return err
 	}
-	c.sweepNurseryDead()
-	c.pruneRemembered()
+	c.finishMinorEvacuation()
 	c.clearCardMetadata() // cards are verification scaffolding, not collection inputs
 	if c.cfg.ForceMajorEveryMinor {
 		if err := c.CollectFull(roots); err != nil {
@@ -94,6 +93,25 @@ func (c *Collector) sweepNurseryDead() {
 	}
 	c.compactNurseryHandles()
 	c.compactNurseryBump()
+}
+
+// finishMinorEvacuation commits the destructive half of a successful minor
+// collection. promoteMarkedNursery has moved every live nursery object before
+// this is called, so every handle still pointing into the nursery is dead.
+func (c *Collector) finishMinorEvacuation() {
+	for _, h := range c.nurseryHandles {
+		if h == 0 || int(h) >= len(c.handles) {
+			continue
+		}
+		c.mark[h] = false
+		if c.handles[h].space == spaceNursery {
+			c.free(h)
+		}
+	}
+	clear(c.nurseryHandles)
+	c.nurseryHandles = c.nurseryHandles[:0]
+	c.nurseryBump = 0
+	c.clearRememberedMetadata()
 }
 
 type plannedPromotion struct {

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -65,9 +65,10 @@ func (c *Collector) CollectMinor(roots RootSet) error {
 			c.scanObjectRefs(h, c.markNurseryRef)
 		}
 	}
-	c.drainNurseryMarkStack()
-	if err := c.promoteMarkedNursery(); err != nil {
-		return err
+	if survivors := c.drainNurseryMarkStack(); survivors != 0 {
+		if err := c.promoteMarkedNursery(); err != nil {
+			return err
+		}
 	}
 	c.finishMinorEvacuation()
 	c.clearCardMetadata() // cards are verification scaffolding, not collection inputs

--- a/src/core/runtime/gc/invariant_test.go
+++ b/src/core/runtime/gc/invariant_test.go
@@ -1,6 +1,9 @@
 package gc
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func nonNullTypes(t *testing.T) []TypeDesc {
 	t.Helper()
@@ -350,6 +353,64 @@ func TestVerifyRejectsInvalidCardMetadata(t *testing.T) {
 	c.slotCards = []slotCard{{kind: SlotTable, index: 0}}
 	if err := c.Verify(nil); err == nil {
 		t.Fatal("Verify accepted out-of-range table slot card")
+	}
+}
+
+func TestRememberedShadowVerifierRejectsMissingOldToNurseryEdge(t *testing.T) {
+	c := newTestCollector(t, Config{})
+	parent, err := c.NewStructDefault(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ForcePromote(parent); err != nil {
+		t.Fatal(err)
+	}
+	child, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.StructSet(parent, 0, RefValue(child)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Verify(nil); err != nil {
+		t.Fatalf("valid remembered edge failed verification: %v", err)
+	}
+
+	h := handleOf(parent)
+	c.handles[h].remembered = false
+	clear(c.remembered)
+	c.remembered = c.remembered[:0]
+	if err := c.Verify(nil); err == nil || !strings.Contains(err.Error(), "shadow verifier found unremembered") {
+		t.Fatalf("Verify error = %v, want missing remembered-edge error", err)
+	}
+}
+
+func TestCollectMinorRunsRememberedShadowBeforeEvacuation(t *testing.T) {
+	c := newTestCollector(t, Config{VerifyAfterCollect: true})
+	parent, err := c.NewStructDefault(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ForcePromote(parent); err != nil {
+		t.Fatal(err)
+	}
+	child, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.StructSet(parent, 0, RefValue(child)); err != nil {
+		t.Fatal(err)
+	}
+	h := handleOf(parent)
+	c.handles[h].remembered = false
+	clear(c.remembered)
+	c.remembered = c.remembered[:0]
+	root := Root(parent)
+	if err := c.CollectMinor(Slots{&root}); err == nil || !strings.Contains(err.Error(), "shadow verifier found unremembered") {
+		t.Fatalf("CollectMinor error = %v, want pre-evacuation shadow error", err)
+	}
+	if c.entry(child).space != spaceNursery {
+		t.Fatalf("failed verification changed child space to %v, want nursery", c.entry(child).space)
 	}
 }
 

--- a/src/core/runtime/gc/invariant_test.go
+++ b/src/core/runtime/gc/invariant_test.go
@@ -401,13 +401,11 @@ func TestCollectMinorRunsRememberedShadowBeforeEvacuation(t *testing.T) {
 	if err := c.StructSet(parent, 0, RefValue(child)); err != nil {
 		t.Fatal(err)
 	}
-	h := handleOf(parent)
-	c.handles[h].remembered = false
 	clear(c.remembered)
 	c.remembered = c.remembered[:0]
 	root := Root(parent)
-	if err := c.CollectMinor(Slots{&root}); err == nil || !strings.Contains(err.Error(), "shadow verifier found unremembered") {
-		t.Fatalf("CollectMinor error = %v, want pre-evacuation shadow error", err)
+	if err := c.CollectMinor(Slots{&root}); err == nil || !strings.Contains(err.Error(), "remembered bit/list mismatch") {
+		t.Fatalf("CollectMinor error = %v, want pre-evacuation remembered-list error", err)
 	}
 	if c.entry(child).space != spaceNursery {
 		t.Fatalf("failed verification changed child space to %v, want nursery", c.entry(child).space)

--- a/src/core/runtime/gc/invariant_test.go
+++ b/src/core/runtime/gc/invariant_test.go
@@ -412,6 +412,18 @@ func TestCollectMinorRunsRememberedShadowBeforeEvacuation(t *testing.T) {
 	}
 }
 
+func TestVerifyTinyRetainsRememberedMetadataChecks(t *testing.T) {
+	c := newTinyTestCollector(t, Config{})
+	r, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.handles[handleOf(r)].remembered = true
+	if err := c.Verify(nil); err == nil || !strings.Contains(err.Error(), "remembered bit/list mismatch") {
+		t.Fatalf("Verify error = %v, want Tiny remembered bit/list mismatch", err)
+	}
+}
+
 func TestRememberedCardMetadataIsBoundedAndPruned(t *testing.T) {
 	t.Run("throughput", func(t *testing.T) {
 		c := newTestCollector(t, Config{})

--- a/src/core/runtime/gc/mark.go
+++ b/src/core/runtime/gc/mark.go
@@ -78,14 +78,17 @@ func (c *Collector) markNurseryRoots(roots RootSet) {
 	}
 }
 
-func (c *Collector) drainNurseryMarkStack() {
+func (c *Collector) drainNurseryMarkStack() uint64 {
+	var scanned uint64
 	for len(c.markStack) > 0 {
 		n := len(c.markStack) - 1
 		h := c.markStack[n]
 		c.markStack = c.markStack[:n]
 		c.stats.MinorObjectsScanned++
+		scanned++
 		c.scanObjectRefs(h, c.markNurseryRef)
 	}
+	return scanned
 }
 
 func (c *Collector) markNurseryRef(r Ref) {

--- a/src/core/runtime/gc/minor_nursery_test.go
+++ b/src/core/runtime/gc/minor_nursery_test.go
@@ -260,13 +260,12 @@ func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
 
 				b.ReportAllocs()
 				b.ResetTimer()
+				b.StopTimer()
 				for i := 0; i < b.N; i++ {
 					if i != 0 && i%1024 == 0 {
-						b.StopTimer()
 						if err := c.CollectFull(oldRoots); err != nil {
 							b.Fatal(err)
 						}
-						b.StartTimer()
 					}
 					for j := 0; j < nurseryObjects; j++ {
 						r, err := c.NewStructDefault(0)
@@ -277,9 +276,11 @@ func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
 							rootValues[j] = Root(r)
 						}
 					}
+					b.StartTimer()
 					if err := c.CollectMinor(roots); err != nil {
 						b.Fatal(err)
 					}
+					b.StopTimer()
 					for j := range rootValues {
 						rootValues[j] = Root(Null())
 					}
@@ -313,13 +314,12 @@ func BenchmarkMinorCollectionRememberedParentScaling(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
+			b.StopTimer()
 			for i := 0; i < b.N; i++ {
 				if i != 0 && i%1024 == 0 {
-					b.StopTimer()
 					if err := c.CollectFull(fullRoots); err != nil {
 						b.Fatal(err)
 					}
-					b.StartTimer()
 				}
 				child, err := c.NewStructDefault(0)
 				if err != nil {
@@ -328,9 +328,11 @@ func BenchmarkMinorCollectionRememberedParentScaling(b *testing.B) {
 				if err := c.ArraySet(parent, 0, RefValue(child)); err != nil {
 					b.Fatal(err)
 				}
+				b.StartTimer()
 				if err := c.CollectMinor(nil); err != nil {
 					b.Fatal(err)
 				}
+				b.StopTimer()
 				if err := c.ArraySet(parent, 0, RefValue(Null())); err != nil {
 					b.Fatal(err)
 				}

--- a/src/core/runtime/gc/minor_nursery_test.go
+++ b/src/core/runtime/gc/minor_nursery_test.go
@@ -148,6 +148,22 @@ func TestSuccessfulMinorCollectionWithNoSurvivorsRecyclesNursery(t *testing.T) {
 			t.Fatalf("dead handle %d state = space %v mark %v, want free/false", h, c.handles[h].space, c.mark[h])
 		}
 	}
+	beforeHandleCount := len(c.handles)
+	reused, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.handles) != beforeHandleCount {
+		t.Fatalf("reusing evacuated nursery handle grew table from %d to %d", beforeHandleCount, len(c.handles))
+	}
+	reusedHandle := handleOf(reused)
+	found := false
+	for _, h := range handles {
+		found = found || h == reusedHandle
+	}
+	if !found {
+		t.Fatalf("allocation used new handle %d instead of an evacuated handle", reusedHandle)
+	}
 }
 
 func minorBenchmarkTypes(b testing.TB) []TypeDesc {
@@ -217,12 +233,14 @@ func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				c, err := NewCollector(Config{
 					NurseryBytes:        1 << 20,
-					ThroughputHeapBytes: 256 << 20,
+					ThroughputHeapBytes: 16 << 20,
 				}, minorBenchmarkTypes(b))
 				if err != nil {
 					b.Fatal(err)
 				}
 				defer c.Close()
+				oldRootValues := make([]Root, oldCount)
+				oldRoots := make(Slots, oldCount)
 				for i := 0; i < oldCount; i++ {
 					old, err := c.NewStructDefault(0)
 					if err != nil {
@@ -231,6 +249,8 @@ func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
 					if err := c.ForcePromote(old); err != nil {
 						b.Fatal(err)
 					}
+					oldRootValues[i] = Root(old)
+					oldRoots[i] = &oldRootValues[i]
 				}
 				rootValues := make([]Root, survivors)
 				roots := make(Slots, survivors)
@@ -241,6 +261,13 @@ func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
+					if i != 0 && i%1024 == 0 {
+						b.StopTimer()
+						if err := c.CollectFull(oldRoots); err != nil {
+							b.Fatal(err)
+						}
+						b.StartTimer()
+					}
 					for j := 0; j < nurseryObjects; j++ {
 						r, err := c.NewStructDefault(0)
 						if err != nil {
@@ -259,5 +286,58 @@ func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
 				}
 			})
 		}
+	}
+}
+
+func BenchmarkMinorCollectionRememberedParentScaling(b *testing.B) {
+	for _, length := range []uint32{1, 1024, 16_384} {
+		b.Run(fmt.Sprintf("elements=%d", length), func(b *testing.B) {
+			c, err := NewCollector(Config{
+				NurseryBytes:        1 << 20,
+				ThroughputHeapBytes: 16 << 20,
+			}, minorBenchmarkTypes(b))
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer c.Close()
+			parent, err := c.NewArrayDefault(3, length)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := c.ForcePromote(parent); err != nil {
+				b.Fatal(err)
+			}
+			parentRoot := Root(parent)
+			fullRoots := Slots{&parentRoot}
+			before := c.Stats()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if i != 0 && i%1024 == 0 {
+					b.StopTimer()
+					if err := c.CollectFull(fullRoots); err != nil {
+						b.Fatal(err)
+					}
+					b.StartTimer()
+				}
+				child, err := c.NewStructDefault(0)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := c.ArraySet(parent, 0, RefValue(child)); err != nil {
+					b.Fatal(err)
+				}
+				if err := c.CollectMinor(nil); err != nil {
+					b.Fatal(err)
+				}
+				if err := c.ArraySet(parent, 0, RefValue(Null())); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			after := c.Stats()
+			b.ReportMetric(float64(after.MinorRememberedScanned-before.MinorRememberedScanned)/float64(b.N), "remembered-scans/op")
+		})
 	}
 }

--- a/src/core/runtime/gc/minor_nursery_test.go
+++ b/src/core/runtime/gc/minor_nursery_test.go
@@ -166,6 +166,23 @@ func TestSuccessfulMinorCollectionWithNoSurvivorsRecyclesNursery(t *testing.T) {
 	}
 }
 
+func TestMinorCollectionNoRootsNoSurvivorsDoesNotAllocate(t *testing.T) {
+	c := newTestCollector(t, Config{NurseryBytes: 1 << 20})
+	allocs := testing.AllocsPerRun(100, func() {
+		for i := 0; i < 64; i++ {
+			if _, err := c.NewStructDefault(0); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := c.CollectMinor(nil); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("no-root/no-survivor minor cycle allocations = %v, want 0", allocs)
+	}
+}
+
 func minorBenchmarkTypes(b testing.TB) []TypeDesc {
 	b.Helper()
 	pf, err := NewStructDesc(0, []StorageKind{StorageI32, StorageI64})
@@ -203,6 +220,9 @@ func BenchmarkMinorCollectionOldGraphScaling(b *testing.B) {
 				if err := c.ForcePromote(old); err != nil {
 					b.Fatal(err)
 				}
+			}
+			if err := c.CollectMinor(nil); err != nil {
+				b.Fatal(err)
 			}
 			before := c.Stats()
 			b.ReportAllocs()
@@ -252,10 +272,17 @@ func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
 					oldRootValues[i] = Root(old)
 					oldRoots[i] = &oldRootValues[i]
 				}
+				if err := c.CollectMinor(nil); err != nil {
+					b.Fatal(err)
+				}
 				rootValues := make([]Root, survivors)
 				roots := make(Slots, survivors)
 				for i := range roots {
 					roots[i] = &rootValues[i]
+				}
+				var collectionRoots RootSet
+				if survivors != 0 {
+					collectionRoots = roots
 				}
 
 				b.ReportAllocs()
@@ -277,7 +304,7 @@ func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
 						}
 					}
 					b.StartTimer()
-					if err := c.CollectMinor(roots); err != nil {
+					if err := c.CollectMinor(collectionRoots); err != nil {
 						b.Fatal(err)
 					}
 					b.StopTimer()
@@ -306,6 +333,9 @@ func BenchmarkMinorCollectionRememberedParentScaling(b *testing.B) {
 				b.Fatal(err)
 			}
 			if err := c.ForcePromote(parent); err != nil {
+				b.Fatal(err)
+			}
+			if err := c.CollectMinor(nil); err != nil {
 				b.Fatal(err)
 			}
 			parentRoot := Root(parent)

--- a/src/core/runtime/gc/minor_nursery_test.go
+++ b/src/core/runtime/gc/minor_nursery_test.go
@@ -79,6 +79,77 @@ func TestMinorCollectionScansNurseryNotOldLiveGraph(t *testing.T) {
 	}
 }
 
+func TestSuccessfulMinorCollectionResetsEvacuatedNurseryMetadata(t *testing.T) {
+	c := newTestCollector(t, Config{PoisonFreed: true, VerifyAfterCollect: true})
+	parent, err := c.NewArrayDefault(3, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ForcePromote(parent); err != nil {
+		t.Fatal(err)
+	}
+	child, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dead, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadHandle := handleOf(dead)
+	if err := c.ArraySet(parent, 0, RefValue(child)); err != nil {
+		t.Fatal(err)
+	}
+	if c.RememberedCount() != 1 || c.CardCount() != 1 {
+		t.Fatalf("pre-collection remembered/cards = %d/%d, want 1/1", c.RememberedCount(), c.CardCount())
+	}
+
+	if err := c.CollectMinor(nil); err != nil {
+		t.Fatal(err)
+	}
+	if c.nurseryBump != 0 || len(c.nurseryHandles) != 0 {
+		t.Fatalf("evacuated nursery bump/handles = %d/%d, want 0/0", c.nurseryBump, len(c.nurseryHandles))
+	}
+	if c.RememberedCount() != 0 || c.CardCount() != 0 || c.handles[handleOf(parent)].remembered {
+		t.Fatalf("post-collection remembered/cards/bit = %d/%d/%v, want 0/0/false", c.RememberedCount(), c.CardCount(), c.handles[handleOf(parent)].remembered)
+	}
+	if got := c.handles[handleOf(child)].space; got != spaceOld {
+		t.Fatalf("survivor space = %v, want old", got)
+	}
+	if got := c.handles[deadHandle].space; got != spaceFree {
+		t.Fatalf("dead nursery space = %v, want free", got)
+	}
+	for h, e := range c.handles {
+		if e.space == spaceNursery {
+			t.Fatalf("handle %d remains in nursery", h)
+		}
+	}
+}
+
+func TestSuccessfulMinorCollectionWithNoSurvivorsRecyclesNursery(t *testing.T) {
+	c := newTestCollector(t, Config{PoisonFreed: true, VerifyAfterCollect: true})
+	const count = 128
+	handles := make([]uint32, 0, count)
+	for i := 0; i < count; i++ {
+		r, err := c.NewStructDefault(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handles = append(handles, handleOf(r))
+	}
+	if err := c.CollectMinor(nil); err != nil {
+		t.Fatal(err)
+	}
+	if c.nurseryBump != 0 || len(c.nurseryHandles) != 0 || len(c.promotionScratch) != 0 {
+		t.Fatalf("post-collection bump/handles/plans = %d/%d/%d, want 0/0/0", c.nurseryBump, len(c.nurseryHandles), len(c.promotionScratch))
+	}
+	for _, h := range handles {
+		if c.handles[h].space != spaceFree || c.mark[h] {
+			t.Fatalf("dead handle %d state = space %v mark %v, want free/false", h, c.handles[h].space, c.mark[h])
+		}
+	}
+}
+
 func minorBenchmarkTypes(b testing.TB) []TypeDesc {
 	b.Helper()
 	pf, err := NewStructDesc(0, []StorageKind{StorageI32, StorageI64})
@@ -135,5 +206,58 @@ func BenchmarkMinorCollectionOldGraphScaling(b *testing.B) {
 			b.ReportMetric(float64(after.MinorObjectsScanned-before.MinorObjectsScanned)/float64(b.N), "nursery-scans/op")
 			b.ReportMetric(float64(after.MinorRememberedScanned-before.MinorRememberedScanned)/float64(b.N), "remembered-scans/op")
 		})
+	}
+}
+
+func BenchmarkMinorCollectionCleanupScaling(b *testing.B) {
+	const nurseryObjects = 64
+	for _, oldCount := range []int{0, 10_000} {
+		for _, survivors := range []int{0, 1, 6} {
+			name := fmt.Sprintf("old=%d/survivors=%d-of-%d", oldCount, survivors, nurseryObjects)
+			b.Run(name, func(b *testing.B) {
+				c, err := NewCollector(Config{
+					NurseryBytes:        1 << 20,
+					ThroughputHeapBytes: 256 << 20,
+				}, minorBenchmarkTypes(b))
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer c.Close()
+				for i := 0; i < oldCount; i++ {
+					old, err := c.NewStructDefault(0)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if err := c.ForcePromote(old); err != nil {
+						b.Fatal(err)
+					}
+				}
+				rootValues := make([]Root, survivors)
+				roots := make(Slots, survivors)
+				for i := range roots {
+					roots[i] = &rootValues[i]
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					for j := 0; j < nurseryObjects; j++ {
+						r, err := c.NewStructDefault(0)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if j < survivors {
+							rootValues[j] = Root(r)
+						}
+					}
+					if err := c.CollectMinor(roots); err != nil {
+						b.Fatal(err)
+					}
+					for j := range rootValues {
+						rootValues[j] = Root(Null())
+					}
+				}
+			})
+		}
 	}
 }

--- a/src/core/runtime/gc/promotion_failure_test.go
+++ b/src/core/runtime/gc/promotion_failure_test.go
@@ -2,6 +2,8 @@ package gc
 
 import (
 	"errors"
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -69,15 +71,45 @@ func TestCollectMinorPromotionFailureLeavesNurserySurvivorsUnmoved(t *testing.T)
 		}
 		roots = append(roots, Root(r))
 	}
+	parent, err := c.NewArrayDefault(3, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ForcePromote(parent); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ArraySet(parent, 0, RefValue(Ref(roots[0]))); err != nil {
+		t.Fatal(err)
+	}
+	global := c.NewGlobalSlot(Null())
+	if err := c.SetGlobalSlot(global, Ref(roots[1])); err != nil {
+		t.Fatal(err)
+	}
 	slots := stressRootSlots(roots)
 	bumpBefore := c.nurseryBump
+	handlesBefore := slices.Clone(c.handles)
+	nurseryHandlesBefore := slices.Clone(c.nurseryHandles)
+	rememberedBefore := slices.Clone(c.remembered)
+	objectCardsBefore := slices.Clone(c.objectCards)
+	slotCardsBefore := slices.Clone(c.slotCards)
+	slotCardSlotBefore := maps.Clone(c.slotCardSlot)
 
-	err := c.CollectMinor(slots)
+	err = c.CollectMinor(slots)
 	if err == nil || !strings.Contains(err.Error(), "throughput heap exhausted") {
 		t.Fatalf("CollectMinor error = %v, want throughput exhaustion", err)
 	}
 	if c.nurseryBump != bumpBefore {
 		t.Fatalf("nursery bump changed after failed promotion: got %d want %d", c.nurseryBump, bumpBefore)
+	}
+	if !slices.Equal(c.handles, handlesBefore) {
+		t.Fatal("handle metadata changed after failed promotion")
+	}
+	if !slices.Equal(c.nurseryHandles, nurseryHandlesBefore) {
+		t.Fatal("nursery handle set changed after failed promotion")
+	}
+	if !slices.Equal(c.remembered, rememberedBefore) || !slices.Equal(c.objectCards, objectCardsBefore) ||
+		!slices.Equal(c.slotCards, slotCardsBefore) || !maps.Equal(c.slotCardSlot, slotCardSlotBefore) {
+		t.Fatal("remembered or card metadata changed after failed promotion")
 	}
 	if len(c.promotionScratch) != 0 || cap(c.promotionScratch) == 0 {
 		t.Fatalf("promotion scratch after rollback len/cap=%d/%d", len(c.promotionScratch), cap(c.promotionScratch))
@@ -103,6 +135,12 @@ func TestCollectMinorPromotionFailureLeavesNurserySurvivorsUnmoved(t *testing.T)
 		if err := c.StructSet(Ref(root), 0, RefValue(Null())); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := c.ArraySet(parent, 0, RefValue(Null())); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.SetGlobalSlot(global, Null()); err != nil {
+		t.Fatal(err)
 	}
 	for i := 1; i < len(roots); i++ {
 		roots[i] = Root(Null())

--- a/src/core/runtime/gc/verify.go
+++ b/src/core/runtime/gc/verify.go
@@ -97,8 +97,52 @@ func (c *Collector) Verify(roots RootSet) error {
 			return fmt.Errorf("gc: handle %d remembered bit/list mismatch", h)
 		}
 	}
+	if err := c.verifyRememberedShadow(); err != nil {
+		return err
+	}
 	if err := c.verifyCardMetadata(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// verifyRememberedShadow independently reconstructs the old-to-nursery parent
+// set from heap contents. Remembered metadata may conservatively retain parents
+// whose young edges were overwritten, so verification requires completeness
+// rather than exact equality between collections.
+func (c *Collector) verifyRememberedShadow() error {
+	if c.cfg.Profile != ProfileThroughput {
+		return nil
+	}
+	for h := uint32(1); int(h) < len(c.handles); h++ {
+		sp := c.handles[h].space
+		if sp != spaceOld && sp != spaceLarge {
+			continue
+		}
+		containsNursery := false
+		c.scanObjectRefs(h, func(child Ref) {
+			if !containsNursery && c.isNurseryRef(child) {
+				containsNursery = true
+			}
+		})
+		if containsNursery && !c.handles[h].remembered {
+			return fmt.Errorf("gc: shadow verifier found unremembered old-to-nursery edge from handle %d", h)
+		}
+	}
+	return nil
+}
+
+// verifyNurseryEvacuated is the expensive assertion for successful throughput
+// minor collections. It deliberately scans all handles only in verification
+// mode; the release cleanup path remains nursery-bounded.
+func (c *Collector) verifyNurseryEvacuated() error {
+	for h := uint32(1); int(h) < len(c.handles); h++ {
+		if c.handles[h].space == spaceNursery {
+			return fmt.Errorf("gc: handle %d remained in nursery after successful evacuation", h)
+		}
+	}
+	if c.nurseryBump != 0 || len(c.nurseryHandles) != 0 {
+		return fmt.Errorf("gc: evacuated nursery retained bump=%d handles=%d", c.nurseryBump, len(c.nurseryHandles))
 	}
 	return nil
 }

--- a/src/core/runtime/gc/verify.go
+++ b/src/core/runtime/gc/verify.go
@@ -82,21 +82,6 @@ func (c *Collector) Verify(roots RootSet) error {
 			return errors.New("gc: invalid table ref")
 		}
 	}
-	seenRemembered := make([]bool, len(c.handles))
-	for _, h := range c.remembered {
-		if h == 0 || !slotIndexOK(h, len(c.handles)) || c.handles[h].space == spaceFree || !c.handles[h].remembered {
-			return fmt.Errorf("gc: invalid remembered handle %d", h)
-		}
-		if seenRemembered[h] {
-			return fmt.Errorf("gc: duplicate remembered handle %d", h)
-		}
-		seenRemembered[h] = true
-	}
-	for h := uint32(1); int(h) < len(c.handles); h++ {
-		if c.handles[h].remembered != seenRemembered[h] {
-			return fmt.Errorf("gc: handle %d remembered bit/list mismatch", h)
-		}
-	}
 	if err := c.verifyRememberedShadow(); err != nil {
 		return err
 	}
@@ -114,7 +99,20 @@ func (c *Collector) verifyRememberedShadow() error {
 	if c.cfg.Profile != ProfileThroughput {
 		return nil
 	}
+	seenRemembered := make([]bool, len(c.handles))
+	for _, h := range c.remembered {
+		if h == 0 || !slotIndexOK(h, len(c.handles)) || c.handles[h].space == spaceFree || !c.handles[h].remembered {
+			return fmt.Errorf("gc: invalid remembered handle %d", h)
+		}
+		if seenRemembered[h] {
+			return fmt.Errorf("gc: duplicate remembered handle %d", h)
+		}
+		seenRemembered[h] = true
+	}
 	for h := uint32(1); int(h) < len(c.handles); h++ {
+		if c.handles[h].remembered != seenRemembered[h] {
+			return fmt.Errorf("gc: handle %d remembered bit/list mismatch", h)
+		}
 		sp := c.handles[h].space
 		if sp != spaceOld && sp != spaceLarge {
 			continue
@@ -125,7 +123,7 @@ func (c *Collector) verifyRememberedShadow() error {
 				containsNursery = true
 			}
 		})
-		if containsNursery && !c.handles[h].remembered {
+		if containsNursery && !seenRemembered[h] {
 			return fmt.Errorf("gc: shadow verifier found unremembered old-to-nursery edge from handle %d", h)
 		}
 	}

--- a/src/core/runtime/gc/verify.go
+++ b/src/core/runtime/gc/verify.go
@@ -96,9 +96,6 @@ func (c *Collector) Verify(roots RootSet) error {
 // whose young edges were overwritten, so verification requires completeness
 // rather than exact equality between collections.
 func (c *Collector) verifyRememberedShadow() error {
-	if c.cfg.Profile != ProfileThroughput {
-		return nil
-	}
 	seenRemembered := make([]bool, len(c.handles))
 	for _, h := range c.remembered {
 		if h == 0 || !slotIndexOK(h, len(c.handles)) || c.handles[h].space == spaceFree || !c.handles[h].remembered {
@@ -112,6 +109,9 @@ func (c *Collector) verifyRememberedShadow() error {
 	for h := uint32(1); int(h) < len(c.handles); h++ {
 		if c.handles[h].remembered != seenRemembered[h] {
 			return fmt.Errorf("gc: handle %d remembered bit/list mismatch", h)
+		}
+		if c.cfg.Profile != ProfileThroughput {
+			continue
 		}
 		sp := c.handles[h].space
 		if sp != spaceOld && sp != spaceLarge {


### PR DESCRIPTION
Fixes #302

## What changed

- replace successful minor-collection handle-table compaction with a direct evacuated-nursery reset
- clear remembered metadata without rescanning old and large parent payloads
- preserve the existing transactional promotion allocation and rollback boundary
- skip promotion planning entirely when mark draining reports zero survivors
- add a verification-only shadow scan that independently reconstructs required old-to-nursery remembered parents before minor evacuation
- validate dense remembered-list membership and bit/list consistency before any destructive evacuation, for both Throughput and Tiny structural verification
- assert in verification mode that successful evacuation leaves no nursery-space handles
- prove promotion failure preserves nursery, handle, remembered, object-card, and root-card metadata exactly
- prove evacuated handles are reused without growing the handle table
- add bounded, pause-only cleanup benchmarks for 0, 1, and 6 survivors with 0 and 10,000 unrelated old handles
- normalize benchmark setup so promoted old objects do not remain in nursery bookkeeping
- add pause-only remembered-parent benchmarks from 1 to 16,384 reference elements

## Why

After successful promotion, no live nursery object remains. Reconstructing the nursery bump from the complete handle table and pruning remembered parents by scanning their payloads repeated work whose result was already implied by complete evacuation. Cleanup latency therefore grew with unrelated old handles and remembered-parent size.

The new finalizer still walks nursery handles to recycle dead objects and bounded metadata lists to clear their ownership bits, but it directly resets the nursery bump and dense handle list. Promotion failures return before this destructive finalizer, retaining failure atomicity. Zero-survivor minors bypass promotion planning. Verification builds scan independently before evacuation to catch missing remembered barriers or dense-list entries, then assert the nursery is completely empty after success; release cleanup remains nursery-bounded.

## Benchmark notes

Targeted pause-only runs on linux/amd64, AMD Ryzen 7 7800X3D:

- `BenchmarkMinorCollectionOldGraphScaling` remains flat after an unmeasured setup evacuation removes stale nursery bookkeeping
- `BenchmarkMinorCollectionRememberedParentScaling/elements=16384`: approximately 57-64 us/op before and 28-34 us/op after, with 0 B/op and 0 allocs/op
- `BenchmarkMinorCollectionCleanupScaling`, 64 objects and zero survivors: approximately 370-379 ns/op with either 0 or 10,000 unrelated old handles, 0 B/op and 0 allocs/op
- the warmed no-root/no-survivor cycle is also guarded by `testing.AllocsPerRun`

These are targeted validation runs, not full benchmark-suite measurements.

## Footprint

The shadow verifier adds about 1.8 KiB (roughly 0.04%) to the stripped TinyGo minimal runtime. `Collector` layout is unchanged, and the verifier allocates and scans only when explicit verification is enabled. This small binary-only cost is retained to keep `VerifyAfterCollect` behavior consistent across minimal and standard builds rather than introducing a build-tag variant that silently weakens verification.

## Validation

- `go test ./src/core/runtime/gc -count=1`
- `go test -race ./src/core/runtime/gc -count=1`
- 50 repeated Throughput graph, reuse, native-batch, and promotion-rollback stress runs
- 5-second `FuzzCollectorOperations` run: approximately 204,000 executions
- `GOOS=linux GOARCH=arm64 go test ./src/core/runtime/gc -run ^$`
- `go vet ./src/core/runtime/gc`
- `BenchmarkMinorCollectionOldGraphScaling`
- `BenchmarkMinorCollectionCleanupScaling`
- `BenchmarkMinorCollectionRememberedParentScaling`
- stripped TinyGo minimal-runtime size comparison
- `git diff --check`

`go test ./...` passed through the affected runtime packages. The local repository-wide run remains blocked in `src/wago` because the checkout lacks the pinned `tests/spec-v3/test/core` corpus; GitHub CI initializes that corpus and covers the full platform matrix.