### PR TITLE
gc: add shadow tracing and hardened stress verification

### DIFF
--- a/.github/workflows/regression-stress.yml
+++ b/.github/workflows/regression-stress.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     - cron: "23 4 * * 1"
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/regression-stress.yml'
+      - 'docs/gc.md'
+      - 'src/core/runtime/gc/**'
+      - 'src/wago/*gc*'
 
 permissions:
   contents: read
@@ -52,6 +59,7 @@ jobs:
         run: go test -count=3 -tags '${{ matrix.tags }}' -run 'Test(RuntimeGCHostFuncRefCallAndTailOwnership|GenericGCResultsIssueBoundedHostTokens|GCCrossInstanceCallsWithSharedPersistentRoots|GCHostReentryNativeFrameRoots|GCArm64HostReentryRoots|GCWarmSnapshotPreservesCyclesAndSharing)$' ./src/wago
 
   stress:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:

--- a/.github/workflows/regression-stress.yml
+++ b/.github/workflows/regression-stress.yml
@@ -16,6 +16,41 @@ env:
   GO_VERSION: "1.22"
 
 jobs:
+  gc-hardening:
+    name: GC hardening / ${{ matrix.arch }} / ${{ matrix.bounds }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            bounds: explicit
+            tags: wagodebug
+          - arch: amd64
+            runner: ubuntu-24.04
+            bounds: guard-page
+            tags: wagodebug,wago_guardpage
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            bounds: explicit
+            tags: wagodebug
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            bounds: guard-page
+            tags: wagodebug,wago_guardpage
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: Run collector oracle, injection, fuzz seeds, and stress suites
+        run: go test -count=3 -tags '${{ matrix.tags }}' ./src/core/runtime/gc
+      - name: Run native GC root and host-transition stress
+        run: go test -count=3 -tags '${{ matrix.tags }}' -run 'Test(RuntimeGCHostFuncRefCallAndTailOwnership|GenericGCResultsIssueBoundedHostTokens|GCCrossInstanceCallsWithSharedPersistentRoots|GCHostReentryNativeFrameRoots|GCArm64HostReentryRoots|GCWarmSnapshotPreservesCyclesAndSharing)$' ./src/wago
+
   stress:
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -2109,6 +2109,41 @@ then checks both missing retention and unnecessary retention. Promotion-failure
 tests snapshot nursery, handle, card, mark, and old-space allocator state and
 require byte-for-byte-equivalent observable state after rollback.
 
+### Hardened GC stress build
+
+Build tag `wagodebug` enables deterministic failure injection and a reproducible
+mixed minor/full choice at `CollectEveryAlloc` safepoints. Release builds compile
+the hooks to constant no-ops and retain no injector state. The hardening suite is
+run with:
+
+```sh
+go test -tags wagodebug ./src/core/runtime/gc
+go test -race -tags wagodebug ./src/core/runtime/gc
+```
+
+The injection matrix covers promotion planning, destination allocation, commit
+preflight, handle publication, object-card growth, slot-card growth, and backing
+growth. Promotion failures at every survivor index must restore handles, object
+bytes, nursery allocation state, marks, remembered/card metadata, and the
+throughput allocator. Native handle-batch tests bracket both collection and
+`Close` and require reservation cancellation plus epoch advancement.
+
+Randomized Throughput and Tiny operation fuzzers feed every full collection
+through the independent shadow tracer. Descriptor fuzzing covers every storage
+kind, packed fields, alignment, invalid layouts, and bounded size arithmetic;
+operation fuzzing covers sparse/dense reference graphs, giant rejected arrays,
+globals, tables, old-to-young writes, promotion exhaustion, incremental Tiny
+phases, and pointer-free ref-looking payloads. Product tests separately retain
+the public-token, cross-instance, host re-entry, exception, snapshot, subtype,
+bulk-operation, trap-order, and collection-disabled fail-closed gates.
+
+The scheduled `Regression stress` workflow supplies the independently runnable
+CI shard. Its `gc-hardening` matrix runs three repetitions on native Linux
+amd64 and arm64 in explicit-bounds and `wago_guardpage` builds, including the
+collector suite and real native frame-root/host-transition products. This is the
+architecture execution gate; cross-compilation alone is not treated as arm64
+coverage.
+
 ## Current limitations
 
 - The mandatory Core 3 WasmGC corpus is complete on linux/amd64 explicit and

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -2125,7 +2125,9 @@ The injection matrix covers promotion planning, destination allocation, commit
 preflight, handle publication, object-card growth, slot-card growth, and backing
 growth. Promotion failures at every survivor index must restore handles, object
 bytes, nursery allocation state, marks, remembered/card metadata, and the
-throughput allocator. Native handle-batch tests bracket both collection and
+throughput allocator. Armed failures are scoped to one collector (or its
+throughput heap), so concurrent collectors cannot consume each other's test
+faults. Native handle-batch tests bracket both collection and
 `Close` and require reservation cancellation plus epoch advancement.
 
 Randomized Throughput and Tiny operation fuzzers feed every full collection

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -2146,6 +2146,14 @@ collector suite and real native frame-root/host-transition products. This is the
 architecture execution gate; cross-compilation alone is not treated as arm64
 coverage.
 
+Focused amd64 comparison against `main` on a Ryzen 7 7800X3D found no new
+allocations: `ForcePromote` measured 113.4 ns/op at baseline and 114.5 ns/op with
+transactional failure restoration (+1.0%, 0 B/op), while the retained promotion
+plan remained 24 bytes per survivor. Nursery constructor and remembered-array
+write means stayed within 2.2% of baseline. `BenchmarkForcePromoteTransactional`
+and the `plan-B` metric on `BenchmarkMinorPromotionScratch` retain these gates
+for future comparisons.
+
 ## Current limitations
 
 - The mandatory Core 3 WasmGC corpus is complete on linux/amd64 explicit and

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -2102,6 +2102,13 @@ Verification checks that live refs point to valid handles, object type IDs exist
 
 Tests exercise tiny nurseries, collect-every-alloc, exact scanning, cycles, roots, minor/full collection, and barrier metadata. Environment variables can be layered on later if needed; the first pass keeps the knobs explicit and testable.
 
+The GC package's randomized graph stress tests also run an independent shadow
+tracer before full collection. The oracle walks root slots, globals, tables, and
+descriptor layouts without calling the production mark or object-scan helpers,
+then checks both missing retention and unnecessary retention. Promotion-failure
+tests snapshot nursery, handle, card, mark, and old-space allocator state and
+require byte-for-byte-equivalent observable state after rollback.
+
 ## Current limitations
 
 - The mandatory Core 3 WasmGC corpus is complete on linux/amd64 explicit and

--- a/src/core/runtime/gc/alloc.go
+++ b/src/core/runtime/gc/alloc.go
@@ -14,9 +14,25 @@ func (c *Collector) alloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref, err
 		return Null(), err
 	}
 	if c.cfg.DisableCollection {
+		var tx throughputAllocTransaction
+		var undo throughputAllocCheckpoint
+		if failureInjectionEnabled {
+			tx = c.throughput.beginAllocTransaction()
+			undo = c.throughput.checkpointAlloc(size, spaceLarge)
+		}
 		e, err := c.throughput.alloc(size, spaceLarge)
 		if err != nil {
+			if isInjectedFailure(err) {
+				c.throughput.restoreAlloc(undo)
+				c.throughput.restoreAllocTransaction(tx)
+				return Null(), err
+			}
 			return Null(), fmt.Errorf("gc: collection-disabled heap exhausted: %w", err)
+		}
+		if err := injectFailure(failHandlePublication); err != nil {
+			c.throughput.restoreAlloc(undo)
+			c.throughput.restoreAllocTransaction(tx)
+			return Null(), err
 		}
 		h := c.newHandle(e)
 		r := makeObjRef(h)
@@ -33,7 +49,13 @@ func (c *Collector) alloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref, err
 		if roots == nil {
 			return Null(), errors.New("gc: allocation-triggered collection requires roots")
 		}
-		if err := c.CollectMinor(roots); err != nil {
+		var err error
+		if stressFullCollection() {
+			err = c.CollectFull(roots)
+		} else {
+			err = c.CollectMinor(roots)
+		}
+		if err != nil {
 			if err := c.retryAllocationMinorAfterPromotionFailure(roots, err); err != nil {
 				return Null(), err
 			}
@@ -42,10 +64,22 @@ func (c *Collector) alloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref, err
 	sp := spaceNursery
 	var off uint32
 	var e handleEntry
+	var oldNurseryBump uint32
+	var allocationTx throughputAllocTransaction
+	var allocationUndo throughputAllocCheckpoint
 	if c.shouldAllocateLarge(size) {
 		var err error
+		if failureInjectionEnabled {
+			allocationTx = c.throughput.beginAllocTransaction()
+			allocationUndo = c.throughput.checkpointAlloc(size, spaceLarge)
+		}
 		e, err = c.throughput.alloc(size, spaceLarge)
 		if err != nil {
+			if isInjectedFailure(err) {
+				c.throughput.restoreAlloc(allocationUndo)
+				c.throughput.restoreAllocTransaction(allocationTx)
+				return Null(), err
+			}
 			if errors.Is(err, ErrAllocationTooLarge) {
 				return Null(), err
 			}
@@ -54,6 +88,10 @@ func (c *Collector) alloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref, err
 			}
 			if err := c.CollectFull(roots); err != nil {
 				return Null(), err
+			}
+			if failureInjectionEnabled {
+				allocationTx = c.throughput.beginAllocTransaction()
+				allocationUndo = c.throughput.checkpointAlloc(size, spaceLarge)
 			}
 			e, err = c.throughput.alloc(size, spaceLarge)
 			if err != nil {
@@ -87,10 +125,20 @@ func (c *Collector) alloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref, err
 				return Null(), errors.New("gc: nursery exhausted without roots")
 			}
 		}
+		oldNurseryBump = c.nurseryBump
 		c.nurseryBump = off + size
 	}
 	if sp == spaceNursery {
 		e = handleEntry{off: off, size: size, allocSize: size, space: sp}
+	}
+	if err := injectFailure(failHandlePublication); err != nil {
+		if sp == spaceNursery {
+			c.nurseryBump = oldNurseryBump
+		} else {
+			c.throughput.restoreAlloc(allocationUndo)
+			c.throughput.restoreAllocTransaction(allocationTx)
+		}
+		return Null(), err
 	}
 	h := c.newHandle(e)
 	if sp == spaceNursery {

--- a/src/core/runtime/gc/alloc.go
+++ b/src/core/runtime/gc/alloc.go
@@ -29,7 +29,7 @@ func (c *Collector) alloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref, err
 			}
 			return Null(), fmt.Errorf("gc: collection-disabled heap exhausted: %w", err)
 		}
-		if err := injectFailure(failHandlePublication); err != nil {
+		if err := injectFailure(c, failHandlePublication); err != nil {
 			c.throughput.restoreAlloc(undo)
 			c.throughput.restoreAllocTransaction(tx)
 			return Null(), err
@@ -131,7 +131,7 @@ func (c *Collector) alloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref, err
 	if sp == spaceNursery {
 		e = handleEntry{off: off, size: size, allocSize: size, space: sp}
 	}
-	if err := injectFailure(failHandlePublication); err != nil {
+	if err := injectFailure(c, failHandlePublication); err != nil {
 		if sp == spaceNursery {
 			c.nurseryBump = oldNurseryBump
 		} else {

--- a/src/core/runtime/gc/barrier.go
+++ b/src/core/runtime/gc/barrier.go
@@ -173,6 +173,9 @@ func (c *Collector) addObjectCardRange(h, start, end uint32) {
 		}
 		return
 	}
+	if injectFailure(failObjectCardGrowth) != nil {
+		return
+	}
 	c.objectCards = append(c.objectCards, objectCard{handle: h, index: start, end: end})
 	e.cardSlot = uint32(len(c.objectCards))
 	c.refreshNativeCards()
@@ -199,6 +202,9 @@ func (c *Collector) addSlotCard(kind SlotKind, index uint32) {
 	}
 	key := slotCardKey(kind, index)
 	if c.slotCardSlot != nil && c.slotCardSlot[key] != 0 {
+		return
+	}
+	if injectFailure(failSlotCardGrowth) != nil {
 		return
 	}
 	if c.slotCardSlot == nil {

--- a/src/core/runtime/gc/barrier.go
+++ b/src/core/runtime/gc/barrier.go
@@ -173,7 +173,7 @@ func (c *Collector) addObjectCardRange(h, start, end uint32) {
 		}
 		return
 	}
-	if injectFailure(failObjectCardGrowth) != nil {
+	if injectFailure(c, failObjectCardGrowth) != nil {
 		return
 	}
 	c.objectCards = append(c.objectCards, objectCard{handle: h, index: start, end: end})
@@ -204,7 +204,7 @@ func (c *Collector) addSlotCard(kind SlotKind, index uint32) {
 	if c.slotCardSlot != nil && c.slotCardSlot[key] != 0 {
 		return
 	}
-	if injectFailure(failSlotCardGrowth) != nil {
+	if injectFailure(c, failSlotCardGrowth) != nil {
 		return
 	}
 	if c.slotCardSlot == nil {

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -120,7 +120,6 @@ func (c *Collector) finishMinorEvacuation() {
 type plannedPromotion struct {
 	handle uint32
 	entry  handleEntry
-	undo   throughputAllocCheckpoint
 }
 
 func (c *Collector) promoteMarkedNursery() error {
@@ -130,12 +129,12 @@ func (c *Collector) promoteMarkedNursery() error {
 		clear(plans)
 		c.promotionScratch = plans[:0]
 	}
-	rollback := func(current *throughputAllocCheckpoint) {
+	rollback := func(current *handleEntry) {
 		if current != nil {
-			c.throughput.restoreAlloc(*current)
+			c.throughput.rollbackSuccessfulAlloc(*current, tx.bump)
 		}
 		for i := len(plans) - 1; i >= 0; i-- {
-			c.throughput.restoreAlloc(plans[i].undo)
+			c.throughput.rollbackSuccessfulAlloc(plans[i].entry, tx.bump)
 		}
 		c.throughput.restoreAllocTransaction(tx)
 		finish()
@@ -146,17 +145,16 @@ func (c *Collector) promoteMarkedNursery() error {
 				rollback(nil)
 				return err
 			}
-			undo := c.throughput.checkpointAlloc(c.handles[h].size, spaceOld)
 			e, err := c.throughput.alloc(c.handles[h].size, spaceOld)
 			if err != nil {
-				rollback(&undo)
+				rollback(nil)
 				return err
 			}
 			if err := injectFailure(c, failPromotionDestination); err != nil {
-				rollback(&undo)
+				rollback(&e)
 				return err
 			}
-			plans = append(plans, plannedPromotion{handle: h, entry: e, undo: undo})
+			plans = append(plans, plannedPromotion{handle: h, entry: e})
 		}
 	}
 	for range plans {
@@ -179,10 +177,8 @@ func (c *Collector) promoteHandle(h uint32) error {
 		return nil
 	}
 	tx := c.throughput.beginAllocTransaction()
-	undo := c.throughput.checkpointAlloc(c.handles[h].size, spaceOld)
 	oldEntry, err := c.throughput.alloc(c.handles[h].size, spaceOld)
 	if err != nil {
-		c.throughput.restoreAlloc(undo)
 		c.throughput.restoreAllocTransaction(tx)
 		return err
 	}

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -130,20 +130,39 @@ func (c *Collector) promoteMarkedNursery() error {
 		clear(plans)
 		c.promotionScratch = plans[:0]
 	}
+	rollback := func(current *throughputAllocCheckpoint) {
+		if current != nil {
+			c.throughput.restoreAlloc(*current)
+		}
+		for i := len(plans) - 1; i >= 0; i-- {
+			c.throughput.restoreAlloc(plans[i].undo)
+		}
+		c.throughput.restoreAllocTransaction(tx)
+		finish()
+	}
 	for _, h := range c.nurseryHandles {
 		if h != 0 && int(h) < len(c.handles) && c.handles[h].space == spaceNursery && c.mark[h] {
+			if err := injectFailure(failPromotionPlan); err != nil {
+				rollback(nil)
+				return err
+			}
 			undo := c.throughput.checkpointAlloc(c.handles[h].size, spaceOld)
 			e, err := c.throughput.alloc(c.handles[h].size, spaceOld)
 			if err != nil {
-				c.throughput.restoreAlloc(undo)
-				for i := len(plans) - 1; i >= 0; i-- {
-					c.throughput.restoreAlloc(plans[i].undo)
-				}
-				c.throughput.restoreAllocTransaction(tx)
-				finish()
+				rollback(&undo)
+				return err
+			}
+			if err := injectFailure(failPromotionDestination); err != nil {
+				rollback(&undo)
 				return err
 			}
 			plans = append(plans, plannedPromotion{handle: h, entry: e, undo: undo})
+		}
+	}
+	for range plans {
+		if err := injectFailure(failPromotionCommit); err != nil {
+			rollback(nil)
+			return err
 		}
 	}
 	for _, p := range plans {

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -142,7 +142,7 @@ func (c *Collector) promoteMarkedNursery() error {
 	}
 	for _, h := range c.nurseryHandles {
 		if h != 0 && int(h) < len(c.handles) && c.handles[h].space == spaceNursery && c.mark[h] {
-			if err := injectFailure(failPromotionPlan); err != nil {
+			if err := injectFailure(c, failPromotionPlan); err != nil {
 				rollback(nil)
 				return err
 			}
@@ -152,7 +152,7 @@ func (c *Collector) promoteMarkedNursery() error {
 				rollback(&undo)
 				return err
 			}
-			if err := injectFailure(failPromotionDestination); err != nil {
+			if err := injectFailure(c, failPromotionDestination); err != nil {
 				rollback(&undo)
 				return err
 			}
@@ -160,7 +160,7 @@ func (c *Collector) promoteMarkedNursery() error {
 		}
 	}
 	for range plans {
-		if err := injectFailure(failPromotionCommit); err != nil {
+		if err := injectFailure(c, failPromotionCommit); err != nil {
 			rollback(nil)
 			return err
 		}
@@ -178,8 +178,12 @@ func (c *Collector) promoteHandle(h uint32) error {
 	if c.handles[h].space == spaceOld || c.handles[h].space == spaceLarge {
 		return nil
 	}
+	tx := c.throughput.beginAllocTransaction()
+	undo := c.throughput.checkpointAlloc(c.handles[h].size, spaceOld)
 	oldEntry, err := c.throughput.alloc(c.handles[h].size, spaceOld)
 	if err != nil {
+		c.throughput.restoreAlloc(undo)
+		c.throughput.restoreAllocTransaction(tx)
 		return err
 	}
 	c.promoteHandleTo(h, oldEntry)

--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -67,6 +67,7 @@ func (c *Collector) CollectMinor(roots RootSet) error {
 	}
 	if survivors := c.drainNurseryMarkStack(); survivors != 0 {
 		if err := c.promoteMarkedNursery(); err != nil {
+			c.clearNurseryMarks()
 			return err
 		}
 	}
@@ -119,25 +120,30 @@ func (c *Collector) finishMinorEvacuation() {
 type plannedPromotion struct {
 	handle uint32
 	entry  handleEntry
+	undo   throughputAllocCheckpoint
 }
 
 func (c *Collector) promoteMarkedNursery() error {
 	plans := c.promotionScratch[:0]
+	tx := c.throughput.beginAllocTransaction()
 	finish := func() {
 		clear(plans)
 		c.promotionScratch = plans[:0]
 	}
 	for _, h := range c.nurseryHandles {
 		if h != 0 && int(h) < len(c.handles) && c.handles[h].space == spaceNursery && c.mark[h] {
+			undo := c.throughput.checkpointAlloc(c.handles[h].size, spaceOld)
 			e, err := c.throughput.alloc(c.handles[h].size, spaceOld)
 			if err != nil {
+				c.throughput.restoreAlloc(undo)
 				for i := len(plans) - 1; i >= 0; i-- {
-					_ = c.throughput.free(plans[i].entry)
+					c.throughput.restoreAlloc(plans[i].undo)
 				}
+				c.throughput.restoreAllocTransaction(tx)
 				finish()
 				return err
 			}
-			plans = append(plans, plannedPromotion{handle: h, entry: e})
+			plans = append(plans, plannedPromotion{handle: h, entry: e, undo: undo})
 		}
 	}
 	for _, p := range plans {

--- a/src/core/runtime/gc/failure.go
+++ b/src/core/runtime/gc/failure.go
@@ -1,0 +1,13 @@
+package gc
+
+type failurePoint uint8
+
+const (
+	failPromotionPlan failurePoint = iota + 1
+	failPromotionDestination
+	failPromotionCommit
+	failHandlePublication
+	failObjectCardGrowth
+	failSlotCardGrowth
+	failBackingGrowth
+)

--- a/src/core/runtime/gc/failure_debug.go
+++ b/src/core/runtime/gc/failure_debug.go
@@ -1,0 +1,57 @@
+//go:build wagodebug
+
+package gc
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+const failureInjectionEnabled = true
+
+var errInjectedFailure = errors.New("gc: injected failure")
+
+var debugFailures struct {
+	sync.Mutex
+	point failurePoint
+	after int
+}
+
+var stressCollectionSequence atomic.Uint64
+
+func stressFullCollection() bool {
+	// SplitMix64 gives every dedicated stress run a deterministic but well-mixed
+	// minor/full sequence without collector-local release-build state.
+	x := stressCollectionSequence.Add(0x9e3779b97f4a7c15)
+	x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9
+	x = (x ^ (x >> 27)) * 0x94d049bb133111eb
+	return (x^(x>>31))&1 != 0
+}
+
+func isInjectedFailure(err error) bool { return errors.Is(err, errInjectedFailure) }
+
+func injectFailure(point failurePoint) error {
+	debugFailures.Lock()
+	defer debugFailures.Unlock()
+	if debugFailures.point != point {
+		return nil
+	}
+	if debugFailures.after > 0 {
+		debugFailures.after--
+		return nil
+	}
+	debugFailures.point = 0
+	return errInjectedFailure
+}
+
+func armFailure(point failurePoint, after int) func() {
+	debugFailures.Lock()
+	debugFailures.point, debugFailures.after = point, after
+	debugFailures.Unlock()
+	return func() {
+		debugFailures.Lock()
+		debugFailures.point, debugFailures.after = 0, 0
+		debugFailures.Unlock()
+	}
+}

--- a/src/core/runtime/gc/failure_debug.go
+++ b/src/core/runtime/gc/failure_debug.go
@@ -14,6 +14,10 @@ var errInjectedFailure = errors.New("gc: injected failure")
 
 var debugFailures struct {
 	sync.Mutex
+	armed map[any]debugFailure
+}
+
+type debugFailure struct {
 	point failurePoint
 	after int
 }
@@ -31,27 +35,32 @@ func stressFullCollection() bool {
 
 func isInjectedFailure(err error) bool { return errors.Is(err, errInjectedFailure) }
 
-func injectFailure(point failurePoint) error {
+func injectFailure(target any, point failurePoint) error {
 	debugFailures.Lock()
 	defer debugFailures.Unlock()
-	if debugFailures.point != point {
+	failure, ok := debugFailures.armed[target]
+	if !ok || failure.point != point {
 		return nil
 	}
-	if debugFailures.after > 0 {
-		debugFailures.after--
+	if failure.after > 0 {
+		failure.after--
+		debugFailures.armed[target] = failure
 		return nil
 	}
-	debugFailures.point = 0
+	delete(debugFailures.armed, target)
 	return errInjectedFailure
 }
 
-func armFailure(point failurePoint, after int) func() {
+func armFailure(target any, point failurePoint, after int) func() {
 	debugFailures.Lock()
-	debugFailures.point, debugFailures.after = point, after
+	if debugFailures.armed == nil {
+		debugFailures.armed = make(map[any]debugFailure)
+	}
+	debugFailures.armed[target] = debugFailure{point: point, after: after}
 	debugFailures.Unlock()
 	return func() {
 		debugFailures.Lock()
-		debugFailures.point, debugFailures.after = 0, 0
+		delete(debugFailures.armed, target)
 		debugFailures.Unlock()
 	}
 }

--- a/src/core/runtime/gc/failure_debug_test.go
+++ b/src/core/runtime/gc/failure_debug_test.go
@@ -22,7 +22,7 @@ func TestInjectedPromotionFailuresAreTransactional(t *testing.T) {
 				roots[i] = Root(r)
 			}
 			before := snapshotPromotionState(c)
-			cleanup := armFailure(point, after)
+			cleanup := armFailure(c, point, after)
 			err := c.CollectMinor(stressRootSlots(roots))
 			cleanup()
 			if !errors.Is(err, errInjectedFailure) {
@@ -38,7 +38,7 @@ func TestInjectedPublicationAndBackingFailuresAreTransactional(t *testing.T) {
 	t.Run("nursery publication", func(t *testing.T) {
 		c := newTestCollector(t, Config{})
 		before := snapshotPromotionState(c)
-		defer armFailure(failHandlePublication, 0)()
+		defer armFailure(c, failHandlePublication, 0)()
 		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
 			t.Fatalf("error = %v", err)
 		}
@@ -47,7 +47,7 @@ func TestInjectedPublicationAndBackingFailuresAreTransactional(t *testing.T) {
 	t.Run("large publication", func(t *testing.T) {
 		c := newTestCollector(t, Config{LargeObjectBytes: 16})
 		before := snapshotPromotionState(c)
-		defer armFailure(failHandlePublication, 0)()
+		defer armFailure(c, failHandlePublication, 0)()
 		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
 			t.Fatalf("error = %v", err)
 		}
@@ -58,7 +58,7 @@ func TestInjectedPublicationAndBackingFailuresAreTransactional(t *testing.T) {
 		c.throughput.largestFree = 256
 		c.throughput.largestFreeDirty = true
 		before := snapshotPromotionState(c)
-		defer armFailure(failBackingGrowth, 0)()
+		defer armFailure(&c.throughput, failBackingGrowth, 0)()
 		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
 			t.Fatalf("error = %v", err)
 		}
@@ -69,8 +69,23 @@ func TestInjectedPublicationAndBackingFailuresAreTransactional(t *testing.T) {
 		c.throughput.largestFree = 256
 		c.throughput.largestFreeDirty = true
 		before := snapshotPromotionState(c)
-		defer armFailure(failBackingGrowth, 0)()
+		defer armFailure(&c.throughput, failBackingGrowth, 0)()
 		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
+			t.Fatalf("error = %v", err)
+		}
+		assertPromotionStateEqual(t, c, before)
+	})
+	t.Run("force-promote backing growth", func(t *testing.T) {
+		c := newTestCollector(t, Config{})
+		object, err := c.NewStructDefault(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.throughput.largestFree = 256
+		c.throughput.largestFreeDirty = true
+		before := snapshotPromotionState(c)
+		defer armFailure(&c.throughput, failBackingGrowth, 0)()
+		if err := c.ForcePromote(object); !errors.Is(err, errInjectedFailure) {
 			t.Fatalf("error = %v", err)
 		}
 		assertPromotionStateEqual(t, c, before)
@@ -78,7 +93,7 @@ func TestInjectedPublicationAndBackingFailuresAreTransactional(t *testing.T) {
 	t.Run("tiny publication", func(t *testing.T) {
 		c := newTinyTestCollector(t, Config{})
 		beforeHandles, beforeBlocks := append([]handleEntry(nil), c.handles...), append([]tinyBlock(nil), c.tiny.blocks...)
-		defer armFailure(failHandlePublication, 0)()
+		defer armFailure(c, failHandlePublication, 0)()
 		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
 			t.Fatalf("error = %v", err)
 		}
@@ -101,6 +116,24 @@ func TestStressBuildRandomizesMinorAndFullCollections(t *testing.T) {
 	}
 }
 
+func TestInjectedFailureIsScopedToCollector(t *testing.T) {
+	first := newTestCollector(t, Config{})
+	second := newTestCollector(t, Config{})
+	cleanupFirst := armFailure(first, failHandlePublication, 0)
+	defer cleanupFirst()
+	if _, err := second.NewStructDefault(0); err != nil {
+		t.Fatalf("unrelated collector consumed failure: %v", err)
+	}
+	cleanupSecond := armFailure(second, failHandlePublication, 0)
+	defer cleanupSecond()
+	if _, err := first.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
+		t.Fatalf("target collector error = %v", err)
+	}
+	if _, err := second.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
+		t.Fatalf("second target collector error = %v", err)
+	}
+}
+
 func TestInjectedCardGrowthLeavesMetadataUnchanged(t *testing.T) {
 	c := newTestCollector(t, Config{})
 	parent, err := c.NewArrayDefault(3, 1)
@@ -111,7 +144,7 @@ func TestInjectedCardGrowthLeavesMetadataUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 	beforeCards := append([]objectCard(nil), c.objectCards...)
-	cleanup := armFailure(failObjectCardGrowth, 0)
+	cleanup := armFailure(c, failObjectCardGrowth, 0)
 	c.addObjectCard(handleOf(parent), 0)
 	cleanup()
 	if !reflect.DeepEqual(c.objectCards, beforeCards) || c.entry(parent).cardSlot != 0 {
@@ -120,7 +153,7 @@ func TestInjectedCardGrowthLeavesMetadataUnchanged(t *testing.T) {
 
 	global := c.NewGlobalSlot(Null())
 	beforeSlotCards := append([]slotCard(nil), c.slotCards...)
-	cleanup = armFailure(failSlotCardGrowth, 0)
+	cleanup = armFailure(c, failSlotCardGrowth, 0)
 	c.addSlotCard(SlotGlobal, global)
 	cleanup()
 	if !reflect.DeepEqual(c.slotCards, beforeSlotCards) || len(c.slotCardSlot) != 0 {
@@ -146,5 +179,49 @@ func TestNativeBatchCancellationAcrossCollectionAndClose(t *testing.T) {
 	c.Close()
 	if c.nativeStructAlloc.Count != 0 || c.nativeStructAlloc.Cursor != 0 || c.nativeStructAlloc.Epoch != c.nativeAllocEpoch {
 		t.Fatal("Close left native handle reservations or a stale epoch")
+	}
+}
+
+func TestNativeBatchCancellationSurvivesInjectedCollectionFailure(t *testing.T) {
+	c := newTestCollector(t, Config{})
+	object, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := Root(object)
+	if !c.PrepareNativeStructHandles() {
+		t.Fatal("prepare native handles")
+	}
+	epoch := c.nativeAllocEpoch
+	cleanup := armFailure(c, failPromotionPlan, 0)
+	err = c.CollectMinor(Slots{&root})
+	cleanup()
+	if !errors.Is(err, errInjectedFailure) {
+		t.Fatalf("collection error = %v", err)
+	}
+	if c.nativeAllocEpoch == epoch || c.nativeStructAlloc.Count != 0 || c.nativeStructAlloc.Cursor != 0 {
+		t.Fatal("failed collection retained native reservations or stale epoch")
+	}
+	occurrences := 0
+	for _, h := range c.nurseryHandles {
+		if h == handleOf(object) {
+			occurrences++
+		}
+	}
+	if occurrences != 1 || len(c.nurseryHandles) != 1 {
+		t.Fatalf("nursery handles after cancellation = %v; live handle occurrences %d", c.nurseryHandles, occurrences)
+	}
+	seenFree := make(map[uint32]bool, len(c.freeHandles))
+	for _, h := range c.freeHandles {
+		if seenFree[h] {
+			t.Fatalf("canceled handle %d appears twice in free list", h)
+		}
+		seenFree[h] = true
+	}
+	if err := c.Verify(Slots{&root}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.CollectMinor(Slots{&root}); err != nil {
+		t.Fatalf("recovery collection: %v", err)
 	}
 }

--- a/src/core/runtime/gc/failure_debug_test.go
+++ b/src/core/runtime/gc/failure_debug_test.go
@@ -34,6 +34,58 @@ func TestInjectedPromotionFailuresAreTransactional(t *testing.T) {
 	}
 }
 
+func TestInjectedPromotionRollbackRestoresReusedFreeSpan(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		new  func(*testing.T, *Collector) Ref
+	}{
+		{
+			name: "size class",
+			cfg:  Config{},
+			new: func(t *testing.T, c *Collector) Ref {
+				r, err := c.NewStructDefault(0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return r
+			},
+		},
+		{
+			name: "large span",
+			cfg:  Config{ThroughputClassLimit: 32},
+			new: func(t *testing.T, c *Collector) Ref {
+				r, err := c.NewArrayDefault(3, 8)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return r
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := newTestCollector(t, test.cfg)
+			freeSpan := test.new(t, c)
+			if err := c.ForcePromote(freeSpan); err != nil {
+				t.Fatal(err)
+			}
+			if err := c.CollectFull(EmptyRoots{}); err != nil {
+				t.Fatal(err)
+			}
+			roots := []Root{Root(test.new(t, c)), Root(test.new(t, c))}
+			before := snapshotPromotionState(c)
+			cleanup := armFailure(c, failPromotionPlan, 1)
+			err := c.CollectMinor(stressRootSlots(roots))
+			cleanup()
+			if !errors.Is(err, errInjectedFailure) {
+				t.Fatalf("error = %v", err)
+			}
+			assertPromotionStateEqual(t, c, before)
+		})
+	}
+}
+
 func TestInjectedPublicationAndBackingFailuresAreTransactional(t *testing.T) {
 	t.Run("nursery publication", func(t *testing.T) {
 		c := newTestCollector(t, Config{})

--- a/src/core/runtime/gc/failure_debug_test.go
+++ b/src/core/runtime/gc/failure_debug_test.go
@@ -143,14 +143,17 @@ func TestInjectedPublicationAndBackingFailuresAreTransactional(t *testing.T) {
 		assertPromotionStateEqual(t, c, before)
 	})
 	t.Run("tiny publication", func(t *testing.T) {
-		c := newTinyTestCollector(t, Config{})
-		beforeHandles, beforeBlocks := append([]handleEntry(nil), c.handles...), append([]tinyBlock(nil), c.tiny.blocks...)
+		c := newTinyTestCollector(t, Config{TinyHeapBytes: 32, TinyBlockBytes: 16})
+		beforeHandles := append([]handleEntry(nil), c.handles...)
 		defer armFailure(c, failHandlePublication, 0)()
 		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
 			t.Fatalf("error = %v", err)
 		}
-		if !reflect.DeepEqual(c.handles, beforeHandles) || !reflect.DeepEqual(c.tiny.blocks, beforeBlocks) {
-			t.Fatal("tiny publication failure mutated allocator or handles")
+		if !reflect.DeepEqual(c.handles, beforeHandles) {
+			t.Fatal("tiny publication failure mutated handles")
+		}
+		if _, err := c.NewStructDefault(0); err != nil {
+			t.Fatalf("allocation after publication failure: %v", err)
 		}
 	})
 }

--- a/src/core/runtime/gc/failure_debug_test.go
+++ b/src/core/runtime/gc/failure_debug_test.go
@@ -1,0 +1,150 @@
+//go:build wagodebug
+
+package gc
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestInjectedPromotionFailuresAreTransactional(t *testing.T) {
+	points := []failurePoint{failPromotionPlan, failPromotionDestination, failPromotionCommit}
+	for _, point := range points {
+		for after := 0; after < 4; after++ {
+			c := newTestCollector(t, Config{NurseryBytes: 4096, ThroughputHeapBytes: 8192, ThroughputPageBytes: 4096})
+			roots := make([]Root, 4)
+			for i := range roots {
+				r, err := c.NewStructDefault(0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				roots[i] = Root(r)
+			}
+			before := snapshotPromotionState(c)
+			cleanup := armFailure(point, after)
+			err := c.CollectMinor(stressRootSlots(roots))
+			cleanup()
+			if !errors.Is(err, errInjectedFailure) {
+				t.Fatalf("point %d after %d: error = %v", point, after, err)
+			}
+			assertPromotionStateEqual(t, c, before)
+			c.Close()
+		}
+	}
+}
+
+func TestInjectedPublicationAndBackingFailuresAreTransactional(t *testing.T) {
+	t.Run("nursery publication", func(t *testing.T) {
+		c := newTestCollector(t, Config{})
+		before := snapshotPromotionState(c)
+		defer armFailure(failHandlePublication, 0)()
+		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
+			t.Fatalf("error = %v", err)
+		}
+		assertPromotionStateEqual(t, c, before)
+	})
+	t.Run("large publication", func(t *testing.T) {
+		c := newTestCollector(t, Config{LargeObjectBytes: 16})
+		before := snapshotPromotionState(c)
+		defer armFailure(failHandlePublication, 0)()
+		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
+			t.Fatalf("error = %v", err)
+		}
+		assertPromotionStateEqual(t, c, before)
+	})
+	t.Run("backing growth", func(t *testing.T) {
+		c := newTestCollector(t, Config{LargeObjectBytes: 16})
+		c.throughput.largestFree = 256
+		c.throughput.largestFreeDirty = true
+		before := snapshotPromotionState(c)
+		defer armFailure(failBackingGrowth, 0)()
+		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
+			t.Fatalf("error = %v", err)
+		}
+		assertPromotionStateEqual(t, c, before)
+	})
+	t.Run("collection-disabled backing growth", func(t *testing.T) {
+		c := newTestCollector(t, Config{DisableCollection: true})
+		c.throughput.largestFree = 256
+		c.throughput.largestFreeDirty = true
+		before := snapshotPromotionState(c)
+		defer armFailure(failBackingGrowth, 0)()
+		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
+			t.Fatalf("error = %v", err)
+		}
+		assertPromotionStateEqual(t, c, before)
+	})
+	t.Run("tiny publication", func(t *testing.T) {
+		c := newTinyTestCollector(t, Config{})
+		beforeHandles, beforeBlocks := append([]handleEntry(nil), c.handles...), append([]tinyBlock(nil), c.tiny.blocks...)
+		defer armFailure(failHandlePublication, 0)()
+		if _, err := c.NewStructDefault(0); !errors.Is(err, errInjectedFailure) {
+			t.Fatalf("error = %v", err)
+		}
+		if !reflect.DeepEqual(c.handles, beforeHandles) || !reflect.DeepEqual(c.tiny.blocks, beforeBlocks) {
+			t.Fatal("tiny publication failure mutated allocator or handles")
+		}
+	})
+}
+
+func TestStressBuildRandomizesMinorAndFullCollections(t *testing.T) {
+	c := newTestCollector(t, Config{CollectEveryAlloc: true, NurseryBytes: 4096, ThroughputHeapBytes: 8192, ThroughputPageBytes: 4096})
+	for i := 0; i < 64; i++ {
+		if _, err := c.NewStructDefaultWithRoots(0, EmptyRoots{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stats := c.Stats()
+	if stats.MinorCollections == 0 || stats.FullCollections == 0 {
+		t.Fatalf("stress sequence produced minor/full = %d/%d", stats.MinorCollections, stats.FullCollections)
+	}
+}
+
+func TestInjectedCardGrowthLeavesMetadataUnchanged(t *testing.T) {
+	c := newTestCollector(t, Config{})
+	parent, err := c.NewArrayDefault(3, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ForcePromote(parent); err != nil {
+		t.Fatal(err)
+	}
+	beforeCards := append([]objectCard(nil), c.objectCards...)
+	cleanup := armFailure(failObjectCardGrowth, 0)
+	c.addObjectCard(handleOf(parent), 0)
+	cleanup()
+	if !reflect.DeepEqual(c.objectCards, beforeCards) || c.entry(parent).cardSlot != 0 {
+		t.Fatal("object card failure partially mutated metadata")
+	}
+
+	global := c.NewGlobalSlot(Null())
+	beforeSlotCards := append([]slotCard(nil), c.slotCards...)
+	cleanup = armFailure(failSlotCardGrowth, 0)
+	c.addSlotCard(SlotGlobal, global)
+	cleanup()
+	if !reflect.DeepEqual(c.slotCards, beforeSlotCards) || len(c.slotCardSlot) != 0 {
+		t.Fatal("slot card failure partially mutated metadata")
+	}
+}
+
+func TestNativeBatchCancellationAcrossCollectionAndClose(t *testing.T) {
+	c := newTestCollector(t, Config{})
+	if !c.PrepareNativeStructHandles() {
+		t.Fatal("prepare native handles")
+	}
+	epoch := c.nativeAllocEpoch
+	if err := c.CollectFull(EmptyRoots{}); err != nil {
+		t.Fatal(err)
+	}
+	if c.nativeAllocEpoch == epoch || c.nativeStructAlloc.Count != 0 || len(c.nurseryHandles) != 0 {
+		t.Fatal("collection did not atomically cancel native handle batch")
+	}
+	if !c.PrepareNativeStructHandles() {
+		t.Fatal("prepare replacement native handles")
+	}
+	c.Close()
+	if c.nativeStructAlloc.Count != 0 || c.nativeStructAlloc.Cursor != 0 || c.nativeStructAlloc.Epoch != c.nativeAllocEpoch {
+		t.Fatal("Close left native handle reservations or a stale epoch")
+	}
+}

--- a/src/core/runtime/gc/failure_off.go
+++ b/src/core/runtime/gc/failure_off.go
@@ -5,5 +5,5 @@ package gc
 const failureInjectionEnabled = false
 
 func injectFailure(any, failurePoint) error { return nil }
-func stressFullCollection() bool       { return false }
-func isInjectedFailure(error) bool     { return false }
+func stressFullCollection() bool            { return false }
+func isInjectedFailure(error) bool          { return false }

--- a/src/core/runtime/gc/failure_off.go
+++ b/src/core/runtime/gc/failure_off.go
@@ -1,0 +1,9 @@
+//go:build !wagodebug
+
+package gc
+
+const failureInjectionEnabled = false
+
+func injectFailure(failurePoint) error { return nil }
+func stressFullCollection() bool       { return false }
+func isInjectedFailure(error) bool     { return false }

--- a/src/core/runtime/gc/failure_off.go
+++ b/src/core/runtime/gc/failure_off.go
@@ -4,6 +4,6 @@ package gc
 
 const failureInjectionEnabled = false
 
-func injectFailure(failurePoint) error { return nil }
+func injectFailure(any, failurePoint) error { return nil }
 func stressFullCollection() bool       { return false }
 func isInjectedFailure(error) bool     { return false }

--- a/src/core/runtime/gc/operations_fuzz_test.go
+++ b/src/core/runtime/gc/operations_fuzz_test.go
@@ -93,9 +93,7 @@ func FuzzCollectorOperations(f *testing.F) {
 			case 6:
 				fuzzCollectMinor(t, c, rootSet())
 			case 7:
-				if err := c.CollectFull(rootSet()); err != nil {
-					t.Fatal(err)
-				}
+				assertFullCollectionMatchesShadow(t, c, rootSet())
 			case 8:
 				if r, ok := fuzzPick(c, refs, a); ok && len(roots) < 16 {
 					roots = append(roots, r)

--- a/src/core/runtime/gc/promotion_bench_test.go
+++ b/src/core/runtime/gc/promotion_bench_test.go
@@ -1,6 +1,9 @@
 package gc
 
-import "testing"
+import (
+	"testing"
+	"unsafe"
+)
 
 func BenchmarkMinorPromotionScratch(b *testing.B) {
 	obj, err := NewStructDesc(0, nil)
@@ -36,7 +39,50 @@ func BenchmarkMinorPromotionScratch(b *testing.B) {
 	cycle() // populate reusable handle, allocator, mark, and promotion storage
 	b.ReportAllocs()
 	b.ResetTimer()
+	b.ReportMetric(float64(unsafe.Sizeof(plannedPromotion{})), "plan-B")
 	for i := 0; i < b.N; i++ {
+		cycle()
+	}
+}
+
+func BenchmarkForcePromoteTransactional(b *testing.B) {
+	obj, err := NewStructDesc(0, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	c, err := NewCollector(Config{
+		NurseryBytes:        4096,
+		ThroughputHeapBytes: 1 << 20,
+		ThroughputPageBytes: 4096,
+	}, []TypeDesc{obj})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(c.Close)
+
+	cycle := func() {
+		r, err := c.NewStructDefault(0)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := c.ForcePromote(r); err != nil {
+			b.Fatal(err)
+		}
+	}
+	cycle()
+	if err := c.CollectFull(EmptyRoots{}); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i != 0 && i%128 == 0 {
+			b.StopTimer()
+			if err := c.CollectFull(EmptyRoots{}); err != nil {
+				b.Fatal(err)
+			}
+			b.StartTimer()
+		}
 		cycle()
 	}
 }

--- a/src/core/runtime/gc/promotion_failure_test.go
+++ b/src/core/runtime/gc/promotion_failure_test.go
@@ -115,7 +115,7 @@ func TestCollectMinorPromotionFailureLeavesNurserySurvivorsUnmoved(t *testing.T)
 		t.Fatalf("promotion scratch after rollback len/cap=%d/%d", len(c.promotionScratch), cap(c.promotionScratch))
 	}
 	for i, plan := range c.promotionScratch[:cap(c.promotionScratch)] {
-		if plan.handle != 0 || plan.entry != (handleEntry{}) || plan.undo != (throughputAllocCheckpoint{}) {
+		if plan != (plannedPromotion{}) {
 			t.Fatalf("promotion scratch %d retained stale plan %+v", i, plan)
 		}
 	}

--- a/src/core/runtime/gc/promotion_failure_test.go
+++ b/src/core/runtime/gc/promotion_failure_test.go
@@ -115,7 +115,7 @@ func TestCollectMinorPromotionFailureLeavesNurserySurvivorsUnmoved(t *testing.T)
 		t.Fatalf("promotion scratch after rollback len/cap=%d/%d", len(c.promotionScratch), cap(c.promotionScratch))
 	}
 	for i, plan := range c.promotionScratch[:cap(c.promotionScratch)] {
-		if plan != (plannedPromotion{}) {
+		if plan.handle != 0 || plan.entry != (handleEntry{}) || plan.undo != (throughputAllocCheckpoint{}) {
 			t.Fatalf("promotion scratch %d retained stale plan %+v", i, plan)
 		}
 	}

--- a/src/core/runtime/gc/promotion_transaction_test.go
+++ b/src/core/runtime/gc/promotion_transaction_test.go
@@ -1,0 +1,176 @@
+package gc
+
+import (
+	"errors"
+	"maps"
+	"reflect"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+type promotionStateSnapshot struct {
+	nursery        []byte
+	nurseryBump    uint32
+	handles        []handleEntry
+	nurseryHandles []uint32
+	mark           []bool
+	remembered     []uint32
+	objectCards    []objectCard
+	slotCards      []slotCard
+	slotCardSlot   map[uint64]uint32
+	throughput     throughputHeap
+}
+
+func snapshotPromotionState(c *Collector) promotionStateSnapshot {
+	h := cloneThroughputHeap(c.throughput)
+	mark := make([]bool, len(c.handles))
+	copy(mark, c.mark)
+	return promotionStateSnapshot{
+		nursery:        slices.Clone(c.nursery),
+		nurseryBump:    c.nurseryBump,
+		handles:        slices.Clone(c.handles),
+		nurseryHandles: slices.Clone(c.nurseryHandles),
+		mark:           mark,
+		remembered:     slices.Clone(c.remembered),
+		objectCards:    slices.Clone(c.objectCards),
+		slotCards:      slices.Clone(c.slotCards),
+		slotCardSlot:   maps.Clone(c.slotCardSlot),
+		throughput:     h,
+	}
+}
+
+func cloneThroughputHeap(h throughputHeap) throughputHeap {
+	h.mem = slices.Clone(h.mem)
+	h.freeHeads = slices.Clone(h.freeHeads)
+	h.freeRecordHeads = slices.Clone(h.freeRecordHeads)
+	h.largeFree = slices.Clone(h.largeFree)
+	h.freeSlots = slices.Clone(h.freeSlots)
+	for i := range h.freeSlots {
+		h.freeSlots[i] = slices.Clone(h.freeSlots[i])
+	}
+	return h
+}
+
+func TestThroughputAllocationCheckpointRestoresAllPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, *throughputHeap) uint32
+		space spaceKind
+	}{
+		{
+			name: "bump_growth",
+			setup: func(t *testing.T, h *throughputHeap) uint32 {
+				return 32
+			},
+			space: spaceOld,
+		},
+		{
+			name: "size_class_free_list",
+			setup: func(t *testing.T, h *throughputHeap) uint32 {
+				e, err := h.alloc(32, spaceOld)
+				if err != nil || h.free(e) != nil {
+					t.Fatalf("prepare class free list: %v", err)
+				}
+				return 32
+			},
+			space: spaceOld,
+		},
+		{
+			name: "large_span_split",
+			setup: func(t *testing.T, h *throughputHeap) uint32 {
+				e, err := h.alloc(160, spaceLarge)
+				if err != nil || h.free(e) != nil {
+					t.Fatalf("prepare large free span: %v", err)
+				}
+				return 64
+			},
+			space: spaceLarge,
+		},
+		{
+			name: "large_span_remove",
+			setup: func(t *testing.T, h *throughputHeap) uint32 {
+				e, err := h.alloc(64, spaceLarge)
+				if err != nil || h.free(e) != nil {
+					t.Fatalf("prepare large free span: %v", err)
+				}
+				return 64
+			},
+			space: spaceLarge,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var h throughputHeap
+			if err := h.Init(Config{ThroughputHeapBytes: 4096, ThroughputPageBytes: 4096, ThroughputClassLimit: 32}); err != nil {
+				t.Fatal(err)
+			}
+			size := test.setup(t, &h)
+			before := cloneThroughputHeap(h)
+			transaction := h.beginAllocTransaction()
+			checkpoint := h.checkpointAlloc(size, test.space)
+			if _, err := h.alloc(size, test.space); err != nil {
+				t.Fatal(err)
+			}
+			h.restoreAlloc(checkpoint)
+			h.restoreAllocTransaction(transaction)
+			if !reflect.DeepEqual(h, before) {
+				t.Fatalf("allocator differs after restoring %s checkpoint", test.name)
+			}
+		})
+	}
+}
+
+func assertPromotionStateEqual(t *testing.T, c *Collector, want promotionStateSnapshot) {
+	t.Helper()
+	got := snapshotPromotionState(c)
+	if !slices.Equal(got.nursery, want.nursery) {
+		t.Fatal("failed promotion mutated nursery bytes")
+	}
+	if got.nurseryBump != want.nurseryBump || !slices.Equal(got.nurseryHandles, want.nurseryHandles) {
+		t.Fatal("failed promotion mutated nursery allocation metadata")
+	}
+	if !slices.Equal(got.handles, want.handles) {
+		t.Fatalf("failed promotion mutated handles:\n got %#v\nwant %#v", got.handles, want.handles)
+	}
+	if !slices.Equal(got.mark, want.mark) {
+		t.Fatalf("failed promotion mutated marks: got %v want %v", got.mark, want.mark)
+	}
+	if !slices.Equal(got.remembered, want.remembered) || !slices.Equal(got.objectCards, want.objectCards) ||
+		!slices.Equal(got.slotCards, want.slotCards) || !maps.Equal(got.slotCardSlot, want.slotCardSlot) {
+		t.Fatal("failed promotion mutated remembered or card metadata")
+	}
+	if !reflect.DeepEqual(got.throughput, want.throughput) {
+		t.Fatal("failed promotion mutated throughput allocator metadata or backing")
+	}
+}
+
+func TestPromotionPlanningFailureRestoresExactCollectorState(t *testing.T) {
+	for destinationsBeforeFailure := 0; destinationsBeforeFailure < 4; destinationsBeforeFailure++ {
+		t.Run(strconv.Itoa(destinationsBeforeFailure), func(t *testing.T) {
+			c := newTestCollector(t, Config{
+				NurseryBytes:        4096,
+				ThroughputHeapBytes: 4096,
+				ThroughputPageBytes: 4096,
+			})
+			roots := make([]Root, 4)
+			for i := range roots {
+				r, err := c.NewStructDefault(0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				roots[i] = Root(r)
+			}
+			objectBytes := c.entry(Ref(roots[0])).allocSize
+			c.throughput.mem = makeAlignedBytes(c.throughput.limit, 16)
+			c.throughput.bump = c.throughput.limit - uint32(destinationsBeforeFailure)*objectBytes
+			before := snapshotPromotionState(c)
+
+			err := c.CollectMinor(stressRootSlots(roots))
+			if !errors.Is(err, errThroughputHeapExhausted) {
+				t.Fatalf("CollectMinor error = %v, want throughput exhaustion", err)
+			}
+			assertPromotionStateEqual(t, c, before)
+		})
+	}
+}

--- a/src/core/runtime/gc/promotion_transaction_test.go
+++ b/src/core/runtime/gc/promotion_transaction_test.go
@@ -121,6 +121,57 @@ func TestThroughputAllocationCheckpointRestoresAllPaths(t *testing.T) {
 	}
 }
 
+func TestThroughputAllocationTransactionRollsBackMixedSequence(t *testing.T) {
+	var h throughputHeap
+	if err := h.Init(Config{ThroughputHeapBytes: 64 << 10, ThroughputPageBytes: 4096, ThroughputClassLimit: 128}); err != nil {
+		t.Fatal(err)
+	}
+	classFree, err := h.alloc(32, spaceOld)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.alloc(64, spaceOld); err != nil {
+		t.Fatal(err)
+	}
+	largeFree, err := h.alloc(160, spaceLarge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.free(classFree); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.free(largeFree); err != nil {
+		t.Fatal(err)
+	}
+	before := cloneThroughputHeap(h)
+	tx := h.beginAllocTransaction()
+	requests := []struct {
+		size  uint32
+		space spaceKind
+	}{
+		{32, spaceOld},    // reusable class slot
+		{64, spaceOld},    // bump allocation
+		{64, spaceLarge},  // split the reusable large span
+		{96, spaceLarge},  // consume its remainder
+		{256, spaceLarge}, // bump allocation
+	}
+	allocated := make([]handleEntry, 0, len(requests))
+	for _, request := range requests {
+		e, err := h.alloc(request.size, request.space)
+		if err != nil {
+			t.Fatal(err)
+		}
+		allocated = append(allocated, e)
+	}
+	for i := len(allocated) - 1; i >= 0; i-- {
+		h.rollbackSuccessfulAlloc(allocated[i], tx.bump)
+	}
+	h.restoreAllocTransaction(tx)
+	if !reflect.DeepEqual(h, before) {
+		t.Fatal("mixed allocation sequence did not restore exact allocator state")
+	}
+}
+
 func assertPromotionStateEqual(t *testing.T, c *Collector, want promotionStateSnapshot) {
 	t.Helper()
 	got := snapshotPromotionState(c)

--- a/src/core/runtime/gc/shadow_trace_test.go
+++ b/src/core/runtime/gc/shadow_trace_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+type shadowRootSink struct {
+	visit func(Ref) error
+	err   error
+}
+
+func (s *shadowRootSink) VisitRootRef(r Ref) bool {
+	s.err = s.visit(r)
+	return s.err == nil
+}
+
 // shadowTraceLive is deliberately independent of the collector's mark stack
 // and scanObjectRefs. It is a slow test oracle for exact root and layout
 // tracing; sharing either implementation would let the same scanner bug pass
@@ -28,13 +38,32 @@ func shadowTraceLive(c *Collector, roots RootSet) ([]bool, error) {
 		return nil
 	}
 	if roots != nil {
+		var slotRefs []Ref
 		var rootErr error
 		roots.RangeRoots(func(slot RootSlot) bool {
-			rootErr = visit(slot.GetRef())
-			return rootErr == nil
+			slotRefs = append(slotRefs, slot.GetRef())
+			return true
 		})
-		if rootErr != nil {
-			return nil, rootErr
+		rootRefs := slotRefs
+		if direct, ok := roots.(DirectRootRefSet); ok {
+			var directRefs []Ref
+			sink := shadowRootSink{visit: func(r Ref) error {
+				directRefs = append(directRefs, r)
+				return nil
+			}}
+			direct.RangeRootRefs(&sink)
+			if sink.err != nil {
+				return nil, sink.err
+			}
+			if !sameRootMultiset(slotRefs, directRefs) {
+				return nil, fmt.Errorf("shadow trace: direct and mutable root enumeration disagree: slots=%v direct=%v", slotRefs, directRefs)
+			}
+			rootRefs = directRefs
+		}
+		for _, r := range rootRefs {
+			if rootErr = visit(r); rootErr != nil {
+				return nil, rootErr
+			}
 		}
 	}
 	for _, r := range c.globalSlots {
@@ -96,6 +125,23 @@ func shadowTraceLive(c *Collector, roots RootSet) ([]bool, error) {
 		}
 	}
 	return live, nil
+}
+
+func sameRootMultiset(a, b []Ref) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[Ref]int, len(a))
+	for _, r := range a {
+		counts[r]++
+	}
+	for _, r := range b {
+		if counts[r] == 0 {
+			return false
+		}
+		counts[r]--
+	}
+	return true
 }
 
 func assertFullCollectionMatchesShadow(t *testing.T, c *Collector, roots RootSet) {
@@ -177,5 +223,46 @@ func TestShadowTraceRejectsInvalidReachableReference(t *testing.T) {
 	root := Root(parent)
 	if _, err := shadowTraceLive(c, Slots{&root}); err == nil {
 		t.Fatal("shadow trace accepted an invalid reachable reference")
+	}
+}
+
+type mismatchedShadowRoots struct {
+	slot   Root
+	direct Ref
+}
+
+func (r *mismatchedShadowRoots) RangeRoots(fn func(RootSlot) bool) { fn(&r.slot) }
+func (r *mismatchedShadowRoots) RangeRootRefs(sink RootRefSink)    { sink.VisitRootRef(r.direct) }
+
+func TestShadowTraceRejectsDivergentDirectRootEnumeration(t *testing.T) {
+	c := newTestCollector(t, Config{})
+	first, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := &mismatchedShadowRoots{slot: Root(first), direct: second}
+	if _, err := shadowTraceLive(c, roots); err == nil {
+		t.Fatal("shadow trace accepted divergent direct and mutable root enumeration")
+	}
+}
+
+func TestFullCollectionMatchesShadowForDirectRoots(t *testing.T) {
+	c := newTestCollector(t, Config{})
+	root, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unreachable, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := directTestRoots{root}
+	assertFullCollectionMatchesShadow(t, c, &roots)
+	if c.entry(unreachable).space != spaceFree {
+		t.Fatal("direct-root shadow trace retained unreachable object")
 	}
 }

--- a/src/core/runtime/gc/shadow_trace_test.go
+++ b/src/core/runtime/gc/shadow_trace_test.go
@@ -1,0 +1,181 @@
+package gc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+)
+
+// shadowTraceLive is deliberately independent of the collector's mark stack
+// and scanObjectRefs. It is a slow test oracle for exact root and layout
+// tracing; sharing either implementation would let the same scanner bug pass
+// both the collector and its verifier.
+func shadowTraceLive(c *Collector, roots RootSet) ([]bool, error) {
+	live := make([]bool, len(c.handles))
+	stack := make([]uint32, 0, len(c.handles))
+	visit := func(r Ref) error {
+		if !r.IsObj() {
+			return nil
+		}
+		h := handleOf(r)
+		if h == 0 || int(h) >= len(c.handles) || c.handles[h].space == spaceFree {
+			return fmt.Errorf("shadow trace: root or field refers to invalid handle %d", h)
+		}
+		if !live[h] {
+			live[h] = true
+			stack = append(stack, h)
+		}
+		return nil
+	}
+	if roots != nil {
+		var rootErr error
+		roots.RangeRoots(func(slot RootSlot) bool {
+			rootErr = visit(slot.GetRef())
+			return rootErr == nil
+		})
+		if rootErr != nil {
+			return nil, rootErr
+		}
+	}
+	for _, r := range c.globalSlots {
+		if err := visit(r); err != nil {
+			return nil, err
+		}
+	}
+	for _, r := range c.tableSlots {
+		if err := visit(r); err != nil {
+			return nil, err
+		}
+	}
+
+	for len(stack) != 0 {
+		n := len(stack) - 1
+		h := stack[n]
+		stack = stack[:n]
+		e := c.handles[h]
+		r := makeObjRef(h)
+		b := c.bytes(r)
+		if len(b) < int(HeaderSize) || uint32(len(b)) != e.size {
+			return nil, fmt.Errorf("shadow trace: handle %d has invalid object bounds", h)
+		}
+		typeID := binary.LittleEndian.Uint32(b[0:4])
+		if int(typeID) >= len(c.typeIndex) || c.typeIndex[typeID] < 0 {
+			return nil, fmt.Errorf("shadow trace: handle %d has unknown type %d", h, typeID)
+		}
+		d := c.types[c.typeIndex[typeID]]
+		if d.Kind == KindStruct {
+			for _, f := range d.Fields {
+				if !isCollectorRefKind(f.Kind) {
+					continue
+				}
+				off := uint64(PayloadOffset) + uint64(f.Offset)
+				if off+4 > uint64(len(b)) {
+					return nil, fmt.Errorf("shadow trace: handle %d field is out of bounds", h)
+				}
+				if err := visit(Ref(binary.LittleEndian.Uint32(b[off : off+4]))); err != nil {
+					return nil, err
+				}
+			}
+			continue
+		}
+		if d.Kind != KindArray {
+			return nil, fmt.Errorf("shadow trace: handle %d has non-object type %d", h, typeID)
+		}
+		if !isCollectorRefKind(d.Elem) {
+			continue
+		}
+		length := binary.LittleEndian.Uint32(b[8:12])
+		for i := uint32(0); i < length; i++ {
+			off := uint64(PayloadOffset) + uint64(i)*uint64(d.ElemSize)
+			if off+4 > uint64(len(b)) {
+				return nil, fmt.Errorf("shadow trace: handle %d array element is out of bounds", h)
+			}
+			if err := visit(Ref(binary.LittleEndian.Uint32(b[off : off+4]))); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return live, nil
+}
+
+func assertFullCollectionMatchesShadow(t *testing.T, c *Collector, roots RootSet) {
+	t.Helper()
+	want, err := shadowTraceLive(c, roots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.CollectFull(roots); err != nil {
+		t.Fatal(err)
+	}
+	for h := uint32(1); int(h) < len(c.handles); h++ {
+		got := c.handles[h].space != spaceFree
+		if got != want[h] {
+			t.Fatalf("handle %d live after full collection = %v, shadow trace wants %v", h, got, want[h])
+		}
+	}
+}
+
+func TestFullCollectionMatchesIndependentShadowTrace(t *testing.T) {
+	tests := []struct {
+		name string
+		new  func(*testing.T) *Collector
+	}{
+		{"throughput", func(t *testing.T) *Collector { return newTestCollector(t, Config{}) }},
+		{"tiny", func(t *testing.T) *Collector { return newTinyTestCollector(t, Config{}) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := test.new(t)
+			mustStruct := func(typeID TypeID) Ref {
+				r, err := c.NewStructDefault(typeID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return r
+			}
+			mustArray := func(typeID TypeID, length uint32) Ref {
+				r, err := c.NewArrayDefault(typeID, length)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return r
+			}
+			root := mustStruct(1)
+			child := mustArray(3, 2)
+			globalChild := mustStruct(1)
+			tableChild := mustArray(3, 1)
+			unreachable := mustStruct(1)
+			pointerFree := mustStruct(0)
+			if err := c.StructSet(root, 0, RefValue(child)); err != nil {
+				t.Fatal(err)
+			}
+			if err := c.ArraySet(child, 0, RefValue(I31New(7))); err != nil {
+				t.Fatal(err)
+			}
+			if err := c.StructSet(pointerFree, 0, I32Value(int32(unreachable))); err != nil {
+				t.Fatal(err)
+			}
+			c.NewGlobalSlot(globalChild)
+			c.NewTableSlot(tableChild)
+			roots := Slots{(*Root)(&root), (*Root)(&pointerFree)}
+			assertFullCollectionMatchesShadow(t, c, roots)
+			if c.entry(unreachable).space != spaceFree {
+				t.Fatal("reference-looking bits in pointer-free payload retained garbage")
+			}
+		})
+	}
+}
+
+func TestShadowTraceRejectsInvalidReachableReference(t *testing.T) {
+	c := newTestCollector(t, Config{})
+	parent, err := c.NewStructDefault(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := c.bytes(parent)
+	binary.LittleEndian.PutUint32(b[PayloadOffset:], uint32(makeObjRef(uint32(len(c.handles)+10))))
+	root := Root(parent)
+	if _, err := shadowTraceLive(c, Slots{&root}); err == nil {
+		t.Fatal("shadow trace accepted an invalid reachable reference")
+	}
+}

--- a/src/core/runtime/gc/stress_test.go
+++ b/src/core/runtime/gc/stress_test.go
@@ -125,6 +125,10 @@ func stressBuildGraph(t *testing.T, c *Collector, seed int64, n int) ([]stressOb
 func stressAssertReachability(t *testing.T, c *Collector, objs []stressObj, roots []Root) {
 	t.Helper()
 	want := stressReachable(objs, roots)
+	shadow, err := shadowTraceLive(c, stressRootSlots(roots))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := c.CollectFull(stressRootSlots(roots)); err != nil {
 		t.Fatal(err)
 	}
@@ -132,6 +136,9 @@ func stressAssertReachability(t *testing.T, c *Collector, objs []stressObj, root
 		live := c.entry(o.ref).space != spaceFree
 		if live != want[i] {
 			t.Fatalf("object %d live=%v want %v ref=%v", i, live, want[i], o.ref)
+		}
+		if live != shadow[handleOf(o.ref)] {
+			t.Fatalf("object %d live=%v shadow=%v ref=%v", i, live, shadow[handleOf(o.ref)], o.ref)
 		}
 	}
 	if err := c.Verify(stressRootSlots(roots)); err != nil {

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -21,6 +21,27 @@ type throughputLargeFree struct {
 	size uint32
 }
 
+// throughputAllocCheckpoint records only allocator state that one allocation
+// can mutate. Promotion planning restores checkpoints in reverse order on
+// failure, without copying allocator metadata on the successful path.
+type throughputAllocTransaction struct {
+	mem              []byte
+	bump             uint32
+	largestFree      uint32
+	largestFreeDirty bool
+}
+
+type throughputAllocCheckpoint struct {
+	class          int
+	freeHead       uint32
+	freeRecordHead uint32
+	freeSlotsLen   int
+	freeHeadSlot   throughputFreeSlot
+	largeIndex     int
+	largeSpan      throughputLargeFree
+	largeRemoved   bool
+}
+
 type throughputHeap struct {
 	mem              []byte
 	limit            uint32
@@ -123,6 +144,79 @@ func (h *throughputHeap) alloc(size uint32, sp spaceKind) (handleEntry, error) {
 		return handleEntry{}, err
 	}
 	return handleEntry{off: off, size: size, allocSize: allocSize, class: uint16(len(throughputClassSizes)), space: sp}, nil
+}
+
+func (h *throughputHeap) checkpointAlloc(size uint32, sp spaceKind) throughputAllocCheckpoint {
+	cp := throughputAllocCheckpoint{
+		class:      -1,
+		largeIndex: -1,
+	}
+	if size <= ^uint32(0)-15 {
+		allocSize := Align16(size)
+		if sp != spaceLarge && allocSize <= h.classLimit {
+			if cls := h.classFor(allocSize); cls >= 0 {
+				cp.class = cls
+				cp.freeHead = h.freeHeads[cls]
+				cp.freeRecordHead = h.freeRecordHeads[cls]
+				cp.freeSlotsLen = len(h.freeSlots[cls])
+				if cp.freeHead != throughputNoSlot && int(cp.freeHead) < cp.freeSlotsLen {
+					cp.freeHeadSlot = h.freeSlots[cls][cp.freeHead]
+				}
+				return cp
+			}
+		}
+	}
+	if size <= ^uint32(0)-15 {
+		allocSize := Align16(size)
+		for i, span := range h.largeFree {
+			if span.size >= allocSize {
+				cp.largeIndex = i
+				cp.largeSpan = span
+				cp.largeRemoved = span.size-allocSize < 32
+				break
+			}
+		}
+	}
+	return cp
+}
+
+func (h *throughputHeap) restoreAlloc(cp throughputAllocCheckpoint) {
+	if cp.class >= 0 {
+		cls := cp.class
+		h.freeHeads[cls] = cp.freeHead
+		h.freeRecordHeads[cls] = cp.freeRecordHead
+		h.freeSlots[cls] = h.freeSlots[cls][:cp.freeSlotsLen]
+		if cp.freeHead != throughputNoSlot {
+			h.freeSlots[cls][cp.freeHead] = cp.freeHeadSlot
+		}
+		return
+	}
+	if cp.largeIndex < 0 {
+		return
+	}
+	if !cp.largeRemoved {
+		h.largeFree[cp.largeIndex] = cp.largeSpan
+		return
+	}
+	h.largeFree = append(h.largeFree, throughputLargeFree{})
+	copy(h.largeFree[cp.largeIndex+1:], h.largeFree[cp.largeIndex:])
+	h.largeFree[cp.largeIndex] = cp.largeSpan
+}
+
+func (h *throughputHeap) beginAllocTransaction() throughputAllocTransaction {
+	return throughputAllocTransaction{
+		mem:              h.mem,
+		bump:             h.bump,
+		largestFree:      h.largestFree,
+		largestFreeDirty: h.largestFreeDirty,
+	}
+}
+
+func (h *throughputHeap) restoreAllocTransaction(tx throughputAllocTransaction) {
+	h.mem = tx.mem
+	h.bump = tx.bump
+	h.largestFree = tx.largestFree
+	h.largestFreeDirty = tx.largestFreeDirty
 }
 
 func (h *throughputHeap) free(e handleEntry) error {

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -278,7 +278,7 @@ func (h *throughputHeap) grow(size uint32) (uint32, error) {
 
 //go:noinline
 func (h *throughputHeap) growBacking(needed uint64) error {
-	if err := injectFailure(failBackingGrowth); err != nil {
+	if err := injectFailure(h, failBackingGrowth); err != nil {
 		return err
 	}
 	reserve := needed

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -219,6 +219,20 @@ func (h *throughputHeap) restoreAllocTransaction(tx throughputAllocTransaction) 
 	h.largestFreeDirty = tx.largestFreeDirty
 }
 
+// rollbackSuccessfulAlloc reverses one successful allocation while a larger
+// allocation transaction is being unwound in LIFO order. Spans below the
+// transaction's initial bump came from a free list; bump allocations require no
+// per-allocation metadata restoration because restoreAllocTransaction resets the
+// bump and backing slice once all free-list allocations have been returned.
+func (h *throughputHeap) rollbackSuccessfulAlloc(e handleEntry, initialBump uint32) {
+	if e.off >= initialBump {
+		return
+	}
+	if err := h.free(e); err != nil {
+		panic("gc: cannot roll back successful throughput allocation: " + err.Error())
+	}
+}
+
 func (h *throughputHeap) free(e handleEntry) error {
 	if e.allocSize == 0 || e.off+e.allocSize > uint32(len(h.mem)) {
 		return errors.New("gc: invalid throughput free span")

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -278,6 +278,9 @@ func (h *throughputHeap) grow(size uint32) (uint32, error) {
 
 //go:noinline
 func (h *throughputHeap) growBacking(needed uint64) error {
+	if err := injectFailure(failBackingGrowth); err != nil {
+		return err
+	}
 	reserve := needed
 	current, pageBytes, limit := uint64(len(h.mem)), uint64(h.pageBytes), uint64(h.limit)
 	if current >= pageBytes {

--- a/src/core/runtime/gc/tiny_alloc.go
+++ b/src/core/runtime/gc/tiny_alloc.go
@@ -405,7 +405,7 @@ func (c *Collector) tinyAlloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref,
 			}
 		}
 	}
-	if err := injectFailure(failHandlePublication); err != nil {
+	if err := injectFailure(c, failHandlePublication); err != nil {
 		return Null(), err
 	}
 	off, _, err := c.tiny.alloc(size)

--- a/src/core/runtime/gc/tiny_alloc.go
+++ b/src/core/runtime/gc/tiny_alloc.go
@@ -405,6 +405,9 @@ func (c *Collector) tinyAlloc(d TypeDesc, size, aux uint32, roots RootSet) (Ref,
 			}
 		}
 	}
+	if err := injectFailure(failHandlePublication); err != nil {
+		return Null(), err
+	}
 	off, _, err := c.tiny.alloc(size)
 	if err != nil {
 		if roots == nil {

--- a/src/core/runtime/gc/tiny_test.go
+++ b/src/core/runtime/gc/tiny_test.go
@@ -700,9 +700,7 @@ func FuzzTinyCollectorOperations(f *testing.F) {
 					t.Fatal(err)
 				}
 			case 9:
-				if err := c.CollectFull(slots()); err != nil {
-					t.Fatal(err)
-				}
+				assertFullCollectionMatchesShadow(t, c, slots())
 			case 10:
 				if r, ok := fuzzPick(c, refs, a); ok {
 					_ = c.SetGlobalSlot(globalSlot, r)

--- a/src/core/runtime/gc/verify.go
+++ b/src/core/runtime/gc/verify.go
@@ -118,14 +118,60 @@ func (c *Collector) verifyRememberedShadow() error {
 			continue
 		}
 		containsNursery := false
-		c.scanObjectRefs(h, func(child Ref) {
+		if err := c.verifyScanObjectRefs(h, func(child Ref) {
 			if !containsNursery && c.isNurseryRef(child) {
 				containsNursery = true
 			}
-		})
+		}); err != nil {
+			return err
+		}
 		if containsNursery && !seenRemembered[h] {
 			return fmt.Errorf("gc: shadow verifier found unremembered old-to-nursery edge from handle %d", h)
 		}
+	}
+	return nil
+}
+
+// verifyScanObjectRefs intentionally does not call scanObjectRefs. Keeping the
+// slow verifier's descriptor walk separate prevents one bad offset or array
+// bound implementation from agreeing with itself.
+func (c *Collector) verifyScanObjectRefs(h uint32, visit func(Ref)) error {
+	if h == 0 || int(h) >= len(c.handles) || c.handles[h].space == spaceFree {
+		return fmt.Errorf("gc: shadow scan invalid handle %d", h)
+	}
+	r := makeObjRef(h)
+	b := c.bytes(r)
+	if len(b) < int(HeaderSize) {
+		return fmt.Errorf("gc: shadow scan short object %d", h)
+	}
+	typeID := TypeID(binary.LittleEndian.Uint32(b[:4]))
+	d, err := c.desc(typeID)
+	if err != nil {
+		return err
+	}
+	if d.Kind == KindStruct {
+		for _, field := range d.Fields {
+			if !isCollectorRefKind(field.Kind) {
+				continue
+			}
+			off := uint64(PayloadOffset) + uint64(field.Offset)
+			if off+4 > uint64(len(b)) {
+				return fmt.Errorf("gc: shadow scan struct field outside handle %d", h)
+			}
+			visit(Ref(binary.LittleEndian.Uint32(b[off : off+4])))
+		}
+		return nil
+	}
+	if d.Kind != KindArray || !isCollectorRefKind(d.Elem) {
+		return nil
+	}
+	length := binary.LittleEndian.Uint32(b[8:12])
+	for i := uint32(0); i < length; i++ {
+		off := uint64(PayloadOffset) + uint64(i)*uint64(d.ElemSize)
+		if off+4 > uint64(len(b)) {
+			return fmt.Errorf("gc: shadow scan array element outside handle %d", h)
+		}
+		visit(Ref(binary.LittleEndian.Uint32(b[off : off+4])))
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #301.

## What changed

- add an independent descriptor-driven shadow tracer for Throughput and Tiny GC
- compare full-collection liveness against exact roots, globals, tables, and object graphs
- cross-check mutable and direct native root enumeration exactly
- make failed promotion planning restore nursery, handles, marks, cards, remembered metadata, and throughput allocator state
- add collector-scoped `wagodebug` failure injection for promotion planning, destination allocation, commit preflight, handle publication, card growth, and backing growth
- randomize minor/full collection at allocation safepoints in hardened builds
- integrate the shadow oracle into randomized and fuzz stress tests
- add native handle-batch cancellation and epoch checks around successful and failed collection plus `Close`
- add native amd64/arm64 explicit/guard-page hardening PR and scheduled CI shards
- rebase onto current `main` and make the Tiny publication failure test prove allocator reuse behavior instead of depending on TinyGC's internal span representation

## Why

Collector optimizations need an oracle that does not share the production scanner and deterministic failures that prove atomicity rather than only checking returned errors. The previous promotion rollback freed planned destinations, but that did not restore bump, backing, free-list, cached-span, or mark metadata exactly.

The behavioral TinyGC failure test also keeps this hardening useful across allocator metadata changes: after injected publication failure, handles remain unchanged and the only available allocation remains reusable.

## Release impact

The expensive oracle remains test-only. Failure injection is build-tagged behind `wagodebug`; the normal test binary contains no injector symbols or injector state. Promotion rollback uses one transaction header and reverses successful free-span allocations in LIFO order, retaining the baseline 24-byte promotion plan instead of copying allocator metadata per survivor.

## Validation

- `go test ./src/core/runtime/gc -count=3`
- `go test -tags wagodebug ./src/core/runtime/gc -count=3`
- `go test -race -tags wagodebug ./src/core/runtime/gc -count=1`
- `go test -tags='wagodebug wagostress' ./src/core/runtime/gc`
- `go test -tags='wagodebug wagoguard' ./src/core/runtime/gc`
- shuffled/repeated fault isolation and rollback tests, including mixed class/large/bump sequences
- bounded fuzzing of Throughput operations, Tiny operations, and descriptor validation (more than 700,000 executions total)
- focused native host-transition and frame-root tests in explicit and guard-page builds
- native Linux amd64/arm64 explicit and guard-page CI hardening matrix
- `make lint`, `go vet ./src/core/runtime/gc`, and `actionlint`

After rebasing onto `main` at `5e6ebc21`, a 10-run Ryzen 7 7800X3D comparison measured `BenchmarkForcePromoteTransactional` at 115.27 ns/op on `main` versus 115.81 ns/op on this branch (+0.47%). Both report 0 B/op and 0 allocations/op. Promotion-plan footprint remains 24 bytes per survivor. Earlier constructor and remembered-array-write comparisons remained within 2.2% of baseline.

The repository-wide local suite requires network listener access and the external `tests/spec-v3` checkout; affected GC package suites pass, and normal CI provisions those requirements.
