### PR TITLE
gc: reject impossible fragmented span searches

### DIFF
--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -86,8 +86,12 @@ The cached maximum is a conservative upper bound after its span is consumed;
 the first later miss refreshes it while scanning, and later impossible misses
 are constant-time. On 64-bit builds this metadata changes `throughputHeap` from
 136 to 144 bytes and `Collector` from 904 to 912 bytes; handle, object, native
-ABI, and serialized layouts are unchanged. A stripped standard-Go `cli/wago`
-build remains 8,663,305 bytes on linux/amd64 before and after this change.
+ABI, and serialized layouts are unchanged. On linux/amd64, `go tool nm -size`
+over a GC package test binary that retains the allocator reports 256 additional
+text bytes: 134 for `findLarge`, 65 for the cold `findLargeDirty` helper, and 57
+of growth in `insertLargeFree`; `alloc` remains 1,616 bytes. Do not use the
+manager-only `cli/wago` binary for this comparison because its dependency graph
+dead-strips the collector.
 
 ## Required companion layers
 

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -89,12 +89,15 @@ The cached maximum is a conservative upper bound after its span is consumed;
 the first later miss refreshes it while scanning, and later impossible misses
 are constant-time. On 64-bit builds this metadata changes `throughputHeap` from
 136 to 144 bytes and `Collector` from 904 to 912 bytes; handle, object, native
-ABI, and serialized layouts are unchanged. On linux/amd64, `go tool nm -size`
-over a GC package test binary that retains the allocator reports 256 additional
-text bytes: 134 for `findLarge`, 65 for the cold `findLargeDirty` helper, and 57
-of growth in `insertLargeFree`; `alloc` remains 1,616 bytes. Do not use the
-manager-only `cli/wago` binary for this comparison because its dependency graph
-dead-strips the collector.
+ABI, and serialized layouts are unchanged. On linux/amd64, a minimal executable
+that constructs the Throughput collector and allocates a 1,024-element `i32`
+array grows from 2,624,923 to 2,625,538 unstripped bytes (+615). Its stripped
+size remains 1,749,154 bytes because the retained growth fits existing file
+alignment. `go tool nm -size` attributes 256 text bytes directly to this change:
+134 for `findLarge`, 65 for the cold `findLargeDirty` helper, and 57 of growth in
+`insertLargeFree`; `alloc` remains 1,616 bytes. Do not use the manager-only
+`cli/wago` binary for this comparison because its dependency graph dead-strips
+the collector.
 
 ## Required companion layers
 

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -77,7 +77,10 @@ amount of scan work.
 64, 1,024, and 16,384 fragmented free spans, none large enough for the request.
 Its `warm` case guards constant-time rejection after the bound is exact; its
 `cold` case measures the one scan that refreshes a conservative dirty bound.
-Both validate the miss result and final bound state after timing.
+The cold case prepares dirty metadata in untimed batches, so it does not charge
+the preceding allocation's summary writes to the miss. Both validate the miss
+result and final bound state after timing, and neither constructs the larger
+churn fixture.
 `BenchmarkThroughputLargeSpanChurn` repeatedly allocates from and returns the
 unique largest span at the same fragmentation levels. Run both benchmarks
 together so a faster miss cannot hide work shifted into successful allocation.

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -75,11 +75,13 @@ amount of scan work.
 
 `BenchmarkThroughputLargeSpanMiss` isolates an old-space allocation miss with
 64, 1,024, and 16,384 fragmented free spans, none large enough for the request.
-It guards the constant-time largest-span rejection path separately from
-successful first-fit search, splitting, and coalescing work.
+Its `warm` case guards constant-time rejection after the bound is exact; its
+`cold` case measures the one scan that refreshes a conservative dirty bound.
+Both validate the miss result and final bound state after timing.
 `BenchmarkThroughputLargeSpanChurn` repeatedly allocates from and returns the
 unique largest span at the same fragmentation levels. Run both benchmarks
 together so a faster miss cannot hide work shifted into successful allocation.
+It validates every final free-span offset and size after timing.
 The cached maximum is a conservative upper bound after its span is consumed;
 the first later miss refreshes it while scanning, and later impossible misses
 are constant-time. On 64-bit builds this metadata changes `throughputHeap` from

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -77,6 +77,14 @@ amount of scan work.
 64, 1,024, and 16,384 fragmented free spans, none large enough for the request.
 It guards the constant-time largest-span rejection path separately from
 successful first-fit search, splitting, and coalescing work.
+`BenchmarkThroughputLargeSpanChurn` repeatedly allocates from and returns the
+unique largest span at the same fragmentation levels. Run both benchmarks
+together so a faster miss cannot hide work shifted into successful allocation.
+The cached maximum is a conservative upper bound after its span is consumed;
+the first later miss refreshes it while scanning, and later impossible misses
+are constant-time. On 64-bit builds this metadata changes `throughputHeap` from
+136 to 144 bytes and `Collector` from 904 to 912 bytes; handle, object, native
+ABI, and serialized layouts are unchanged.
 
 ## Required companion layers
 

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -86,7 +86,8 @@ The cached maximum is a conservative upper bound after its span is consumed;
 the first later miss refreshes it while scanning, and later impossible misses
 are constant-time. On 64-bit builds this metadata changes `throughputHeap` from
 136 to 144 bytes and `Collector` from 904 to 912 bytes; handle, object, native
