### PR TITLE
gc: compact Tiny allocator span metadata

### DIFF
--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -99,6 +99,28 @@ alignment. `go tool nm -size` attributes 256 text bytes directly to this change:
 `cli/wago` binary for this comparison because its dependency graph dead-strips
 the collector.
 
+`BenchmarkTinyAllocatorCommonSpanReuse`, `BenchmarkTinyAllocatorFragmentedFit`,
+and `BenchmarkTinyAllocatorFragmentedMiss` isolate the compact Tiny span
+allocator tracked by #318. Always run the common reuse case with the fragmented
+cases: bounded misses must not hide work shifted into successful allocation or
+free/coalescing. `CommonSpanReuse` also reports `metadata-bytes`, which counts
+the boundary-tag, allocation-start, bin-head, and bin-occupancy backing storage;
+the eight intrusive link bytes inside each free span remain part of the managed
+heap rather than a separately retained metadata allocation.
+
+On linux/amd64 with the default 64 KiB heap, allocator backing metadata changes
+from 65,536 bytes (4,096 16-byte `tinyBlock` records) to 9,180 bytes, an 86.0%
+reduction. A 2,048-span impossible fragmented allocation changes from about
+2.29 us and 16 B/op to about 4.95 ns and 0 B/op. The stricter metadata and
+coalescing work makes the isolated allocate/free/full-coalesce microbenchmark
+about 39.5 ns instead of 9.8 ns; use end-to-end allocation workloads when
+deciding whether that explicit footprint/fragmentation tradeoff is acceptable.
+The minimal Tiny collector constructor executable changes from 2,473,626 to
+2,479,440 unstripped bytes (+5,814) and from 1,642,658 to 1,646,754 stripped
+bytes (+4,096, including file alignment). Directly retained Tiny initialization
+text includes 1,049 bytes for `newTinyHeap`, 533 bytes for `insertFree`, and a
+122-byte increase in `newTinyCollector`.
+
 ## Required companion layers
 
 Collector microbenchmarks cannot observe every cost. Keep the following as

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -186,7 +186,7 @@ func (c *Collector) free(h uint32) {
 			}
 		case spaceTiny:
 			bi := e.off / c.tiny.blockBytes
-			span := c.tiny.blocks[bi].size * c.tiny.blockBytes
+			span := c.tiny.spanSize(bi) * c.tiny.blockBytes
 			for i := range c.tiny.mem[e.off : e.off+span] {
 				c.tiny.mem[e.off+uint32(i)] = 0xdd
 			}

