### PR TITLE
runtime: unify code-image ownership and stream artifact v33

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,7 +13,17 @@ on amd64 and arm64. Linux and Darwin/arm64 additionally support signal-backed
 guard-page bounds checks; all six targets support explicit bounds checks and
 cooperative cancellation safepoints.
 
-<!-- artifact:codec-version 32 -->
+<!-- artifact:codec-version 33 -->
+
+Compiled artifact v33 is a strict ordered section stream: a fixed header and
+section count followed by length-delimited native-code and metadata sections.
+Unknown, duplicate, reordered, truncated, over-limit, and non-canonical section
+encodings fail closed. `Compiled.WriteTo` streams code without constructing a
+second full image; `Compiled.ReadFromWithLimits` reads code directly into an RW
+mapping, bounds code and metadata independently, validates all metadata, and
+seals that same mapping RX on first use. Version 32 and older artifacts are
+intentionally rejected; Wago was unreleased, so there is no compatibility
+decoder or dual-format ambiguity.
 
 **CPU baseline: modern x86-64 with SSSE3/SSE4.1 plus AVX/VEX.128 XMM encodings.** The backend emits
 some instructions beyond original x86-64 without a CPUID gate or fallback:
@@ -58,7 +68,7 @@ callsite; amd64 adds hidden operand spill offsets, compact safepoint IDs, frame
 size, adapter return, and recursive call return-PC maps. The synchronous helper
 control frame publishes parked RSP, and Go exposes validated off-heap slots from
 each walked frame directly as mutable collector roots. Throughput/Tiny stress
-collection and the root walker remain zero-allocation after warm-up. Codec v32
+collection and the root walker remain zero-allocation after warm-up. Codec v33
 persists and strictly revalidates the map, including dynamic-import stack
 adjustments. Direct tail calls discard their caller frame. Numeric host callbacks
 use a bounded suspended-activation stack plus separate nested foreign stacks, and
@@ -92,7 +102,7 @@ cross-Runtime compact-handle sharing remains impossible. `CaptureDomain` separat
 collector domain and persists every member, internal function/global/table edge,
 memory32/memory64 and tag aliases, typed live passive roots, and one stable-ID heap
 graph in `WGDN` v3 with strict v1/v2 loading; restore publishes the complete member
-slice only after transactional graph reconstruction. Codec v32 persists helper admission and
+slice only after transactional graph reconstruction. Codec v33 persists helper admission and
 the 16-byte `v128` storage contract, but never compact handles.
 Snapshot v4 persists reachable local-global object graphs with stable IDs and
 two-pass cycle/sharing reconstruction; snapshot v5 adds one owned local
@@ -280,17 +290,19 @@ references before any optimizer or IR backend consumes a function.
 
 ## 6. The compiled artifact & serialization
 
-`Compiled` holds the emitted code plus everything `Instantiate` needs without
-re-decoding:
+`Compiled` privately owns the emitted code plus everything `Instantiate` needs
+without re-decoding. `CodeSize` reports its length and `WriteCodeTo` provides a
+read-only diagnostic stream; callers never receive a mutable alias:
 
-- `Code`, wrapper/internal `Entry` offsets, and `Funcs` signatures
+- native code, wrapper/internal `Entry` offsets, and `Funcs` signatures
 - `Imports` / `NumImports`, import signatures, dynamic-dispatch shape, and `Exports`
 - `GlobalImports`, `Globals`, `GlobalExports` (numeric global metadata)
 - `TableSize`, `FuncTypeID`, `Elems` (active element segments)
 - `Data` (active data segments)
 
-`Compiled` serializes to a compact versioned **`.wago` blob**
-(`MarshalBinary`/`UnmarshalBinary`, magic `WAGO` + version byte). `Load` accepts
+`Compiled` serializes to a compact versioned **`.wago` blob** through either the
+slice APIs (`MarshalBinary`/`UnmarshalBinary`) or bounded streaming APIs
+(`WriteTo`/`ReadFromWithLimits`). `Load` accepts
 either a precompiled blob (fast reload, no recompile) or raw wasm (compiled on
 load); `IsCompiled` distinguishes them. `validate()` hardens every blob against
 malformed metadata before any memory is mapped. The codec persists the
@@ -358,10 +370,14 @@ pointer.
 
 ### Mapping code (W^X)
 
-`MapCode` mmaps the compiled bytes `PROT_READ|PROT_WRITE`, copies the code in,
-then `mprotect`s to `PROT_READ|PROT_EXEC` — write-xor-execute. A refcounted cache
-shares one executable mapping across instances of a `Compiled`; the mapping is
-unmapped after the compiled owner is closed and the last instance releases it.
+Serial compilation and streamed artifact loading write directly into an owned
+`PROT_READ|PROT_WRITE` mapping, then first instantiation changes that same
+mapping to `PROT_READ|PROT_EXEC`—write-xor-execute—without copying. The
+latency-gated parallel compiler retains its faster heap join and maps it on first
+use. A refcounted cache shares one executable mapping across instances of a
+`Compiled`; `Close` rejects future instances, while existing instances retain
+the mapping until the last one closes. Decode replacement is rejected while any
+instance is live, so it cannot orphan that ownership chain.
 
 ### Execution: the foreign stack & trampoline
 

--- a/bench/cmd/jsonprof/main.go
+++ b/bench/cmd/jsonprof/main.go
@@ -98,7 +98,7 @@ func writePerfMap(in *wago.Instance, c *wago.Compiled) {
 		return
 	}
 	defer f.Close()
-	codeLen := len(c.Code)
+	codeLen := c.CodeSize()
 	for i, off := range entries {
 		end := codeLen
 		if i+1 < len(entries) {

--- a/bench/corpus_runner_test.go
+++ b/bench/corpus_runner_test.go
@@ -384,8 +384,13 @@ func corpusWagoChild(t *testing.T, m corpusModule, stage, bounds, export string)
 		if err != nil || idx < 0 || idx+1 >= len(c.Entry) {
 			t.Fatalf("bad WAGO_CORPUS_DEBUG_CODE_FUNC %q", raw)
 		}
-		fmt.Printf("WAGO_CORPUS_CODE_FUNC=%d hex=%x\n", idx, c.Code[c.Entry[idx]:c.Entry[idx+1]])
-		fmt.Printf("WAGO_CORPUS_CODE_BRANCHES=%s\n", arm64BranchTargets(c.Code, c.Entry[idx], c.Entry[idx+1]))
+		var code bytes.Buffer
+		if _, err := c.WriteCodeTo(&code); err != nil {
+			t.Fatalf("write compiled code: %v", err)
+		}
+		image := code.Bytes()
+		fmt.Printf("WAGO_CORPUS_CODE_FUNC=%d hex=%x\n", idx, image[c.Entry[idx]:c.Entry[idx+1]])
+		fmt.Printf("WAGO_CORPUS_CODE_BRANCHES=%s\n", arm64BranchTargets(image, c.Entry[idx], c.Entry[idx+1]))
 	}
 	if stage == "Instantiate" {
 		return "ok"

--- a/bench/suite_test.go
+++ b/bench/suite_test.go
@@ -308,7 +308,7 @@ func BenchmarkCompileFullWorkers(b *testing.B) {
 						}
 					}
 					if cm != nil {
-						b.ReportMetric(float64(len(cm.Code)), "code-B")
+						b.ReportMetric(float64(cm.CodeSize()), "code-B")
 					}
 				})
 			}

--- a/docs/code-image-pipeline-plan.md
+++ b/docs/code-image-pipeline-plan.md
@@ -1,15 +1,16 @@
 # Code-image and artifact pipeline
 
-Status: active. Phase 1 is implemented on `codex/code-image-pipeline`.
+Status: complete on `codex/code-image-pipeline`.
 
 Tracking issues: #316, #330, #331.
 
 ## Goal
 
 Give one bounded owner responsibility for native code from Railshot emission to
-execution and `.wago` persistence. The finished path should not construct the
-same full native image repeatedly in assembler scratch, a Go-heap module slice,
-a serialized blob, and an executable mapping.
+execution and `.wago` persistence wherever the balanced performance gate allows
+it. The serial and streamed-artifact paths must not construct the same full
+native image repeatedly. The parallel join may retain its heap image only when
+direct executable-image alternatives measurably regress compile latency.
 
 This is not a revival of the superseded WARP topology redesign. The frontend
 and architecture backends remain separate where their semantics differ. The
@@ -78,39 +79,66 @@ flushes the instruction cache.
 - [x] Prove first instantiation retains the exact code address.
 - [x] Preserve byte-identical code, codec output, and execution behavior.
 
-### Phase 2: bounded parallel join
+### Phase 2: bounded parallel join investigation
 
-- [ ] Replace per-worker geometric byte slices with reusable bounded arenas.
-- [ ] Precompute deterministic final offsets after workers report function sizes.
-- [ ] Join worker products directly into one final RW image.
-- [ ] Retain serial/parallel byte identity and source-ordered errors.
-- [ ] Measure compile latency, Go allocations, peak RSS, and copied bytes at 1,
-  2, 4, 8, and adaptive workers on the benchmark corpus.
+The direct-mapping join is deliberately rejected. On the 1,600-function p4
+benchmark it reduced Go heap from 6,250,485 B/op to 3,727,622 B/op (1.68x less)
+but increased median compile latency from 19.97 ms to 22.54 ms (12.9% slower).
+The mmap-backed join was removed rather than trading away parallel throughput.
+A second version computed compact offsets first and had four workers populate
+disjoint final ranges concurrently, leaving mapping pages untouched until each
+worker first-used them. It still measured about 22.7 ms and added four join
+allocations. A third version allocated the mapping concurrently with codegen,
+prefaulted it, kept the original workers alive across an offset barrier, and had
+those workers populate disjoint final ranges. It reduced Go heap from about
+6.25 MB/op to 3.73 MB/op, but the best six-sample p4 median moved from 21.92 ms
+to 22.44 ms (+2.4%) and added about six allocations. The version without
+prefaulting was slower. All three prototypes were removed: merely replacing the
+final heap slice does not pass the balanced gate.
+
+- [x] Measure the existing worker arenas and deterministic heap join.
+- [x] Prototype a direct RW-image join and record heap/latency deltas.
+- [x] Prototype precomputed offsets with concurrent disjoint population.
+- [x] Prototype overlapped mapping allocation, prefaulting, and worker reuse.
+- [x] Retain serial/parallel byte identity and source-ordered errors.
+- [x] Retain the heap-backed parallel join as the measured low-latency exception.
 
 Parallel workers will keep independent per-function scratch. Sharing a mutable
 assembler or making output order scheduling-dependent is out of scope.
 
 ### Phase 3: sectioned artifact v33
 
-- [ ] Attribute bytes to code, entries, types, imports/exports, names, globals,
+- [x] Attribute bytes to code, entries, types, imports/exports, names, globals,
   tables, data, memories, tags, feature requirements, and GC roots.
-- [ ] Replace the positional codec with strictly ordered, length-delimited
+- [x] Replace the positional outer codec with strictly ordered, length-delimited
   sections. Unknown required sections and duplicate sections fail closed.
-- [ ] Add `Compiled.WriteTo(io.Writer)` without first materializing the complete
+- [x] Add `Compiled.WriteTo(io.Writer)` without first materializing the complete
   artifact.
-- [ ] Add a bounded reader API with explicit artifact, section, count, string,
-  and native-code limits.
-- [ ] Decode code directly into an RW image and seal it on first execution.
-- [ ] Reject v32 rather than retain an unreleased compatibility reader.
-- [ ] Keep malformed structured metadata strict and deterministic.
+- [x] Add a bounded reader API with explicit code and metadata section limits;
+  nested counts and strings remain bounded by their section's remaining bytes.
+- [x] Decode code directly into an RW image and seal it on first execution.
+- [x] Reject v32 rather than retain an unreleased compatibility reader.
+- [x] Keep malformed structured metadata strict and deterministic.
+
+For the 1,600-function imported-module fixture, five one-second samples put
+`WriteTo(io.Discard)` at a 182.5 us median and 263,265 B/op versus
+`MarshalBinary` at 280.3 us and 1,992,885 B/op: 1.54x faster and 7.57x less Go
+heap. Streamed read plus first code acquisition measured 264.7 us and
+224,095 B/op versus 255.3 us and 190,512 B/op for whole-blob unmarshal plus its
+first mapping: 3.7% slower and 1.18x more decoder heap. That comparison excludes
+the caller-owned complete artifact buffer required by `UnmarshalBinary`;
+`ReadFrom` consumes a file/network stream directly and therefore avoids that
+additional artifact-sized allocation. `ReadFrom` alone is intentionally slower
+than slice-backed unmarshal because it performs the executable mapping up front.
 
 ### Phase 4: compact public surface
 
-- [ ] Make native code storage private.
-- [ ] Replace mutable `Compiled.Code` access with `CodeSize` and streaming/debug
+- [x] Make native code storage private.
+- [x] Replace mutable `Compiled.Code` access with `CodeSize` and streaming/debug
   accessors that cannot mutate a sealed image.
-- [ ] Move hand-built test modules to a dedicated internal constructor.
-- [ ] Make `Close` and instance ownership rules explicit in package docs.
+- [x] Move hand-built test modules to a dedicated internal constructor.
+- [x] Make `Close`, decode replacement, and live-instance ownership rules
+  explicit in API documentation and tests.
 
 This is intentionally breaking: Wago has not released the artifact or the
 mutable `Compiled.Code` field, so carrying aliases or two codec generations

--- a/docs/code-image-pipeline-plan.md
+++ b/docs/code-image-pipeline-plan.md
@@ -1,0 +1,133 @@
+# Code-image and artifact pipeline
+
+Status: active. Phase 1 is implemented on `codex/code-image-pipeline`.
+
+Tracking issues: #316, #330, #331.
+
+## Goal
+
+Give one bounded owner responsibility for native code from Railshot emission to
+execution and `.wago` persistence. The finished path should not construct the
+same full native image repeatedly in assembler scratch, a Go-heap module slice,
+a serialized blob, and an executable mapping.
+
+This is not a revival of the superseded WARP topology redesign. The frontend
+and architecture backends remain separate where their semantics differ. The
+shared seam is ownership of already-selected native bytes, their relocations,
+and their persisted sections.
+
+## Current costs
+
+Before this project, serial compilation copied every completed function from a
+reused assembler scratch into a growable Go slice. First instantiation then
+allocated an RW executable mapping, copied the complete slice again, changed it
+to RX, and discarded the heap backing. `MarshalBinary` constructs another full
+blob. `UnmarshalBinary` requires the complete artifact in memory and copies its
+code into RX on first instantiation.
+
+The initial Darwin/ARM64 baseline was captured on an Apple M4 Max with Go's
+default benchmark duration, eight repetitions:
+
+| Measurement | Before | Phase 1 | Delta |
+| --- | ---: | ---: | ---: |
+| Serial 1,600-function compile, median | 36.93 ms | 36.81 ms | 1.003x faster |
+| Serial 1,600-function compile, Go heap | 3,283,350 B/op | 759,784 B/op | 4.32x less |
+| Serial 1,600-function compile allocations | 1,705 allocs/op | 1,704 allocs/op | 1 fewer |
+| Serial 1,600-function compile, median peak RSS | 25,886,720 B | 20,119,552 B | 1.29x less |
+| 1 MiB code transition, copy and seal vs seal in place | 72.08 us | 2.68 us | 26.9x faster |
+| Small artifact decode, Go heap | 1,857 B/op | 1,857 B/op | unchanged |
+
+Peak RSS is the median of five fresh ten-compile processes, alternated between
+the main and phase-1 test binaries. The transition microbenchmark times only the
+first-execution mapping step; RW image allocation and compiler writes occur
+during compilation. Steady-state execution, artifact bytes, and machine-code
+bytes are intentionally unchanged. The ordinary instantiate benchmark is also
+unchanged because it amortizes the one-time transition across all iterations.
+
+## Ownership model
+
+The neutral `core/codeimage.Image` interface transfers an image between the
+backend and public runtime without making encoders depend on runtime internals.
+The current implementation has these states:
+
+1. Railshot allocates a page-backed RW image using its measured capacity hint.
+2. It appends aligned functions and patches relocations in that image.
+3. Capacity underestimates grow geometrically and preserve existing bytes; they
+   never reject an otherwise valid module.
+4. `Compiled` takes the raw mapping and records the writable state in its
+   existing compact cache flags. No extra per-decoded-module owner allocation or
+   interface storage remains.
+5. First instantiation flips the same mapping to RX and registers it for host
+   interruption. The address cannot change across the transition.
+6. `Compiled.Close` owns unmapping before first instantiation; after sealing,
+   instances retain the existing reference-counted lifetime.
+
+There is no RWX state. Darwin uses `MAP_JIT` plus `mprotect`, Linux uses an
+anonymous RW mapping plus `mprotect`, and Windows uses `VirtualProtect` and
+flushes the instruction cache.
+
+## Phases
+
+### Phase 1: serial direct image
+
+- [x] Add a checked growable RW code-image owner.
+- [x] Keep platform-specific W^X operations in the runtime.
+- [x] Emit the serial AMD64 and ARM64 module image off heap.
+- [x] Patch calls before sealing.
+- [x] Transfer ownership without growing decoded-module footprint.
+- [x] Prove first instantiation retains the exact code address.
+- [x] Preserve byte-identical code, codec output, and execution behavior.
+
+### Phase 2: bounded parallel join
+
+- [ ] Replace per-worker geometric byte slices with reusable bounded arenas.
+- [ ] Precompute deterministic final offsets after workers report function sizes.
+- [ ] Join worker products directly into one final RW image.
+- [ ] Retain serial/parallel byte identity and source-ordered errors.
+- [ ] Measure compile latency, Go allocations, peak RSS, and copied bytes at 1,
+  2, 4, 8, and adaptive workers on the benchmark corpus.
+
+Parallel workers will keep independent per-function scratch. Sharing a mutable
+assembler or making output order scheduling-dependent is out of scope.
+
+### Phase 3: sectioned artifact v33
+
+- [ ] Attribute bytes to code, entries, types, imports/exports, names, globals,
+  tables, data, memories, tags, feature requirements, and GC roots.
+- [ ] Replace the positional codec with strictly ordered, length-delimited
+  sections. Unknown required sections and duplicate sections fail closed.
+- [ ] Add `Compiled.WriteTo(io.Writer)` without first materializing the complete
+  artifact.
+- [ ] Add a bounded reader API with explicit artifact, section, count, string,
+  and native-code limits.
+- [ ] Decode code directly into an RW image and seal it on first execution.
+- [ ] Reject v32 rather than retain an unreleased compatibility reader.
+- [ ] Keep malformed structured metadata strict and deterministic.
+
+### Phase 4: compact public surface
+
+- [ ] Make native code storage private.
+- [ ] Replace mutable `Compiled.Code` access with `CodeSize` and streaming/debug
+  accessors that cannot mutate a sealed image.
+- [ ] Move hand-built test modules to a dedicated internal constructor.
+- [ ] Make `Close` and instance ownership rules explicit in package docs.
+
+This is intentionally breaking: Wago has not released the artifact or the
+mutable `Compiled.Code` field, so carrying aliases or two codec generations
+would add permanent surface without protecting real users.
+
+## Gates
+
+Every phase must keep:
+
+- Wasm semantics and malformed-module rejection unchanged;
+- serial and parallel native bytes identical for the same target and config;
+- RW to RX transition only, with no writable executable interval;
+- bounded counts and sizes for every loaded section;
+- deterministic errors independent of worker scheduling;
+- no regression in steady-state execution or native code size.
+
+Measurements must report raw values and deltas for compile latency, first-load
+latency, execution, Go allocations, peak RSS, `.wago` bytes, native-code bytes,
+and bytes copied. A phase that moves cost off Go's heap without lowering RSS is
+reported as such rather than called a memory reduction.

--- a/src/core/codeimage/image.go
+++ b/src/core/codeimage/image.go
@@ -1,0 +1,10 @@
+// Package codeimage defines the ownership boundary between native-code
+// producers and the runtime that seals and executes their output.
+package codeimage
+
+// Image transfers an unsealed machine-code mapping from a producer to its
+// runtime owner. Take succeeds once; Close releases an image not yet taken.
+type Image interface {
+	Take() (mapping []byte, base uintptr, err error)
+	Close() error
+}

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -19,6 +19,7 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/encoder/amd64"
+	coreruntime "github.com/wago-org/wago/src/core/runtime"
 	"github.com/wago-org/wago/src/core/runtime/abi"
 )
 
@@ -874,9 +875,18 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		// Keep the serial compiler as a distinct fast path: one reusable scratch,
 		// no goroutines, channels, atomics, worker metadata, or intermediate arena.
 		sc := newScratch()
-		code := make([]byte, 0, codeCap)
+		codeBuffer, err := coreruntime.NewCodeBuffer(codeCap)
+		if err != nil {
+			return nil, fmt.Errorf("amd64: allocate code image: %w", err)
+		}
+		keepCodeBuffer := false
+		defer func() {
+			if !keepCodeBuffer {
+				_ = codeBuffer.Close()
+			}
+		}()
 		pressureDone := false
-		pressureAt := shared.PressureThreshold(opts.MemoryPressureAt, cap(code))
+		pressureAt := shared.PressureThreshold(opts.MemoryPressureAt, codeCap)
 		var directPrepared []uint64
 		for i := range m.Code {
 			hints := allHints[i]
@@ -892,22 +902,28 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 			}
 			requiresBMI2 = requiresBMI2 || sc.asm.UsesBMI2
 			// 16-byte align each function (append zeros without a temp allocation).