-ABI, and serialized layouts are unchanged.
+ABI, and serialized layouts are unchanged. A stripped standard-Go `cli/wago`
+build remains 8,663,305 bytes on linux/amd64 before and after this change.
 
 ## Required companion layers
 

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -73,6 +73,11 @@ Today one Tiny step may scan the whole object. A slot/byte-budgeted implementati
 must keep p99 and maximum step time bounded while increasing `steps/op` with the
 amount of scan work.
 
+`BenchmarkThroughputLargeSpanMiss` isolates an old-space allocation miss with
+64, 1,024, and 16,384 fragmented free spans, none large enough for the request.
+It guards the constant-time largest-span rejection path separately from
+successful first-fit search, splitting, and coalescing work.
+
 ## Required companion layers
 
 Collector microbenchmarks cannot observe every cost. Keep the following as

--- a/src/core/runtime/gc/hardening_test.go
+++ b/src/core/runtime/gc/hardening_test.go
@@ -464,6 +464,7 @@ func TestThroughputVerifyFreeSpanCorruption(t *testing.T) {
 	idx = c.throughput.freeHeads[cls]
 	slotOff := c.throughput.freeSlots[cls][idx].off
 	c.throughput.largeFree = append(c.throughput.largeFree, throughputLargeFree{off: slotOff, size: 64})
+	c.throughput.recomputeLargestFree()
 	if err := c.Verify(nil); err == nil {
 		t.Fatal("class free slot overlapping large free span passed verify")
 	}
@@ -483,6 +484,7 @@ func TestThroughputVerifyFreeSpanCorruption(t *testing.T) {
 	}
 	s := c.throughput.largeFree[0]
 	c.throughput.largeFree = append(c.throughput.largeFree, throughputLargeFree{off: s.off + 8, size: 32})
+	c.throughput.recomputeLargestFree()
 	if err := c.Verify(nil); err == nil {
 		t.Fatal("overlapping large free spans passed verify")
 	}

--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -264,6 +264,61 @@ func TestThroughputLargestFreeTracksMutations(t *testing.T) {
 	}
 }
 
