### PR TITLE
compiler: precompute Wasm GC layouts

### DIFF
--- a/docs/gc.md
+++ b/docs/gc.md
@@ -410,7 +410,19 @@ Payload begins at `PayloadOffset == HeaderSize`, currently 16 bytes. Logical obj
 
 ## Compiled metadata and instantiation
 
-Frontend lowering produces immutable descriptor metadata during compile. `Compiled.GCTypeDescs` stores the descriptor slice so `.wago` blobs can instantiate without re-decoding the Wasm type section. The descriptor slice index matches flattened `wasm.TypeIdx.Index`, including function sentinels used only to preserve indexes. Codec v34 retains the appended `StorageV128` kind, the 16-byte layout contract, and validated native safepoint/callsite root maps; older codec versions are rejected.
+Frontend lowering produces immutable descriptor metadata during compile. The same
+flattened type-section traversal also builds a compiler-only table containing each
+type's recursive-group bounds, struct field offsets/sizes/initializer slots,
+array-element layout, alignment, object size, and collector-reference classification.
+Railshot indexes that table directly while compiling GC instructions instead of
+walking recursive groups and preceding fields at every use. The table points at the
+immutable decoded subtype declarations and is discarded after code generation; it is
+not retained by `Compiled` or serialized. `Compiled.GCTypeDescs` stores the runtime
+descriptor slice so `.wago` blobs can instantiate without re-decoding the Wasm type
+section. The descriptor slice index matches flattened `wasm.TypeIdx.Index`, including
+function sentinels used only to preserve indexes. Codec v34 retains the appended
+`StorageV128` kind, the 16-byte layout contract, and validated native
+safepoint/callsite root maps; older codec versions are rejected.
 
 Each `Instance` normally owns its own `gc.Collector` when its executable product can create or retain heap objects. Collectors are never shared across instances: nursery state, old-space state, roots, remembered sets, cards, and collection statistics are per-instance runtime state. MVP/non-GC modules keep `Instance.gc == nil` to avoid allocating an unused heap.
 

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -183,10 +183,11 @@ const mergeFReg Reg = 11
 // fn holds the per-function code-generation state — the port's equivalent of
 // WARP's Compiler/backend working set. One is created per compiled function.
 type fn struct {
-	a  *amd64.Asm // the (reused) x86-64 encoder
-	s  *stack     // the valent-block operand stack
-	m  *wasm.Module
-	ft *wasm.CompType // this function's signature
+	a             *amd64.Asm // the (reused) x86-64 encoder
+	s             *stack     // the valent-block operand stack
+	m             *wasm.Module
+	ft            *wasm.CompType // this function's signature
+	gcTypeLayouts []codegen.GCTypeLayout
 	transient
 	globalIdx          int
 	traceFuncIdx       uint32
@@ -930,7 +931,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 				st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
 				ms.Funcs[i] = st
 			}