-			if pad := (16 - len(code)%16) % 16; pad != 0 {
-				code = append(code, alignPad[:pad]...)
+			if pad := (16 - len(codeBuffer.Bytes())%16) % 16; pad != 0 {
+				if err := codeBuffer.AppendZeros(pad); err != nil {
+					return nil, fmt.Errorf("amd64: grow code image: %w", err)
+				}
 			}
+			code := codeBuffer.Bytes()
 			entry[i] = len(code)
 			internalEntry[i] = len(code) + internalOff
 			if sc.directPrepared {
 				directPrepared = markDirectPrepared(directPrepared, n, i)
 			}
 			relocs[i] = rl
-			code = append(code, fnCode...)
-			if !pressureDone && opts.MemoryPressure != nil && len(code) >= pressureAt {
+			if err := codeBuffer.Append(fnCode); err != nil {
+				return nil, fmt.Errorf("amd64: grow code image: %w", err)
+			}
+			if !pressureDone && opts.MemoryPressure != nil && len(codeBuffer.Bytes()) >= pressureAt {
 				pressureDone = true
 				opts.MemoryPressure()
 			}
 		}
 		// Patch call sites now that every function's entry offsets are known.
+		code := codeBuffer.Bytes()
 		for i := 0; i < n; i++ {
 			for _, rl := range relocs[i] {
 				site := entry[i] + rl.at
@@ -921,7 +937,8 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		if explainEnabled && ms != nil {
 			fmt.Fprint(os.Stderr, ms.String())
 		}
-		return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, RequiresBMI2: requiresBMI2, RequiresAVX2: requiresAVX2, RequiresAVX512: requiresAVX512}, nil
+		keepCodeBuffer = true
+		return &amd64.CompiledModule{Code: code, CodeImage: codeBuffer, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, RequiresBMI2: requiresBMI2, RequiresAVX2: requiresAVX2, RequiresAVX512: requiresAVX512}, nil
 	}
 
 	return compileModuleParallel(m, opts, workers, codeCap, entry, internalEntry, relocs, allHints, modGlobals, hostAdapters, inlineTargets, ms, guardMode, boundsFacts, importedFuncs)

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	a64 "github.com/wago-org/wago/src/core/encoder/arm64"
+	coreruntime "github.com/wago-org/wago/src/core/runtime"
 	"github.com/wago-org/wago/src/core/runtime/abi"
 )
 
@@ -763,9 +764,18 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 		// Keep the serial compiler as a distinct fast path: one reusable scratch,
 		// no goroutines, channels, atomics, worker metadata, or intermediate arena.
 		sc := newScratch()
-		code := make([]byte, 0, codeCap)
+		codeBuffer, err := coreruntime.NewCodeBuffer(codeCap)
+		if err != nil {
+			return nil, fmt.Errorf("arm64: allocate code image: %w", err)
+		}
+		keepCodeBuffer := false
+		defer func() {
+			if !keepCodeBuffer {
+				_ = codeBuffer.Close()
+			}
+		}()
 		pressureDone := false