+func TestThroughputLargestFreeTracksCompleteRemoval(t *testing.T) {
+	h := throughputHeap{
+		mem:       makeAlignedBytes(256, 16),
+		limit:     256,
+		pageBytes: 4096,
+		bump:      256,
+	}
+	h.insertLargeFree(throughputLargeFree{off: 0, size: 64})
+	h.insertLargeFree(throughputLargeFree{off: 128, size: 32})
+	entry, err := h.alloc(64, spaceLarge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.off != 0 || len(h.largeFree) != 1 || h.largestFree != 64 || !h.largestFreeDirty {
+		t.Fatalf("after removal: entry=%+v spans=%v largest=%d dirty=%t", entry, h.largeFree, h.largestFree, h.largestFreeDirty)
+	}
+	if err := h.verify(nil); err != nil {
+		t.Fatalf("verify conservative bound after removal: %v", err)
+	}
+	if h.findLarge(48) != -1 || h.largestFree != 32 || h.largestFreeDirty {
+		t.Fatalf("after removal refresh: largest=%d dirty=%t spans=%v", h.largestFree, h.largestFreeDirty, h.largeFree)
+	}
+}
+
+func TestThroughputLargestFreeTracksDuplicateMaxima(t *testing.T) {
+	h := throughputHeap{
+		mem:       makeAlignedBytes(256, 16),
+		limit:     256,
+		pageBytes: 4096,
+		bump:      256,
+	}
+	h.insertLargeFree(throughputLargeFree{off: 0, size: 64})
+	h.insertLargeFree(throughputLargeFree{off: 128, size: 64})
+	first, err := h.alloc(64, spaceLarge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.off != 0 || h.largestFree != 64 || !h.largestFreeDirty || h.findLarge(64) != 0 {
+		t.Fatalf("after first maximum: entry=%+v largest=%d dirty=%t spans=%v", first, h.largestFree, h.largestFreeDirty, h.largeFree)
+	}
+	if err := h.verify(nil); err != nil {
+		t.Fatalf("verify duplicate maximum bound: %v", err)
+	}
+	second, err := h.alloc(64, spaceLarge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.off != 128 || h.largestFree != 64 || !h.largestFreeDirty || len(h.largeFree) != 0 {
+		t.Fatalf("after second maximum: entry=%+v largest=%d dirty=%t spans=%v", second, h.largestFree, h.largestFreeDirty, h.largeFree)
+	}
+	if h.findLarge(1) != -1 || h.largestFree != 0 || h.largestFreeDirty {
+		t.Fatalf("after duplicate refresh: largest=%d dirty=%t spans=%v", h.largestFree, h.largestFreeDirty, h.largeFree)
+	}
+}
+
 func TestThroughputVerifyRejectsStaleLargestFree(t *testing.T) {
 	c := newTestCollector(t, Config{})
 	c.throughput.largestFree = 32

--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -199,34 +199,38 @@ type throughputLargeSpanBenchmarkFixture struct {
 	churn throughputHeap
 }
 
-var throughputLargeSpanBenchmarkFixtures = func() []throughputLargeSpanBenchmarkFixture {
-	fixtures := make([]throughputLargeSpanBenchmarkFixture, 0, 3)
-	for _, spans := range []int{64, 1024, 16384} {
-		miss := throughputHeap{
-			largeFree:   make([]throughputLargeFree, spans),
-			largestFree: 32,
-		}
-		for i := range miss.largeFree {
-			miss.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
-		}
-
-		memBytes := uint32(spans*128 + 128)
-		churn := throughputHeap{
-			mem:         makeAlignedBytes(memBytes, 16),
-			limit:       memBytes,
-			pageBytes:   4096,
-			bump:        memBytes,
-			largeFree:   make([]throughputLargeFree, spans+1),
-			largestFree: 128,
-		}
-		for i := 0; i < spans; i++ {
-			churn.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
-		}
-		churn.largeFree[spans] = throughputLargeFree{off: uint32(spans * 128), size: 128}
-		fixtures = append(fixtures, throughputLargeSpanBenchmarkFixture{spans: spans, miss: miss, churn: churn})
+func newThroughputLargeSpanBenchmarkFixture(spans int) throughputLargeSpanBenchmarkFixture {
+	miss := throughputHeap{
+		largeFree:   make([]throughputLargeFree, spans),
+		largestFree: 32,
 	}
-	return fixtures
-}()
+	for i := range miss.largeFree {
+		miss.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
+	}
+
+	memBytes := uint32(spans*128 + 128)
+	churn := throughputHeap{
+		mem:         makeAlignedBytes(memBytes, 16),
+		limit:       memBytes,
+		pageBytes:   4096,
+		bump:        memBytes,
+		largeFree:   make([]throughputLargeFree, spans+1),
+		largestFree: 128,
+	}
+	for i := 0; i < spans; i++ {
+		churn.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
+	}
+	churn.largeFree[spans] = throughputLargeFree{off: uint32(spans * 128), size: 128}
+	return throughputLargeSpanBenchmarkFixture{spans: spans, miss: miss, churn: churn}
+}
+
+func churnThroughputLargeSpan(h *throughputHeap) error {
+	entry, err := h.alloc(64, spaceLarge)
+	if err != nil {
+		return err
+	}
+	return h.free(entry)
+}
 
 //go:noinline
 func benchmarkFindThroughputLargeSpan(h *throughputHeap, size uint32) int {
@@ -285,15 +289,12 @@ func TestThroughputLargestFreeFootprint(t *testing.T) {
 	if got := unsafe.Sizeof(throughputHeap{}); got != 144 {
 		t.Fatalf("throughputHeap size = %d, want 144", got)
 	}
-	if got := unsafe.Sizeof(Collector{}); got != 912 {
-		t.Fatalf("Collector size = %d, want 912", got)
-	}
 }
 
 func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
-	for i := range throughputLargeSpanBenchmarkFixtures {
-		fixture := &throughputLargeSpanBenchmarkFixtures[i]
-		b.Run(fmt.Sprintf("spans=%d", fixture.spans), func(b *testing.B) {
+	for _, spans := range []int{64, 1024, 16384} {
+		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
+			fixture := newThroughputLargeSpanBenchmarkFixture(spans)
 			b.Run("warm", func(b *testing.B) {
 				h := &fixture.miss
 				var found int
@@ -325,17 +326,19 @@ func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
 }
 
 func BenchmarkThroughputLargeSpanChurn(b *testing.B) {
-	for i := range throughputLargeSpanBenchmarkFixtures {
-		fixture := &throughputLargeSpanBenchmarkFixtures[i]
-		b.Run(fmt.Sprintf("spans=%d", fixture.spans), func(b *testing.B) {
+	for _, spans := range []int{64, 1024, 16384} {
+		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
+			fixture := newThroughputLargeSpanBenchmarkFixture(spans)
 			h := &fixture.churn
+			// The first insertion grows the free-span scratch capacity. Keep
+			// that one-time fixture cost outside the measured steady-state loop.
+			if err := churnThroughputLargeSpan(h); err != nil {
+				b.Fatal(err)
+			}
 			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				entry, err := h.alloc(64, spaceLarge)
-				if err != nil {
-					b.Fatal(err)
-				}
-				if err := h.free(entry); err != nil {
+				if err := churnThroughputLargeSpan(h); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -193,6 +193,41 @@ func TestThroughputClassLimitMustBeSupportedSizeClass(t *testing.T) {
 
 var benchmarkThroughputLargeSpan int
 
+type throughputLargeSpanBenchmarkFixture struct {
+	spans int
+	miss  throughputHeap
+	churn throughputHeap
+}
+
+var throughputLargeSpanBenchmarkFixtures = func() []throughputLargeSpanBenchmarkFixture {
+	fixtures := make([]throughputLargeSpanBenchmarkFixture, 0, 3)
+	for _, spans := range []int{64, 1024, 16384} {
+		miss := throughputHeap{
+			largeFree:   make([]throughputLargeFree, spans),
+			largestFree: 32,
+		}
+		for i := range miss.largeFree {
+			miss.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
+		}
+
+		memBytes := uint32(spans*128 + 128)
+		churn := throughputHeap{
+			mem:         makeAlignedBytes(memBytes, 16),
+			limit:       memBytes,
+			pageBytes:   4096,
+			bump:        memBytes,
+			largeFree:   make([]throughputLargeFree, spans+1),
+			largestFree: 128,
+		}
+		for i := 0; i < spans; i++ {
+			churn.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
+		}
+		churn.largeFree[spans] = throughputLargeFree{off: uint32(spans * 128), size: 128}
+		fixtures = append(fixtures, throughputLargeSpanBenchmarkFixture{spans: spans, miss: miss, churn: churn})
+	}
+	return fixtures
+}()
+
 //go:noinline
 func benchmarkFindThroughputLargeSpan(h *throughputHeap, size uint32) int {
 	return h.findLarge(size)
@@ -256,47 +291,45 @@ func TestThroughputLargestFreeFootprint(t *testing.T) {
 }
 
 func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
-	for _, spans := range []int{64, 1024, 16384} {
-		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
-			b.StopTimer()
-			h := throughputHeap{
-				largeFree:   make([]throughputLargeFree, spans),
-				largestFree: 32,
-			}
-			for i := range h.largeFree {
-				h.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
-			}
-			var found int
-			b.ReportAllocs()
-			b.StartTimer()
-			for i := 0; i < b.N; i++ {
-				found += benchmarkFindThroughputLargeSpan(&h, 64)
-			}
-			benchmarkThroughputLargeSpan = found
+	for i := range throughputLargeSpanBenchmarkFixtures {
+		fixture := &throughputLargeSpanBenchmarkFixtures[i]
+		b.Run(fmt.Sprintf("spans=%d", fixture.spans), func(b *testing.B) {
+			b.Run("warm", func(b *testing.B) {
+				h := &fixture.miss
+				var found int
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					found += benchmarkFindThroughputLargeSpan(h, 64)
+				}
+				benchmarkThroughputLargeSpan = found
+				if found != -b.N || h.largestFree != 32 || h.largestFreeDirty {
+					b.Fatalf("warm miss result=%d largest=%d dirty=%t", found, h.largestFree, h.largestFreeDirty)
+				}
+			})
+			b.Run("cold", func(b *testing.B) {
+				h := &fixture.miss
+				var found int
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					h.largestFree = 64
+					h.largestFreeDirty = true
+					found += benchmarkFindThroughputLargeSpan(h, 64)
+				}
+				benchmarkThroughputLargeSpan = found
+				if found != -b.N || h.largestFree != 32 || h.largestFreeDirty {
+					b.Fatalf("cold miss result=%d largest=%d dirty=%t", found, h.largestFree, h.largestFreeDirty)
+				}
+			})
 		})
 	}
 }
 
 func BenchmarkThroughputLargeSpanChurn(b *testing.B) {
-	for _, spans := range []int{64, 1024, 16384} {
-		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
-			b.StopTimer()
-			memBytes := uint32(spans*128 + 128)
-			h := throughputHeap{
-				mem:         makeAlignedBytes(memBytes, 16),
-				limit:       memBytes,
-				pageBytes:   4096,
-				bump:        memBytes,
-				largeFree:   make([]throughputLargeFree, spans+1),
-				largestFree: 128,
-			}
-			for i := 0; i < spans; i++ {
-				h.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
-			}
-			h.largeFree[spans] = throughputLargeFree{off: uint32(spans * 128), size: 128}
-
+	for i := range throughputLargeSpanBenchmarkFixtures {
+		fixture := &throughputLargeSpanBenchmarkFixtures[i]
+		b.Run(fmt.Sprintf("spans=%d", fixture.spans), func(b *testing.B) {
+			h := &fixture.churn
 			b.ReportAllocs()
-			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				entry, err := h.alloc(64, spaceLarge)
 				if err != nil {
@@ -307,6 +340,18 @@ func BenchmarkThroughputLargeSpanChurn(b *testing.B) {
 				}
 			}
 			b.StopTimer()
+			if len(h.largeFree) != fixture.spans+1 || h.largeFree[fixture.spans].size != 128 || h.largestFree != 128 || h.largestFreeDirty {
+				b.Fatalf("final churn state: spans=%d tail=%v largest=%d dirty=%t", len(h.largeFree), h.largeFree[len(h.largeFree)-1], h.largestFree, h.largestFreeDirty)
+			}
+			for i, span := range h.largeFree {
+				wantOff, wantSize := uint32(i*128), uint32(32)
+				if i == fixture.spans {
+					wantSize = 128
+				}
+				if span.off != wantOff || span.size != wantSize {
+					b.Fatalf("final churn span[%d]=%v, want off=%d size=%d", i, span, wantOff, wantSize)
+				}
+			}
 		})
 	}
 }

--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -1,6 +1,9 @@
 package gc
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestThroughputBackingGrowthIsGeometricAfterFirstPage(t *testing.T) {
 	h := throughputHeap{pageBytes: 64 << 10, limit: 4 << 20}
@@ -183,6 +186,58 @@ func TestThroughputClassLimitMustBeSupportedSizeClass(t *testing.T) {
 		if _, err := NewCollector(Config{ThroughputClassLimit: limit}, testTypes(t)); err == nil {
 			t.Fatalf("unsupported class limit %d accepted", limit)
 		}
+	}
+}
+
+var benchmarkThroughputLargeSpan int
+
+//go:noinline
+func benchmarkFindThroughputLargeSpan(h *throughputHeap, size uint32) int {
+	return h.findLarge(size)
+}
+
+func TestThroughputLargestFreeTracksMutations(t *testing.T) {
+	h := throughputHeap{
+		mem:       makeAlignedBytes(256, 16),
+		limit:     256,
+		pageBytes: 4096,
+	}
+	h.insertLargeFree(throughputLargeFree{off: 0, size: 64})
+	h.insertLargeFree(throughputLargeFree{off: 128, size: 128})
+	if h.largestFree != 128 || h.findLarge(96) != 1 {
+		t.Fatalf("initial largest span = %d at %d, want 128 at 1", h.largestFree, h.findLarge(96))
+	}
+	entry, err := h.alloc(96, spaceLarge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.off != 128 || h.largestFree != 64 || h.findLarge(80) != -1 {
+		t.Fatalf("after split: entry offset=%d largest=%d find(80)=%d", entry.off, h.largestFree, h.findLarge(80))
+	}
+	h.insertLargeFree(throughputLargeFree{off: 64, size: 64})
+	if h.largestFree != 128 || len(h.largeFree) != 2 {
+		t.Fatalf("after coalesce: largest=%d spans=%v", h.largestFree, h.largeFree)
+	}
+}
+
+func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
+	for _, spans := range []int{64, 1024, 16384} {
+		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
+			h := throughputHeap{
+				largeFree:   make([]throughputLargeFree, spans),
+				largestFree: 32,
+			}
+			for i := range h.largeFree {
+				h.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
+			}
+			var found int
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				found += benchmarkFindThroughputLargeSpan(&h, 64)
+			}
+			benchmarkThroughputLargeSpan = found
+		})
 	}
 }
 

--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -298,6 +298,7 @@ func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					found += benchmarkFindThroughputLargeSpan(&h, 64)
 				}
+				b.StopTimer()
 				benchmarkThroughputLargeSpan = found
 				if found != -b.N || h.largestFree != 32 || h.largestFreeDirty {
 					b.Fatalf("warm miss result=%d largest=%d dirty=%t", found, h.largestFree, h.largestFreeDirty)

--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -2,7 +2,9 @@ package gc
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"unsafe"
 )
 
 func TestThroughputBackingGrowthIsGeometricAfterFirstPage(t *testing.T) {
@@ -211,7 +213,13 @@ func TestThroughputLargestFreeTracksMutations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if entry.off != 128 || h.largestFree != 64 || h.findLarge(80) != -1 {
+	if entry.off != 128 || h.largestFree != 128 || !h.largestFreeDirty {
+		t.Fatalf("after split: entry offset=%d largest=%d dirty=%t", entry.off, h.largestFree, h.largestFreeDirty)
+	}
+	if err := h.verify(nil); err != nil {
+		t.Fatalf("verify conservative largest span: %v", err)
+	}
+	if h.findLarge(80) != -1 || h.largestFree != 64 || h.largestFreeDirty {
 		t.Fatalf("after split: entry offset=%d largest=%d find(80)=%d", entry.off, h.largestFree, h.findLarge(80))
 	}
 	h.insertLargeFree(throughputLargeFree{off: 64, size: 64})
@@ -220,9 +228,37 @@ func TestThroughputLargestFreeTracksMutations(t *testing.T) {
 	}
 }
 
+func TestThroughputVerifyRejectsStaleLargestFree(t *testing.T) {
+	c := newTestCollector(t, Config{})
+	c.throughput.largestFree = 32
+	err := c.Verify(nil)
+	if err == nil || !strings.Contains(err.Error(), "largest free span is stale") {
+		t.Fatalf("Verify stale largest span error = %v", err)
+	}
+	c.throughput.largestFreeDirty = true
+	c.throughput.largestFree = ^uint32(0)
+	err = c.Verify(nil)
+	if err == nil || !strings.Contains(err.Error(), "largest free span is stale") {
+		t.Fatalf("Verify impossible dirty largest span error = %v", err)
+	}
+}
+
+func TestThroughputLargestFreeFootprint(t *testing.T) {
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		t.Skip("64-bit fixed-footprint assertion")
+	}
+	if got := unsafe.Sizeof(throughputHeap{}); got != 144 {
+		t.Fatalf("throughputHeap size = %d, want 144", got)
+	}
+	if got := unsafe.Sizeof(Collector{}); got != 912 {
+		t.Fatalf("Collector size = %d, want 912", got)
+	}
+}
+
 func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
 	for _, spans := range []int{64, 1024, 16384} {
 		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
+			b.StopTimer()
 			h := throughputHeap{
 				largeFree:   make([]throughputLargeFree, spans),
 				largestFree: 32,
@@ -232,11 +268,45 @@ func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
 			}
 			var found int
 			b.ReportAllocs()
-			b.ResetTimer()
+			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				found += benchmarkFindThroughputLargeSpan(&h, 64)
 			}
 			benchmarkThroughputLargeSpan = found
+		})
+	}
+}
+
+func BenchmarkThroughputLargeSpanChurn(b *testing.B) {
+	for _, spans := range []int{64, 1024, 16384} {
+		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
+			b.StopTimer()
+			memBytes := uint32(spans*128 + 128)
+			h := throughputHeap{
+				mem:         makeAlignedBytes(memBytes, 16),
+				limit:       memBytes,
+				pageBytes:   4096,
+				bump:        memBytes,
+				largeFree:   make([]throughputLargeFree, spans+1),
+				largestFree: 128,
+			}
+			for i := 0; i < spans; i++ {
+				h.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
+			}
+			h.largeFree[spans] = throughputLargeFree{off: uint32(spans * 128), size: 128}
+
+			b.ReportAllocs()
+			b.StartTimer()
+			for i := 0; i < b.N; i++ {
+				entry, err := h.alloc(64, spaceLarge)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := h.free(entry); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
 		})
 	}
 }

--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -193,23 +193,20 @@ func TestThroughputClassLimitMustBeSupportedSizeClass(t *testing.T) {
 
 var benchmarkThroughputLargeSpan int
 
-type throughputLargeSpanBenchmarkFixture struct {
-	spans int
-	miss  throughputHeap
-	churn throughputHeap
-}
-
-func newThroughputLargeSpanBenchmarkFixture(spans int) throughputLargeSpanBenchmarkFixture {
-	miss := throughputHeap{
+func newThroughputLargeSpanMissFixture(spans int) throughputHeap {
+	h := throughputHeap{
 		largeFree:   make([]throughputLargeFree, spans),
 		largestFree: 32,
 	}
-	for i := range miss.largeFree {
-		miss.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
+	for i := range h.largeFree {
+		h.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
 	}
+	return h
+}
 
+func newThroughputLargeSpanChurnFixture(spans int) throughputHeap {
 	memBytes := uint32(spans*128 + 128)
-	churn := throughputHeap{
+	h := throughputHeap{
 		mem:         makeAlignedBytes(memBytes, 16),
 		limit:       memBytes,
 		pageBytes:   4096,
@@ -218,10 +215,10 @@ func newThroughputLargeSpanBenchmarkFixture(spans int) throughputLargeSpanBenchm
 		largestFree: 128,
 	}
 	for i := 0; i < spans; i++ {
-		churn.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
+		h.largeFree[i] = throughputLargeFree{off: uint32(i * 128), size: 32}
 	}
-	churn.largeFree[spans] = throughputLargeFree{off: uint32(spans * 128), size: 128}
-	return throughputLargeSpanBenchmarkFixture{spans: spans, miss: miss, churn: churn}
+	h.largeFree[spans] = throughputLargeFree{off: uint32(spans * 128), size: 128}
+	return h
 }
 
 func churnThroughputLargeSpan(h *throughputHeap) error {
@@ -294,13 +291,12 @@ func TestThroughputLargestFreeFootprint(t *testing.T) {
 func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
 	for _, spans := range []int{64, 1024, 16384} {
 		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
-			fixture := newThroughputLargeSpanBenchmarkFixture(spans)
+			h := newThroughputLargeSpanMissFixture(spans)
 			b.Run("warm", func(b *testing.B) {
-				h := &fixture.miss
 				var found int
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
-					found += benchmarkFindThroughputLargeSpan(h, 64)
+					found += benchmarkFindThroughputLargeSpan(&h, 64)
 				}
 				benchmarkThroughputLargeSpan = found
 				if found != -b.N || h.largestFree != 32 || h.largestFreeDirty {
@@ -308,17 +304,34 @@ func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
 				}
 			})
 			b.Run("cold", func(b *testing.B) {
-				h := &fixture.miss
-				var found int
+				const batchSize = 64
+				var batch [batchSize]throughputHeap
+				var found, lastCount int
 				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
-					h.largestFree = 64
-					h.largestFreeDirty = true
-					found += benchmarkFindThroughputLargeSpan(h, 64)
+				for done := 0; done < b.N; {
+					count := min(batchSize, b.N-done)
+					lastCount = count
+					b.StopTimer()
+					for i := 0; i < count; i++ {
+						batch[i] = h
+						batch[i].largestFree = 64
+						batch[i].largestFreeDirty = true
+					}
+					b.StartTimer()
+					for i := 0; i < count; i++ {
+						found += benchmarkFindThroughputLargeSpan(&batch[i], 64)
+					}
+					done += count
 				}
+				b.StopTimer()
 				benchmarkThroughputLargeSpan = found
-				if found != -b.N || h.largestFree != 32 || h.largestFreeDirty {
-					b.Fatalf("cold miss result=%d largest=%d dirty=%t", found, h.largestFree, h.largestFreeDirty)
+				if found != -b.N {
+					b.Fatalf("cold miss result=%d, want %d", found, -b.N)
+				}
+				for i := 0; i < lastCount; i++ {
+					if batch[i].largestFree != 32 || batch[i].largestFreeDirty {
+						b.Fatalf("cold miss batch[%d] largest=%d dirty=%t", i, batch[i].largestFree, batch[i].largestFreeDirty)
+					}
 				}
 			})
 		})
@@ -328,27 +341,26 @@ func BenchmarkThroughputLargeSpanMiss(b *testing.B) {
 func BenchmarkThroughputLargeSpanChurn(b *testing.B) {
 	for _, spans := range []int{64, 1024, 16384} {
 		b.Run(fmt.Sprintf("spans=%d", spans), func(b *testing.B) {
-			fixture := newThroughputLargeSpanBenchmarkFixture(spans)
-			h := &fixture.churn
+			h := newThroughputLargeSpanChurnFixture(spans)
 			// The first insertion grows the free-span scratch capacity. Keep
 			// that one-time fixture cost outside the measured steady-state loop.
-			if err := churnThroughputLargeSpan(h); err != nil {
+			if err := churnThroughputLargeSpan(&h); err != nil {
 				b.Fatal(err)
 			}
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if err := churnThroughputLargeSpan(h); err != nil {
+				if err := churnThroughputLargeSpan(&h); err != nil {
 					b.Fatal(err)
 				}
 			}
 			b.StopTimer()
-			if len(h.largeFree) != fixture.spans+1 || h.largeFree[fixture.spans].size != 128 || h.largestFree != 128 || h.largestFreeDirty {
+			if len(h.largeFree) != spans+1 || h.largeFree[spans].size != 128 || h.largestFree != 128 || h.largestFreeDirty {
 				b.Fatalf("final churn state: spans=%d tail=%v largest=%d dirty=%t", len(h.largeFree), h.largeFree[len(h.largeFree)-1], h.largestFree, h.largestFreeDirty)
 			}
 			for i, span := range h.largeFree {
 				wantOff, wantSize := uint32(i*128), uint32(32)
-				if i == fixture.spans {
+				if i == spans {
 					wantSize = 128
 				}
 				if span.off != wantOff || span.size != wantSize {

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -22,16 +22,17 @@ type throughputLargeFree struct {
 }
 
 type throughputHeap struct {
-	mem             []byte
-	limit           uint32
-	pageBytes       uint32
-	classLimit      uint32
-	bump            uint32
-	freeHeads       []uint32
-	freeRecordHeads []uint32 // reusable metadata records popped from freeHeads
-	freeSlots       [][]throughputFreeSlot
-	largeFree       []throughputLargeFree
-	largestFree     uint32
+	mem              []byte
+	limit            uint32
+	pageBytes        uint32
+	classLimit       uint32
+	bump             uint32
+	freeHeads        []uint32
+	freeRecordHeads  []uint32 // reusable metadata records popped from freeHeads
+	freeSlots        [][]throughputFreeSlot
+	largeFree        []throughputLargeFree
+	largestFree      uint32
+	largestFreeDirty bool
 }
 
 func (h *throughputHeap) Init(cfg Config) error {
@@ -57,6 +58,7 @@ func (h *throughputHeap) Init(cfg Config) error {
 	h.freeSlots = make([][]throughputFreeSlot, len(throughputClassSizes))
 	h.largeFree = nil
 	h.largestFree = 0
+	h.largestFreeDirty = false
 	for i := range h.freeHeads {
 		h.freeHeads[i] = throughputNoSlot
 		h.freeRecordHeads[i] = throughputNoSlot
@@ -71,6 +73,7 @@ func (h *throughputHeap) Close() {
 	h.freeSlots = nil
 	h.largeFree = nil
 	h.largestFree = 0
+	h.largestFreeDirty = false
 	h.bump = 0
 }
 
@@ -111,7 +114,7 @@ func (h *throughputHeap) alloc(size uint32, sp spaceKind) (handleEntry, error) {
 			h.largeFree = append(h.largeFree[:idx], h.largeFree[idx+1:]...)
 		}
 		if span.size == h.largestFree {
-			h.recomputeLargestFree()
+			h.largestFreeDirty = true
 		}
 		return handleEntry{off: off, size: size, allocSize: allocSize, class: uint16(len(throughputClassSizes)), space: sp}, nil
 	}
@@ -227,11 +230,25 @@ func (h *throughputHeap) findLarge(size uint32) int {
 	if size > h.largestFree {
 		return -1
 	}
+	if !h.largestFreeDirty {
+		for i, span := range h.largeFree {
+			if span.size >= size {
+				return i
+			}
+		}
+		return -1
+	}
+	largestFree := uint32(0)
 	for i, s := range h.largeFree {
+		if s.size > largestFree {
+			largestFree = s.size
+		}
 		if s.size >= size {
 			return i
 		}
 	}
+	h.largestFree = largestFree
+	h.largestFreeDirty = false
 	return -1
 }
 
@@ -252,8 +269,9 @@ func (h *throughputHeap) insertLargeFree(s throughputLargeFree) {
 		h.largeFree[pos].size += h.largeFree[pos+1].size
 		h.largeFree = append(h.largeFree[:pos+1], h.largeFree[pos+2:]...)
 	}
-	if h.largeFree[pos].size > h.largestFree {
+	if h.largeFree[pos].size >= h.largestFree {
 		h.largestFree = h.largeFree[pos].size
+		h.largestFreeDirty = false
 	}
 }
 
@@ -264,6 +282,7 @@ func (h *throughputHeap) recomputeLargestFree() {
 			h.largestFree = span.size
 		}
 	}
+	h.largestFreeDirty = false
 }
 
 func (h *throughputHeap) verify(handles []handleEntry) error {
@@ -329,7 +348,8 @@ func (h *throughputHeap) verify(handles []handleEntry) error {
 			largestFree = span.size
 		}
 	}
-	if h.largestFree != largestFree {
+	if (!h.largestFreeDirty && h.largestFree != largestFree) ||
+		(h.largestFreeDirty && (h.largestFree < largestFree || h.largestFree > memLen)) {
 		return errors.New("gc: throughput largest free span is stale")
 	}
 	seenFree := make(map[uint32]bool)

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -230,20 +230,25 @@ func (h *throughputHeap) findLarge(size uint32) int {
 	if size > h.largestFree {
 		return -1
 	}
-	if !h.largestFreeDirty {
-		for i, span := range h.largeFree {
-			if span.size >= size {
-				return i
-			}
-		}
-		return -1
+	if h.largestFreeDirty {
+		return h.findLargeDirty(size)
 	}
-	largestFree := uint32(0)
-	for i, s := range h.largeFree {
-		if s.size > largestFree {
-			largestFree = s.size
+	for i, span := range h.largeFree {
+		if span.size >= size {
+			return i
 		}
-		if s.size >= size {
+	}
+	return -1
+}
+
+//go:noinline
+func (h *throughputHeap) findLargeDirty(size uint32) int {
+	largestFree := uint32(0)
+	for i, span := range h.largeFree {
+		if span.size > largestFree {
+			largestFree = span.size
+		}
+		if span.size >= size {
 			return i
 		}
 	}

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -31,6 +31,7 @@ type throughputHeap struct {
 	freeRecordHeads []uint32 // reusable metadata records popped from freeHeads
 	freeSlots       [][]throughputFreeSlot
 	largeFree       []throughputLargeFree
+	largestFree     uint32
 }
 
 func (h *throughputHeap) Init(cfg Config) error {
@@ -54,6 +55,8 @@ func (h *throughputHeap) Init(cfg Config) error {
 	h.freeHeads = make([]uint32, len(throughputClassSizes))
 	h.freeRecordHeads = make([]uint32, len(throughputClassSizes))
 	h.freeSlots = make([][]throughputFreeSlot, len(throughputClassSizes))
+	h.largeFree = nil
+	h.largestFree = 0
 	for i := range h.freeHeads {
 		h.freeHeads[i] = throughputNoSlot
 		h.freeRecordHeads[i] = throughputNoSlot
@@ -67,6 +70,7 @@ func (h *throughputHeap) Close() {
 	h.freeRecordHeads = nil
 	h.freeSlots = nil
 	h.largeFree = nil
+	h.largestFree = 0
 	h.bump = 0
 }
 
@@ -105,6 +109,9 @@ func (h *throughputHeap) alloc(size uint32, sp spaceKind) (handleEntry, error) {
 		} else {
 			allocSize = span.size
 			h.largeFree = append(h.largeFree[:idx], h.largeFree[idx+1:]...)
+		}
+		if span.size == h.largestFree {
+			h.recomputeLargestFree()
 		}
 		return handleEntry{off: off, size: size, allocSize: allocSize, class: uint16(len(throughputClassSizes)), space: sp}, nil
 	}
@@ -217,6 +224,9 @@ func align64(v, a uint64) uint64 {
 }
 
 func (h *throughputHeap) findLarge(size uint32) int {
+	if size > h.largestFree {
+		return -1
+	}
 	for i, s := range h.largeFree {
 		if s.size >= size {
 			return i
@@ -241,6 +251,18 @@ func (h *throughputHeap) insertLargeFree(s throughputLargeFree) {
 	if pos+1 < len(h.largeFree) && h.largeFree[pos].off+h.largeFree[pos].size == h.largeFree[pos+1].off {
 		h.largeFree[pos].size += h.largeFree[pos+1].size
 		h.largeFree = append(h.largeFree[:pos+1], h.largeFree[pos+2:]...)
+	}
+	if h.largeFree[pos].size > h.largestFree {
+		h.largestFree = h.largeFree[pos].size
+	}
+}
+
+func (h *throughputHeap) recomputeLargestFree() {
+	h.largestFree = 0
+	for _, span := range h.largeFree {
+		if span.size > h.largestFree {
+			h.largestFree = span.size
+		}
 	}
 }
 
@@ -300,6 +322,15 @@ func (h *throughputHeap) verify(handles []handleEntry) error {
 			return errors.New("gc: throughput large free spans not sorted and coalesced")
 		}
 		free = append(free, s)
+	}
+	largestFree := uint32(0)
+	for _, span := range h.largeFree {
+		if span.size > largestFree {
+			largestFree = span.size
+		}
+	}
+	if h.largestFree != largestFree {
+		return errors.New("gc: throughput largest free span is stale")
 	}
 	seenFree := make(map[uint32]bool)
 	for i, f := range free {


### PR DESCRIPTION
## Summary

- track a bounded largest-free-span summary in the Throughput old-space allocator
- reject impossible fragmented-span searches in constant time
- refresh a consumed maximum lazily without adding a second scan to successful allocation
- add warm-miss, cold-refresh, and successful-churn benchmark gates with semantic validation

This is a focused part of #312; it does not claim to replace the remaining linear first-fit, insertion, or coalescing work.

## Why

Large allocations previously scanned every free span even when the largest span was too small. On a heavily fragmented heap, an impossible request therefore scaled linearly with the number of spans.

The retained design keeps a conservative upper bound after the maximum is consumed. A clean bound rejects impossible requests immediately. The first later miss refreshes a dirty bound during one cold scan, while successful first-fit allocation keeps the compact existing loop.

## Measurements

Linux/amd64, Ryzen 7 7800X3D:

| 16,384-span workload | Before | After |
|---|---:|---:|
| warm impossible miss | about 7.16 us | 2.25–2.43 ns |
| cold dirty refresh | about 7.16 us baseline scan | about 7.20 us |
| successful split/free/coalesce churn | about 12.2 us | about 11.5 us |

All retained benchmark cases report 0 B/op and 0 allocs/op. Fixtures are workload-specific, cold dirty-state preparation is batched outside timing, and all semantic validation is outside timing.

Fixed 64-bit metadata grows throughputHeap from 136 to 144 bytes and Collector from 904 to 912 bytes. A minimal executable that constructs the Throughput collector and allocates a 1,024-element i32 array grows from 2,624,923 to 2,625,538 unstripped bytes (+615); its stripped size remains 1,749,154 bytes because the growth fits existing file alignment. Retained allocator symbols attribute 256 text bytes to the change. Handle, object, native ABI, and serialized layouts are unchanged.

## Validation

- go test ./src/core/runtime/gc -count=1
- go test -race ./src/core/runtime/gc -count=1
- FuzzCollectorOperations for 5 seconds
- go vet ./src/core/runtime/gc
- linux/arm64 package cross-compilation
- clean diff check

Repository-wide tests were also run earlier; staged specification tests require the absent tests/spec-v3/test/core checkout, while all available packages passed.