--- a/src/core/runtime/gc/tiny_alloc.go
+++ b/src/core/runtime/gc/tiny_alloc.go
@@ -1,8 +1,10 @@
 package gc
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/bits"
 )
 
 const (
@@ -10,20 +12,34 @@ const (
 	defaultTinyBlockBytes = 16
 	defaultTinyStepBudget = 1
 	tinyNoBlock           = ^uint32(0)
+	tinyExactBins         = 64
+	tinySecondLevelBits   = 3
+	tinySecondLevelBins   = 1 << tinySecondLevelBits
+	tinyFreeLinkBytes     = 8
 )
 
-type tinyBlock struct {
-	next uint32
-	prev uint32
-	size uint32
-	used bool
-}
+var errTinyHeapExhausted = errors.New("gc: tiny heap exhausted")
 
 type tinyHeap struct {
-	mem        []byte
-	blocks     []tinyBlock
-	blockBytes uint32
-	freeHead   uint32
+	mem []byte
+
+	// span16/span32 contain a span's block count at its first and last
+	// blocks; interior entries are zero. Default heaps use 16-bit tags.
+	span16 []uint16
+	span32 []uint32
+	// usedStarts distinguishes allocated span starts from free span starts.
+	usedStarts []uint64
+
+	// Free spans are grouped into exact small bins and logarithmic large
+	// bins. Their first eight payload bytes hold next/previous block indexes.
+	// binWords and binSummary find the next occupied size class without
+	// walking unrelated free spans.
+	binHeads    []uint32
+	binWords    []uint64
+	binSummary  uint64
+	blockCount  uint32
+	blockBytes  uint32
+	poisonFreed bool
 }
 
 func newTinyCollector(config Config, types []TypeDesc) (*Collector, error) {
@@ -55,8 +71,7 @@ func newTinyCollector(config Config, types []TypeDesc) (*Collector, error) {
 		return nil, err
 	}
 	blocks := config.TinyHeapBytes / config.TinyBlockBytes
-	c.tiny = tinyHeap{mem: makeAlignedBytes(config.TinyHeapBytes, uintptr(objectAlign)), blocks: make([]tinyBlock, blocks), blockBytes: config.TinyBlockBytes, freeHead: 0}
-	c.tiny.blocks[0] = tinyBlock{next: tinyNoBlock, prev: tinyNoBlock, size: blocks}
+	c.tiny = newTinyHeap(makeAlignedBytes(config.TinyHeapBytes, uintptr(objectAlign)), blocks, config.TinyBlockBytes, config.PoisonFreed)
 	c.tinyGC.state = tinyIdle
 	c.tinyGC.sweep = 1
 	c.tinyGC.color = []tinyColor{tinyWhite}
@@ -109,8 +124,13 @@ func validateTinyConfig(config Config) error {
 
 func (h *tinyHeap) Close() {
 	h.mem = nil
-	h.blocks = nil
-	h.freeHead = tinyNoBlock
+	h.span16 = nil
+	h.span32 = nil
+	h.usedStarts = nil
+	h.binHeads = nil
+	h.binWords = nil
+	h.binSummary = 0
+	h.blockCount = 0
 }
 
 func (h *tinyHeap) bytes(off, size uint32) []byte { return h.mem[off : off+size] }
@@ -124,30 +144,25 @@ func (h *tinyHeap) alloc(size uint32) (uint32, uint32, error) {
 		return 0, 0, errors.New("gc: tiny allocation size overflow")
 	}
 	need := uint32(need64)
-	for b := h.freeHead; b != tinyNoBlock; b = h.blocks[b].next {
-		span := h.blocks[b].size
-		if span < need {
-			continue
-		}
-		if span == need {
-			h.unlinkFree(b)
-			h.blocks[b].used = true
-			return b * h.blockBytes, span * h.blockBytes, nil
-		}
-		rem := b + need
-		h.blocks[rem] = tinyBlock{next: h.blocks[b].next, prev: h.blocks[b].prev, size: span - need}
-		if h.blocks[rem].next != tinyNoBlock {
-			h.blocks[h.blocks[rem].next].prev = rem
-		}
-		if h.blocks[rem].prev != tinyNoBlock {
-			h.blocks[h.blocks[rem].prev].next = rem
-		} else {
-			h.freeHead = rem
-		}
-		h.blocks[b] = tinyBlock{next: tinyNoBlock, prev: tinyNoBlock, size: need, used: true}
-		return b * h.blockBytes, need * h.blockBytes, nil
+	if need > h.blockCount {
+		return 0, 0, errTinyHeapExhausted
 	}
-	return 0, 0, errors.New("gc: tiny heap exhausted")
+	b := h.findFreeSpan(need)
+	if b == tinyNoBlock {
+		return 0, 0, errTinyHeapExhausted
+	}
+	span := h.spanSize(b)
+	h.removeFree(b, span)
+	if span == need {
+		h.setUsedStart(b, true)
+	} else {
+		h.clearSpan(b, span)
+		h.setSpan(b, need, true)
+		rem := b + need
+		h.setSpan(rem, span-need, false)
+		h.insertFree(rem, span-need)
+	}
+	return b * h.blockBytes, need * h.blockBytes, nil
 }
 
 func (h *tinyHeap) free(off uint32) error {
@@ -155,63 +170,208 @@ func (h *tinyHeap) free(off uint32) error {
 		return errors.New("gc: invalid tiny free offset")
 	}
 	b := off / h.blockBytes
-	if int(b) >= len(h.blocks) || !h.blocks[b].used || h.blocks[b].size == 0 {
+	if b >= h.blockCount || !h.isUsedStart(b) || h.spanSize(b) == 0 {
 		return errors.New("gc: invalid tiny free span")
 	}
-	h.blocks[b].used = false
-	h.insertFreeSorted(b)
-	h.coalesce(b)
+	span := h.spanSize(b)
+	h.setUsedStart(b, false)
+	if b > 0 {
+		prevSize := h.spanSize(b - 1)
+		if prevSize > 0 && prevSize <= b {
+			prev := b - prevSize
+			if !h.isUsedStart(prev) && h.spanSize(prev) == prevSize && prev+prevSize == b {
+				h.removeFree(prev, prevSize)
+				h.clearSpan(prev, prevSize)
+				h.clearSpan(b, span)
+				b, span = prev, prevSize+span
+				h.setSpan(b, span, false)
+			}
+		}
+	}
+	if next := b + span; next < h.blockCount {
+		nextSize := h.spanSize(next)
+		if nextSize > 0 && nextSize <= h.blockCount-next && !h.isUsedStart(next) {
+			h.removeFree(next, nextSize)
+			h.clearSpan(b, span)
+			h.clearSpan(next, nextSize)
+			span += nextSize
+			h.setSpan(b, span, false)
+		}
+	}
+	if h.poisonFreed {
+		freed := h.mem[b*h.blockBytes : (b+span)*h.blockBytes]
+		for i := range freed {
+			freed[i] = 0xdd
+		}
+	}
+	h.insertFree(b, span)
 	return nil
 }
 
-func (h *tinyHeap) unlinkFree(b uint32) {
-	n, p := h.blocks[b].next, h.blocks[b].prev
-	if p != tinyNoBlock {
-		h.blocks[p].next = n
+func newTinyHeap(mem []byte, blocks, blockBytes uint32, poisonFreed bool) tinyHeap {
+	h := tinyHeap{mem: mem, blockCount: blocks, blockBytes: blockBytes, poisonFreed: poisonFreed}
+	if blocks <= uint32(^uint16(0)) {
+		h.span16 = make([]uint16, blocks)
 	} else {
-		h.freeHead = n
+		h.span32 = make([]uint32, blocks)
 	}
-	if n != tinyNoBlock {
-		h.blocks[n].prev = p
+	h.usedStarts = make([]uint64, (uint64(blocks)+63)/64)
+	binCount := tinyBinForSize(blocks) + 1
+	h.binHeads = make([]uint32, binCount)
+	for i := range h.binHeads {
+		h.binHeads[i] = tinyNoBlock
 	}
-	h.blocks[b].next, h.blocks[b].prev = tinyNoBlock, tinyNoBlock
+	h.binWords = make([]uint64, (uint64(binCount)+63)/64)
+	h.setSpan(0, blocks, false)
+	h.insertFree(0, blocks)
+	return h
 }
 
-func (h *tinyHeap) insertFreeSorted(b uint32) {
-	h.blocks[b].next, h.blocks[b].prev = tinyNoBlock, tinyNoBlock
-	if h.freeHead == tinyNoBlock || b < h.freeHead {
-		h.blocks[b].next = h.freeHead
-		if h.freeHead != tinyNoBlock {
-			h.blocks[h.freeHead].prev = b
-		}
-		h.freeHead = b
+func (h *tinyHeap) spanSize(b uint32) uint32 {
+	if b >= h.blockCount {
+		return 0
+	}
+	if h.span16 != nil {
+		return uint32(h.span16[b])
+	}
+	return h.span32[b]
+}
+
+func (h *tinyHeap) putSpanSize(b, size uint32) {
+	if h.span16 != nil {
+		h.span16[b] = uint16(size)
+	} else {
+		h.span32[b] = size
+	}
+}
+
+func (h *tinyHeap) setSpan(b, size uint32, used bool) {
+	h.putSpanSize(b, size)
+	h.putSpanSize(b+size-1, size)
+	h.setUsedStart(b, used)
+}
+
+func (h *tinyHeap) clearSpan(b, size uint32) {
+	h.putSpanSize(b, 0)
+	if size > 1 {
+		h.putSpanSize(b+size-1, 0)
+	}
+	h.setUsedStart(b, false)
+}
+
+func (h *tinyHeap) isUsedStart(b uint32) bool {
+	return h.usedStarts[b>>6]&(uint64(1)<<(b&63)) != 0
+}
+
+func (h *tinyHeap) setUsedStart(b uint32, used bool) {
+	word, bit := b>>6, uint64(1)<<(b&63)
+	if used {
+		h.usedStarts[word] |= bit
+	} else {
+		h.usedStarts[word] &^= bit
+	}
+}
+
+func tinyBinForSize(size uint32) uint32 {
+	if size <= tinyExactBins {
+		return size - 1
+	}
+	fl := uint32(bits.Len32(size) - 1)
+	base := uint32(1) << fl
+	width := base >> tinySecondLevelBits
+	sl := (size - base) / width
+	return tinyExactBins + (fl-6)*tinySecondLevelBins + sl
+}
+
+func (h *tinyHeap) freeLinks(b uint32) (next, prev uint32) {
+	off := b * h.blockBytes
+	return binary.LittleEndian.Uint32(h.mem[off:]), binary.LittleEndian.Uint32(h.mem[off+4:])
+}
+
+func (h *tinyHeap) setFreeLinks(b, next, prev uint32) {
+	off := b * h.blockBytes
+	binary.LittleEndian.PutUint32(h.mem[off:], next)
+	binary.LittleEndian.PutUint32(h.mem[off+4:], prev)
+}
+
+func (h *tinyHeap) insertFree(b, size uint32) {
+	bin := tinyBinForSize(size)
+	head := h.binHeads[bin]
+	h.setFreeLinks(b, head, tinyNoBlock)
+	if head != tinyNoBlock {
+		next, _ := h.freeLinks(head)
+		h.setFreeLinks(head, next, b)
+	}
+	h.binHeads[bin] = b
+	h.markBin(bin, true)
+}
+
+func (h *tinyHeap) removeFree(b, size uint32) {
+	bin := tinyBinForSize(size)
+	next, prev := h.freeLinks(b)
+	if prev == tinyNoBlock {
+		h.binHeads[bin] = next
+	} else {
+		_, pp := h.freeLinks(prev)
+		h.setFreeLinks(prev, next, pp)
+	}
+	if next != tinyNoBlock {
+		nn, _ := h.freeLinks(next)
+		h.setFreeLinks(next, nn, prev)
+	}
+	if h.binHeads[bin] == tinyNoBlock {
+		h.markBin(bin, false)
+	}
+}
+
+func (h *tinyHeap) markBin(bin uint32, nonempty bool) {
+	word, bit := bin>>6, uint64(1)<<(bin&63)
+	if nonempty {
+		h.binWords[word] |= bit
+		h.binSummary |= uint64(1) << word
 		return
 	}
-	cur := h.freeHead
-	for h.blocks[cur].next != tinyNoBlock && h.blocks[cur].next < b {
-		cur = h.blocks[cur].next
+	h.binWords[word] &^= bit
+	if h.binWords[word] == 0 {
+		h.binSummary &^= uint64(1) << word
 	}
-	h.blocks[b].next = h.blocks[cur].next
-	h.blocks[b].prev = cur
-	if h.blocks[b].next != tinyNoBlock {
-		h.blocks[h.blocks[b].next].prev = b
-	}
-	h.blocks[cur].next = b
 }
 
-func (h *tinyHeap) coalesce(b uint32) uint32 {
-	if p := h.blocks[b].prev; p != tinyNoBlock && p+h.blocks[p].size == b {
-		h.blocks[p].size += h.blocks[b].size
-		h.unlinkFree(b)
-		h.blocks[b] = tinyBlock{}
-		b = p
+func (h *tinyHeap) findFreeSpan(need uint32) uint32 {
+	bin := tinyBinForSize(need)
+	// Large bins cover a narrow size range, so only the request's own bin
+	// can contain undersized spans. Every later occupied bin is a fit.
+	for b := h.binHeads[bin]; b != tinyNoBlock; {
+		next, _ := h.freeLinks(b)
+		if h.spanSize(b) >= need {
+			return b
+		}
+		b = next
 	}
-	if n := h.blocks[b].next; n != tinyNoBlock && b+h.blocks[b].size == n {
-		h.blocks[b].size += h.blocks[n].size
-		h.unlinkFree(n)
-		h.blocks[n] = tinyBlock{}
+	return h.firstSpanAfterBin(bin)
+}
+
+func (h *tinyHeap) firstSpanAfterBin(bin uint32) uint32 {
+	word := bin >> 6
+	shift := (bin & 63) + 1
+	var candidates uint64
+	if shift < 64 {
+		candidates = h.binWords[word] & (^uint64(0) << shift)
 	}
-	return b
+	if candidates != 0 {
+		return h.binHeads[word*64+uint32(bits.TrailingZeros64(candidates))]
+	}
+	remaining := h.binSummary & (^uint64(0) << (word + 1))
+	if remaining == 0 {
+		return tinyNoBlock
+	}
+	word = uint32(bits.TrailingZeros64(remaining))
+	return h.binHeads[word*64+uint32(bits.TrailingZeros64(h.binWords[word]))]
+}
+
+func (h *tinyHeap) metadataBytes() uintptr {
+	return uintptr(len(h.span16))*2 + uintptr(len(h.span32))*4 +
+		uintptr(len(h.usedStarts))*8 + uintptr(len(h.binHeads))*4 + uintptr(len(h.binWords))*8 + 8
 }
 
 func (c *Collector) tinyAlloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref, error) {

--- a/src/core/runtime/gc/tiny_alloc_bench_test.go
+++ b/src/core/runtime/gc/tiny_alloc_bench_test.go
@@ -1,0 +1,92 @@
+package gc
+
+import "testing"
+
+func BenchmarkTinyAllocatorCommonSpanReuse(b *testing.B) {
+	h := newTinyBenchmarkHeap(b, defaultTinyHeapBytes, defaultTinyBlockBytes)
+	b.ReportAllocs()
+	b.SetBytes(32)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		off, _, err := h.alloc(32)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := h.free(off); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(h.metadataBytes()), "metadata-bytes")
+}
+
+func BenchmarkTinyAllocatorFragmentedFit(b *testing.B) {
+	const heapBytes = 64 << 10
+	h := newTinyBenchmarkHeap(b, heapBytes, defaultTinyBlockBytes)
+	offsets := make([]uint32, 0, heapBytes/(2*defaultTinyBlockBytes))
+	for {
+		off, _, err := h.alloc(32)
+		if err != nil {
+			break
+		}
+		offsets = append(offsets, off)
+	}
+	for i := 0; i < len(offsets); i += 2 {
+		if err := h.free(offsets[i]); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		off, _, err := h.alloc(32)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := h.free(off); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTinyAllocatorFragmentedMiss(b *testing.B) {
+	const heapBytes = 64 << 10
+	h := newTinyBenchmarkHeap(b, heapBytes, defaultTinyBlockBytes)
+	offsets := make([]uint32, 0, heapBytes/defaultTinyBlockBytes)
+	for {
+		off, _, err := h.alloc(defaultTinyBlockBytes)
+		if err != nil {
+			break
+		}
+		offsets = append(offsets, off)
+	}
+	for i := 0; i < len(offsets); i += 2 {
+		if err := h.free(offsets[i]); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := h.alloc(2 * defaultTinyBlockBytes); err == nil {
+			b.Fatal("fragmented heap unexpectedly satisfied two-block allocation")
+		}
+	}
+}
+
+func newTinyBenchmarkHeap(tb testing.TB, heapBytes, blockBytes uint32) *tinyHeap {
+	tb.Helper()
+	pf, err := NewStructDesc(0, []StorageKind{StorageI32, StorageI64})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	c, err := NewCollector(Config{
+		Profile:        ProfileTiny,
+		TinyHeapBytes:  heapBytes,
+		TinyBlockBytes: blockBytes,
+	}, []TypeDesc{pf})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(c.Close)
+	return &c.tiny
+}

--- a/src/core/runtime/gc/tiny_alloc_fuzz_test.go
+++ b/src/core/runtime/gc/tiny_alloc_fuzz_test.go
@@ -2,6 +2,53 @@ package gc
 
 import "testing"
 
+func FuzzTinySpanAllocator(f *testing.F) {
+	for _, seed := range [][]byte{
+		{1, 2, 3, 0x80, 4, 0x81},
+		{64, 64, 64, 64, 0x80, 0x81, 127},
+		{1, 1, 1, 1, 0x82, 2, 0x80, 3},
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, operations []byte) {
+		if len(operations) > 256 {
+			operations = operations[:256]
+		}
+		const blocks = uint32(257)
+		h := newTinyHeap(make([]byte, blocks*16), blocks, 16, false)
+		live := make([]tinyTestAllocation, 0, blocks)
+		for step, op := range operations {
+			if op&0x80 != 0 {
+				if len(live) != 0 {
+					i := int(op&0x7f) % len(live)
+					if err := h.free(live[i].off * h.blockBytes); err != nil {
+						t.Fatalf("step %d free %+v: %v", step, live[i], err)
+					}
+					live[i] = live[len(live)-1]
+					live = live[:len(live)-1]
+				}
+			} else {
+				need := uint32(op%96) + 1
+				offBytes, spanBytes, err := h.alloc(need * h.blockBytes)
+				if err != nil {
+					if maxFreeGap(live, blocks) >= need {
+						t.Fatalf("step %d rejected %d blocks with a fitting interval", step, need)
+					}
+				} else {
+					a := tinyTestAllocation{off: offBytes / h.blockBytes, blocks: spanBytes / h.blockBytes}
+					for _, other := range live {
+						if a.off < other.off+other.blocks && other.off < a.off+a.blocks {
+							t.Fatalf("step %d overlap: %+v and %+v", step, a, other)
+						}
+					}
+					live = append(live, a)
+				}
+			}
+			assertTinyHeapMetadata(t, &h)
+		}
+	})
+}
+
 func FuzzTinyAllocationBounds(f *testing.F) {
 	maxRounded := ^uint32(0) - 7
 	maxI8ArrayLength := ^uint32(0) - HeaderSize - 7
@@ -37,11 +84,11 @@ func FuzzTinyAllocationBounds(f *testing.F) {
 		}
 		defer c.Close()
 
-		before := c.tiny.blocks[0]
+		beforeSize, beforeSummary := c.tiny.spanSize(0), c.tiny.binSummary
 		off, span, err := c.tiny.alloc(rawSize)
 		if err != nil {
-			if c.tiny.freeHead != 0 || c.tiny.blocks[0] != before {
-				t.Fatalf("failed raw tiny allocation corrupted metadata: size=%d head=%d before=%+v after=%+v", rawSize, c.tiny.freeHead, before, c.tiny.blocks[0])
+			if c.tiny.findFreeSpan(8) != 0 || c.tiny.spanSize(0) != beforeSize || c.tiny.binSummary != beforeSummary {
+				t.Fatalf("failed raw tiny allocation corrupted metadata: size=%d start=%d before=%d after=%d", rawSize, c.tiny.findFreeSpan(8), beforeSize, c.tiny.spanSize(0))
 			}
 		} else {
 			if span == 0 || off+span > uint32(len(c.tiny.mem)) {

--- a/src/core/runtime/gc/tiny_collect.go
+++ b/src/core/runtime/gc/tiny_collect.go
@@ -225,7 +225,8 @@ func (c *Collector) verifyTiny(roots RootSet) error {
 		if e.space != spaceTiny {
 			return fmt.Errorf("gc: non-tiny handle %d in tiny collector", h)
 		}
-		if e.off%c.tiny.blockBytes != 0 || e.off+e.size > uint32(len(c.tiny.mem)) {
+		memBytes := uint32(len(c.tiny.mem))
+		if e.off%c.tiny.blockBytes != 0 || e.off > memBytes || e.size > memBytes-e.off {
 			return fmt.Errorf("gc: tiny handle %d out of bounds", h)
 		}
 		bi := e.off / c.tiny.blockBytes
@@ -267,6 +268,12 @@ func (c *Collector) verifyTinyFreeList(live []bool) error {
 	}
 	if summary != c.tiny.binSummary {
 		return errors.New("gc: tiny free-bin summary disagrees with occupancy")
+	}
+	if lastBits := uint32(len(c.tiny.binHeads)) & 63; lastBits != 0 {
+		valid := (uint64(1) << lastBits) - 1
+		if c.tiny.binWords[len(c.tiny.binWords)-1]&^valid != 0 {
+			return errors.New("gc: tiny free-bin bitmap marks an invalid bin")
+		}
 	}
 	for bin, head := range c.tiny.binHeads {
 		marked := c.tiny.binWords[uint32(bin)>>6]&(uint64(1)<<(uint32(bin)&63)) != 0

--- a/src/core/runtime/gc/tiny_collect.go
+++ b/src/core/runtime/gc/tiny_collect.go
@@ -216,7 +216,7 @@ func (c *Collector) verifyTiny(roots RootSet) error {
 	if c.tiny.blockBytes == 0 || len(c.tiny.mem) == 0 {
 		return errors.New("gc: tiny heap is not initialized")
 	}
-	liveBlocks := make([]bool, len(c.tiny.blocks))
+	liveBlocks := make([]bool, c.tiny.blockCount)
 	for h := uint32(1); int(h) < len(c.handles); h++ {
 		e := c.handles[h]
 		if e.space == spaceFree {
@@ -229,14 +229,18 @@ func (c *Collector) verifyTiny(roots RootSet) error {
 			return fmt.Errorf("gc: tiny handle %d out of bounds", h)
 		}
 		bi := e.off / c.tiny.blockBytes
-		if int(bi) >= len(c.tiny.blocks) || !c.tiny.blocks[bi].used {
+		if bi >= c.tiny.blockCount || !c.tiny.isUsedStart(bi) {
 			return fmt.Errorf("gc: tiny handle %d points to free span", h)
 		}
-		spanBytes := c.tiny.blocks[bi].size * c.tiny.blockBytes
+		spanBlocks := c.tiny.spanSize(bi)
+		if spanBlocks == 0 || spanBlocks > c.tiny.blockCount-bi {
+			return fmt.Errorf("gc: tiny handle %d has invalid allocation span", h)
+		}
+		spanBytes := spanBlocks * c.tiny.blockBytes
 		if e.size > spanBytes {
 			return fmt.Errorf("gc: tiny handle %d exceeds allocation span", h)
 		}
-		for i := bi; i < bi+c.tiny.blocks[bi].size; i++ {
+		for i := bi; i < bi+spanBlocks; i++ {
 			if int(i) >= len(liveBlocks) || liveBlocks[i] {
 				return fmt.Errorf("gc: tiny live span overlap at block %d", i)
 			}
@@ -253,32 +257,68 @@ func (c *Collector) verifyTiny(roots RootSet) error {
 }
 
 func (c *Collector) verifyTinyFreeList(live []bool) error {
-	seen := make([]bool, len(c.tiny.blocks))
-	prev := tinyNoBlock
-	for b := c.tiny.freeHead; b != tinyNoBlock; b = c.tiny.blocks[b].next {
-		if int(b) >= len(c.tiny.blocks) {
-			return errors.New("gc: tiny free list out of bounds")
+	seenStarts := make([]bool, c.tiny.blockCount)
+	freeBlocks := make([]bool, c.tiny.blockCount)
+	var summary uint64
+	for word, occupied := range c.tiny.binWords {
+		if occupied != 0 {
+			summary |= uint64(1) << uint32(word)
 		}
-		if seen[b] {
-			return errors.New("gc: tiny free list cycle")
+	}
+	if summary != c.tiny.binSummary {
+		return errors.New("gc: tiny free-bin summary disagrees with occupancy")
+	}
+	for bin, head := range c.tiny.binHeads {
+		marked := c.tiny.binWords[uint32(bin)>>6]&(uint64(1)<<(uint32(bin)&63)) != 0
+		if (head != tinyNoBlock) != marked {
+			return errors.New("gc: tiny free-bin bitmap disagrees with head")
 		}
-		seen[b] = true
-		blk := c.tiny.blocks[b]
-		if blk.used || blk.size == 0 || blk.prev != prev {
-			return errors.New("gc: malformed tiny free span")
+		prev := tinyNoBlock
+		for b := head; b != tinyNoBlock; {
+			if b >= c.tiny.blockCount || seenStarts[b] {
+				return errors.New("gc: tiny free list out of bounds or cyclic")
+			}
+			seenStarts[b] = true
+			size := c.tiny.spanSize(b)
+			if size == 0 || size > c.tiny.blockCount-b || c.tiny.isUsedStart(b) || tinyBinForSize(size) != uint32(bin) {
+				return errors.New("gc: malformed tiny free span")
+			}
+			next, recordedPrev := c.tiny.freeLinks(b)
+			if recordedPrev != prev {
+				return errors.New("gc: malformed tiny free links")
+			}
+			for i := b; i < b+size; i++ {
+				if live[i] || freeBlocks[i] {
+					return errors.New("gc: tiny free span overlaps another span")
+				}
+				freeBlocks[i] = true
+			}
+			prev, b = b, next
 		}
-		if blk.next != tinyNoBlock && b+blk.size > blk.next {
-			return errors.New("gc: overlapping tiny free spans")
+	}
+	var previousFree bool
+	for b := uint32(0); b < c.tiny.blockCount; {
+		size := c.tiny.spanSize(b)
+		if size == 0 || size > c.tiny.blockCount-b || c.tiny.spanSize(b+size-1) != size {
+			return errors.New("gc: malformed tiny span boundaries")
 		}
-		if blk.next != tinyNoBlock && b+blk.size == blk.next {
+		used := c.tiny.isUsedStart(b)
+		if used == seenStarts[b] {
+			return errors.New("gc: tiny span missing from allocation or free metadata")
+		}
+		if !used && previousFree {
 			return errors.New("gc: adjacent tiny free spans not coalesced")
 		}
-		for i := b; i < b+blk.size; i++ {
-			if int(i) >= len(live) || live[i] {
-				return errors.New("gc: tiny free span overlaps live object")
+		for i := b; i < b+size; i++ {
+			if used != live[i] || (!used) != freeBlocks[i] {
+				return errors.New("gc: tiny span coverage disagrees with handles")
+			}
+			if i != b && c.tiny.isUsedStart(i) {
+				return errors.New("gc: tiny allocation-start bitmap marks a span interior")
 			}
 		}
-		prev = b
+		previousFree = !used
+		b += size
 	}
 	return nil
 }

--- a/src/core/runtime/gc/tiny_collect.go
+++ b/src/core/runtime/gc/tiny_collect.go
@@ -216,6 +216,9 @@ func (c *Collector) verifyTiny(roots RootSet) error {
 	if c.tiny.blockBytes == 0 || len(c.tiny.mem) == 0 {
 		return errors.New("gc: tiny heap is not initialized")
 	}
+	if err := c.tiny.verifyMetadataShape(); err != nil {
+		return err
+	}
 	liveBlocks := make([]bool, c.tiny.blockCount)
 	for h := uint32(1); int(h) < len(c.handles); h++ {
 		e := c.handles[h]
@@ -253,6 +256,27 @@ func (c *Collector) verifyTiny(roots RootSet) error {
 	}
 	if err := c.verifyTinyFreeList(liveBlocks); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (h *tinyHeap) verifyMetadataShape() error {
+	if h.blockCount == 0 || uint64(h.blockCount)*uint64(h.blockBytes) != uint64(len(h.mem)) {
+		return errors.New("gc: tiny heap geometry disagrees with memory")
+	}
+	if h.blockCount <= uint32(^uint16(0)) {
+		if len(h.span16) != int(h.blockCount) || h.span32 != nil {
+			return errors.New("gc: tiny compact boundary metadata has invalid shape")
+		}
+	} else if len(h.span32) != int(h.blockCount) || h.span16 != nil {
+		return errors.New("gc: tiny wide boundary metadata has invalid shape")
+	}
+	if len(h.usedStarts) != int((uint64(h.blockCount)+63)/64) {
+		return errors.New("gc: tiny allocation-start bitmap has invalid shape")
+	}
+	binCount := tinyBinForSize(h.blockCount) + 1
+	if len(h.binHeads) != int(binCount) || len(h.binWords) != int((uint64(binCount)+63)/64) {
+		return errors.New("gc: tiny free-bin metadata has invalid shape")
 	}
 	return nil
 }

--- a/src/core/runtime/gc/tiny_test.go
+++ b/src/core/runtime/gc/tiny_test.go
@@ -172,6 +172,32 @@ func TestTinyAllocatorInvalidFreesDoNotMutateMetadata(t *testing.T) {
 	assertTinyHeapMetadata(t, &h)
 }
 
+func TestTinyAllocatorPoisonSurvivesRepeatedCoalescing(t *testing.T) {
+	h := newTinyHeap(make([]byte, 8*16), 8, 16, true)
+	offsets := make([]uint32, 4)
+	for i := range offsets {
+		off, _, err := h.alloc(32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		offsets[i] = off
+		for j := off; j < off+32; j++ {
+			h.mem[j] = 0xaa
+		}
+	}
+	for _, i := range []int{1, 3, 2, 0} {
+		if err := h.free(offsets[i]); err != nil {
+			t.Fatal(err)
+		}
+		assertTinyHeapMetadata(t, &h)
+	}
+	for i, got := range h.mem[tinyFreeLinkBytes:] {
+		if got != 0xdd {
+			t.Fatalf("coalesced free byte %d = %#x, want poison", i+tinyFreeLinkBytes, got)
+		}
+	}
+}
+
 func TestTinyVerifyRejectsCompactMetadataCorruption(t *testing.T) {
 	t.Run("bin summary", func(t *testing.T) {
 		c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
@@ -268,7 +294,15 @@ func maxFreeGap(live []tinyTestAllocation, total uint32) uint32 {
 func assertTinyHeapMetadata(t *testing.T, h *tinyHeap) {
 	t.Helper()
 	seen := make([]bool, h.blockCount)
+	var summary uint64
 	for bin, head := range h.binHeads {
+		marked := h.binWords[uint32(bin)>>6]&(uint64(1)<<(uint32(bin)&63)) != 0
+		if marked != (head != tinyNoBlock) {
+			t.Fatalf("bin %d occupancy=%v head=%d", bin, marked, head)
+		}
+		if marked {
+			summary |= uint64(1) << (uint32(bin) >> 6)
+		}
 		prev := tinyNoBlock
 		for b := head; b != tinyNoBlock; {
 			if b >= h.blockCount || seen[b] {
@@ -285,6 +319,9 @@ func assertTinyHeapMetadata(t *testing.T, h *tinyHeap) {
 			}
 			prev, b = b, next
 		}
+	}
+	if h.binSummary != summary {
+		t.Fatalf("bin summary=%#x want %#x", h.binSummary, summary)
 	}
 	for b := uint32(0); b < h.blockCount; {
 		size := h.spanSize(b)

--- a/src/core/runtime/gc/tiny_test.go
+++ b/src/core/runtime/gc/tiny_test.go
@@ -111,6 +111,67 @@ func TestTinyAllocatorRandomizedAgainstIntervals(t *testing.T) {
 	}
 }
 
+func TestTinyAllocatorSkipsUndersizedSpanInSameLargeBin(t *testing.T) {
+	const blocks = uint32(256)
+	h := newTinyHeap(make([]byte, blocks*8), blocks, 8, false)
+	a, _, err := h.alloc(65 * 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	separator, _, err := h.alloc(8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _, err := h.alloc(71 * 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.free(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.free(a); err != nil { // Put the undersized span at the bin head.
+		t.Fatal(err)
+	}
+	if tinyBinForSize(65) != tinyBinForSize(71) {
+		t.Fatal("test sizes no longer share a large bin")
+	}
+	off, span, err := h.alloc(70 * 8)
+	if err != nil {
+		t.Fatalf("allocator did not find fitting span behind undersized bin head: %v", err)
+	}
+	if off != b || span != 70*8 {
+		t.Fatalf("allocation = off %d span %d, want off %d span %d", off, span, b, 70*8)
+	}
+	if err := h.free(off); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.free(separator); err != nil {
+		t.Fatal(err)
+	}
+	assertTinyHeapMetadata(t, &h)
+}
+
+func TestTinyAllocatorInvalidFreesDoNotMutateMetadata(t *testing.T) {
+	h := newTinyHeap(make([]byte, 128), 8, 16, false)
+	off, _, err := h.alloc(32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, invalid := range []uint32{off + 1, off + 16, 128, ^uint32(0)} {
+		if err := h.free(invalid); err == nil {
+			t.Fatalf("free(%d) succeeded", invalid)
+		}
+		assertTinyHeapMetadata(t, &h)
+	}
+	if err := h.free(off); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.free(off); err == nil {
+		t.Fatal("double free succeeded")
+	}
+	assertTinyHeapMetadata(t, &h)
+}
+
 func TestTinyVerifyRejectsCompactMetadataCorruption(t *testing.T) {
 	t.Run("bin summary", func(t *testing.T) {
 		c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
@@ -147,6 +208,15 @@ func TestTinyVerifyRejectsCompactMetadataCorruption(t *testing.T) {
 		root := Root(r)
 		if err := c.Verify(Slots{&root}); err == nil {
 			t.Fatal("Verify accepted an allocation-start bit inside a live span")
+		}
+	})
+	t.Run("invalid trailing bin bit", func(t *testing.T) {
+		c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
+		last := len(c.tiny.binWords) - 1
+		c.tiny.binWords[last] |= uint64(1) << 63
+		c.tiny.binSummary |= uint64(1) << uint32(last)
+		if err := c.Verify(nil); err == nil {
+			t.Fatal("Verify accepted an occupancy bit beyond the final bin")
 		}
 	})
 }

--- a/src/core/runtime/gc/tiny_test.go
+++ b/src/core/runtime/gc/tiny_test.go
@@ -1,6 +1,11 @@
 package gc
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
+
+type tinyTestAllocation struct{ off, blocks uint32 }
 
 func newTinyTestCollector(t *testing.T, cfg Config) *Collector {
 	t.Helper()
@@ -21,8 +26,187 @@ func newTinyTestCollector(t *testing.T, cfg Config) *Collector {
 
 func TestTinyHeapInitializesOneFreeSpan(t *testing.T) {
 	c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
-	if c.tiny.freeHead != 0 || c.tiny.blocks[0].size != 8 || c.tiny.blocks[0].used {
-		t.Fatalf("bad initial span: head=%d span=%+v", c.tiny.freeHead, c.tiny.blocks[0])
+	if c.tiny.findFreeSpan(8) != 0 || c.tiny.spanSize(0) != 8 || c.tiny.isUsedStart(0) {
+		t.Fatalf("bad initial span: start=%d size=%d used=%v", c.tiny.findFreeSpan(8), c.tiny.spanSize(0), c.tiny.isUsedStart(0))
+	}
+}
+
+func TestTinyAllocatorMetadataIsCompact(t *testing.T) {
+	c := newTinyTestCollector(t, Config{TinyHeapBytes: defaultTinyHeapBytes, TinyBlockBytes: defaultTinyBlockBytes})
+	metadataBytes := c.tiny.metadataBytes()
+	if max := uintptr(defaultTinyHeapBytes / 4); metadataBytes > max {
+		t.Fatalf("tiny allocator metadata = %d bytes, want at most %d for a %d-byte heap", metadataBytes, max, defaultTinyHeapBytes)
+	}
+}
+
+func TestTinyAllocatorBinClassBoundaries(t *testing.T) {
+	for _, blocks := range []uint32{1, 2, 63, 64, 65, 71, 72, 127, 128, 129, 255, 256, 4096} {
+		h := newTinyHeap(make([]byte, blocks*8), blocks, 8, false)
+		off, span, err := h.alloc(blocks * 8)
+		if err != nil {
+			t.Fatalf("allocate %d blocks: %v", blocks, err)
+		}
+		if off != 0 || span != blocks*8 {
+			t.Fatalf("allocate %d blocks = off %d span %d", blocks, off, span)
+		}
+		if err := h.free(off); err != nil {
+			t.Fatalf("free %d blocks: %v", blocks, err)
+		}
+		assertTinyHeapMetadata(t, &h)
+	}
+}
+
+func TestTinyAllocatorUsesWideBoundariesAboveUint16(t *testing.T) {
+	const blocks = uint32(1 << 16)
+	h := newTinyHeap(make([]byte, blocks*8), blocks, 8, false)
+	if h.span16 != nil || len(h.span32) != int(blocks) {
+		t.Fatalf("wide heap metadata = span16 %d span32 %d", len(h.span16), len(h.span32))
+	}
+	off, span, err := h.alloc((blocks - 1) * 8)
+	if err != nil || off != 0 || span != (blocks-1)*8 {
+		t.Fatalf("wide allocation = off %d span %d err %v", off, span, err)
+	}
+	if err := h.free(off); err != nil {
+		t.Fatal(err)
+	}
+	assertTinyHeapMetadata(t, &h)
+}
+
+func TestTinyAllocatorRandomizedAgainstIntervals(t *testing.T) {
+	const blocks = uint32(257)
+	h := newTinyHeap(make([]byte, blocks*16), blocks, 16, false)
+	live := make([]tinyTestAllocation, 0, blocks)
+	rng := rand.New(rand.NewSource(0x318))
+	for step := 0; step < 50_000; step++ {
+		if len(live) != 0 && rng.Intn(3) == 0 {
+			i := rng.Intn(len(live))
+			if err := h.free(live[i].off * h.blockBytes); err != nil {
+				t.Fatalf("step %d free %+v: %v", step, live[i], err)
+			}
+			live[i] = live[len(live)-1]
+			live = live[:len(live)-1]
+		} else {
+			need := uint32(rng.Intn(96) + 1)
+			offBytes, spanBytes, err := h.alloc(need * h.blockBytes)
+			if err != nil {
+				if maxFreeGap(live, blocks) >= need {
+					t.Fatalf("step %d rejected %d blocks with a fitting interval", step, need)
+				}
+			} else {
+				a := tinyTestAllocation{off: offBytes / h.blockBytes, blocks: spanBytes / h.blockBytes}
+				if a.blocks != need || a.off+a.blocks > blocks {
+					t.Fatalf("step %d invalid allocation: %+v need=%d", step, a, need)
+				}
+				for _, other := range live {
+					if a.off < other.off+other.blocks && other.off < a.off+a.blocks {
+						t.Fatalf("step %d overlap: %+v and %+v", step, a, other)
+					}
+				}
+				live = append(live, a)
+			}
+		}
+		if step%127 == 0 {
+			assertTinyHeapMetadata(t, &h)
+		}
+	}
+}
+
+func TestTinyVerifyRejectsCompactMetadataCorruption(t *testing.T) {
+	t.Run("bin summary", func(t *testing.T) {
+		c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
+		c.tiny.binSummary = 0
+		if err := c.Verify(nil); err == nil {
+			t.Fatal("Verify accepted a missing free-bin summary bit")
+		}
+	})
+	t.Run("free link cycle", func(t *testing.T) {
+		c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
+		c.tiny.setFreeLinks(0, 0, tinyNoBlock)
+		if err := c.Verify(nil); err == nil {
+			t.Fatal("Verify accepted a cyclic free bin")
+		}
+	})
+	t.Run("span endpoint", func(t *testing.T) {
+		c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
+		c.tiny.putSpanSize(7, 7)
+		if err := c.Verify(nil); err == nil {
+			t.Fatal("Verify accepted mismatched span boundaries")
+		}
+	})
+	t.Run("interior allocation start", func(t *testing.T) {
+		c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
+		r, err := c.NewStructDefault(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		start := c.entry(r).off / c.tiny.blockBytes
+		if c.tiny.spanSize(start) < 2 {
+			t.Fatal("test object does not span two blocks")
+		}
+		c.tiny.setUsedStart(start+1, true)
+		root := Root(r)
+		if err := c.Verify(Slots{&root}); err == nil {
+			t.Fatal("Verify accepted an allocation-start bit inside a live span")
+		}
+	})
+}
+
+func maxFreeGap(live []tinyTestAllocation, total uint32) uint32 {
+	var max uint32
+	for start := uint32(0); start < total; {
+		end := total
+		for _, a := range live {
+			if a.off >= start && a.off < end {
+				end = a.off
+			}
+		}
+		if end-start > max {
+			max = end - start
+		}
+		if end == total {
+			break
+		}
+		start = end
+		for _, a := range live {
+			if a.off == end {
+				start = a.off + a.blocks
+				break
+			}
+		}
+	}
+	return max
+}
+
+func assertTinyHeapMetadata(t *testing.T, h *tinyHeap) {
+	t.Helper()
+	seen := make([]bool, h.blockCount)
+	for bin, head := range h.binHeads {
+		prev := tinyNoBlock
+		for b := head; b != tinyNoBlock; {
+			if b >= h.blockCount || seen[b] {
+				t.Fatalf("bin %d contains invalid/cyclic start %d", bin, b)
+			}
+			seen[b] = true
+			size := h.spanSize(b)
+			if size == 0 || tinyBinForSize(size) != uint32(bin) || h.isUsedStart(b) {
+				t.Fatalf("bin %d contains malformed span %d size %d", bin, b, size)
+			}
+			next, gotPrev := h.freeLinks(b)
+			if gotPrev != prev {
+				t.Fatalf("span %d prev=%d want %d", b, gotPrev, prev)
+			}
+			prev, b = b, next
+		}
+	}
+	for b := uint32(0); b < h.blockCount; {
+		size := h.spanSize(b)
+		if size == 0 || size > h.blockCount-b || h.spanSize(b+size-1) != size {
+			t.Fatalf("invalid boundary at block %d size %d", b, size)
+		}
+		if h.isUsedStart(b) == seen[b] {
+			t.Fatalf("span %d is neither exactly allocated nor free", b)
+		}
+		b += size
 	}
 }
 
@@ -47,10 +231,12 @@ func TestTinyAllocateFreeReuseCoalesceAndFailure(t *testing.T) {
 	if err := c.Verify(nil); err != nil {
 		t.Fatal(err)
 	}
-	if c.tiny.freeHead != 0 || c.tiny.blocks[0].size != 6 {
-		t.Fatalf("free spans not coalesced: head=%d span=%+v", c.tiny.freeHead, c.tiny.blocks[0])
+	if c.tiny.findFreeSpan(6) != 0 || c.tiny.spanSize(0) != 6 {
+		t.Fatalf("free spans not coalesced: start=%d size=%d", c.tiny.findFreeSpan(6), c.tiny.spanSize(0))
 	}
-	for i := range c.tiny.mem[:32] {
+	// The first eight bytes of a free span hold its intrusive bin links. All
+	// remaining bytes retain the configured free-memory poison.
+	for i := tinyFreeLinkBytes; i < 32; i++ {
 		if c.tiny.mem[i] != 0xdd {
 			t.Fatalf("freed byte %d not poisoned", i)
 		}
@@ -91,12 +277,12 @@ func TestTinyFragmentationFailureThenCoalesceSucceeds(t *testing.T) {
 
 func TestTinyHugeRoundedAllocationDoesNotConsumeZeroBlocks(t *testing.T) {
 	c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
-	before := c.tiny.blocks[0]
+	beforeSize, beforeSummary := c.tiny.spanSize(0), c.tiny.binSummary
 	if off, span, err := c.tiny.alloc(^uint32(0) - 7); err == nil {
 		t.Fatalf("huge rounded allocation succeeded: off=%d span=%d", off, span)
 	}
-	if c.tiny.freeHead != 0 || c.tiny.blocks[0] != before {
-		t.Fatalf("failed huge allocation corrupted free span: head=%d before=%+v after=%+v", c.tiny.freeHead, before, c.tiny.blocks[0])
+	if c.tiny.findFreeSpan(8) != 0 || c.tiny.spanSize(0) != beforeSize || c.tiny.binSummary != beforeSummary {
+		t.Fatalf("failed huge allocation corrupted free span: start=%d before=%d after=%d", c.tiny.findFreeSpan(8), beforeSize, c.tiny.spanSize(0))
 	}
 }
 
@@ -110,8 +296,8 @@ func TestTinyHugeArrayLengthRejectedWithoutMetadataCorruption(t *testing.T) {
 	if _, err := c.NewArrayDefault(4, length); err == nil {
 		t.Fatal("huge tiny array allocation succeeded")
 	}
-	if len(c.handles) != 1 || c.tiny.freeHead != 0 || c.tiny.blocks[0].used || c.tiny.blocks[0].size != 8 {
-		t.Fatalf("failed huge array allocation corrupted metadata: handles=%d head=%d span=%+v", len(c.handles), c.tiny.freeHead, c.tiny.blocks[0])
+	if len(c.handles) != 1 || c.tiny.findFreeSpan(8) != 0 || c.tiny.isUsedStart(0) || c.tiny.spanSize(0) != 8 {
+		t.Fatalf("failed huge array allocation corrupted metadata: handles=%d start=%d size=%d", len(c.handles), c.tiny.findFreeSpan(8), c.tiny.spanSize(0))
 	}
 	if err := c.Verify(nil); err != nil {
 		t.Fatal(err)

--- a/src/core/runtime/gc/tiny_test.go
+++ b/src/core/runtime/gc/tiny_test.go
@@ -219,6 +219,24 @@ func TestTinyVerifyRejectsCompactMetadataCorruption(t *testing.T) {
 			t.Fatal("Verify accepted an occupancy bit beyond the final bin")
 		}
 	})
+	for _, tc := range []struct {
+		name   string
+		mutate func(*tinyHeap)
+	}{
+		{name: "boundary tags", mutate: func(h *tinyHeap) { h.span16 = h.span16[:len(h.span16)-1] }},
+		{name: "allocation starts", mutate: func(h *tinyHeap) { h.usedStarts = nil }},
+		{name: "bin heads", mutate: func(h *tinyHeap) { h.binHeads = h.binHeads[:len(h.binHeads)-1] }},
+		{name: "bin words", mutate: func(h *tinyHeap) { h.binWords = nil }},
+		{name: "heap geometry", mutate: func(h *tinyHeap) { h.blockCount-- }},
+	} {
+		t.Run(tc.name+" shape", func(t *testing.T) {
+			c := newTinyTestCollector(t, Config{TinyHeapBytes: 128, TinyBlockBytes: 16})
+			tc.mutate(&c.tiny)
+			if err := c.Verify(nil); err == nil {
+				t.Fatal("Verify accepted malformed compact metadata shape")
+			}
+		})
+	}
 }
 
 func maxFreeGap(live []tinyTestAllocation, total uint32) uint32 {


### PR DESCRIPTION
## Summary

- replace TinyGC's 16-byte record for every heap block with compact boundary tags and an allocation-start bitmap
- use exact small-span bins, logarithmic large-span bins, and two-level occupancy metadata for bounded fitting-bin lookup
- retain deterministic exhaustion, exact coalescing, alignment, poisoning, and support for heaps above 65,535 blocks
- harden verification against corrupt boundaries, links, occupancy bits, metadata shapes, and overflow-prone handle extents

Closes #318.

## Measurements

On linux/amd64 with the default 64 KiB Tiny heap:

- allocator backing metadata: **65,536 -> 9,180 bytes** (-86.0%)
- 2,048-span impossible fragmented allocation: **~2.29 us / 16 B/op -> ~4.9 ns / 0 B/op**
- common allocate/free/full-coalesce microbenchmark: **~9.8 ns -> ~39.5-41 ns**
- minimal Tiny constructor executable: **+5,814 bytes unstripped**, **+4,096 bytes stripped** including file alignment

The common full-coalescing regression is documented explicitly in `docs/gc-benchmarks.md`; the fragmented lookup and metadata improvements should be reviewed as a measured footprint/latency tradeoff.

## Hardening

- randomized interval-oracle testing and stateful fuzzing
- bin-class and wide-boundary transition tests
- same-large-bin fitting-span selection behind an undersized head
- invalid, misaligned, interior, out-of-range, and double-free rejection
- repeated poison/coalescing validation
- corruption tests for cyclic links, mismatched boundaries, forged occupancy, interior start bits, and truncated metadata

## Validation

- `go test ./src/core/runtime/gc -count=1`
- `go test -race ./src/core/runtime/gc -count=1`
- `go vet ./src/core/runtime/gc`
- package tests with `-gcflags=all=-d=checkptr=2`
- repeated allocator and allocation-bound fuzz campaigns, including multi-million-trace runs
- linux/386 and linux/arm64 test cross-compilation
- repository-wide tests passed outside staged conformance cases requiring the absent local WebAssembly 3 corpus