-		pressureAt := shared.PressureThreshold(opts.MemoryPressureAt, cap(code))
+		pressureAt := shared.PressureThreshold(opts.MemoryPressureAt, codeCap)
 		for i := range m.Code {
 			hints := allHints[i]
 			var st *CodegenStats
@@ -778,25 +788,32 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 			if err != nil {
 				return nil, fmt.Errorf("arm64: function %d: %w", i, err)
 			}
-			if pad := (16 - len(code)%16) % 16; pad != 0 {
-				code = append(code, alignPad[:pad]...)
+			if pad := (16 - len(codeBuffer.Bytes())%16) % 16; pad != 0 {
+				if err := codeBuffer.AppendZeros(pad); err != nil {
+					return nil, fmt.Errorf("arm64: grow code image: %w", err)
+				}
 			}
+			code := codeBuffer.Bytes()
 			entry[i] = len(code)
 			internalEntry[i] = len(code) + internalOff
 			relocs[i] = rl
-			code = append(code, fnCode...)
-			if !pressureDone && opts.MemoryPressure != nil && len(code) >= pressureAt {
+			if err := codeBuffer.Append(fnCode); err != nil {
+				return nil, fmt.Errorf("arm64: grow code image: %w", err)
+			}
+			if !pressureDone && opts.MemoryPressure != nil && len(codeBuffer.Bytes()) >= pressureAt {
 				pressureDone = true
 				opts.MemoryPressure()
 			}
 		}
+		code := codeBuffer.Bytes()
 		if err := patchCallRelocs(code, entry, internalEntry, relocs); err != nil {
 			return nil, err
 		}
 		if explainEnabled && ms != nil {
 			fmt.Fprint(os.Stderr, ms.String())
 		}
-		return &a64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
+		keepCodeBuffer = true
+		return &a64.CompiledModule{Code: code, CodeImage: codeBuffer, Entry: entry, InternalEntry: internalEntry}, nil
 	}
 
 	return compileModuleParallel(m, opts, workers, codeCap, entry, internalEntry, relocs, allHints, modGlobals, hostAdapters, inlineTargets, calleePreservesPins, ms, guardMode, boundsFacts, importedFuncs)

--- a/src/core/encoder/amd64/module.go
+++ b/src/core/encoder/amd64/module.go
@@ -1,5 +1,7 @@
 package amd64
 
+import "github.com/wago-org/wago/src/core/codeimage"
+
 // CompiledModule is the output of a code generator built on this encoder: the
 // concatenated machine code for all local functions plus each function's entry
 // offset into it. The amd64 package is now an x86-64 instruction *encoder* only
@@ -8,6 +10,10 @@ package amd64
 type CompiledModule struct {
 	Code  []byte // all local functions concatenated, 16-byte aligned
 	Entry []int  // Entry[localFuncIdx] = byte offset of that function in Code
+
+	// CodeImage owns Code when serial module compilation emitted directly into
+	// an off-heap image. Parallel and hand-built compiler results leave it nil.
+	CodeImage codeimage.Image
 
 	// InternalEntry[localFuncIdx] = byte offset of the function's register-ABI
 	// internal entry (== Entry[i] when the function has none). Lets indirect

--- a/src/core/encoder/arm64/module.go
+++ b/src/core/encoder/arm64/module.go
@@ -1,16 +1,19 @@
 package arm64
 
+import "github.com/wago-org/wago/src/core/codeimage"
+
 // CompiledModule is the output of a code generator built on this encoder: the
 // concatenated machine code for all local functions plus each function's entry
 // offset. The arm64 package is an AArch64 instruction *encoder* only (Asm); the
 // wasm→native code generator lives in backend/railshot/arm64 and returns a
 // *CompiledModule. Mirrors encoder/amd64.CompiledModule.
 type CompiledModule struct {
-	Code           []byte   // all local functions concatenated, 16-byte aligned
-	Entry          []int    // Entry[localFuncIdx] = byte offset in Code
-	InternalEntry  []int    // register-ABI internal entry offset (== Entry[i] when none)
-	DirectPrepared []uint64 // reserved for parity with AMD64 prepared-entry metadata
-	RequiresBMI2   bool     // always false on arm64; keeps backend result metadata uniform
-	RequiresAVX2   bool     // always false on arm64; keeps backend result metadata uniform
-	RequiresAVX512 bool     // always false on arm64; keeps backend result metadata uniform
+	Code           []byte          // all local functions concatenated, 16-byte aligned
+	CodeImage      codeimage.Image // owns Code on the serial direct-image path
+	Entry          []int           // Entry[localFuncIdx] = byte offset in Code
+	InternalEntry  []int           // register-ABI internal entry offset (== Entry[i] when none)
+	DirectPrepared []uint64        // reserved for parity with AMD64 prepared-entry metadata
+	RequiresBMI2   bool            // always false on arm64; keeps backend result metadata uniform
+	RequiresAVX2   bool            // always false on arm64; keeps backend result metadata uniform
+	RequiresAVX512 bool            // always false on arm64; keeps backend result metadata uniform
 }

--- a/src/core/runtime/code_buffer.go
+++ b/src/core/runtime/code_buffer.go
@@ -55,6 +55,20 @@ func (b *CodeBuffer) AppendZeros(n int) error {
 	return nil
 }
 
+// AppendSpace extends the image and returns the new writable range. The caller
+// must initialize every byte before the image is read or sealed.
+func (b *CodeBuffer) AppendSpace(n int) ([]byte, error) {
+	if n < 0 {
+		return nil, fmt.Errorf("jit: negative code space %d", n)
+	}
+	if err := b.grow(n); err != nil {
+		return nil, err
+	}
+	start := b.n
+	b.n += n
+	return b.mem[start:b.n:b.n], nil
+}
+
 // Bytes returns the exact logical image. It is writable until Seal succeeds
 // and read-only afterward. Callers must not retain it after Close.
 func (b *CodeBuffer) Bytes() []byte {

--- a/src/core/runtime/code_buffer.go
+++ b/src/core/runtime/code_buffer.go
@@ -1,0 +1,179 @@
+package runtime
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// CodeBuffer owns a growable off-heap machine-code image. It is writable while
+// the compiler appends and patches code, then permanently sealed executable.
+// The zero value is not usable.
+//
+// CodeBuffer is deliberately not safe for concurrent use. Compilation and
+// sealing transfer exclusive ownership between phases.
+type CodeBuffer struct {
+	mem        []byte
+	n          int
+	sealed     bool
+	registered bool
+	closed     bool
+}
+
+// NewCodeBuffer allocates an RW code image with at least capacity bytes.
+func NewCodeBuffer(capacity int) (*CodeBuffer, error) {
+	if capacity < 0 {
+		return nil, fmt.Errorf("jit: negative code capacity %d", capacity)
+	}
+	mem, err := mmapCodeRW(capacity)
+	if err != nil {
+		return nil, err
+	}
+	return &CodeBuffer{mem: mem}, nil
+}
+
+// Append adds p to the image. A capacity underestimate grows the mapping
+// geometrically instead of turning a valid Wasm module into a compile failure.
+func (b *CodeBuffer) Append(p []byte) error {
+	if err := b.grow(len(p)); err != nil {
+		return err
+	}
+	copy(b.mem[b.n:], p)
+	b.n += len(p)
+	return nil
+}
+
+// AppendZeros adds n zero bytes, used for deterministic function alignment.
+func (b *CodeBuffer) AppendZeros(n int) error {
+	if n < 0 {
+		return fmt.Errorf("jit: negative code padding %d", n)
+	}
+	if err := b.grow(n); err != nil {
+		return err
+	}
+	clear(b.mem[b.n : b.n+n])
+	b.n += n
+	return nil
+}
+
+// Bytes returns the exact logical image. It is writable until Seal succeeds
+// and read-only afterward. Callers must not retain it after Close.
+func (b *CodeBuffer) Bytes() []byte {
+	if b == nil || b.closed {
+		return nil
+	}
+	return b.mem[:b.n:b.n]
+}
+
+// Mapping returns the opaque page-rounded mapping used for registration and
+// unmapping. Most callers should use Bytes.
+func (b *CodeBuffer) Mapping() []byte {
+	if b == nil || b.closed {
+		return nil
+	}
+	return b.mem
+}
+
+// Base returns the stable address of the code image.
+func (b *CodeBuffer) Base() uintptr {
+	if b == nil || b.closed || len(b.mem) == 0 {
+		return 0
+	}
+	return uintptr(unsafe.Pointer(&b.mem[0]))
+}
+
+// Seal changes the complete mapping from RW to RX and registers it with the
+// host interruption machinery. Sealing is idempotent.
+func (b *CodeBuffer) Seal() error {
+	if b == nil {
+		return fmt.Errorf("jit: nil code buffer")
+	}
+	if b.closed {
+		return fmt.Errorf("jit: code buffer is closed")
+	}
+	if b.sealed {
+		return nil
+	}
+	if err := SealCode(b.mem); err != nil {
+		_ = munmap(b.mem)
+		b.mem = nil
+		b.n = 0
+		b.closed = true
+		return err
+	}
+	b.sealed = true
+	b.registered = true
+	return nil
+}
+
+// Take transfers an unsealed mapping to another owner. It is used at the
+// compiler/runtime boundary to keep Compiled's cache compact.
+func (b *CodeBuffer) Take() ([]byte, uintptr, error) {
+	if b == nil {
+		return nil, 0, fmt.Errorf("jit: nil code buffer")
+	}
+	if b.closed {
+		return nil, 0, fmt.Errorf("jit: code buffer is closed")
+	}
+	if b.sealed {
+		return nil, 0, fmt.Errorf("jit: sealed code buffer cannot transfer ownership")
+	}
+	mem, base := b.mem, b.Base()
+	b.mem = nil
+	b.n = 0
+	b.closed = true
+	return mem, base, nil
+}
+
+// Close releases the mapping. Callers must ensure no instance can still enter
+// the image.
+func (b *CodeBuffer) Close() error {
+	if b == nil || b.closed {
+		return nil
+	}
+	if b.registered {
+		unregisterExecutableCode(b.mem)
+	}
+	mem := b.mem
+	b.mem = nil
+	b.n = 0
+	b.closed = true
+	return munmap(mem)
+}
+
+func (b *CodeBuffer) grow(extra int) error {
+	if b == nil {
+		return fmt.Errorf("jit: nil code buffer")
+	}
+	if b.closed {
+		return fmt.Errorf("jit: code buffer is closed")
+	}
+	if b.sealed {
+		return fmt.Errorf("jit: code buffer is sealed")
+	}
+	if extra < 0 || b.n > int(^uint(0)>>1)-extra {
+		return fmt.Errorf("jit: code image size overflow")
+	}
+	need := b.n + extra
+	if need <= len(b.mem) {
+		return nil
+	}
+	capacity := len(b.mem) * 2
+	if capacity < need {
+		capacity = need
+	}
+	mem, err := mmapCodeRW(capacity)
+	if err != nil {
+		return err
+	}
+	copy(mem, b.mem[:b.n])
+	old := b.mem
+	b.mem = mem
+	if err := munmap(old); err != nil {
+		_ = munmap(mem)
+		b.mem = nil
+		b.n = 0
+		b.closed = true
+		return err
+	}
+	return nil
+}

--- a/src/core/runtime/code_buffer_test.go
+++ b/src/core/runtime/code_buffer_test.go
@@ -21,11 +21,21 @@ func TestCodeBufferGrowSealClose(t *testing.T) {
 	if err := b.AppendZeros(16); err != nil {
 		t.Fatal(err)
 	}
+	space, err := b.AppendSpace(32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range space {
+		space[i] = 0x5a
+	}
 	if err := b.Append(want[3000:]); err != nil {
 		t.Fatal(err)
 	}
-	if got := b.Bytes(); !bytes.Equal(got[:3000], want[:3000]) || !bytes.Equal(got[3016:], want[3000:]) || !bytes.Equal(got[3000:3016], make([]byte, 16)) {
+	if got := b.Bytes(); !bytes.Equal(got[:3000], want[:3000]) || !bytes.Equal(got[3048:], want[3000:]) || !bytes.Equal(got[3000:3016], make([]byte, 16)) || !bytes.Equal(got[3016:3048], bytes.Repeat([]byte{0x5a}, 32)) {
 		t.Fatal("grown code image did not preserve appended bytes and zero padding")
+	}
+	if _, err := b.AppendSpace(-1); err == nil {
+		t.Fatal("AppendSpace accepted a negative length")
 	}
 	base := b.Base()
 	if base == 0 {

--- a/src/core/runtime/code_buffer_test.go
+++ b/src/core/runtime/code_buffer_test.go
@@ -1,0 +1,88 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64)
+
+package runtime
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCodeBufferGrowSealClose(t *testing.T) {
+	b, err := NewCodeBuffer(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	want := bytes.Repeat([]byte{0xa5}, 5000)
+	if err := b.Append(want[:3000]); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.AppendZeros(16); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Append(want[3000:]); err != nil {
+		t.Fatal(err)
+	}
+	if got := b.Bytes(); !bytes.Equal(got[:3000], want[:3000]) || !bytes.Equal(got[3016:], want[3000:]) || !bytes.Equal(got[3000:3016], make([]byte, 16)) {
+		t.Fatal("grown code image did not preserve appended bytes and zero padding")
+	}
+	base := b.Base()
+	if base == 0 {
+		t.Fatal("code image has no base address")
+	}
+	if err := b.Seal(); err != nil {
+		t.Fatal(err)
+	}
+	if b.Base() != base {
+		t.Fatalf("Seal moved code image: %#x -> %#x", base, b.Base())
+	}
+	if err := b.Seal(); err != nil {
+		t.Fatalf("second Seal: %v", err)
+	}
+	if err := b.Append([]byte{1}); err == nil {
+		t.Fatal("Append succeeded after Seal")
+	}
+	if err := b.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := b.Bytes(); got != nil {
+		t.Fatalf("Bytes after Close = %d bytes, want nil", len(got))
+	}
+}
+
+func BenchmarkCodeImageTransition(b *testing.B) {
+	code := bytes.Repeat([]byte{0x90}, 1<<20)
+	b.Run("copy-and-seal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			mem, _, err := MapCode(code)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := Unmap(mem); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("seal-in-place", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			image, err := NewCodeBuffer(len(code))
+			if err == nil {
+				err = image.Append(code)
+			}
+			b.StartTimer()
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := image.Seal(); err != nil {
+				b.Fatal(err)
+			}
+			b.StopTimer()
+			if err := image.Close(); err != nil {
+				b.Fatal(err)
+			}
+			b.StartTimer()
+		}
+	})
+}

--- a/src/core/runtime/engine.go
+++ b/src/core/runtime/engine.go
@@ -304,6 +304,18 @@ func MapCode(code []byte) (mem []byte, entry uintptr, err error) {
 	return mem, slicePtr(mem), nil
 }
 
+// SealCode changes an existing code mapping from RW to RX and registers it for
+// safe host interruption. The caller retains ownership on failure.
+func SealCode(mem []byte) error {
+	if len(mem) == 0 {
+		return fmt.Errorf("seal executable code: empty mapping")
+	}
+	if err := protectCodeRX(mem); err != nil {
+		return err
+	}
+	return registerExecutableCode(mem)
+}
+
 // Unmap releases a mapping returned by MapCode.
 func Unmap(mem []byte) error {
 	unregisterExecutableCode(mem)

--- a/src/core/runtime/mem_darwin.go
+++ b/src/core/runtime/mem_darwin.go
@@ -31,18 +31,26 @@ func mmapRWReserve(n int) ([]byte, error) {
 	return mmapRW(n)
 }
 
+func mmapCodeRW(n int) ([]byte, error) {
+	return syscall.Mmap(-1, 0, roundUpPage(n),
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE|syscall.MAP_JIT)
+}
+
+func protectCodeRX(mem []byte) error {
+	return syscall.Mprotect(mem, syscall.PROT_READ|syscall.PROT_EXEC)
+}
+
 // mmapExec maps executable code on macOS. MAP_JIT is required on many hardened
 // configurations; the mapping is writable only
 // during the copy and then flipped to RX to preserve W^X at the syscall level.
 func mmapExec(code []byte) ([]byte, error) {
-	mem, err := syscall.Mmap(-1, 0, roundUpPage(len(code)),
-		syscall.PROT_READ|syscall.PROT_WRITE,
-		syscall.MAP_ANON|syscall.MAP_PRIVATE|syscall.MAP_JIT)
+	mem, err := mmapCodeRW(len(code))
 	if err != nil {
 		return nil, err
 	}
 	copy(mem, code)
-	if err := syscall.Mprotect(mem, syscall.PROT_READ|syscall.PROT_EXEC); err != nil {
+	if err := protectCodeRX(mem); err != nil {
 		_ = syscall.Munmap(mem)
 		return nil, err
 	}

--- a/src/core/runtime/mem_linux.go
+++ b/src/core/runtime/mem_linux.go
@@ -48,6 +48,12 @@ func mmapRWReserve(n int) ([]byte, error) {
 		syscall.MAP_ANON|syscall.MAP_PRIVATE|syscall.MAP_NORESERVE)
 }
 
+func mmapCodeRW(n int) ([]byte, error) { return mmapRW(n) }
+
+func protectCodeRX(mem []byte) error {
+	return syscall.Mprotect(mem, syscall.PROT_READ|syscall.PROT_EXEC)
+}
+
 // mmapExec uses W^X: allocate RW, copy, then flip to R-X.
 func mmapExec(code []byte) ([]byte, error) {
 	mem, err := mmapRW(len(code))
@@ -55,7 +61,7 @@ func mmapExec(code []byte) ([]byte, error) {
 		return nil, err
 	}
 	copy(mem, code)
-	if err := syscall.Mprotect(mem, syscall.PROT_READ|syscall.PROT_EXEC); err != nil {
+	if err := protectCodeRX(mem); err != nil {
 		_ = syscall.Munmap(mem)
 		return nil, err
 	}

--- a/src/core/runtime/mem_windows.go
+++ b/src/core/runtime/mem_windows.go
@@ -55,28 +55,36 @@ func mmapRW(n int) ([]byte, error) {
 // consume physical memory until touched.
 func mmapRWReserve(n int) ([]byte, error) { return mmapRW(n) }
 
-func mmapExec(code []byte) ([]byte, error) {
-	mem, err := mmapRW(len(code))
-	if err != nil {
-		return nil, err
-	}
-	copy(mem, code)
+func mmapCodeRW(n int) ([]byte, error) { return mmapRW(n) }
+
+func protectCodeRX(mem []byte) error {
 	var oldProtect uintptr
 	ok, _, callErr := procVirtualProtect.Call(
 		uintptr(unsafe.Pointer(&mem[0])), uintptr(len(mem)), pageExecuteRead,
 		uintptr(unsafe.Pointer(&oldProtect)),
 	)
 	if ok == 0 {
-		_ = munmap(mem)
-		return nil, fmt.Errorf("VirtualProtect(RX): %w", callErr)
+		return fmt.Errorf("VirtualProtect(RX): %w", callErr)
 	}
 	process, _, _ := procGetCurrentProcess.Call()
 	ok, _, callErr = procFlushInstructionCache.Call(
 		process, uintptr(unsafe.Pointer(&mem[0])), uintptr(len(mem)),
 	)
 	if ok == 0 {
+		return fmt.Errorf("FlushInstructionCache: %w", callErr)
+	}
+	return nil
+}
+
+func mmapExec(code []byte) ([]byte, error) {
+	mem, err := mmapRW(len(code))
+	if err != nil {
+		return nil, err
+	}
+	copy(mem, code)
+	if err := protectCodeRX(mem); err != nil {
 		_ = munmap(mem)
-		return nil, fmt.Errorf("FlushInstructionCache: %w", callErr)
+		return nil, err
 	}
 	return mem, nil
 }

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1290,6 +1290,12 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	if err != nil {
 		return nil, fmt.Errorf("compile: %w", err)
 	}
+	keepCodeImage := false
+	defer func() {
+		if cm.CodeImage != nil && !keepCodeImage {
+			_ = cm.CodeImage.Close()
+		}
+	}()
 	code, entry, internalEntry := cm.Code, cm.Entry, cm.InternalEntry
 	for i := range internalEntry {
 		if i>>6 < len(cm.DirectPrepared) && cm.DirectPrepared[i>>6]&(uint64(1)<<uint(i&63)) != 0 {
@@ -1799,6 +1805,16 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 		c.Data = append(c.Data, init)
 	}
 	compiled := installCompiledFinalizer(c)
+	if cm.CodeImage != nil {
+		mapping, base, err := cm.CodeImage.Take()
+		if err != nil {
+			return nil, fmt.Errorf("compile: transfer code image: %w", err)
+		}
+		compiled.codeCache.mem = mapping
+		compiled.codeCache.base = base
+		compiled.codeCache.flags |= compiledCacheWritableCode
+	}
+	keepCodeImage = true
 	if guardPageBuilt && cfg.boundsChecks == BoundsChecksSignalsBased {
 		compiled.codeCache.flags |= compiledCacheGuardMemory
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	goruntime "runtime"
 	"sort"
 	"strings"
@@ -23,6 +24,39 @@ type GCConfig = gc.Config
 type GCProfile = gc.Profile
 type GCAllocatorKind = gc.AllocatorKind
 type GCRuntimeKind = gc.RuntimeKind
+
+// ArtifactLimits bounds allocation while streaming a compiled artifact.
+// Values must be non-negative; zero rejects a non-empty corresponding section.
+type ArtifactLimits struct {
+	MaxCodeBytes     int64
+	MaxMetadataBytes int64
+}
+
+// ArtifactSectionSizes attributes bytes in a sectioned compiled artifact.
+type ArtifactSectionSizes struct {
+	Framing         int64
+	Code            int64
+	Entries         int64
+	Imports         int64
+	Types           int64
+	Functions       int64
+	ExportsAndNames int64
+	Globals         int64
+	Tables          int64
+	Elements        int64
+	Data            int64
+	Memories        int64
+	Tags            int64
+	Features        int64
+	GC              int64
+	Metadata        int64
+	Total           int64
+}
+
+// DefaultArtifactLimits returns the limits used by Compiled.ReadFrom.
+func DefaultArtifactLimits() ArtifactLimits {
+	return ArtifactLimits{MaxCodeBytes: 1 << 30, MaxMetadataBytes: 256 << 20}
+}
 
 const (
 	GCAllocatorPagedSizeClass     = gc.AllocatorPagedSizeClass
@@ -1307,7 +1341,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	if err != nil {
 		return nil, fmt.Errorf("type metadata: %w", err)
 	}
-	c := &Compiled{Code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Types: types, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, memoryDir: &compiledMemoryDirectory{exports: map[string]int{}, exactExports: true, staged: features.MultiMemory && (m.MemCount() > 1 || m.ImportedMemCount() > 0), stagedMemory64: features.Memory64 && usesMemory64}, boundsMode: boundsMode, stagedTable64: features.Table64 && usesTable64, GCTypeDescs: gcDescs, requiredFeatures: requiredByModule, dynamicImports: importedFuncs > 0, customInstructions: customInstructions, requiresBMI2: cm.RequiresBMI2, requiresAVX2: cm.RequiresAVX2, requiresAVX512: cm.RequiresAVX512}
+	c := &Compiled{code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Types: types, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, memoryDir: &compiledMemoryDirectory{exports: map[string]int{}, exactExports: true, staged: features.MultiMemory && (m.MemCount() > 1 || m.ImportedMemCount() > 0), stagedMemory64: features.Memory64 && usesMemory64}, boundsMode: boundsMode, stagedTable64: features.Table64 && usesTable64, GCTypeDescs: gcDescs, requiredFeatures: requiredByModule, dynamicImports: importedFuncs > 0, customInstructions: customInstructions, requiresBMI2: cm.RequiresBMI2, requiresAVX2: cm.RequiresAVX2, requiresAVX512: cm.RequiresAVX512}
 	typeConverter := newWasmTypeDescriptorConverter(m)
 	constExprCtx := &constExprCompileContext{module: m, types: c.Types, converter: typeConverter}
 	if gcI31Product == stagedGCI31ProductTableGlobalInitializer {
@@ -2773,8 +2807,8 @@ func (c *Compiled) validate() error {
 		return fmt.Errorf("compiled metadata invalid: Entry length %d != Funcs length %d", len(c.Entry), len(c.Funcs))
 	}
 	for i, off := range c.Entry {
-		if off < 0 || off >= len(c.Code) {
-			return fmt.Errorf("compiled metadata invalid: Entry[%d] offset %d out of code range %d", i, off, len(c.Code))
+		if off < 0 || off >= len(c.code) {
+			return fmt.Errorf("compiled metadata invalid: Entry[%d] offset %d out of code range %d", i, off, len(c.code))
 		}
 	}
 	totalFuncs := c.NumImports + len(c.Funcs)
@@ -3663,10 +3697,13 @@ const wagoMagic = "WAGO"
 // Version 31 moves generated memory bounds to the u64 byte-size cache and widens
 // indexed-memory directory entries, so older native code must not be loaded by a
 // runtime using the new basedata ABI (or vice versa). Older blobs are rejected.
-// Version 32 adds the persisted threads feature and atomic wait-helper product.
+// Version 32 added the persisted threads feature and atomic wait-helper product.
+// Version 33 replaces the positional outer stream with strict length-delimited
+// code and metadata sections. Older blobs are rejected rather than carrying an
+// unreleased compatibility decoder.
 // The codec never serializes live owners, collector handles, mappings, tokens,
 // active handlers, thunk addresses, or store identity.
-const wagoVersion = 32
+const wagoVersion = 33
 
 // MarshalBinary serializes the precompiled module to a ".wago" blob.
 //
@@ -3681,25 +3718,152 @@ func (c *Compiled) MarshalBinary() ([]byte, error) {
 	c.ensureCodeCache()
 	c.codeCache.mu.Lock()
 	defer c.codeCache.mu.Unlock()
-	if c.codeCache.closed {
-		return nil, errors.New("wago: compiled module is closed")
-	}
-	if c.boundsMode == BoundsChecksSignalsBased {
-		return nil, errors.New("wago: signals-based compiled modules cannot be serialized; recompile from wasm at load time")
-	}
-	if len(c.Entry) == 0 && len(c.Funcs) > 0 {
-		return nil, errors.New("wago: compiled module has functions but no native entries")
-	}
-	if c.NumImports > 0 && !c.dynamicImports {
-		return nil, errors.New("wago: imported-function code lacks dynamic dispatch metadata")
-	}
-	if err := c.validateCodecMetadata(); err != nil {
+	if err := c.validateSerializableLocked(); err != nil {
 		return nil, err
 	}
 	return marshalCompiled(c)
 }
 
-// UnmarshalBinary loads a ".wago" blob produced by MarshalBinary.
+// WriteTo streams a sectioned ".wago" artifact to w. Native code is written
+// directly from its readable image; only the smaller metadata section is
+// buffered. The returned count includes bytes accepted before an error.
+func (c *Compiled) WriteTo(w io.Writer) (int64, error) {
+	if c == nil {
+		return 0, errors.New("wago: compiled module is nil")
+	}
+	if w == nil {
+		return 0, errors.New("wago: compiled artifact writer is nil")
+	}
+	c.ensureCodeCache()
+	c.codeCache.mu.Lock()
+	defer c.codeCache.mu.Unlock()
+	if err := c.validateSerializableLocked(); err != nil {
+		return 0, err
+	}
+	return writeCompiled(w, c)
+}
+
+// CodeSize reports the exact native-code byte length. It returns zero after
+// the compiled module is closed.
+func (c *Compiled) CodeSize() int {
+	if c == nil {
+		return 0
+	}
+	c.ensureCodeCache()
+	c.codeCache.mu.Lock()
+	defer c.codeCache.mu.Unlock()
+	if c.codeCache.closed {
+		return 0
+	}
+	return len(c.code)
+}
+
+// WriteCodeTo streams the native-code bytes for diagnostics and artifact
+// tooling without exposing mutable storage. It does not change the image's W^X
+// state.
+func (c *Compiled) WriteCodeTo(w io.Writer) (int64, error) {
+	if c == nil {
+		return 0, errors.New("wago: compiled module is nil")
+	}
+	if w == nil {
+		return 0, errors.New("wago: native code writer is nil")
+	}
+	c.ensureCodeCache()
+	c.codeCache.mu.Lock()
+	defer c.codeCache.mu.Unlock()
+	if c.codeCache.closed {
+		return 0, errors.New("wago: compiled module is closed")
+	}
+	n, err := w.Write(c.code)
+	if err != nil {
+		return int64(n), err
+	}
+	if n != len(c.code) {
+		return int64(n), io.ErrShortWrite
+	}
+	return int64(n), nil
+}
+
+// ArtifactSectionSizes reports exact encoded byte attribution without
+// materializing the complete artifact.
+func (c *Compiled) ArtifactSectionSizes() (ArtifactSectionSizes, error) {
+	if c == nil {
+		return ArtifactSectionSizes{}, errors.New("wago: compiled module is nil")
+	}
+	c.ensureCodeCache()
+	c.codeCache.mu.Lock()
+	defer c.codeCache.mu.Unlock()
+	if err := c.validateSerializableLocked(); err != nil {
+		return ArtifactSectionSizes{}, err
+	}
+	metadata, result, err := marshalCompiledMetadataMeasured(c)
+	if err != nil {
+		return ArtifactSectionSizes{}, err
+	}
+	framing := int64(6 + 2 + compiledUvarintLen(uint64(len(c.code))) + compiledUvarintLen(uint64(len(metadata))))
+	result.Framing = framing
+	result.Code = int64(len(c.code))
+	result.Metadata = int64(len(metadata))
+	result.Total = result.Framing + result.Code + result.Metadata
+	return result, nil
+}
+
+func (c *Compiled) validateSerializableLocked() error {
+	if c.codeCache.closed {
+		return errors.New("wago: compiled module is closed")
+	}
+	if c.boundsMode == BoundsChecksSignalsBased {
+		return errors.New("wago: signals-based compiled modules cannot be serialized; recompile from wasm at load time")
+	}
+	if len(c.Entry) == 0 && len(c.Funcs) > 0 {
+		return errors.New("wago: compiled module has functions but no native entries")
+	}
+	if c.NumImports > 0 && !c.dynamicImports {
+		return errors.New("wago: imported-function code lacks dynamic dispatch metadata")
+	}
+	return c.validateCodecMetadata()
+}
+
+// ReadFrom streams one sectioned ".wago" artifact using bounded default
+// allocations. Native code is read directly into its RW image and sealed in
+// place on first instantiation.
+func (c *Compiled) ReadFrom(r io.Reader) (int64, error) {
+	return c.ReadFromWithLimits(r, DefaultArtifactLimits())
+}
+
+// ReadFromWithLimits is ReadFrom with explicit code and metadata byte limits.
+// It may replace receiver state before instantiation; replacement is rejected
+// while instances of the receiver are live.
+func (c *Compiled) ReadFromWithLimits(r io.Reader, limits ArtifactLimits) (int64, error) {
+	if c == nil {
+		return 0, errors.New("wago: compiled module is nil")
+	}
+	decoded, image, n, err := readCompiledFrom(r, limits)
+	if err != nil {
+		return n, err
+	}
+	defer image.Close()
+	if err := finishDecodedCompiled(&decoded); err != nil {
+		return n, err
+	}
+	mapping, base, err := image.Take()
+	if err != nil {
+		return n, fmt.Errorf("load compiled code image: %w", err)
+	}
+	decoded.ensureCodeCache()
+	decoded.codeCache.mem = mapping
+	decoded.codeCache.base = base
+	decoded.codeCache.flags |= compiledCacheWritableCode
+	if err := c.replaceDecoded(decoded); err != nil {
+		_ = decoded.Close()
+		return n, err
+	}
+	return n, nil
+}
+
+// UnmarshalBinary loads a ".wago" blob produced by MarshalBinary. It may
+// replace receiver state before instantiation; replacement is rejected while
+// instances of the receiver are live.
 func (c *Compiled) UnmarshalBinary(data []byte) error {
 	if !IsCompiled(data) {
 		return fmt.Errorf("not a wago module")
@@ -3711,6 +3875,13 @@ func (c *Compiled) UnmarshalBinary(data []byte) error {
 	if err := unmarshalCompiled(&decoded, data[5:]); err != nil {
 		return err
 	}
+	if err := finishDecodedCompiled(&decoded); err != nil {
+		return err
+	}
+	return c.replaceDecoded(decoded)
+}
+
+func finishDecodedCompiled(decoded *Compiled) error {
 	if len(decoded.tableExports) == 0 {
 		decoded.tableExports = nil
 	}
@@ -3722,7 +3893,7 @@ func (c *Compiled) UnmarshalBinary(data []byte) error {
 		decoded.memoryDir.exports = nil
 	}
 	decoded.memoryDir.exactExports = true
-	if inferred := compiledStructuralRequiredFeatures(&decoded); inferred&^decoded.requiredFeatures != 0 {
+	if inferred := compiledStructuralRequiredFeatures(decoded); inferred&^decoded.requiredFeatures != 0 {
 		return fmt.Errorf("compiled metadata invalid: structural metadata requires unrecorded features %s", inferred&^decoded.requiredFeatures)
 	}
 	if err := decoded.validate(); err != nil {
@@ -3734,8 +3905,6 @@ func (c *Compiled) UnmarshalBinary(data []byte) error {
 	if decoded.requiresBMI2 && !hostSupportsBMI2() {
 		return fmt.Errorf("wago: compiled module requires BMI2 CPU features unavailable on this host")
 	}
-	*c = decoded
-	installCompiledFinalizer(c)
 	return nil
 }
 

--- a/src/wago/api_compat_test.go
+++ b/src/wago/api_compat_test.go
@@ -241,8 +241,8 @@ func TestReturningHostImportUsesCompiledDispatch(t *testing.T) {
 	if err := c.validateImportBindings(imports, nil); err != nil {
 		t.Fatalf("validate returning host bindings: %v", err)
 	}
-	if !c.dynamicImports || len(c.Code) == 0 {
-		t.Fatalf("compiled import dispatch dynamic=%v code=%d", c.dynamicImports, len(c.Code))
+	if !c.dynamicImports || len(c.code) == 0 {
+		t.Fatalf("compiled import dispatch dynamic=%v code=%d", c.dynamicImports, len(c.code))
 	}
 	in, err := Instantiate(c, imports)
 	if err != nil {

--- a/src/wago/bench_test.go
+++ b/src/wago/bench_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	goruntime "runtime"
 	"testing"
 
@@ -323,6 +324,7 @@ func BenchmarkCompileImportedWorkers(b *testing.B) {
 	}{{"p1", 1}, {"p2", 2}, {"p4", 4}, {"p8", 8}, {"auto", 0}} {
 		b.Run(mode.name, func(b *testing.B) {
 			cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(mode.workers)
+			codeBytes := 0
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				c, err := Compile(cfg, mod)
@@ -330,10 +332,12 @@ func BenchmarkCompileImportedWorkers(b *testing.B) {
 					b.Fatal(err)
 				}
 				benchCompiledSink = c
+				codeBytes = len(c.code)
 				if err := c.Close(); err != nil {
 					b.Fatal(err)
 				}
 			}
+			b.ReportMetric(float64(codeBytes), "code-B")
 		})
 	}
 }
@@ -365,7 +369,7 @@ func BenchmarkInvokeBranchHintLoop(b *testing.B) {
 	}
 	withoutHint := benchMustCompile(b, benchBranchHintExecModule(false))
 	withHint := benchMustCompile(b, benchBranchHintExecModule(true))
-	if len(withoutHint.Code) == 0 || bytes.Equal(withoutHint.Code, withHint.Code) {
+	if len(withoutHint.code) == 0 || bytes.Equal(withoutHint.code, withHint.code) {
 		b.Fatal("unlikely br_if hint did not select deferred cold-edge layout")
 	}
 	for _, tc := range []struct {
@@ -2138,6 +2142,109 @@ func BenchmarkMarshalCompiledSmallScalar(b *testing.B) {
 			b.Fatal(err)
 		}
 		benchBytesSink = blob
+	}
+}
+
+func BenchmarkWriteCompiledImportedModule(b *testing.B) {
+	c := benchMustCompile(b, benchImportedModule(1600, 128))
+	b.ReportMetric(float64(len(c.code)), "code-B")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.WriteTo(io.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshalCompiledImportedModule(b *testing.B) {
+	c := benchMustCompile(b, benchImportedModule(1600, 128))
+	b.ReportMetric(float64(len(c.code)), "code-B")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		blob, err := c.MarshalBinary()
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchBytesSink = blob
+	}
+}
+
+func BenchmarkReadCompiledImportedModule(b *testing.B) {
+	c := benchMustCompile(b, benchImportedModule(1600, 128))
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+	c.Close()
+	reader := bytes.NewReader(blob)
+	b.ReportMetric(float64(len(blob)), "artifact-B")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader.Reset(blob)
+		var loaded Compiled
+		if _, err := loaded.ReadFrom(reader); err != nil {
+			b.Fatal(err)
+		}
+		if err := loaded.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalCompiledImportedModule(b *testing.B) {
+	c := benchMustCompile(b, benchImportedModule(1600, 128))
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+	c.Close()
+	b.ReportMetric(float64(len(blob)), "artifact-B")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var loaded Compiled
+		if err := loaded.UnmarshalBinary(blob); err != nil {
+			b.Fatal(err)
+		}
+		if err := loaded.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFirstUseCompiledImportedModule(b *testing.B) {
+	c := benchMustCompile(b, benchImportedModule(1600, 128))
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+	c.Close()
+	for _, mode := range []string{"read", "unmarshal"} {
+		b.Run(mode, func(b *testing.B) {
+			reader := bytes.NewReader(blob)
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var loaded Compiled
+				if mode == "read" {
+					reader.Reset(blob)
+					if _, err := loaded.ReadFrom(reader); err != nil {
+						b.Fatal(err)
+					}
+				} else if err := loaded.UnmarshalBinary(blob); err != nil {
+					b.Fatal(err)
+				}
+				if _, err := loaded.acquireCode(); err != nil {
+					b.Fatal(err)
+				}
+				loaded.releaseCode()
+				if err := loaded.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -220,6 +220,16 @@ func (c *Compiled) ensureCodeCache() {
 	}
 }
 
+func (c *Compiled) checkOpen() error {
+	c.ensureCodeCache()
+	c.codeCache.mu.Lock()
+	defer c.codeCache.mu.Unlock()
+	if c.codeCache.closed {
+		return fmt.Errorf("compiled module is closed")
+	}
+	return nil
+}
+
 func (c *Compiled) acquireCode() (uintptr, error) {
 	c.ensureCodeCache()
 	cc := c.codeCache

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -14,6 +14,7 @@ const (
 	compiledCacheDynamicFuncRefTest compiledCodeCacheFlags = 1 << iota
 	compiledCacheGuardMemory
 	compiledCacheAtomicWaitHelpers
+	compiledCacheWritableCode
 )
 
 type compiledCodeCache struct {
@@ -239,6 +240,12 @@ func (c *Compiled) acquireCode() (uintptr, error) {
 		// padding would change codec bytes and binding-independent declarations.
 		// The original Go-heap backing can now be reclaimed.
 		c.Code = mem[:codeLen:codeLen]
+	}
+	if cc.flags&compiledCacheWritableCode != 0 {
+		if err := coreruntime.SealCode(cc.mem); err != nil {
+			return 0, err
+		}
+		cc.flags &^= compiledCacheWritableCode
 	}
 	cc.refs++
 	return cc.base, nil

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -239,8 +239,8 @@ func (c *Compiled) acquireCode() (uintptr, error) {
 		return 0, fmt.Errorf("compiled module is closed")
 	}
 	if cc.mem == nil {
-		codeLen := len(c.Code)
-		mem, base, err := coreruntime.MapCode(c.Code)
+		codeLen := len(c.code)
+		mem, base, err := coreruntime.MapCode(c.code)
 		if err != nil {
 			return 0, err
 		}
@@ -249,7 +249,7 @@ func (c *Compiled) acquireCode() (uintptr, error) {
 		// onto the RX mapping. MapCode's mmap slice is page-rounded; exposing that
 		// padding would change codec bytes and binding-independent declarations.
 		// The original Go-heap backing can now be reclaimed.
-		c.Code = mem[:codeLen:codeLen]
+		c.code = mem[:codeLen:codeLen]
 	}
 	if cc.flags&compiledCacheWritableCode != 0 {
 		if err := coreruntime.SealCode(cc.mem); err != nil {
@@ -275,8 +275,36 @@ func (c *Compiled) releaseCode() {
 		_ = coreruntime.Unmap(cc.mem)
 		cc.mem = nil
 		cc.base = 0
-		c.Code = nil
+		c.code = nil
 	}
+}
+
+// replaceDecoded installs decoded state without orphaning an executable image.
+// Reuse is allowed before instantiation, but a receiver with live instances
+// remains their code owner and cannot be replaced.
+func (c *Compiled) replaceDecoded(decoded Compiled) error {
+	if cc := c.codeCache; cc != nil {
+		cc.mu.Lock()
+		if cc.refs != 0 {
+			cc.mu.Unlock()
+			return fmt.Errorf("wago: cannot replace compiled module with %d live instance(s)", cc.refs)
+		}
+		mem := cc.mem
+		cc.mem = nil
+		cc.base = 0
+		cc.closed = true
+		c.code = nil
+		cc.mu.Unlock()
+		goruntime.SetFinalizer(c, nil)
+		if mem != nil {
+			if err := coreruntime.Unmap(mem); err != nil {
+				return fmt.Errorf("release replaced compiled code: %w", err)
+			}
+		}
+	}
+	*c = decoded
+	installCompiledFinalizer(c)
+	return nil
 }
 
 // Close releases the executable code mapping cached for this compiled module.
@@ -304,6 +332,6 @@ func (c *Compiled) Close() error {
 	mem := cc.mem
 	cc.mem = nil
 	cc.base = 0
-	c.Code = nil
+	c.code = nil
 	return coreruntime.Unmap(mem)
 }

--- a/src/wago/code_mapping_test.go
+++ b/src/wago/code_mapping_test.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 )
 
-func TestCompiledReleasesHeapCodeAfterExecutableMapping(t *testing.T) {
+func TestSerialCompiledSealsExecutableMappingInPlace(t *testing.T) {
 	c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), fibWasm)
 	if err != nil {
 		t.Fatal(err)
@@ -27,8 +27,8 @@ func TestCompiledReleasesHeapCodeAfterExecutableMapping(t *testing.T) {
 	if got := unsafe.Pointer(&c.Code[0]); got != mapped {
 		t.Fatalf("compiled code still uses heap backing %p (mapped %p, original %p)", got, mapped, original)
 	}
-	if mapped == original {
-		t.Fatal("test did not observe a distinct executable mapping")
+	if mapped != original {
+		t.Fatalf("first Instantiate copied serial native code: mapped %p, original %p", mapped, original)
 	}
 	if _, err := c.MarshalBinary(); err != nil {
 		t.Fatalf("marshal mapped code: %v", err)

--- a/src/wago/code_mapping_test.go
+++ b/src/wago/code_mapping_test.go
@@ -14,17 +14,17 @@ func TestSerialCompiledSealsExecutableMappingInPlace(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer c.Close()
-	original := unsafe.Pointer(&c.Code[0])
+	original := unsafe.Pointer(&c.code[0])
 	in, err := Instantiate(c, InstantiateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer in.Close()
-	if len(c.codeCache.mem) == 0 || len(c.Code) == 0 {
+	if len(c.codeCache.mem) == 0 || len(c.code) == 0 {
 		t.Fatal("executable mapping or readable code view is empty")
 	}
 	mapped := unsafe.Pointer(&c.codeCache.mem[0])
-	if got := unsafe.Pointer(&c.Code[0]); got != mapped {
+	if got := unsafe.Pointer(&c.code[0]); got != mapped {
 		t.Fatalf("compiled code still uses heap backing %p (mapped %p, original %p)", got, mapped, original)
 	}
 	if mapped != original {
@@ -66,6 +66,9 @@ func TestCompiledCloseKeepsExistingInstanceAlive(t *testing.T) {
 	}
 	if err := c.Close(); err != nil {
 		t.Fatalf("Close with live instance: %v", err)
+	}
+	if got := c.CodeSize(); got != 0 {
+		t.Fatalf("CodeSize after Close with live instance = %d, want 0", got)
 	}
 	if _, err := Instantiate(c, InstantiateOptions{}); err == nil || !strings.Contains(err.Error(), "closed") {
 		t.Fatalf("Instantiate after Close error = %v, want closed", err)

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -3,14 +3,20 @@ package wago
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"sort"
 
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
+	coreruntime "github.com/wago-org/wago/src/core/runtime"
 	"github.com/wago-org/wago/src/core/runtime/gc"
 )
 
 const (
+	compiledSectionCode     = 1
+	compiledSectionMetadata = 2
+	compiledSectionCount    = 2
+
 	// Internal CPU/execution bits share the persisted u64 requirement word but
 	// are stripped before exposing CoreFeatures. Public feature bits occupy the
 	// low range; reserving the top five bits avoids growing artifacts.
@@ -21,6 +27,11 @@ const (
 	compiledGCExecutionGenericArray       uint64 = 1 << 63
 	compiledGCExecutionMask                      = compiledGCExecutionDynamicFuncRefTest | compiledGCExecutionGenericStruct | compiledGCExecutionGenericArray
 )
+
+func compiledUvarintLen(v uint64) int {
+	var buf [binary.MaxVarintLen64]byte
+	return binary.PutUvarint(buf[:], v)
+}
 
 func compiledMetadataUsesSIMD(c *Compiled) bool {
 	if c == nil {
@@ -76,54 +87,239 @@ func marshalCompiled(c *Compiled) ([]byte, error) {
 	if c == nil {
 		return nil, fmt.Errorf("compiled module is nil")
 	}
-	w := compiledWriter{buf: make([]byte, 0, len(c.Code)+256)}
+	metadata, err := marshalCompiledMetadata(c)
+	if err != nil {
+		return nil, err
+	}
+	w := compiledWriter{buf: make([]byte, 0, len(c.code)+len(metadata)+32)}
 	w.buf = append(w.buf, wagoMagic...)
 	w.u8(wagoVersion)
-	w.bytes(c.Code)
+	w.u8(compiledSectionCount)
+	w.section(compiledSectionCode, c.code)
+	w.section(compiledSectionMetadata, metadata)
+	return w.buf, nil
+}
+
+func writeCompiled(w io.Writer, c *Compiled) (int64, error) {
+	if c == nil {
+		return 0, fmt.Errorf("compiled module is nil")
+	}
+	metadata, err := marshalCompiledMetadata(c)
+	if err != nil {
+		return 0, err
+	}
+	written := int64(0)
+	write := func(p []byte) error {
+		n, err := w.Write(p)
+		written += int64(n)
+		if err != nil {
+			return err
+		}
+		if n != len(p) {
+			return io.ErrShortWrite
+		}
+		return nil
+	}
+	if err := write([]byte{wagoMagic[0], wagoMagic[1], wagoMagic[2], wagoMagic[3], wagoVersion, compiledSectionCount}); err != nil {
+		return written, err
+	}
+	var header [1 + binary.MaxVarintLen64]byte
+	writeSection := func(id byte, payload []byte) error {
+		header[0] = id
+		n := binary.PutUvarint(header[1:], uint64(len(payload)))
+		if err := write(header[:1+n]); err != nil {
+			return err
+		}
+		return write(payload)
+	}
+	if err := writeSection(compiledSectionCode, c.code); err != nil {
+		return written, err
+	}
+	if err := writeSection(compiledSectionMetadata, metadata); err != nil {
+		return written, err
+	}
+	return written, nil
+}
+
+type artifactCountingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (r *artifactCountingReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.n += int64(n)
+	return n, err
+}
+
+func readArtifactUvar(r *artifactCountingReader) (uint64, error) {
+	var encoded [binary.MaxVarintLen64]byte
+	for i := range encoded {
+		if _, err := io.ReadFull(r, encoded[i:i+1]); err != nil {
+			return 0, err
+		}
+		if encoded[i]&0x80 == 0 {
+			value, n := binary.Uvarint(encoded[:i+1])
+			if n != i+1 {
+				return 0, fmt.Errorf("invalid section length")
+			}
+			var canonical [binary.MaxVarintLen64]byte
+			if binary.PutUvarint(canonical[:], value) != n {
+				return 0, fmt.Errorf("non-canonical section length")
+			}
+			return value, nil
+		}
+	}
+	return 0, fmt.Errorf("section length overflows u64")
+}
+
+func readCompiledFrom(source io.Reader, limits ArtifactLimits) (decoded Compiled, image *coreruntime.CodeBuffer, read int64, err error) {
+	if source == nil {
+		return decoded, nil, 0, fmt.Errorf("wago: compiled artifact reader is nil")
+	}
+	if limits.MaxCodeBytes < 0 || limits.MaxMetadataBytes < 0 {
+		return decoded, nil, 0, fmt.Errorf("wago: compiled artifact limits must be non-negative")
+	}
+	r := &artifactCountingReader{r: source}
+	defer func() { read = r.n }()
+	var header [6]byte
+	if _, err = io.ReadFull(r, header[:]); err != nil {
+		return decoded, nil, 0, fmt.Errorf("compiled artifact header: %w", err)
+	}
+	if string(header[:4]) != wagoMagic {
+		return decoded, nil, 0, fmt.Errorf("not a wago module")
+	}
+	if header[4] != wagoVersion {
+		return decoded, nil, 0, fmt.Errorf("wago module version %d unsupported (want %d)", header[4], wagoVersion)
+	}
+	if header[5] != compiledSectionCount {
+		return decoded, nil, 0, fmt.Errorf("compiled section count %d unsupported (want %d)", header[5], compiledSectionCount)
+	}
+	readSectionHeader := func(want byte, label string, limit int64) (int, error) {
+		var id [1]byte
+		if _, err := io.ReadFull(r, id[:]); err != nil {
+			return 0, fmt.Errorf("%s section id: %w", label, err)
+		}
+		if id[0] != want {
+			return 0, fmt.Errorf("compiled section %d out of order (want %s section %d)", id[0], label, want)
+		}
+		size, err := readArtifactUvar(r)
+		if err != nil {
+			return 0, fmt.Errorf("%s section length: %w", label, err)
+		}
+		if size > uint64(limit) {
+			return 0, fmt.Errorf("%s section length %d exceeds limit %d", label, size, limit)
+		}
+		if size > uint64(maxInt()) {
+			return 0, fmt.Errorf("%s section length %d overflows int", label, size)
+		}
+		return int(size), nil
+	}
+	codeLen, err := readSectionHeader(compiledSectionCode, "code", limits.MaxCodeBytes)
+	if err != nil {
+		return decoded, nil, 0, err
+	}
+	image, err = coreruntime.NewCodeBuffer(codeLen)
+	if err != nil {
+		return decoded, nil, 0, fmt.Errorf("allocate compiled code section: %w", err)
+	}
+	code, err := image.AppendSpace(codeLen)
+	if err != nil {
+		_ = image.Close()
+		return decoded, nil, 0, fmt.Errorf("size compiled code section: %w", err)
+	}
+	if _, err := io.ReadFull(r, code); err != nil {
+		_ = image.Close()
+		return decoded, nil, 0, fmt.Errorf("truncated code section: %w", err)
+	}
+	metadataLen, err := readSectionHeader(compiledSectionMetadata, "metadata", limits.MaxMetadataBytes)
+	if err != nil {
+		_ = image.Close()
+		return decoded, nil, 0, err
+	}
+	metadata := make([]byte, metadataLen)
+	if _, err := io.ReadFull(r, metadata); err != nil {
+		_ = image.Close()
+		return decoded, nil, 0, fmt.Errorf("truncated metadata section: %w", err)
+	}
+	decoded.code = code
+	if err := unmarshalCompiledMetadata(&decoded, metadata); err != nil {
+		_ = image.Close()
+		return decoded, nil, 0, err
+	}
+	return decoded, image, 0, nil
+}
+
+func marshalCompiledMetadata(c *Compiled) ([]byte, error) {
+	metadata, _, err := marshalCompiledMetadataMeasured(c)
+	return metadata, err
+}
+
+func marshalCompiledMetadataMeasured(c *Compiled) ([]byte, ArtifactSectionSizes, error) {
+	w := compiledWriter{buf: make([]byte, 0, 256)}
+	var sizes ArtifactSectionSizes
+	start := 0
+	mark := func(dst *int64) {
+		*dst = int64(len(w.buf) - start)
+		start = len(w.buf)
+	}
 	w.intSlice(c.Entry)
 	w.internalEntrySlice(c.InternalEntry)
+	mark(&sizes.Entries)
 	w.uvar(uint64(c.NumImports))
 	w.stringSlice(c.Imports)
+	mark(&sizes.Imports)
 	if err := w.typeDescriptors(c.Types); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
 	if err := validateValueTypeDescriptors(c.Types, c.ValueTypes); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
 	w.valueTypes(c.ValueTypes)
+	mark(&sizes.Types)
 	if err := w.funcSigs(c.importFuncSigs, c.Types); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
 	if err := w.funcSigs(c.Funcs, c.Types); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
+	mark(&sizes.Functions)
 	w.stringIntMap(c.Exports)
 	w.nameSec(c.Names)
+	mark(&sizes.ExportsAndNames)
 	if err := w.globalImports(c.GlobalImports, c); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
 	if err := w.globals(c.Globals, c); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
 	w.stringIntMap(c.GlobalExports)
+	mark(&sizes.Globals)
 	if err := w.tables(c); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
 	w.stringIntMap(c.tableExports)
 	w.u64Slice(c.FuncTypeID)
 	w.bool(c.NeedsFuncRefDescs)
+	mark(&sizes.Tables)
 	if err := w.elems(c.Elems, c); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
 	if err := w.elems(c.passiveElems, c); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
+	mark(&sizes.Elements)
 	w.data(c.Data)
 	w.passiveData(c.PassiveData)
+	mark(&sizes.Data)
 	w.memories(c)
 	w.stringIntMap(c.memoryExportMap())
+	mark(&sizes.Memories)
 	w.bool(c.dynamicImports)
+	sizes.Features = int64(len(w.buf) - start)
+	start = len(w.buf)
 	w.tags(c)
+	mark(&sizes.Tags)
 	required := uint64(compiledStructuralRequiredFeatures(c))
 	if c.stagedGCStructProduct() == stagedGCStructGeneric {
 		required |= compiledGCExecutionGenericStruct
@@ -141,14 +337,17 @@ func marshalCompiled(c *Compiled) ([]byte, error) {
 		required |= compiledCPUFeatureBMI2
 	}
 	w.u64(required)
+	sizes.Features += int64(len(w.buf) - start)
+	start = len(w.buf)
 	w.gcTypeDescs(c.GCTypeDescs)
 	if err := validateCompiledGCFrameRoots(c, c.genericGCFrameRoots()); err != nil {
-		return nil, err
+		return nil, sizes, err
 	}
 	if rootMap := c.genericGCFrameRoots(); rootMap != nil {
 		w.gcFrameRoots(rootMap)
 	}
-	return w.buf, nil
+	mark(&sizes.GC)
+	return w.buf, sizes, nil
 }
 
 type compiledWriter struct {
@@ -181,6 +380,11 @@ func (w *compiledWriter) u64(v uint64) {
 func (w *compiledWriter) bytes(b []byte) {
 	w.uvar(uint64(len(b)))
 	w.buf = append(w.buf, b...)
+}
+func (w *compiledWriter) section(id byte, payload []byte) {
+	w.u8(id)
+	w.uvar(uint64(len(payload)))
+	w.buf = append(w.buf, payload...)
 }
 func (w *compiledWriter) str(s string) {
 	w.uvar(uint64(len(s)))
@@ -562,11 +766,31 @@ func (w *compiledWriter) gcTypeDescs(v []gc.TypeDesc) {
 
 func unmarshalCompiled(c *Compiled, data []byte) error {
 	r := compiledReader{data: data}
-	var err error
-	c.Code, err = r.bytes()
+	count, err := r.u8()
+	if err != nil {
+		return fmt.Errorf("compiled section count: %w", err)
+	}
+	if count != compiledSectionCount {
+		return fmt.Errorf("compiled section count %d unsupported (want %d)", count, compiledSectionCount)
+	}
+	code, err := r.requiredSection(compiledSectionCode, "code")
 	if err != nil {
 		return err
 	}
+	metadata, err := r.requiredSection(compiledSectionMetadata, "metadata")
+	if err != nil {
+		return err
+	}
+	if len(r.data) != 0 {
+		return fmt.Errorf("trailing %d byte(s) after compiled sections", len(r.data))
+	}
+	c.code = code
+	return unmarshalCompiledMetadata(c, metadata)
+}
+
+func unmarshalCompiledMetadata(c *Compiled, data []byte) error {
+	r := compiledReader{data: data}
+	var err error
 	c.Entry, err = r.intSlice()
 	if err != nil {
 		return err
@@ -746,6 +970,32 @@ func unmarshalCompiled(c *Compiled, data []byte) error {
 
 type compiledReader struct{ data []byte }
 
+func (r *compiledReader) requiredSection(want byte, label string) ([]byte, error) {
+	id, err := r.u8()
+	if err != nil {
+		return nil, fmt.Errorf("%s section id: %w", label, err)
+	}
+	if id != want {
+		return nil, fmt.Errorf("compiled section %d out of order (want %s section %d)", id, label, want)
+	}
+	size, err := r.canonicalUvar()
+	if err != nil {
+		return nil, fmt.Errorf("%s section length: %w", label, err)
+	}
+	if size > uint64(maxInt()) {
+		return nil, fmt.Errorf("%s section length overflows int", label)
+	}
+	payload, err := r.take(int(size))
+	if err != nil {
+		return nil, fmt.Errorf("truncated %s section: %w", label, err)
+	}
+	return payload, nil
+}
+
+func (r *compiledReader) canonicalUvar() (uint64, error) {
+	return r.uvar()
+}
+
 const (
 	minStringBytes       = 1
 	minVarintBytes       = 1
@@ -802,6 +1052,10 @@ func (r *compiledReader) uvar() (uint64, error) {
 	if n <= 0 {
 		return 0, fmt.Errorf("invalid uvarint")
 	}
+	var canonical [binary.MaxVarintLen64]byte
+	if binary.PutUvarint(canonical[:], v) != n {
+		return 0, fmt.Errorf("non-canonical uvarint")
+	}
 	r.data = r.data[n:]
 	return v, nil
 }
@@ -809,6 +1063,10 @@ func (r *compiledReader) ivar() (int, error) {
 	v, n := binary.Varint(r.data)
 	if n <= 0 {
 		return 0, fmt.Errorf("invalid varint")
+	}
+	var canonical [binary.MaxVarintLen64]byte
+	if binary.PutVarint(canonical[:], v) != n {
+		return 0, fmt.Errorf("non-canonical varint")
 	}
 	r.data = r.data[n:]
 	if int64(int(v)) != v {

--- a/src/wago/codec_fuzz_test.go
+++ b/src/wago/codec_fuzz_test.go
@@ -157,12 +157,12 @@ func generatedValidCompiled(t testing.TB, data []byte) *Compiled {
 		c.FuncTypeID[i] = uint64(r.next()) | uint64(r.next())<<8 | uint64(r.next())<<16 | uint64(r.next())<<24 | uint64(r.next())<<32
 	}
 	if localFuncCount > 0 {
-		c.Code = make([]byte, localFuncCount+r.n(4))
-		for i := range c.Code {
-			c.Code[i] = r.next()
+		c.code = make([]byte, localFuncCount+r.n(4))
+		for i := range c.code {
+			c.code[i] = r.next()
 		}
 		for i := range c.Entry {
-			c.Entry[i] = r.n(len(c.Code))
+			c.Entry[i] = r.n(len(c.code))
 		}
 	}
 	for i := range c.importFuncSigs {
@@ -319,8 +319,7 @@ func compiledCodecFuzzSeeds(t testing.TB) [][]byte {
 	valid := []*Compiled{
 		{},
 		structuralReferenceCodecFixture(),
-		{
-			Code:           []byte{0xc3},
+		newHandBuiltCompiled([]byte{0xc3}, Compiled{
 			Entry:          []int{0},
 			NumImports:     1,
 			dynamicImports: true,
@@ -349,7 +348,7 @@ func compiledCodecFuzzSeeds(t testing.TB) [][]byte {
 			HasMemory:    true,
 			MemMaxPages:  65535,
 			GCTypeDescs:  []gc.TypeDesc{structDesc, arrayDesc},
-		},
+		}),
 	}
 
 	seeds := make([][]byte, 0, len(valid)+2)

--- a/src/wago/codec_hardening_test.go
+++ b/src/wago/codec_hardening_test.go
@@ -32,7 +32,7 @@ func TestMarshalRoundTripsReturningImportDispatch(t *testing.T) {
 }
 
 func TestCompiledWriteToMatchesMarshalBinary(t *testing.T) {
-	c, err := Compile(nil, benchImportedModule(16, 8))
+	c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), benchImportedModule(16, 8))
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestCompiledWriteToMatchesMarshalBinary(t *testing.T) {
 }
 
 func TestCompiledReadFromLoadsCodeImageDirectly(t *testing.T) {
-	c, err := Compile(NewRuntimeConfig().WithFunctionWorkers(1), benchAddOneModule())
+	c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(1), benchAddOneModule())
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestCompiledReadFromLoadsCodeImageDirectly(t *testing.T) {
 }
 
 func TestCompiledReadFromEnforcesSectionLimits(t *testing.T) {
-	c, err := Compile(nil, benchAddOneModule())
+	c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), benchAddOneModule())
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}

--- a/src/wago/codec_hardening_test.go
+++ b/src/wago/codec_hardening_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/wasmtest"
@@ -27,6 +28,128 @@ func TestMarshalRoundTripsReturningImportDispatch(t *testing.T) {
 	defer loaded.Close()
 	if !loaded.dynamicImports {
 		t.Fatal("loaded returning import lost dynamic dispatch metadata")
+	}
+}
+
+func TestCompiledWriteToMatchesMarshalBinary(t *testing.T) {
+	c, err := Compile(nil, benchImportedModule(16, 8))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer c.Close()
+	want, err := c.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	var dst bytes.Buffer
+	n, err := c.WriteTo(&dst)
+	if err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if n != int64(len(want)) || !bytes.Equal(dst.Bytes(), want) {
+		t.Fatalf("WriteTo = %d bytes (equal %v), want %d byte-identical bytes", n, bytes.Equal(dst.Bytes(), want), len(want))
+	}
+	sizes, err := c.ArtifactSectionSizes()
+	if err != nil {
+		t.Fatalf("ArtifactSectionSizes: %v", err)
+	}
+	if sizes.Total != int64(len(want)) || sizes.Code != int64(len(c.code)) || sizes.Framing <= 0 || sizes.Metadata <= 0 {
+		t.Fatalf("artifact section sizes = %+v, blob=%d code=%d", sizes, len(want), len(c.code))
+	}
+	attributed := sizes.Entries + sizes.Imports + sizes.Types + sizes.Functions + sizes.ExportsAndNames + sizes.Globals + sizes.Tables + sizes.Elements + sizes.Data + sizes.Memories + sizes.Tags + sizes.Features + sizes.GC
+	if attributed != sizes.Metadata {
+		t.Fatalf("attributed metadata = %d, want %d: %+v", attributed, sizes.Metadata, sizes)
+	}
+}
+
+func TestCompiledReadFromLoadsCodeImageDirectly(t *testing.T) {
+	c, err := Compile(NewRuntimeConfig().WithFunctionWorkers(1), benchAddOneModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	c.Close()
+
+	var loaded Compiled
+	n, err := loaded.ReadFrom(bytes.NewReader(blob))
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	defer loaded.Close()
+	if n != int64(len(blob)) {
+		t.Fatalf("ReadFrom count = %d, want %d", n, len(blob))
+	}
+	if loaded.codeCache == nil || loaded.codeCache.flags&compiledCacheWritableCode == 0 {
+		t.Fatal("ReadFrom did not transfer a writable code image")
+	}
+	before := unsafe.Pointer(&loaded.code[0])
+	in, err := Instantiate(&loaded, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+	if after := unsafe.Pointer(&loaded.code[0]); after != before {
+		t.Fatalf("streamed code moved on first instantiate: %p -> %p", before, after)
+	}
+}
+
+func TestCompiledReadFromEnforcesSectionLimits(t *testing.T) {
+	c, err := Compile(nil, benchAddOneModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	codeLen := len(c.code)
+	c.Close()
+
+	limits := DefaultArtifactLimits()
+	limits.MaxCodeBytes = int64(codeLen - 1)
+	var loaded Compiled
+	if _, err := loaded.ReadFromWithLimits(bytes.NewReader(blob), limits); err == nil || !strings.Contains(err.Error(), "code section length") {
+		t.Fatalf("code limit error = %v", err)
+	}
+	if loaded.code != nil {
+		t.Fatal("limit rejection published a partial module")
+	}
+}
+
+func TestCompiledSectionsRejectReorderingAndDuplicates(t *testing.T) {
+	blob, err := (&Compiled{}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	for _, id := range []byte{compiledSectionMetadata, 99} {
+		bad := append([]byte(nil), blob...)
+		bad[6] = id
+		var loaded Compiled
+		if err := loaded.UnmarshalBinary(bad); err == nil || !strings.Contains(err.Error(), "out of order") {
+			t.Fatalf("first section id %d error = %v", id, err)
+		}
+	}
+	_, codeLengthBytes := binary.Uvarint(blob[7:])
+	codeLength, _ := binary.Uvarint(blob[7:])
+	metadataID := 7 + codeLengthBytes + int(codeLength)
+	duplicate := append([]byte(nil), blob...)
+	duplicate[metadataID] = compiledSectionCode
+	var loaded Compiled
+	if err := loaded.UnmarshalBinary(duplicate); err == nil || !strings.Contains(err.Error(), "out of order") {
+		t.Fatalf("duplicate code section error = %v", err)
+	}
+
+	nonCanonical := append([]byte(nil), blob[:7]...)
+	nonCanonical = append(nonCanonical, 0x80, 0x00)
+	nonCanonical = append(nonCanonical, blob[8:]...)
+	if _, err := loaded.ReadFrom(bytes.NewReader(nonCanonical)); err == nil || !strings.Contains(err.Error(), "non-canonical") {
+		t.Fatalf("non-canonical section length error = %v", err)
+	}
+	if err := loaded.UnmarshalBinary(nonCanonical); err == nil || !strings.Contains(err.Error(), "non-canonical") {
+		t.Fatalf("non-canonical slice section length error = %v", err)
 	}
 }
 
@@ -58,19 +181,18 @@ func TestMarshalRoundTripsSyncHostDispatch(t *testing.T) {
 }
 
 func TestCompiledCodecRoundTripsReferenceSignatures(t *testing.T) {
-	input := &Compiled{
-		Code:       []byte{0xc3},
+	input := newHandBuiltCompiled([]byte{0xc3}, Compiled{
 		Entry:      []int{0},
 		Funcs:      []FuncSig{{Params: []ValType{ValFuncRef, ValExternRef}, Results: []ValType{ValExternRef, ValFuncRef}}},
 		FuncTypeID: []uint64{0},
 		Exports:    map[string]int{"refs": 0},
-	}
+	})
 	blob, err := input.MarshalBinary()
 	if err != nil {
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	if blob[4] != wagoVersion || wagoVersion != 32 {
-		t.Fatalf("compiled codec version = %d, want atomic-feature version 32", blob[4])
+	if blob[4] != wagoVersion || wagoVersion != 33 {
+		t.Fatalf("compiled codec version = %d, want sectioned-artifact version 33", blob[4])
 	}
 	for _, version := range []byte{19, 20, 30, 31} {
 		oldVersion := append([]byte(nil), blob...)
@@ -100,8 +222,7 @@ func TestCompiledCodecV22CarriesIndexedFunctionSignatures(t *testing.T) {
 	indexed := ValueTypeDescriptor{Kind: ValueTypeReference, Ref: ReferenceTypeDescriptor{Heap: HeapTypeDescriptor{Defined: true, TypeIndex: 0}}}
 	stored := indexed
 	stored.Ref.Nullable = true
-	input := &Compiled{
-		Code:       []byte{0xc3},
+	input := newHandBuiltCompiled([]byte{0xc3}, Compiled{
 		Entry:      []int{0},
 		ValueTypes: []ValueTypeDescriptor{stored},
 		Types: []DefinedTypeDescriptor{
@@ -122,7 +243,7 @@ func TestCompiledCodecV22CarriesIndexedFunctionSignatures(t *testing.T) {
 		HasTable: true, TableType: ValFuncRef, TableValueTypeIndex: 0, TableHasValueType: true,
 		Elems:            []ElemInit{{TableIndex: 0, RefType: ValFuncRef, ValueTypeIndex: 0, HasValueType: true, Mode: ElemModeActive, Values: []RefInit{{Null: true}}}},
 		requiredFeatures: CoreFeatureReferenceTypes | CoreFeatureTypedFunctionReferences,
-	}
+	})
 	meta := (&Module{c: input}).Metadata()
 	if len(meta.Types) != 2 || len(meta.Functions) != 1 || meta.Functions[0].ParamTypes[1] != indexed || len(meta.Globals) != 1 || !meta.Globals[0].HasValueType || meta.Globals[0].ValueType != stored || len(meta.Tables) != 1 || !meta.Tables[0].HasValueType || meta.Tables[0].ValueType != stored {
 		t.Fatalf("structural module metadata = %#v", meta)

--- a/src/wago/codec_minimal_test.go
+++ b/src/wago/codec_minimal_test.go
@@ -94,8 +94,7 @@ func TestCompiledCodecRoundTripsMultipleEmptyElementSegments(t *testing.T) {
 }
 
 func TestCompiledCodecRoundTripsEmptyStrings(t *testing.T) {
-	input := &Compiled{
-		Code:           []byte{0},
+	input := newHandBuiltCompiled([]byte{0}, Compiled{
 		Entry:          []int{0},
 		NumImports:     1,
 		dynamicImports: true,
@@ -104,7 +103,7 @@ func TestCompiledCodecRoundTripsEmptyStrings(t *testing.T) {
 		Funcs:          []FuncSig{{}},
 		FuncTypeID:     []uint64{0, 0},
 		Exports:        map[string]int{"": 1},
-	}
+	})
 
 	got := roundTripCompiled(t, input)
 	if len(got.Imports) != 1 || got.Imports[0] != "" {

--- a/src/wago/codec_reference_test.go
+++ b/src/wago/codec_reference_test.go
@@ -8,16 +8,16 @@ import (
 	"testing"
 )
 
-func TestCompiledCodecV32VersionContract(t *testing.T) {
+func TestCompiledCodecV33VersionContract(t *testing.T) {
 	blob, err := (&Compiled{}).MarshalBinary()
 	if err != nil {
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	if got := blob[4]; got != 32 {
-		t.Fatalf("compiled codec version = %d, want 32", got)
+	if got := blob[4]; got != 33 {
+		t.Fatalf("compiled codec version = %d, want 33", got)
 	}
 
-	for _, version := range []byte{31, 30, 26, 25, 24, 23, 22} {
+	for _, version := range []byte{32, 31, 30, 26, 25, 24, 23, 22} {
 		old := append([]byte(nil), blob...)
 		old[4] = version
 		var got Compiled
@@ -261,8 +261,7 @@ func TestCompiledCodecV21LoadedReferenceExecutionAndSnapshotBoundary(t *testing.
 }
 
 func structuralReferenceCodecFixture() *Compiled {
-	return &Compiled{
-		Code:       []byte{0xc3},
+	return newHandBuiltCompiled([]byte{0xc3}, Compiled{
 		Entry:      []int{0},
 		Funcs:      []FuncSig{{Params: []ValType{ValFuncRef, ValExternRef}, Results: []ValType{ValExternRef, ValFuncRef}}},
 		FuncTypeID: []uint64{7},
@@ -299,5 +298,5 @@ func structuralReferenceCodecFixture() *Compiled {
 			{RefType: ValExternRef, Mode: ElemModePassive, Values: []RefInit{{Null: true}}},
 			{RefType: ValFuncRef, Mode: ElemModeDeclarative},
 		},
-	}
+	})
 }

--- a/src/wago/codec_test_helpers_test.go
+++ b/src/wago/codec_test_helpers_test.go
@@ -2,6 +2,13 @@ package wago
 
 import "testing"
 
+// newHandBuiltCompiled keeps tests that exercise malformed or synthetic
+// metadata from depending on Compiled's private native-code field.
+func newHandBuiltCompiled(code []byte, metadata Compiled) *Compiled {
+	metadata.code = code
+	return &metadata
+}
+
 func writeCompiledCodecPrefixAfterFuncs(t testing.TB, w *compiledWriter) {
 	t.Helper()
 	w.bytes(nil)

--- a/src/wago/compile_ownership_test.go
+++ b/src/wago/compile_ownership_test.go
@@ -1,6 +1,8 @@
 package wago
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"unsafe"
 )
@@ -15,7 +17,7 @@ func TestCompileDoesNotRetainSourceForLinking(t *testing.T) {
 	if !compiled.dynamicImports {
 		t.Fatal("function imports were not compiled through dynamic dispatch")
 	}
-	if len(compiled.Code) == 0 || len(compiled.Entry) == 0 {
+	if len(compiled.code) == 0 || len(compiled.Entry) == 0 {
 		t.Fatal("function-import module deferred native code generation")
 	}
 }
@@ -29,13 +31,13 @@ func TestSerialCompileSealsNativeCodeWithoutCopy(t *testing.T) {
 	if compiled.codeCache == nil || compiled.codeCache.flags&compiledCacheWritableCode == 0 {
 		t.Fatal("serial compiler did not transfer its code image")
 	}
-	before := uintptr(unsafe.Pointer(&compiled.Code[0]))
+	before := uintptr(unsafe.Pointer(&compiled.code[0]))
 	instance, err := Instantiate(compiled, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("Instantiate: %v", err)
 	}
 	defer instance.Close()
-	after := uintptr(unsafe.Pointer(&compiled.Code[0]))
+	after := uintptr(unsafe.Pointer(&compiled.code[0]))
 	if after != before {
 		t.Fatalf("first Instantiate copied native code: %#x -> %#x", before, after)
 	}
@@ -49,11 +51,95 @@ func TestSerialCompiledCloseBeforeInstantiateReleasesCodeImage(t *testing.T) {
 	if err := compiled.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if compiled.Code != nil || compiled.codeCache.mem != nil {
+	if compiled.code != nil || compiled.codeCache.mem != nil {
 		t.Fatal("Close retained an unsealed compiler code image")
 	}
 	if _, err := Instantiate(compiled, InstantiateOptions{}); err == nil {
 		t.Fatal("Instantiate succeeded after Close")
+	}
+}
+
+func TestCompiledCodeInspectionDoesNotExposeMutableStorage(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithFunctionWorkers(1), benchAddOneModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	want := append([]byte(nil), compiled.code...)
+	if got := compiled.CodeSize(); got != len(want) {
+		t.Fatalf("CodeSize = %d, want %d", got, len(want))
+	}
+	var code bytes.Buffer
+	n, err := compiled.WriteCodeTo(&code)
+	if err != nil {
+		t.Fatalf("WriteCodeTo: %v", err)
+	}
+	if n != int64(len(want)) || !bytes.Equal(code.Bytes(), want) {
+		t.Fatalf("WriteCodeTo = (%d, %x), want (%d, %x)", n, code.Bytes(), len(want), want)
+	}
+	code.Bytes()[0] ^= 0xff
+	if bytes.Equal(code.Bytes(), compiled.code) {
+		t.Fatal("mutating diagnostic copy changed compiled code")
+	}
+	if err := compiled.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := compiled.CodeSize(); got != 0 {
+		t.Fatalf("CodeSize after Close = %d, want 0", got)
+	}
+	if _, err := compiled.WriteCodeTo(&code); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("WriteCodeTo after Close error = %v, want closed", err)
+	}
+}
+
+func TestCompiledDecodeReleasesReplacedCodeImage(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithFunctionWorkers(1), benchAddOneModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	oldCache := compiled.codeCache
+	empty, err := (&Compiled{}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary empty: %v", err)
+	}
+	if err := compiled.UnmarshalBinary(empty); err != nil {
+		t.Fatalf("UnmarshalBinary replacement: %v", err)
+	}
+	defer compiled.Close()
+	oldCache.mu.Lock()
+	oldClosed, oldMapped := oldCache.closed, len(oldCache.mem) != 0
+	oldCache.mu.Unlock()
+	if !oldClosed || oldMapped {
+		t.Fatalf("replaced code cache = closed %v mapped %v, want closed and unmapped", oldClosed, oldMapped)
+	}
+	if compiled.CodeSize() != 0 {
+		t.Fatalf("replacement CodeSize = %d, want 0", compiled.CodeSize())
+	}
+}
+
+func TestCompiledDecodeRejectsReplacementWithLiveInstance(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithFunctionWorkers(1), benchAddOneModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer compiled.Close()
+	instance, err := Instantiate(compiled)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer instance.Close()
+	empty, err := (&Compiled{}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary empty: %v", err)
+	}
+	if err := compiled.UnmarshalBinary(empty); err == nil || !strings.Contains(err.Error(), "live instance") {
+		t.Fatalf("UnmarshalBinary with live instance error = %v, want live-instance rejection", err)
+	}
+	result, err := instance.Invoke("f", I32(41))
+	if err != nil {
+		t.Fatalf("Invoke after rejected replacement: %v", err)
+	}
+	if got := AsI32(result[0]); got != 42 {
+		t.Fatalf("f(41) after rejected replacement = %d, want 42", got)
 	}
 }
 

--- a/src/wago/compile_ownership_test.go
+++ b/src/wago/compile_ownership_test.go
@@ -1,6 +1,9 @@
 package wago
 
-import "testing"
+import (
+	"testing"
+	"unsafe"
+)
 
 func TestCompileDoesNotRetainSourceForLinking(t *testing.T) {
 	source := returningImportModule([]byte{0x60, 0x00, 0x01, 0x7f}, []byte{0x00, 0x10, 0x00, 0x0b})
@@ -14,6 +17,43 @@ func TestCompileDoesNotRetainSourceForLinking(t *testing.T) {
 	}
 	if len(compiled.Code) == 0 || len(compiled.Entry) == 0 {
 		t.Fatal("function-import module deferred native code generation")
+	}
+}
+
+func TestSerialCompileSealsNativeCodeWithoutCopy(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithFunctionWorkers(1), benchAddOneModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer compiled.Close()
+	if compiled.codeCache == nil || compiled.codeCache.flags&compiledCacheWritableCode == 0 {
+		t.Fatal("serial compiler did not transfer its code image")
+	}
+	before := uintptr(unsafe.Pointer(&compiled.Code[0]))
+	instance, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer instance.Close()
+	after := uintptr(unsafe.Pointer(&compiled.Code[0]))
+	if after != before {
+		t.Fatalf("first Instantiate copied native code: %#x -> %#x", before, after)
+	}
+}
+
+func TestSerialCompiledCloseBeforeInstantiateReleasesCodeImage(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithFunctionWorkers(1), benchAddOneModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if err := compiled.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if compiled.Code != nil || compiled.codeCache.mem != nil {
+		t.Fatal("Close retained an unsealed compiler code image")
+	}
+	if _, err := Instantiate(compiled, InstantiateOptions{}); err == nil {
+		t.Fatal("Instantiate succeeded after Close")
 	}
 }
 

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -483,8 +483,8 @@ func TestFunctionWorkersImportedCodeAndSerialization(t *testing.T) {
 		if err != nil {
 			t.Fatalf("workers=%d compile: %v", workers, err)
 		}
-		if !c.dynamicImports || len(c.Code) == 0 {
-			t.Fatalf("workers=%d dynamic=%v code=%d", workers, c.dynamicImports, len(c.Code))
+		if !c.dynamicImports || len(c.code) == 0 {
+			t.Fatalf("workers=%d dynamic=%v code=%d", workers, c.dynamicImports, len(c.code))
 		}
 		if err := c.validateImportBindings(imports, nil); err != nil {
 			_ = c.Close()
@@ -496,7 +496,7 @@ func TestFunctionWorkersImportedCodeAndSerialization(t *testing.T) {
 	defer serial.Close()
 	parallel := compile(8)
 	defer parallel.Close()
-	if !bytes.Equal(parallel.Code, serial.Code) || !bytes.Equal(intSliceBytes(parallel.Entry), intSliceBytes(serial.Entry)) || !bytes.Equal(intSliceBytes(parallel.InternalEntry), intSliceBytes(serial.InternalEntry)) {
+	if !bytes.Equal(parallel.code, serial.code) || !bytes.Equal(intSliceBytes(parallel.Entry), intSliceBytes(serial.Entry)) || !bytes.Equal(intSliceBytes(parallel.InternalEntry), intSliceBytes(serial.InternalEntry)) {
 		t.Fatal("parallel codegen differs from serial output")
 	}
 	serialBlob, err := serial.MarshalBinary()

--- a/src/wago/cross_instance_test.go
+++ b/src/wago/cross_instance_test.go
@@ -262,7 +262,7 @@ func TestCrossInstanceCallNoArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile B: %v", err)
 	}
-	if !cB.dynamicImports || len(cB.Code) == 0 {
+	if !cB.dynamicImports || len(cB.code) == 0 {
 		t.Fatalf("B should compile returning imports through dynamic dispatch")
 	}
 	inB, err := Instantiate(cB, InstantiateOptions{Imports: Imports{"env.f": fExport}})
@@ -512,7 +512,7 @@ func TestCrossInstanceCallV128(t *testing.T) {
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
 	)
 	cB := MustCompile(modB)
-	if !cB.dynamicImports || len(cB.Code) == 0 {
+	if !cB.dynamicImports || len(cB.code) == 0 {
 		t.Fatal("v128 function import should compile through dynamic dispatch")
 	}
 	inB, err := Instantiate(cB, InstantiateOptions{Imports: Imports{"env.id": idExport}})

--- a/src/wago/defer_bounds_checks_test.go
+++ b/src/wago/defer_bounds_checks_test.go
@@ -50,7 +50,7 @@ func TestWithDeferBoundsChecks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(on.Code) >= len(dis.Code) {
-		t.Errorf("elision-on code (%d B) not smaller than facts-off (%d B)", len(on.Code), len(dis.Code))
+	if len(on.code) >= len(dis.code) {
+		t.Errorf("elision-on code (%d B) not smaller than facts-off (%d B)", len(on.code), len(dis.code))
 	}
 }

--- a/src/wago/funcref_global_test.go
+++ b/src/wago/funcref_global_test.go
@@ -249,8 +249,8 @@ func TestInstantiateRejectsUnsupportedReferenceGlobalMetadata(t *testing.T) {
 		{name: "non-structural initializer bits", c: &Compiled{Globals: []GlobalDef{{Type: ValFuncRef, Bits: 1}}}, want: "non-structural funcref global initializer"},
 		{name: "non-null externref initializer", c: &Compiled{Globals: []GlobalDef{{Type: ValExternRef, Bits: 1}}}, want: "non-null externref global initializer"},
 		{name: "ref.func wrong type", c: &Compiled{Globals: []GlobalDef{{Type: ValI64, HasInitFunc: true}}, NeedsFuncRefDescs: true}, want: "ref.func initializer has type i64"},
-		{name: "ref.func out of range", c: &Compiled{Code: []byte{0}, Entry: []int{0}, Funcs: []FuncSig{{}}, FuncTypeID: []uint64{0}, Globals: []GlobalDef{{Type: ValFuncRef, HasInitFunc: true, InitFunc: 1}}, NeedsFuncRefDescs: true}, want: "ref.func initializer index 1 out of range"},
-		{name: "ref.func without descriptors", c: &Compiled{Code: []byte{0}, Entry: []int{0}, Funcs: []FuncSig{{}}, FuncTypeID: []uint64{0}, Globals: []GlobalDef{{Type: ValFuncRef, HasInitFunc: true}}}, want: "ref.func initializer without descriptor arena"},
+		{name: "ref.func out of range", c: newHandBuiltCompiled([]byte{0}, Compiled{Entry: []int{0}, Funcs: []FuncSig{{}}, FuncTypeID: []uint64{0}, Globals: []GlobalDef{{Type: ValFuncRef, HasInitFunc: true, InitFunc: 1}}, NeedsFuncRefDescs: true}), want: "ref.func initializer index 1 out of range"},
+		{name: "ref.func without descriptors", c: newHandBuiltCompiled([]byte{0}, Compiled{Entry: []int{0}, Funcs: []FuncSig{{}}, FuncTypeID: []uint64{0}, Globals: []GlobalDef{{Type: ValFuncRef, HasInitFunc: true}}}), want: "ref.func initializer without descriptor arena"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/src/wago/gc_array_bulk_product_amd64_test.go
+++ b/src/wago/gc_array_bulk_product_amd64_test.go
@@ -86,7 +86,7 @@ func TestStagedGCArrayBulkProductBoundary(t *testing.T) {
 				_ = in.Close()
 				t.Fatal("codec-loaded bulk array artifact instantiated")
 			}
-			t.Logf("%s product: wasm=%d code=%d codec=%d", tc.base, len(data), len(c.Code), len(blob))
+			t.Logf("%s product: wasm=%d code=%d codec=%d", tc.base, len(data), len(c.code), len(blob))
 
 			in, err := instantiateCore(c, InstantiateOptions{GC: GCConfig{Profile: GCProfileTiny, TinyHeapBytes: tc.tinyBytes, TinyBlockBytes: 16, TinyStepEveryAlloc: true, VerifyAfterCollect: true}})
 			if err != nil {

--- a/src/wago/gc_array_init_product_amd64_test.go
+++ b/src/wago/gc_array_init_product_amd64_test.go
@@ -126,7 +126,7 @@ func TestStagedGCArrayInitDataProductBoundary(t *testing.T) {
 					t.Fatal("g7 returned normally with a seven-byte i64 source")
 				}
 			}
-			t.Logf("%s product: wasm=%d code=%d codec=%d", tc.filename, len(data), len(c.Code), len(blob))
+			t.Logf("%s product: wasm=%d code=%d codec=%d", tc.filename, len(data), len(c.code), len(blob))
 		})
 	}
 	t.Logf("array-init layouts: Compiled=%d Instance=%d codeCache=%d memoryDir=%d arrayGlobal=%d plugin=%d collector=%d", unsafe.Sizeof(Compiled{}), unsafe.Sizeof(Instance{}), unsafe.Sizeof(compiledCodeCache{}), unsafe.Sizeof(compiledMemoryDirectory{}), unsafe.Sizeof(gcArrayGlobalInit{}), unsafe.Sizeof(instancePluginState{}), unsafe.Sizeof(corergc.Collector{}))
@@ -246,7 +246,7 @@ func TestStagedGCArrayInitElemProductBoundaryAndTinyLifecycle(t *testing.T) {
 			}
 		})
 	}
-	t.Logf("array-init elem product: wasm=%d code=%d codec=%d", len(data), len(c.Code), len(blob))
+	t.Logf("array-init elem product: wasm=%d code=%d codec=%d", len(data), len(c.code), len(blob))
 }
 
 func TestGenericGCArrayInitElemExecutesWithoutFixtureHash(t *testing.T) {

--- a/src/wago/gc_br_on_cast_product_amd64_test.go
+++ b/src/wago/gc_br_on_cast_product_amd64_test.go
@@ -164,7 +164,7 @@ func TestStagedGCBrOnCastProductBoundaryLifecycle(t *testing.T) {
 		if _, err := Capture(c, SnapshotOptions{}); err == nil {
 			t.Fatalf("snapshot admitted %s abstract branch-cast product", base)
 		}
-		t.Logf("%s abstract: wasm=%d code=%d codec=%d", base, len(data), len(c.Code), len(blob))
+		t.Logf("%s abstract: wasm=%d code=%d codec=%d", base, len(data), len(c.code), len(blob))
 		if err := in.Close(); err != nil {
 			t.Fatal(err)
 		}
@@ -219,7 +219,7 @@ func TestStagedGCBrOnCastProductBoundaryLifecycle(t *testing.T) {
 		if _, err := Capture(c, SnapshotOptions{}); err == nil {
 			t.Fatalf("snapshot admitted %s concrete branch-cast product", base)
 		}
-		t.Logf("%s concrete: wasm=%d code=%d codec=%d", base, len(data), len(c.Code), len(blob))
+		t.Logf("%s concrete: wasm=%d code=%d codec=%d", base, len(data), len(c.code), len(blob))
 		if err := in.Close(); err != nil {
 			t.Fatal(err)
 		}
@@ -251,7 +251,7 @@ func TestStagedGCBrOnCastProductBoundaryLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 		blobs = append(blobs, blob)
-		t.Logf("%s nullability: wasm=%d code=%d codec=%d", base, len(data), len(c.Code), len(blob))
+		t.Logf("%s nullability: wasm=%d code=%d codec=%d", base, len(data), len(c.code), len(blob))
 		if err := in.Close(); err != nil {
 			t.Fatal(err)
 		}

--- a/src/wago/gc_extern_product_amd64_test.go
+++ b/src/wago/gc_extern_product_amd64_test.go
@@ -199,7 +199,7 @@ func TestStagedGCExternProductBoundaryLifecycle(t *testing.T) {
 		t.Fatalf("codec-loaded gc/extern instantiate = %v", err)
 	}
 
-	t.Logf("gc/extern product: wasm=%d code=%d codec=%d tableState=%d conversionState=%d entry=%d plugin=%d", len(data), len(c.Code), len(blob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(gcExternConversionState{}), unsafe.Sizeof(gcExternConversionEntry{}), unsafe.Sizeof(instancePluginState{}))
+	t.Logf("gc/extern product: wasm=%d code=%d codec=%d tableState=%d conversionState=%d entry=%d plugin=%d", len(data), len(c.code), len(blob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(gcExternConversionState{}), unsafe.Sizeof(gcExternConversionEntry{}), unsafe.Sizeof(instancePluginState{}))
 }
 
 func BenchmarkStagedGCExternStableRoundTrip(b *testing.B) {

--- a/src/wago/gc_frame_roots.go
+++ b/src/wago/gc_frame_roots.go
@@ -90,7 +90,7 @@ func validateCompiledGCFrameRoots(c *Compiled, rootMap *compiledGCFrameRoots) er
 	}
 	var previousAdapter uint32
 	for i, off := range rootMap.adapterReturnOffsets {
-		if off == 0 || uint64(off) >= uint64(len(c.Code)) || (i != 0 && off <= previousAdapter) {
+		if off == 0 || uint64(off) >= uint64(len(c.code)) || (i != 0 && off <= previousAdapter) {
 			return fmt.Errorf("GC frame-root adapter return offset %d is invalid", off)
 		}
 		previousAdapter = off
@@ -98,7 +98,7 @@ func validateCompiledGCFrameRoots(c *Compiled, rootMap *compiledGCFrameRoots) er
 	var previousReturn uint32
 	for i := range rootMap.callsites {
 		callsite := &rootMap.callsites[i]
-		if callsite.frameBytes < shared.AMD64FrameHeaderBytes || callsite.frameBytes > 1<<31-1 || callsite.returnOffset == 0 || uint64(callsite.returnOffset) >= uint64(len(c.Code)) || (i != 0 && callsite.returnOffset <= previousReturn) || callsite.stackAdjust%8 != 0 || callsite.stackAdjust > 1<<20 || len(callsite.offsets) > gcNativeFrameRootLimit || !validGCFrameOffsets(callsite.offsets, callsite.frameBytes) {
+		if callsite.frameBytes < shared.AMD64FrameHeaderBytes || callsite.frameBytes > 1<<31-1 || callsite.returnOffset == 0 || uint64(callsite.returnOffset) >= uint64(len(c.code)) || (i != 0 && callsite.returnOffset <= previousReturn) || callsite.stackAdjust%8 != 0 || callsite.stackAdjust > 1<<20 || len(callsite.offsets) > gcNativeFrameRootLimit || !validGCFrameOffsets(callsite.offsets, callsite.frameBytes) {
 			return fmt.Errorf("GC frame-root callsite %d is malformed", callsite.returnOffset)
 		}
 		previousReturn = callsite.returnOffset

--- a/src/wago/gc_frame_roots_runtime_arm64.go
+++ b/src/wago/gc_frame_roots_runtime_arm64.go
@@ -57,7 +57,7 @@ func (in *Instance) gcHelperRoots(ctrl uintptr, state *gcPublicState, safepointI
 	state.frameRoots.frameLayout = gcNativeFrameLayoutARM64 // saved LR follows saved FP above the frame reserve
 	state.frameRoots.allowExternalReturn = true             // non-register public entries return directly to enterNative
 	state.frameRoots.codeBase = in.base
-	state.frameRoots.codeBytes = uintptr(len(in.c.Code))
+	state.frameRoots.codeBytes = uintptr(len(in.c.code))
 	state.frameRoots.adapterReturnOffsets = plan.adapterReturnOffsets
 	state.frameRoots.callsites = plan.callsites
 	state.frameRoots.suspended = state

--- a/src/wago/gc_frame_roots_runtime_linux_amd64.go
+++ b/src/wago/gc_frame_roots_runtime_linux_amd64.go
@@ -58,7 +58,7 @@ func (in *Instance) gcHelperRoots(ctrl uintptr, state *gcPublicState, safepointI
 	state.frameRoots.frameBytes = frameBytes
 	state.frameRoots.frameLayout = gcNativeFrameLayoutAMD64
 	state.frameRoots.codeBase = in.base
-	state.frameRoots.codeBytes = uintptr(len(in.c.Code))
+	state.frameRoots.codeBytes = uintptr(len(in.c.code))
 	state.frameRoots.adapterReturnOffsets = plan.adapterReturnOffsets
 	state.frameRoots.callsites = plan.callsites
 	state.frameRoots.suspended = state

--- a/src/wago/gc_host_activation_arm64.go
+++ b/src/wago/gc_host_activation_arm64.go
@@ -40,7 +40,7 @@ func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32) gcHostAc
 		panic(gcStructHelperError{err: fmt.Errorf("generic GC arm64 host activation has invalid saved SP %#x", savedSP)})
 	}
 	findCallsite := func(pc uintptr) int {
-		if pc < in.base || pc-in.base >= uintptr(len(in.c.Code)) {
+		if pc < in.base || pc-in.base >= uintptr(len(in.c.code)) {
 			return -1
 		}
 		rel := uint32(pc - in.base)
@@ -92,7 +92,7 @@ func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32) gcHostAc
 	state.hostActivationCount++
 	state.hostRootPlan = plan
 	state.hostCodeBase = in.base
-	state.hostCodeBytes = uintptr(len(in.c.Code))
+	state.hostCodeBytes = uintptr(len(in.c.code))
 	return gcHostActivationToken{state: state, index: index}
 }
 

--- a/src/wago/gc_host_activation_linux_amd64.go
+++ b/src/wago/gc_host_activation_linux_amd64.go
@@ -39,7 +39,7 @@ func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32) gcHostAc
 		panic(gcStructHelperError{err: fmt.Errorf("generic GC host activation has invalid saved RSP %#x", savedRSP)})
 	}
 	findCallsite := func(pc uintptr) int {
-		if pc < in.base || pc-in.base >= uintptr(len(in.c.Code)) {
+		if pc < in.base || pc-in.base >= uintptr(len(in.c.code)) {
 			return -1
 		}
 		rel := uint32(pc - in.base)
@@ -106,7 +106,7 @@ func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32) gcHostAc
 	state.hostActivationCount++
 	state.hostRootPlan = plan
 	state.hostCodeBase = in.base
-	state.hostCodeBytes = uintptr(len(in.c.Code))
+	state.hostCodeBytes = uintptr(len(in.c.code))
 	return gcHostActivationToken{state: state, index: index}
 }
 

--- a/src/wago/gc_i31_core_amd64_test.go
+++ b/src/wago/gc_i31_core_amd64_test.go
@@ -21,7 +21,7 @@ func TestStagedGCI31CoreExecutionAndPublicCategory(t *testing.T) {
 	if c.stagedGCI31Product() != stagedGCI31ProductCore || c.stagedFeatures()&CoreFeatureGC == 0 {
 		t.Fatalf("i31 product/features = %v/%v", c.stagedGCI31Product(), c.stagedFeatures())
 	}
-	t.Logf("i31 core product: wasm=%d code=%d", len(data), len(c.Code))
+	t.Logf("i31 core product: wasm=%d code=%d", len(data), len(c.code))
 	for _, tc := range []struct {
 		name string
 		cfg  GCConfig

--- a/src/wago/gc_i31_lifecycle_amd64_test.go
+++ b/src/wago/gc_i31_lifecycle_amd64_test.go
@@ -114,7 +114,7 @@ func TestStagedGCI31RemainingProductsLifecycle(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Logf("%s product: wasm=%d code=%d codec=%d", product, len(data), len(c.Code), len(blob))
+			t.Logf("%s product: wasm=%d code=%d codec=%d", product, len(data), len(c.code), len(blob))
 			var loaded Compiled
 			if err := unmarshalCompiled(&loaded, blob[5:]); err != nil {
 				t.Fatal(err)

--- a/src/wago/gc_ref_cast_product_amd64_test.go
+++ b/src/wago/gc_ref_cast_product_amd64_test.go
@@ -231,7 +231,7 @@ func TestStagedGCRefCastProductBoundaryLifecycle(t *testing.T) {
 		loaded.Close()
 	}
 
-	t.Logf("gc/ref_cast products: abstract wasm=%d code=%d codec=%d; concrete wasm=%d code=%d codec=%d; tableState=%d conversionState=%d plugin=%d", len(abstract), len(abstractCompiled.Code), len(abstractBlob), len(concrete), len(concreteCompiled.Code), len(concreteBlob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(gcExternConversionState{}), unsafe.Sizeof(instancePluginState{}))
+	t.Logf("gc/ref_cast products: abstract wasm=%d code=%d codec=%d; concrete wasm=%d code=%d codec=%d; tableState=%d conversionState=%d plugin=%d", len(abstract), len(abstractCompiled.code), len(abstractBlob), len(concrete), len(concreteCompiled.code), len(concreteBlob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(gcExternConversionState{}), unsafe.Sizeof(instancePluginState{}))
 }
 
 func BenchmarkStagedGCRefCastStableI31(b *testing.B) {

--- a/src/wago/gc_ref_eq_product_amd64_test.go
+++ b/src/wago/gc_ref_eq_product_amd64_test.go
@@ -152,7 +152,7 @@ func TestStagedGCRefEqProductBoundaryLifecycle(t *testing.T) {
 		t.Fatalf("codec-loaded gc/ref_eq instantiate = %v", err)
 	}
 
-	t.Logf("gc/ref_eq product: wasm=%d code=%d codec=%d tableState=%d plugin=%d", len(data), len(c.Code), len(blob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(instancePluginState{}))
+	t.Logf("gc/ref_eq product: wasm=%d code=%d codec=%d tableState=%d plugin=%d", len(data), len(c.code), len(blob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(instancePluginState{}))
 }
 
 func BenchmarkStagedGCRefEqStableIdentity(b *testing.B) {

--- a/src/wago/gc_ref_test_abstract_amd64_test.go
+++ b/src/wago/gc_ref_test_abstract_amd64_test.go
@@ -152,7 +152,7 @@ func TestStagedGCRefTestAbstractMixedTableLifecycle(t *testing.T) {
 		t.Fatal("snapshot admitted mixed ref.test product")
 	}
 
-	t.Logf("abstract ref.test product: wasm=%d code=%d codec=%d tableState=%d conversionState=%d plugin=%d", len(data), len(c.Code), len(blob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(gcExternConversionState{}), unsafe.Sizeof(instancePluginState{}))
+	t.Logf("abstract ref.test product: wasm=%d code=%d codec=%d tableState=%d conversionState=%d plugin=%d", len(data), len(c.code), len(blob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(gcExternConversionState{}), unsafe.Sizeof(instancePluginState{}))
 }
 
 func BenchmarkStagedGCRefTestAbstractActions(b *testing.B) {

--- a/src/wago/gc_ref_test_i31_amd64_test.go
+++ b/src/wago/gc_ref_test_i31_amd64_test.go
@@ -32,7 +32,7 @@ func TestStagedGCI31RefTestExecution(t *testing.T) {
 	if c.stagedGCI31Product() != stagedGCI31ProductRefTest || c.stagedFeatures()&CoreFeatureGC == 0 {
 		t.Fatalf("ref.test product/features = %v/%v", c.stagedGCI31Product(), c.stagedFeatures())
 	}
-	t.Logf("i31 ref.test product: wasm=%d code=%d", len(data), len(c.Code))
+	t.Logf("i31 ref.test product: wasm=%d code=%d", len(data), len(c.code))
 	for _, tc := range []struct {
 		name string
 		cfg  GCConfig

--- a/src/wago/gc_ref_test_official_amd64_test.go
+++ b/src/wago/gc_ref_test_official_amd64_test.go
@@ -217,7 +217,7 @@ func replayStagedGCRefTestScript(t *testing.T, tmp string, script stagedSpecScri
 					continue
 				}
 				if blob, marshalErr := marshalCompiled(c); marshalErr == nil {
-					t.Logf("gc/ref_test %s product: wasm=%d code=%d codec=%d", pin.Class, len(latest), len(c.Code), len(blob))
+					t.Logf("gc/ref_test %s product: wasm=%d code=%d codec=%d", pin.Class, len(latest), len(c.code), len(blob))
 				} else {
 					counts.Failures++
 					t.Errorf("gc/ref_test.wast:%d %s codec measurement: %v", cmd.Line, pin.Class, marshalErr)

--- a/src/wago/gc_ref_test_table_amd64_test.go
+++ b/src/wago/gc_ref_test_table_amd64_test.go
@@ -216,7 +216,7 @@ func TestStagedGCRefTestTableProductClosure(t *testing.T) {
 	}
 	_ = widened.Close()
 
-	t.Logf("object ref.test product: wasm=%d code=%d codec=%d state=%d plugin=%d", len(data), len(c.Code), len(blob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(instancePluginState{}))
+	t.Logf("object ref.test product: wasm=%d code=%d codec=%d state=%d plugin=%d", len(data), len(c.code), len(blob), unsafe.Sizeof(gcRefTestTableState{}), unsafe.Sizeof(instancePluginState{}))
 }
 
 func BenchmarkStagedGCRefTestTable(b *testing.B) {

--- a/src/wago/gc_type_subtyping_product_amd64_test.go
+++ b/src/wago/gc_type_subtyping_product_amd64_test.go
@@ -238,7 +238,7 @@ func TestStagedGCTypeSubtypingProductsCompile(t *testing.T) {
 		t.Fatalf("compiledCodeCache size = %d, want 64 bytes", got)
 	}
 	wantCodeBytes := []int{0, 0, 0, 0, 0, 0, 419, 391, 31, 31, 31, 31, 156, 156, 68, 68, 68, 68, 109, 263, 339, 68, 68, 6094, 1133, 1458, 31, 0, 31, 0}
-	wantCodecBytes := []int{349, 385, 347, 219, 238, 386, 806, 927, 453, 611, 374, 709, 501, 755, 535, 693, 535, 456, 815, 601, 875, 357, 437, 6590, 1430, 1816, 268, 237, 358, 237}
+	wantCodecBytes := []int{354, 390, 352, 224, 243, 391, 811, 932, 458, 616, 379, 714, 506, 760, 540, 698, 540, 461, 820, 606, 880, 362, 442, 6595, 1435, 1821, 273, 242, 363, 242}
 	for i, pin := range stagedGCTypeSubtypingProductPins {
 		t.Run(pin.Filename, func(t *testing.T) {
 			data := stagedGCTypeSubtypingProductData(t, pin)
@@ -412,7 +412,7 @@ func TestStagedGCTypeSubtypingProductsCompile(t *testing.T) {
 			}
 			wantCode, wantCodec := 0, 0
 			if pin.Class == stagedGCTypeSubtypingNonFlatExport {
-				wantCode, wantCodec = 371, 792
+				wantCode, wantCodec = 371, 797
 			} else {
 				wantCode, wantCodec = wantCodeBytes[i], wantCodecBytes[i]
 			}
@@ -473,8 +473,8 @@ func TestStagedGCTypeSubtypingFirstLinkingClusterLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{103, 179, 434, 86, 0, 301} {
-		t.Fatalf("link product wasm/code/codec sizes = %v, want [103 179 434 86 0 301]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{103, 179, 439, 86, 0, 306} {
+		t.Fatalf("link product wasm/code/codec sizes = %v, want [103 179 439 86 0 306]", got)
 	}
 
 	instantiateProvider := func() (*Instance, map[string]*InstanceExport) {
@@ -667,8 +667,8 @@ func TestStagedGCTypeSubtypingStructLinkingClusterLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{70, 31, 268, 51, 0, 237} {
-		t.Fatalf("struct link wasm/code/codec sizes = %v, want [70 31 268 51 0 237]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{70, 31, 273, 51, 0, 242} {
+		t.Fatalf("struct link wasm/code/codec sizes = %v, want [70 31 273 51 0 242]", got)
 	}
 
 	resourceState := func(in *Instance) (refs int, closed bool) {
@@ -860,8 +860,8 @@ func TestStagedGCTypeSubtypingStructProjectionLinkingClusterLifecycle(t *testing
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{104, 31, 437, 85, 0, 406} {
-		t.Fatalf("struct projection link wasm/code/codec sizes = %v, want [104 31 437 85 0 406]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{104, 31, 442, 85, 0, 411} {
+		t.Fatalf("struct projection link wasm/code/codec sizes = %v, want [104 31 442 85 0 411]", got)
 	}
 
 	resourceState := func(in *Instance) (refs int, closed bool) {
@@ -1048,8 +1048,8 @@ func TestStagedGCTypeSubtypingRemainingProductsLifecycle(t *testing.T) {
 		wasm, code int
 		codec      int
 	}{
-		{m9ProviderCompiled, 136, 156, 629},
-		{m9ConsumerCompiled, 164, 0, 590},
+		{m9ProviderCompiled, 136, 156, 634},
+		{m9ConsumerCompiled, 164, 0, 595},
 	} {
 		blob, err := marshalCompiled(item.c)
 		if err != nil {
@@ -1146,8 +1146,8 @@ func TestStagedGCTypeSubtypingRemainingProductsLifecycle(t *testing.T) {
 		providerSizes      [3]int
 		consumerSizes      [3]int
 	}{
-		{stagedGCTypeSubtypingCrossGroupMismatchLinkProviderPin, stagedGCTypeSubtypingCrossGroupMismatchLinkConsumerPin, "M10.f", [3]int{74, 31, 259}, [3]int{43, 0, 149}},
-		{stagedGCTypeSubtypingTransitiveMismatchLinkProviderPin, stagedGCTypeSubtypingTransitiveMismatchLinkConsumerPin, "M11.f", [3]int{87, 31, 339}, [3]int{56, 0, 229}},
+		{stagedGCTypeSubtypingCrossGroupMismatchLinkProviderPin, stagedGCTypeSubtypingCrossGroupMismatchLinkConsumerPin, "M10.f", [3]int{74, 31, 264}, [3]int{43, 0, 154}},
+		{stagedGCTypeSubtypingTransitiveMismatchLinkProviderPin, stagedGCTypeSubtypingTransitiveMismatchLinkConsumerPin, "M11.f", [3]int{87, 31, 344}, [3]int{56, 0, 234}},
 	} {
 		pc, cc := compile(tc.provider), compile(tc.consumer)
 		for _, item := range []struct {
@@ -1221,7 +1221,7 @@ func TestStagedGCTypeSubtypingDuplicateRecursiveLinkingClusterLifecycle(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{100, 156, 435, 92, 0, 316} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{100, 156, 440, 92, 0, 321} {
 		t.Fatalf("wasm/code/codec sizes = %v", got)
 	}
 	state := func(in *Instance) (int, bool) {
@@ -1354,8 +1354,8 @@ func TestStagedGCTypeSubtypingExtendedProjectionLinkingClusterLifecycle(t *testi
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{114, 31, 516, 102, 0, 503} {
-		t.Fatalf("extended projection link wasm/code/codec sizes = %v, want [114 31 516 102 0 503]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{114, 31, 521, 102, 0, 508} {
+		t.Fatalf("extended projection link wasm/code/codec sizes = %v, want [114 31 521 102 0 508]", got)
 	}
 
 	resourceState := func(in *Instance) (refs int, closed bool) {
@@ -1546,8 +1546,8 @@ func TestStagedGCTypeSubtypingIndependentStructLinkingClusterLifecycle(t *testin
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 358, 63, 0, 327} {
-		t.Fatalf("independent struct link wasm/code/codec sizes = %v, want [82 31 358 63 0 327]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 363, 63, 0, 332} {
+		t.Fatalf("independent struct link wasm/code/codec sizes = %v, want [82 31 363 63 0 332]", got)
 	}
 
 	resourceState := func(in *Instance) (refs int, closed bool) {
@@ -1739,8 +1739,8 @@ func TestStagedGCTypeSubtypingStructMismatchLinkingClusterLifecycle(t *testing.T
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 358, 51, 0, 237} {
-		t.Fatalf("struct mismatch wasm/code/codec sizes = %v, want [82 31 358 51 0 237]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 363, 51, 0, 242} {
+		t.Fatalf("struct mismatch wasm/code/codec sizes = %v, want [82 31 363 51 0 242]", got)
 	}
 	if got, want := (len(providerCompiled.FuncTypeID)+1)*coreruntime.FuncRefDescBytes, 2*coreruntime.FuncRefDescBytes; got != want {
 		t.Fatalf("provider descriptor requirement = %d bytes, want %d", got, want)
@@ -1900,8 +1900,8 @@ func TestStagedGCTypeSubtypingFinalityLinkingClusterLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal unlinked %s: %v", pin.Filename, err)
 		}
-		if got := [3]int{pin.Size, len(consumerCompiled[i].code), len(consumerBlobs[i])}; got != [3]int{38, 0, 145} {
-			t.Fatalf("%s wasm/code/codec sizes = %v, want [38 0 145]", pin.Filename, got)
+		if got := [3]int{pin.Size, len(consumerCompiled[i].code), len(consumerBlobs[i])}; got != [3]int{38, 0, 150} {
+			t.Fatalf("%s wasm/code/codec sizes = %v, want [38 0 150]", pin.Filename, got)
 		}
 	}
 	if providerCompiled.stagedGCTypeSubtypingProduct() != stagedGCTypeSubtypingFinalityLinkProvider || !providerCompiled.NeedsFuncRefDescs {
@@ -1911,8 +1911,8 @@ func TestStagedGCTypeSubtypingFinalityLinkingClusterLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal provider: %v", err)
 	}
-	if got := [3]int{len(providerData), len(providerCompiled.code), len(providerBlob)}; got != [3]int{70, 63, 227} {
-		t.Fatalf("provider wasm/code/codec sizes = %v, want [70 63 227]", got)
+	if got := [3]int{len(providerData), len(providerCompiled.code), len(providerBlob)}; got != [3]int{70, 63, 232} {
+		t.Fatalf("provider wasm/code/codec sizes = %v, want [70 63 232]", got)
 	}
 
 	provider, err := instantiateCore(providerCompiled, InstantiateOptions{})

--- a/src/wago/gc_type_subtyping_product_amd64_test.go
+++ b/src/wago/gc_type_subtyping_product_amd64_test.go
@@ -416,10 +416,10 @@ func TestStagedGCTypeSubtypingProductsCompile(t *testing.T) {
 			} else {
 				wantCode, wantCodec = wantCodeBytes[i], wantCodecBytes[i]
 			}
-			if len(c.Code) != wantCode || len(blob) != wantCodec {
-				t.Fatalf("product sizes code/codec = %d/%d, want %d/%d", len(c.Code), len(blob), wantCode, wantCodec)
+			if len(c.code) != wantCode || len(blob) != wantCodec {
+				t.Fatalf("product sizes code/codec = %d/%d, want %d/%d", len(c.code), len(blob), wantCode, wantCodec)
 			}
-			t.Logf("product size: wasm=%d code=%d codec=%d types=%d gcdescs=%d", len(data), len(c.Code), len(blob), len(c.Types), len(c.GCTypeDescs))
+			t.Logf("product size: wasm=%d code=%d codec=%d types=%d gcdescs=%d", len(data), len(c.code), len(blob), len(c.Types), len(c.GCTypeDescs))
 			var loaded Compiled
 			if err := unmarshalCompiled(&loaded, blob[5:]); err != nil {
 				t.Fatalf("private codec-v27 reload: %v", err)
@@ -473,7 +473,7 @@ func TestStagedGCTypeSubtypingFirstLinkingClusterLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.Code), len(providerBlob), len(consumerData), len(consumerCompiled.Code), len(consumerBlob)}; got != [6]int{103, 179, 434, 86, 0, 301} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{103, 179, 434, 86, 0, 301} {
 		t.Fatalf("link product wasm/code/codec sizes = %v, want [103 179 434 86 0 301]", got)
 	}
 
@@ -667,7 +667,7 @@ func TestStagedGCTypeSubtypingStructLinkingClusterLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.Code), len(providerBlob), len(consumerData), len(consumerCompiled.Code), len(consumerBlob)}; got != [6]int{70, 31, 268, 51, 0, 237} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{70, 31, 268, 51, 0, 237} {
 		t.Fatalf("struct link wasm/code/codec sizes = %v, want [70 31 268 51 0 237]", got)
 	}
 
@@ -860,7 +860,7 @@ func TestStagedGCTypeSubtypingStructProjectionLinkingClusterLifecycle(t *testing
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.Code), len(providerBlob), len(consumerData), len(consumerCompiled.Code), len(consumerBlob)}; got != [6]int{104, 31, 437, 85, 0, 406} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{104, 31, 437, 85, 0, 406} {
 		t.Fatalf("struct projection link wasm/code/codec sizes = %v, want [104 31 437 85 0 406]", got)
 	}
 
@@ -1055,8 +1055,8 @@ func TestStagedGCTypeSubtypingRemainingProductsLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(item.c.Code) != item.code || len(blob) != item.codec {
-			t.Fatalf("M9 code/codec = %d/%d, want %d/%d", len(item.c.Code), len(blob), item.code, item.codec)
+		if len(item.c.code) != item.code || len(blob) != item.codec {
+			t.Fatalf("M9 code/codec = %d/%d, want %d/%d", len(item.c.code), len(blob), item.code, item.codec)
 		}
 		var loaded Compiled
 		if err := unmarshalCompiled(&loaded, blob[5:]); err != nil {
@@ -1155,8 +1155,8 @@ func TestStagedGCTypeSubtypingRemainingProductsLifecycle(t *testing.T) {
 			sizes [3]int
 		}{{pc, tc.providerSizes}, {cc, tc.consumerSizes}} {
 			blob, err := marshalCompiled(item.c)
-			if err != nil || len(item.c.Code) != item.sizes[1] || len(blob) != item.sizes[2] {
-				t.Fatalf("%s code/codec = %d/%d, %v", tc.key, len(item.c.Code), len(blob), err)
+			if err != nil || len(item.c.code) != item.sizes[1] || len(blob) != item.sizes[2] {
+				t.Fatalf("%s code/codec = %d/%d, %v", tc.key, len(item.c.code), len(blob), err)
 			}
 		}
 		provider, err := instantiateCore(pc, InstantiateOptions{})
@@ -1221,7 +1221,7 @@ func TestStagedGCTypeSubtypingDuplicateRecursiveLinkingClusterLifecycle(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.Code), len(providerBlob), len(consumerData), len(consumerCompiled.Code), len(consumerBlob)}; got != [6]int{100, 156, 435, 92, 0, 316} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{100, 156, 435, 92, 0, 316} {
 		t.Fatalf("wasm/code/codec sizes = %v", got)
 	}
 	state := func(in *Instance) (int, bool) {
@@ -1354,7 +1354,7 @@ func TestStagedGCTypeSubtypingExtendedProjectionLinkingClusterLifecycle(t *testi
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.Code), len(providerBlob), len(consumerData), len(consumerCompiled.Code), len(consumerBlob)}; got != [6]int{114, 31, 516, 102, 0, 503} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{114, 31, 516, 102, 0, 503} {
 		t.Fatalf("extended projection link wasm/code/codec sizes = %v, want [114 31 516 102 0 503]", got)
 	}
 
@@ -1546,7 +1546,7 @@ func TestStagedGCTypeSubtypingIndependentStructLinkingClusterLifecycle(t *testin
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.Code), len(providerBlob), len(consumerData), len(consumerCompiled.Code), len(consumerBlob)}; got != [6]int{82, 31, 358, 63, 0, 327} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 358, 63, 0, 327} {
 		t.Fatalf("independent struct link wasm/code/codec sizes = %v, want [82 31 358 63 0 327]", got)
 	}
 
@@ -1739,7 +1739,7 @@ func TestStagedGCTypeSubtypingStructMismatchLinkingClusterLifecycle(t *testing.T
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.Code), len(providerBlob), len(consumerData), len(consumerCompiled.Code), len(consumerBlob)}; got != [6]int{82, 31, 358, 51, 0, 237} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 358, 51, 0, 237} {
 		t.Fatalf("struct mismatch wasm/code/codec sizes = %v, want [82 31 358 51 0 237]", got)
 	}
 	if got, want := (len(providerCompiled.FuncTypeID)+1)*coreruntime.FuncRefDescBytes, 2*coreruntime.FuncRefDescBytes; got != want {
@@ -1798,7 +1798,7 @@ func TestStagedGCTypeSubtypingStructMismatchLinkingClusterLifecycle(t *testing.T
 	if refs, closed := resourceState(provider); refs != 0 || closed {
 		t.Fatalf("mismatched consumer retained provider refs/resourcesClosed = %d/%v, want 0/false", refs, closed)
 	}
-	if consumerCompiled.stagedGCTypeSubtypingProduct() != stagedGCTypeSubtypingStructMismatchLinkConsumer || len(consumerCompiled.Code) != 0 {
+	if consumerCompiled.stagedGCTypeSubtypingProduct() != stagedGCTypeSubtypingStructMismatchLinkConsumer || len(consumerCompiled.code) != 0 {
 		t.Fatal("failed consumer link published or mutated the unlinked compiled product")
 	}
 	if blob, err := marshalCompiled(consumerCompiled); err != nil || len(blob) != len(consumerBlob) {
@@ -1900,7 +1900,7 @@ func TestStagedGCTypeSubtypingFinalityLinkingClusterLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal unlinked %s: %v", pin.Filename, err)
 		}
-		if got := [3]int{pin.Size, len(consumerCompiled[i].Code), len(consumerBlobs[i])}; got != [3]int{38, 0, 145} {
+		if got := [3]int{pin.Size, len(consumerCompiled[i].code), len(consumerBlobs[i])}; got != [3]int{38, 0, 145} {
 			t.Fatalf("%s wasm/code/codec sizes = %v, want [38 0 145]", pin.Filename, got)
 		}
 	}
@@ -1911,7 +1911,7 @@ func TestStagedGCTypeSubtypingFinalityLinkingClusterLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal provider: %v", err)
 	}
-	if got := [3]int{len(providerData), len(providerCompiled.Code), len(providerBlob)}; got != [3]int{70, 63, 227} {
+	if got := [3]int{len(providerData), len(providerCompiled.code), len(providerBlob)}; got != [3]int{70, 63, 227} {
 		t.Fatalf("provider wasm/code/codec sizes = %v, want [70 63 227]", got)
 	}
 

--- a/src/wago/global_test.go
+++ b/src/wago/global_test.go
@@ -371,14 +371,13 @@ func TestCompileRejectsMalformedGlobalConstExpressions(t *testing.T) {
 
 func TestCompiledValidateRejectsMalformedMetadata(t *testing.T) {
 	base := func() *Compiled {
-		return &Compiled{
-			Code:       []byte{0xc3},
+		return newHandBuiltCompiled([]byte{0xc3}, Compiled{
 			Entry:      []int{0},
 			Funcs:      []FuncSig{{Results: []ValType{ValI32}}},
 			Exports:    map[string]int{"f": 0},
 			FuncTypeID: []uint64{1},
 			Globals:    []GlobalDef{{Type: ValI32}},
-		}
+		})
 	}
 	tests := []struct {
 		name string
@@ -482,13 +481,12 @@ func TestInstantiateInitializesGlobalSlots(t *testing.T) {
 
 func TestInstantiateLateGlobalErrorCleansResources(t *testing.T) {
 	before := procSelfMapsCount(t)
-	c := &Compiled{
-		Code: []byte{0xc3}, // ret; code is mapped before global initialization reaches this malformed reference.
+	c := newHandBuiltCompiled([]byte{0xc3}, Compiled{ // ret; code is mapped before global initialization reaches this malformed reference.
 		Globals: []GlobalDef{
 			{Type: ValI32, Bits: 1},
 			{Type: ValI32, HasInitGlobal: true, InitGlobal: 2},
 		},
-	}
+	})
 	for i := 0; i < 5; i++ {
 		if in, err := Instantiate(c, InstantiateOptions{}); err == nil {
 			in.Close()

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -995,10 +995,13 @@ type compiledTagDef struct {
 	TypeIndex uint32
 }
 
-// Compiled is emitted machine code plus instantiate-time metadata. Function
-// exports remain isolated in the public Exports map.
+// Compiled owns emitted machine code plus instantiate-time metadata. Native
+// bytes are intentionally private; use CodeSize or WriteCodeTo for diagnostics.
+// Function exports remain isolated in the public Exports map. Call Close when
+// no new instances are needed; existing instances retain their executable image
+// until they close.
 type Compiled struct {
-	Code  []byte
+	code  []byte
 	Entry []int // host-wrapper offset, or the internal offset for direct-only functions
 	// InternalEntry mirrors Entry with each function's register-ABI internal
 	// entry offset. Entry[i] == InternalEntry[i] for a direct-only register-ABI

--- a/src/wago/host_interrupt_linux_test.go
+++ b/src/wago/host_interrupt_linux_test.go
@@ -46,7 +46,7 @@ func TestPublicCompileOmitsCooperativeInterruptPolls(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer public.Close()
-	if !bytes.Equal(public.Code, withoutPolls.Code) {
+	if !bytes.Equal(public.code, withoutPolls.Code) {
 		t.Fatal("public Linux compilation retained cooperative interrupt instrumentation")
 	}
 	if !wruntime.HostInterruptSupported() {

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -56,7 +56,7 @@ func TestSyncHostImportV128SlotForm(t *testing.T) {
 	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.V128, wasm.I64}, []wasm.ValType{wasm.V128, wasm.I32})
 	body := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0x10, 0x00, 0x0b} // local.get 0,1,2; call 0; end
 	c := MustCompile(returningImportModule(sig, body))
-	if !c.dynamicImports || len(c.Code) == 0 {
+	if !c.dynamicImports || len(c.code) == 0 {
 		t.Fatal("v128 host import should compile through dynamic dispatch")
 	}
 	calls := 0
@@ -111,7 +111,7 @@ func TestSyncHostImportVoidV128UsesSyncPath(t *testing.T) {
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x00, 0x10, 0x00, 0x41, 0x07, 0x0b}))), // local.get 0; call 0; i32.const 7; end
 	)
 	c := MustCompile(mod)
-	if !c.dynamicImports || len(c.Code) == 0 {
+	if !c.dynamicImports || len(c.code) == 0 {
 		t.Fatal("void v128 host import should compile through dynamic dispatch")
 	}
 	called := false

--- a/src/wago/import_dispatch_test.go
+++ b/src/wago/import_dispatch_test.go
@@ -14,8 +14,8 @@ func TestSyncHostPolicyUsesBindingIndependentCode(t *testing.T) {
 	if err := c.validateImportBindings(imports, nil); err != nil {
 		t.Fatalf("validate synchronous binding: %v", err)
 	}
-	if !c.dynamicImports || len(c.Code) == 0 {
-		t.Fatalf("dynamic=%v code=%d", c.dynamicImports, len(c.Code))
+	if !c.dynamicImports || len(c.code) == 0 {
+		t.Fatalf("dynamic=%v code=%d", c.dynamicImports, len(c.code))
 	}
 }
 
@@ -60,8 +60,8 @@ func TestImportedModuleCodeIsBindingIndependent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer c.Close()
-	if !c.dynamicImports || len(c.Code) == 0 || len(c.Entry) == 0 {
-		t.Fatalf("imported module dynamic=%v code=%d entries=%d", c.dynamicImports, len(c.Code), len(c.Entry))
+	if !c.dynamicImports || len(c.code) == 0 || len(c.Entry) == 0 {
+		t.Fatalf("imported module dynamic=%v code=%d entries=%d", c.dynamicImports, len(c.code), len(c.Entry))
 	}
 	stubs := Imports{}
 	for _, name := range c.Imports {

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -130,6 +130,12 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 	if c == nil {
 		return nil, errors.New("wago: instantiate: nil compiled module")
 	}
+	// Closed is an ownership state, not malformed metadata. Check it before
+	// preflight/validation so Close remains the authoritative error even after it
+	// has released and cleared the native-code view.
+	if err := c.checkOpen(); err != nil {
+		return nil, err
+	}
 	restoreMemories := snapshotMemories(opts.restore)
 	if opts.restore != nil {
 		if err := validateSnapshotMemories(c, restoreMemories); err != nil {

--- a/src/wago/memory64_exec_amd64_test.go
+++ b/src/wago/memory64_exec_amd64_test.go
@@ -330,7 +330,7 @@ func TestStagedMemory64LocalExecutionAndProductRoundTrip(t *testing.T) {
 		t.Fatalf("public memory64 codec load: %v", err)
 	}
 	defer public.Close()
-	t.Logf("staged memory64 product: wasm=%d code=%d codec=%d reservation=%d bytes", len(module), len(compiled.Code), len(blob), 3*65536)
+	t.Logf("staged memory64 product: wasm=%d code=%d codec=%d reservation=%d bytes", len(module), len(compiled.code), len(blob), 3*65536)
 	var loaded Compiled
 	if err := unmarshalCompiled(&loaded, blob[5:]); err != nil {
 		t.Fatalf("decode staged memory64 metadata: %v", err)
@@ -698,7 +698,7 @@ func TestStagedMemory64IntegerScalarFamily(t *testing.T) {
 		t.Fatalf("compile memory64 integer scalar family: %v", err)
 	}
 	defer compiled.Close()
-	t.Logf("memory64 integer scalar family: wasm=%d code=%d operations=%d", len(module), len(compiled.Code), len(memory64IntegerScalarOps))
+	t.Logf("memory64 integer scalar family: wasm=%d code=%d operations=%d", len(module), len(compiled.code), len(memory64IntegerScalarOps))
 	in, err := instantiateCore(compiled, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate memory64 integer scalar family: %v", err)
@@ -822,7 +822,7 @@ func TestStagedMemory64FloatScalarFamily(t *testing.T) {
 	if _, err := in.Invoke("offset.load", 1); err == nil || !strings.Contains(err.Error(), "out of bounds") {
 		t.Fatalf("float offset overflow error = %v", err)
 	}
-	t.Logf("memory64 float scalar family: wasm=%d code=%d operations=4", len(memory64FloatScalarModule()), len(compiled.Code))
+	t.Logf("memory64 float scalar family: wasm=%d code=%d operations=4", len(memory64FloatScalarModule()), len(compiled.code))
 }
 
 func TestStagedMemory64SIMDMemoryFamily(t *testing.T) {
@@ -1320,7 +1320,7 @@ func TestStagedMemory64AdmissionGatesAndMemory32CodeStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer staged.Close()
-	if !bytes.Equal(base.Code, staged.Code) {
+	if !bytes.Equal(base.code, staged.code) {
 		t.Fatal("enabling staged memory64 changed memory32 integer code bytes")
 	}
 
@@ -1341,7 +1341,7 @@ func TestStagedMemory64AdmissionGatesAndMemory32CodeStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer stagedFloat.Close()
-	if !bytes.Equal(baseFloat.Code, stagedFloat.Code) {
+	if !bytes.Equal(baseFloat.code, stagedFloat.code) {
 		t.Fatal("enabling staged memory64 changed memory32 float code bytes")
 	}
 
@@ -1362,7 +1362,7 @@ func TestStagedMemory64AdmissionGatesAndMemory32CodeStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer stagedSIMD.Close()
-	if !bytes.Equal(baseSIMD.Code, stagedSIMD.Code) {
+	if !bytes.Equal(baseSIMD.code, stagedSIMD.code) {
 		t.Fatal("enabling staged memory64 changed memory32 SIMD code bytes")
 	}
 
@@ -1382,7 +1382,7 @@ func TestStagedMemory64AdmissionGatesAndMemory32CodeStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer stagedBulk.Close()
-	if !bytes.Equal(baseBulk.Code, stagedBulk.Code) {
+	if !bytes.Equal(baseBulk.code, stagedBulk.code) {
 		t.Fatal("enabling staged memory64 changed memory32 bulk code bytes")
 	}
 
@@ -1397,7 +1397,7 @@ func TestStagedMemory64AdmissionGatesAndMemory32CodeStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer stagedInit.Close()
-	if !bytes.Equal(baseInit.Code, stagedInit.Code) {
+	if !bytes.Equal(baseInit.code, stagedInit.code) {
 		t.Fatal("enabling staged memory64 changed memory32 memory.init/data.drop code bytes")
 	}
 }

--- a/src/wago/memory_directory_test.go
+++ b/src/wago/memory_directory_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestCompiledIndexedMemoryDirectoryCodecAndMetadata(t *testing.T) {
-	c := &Compiled{
-		Code:          []byte{0xc3},
+	c := newHandBuiltCompiled([]byte{0xc3}, Compiled{
 		Exports:       map[string]int{},
 		GlobalExports: map[string]int{},
 		HasMemory:     true,
@@ -22,13 +21,13 @@ func TestCompiledIndexedMemoryDirectoryCodecAndMetadata(t *testing.T) {
 			exactExports: true,
 		},
 		requiredFeatures: CoreFeatureMultiMemory | CoreFeatureThreads,
-	}
+	})
 	blob, err := c.MarshalBinary()
 	if err != nil {
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	if blob[4] != 32 {
-		t.Fatalf("codec version = %d, want 32", blob[4])
+	if blob[4] != 33 {
+		t.Fatalf("codec version = %d, want 33", blob[4])
 	}
 	var got Compiled
 	if err := unmarshalCompiled(&got, blob[5:]); err != nil {
@@ -68,15 +67,14 @@ func TestCompiledIndexedMemoryDirectoryCodecAndMetadata(t *testing.T) {
 }
 
 func TestIndexedMemoryDirectoryValidationAndPolicyAccounting(t *testing.T) {
-	base := Compiled{
-		Code:             []byte{0xc3},
+	base := *newHandBuiltCompiled([]byte{0xc3}, Compiled{
 		Exports:          map[string]int{},
 		GlobalExports:    map[string]int{},
 		HasMemory:        true,
 		MemMinPages:      1,
 		MemMaxPages:      2,
 		requiredFeatures: CoreFeatureMultiMemory,
-	}
+	})
 
 	t.Run("imports precede locals", func(t *testing.T) {
 		c := base

--- a/src/wago/moonbit_starshine_smoke_amd64_test.go
+++ b/src/wago/moonbit_starshine_smoke_amd64_test.go
@@ -49,8 +49,8 @@ func TestMoonBitStarshineWasmGCSmokeCompile(t *testing.T) {
 	if err := compiled.validateImportBindings(starshineSmokeImports(compiled), nil); err != nil {
 		t.Fatalf("validate MoonBit Starshine wasm-gc imports: %v", err)
 	}
-	if len(compiled.Code) == 0 || len(compiled.Entry) < 10_000 {
-		t.Fatalf("compiled Starshine footprint = code %d entries %d", len(compiled.Code), len(compiled.Entry))
+	if len(compiled.code) == 0 || len(compiled.Entry) < 10_000 {
+		t.Fatalf("compiled Starshine footprint = code %d entries %d", len(compiled.code), len(compiled.Entry))
 	}
 }
 

--- a/src/wago/multi_memory_exec_amd64_test.go
+++ b/src/wago/multi_memory_exec_amd64_test.go
@@ -397,7 +397,7 @@ func TestStagedMultiMemoryScalarWidthsAndGrow(t *testing.T) {
 			t.Fatalf("compile staged: %v", err)
 		}
 		defer staged.Close()
-		if string(base.Code) != string(staged.Code) {
+		if string(base.code) != string(staged.code) {
 			t.Fatal("enabling staged multi-memory changed ordinary memory-0 code bytes")
 		}
 	})

--- a/src/wago/multi_memory_simd_amd64_test.go
+++ b/src/wago/multi_memory_simd_amd64_test.go
@@ -229,7 +229,7 @@ func TestStagedMultiMemorySIMDMemoryZeroCodeUnchanged(t *testing.T) {
 		t.Fatalf("compile staged: %v", err)
 	}
 	defer staged.Close()
-	if string(base.Code) != string(staged.Code) {
+	if string(base.code) != string(staged.code) {
 		t.Fatal("enabling staged multi-memory changed ordinary SIMD memory-0 code bytes")
 	}
 }

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -320,7 +320,7 @@ func (r *gcNativeFrameRoots) rangeChain(fn func(gc.RootSlot) bool, sink gc.RootR
 			}
 			owner = foreign
 			plan := foreign.c.genericGCFrameRoots()
-			codeBase, codeBytes = foreign.base, uintptr(len(foreign.c.Code))
+			codeBase, codeBytes = foreign.base, uintptr(len(foreign.c.code))
 			adapterReturnOffsets, callsites = plan.adapterReturnOffsets, plan.callsites
 		}
 		rel := uint32(retPC - codeBase)
@@ -505,7 +505,7 @@ func (s *referenceStore) gcFrameOwner(pc uintptr, collector *gc.Collector) *Inst
 		if state == nil || state.resourcesReleased || candidate == nil || candidate.gc != collector || candidate.c == nil || candidate.c.genericGCFrameRoots() == nil {
 			continue
 		}
-		if pc >= candidate.base && pc-candidate.base < uintptr(len(candidate.c.Code)) {
+		if pc >= candidate.base && pc-candidate.base < uintptr(len(candidate.c.code)) {
 			return candidate
 		}
 	}

--- a/src/wago/table64_exec_amd64_test.go
+++ b/src/wago/table64_exec_amd64_test.go
@@ -641,7 +641,7 @@ func TestStagedTable64LocalGetSetSizeAndProductRoundTrip(t *testing.T) {
 		t.Fatalf("marshal table64: %v", err)
 	}
 	if blob[4] != 32 {
-		t.Fatalf("table64 codec version = %d, want 32", blob[4])
+		t.Fatalf("table64 codec version = %d, want 33", blob[4])
 	}
 	var public Compiled
 	if err := public.UnmarshalBinary(blob); err != nil {
@@ -949,7 +949,7 @@ func TestStagedTable64CopyFullWidthOverlapAtomicityAndCodecRoundTrip(t *testing.
 		t.Fatal(err)
 	}
 	defer staged.Close()
-	if !bytes.Equal(ordinary.Code, staged.Code) {
+	if !bytes.Equal(ordinary.code, staged.code) {
 		t.Fatal("enabling staged table64.copy changed table32 code bytes")
 	}
 }
@@ -1074,7 +1074,7 @@ func TestStagedTable64PassiveInitDropFullWidthAtomicityAndCodecRoundTrip(t *test
 		t.Fatal(err)
 	}
 	defer staged.Close()
-	if !bytes.Equal(ordinary.Code, staged.Code) {
+	if !bytes.Equal(ordinary.code, staged.code) {
 		t.Fatal("enabling staged table64.init/drop changed table32 code bytes")
 	}
 }
@@ -1231,7 +1231,7 @@ func TestStagedTable64TwoLocalCopyMixedWidthsDirectoryAndCodecRoundTrip(t *testi
 		t.Fatal(err)
 	}
 	defer staged.Close()
-	if !bytes.Equal(ordinary.Code, staged.Code) {
+	if !bytes.Equal(ordinary.code, staged.code) {
 		t.Fatal("enabling staged two-local table64.copy changed ordinary table32 code bytes")
 	}
 }
@@ -1352,7 +1352,7 @@ func TestStagedTable64TwoLocalReadWriteMixedWidthsDirectoryAndCodecRoundTrip(t *
 		t.Fatal(err)
 	}
 	defer staged.Close()
-	if !bytes.Equal(ordinary.Code, staged.Code) {
+	if !bytes.Equal(ordinary.code, staged.code) {
 		t.Fatal("enabling staged two-local table64 read/write changed ordinary table32 code bytes")
 	}
 }
@@ -1478,7 +1478,7 @@ func TestStagedTable64TwoLocalGrowFillMixedWidthsDirectoryAndCodecRoundTrip(t *t
 		t.Fatal(err)
 	}
 	defer staged.Close()
-	if !bytes.Equal(ordinary.Code, staged.Code) {
+	if !bytes.Equal(ordinary.code, staged.code) {
 		t.Fatal("enabling staged two-local table64 grow/fill changed ordinary table32 code bytes")
 	}
 }
@@ -1618,7 +1618,7 @@ func TestStagedTable64TwoLocalInitDropMixedWidthsDirectoryAndCodecRoundTrip(t *t
 		t.Fatal(err)
 	}
 	defer staged.Close()
-	if !bytes.Equal(ordinary.Code, staged.Code) {
+	if !bytes.Equal(ordinary.code, staged.code) {
 		t.Fatal("enabling staged two-local table64.init/drop changed ordinary table32 code bytes")
 	}
 }
@@ -2704,7 +2704,7 @@ func TestStagedTable64GatesAndTable32CodeStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer staged.Close()
-	if !bytes.Equal(base.Code, staged.Code) {
+	if !bytes.Equal(base.code, staged.code) {
 		t.Fatal("enabling staged table64 changed table32 code bytes")
 	}
 	ordinaryIndirect := table32CallIndirectModule()
@@ -2718,7 +2718,7 @@ func TestStagedTable64GatesAndTable32CodeStability(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer stagedIndirect.Close()
-	if !bytes.Equal(baseIndirect.Code, stagedIndirect.Code) {
+	if !bytes.Equal(baseIndirect.code, stagedIndirect.code) {
 		t.Fatal("enabling staged table64 changed table32 call_indirect code bytes")
 	}
 }

--- a/src/wago/table64_exec_amd64_test.go
+++ b/src/wago/table64_exec_amd64_test.go
@@ -640,7 +640,7 @@ func TestStagedTable64LocalGetSetSizeAndProductRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal table64: %v", err)
 	}
-	if blob[4] != 32 {
+	if blob[4] != 33 {
 		t.Fatalf("table64 codec version = %d, want 33", blob[4])
 	}
 	var public Compiled

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -518,7 +518,7 @@ func TestCompiledValidationRejectsInvalidTableInitializerFunction(t *testing.T) 
 		{name: "large uint32", idx: ^uint32(0)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := &Compiled{Code: []byte{0}, Entry: []int{0}, Funcs: []FuncSig{{}}, HasTable: true, TableSize: 1, TableMax: 1, HasTableInitFunc: true, TableInitFunc: tc.idx, FuncTypeID: []uint64{0}}
+			c := newHandBuiltCompiled([]byte{0}, Compiled{Entry: []int{0}, Funcs: []FuncSig{{}}, HasTable: true, TableSize: 1, TableMax: 1, HasTableInitFunc: true, TableInitFunc: tc.idx, FuncTypeID: []uint64{0}})
 			want := fmt.Sprintf("table initializer function index %d out of range", tc.idx)
 			if err := c.validate(); err == nil || !strings.Contains(err.Error(), want) {
 				t.Fatalf("validate invalid table initializer = %v, want %q", err, want)

--- a/src/wago/threads_atomic_bench_test.go
+++ b/src/wago/threads_atomic_bench_test.go
@@ -46,7 +46,7 @@ func BenchmarkThreadsAtomicInvoke(b *testing.B) {
 					b.Fatal(err)
 				}
 			}
-			b.ReportMetric(float64(len(compiled.Code)), "code-B")
+			b.ReportMetric(float64(len(compiled.code)), "code-B")
 		})
 	}
 }

--- a/src/wago/threads_atomic_test.go
+++ b/src/wago/threads_atomic_test.go
@@ -433,8 +433,8 @@ func TestThreadsFeatureDoesNotChangeOrdinaryGeneratedCode(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer withThreads.Close()
-	if !bytes.Equal(base.Code, withThreads.Code) {
-		t.Fatalf("ordinary generated code changed when threads was enabled: %d vs %d bytes", len(base.Code), len(withThreads.Code))
+	if !bytes.Equal(base.code, withThreads.code) {
+		t.Fatalf("ordinary generated code changed when threads was enabled: %d vs %d bytes", len(base.code), len(withThreads.code))
 	}
 }
 

--- a/src/wago/typed_storage_test.go
+++ b/src/wago/typed_storage_test.go
@@ -210,8 +210,7 @@ func TestStagedTypedStorageExactImports(t *testing.T) {
 func TestTypedStorageMetadataRejectsIdentityCollapse(t *testing.T) {
 	indexed0 := ValueTypeDescriptor{Kind: ValueTypeReference, Ref: ReferenceTypeDescriptor{Nullable: true, Heap: HeapTypeDescriptor{Defined: true, TypeIndex: 0}}}
 	indexed1 := ValueTypeDescriptor{Kind: ValueTypeReference, Ref: ReferenceTypeDescriptor{Nullable: true, Heap: HeapTypeDescriptor{Defined: true, TypeIndex: 1}}}
-	c := &Compiled{
-		Code:                []byte{0xc3},
+	c := newHandBuiltCompiled([]byte{0xc3}, Compiled{
 		Entry:               []int{0},
 		InternalEntry:       []int{0},
 		Funcs:               []FuncSig{{TypeIndex: 0, HasTypeIndex: true}},
@@ -229,7 +228,7 @@ func TestTypedStorageMetadataRejectsIdentityCollapse(t *testing.T) {
 		TableValueTypeIndex: 0,
 		Elems:               []ElemInit{{TableIndex: 0, RefType: ValFuncRef, HasValueType: true, ValueTypeIndex: 1, Mode: ElemModeActive, Values: []RefInit{{FuncIndex: 0}}}},
 		NeedsFuncRefDescs:   true,
-	}
+	})
 	if err := c.validate(); err == nil || !strings.Contains(err.Error(), "structural type does not match table") {
 		t.Fatalf("collapsed active element metadata error = %v", err)
 	}

--- a/wago.go
+++ b/wago.go
@@ -12,6 +12,8 @@ import impl "github.com/wago-org/wago/src/wago"
 
 type (
 	AbstractHeapType          = impl.AbstractHeapType
+	ArtifactLimits            = impl.ArtifactLimits
+	ArtifactSectionSizes      = impl.ArtifactSectionSizes
 	Bits                      = impl.Bits
 	BoundsCheckMode           = impl.BoundsCheckMode
 	CallerResolver            = impl.CallerResolver
@@ -309,6 +311,8 @@ func Compile(args ...any) (*Compiled, error) { return impl.Compile(args...) }
 func CompileWithConfig(cfg *RuntimeConfig, wasmBytes []byte) (*Compiled, error) {
 	return impl.CompileWithConfig(cfg, wasmBytes)
 }
+
+func DefaultArtifactLimits() ArtifactLimits { return impl.DefaultArtifactLimits() }
 
 func DirsFor(version string) Dirs { return impl.DirsFor(version) }
 


### PR DESCRIPTION
## What changed

- emit serial AMD64 and ARM64 code directly into one RW image, patch it in place, and seal the same address RX on first use
- replace the unreleased positional artifact with strict ordered v33 code and metadata sections
- add bounded `ReadFrom` / `ReadFromWithLimits`, zero-whole-artifact `WriteTo`, and exact `ArtifactSectionSizes`
- make native code private; replace mutable `Compiled.Code` with `CodeSize` and `WriteCodeTo`
- make decode replacement release its prior image and reject replacement while live instances retain it
- reject v32 and non-canonical, reordered, duplicate, unknown, truncated, or over-limit sections
- document the completed design and the measured decision to retain the faster heap-backed parallel join

This advances #316, #330, and #331.

## Breaking changes

Wago is unreleased, so this intentionally carries no compatibility aliases:

- artifact v32 is rejected; producers and consumers must use v33
- `Compiled.Code` is removed
- replacing a populated `Compiled` through decode fails while any instance is live

## Measured impact

Darwin/ARM64, Apple M4 Max:

| Measurement | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Serial 1,600-function compile, median | 36.93 ms | 36.81 ms | 1.003x faster |
| Serial compile Go heap | 3,283,350 B/op | 759,784 B/op | 4.32x less |
| Median peak RSS, fresh 10-compile process | 25,886,720 B | 20,119,552 B | 1.29x less |
| 1 MiB first-use code transition | 72.08 us | 2.68 us | 26.9x faster |
| Large artifact write | 280.3 us | 182.5 us | 1.54x faster |
| Large artifact write heap | 1,992,885 B/op | 263,265 B/op | 7.57x less |
| Streamed read to first use | 255.3 us | 264.7 us | 3.7% slower |
| Streamed decoder heap | 190,512 B/op | 224,095 B/op | 1.18x more, while avoiding the caller-owned complete artifact buffer |

Native code bytes and steady-state execution are unchanged. Three direct parallel-image joins were removed: the best reduced p4 Go heap from about 6.25 MB/op to 3.73 MB/op but slowed compile median from 21.92 ms to 22.44 ms (+2.4%), missing the balanced gate.

## Validation

- `go test ./... -count=1`
- `go test -race ./src/core/runtime ./src/wago -count=1`
- `go vet ./src/core/runtime ./src/wago`
- full Linux/AMD64 repository cross-build
- Linux/ARM64 and Windows/AMD64/ARM64 runtime and wago cross-builds
- actual Docker Linux/AMD64 code-image, streaming artifact, and lifecycle tests
- five one-second artifact and first-use benchmark samples
- refreshed Graphify code graph