-			fnCode, rl, internalOff, err := compileFunc(m, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.CustomInstructions, opts.GCFrameRoots.Function(i), st, inlineTargets, sc)
+			fnCode, rl, internalOff, err := compileFunc(m, opts.Codegen.Module.GCTypeLayouts, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.CustomInstructions, opts.GCFrameRoots.Function(i), st, inlineTargets, sc)
 			allHints[i] = funcHints{}
 			if err != nil {
 				return nil, fmt.Errorf("amd64: function %d: %w", i, err)
@@ -1010,7 +1011,7 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 				if ms != nil {
 					st = ms.Funcs[i]
 				}
-				fnCode, rl, internalOff, err := compileFunc(m, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, allHints[i], opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.CustomInstructions, opts.GCFrameRoots.Function(i), st, inlineTargets, ws.scratch)
+				fnCode, rl, internalOff, err := compileFunc(m, opts.Codegen.Module.GCTypeLayouts, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, allHints[i], opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.CustomInstructions, opts.GCFrameRoots.Function(i), st, inlineTargets, ws.scratch)
 				allHints[i] = funcHints{}
 				if err != nil {
 					results[i].err = err
@@ -1489,7 +1490,7 @@ var errRegExhausted = errors.New("amd64: no register available to spill")
 // compileFunc compiles one function, retrying with local pinning disabled if the
 // first (pinned) attempt exhausts the register file. Pinning is a pure speed
 // optimization, so the unpinned recompile is always correct.
-func compileFunc(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers bool, custom map[uint32]CustomInstruction, gcFrameRoots *shared.GCFrameRootPlan, stats *CodegenStats, inlineTargets inlineTargetTable, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFunc(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, funcIdx int, hostAdapter, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers bool, custom map[uint32]CustomInstruction, gcFrameRoots *shared.GCFrameRootPlan, stats *CodegenStats, inlineTargets inlineTargetTable, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
 	if gcFrameRoots != nil && gcFrameRoots.Candidate {
 		gcFrameRoots.Exact = true
 		gcFrameRoots.Safepoints = gcFrameRoots.Safepoints[:0]
@@ -1505,10 +1506,10 @@ func compileFunc(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFact
 		// generalized to pinned registers.
 		modGlobals = nil
 	}
-	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, hostAdapter, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, moduleEH, custom, gcFrameRoots, stats, pinLocals, inlineTargets, sc)
+	code, relocs, internalOff, err = compileFuncAttempt(m, gcTypeLayouts, funcIdx, hostAdapter, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, moduleEH, custom, gcFrameRoots, stats, pinLocals, inlineTargets, sc)
 	if errors.Is(err, errRegExhausted) {
 		resetFuncStats(stats)
-		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, hostAdapter, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, moduleEH, custom, gcFrameRoots, stats, false, inlineTargets, sc)
+		code, relocs, internalOff, err = compileFuncAttempt(m, gcTypeLayouts, funcIdx, hostAdapter, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, moduleEH, custom, gcFrameRoots, stats, false, inlineTargets, sc)
 		if err == nil {
 			stats.setUnpinnedRetry()
 		}
@@ -1516,7 +1517,7 @@ func compileFunc(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFact
 	return
 }
 
-func compileFuncAttempt(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, moduleEH bool, custom map[uint32]CustomInstruction, gcFrameRoots *shared.GCFrameRootPlan, stats *CodegenStats, pinLocals bool, inlineTargets inlineTargetTable, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, funcIdx int, hostAdapter, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, moduleEH bool, custom map[uint32]CustomInstruction, gcFrameRoots *shared.GCFrameRootPlan, stats *CodegenStats, pinLocals bool, inlineTargets inlineTargetTable, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(regExhausted); ok {
@@ -1553,7 +1554,7 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, hostAdapter, guardMode, bou
 	f := &sc.fnState
 	localType, localSlot, localExactGCType, locals := f.localType, f.localSlot, f.localExactGCType, f.locals
 	mt0, _ := m.MemoryType(0)
-	*f = fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, transient: sc.transient, globalIdx: globalIdx, traceFuncIdx: uint32(globalIdx), tracePCBase: c.LocalDeclBytes, customInstructions: custom, nParams: len(ft.Params), nLocals: nLocals, localType: localType, localSlot: localSlot, localExactGCType: localExactGCType, locals: locals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled && !moduleEH, globalCellReg: regNone, memSizeReg: regNone, immutableTables: hints.immutableTables, stagedTailDescriptors: hints.hasTailCall, importBindings: importBindings, stats: stats, entryInitialized: entryInitialized, gcFrameRoots: gcFrameRoots, moduleEH: moduleEH, threadedMemory0: mt0.Shared}
+	*f = fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, gcTypeLayouts: gcTypeLayouts, transient: sc.transient, globalIdx: globalIdx, traceFuncIdx: uint32(globalIdx), tracePCBase: c.LocalDeclBytes, customInstructions: custom, nParams: len(ft.Params), nLocals: nLocals, localType: localType, localSlot: localSlot, localExactGCType: localExactGCType, locals: locals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled && !moduleEH, globalCellReg: regNone, memSizeReg: regNone, immutableTables: hints.immutableTables, stagedTailDescriptors: hints.hasTailCall, importBindings: importBindings, stats: stats, entryInitialized: entryInitialized, gcFrameRoots: gcFrameRoots, moduleEH: moduleEH, threadedMemory0: mt0.Shared}
 	// Retain the (possibly grown) control-frame backing for the next function.
 	defer func() {
 		sc.ctrl = f.ctrl

--- a/src/core/compiler/backend/railshot/amd64/gc_array.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_array.go
@@ -41,7 +41,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("amd64: array.new type %d is unavailable", typeIndex)
 		}
@@ -72,7 +72,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok || field.Storage().Val().Kind() != wasm.ValRef {
 			return fmt.Errorf("amd64: array.new_elem type %d is not a reference array", typeIndex)
 		}
@@ -93,7 +93,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("amd64: array.new_data type %d is unavailable", typeIndex)
 		}
@@ -117,7 +117,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("amd64: array.new_fixed type %d is unavailable", typeIndex)
 		}
@@ -167,7 +167,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		if _, ok := stagedArrayType(f.m, typeIndex); !ok {
+		if _, ok := f.stagedArrayType(typeIndex); !ok {
 			return fmt.Errorf("amd64: array.new_default type %d is unavailable", typeIndex)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -189,7 +189,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("amd64: array.get type %d is unavailable", typeIndex)
 		}
@@ -212,7 +212,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return nil
 		}
 		if sub == 11 && field.Storage().Val().Kind() == wasm.ValRef && gcFrameRefType(f.m, field.Storage().Val()) {
-			if target, ok := nativeGCFlatType(f.m, typeIndex); ok && target.Final {
+			if target, ok := f.stagedGCType(typeIndex); ok && target.Final {
 				return f.emitNativeFinalArrayRefGet(typeIndex)
 			}
 		}
@@ -224,7 +224,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("amd64: array.set type %d is unavailable", typeIndex)
 		}
@@ -238,7 +238,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if f.emitDirectGCArraySet(typeIndex) {
 			return nil
 		}
-		if target, found := nativeGCFlatType(f.m, typeIndex); found && target.Final && field.Storage().Val().Kind() == wasm.ValRef && field.Storage().Val().Ref().Heap().Kind() == wasm.HeapAbs && (field.Storage().Val().Ref().Heap().Abs() == wasm.HeapAny || field.Storage().Val().Ref().Heap().Abs() == wasm.HeapEq) {
+		if target, found := f.stagedGCType(typeIndex); found && target.Final && field.Storage().Val().Kind() == wasm.ValRef && field.Storage().Val().Ref().Heap().Kind() == wasm.HeapAbs && (field.Storage().Val().Ref().Heap().Abs() == wasm.HeapAny || field.Storage().Val().Ref().Heap().Abs() == wasm.HeapEq) {
 			return f.emitNativeCardSafeArrayRefSet(typeIndex, valueType)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -255,7 +255,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("amd64: array.fill type %d is unavailable or immutable", typeIndex)
 		}
@@ -275,7 +275,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok || field.Mut() != wasm.Var || (!field.Storage().Packed() && field.Storage().Val().Kind() == wasm.ValRef) {
 			return fmt.Errorf("amd64: array.init_data type %d is unavailable", typeIndex)
 		}
@@ -292,7 +292,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok || field.Mut() != wasm.Var || field.Storage().Val().Kind() != wasm.ValRef {
 			return fmt.Errorf("amd64: array.init_elem type %d is unavailable", typeIndex)
 		}
@@ -309,11 +309,11 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		dstField, ok := stagedArrayType(f.m, dstType)
+		dstField, ok := f.stagedArrayType(dstType)
 		if !ok || dstField.Mut() != wasm.Var {
 			return fmt.Errorf("amd64: array.copy destination type %d is unavailable or immutable", dstType)
 		}
-		if _, ok := stagedArrayType(f.m, srcType); !ok {
+		if _, ok := f.stagedArrayType(srcType); !ok {
 			return fmt.Errorf("amd64: array.copy source type %d is unavailable", srcType)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(dstType)})

--- a/src/core/compiler/backend/railshot/amd64/gc_dead_new.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_dead_new.go
@@ -106,7 +106,7 @@ func (f *fn) gcConstructorFeedsDroppedStruct(r *wasm.Reader) bool {
 			if err != nil {
 				return false
 			}
-			st, ok := stagedStructType(f.m, typeIndex)
+			st, ok := f.stagedStructType(typeIndex)
 			if !ok || len(st.Comp.Fields) <= above {
 				// The outer constructor does not consume the candidate.
 				return false

--- a/src/core/compiler/backend/railshot/amd64/gc_direct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_direct.go
@@ -1013,10 +1013,11 @@ func (f *fn) emitNativeArrayAllocStub(site gcArrayAllocStubSite) {
 // has been validated. It writes the result directly to the synchronous control frame and
 // returns nonzero in RAX on success; zero selects the ordinary rooted helper.
 func (f *fn) emitNativeStructAllocStub(typeIndex uint32) {
-	fields, objectSize, objectAlign, pointerFree, ok := nativeGCStructAllocLayout(f.m, typeIndex)
+	plan, ok := f.nativeGCStructAllocLayout(typeIndex)
 	if !ok {
 		panic("amd64: invalid native struct allocation layout")
 	}
+	fields, objectSize, objectAlign, pointerFree := plan.fields, plan.objectSize, plan.objectAlign, plan.pointerFree
 	a := f.a
 	var preserve [3]bool
 	for _, local := range f.pinnedLocals {
@@ -1115,13 +1116,13 @@ func (f *fn) emitNativeStructAllocStub(typeIndex uint32) {
 	addFallback(a.JccPlaceholder(condE))
 
 	for _, field := range fields {
-		if !field.ref {
+		if !field.CollectorRef {
 			continue
 		}
-		a.Load32(RAX, RDI, hcArgs+int32(field.slot*8))
+		a.Load32(RAX, RDI, hcArgs+int32(field.Slot*8))
 		a.TestSelf(RAX, false)
 		nullOK := -1
-		if field.nullable {
+		if field.Nullable {
 			nullOK = a.JccPlaceholder(condE)
 		} else {
 			addFallback(a.JccPlaceholder(condE))
@@ -1165,9 +1166,9 @@ func (f *fn) emitNativeStructAllocStub(typeIndex uint32) {
 	}
 	a.StoreImm32Mem(R11, 12, flags)
 	for _, field := range fields {
-		disp := int32(gc.PayloadOffset + field.offset)
-		src := hcArgs + int32(field.slot*8)
-		switch field.size {
+		disp := int32(gc.PayloadOffset + field.Offset)
+		src := hcArgs + int32(field.Slot*8)
+		switch field.Size {
 		case 4:
 			a.Load32(RAX, RDI, src)
 			a.Store32(R11, disp, RAX)
@@ -1989,7 +1990,7 @@ func (f *fn) emitNativeCardSafeArrayRefSetStub() {
 }
 
 func (f *fn) emitDirectGCStructGet(typeIndex, fieldIndex uint32, helper uint32) bool {
-	off, scalar, final, ok := directGCStructLayout(f.m, typeIndex, fieldIndex)
+	off, scalar, final, ok := f.directGCStructLayout(typeIndex, fieldIndex)
 	if !ok || !final {
 		return false
 	}
@@ -2018,7 +2019,7 @@ func (f *fn) emitDirectGCStructGet(typeIndex, fieldIndex uint32, helper uint32) 
 }
 
 func (f *fn) emitDirectGCStructSet(typeIndex, fieldIndex uint32) bool {
-	off, scalar, final, ok := directGCStructLayout(f.m, typeIndex, fieldIndex)
+	off, scalar, final, ok := f.directGCStructLayout(typeIndex, fieldIndex)
 	if !ok || !final {
 		return false
 	}
@@ -2045,7 +2046,7 @@ func (f *fn) emitDirectGCStructSet(typeIndex, fieldIndex uint32) bool {
 }
 
 func (f *fn) emitDirectGCArrayGet(typeIndex uint32, helper uint32) bool {
-	scalar, final, ok := directGCArrayLayout(f.m, typeIndex)
+	scalar, final, ok := f.directGCArrayLayout(typeIndex)
 	if !ok || !final {
 		return false
 	}
@@ -2098,7 +2099,7 @@ func (f *fn) emitDirectGCArrayGet(typeIndex uint32, helper uint32) bool {
 }
 
 func (f *fn) emitDirectGCArraySet(typeIndex uint32) bool {
-	scalar, final, ok := directGCArrayLayout(f.m, typeIndex)
+	scalar, final, ok := f.directGCArrayLayout(typeIndex)
 	if !ok || !final {
 		return false
 	}

--- a/src/core/compiler/backend/railshot/amd64/gc_layout.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_layout.go
@@ -1,0 +1,120 @@
+//go:build amd64
+
+package amd64
+
+import (
+	"github.com/wago-org/wago/src/core/compiler/codegen"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func (f *fn) gcTypeLayout(typeIndex uint32, kind wasm.CompTypeKind) (codegen.GCTypeLayout, bool) {
+	if int(typeIndex) >= len(f.gcTypeLayouts) {
+		return codegen.GCTypeLayout{}, false
+	}
+	layout := f.gcTypeLayouts[typeIndex]
+	return layout, layout.Type != nil && layout.Type.Comp.Kind == kind
+}
+
+func (f *fn) stagedGCType(typeIndex uint32) (wasm.SubType, bool) {
+	if int(typeIndex) < len(f.gcTypeLayouts) && f.gcTypeLayouts[typeIndex].Type != nil {
+		return *f.gcTypeLayouts[typeIndex].Type, true
+	}
+	return nativeGCFlatType(f.m, typeIndex)
+}
+
+func (f *fn) stagedStructType(typeIndex uint32) (wasm.SubType, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompStruct); ok {
+		return *layout.Type, true
+	}
+	return stagedStructType(f.m, typeIndex)
+}
+
+func (f *fn) stagedStructField(typeIndex, fieldIndex uint32) (wasm.FieldType, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompStruct); ok {
+		if int(fieldIndex) >= len(layout.Type.Comp.Fields) {
+			return wasm.FieldType{}, false
+		}
+		return layout.Type.Comp.Fields[fieldIndex], true
+	}
+	return stagedStructField(f.m, typeIndex, fieldIndex)
+}
+
+func (f *fn) stagedArraySubtype(typeIndex uint32) (wasm.SubType, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompArray); ok {
+		return *layout.Type, true
+	}
+	return stagedArraySubtype(f.m, typeIndex)
+}
+
+func (f *fn) stagedArrayType(typeIndex uint32) (wasm.FieldType, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompArray); ok {
+		return layout.Type.Comp.Array, true
+	}
+	return stagedArrayType(f.m, typeIndex)
+}
+
+func (f *fn) gcStructFieldLayout(typeIndex, fieldIndex uint32) (codegen.GCFieldLayout, bool, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompStruct); ok {
+		if int(fieldIndex) >= len(layout.FieldLayout) {
+			return codegen.GCFieldLayout{}, false, false
+		}
+		return layout.FieldLayout[fieldIndex], layout.Type.Final, true
+	}
+	off, size, final, ok := nativeGCStructFieldLayout(f.m, typeIndex, fieldIndex)
+	field, found := stagedStructField(f.m, typeIndex, fieldIndex)
+	return codegen.GCFieldLayout{Offset: off, Size: size, CollectorRef: found && nativeGCCollectorRefStorage(f.m, typeIndex, field.Storage())}, final, ok
+}
+
+type nativeGCStructAllocPlan struct {
+	fields      []codegen.GCFieldLayout
+	objectSize  uint32
+	objectAlign uint32
+	pointerFree bool
+}
+
+func (f *fn) nativeGCStructAllocLayout(typeIndex uint32) (nativeGCStructAllocPlan, bool) {
+	if !nativeGCStructAllocEnabled {
+		return nativeGCStructAllocPlan{}, false
+	}
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompStruct); ok {
+		if !layout.NativeAlloc {
+			return nativeGCStructAllocPlan{}, false
+		}
+		align := layout.Align
+		if align < 8 {
+			align = 8
+		}
+		return nativeGCStructAllocPlan{fields: layout.FieldLayout, objectSize: layout.ObjectSize, objectAlign: align, pointerFree: layout.PointerFree}, true
+	}
+	fields, size, align, pointerFree, ok := nativeGCStructAllocLayout(f.m, typeIndex)
+	if !ok {
+		return nativeGCStructAllocPlan{}, false
+	}
+	layoutFields := make([]codegen.GCFieldLayout, len(fields))
+	for i, field := range fields {
+		layoutFields[i] = codegen.GCFieldLayout{Offset: field.offset, Size: field.size, Slot: field.slot, Nullable: field.nullable, CollectorRef: field.ref}
+	}
+	return nativeGCStructAllocPlan{fields: layoutFields, objectSize: size, objectAlign: align, pointerFree: pointerFree}, true
+}
+
+func (f *fn) directGCStructLayout(typeIndex, fieldIndex uint32) (uint32, directGCScalar, bool, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompStruct); ok {
+		if int(fieldIndex) >= len(layout.FieldLayout) {
+			return 0, directGCScalar{}, false, false
+		}
+		scalar, ok := directGCScalarStorage(layout.Type.Comp.Fields[fieldIndex].Storage())
+		if !ok {
+			return 0, directGCScalar{}, false, false
+		}
+		return layout.FieldLayout[fieldIndex].Offset, scalar, layout.Type.Final, true
+	}
+	return directGCStructLayout(f.m, typeIndex, fieldIndex)
+}
+
+func (f *fn) directGCArrayLayout(typeIndex uint32) (directGCScalar, bool, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompArray); ok {
+		scalar, ok := directGCScalarStorage(layout.Type.Comp.Array.Storage())
+		return scalar, layout.Type.Final, ok
+	}
+	return directGCArrayLayout(f.m, typeIndex)
+}

--- a/src/core/compiler/backend/railshot/amd64/gc_layout_test.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_layout_test.go
@@ -1,0 +1,136 @@
+//go:build amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/codegen"
+	"github.com/wago-org/wago/src/core/compiler/frontend"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func gcLayoutTestModule(groupN, fieldN int) *wasm.Module {
+	groups := make([]wasm.RecType, groupN)
+	for i := range groups {
+		fields := make([]wasm.FieldType, fieldN)
+		for j := range fields {
+			fields[j] = wasm.NewFieldType(wasm.StorageVal(wasm.I64), wasm.Const)
+		}
+		groups[i].SubTypes = []wasm.SubType{{Final: true, Comp: wasm.CompType{Kind: wasm.CompStruct, Fields: fields}}}
+	}
+	return &wasm.Module{Types: groups}
+}
+
+func gcLayoutHeavyCompileModule(tb testing.TB, sites int) *wasm.Module {
+	tb.Helper()
+	composite := append([]byte{0x5f}, wasmtest.ULEB(64)...)
+	for i := 0; i < 64; i++ {
+		composite = append(composite, 0x7e, 0x00) // immutable i64
+	}
+	body := []byte{0x01, 0x01, 0x63, 0x00}
+	for i := 0; i < sites; i++ {
+		body = append(body,
+			0xfb, 0x01, 0x00, 0x21, 0x00, // struct.new_default type 0; local.set
+			0x20, 0x00, 0xfb, 0x02, 0x00, 0x3f, 0x1a, // local.get; struct.get type 0 field 63; drop
+		)
+	}
+	body = append(body, 0x0b)
+	data := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(composite, wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+	m, err := wasm.DecodeModule(data)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if err := wasm.ValidateModule(m); err != nil {
+		tb.Fatal(err)
+	}
+	return m
+}
+
+func TestGCLayoutMetadataMatchesLegacyDerivation(t *testing.T) {
+	m := gcLayoutTestModule(8, 12)
+	metadata, err := frontend.BuildGCTypeMetadata(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withMetadata := &fn{m: m, gcTypeLayouts: metadata.Layouts}
+	withoutMetadata := &fn{m: m}
+	for typeIndex := uint32(0); typeIndex < 8; typeIndex++ {
+		for fieldIndex := uint32(0); fieldIndex < 12; fieldIndex++ {
+			gotOffset, gotScalar, gotFinal, gotOK := withMetadata.directGCStructLayout(typeIndex, fieldIndex)
+			wantOffset, wantScalar, wantFinal, wantOK := withoutMetadata.directGCStructLayout(typeIndex, fieldIndex)
+			if gotOffset != wantOffset || gotScalar != wantScalar || gotFinal != wantFinal || gotOK != wantOK {
+				t.Fatalf("type %d field %d: metadata=(%d,%+v,%v,%v) legacy=(%d,%+v,%v,%v)", typeIndex, fieldIndex, gotOffset, gotScalar, gotFinal, gotOK, wantOffset, wantScalar, wantFinal, wantOK)
+			}
+		}
+	}
+
+	// The precomputed path must not consult the decoded module after lowering.
+	withMetadata.m = nil
+	if off, _, final, ok := withMetadata.directGCStructLayout(7, 11); !ok || !final || off != 88 {
+		t.Fatalf("metadata-only lookup = (%d,%v,%v), want (88,true,true)", off, final, ok)
+	}
+	if allocs := testing.AllocsPerRun(100, func() {
+		if _, ok := withMetadata.nativeGCStructAllocLayout(7); !ok {
+			t.Fatal("native allocation plan unavailable")
+		}
+	}); allocs != 0 {
+		t.Fatalf("precomputed native allocation plan allocs = %v, want 0", allocs)
+	}
+}
+
+func BenchmarkGCStructFieldLayoutLookup(b *testing.B) {
+	m := gcLayoutTestModule(256, 64)
+	metadata, err := frontend.BuildGCTypeMetadata(m)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		fn   *fn
+	}{
+		{name: "legacy", fn: &fn{m: m}},
+		{name: "precomputed", fn: &fn{m: m, gcTypeLayouts: metadata.Layouts}},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, _, _, ok := tc.fn.directGCStructLayout(255, 63); !ok {
+					b.Fatal("layout unavailable")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGCLayoutHeavyCompile(b *testing.B) {
+	m := gcLayoutHeavyCompileModule(b, 2000)
+	metadata, err := frontend.BuildGCTypeMetadata(m)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name    string
+		layouts []codegen.GCTypeLayout
+	}{
+		{name: "legacy"},
+		{name: "precomputed", layouts: metadata.Layouts},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				cm, err := CompileModuleWith(m, CompileOptions{GCStructHelpers: true, Codegen: codegen.Options{Module: codegen.ModuleInfo{GCTypeLayouts: tc.layouts}}})
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.ReportMetric(float64(len(cm.Code)), "code-bytes")
+				benchCompiledSink = cm
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/amd64/gc_struct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_struct.go
@@ -73,7 +73,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		st, ok := stagedStructType(f.m, typeIndex)
+		st, ok := f.stagedStructType(typeIndex)
 		if !ok {
 			return fmt.Errorf("amd64: struct.new type %d is unavailable", typeIndex)
 		}
@@ -92,7 +92,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
 		params = append(params, wasm.I32)
 		result := wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: typeIndex}), false))
-		if _, _, _, _, native := nativeGCStructAllocLayout(f.m, typeIndex); native {
+		if _, native := f.nativeGCStructAllocLayout(typeIndex); native {
 			f.nativeStructAllocType = typeIndex + 1
 		}
 		if err := f.callGCStructHelper(gcStructAllocOne, params, []wasm.ValType{result}); err != nil {
@@ -105,7 +105,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		if _, ok := stagedStructType(f.m, typeIndex); !ok {
+		if _, ok := f.stagedStructType(typeIndex); !ok {
 			return fmt.Errorf("amd64: struct.new_default type %d is unavailable", typeIndex)
 		}
 		if f.skipDroppedGCConstructor(r, 0) || f.deferGCConstructorForDroppedStruct(r, 0) {
@@ -127,7 +127,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedStructField(f.m, typeIndex, fieldIndex)
+		field, ok := f.stagedStructField(typeIndex, fieldIndex)
 		if !ok {
 			return fmt.Errorf("amd64: struct.get type %d field %d is unavailable", typeIndex, fieldIndex)
 		}
@@ -163,7 +163,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedStructField(f.m, typeIndex, fieldIndex)
+		field, ok := f.stagedStructField(typeIndex, fieldIndex)
 		if !ok {
 			return fmt.Errorf("amd64: struct.set type %d field %d is unavailable", typeIndex, fieldIndex)
 		}
@@ -179,9 +179,9 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if f.emitDirectGCStructSet(typeIndex, fieldIndex) {
 			return nil
 		}
-		if st, found := nativeGCFlatType(f.m, typeIndex); found && st.Final && field.Storage().Val().Kind() == wasm.ValRef && field.Storage().Val().Ref().Heap().Kind() == wasm.HeapAbs && (field.Storage().Val().Ref().Heap().Abs() == wasm.HeapAny || field.Storage().Val().Ref().Heap().Abs() == wasm.HeapEq) {
-			if off, size, final, layoutOK := nativeGCStructFieldLayout(f.m, typeIndex, fieldIndex); layoutOK && final && size == 4 {
-				return f.emitNativeBarrierSafeStructRefSet(typeIndex, fieldIndex, off, field.Storage().Val())
+		if field.Storage().Val().Kind() == wasm.ValRef && field.Storage().Val().Ref().Heap().Kind() == wasm.HeapAbs && (field.Storage().Val().Ref().Heap().Abs() == wasm.HeapAny || field.Storage().Val().Ref().Heap().Abs() == wasm.HeapEq) {
+			if layout, final, layoutOK := f.gcStructFieldLayout(typeIndex, fieldIndex); layoutOK && final && layout.Size == 4 {
+				return f.emitNativeBarrierSafeStructRefSet(typeIndex, fieldIndex, layout.Offset, field.Storage().Val())
 			}
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -293,7 +293,7 @@ func (f *fn) emitGCI31Cast(sub uint32, r *wasm.Reader) error {
 	finalTarget := false
 	knownExactTarget := false
 	if heap >= 0 {
-		if target, ok := nativeGCFlatType(f.m, uint32(heap)); ok && target.Final {
+		if target, ok := f.stagedGCType(uint32(heap)); ok && target.Final {
 			finalTarget = true
 			if known, exact := exactGCType(f.s.back()); exact && known == uint32(heap) {
 				knownExactTarget = true
@@ -320,7 +320,7 @@ func (f *fn) emitGCI31Cast(sub uint32, r *wasm.Reader) error {
 			f.stats.peep("gc-ref-cast-elide")
 			return nil
 		}
-		if target, ok := nativeGCFlatType(f.m, uint32(heap)); ok && target.Final && (target.Comp.Kind == wasm.CompStruct || target.Comp.Kind == wasm.CompArray) {
+		if target, ok := f.stagedGCType(uint32(heap)); ok && target.Final && (target.Comp.Kind == wasm.CompStruct || target.Comp.Kind == wasm.CompArray) {
 			if err := f.emitNativeFinalCast(uint32(heap), sub == 23); err != nil {
 				return err
 			}
@@ -388,7 +388,7 @@ func (f *fn) emitGCI31Cast(sub uint32, r *wasm.Reader) error {
 }
 
 func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.Reader) (bool, error) {
-	st, ok := stagedStructType(f.m, typeIndex)
+	st, ok := f.stagedStructType(typeIndex)
 	if !ok || !st.Final {
 		return false, nil
 	}
@@ -417,7 +417,7 @@ func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.
 	if err != nil {
 		return false, err
 	}
-	field, ok := stagedStructField(f.m, accessType, fieldIndex)
+	field, ok := f.stagedStructField(accessType, fieldIndex)
 	if !ok || accessType != typeIndex || (sub == 2) == field.Storage().Packed() {
 		_ = r.JumpTo(start)
 		return false, nil
@@ -429,11 +429,10 @@ func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.
 		return false, nil
 	}
 	f.observeGCStructGet(typeIndex, fieldIndex)
-	if nativeGCCollectorRefStorage(f.m, typeIndex, field.Storage()) {
-		off, size, final, layoutOK := nativeGCStructFieldLayout(f.m, typeIndex, fieldIndex)
-		if layoutOK && final && size == 4 {
+	if layout, final, layoutOK := f.gcStructFieldLayout(typeIndex, fieldIndex); layoutOK && layout.CollectorRef {
+		if final && layout.Size == 4 {
 			f.stats.peep("final-cast-struct-get-fuse")
-			return true, f.emitNativeFinalCastStructRefGet(typeIndex, off, nullable)
+			return true, f.emitNativeFinalCastStructRefGet(typeIndex, layout.Offset, nullable)
 		}
 	}
 	resultType := field.Storage().Val()
@@ -454,7 +453,7 @@ func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.
 }
 
 func (f *fn) tryFuseFinalCastArrayLen(typeIndex uint32, nullable bool, r *wasm.Reader) (bool, error) {
-	st, ok := stagedArraySubtype(f.m, typeIndex)
+	st, ok := f.stagedArraySubtype(typeIndex)
 	if !ok || !st.Final {
 		return false, nil
 	}

--- a/src/core/compiler/backend/railshot/amd64/table.go
+++ b/src/core/compiler/backend/railshot/amd64/table.go
@@ -60,7 +60,7 @@ func (f *fn) tableIsExternref(tableIdx uint32) bool {
 	}
 	heap := tt.Ref.Heap()
 	if heap.Kind() == wasm.HeapTypeIndex {
-		sub, ok := stagedStructType(f.m, heap.Type().Index)
+		sub, ok := f.stagedStructType(heap.Type().Index)
 		return ok && (sub.Comp.Kind == wasm.CompStruct || sub.Comp.Kind == wasm.CompArray)
 	}
 	if heap.Kind() != wasm.HeapAbs {
@@ -81,7 +81,7 @@ func (f *fn) tableIsGCObjectRef(tableIdx uint32) bool {
 	}
 	heap := tt.Ref.Heap()
 	if heap.Kind() == wasm.HeapTypeIndex {
-		sub, ok := stagedStructType(f.m, heap.Type().Index)
+		sub, ok := f.stagedStructType(heap.Type().Index)
 		return ok && (sub.Comp.Kind == wasm.CompStruct || sub.Comp.Kind == wasm.CompArray)
 	}
 	if heap.Kind() != wasm.HeapAbs {

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -123,11 +123,12 @@ const mergeFReg Reg = 15
 // fn holds the per-function code-generation state — the port's equivalent of
 // WARP's Compiler/backend working set. One is created per compiled function.
 type fn struct {
-	a  *a64.Asm // the (reused) AArch64 encoder
-	s  *stack   // the valent-block operand stack
-	sc *scratch // module-wide reusable compile scratch
-	m  *wasm.Module
-	ft *wasm.CompType // this function's signature
+	a             *a64.Asm // the (reused) AArch64 encoder
+	s             *stack   // the valent-block operand stack
+	sc            *scratch // module-wide reusable compile scratch
+	m             *wasm.Module
+	ft            *wasm.CompType // this function's signature
+	gcTypeLayouts []codegen.GCTypeLayout
 	transient
 	traceFuncIdx       uint32
 	tracePCBase        uint32
@@ -799,7 +800,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 				st = &CodegenStats{FuncIdx: i, Name: funcDisplayName(m, i, importedFuncs)}
 				ms.Funcs[i] = st
 			}
-			fnCode, rl, internalOff, err := compileFunc(m, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.GCFrameRoots.Function(i), opts.CustomInstructions, st, inlineTargets, calleePreservesPins, sc)
+			fnCode, rl, internalOff, err := compileFunc(m, opts.Codegen.Module.GCTypeLayouts, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.GCFrameRoots.Function(i), opts.CustomInstructions, st, inlineTargets, calleePreservesPins, sc)
 			allHints[i] = funcHints{}
 			if err != nil {
 				return nil, fmt.Errorf("arm64: function %d: %w", i, err)
@@ -864,7 +865,7 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 				if ms != nil {
 					st = ms.Funcs[i]
 				}
-				fnCode, rl, internalOff, err := compileFunc(m, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, allHints[i], opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.GCFrameRoots.Function(i), opts.CustomInstructions, st, inlineTargets, calleePreservesPins, ws.scratch)
+				fnCode, rl, internalOff, err := compileFunc(m, opts.Codegen.Module.GCTypeLayouts, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, allHints[i], opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.GCFrameRoots.Function(i), opts.CustomInstructions, st, inlineTargets, calleePreservesPins, ws.scratch)
 				allHints[i] = funcHints{}
 				if err != nil {
 					results[i].err = err
@@ -1267,7 +1268,7 @@ var errRegExhausted = errors.New("arm64: no register available to spill")
 // compileFunc compiles one function, retrying with local pinning disabled if the
 // first (pinned) attempt exhausts the register file. Pinning is a pure speed
 // optimization, so the unpinned recompile is always correct.
-func compileFunc(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers bool, gcFrameRoots *shared.GCFrameRootPlan, customInstructions map[uint32]railcore.CustomInstruction, stats *CodegenStats, inlineTargets inlineTargetTable, calleePreservesPins []bool, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFunc(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, funcIdx int, hostAdapter, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers bool, gcFrameRoots *shared.GCFrameRootPlan, customInstructions map[uint32]railcore.CustomInstruction, stats *CodegenStats, inlineTargets inlineTargetTable, calleePreservesPins []bool, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
 	if gcFrameRoots != nil && gcFrameRoots.Candidate {
 		gcFrameRoots.Exact = true
 		gcFrameRoots.Safepoints = gcFrameRoots.Safepoints[:0]
@@ -1275,7 +1276,7 @@ func compileFunc(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFact
 		gcFrameRoots.FrameBytes = 0
 		gcFrameRoots.AdapterReturnOffset = 0
 	}
-	code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, hostAdapter, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, gcFrameRoots, customInstructions, stats, true, inlineTargets, calleePreservesPins, sc)
+	code, relocs, internalOff, err = compileFuncAttempt(m, gcTypeLayouts, funcIdx, hostAdapter, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, gcFrameRoots, customInstructions, stats, true, inlineTargets, calleePreservesPins, sc)
 	if errors.Is(err, errRegExhausted) {
 		resetFuncStats(stats)
 		if gcFrameRoots != nil && gcFrameRoots.Candidate {
@@ -1285,7 +1286,7 @@ func compileFunc(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFact
 			gcFrameRoots.FrameBytes = 0
 			gcFrameRoots.AdapterReturnOffset = 0
 		}
-		code, relocs, internalOff, err = compileFuncAttempt(m, funcIdx, hostAdapter, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, gcFrameRoots, customInstructions, stats, false, inlineTargets, calleePreservesPins, sc)
+		code, relocs, internalOff, err = compileFuncAttempt(m, gcTypeLayouts, funcIdx, hostAdapter, guardMode, boundsFacts, interruptible, modGlobals, hints, importBindings, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers, gcFrameRoots, customInstructions, stats, false, inlineTargets, calleePreservesPins, sc)
 		if err == nil {
 			stats.setUnpinnedRetry()
 		}
@@ -1293,7 +1294,7 @@ func compileFunc(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFact
 	return
 }
 
-func compileFuncAttempt(m *wasm.Module, funcIdx int, hostAdapter, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers bool, gcFrameRoots *shared.GCFrameRootPlan, customInstructions map[uint32]railcore.CustomInstruction, stats *CodegenStats, pinLocals bool, inlineTargets inlineTargetTable, calleePreservesPins []bool, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
+func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, funcIdx int, hostAdapter, guardMode, boundsFacts, interruptible bool, modGlobals []moduleGlobalPin, hints funcHints, importBindings []ImportBinding, syncHostCalls, gcTypeSubtypingRefTest, gcStructHelpers, gcArrayHelpers bool, gcFrameRoots *shared.GCFrameRootPlan, customInstructions map[uint32]railcore.CustomInstruction, stats *CodegenStats, pinLocals bool, inlineTargets inlineTargetTable, calleePreservesPins []bool, sc *scratch) (code []byte, relocs []callReloc, internalOff int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(regExhausted); ok {
@@ -1324,7 +1325,7 @@ func compileFuncAttempt(m *wasm.Module, funcIdx int, hostAdapter, guardMode, bou
 	f := &sc.fnState
 	localType, localSlot, locals := f.localType, f.localSlot, f.locals
 	mt0, _ := m.MemoryType(0)
-	*f = fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, transient: sc.transient, traceFuncIdx: uint32(globalIdx), tracePCBase: c.LocalDeclBytes, customInstructions: customInstructions, nParams: len(ft.Params), nLocals: nLocals, localType: localType, localSlot: localSlot, locals: locals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, gcStructHelpers: gcStructHelpers, gcArrayHelpers: gcArrayHelpers, gcFrameRoots: gcFrameRoots, moduleEH: hints.moduleEH, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stagedTailDescriptors: true, stats: stats, branchHints: m.BranchHintsForFunc(uint32(globalIdx)), branchHintLocalDecl: c.LocalDeclBytes, calleePreservesPins: calleePreservesPins, threadedMemory0: mt0.Shared}
+	*f = fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, gcTypeLayouts: gcTypeLayouts, transient: sc.transient, traceFuncIdx: uint32(globalIdx), tracePCBase: c.LocalDeclBytes, customInstructions: customInstructions, nParams: len(ft.Params), nLocals: nLocals, localType: localType, localSlot: localSlot, locals: locals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, gcStructHelpers: gcStructHelpers, gcArrayHelpers: gcArrayHelpers, gcFrameRoots: gcFrameRoots, moduleEH: hints.moduleEH, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stagedTailDescriptors: true, stats: stats, branchHints: m.BranchHintsForFunc(uint32(globalIdx)), branchHintLocalDecl: c.LocalDeclBytes, calleePreservesPins: calleePreservesPins, threadedMemory0: mt0.Shared}
 	defer func() {
 		sc.ctrl = f.ctrl
 		sc.transient = f.transient

--- a/src/core/compiler/backend/railshot/arm64/gc.go
+++ b/src/core/compiler/backend/railshot/arm64/gc.go
@@ -221,7 +221,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		st, ok := stagedStructType(f.m, typeIndex)
+		st, ok := f.stagedStructType(typeIndex)
 		if !ok {
 			return fmt.Errorf("arm64: struct.new type %d is unavailable", typeIndex)
 		}
@@ -242,7 +242,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		if _, ok := stagedStructType(f.m, typeIndex); !ok {
+		if _, ok := f.stagedStructType(typeIndex); !ok {
 			return fmt.Errorf("arm64: struct.new_default type %d is unavailable", typeIndex)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -257,7 +257,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedStructField(f.m, typeIndex, fieldIndex)
+		field, ok := f.stagedStructField(typeIndex, fieldIndex)
 		if !ok {
 			return fmt.Errorf("arm64: struct.get type %d field %d is unavailable", typeIndex, fieldIndex)
 		}
@@ -288,7 +288,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedStructField(f.m, typeIndex, fieldIndex)
+		field, ok := f.stagedStructField(typeIndex, fieldIndex)
 		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: struct.set type %d field %d is unavailable or immutable", typeIndex, fieldIndex)
 		}
@@ -315,7 +315,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("arm64: array.new type %d is unavailable", typeIndex)
 		}
@@ -331,7 +331,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		if _, ok := stagedArrayType(f.m, typeIndex); !ok {
+		if _, ok := f.stagedArrayType(typeIndex); !ok {
 			return fmt.Errorf("arm64: array.new_default type %d is unavailable", typeIndex)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -346,7 +346,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("arm64: array.new_fixed type %d is unavailable", typeIndex)
 		}
@@ -380,7 +380,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("arm64: array constructor type %d is unavailable", typeIndex)
 		}
@@ -402,7 +402,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok {
 			return fmt.Errorf("arm64: array.get type %d is unavailable", typeIndex)
 		}
@@ -428,7 +428,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: array.set type %d is unavailable or immutable", typeIndex)
 		}
@@ -447,7 +447,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: array.fill type %d is unavailable or immutable", typeIndex)
 		}
@@ -467,11 +467,11 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		dstField, ok := stagedArrayType(f.m, dstType)
+		dstField, ok := f.stagedArrayType(dstType)
 		if !ok || dstField.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: array.copy destination is unavailable")
 		}
-		if _, ok := stagedArrayType(f.m, srcType); !ok {
+		if _, ok := f.stagedArrayType(srcType); !ok {
 			return fmt.Errorf("arm64: array.copy source is unavailable")
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(dstType)})
@@ -488,7 +488,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if err != nil {
 			return err
 		}
-		field, ok := stagedArrayType(f.m, typeIndex)
+		field, ok := f.stagedArrayType(typeIndex)
 		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: array.init type %d is unavailable", typeIndex)
 		}
@@ -509,7 +509,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 }
 
 func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.Reader) (bool, error) {
-	st, ok := stagedStructType(f.m, typeIndex)
+	st, ok := f.stagedStructType(typeIndex)
 	if !ok || !st.Final {
 		return false, nil
 	}
@@ -538,7 +538,7 @@ func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.
 	if err != nil {
 		return false, err
 	}
-	field, ok := stagedStructField(f.m, accessType, fieldIndex)
+	field, ok := f.stagedStructField(accessType, fieldIndex)
 	if !ok || accessType != typeIndex || (sub == 2) == field.Storage().Packed() {
 		_ = r.JumpTo(start)
 		return false, nil
@@ -561,7 +561,7 @@ func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.
 }
 
 func (f *fn) tryFuseFinalCastArrayLen(typeIndex uint32, nullable bool, r *wasm.Reader) (bool, error) {
-	st, ok := stagedArraySubtype(f.m, typeIndex)
+	st, ok := f.stagedArraySubtype(typeIndex)
 	if !ok || !st.Final {
 		return false, nil
 	}

--- a/src/core/compiler/backend/railshot/arm64/gc_layout.go
+++ b/src/core/compiler/backend/railshot/arm64/gc_layout.go
@@ -1,0 +1,47 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"github.com/wago-org/wago/src/core/compiler/codegen"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func (f *fn) gcTypeLayout(typeIndex uint32, kind wasm.CompTypeKind) (codegen.GCTypeLayout, bool) {
+	if int(typeIndex) >= len(f.gcTypeLayouts) {
+		return codegen.GCTypeLayout{}, false
+	}
+	layout := f.gcTypeLayouts[typeIndex]
+	return layout, layout.Type != nil && layout.Type.Comp.Kind == kind
+}
+
+func (f *fn) stagedStructType(typeIndex uint32) (wasm.SubType, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompStruct); ok {
+		return *layout.Type, true
+	}
+	return stagedStructType(f.m, typeIndex)
+}
+
+func (f *fn) stagedStructField(typeIndex, fieldIndex uint32) (wasm.FieldType, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompStruct); ok {
+		if int(fieldIndex) >= len(layout.Type.Comp.Fields) {
+			return wasm.FieldType{}, false
+		}
+		return layout.Type.Comp.Fields[fieldIndex], true
+	}
+	return stagedStructField(f.m, typeIndex, fieldIndex)
+}
+
+func (f *fn) stagedArraySubtype(typeIndex uint32) (wasm.SubType, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompArray); ok {
+		return *layout.Type, true
+	}
+	return stagedArraySubtype(f.m, typeIndex)
+}
+
+func (f *fn) stagedArrayType(typeIndex uint32) (wasm.FieldType, bool) {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompArray); ok {
+		return layout.Type.Comp.Array, true
+	}
+	return stagedArrayType(f.m, typeIndex)
+}

--- a/src/core/compiler/backend/railshot/arm64/table.go
+++ b/src/core/compiler/backend/railshot/arm64/table.go
@@ -75,7 +75,7 @@ func (f *fn) tableIsExternref(tableIdx uint32) bool {
 		return ok && wasm.EqualValType(wasm.RefVal(tt.Ref), wasm.ExternRef)
 	}
 	if tt.Ref.Heap().Kind() == wasm.HeapTypeIndex {
-		sub, ok := stagedStructType(f.m, tt.Ref.Heap().Type().Index)
+		sub, ok := f.stagedStructType(tt.Ref.Heap().Type().Index)
 		return ok && (sub.Comp.Kind == wasm.CompStruct || sub.Comp.Kind == wasm.CompArray)
 	}
 	if tt.Ref.Heap().Kind() != wasm.HeapAbs {
@@ -100,7 +100,7 @@ func (f *fn) tableIsGCObjectRef(tableIdx uint32) bool {
 		return false
 	}
 	if tt.Ref.Heap().Kind() == wasm.HeapTypeIndex {
-		sub, ok := stagedStructType(f.m, tt.Ref.Heap().Type().Index)
+		sub, ok := f.stagedStructType(tt.Ref.Heap().Type().Index)
 		return ok && (sub.Comp.Kind == wasm.CompStruct || sub.Comp.Kind == wasm.CompArray)
 	}
 	if tt.Ref.Heap().Kind() != wasm.HeapAbs {

--- a/src/core/compiler/codegen/types.go
+++ b/src/core/compiler/codegen/types.go
@@ -32,6 +32,7 @@ type Backend[M any] interface {
 type Options struct {
 	Runtime RuntimeABI
 	Heap    HeapABI
+	Module  ModuleInfo
 }
 
 // Value is an opaque backend-owned value handle paired with its wasm type.
@@ -72,9 +73,61 @@ var GCRefLayout = RefLayout{
 
 // ModuleInfo is the heap-relevant module metadata passed to HeapABI.
 type ModuleInfo struct {
-	Features    Features
-	GCTypeDescs []gc.TypeDesc
+	Features      Features
+	GCTypeDescs   []gc.TypeDesc
+	GCTypeLayouts []GCTypeLayout
 }
+
+// GCTypeLayout is immutable compile-time metadata indexed by flattened Wasm
+// type index. It keeps the decoded storage declarations alongside offsets and
+// sizes derived during descriptor lowering, so backends do not repeatedly walk
+// recursive groups or preceding struct fields at each GC instruction.
+type GCTypeLayout struct {
+	Type        *wasm.SubType
+	RecBase     uint32
+	RecLen      uint32
+	FieldLayout []GCFieldLayout
+	ScanOffsets []uint32
+	ElemLayout  GCFieldLayout
+	ObjectSize  uint32
+	Align       uint32
+	PointerFree bool
+	NativeAlloc bool
+	DirectCast  bool
+	DirectLen   bool
+}
+
+// GCFieldLayout is the precomputed payload layout and initializer-slot shape
+// for one struct field or array element.
+type GCFieldLayout struct {
+	Offset       uint32
+	Size         uint32
+	Align        uint32
+	Slot         uint32
+	Storage      gc.StorageKind
+	Mutable      bool
+	Nullable     bool
+	CollectorRef bool
+	DirectAccess bool
+	RefClass     GCRefClass
+	Barrier      GCBarrierClass
+}
+
+type GCRefClass uint8
+
+const (
+	GCRefNone GCRefClass = iota
+	GCRefCollector
+	GCRefFunction
+	GCRefExtern
+)
+
+type GCBarrierClass uint8
+
+const (
+	GCBarrierNone GCBarrierClass = iota
+	GCBarrierCollector
+)
 
 // FuncInfo is the heap-relevant function metadata passed to ModuleHeapABI.
 type FuncInfo struct {

--- a/src/core/compiler/frontend/gcdesc.go
+++ b/src/core/compiler/frontend/gcdesc.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"fmt"
 
+	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/runtime/gc"
 )
@@ -10,10 +11,26 @@ import (
 // BuildGCTypeDescs lowers decoded Wasm GC recursive type groups into runtime GC
 // descriptors. The returned slice is indexed by flattened wasm.TypeIdx.Index.
 func BuildGCTypeDescs(m *wasm.Module) ([]gc.TypeDesc, error) {
-	if m == nil {
-		return nil, fmt.Errorf("frontend: nil wasm module")
+	metadata, err := BuildGCTypeMetadata(m)
+	if err != nil {
+		return nil, err
 	}
-	return LowerGCTypeDescs(m.Types)
+	return metadata.Descs, nil
+}
+
+// GCTypeMetadata contains the runtime descriptors and compiler-only layout
+// table derived together from one flattened traversal of the type section.
+type GCTypeMetadata struct {
+	Descs   []gc.TypeDesc
+	Layouts []codegen.GCTypeLayout
+}
+
+// BuildGCTypeMetadata lowers one module's immutable GC type metadata once.
+func BuildGCTypeMetadata(m *wasm.Module) (GCTypeMetadata, error) {
+	if m == nil {
+		return GCTypeMetadata{}, fmt.Errorf("frontend: nil wasm module")
+	}
+	return LowerGCTypeMetadata(m.Types)
 }
 
 // LowerGCTypeDescs flattens recursive groups in decoder/validator order and
@@ -22,12 +39,29 @@ func BuildGCTypeDescs(m *wasm.Module) ([]gc.TypeDesc, error) {
 // shifted. Field mutability affects validation/codegen, not GC layout or scan
 // reachability, so it is intentionally not represented in gc.TypeDesc.
 func LowerGCTypeDescs(types []wasm.RecType) ([]gc.TypeDesc, error) {
+	metadata, err := LowerGCTypeMetadata(types)
+	if err != nil {
+		return nil, err
+	}
+	return metadata.Descs, nil
+}
+
+// LowerGCTypeMetadata derives runtime and compiler layout metadata in one pass.
+func LowerGCTypeMetadata(types []wasm.RecType) (GCTypeMetadata, error) {
 	flat := flattenGCTypes(types)
 	descs := make([]gc.TypeDesc, len(flat))
+	var layouts []codegen.GCTypeLayout
+	for i := range flat {
+		if flat[i].Comp.Kind == wasm.CompStruct || flat[i].Comp.Kind == wasm.CompArray {
+			layouts = make([]codegen.GCTypeLayout, len(flat))
+			break
+		}
+	}
 	for i, ft := range flat {
 		st := ft.SubType
 		id := gc.TypeID(i)
 		resolver := gcTypeResolver{total: len(flat), recBase: ft.RecBase, recLen: ft.RecLen, flat: flat}
+		layout := codegen.GCTypeLayout{Type: ft.Source, RecBase: uint32(ft.RecBase), RecLen: uint32(ft.RecLen), PointerFree: true, DirectCast: st.Final && (st.Comp.Kind == wasm.CompStruct || st.Comp.Kind == wasm.CompArray), DirectLen: st.Final && st.Comp.Kind == wasm.CompArray}
 		var d gc.TypeDesc
 		var err error
 		switch st.Comp.Kind {
@@ -39,51 +73,155 @@ func LowerGCTypeDescs(types []wasm.RecType) ([]gc.TypeDesc, error) {
 				var field gc.StorageKind
 				field, err = lowerGCStorage(f.Storage(), resolver)
 				if err != nil {
-					return nil, fmt.Errorf("frontend: type %d field %d: %w", i, j, err)
+					return GCTypeMetadata{}, fmt.Errorf("frontend: type %d field %d: %w", i, j, err)
 				}
 				if err = builder.Add(field); err != nil {
-					return nil, fmt.Errorf("frontend: type %d field %d: %w", i, j, err)
+					return GCTypeMetadata{}, fmt.Errorf("frontend: type %d field %d: %w", i, j, err)
 				}
 			}
 			d, err = builder.Finish()
 			if err != nil {
-				return nil, fmt.Errorf("frontend: type %d struct: %w", i, err)
+				return GCTypeMetadata{}, fmt.Errorf("frontend: type %d struct: %w", i, err)
 			}
 			d.Final = st.Final
+			layout.FieldLayout = make([]codegen.GCFieldLayout, len(d.Fields))
+			var slot uint32
+			for j, field := range d.Fields {
+				align, size := gcStorageLayout(field.Kind)
+				collectorRef := field.Kind == gc.StorageRef || field.Kind == gc.StorageRefNull
+				mutable := st.Comp.Fields[j].Mut() == wasm.Var
+				storage := st.Comp.Fields[j].Storage()
+				layout.FieldLayout[j] = codegen.GCFieldLayout{Offset: field.Offset, Size: size, Align: align, Slot: slot, Storage: field.Kind, Mutable: mutable, Nullable: isNullableStorage(storage), CollectorRef: collectorRef, DirectAccess: directStorage(storage), RefClass: gcRefClass(field.Kind), Barrier: gcBarrierClass(collectorRef && mutable)}
+				if collectorRef {
+					layout.ScanOffsets = append(layout.ScanOffsets, field.Offset)
+				}
+				slot++
+				if size == 16 {
+					slot++
+				}
+			}
+			layout.ObjectSize, err = gc.StructSize(d)
+			if err != nil {
+				return GCTypeMetadata{}, fmt.Errorf("frontend: type %d struct size: %w", i, err)
+			}
+			layout.Align = d.Align
+			layout.PointerFree = d.PointerFree()
+			layout.NativeAlloc = nativeStructAllocEligible(st, layout.FieldLayout)
 		case wasm.CompArray:
 			elem, err := lowerGCStorage(st.Comp.Array.Storage(), resolver)
 			if err != nil {
-				return nil, fmt.Errorf("frontend: type %d array: %w", i, err)
+				return GCTypeMetadata{}, fmt.Errorf("frontend: type %d array: %w", i, err)
 			}
 			d, err = gc.NewArrayDesc(id, elem)
 			if err != nil {
-				return nil, fmt.Errorf("frontend: type %d array: %w", i, err)
+				return GCTypeMetadata{}, fmt.Errorf("frontend: type %d array: %w", i, err)
 			}
 			d.Final = st.Final
+			collectorRef := d.ArrayElementsAreRefs()
+			mutable := st.Comp.Array.Mut() == wasm.Var
+			storage := st.Comp.Array.Storage()
+			layout.ElemLayout = codegen.GCFieldLayout{Size: d.ElemSize, Align: d.Align, Storage: elem, Mutable: mutable, Nullable: isNullableStorage(storage), CollectorRef: collectorRef, DirectAccess: directStorage(storage), RefClass: gcRefClass(elem), Barrier: gcBarrierClass(collectorRef && mutable)}
+			layout.Align = d.Align
+			layout.PointerFree = d.PointerFree()
 		default:
-			return nil, fmt.Errorf("frontend: type %d has unsupported component kind %d", i, st.Comp.Kind)
+			return GCTypeMetadata{}, fmt.Errorf("frontend: type %d has unsupported component kind %d", i, st.Comp.Kind)
 		}
 		if len(st.Supers) > 0 {
 			if len(st.Supers) > 1 {
-				return nil, fmt.Errorf("frontend: type %d has multiple supers; runtime descriptor stores one", i)
+				return GCTypeMetadata{}, fmt.Errorf("frontend: type %d has multiple supers; runtime descriptor stores one", i)
 			}
 			super, err := resolver.resolve(st.Supers[0])
 			if err != nil {
-				return nil, fmt.Errorf("frontend: type %d has invalid super type index %d", i, st.Supers[0].Index)
+				return GCTypeMetadata{}, fmt.Errorf("frontend: type %d has invalid super type index %d", i, st.Supers[0].Index)
 			}
 			d.Super = gc.TypeID(super)
 			d.HasSuper = true
 		}
 		descs[i] = d
+		if layouts != nil {
+			layouts[i] = layout
+		}
 	}
 	if err := gc.ValidateTypeDescs(descs); err != nil {
-		return nil, fmt.Errorf("frontend: lowered GC type descriptors invalid: %w", err)
+		return GCTypeMetadata{}, fmt.Errorf("frontend: lowered GC type descriptors invalid: %w", err)
 	}
-	return descs, nil
+	return GCTypeMetadata{Descs: descs, Layouts: layouts}, nil
+}
+
+func isNullableStorage(st wasm.StorageType) bool {
+	return !st.Packed() && st.Val().Kind() == wasm.ValRef && st.Val().Ref().Nullable()
+}
+
+func directStorage(st wasm.StorageType) bool {
+	return st.Packed() || st.Val().Kind() == wasm.ValNum
+}
+
+func gcRefClass(kind gc.StorageKind) codegen.GCRefClass {
+	switch kind {
+	case gc.StorageRef, gc.StorageRefNull:
+		return codegen.GCRefCollector
+	case gc.StorageFuncRef, gc.StorageFuncRefNull:
+		return codegen.GCRefFunction
+	case gc.StorageExternRef, gc.StorageExternRefNull:
+		return codegen.GCRefExtern
+	default:
+		return codegen.GCRefNone
+	}
+}
+
+func gcBarrierClass(needsBarrier bool) codegen.GCBarrierClass {
+	if needsBarrier {
+		return codegen.GCBarrierCollector
+	}
+	return codegen.GCBarrierNone
+}
+
+func nativeStructAllocEligible(st wasm.SubType, fields []codegen.GCFieldLayout) bool {
+	if !st.Final || len(fields) != len(st.Comp.Fields) {
+		return false
+	}
+	for i, field := range st.Comp.Fields {
+		nextSlot := fields[i].Slot + 1
+		if fields[i].Size == 16 {
+			nextSlot++
+		}
+		// One final helper slot carries the type index.
+		storage := field.Storage()
+		if storage.Packed() || nextSlot+1 > 64 {
+			return false
+		}
+		if storage.Val().Kind() == wasm.ValRef {
+			heap := storage.Val().Ref().Heap()
+			if heap.Kind() != wasm.HeapAbs || (heap.Abs() != wasm.HeapAny && heap.Abs() != wasm.HeapEq) || fields[i].Size != 4 {
+				return false
+			}
+		} else if storage.Val().Kind() != wasm.ValNum && storage.Val().Kind() != wasm.ValVec {
+			return false
+		}
+	}
+	return true
+}
+
+func gcStorageLayout(kind gc.StorageKind) (align, size uint32) {
+	switch kind {
+	case gc.StorageI8:
+		return 1, 1
+	case gc.StorageI16:
+		return 2, 2
+	case gc.StorageI32, gc.StorageF32, gc.StorageRef, gc.StorageRefNull:
+		return 4, 4
+	case gc.StorageI64, gc.StorageF64, gc.StorageFuncRef, gc.StorageFuncRefNull, gc.StorageExternRef, gc.StorageExternRefNull:
+		return 8, 8
+	case gc.StorageV128:
+		return 16, 16
+	default:
+		panic("frontend: validated GC storage kind has no layout")
+	}
 }
 
 type flattenedGCType struct {
 	wasm.SubType
+	Source  *wasm.SubType
 	RecBase int
 	RecLen  int
 }
@@ -110,10 +248,12 @@ func (r gcTypeResolver) resolve(idx wasm.TypeIdx) (uint32, error) {
 
 func flattenGCTypes(types []wasm.RecType) []flattenedGCType {
 	var flat []flattenedGCType
-	for _, rt := range types {
+	for ri := range types {
+		rt := &types[ri]
 		base := len(flat)
-		for _, st := range rt.SubTypes {
-			flat = append(flat, flattenedGCType{SubType: st, RecBase: base, RecLen: len(rt.SubTypes)})
+		for si := range rt.SubTypes {
+			st := &rt.SubTypes[si]
+			flat = append(flat, flattenedGCType{SubType: *st, Source: st, RecBase: base, RecLen: len(rt.SubTypes)})
 		}
 	}
 	return flat

--- a/src/core/compiler/frontend/gcdesc_test.go
+++ b/src/core/compiler/frontend/gcdesc_test.go
@@ -2,7 +2,9 @@ package frontend
 
 import (
 	"testing"
+	"unsafe"
 
+	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/runtime/gc"
 	"github.com/wago-org/wago/tests/wasmtest"
@@ -12,6 +14,27 @@ func val(v wasm.ValType) wasm.StorageType     { return wasm.StorageVal(v) }
 func packed(p wasm.PackType) wasm.StorageType { return wasm.StoragePacked(p) }
 func ref(nullable bool, h wasm.AbsHeapType) wasm.StorageType {
 	return wasm.StorageVal(wasm.RefVal(wasm.Ref(nullable, wasm.AbsHeap(h), false)))
+}
+
+func BenchmarkLowerGCTypeMetadataLarge(b *testing.B) {
+	types := make([]wasm.RecType, 256)
+	for i := range types {
+		fields := make([]wasm.FieldType, 64)
+		for j := range fields {
+			fields[j] = field(val(wasm.I64))
+		}
+		types[i].SubTypes = []wasm.SubType{st(fields...)}
+	}
+	retained := uintptr(256) * unsafe.Sizeof(codegen.GCTypeLayout{})
+	retained += uintptr(256*64) * unsafe.Sizeof(codegen.GCFieldLayout{})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := LowerGCTypeMetadata(types); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(retained), "retained-layout-bytes")
 }
 func concrete(nullable bool, idx uint32) wasm.StorageType {
 	return concreteType(nullable, wasm.TypeIdx{Index: idx})
@@ -302,6 +325,70 @@ func TestBuildGCTypeDescsFromModule(t *testing.T) {
 	}
 	if len(descs) != 1 || descs[0].ID != 0 {
 		t.Fatalf("bad descs %+v", descs)
+	}
+}
+
+func TestLowerGCTypeMetadataPrecomputesCompilerLayout(t *testing.T) {
+	types := []wasm.RecType{{SubTypes: []wasm.SubType{
+		fn(),
+		st(field(packed(wasm.PackI8)), field(val(wasm.I64)), field(val(wasm.V128)), field(ref(true, wasm.HeapAny))),
+		arr(concreteRec(true, 1)),
+	}}}
+	metadata, err := LowerGCTypeMetadata(types)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metadata.Layouts) != 3 || metadata.Layouts[1].Type != &types[0].SubTypes[1] {
+		t.Fatalf("layouts do not preserve flattened type identity: %+v", metadata.Layouts)
+	}
+	structLayout := metadata.Layouts[1]
+	if structLayout.RecBase != 0 || structLayout.RecLen != 3 || !structLayout.Type.Final {
+		t.Fatalf("struct recursive-group metadata = %+v", structLayout)
+	}
+	wantOffsets := []uint32{0, 8, 16, 32}
+	wantSizes := []uint32{1, 8, 16, 4}
+	wantSlots := []uint32{0, 1, 2, 4}
+	for i, got := range structLayout.FieldLayout {
+		if got.Offset != wantOffsets[i] || got.Size != wantSizes[i] || got.Slot != wantSlots[i] {
+			t.Fatalf("field %d layout = %+v", i, got)
+		}
+		if got.Offset != metadata.Descs[1].Fields[i].Offset {
+			t.Fatalf("field %d compiler/runtime offsets differ", i)
+		}
+	}
+	if structLayout.FieldLayout[0].Align != 1 || structLayout.FieldLayout[2].Align != 16 || !structLayout.FieldLayout[3].CollectorRef {
+		t.Fatalf("field layout classification = %+v", structLayout.FieldLayout)
+	}
+	if len(structLayout.ScanOffsets) != 1 || structLayout.ScanOffsets[0] != 32 || structLayout.FieldLayout[3].RefClass != codegen.GCRefCollector {
+		t.Fatalf("struct scan metadata = %v, field=%+v", structLayout.ScanOffsets, structLayout.FieldLayout[3])
+	}
+	wantSize, err := gc.StructSize(metadata.Descs[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if structLayout.ObjectSize != wantSize || structLayout.Align != metadata.Descs[1].Align || structLayout.PointerFree {
+		t.Fatalf("struct aggregate layout = %+v", structLayout)
+	}
+	arrayLayout := metadata.Layouts[2]
+	if arrayLayout.Type.Comp.Kind != wasm.CompArray || arrayLayout.ElemLayout.Size != 4 || arrayLayout.ElemLayout.Align != 4 || !arrayLayout.ElemLayout.CollectorRef || arrayLayout.PointerFree {
+		t.Fatalf("array layout = %+v", arrayLayout)
+	}
+}
+
+func TestGCTypeMetadataNativeConstructorSlotBoundary(t *testing.T) {
+	fields := make([]wasm.FieldType, 64)
+	for i := range fields {
+		fields[i] = field(val(wasm.I64))
+	}
+	metadata, err := LowerGCTypeMetadata([]wasm.RecType{{SubTypes: []wasm.SubType{st(fields[:63]...), st(fields...)}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !metadata.Layouts[0].NativeAlloc {
+		t.Fatal("63-field constructor should fit 64 slots including type index")
+	}
+	if metadata.Layouts[1].NativeAlloc {
+		t.Fatal("64-field constructor exceeds 64 slots including type index")
 	}
 }
 

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	"github.com/wago-org/wago/internal/functionworkers"
+	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/frontend"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	wruntime "github.com/wago-org/wago/src/core/runtime"
@@ -1312,10 +1313,11 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 			}
 		}
 	}
-	gcDescs, err := frontend.BuildGCTypeDescs(m)
+	gcMetadata, err := frontend.BuildGCTypeMetadata(m)
 	if err != nil {
 		return nil, fmt.Errorf("gc descriptors: %w", err)
 	}
+	gcDescs := gcMetadata.Descs
 	if err := configureStagedGCArrayTypeDescs(gcArrayProduct, gcDescs); err != nil {
 		return nil, fmt.Errorf("gc array descriptors: %w", err)
 	}
@@ -1351,7 +1353,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	if cfg.gcCodeTelemetry {
 		gcCodeStatsSink = &gcCodeStats
 	}
-	cm, err := railshotCompileModuleWith(m, railshotCompileOptions{Workers: workers, Optimizations: cfg.optimizations, ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds, ImportBindings: dynamicBindings, SyncHostCalls: atomicWaitHelpers, GCTypeSubtypingRefTest: gcFunctionRefTest, GCStructHelpers: gcStructProduct.requiresHelpers(), GCArrayHelpers: gcArrayProduct.requiresHelpers() || gcStructProduct.requiresArrayHelpers(), GCFrameRoots: gcFrameRoots, Interruptible: !wruntime.HostInterruptSupported(), MemoryPressureAt: pressureAt, MemoryPressure: pressure, CustomInstructions: customInstructions, Stats: gcCodeStatsSink})
+	cm, err := railshotCompileModuleWith(m, railshotCompileOptions{Workers: workers, Optimizations: cfg.optimizations, ElideBoundsChecks: elide, NoBoundsFacts: cfg.noDeferBounds, ImportBindings: dynamicBindings, SyncHostCalls: atomicWaitHelpers, GCTypeSubtypingRefTest: gcFunctionRefTest, GCStructHelpers: gcStructProduct.requiresHelpers(), GCArrayHelpers: gcArrayProduct.requiresHelpers() || gcStructProduct.requiresArrayHelpers(), GCFrameRoots: gcFrameRoots, Interruptible: !wruntime.HostInterruptSupported(), MemoryPressureAt: pressureAt, MemoryPressure: pressure, CustomInstructions: customInstructions, Codegen: codegen.Options{Module: codegen.ModuleInfo{GCTypeDescs: gcMetadata.Descs, GCTypeLayouts: gcMetadata.Layouts}}, Stats: gcCodeStatsSink})
 	if err != nil {
 		return nil, fmt.Errorf("compile: %w", err)
 	}


### PR DESCRIPTION
Closes #306.

## What changed

- build immutable compiler metadata alongside runtime GC type descriptors in one flattened type-section traversal
- precompute recursive-group bounds, struct field offsets/widths/alignment, constructor slots, scan offsets, storage/reference/nullability/mutability classes, initial barrier classes, array element layouts, object sizing, and direct/native eligibility
- pass the compiler-only metadata to AMD64 and ARM64 Railshot compilation
- replace repeated recursive-group and preceding-field walks with indexed lookups while retaining the legacy derivation path for low-level callers
- reuse immutable constructor plans in the production native allocation path without per-site allocation
- document that the side table points into validated decoded types and is discarded after code generation rather than serialized

## Why

GC type facts are immutable for a compiled module, but GC lowering repeatedly rediscovered them at instruction sites. Large modules with many recursive groups, wide structs, casts, and allocation/access sites consequently paid linear lookup and layout costs throughout code generation.

## Measurements

On an AMD Ryzen 7 7800X3D:

- worst-case lookup across 256 recursive groups and 64 fields: 597–611 ns/op legacy versus 15.17–15.26 ns/op precomputed, with 0 B/op and 0 allocs/op in both cases
- layout-heavy compilation with 2,000 constructor/last-field access sites: 5.57–6.38 ms/op legacy versus 4.83–5.37 ms/op precomputed
- emitted output is identical at 642,141 bytes
- allocation traffic for that compile workload is unchanged at approximately 8.20 MB and 2,087–2,088 allocations/op; native constructor-plan lookup itself is asserted at 0 allocations
- the synthetic 256-type × 64-field table retains 419,840 bytes of compiler-only layout metadata
- small scalar compilation remains at 79 allocs/op; timing samples overlap baseline noise

## Validation

- `go test ./src/core/...`
- targeted WasmGC integration tests in `./src/wago`
- AMD64 metadata/legacy equivalence and constructor slot-boundary tests
- ARM64 backend cross-build
- `go vet ./src/core/compiler/...`
- `git diff --check`
