### PR TITLE
wasm: pack compiler type metadata

### DIFF
--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -1,5 +1,33 @@
 # WasmGC measurement matrix
 
+## Compiler type-metadata matrix
+
+Compiler-side WasmGC metadata is measured separately from collector behavior.
+`src/core/compiler/wasm/type_rep_bench_test.go` covers construction, semantic
+equality, decode, validation, and cold/warm structural identity at 10, 100,
+1,000, and 10,000 types and at 1, 4, 16, and 64 fields per type where the
+operation permits. Fixtures include numeric, vector, packed, mutable, abstract,
+indexed, recursive, exact, nullable, and shorthand reference forms. Fixture
+construction is outside timed decode, validation, equality, and identity loops.
+
+Record a baseline before changing the representation, then repeat the exact
+command and compare the raw files:
+
+```sh
+go test ./src/core/compiler/wasm -run '^$' \
+  -bench 'BenchmarkGCType' -benchmem -benchtime=100ms -count=10
+
+cd bench
+go test -run '^$' \
+  -bench 'Benchmark(Decode|Validate|Compile)$' -benchmem -count=10
+```
+
+`TestCompilerTypeRepresentationLayout` is the deterministic layout contract.
+It records both size and Go-pointer containment for compiler leaf metadata and
+the separately owned runtime collector descriptors. Keep the two result sets
+separate: denser compiler values do not by themselves prove a collector heap or
+pause-time improvement.
+
 This document defines the measurement contract for collector changes tracked by
 issue #300. The matrix is intentionally broader than the current implementation:
 it covers the Throughput and Tiny collectors that exist today and the collector

--- a/docs/wasm-type-representation.md
+++ b/docs/wasm-type-representation.md
@@ -1,0 +1,49 @@
+# Compiler Wasm type representation
+
+The compiler stores `HeapType`, `RefType`, `ValType`, `StorageType`, and
+`FieldType` as the same pointer-free pair of `uint64` words. Constructors and
+accessors in `src/core/compiler/wasm/types.go` are the only supported way to
+interpret the bits.
+
+The low word contains variant tags and flags:
+
+| Bits | Meaning |
+| --- | --- |
+| 0..1 | heap-type variant |
+| 8..15 | abstract heap type |
+| 16 | recursive `TypeIdx` |
+| 17 | resolved-definition coordinates present |
+| 18..19 | resolved definition's component kind |
+| 20 | nullable reference |
+| 21 | exact reference |
+| 22 | one-byte bare reference spelling |
+| 23 | resolved component kind valid |
+| 24..25 | value-type variant |
+| 32..39 | numeric type |
+| 40 | packed storage |
+| 41..48 | packed storage type |
+| 49 | mutable field |
+
+The high word contains either the complete `uint32` type index or two complete
+`uint32` resolved-definition coordinates (recursion-group and member). Ordinary
+scalar shifts and masks are endian-independent. No unsafe reinterpretation is
+used.
+
+Two words are intentional. A resolved definition needs 64 payload bits before
+its variant and validity tags are encoded. Reducing either coordinate would
+narrow Wago's accepted domain. A one-word representation would therefore need
+a module-owned side table and lifetime plumbing through every standalone value;
+the measured two-word representation captures most of the density benefit with
+substantially less ownership complexity.
+
+The bare-spelling bit is binary metadata, not semantic type identity.
+`EqualValType` ignores it, so `funcref` remains equal to the equivalent expanded
+`ref null func` form. Resolved-definition component kind is cached only for
+pointer-free consumers; definition identity remains its group/member pair.
+
+Variable-length fields, parameters, results, and supertypes remain ordinary
+dense slices owned by their composite/subtype. An arena was deliberately
+deferred: leaf packing removes the dominant per-element cost without changing
+slice ownership or public compiler lifetimes. Revisit an arena only if profiles
+show backing-array allocation or retained slice metadata as a material remaining
+cost.

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -144,7 +144,7 @@ func preparedDirectIntSig(ft *wasm.CompType) bool {
 // The descriptor pointer remains owned by the instance's bounded descriptor arena;
 // no GC-managed reference or foreign wrapper result is admitted by this shape.
 func sigFitsReferenceResultRegABI(ft *wasm.CompType) bool {
-	if len(ft.Results) != 1 || ft.Results[0].Kind != wasm.ValRef || len(ft.Params) > len(intArgRegs)+len(fpArgRegs) {
+	if len(ft.Results) != 1 || ft.Results[0].Kind() != wasm.ValRef || len(ft.Params) > len(intArgRegs)+len(fpArgRegs) {
 		return false
 	}
 	gp, fp := 0, 0
@@ -171,7 +171,7 @@ func sigFitsTypedReferenceRegABI(ft *wasm.CompType) bool {
 	gp, fp := 0, 0
 	for _, typ := range ft.Params {
 		switch {
-		case isIntValType(typ), typ.Kind == wasm.ValRef:
+		case isIntValType(typ), typ.Kind() == wasm.ValRef:
 			gp++
 		case isFloatValType(typ):
 			fp++
@@ -183,7 +183,7 @@ func sigFitsTypedReferenceRegABI(ft *wasm.CompType) bool {
 		return false
 	}
 	for _, typ := range ft.Results {
-		if !isIntValType(typ) && !isFloatValType(typ) && typ.Kind != wasm.ValRef {
+		if !isIntValType(typ) && !isFloatValType(typ) && typ.Kind() != wasm.ValRef {
 			return false
 		}
 	}
@@ -207,7 +207,7 @@ func tailResultABICompatible(a, b []wasm.ValType) bool {
 		}
 		// Validation already proved reference-result covariance. Native tail
 		// transfer only needs the common one-slot descriptor-pointer ABI here.
-		if a[i].Kind != wasm.ValRef || b[i].Kind != wasm.ValRef {
+		if a[i].Kind() != wasm.ValRef || b[i].Kind() != wasm.ValRef {
 			return false
 		}
 	}

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -2407,7 +2407,7 @@ func mtOf(t wasm.ValType) machineType {
 		return mtF64
 	case wasm.EqualValType(t, wasm.V128):
 		return mtV128
-	case t.Kind == wasm.ValRef:
+	case t.Kind() == wasm.ValRef:
 		return mtI64
 	}
 	return mtNone

--- a/src/core/compiler/backend/railshot/amd64/control.go
+++ b/src/core/compiler/backend/railshot/amd64/control.go
@@ -706,10 +706,10 @@ func exceptionPayloadMachineType(m *wasm.Module, typ wasm.ValType) (machineType,
 	if wasm.EqualValType(typ, wasm.I32) || wasm.EqualValType(typ, wasm.I64) || wasm.EqualValType(typ, wasm.F32) || wasm.EqualValType(typ, wasm.F64) {
 		return mtOf(typ), true
 	}
-	if typ.Kind != wasm.ValRef || typ.Ref.Nullable || typ.Ref.Exact || typ.Ref.Heap.Kind != wasm.HeapTypeIndex {
+	if typ.Kind() != wasm.ValRef || typ.Ref().Nullable() || typ.Ref().Exact() || typ.Ref().Heap().Kind() != wasm.HeapTypeIndex {
 		return mtNone, false
 	}
-	if ft, ok := m.ResolvedTypeFunc(typ.Ref.Heap.Type.Index); !ok || ft == nil {
+	if ft, ok := m.ResolvedTypeFunc(typ.Ref().Heap().Type().Index); !ok || ft == nil {
 		return mtNone, false
 	}
 	return mtI64, true

--- a/src/core/compiler/backend/railshot/amd64/eh_rootmap.go
+++ b/src/core/compiler/backend/railshot/amd64/eh_rootmap.go
@@ -10,18 +10,18 @@ import (
 )
 
 func exceptionPayloadRootKind(m *wasm.Module, typ wasm.ValType) (nativeabi.RootKind, bool) {
-	if typ.Kind != wasm.ValRef {
+	if typ.Kind() != wasm.ValRef {
 		return 0, false
 	}
-	heap := typ.Ref.Heap
-	switch heap.Kind {
+	heap := typ.Ref().Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		if heap.Abs == wasm.HeapFunc || heap.Abs == wasm.HeapNoFunc {
+		if heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc {
 			return nativeabi.RootFuncRef, true
 		}
 		return nativeabi.RootGCRef, true
 	case wasm.HeapTypeIndex:
-		if ft, ok := m.ResolvedTypeFunc(heap.Type.Index); ok && ft != nil {
+		if ft, ok := m.ResolvedTypeFunc(heap.Type().Index); ok && ft != nil {
 			return nativeabi.RootFuncRef, true
 		}
 		return nativeabi.RootGCRef, true

--- a/src/core/compiler/backend/railshot/amd64/gc_array.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_array.go
@@ -41,8 +41,8 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("amd64: array.new type %d is unavailable", typeIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -62,7 +62,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		field, ok := stagedArrayType(f.m, typeIndex)
-		if !ok || field.Storage.Val.Kind != wasm.ValRef {
+		if !ok || field.Storage().Val().Kind() != wasm.ValRef {
 			return fmt.Errorf("amd64: array.new_elem type %d is not a reference array", typeIndex)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -86,7 +86,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("amd64: array.new_data type %d is unavailable", typeIndex)
 		}
-		if field.Storage.Val.Kind == wasm.ValRef || (field.Storage.Packed && field.Storage.Pack != wasm.PackI8 && field.Storage.Pack != wasm.PackI16) {
+		if field.Storage().Val().Kind() == wasm.ValRef || (field.Storage().Packed() && field.Storage().Pack() != wasm.PackI8 && field.Storage().Pack() != wasm.PackI16) {
 			return fmt.Errorf("amd64: array.new_data type %d has unsupported storage", typeIndex)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -110,8 +110,8 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("amd64: array.new_fixed type %d is unavailable", typeIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		valueSlots := funcTypeSlots([]wasm.ValType{valueType})
@@ -167,9 +167,9 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return fmt.Errorf("amd64: array.get type %d is unavailable", typeIndex)
 		}
 		helper := uint32(gcArrayGet)
-		resultType := field.Storage.Val
+		resultType := field.Storage().Val()
 		if sub == 12 || sub == 13 {
-			if !field.Storage.Packed {
+			if !field.Storage().Packed() {
 				return fmt.Errorf("amd64: array.get_s/u type %d is not packed", typeIndex)
 			}
 			resultType = wasm.I32
@@ -178,13 +178,13 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			} else {
 				helper = gcArrayGetU
 			}
-		} else if field.Storage.Packed {
+		} else if field.Storage().Packed() {
 			return fmt.Errorf("amd64: plain array.get cannot access packed type %d", typeIndex)
 		}
 		if f.emitDirectGCArrayGet(typeIndex, helper) {
 			return nil
 		}
-		if sub == 11 && field.Storage.Val.Kind == wasm.ValRef && gcFrameRefType(f.m, field.Storage.Val) {
+		if sub == 11 && field.Storage().Val().Kind() == wasm.ValRef && gcFrameRefType(f.m, field.Storage().Val()) {
 			if target, ok := nativeGCFlatType(f.m, typeIndex); ok && target.Final {
 				return f.emitNativeFinalArrayRefGet(typeIndex)
 			}
@@ -201,17 +201,17 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("amd64: array.set type %d is unavailable", typeIndex)
 		}
-		if field.Mut != wasm.Var {
+		if field.Mut() != wasm.Var {
 			return fmt.Errorf("amd64: array.set type %d is immutable", typeIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		if f.emitDirectGCArraySet(typeIndex) {
 			return nil
 		}
-		if target, found := nativeGCFlatType(f.m, typeIndex); found && target.Final && field.Storage.Val.Kind == wasm.ValRef && field.Storage.Val.Ref.Heap.Kind == wasm.HeapAbs && (field.Storage.Val.Ref.Heap.Abs == wasm.HeapAny || field.Storage.Val.Ref.Heap.Abs == wasm.HeapEq) {
+		if target, found := nativeGCFlatType(f.m, typeIndex); found && target.Final && field.Storage().Val().Kind() == wasm.ValRef && field.Storage().Val().Ref().Heap().Kind() == wasm.HeapAbs && (field.Storage().Val().Ref().Heap().Abs() == wasm.HeapAny || field.Storage().Val().Ref().Heap().Abs() == wasm.HeapEq) {
 			return f.emitNativeCardSafeArrayRefSet(typeIndex, valueType)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -229,11 +229,11 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		field, ok := stagedArrayType(f.m, typeIndex)
-		if !ok || field.Mut != wasm.Var {
+		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("amd64: array.fill type %d is unavailable or immutable", typeIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -249,7 +249,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		field, ok := stagedArrayType(f.m, typeIndex)
-		if !ok || field.Mut != wasm.Var || (!field.Storage.Packed && field.Storage.Val.Kind == wasm.ValRef) {
+		if !ok || field.Mut() != wasm.Var || (!field.Storage().Packed() && field.Storage().Val().Kind() == wasm.ValRef) {
 			return fmt.Errorf("amd64: array.init_data type %d is unavailable", typeIndex)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -266,7 +266,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		field, ok := stagedArrayType(f.m, typeIndex)
-		if !ok || field.Mut != wasm.Var || field.Storage.Val.Kind != wasm.ValRef {
+		if !ok || field.Mut() != wasm.Var || field.Storage().Val().Kind() != wasm.ValRef {
 			return fmt.Errorf("amd64: array.init_elem type %d is unavailable", typeIndex)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -283,7 +283,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		dstField, ok := stagedArrayType(f.m, dstType)
-		if !ok || dstField.Mut != wasm.Var {
+		if !ok || dstField.Mut() != wasm.Var {
 			return fmt.Errorf("amd64: array.copy destination type %d is unavailable or immutable", dstType)
 		}
 		if _, ok := stagedArrayType(f.m, srcType); !ok {

--- a/src/core/compiler/backend/railshot/amd64/gc_direct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_direct.go
@@ -40,21 +40,21 @@ func nativeGCStructAllocLayout(m *wasm.Module, typeIndex uint32) (fields []nativ
 	maxAlign := uint32(1)
 	pointerFree = true
 	for _, field := range st.Comp.Fields {
-		align, size, valid := nativeGCStorageLayout(m, typeIndex, field.Storage)
-		if !valid || field.Storage.Packed || align == 0 || off > math.MaxUint32-(align-1) {
+		align, size, valid := nativeGCStorageLayout(m, typeIndex, field.Storage())
+		if !valid || field.Storage().Packed() || align == 0 || off > math.MaxUint32-(align-1) {
 			return nil, 0, 0, false, false
 		}
 		off = (off + align - 1) &^ (align - 1)
 		entry := nativeGCStructAllocField{offset: off, size: size, slot: slot}
-		if field.Storage.Val.Kind == wasm.ValRef {
-			heap := field.Storage.Val.Ref.Heap
-			if heap.Kind != wasm.HeapAbs || (heap.Abs != wasm.HeapAny && heap.Abs != wasm.HeapEq) || size != 4 {
+		if field.Storage().Val().Kind() == wasm.ValRef {
+			heap := field.Storage().Val().Ref().Heap()
+			if heap.Kind() != wasm.HeapAbs || (heap.Abs() != wasm.HeapAny && heap.Abs() != wasm.HeapEq) || size != 4 {
 				return nil, 0, 0, false, false
 			}
 			entry.ref = true
-			entry.nullable = field.Storage.Val.Ref.Nullable
+			entry.nullable = field.Storage().Val().Ref().Nullable()
 			pointerFree = false
-		} else if field.Storage.Val.Kind != wasm.ValNum && field.Storage.Val.Kind != wasm.ValVec {
+		} else if field.Storage().Val().Kind() != wasm.ValNum && field.Storage().Val().Kind() != wasm.ValVec {
 			return nil, 0, 0, false, false
 		}
 		fields = append(fields, entry)
@@ -89,8 +89,8 @@ func nativeGCStructAllocLayout(m *wasm.Module, typeIndex uint32) (fields []nativ
 }
 
 func directGCScalarStorage(st wasm.StorageType) (directGCScalar, bool) {
-	if st.Packed {
-		switch st.Pack {
+	if st.Packed() {
+		switch st.Pack() {
 		case wasm.PackI8:
 			return directGCScalar{size: 1, typ: mtI32}, true
 		case wasm.PackI16:
@@ -99,10 +99,10 @@ func directGCScalarStorage(st wasm.StorageType) (directGCScalar, bool) {
 			return directGCScalar{}, false
 		}
 	}
-	if st.Val.Kind != wasm.ValNum {
+	if st.Val().Kind() != wasm.ValNum {
 		return directGCScalar{}, false
 	}
-	switch st.Val.Num {
+	switch st.Val().Num() {
 	case wasm.NumI32:
 		return directGCScalar{size: 4, typ: mtI32}, true
 	case wasm.NumI64:
@@ -117,8 +117,8 @@ func directGCScalarStorage(st wasm.StorageType) (directGCScalar, bool) {
 }
 
 func nativeGCStorageLayout(m *wasm.Module, containingType uint32, st wasm.StorageType) (align, size uint32, ok bool) {
-	if st.Packed {
-		switch st.Pack {
+	if st.Packed() {
+		switch st.Pack() {
 		case wasm.PackI8:
 			return 1, 1, true
 		case wasm.PackI16:
@@ -127,9 +127,9 @@ func nativeGCStorageLayout(m *wasm.Module, containingType uint32, st wasm.Storag
 			return 0, 0, false
 		}
 	}
-	switch st.Val.Kind {
+	switch st.Val().Kind() {
 	case wasm.ValNum:
-		switch st.Val.Num {
+		switch st.Val().Num() {
 		case wasm.NumI32, wasm.NumF32:
 			return 4, 4, true
 		case wasm.NumI64, wasm.NumF64:
@@ -138,24 +138,25 @@ func nativeGCStorageLayout(m *wasm.Module, containingType uint32, st wasm.Storag
 	case wasm.ValVec:
 		return 16, 16, true
 	case wasm.ValRef:
-		h := st.Val.Ref.Heap
-		if h.Kind == wasm.HeapAbs {
-			switch h.Abs {
+		h := st.Val().Ref().Heap()
+		if h.Kind() == wasm.HeapAbs {
+			switch h.Abs() {
 			case wasm.HeapFunc, wasm.HeapNoFunc, wasm.HeapExtern, wasm.HeapNoExtern:
 				return 8, 8, true
 			default:
 				return 4, 4, true
 			}
 		}
-		if h.Kind == wasm.HeapDefType && h.Def != nil {
-			if int(h.Def.Index) < len(h.Def.Rec.SubTypes) && h.Def.Rec.SubTypes[h.Def.Index].Comp.Kind == wasm.CompFunc {
+		if h.Kind() == wasm.HeapDefType {
+			kind, valid := h.DefCompKind()
+			if valid && kind == wasm.CompFunc {
 				return 8, 8, true
 			}
 			return 4, 4, true
 		}
-		if h.Kind == wasm.HeapTypeIndex {
-			target := h.Type.Index
-			if h.Type.Rec {
+		if h.Kind() == wasm.HeapTypeIndex {
+			target := h.Type().Index
+			if h.Type().Rec {
 				base, _, found := nativeGCRecGroup(m, containingType)
 				if !found {
 					return 0, 0, false
@@ -200,28 +201,28 @@ func nativeGCRecGroup(m *wasm.Module, index uint32) (base, length uint32, ok boo
 }
 
 func nativeGCCollectorRefStorage(m *wasm.Module, containingType uint32, st wasm.StorageType) bool {
-	if st.Packed || st.Val.Kind != wasm.ValRef {
+	if st.Packed() || st.Val().Kind() != wasm.ValRef {
 		return false
 	}
-	heap := st.Val.Ref.Heap
-	if heap.Kind == wasm.HeapAbs {
-		switch heap.Abs {
+	heap := st.Val().Ref().Heap()
+	if heap.Kind() == wasm.HeapAbs {
+		switch heap.Abs() {
 		case wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 			return true
 		default:
 			return false
 		}
 	}
-	if heap.Kind == wasm.HeapDefType && heap.Def != nil {
-		if int(heap.Def.Index) >= len(heap.Def.Rec.SubTypes) {
+	if heap.Kind() == wasm.HeapDefType {
+		kind, valid := heap.DefCompKind()
+		if !valid {
 			return false
 		}
-		kind := heap.Def.Rec.SubTypes[heap.Def.Index].Comp.Kind
 		return kind == wasm.CompStruct || kind == wasm.CompArray
 	}
-	if heap.Kind == wasm.HeapTypeIndex {
-		target := heap.Type.Index
-		if heap.Type.Rec {
+	if heap.Kind() == wasm.HeapTypeIndex {
+		target := heap.Type().Index
+		if heap.Type().Rec {
 			base, _, found := nativeGCRecGroup(m, containingType)
 			if !found {
 				return false
@@ -241,7 +242,7 @@ func nativeGCStructFieldLayout(m *wasm.Module, typeIndex, fieldIndex uint32) (pa
 	}
 	var off uint32
 	for i, field := range st.Comp.Fields {
-		align, fieldSize, valid := nativeGCStorageLayout(m, typeIndex, field.Storage)
+		align, fieldSize, valid := nativeGCStorageLayout(m, typeIndex, field.Storage())
 		if !valid || align == 0 || off > math.MaxUint32-(align-1) {
 			return 0, 0, false, false
 		}
@@ -262,13 +263,13 @@ func directGCStructLayout(m *wasm.Module, typeIndex, fieldIndex uint32) (payload
 	if !found || st.Comp.Kind != wasm.CompStruct || fieldIndex >= uint32(len(st.Comp.Fields)) {
 		return 0, directGCScalar{}, false, false
 	}
-	scalar, ok = directGCScalarStorage(st.Comp.Fields[fieldIndex].Storage)
+	scalar, ok = directGCScalarStorage(st.Comp.Fields[fieldIndex].Storage())
 	if !ok {
 		return 0, directGCScalar{}, false, false
 	}
 	var off uint32
 	for i, field := range st.Comp.Fields {
-		align, size, valid := nativeGCStorageLayout(m, typeIndex, field.Storage)
+		align, size, valid := nativeGCStorageLayout(m, typeIndex, field.Storage())
 		if !valid || align == 0 || off > math.MaxUint32-(align-1) {
 			return 0, directGCScalar{}, false, false
 		}
@@ -289,7 +290,7 @@ func directGCArrayLayout(m *wasm.Module, typeIndex uint32) (directGCScalar, bool
 	if !found || st.Comp.Kind != wasm.CompArray {
 		return directGCScalar{}, false, false
 	}
-	scalar, ok := directGCScalarStorage(st.Comp.Array.Storage)
+	scalar, ok := directGCScalarStorage(st.Comp.Array.Storage())
 	return scalar, st.Final, ok
 }
 

--- a/src/core/compiler/backend/railshot/amd64/gc_struct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_struct.go
@@ -81,8 +81,8 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		}
 		params := make([]wasm.ValType, 0, fieldN+1)
 		for _, field := range st.Comp.Fields {
-			valueType := field.Storage.Val
-			if field.Storage.Packed {
+			valueType := field.Storage().Val()
+			if field.Storage().Packed() {
 				valueType = wasm.I32
 			}
 			params = append(params, valueType)
@@ -131,9 +131,9 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		}
 		f.observeGCStructGet(typeIndex, fieldIndex)
 		helper := uint32(gcStructGet)
-		resultType := field.Storage.Val
+		resultType := field.Storage().Val()
 		if sub == 3 || sub == 4 {
-			if !field.Storage.Packed {
+			if !field.Storage().Packed() {
 				return fmt.Errorf("amd64: struct.get_s/u type %d field %d is not packed", typeIndex, fieldIndex)
 			}
 			resultType = wasm.I32
@@ -142,7 +142,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 			} else {
 				helper = gcStructGetU
 			}
-		} else if field.Storage.Packed {
+		} else if field.Storage().Packed() {
 			return fmt.Errorf("amd64: plain struct.get cannot access packed type %d field %d", typeIndex, fieldIndex)
 		}
 		if f.emitDirectGCStructGet(typeIndex, fieldIndex, helper) {
@@ -165,21 +165,21 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("amd64: struct.set type %d field %d is unavailable", typeIndex, fieldIndex)
 		}
-		if field.Mut != wasm.Var {
+		if field.Mut() != wasm.Var {
 			return fmt.Errorf("amd64: struct.set type %d field %d is immutable", typeIndex, fieldIndex)
 		}
 		valueRoot := f.s.back()
 		f.observeGCStructSet(baseOfValentBlock(valueRoot).prev, typeIndex, fieldIndex)
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		if f.emitDirectGCStructSet(typeIndex, fieldIndex) {
 			return nil
 		}
-		if st, found := nativeGCFlatType(f.m, typeIndex); found && st.Final && field.Storage.Val.Kind == wasm.ValRef && field.Storage.Val.Ref.Heap.Kind == wasm.HeapAbs && (field.Storage.Val.Ref.Heap.Abs == wasm.HeapAny || field.Storage.Val.Ref.Heap.Abs == wasm.HeapEq) {
+		if st, found := nativeGCFlatType(f.m, typeIndex); found && st.Final && field.Storage().Val().Kind() == wasm.ValRef && field.Storage().Val().Ref().Heap().Kind() == wasm.HeapAbs && (field.Storage().Val().Ref().Heap().Abs() == wasm.HeapAny || field.Storage().Val().Ref().Heap().Abs() == wasm.HeapEq) {
 			if off, size, final, layoutOK := nativeGCStructFieldLayout(f.m, typeIndex, fieldIndex); layoutOK && final && size == 4 {
-				return f.emitNativeBarrierSafeStructRefSet(typeIndex, fieldIndex, off, field.Storage.Val)
+				return f.emitNativeBarrierSafeStructRefSet(typeIndex, fieldIndex, off, field.Storage().Val())
 			}
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -416,26 +416,26 @@ func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.
 		return false, err
 	}
 	field, ok := stagedStructField(f.m, accessType, fieldIndex)
-	if !ok || accessType != typeIndex || (sub == 2) == field.Storage.Packed {
+	if !ok || accessType != typeIndex || (sub == 2) == field.Storage().Packed() {
 		_ = r.JumpTo(start)
 		return false, nil
 	}
-	if _, direct := directGCScalarStorage(field.Storage); direct {
+	if _, direct := directGCScalarStorage(field.Storage()); direct {
 		// Let the shared native final-cast stub and existing direct scalar access
 		// run independently; this removes the Go transition at a measured code-size cost.
 		_ = r.JumpTo(start)
 		return false, nil
 	}
 	f.observeGCStructGet(typeIndex, fieldIndex)
-	if nativeGCCollectorRefStorage(f.m, typeIndex, field.Storage) {
+	if nativeGCCollectorRefStorage(f.m, typeIndex, field.Storage()) {
 		off, size, final, layoutOK := nativeGCStructFieldLayout(f.m, typeIndex, fieldIndex)
 		if layoutOK && final && size == 4 {
 			f.stats.peep("final-cast-struct-get-fuse")
 			return true, f.emitNativeFinalCastStructRefGet(typeIndex, off, nullable)
 		}
 	}
-	resultType := field.Storage.Val
-	if field.Storage.Packed {
+	resultType := field.Storage().Val()
+	if field.Storage().Packed() {
 		resultType = wasm.I32
 	}
 	f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -736,26 +736,26 @@ func (f *fn) recordGCFrameSafepoint(paramCount int) uint32 {
 }
 
 func gcFrameRefType(m *wasm.Module, t wasm.ValType) bool {
-	if t.Kind != wasm.ValRef {
+	if t.Kind() != wasm.ValRef {
 		return false
 	}
-	switch t.Ref.Heap.Kind {
+	heap := t.Ref().Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		switch t.Ref.Heap.Abs {
+		switch heap.Abs() {
 		case wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 			return true
 		default:
 			return false
 		}
 	case wasm.HeapDefType:
-		def := t.Ref.Heap.Def
-		if def == nil || def.Index >= uint32(len(def.Rec.SubTypes)) {
+		kind, valid := heap.DefCompKind()
+		if !valid {
 			return true
 		}
-		kind := def.Rec.SubTypes[def.Index].Comp.Kind
 		return kind == wasm.CompStruct || kind == wasm.CompArray
 	case wasm.HeapTypeIndex:
-		index := t.Ref.Heap.Type.Index
+		index := heap.Type().Index
 		for _, group := range m.Types {
 			if index < uint32(len(group.SubTypes)) {
 				kind := group.SubTypes[index].Comp.Kind

--- a/src/core/compiler/backend/railshot/amd64/globals.go
+++ b/src/core/compiler/backend/railshot/amd64/globals.go
@@ -79,7 +79,7 @@ func (f *fn) globalGet(r *wasm.Reader) error {
 	}
 	cell := f.globalCellPtr(x) // cached, pinned — read the value into a separate reg
 	switch {
-	case wasm.EqualValType(gtv, wasm.I64) || gtv.Kind == wasm.ValRef:
+	case wasm.EqualValType(gtv, wasm.I64) || gtv.Kind() == wasm.ValRef:
 		dst := f.allocReg(0)
 		f.a.Load64(dst, cell, 0)
 		f.pushReg(dst, mtI64)
@@ -193,7 +193,7 @@ func (f *fn) globalSet(r *wasm.Reader) error {
 	f.pinned = f.pinned.add(rg)
 	cell := f.globalCellPtr(x) // cached, pinned (rg excluded)
 	switch {
-	case wasm.EqualValType(gtv, wasm.I64) || gtv.Kind == wasm.ValRef:
+	case wasm.EqualValType(gtv, wasm.I64) || gtv.Kind() == wasm.ValRef:
 		f.a.Store64(cell, 0, rg)
 	case wasm.EqualValType(gtv, wasm.I32):
 		f.a.Store32(cell, 0, rg)

--- a/src/core/compiler/backend/railshot/amd64/table.go
+++ b/src/core/compiler/backend/railshot/amd64/table.go
@@ -55,17 +55,18 @@ func (f *fn) tableEntryAddr(dst, tbl Reg) {
 // descriptors remain 32 bytes.
 func (f *fn) tableIsExternref(tableIdx uint32) bool {
 	tt, ok := f.m.TableType(tableIdx)
-	if !ok || tt.Ref.Exact {
+	if !ok || tt.Ref.Exact() {
 		return ok && wasm.EqualValType(wasm.RefVal(tt.Ref), wasm.ExternRef)
 	}
-	if tt.Ref.Heap.Kind == wasm.HeapTypeIndex {
-		sub, ok := stagedStructType(f.m, tt.Ref.Heap.Type.Index)
+	heap := tt.Ref.Heap()
+	if heap.Kind() == wasm.HeapTypeIndex {
+		sub, ok := stagedStructType(f.m, heap.Type().Index)
 		return ok && (sub.Comp.Kind == wasm.CompStruct || sub.Comp.Kind == wasm.CompArray)
 	}
-	if tt.Ref.Heap.Kind != wasm.HeapAbs {
+	if heap.Kind() != wasm.HeapAbs {
 		return false
 	}
-	switch tt.Ref.Heap.Abs {
+	switch heap.Abs() {
 	case wasm.HeapExtern, wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 		return true
 	default:
@@ -75,17 +76,18 @@ func (f *fn) tableIsExternref(tableIdx uint32) bool {
 
 func (f *fn) tableIsGCObjectRef(tableIdx uint32) bool {
 	tt, ok := f.m.TableType(tableIdx)
-	if !ok || tt.Ref.Exact {
+	if !ok || tt.Ref.Exact() {
 		return false
 	}
-	if tt.Ref.Heap.Kind == wasm.HeapTypeIndex {
-		sub, ok := stagedStructType(f.m, tt.Ref.Heap.Type.Index)
+	heap := tt.Ref.Heap()
+	if heap.Kind() == wasm.HeapTypeIndex {
+		sub, ok := stagedStructType(f.m, heap.Type().Index)
 		return ok && (sub.Comp.Kind == wasm.CompStruct || sub.Comp.Kind == wasm.CompArray)
 	}
-	if tt.Ref.Heap.Kind != wasm.HeapAbs {
+	if heap.Kind() != wasm.HeapAbs {
 		return false
 	}
-	switch tt.Ref.Heap.Abs {
+	switch heap.Abs() {
 	case wasm.HeapAny, wasm.HeapEq, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 		return true
 	default:

--- a/src/core/compiler/backend/railshot/amd64/typed_ref_control_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/typed_ref_control_exec_test.go
@@ -14,7 +14,7 @@ import (
 func typedRefControlModule(body []byte, result wasm.ValType) *wasm.Module {
 	indexedNullable := wasm.RefVal(wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: 0}), false))
 	returnType := result
-	if result.Kind == wasm.ValRef {
+	if result.Kind() == wasm.ValRef {
 		returnType = wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: 0}), false))
 	}
 	return &wasm.Module{

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -2272,7 +2272,7 @@ func mtOf(t wasm.ValType) machineType {
 		return mtF64
 	case wasm.EqualValType(t, wasm.V128):
 		return mtV128
-	case t.Kind == wasm.ValRef:
+	case t.Kind() == wasm.ValRef:
 		return mtI64
 	}
 	return mtNone

--- a/src/core/compiler/backend/railshot/arm64/control.go
+++ b/src/core/compiler/backend/railshot/arm64/control.go
@@ -989,10 +989,10 @@ func exceptionPayloadMachineType(m *wasm.Module, typ wasm.ValType) (machineType,
 	if wasm.EqualValType(typ, wasm.I32) || wasm.EqualValType(typ, wasm.I64) || wasm.EqualValType(typ, wasm.F32) || wasm.EqualValType(typ, wasm.F64) {
 		return mtOf(typ), true
 	}
-	if typ.Kind != wasm.ValRef || typ.Ref.Nullable || typ.Ref.Exact || typ.Ref.Heap.Kind != wasm.HeapTypeIndex {
+	if typ.Kind() != wasm.ValRef || typ.Ref().Nullable() || typ.Ref().Exact() || typ.Ref().Heap().Kind() != wasm.HeapTypeIndex {
 		return mtNone, false
 	}
-	if ft, ok := m.ResolvedTypeFunc(typ.Ref.Heap.Type.Index); !ok || ft == nil {
+	if ft, ok := m.ResolvedTypeFunc(typ.Ref().Heap().Type().Index); !ok || ft == nil {
 		return mtNone, false
 	}
 	return mtI64, true

--- a/src/core/compiler/backend/railshot/arm64/eh_rootmap.go
+++ b/src/core/compiler/backend/railshot/arm64/eh_rootmap.go
@@ -10,18 +10,18 @@ import (
 )
 
 func exceptionPayloadRootKind(m *wasm.Module, typ wasm.ValType) (nativeabi.RootKind, bool) {
-	if typ.Kind != wasm.ValRef {
+	if typ.Kind() != wasm.ValRef {
 		return 0, false
 	}
-	heap := typ.Ref.Heap
-	switch heap.Kind {
+	heap := typ.Ref().Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		if heap.Abs == wasm.HeapFunc || heap.Abs == wasm.HeapNoFunc {
+		if heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc {
 			return nativeabi.RootFuncRef, true
 		}
 		return nativeabi.RootGCRef, true
 	case wasm.HeapTypeIndex:
-		if ft, ok := m.ResolvedTypeFunc(heap.Type.Index); ok && ft != nil {
+		if ft, ok := m.ResolvedTypeFunc(heap.Type().Index); ok && ft != nil {
 			return nativeabi.RootFuncRef, true
 		}
 		return nativeabi.RootGCRef, true

--- a/src/core/compiler/backend/railshot/arm64/gc.go
+++ b/src/core/compiler/backend/railshot/arm64/gc.go
@@ -225,8 +225,8 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		}
 		params := make([]wasm.ValType, 0, len(st.Comp.Fields)+1)
 		for _, field := range st.Comp.Fields {
-			valueType := field.Storage.Val
-			if field.Storage.Packed {
+			valueType := field.Storage().Val()
+			if field.Storage().Packed() {
 				valueType = wasm.I32
 			}
 			params = append(params, valueType)
@@ -259,9 +259,9 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("arm64: struct.get type %d field %d is unavailable", typeIndex, fieldIndex)
 		}
-		helper, resultType := uint32(gcStructGet), field.Storage.Val
+		helper, resultType := uint32(gcStructGet), field.Storage().Val()
 		if sub == 3 || sub == 4 {
-			if !field.Storage.Packed {
+			if !field.Storage().Packed() {
 				return fmt.Errorf("arm64: struct.get_s/u field is not packed")
 			}
 			resultType = wasm.I32
@@ -270,7 +270,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 			} else {
 				helper = gcStructGetU
 			}
-		} else if field.Storage.Packed {
+		} else if field.Storage().Packed() {
 			return fmt.Errorf("arm64: plain struct.get cannot access a packed field")
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -287,11 +287,11 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 			return err
 		}
 		field, ok := stagedStructField(f.m, typeIndex, fieldIndex)
-		if !ok || field.Mut != wasm.Var {
+		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: struct.set type %d field %d is unavailable or immutable", typeIndex, fieldIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -317,8 +317,8 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("arm64: array.new type %d is unavailable", typeIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -348,8 +348,8 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("arm64: array.new_fixed type %d is unavailable", typeIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		valueSlots := funcTypeSlots([]wasm.ValType{valueType})
@@ -384,11 +384,11 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		}
 		helper := uint32(gcArrayAllocData)
 		if sub == 10 {
-			if field.Storage.Val.Kind != wasm.ValRef {
+			if field.Storage().Val().Kind() != wasm.ValRef {
 				return fmt.Errorf("arm64: array.new_elem type %d is not a reference array", typeIndex)
 			}
 			helper = gcArrayAllocElem
-		} else if field.Storage.Val.Kind == wasm.ValRef {
+		} else if field.Storage().Val().Kind() == wasm.ValRef {
 			return fmt.Errorf("arm64: array.new_data type %d has reference storage", typeIndex)
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -404,9 +404,9 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 		if !ok {
 			return fmt.Errorf("arm64: array.get type %d is unavailable", typeIndex)
 		}
-		helper, resultType := uint32(gcArrayGet), field.Storage.Val
+		helper, resultType := uint32(gcArrayGet), field.Storage().Val()
 		if sub == 12 || sub == 13 {
-			if !field.Storage.Packed {
+			if !field.Storage().Packed() {
 				return fmt.Errorf("arm64: array.get_s/u type %d is not packed", typeIndex)
 			}
 			resultType = wasm.I32
@@ -415,7 +415,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			} else {
 				helper = gcArrayGetU
 			}
-		} else if field.Storage.Packed {
+		} else if field.Storage().Packed() {
 			return fmt.Errorf("arm64: plain array.get cannot access packed storage")
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -427,11 +427,11 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		field, ok := stagedArrayType(f.m, typeIndex)
-		if !ok || field.Mut != wasm.Var {
+		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: array.set type %d is unavailable or immutable", typeIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -446,11 +446,11 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		field, ok := stagedArrayType(f.m, typeIndex)
-		if !ok || field.Mut != wasm.Var {
+		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: array.fill type %d is unavailable or immutable", typeIndex)
 		}
-		valueType := field.Storage.Val
-		if field.Storage.Packed {
+		valueType := field.Storage().Val()
+		if field.Storage().Packed() {
 			valueType = wasm.I32
 		}
 		f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -466,7 +466,7 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		dstField, ok := stagedArrayType(f.m, dstType)
-		if !ok || dstField.Mut != wasm.Var {
+		if !ok || dstField.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: array.copy destination is unavailable")
 		}
 		if _, ok := stagedArrayType(f.m, srcType); !ok {
@@ -487,13 +487,13 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 			return err
 		}
 		field, ok := stagedArrayType(f.m, typeIndex)
-		if !ok || field.Mut != wasm.Var {
+		if !ok || field.Mut() != wasm.Var {
 			return fmt.Errorf("arm64: array.init type %d is unavailable", typeIndex)
 		}
 		helper := uint32(gcArrayInitData)
 		if sub == 19 {
 			helper = gcArrayInitElem
-			if field.Storage.Val.Kind != wasm.ValRef {
+			if field.Storage().Val().Kind() != wasm.ValRef {
 				return fmt.Errorf("arm64: array.init_elem requires reference storage")
 			}
 		}
@@ -537,12 +537,12 @@ func (f *fn) tryFuseFinalCastStructGet(typeIndex uint32, nullable bool, r *wasm.
 		return false, err
 	}
 	field, ok := stagedStructField(f.m, accessType, fieldIndex)
-	if !ok || accessType != typeIndex || (sub == 2) == field.Storage.Packed {
+	if !ok || accessType != typeIndex || (sub == 2) == field.Storage().Packed() {
 		_ = r.JumpTo(start)
 		return false, nil
 	}
-	resultType := field.Storage.Val
-	if field.Storage.Packed {
+	resultType := field.Storage().Val()
+	if field.Storage().Packed() {
 		resultType = wasm.I32
 	}
 	f.pushValue(storage{kind: stConst, typ: mtI32, cval: int64(typeIndex)})
@@ -867,26 +867,26 @@ func (f *fn) recordGCFrameSafepoint(paramCount int) uint32 {
 }
 
 func arm64GCFrameRefType(m *wasm.Module, t wasm.ValType) bool {
-	if t.Kind != wasm.ValRef {
+	if t.Kind() != wasm.ValRef {
 		return false
 	}
-	switch t.Ref.Heap.Kind {
+	heap := t.Ref().Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		switch t.Ref.Heap.Abs {
+		switch heap.Abs() {
 		case wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 			return true
 		default:
 			return false
 		}
 	case wasm.HeapDefType:
-		def := t.Ref.Heap.Def
-		if def == nil || def.Index >= uint32(len(def.Rec.SubTypes)) {
+		kind, valid := heap.DefCompKind()
+		if !valid {
 			return true
 		}
-		kind := def.Rec.SubTypes[def.Index].Comp.Kind
 		return kind == wasm.CompStruct || kind == wasm.CompArray
 	case wasm.HeapTypeIndex:
-		index := t.Ref.Heap.Type.Index
+		index := heap.Type().Index
 		for _, group := range m.Types {
 			if index < uint32(len(group.SubTypes)) {
 				kind := group.SubTypes[index].Comp.Kind

--- a/src/core/compiler/backend/railshot/arm64/globals.go
+++ b/src/core/compiler/backend/railshot/arm64/globals.go
@@ -80,7 +80,7 @@ func (f *fn) globalGet(r *wasm.Reader) error {
 	}
 	cell := f.globalCellPtr(x) // cached, pinned — read the value into a separate reg
 	switch {
-	case gtv.Kind == wasm.ValRef:
+	case gtv.Kind() == wasm.ValRef:
 		dst := f.allocReg(0)
 		f.ld64(dst, cell, 0)
 		f.pushReg(dst, mtI64).st.gcRoot = f.tracksGCFrameRoots() && arm64GCFrameRefType(f.m, gtv)
@@ -208,7 +208,7 @@ func (f *fn) globalSet(r *wasm.Reader) error {
 	f.pinned = f.pinned.add(rg)
 	cell := f.globalCellPtr(x) // cached, pinned (rg excluded)
 	switch {
-	case wasm.EqualValType(gtv, wasm.I64) || gtv.Kind == wasm.ValRef:
+	case wasm.EqualValType(gtv, wasm.I64) || gtv.Kind() == wasm.ValRef:
 		f.st64(cell, 0, rg)
 	case wasm.EqualValType(gtv, wasm.I32):
 		f.st32(cell, 0, rg)

--- a/src/core/compiler/backend/railshot/arm64/table.go
+++ b/src/core/compiler/backend/railshot/arm64/table.go
@@ -71,17 +71,17 @@ func (f *fn) tableEntryAddr(dst, tbl Reg) {
 // 8-byte compact-reference table. Funcref descriptors remain 32 bytes.
 func (f *fn) tableIsExternref(tableIdx uint32) bool {
 	tt, ok := f.m.TableType(tableIdx)
-	if !ok || tt.Ref.Exact {
+	if !ok || tt.Ref.Exact() {
 		return ok && wasm.EqualValType(wasm.RefVal(tt.Ref), wasm.ExternRef)
 	}
-	if tt.Ref.Heap.Kind == wasm.HeapTypeIndex {
-		sub, ok := stagedStructType(f.m, tt.Ref.Heap.Type.Index)
+	if tt.Ref.Heap().Kind() == wasm.HeapTypeIndex {
+		sub, ok := stagedStructType(f.m, tt.Ref.Heap().Type().Index)
 		return ok && (sub.Comp.Kind == wasm.CompStruct || sub.Comp.Kind == wasm.CompArray)
 	}
-	if tt.Ref.Heap.Kind != wasm.HeapAbs {
+	if tt.Ref.Heap().Kind() != wasm.HeapAbs {
 		return false
 	}
-	switch tt.Ref.Heap.Abs {
+	switch tt.Ref.Heap().Abs() {
 	case wasm.HeapExtern, wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 		return true
 	default:
@@ -96,17 +96,17 @@ func (f *fn) tableIsGCFrameRef(tableIdx uint32) bool {
 
 func (f *fn) tableIsGCObjectRef(tableIdx uint32) bool {
 	tt, ok := f.m.TableType(tableIdx)
-	if !ok || tt.Ref.Exact {
+	if !ok || tt.Ref.Exact() {
 		return false
 	}
-	if tt.Ref.Heap.Kind == wasm.HeapTypeIndex {
-		sub, ok := stagedStructType(f.m, tt.Ref.Heap.Type.Index)
+	if tt.Ref.Heap().Kind() == wasm.HeapTypeIndex {
+		sub, ok := stagedStructType(f.m, tt.Ref.Heap().Type().Index)
 		return ok && (sub.Comp.Kind == wasm.CompStruct || sub.Comp.Kind == wasm.CompArray)
 	}
-	if tt.Ref.Heap.Kind != wasm.HeapAbs {
+	if tt.Ref.Heap().Kind() != wasm.HeapAbs {
 		return false
 	}
-	switch tt.Ref.Heap.Abs {
+	switch tt.Ref.Heap().Abs() {
 	case wasm.HeapAny, wasm.HeapEq, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 		return true
 	default:

--- a/src/core/compiler/codegen/heap_test.go
+++ b/src/core/compiler/codegen/heap_test.go
@@ -140,7 +140,7 @@ func TestHelperHeapAllocObjectFiltersNonRefOperands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AllocObject: %v", err)
 	}
-	if got.Type.Kind != wasm.ValRef {
+	if got.Type.Kind() != wasm.ValRef {
 		t.Fatalf("AllocObject result type = %s, want ref", got.Type)
 	}
 	if len(emit.calls) != 1 {

--- a/src/core/compiler/codegen/types.go
+++ b/src/core/compiler/codegen/types.go
@@ -46,7 +46,7 @@ type Value struct {
 
 // IsRef reports whether v is a wasm reference value and therefore may need root
 // publication across allocating runtime calls.
-func (v Value) IsRef() bool { return v.Type.Kind == wasm.ValRef }
+func (v Value) IsRef() bool { return v.Type.Kind() == wasm.ValRef }
 
 // RefLayout documents the compact guest reference representation used by a heap
 // policy. The current runtime/gc.Ref layout is 32-bit: null is 0, i31 immediates

--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -543,12 +543,12 @@ func (p supportPass) types() error {
 					switch st.Comp.Kind {
 					case wasm.CompStruct:
 						for fi := range st.Comp.Fields {
-							if storageTypeRequiresSIMD(st.Comp.Fields[fi].Storage) {
+							if storageTypeRequiresSIMD(st.Comp.Fields[fi].Storage()) {
 								return p.unsupported("v128", "simd disabled", fmt.Sprintf("%s field %d", ctx, fi))
 							}
 						}
 					case wasm.CompArray:
-						if storageTypeRequiresSIMD(st.Comp.Array.Storage) {
+						if storageTypeRequiresSIMD(st.Comp.Array.Storage()) {
 							return p.unsupported("v128", "simd disabled", ctx+" array element")
 						}
 					}
@@ -990,7 +990,7 @@ func needsPublicFuncrefHostReentry(m *wasm.Module, tables []TableRuntimeShape) b
 			continue
 		}
 		for _, param := range ft.Params {
-			if param.Kind == wasm.ValRef && isFuncRef(param.Ref) {
+			if param.Kind() == wasm.ValRef && isFuncRef(param.Ref()) {
 				return true
 			}
 		}
@@ -2170,37 +2170,40 @@ func (p supportPass) supportedValTypes(vs []wasm.ValType) bool {
 }
 
 func (p supportPass) supportedValType(v wasm.ValType) bool {
-	if v.Kind == wasm.ValNum {
-		switch v.Num {
+	if v.Kind() == wasm.ValNum {
+		switch v.Num() {
 		case wasm.NumI32, wasm.NumI64, wasm.NumF32, wasm.NumF64:
 			return true
 		}
 	}
-	if p.feat.SIMD && v.Kind == wasm.ValVec && wasm.EqualValType(v, wasm.V128) {
+	if p.feat.SIMD && v.Kind() == wasm.ValVec && wasm.EqualValType(v, wasm.V128) {
 		return true
 	}
-	return p.feat.ReferenceTypes && v.Kind == wasm.ValRef && (isFuncRef(v.Ref) || isExternRef(v.Ref) || p.supportedTypedFuncRef(v.Ref) || p.supportedStagedExternRef(v.Ref) || p.supportedExceptionRef(v.Ref) || p.supportedNullReference(v.Ref) || p.supportedGCReference(v.Ref) || p.supportedStructuralTypeRef(v.Ref))
+	return p.feat.ReferenceTypes && v.Kind() == wasm.ValRef && (isFuncRef(v.Ref()) || isExternRef(v.Ref()) || p.supportedTypedFuncRef(v.Ref()) || p.supportedStagedExternRef(v.Ref()) || p.supportedExceptionRef(v.Ref()) || p.supportedNullReference(v.Ref()) || p.supportedGCReference(v.Ref()) || p.supportedStructuralTypeRef(v.Ref()))
 }
 
 func (p supportPass) supportedExceptionRef(rt wasm.RefType) bool {
-	return p.feat.ExceptionReferences && rt.Heap.Kind == wasm.HeapAbs && (rt.Heap.Abs == wasm.HeapExn || rt.Heap.Abs == wasm.HeapNoExn)
+	heap := rt.Heap()
+	return p.feat.ExceptionReferences && heap.Kind() == wasm.HeapAbs && (heap.Abs() == wasm.HeapExn || heap.Abs() == wasm.HeapNoExn)
 }
 
 func (p supportPass) supportedGCReference(rt wasm.RefType) bool {
-	if rt.Exact || rt.Heap.Kind != wasm.HeapAbs {
+	heap := rt.Heap()
+	if rt.Exact() || heap.Kind() != wasm.HeapAbs {
 		return false
 	}
-	if p.feat.GCI31Products && (rt.Heap.Abs == wasm.HeapI31 || rt.Heap.Abs == wasm.HeapAny || rt.Heap.Abs == wasm.HeapNone) {
+	if p.feat.GCI31Products && (heap.Abs() == wasm.HeapI31 || heap.Abs() == wasm.HeapAny || heap.Abs() == wasm.HeapNone) {
 		return true
 	}
-	return (p.feat.GCTypeSubtypingProducts || p.feat.GCStructProducts || p.feat.GCArrayProducts) && (rt.Heap.Abs == wasm.HeapAny || rt.Heap.Abs == wasm.HeapEq || rt.Heap.Abs == wasm.HeapNone || rt.Heap.Abs == wasm.HeapStruct || rt.Heap.Abs == wasm.HeapArray)
+	return (p.feat.GCTypeSubtypingProducts || p.feat.GCStructProducts || p.feat.GCArrayProducts) && (heap.Abs() == wasm.HeapAny || heap.Abs() == wasm.HeapEq || heap.Abs() == wasm.HeapNone || heap.Abs() == wasm.HeapStruct || heap.Abs() == wasm.HeapArray)
 }
 
 func (p supportPass) supportedStructuralTypeRef(rt wasm.RefType) bool {
-	if (!p.feat.StructuralTypeProducts && !p.feat.GCTypeSubtypingProducts && !p.feat.GCStructProducts && !p.feat.GCArrayProducts) || rt.Exact || rt.Heap.Kind != wasm.HeapTypeIndex {
+	heap := rt.Heap()
+	if (!p.feat.StructuralTypeProducts && !p.feat.GCTypeSubtypingProducts && !p.feat.GCStructProducts && !p.feat.GCArrayProducts) || rt.Exact() || heap.Kind() != wasm.HeapTypeIndex {
 		return false
 	}
-	index := rt.Heap.Type.Index
+	index := heap.Type().Index
 	for gi := range p.m.Types {
 		if index < uint32(len(p.m.Types[gi].SubTypes)) {
 			kind := p.m.Types[gi].SubTypes[index].Comp.Kind
@@ -2212,10 +2215,11 @@ func (p supportPass) supportedStructuralTypeRef(rt wasm.RefType) bool {
 }
 
 func (p supportPass) supportedNullReference(rt wasm.RefType) bool {
-	if !p.feat.NullReferenceProducts || !rt.Nullable || rt.Exact || rt.Heap.Kind != wasm.HeapAbs {
+	heap := rt.Heap()
+	if !p.feat.NullReferenceProducts || !rt.Nullable() || rt.Exact() || heap.Kind() != wasm.HeapAbs {
 		return false
 	}
-	switch rt.Heap.Abs {
+	switch heap.Abs() {
 	case wasm.HeapAny, wasm.HeapNone, wasm.HeapExn, wasm.HeapNoExn, wasm.HeapNoFunc, wasm.HeapNoExtern:
 		return true
 	default:
@@ -2255,14 +2259,14 @@ func (p supportPass) valType(v wasm.ValType, context string) error {
 	if p.supportedValType(v) {
 		return nil
 	}
-	if v.Kind == wasm.ValVec && wasm.EqualValType(v, wasm.V128) && !p.feat.SIMD {
+	if v.Kind() == wasm.ValVec && wasm.EqualValType(v, wasm.V128) && !p.feat.SIMD {
 		return p.unsupported("value type", "v128 (simd disabled)", context)
 	}
-	if v.Kind == wasm.ValRef {
+	if v.Kind() == wasm.ValRef {
 		feature := valTypeName(v)
 		if !p.feat.ReferenceTypes {
 			feature += " (reference-types disabled)"
-		} else if p.isTypedFuncRef(v.Ref) && !p.feat.TypedFunctionReferences {
+		} else if p.isTypedFuncRef(v.Ref()) && !p.feat.TypedFunctionReferences {
 			feature += " (typed-function-references disabled)"
 		}
 		return p.unsupported("reference type", feature, context)
@@ -2271,14 +2275,14 @@ func (p supportPass) valType(v wasm.ValType, context string) error {
 }
 
 func (p supportPass) globalType(v wasm.ValType, context string) error {
-	if v.Kind == wasm.ValRef {
-		if p.feat.ReferenceTypes && (isFuncRef(v.Ref) || isExternRef(v.Ref) || p.supportedTypedFuncRef(v.Ref) || p.supportedStagedExternRef(v.Ref) || p.supportedNullReference(v.Ref) || p.supportedGCReference(v.Ref) || p.supportedStructuralTypeRef(v.Ref)) {
+	if v.Kind() == wasm.ValRef {
+		if p.feat.ReferenceTypes && (isFuncRef(v.Ref()) || isExternRef(v.Ref()) || p.supportedTypedFuncRef(v.Ref()) || p.supportedStagedExternRef(v.Ref()) || p.supportedNullReference(v.Ref()) || p.supportedGCReference(v.Ref()) || p.supportedStructuralTypeRef(v.Ref())) {
 			return nil
 		}
 		feature := valTypeName(v)
 		if !p.feat.ReferenceTypes {
 			feature += " (reference-types disabled)"
-		} else if p.isTypedFuncRef(v.Ref) && !p.feat.TypedFunctionReferences {
+		} else if p.isTypedFuncRef(v.Ref()) && !p.feat.TypedFunctionReferences {
 			feature += " (typed-function-references disabled)"
 		}
 		return p.unsupported("global type", feature, context)
@@ -2290,8 +2294,8 @@ func (p supportPass) globalType(v wasm.ValType, context string) error {
 }
 
 func valTypeName(v wasm.ValType) string {
-	if v.Kind == wasm.ValRef {
-		return refTypeName(v.Ref)
+	if v.Kind() == wasm.ValRef {
+		return refTypeName(v.Ref())
 	}
 	return v.String()
 }
@@ -2300,7 +2304,8 @@ func refTypeName(rt wasm.RefType) string {
 	if isFuncRef(rt) {
 		return "funcref"
 	}
-	if rt.Nullable && rt.Bare && !rt.Exact && rt.Heap.Kind == wasm.HeapAbs && rt.Heap.Abs == wasm.HeapExtern {
+	heap := rt.Heap()
+	if rt.Nullable() && rt.Bare() && !rt.Exact() && heap.Kind() == wasm.HeapAbs && heap.Abs() == wasm.HeapExtern {
 		return "externref"
 	}
 	return wasm.RefVal(rt).String()
@@ -2347,12 +2352,12 @@ func ModuleNonCodeRequiresSIMD(m *wasm.Module) bool {
 			switch comp.Kind {
 			case wasm.CompStruct:
 				for k := range comp.Fields {
-					if storageTypeRequiresSIMD(comp.Fields[k].Storage) {
+					if storageTypeRequiresSIMD(comp.Fields[k].Storage()) {
 						return true
 					}
 				}
 			case wasm.CompArray:
-				if storageTypeRequiresSIMD(comp.Array.Storage) {
+				if storageTypeRequiresSIMD(comp.Array.Storage()) {
 					return true
 				}
 			}
@@ -2410,11 +2415,11 @@ func compValTypesRequireSIMD(vs []wasm.ValType) bool {
 }
 
 func valTypeRequiresSIMD(v wasm.ValType) bool {
-	return v.Kind == wasm.ValVec && wasm.EqualValType(v, wasm.V128)
+	return v.Kind() == wasm.ValVec && wasm.EqualValType(v, wasm.V128)
 }
 
 func storageTypeRequiresSIMD(s wasm.StorageType) bool {
-	return !s.Packed && valTypeRequiresSIMD(s.Val)
+	return !s.Packed() && valTypeRequiresSIMD(s.Val())
 }
 
 func exprRequiresSIMD(e wasm.Expr) bool {
@@ -2546,18 +2551,20 @@ func (p supportPass) supportedTypedFuncHeap(heap int64) bool {
 }
 
 func (p supportPass) supportedStagedExternRef(rt wasm.RefType) bool {
-	if !p.feat.TypedFunctionReferences || rt.Exact || rt.Heap.Kind != wasm.HeapAbs {
+	heap := rt.Heap()
+	if !p.feat.TypedFunctionReferences || rt.Exact() || heap.Kind() != wasm.HeapAbs {
 		return false
 	}
-	return rt.Heap.Abs == wasm.HeapExtern || rt.Heap.Abs == wasm.HeapNoExtern
+	return heap.Abs() == wasm.HeapExtern || heap.Abs() == wasm.HeapNoExtern
 }
 
 func (p supportPass) isTypedFuncRef(rt wasm.RefType) bool {
-	switch rt.Heap.Kind {
+	heap := rt.Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		return !isFuncRef(rt) && (rt.Heap.Abs == wasm.HeapFunc || rt.Heap.Abs == wasm.HeapNoFunc)
+		return !isFuncRef(rt) && (heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc)
 	case wasm.HeapTypeIndex:
-		_, ok := p.m.TypeFunc(rt.Heap.Type.Index)
+		_, ok := p.m.TypeFunc(heap.Type().Index)
 		return ok
 	default:
 		return false
@@ -2565,18 +2572,21 @@ func (p supportPass) isTypedFuncRef(rt wasm.RefType) bool {
 }
 
 func isFuncRef(rt wasm.RefType) bool {
-	return rt.Nullable && !rt.Exact && rt.Heap.Kind == wasm.HeapAbs && rt.Heap.Abs == wasm.HeapFunc
+	heap := rt.Heap()
+	return rt.Nullable() && !rt.Exact() && heap.Kind() == wasm.HeapAbs && heap.Abs() == wasm.HeapFunc
 }
 
 func isExternRef(rt wasm.RefType) bool {
-	return rt.Nullable && !rt.Exact && rt.Heap.Kind == wasm.HeapAbs && rt.Heap.Abs == wasm.HeapExtern
+	heap := rt.Heap()
+	return rt.Nullable() && !rt.Exact() && heap.Kind() == wasm.HeapAbs && heap.Abs() == wasm.HeapExtern
 }
 
 func compactRefTableType(rt wasm.RefType) bool {
-	if isExternRef(rt) || rt.Exact || rt.Heap.Kind != wasm.HeapAbs {
+	heap := rt.Heap()
+	if isExternRef(rt) || rt.Exact() || heap.Kind() != wasm.HeapAbs {
 		return isExternRef(rt)
 	}
-	switch rt.Heap.Abs {
+	switch heap.Abs() {
 	case wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 		return true
 	default:
@@ -2590,10 +2600,11 @@ func compactRefTableType(rt wasm.RefType) bool {
 // null (e.g. ref.null nofunc) as a subtype of func/extern, so the const-expr
 // support pass must accept it too or it rejects valid WebAssembly 2.0 modules.
 func isNullableAbsRef(rt wasm.RefType) bool {
-	if !(rt.Nullable && !rt.Exact && rt.Heap.Kind == wasm.HeapAbs) {
+	heap := rt.Heap()
+	if !(rt.Nullable() && !rt.Exact() && heap.Kind() == wasm.HeapAbs) {
 		return false
 	}
-	switch rt.Heap.Abs {
+	switch heap.Abs() {
 	case wasm.HeapFunc, wasm.HeapExtern, wasm.HeapNoFunc, wasm.HeapNoExtern:
 		return true
 	}

--- a/src/core/compiler/frontend/gcdesc.go
+++ b/src/core/compiler/frontend/gcdesc.go
@@ -36,7 +36,7 @@ func LowerGCTypeDescs(types []wasm.RecType) ([]gc.TypeDesc, error) {
 		case wasm.CompStruct:
 			fields := make([]gc.StorageKind, len(st.Comp.Fields))
 			for j, f := range st.Comp.Fields {
-				fields[j], err = lowerGCStorage(f.Storage, resolver)
+				fields[j], err = lowerGCStorage(f.Storage(), resolver)
 				if err != nil {
 					return nil, fmt.Errorf("frontend: type %d field %d: %w", i, j, err)
 				}
@@ -47,7 +47,7 @@ func LowerGCTypeDescs(types []wasm.RecType) ([]gc.TypeDesc, error) {
 			}
 			d.Final = st.Final
 		case wasm.CompArray:
-			elem, err := lowerGCStorage(st.Comp.Array.Storage, resolver)
+			elem, err := lowerGCStorage(st.Comp.Array.Storage(), resolver)
 			if err != nil {
 				return nil, fmt.Errorf("frontend: type %d array: %w", i, err)
 			}
@@ -116,23 +116,23 @@ func flattenGCTypes(types []wasm.RecType) []flattenedGCType {
 }
 
 func lowerGCStorage(st wasm.StorageType, resolver gcTypeResolver) (gc.StorageKind, error) {
-	if st.Packed {
-		switch st.Pack {
+	if st.Packed() {
+		switch st.Pack() {
 		case wasm.PackI8:
 			return gc.StorageI8, nil
 		case wasm.PackI16:
 			return gc.StorageI16, nil
 		default:
-			return 0, fmt.Errorf("unsupported packed storage %d", st.Pack)
+			return 0, fmt.Errorf("unsupported packed storage %d", st.Pack())
 		}
 	}
-	return lowerGCValType(st.Val, resolver)
+	return lowerGCValType(st.Val(), resolver)
 }
 
 func lowerGCValType(v wasm.ValType, resolver gcTypeResolver) (gc.StorageKind, error) {
-	switch v.Kind {
+	switch v.Kind() {
 	case wasm.ValNum:
-		switch v.Num {
+		switch v.Num() {
 		case wasm.NumI32:
 			return gc.StorageI32, nil
 		case wasm.NumI64:
@@ -142,7 +142,7 @@ func lowerGCValType(v wasm.ValType, resolver gcTypeResolver) (gc.StorageKind, er
 		case wasm.NumF64:
 			return gc.StorageF64, nil
 		default:
-			return 0, fmt.Errorf("unsupported numeric storage %d", v.Num)
+			return 0, fmt.Errorf("unsupported numeric storage %d", v.Num())
 		}
 	case wasm.ValVec:
 		if wasm.EqualValType(v, wasm.V128) {
@@ -151,16 +151,18 @@ func lowerGCValType(v wasm.ValType, resolver gcTypeResolver) (gc.StorageKind, er
 		return 0, fmt.Errorf("unsupported vector storage")
 	case wasm.ValRef:
 		opaque := gc.StorageKind(0)
-		if v.Ref.Heap.Kind == wasm.HeapTypeIndex {
-			idx, err := resolver.resolve(v.Ref.Heap.Type)
+		rt := v.Ref()
+		heap := rt.Heap()
+		if heap.Kind() == wasm.HeapTypeIndex {
+			idx, err := resolver.resolve(heap.Type())
 			if err != nil {
-				return 0, fmt.Errorf("invalid referenced type index %d", v.Ref.Heap.Type.Index)
+				return 0, fmt.Errorf("invalid referenced type index %d", heap.Type().Index)
 			}
 			if int(idx) < len(resolver.flat) && resolver.flat[idx].Comp.Kind == wasm.CompFunc {
 				opaque = gc.StorageFuncRef
 			}
 		} else {
-			switch v.Ref.Heap.Abs {
+			switch heap.Abs() {
 			case wasm.HeapFunc, wasm.HeapNoFunc:
 				opaque = gc.StorageFuncRef
 			case wasm.HeapExtern, wasm.HeapNoExtern:
@@ -168,7 +170,7 @@ func lowerGCValType(v wasm.ValType, resolver gcTypeResolver) (gc.StorageKind, er
 			}
 		}
 		if opaque != 0 {
-			if v.Ref.Nullable {
+			if rt.Nullable() {
 				if opaque == gc.StorageFuncRef {
 					return gc.StorageFuncRefNull, nil
 				}
@@ -176,7 +178,7 @@ func lowerGCValType(v wasm.ValType, resolver gcTypeResolver) (gc.StorageKind, er
 			}
 			return opaque, nil
 		}
-		if v.Ref.Nullable {
+		if rt.Nullable() {
 			return gc.StorageRefNull, nil
 		}
 		// GC-category references use compact collector handles. i31 immediates and
@@ -185,6 +187,6 @@ func lowerGCValType(v wasm.ValType, resolver gcTypeResolver) (gc.StorageKind, er
 	case wasm.ValBot:
 		return 0, fmt.Errorf("unsupported bottom storage")
 	default:
-		return 0, fmt.Errorf("unsupported value kind %d", v.Kind)
+		return 0, fmt.Errorf("unsupported value kind %d", v.Kind())
 	}
 }

--- a/src/core/compiler/frontend/gcdesc_bench_test.go
+++ b/src/core/compiler/frontend/gcdesc_bench_test.go
@@ -1,0 +1,63 @@
+package frontend
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/src/core/runtime/gc"
+)
+
+var gcTypeDescBenchmarkSink []gc.TypeDesc
+
+func gcTypeLoweringFixture(types, fields int) []wasm.RecType {
+	out := make([]wasm.RecType, types)
+	for i := range out {
+		var comp wasm.CompType
+		switch i % 3 {
+		case 0:
+			comp = wasm.CompType{Kind: wasm.CompFunc, Params: []wasm.ValType{wasm.I32, wasm.I64, wasm.FuncRef}, Results: []wasm.ValType{wasm.I32}}
+		case 1:
+			fs := make([]wasm.FieldType, fields)
+			for j := range fs {
+				mut := wasm.Const
+				if j&1 != 0 {
+					mut = wasm.Var
+				}
+				switch j % 5 {
+				case 0:
+					fs[j] = wasm.NewFieldType(wasm.StorageVal(wasm.I32), mut)
+				case 1:
+					fs[j] = wasm.NewFieldType(wasm.StorageVal(wasm.V128), mut)
+				case 2:
+					fs[j] = wasm.NewFieldType(wasm.StoragePacked(wasm.PackI8), mut)
+				case 3:
+					fs[j] = wasm.NewFieldType(wasm.StoragePacked(wasm.PackI16), mut)
+				case 4:
+					fs[j] = wasm.NewFieldType(wasm.StorageVal(wasm.AnyRef), mut)
+				}
+			}
+			comp = wasm.CompType{Kind: wasm.CompStruct, Fields: fs}
+		case 2:
+			comp = wasm.CompType{Kind: wasm.CompArray, Array: wasm.NewFieldType(wasm.StorageVal(wasm.AnyRef), wasm.Var)}
+		}
+		out[i] = wasm.RecType{SubTypes: []wasm.SubType{{Final: true, Comp: comp}}}
+	}
+	return out
+}
+
+func BenchmarkGCTypeLowering(b *testing.B) {
+	for _, shape := range []struct{ types, fields int }{{10, 64}, {100, 16}, {1000, 4}, {10000, 1}} {
+		fixture := gcTypeLoweringFixture(shape.types, shape.fields)
+		b.Run(fmt.Sprintf("types=%d/fields=%d", shape.types, shape.fields), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				descs, err := LowerGCTypeDescs(fixture)
+				if err != nil || len(descs) != shape.types {
+					b.Fatalf("lowering: descriptors=%d err=%v", len(descs), err)
+				}
+				gcTypeDescBenchmarkSink = descs
+			}
+		})
+	}
+}

--- a/src/core/compiler/frontend/gcdesc_fuzz_test.go
+++ b/src/core/compiler/frontend/gcdesc_fuzz_test.go
@@ -143,6 +143,6 @@ func fuzzGCStorage(r *gcDescFuzzBytes, total, recLen int) wasm.StorageType {
 		}
 		return concreteRec(nullable, uint32(r.n(recLen+2)))
 	default:
-		return wasm.StorageType{Packed: true, Pack: wasm.PackType(255)}
+		return wasm.StoragePacked(wasm.PackType(255))
 	}
 }

--- a/src/core/compiler/frontend/gcdesc_test.go
+++ b/src/core/compiler/frontend/gcdesc_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/wago-org/wago/tests/wasmtest"
 )
 
-func val(v wasm.ValType) wasm.StorageType     { return wasm.StorageType{Val: v} }
-func packed(p wasm.PackType) wasm.StorageType { return wasm.StorageType{Packed: true, Pack: p} }
+func val(v wasm.ValType) wasm.StorageType     { return wasm.StorageVal(v) }
+func packed(p wasm.PackType) wasm.StorageType { return wasm.StoragePacked(p) }
 func ref(nullable bool, h wasm.AbsHeapType) wasm.StorageType {
-	return wasm.StorageType{Val: wasm.RefVal(wasm.Ref(nullable, wasm.AbsHeap(h), false))}
+	return wasm.StorageVal(wasm.RefVal(wasm.Ref(nullable, wasm.AbsHeap(h), false)))
 }
 func concrete(nullable bool, idx uint32) wasm.StorageType {
 	return concreteType(nullable, wasm.TypeIdx{Index: idx})
@@ -20,9 +20,9 @@ func concreteRec(nullable bool, idx uint32) wasm.StorageType {
 	return concreteType(nullable, wasm.TypeIdx{Index: idx, Rec: true})
 }
 func concreteType(nullable bool, idx wasm.TypeIdx) wasm.StorageType {
-	return wasm.StorageType{Val: wasm.RefVal(wasm.Ref(nullable, wasm.IndexedHeap(idx), false))}
+	return wasm.StorageVal(wasm.RefVal(wasm.Ref(nullable, wasm.IndexedHeap(idx), false)))
 }
-func field(s wasm.StorageType) wasm.FieldType { return wasm.FieldType{Storage: s} }
+func field(s wasm.StorageType) wasm.FieldType { return wasm.NewFieldType(s, wasm.Const) }
 func st(fields ...wasm.FieldType) wasm.SubType {
 	return wasm.SubType{Final: true, Comp: wasm.CompType{Kind: wasm.CompStruct, Fields: fields}}
 }
@@ -329,8 +329,8 @@ func TestBuildGCTypeDescsFromDecodedRecursiveTypeIndexes(t *testing.T) {
 	if idx := group[2].Supers[0]; !idx.Rec || idx.Index != 1 {
 		t.Fatalf("child super index = %#v, want rec 1", idx)
 	}
-	fieldHeap := group[2].Comp.Fields[1].Storage.Val.Ref.Heap
-	if fieldHeap.Kind != wasm.HeapTypeIndex || !fieldHeap.Type.Rec || fieldHeap.Type.Index != 1 {
+	fieldHeap := group[2].Comp.Fields[1].Storage().Val().Ref().Heap()
+	if fieldHeap.Kind() != wasm.HeapTypeIndex || !fieldHeap.Type().Rec || fieldHeap.Type().Index != 1 {
 		t.Fatalf("child field heap = %#v, want rec type 1", fieldHeap)
 	}
 	if err := wasm.ValidateModule(m); err != nil {

--- a/src/core/compiler/frontend/module_facts_test.go
+++ b/src/core/compiler/frontend/module_facts_test.go
@@ -47,7 +47,7 @@ func TestAnalyzeModuleFactsMatchesByteAndInstructionForms(t *testing.T) {
 }
 
 func TestRejectUnsupportedWithFeaturesAndFactsUsesCallerAnalysis(t *testing.T) {
-	m := &wasm.Module{Tables: []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref, Limits: wasm.Limits{Min: 1}}}}}
+	m := &wasm.Module{Tables: []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1}}}}}
 	facts, err := AnalyzeModuleFacts(m)
 	if err != nil {
 		t.Fatal(err)

--- a/src/core/compiler/frontend/support_helpers_test.go
+++ b/src/core/compiler/frontend/support_helpers_test.go
@@ -151,8 +151,8 @@ func TestModuleRequiresSIMDScansEveryModuleComponent(t *testing.T) {
 		m    *wasm.Module
 	}{
 		{"type", &wasm.Module{Types: []wasm.RecType{funcType}}},
-		{"struct field", &wasm.Module{Types: []wasm.RecType{{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompStruct, Fields: []wasm.FieldType{{Storage: wasm.StorageType{Val: wasm.V128}}}}}}}}}},
-		{"array element", &wasm.Module{Types: []wasm.RecType{{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompArray, Array: wasm.FieldType{Storage: wasm.StorageType{Val: wasm.V128}}}}}}}}},
+		{"struct field", &wasm.Module{Types: []wasm.RecType{{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompStruct, Fields: []wasm.FieldType{wasm.NewFieldType(wasm.StorageVal(wasm.V128), wasm.Const)}}}}}}}},
+		{"array element", &wasm.Module{Types: []wasm.RecType{{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompArray, Array: wasm.NewFieldType(wasm.StorageVal(wasm.V128), wasm.Const)}}}}}}},
 		{"function import", &wasm.Module{Types: []wasm.RecType{funcType}, Imports: []wasm.Import{{Type: wasm.ExternType{Kind: wasm.ExternFunc, Type: wasm.TypeIdx{Index: 0}}}}}},
 		{"global import", &wasm.Module{Imports: []wasm.Import{{Type: wasm.ExternType{Kind: wasm.ExternGlobal, Global: wasm.GlobalType{Type: wasm.V128}}}}}},
 		{"global type", &wasm.Module{Globals: []wasm.Global{{Type: wasm.GlobalType{Type: wasm.V128}}}}},
@@ -176,7 +176,7 @@ func TestModuleRequiresSIMDScansEveryModuleComponent(t *testing.T) {
 
 func TestSupportPassRejectsV128ArrayStorageWhenSIMDDisabled(t *testing.T) {
 	m := &wasm.Module{Types: []wasm.RecType{{SubTypes: []wasm.SubType{{
-		Comp: wasm.CompType{Kind: wasm.CompArray, Array: wasm.FieldType{Storage: wasm.StorageType{Val: wasm.V128}}},
+		Comp: wasm.CompType{Kind: wasm.CompArray, Array: wasm.NewFieldType(wasm.StorageVal(wasm.V128), wasm.Const)},
 	}}}}}
 	err := RejectUnsupportedWithFeatures(m, Features{TypedFunctionReferences: true, GCArrayProducts: true})
 	if err == nil || !strings.Contains(err.Error(), "simd disabled") {
@@ -191,7 +191,7 @@ func TestRuntimeFootprintSupportValidation(t *testing.T) {
 	}
 	funcRef := wasm.AbsRef(wasm.HeapFunc)
 	m := &wasm.Module{
-		Types:     []wasm.RecType{{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompFunc, Params: []wasm.ValType{{Kind: wasm.ValRef, Ref: funcRef}}}}}}},
+		Types:     []wasm.RecType{{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompFunc, Params: []wasm.ValType{wasm.RefVal(funcRef)}}}}}},
 		FuncTypes: []wasm.TypeIdx{{Index: 0}},
 		Tables:    []wasm.Table{{Type: wasm.TableType{Ref: funcRef, Limits: wasm.Limits{Min: 2}}}},
 		Elements:  []wasm.Elem{{Mode: wasm.ElemMode{Kind: wasm.ElemPassive}, Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0, 1}}}},
@@ -457,7 +457,7 @@ func TestGlobalSupportValidation(t *testing.T) {
 	}{
 		{"simd disabled", supportPass{m: &wasm.Module{Globals: valid.Globals[1:2]}, feat: Features{}}},
 		{"reference disabled", supportPass{m: &wasm.Module{Globals: valid.Globals[2:]}, feat: Features{}}},
-		{"invalid type", supportPass{m: &wasm.Module{Globals: []wasm.Global{{Type: wasm.GlobalType{Type: wasm.ValType{Kind: wasm.ValBot}}, Init: wasm.Expr{BodyBytes: []byte{0x41, 0x00, 0x0b}}}}}, feat: AllFeatures()}},
+		{"invalid type", supportPass{m: &wasm.Module{Globals: []wasm.Global{{Type: wasm.GlobalType{Type: wasm.Bot}, Init: wasm.Expr{BodyBytes: []byte{0x41, 0x00, 0x0b}}}}}, feat: AllFeatures()}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := tc.pass.globals(); err == nil {
@@ -664,7 +664,7 @@ func TestValueAndGlobalTypeSupportHelpers(t *testing.T) {
 		}
 	}
 	unsupportedRef := wasm.RefVal(wasm.Ref(true, wasm.AbsHeap(wasm.HeapEq), false))
-	if err := full.globalType(unsupportedRef, "test"); err == nil || valTypeName(unsupportedRef) == "" || refTypeName(unsupportedRef.Ref) == "" {
+	if err := full.globalType(unsupportedRef, "test"); err == nil || valTypeName(unsupportedRef) == "" || refTypeName(unsupportedRef.Ref()) == "" {
 		t.Fatal("unsupported reference global accepted")
 	}
 	if err := base.globalType(wasm.FuncRef, "test"); err == nil || base.supportedValTypes([]wasm.ValType{wasm.FuncRef}) {

--- a/src/core/compiler/ir/build.go
+++ b/src/core/compiler/ir/build.go
@@ -106,20 +106,19 @@ func minAddrType(a, b wasm.ValType) wasm.ValType {
 }
 
 func isFuncRefTableType(m *wasm.Module, rt wasm.RefType) bool {
-	switch rt.Heap.Kind {
+	heap := rt.Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		return rt.Heap.Abs == wasm.HeapFunc || rt.Heap.Abs == wasm.HeapNoFunc
+		return heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc
 	case wasm.HeapTypeIndex:
 		if m == nil {
 			return true
 		}
-		_, ok := m.TypeFunc(rt.Heap.Type.Index)
+		_, ok := m.TypeFunc(heap.Type().Index)
 		return ok
 	case wasm.HeapDefType:
-		if rt.Heap.Def == nil || int(rt.Heap.Def.Index) >= len(rt.Heap.Def.Rec.SubTypes) {
-			return false
-		}
-		return rt.Heap.Def.Rec.SubTypes[int(rt.Heap.Def.Index)].Comp.Kind == wasm.CompFunc
+		kind, valid := heap.DefCompKind()
+		return valid && kind == wasm.CompFunc
 	default:
 		return false
 	}

--- a/src/core/compiler/ir/build_edge_test.go
+++ b/src/core/compiler/ir/build_edge_test.go
@@ -92,7 +92,7 @@ func TestBuildCallMultipleParamsAndResults(t *testing.T) {
 
 func TestBuildCallIndirectCanonicalTypeID(t *testing.T) {
 	types := []wasm.FuncType{{Results: []wasm.ValType{wasm.I32}}, {Results: []wasm.ValType{wasm.I32}}}
-	m := decodeValidate(t, module(types, []uint32{1}, []wasm.TableType{{Ref: wasm.FuncRef.Ref, Limits: wasm.Limits{Min: 1}}}, nil, nil, [][]byte{wasmtest.Code(bytes(0x41, 0x00, 0x11, 0x01, 0x00, 0x0b))}))
+	m := decodeValidate(t, module(types, []uint32{1}, []wasm.TableType{{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1}}}, nil, nil, [][]byte{wasmtest.Code(bytes(0x41, 0x00, 0x11, 0x01, 0x00, 0x0b))}))
 	f, dump := buildOne(t, m)
 	if !strings.Contains(dump, "call_indirect type=1 table=0 canon=0") {
 		t.Fatalf("unexpected dump:\n%s", dump)
@@ -157,7 +157,7 @@ func TestBuildFuncUsesFlattenedImportedMetadata(t *testing.T) {
 	}
 
 	tableMod := rawModule(wasm.FuncType{}, bytes(0x41, 0x00, 0x11, 0x00, 0x00, 0x0b))
-	tableMod.Imports = []wasm.Import{{Type: wasm.ExternType{Kind: wasm.ExternTable, Table: wasm.TableType{Ref: wasm.FuncRef.Ref, Limits: wasm.Limits{Min: 1}}}}}
+	tableMod.Imports = []wasm.Import{{Type: wasm.ExternType{Kind: wasm.ExternTable, Table: wasm.TableType{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1}}}}}
 	if f, err := BuildFunc(tableMod, 0); err != nil {
 		t.Fatal(err)
 	} else if !strings.Contains(FormatFunc(f), "call_indirect type=0 table=0") {

--- a/src/core/compiler/ir/build_more_test.go
+++ b/src/core/compiler/ir/build_more_test.go
@@ -18,11 +18,11 @@ func TestBuildModuleCopiesMetadata(t *testing.T) {
 			{Module: "env", Name: "f", Type: wasm.ExternType{Kind: wasm.ExternFunc, Type: wasm.TypeIdx{Index: 0}}},
 			{Type: wasm.ExternType{Kind: wasm.ExternGlobal, Global: wasm.GlobalType{Type: wasm.I64}}},
 			{Type: wasm.ExternType{Kind: wasm.ExternMem, Mem: wasm.MemType{Limits: wasm.Limits{Min: 1, Max: &maxMem}}}},
-			{Type: wasm.ExternType{Kind: wasm.ExternTable, Table: wasm.TableType{Ref: wasm.FuncRef.Ref, Limits: wasm.Limits{Min: 3}}}},
+			{Type: wasm.ExternType{Kind: wasm.ExternTable, Table: wasm.TableType{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 3}}}},
 		},
 		FuncTypes: []wasm.TypeIdx{{Index: 1}},
 		Globals:   []wasm.Global{{Type: wasm.GlobalType{Type: wasm.I32, Mutable: true}}},
-		Tables:    []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref, Limits: wasm.Limits{Min: 5}}}},
+		Tables:    []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 5}}}},
 		Elements:  []wasm.Elem{{Mode: wasm.ElemMode{Kind: wasm.ElemPassive, Table: 1}, Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0, 1}}}},
 		Data:      []wasm.Data{{Mode: wasm.DataMode{Kind: wasm.DataActive, Mem: 0}, Init: []byte{1, 2, 3}}},
 		Code:      []wasm.Func{{BodyBytes: bytes(0x41, 0x00, 0x0b)}},
@@ -316,7 +316,7 @@ func TestBuildMemory64UsesI64AddressesAndSizes(t *testing.T) {
 
 func TestBuildCallIndirectReferenceAndAddressTypes(t *testing.T) {
 	t.Run("non-bare funcref table", func(t *testing.T) {
-		m := decodeValidate(t, module([]wasm.FuncType{{Results: []wasm.ValType{wasm.I32}}}, []uint32{0}, []wasm.TableType{{Ref: wasm.FuncRef.Ref, Limits: wasm.Limits{Min: 1}}}, nil, nil, [][]byte{
+		m := decodeValidate(t, module([]wasm.FuncType{{Results: []wasm.ValType{wasm.I32}}}, []uint32{0}, []wasm.TableType{{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1}}}, nil, nil, [][]byte{
 			wasmtest.Code(bytes(0x41, 0x00, 0x11, 0x00, 0x00, 0x0b)),
 		}))
 		m.Tables[0].Type.Ref = wasm.Ref(true, wasm.AbsHeap(wasm.HeapFunc), false)
@@ -327,7 +327,7 @@ func TestBuildCallIndirectReferenceAndAddressTypes(t *testing.T) {
 	})
 
 	t.Run("table64 index", func(t *testing.T) {
-		m := decodeValidate(t, module([]wasm.FuncType{{Results: []wasm.ValType{wasm.I32}}}, []uint32{0}, []wasm.TableType{{Ref: wasm.FuncRef.Ref, Limits: wasm.Limits{Min: 1, Addr64: true}}}, nil, nil, [][]byte{
+		m := decodeValidate(t, module([]wasm.FuncType{{Results: []wasm.ValType{wasm.I32}}}, []uint32{0}, []wasm.TableType{{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1, Addr64: true}}}, nil, nil, [][]byte{
 			wasmtest.Code(bytes(0x42, 0x00, 0x11, 0x00, 0x00, 0x0b)),
 		}))
 		assertBuilds(t, m, "call_indirect type=0 table=0")
@@ -448,9 +448,9 @@ func TestMetadataAndReferenceHelpers(t *testing.T) {
 		{"indexed_nonfunction", wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: 1}), false), false, false},
 		{"indexed_recursive", wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: 0, Rec: true}), false), true, false},
 		{"indexed_out_of_range", wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: 9}), false), false, false},
-		{"defined_function", wasm.Ref(true, wasm.HeapType{Kind: wasm.HeapDefType, Def: funcDef}, false), true, true},
-		{"defined_nonfunction", wasm.Ref(true, wasm.HeapType{Kind: wasm.HeapDefType, Def: structDef}, false), false, false},
-		{"defined_invalid", wasm.Ref(true, wasm.HeapType{Kind: wasm.HeapDefType, Def: &wasm.DefType{Index: 1}}, false), false, false},
+		{"defined_function", wasm.Ref(true, wasm.DefinedHeap(funcDef), false), true, true},
+		{"defined_nonfunction", wasm.Ref(true, wasm.DefinedHeap(structDef), false), false, false},
+		{"defined_invalid", wasm.Ref(true, wasm.DefinedHeap(&wasm.DefType{Index: 1}), false), false, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isFuncRefTableType(wasmModule, tc.ref); got != tc.build {

--- a/src/core/compiler/ir/build_negative_test.go
+++ b/src/core/compiler/ir/build_negative_test.go
@@ -28,8 +28,8 @@ func TestBuildMalformedBodiesReturnErrors(t *testing.T) {
 		{"unknown_global", rawModule(wasm.FuncType{}, bytes(0x23, 0x00, 0x0b)), "unknown global"},
 		{"unknown_func_call", rawModule(wasm.FuncType{}, bytes(0x10, 0x01, 0x0b)), "unknown function"},
 		{"unknown_call_indirect_table", rawModule(wasm.FuncType{}, bytes(0x41, 0x00, 0x11, 0x00, 0x00, 0x0b)), "unknown table"},
-		{"unknown_call_indirect_type", moduleWith(rawModule(wasm.FuncType{}, bytes(0x41, 0x00, 0x11, 0x09, 0x00, 0x0b)), func(m *wasm.Module) { m.Tables = []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref}}} }), "unknown type"},
-		{"call_indirect_non_funcref_table", moduleWith(rawModule(wasm.FuncType{}, bytes(0x41, 0x00, 0x11, 0x00, 0x00, 0x0b)), func(m *wasm.Module) { m.Tables = []wasm.Table{{Type: wasm.TableType{Ref: wasm.ExternRef.Ref}}} }), "element type"},
+		{"unknown_call_indirect_type", moduleWith(rawModule(wasm.FuncType{}, bytes(0x41, 0x00, 0x11, 0x09, 0x00, 0x0b)), func(m *wasm.Module) { m.Tables = []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref()}}} }), "unknown type"},
+		{"call_indirect_non_funcref_table", moduleWith(rawModule(wasm.FuncType{}, bytes(0x41, 0x00, 0x11, 0x00, 0x00, 0x0b)), func(m *wasm.Module) { m.Tables = []wasm.Table{{Type: wasm.TableType{Ref: wasm.ExternRef.Ref()}}} }), "element type"},
 		{"load_without_memory", rawModule(wasm.FuncType{Params: []wasm.ValType{wasm.I32}, Results: []wasm.ValType{wasm.I32}}, bytes(0x20, 0x00, 0x28, 0x00, 0x00, 0x0b)), "unknown memory"},
 		{"memory_size_without_memory", rawModule(wasm.FuncType{Results: []wasm.ValType{wasm.I32}}, bytes(0x3f, 0x00, 0x0b)), "unknown memory"},
 		{"memory_size_nonzero_memory", moduleWith(rawModule(wasm.FuncType{Results: []wasm.ValType{wasm.I32}}, bytes(0x3f, 0x01, 0x0b)), func(m *wasm.Module) { m.Memories = []wasm.MemType{{}} }), "multi-memory unsupported"},
@@ -104,7 +104,7 @@ func TestBuildRejectsUnsupportedCallIndirectSignature(t *testing.T) {
 			recFuncType(wasm.FuncType{}),
 		},
 		FuncTypes: []wasm.TypeIdx{{Index: 1}},
-		Tables:    []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref}}},
+		Tables:    []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref()}}},
 		Code:      []wasm.Func{{BodyBytes: bytes(0x41, 0x00, 0x11, 0x00, 0x00, 0x0b)}},
 	}
 	_, err := BuildFunc(m, 0)

--- a/src/core/compiler/ir/build_test.go
+++ b/src/core/compiler/ir/build_test.go
@@ -86,7 +86,7 @@ func TestBuildCall(t *testing.T) {
 }
 
 func TestBuildCallIndirect(t *testing.T) {
-	m := decodeValidate(t, module([]wasm.FuncType{{Results: []wasm.ValType{wasm.I32}}}, []uint32{0}, []wasm.TableType{{Ref: wasm.FuncRef.Ref, Limits: wasm.Limits{Min: 1}}}, nil, nil, [][]byte{
+	m := decodeValidate(t, module([]wasm.FuncType{{Results: []wasm.ValType{wasm.I32}}}, []uint32{0}, []wasm.TableType{{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1}}}, nil, nil, [][]byte{
 		wasmtest.Code(bytes(0x41, 0x00, 0x11, 0x00, 0x00, 0x0b)),
 	}))
 	assertBuilds(t, m, "call_indirect type=0 table=0 canon=0")

--- a/src/core/compiler/ir/verify.go
+++ b/src/core/compiler/ir/verify.go
@@ -962,19 +962,18 @@ func verifyCall(m *Module, id InstID, in *Inst, argc, resc int, argt, rest func(
 }
 
 func irIsFuncRefTableType(m *Module, rt wasm.RefType) bool {
-	switch rt.Heap.Kind {
+	heap := rt.Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		return rt.Heap.Abs == wasm.HeapFunc || rt.Heap.Abs == wasm.HeapNoFunc
+		return heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc
 	case wasm.HeapTypeIndex:
-		if m == nil || rt.Heap.Type.Rec || int(rt.Heap.Type.Index) >= len(m.Types) {
+		if m == nil || heap.Type().Rec || int(heap.Type().Index) >= len(m.Types) {
 			return false
 		}
-		return irTypeIsFunc(m, rt.Heap.Type.Index)
+		return irTypeIsFunc(m, heap.Type().Index)
 	case wasm.HeapDefType:
-		if rt.Heap.Def == nil || int(rt.Heap.Def.Index) >= len(rt.Heap.Def.Rec.SubTypes) {
-			return false
-		}
-		return rt.Heap.Def.Rec.SubTypes[int(rt.Heap.Def.Index)].Comp.Kind == wasm.CompFunc
+		kind, valid := heap.DefCompKind()
+		return valid && kind == wasm.CompFunc
 	default:
 		return false
 	}

--- a/src/core/compiler/ir/verify_more_test.go
+++ b/src/core/compiler/ir/verify_more_test.go
@@ -428,7 +428,7 @@ func TestVerifyModuleRejectsInstructionMetadataMismatches(t *testing.T) {
 			FuncTypes:         []uint32{1, 0},
 			Globals:           []wasm.GlobalType{{Type: wasm.I32}},
 			Memories:          []wasm.MemType{{}},
-			Tables:            []wasm.TableType{{Ref: wasm.FuncRef.Ref}},
+			Tables:            []wasm.TableType{{Ref: wasm.FuncRef.Ref()}},
 		}
 	}
 	placeFunc := func(m *Module, f *Func) {
@@ -564,7 +564,7 @@ func callIndirectModuleForVerify() *Module {
 		TypeIsFunc:       []bool{true, true, true},
 		CanonicalTypeIDs: []uint32{0, 1, 1},
 		FuncTypes:        []uint32{0},
-		Tables:           []wasm.TableType{{Ref: wasm.FuncRef.Ref}},
+		Tables:           []wasm.TableType{{Ref: wasm.FuncRef.Ref()}},
 		Funcs:            []Func{*f},
 	}
 }

--- a/src/core/compiler/wasm/decode.go
+++ b/src/core/compiler/wasm/decode.go
@@ -216,7 +216,7 @@ func decodeValType(r *reader) (ValType, error) {
 	switch b {
 	case 0x7f, 0x7e, 0x7d, 0x7c:
 		n, err := decodeNumType(r)
-		return ValType{Kind: ValNum, Num: n}, err
+		return newValType(ValNum, n), err
 	case 0x7b:
 		_, _ = r.byte()
 		return V128, nil
@@ -249,10 +249,10 @@ func decodeMut(r *reader) (Mut, error) {
 func decodeStorageType(r *reader) (StorageType, error) {
 	if b, ok := r.peek(); ok && (b == 0x77 || b == 0x78) {
 		_, _ = r.byte()
-		return StorageType{Packed: true, Pack: PackType(b)}, nil
+		return StoragePacked(PackType(b)), nil
 	}
 	vt, err := decodeValType(r)
-	return StorageType{Val: vt}, err
+	return StorageVal(vt), err
 }
 func decodeFieldType(r *reader) (FieldType, error) {
 	st, err := decodeStorageType(r)
@@ -263,7 +263,7 @@ func decodeFieldType(r *reader) (FieldType, error) {
 	if err != nil {
 		return FieldType{}, err
 	}
-	return FieldType{Storage: st, Mut: m}, nil
+	return NewFieldType(st, m), nil
 }
 
 func decodeCompType(r *reader) (CompType, error) {

--- a/src/core/compiler/wasm/decode_edges_test.go
+++ b/src/core/compiler/wasm/decode_edges_test.go
@@ -232,7 +232,7 @@ func TestDecodeTypeForms(t *testing.T) {
 	t.Run("exact reference heap type", func(t *testing.T) {
 		r := newReader([]byte{0x64, 0x62, 0x03})
 		rt, err := decodeRefType(r)
-		if err != nil || rt.Nullable || !rt.Exact || rt.Heap.Type.Index != 3 {
+		if err != nil || rt.Nullable() || !rt.Exact() || rt.Heap().Type().Index != 3 {
 			t.Fatalf("rt=%#v err=%v", rt, err)
 		}
 	})
@@ -260,8 +260,8 @@ func TestDecodeRecursiveFunctionSignatureIndexesValidate(t *testing.T) {
 		t.Fatalf("DecodeModule: %v", err)
 	}
 	result := m.Types[0].SubTypes[1].Comp.Results[0]
-	if !result.Ref.Heap.Type.Rec || result.Ref.Heap.Type.Index != 0 {
-		t.Fatalf("function result heap = %#v, want recursive type 0", result.Ref.Heap)
+	if !result.Ref().Heap().Type().Rec || result.Ref().Heap().Type().Index != 0 {
+		t.Fatalf("function result heap = %#v, want recursive type 0", result.Ref().Heap())
 	}
 	if err := ValidateModule(m); err != nil {
 		t.Fatalf("ValidateModule: %v", err)
@@ -286,7 +286,7 @@ func TestDecodeInstructionImmediates(t *testing.T) {
 	t.Run("descriptor br_on_cast immediate order", func(t *testing.T) {
 		r := newReader([]byte{0xfb, 0x18, 0x03, 0x02, 0x6e, 0x6d})
 		in, err := decodeInstruction(r, 0)
-		if err != nil || in.Kind != InstrBrOnCast || in.Index != 2 || !in.Cast.SourceNullable || !in.Cast.TargetNullable || in.HeapType().Abs != HeapAny || in.HeapType2().Abs != HeapEq {
+		if err != nil || in.Kind != InstrBrOnCast || in.Index != 2 || !in.Cast.SourceNullable || !in.Cast.TargetNullable || in.HeapType().Abs() != HeapAny || in.HeapType2().Abs() != HeapEq {
 			t.Fatalf("instr=%#v err=%v", in, err)
 		}
 	})

--- a/src/core/compiler/wasm/decode_recidx.go
+++ b/src/core/compiler/wasm/decode_recidx.go
@@ -38,10 +38,10 @@ func markRecursiveCompTypeIndexes(ct *CompType, base, limit uint32) {
 	switch ct.Kind {
 	case CompFunc:
 		for i := range ct.Params {
-			markRecursiveValTypeIndexes(&ct.Params[i], base, limit)
+			ct.Params[i] = markRecursiveValTypeIndexes(ct.Params[i], base, limit)
 		}
 		for i := range ct.Results {
-			markRecursiveValTypeIndexes(&ct.Results[i], base, limit)
+			ct.Results[i] = markRecursiveValTypeIndexes(ct.Results[i], base, limit)
 		}
 	case CompStruct:
 		for i := range ct.Fields {
@@ -53,24 +53,26 @@ func markRecursiveCompTypeIndexes(ct *CompType, base, limit uint32) {
 }
 
 func markRecursiveFieldTypeIndexes(ft *FieldType, base, limit uint32) {
-	if ft.Storage.Packed {
+	storage := ft.Storage()
+	if storage.Packed() {
 		return
 	}
-	markRecursiveValTypeIndexes(&ft.Storage.Val, base, limit)
+	*ft = NewFieldType(StorageVal(markRecursiveValTypeIndexes(storage.Val(), base, limit)), ft.Mut())
 }
 
-func markRecursiveValTypeIndexes(vt *ValType, base, limit uint32) {
-	if vt.Kind != ValRef {
-		return
+func markRecursiveValTypeIndexes(vt ValType, base, limit uint32) ValType {
+	if vt.Kind() != ValRef {
+		return vt
 	}
-	markRecursiveRefTypeIndexes(&vt.Ref, base, limit)
+	return RefVal(markRecursiveRefTypeIndexes(vt.Ref(), base, limit))
 }
 
-func markRecursiveRefTypeIndexes(rt *RefType, base, limit uint32) {
-	if rt.Heap.Kind != HeapTypeIndex {
-		return
+func markRecursiveRefTypeIndexes(rt RefType, base, limit uint32) RefType {
+	heap := rt.Heap()
+	if heap.Kind() != HeapTypeIndex {
+		return rt
 	}
-	rt.Heap.Type = markRecursiveTypeIdx(rt.Heap.Type, base, limit)
+	return rt.WithHeap(IndexedHeap(markRecursiveTypeIdx(heap.Type(), base, limit)))
 }
 
 func markRecursiveTypeIdx(idx TypeIdx, base, limit uint32) TypeIdx {

--- a/src/core/compiler/wasm/element_expr.go
+++ b/src/core/compiler/wasm/element_expr.go
@@ -27,7 +27,7 @@ func ParseElementExpr(e Expr) (ElementExpr, error) {
 			}
 			return ElementExpr{RefType: ref, Null: true}, nil
 		case InstrRefFunc:
-			return ElementExpr{RefType: FuncRef.Ref, FuncIndex: in.Index}, nil
+			return ElementExpr{RefType: FuncRef.Ref(), FuncIndex: in.Index}, nil
 		case InstrGlobalGet:
 			return ElementExpr{HasGlobal: true, GlobalIndex: in.Index}, nil
 		default:
@@ -51,9 +51,9 @@ func ParseElementExpr(e Expr) (ElementExpr, error) {
 		}
 		switch ht {
 		case -16, -13: // func (0x70) / nofunc (0x73): null funcref
-			out.RefType = FuncRef.Ref
+			out.RefType = FuncRef.Ref()
 		case -17, -14: // extern (0x6f) / noextern (0x72): null externref
-			out.RefType = ExternRef.Ref
+			out.RefType = ExternRef.Ref()
 		default:
 			return ElementExpr{}, fmt.Errorf("ref.null heap type %d is not funcref or externref", ht)
 		}
@@ -63,7 +63,7 @@ func ParseElementExpr(e Expr) (ElementExpr, error) {
 		if err != nil {
 			return ElementExpr{}, err
 		}
-		out.RefType = FuncRef.Ref
+		out.RefType = FuncRef.Ref()
 		out.FuncIndex = idx
 	case 0x23: // global.get (extended constant expressions)
 		idx, err := r.U32()

--- a/src/core/compiler/wasm/encode.go
+++ b/src/core/compiler/wasm/encode.go
@@ -221,25 +221,28 @@ func appendValType(out *[]byte, t ValType) error {
 		*out = append(*out, b)
 		return nil
 	}
-	if t.Kind != ValRef || t.Ref.Bare {
+	if t.Kind() != ValRef || t.Ref().Bare() {
 		return fmt.Errorf("unsupported value type")
 	}
-	if t.Ref.Nullable {
+	rt := t.Ref()
+	if rt.Nullable() {
 		*out = append(*out, 0x63)
 	} else {
 		*out = append(*out, 0x64)
 	}
-	if t.Ref.Exact {
+	if rt.Exact() {
 		*out = append(*out, 0x62)
 	}
-	switch t.Ref.Heap.Kind {
+	heap := rt.Heap()
+	switch heap.Kind() {
 	case HeapAbs:
-		*out = append(*out, byte(t.Ref.Heap.Abs))
+		*out = append(*out, byte(heap.Abs()))
 	case HeapTypeIndex:
-		if t.Ref.Heap.Type.Rec {
-			return fmt.Errorf("recursive-local heap type %d", t.Ref.Heap.Type.Index)
+		idx := heap.Type()
+		if idx.Rec {
+			return fmt.Errorf("recursive-local heap type %d", idx.Index)
 		}
-		appendS64(out, int64(t.Ref.Heap.Type.Index))
+		appendS64(out, int64(idx.Index))
 	case HeapDefType:
 		return fmt.Errorf("defined heap type requires module index context")
 	default:

--- a/src/core/compiler/wasm/encode_test.go
+++ b/src/core/compiler/wasm/encode_test.go
@@ -154,16 +154,16 @@ func TestEncodingHelpersAndStructuralTypeEquality(t *testing.T) {
 		t.Fatal("invalid block type accepted")
 	}
 
-	field := FieldType{Storage: StorageType{Val: I32}, Mut: Var}
-	if !equalFieldType(field, field) || equalFieldType(field, FieldType{Storage: StorageType{Val: I64}, Mut: Var}) {
+	field := NewFieldType(StorageVal(I32), Var)
+	if !equalFieldType(field, field) || equalFieldType(field, NewFieldType(StorageVal(I64), Var)) {
 		t.Fatal("field type structural equality mismatch")
 	}
-	packed := StorageType{Packed: true, Pack: PackI8}
-	if !equalStorageType(packed, packed) || equalStorageType(packed, StorageType{Packed: true, Pack: PackI16}) {
+	packed := StoragePacked(PackI8)
+	if !equalStorageType(packed, packed) || equalStorageType(packed, StoragePacked(PackI16)) {
 		t.Fatal("storage type structural equality mismatch")
 	}
-	ref := ValType{Kind: ValRef, Ref: Ref(true, IndexedHeap(TypeIdx{Index: 3}), false)}
-	if !EqualValType(ref, ref) || EqualValType(ref, ValType{Kind: ValRef, Ref: Ref(false, IndexedHeap(TypeIdx{Index: 3}), false)}) {
+	ref := RefVal(Ref(true, IndexedHeap(TypeIdx{Index: 3}), false))
+	if !EqualValType(ref, ref) || EqualValType(ref, RefVal(Ref(false, IndexedHeap(TypeIdx{Index: 3}), false))) {
 		t.Fatal("reference value type structural equality mismatch")
 	}
 }

--- a/src/core/compiler/wasm/equal.go
+++ b/src/core/compiler/wasm/equal.go
@@ -4,11 +4,11 @@ package wasm
 func EqualValType(a, b ValType) bool { return equalValType(a, b) }
 
 func equalValType(a, b ValType) bool {
-	if a.Kind != b.Kind || a.Num != b.Num {
+	if a.Kind() != b.Kind() || a.Num() != b.Num() {
 		return false
 	}
-	if a.Kind == ValRef {
-		return equalRefType(a.Ref, b.Ref)
+	if a.Kind() == ValRef {
+		return equalRefType(a.Ref(), b.Ref())
 	}
 	return true
 }
@@ -16,34 +16,33 @@ func equalValType(a, b ValType) bool {
 func equalRefType(a, b RefType) bool {
 	// Bare records whether the binary used a one-byte shorthand such as
 	// funcref. It is encoding metadata, not part of WebAssembly type identity.
-	return a.Nullable == b.Nullable && a.Exact == b.Exact && equalHeapType(a.Heap, b.Heap)
+	return a.Nullable() == b.Nullable() && a.Exact() == b.Exact() && equalHeapType(a.Heap(), b.Heap())
 }
 
 func equalHeapType(a, b HeapType) bool {
-	if a.Kind != b.Kind || a.Abs != b.Abs || a.Type != b.Type {
+	if a.Kind() != b.Kind() || a.Abs() != b.Abs() || a.Type() != b.Type() {
 		return false
 	}
-	if a.Kind == HeapDefType {
-		if a.Def == nil || b.Def == nil {
-			return a.Def == b.Def
-		}
-		return a.Def.GroupIndex == b.Def.GroupIndex && a.Def.Index == b.Def.Index
+	if a.Kind() == HeapDefType {
+		ag, ai, _, av := a.Def()
+		bg, bi, _, bv := b.Def()
+		return av == bv && (!av || ag == bg && ai == bi)
 	}
 	return true
 }
 
 func equalStorageType(a, b StorageType) bool {
-	if a.Packed != b.Packed || a.Pack != b.Pack {
+	if a.Packed() != b.Packed() || a.Pack() != b.Pack() {
 		return false
 	}
-	if !a.Packed && !equalValType(a.Val, b.Val) {
+	if !a.Packed() && !equalValType(a.Val(), b.Val()) {
 		return false
 	}
 	return true
 }
 
 func equalFieldType(a, b FieldType) bool {
-	return a.Mut == b.Mut && equalStorageType(a.Storage, b.Storage)
+	return a.Mut() == b.Mut() && equalStorageType(a.Storage(), b.Storage())
 }
 
 func equalCompType(a, b CompType) bool {

--- a/src/core/compiler/wasm/module_helpers.go
+++ b/src/core/compiler/wasm/module_helpers.go
@@ -120,17 +120,18 @@ func IsNumericGlobalType(t ValType) bool {
 // helper intentionally observes RefType.Bare so an explicit (ref null ...)
 // value type is not silently rewritten as shorthand during a binary round trip.
 func EncodeValType(t ValType) (byte, bool) {
-	switch t.Kind {
+	switch t.Kind() {
 	case ValNum:
-		switch t.Num {
+		switch t.Num() {
 		case NumI32, NumI64, NumF32, NumF64:
-			return byte(t.Num), true
+			return byte(t.Num()), true
 		}
 	case ValVec:
 		return 0x7b, true
 	case ValRef:
-		if t.Ref.Bare && t.Ref.Nullable && !t.Ref.Exact && t.Ref.Heap.Kind == HeapAbs {
-			return byte(t.Ref.Heap.Abs), true
+		rt := t.Ref()
+		if rt.Bare() && rt.Nullable() && !rt.Exact() && rt.Heap().Kind() == HeapAbs {
+			return byte(rt.Heap().Abs()), true
 		}
 	}
 	return 0, false
@@ -263,12 +264,12 @@ func (m *Module) resolvedTypeFunc(idx TypeIdx) (*CompType, bool) {
 
 func funcTypeHasRecIndexes(ct *CompType) bool {
 	for _, t := range ct.Params {
-		if t.Kind == ValRef && t.Ref.Heap.Kind == HeapTypeIndex && t.Ref.Heap.Type.Rec {
+		if t.Kind() == ValRef && t.Ref().Heap().Kind() == HeapTypeIndex && t.Ref().Heap().Type().Rec {
 			return true
 		}
 	}
 	for _, t := range ct.Results {
-		if t.Kind == ValRef && t.Ref.Heap.Kind == HeapTypeIndex && t.Ref.Heap.Type.Rec {
+		if t.Kind() == ValRef && t.Ref().Heap().Kind() == HeapTypeIndex && t.Ref().Heap().Type().Rec {
 			return true
 		}
 	}
@@ -345,27 +346,26 @@ func (m *Module) resolveCompTypeRecIndexes(ct CompType, recGroup int) CompType {
 }
 
 func (m *Module) resolveFieldTypeRecIndexes(ft FieldType, recGroup int) FieldType {
-	if ft.Storage.Packed {
+	storage := ft.Storage()
+	if storage.Packed() {
 		return ft
 	}
-	ft.Storage.Val = m.resolveValTypeRecIndexes(ft.Storage.Val, recGroup)
-	return ft
+	return NewFieldType(StorageVal(m.resolveValTypeRecIndexes(storage.Val(), recGroup)), ft.Mut())
 }
 
 func (m *Module) resolveValTypeRecIndexes(t ValType, recGroup int) ValType {
-	if t.Kind != ValRef {
+	if t.Kind() != ValRef {
 		return t
 	}
-	t.Ref = m.resolveRefTypeRecIndexes(t.Ref, recGroup)
-	return t
+	return RefVal(m.resolveRefTypeRecIndexes(t.Ref(), recGroup))
 }
 
 func (m *Module) resolveRefTypeRecIndexes(rt RefType, recGroup int) RefType {
-	if rt.Heap.Kind != HeapTypeIndex {
+	heap := rt.Heap()
+	if heap.Kind() != HeapTypeIndex {
 		return rt
 	}
-	rt.Heap.Type = m.resolveTypeIdxRecIndex(rt.Heap.Type, recGroup)
-	return rt
+	return rt.WithHeap(IndexedHeap(m.resolveTypeIdxRecIndex(heap.Type(), recGroup)))
 }
 
 func (m *Module) resolveTypeIdxRecIndex(idx TypeIdx, recGroup int) TypeIdx {
@@ -521,16 +521,17 @@ func StructuralFuncTypeID(ft *CompType) uint32 {
 // key prevents collisions in the legacy 32-bit FNV discriminator from admitting
 // a wrong native target.
 func structuralLegacyValTypeByte(t ValType) byte {
-	switch t.Kind {
+	switch t.Kind() {
 	case ValNum:
-		return byte(t.Num)
+		return byte(t.Num())
 	case ValVec:
 		return 0x7b
 	case ValRef:
 		// Canonicalize shorthand and explicit nullable abstract references to
 		// the same legacy byte. Wider identity is provided by StructuralTypeKey.
-		if t.Ref.Nullable && !t.Ref.Exact && t.Ref.Heap.Kind == HeapAbs {
-			return byte(t.Ref.Heap.Abs)
+		rt := t.Ref()
+		if rt.Nullable() && !rt.Exact() && rt.Heap().Kind() == HeapAbs {
+			return byte(rt.Heap().Abs())
 		}
 	}
 	return 0
@@ -542,19 +543,20 @@ func StructuralFuncTypeKey(ft *CompType) uint64 {
 		encoded = append(encoded, byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
 	}
 	writeValue := func(t ValType) {
-		encoded = append(encoded, byte(t.Kind))
-		switch t.Kind {
+		encoded = append(encoded, byte(t.Kind()))
+		switch t.Kind() {
 		case ValNum:
-			encoded = append(encoded, byte(t.Num))
+			encoded = append(encoded, byte(t.Num()))
 		case ValRef:
 			flags := byte(0)
-			if t.Ref.Nullable {
+			rt := t.Ref()
+			if rt.Nullable() {
 				flags |= 1
 			}
-			if t.Ref.Exact {
+			if rt.Exact() {
 				flags |= 2
 			}
-			encoded = append(encoded, flags, byte(t.Ref.Heap.Kind), byte(t.Ref.Heap.Abs))
+			encoded = append(encoded, flags, byte(rt.Heap().Kind()), byte(rt.Heap().Abs()))
 		}
 	}
 	mixU32(uint32(len(ft.Params)))

--- a/src/core/compiler/wasm/module_helpers_rec_test.go
+++ b/src/core/compiler/wasm/module_helpers_rec_test.go
@@ -18,7 +18,7 @@ func TestResolvedTypeFuncResolvesRecursiveTypeIndexes(t *testing.T) {
 	if !ok {
 		t.Fatal("TypeFunc(2) failed")
 	}
-	if got := stored.Params[0].Ref.Heap.Type; !got.Rec || got.Index != 0 {
+	if got := stored.Params[0].Ref().Heap().Type(); !got.Rec || got.Index != 0 {
 		t.Fatalf("stored param type idx = %+v, want recursive local 0", got)
 	}
 
@@ -29,13 +29,13 @@ func TestResolvedTypeFuncResolvesRecursiveTypeIndexes(t *testing.T) {
 	if resolved == stored {
 		t.Fatal("ResolvedTypeFunc returned module storage pointer, want copy")
 	}
-	if got := resolved.Params[0].Ref.Heap.Type; got.Rec || got.Index != 1 {
+	if got := resolved.Params[0].Ref().Heap().Type(); got.Rec || got.Index != 1 {
 		t.Fatalf("resolved param type idx = %+v, want absolute 1", got)
 	}
-	if got := resolved.Results[0].Ref.Heap.Type; got.Rec || got.Index != 2 {
+	if got := resolved.Results[0].Ref().Heap().Type(); got.Rec || got.Index != 2 {
 		t.Fatalf("resolved result type idx = %+v, want absolute 2", got)
 	}
-	if got := stored.Params[0].Ref.Heap.Type; !got.Rec || got.Index != 0 {
+	if got := stored.Params[0].Ref().Heap().Type(); !got.Rec || got.Index != 0 {
 		t.Fatalf("stored signature was mutated: %+v", got)
 	}
 }
@@ -46,7 +46,7 @@ func TestResolvedLocalFuncTypeResolvesRecursiveAndPreservesAbsoluteIndexes(t *te
 			{SubTypes: []SubType{{Comp: CompType{Kind: CompStruct}}}},
 			{SubTypes: []SubType{
 				{Comp: CompType{Kind: CompStruct}},
-				{Comp: CompType{Kind: CompArray, Array: FieldType{Storage: StorageType{Val: I32}}}},
+				{Comp: CompType{Kind: CompArray, Array: NewFieldType(StorageVal(I32), Const)}},
 				{Comp: CompType{Kind: CompFunc,
 					Params: []ValType{
 						RefVal(Ref(true, IndexedHeap(TypeIdx{Index: 0}), false)),
@@ -62,10 +62,10 @@ func TestResolvedLocalFuncTypeResolvesRecursiveAndPreservesAbsoluteIndexes(t *te
 	if !ok {
 		t.Fatal("ResolvedLocalFuncType(0) failed")
 	}
-	if got := resolved.Params[0].Ref.Heap.Type; got.Rec || got.Index != 0 {
+	if got := resolved.Params[0].Ref().Heap().Type(); got.Rec || got.Index != 0 {
 		t.Fatalf("absolute param type idx = %+v, want absolute 0", got)
 	}
-	if got := resolved.Params[1].Ref.Heap.Type; got.Rec || got.Index != 2 {
+	if got := resolved.Params[1].Ref().Heap().Type(); got.Rec || got.Index != 2 {
 		t.Fatalf("recursive param type idx = %+v, want absolute 2", got)
 	}
 }

--- a/src/core/compiler/wasm/module_helpers_test.go
+++ b/src/core/compiler/wasm/module_helpers_test.go
@@ -8,7 +8,7 @@ func TestTypeMetadataHelpersUseCanonicalFields(t *testing.T) {
 	if got := GlobalValueType(GlobalType{Type: F32}); got != F32 {
 		t.Fatalf("GlobalValueType = %s, want f32", got)
 	}
-	if got := TableRefType(TableType{Ref: ExternRef.Ref}); !EqualValType(RefVal(got), ExternRef) {
+	if got := TableRefType(TableType{Ref: ExternRef.Ref()}); !EqualValType(RefVal(got), ExternRef) {
 		t.Fatalf("TableRefType = %s, want externref", RefVal(got))
 	}
 	if got := TableAddrType(TableType{}); got != I32 {
@@ -84,11 +84,11 @@ func TestModuleMetadataHelpers(t *testing.T) {
 		Types: []RecType{{SubTypes: []SubType{{Comp: func0}, {Comp: CompType{Kind: CompStruct}}}}, {SubTypes: []SubType{{Comp: func1}}}},
 		Imports: []Import{
 			{Type: ExternType{Kind: ExternFunc, Type: TypeIdx{Index: 0}}},
-			{Type: ExternType{Kind: ExternTable, Table: TableType{Ref: FuncRef.Ref}}},
+			{Type: ExternType{Kind: ExternTable, Table: TableType{Ref: FuncRef.Ref()}}},
 			{Type: ExternType{Kind: ExternGlobal, Global: GlobalType{Type: I64}}},
 		},
 		FuncTypes: []TypeIdx{{Index: 2}},
-		Tables:    []Table{{Type: TableType{Ref: ExternRef.Ref, Limits: Limits{Addr64: true}}}},
+		Tables:    []Table{{Type: TableType{Ref: ExternRef.Ref(), Limits: Limits{Addr64: true}}}},
 		Globals:   []Global{{Type: GlobalType{Type: F32}}},
 	}
 	if got := m.flattenedTypeCount(); got != 3 {
@@ -215,13 +215,13 @@ func TestInstructionPayloadAccessorsAndErrorFormatting(t *testing.T) {
 	}}
 	if in.BlockType().Val != I32 || len(in.Body().Instrs) != 1 || len(in.Then()) != 1 || len(in.Else()) != 1 ||
 		len(in.Catches()) != 1 || len(in.Indices()) != 1 || len(in.ValTypes()) != 1 || in.MemArg().Mem == nil ||
-		len(in.Bytes()) != 1 || in.Lanes()[0] != 3 || !in.RefType().Nullable || in.HeapType().Abs != HeapFunc || in.HeapType2().Type.Index != 4 {
+		len(in.Bytes()) != 1 || in.Lanes()[0] != 3 || !in.RefType().Nullable() || in.HeapType().Abs() != HeapFunc || in.HeapType2().Type().Index != 4 {
 		t.Fatal("instruction payload accessors changed")
 	}
 	var zero Instruction
 	if zero.BlockType().Kind != BlockVoid || len(zero.Body().Instrs) != 0 || zero.Then() != nil || zero.Else() != nil ||
 		zero.Catches() != nil || zero.Indices() != nil || zero.ValTypes() != nil || zero.MemArg().Mem != nil || zero.Bytes() != nil ||
-		zero.Lanes()[0] != 0 || zero.RefType().Nullable || zero.HeapType().Kind != HeapAbs || zero.HeapType2().Kind != HeapAbs {
+		zero.Lanes()[0] != 0 || zero.RefType().Nullable() || zero.HeapType().Kind() != HeapAbs || zero.HeapType2().Kind() != HeapAbs {
 		t.Fatal("zero instruction accessors changed")
 	}
 	if !AbsRef(HeapFunc).IsDefaultable() || Ref(false, AbsHeap(HeapFunc), false).IsDefaultable() {
@@ -296,10 +296,10 @@ func TestDecodeTagType(t *testing.T) {
 }
 
 func TestDecodeNullableReferenceType(t *testing.T) {
-	if got, err := decodeRefTypeForNull(newReader([]byte{0x70})); err != nil || !got.Nullable || got.Exact || got.Heap.Abs != HeapFunc {
+	if got, err := decodeRefTypeForNull(newReader([]byte{0x70})); err != nil || !got.Nullable() || got.Exact() || got.Heap().Abs() != HeapFunc {
 		t.Fatalf("decodeRefTypeForNull(funcref) = %#v, %v", got, err)
 	}
-	if got, err := decodeRefTypeForNull(newReader([]byte{0x62, 3})); err != nil || !got.Nullable || !got.Exact || got.Heap.Type != (TypeIdx{Index: 3}) {
+	if got, err := decodeRefTypeForNull(newReader([]byte{0x62, 3})); err != nil || !got.Nullable() || !got.Exact() || got.Heap().Type() != (TypeIdx{Index: 3}) {
 		t.Fatalf("decodeRefTypeForNull(exact indexed) = %#v, %v", got, err)
 	}
 	if _, err := decodeRefTypeForNull(newReader([]byte{0x62, 0x80})); err == nil {
@@ -430,20 +430,20 @@ func TestStructuralTypeEqualityHelpers(t *testing.T) {
 	if !equalCompType(fun, fun) || equalCompType(fun, CompType{Kind: CompFunc, Params: []ValType{I64}, Results: []ValType{I64}}) {
 		t.Fatal("function type equality changed")
 	}
-	field := FieldType{Storage: StorageType{Val: I32}, Mut: Var}
+	field := NewFieldType(StorageVal(I32), Var)
 	strct := CompType{Kind: CompStruct, Fields: []FieldType{field}}
-	if !equalCompType(strct, strct) || equalCompType(strct, CompType{Kind: CompStruct, Fields: []FieldType{{Storage: StorageType{Val: I32}, Mut: Const}}}) {
+	if !equalCompType(strct, strct) || equalCompType(strct, CompType{Kind: CompStruct, Fields: []FieldType{NewFieldType(StorageVal(I32), Const)}}) {
 		t.Fatal("struct type equality changed")
 	}
-	array := CompType{Kind: CompArray, Array: FieldType{Storage: StorageType{Packed: true, Pack: PackI8}}}
-	if !equalCompType(array, array) || equalCompType(array, CompType{Kind: CompArray, Array: FieldType{Storage: StorageType{Packed: true, Pack: PackI16}}}) {
+	array := CompType{Kind: CompArray, Array: NewFieldType(StoragePacked(PackI8), Const)}
+	if !equalCompType(array, array) || equalCompType(array, CompType{Kind: CompArray, Array: NewFieldType(StoragePacked(PackI16), Const)}) {
 		t.Fatal("array type equality changed")
 	}
 	if EqualValType(RefVal(AbsRef(HeapFunc)), RefVal(AbsRef(HeapExtern))) || !EqualValType(RefVal(Ref(true, IndexedHeap(TypeIdx{Index: 2}), true)), RefVal(Ref(true, IndexedHeap(TypeIdx{Index: 2}), true))) {
 		t.Fatal("reference value type equality changed")
 	}
 	def := &DefType{GroupIndex: 1, Index: 2}
-	if !equalHeapType(HeapType{Kind: HeapDefType, Def: def}, HeapType{Kind: HeapDefType, Def: &DefType{GroupIndex: 1, Index: 2}}) || equalHeapType(HeapType{Kind: HeapDefType, Def: def}, HeapType{Kind: HeapDefType}) {
+	if !equalHeapType(DefinedHeap(def), DefinedHeap(&DefType{GroupIndex: 1, Index: 2})) || equalHeapType(DefinedHeap(def), DefinedHeap(nil)) {
 		t.Fatal("defined heap type equality changed")
 	}
 }
@@ -460,16 +460,16 @@ func TestDecodeSignedTypeIndex(t *testing.T) {
 }
 
 func TestDecodeReferenceTypeEncodings(t *testing.T) {
-	if got, err := decodeRefType(newReader([]byte{0x63, 0x70})); err != nil || !EqualValType(RefVal(got), FuncRef) || got.Bare {
+	if got, err := decodeRefType(newReader([]byte{0x63, 0x70})); err != nil || !EqualValType(RefVal(got), FuncRef) || got.Bare() {
 		t.Fatalf("decodeRefType(nullable funcref) = %#v, %v", got, err)
 	}
-	if got, err := decodeRefType(newReader([]byte{0x64, 0x70})); err != nil || got.Nullable || got.Bare || got.Heap.Abs != HeapFunc {
+	if got, err := decodeRefType(newReader([]byte{0x64, 0x70})); err != nil || got.Nullable() || got.Bare() || got.Heap().Abs() != HeapFunc {
 		t.Fatalf("decodeRefType(non-null funcref) = %#v, %v", got, err)
 	}
-	if got, err := decodeRefType(newReader([]byte{0x63, 0x62, 4})); err != nil || !got.Nullable || !got.Exact || got.Bare || got.Heap.Type != (TypeIdx{Index: 4}) {
+	if got, err := decodeRefType(newReader([]byte{0x63, 0x62, 4})); err != nil || !got.Nullable() || !got.Exact() || got.Bare() || got.Heap().Type() != (TypeIdx{Index: 4}) {
 		t.Fatalf("decodeRefType(exact index) = %#v, %v", got, err)
 	}
-	if got, err := decodeRefType(newReader([]byte{0x6f})); err != nil || !EqualValType(RefVal(got), ExternRef) || !got.Bare {
+	if got, err := decodeRefType(newReader([]byte{0x6f})); err != nil || !EqualValType(RefVal(got), ExternRef) || !got.Bare() {
 		t.Fatalf("decodeRefType(shorthand externref) = %#v, %v", got, err)
 	}
 	for _, data := range [][]byte{nil, {0x63}, {0xff}} {
@@ -491,7 +491,7 @@ func TestDecodeStorageAndFieldTypes(t *testing.T) {
 		{[]byte{0x7f}, false, 0, I32},
 	} {
 		got, err := decodeStorageType(newReader(tc.data))
-		if err != nil || got.Packed != tc.packed || got.Pack != tc.pack || got.Val != tc.val {
+		if err != nil || got.Packed() != tc.packed || got.Pack() != tc.pack || got.Val() != tc.val {
 			t.Fatalf("decodeStorageType(%x) = %#v, %v", tc.data, got, err)
 		}
 	}
@@ -500,10 +500,10 @@ func TestDecodeStorageAndFieldTypes(t *testing.T) {
 			t.Fatalf("decodeStorageType(%x) accepted malformed input", data)
 		}
 	}
-	if got, err := decodeFieldType(newReader([]byte{0x77, 1})); err != nil || !got.Storage.Packed || got.Mut != Var {
+	if got, err := decodeFieldType(newReader([]byte{0x77, 1})); err != nil || !got.Storage().Packed() || got.Mut() != Var {
 		t.Fatalf("decodeFieldType(packed) = %#v, %v", got, err)
 	}
-	if got, err := decodeFieldType(newReader([]byte{0x7e, 0})); err != nil || got.Storage.Val != I64 || got.Mut != Const {
+	if got, err := decodeFieldType(newReader([]byte{0x7e, 0})); err != nil || got.Storage().Val() != I64 || got.Mut() != Const {
 		t.Fatalf("decodeFieldType(value) = %#v, %v", got, err)
 	}
 	if _, err := decodeFieldType(newReader([]byte{0x7f, 2})); err == nil {
@@ -513,32 +513,32 @@ func TestDecodeStorageAndFieldTypes(t *testing.T) {
 
 func TestRecursiveTypeIndexMarkingIncludesStructAndArrayFields(t *testing.T) {
 	ref := func(index uint32) ValType {
-		return ValType{Kind: ValRef, Ref: Ref(true, IndexedHeap(TypeIdx{Index: index}), false)}
+		return RefVal(Ref(true, IndexedHeap(TypeIdx{Index: index}), false))
 	}
 	types := []RecType{
 		{SubTypes: []SubType{
-			{Comp: CompType{Kind: CompStruct, Fields: []FieldType{{Storage: StorageType{Val: ref(1)}}, {Storage: StorageType{Packed: true, Pack: PackI8}}}}},
-			{Comp: CompType{Kind: CompArray, Array: FieldType{Storage: StorageType{Val: ref(0)}}}},
+			{Comp: CompType{Kind: CompStruct, Fields: []FieldType{NewFieldType(StorageVal(ref(1)), Const), NewFieldType(StoragePacked(PackI8), Const)}}},
+			{Comp: CompType{Kind: CompArray, Array: NewFieldType(StorageVal(ref(0)), Const)}},
 		}},
 		{SubTypes: []SubType{{Comp: CompType{Kind: CompFunc, Params: []ValType{ref(0)}}}}},
 	}
 	markRecursiveTypeIndexes(types)
-	structRef := types[0].SubTypes[0].Comp.Fields[0].Storage.Val.Ref.Heap.Type
-	arrayRef := types[0].SubTypes[1].Comp.Array.Storage.Val.Ref.Heap.Type
-	outerRef := types[1].SubTypes[0].Comp.Params[0].Ref.Heap.Type
+	structRef := types[0].SubTypes[0].Comp.Fields[0].Storage().Val().Ref().Heap().Type()
+	arrayRef := types[0].SubTypes[1].Comp.Array.Storage().Val().Ref().Heap().Type()
+	outerRef := types[1].SubTypes[0].Comp.Params[0].Ref().Heap().Type()
 	if !structRef.Rec || structRef.Index != 1 || !arrayRef.Rec || arrayRef.Index != 0 || outerRef.Rec || outerRef.Index != 0 {
 		t.Fatalf("recursive type indexes = struct=%#v array=%#v outer=%#v", structRef, arrayRef, outerRef)
 	}
 	m := &Module{Types: types}
 	resolvedStruct := m.resolveCompTypeRecIndexes(types[0].SubTypes[0].Comp, 0)
 	resolvedArray := m.resolveCompTypeRecIndexes(types[0].SubTypes[1].Comp, 0)
-	if got := resolvedStruct.Fields[0].Storage.Val.Ref.Heap.Type; got.Rec || got.Index != 1 {
+	if got := resolvedStruct.Fields[0].Storage().Val().Ref().Heap().Type(); got.Rec || got.Index != 1 {
 		t.Fatalf("resolved struct field index = %#v", got)
 	}
-	if got := resolvedArray.Array.Storage.Val.Ref.Heap.Type; got.Rec || got.Index != 0 {
+	if got := resolvedArray.Array.Storage().Val().Ref().Heap().Type(); got.Rec || got.Index != 0 {
 		t.Fatalf("resolved array field index = %#v", got)
 	}
-	if !resolvedStruct.Fields[1].Storage.Packed {
+	if !resolvedStruct.Fields[1].Storage().Packed() {
 		t.Fatal("packed struct field was changed while resolving indexes")
 	}
 	if got := m.resolveValTypeRecIndexes(I32, 0); got != I32 {

--- a/src/core/compiler/wasm/more_decode_edges_test.go
+++ b/src/core/compiler/wasm/more_decode_edges_test.go
@@ -64,28 +64,28 @@ func TestMoreReferenceDecodeEdges(t *testing.T) {
 		}{{[]byte{0x64}, true}, {[]byte{0x63, 0x64}, true}, {[]byte{0x64, 0x64}, false}}
 		for _, tc := range cases {
 			vt, err := decodeValType(newReader(tc.bytes))
-			if err != nil || vt.Kind != ValRef || vt.Ref.Heap.Abs != HeapString || vt.Ref.Nullable != tc.nullable {
+			if err != nil || vt.Kind() != ValRef || vt.Ref().Heap().Abs() != HeapString || vt.Ref().Nullable() != tc.nullable {
 				t.Fatalf("%x -> %#v err=%v", tc.bytes, vt, err)
 			}
 		}
 	})
 	t.Run("ref.null abstract and exact indexed", func(t *testing.T) {
 		in, err := decodeInstruction(newReader([]byte{0xd0, 0x6f}), 0)
-		if err != nil || in.Kind != InstrRefNull || in.RefType().Heap.Abs != HeapExtern {
+		if err != nil || in.Kind != InstrRefNull || in.RefType().Heap().Abs() != HeapExtern {
 			t.Fatalf("ref.null extern=%#v err=%v", in, err)
 		}
 		in, err = decodeInstruction(newReader([]byte{0xd0, 0x62, 0x00}), 0)
-		if err != nil || in.Kind != InstrRefNull || !in.RefType().Exact || in.RefType().Heap.Type.Index != 0 {
+		if err != nil || in.Kind != InstrRefNull || !in.RefType().Exact() || in.RefType().Heap().Type().Index != 0 {
 			t.Fatalf("ref.null exact=%#v err=%v", in, err)
 		}
 	})
 	t.Run("exact ref.cast and ref.cast_desc_eq", func(t *testing.T) {
 		in, err := decodeInstruction(newReader([]byte{0xfb, 0x16, 0x62, 0x01}), 0)
-		if err != nil || in.Kind != InstrRefCast || !in.Cast.SourceNullable || in.HeapType().Type.Index != 1 {
+		if err != nil || in.Kind != InstrRefCast || !in.Cast.SourceNullable || in.HeapType().Type().Index != 1 {
 			t.Fatalf("ref.cast=%#v err=%v", in, err)
 		}
 		in, err = decodeInstruction(newReader([]byte{0xfb, 0x24, 0x62, 0x01}), 0)
-		if err != nil || in.Kind != InstrRefCastDescEq || !in.Cast.SourceNullable || !in.Cast.TargetNullable || in.HeapType().Type.Index != 1 {
+		if err != nil || in.Kind != InstrRefCastDescEq || !in.Cast.SourceNullable || !in.Cast.TargetNullable || in.HeapType().Type().Index != 1 {
 			t.Fatalf("ref.cast_desc_eq=%#v err=%v", in, err)
 		}
 	})

--- a/src/core/compiler/wasm/proposal_validate_edges_test.go
+++ b/src/core/compiler/wasm/proposal_validate_edges_test.go
@@ -8,9 +8,9 @@ func structType(fields []FieldType, meta TypeMetadata) RecType {
 func arrayType(field FieldType) RecType {
 	return RecType{SubTypes: []SubType{{Final: true, Comp: CompType{Kind: CompArray, Array: field}}}}
 }
-func field(v ValType, mut Mut) FieldType { return FieldType{Storage: StorageType{Val: v}, Mut: mut} }
+func field(v ValType, mut Mut) FieldType { return NewFieldType(StorageVal(v), mut) }
 func packedField(p PackType, mut Mut) FieldType {
-	return FieldType{Storage: StorageType{Packed: true, Pack: p}, Mut: mut}
+	return NewFieldType(StoragePacked(p), mut)
 }
 func refToType(idx uint32, nullable bool) ValType {
 	return RefVal(Ref(nullable, IndexedHeap(TypeIdx{Index: idx}), false))

--- a/src/core/compiler/wasm/reference_encoding_identity_test.go
+++ b/src/core/compiler/wasm/reference_encoding_identity_test.go
@@ -29,8 +29,8 @@ func TestReferenceEncodingFormIsNotSemanticTypeIdentity(t *testing.T) {
 		{name: "extern", bare: bareExtern, explicit: explicitExtern},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if !tc.bare.Ref.Bare || tc.explicit.Ref.Bare {
-				t.Fatalf("test encoding forms bare=%v explicit=%v", tc.bare.Ref.Bare, tc.explicit.Ref.Bare)
+			if !tc.bare.Ref().Bare() || tc.explicit.Ref().Bare() {
+				t.Fatalf("test encoding forms bare=%v explicit=%v", tc.bare.Ref().Bare(), tc.explicit.Ref().Bare())
 			}
 			if !EqualValType(tc.bare, tc.explicit) {
 				t.Fatalf("%s shorthand and explicit reference types differ semantically", tc.name)
@@ -75,10 +75,10 @@ func TestDecodePreservesReferenceEncodingFormWithoutChangingIdentity(t *testing.
 	if !ok {
 		t.Fatal("explicit function type unavailable")
 	}
-	if !bareType.Params[0].Ref.Bare || !bareType.Results[0].Ref.Bare {
+	if !bareType.Params[0].Ref().Bare() || !bareType.Results[0].Ref().Bare() {
 		t.Fatalf("shorthand form lost: %+v", bareType)
 	}
-	if explicitType.Params[0].Ref.Bare || explicitType.Results[0].Ref.Bare {
+	if explicitType.Params[0].Ref().Bare() || explicitType.Results[0].Ref().Bare() {
 		t.Fatalf("explicit form canonicalized to shorthand: %+v", explicitType)
 	}
 	if !FuncTypeEqual(bareType, explicitType) {
@@ -97,7 +97,7 @@ func TestStructuralTypeKeyIgnoresReferenceEncodingFormInRecursiveGroups(t *testi
 		}
 		return &Module{Types: []RecType{{SubTypes: []SubType{
 			{Final: true, Comp: CompType{Kind: CompFunc, Params: []ValType{ref}}},
-			{Final: true, Comp: CompType{Kind: CompStruct, Fields: []FieldType{{Storage: StorageType{Val: ref}}}}},
+			{Final: true, Comp: CompType{Kind: CompStruct, Fields: []FieldType{NewFieldType(StorageVal(ref), Const)}}},
 		}}}}
 	}
 	bare, explicit := module(true), module(false)

--- a/src/core/compiler/wasm/structural_type_id.go
+++ b/src/core/compiler/wasm/structural_type_id.go
@@ -150,16 +150,17 @@ func (m *Module) writeStructuralIndexedFuncTypeLinear(typeIdx uint32, mix func(b
 	}
 
 	writeValue = func(dst *[]byte, value ValType, currentGroup int) bool {
-		if !appendByte(dst, byte(value.Kind)) {
+		if !appendByte(dst, byte(value.Kind())) {
 			return false
 		}
-		switch value.Kind {
+		switch value.Kind() {
 		case ValNum:
-			return appendByte(dst, byte(value.Num))
+			return appendByte(dst, byte(value.Num()))
 		case ValVec, ValBot:
 			return true
 		case ValRef:
-			for _, flag := range []bool{value.Ref.Nullable, value.Ref.Exact} {
+			rt := value.Ref()
+			for _, flag := range []bool{rt.Nullable(), rt.Exact()} {
 				b := byte(0)
 				if flag {
 					b = 1
@@ -168,20 +169,21 @@ func (m *Module) writeStructuralIndexedFuncTypeLinear(typeIdx uint32, mix func(b
 					return false
 				}
 			}
-			if !appendByte(dst, byte(value.Ref.Heap.Kind)) {
+			heap := rt.Heap()
+			if !appendByte(dst, byte(heap.Kind())) {
 				return false
 			}
-			switch value.Ref.Heap.Kind {
+			switch heap.Kind() {
 			case HeapAbs:
-				return appendByte(dst, byte(value.Ref.Heap.Abs))
+				return appendByte(dst, byte(heap.Abs()))
 			case HeapTypeIndex:
-				return writeRef(dst, value.Ref.Heap.Type, currentGroup)
+				return writeRef(dst, heap.Type(), currentGroup)
 			case HeapDefType:
-				def := value.Ref.Heap.Def
-				if def == nil || int(def.GroupIndex) >= len(starts) || def.Index >= uint32(len(m.Types[def.GroupIndex].SubTypes)) {
+				group, member, _, valid := heap.Def()
+				if !valid || int(group) >= len(starts) || member >= uint32(len(m.Types[group].SubTypes)) {
 					return false
 				}
-				return writeRef(dst, TypeIdx{Index: starts[def.GroupIndex] + def.Index}, currentGroup)
+				return writeRef(dst, TypeIdx{Index: starts[group] + member}, currentGroup)
 			default:
 				return false
 			}
@@ -191,14 +193,15 @@ func (m *Module) writeStructuralIndexedFuncTypeLinear(typeIdx uint32, mix func(b
 	}
 
 	writeField = func(dst *[]byte, field FieldType, currentGroup int) bool {
-		if field.Storage.Packed {
-			if !appendByte(dst, 1) || !appendByte(dst, byte(field.Storage.Pack)) {
+		storage := field.Storage()
+		if storage.Packed() {
+			if !appendByte(dst, 1) || !appendByte(dst, byte(storage.Pack())) {
 				return false
 			}
-		} else if !appendByte(dst, 0) || !writeValue(dst, field.Storage.Val, currentGroup) {
+		} else if !appendByte(dst, 0) || !writeValue(dst, storage.Val(), currentGroup) {
 			return false
 		}
-		return appendByte(dst, byte(field.Mut))
+		return appendByte(dst, byte(field.Mut()))
 	}
 
 	buildGroup = func(group int) ([]byte, bool) {
@@ -380,40 +383,42 @@ func (m *Module) writeStructuralIndexedFuncTypeExpanded(typeIdx uint32, mix func
 		if overflow {
 			return false
 		}
-		mix(byte(v.Kind))
-		switch v.Kind {
+		mix(byte(v.Kind()))
+		switch v.Kind() {
 		case ValNum:
-			mix(byte(v.Num))
+			mix(byte(v.Num()))
 		case ValVec, ValBot:
 			// The kind fully identifies these value types.
 		case ValRef:
-			if v.Ref.Nullable {
+			rt := v.Ref()
+			if rt.Nullable() {
 				mix(1)
 			} else {
 				mix(0)
 			}
-			if v.Ref.Exact {
+			if rt.Exact() {
 				mix(1)
 			} else {
 				mix(0)
 			}
-			mix(byte(v.Ref.Heap.Kind))
-			switch v.Ref.Heap.Kind {
+			heap := rt.Heap()
+			mix(byte(heap.Kind()))
+			switch heap.Kind() {
 			case HeapAbs:
-				mix(byte(v.Ref.Heap.Abs))
+				mix(byte(heap.Abs()))
 			case HeapTypeIndex:
-				idx, ok := flatIndex(v.Ref.Heap.Type, recGroup)
+				idx, ok := flatIndex(heap.Type(), recGroup)
 				return ok && writeType(idx)
 			case HeapDefType:
-				def := v.Ref.Heap.Def
-				if def == nil || int(def.GroupIndex) >= len(m.Types) || def.Index >= uint32(len(m.Types[def.GroupIndex].SubTypes)) {
+				group, member, _, valid := heap.Def()
+				if !valid || int(group) >= len(m.Types) || member >= uint32(len(m.Types[group].SubTypes)) {
 					return false
 				}
 				idx := uint32(0)
-				for gi := uint32(0); gi < def.GroupIndex; gi++ {
+				for gi := uint32(0); gi < group; gi++ {
 					idx += uint32(len(m.Types[gi].SubTypes))
 				}
-				return writeType(idx + def.Index)
+				return writeType(idx + member)
 			default:
 				return false
 			}
@@ -427,16 +432,17 @@ func (m *Module) writeStructuralIndexedFuncTypeExpanded(typeIdx uint32, mix func
 		if overflow {
 			return false
 		}
-		if field.Storage.Packed {
+		storage := field.Storage()
+		if storage.Packed() {
 			mix(1)
-			mix(byte(field.Storage.Pack))
+			mix(byte(storage.Pack()))
 		} else {
 			mix(0)
-			if !writeValue(field.Storage.Val, recGroup) {
+			if !writeValue(storage.Val(), recGroup) {
 				return false
 			}
 		}
-		mix(byte(field.Mut))
+		mix(byte(field.Mut()))
 		return true
 	}
 
@@ -556,7 +562,7 @@ func compTypeHasIndexedReferences(ft *CompType) bool {
 	}
 	for _, values := range [][]ValType{ft.Params, ft.Results} {
 		for _, value := range values {
-			if value.Kind == ValRef && value.Ref.Heap.Kind != HeapAbs {
+			if value.Kind() == ValRef && value.Ref().Heap().Kind() != HeapAbs {
 				return true
 			}
 		}

--- a/src/core/compiler/wasm/structural_type_id_test.go
+++ b/src/core/compiler/wasm/structural_type_id_test.go
@@ -96,9 +96,9 @@ func TestStructuralTypeKeyIncludesWholeRecursiveGroup(t *testing.T) {
 		t.Fatalf("non-singleton recursive group collapsed to singleton key %#x", got)
 	}
 
-	selfField := FieldType{Storage: StorageType{Val: RefVal(Ref(false, IndexedHeap(TypeIdx{Index: 0, Rec: true}), false))}}
+	selfField := NewFieldType(StorageVal(RefVal(Ref(false, IndexedHeap(TypeIdx{Index: 0, Rec: true}), false))), Const)
 	selfGroup := RecType{SubTypes: []SubType{emptyFunc, {Final: true, Comp: CompType{Kind: CompStruct, Fields: []FieldType{selfField}}}}}
-	externalField := FieldType{Storage: StorageType{Val: indexedRef(0, false)}}
+	externalField := NewFieldType(StorageVal(indexedRef(0, false)), Const)
 	externalGroup := RecType{SubTypes: []SubType{emptyFunc, {Final: true, Comp: CompType{Kind: CompStruct, Fields: []FieldType{externalField}}}}}
 	linked := &Module{Types: []RecType{selfGroup, externalGroup}}
 	if got, bad := linked.StructuralTypeKey(0), linked.StructuralTypeKey(2); got == bad {

--- a/src/core/compiler/wasm/type_rep_bench_test.go
+++ b/src/core/compiler/wasm/type_rep_bench_test.go
@@ -1,0 +1,228 @@
+package wasm
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+func typeContainsGoPointer(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.String, reflect.UnsafePointer:
+		return true
+	case reflect.Array:
+		return typeContainsGoPointer(t.Elem())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if typeContainsGoPointer(t.Field(i).Type) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestCompilerTypeRepresentationLayout(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+		size  uintptr
+	}{
+		{"TypeIdx", TypeIdx{}, unsafe.Sizeof(TypeIdx{})},
+		{"HeapType", HeapType{}, unsafe.Sizeof(HeapType{})},
+		{"RefType", RefType{}, unsafe.Sizeof(RefType{})},
+		{"ValType", ValType{}, unsafe.Sizeof(ValType{})},
+		{"StorageType", StorageType{}, unsafe.Sizeof(StorageType{})},
+		{"FieldType", FieldType{}, unsafe.Sizeof(FieldType{})},
+		{"CompType", CompType{}, unsafe.Sizeof(CompType{})},
+		{"SubType", SubType{}, unsafe.Sizeof(SubType{})},
+	} {
+		t.Logf("%s: size=%d pointer-scanned=%v", tc.name, tc.size, typeContainsGoPointer(reflect.TypeOf(tc.value)))
+	}
+}
+
+var (
+	typeRepFieldsSink []FieldType
+	typeRepBoolSink   bool
+	typeRepModuleSink *Module
+	typeRepKeySink    uint64
+)
+
+func syntheticGCFields(n int) []FieldType {
+	fields := make([]FieldType, n)
+	for i := range fields {
+		mut := Const
+		if i&1 != 0 {
+			mut = Var
+		}
+		switch i % 8 {
+		case 0:
+			fields[i] = FieldType{Storage: StorageType{Val: I32}, Mut: mut}
+		case 1:
+			fields[i] = FieldType{Storage: StorageType{Val: I64}, Mut: mut}
+		case 2:
+			fields[i] = FieldType{Storage: StorageType{Val: V128}, Mut: mut}
+		case 3:
+			fields[i] = FieldType{Storage: StorageType{Packed: true, Pack: PackI8}, Mut: mut}
+		case 4:
+			fields[i] = FieldType{Storage: StorageType{Packed: true, Pack: PackI16}, Mut: mut}
+		case 5:
+			fields[i] = FieldType{Storage: StorageType{Val: RefVal(Ref(true, AbsHeap(HeapAny), false))}, Mut: mut}
+		case 6:
+			fields[i] = FieldType{Storage: StorageType{Val: RefVal(Ref(false, IndexedHeap(TypeIdx{Index: uint32(i), Rec: true}), true))}, Mut: mut}
+		case 7:
+			fields[i] = FieldType{Storage: StorageType{Val: FuncRef}, Mut: mut}
+		}
+	}
+	return fields
+}
+
+func BenchmarkGCTypeConstruction(b *testing.B) {
+	for _, types := range []int{10, 100, 1000, 10000} {
+		for _, fields := range []int{1, 4, 16, 64} {
+			prototype := syntheticGCFields(8)
+			b.Run(fmt.Sprintf("types=%d/fields=%d", types, fields), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					out := make([]FieldType, types*fields)
+					for j := range out {
+						out[j] = prototype[j&7]
+					}
+					typeRepFieldsSink = out
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkGCTypeEquality(b *testing.B) {
+	for _, fields := range []int{1, 4, 16, 64} {
+		a := syntheticGCFields(fields)
+		z := append([]FieldType(nil), a...)
+		b.Run(fmt.Sprintf("fields=%d", fields), func(b *testing.B) {
+			b.ReportAllocs()
+			var equal bool
+			for i := 0; i < b.N; i++ {
+				equal = true
+				for j := range a {
+					equal = equal && equalFieldType(a[j], z[j])
+				}
+			}
+			if !equal {
+				b.Fatal("equal fields compared unequal")
+			}
+			typeRepBoolSink = equal
+		})
+	}
+}
+
+func appendTypeRepU32(dst []byte, value uint32) []byte {
+	for {
+		out := byte(value & 0x7f)
+		value >>= 7
+		if value != 0 {
+			out |= 0x80
+		}
+		dst = append(dst, out)
+		if value == 0 {
+			return dst
+		}
+	}
+}
+
+func syntheticGCTypeModuleBytes(types, fields int) []byte {
+	payload := appendTypeRepU32(nil, uint32(types))
+	for i := 0; i < types; i++ {
+		payload = append(payload, 0x5f)
+		payload = appendTypeRepU32(payload, uint32(fields))
+		for j := 0; j < fields; j++ {
+			switch j % 6 {
+			case 0:
+				payload = append(payload, 0x7f, byte(Const))
+			case 1:
+				payload = append(payload, 0x7e, byte(Var))
+			case 2:
+				payload = append(payload, 0x7b, byte(Const))
+			case 3:
+				payload = append(payload, byte(PackI8), byte(Var))
+			case 4:
+				payload = append(payload, byte(PackI16), byte(Const))
+			case 5:
+				payload = append(payload, 0x63, byte(HeapAny), byte(Var))
+			}
+		}
+	}
+	module := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, secType}
+	module = appendTypeRepU32(module, uint32(len(payload)))
+	return append(module, payload...)
+}
+
+func BenchmarkGCTypeDecode(b *testing.B) {
+	for _, shape := range []struct{ types, fields int }{{10, 64}, {100, 16}, {1000, 4}, {10000, 1}} {
+		data := syntheticGCTypeModuleBytes(shape.types, shape.fields)
+		b.Run(fmt.Sprintf("types=%d/fields=%d", shape.types, shape.fields), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				m, err := DecodeModule(data)
+				if err != nil || len(m.Types) != shape.types {
+					b.Fatalf("decode: types=%d err=%v", len(m.Types), err)
+				}
+				typeRepModuleSink = m
+			}
+		})
+	}
+}
+
+func BenchmarkGCTypeValidate(b *testing.B) {
+	for _, shape := range []struct{ types, fields int }{{10, 64}, {100, 16}, {1000, 4}, {10000, 1}} {
+		m, err := DecodeModule(syntheticGCTypeModuleBytes(shape.types, shape.fields))
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("types=%d/fields=%d", shape.types, shape.fields), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := ValidateModule(m); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGCTypeStructuralKey(b *testing.B) {
+	params := make([]ValType, 64)
+	results := make([]ValType, 16)
+	for i := range params {
+		params[i] = syntheticGCFields(1)[0].Storage.Val
+	}
+	for i := range results {
+		results[i] = RefVal(Ref(i&1 == 0, AbsHeap(HeapFunc), i&1 != 0))
+	}
+	m := &Module{Types: []RecType{{SubTypes: []SubType{{Final: true, Comp: CompType{Kind: CompFunc, Params: params, Results: results}}}}}}
+	b.Run("cold", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			m.structuralTypeCache = nil
+			key, ok := m.structuralIndexedFuncTypeKey(0)
+			if !ok {
+				b.Fatal("key unavailable")
+			}
+			typeRepKeySink = key
+		}
+	})
+	if _, ok := m.structuralIndexedFuncTypeKey(0); !ok {
+		b.Fatal("warm key unavailable")
+	}
+	b.Run("warm", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			key, ok := m.structuralIndexedFuncTypeKey(0)
+			if !ok {
+				b.Fatal("key unavailable")
+			}
+			typeRepKeySink = key
+		}
+	})
+}

--- a/src/core/compiler/wasm/type_rep_bench_test.go
+++ b/src/core/compiler/wasm/type_rep_bench_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"unsafe"
+
+	corergc "github.com/wago-org/wago/src/core/runtime/gc"
 )
 
 func typeContainsGoPointer(t reflect.Type) bool {
@@ -24,21 +26,35 @@ func typeContainsGoPointer(t reflect.Type) bool {
 }
 
 func TestCompilerTypeRepresentationLayout(t *testing.T) {
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		t.Skip("layout contract records Wago's supported 64-bit compiler targets")
+	}
 	for _, tc := range []struct {
 		name  string
 		value any
-		size  uintptr
+		got   uintptr
+		want  uintptr
 	}{
-		{"TypeIdx", TypeIdx{}, unsafe.Sizeof(TypeIdx{})},
-		{"HeapType", HeapType{}, unsafe.Sizeof(HeapType{})},
-		{"RefType", RefType{}, unsafe.Sizeof(RefType{})},
-		{"ValType", ValType{}, unsafe.Sizeof(ValType{})},
-		{"StorageType", StorageType{}, unsafe.Sizeof(StorageType{})},
-		{"FieldType", FieldType{}, unsafe.Sizeof(FieldType{})},
-		{"CompType", CompType{}, unsafe.Sizeof(CompType{})},
-		{"SubType", SubType{}, unsafe.Sizeof(SubType{})},
+		{"TypeIdx", TypeIdx{}, unsafe.Sizeof(TypeIdx{}), 8},
+		{"HeapType", HeapType{}, unsafe.Sizeof(HeapType{}), 16},
+		{"RefType", RefType{}, unsafe.Sizeof(RefType{}), 16},
+		{"ValType", ValType{}, unsafe.Sizeof(ValType{}), 16},
+		{"StorageType", StorageType{}, unsafe.Sizeof(StorageType{}), 16},
+		{"FieldType", FieldType{}, unsafe.Sizeof(FieldType{}), 16},
+		{"CompType", CompType{}, unsafe.Sizeof(CompType{}), 96},
+		{"SubType", SubType{}, unsafe.Sizeof(SubType{}), 152},
+		{"gc.FieldDesc", corergc.FieldDesc{}, unsafe.Sizeof(corergc.FieldDesc{}), 8},
+		{"gc.TypeDesc", corergc.TypeDesc{}, unsafe.Sizeof(corergc.TypeDesc{}), 64},
 	} {
-		t.Logf("%s: size=%d pointer-scanned=%v", tc.name, tc.size, typeContainsGoPointer(reflect.TypeOf(tc.value)))
+		if tc.got != tc.want {
+			t.Errorf("%s size = %d, want %d", tc.name, tc.got, tc.want)
+		}
+		t.Logf("%s: size=%d pointer-scanned=%v", tc.name, tc.got, typeContainsGoPointer(reflect.TypeOf(tc.value)))
+	}
+	for _, value := range []any{HeapType{}, RefType{}, ValType{}, StorageType{}, FieldType{}} {
+		if typ := reflect.TypeOf(value); typeContainsGoPointer(typ) {
+			t.Errorf("%s unexpectedly contains a Go pointer", typ)
+		}
 	}
 }
 
@@ -58,21 +74,21 @@ func syntheticGCFields(n int) []FieldType {
 		}
 		switch i % 8 {
 		case 0:
-			fields[i] = FieldType{Storage: StorageType{Val: I32}, Mut: mut}
+			fields[i] = NewFieldType(StorageVal(I32), mut)
 		case 1:
-			fields[i] = FieldType{Storage: StorageType{Val: I64}, Mut: mut}
+			fields[i] = NewFieldType(StorageVal(I64), mut)
 		case 2:
-			fields[i] = FieldType{Storage: StorageType{Val: V128}, Mut: mut}
+			fields[i] = NewFieldType(StorageVal(V128), mut)
 		case 3:
-			fields[i] = FieldType{Storage: StorageType{Packed: true, Pack: PackI8}, Mut: mut}
+			fields[i] = NewFieldType(StoragePacked(PackI8), mut)
 		case 4:
-			fields[i] = FieldType{Storage: StorageType{Packed: true, Pack: PackI16}, Mut: mut}
+			fields[i] = NewFieldType(StoragePacked(PackI16), mut)
 		case 5:
-			fields[i] = FieldType{Storage: StorageType{Val: RefVal(Ref(true, AbsHeap(HeapAny), false))}, Mut: mut}
+			fields[i] = NewFieldType(StorageVal(RefVal(Ref(true, AbsHeap(HeapAny), false))), mut)
 		case 6:
-			fields[i] = FieldType{Storage: StorageType{Val: RefVal(Ref(false, IndexedHeap(TypeIdx{Index: uint32(i), Rec: true}), true))}, Mut: mut}
+			fields[i] = NewFieldType(StorageVal(RefVal(Ref(false, IndexedHeap(TypeIdx{Index: uint32(i), Rec: true}), true))), mut)
 		case 7:
-			fields[i] = FieldType{Storage: StorageType{Val: FuncRef}, Mut: mut}
+			fields[i] = NewFieldType(StorageVal(FuncRef), mut)
 		}
 	}
 	return fields
@@ -195,7 +211,7 @@ func BenchmarkGCTypeStructuralKey(b *testing.B) {
 	params := make([]ValType, 64)
 	results := make([]ValType, 16)
 	for i := range params {
-		params[i] = syntheticGCFields(1)[0].Storage.Val
+		params[i] = syntheticGCFields(1)[0].Storage().Val()
 	}
 	for i := range results {
 		results[i] = RefVal(Ref(i&1 == 0, AbsHeap(HeapFunc), i&1 != 0))

--- a/src/core/compiler/wasm/type_rep_encoding_test.go
+++ b/src/core/compiler/wasm/type_rep_encoding_test.go
@@ -1,0 +1,116 @@
+package wasm
+
+import (
+	"math"
+	"testing"
+)
+
+func TestPackedTypeRepresentationPreservesFullIndexes(t *testing.T) {
+	for _, rec := range []bool{false, true} {
+		want := TypeIdx{Index: math.MaxUint32, Rec: rec}
+		heap := IndexedHeap(want)
+		if heap.Kind() != HeapTypeIndex || heap.Type() != want {
+			t.Fatalf("indexed heap round trip = kind %d index %+v, want %+v", heap.Kind(), heap.Type(), want)
+		}
+	}
+
+	def := &DefType{GroupIndex: math.MaxUint32, Index: math.MaxUint32}
+	heap := DefinedHeap(def)
+	group, member, _, present := heap.Def()
+	if !present || group != math.MaxUint32 || member != math.MaxUint32 {
+		t.Fatalf("defined heap coordinates = %d.%d present=%t", group, member, present)
+	}
+	if _, valid := heap.DefCompKind(); valid {
+		t.Fatal("out-of-range definition unexpectedly has a component kind")
+	}
+}
+
+func TestPackedTypeRepresentationSemanticSurface(t *testing.T) {
+	def := &DefType{GroupIndex: 7, Index: 1, Rec: RecType{SubTypes: []SubType{
+		{Comp: CompType{Kind: CompFunc}},
+		{Comp: CompType{Kind: CompStruct}},
+	}}}
+	defHeap := DefinedHeap(def)
+	if group, member, _, present := defHeap.Def(); !present || group != 7 || member != 1 {
+		t.Fatalf("definition = %d.%d present=%t", group, member, present)
+	}
+	if kind, valid := defHeap.DefCompKind(); !valid || kind != CompStruct {
+		t.Fatalf("definition component = %d valid=%t", kind, valid)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		value    ValType
+		kind     ValTypeKind
+		num      NumType
+		nullable bool
+		exact    bool
+		heap     HeapType
+	}{
+		{"i32", I32, ValNum, NumI32, false, false, HeapType{}},
+		{"i64", I64, ValNum, NumI64, false, false, HeapType{}},
+		{"f32", F32, ValNum, NumF32, false, false, HeapType{}},
+		{"f64", F64, ValNum, NumF64, false, false, HeapType{}},
+		{"v128", V128, ValVec, 0, false, false, HeapType{}},
+		{"bottom", Bot, ValBot, 0, false, false, HeapType{}},
+		{"abstract", RefVal(Ref(true, AbsHeap(HeapAny), false)), ValRef, 0, true, false, AbsHeap(HeapAny)},
+		{"indexed exact", RefVal(Ref(false, IndexedHeap(TypeIdx{Index: math.MaxUint32, Rec: true}), true)), ValRef, 0, false, true, IndexedHeap(TypeIdx{Index: math.MaxUint32, Rec: true})},
+		{"defined", RefVal(Ref(false, defHeap, true)), ValRef, 0, false, true, defHeap},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.value.Kind() != tc.kind || tc.value.Num() != tc.num {
+				t.Fatalf("kind/num = %d/%d, want %d/%d", tc.value.Kind(), tc.value.Num(), tc.kind, tc.num)
+			}
+			if tc.kind == ValRef {
+				rt := tc.value.Ref()
+				if rt.Nullable() != tc.nullable || rt.Exact() != tc.exact || !equalHeapType(rt.Heap(), tc.heap) {
+					t.Fatalf("reference round trip = %s", tc.value)
+				}
+			}
+		})
+	}
+}
+
+func TestPackedFieldRepresentationRoundTrip(t *testing.T) {
+	storages := []StorageType{
+		StorageVal(I32),
+		StorageVal(V128),
+		StorageVal(RefVal(Ref(true, AbsHeap(HeapEq), true))),
+		StoragePacked(PackI8),
+		StoragePacked(PackI16),
+	}
+	for _, storage := range storages {
+		for _, mut := range []Mut{Const, Var} {
+			field := NewFieldType(storage, mut)
+			if field.Mut() != mut || !equalStorageType(field.Storage(), storage) {
+				t.Fatalf("field round trip = storage %v mut %d", field.Storage(), field.Mut())
+			}
+		}
+	}
+}
+
+func TestPackedReferenceBareFlagIsNotSemanticIdentity(t *testing.T) {
+	bare := FuncRef
+	expanded := RefVal(Ref(true, AbsHeap(HeapFunc), false))
+	if bare == expanded {
+		t.Fatal("binary spelling flag was not retained")
+	}
+	if !EqualValType(bare, expanded) {
+		t.Fatal("equivalent bare and expanded funcref compared unequal")
+	}
+	if !bare.Ref().Bare() || expanded.Ref().Bare() {
+		t.Fatal("bare spelling flag round trip failed")
+	}
+}
+
+func TestPackedTypeAccessorsDoNotAllocate(t *testing.T) {
+	field := NewFieldType(StorageVal(RefVal(Ref(true, IndexedHeap(TypeIdx{Index: math.MaxUint32, Rec: true}), true))), Var)
+	if got := testing.AllocsPerRun(1000, func() {
+		storage := field.Storage()
+		_ = storage.Packed()
+		_ = storage.Val().Ref().Heap().Type()
+		_ = field.Mut()
+	}); got != 0 {
+		t.Fatalf("accessors allocate %g times/run", got)
+	}
+}

--- a/src/core/compiler/wasm/types.go
+++ b/src/core/compiler/wasm/types.go
@@ -44,53 +44,145 @@ const (
 	HeapDefType
 )
 
-type HeapType struct {
-	Kind HeapTypeKind
-	Abs  AbsHeapType
-	Type TypeIdx
-	Def  *DefType
+// HeapType, RefType, ValType, StorageType, and FieldType share one canonical,
+// pointer-free two-word encoding. The second word is necessary only because a
+// resolved definition carries two full uint32 coordinates; retaining the full
+// accepted domain leaves no room for a variant tag in one uint64. Ordinary
+// decoded types use only a uint32 payload, but keeping one representation makes
+// values directly comparable and avoids pointer-rich tagged unions.
+//
+// lo bit layout:
+//
+//	0..1   heap kind      8..15  abstract heap type
+//	16     recursive TypeIdx
+//	17     defined-type coordinate is present
+//	18..19 defined component kind
+//	20     nullable      21 exact      22 bare binary alias
+//	23     defined component kind is valid
+//	24..25 value kind    32..39 numeric type
+//	40     packed        41..48 packed storage type
+//	49     mutable
+//
+// hi contains a uint32 TypeIdx, or group/member uint32 coordinates for a
+// resolved definition. Scalar operations are endian-independent.
+type HeapType struct{ lo, hi uint64 }
+
+const (
+	heapKindShift   = 0
+	heapKindMask    = uint64(0x3)
+	heapAbsShift    = 8
+	heapAbsMask     = uint64(0xff) << heapAbsShift
+	typeRecBit      = uint64(1) << 16
+	defPresentBit   = uint64(1) << 17
+	defKindShift    = 18
+	defKindMask     = uint64(0x3) << defKindShift
+	nullableBit     = uint64(1) << 20
+	exactBit        = uint64(1) << 21
+	bareBit         = uint64(1) << 22
+	defKindValidBit = uint64(1) << 23
+	valKindShift    = 24
+	valKindMask     = uint64(0x3) << valKindShift
+	numTypeShift    = 32
+	numTypeMask     = uint64(0xff) << numTypeShift
+	packedBit       = uint64(1) << 40
+	packTypeShift   = 41
+	packTypeMask    = uint64(0xff) << packTypeShift
+	mutableBit      = uint64(1) << 49
+)
+
+func AbsHeap(abs AbsHeapType) HeapType {
+	return HeapType{lo: uint64(HeapAbs)<<heapKindShift | uint64(abs)<<heapAbsShift}
+}
+func IndexedHeap(idx TypeIdx) HeapType {
+	lo := uint64(HeapTypeIndex) << heapKindShift
+	if idx.Rec {
+		lo |= typeRecBit
+	}
+	return HeapType{lo: lo, hi: uint64(idx.Index)}
+}
+func DefinedHeap(def *DefType) HeapType {
+	h := HeapType{lo: uint64(HeapDefType) << heapKindShift}
+	if def == nil {
+		return h
+	}
+	h.lo |= defPresentBit
+	h.hi = uint64(def.GroupIndex) | uint64(def.Index)<<32
+	if def.Index < uint32(len(def.Rec.SubTypes)) {
+		h.lo |= defKindValidBit | uint64(def.Rec.SubTypes[def.Index].Comp.Kind)<<defKindShift
+	}
+	return h
+}
+func (h HeapType) Kind() HeapTypeKind { return HeapTypeKind((h.lo >> heapKindShift) & heapKindMask) }
+func (h HeapType) Abs() AbsHeapType   { return AbsHeapType((h.lo & heapAbsMask) >> heapAbsShift) }
+func (h HeapType) Type() TypeIdx {
+	return TypeIdx{Index: uint32(h.hi), Rec: h.lo&typeRecBit != 0}
+}
+func (h HeapType) Def() (group, member uint32, kind CompTypeKind, valid bool) {
+	return uint32(h.hi), uint32(h.hi >> 32), CompTypeKind((h.lo & defKindMask) >> defKindShift), h.lo&defPresentBit != 0
+}
+func (h HeapType) DefCompKind() (CompTypeKind, bool) {
+	return CompTypeKind((h.lo & defKindMask) >> defKindShift), h.lo&defKindValidBit != 0
 }
 
-func AbsHeap(abs AbsHeapType) HeapType { return HeapType{Kind: HeapAbs, Abs: abs} }
-func IndexedHeap(idx TypeIdx) HeapType { return HeapType{Kind: HeapTypeIndex, Type: idx} }
+type RefType struct{ lo, hi uint64 }
 
-type RefType struct {
-	Nullable bool
-	Exact    bool
-	Heap     HeapType
-	// Bare is true for one-byte abstract aliases such as funcref/externref.
-	Bare bool
+func AbsRef(abs AbsHeapType) RefType {
+	h := AbsHeap(abs)
+	return RefType{lo: h.lo | nullableBit | bareBit, hi: h.hi}
 }
-
-func AbsRef(abs AbsHeapType) RefType { return RefType{Nullable: true, Heap: AbsHeap(abs), Bare: true} }
 func Ref(nullable bool, heap HeapType, exact bool) RefType {
-	return RefType{Nullable: nullable, Heap: heap, Exact: exact}
+	lo := heap.lo
+	if nullable {
+		lo |= nullableBit
+	}
+	if exact {
+		lo |= exactBit
+	}
+	return RefType{lo: lo, hi: heap.hi}
 }
 
-func (rt RefType) IsDefaultable() bool { return rt.Nullable }
+func (rt RefType) Nullable() bool { return rt.lo&nullableBit != 0 }
+func (rt RefType) Exact() bool    { return rt.lo&exactBit != 0 }
+func (rt RefType) Bare() bool     { return rt.lo&bareBit != 0 }
+func (rt RefType) Heap() HeapType {
+	return HeapType{lo: rt.lo & (heapKindMask | heapAbsMask | typeRecBit | defPresentBit | defKindMask | defKindValidBit), hi: rt.hi}
+}
+func (rt RefType) WithNullable(nullable bool) RefType {
+	if nullable {
+		rt.lo |= nullableBit
+	} else {
+		rt.lo &^= nullableBit
+	}
+	return rt
+}
+func (rt RefType) WithHeap(heap HeapType) RefType {
+	return RefType{lo: heap.lo | rt.lo&(nullableBit|exactBit|bareBit), hi: heap.hi}
+}
+func (rt RefType) IsDefaultable() bool { return rt.Nullable() }
 
 func (rt RefType) String() string {
 	prefix := "ref"
-	if rt.Nullable {
+	if rt.Nullable() {
 		prefix = "ref null"
 	}
-	if rt.Exact {
+	if rt.Exact() {
 		prefix += " exact"
 	}
-	return prefix + " " + rt.Heap.String()
+	return prefix + " " + rt.Heap().String()
 }
 
 func (h HeapType) String() string {
-	switch h.Kind {
+	switch h.Kind() {
 	case HeapAbs:
-		return h.Abs.String()
+		return h.Abs().String()
 	case HeapTypeIndex:
-		return fmt.Sprintf("type %d", h.Type.Index)
+		return fmt.Sprintf("type %d", h.Type().Index)
 	case HeapDefType:
-		if h.Def == nil {
+		group, member, _, valid := h.Def()
+		if !valid {
 			return "def ?"
 		}
-		return fmt.Sprintf("def %d.%d", h.Def.GroupIndex, h.Def.Index)
+		return fmt.Sprintf("def %d.%d", group, member)
 	default:
 		return "heap?"
 	}
@@ -138,33 +230,40 @@ const (
 	ValBot
 )
 
-type ValType struct {
-	Kind ValTypeKind
-	Num  NumType
-	Ref  RefType
+type ValType struct{ lo, hi uint64 }
+
+func newValType(kind ValTypeKind, num NumType) ValType {
+	return ValType{lo: uint64(kind)<<valKindShift | uint64(num)<<numTypeShift}
 }
 
 var (
-	I32       = ValType{Kind: ValNum, Num: NumI32}
-	I64       = ValType{Kind: ValNum, Num: NumI64}
-	F32       = ValType{Kind: ValNum, Num: NumF32}
-	F64       = ValType{Kind: ValNum, Num: NumF64}
-	V128      = ValType{Kind: ValVec}
-	Bot       = ValType{Kind: ValBot}
-	FuncRef   = ValType{Kind: ValRef, Ref: AbsRef(HeapFunc)}
-	ExternRef = ValType{Kind: ValRef, Ref: AbsRef(HeapExtern)}
-	AnyRef    = ValType{Kind: ValRef, Ref: AbsRef(HeapAny)}
-	EqRef     = ValType{Kind: ValRef, Ref: AbsRef(HeapEq)}
-	I31Ref    = ValType{Kind: ValRef, Ref: AbsRef(HeapI31)}
-	StringRef = ValType{Kind: ValRef, Ref: AbsRef(HeapString)}
+	I32       = newValType(ValNum, NumI32)
+	I64       = newValType(ValNum, NumI64)
+	F32       = newValType(ValNum, NumF32)
+	F64       = newValType(ValNum, NumF64)
+	V128      = newValType(ValVec, 0)
+	Bot       = newValType(ValBot, 0)
+	FuncRef   = RefVal(AbsRef(HeapFunc))
+	ExternRef = RefVal(AbsRef(HeapExtern))
+	AnyRef    = RefVal(AbsRef(HeapAny))
+	EqRef     = RefVal(AbsRef(HeapEq))
+	I31Ref    = RefVal(AbsRef(HeapI31))
+	StringRef = RefVal(AbsRef(HeapString))
 )
 
-func RefVal(rt RefType) ValType { return ValType{Kind: ValRef, Ref: rt} }
+func RefVal(rt RefType) ValType {
+	return ValType{lo: rt.lo | uint64(ValRef)<<valKindShift, hi: rt.hi}
+}
+func (v ValType) Kind() ValTypeKind { return ValTypeKind((v.lo & valKindMask) >> valKindShift) }
+func (v ValType) Num() NumType      { return NumType((v.lo & numTypeMask) >> numTypeShift) }
+func (v ValType) Ref() RefType {
+	return RefType{lo: v.lo &^ (valKindMask | numTypeMask | packedBit | packTypeMask | mutableBit), hi: v.hi}
+}
 
 func (v ValType) String() string {
-	switch v.Kind {
+	switch v.Kind() {
 	case ValNum:
-		switch v.Num {
+		switch v.Num() {
 		case NumI32:
 			return "i32"
 		case NumI64:
@@ -177,15 +276,16 @@ func (v ValType) String() string {
 	case ValVec:
 		return "v128"
 	case ValRef:
-		if v.Ref.Bare && v.Ref.Nullable && !v.Ref.Exact && v.Ref.Heap.Kind == HeapAbs {
-			switch v.Ref.Heap.Abs {
+		rt := v.Ref()
+		if rt.Bare() && rt.Nullable() && !rt.Exact() && rt.Heap().Kind() == HeapAbs {
+			switch rt.Heap().Abs() {
 			case HeapFunc:
 				return "funcref"
 			case HeapExtern:
 				return "externref"
 			}
 		}
-		return v.Ref.String()
+		return rt.String()
 	case ValBot:
 		return "⊥"
 	}
@@ -206,15 +306,35 @@ const (
 	PackI8  PackType = 0x78
 )
 
-type StorageType struct {
-	Packed bool
-	Val    ValType
-	Pack   PackType
-}
+type StorageType struct{ lo, hi uint64 }
 
-type FieldType struct {
-	Storage StorageType
-	Mut     Mut
+func StorageVal(v ValType) StorageType { return StorageType(v) }
+func StoragePacked(pack PackType) StorageType {
+	return StorageType{lo: packedBit | uint64(pack)<<packTypeShift}
+}
+func (s StorageType) Packed() bool { return s.lo&packedBit != 0 }
+func (s StorageType) Val() ValType {
+	return ValType{lo: s.lo &^ (packedBit | packTypeMask | mutableBit), hi: s.hi}
+}
+func (s StorageType) Pack() PackType { return PackType((s.lo & packTypeMask) >> packTypeShift) }
+
+type FieldType struct{ lo, hi uint64 }
+
+func NewFieldType(storage StorageType, mut Mut) FieldType {
+	lo := storage.lo
+	if mut == Var {
+		lo |= mutableBit
+	}
+	return FieldType{lo: lo, hi: storage.hi}
+}
+func (f FieldType) Storage() StorageType {
+	return StorageType{lo: f.lo &^ mutableBit, hi: f.hi}
+}
+func (f FieldType) Mut() Mut {
+	if f.lo&mutableBit != 0 {
+		return Var
+	}
+	return Const
 }
 
 type TypeIdx struct {

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -234,7 +234,7 @@ func (v *moduleValidator) validateModule() error {
 				return err
 			}
 		}
-		if !hasInit && !t.Type.Ref.Nullable {
+		if !hasInit && !t.Type.Ref.Nullable() {
 			return v.err(ErrTypeMismatch, "non-defaultable table requires an initializer")
 		}
 	}
@@ -485,19 +485,19 @@ func (v *moduleValidator) validateCompTypeInRecGroup(ct CompType, recGroup int) 
 }
 
 func (v *moduleValidator) validateFieldTypeInRecGroup(ft FieldType, recGroup int) error {
-	return v.validateStorageTypeInRecGroup(ft.Storage, recGroup)
+	return v.validateStorageTypeInRecGroup(ft.Storage(), recGroup)
 }
 
 func (v *moduleValidator) validateStorageTypeInRecGroup(st StorageType, recGroup int) error {
-	if st.Packed {
-		switch st.Pack {
+	if st.Packed() {
+		switch st.Pack() {
 		case PackI8, PackI16:
 			return nil
 		default:
 			return v.err(ErrUnknownType, "packed storage")
 		}
 	}
-	return v.validateValTypeInRecGroup(st.Val, recGroup)
+	return v.validateValTypeInRecGroup(st.Val(), recGroup)
 }
 
 func (v *moduleValidator) validateValType(t ValType) error {
@@ -505,11 +505,11 @@ func (v *moduleValidator) validateValType(t ValType) error {
 }
 
 func (v *moduleValidator) validateValTypeInRecGroup(t ValType, recGroup int) error {
-	switch t.Kind {
+	switch t.Kind() {
 	case ValNum, ValVec:
 		return nil
 	case ValRef:
-		return v.validateRefTypeInRecGroup(t.Ref, recGroup)
+		return v.validateRefTypeInRecGroup(t.Ref(), recGroup)
 	default:
 		return v.err(ErrUnknownType, "value type")
 	}
@@ -520,7 +520,7 @@ func (v *moduleValidator) validateRefType(rt RefType) error {
 }
 
 func (v *moduleValidator) validateRefTypeInRecGroup(rt RefType, recGroup int) error {
-	return v.validateHeapTypeInRecGroup(rt.Heap, recGroup)
+	return v.validateHeapTypeInRecGroup(rt.Heap(), recGroup)
 }
 
 func (v *moduleValidator) validateHeapType(ht HeapType) error {
@@ -528,16 +528,16 @@ func (v *moduleValidator) validateHeapType(ht HeapType) error {
 }
 
 func (v *moduleValidator) validateHeapTypeInRecGroup(ht HeapType, recGroup int) error {
-	switch ht.Kind {
+	switch ht.Kind() {
 	case HeapAbs:
 		return nil
 	case HeapTypeIndex:
-		if !v.validTypeIdxInRecGroup(ht.Type, recGroup) {
+		if !v.validTypeIdxInRecGroup(ht.Type(), recGroup) {
 			return v.err(ErrUnknownType, "heap type")
 		}
 		return nil
 	case HeapDefType:
-		if ht.Def == nil {
+		if _, _, _, valid := ht.Def(); !valid {
 			return v.err(ErrUnknownType, "heap def type")
 		}
 		return nil
@@ -717,7 +717,7 @@ func (v *moduleValidator) validateElemPayload(e Elem) (RefType, error) {
 				return RefType{}, err
 			}
 		}
-		return FuncRef.Ref, nil
+		return FuncRef.Ref(), nil
 	case ElemTypedExprs:
 		// Validate the declared element reference type even when the segment has no
 		// initializer expressions; empty typed segments still carry type indexes.
@@ -748,7 +748,7 @@ func (v *funcValidator) elemRefType(index uint32) (RefType, error) {
 	e := &v.m.Elements[index]
 	switch e.Kind.Kind {
 	case ElemFuncs, ElemFuncExprs:
-		return FuncRef.Ref, nil
+		return FuncRef.Ref(), nil
 	case ElemTypedExprs:
 		return e.Kind.Ref, nil
 	default:
@@ -952,7 +952,7 @@ func (v *funcValidator) resetLocalInitialization() {
 func (v *funcValidator) localIsInitialized(idx uint32, t ValType) bool {
 	// Function parameters are initialized by the caller. Numeric, vector, and
 	// nullable reference locals have a default value at function entry.
-	if uint64(idx) < uint64(len(v.localParams)) || t.Kind != ValRef || t.Ref.Nullable {
+	if uint64(idx) < uint64(len(v.localParams)) || t.Kind() != ValRef || t.Ref().Nullable() {
 		return true
 	}
 	_, ok := v.initializedLocals[idx]
@@ -960,7 +960,7 @@ func (v *funcValidator) localIsInitialized(idx uint32, t ValType) bool {
 }
 
 func (v *funcValidator) initializeLocal(idx uint32, t ValType) {
-	if uint64(idx) < uint64(len(v.localParams)) || t.Kind != ValRef || t.Ref.Nullable {
+	if uint64(idx) < uint64(len(v.localParams)) || t.Kind() != ValRef || t.Ref().Nullable() {
 		return
 	}
 	if _, ok := v.initializedLocals[idx]; ok {
@@ -992,14 +992,14 @@ func (v *funcValidator) label(depth uint32) ([]ValType, error) {
 	return f.out, nil
 }
 func (v *funcValidator) subtype(a, b ValType) bool {
-	if b.Kind == ValBot || a.Kind == ValBot {
+	if b.Kind() == ValBot || a.Kind() == ValBot {
 		return true
 	}
 	if equalValType(a, b) {
 		return true
 	}
-	if a.Kind == ValRef && b.Kind == ValRef {
-		return v.refSubtype(a.Ref, b.Ref)
+	if a.Kind() == ValRef && b.Kind() == ValRef {
+		return v.refSubtype(a.Ref(), b.Ref())
 	}
 	return false
 }
@@ -1040,9 +1040,9 @@ var (
 )
 
 func singleValTypeSlice(t ValType) []ValType {
-	switch t.Kind {
+	switch t.Kind() {
 	case ValNum:
-		switch t.Num {
+		switch t.Num() {
 		case NumI32:
 			return blockOutI32
 		case NumI64:

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -835,7 +835,7 @@ func (v *moduleValidator) validateDirectElemPayload(e directElem) (RefType, erro
 				return RefType{}, err
 			}
 		}
-		return FuncRef.Ref, nil
+		return FuncRef.Ref(), nil
 	case ElemTypedExprs:
 		if err := v.validateRefType(e.ref); err != nil {
 			return RefType{}, err
@@ -860,7 +860,7 @@ func (v *funcValidator) directElemRefType(index uint32) (RefType, error) {
 	e := &v.direct.elements[index]
 	switch e.kind {
 	case ElemFuncs, ElemFuncExprs:
-		return FuncRef.Ref, nil
+		return FuncRef.Ref(), nil
 	case ElemTypedExprs:
 		return e.ref, nil
 	default:

--- a/src/core/compiler/wasm/validate_edges_test.go
+++ b/src/core/compiler/wasm/validate_edges_test.go
@@ -213,7 +213,7 @@ func TestValidateModuleLevelIndexes(t *testing.T) {
 		expectValidateErr(t, &Module{Types: []RecType{ft(nil, nil)}, Imports: []Import{{Type: ExternType{Kind: ExternGlobal, Global: GlobalType{Type: badRef}}}}}, ErrUnknownType)
 	})
 	t.Run("table unknown heap type", func(t *testing.T) {
-		expectValidateErr(t, &Module{Tables: []Table{{Type: TableType{Ref: badRef.Ref, Limits: Limits{Min: 1}}}}}, ErrUnknownType)
+		expectValidateErr(t, &Module{Tables: []Table{{Type: TableType{Ref: badRef.Ref(), Limits: Limits{Min: 1}}}}}, ErrUnknownType)
 	})
 	t.Run("unused local unknown heap type", func(t *testing.T) {
 		m := modWithFunc(nil, nil)

--- a/src/core/compiler/wasm/validate_gc_helpers.go
+++ b/src/core/compiler/wasm/validate_gc_helpers.go
@@ -152,28 +152,28 @@ func (v *moduleValidator) compTypeSubtype(sub CompType, subGroup int, sup CompTy
 	subVal := func(a ValType, aGroup int, b ValType, bGroup int) bool {
 		a = v.resolveValTypeRecIndexes(a, aGroup)
 		b = v.resolveValTypeRecIndexes(b, bGroup)
-		if a.Kind == ValBot {
+		if a.Kind() == ValBot {
 			return true
 		}
-		if a.Kind != b.Kind || a.Num != b.Num {
+		if a.Kind() != b.Kind() || a.Num() != b.Num() {
 			return false
 		}
-		return a.Kind != ValRef || v.refSubtype(a.Ref, b.Ref)
+		return a.Kind() != ValRef || v.refSubtype(a.Ref(), b.Ref())
 	}
 	storageSubtype := func(a StorageType, aGroup int, b StorageType, bGroup int) bool {
-		if a.Packed || b.Packed {
-			return a.Packed == b.Packed && a.Pack == b.Pack
+		if a.Packed() || b.Packed() {
+			return a.Packed() == b.Packed() && a.Pack() == b.Pack()
 		}
-		return subVal(a.Val, aGroup, b.Val, bGroup)
+		return subVal(a.Val(), aGroup, b.Val(), bGroup)
 	}
 	fieldSubtype := func(a FieldType, aGroup int, b FieldType, bGroup int) bool {
-		if a.Mut != b.Mut {
+		if a.Mut() != b.Mut() {
 			return false
 		}
-		if !storageSubtype(a.Storage, aGroup, b.Storage, bGroup) {
+		if !storageSubtype(a.Storage(), aGroup, b.Storage(), bGroup) {
 			return false
 		}
-		return a.Mut == Const || storageSubtype(b.Storage, bGroup, a.Storage, aGroup)
+		return a.Mut() == Const || storageSubtype(b.Storage(), bGroup, a.Storage(), aGroup)
 	}
 	switch sub.Kind {
 	case CompFunc:
@@ -298,27 +298,26 @@ func (v *moduleValidator) resolveCompTypeRecIndexes(ct CompType, recGroup int) C
 }
 
 func (v *moduleValidator) resolveFieldTypeRecIndexes(ft FieldType, recGroup int) FieldType {
-	if ft.Storage.Packed {
+	storage := ft.Storage()
+	if storage.Packed() {
 		return ft
 	}
-	ft.Storage.Val = v.resolveValTypeRecIndexes(ft.Storage.Val, recGroup)
-	return ft
+	return NewFieldType(StorageVal(v.resolveValTypeRecIndexes(storage.Val(), recGroup)), ft.Mut())
 }
 
 func (v *moduleValidator) resolveValTypeRecIndexes(t ValType, recGroup int) ValType {
-	if t.Kind != ValRef {
+	if t.Kind() != ValRef {
 		return t
 	}
-	t.Ref = v.resolveRefTypeRecIndexes(t.Ref, recGroup)
-	return t
+	return RefVal(v.resolveRefTypeRecIndexes(t.Ref(), recGroup))
 }
 
 func (v *moduleValidator) resolveRefTypeRecIndexes(rt RefType, recGroup int) RefType {
-	if rt.Heap.Kind != HeapTypeIndex {
+	heap := rt.Heap()
+	if heap.Kind() != HeapTypeIndex {
 		return rt
 	}
-	rt.Heap.Type = v.resolveTypeIdxRecIndex(rt.Heap.Type, recGroup)
-	return rt
+	return rt.WithHeap(IndexedHeap(v.resolveTypeIdxRecIndex(heap.Type(), recGroup)))
 }
 
 func (v *moduleValidator) resolveTypeIdxRecIndex(idx TypeIdx, recGroup int) TypeIdx {
@@ -330,20 +329,20 @@ func (v *moduleValidator) resolveTypeIdxRecIndex(idx TypeIdx, recGroup int) Type
 }
 
 func storageValType(st StorageType, signedGet bool) ValType {
-	if !st.Packed {
-		return st.Val
+	if !st.Packed() {
+		return st.Val()
 	}
 	_ = signedGet
 	return I32
 }
 
 func valTypeDefaultable(t ValType) bool {
-	return t.Kind != ValRef || t.Ref.Nullable
+	return t.Kind() != ValRef || t.Ref().Nullable()
 }
 
 func (v *moduleValidator) descriptorTargetRefType(nullable bool, ht HeapType, exact bool) (ValType, bool) {
-	if ht.Kind == HeapTypeIndex {
-		if _, ok := v.subtypeByTypeIdx(ht.Type); !ok {
+	if ht.Kind() == HeapTypeIndex {
+		if _, ok := v.subtypeByTypeIdx(ht.Type()); !ok {
 			return ValType{}, false
 		}
 	}
@@ -396,14 +395,14 @@ const (
 // the other: the dynamic result is simply false. Disjoint top-level reference
 // hierarchies (for example func and i31/data) remain validation errors.
 func (v *moduleValidator) refTestCompatible(a, b RefType) bool {
-	af, aok := v.refTestHeapFamily(a.Heap)
-	bf, bok := v.refTestHeapFamily(b.Heap)
+	af, aok := v.refTestHeapFamily(a.Heap())
+	bf, bok := v.refTestHeapFamily(b.Heap())
 	return aok && bok && af == bf
 }
 
 func (v *moduleValidator) refTestHeapFamily(h HeapType) (refTestFamily, bool) {
-	if h.Kind == HeapAbs {
-		switch h.Abs {
+	if h.Kind() == HeapAbs {
+		switch h.Abs() {
 		case HeapNone, HeapI31, HeapStruct, HeapArray, HeapEq, HeapAny:
 			return refTestFamilyData, true
 		case HeapNoFunc, HeapFunc:
@@ -419,18 +418,19 @@ func (v *moduleValidator) refTestHeapFamily(h HeapType) (refTestFamily, bool) {
 		}
 	}
 	var kind CompTypeKind
-	switch h.Kind {
+	switch h.Kind() {
 	case HeapTypeIndex:
-		ct, ok := v.compTypeFromTypeIdx(h.Type)
+		ct, ok := v.compTypeFromTypeIdx(h.Type())
 		if !ok {
 			return 0, false
 		}
 		kind = ct.Kind
 	case HeapDefType:
-		if h.Def == nil || h.Def.Index >= uint32(len(h.Def.Rec.SubTypes)) {
+		defKind, valid := h.DefCompKind()
+		if !valid {
 			return 0, false
 		}
-		kind = h.Def.Rec.SubTypes[h.Def.Index].Comp.Kind
+		kind = defKind
 	default:
 		return 0, false
 	}
@@ -445,56 +445,56 @@ func (v *moduleValidator) refTestHeapFamily(h HeapType) (refTestFamily, bool) {
 }
 
 func (v *moduleValidator) descriptorCompatible(a, b RefType) bool {
-	if a.Heap.Kind == HeapAbs && b.Heap.Kind == HeapAbs {
-		return absHeapSubtype(a.Heap.Abs, b.Heap.Abs) || absHeapSubtype(b.Heap.Abs, a.Heap.Abs)
+	if a.Heap().Kind() == HeapAbs && b.Heap().Kind() == HeapAbs {
+		return absHeapSubtype(a.Heap().Abs(), b.Heap().Abs()) || absHeapSubtype(b.Heap().Abs(), a.Heap().Abs())
 	}
-	if a.Exact && b.Exact && a.Heap.Kind == HeapTypeIndex && b.Heap.Kind == HeapTypeIndex {
-		return v.typeIdxEquivalent(a.Heap.Type, b.Heap.Type)
+	if a.Exact() && b.Exact() && a.Heap().Kind() == HeapTypeIndex && b.Heap().Kind() == HeapTypeIndex {
+		return v.typeIdxEquivalent(a.Heap().Type(), b.Heap().Type())
 	}
 	return v.refSubtype(a, b) || v.refSubtype(b, a)
 }
 
 func (v *moduleValidator) refSubtype(a, b RefType) bool {
-	if !b.Nullable && a.Nullable {
+	if !b.Nullable() && a.Nullable() {
 		return false
 	}
-	if v.heapTypeEquivalent(a.Heap, b.Heap) {
-		if b.Exact && !a.Exact {
+	if v.heapTypeEquivalent(a.Heap(), b.Heap()) {
+		if b.Exact() && !a.Exact() {
 			return false
 		}
 		return true
 	}
-	if a.Heap.Kind == HeapTypeIndex && b.Heap.Kind == HeapTypeIndex {
-		return !b.Exact && v.typeIdxSuperSubtype(a.Heap.Type, b.Heap.Type)
+	if a.Heap().Kind() == HeapTypeIndex && b.Heap().Kind() == HeapTypeIndex {
+		return !b.Exact() && v.typeIdxSuperSubtype(a.Heap().Type(), b.Heap().Type())
 	}
-	if a.Heap.Kind == HeapAbs && b.Heap.Kind == HeapTypeIndex {
-		ct, ok := v.compTypeFromTypeIdx(b.Heap.Type)
+	if a.Heap().Kind() == HeapAbs && b.Heap().Kind() == HeapTypeIndex {
+		ct, ok := v.compTypeFromTypeIdx(b.Heap().Type())
 		if !ok {
 			return false
 		}
 		switch ct.Kind {
 		case CompFunc:
-			return a.Heap.Abs == HeapNoFunc
+			return a.Heap().Abs() == HeapNoFunc
 		case CompStruct, CompArray:
-			return a.Heap.Abs == HeapNone
+			return a.Heap().Abs() == HeapNone
 		}
 	}
-	if a.Heap.Kind == HeapTypeIndex && b.Heap.Kind == HeapAbs {
-		ct, ok := v.compTypeFromTypeIdx(a.Heap.Type)
+	if a.Heap().Kind() == HeapTypeIndex && b.Heap().Kind() == HeapAbs {
+		ct, ok := v.compTypeFromTypeIdx(a.Heap().Type())
 		if !ok {
 			return false
 		}
 		switch ct.Kind {
 		case CompStruct:
-			return absHeapSubtype(HeapStruct, b.Heap.Abs)
+			return absHeapSubtype(HeapStruct, b.Heap().Abs())
 		case CompArray:
-			return absHeapSubtype(HeapArray, b.Heap.Abs)
+			return absHeapSubtype(HeapArray, b.Heap().Abs())
 		case CompFunc:
-			return absHeapSubtype(HeapFunc, b.Heap.Abs)
+			return absHeapSubtype(HeapFunc, b.Heap().Abs())
 		}
 	}
-	if a.Heap.Kind == HeapAbs && b.Heap.Kind == HeapAbs {
-		return absHeapSubtype(a.Heap.Abs, b.Heap.Abs)
+	if a.Heap().Kind() == HeapAbs && b.Heap().Kind() == HeapAbs {
+		return absHeapSubtype(a.Heap().Abs(), b.Heap().Abs())
 	}
 	return false
 }
@@ -520,45 +520,44 @@ func (v *moduleValidator) typeIdxEquivalent(a, b TypeIdx) bool {
 	var eqType func(int, int) bool
 	var eqVal func(ValType, ValType, int, int) bool
 	eqHeap := func(x, y HeapType, xGroup, yGroup int) bool {
-		if x.Kind != y.Kind {
+		if x.Kind() != y.Kind() {
 			return false
 		}
-		switch x.Kind {
+		switch x.Kind() {
 		case HeapAbs:
-			return x.Abs == y.Abs
+			return x.Abs() == y.Abs()
 		case HeapTypeIndex:
-			if x.Type.Rec != y.Type.Rec {
+			if x.Type().Rec != y.Type().Rec {
 				return false
 			}
-			xi, xok := v.flatTypeIdxInRecGroup(x.Type, xGroup)
-			yi, yok := v.flatTypeIdxInRecGroup(y.Type, yGroup)
+			xi, xok := v.flatTypeIdxInRecGroup(x.Type(), xGroup)
+			yi, yok := v.flatTypeIdxInRecGroup(y.Type(), yGroup)
 			return xok && yok && eqType(xi, yi)
 		case HeapDefType:
-			if x.Def == nil || y.Def == nil {
-				return x.Def == y.Def
-			}
-			return x.Def.GroupIndex == y.Def.GroupIndex && x.Def.Index == y.Def.Index
+			xg, xi, _, xv := x.Def()
+			yg, yi, _, yv := y.Def()
+			return xv == yv && (!xv || xg == yg && xi == yi)
 		default:
 			return false
 		}
 	}
 	eqVal = func(x, y ValType, xGroup, yGroup int) bool {
-		if x.Kind != y.Kind || x.Num != y.Num {
+		if x.Kind() != y.Kind() || x.Num() != y.Num() {
 			return false
 		}
-		if x.Kind != ValRef {
+		if x.Kind() != ValRef {
 			return true
 		}
-		return x.Ref.Nullable == y.Ref.Nullable && x.Ref.Exact == y.Ref.Exact && eqHeap(x.Ref.Heap, y.Ref.Heap, xGroup, yGroup)
+		return x.Ref().Nullable() == y.Ref().Nullable() && x.Ref().Exact() == y.Ref().Exact() && eqHeap(x.Ref().Heap(), y.Ref().Heap(), xGroup, yGroup)
 	}
 	eqStorage := func(x, y StorageType, xGroup, yGroup int) bool {
-		if x.Packed != y.Packed || x.Pack != y.Pack {
+		if x.Packed() != y.Packed() || x.Pack() != y.Pack() {
 			return false
 		}
-		return x.Packed || eqVal(x.Val, y.Val, xGroup, yGroup)
+		return x.Packed() || eqVal(x.Val(), y.Val(), xGroup, yGroup)
 	}
 	eqField := func(x, y FieldType, xGroup, yGroup int) bool {
-		return x.Mut == y.Mut && eqStorage(x.Storage, y.Storage, xGroup, yGroup)
+		return x.Mut() == y.Mut() && eqStorage(x.Storage(), y.Storage(), xGroup, yGroup)
 	}
 	groupLocation := func(flat int) (group, local, base int, ok bool) {
 		if flat < 0 {
@@ -670,5 +669,5 @@ func (v *moduleValidator) heapTypeEquivalent(a, b HeapType) bool {
 	if equalHeapType(a, b) {
 		return true
 	}
-	return a.Kind == HeapTypeIndex && b.Kind == HeapTypeIndex && v.typeIdxEquivalent(a.Type, b.Type)
+	return a.Kind() == HeapTypeIndex && b.Kind() == HeapTypeIndex && v.typeIdxEquivalent(a.Type(), b.Type())
 }

--- a/src/core/compiler/wasm/validate_internal_test.go
+++ b/src/core/compiler/wasm/validate_internal_test.go
@@ -521,10 +521,10 @@ func TestValidatorCoverageModuleLevelBranches(t *testing.T) {
 		expectValidateErr(t, &Module{Types: []RecType{{SubTypes: []SubType{{Metadata: TypeMetadata{Describes: ptr(TypeIdx{Index: 9})}, Comp: CompType{Kind: CompStruct}}}}}}, ErrUnknownType)
 		expectValidateErr(t, &Module{Types: []RecType{{SubTypes: []SubType{{Metadata: TypeMetadata{Descriptor: ptr(TypeIdx{Index: 9})}, Comp: CompType{Kind: CompStruct}}}}}}, ErrUnknownType)
 		expectValidateErr(t, &Module{Types: []RecType{{SubTypes: []SubType{{Comp: CompType{Kind: CompTypeKind(99)}}}}}}, ErrUnknownType)
-		expectValidateErr(t, &Module{Types: []RecType{{SubTypes: []SubType{{Comp: CompType{Kind: CompStruct, Fields: []FieldType{{Storage: StorageType{Packed: true, Pack: PackType(0xff)}}}}}}}}}, ErrUnknownType)
-		expectValidateErr(t, &Module{Types: []RecType{ft(nil, []ValType{{Kind: ValTypeKind(99)}})}}, ErrUnknownType)
-		expectValidateErr(t, &Module{Tables: []Table{{Type: TableType{Ref: Ref(true, HeapType{Kind: HeapTypeKind(99)}, false)}}}}, ErrUnknownType)
-		expectValidateErr(t, &Module{Tables: []Table{{Type: TableType{Ref: Ref(true, HeapType{Kind: HeapDefType}, false)}}}}, ErrUnknownType)
+		expectValidateErr(t, &Module{Types: []RecType{{SubTypes: []SubType{{Comp: CompType{Kind: CompStruct, Fields: []FieldType{NewFieldType(StoragePacked(PackType(0xff)), Const)}}}}}}}, ErrUnknownType)
+		expectValidateErr(t, &Module{Types: []RecType{ft(nil, []ValType{newValType(ValTypeKind(99), 0)})}}, ErrUnknownType)
+		expectValidateErr(t, &Module{Tables: []Table{{Type: TableType{Ref: Ref(true, HeapType{lo: uint64(HeapTypeKind(99))}, false)}}}}, ErrUnknownType)
+		expectValidateErr(t, &Module{Tables: []Table{{Type: TableType{Ref: Ref(true, DefinedHeap(nil), false)}}}}, ErrUnknownType)
 	})
 	t.Run("extern imports all kinds validate", func(t *testing.T) {
 		max := uint64(1)
@@ -789,7 +789,7 @@ func TestDirectStartTryTableCatchPayloads(t *testing.T) {
 		bt   BlockType
 		c    []Catch
 	}{
-		{"invalid-block-type", coverageFuncValidator(&Module{}, nil), BlockType{Kind: BlockVal, Val: ValType{Kind: ValTypeKind(99)}}, nil},
+		{"invalid-block-type", coverageFuncValidator(&Module{}, nil), BlockType{Kind: BlockVal, Val: newValType(ValTypeKind(99), 0)}, nil},
 		{"unknown-label", coverageFuncValidator(&Module{}, nil), BlockType{Kind: BlockVoid}, []Catch{{Kind: CatchAll, Label: 1}}},
 		{"unknown-tag", coverageFuncValidator(tagged, []ValType{I32}), BlockType{Kind: BlockVoid}, []Catch{{Kind: CatchTag, Tag: 1, Label: 0}}},
 		{"tag-is-not-function", coverageFuncValidator(&Module{Types: []RecType{structType(nil, TypeMetadata{}), ft(nil, nil)}, Tags: []TagType{{Type: TypeIdx{Index: 0}}}}, nil), BlockType{Kind: BlockVoid}, []Catch{{Kind: CatchTag, Tag: 0, Label: 0}}},
@@ -812,7 +812,7 @@ func TestValidatorCoverageModuleLevelNegativeBranches(t *testing.T) {
 		expectValidateErr(t, m, ErrTypeMismatch)
 	})
 	t.Run("global has invalid value type", func(t *testing.T) {
-		expectValidateErr(t, &Module{Globals: []Global{{Type: GlobalType{Type: ValType{Kind: ValTypeKind(99)}}}}}, ErrUnknownType)
+		expectValidateErr(t, &Module{Globals: []Global{{Type: GlobalType{Type: newValType(ValTypeKind(99), 0)}}}}, ErrUnknownType)
 	})
 	t.Run("active data has unknown memory", func(t *testing.T) {
 		m := &Module{Data: []Data{{Mode: DataMode{Kind: DataActive, Offset: Expr{Instrs: []Instruction{{Kind: InstrI32Const}}}}}}}
@@ -824,7 +824,7 @@ func TestValidatorCoverageModuleLevelNegativeBranches(t *testing.T) {
 		expectValidateErr(t, &Module{Types: types, Imports: []Import{{Type: ExternType{Kind: ExternTag, Tag: TagType{Type: TypeIdx{Index: 0}}}}}}, ErrUnknownType)
 	})
 	t.Run("function parameter has invalid value type", func(t *testing.T) {
-		expectValidateErr(t, &Module{Types: []RecType{ft([]ValType{{Kind: ValTypeKind(99)}}, nil)}}, ErrUnknownType)
+		expectValidateErr(t, &Module{Types: []RecType{ft([]ValType{newValType(ValTypeKind(99), 0)}, nil)}}, ErrUnknownType)
 	})
 	t.Run("active element has unknown table", func(t *testing.T) {
 		m := &Module{Elements: []Elem{{Mode: ElemMode{Kind: ElemActive, Offset: Expr{Instrs: []Instruction{{Kind: InstrI32Const}}}}, Kind: ElemKind{Kind: ElemFuncExprs, Exprs: []Expr{{Instrs: []Instruction{{Kind: InstrRefNull, ext: &instrExt{RefType: AbsRef(HeapFunc)}}}}}}}}}
@@ -884,10 +884,10 @@ func TestValidatorCoverageInternalHelperBranches(t *testing.T) {
 	if mv.refSubtype(Ref(false, AbsHeap(HeapExtern), false), Ref(false, IndexedHeap(TypeIdx{Index: 0}), false)) {
 		t.Fatal("abstract heap should not subtype indexed heap")
 	}
-	if !coverageFuncValidator(mv.m, nil).subtype(ValType{Kind: ValBot}, I32) {
+	if !coverageFuncValidator(mv.m, nil).subtype(Bot, I32) {
 		t.Fatal("value bottom should subtype any value")
 	}
-	if _, _, err := coverageFuncValidator(&Module{}, nil).blockSig(BlockType{Kind: BlockVal, Val: ValType{Kind: ValTypeKind(99)}}); err == nil {
+	if _, _, err := coverageFuncValidator(&Module{}, nil).blockSig(BlockType{Kind: BlockVal, Val: newValType(ValTypeKind(99), 0)}); err == nil {
 		t.Fatal("invalid block result type accepted")
 	}
 	if _, _, err := coverageFuncValidator(&Module{}, nil).blockSig(BlockType{Kind: BlockTypeKind(99)}); err == nil {
@@ -899,7 +899,7 @@ func TestValidatorCoverageInternalHelperBranches(t *testing.T) {
 	if !mv.heapSubtype(AbsHeap(HeapExtern), AbsHeap(HeapExtern)) {
 		t.Fatal("equal heaps should subtype")
 	}
-	if err := mv.validateHeapType(HeapType{Kind: HeapDefType, Def: &DefType{}}); err != nil {
+	if err := mv.validateHeapType(DefinedHeap(&DefType{})); err != nil {
 		t.Fatalf("heap def type: %v", err)
 	}
 }
@@ -911,7 +911,7 @@ func TestValidatorCoverageCoreNegativeStepBranches(t *testing.T) {
 		expectStepErr(t, fv, Instruction{Kind: InstrNop}, ErrConstExprRequired)
 	})
 	t.Run("typed select validates immediate value type", func(t *testing.T) {
-		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrSelect, ext: &instrExt{ValTypes: []ValType{{Kind: ValTypeKind(99)}}}}), ErrUnknownType)
+		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrSelect, ext: &instrExt{ValTypes: []ValType{newValType(ValTypeKind(99), 0)}}}), ErrUnknownType)
 	})
 	t.Run("load and store stack failures", func(t *testing.T) {
 		expectStepErr(t, coverageFuncValidator(&Module{}, nil), Instruction{Kind: InstrI32Load}, ErrUnknownMemory)
@@ -941,7 +941,7 @@ func TestValidatorCoverageCoreNegativeStepBranches(t *testing.T) {
 		}
 	})
 	t.Run("if branch bookkeeping errors", func(t *testing.T) {
-		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrIf, ext: &instrExt{BlockType: BlockType{Kind: BlockVal, Val: ValType{Kind: ValTypeKind(99)}}}}), ErrUnknownType)
+		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrIf, ext: &instrExt{BlockType: BlockType{Kind: BlockVal, Val: newValType(ValTypeKind(99), 0)}}}), ErrUnknownType)
 		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrIf, ext: &instrExt{Then: []Instruction{{Kind: InstrLocalGet, Index: 0}}}}), ErrUnknownLocal)
 		expectValidateErr(t, modWithFunc(nil, []ValType{I32}, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrIf, ext: &instrExt{BlockType: BlockType{Kind: BlockVal, Val: I32}, Then: []Instruction{{Kind: InstrI32Const}}}}), ErrTypeMismatch)
 		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrI32Const}, Instruction{Kind: InstrIf, ext: &instrExt{Then: []Instruction{{Kind: InstrI32Const}}, Else: []Instruction{}}}), ErrTypeMismatch)
@@ -971,7 +971,7 @@ func TestValidatorCoverageCoreNegativeStepBranches(t *testing.T) {
 		expectValidateErr(t, &Module{Globals: []Global{{Type: GlobalType{Type: I32}, Init: Expr{Instrs: []Instruction{{Kind: InstrI32Const}}}}}, Types: []RecType{ft(nil, nil)}, FuncTypes: []TypeIdx{{Index: 0}}, Code: []Func{{Body: Expr{Instrs: []Instruction{{Kind: InstrI32Const}, {Kind: InstrGlobalSet, Index: 0}}}}}}, ErrImmutableGlobal)
 		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrTableGet, Index: 0}), ErrUnknownTable)
 		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrTableSet, Index: 0}), ErrUnknownTable)
-		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrRefNull, ext: &instrExt{RefType: Ref(true, HeapType{Kind: HeapTypeKind(99)}, false)}}), ErrUnknownType)
+		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrRefNull, ext: &instrExt{RefType: Ref(true, HeapType{lo: uint64(HeapTypeKind(99))}, false)}}), ErrUnknownType)
 		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrRefFunc, Index: 1}, Instruction{Kind: InstrDrop}), ErrUnknownFunc)
 		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrRefIsNull}), ErrTypeMismatch)
 		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrRefEq}), ErrTypeMismatch)
@@ -1137,7 +1137,7 @@ func TestValidatorCoverageProposalNegativeBranches(t *testing.T) {
 		}
 	})
 	t.Run("try_table negative paths", func(t *testing.T) {
-		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrTryTable, ext: &instrExt{BlockType: BlockType{Kind: BlockVal, Val: ValType{Kind: ValTypeKind(99)}}}}), ErrUnknownType)
+		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrTryTable, ext: &instrExt{BlockType: BlockType{Kind: BlockVal, Val: newValType(ValTypeKind(99), 0)}}}), ErrUnknownType)
 		expectValidateErr(t, modWithFunc(nil, nil, Instruction{Kind: InstrBlock, ext: &instrExt{Body: Expr{Instrs: []Instruction{{Kind: InstrTryTable, ext: &instrExt{Catches: []Catch{{Kind: CatchTag, Tag: 99, Label: 0}}}}}}}}), ErrUnknownTag)
 		m := &Module{Types: []RecType{ft([]ValType{I32}, nil), ft(nil, nil)}, Tags: []TagType{{Type: TypeIdx{Index: 0}}}, FuncTypes: []TypeIdx{{Index: 1}}, Code: []Func{{Body: Expr{Instrs: []Instruction{{Kind: InstrBlock, ext: &instrExt{Body: Expr{Instrs: []Instruction{{Kind: InstrTryTable, ext: &instrExt{Catches: []Catch{{Kind: CatchTag, Tag: 0, Label: 0}}}}}}}}}}}}}
 		expectValidateErr(t, m, ErrTypeMismatch)

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -366,11 +366,11 @@ func (v *funcValidator) step(in *Instruction) error {
 		if err != nil {
 			return err
 		}
-		if !x.unknown && x.t.Kind != ValRef {
+		if !x.unknown && x.t.Kind() != ValRef {
 			return v.verr(ErrTypeMismatch, "ref.as_non_null")
 		}
 		if !x.unknown {
-			x.t.Ref.Nullable = false
+			x.t = RefVal(x.t.Ref().WithNullable(false))
 		}
 		v.vals = append(v.vals, x)
 	case InstrBrOnNull:
@@ -382,7 +382,7 @@ func (v *funcValidator) step(in *Instruction) error {
 		if err != nil {
 			return err
 		}
-		if !x.unknown && x.t.Kind != ValRef {
+		if !x.unknown && x.t.Kind() != ValRef {
 			return v.verr(ErrTypeMismatch, "br_on_null")
 		}
 		if err := v.popAll(lt); err != nil {
@@ -390,7 +390,7 @@ func (v *funcValidator) step(in *Instruction) error {
 		}
 		v.pushAll(lt)
 		if !x.unknown {
-			x.t.Ref.Nullable = false
+			x.t = RefVal(x.t.Ref().WithNullable(false))
 		}
 		v.vals = append(v.vals, x)
 	case InstrBrOnNonNull:
@@ -402,11 +402,11 @@ func (v *funcValidator) step(in *Instruction) error {
 		if err != nil {
 			return err
 		}
-		if len(lt) == 0 || lt[len(lt)-1].Kind != ValRef || (!x.unknown && x.t.Kind != ValRef) {
+		if len(lt) == 0 || lt[len(lt)-1].Kind() != ValRef || (!x.unknown && x.t.Kind() != ValRef) {
 			return v.verr(ErrTypeMismatch, "br_on_non_null")
 		}
 		if !x.unknown {
-			x.t.Ref.Nullable = false
+			x.t = RefVal(x.t.Ref().WithNullable(false))
 			if !v.subtype(x.t, lt[len(lt)-1]) {
 				return v.verr(ErrTypeMismatch, x.t.String()+" is not "+lt[len(lt)-1].String())
 			}
@@ -564,7 +564,7 @@ func isConstInstruction(k InstrKind) bool {
 	return false
 }
 func isImplicitSelectType(t ValType) bool {
-	return t.Kind == ValNum || t.Kind == ValVec
+	return t.Kind() == ValNum || t.Kind() == ValVec
 }
 
 // matchValTypes reports whether actual values may flow to expected result
@@ -813,11 +813,11 @@ const (
 
 var effectValTypes = [...]ValType{
 	effectNone: {},
-	effectI32:  {Kind: ValNum, Num: NumI32},
-	effectI64:  {Kind: ValNum, Num: NumI64},
-	effectF32:  {Kind: ValNum, Num: NumF32},
-	effectF64:  {Kind: ValNum, Num: NumF64},
-	effectV128: {Kind: ValVec},
+	effectI32:  I32,
+	effectI64:  I64,
+	effectF32:  F32,
+	effectF64:  F64,
+	effectV128: V128,
 }
 
 func (t effectValue) valType() ValType { return effectValTypes[t] }

--- a/src/core/compiler/wasm/validate_proposal.go
+++ b/src/core/compiler/wasm/validate_proposal.go
@@ -360,7 +360,7 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if err != nil {
 			return err
 		}
-		if !x.unknown && x.t.Kind != ValRef {
+		if !x.unknown && x.t.Kind() != ValRef {
 			return v.verr(ErrTypeMismatch, in.Kind.String()+" expects a reference operand")
 		}
 		target, ok := v.descriptorTargetRefType(in.Cast.TargetNullable, in.HeapType(), false)
@@ -368,9 +368,9 @@ func (v *funcValidator) stepGC(in Instruction) error {
 			return v.verr(ErrUnknownType, "invalid descriptor target reftype")
 		}
 		if !x.unknown {
-			compatible := v.refTestCompatible(x.t.Ref, target.Ref)
+			compatible := v.refTestCompatible(x.t.Ref(), target.Ref())
 			if in.Kind == InstrRefTestDesc {
-				compatible = v.descriptorCompatible(x.t.Ref, target.Ref)
+				compatible = v.descriptorCompatible(x.t.Ref(), target.Ref())
 			}
 			if !compatible {
 				return v.verr(ErrTypeMismatch, "target does not match operand type")
@@ -388,7 +388,7 @@ func (v *funcValidator) stepGC(in Instruction) error {
 			if err != nil {
 				return err
 			}
-			if !desc.unknown && desc.t.Kind != ValRef {
+			if !desc.unknown && desc.t.Kind() != ValRef {
 				return v.verr(ErrTypeMismatch, "descriptor operand")
 			}
 		}
@@ -396,10 +396,10 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if err != nil {
 			return err
 		}
-		if !x.unknown && x.t.Kind != ValRef {
+		if !x.unknown && x.t.Kind() != ValRef {
 			return v.verr(ErrTypeMismatch, "ref.cast expects a reference operand")
 		}
-		if !x.unknown && in.Kind == InstrRefCastDescEq && !v.descriptorCompatible(x.t.Ref, target.Ref) {
+		if !x.unknown && in.Kind == InstrRefCastDescEq && !v.descriptorCompatible(x.t.Ref(), target.Ref()) {
 			return v.verr(ErrTypeMismatch, "target does not match operand type")
 		}
 		v.push(target)
@@ -418,10 +418,10 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if err != nil {
 			return err
 		}
-		if !x.unknown && x.t.Kind != ValRef {
+		if !x.unknown && x.t.Kind() != ValRef {
 			return v.verr(ErrTypeMismatch, "expected a reference operand")
 		}
-		if !x.unknown && !v.refSubtype(x.t.Ref, Ref(true, IndexedHeap(TypeIdx{Index: in.Index}), false)) {
+		if !x.unknown && !v.refSubtype(x.t.Ref(), Ref(true, IndexedHeap(TypeIdx{Index: in.Index}), false)) {
 			return v.verr(ErrTypeMismatch, "ref.get_desc target")
 		}
 		v.push(RefVal(Ref(false, IndexedHeap(*st.Metadata.Descriptor), true)))
@@ -439,7 +439,7 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if err := v.popExpect(RefVal(Ref(true, IndexedHeap(TypeIdx{Index: in.Index}), false))); err != nil {
 			return err
 		}
-		v.push(storageValType(fields[in.Index2].Storage, in.Kind != InstrStructGet))
+		v.push(storageValType(fields[in.Index2].Storage(), in.Kind != InstrStructGet))
 		return nil
 	case InstrStructSet:
 		fields, _, ok := v.structFields(TypeIdx{Index: in.Index})
@@ -450,10 +450,10 @@ func (v *funcValidator) stepGC(in Instruction) error {
 			return v.verr(ErrTypeMismatch, "unknown field")
 		}
 		f := fields[in.Index2]
-		if f.Mut != Var {
+		if f.Mut() != Var {
 			return v.verr(ErrTypeMismatch, "immutable field")
 		}
-		if err := v.popExpect(storageValType(f.Storage, false)); err != nil {
+		if err := v.popExpect(storageValType(f.Storage(), false)); err != nil {
 			return err
 		}
 		return v.popExpect(RefVal(Ref(true, IndexedHeap(TypeIdx{Index: in.Index}), false)))
@@ -470,17 +470,17 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if err := v.popExpect(RefVal(Ref(true, IndexedHeap(TypeIdx{Index: in.Index}), false))); err != nil {
 			return err
 		}
-		v.push(storageValType(f.Storage, in.Kind != InstrArrayGet))
+		v.push(storageValType(f.Storage(), in.Kind != InstrArrayGet))
 		return nil
 	case InstrArraySet:
 		f, _, ok := v.arrayField(TypeIdx{Index: in.Index})
 		if !ok {
 			return v.verr(ErrUnknownType, "array.set")
 		}
-		if f.Mut != Var {
+		if f.Mut() != Var {
 			return v.verr(ErrTypeMismatch, "immutable array")
 		}
-		if err := v.popExpect(storageValType(f.Storage, false)); err != nil {
+		if err := v.popExpect(storageValType(f.Storage(), false)); err != nil {
 			return err
 		}
 		if err := v.popExpect(I32); err != nil {
@@ -492,7 +492,7 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if err != nil {
 			return err
 		}
-		if !x.unknown && (x.t.Kind != ValRef || !v.heapSubtype(x.t.Ref.Heap, AbsHeap(HeapArray))) {
+		if !x.unknown && (x.t.Kind() != ValRef || !v.heapSubtype(x.t.Ref().Heap(), AbsHeap(HeapArray))) {
 			return v.verr(ErrTypeMismatch, "array.len")
 		}
 		v.push(I32)
@@ -502,13 +502,13 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if !ok {
 			return v.verr(ErrUnknownType, "array.fill")
 		}
-		if f.Mut != Var {
+		if f.Mut() != Var {
 			return v.verr(ErrTypeMismatch, "immutable array")
 		}
 		if err := v.popExpect(I32); err != nil {
 			return err
 		}
-		if err := v.popExpect(storageValType(f.Storage, false)); err != nil {
+		if err := v.popExpect(storageValType(f.Storage(), false)); err != nil {
 			return err
 		}
 		if err := v.popExpect(I32); err != nil {
@@ -521,14 +521,14 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if !okDst || !okSrc {
 			return v.verr(ErrUnknownType, "array.copy")
 		}
-		if dst.Mut != Var {
+		if dst.Mut() != Var {
 			return v.verr(ErrTypeMismatch, "immutable array")
 		}
 		storageMatches := false
-		if dst.Storage.Packed || src.Storage.Packed {
-			storageMatches = dst.Storage.Packed && src.Storage.Packed && dst.Storage.Pack == src.Storage.Pack
+		if dst.Storage().Packed() || src.Storage().Packed() {
+			storageMatches = dst.Storage().Packed() && src.Storage().Packed() && dst.Storage().Pack() == src.Storage().Pack()
 		} else {
-			storageMatches = v.subtype(src.Storage.Val, dst.Storage.Val)
+			storageMatches = v.subtype(src.Storage().Val(), dst.Storage().Val())
 		}
 		if !storageMatches {
 			return v.verr(ErrTypeMismatch, "array types do not match")
@@ -551,10 +551,10 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if !ok {
 			return v.verr(ErrUnknownType, "array.init_data")
 		}
-		if field.Mut != Var {
+		if field.Mut() != Var {
 			return v.verr(ErrTypeMismatch, "immutable array")
 		}
-		if !field.Storage.Packed && field.Storage.Val.Kind == ValRef {
+		if !field.Storage().Packed() && field.Storage().Val().Kind() == ValRef {
 			return v.verr(ErrTypeMismatch, "array type is not numeric or vector")
 		}
 		if int(in.Index2) >= len(v.m.Data) {
@@ -571,17 +571,17 @@ func (v *funcValidator) stepGC(in Instruction) error {
 		if !ok {
 			return v.verr(ErrUnknownType, "array.init_elem")
 		}
-		if field.Mut != Var {
+		if field.Mut() != Var {
 			return v.verr(ErrTypeMismatch, "immutable array")
 		}
-		if field.Storage.Packed || field.Storage.Val.Kind != ValRef {
+		if field.Storage().Packed() || field.Storage().Val().Kind() != ValRef {
 			return v.verr(ErrTypeMismatch, "array.init_elem destination is not a reference array")
 		}
 		elemRef, err := v.elemRefType(in.Index2)
 		if err != nil {
 			return err
 		}
-		if !v.refSubtype(elemRef, field.Storage.Val.Ref) {
+		if !v.refSubtype(elemRef, field.Storage().Val().Ref()) {
 			return v.verr(ErrTypeMismatch, "array.init_elem element type")
 		}
 		for range 3 {
@@ -604,13 +604,13 @@ func (v *funcValidator) stepStructNew(in Instruction) error {
 	}
 	if in.Kind == InstrStructNewDefault || in.Kind == InstrStructNewDefaultDesc {
 		for _, f := range fields {
-			if !f.Storage.Packed && !valTypeDefaultable(storageValType(f.Storage, false)) {
+			if !f.Storage().Packed() && !valTypeDefaultable(storageValType(f.Storage(), false)) {
 				return v.verr(ErrTypeMismatch, "field not defaultable")
 			}
 		}
 	} else {
 		for i := len(fields) - 1; i >= 0; i-- {
-			if err := v.popExpect(storageValType(fields[i].Storage, false)); err != nil {
+			if err := v.popExpect(storageValType(fields[i].Storage(), false)); err != nil {
 				return err
 			}
 		}
@@ -633,7 +633,7 @@ func (v *funcValidator) stepArrayNew(in Instruction) error {
 	if !ok {
 		return v.verr(ErrUnknownType, "array.new")
 	}
-	elem := storageValType(f.Storage, false)
+	elem := storageValType(f.Storage(), false)
 	switch in.Kind {
 	case InstrArrayNew:
 		if err := v.popExpect(I32); err != nil {
@@ -643,7 +643,7 @@ func (v *funcValidator) stepArrayNew(in Instruction) error {
 			return err
 		}
 	case InstrArrayNewDefault:
-		if !f.Storage.Packed && !valTypeDefaultable(elem) {
+		if !f.Storage().Packed() && !valTypeDefaultable(elem) {
 			return v.verr(ErrTypeMismatch, "element not defaultable")
 		}
 		if err := v.popExpect(I32); err != nil {
@@ -669,7 +669,7 @@ func (v *funcValidator) stepArrayNew(in Instruction) error {
 			}
 		}
 	case InstrArrayNewData:
-		if !f.Storage.Packed && f.Storage.Val.Kind == ValRef {
+		if !f.Storage().Packed() && f.Storage().Val().Kind() == ValRef {
 			return v.verr(ErrTypeMismatch, "array type is not numeric or vector")
 		}
 		if int(in.Index2) >= len(v.m.Data) {
@@ -682,14 +682,14 @@ func (v *funcValidator) stepArrayNew(in Instruction) error {
 			return err
 		}
 	case InstrArrayNewElem:
-		if f.Storage.Packed || f.Storage.Val.Kind != ValRef {
+		if f.Storage().Packed() || f.Storage().Val().Kind() != ValRef {
 			return v.verr(ErrTypeMismatch, "array.new_elem destination is not a reference array")
 		}
 		elemRef, err := v.elemRefType(in.Index2)
 		if err != nil {
 			return err
 		}
-		if !v.refSubtype(elemRef, f.Storage.Val.Ref) {
+		if !v.refSubtype(elemRef, f.Storage().Val().Ref()) {
 			return v.verr(ErrTypeMismatch, "array.new_elem element type")
 		}
 		if err := v.popExpect(I32); err != nil {
@@ -712,7 +712,7 @@ func (v *funcValidator) stepBrOnCast(in Instruction) error {
 		return v.verr(ErrTypeMismatch, "label type too short")
 	}
 	labelRef := lt[len(lt)-1]
-	if labelRef.Kind != ValRef {
+	if labelRef.Kind() != ValRef {
 		return v.verr(ErrTypeMismatch, "label must end with a reftype")
 	}
 	rt1 := Ref(in.Cast.SourceNullable, in.HeapType(), false)
@@ -724,7 +724,7 @@ func (v *funcValidator) stepBrOnCast(in Instruction) error {
 	if err != nil {
 		return err
 	}
-	if !x.unknown && (x.t.Kind != ValRef || !v.refSubtype(x.t.Ref, rt1)) {
+	if !x.unknown && (x.t.Kind() != ValRef || !v.refSubtype(x.t.Ref(), rt1)) {
 		return v.verr(ErrTypeMismatch, "br_on_cast operand")
 	}
 	// A nullable target consumes null on the successful cast edge. The failed
@@ -732,8 +732,8 @@ func (v *funcValidator) stepBrOnCast(in Instruction) error {
 	// When the target is non-null, null remains a possible failed value and the
 	// source nullability is preserved.
 	failed := rt1
-	if rt2.Nullable {
-		failed.Nullable = false
+	if rt2.Nullable() {
+		failed = failed.WithNullable(false)
 	}
 	branchTypes := append([]ValType(nil), lt...)
 	if in.Kind == InstrBrOnCastFail {

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -461,14 +461,16 @@ func stagedLocalFuncrefExceptionPayload(m *wasm.Module) (funcIndex uint32, typeI
 			if ok {
 				return 0, 0, false, fmt.Errorf("bounded exception handling admits only one reference tag payload")
 			}
-			if m.TagCount() != 1 || len(ft.Params) != 1 || typ.Kind != wasm.ValRef || typ.Ref.Nullable || typ.Ref.Exact || typ.Ref.Heap.Kind != wasm.HeapTypeIndex {
+			rt := typ.Ref()
+			heap := rt.Heap()
+			if m.TagCount() != 1 || len(ft.Params) != 1 || typ.Kind() != wasm.ValRef || rt.Nullable() || rt.Exact() || heap.Kind() != wasm.HeapTypeIndex {
 				return 0, 0, false, fmt.Errorf("bounded exception handling admits only one local non-null indexed-function tag payload")
 			}
-			payloadFunc, found := m.ResolvedTypeFunc(typ.Ref.Heap.Type.Index)
+			payloadFunc, found := m.ResolvedTypeFunc(heap.Type().Index)
 			if !found || payloadFunc == nil || len(payloadFunc.Params) != 0 || len(payloadFunc.Results) != 0 {
 				return 0, 0, false, fmt.Errorf("bounded exception handling indexed-function payload must have type () -> ()")
 			}
-			typeIndex, ok = typ.Ref.Heap.Type.Index, true
+			typeIndex, ok = heap.Type().Index, true
 		}
 	}
 	if !ok {
@@ -521,13 +523,15 @@ func stagedExceptionHandlingShape(m *wasm.Module, exceptionReferences, tailCalls
 				}
 				if len(ft.Results) == 1 {
 					result := ft.Results[0]
-					if result.Kind != wasm.ValRef || !result.Ref.Nullable || result.Ref.Exact || result.Ref.Heap.Kind != wasm.HeapTypeIndex || result.Ref.Heap.Type.Index != payloadType {
+					rt := result.Ref()
+					heap := rt.Heap()
+					if result.Kind() != wasm.ValRef || !rt.Nullable() || rt.Exact() || heap.Kind() != wasm.HeapTypeIndex || heap.Type().Index != payloadType {
 						return fmt.Errorf("bounded exception handling reference-payload export %q has an unsupported result", ex.Name)
 					}
 				}
 			}
 			for _, typ := range append(append([]wasm.ValType(nil), ft.Params...), ft.Results...) {
-				if typ.Kind == wasm.ValRef && typ.Ref.Heap.Kind == wasm.HeapAbs && (typ.Ref.Heap.Abs == wasm.HeapExn || typ.Ref.Heap.Abs == wasm.HeapNoExn) {
+				if typ.Kind() == wasm.ValRef && typ.Ref().Heap().Kind() == wasm.HeapAbs && (typ.Ref().Heap().Abs() == wasm.HeapExn || typ.Ref().Heap().Abs() == wasm.HeapNoExn) {
 					return fmt.Errorf("bounded exception handling rejects exported exception-reference ABI in %q", ex.Name)
 				}
 			}
@@ -819,7 +823,7 @@ func moduleUsesTypedTableReferences(m *wasm.Module) bool {
 		}
 	}
 	check := func(ref wasm.RefType) bool {
-		return ref.Heap.Kind == wasm.HeapTypeIndex || !ref.Nullable || ref.Exact
+		return ref.Heap().Kind() == wasm.HeapTypeIndex || !ref.Nullable() || ref.Exact()
 	}
 	for _, im := range m.Imports {
 		if im.Type.Kind == wasm.ExternTable && check(im.Type.Table.Ref) {

--- a/src/wago/constexpr.go
+++ b/src/wago/constexpr.go
@@ -107,7 +107,7 @@ func evalConstExprBytesWithContext(b []byte, want wasm.ValType, ctx *constExprCo
 			return got, nil
 		}
 	}
-	if want.Kind == wasm.ValRef && m != nil && len(b) != 0 && b[0] == 0xfb {
+	if want.Kind() == wasm.ValRef && m != nil && len(b) != 0 && b[0] == 0xfb {
 		return constExprResult{vtype: want, GlobalIndex: -1, FuncIndex: -1, Expr: append([]byte(nil), b...)}, nil
 	}
 	r := wasm.NewReader(b)
@@ -233,7 +233,7 @@ func evalConstExprBytesWithContext(b []byte, want wasm.ValType, ctx *constExprCo
 		return constExprResult{}, fmt.Errorf("const expression missing end: %w", err)
 	}
 	if end != 0x0B {
-		if want.Kind == wasm.ValRef && m != nil {
+		if want.Kind() == wasm.ValRef && m != nil {
 			// Validation has already type-checked the complete Core 3 constant
 			// expression. Preserve object-building programs for collector-backed
 			// evaluation after preceding globals and function descriptors exist.
@@ -306,11 +306,11 @@ func evalNullExternConversionConstExpr(b []byte, want wasm.ValType) (constExprRe
 }
 
 func isI31RefType(t wasm.ValType) bool {
-	return t.Kind == wasm.ValRef && t.Ref.Heap.Kind == wasm.HeapAbs && t.Ref.Heap.Abs == wasm.HeapI31
+	return t.Kind() == wasm.ValRef && t.Ref().Heap().Kind() == wasm.HeapAbs && t.Ref().Heap().Abs() == wasm.HeapI31
 }
 
 func isAnyRefType(t wasm.ValType) bool {
-	return t.Kind == wasm.ValRef && t.Ref.Heap.Kind == wasm.HeapAbs && t.Ref.Heap.Abs == wasm.HeapAny
+	return t.Kind() == wasm.ValRef && t.Ref().Heap().Kind() == wasm.HeapAbs && t.Ref().Heap().Abs() == wasm.HeapAny
 }
 
 func evalI31ConstExprBytes(b []byte, want wasm.ValType, ctx *constExprCompileContext) (constExprResult, bool, error) {
@@ -382,7 +382,7 @@ func constExprTypeMatches(actual, required wasm.ValType, ctx *constExprCompileCo
 	if valTypeEqual(actual, required) {
 		return true
 	}
-	if ctx == nil || actual.Kind != wasm.ValRef || required.Kind != wasm.ValRef {
+	if ctx == nil || actual.Kind() != wasm.ValRef || required.Kind() != wasm.ValRef {
 		return false
 	}
 	a, err := ctx.converter.valueType(actual, -1)

--- a/src/wago/exception_handling_official_amd64_test.go
+++ b/src/wago/exception_handling_official_amd64_test.go
@@ -99,15 +99,15 @@ func stagedExceptionHandlingGateList(counts map[string]int) []stagedExceptionHan
 }
 
 func stagedReferencePayloadIsFunc(m *corewasm.Module, typ corewasm.ValType) bool {
-	if typ.Kind != corewasm.ValRef {
+	if typ.Kind() != corewasm.ValRef {
 		return false
 	}
-	heap := typ.Ref.Heap
-	if heap.Kind == corewasm.HeapAbs {
-		return heap.Abs == corewasm.HeapFunc || heap.Abs == corewasm.HeapNoFunc
+	heap := typ.Ref().Heap()
+	if heap.Kind() == corewasm.HeapAbs {
+		return heap.Abs() == corewasm.HeapFunc || heap.Abs() == corewasm.HeapNoFunc
 	}
-	if heap.Kind == corewasm.HeapTypeIndex {
-		_, ok := m.ResolvedTypeFunc(heap.Type.Index)
+	if heap.Kind() == corewasm.HeapTypeIndex {
+		_, ok := m.ResolvedTypeFunc(heap.Type().Index)
 		return ok
 	}
 	return false

--- a/src/wago/feature_usage.go
+++ b/src/wago/feature_usage.go
@@ -212,18 +212,20 @@ func requiredFeaturesForValTypes(types []wasm.ValType) CoreFeatures {
 }
 
 func requiredFeaturesForValType(typ wasm.ValType) CoreFeatures {
-	switch typ.Kind {
+	switch typ.Kind() {
 	case wasm.ValRef:
 		out := CoreFeatureReferenceTypes
-		if typ.Ref.Heap.Kind == wasm.HeapAbs {
-			switch typ.Ref.Heap.Abs {
+		rt := typ.Ref()
+		heap := rt.Heap()
+		if heap.Kind() == wasm.HeapAbs {
+			switch heap.Abs() {
 			case wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 				out |= CoreFeatureGC
 			case wasm.HeapExn, wasm.HeapNoExn:
 				out |= CoreFeatureExceptionHandling
 			}
 		}
-		if typ.Ref.Heap.Kind == wasm.HeapTypeIndex || !typ.Ref.Nullable || typ.Ref.Exact {
+		if heap.Kind() == wasm.HeapTypeIndex || !rt.Nullable() || rt.Exact() {
 			out |= CoreFeatureTypedFunctionReferences
 		}
 		return out

--- a/src/wago/gc_array_elements.go
+++ b/src/wago/gc_array_elements.go
@@ -49,11 +49,11 @@ func stagedGCArrayElementInitializer(m *wasm.Module) (*gcArrayElementInit, error
 	if e.Mode.Kind != wasm.ElemPassive || e.Kind.Kind != wasm.ElemTypedExprs || len(e.Kind.Exprs) != maxGCArrayElementValues {
 		return nil, fmt.Errorf("reference array product requires one passive typed segment with two expressions")
 	}
-	if e.Kind.Ref.Nullable || e.Kind.Ref.Exact || e.Kind.Ref.Heap.Kind != wasm.HeapTypeIndex || e.Kind.Ref.Heap.Type.Index != 0 {
+	if e.Kind.Ref.Nullable() || e.Kind.Ref.Exact() || e.Kind.Ref.Heap().Kind() != wasm.HeapTypeIndex || e.Kind.Ref.Heap().Type().Index != 0 {
 		return nil, fmt.Errorf("reference array product segment type must be non-null type 0")
 	}
 	sub, ok := stagedGCStructSubtype(m, 0)
-	if !ok || sub.Comp.Kind != wasm.CompArray || !sub.Comp.Array.Storage.Packed || sub.Comp.Array.Storage.Pack != wasm.PackI8 || sub.Comp.Array.Mut != wasm.Const {
+	if !ok || sub.Comp.Kind != wasm.CompArray || !sub.Comp.Array.Storage().Packed() || sub.Comp.Array.Storage().Pack() != wasm.PackI8 || sub.Comp.Array.Mut() != wasm.Const {
 		return nil, fmt.Errorf("reference array product type 0 must be immutable i8 array")
 	}
 	init := &gcArrayElementInit{SegmentIndex: 0, TypeID: 0, Count: maxGCArrayElementValues}

--- a/src/wago/gc_array_globals.go
+++ b/src/wago/gc_array_globals.go
@@ -48,10 +48,10 @@ func stagedGCArrayGlobalInitializers(m *wasm.Module, product stagedGCArrayProduc
 	imports := m.ImportedGlobalCount()
 	out := make([]gcArrayGlobalInit, 0, 2)
 	for i, g := range m.Globals {
-		if g.Type.Type.Kind != wasm.ValRef || g.Type.Type.Ref.Heap.Kind != wasm.HeapTypeIndex {
+		if g.Type.Type.Kind() != wasm.ValRef || g.Type.Type.Ref().Heap().Kind() != wasm.HeapTypeIndex {
 			continue
 		}
-		sub, ok := stagedGCStructSubtype(m, g.Type.Type.Ref.Heap.Type.Index)
+		sub, ok := stagedGCStructSubtype(m, g.Type.Type.Ref().Heap().Type().Index)
 		if !ok || sub.Comp.Kind != wasm.CompArray {
 			continue
 		}
@@ -140,18 +140,18 @@ func decodeStagedGCArrayGlobalInit(m *wasm.Module, product stagedGCArrayProduct,
 			if err != nil {
 				return gcArrayGlobalInit{}, err
 			}
-			if g.Type.Type.Ref.Heap.Type.Index != typeID || g.Type.Type.Ref.Nullable {
+			if g.Type.Type.Ref().Heap().Type().Index != typeID || g.Type.Type.Ref().Nullable() {
 				return gcArrayGlobalInit{}, fmt.Errorf("result type does not match non-null array type %d", typeID)
 			}
 			sub, ok := stagedGCStructSubtype(m, typeID)
 			if !ok || sub.Comp.Kind != wasm.CompArray {
 				return gcArrayGlobalInit{}, fmt.Errorf("type %d is not an array", typeID)
 			}
-			want := sub.Comp.Array.Storage.Val
-			if sub.Comp.Array.Storage.Packed {
+			want := sub.Comp.Array.Storage().Val()
+			if sub.Comp.Array.Storage().Packed() {
 				want = wasm.I32
 			}
-			if want.Kind == wasm.ValRef && product != stagedGCArrayProductInitElem {
+			if want.Kind() == wasm.ValRef && product != stagedGCArrayProductInitElem {
 				return gcArrayGlobalInit{}, fmt.Errorf("reference array initializer remains unsupported")
 			}
 			init := gcArrayGlobalInit{GlobalIndex: globalIndex, TypeID: typeID}
@@ -161,7 +161,7 @@ func decodeStagedGCArrayGlobalInit(m *wasm.Module, product stagedGCArrayProduct,
 					return gcArrayGlobalInit{}, fmt.Errorf("array.new operands do not match %s, i32", want)
 				}
 				init.Mode = gcArrayGlobalInitUniform
-				if want.Kind == wasm.ValRef {
+				if want.Kind() == wasm.ValRef {
 					init.Mode = gcArrayGlobalInitFuncUniform
 				}
 				init.Length = uint32(values[1].bits)

--- a/src/wago/gc_frame_roots_arm64.go
+++ b/src/wago/gc_frame_roots_arm64.go
@@ -187,7 +187,7 @@ func arm64GCFrameTablesSafe(m *wasm.Module) bool {
 			continue
 		}
 		for _, expr := range e.Kind.Exprs {
-			if kind == 2 && e.Kind.Ref.Heap.Kind == wasm.HeapAbs && e.Kind.Ref.Heap.Abs == wasm.HeapI31 {
+			if kind == 2 && e.Kind.Ref.Heap().Kind() == wasm.HeapAbs && e.Kind.Ref.Heap().Abs() == wasm.HeapI31 {
 				// Exact i31 element expressions are immediate or immutable-global
 				// values, not independent object roots.
 				continue
@@ -422,44 +422,45 @@ func arm64GCFrameCallABI(m *wasm.Module, ft *wasm.CompType) bool {
 }
 
 func arm64FunctionFrameRefType(m *wasm.Module, t wasm.ValType) bool {
-	if t.Kind != wasm.ValRef {
+	if t.Kind() != wasm.ValRef {
 		return false
 	}
-	switch t.Ref.Heap.Kind {
+	heap := t.Ref().Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		return t.Ref.Heap.Abs == wasm.HeapFunc || t.Ref.Heap.Abs == wasm.HeapNoFunc
+		return heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc
 	case wasm.HeapTypeIndex:
-		ft, ok := m.ResolvedTypeFunc(t.Ref.Heap.Type.Index)
+		ft, ok := m.ResolvedTypeFunc(heap.Type().Index)
 		return ok && ft != nil
 	case wasm.HeapDefType:
-		def := t.Ref.Heap.Def
-		return def != nil && def.Index < uint32(len(def.Rec.SubTypes)) && def.Rec.SubTypes[def.Index].Comp.Kind == wasm.CompFunc
+		kind, valid := heap.DefCompKind()
+		return valid && kind == wasm.CompFunc
 	default:
 		return false
 	}
 }
 
 func arm64CollectorFrameRefType(m *wasm.Module, t wasm.ValType) bool {
-	if t.Kind != wasm.ValRef {
+	if t.Kind() != wasm.ValRef {
 		return false
 	}
-	switch t.Ref.Heap.Kind {
+	heap := t.Ref().Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		switch t.Ref.Heap.Abs {
+		switch heap.Abs() {
 		case wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 			return true
 		default:
 			return false
 		}
 	case wasm.HeapDefType:
-		def := t.Ref.Heap.Def
-		if def == nil || def.Index >= uint32(len(def.Rec.SubTypes)) {
+		kind, valid := heap.DefCompKind()
+		if !valid {
 			return true
 		}
-		kind := def.Rec.SubTypes[def.Index].Comp.Kind
 		return kind == wasm.CompStruct || kind == wasm.CompArray
 	case wasm.HeapTypeIndex:
-		index := t.Ref.Heap.Type.Index
+		index := heap.Type().Index
 		for _, group := range m.Types {
 			if index < uint32(len(group.SubTypes)) {
 				kind := group.SubTypes[index].Comp.Kind

--- a/src/wago/gc_frame_roots_linux_amd64.go
+++ b/src/wago/gc_frame_roots_linux_amd64.go
@@ -190,7 +190,7 @@ func gcFrameTablesSafe(m *wasm.Module) bool {
 			continue
 		}
 		for _, expr := range e.Kind.Exprs {
-			if kind == 2 && e.Kind.Ref.Heap.Kind == wasm.HeapAbs && e.Kind.Ref.Heap.Abs == wasm.HeapI31 {
+			if kind == 2 && e.Kind.Ref.Heap().Kind() == wasm.HeapAbs && e.Kind.Ref.Heap().Abs() == wasm.HeapI31 {
 				// Validation and compileElemValues already proved each expression is
 				// an exact immediate i31 or immutable global value; neither adds an
 				// independent collector root beyond the global root.
@@ -337,44 +337,45 @@ func gcFrameCallABI(m *wasm.Module, ft *wasm.CompType) bool {
 }
 
 func frameFunctionRefType(m *wasm.Module, t wasm.ValType) bool {
-	if t.Kind != wasm.ValRef {
+	if t.Kind() != wasm.ValRef {
 		return false
 	}
-	switch t.Ref.Heap.Kind {
+	heap := t.Ref().Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		return t.Ref.Heap.Abs == wasm.HeapFunc || t.Ref.Heap.Abs == wasm.HeapNoFunc
+		return heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc
 	case wasm.HeapTypeIndex:
-		ft, ok := m.ResolvedTypeFunc(t.Ref.Heap.Type.Index)
+		ft, ok := m.ResolvedTypeFunc(heap.Type().Index)
 		return ok && ft != nil
 	case wasm.HeapDefType:
-		def := t.Ref.Heap.Def
-		return def != nil && def.Index < uint32(len(def.Rec.SubTypes)) && def.Rec.SubTypes[def.Index].Comp.Kind == wasm.CompFunc
+		kind, valid := heap.DefCompKind()
+		return valid && kind == wasm.CompFunc
 	default:
 		return false
 	}
 }
 
 func collectorFrameRefType(m *wasm.Module, t wasm.ValType) bool {
-	if t.Kind != wasm.ValRef {
+	if t.Kind() != wasm.ValRef {
 		return false
 	}
-	switch t.Ref.Heap.Kind {
+	heap := t.Ref().Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		switch t.Ref.Heap.Abs {
+		switch heap.Abs() {
 		case wasm.HeapAny, wasm.HeapEq, wasm.HeapI31, wasm.HeapStruct, wasm.HeapArray, wasm.HeapNone:
 			return true
 		default:
 			return false
 		}
 	case wasm.HeapDefType:
-		def := t.Ref.Heap.Def
-		if def == nil || def.Index >= uint32(len(def.Rec.SubTypes)) {
+		kind, valid := heap.DefCompKind()
+		if !valid {
 			return true
 		}
-		kind := def.Rec.SubTypes[def.Index].Comp.Kind
 		return kind == wasm.CompStruct || kind == wasm.CompArray
 	case wasm.HeapTypeIndex:
-		index := t.Ref.Heap.Type.Index
+		index := heap.Type().Index
 		for _, group := range m.Types {
 			if index < uint32(len(group.SubTypes)) {
 				kind := group.SubTypes[index].Comp.Kind

--- a/src/wago/gc_struct_globals.go
+++ b/src/wago/gc_struct_globals.go
@@ -39,10 +39,10 @@ func stagedGCStructGlobalInitializers(m *wasm.Module) ([]gcStructGlobalInit, err
 	out := make([]gcStructGlobalInit, 0, len(m.Globals))
 	for i := range m.Globals {
 		g := m.Globals[i]
-		if g.Type.Type.Kind != wasm.ValRef || g.Type.Type.Ref.Heap.Kind != wasm.HeapTypeIndex {
+		if g.Type.Type.Kind() != wasm.ValRef || g.Type.Type.Ref().Heap().Kind() != wasm.HeapTypeIndex {
 			continue
 		}
-		sub, ok := stagedGCStructSubtype(m, g.Type.Type.Ref.Heap.Type.Index)
+		sub, ok := stagedGCStructSubtype(m, g.Type.Type.Ref().Heap().Type().Index)
 		if !ok || sub.Comp.Kind != wasm.CompStruct {
 			continue
 		}
@@ -114,7 +114,7 @@ func decodeStagedGCStructGlobalInit(m *wasm.Module, globalIndex uint32, g wasm.G
 			if err != nil {
 				return gcStructGlobalInit{}, err
 			}
-			if g.Type.Type.Ref.Heap.Type.Index != typeID || g.Type.Type.Ref.Nullable {
+			if g.Type.Type.Ref().Heap().Type().Index != typeID || g.Type.Type.Ref().Nullable() {
 				return gcStructGlobalInit{}, fmt.Errorf("result type does not match non-null struct type %d", typeID)
 			}
 			st, ok := stagedGCStructSubtype(m, typeID)
@@ -134,11 +134,11 @@ func decodeStagedGCStructGlobalInit(m *wasm.Module, globalIndex uint32, g wasm.G
 					return gcStructGlobalInit{}, fmt.Errorf("struct.new has %d operands, want %d", len(values), len(st.Comp.Fields))
 				}
 				for i, field := range st.Comp.Fields {
-					want := field.Storage.Val
-					if field.Storage.Packed {
+					want := field.Storage().Val()
+					if field.Storage().Packed() {
 						want = wasm.I32
 					}
-					if want.Kind == wasm.ValRef || !wasm.EqualValType(values[i].typ, want) {
+					if want.Kind() == wasm.ValRef || !wasm.EqualValType(values[i].typ, want) {
 						return gcStructGlobalInit{}, fmt.Errorf("field %d operand type %s, want numeric %s", i, values[i].typ, want)
 					}
 					init.Bits[i] = values[i].bits

--- a/src/wago/gc_struct_product.go
+++ b/src/wago/gc_struct_product.go
@@ -482,15 +482,15 @@ func stagedGCStructTypeGraph(m *wasm.Module) string {
 }
 
 func stagedGCStructFieldString(field wasm.FieldType) string {
-	storage := field.Storage.Val.String()
-	if field.Storage.Packed {
-		if field.Storage.Pack == wasm.PackI8 {
+	storage := field.Storage().Val().String()
+	if field.Storage().Packed() {
+		if field.Storage().Pack() == wasm.PackI8 {
 			storage = "i8"
 		} else {
 			storage = "i16"
 		}
 	}
-	if field.Mut == wasm.Var {
+	if field.Mut() == wasm.Var {
 		return "mut " + storage
 	}
 	return storage

--- a/src/wago/gc_type_subtyping_product.go
+++ b/src/wago/gc_type_subtyping_product.go
@@ -308,7 +308,7 @@ func stagedGCTypeSubtypingLinkShape(m *wasm.Module) (stagedGCTypeSubtypingProduc
 			}
 		} else {
 			result := st.Comp.Results[0]
-			if len(st.Supers) != 1 || st.Supers[0].Rec || st.Supers[0].Index != uint32(i-1) || result.Kind != wasm.ValRef || !result.Ref.Nullable || result.Ref.Exact || result.Ref.Heap.Kind != wasm.HeapTypeIndex || !result.Ref.Heap.Type.Rec || result.Ref.Heap.Type.Index != 0 {
+			if len(st.Supers) != 1 || st.Supers[0].Rec || st.Supers[0].Index != uint32(i-1) || result.Kind() != wasm.ValRef || !result.Ref().Nullable() || result.Ref().Exact() || result.Ref().Heap().Kind() != wasm.HeapTypeIndex || !result.Ref().Heap().Type().Rec || result.Ref().Heap().Type().Index != 0 {
 				return 0, fmt.Errorf("link product type %d must extend type %d and return its own nullable reference", i, i-1)
 			}
 		}
@@ -378,7 +378,7 @@ func stagedGCTypeSubtypingExtendedRecursiveLinkShape(m *wasm.Module) (stagedGCTy
 			return 0, fmt.Errorf("extended recursive link group %d root super is outside the exact product", groupIndex)
 		}
 		result := child.Comp.Results
-		if child.Final || !child.HasPrefix || len(child.Supers) != 1 || !child.Supers[0].Rec || child.Supers[0].Index != 0 || len(child.Comp.Params) != 0 || len(result) != 1 || result[0].Kind != wasm.ValRef || result[0].Ref.Nullable || result[0].Ref.Heap.Kind != wasm.HeapTypeIndex || !result[0].Ref.Heap.Type.Rec || result[0].Ref.Heap.Type.Index != 0 {
+		if child.Final || !child.HasPrefix || len(child.Supers) != 1 || !child.Supers[0].Rec || child.Supers[0].Index != 0 || len(child.Comp.Params) != 0 || len(result) != 1 || result[0].Kind() != wasm.ValRef || result[0].Ref().Nullable() || result[0].Ref().Heap().Kind() != wasm.HeapTypeIndex || !result[0].Ref().Heap().Type().Rec || result[0].Ref().Heap().Type().Index != 0 {
 			return 0, fmt.Errorf("extended recursive link group %d child is outside the exact product", groupIndex)
 		}
 	}
@@ -476,7 +476,7 @@ func stagedGCTypeSubtypingDuplicateRecursiveLinkShape(m *wasm.Module) (stagedGCT
 			return 0, fmt.Errorf("duplicate recursive link group %d root must be open () -> (ref func)", groupIndex)
 		}
 		result := child.Comp.Results
-		if child.Final || !child.HasPrefix || len(child.Supers) != 1 || !child.Supers[0].Rec || child.Supers[0].Index != 0 || child.Comp.Kind != wasm.CompFunc || len(child.Comp.Params) != 0 || len(result) != 1 || result[0].Kind != wasm.ValRef || result[0].Ref.Nullable || result[0].Ref.Exact || result[0].Ref.Heap.Kind != wasm.HeapTypeIndex || !result[0].Ref.Heap.Type.Rec || result[0].Ref.Heap.Type.Index != 0 {
+		if child.Final || !child.HasPrefix || len(child.Supers) != 1 || !child.Supers[0].Rec || child.Supers[0].Index != 0 || child.Comp.Kind != wasm.CompFunc || len(child.Comp.Params) != 0 || len(result) != 1 || result[0].Kind() != wasm.ValRef || result[0].Ref().Nullable() || result[0].Ref().Exact() || result[0].Ref().Heap().Kind() != wasm.HeapTypeIndex || !result[0].Ref().Heap().Type().Rec || result[0].Ref().Heap().Type().Index != 0 {
 			return 0, fmt.Errorf("duplicate recursive link group %d child must extend and return recursive member 0", groupIndex)
 		}
 	}
@@ -586,8 +586,8 @@ func stagedGCTypeSubtypingStructLinkShape(m *wasm.Module) (stagedGCTypeSubtyping
 		return 0, fmt.Errorf("struct link first-group companion must be a final one-field struct")
 	}
 	field := s.Comp.Fields[0]
-	ref := field.Storage.Val
-	if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || !ref.Ref.Heap.Type.Rec || ref.Ref.Heap.Type.Index != 0 {
+	ref := field.Storage().Val()
+	if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || !ref.Ref().Heap().Type().Rec || ref.Ref().Heap().Type().Index != 0 {
 		return 0, fmt.Errorf("struct link first-group field must be an immutable non-null reference to recursive member 0")
 	}
 	g := &m.Types[1].SubTypes[0]
@@ -661,8 +661,8 @@ func stagedGCTypeSubtypingStructProjectionLinkShape(m *wasm.Module) (stagedGCTyp
 			}
 		}
 		field := m.Types[groupIndex].SubTypes[1].Comp.Fields[0]
-		ref := field.Storage.Val
-		if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || !ref.Ref.Heap.Type.Rec || ref.Ref.Heap.Type.Index != 0 {
+		ref := field.Storage().Val()
+		if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || !ref.Ref().Heap().Type().Rec || ref.Ref().Heap().Type().Index != 0 {
 			return 0, fmt.Errorf("struct projection link root group %d field must be an immutable non-null reference to recursive member 0", groupIndex)
 		}
 	}
@@ -684,8 +684,8 @@ func stagedGCTypeSubtypingStructProjectionLinkShape(m *wasm.Module) (stagedGCTyp
 	}
 	for fieldIndex, want := range wantFields {
 		field := last.SubTypes[1].Comp.Fields[fieldIndex]
-		ref := field.Storage.Val
-		if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || ref.Ref.Heap.Type != want {
+		ref := field.Storage().Val()
+		if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || ref.Ref().Heap().Type() != want {
 			return 0, fmt.Errorf("struct projection link final struct field %d is outside the exact ordered projection", fieldIndex)
 		}
 	}
@@ -745,9 +745,9 @@ func stagedGCTypeSubtypingStructMismatchLinkShape(m *wasm.Module) (stagedGCTypeS
 			return 0, fmt.Errorf("struct mismatch link root group %d must have no function super and one struct field", groupIndex)
 		}
 		field := s.Comp.Fields[0]
-		ref := field.Storage.Val
+		ref := field.Storage().Val()
 		want := wasm.TypeIdx{Index: 0, Rec: groupIndex == 0}
-		if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || ref.Ref.Heap.Type != want {
+		if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || ref.Ref().Heap().Type() != want {
 			return 0, fmt.Errorf("struct mismatch link root group %d field is outside the exact recursive projection", groupIndex)
 		}
 	}
@@ -803,8 +803,8 @@ func stagedGCTypeSubtypingIndependentStructLinkShape(m *wasm.Module) (stagedGCTy
 				return 0, fmt.Errorf("independent struct link root group %d must have no function super and one struct field", groupIndex)
 			}
 			field := s.Comp.Fields[0]
-			ref := field.Storage.Val
-			if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || !ref.Ref.Heap.Type.Rec || ref.Ref.Heap.Type.Index != 0 {
+			ref := field.Storage().Val()
+			if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || !ref.Ref().Heap().Type().Rec || ref.Ref().Heap().Type().Index != 0 {
 				return 0, fmt.Errorf("independent struct link root group %d field must be an immutable non-null self reference", groupIndex)
 			}
 			continue
@@ -866,8 +866,8 @@ func stagedGCTypeSubtypingExtendedProjectionLinkShape(m *wasm.Module) (stagedGCT
 			return 0, fmt.Errorf("extended projection link root group %d must be an open self-recursive pair", groupIndex)
 		}
 		field := s.Comp.Fields[0]
-		ref := field.Storage.Val
-		if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || !ref.Ref.Heap.Type.Rec || ref.Ref.Heap.Type.Index != 0 {
+		ref := field.Storage().Val()
+		if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || !ref.Ref().Heap().Type().Rec || ref.Ref().Heap().Type().Index != 0 {
 			return 0, fmt.Errorf("extended projection link root group %d field must be an immutable non-null self reference", groupIndex)
 		}
 	}
@@ -887,8 +887,8 @@ func stagedGCTypeSubtypingExtendedProjectionLinkShape(m *wasm.Module) (stagedGCT
 	}
 	for fieldIndex, want := range wantFields {
 		field := projected.SubTypes[1].Comp.Fields[fieldIndex]
-		ref := field.Storage.Val
-		if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || ref.Ref.Heap.Type != want {
+		ref := field.Storage().Val()
+		if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || ref.Ref().Heap().Type() != want {
 			return 0, fmt.Errorf("extended projection link projected field %d is outside the exact ordered projection", fieldIndex)
 		}
 	}
@@ -991,7 +991,7 @@ func stagedGCTypeSubtypingRuntimeCallCastShape(m *wasm.Module) (stagedGCTypeSubt
 			}
 		} else {
 			result := st.Comp.Results[0]
-			if len(st.Supers) != 1 || st.Supers[0].Rec || st.Supers[0].Index != uint32(i-1) || result.Kind != wasm.ValRef || !result.Ref.Nullable || result.Ref.Heap.Kind != wasm.HeapTypeIndex || !result.Ref.Heap.Type.Rec || result.Ref.Heap.Type.Index != 0 {
+			if len(st.Supers) != 1 || st.Supers[0].Rec || st.Supers[0].Index != uint32(i-1) || result.Kind() != wasm.ValRef || !result.Ref().Nullable() || result.Ref().Heap().Kind() != wasm.HeapTypeIndex || !result.Ref().Heap().Type().Rec || result.Ref().Heap().Type().Index != 0 {
 				return 0, fmt.Errorf("runtime call/cast type %d must extend type %d and return its own nullable reference", i, i-1)
 			}
 		}

--- a/src/wago/gc_type_subtyping_product_test.go
+++ b/src/wago/gc_type_subtyping_product_test.go
@@ -11,6 +11,22 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
+// rewriteTestFieldRefIndex replaces an encoded field value instead of mutating
+// nested representation details, which are intentionally opaque scalar bits.
+func rewriteTestFieldRefIndex(field *wasm.FieldType, rewrite func(*wasm.TypeIdx)) {
+	storage := field.Storage()
+	rt := storage.Val().Ref()
+	idx := rt.Heap().Type()
+	rewrite(&idx)
+	*field = wasm.NewFieldType(wasm.StorageVal(wasm.RefVal(wasm.Ref(rt.Nullable(), wasm.IndexedHeap(idx), rt.Exact()))), field.Mut())
+}
+
+func setTestFieldRefNullable(field *wasm.FieldType, nullable bool) {
+	storage := field.Storage()
+	rt := storage.Val().Ref().WithNullable(nullable)
+	*field = wasm.NewFieldType(wasm.StorageVal(wasm.RefVal(rt)), field.Mut())
+}
+
 type stagedGCTypeSubtypingProductPin struct {
 	Filename string
 	Line     int
@@ -683,7 +699,7 @@ func TestStagedGCTypeSubtypingFirstLinkingClusterInventory(t *testing.T) {
 				}
 			} else {
 				result := st.Comp.Results[0]
-				if len(st.Supers) != 1 || st.Supers[0].Rec || st.Supers[0].Index != uint32(typeIndex-1) || result.Kind != wasm.ValRef || !result.Ref.Nullable || result.Ref.Heap.Kind != wasm.HeapTypeIndex || !result.Ref.Heap.Type.Rec || result.Ref.Heap.Type.Index != 0 {
+				if len(st.Supers) != 1 || st.Supers[0].Rec || st.Supers[0].Index != uint32(typeIndex-1) || result.Kind() != wasm.ValRef || !result.Ref().Nullable() || result.Ref().Heap().Kind() != wasm.HeapTypeIndex || !result.Ref().Heap().Type().Rec || result.Ref().Heap().Type().Index != 0 {
 					t.Fatalf("%s type %d = %+v, want exact recursive subtype/result chain", pin.Filename, typeIndex, st)
 				}
 			}
@@ -876,8 +892,8 @@ func TestStagedGCTypeSubtypingStructLinkingClusterInventory(t *testing.T) {
 			t.Fatalf("%s first-group struct = %+v, want final one-field struct", pin.Filename, s)
 		}
 		field := s.Comp.Fields[0]
-		ref := field.Storage.Val
-		if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || !ref.Ref.Heap.Type.Rec || ref.Ref.Heap.Type.Index != 0 {
+		ref := field.Storage().Val()
+		if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || !ref.Ref().Heap().Type().Rec || ref.Ref().Heap().Type().Index != 0 {
 			t.Fatalf("%s struct field = %+v, want immutable non-null reference to recursive member 0", pin.Filename, field)
 		}
 		g := m.Types[1].SubTypes[0]
@@ -1005,8 +1021,8 @@ func TestStagedGCTypeSubtypingStructProjectionLinkingClusterInventory(t *testing
 				}
 			}
 			field := m.Types[groupIndex].SubTypes[1].Comp.Fields[0]
-			ref := field.Storage.Val
-			if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || !ref.Ref.Heap.Type.Rec || ref.Ref.Heap.Type.Index != 0 {
+			ref := field.Storage().Val()
+			if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || !ref.Ref().Heap().Type().Rec || ref.Ref().Heap().Type().Index != 0 {
 				t.Fatalf("%s root group %d field = %+v, want immutable non-null recursive function member 0", pin.Filename, groupIndex, field)
 			}
 		}
@@ -1027,8 +1043,8 @@ func TestStagedGCTypeSubtypingStructProjectionLinkingClusterInventory(t *testing
 		}
 		for fieldIndex, want := range wantFields {
 			field := last.SubTypes[1].Comp.Fields[fieldIndex]
-			ref := field.Storage.Val
-			if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || ref.Ref.Heap.Type != want {
+			ref := field.Storage().Val()
+			if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || ref.Ref().Heap().Type() != want {
 				t.Fatalf("%s projected struct field %d = %+v, want immutable non-null %v", pin.Filename, fieldIndex, field, want)
 			}
 		}
@@ -1140,9 +1156,9 @@ func TestStagedGCTypeSubtypingStructMismatchLinkingClusterInventory(t *testing.T
 				t.Fatalf("%s root group %d struct fields = %d, want 1", pin.Filename, groupIndex, len(s.Comp.Fields))
 			}
 			field := s.Comp.Fields[0]
-			ref := field.Storage.Val
+			ref := field.Storage().Val()
 			want := wasm.TypeIdx{Index: 0, Rec: groupIndex == 0}
-			if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || ref.Ref.Heap.Type != want {
+			if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || ref.Ref().Heap().Type() != want {
 				t.Fatalf("%s root group %d field = %+v, want immutable non-null reference %v", pin.Filename, groupIndex, field, want)
 			}
 		}
@@ -1241,8 +1257,8 @@ func TestStagedGCTypeSubtypingIndependentStructLinkingClusterInventory(t *testin
 					t.Fatalf("%s root group %d supers/fields = %v/%d, want none/one", pin.Filename, groupIndex, f.Supers, len(s.Comp.Fields))
 				}
 				field := s.Comp.Fields[0]
-				ref := field.Storage.Val
-				if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || !ref.Ref.Heap.Type.Rec || ref.Ref.Heap.Type.Index != 0 {
+				ref := field.Storage().Val()
+				if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || !ref.Ref().Heap().Type().Rec || ref.Ref().Heap().Type().Index != 0 {
 					t.Fatalf("%s root group %d field = %+v, want immutable non-null self reference", pin.Filename, groupIndex, field)
 				}
 				continue
@@ -1347,8 +1363,8 @@ func TestStagedGCTypeSubtypingExtendedProjectionLinkingClusterInventory(t *testi
 				t.Fatalf("%s root group %d is outside the exact open self-recursive pair", pin.Filename, groupIndex)
 			}
 			field := s.Comp.Fields[0]
-			ref := field.Storage.Val
-			if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || !ref.Ref.Heap.Type.Rec || ref.Ref.Heap.Type.Index != 0 {
+			ref := field.Storage().Val()
+			if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || !ref.Ref().Heap().Type().Rec || ref.Ref().Heap().Type().Index != 0 {
 				t.Fatalf("%s root group %d field = %+v, want immutable non-null self reference", pin.Filename, groupIndex, field)
 			}
 		}
@@ -1367,8 +1383,8 @@ func TestStagedGCTypeSubtypingExtendedProjectionLinkingClusterInventory(t *testi
 		}
 		for fieldIndex, want := range wantFields {
 			field := projected.SubTypes[1].Comp.Fields[fieldIndex]
-			ref := field.Storage.Val
-			if field.Mut != wasm.Const || field.Storage.Packed || ref.Kind != wasm.ValRef || ref.Ref.Nullable || ref.Ref.Exact || ref.Ref.Heap.Kind != wasm.HeapTypeIndex || ref.Ref.Heap.Type != want {
+			ref := field.Storage().Val()
+			if field.Mut() != wasm.Const || field.Storage().Packed() || ref.Kind() != wasm.ValRef || ref.Ref().Nullable() || ref.Ref().Exact() || ref.Ref().Heap().Kind() != wasm.HeapTypeIndex || ref.Ref().Heap().Type() != want {
 				t.Fatalf("%s projected field %d = %+v, want immutable non-null %v", pin.Filename, fieldIndex, field, want)
 			}
 		}
@@ -1463,7 +1479,7 @@ func TestStagedGCTypeSubtypingDuplicateRecursiveLinkingClusterInventory(t *testi
 				t.Fatalf("%s group %d root = %+v, want open () -> (ref func)", pin.Filename, groupIndex, root)
 			}
 			result := child.Comp.Results
-			if child.Final || !child.HasPrefix || len(child.Supers) != 1 || !child.Supers[0].Rec || child.Supers[0].Index != 0 || child.Comp.Kind != wasm.CompFunc || len(child.Comp.Params) != 0 || len(result) != 1 || result[0].Kind != wasm.ValRef || result[0].Ref.Nullable || result[0].Ref.Heap.Kind != wasm.HeapTypeIndex || !result[0].Ref.Heap.Type.Rec || result[0].Ref.Heap.Type.Index != 0 {
+			if child.Final || !child.HasPrefix || len(child.Supers) != 1 || !child.Supers[0].Rec || child.Supers[0].Index != 0 || child.Comp.Kind != wasm.CompFunc || len(child.Comp.Params) != 0 || len(result) != 1 || result[0].Kind() != wasm.ValRef || result[0].Ref().Nullable() || result[0].Ref().Heap().Kind() != wasm.HeapTypeIndex || !result[0].Ref().Heap().Type().Rec || result[0].Ref().Heap().Type().Index != 0 {
 				t.Fatalf("%s group %d child = %+v, want open recursive subtype returning its root", pin.Filename, groupIndex, child)
 			}
 		}
@@ -1643,7 +1659,7 @@ func TestStagedGCTypeSubtypingProductRejectsWidening(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	structProvider.Types[0].SubTypes[1].Comp.Fields[0].Storage.Val.Ref.Nullable = true
+	setTestFieldRefNullable(&structProvider.Types[0].SubTypes[1].Comp.Fields[0], true)
 	if product, err := stagedGCTypeSubtypingProductShape(structProvider); err == nil && product == stagedGCTypeSubtypingStructLinkProvider {
 		t.Fatal("struct link provider with a nullable recursive field unexpectedly retained exact admission")
 	}
@@ -1660,7 +1676,7 @@ func TestStagedGCTypeSubtypingProductRejectsWidening(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	projectionProvider.Types[2].SubTypes[1].Comp.Fields[1].Storage.Val.Ref.Heap.Type.Index = 0
+	rewriteTestFieldRefIndex(&projectionProvider.Types[2].SubTypes[1].Comp.Fields[1], func(idx *wasm.TypeIdx) { idx.Index = 0 })
 	if product, err := stagedGCTypeSubtypingProductShape(projectionProvider); err == nil && product == stagedGCTypeSubtypingStructProjectionLinkProvider {
 		t.Fatal("struct projection provider with reordered field identity unexpectedly retained exact admission")
 	}
@@ -1677,7 +1693,7 @@ func TestStagedGCTypeSubtypingProductRejectsWidening(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mismatchProvider.Types[1].SubTypes[1].Comp.Fields[0].Storage.Val.Ref.Heap.Type.Rec = true
+	rewriteTestFieldRefIndex(&mismatchProvider.Types[1].SubTypes[1].Comp.Fields[0], func(idx *wasm.TypeIdx) { idx.Rec = true })
 	if product, err := stagedGCTypeSubtypingProductShape(mismatchProvider); err == nil && product == stagedGCTypeSubtypingStructMismatchLinkProvider {
 		t.Fatal("struct mismatch provider with a self-recursive second group unexpectedly retained exact admission")
 	}
@@ -1694,7 +1710,7 @@ func TestStagedGCTypeSubtypingProductRejectsWidening(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	independentProvider.Types[1].SubTypes[1].Comp.Fields[0].Storage.Val.Ref.Heap.Type.Rec = false
+	rewriteTestFieldRefIndex(&independentProvider.Types[1].SubTypes[1].Comp.Fields[0], func(idx *wasm.TypeIdx) { idx.Rec = false })
 	if product, err := stagedGCTypeSubtypingProductShape(independentProvider); err == nil && product == stagedGCTypeSubtypingIndependentStructLinkProvider {
 		t.Fatal("independent struct provider with an external second-group field unexpectedly retained exact admission")
 	}
@@ -1711,7 +1727,7 @@ func TestStagedGCTypeSubtypingProductRejectsWidening(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	extendedProvider.Types[2].SubTypes[1].Comp.Fields[1].Storage.Val.Ref.Heap.Type.Index = 0
+	rewriteTestFieldRefIndex(&extendedProvider.Types[2].SubTypes[1].Comp.Fields[1], func(idx *wasm.TypeIdx) { idx.Index = 0 })
 	if product, err := stagedGCTypeSubtypingProductShape(extendedProvider); err == nil && product == stagedGCTypeSubtypingExtendedProjectionLinkProvider {
 		t.Fatal("extended projection provider with reordered field identity unexpectedly retained exact admission")
 	}

--- a/src/wago/structural_type_product.go
+++ b/src/wago/structural_type_product.go
@@ -102,7 +102,7 @@ func stagedStructuralTypeMetadataShape(m *wasm.Module) error {
 			case wasm.CompStruct:
 				hasStruct = true
 				for i := range st.Comp.Fields {
-					if st.Comp.Fields[i].Mut != 0 {
+					if st.Comp.Fields[i].Mut() != 0 {
 						return fmt.Errorf("collector-free structural products reject mutable struct fields")
 					}
 				}
@@ -131,7 +131,7 @@ func stagedStructuralRefFuncGlobalShape(m *wasm.Module) (stagedStructuralTypePro
 		return 0, false
 	}
 	types, err := typeDescriptorsFromWasm(m)
-	if err != nil || !tagTypeEquivalent(m.FuncTypes[0].Index, types, g.Type.Type.Ref.Heap.Type.Index, types) {
+	if err != nil || !tagTypeEquivalent(m.FuncTypes[0].Index, types, g.Type.Type.Ref().Heap().Type().Index, types) {
 		return 0, false
 	}
 	return stagedStructuralRefFuncGlobal, true
@@ -193,10 +193,10 @@ func stagedStructuralCallIndirectShape(m *wasm.Module) (stagedStructuralTypeProd
 }
 
 func isNonNullIndexedFunctionRef(m *wasm.Module, typ wasm.ValType) bool {
-	if typ.Kind != wasm.ValRef || typ.Ref.Nullable || typ.Ref.Exact || typ.Ref.Heap.Kind != wasm.HeapTypeIndex {
+	if typ.Kind() != wasm.ValRef || typ.Ref().Nullable() || typ.Ref().Exact() || typ.Ref().Heap().Kind() != wasm.HeapTypeIndex {
 		return false
 	}
-	_, ok := m.ResolvedTypeFunc(typ.Ref.Heap.Type.Index)
+	_, ok := m.ResolvedTypeFunc(typ.Ref().Heap().Type().Index)
 	return ok
 }
 

--- a/src/wago/structural_type_product_test.go
+++ b/src/wago/structural_type_product_test.go
@@ -127,7 +127,7 @@ func TestStagedStructuralTypeProductRejectsWidening(t *testing.T) {
 		t.Fatal("structural product with start unexpectedly admitted")
 	}
 	m.Start = nil
-	m.Types[0].SubTypes[1].Comp.Fields = append(m.Types[0].SubTypes[1].Comp.Fields, wasm.FieldType{Mut: 1})
+	m.Types[0].SubTypes[1].Comp.Fields = append(m.Types[0].SubTypes[1].Comp.Fields, wasm.NewFieldType(wasm.StorageVal(wasm.I32), wasm.Var))
 	if _, err := stagedStructuralTypeProductShape(m); err == nil {
 		t.Fatal("structural product with mutable struct field unexpectedly admitted")
 	}

--- a/src/wago/type_descriptor.go
+++ b/src/wago/type_descriptor.go
@@ -692,20 +692,20 @@ func (c wasmTypeDescriptorConverter) definedType(st *wasm.SubType, sourceGroup i
 }
 
 func (c wasmTypeDescriptorConverter) fieldType(f wasm.FieldType, group int) (FieldTypeDescriptor, error) {
-	out := FieldTypeDescriptor{Mutable: f.Mut == wasm.Var}
-	if f.Storage.Packed {
+	out := FieldTypeDescriptor{Mutable: f.Mut() == wasm.Var}
+	if f.Storage().Packed() {
 		out.Storage.Packed = true
-		switch f.Storage.Pack {
+		switch f.Storage().Pack() {
 		case wasm.PackI8:
 			out.Storage.PackedType = PackedTypeI8
 		case wasm.PackI16:
 			out.Storage.PackedType = PackedTypeI16
 		default:
-			return out, fmt.Errorf("unknown packed type 0x%x", byte(f.Storage.Pack))
+			return out, fmt.Errorf("unknown packed type 0x%x", byte(f.Storage().Pack()))
 		}
 		return out, nil
 	}
-	v, err := c.valueType(f.Storage.Val, group)
+	v, err := c.valueType(f.Storage().Val(), group)
 	if err != nil {
 		return out, err
 	}
@@ -726,9 +726,9 @@ func (c wasmTypeDescriptorConverter) valueTypes(ts []wasm.ValType, group int) ([
 }
 
 func (c wasmTypeDescriptorConverter) valueType(t wasm.ValType, group int) (ValueTypeDescriptor, error) {
-	switch t.Kind {
+	switch t.Kind() {
 	case wasm.ValNum:
-		switch t.Num {
+		switch t.Num() {
 		case wasm.NumI32:
 			return ValueTypeDescriptor{Kind: ValueTypeI32}, nil
 		case wasm.NumI64:
@@ -738,41 +738,43 @@ func (c wasmTypeDescriptorConverter) valueType(t wasm.ValType, group int) (Value
 		case wasm.NumF64:
 			return ValueTypeDescriptor{Kind: ValueTypeF64}, nil
 		default:
-			return ValueTypeDescriptor{}, fmt.Errorf("unknown numeric type 0x%x", byte(t.Num))
+			return ValueTypeDescriptor{}, fmt.Errorf("unknown numeric type 0x%x", byte(t.Num()))
 		}
 	case wasm.ValVec:
 		return ValueTypeDescriptor{Kind: ValueTypeV128}, nil
 	case wasm.ValRef:
-		r, err := c.refType(t.Ref, group)
+		r, err := c.refType(t.Ref(), group)
 		return ValueTypeDescriptor{Kind: ValueTypeReference, Ref: r}, err
 	default:
-		return ValueTypeDescriptor{}, fmt.Errorf("unsupported value type kind %d", t.Kind)
+		return ValueTypeDescriptor{}, fmt.Errorf("unsupported value type kind %d", t.Kind())
 	}
 }
 
 func (c wasmTypeDescriptorConverter) refType(t wasm.RefType, group int) (ReferenceTypeDescriptor, error) {
-	out := ReferenceTypeDescriptor{Nullable: t.Nullable, Exact: t.Exact}
-	switch t.Heap.Kind {
+	out := ReferenceTypeDescriptor{Nullable: t.Nullable(), Exact: t.Exact()}
+	heap := t.Heap()
+	switch heap.Kind() {
 	case wasm.HeapAbs:
-		a, ok := abstractHeapTypeFromWasm(t.Heap.Abs)
+		a, ok := abstractHeapTypeFromWasm(heap.Abs())
 		if !ok {
-			return out, fmt.Errorf("unknown abstract heap type 0x%x", byte(t.Heap.Abs))
+			return out, fmt.Errorf("unknown abstract heap type 0x%x", byte(heap.Abs()))
 		}
 		out.Heap.Abstract = a
 	case wasm.HeapTypeIndex:
-		x, err := c.typeIndex(t.Heap.Type, group)
+		x, err := c.typeIndex(heap.Type(), group)
 		if err != nil {
 			return out, err
 		}
 		out.Heap.Defined, out.Heap.TypeIndex = true, x
 	case wasm.HeapDefType:
-		if c.m == nil || t.Heap.Def == nil || int(t.Heap.Def.GroupIndex) >= len(c.groupAt)-1 || t.Heap.Def.Index >= uint32(len(c.m.Types[t.Heap.Def.GroupIndex].SubTypes)) {
+		groupIndex, memberIndex, _, valid := heap.Def()
+		if c.m == nil || !valid || int(groupIndex) >= len(c.groupAt)-1 || memberIndex >= uint32(len(c.m.Types[groupIndex].SubTypes)) {
 			return out, fmt.Errorf("unknown defined heap type")
 		}
 		out.Heap.Defined = true
-		out.Heap.TypeIndex = c.groupAt[t.Heap.Def.GroupIndex] + t.Heap.Def.Index
+		out.Heap.TypeIndex = c.groupAt[groupIndex] + memberIndex
 	default:
-		return out, fmt.Errorf("unknown heap type kind %d", t.Heap.Kind)
+		return out, fmt.Errorf("unknown heap type kind %d", heap.Kind())
 	}
 	return out, nil
 }

--- a/src/wago/type_descriptor_test.go
+++ b/src/wago/type_descriptor_test.go
@@ -28,8 +28,8 @@ func TestTypeDescriptorsPreserveRecursiveReferenceStructure(t *testing.T) {
 			{
 				Final: true,
 				Comp: wasm.CompType{Kind: wasm.CompStruct, Fields: []wasm.FieldType{
-					{Storage: wasm.StorageType{Val: recRef(0)}, Mut: wasm.Var},
-					{Storage: wasm.StorageType{Packed: true, Pack: wasm.PackI16}},
+					wasm.NewFieldType(wasm.StorageVal(recRef(0)), wasm.Var),
+					wasm.NewFieldType(wasm.StoragePacked(wasm.PackI16), wasm.Const),
 				}},
 			},
 		}},

--- a/src/wago/typed_reference_assertion_test.go
+++ b/src/wago/typed_reference_assertion_test.go
@@ -545,7 +545,7 @@ func proposalSpectestTypes() map[string]proposalExternType {
 		"spectest.global_f32":    global(corewasm.F32),
 		"spectest.global_f64":    global(corewasm.F64),
 		"spectest.memory":        {kind: proposalExternMemory, memory: corewasm.MemType{Limits: corewasm.Limits{Min: 1, Max: &memoryMax}}},
-		"spectest.table":         {kind: proposalExternTable, table: corewasm.TableType{Ref: corewasm.FuncRef.Ref, Limits: corewasm.Limits{Min: 10, Max: &tableMax}}},
+		"spectest.table":         {kind: proposalExternTable, table: corewasm.TableType{Ref: corewasm.FuncRef.Ref(), Limits: corewasm.Limits{Min: 10, Max: &tableMax}}},
 	}
 }
 
@@ -860,32 +860,32 @@ func proposalValTypesEquivalent(a corewasm.ValType, am *corewasm.Module, b corew
 }
 
 func proposalValTypeSubtype(a corewasm.ValType, am *corewasm.Module, b corewasm.ValType, bm *corewasm.Module, depth int) bool {
-	if depth > 32 || a.Kind != b.Kind {
+	if depth > 32 || a.Kind() != b.Kind() {
 		return false
 	}
-	if a.Kind != corewasm.ValRef {
-		return a.Num == b.Num
+	if a.Kind() != corewasm.ValRef {
+		return a.Num() == b.Num()
 	}
-	if a.Ref.Nullable && !b.Ref.Nullable || b.Ref.Exact && !a.Ref.Exact {
+	if a.Ref().Nullable() && !b.Ref().Nullable() || b.Ref().Exact() && !a.Ref().Exact() {
 		return false
 	}
-	return proposalHeapTypeSubtype(a.Ref.Heap, am, b.Ref.Heap, bm, depth+1)
+	return proposalHeapTypeSubtype(a.Ref().Heap(), am, b.Ref().Heap(), bm, depth+1)
 }
 
 func proposalHeapTypeSubtype(a corewasm.HeapType, am *corewasm.Module, b corewasm.HeapType, bm *corewasm.Module, depth int) bool {
 	if depth > 32 {
 		return false
 	}
-	if a.Kind == corewasm.HeapAbs && b.Kind == corewasm.HeapAbs {
-		return proposalAbsHeapSubtype(a.Abs, b.Abs)
+	if a.Kind() == corewasm.HeapAbs && b.Kind() == corewasm.HeapAbs {
+		return proposalAbsHeapSubtype(a.Abs(), b.Abs())
 	}
-	if a.Kind == corewasm.HeapTypeIndex {
-		afn, aok := proposalIndexedFuncType(am, a.Type)
-		if b.Kind == corewasm.HeapAbs {
-			return aok && proposalAbsHeapSubtype(corewasm.HeapFunc, b.Abs)
+	if a.Kind() == corewasm.HeapTypeIndex {
+		afn, aok := proposalIndexedFuncType(am, a.Type())
+		if b.Kind() == corewasm.HeapAbs {
+			return aok && proposalAbsHeapSubtype(corewasm.HeapFunc, b.Abs())
 		}
-		if b.Kind == corewasm.HeapTypeIndex {
-			bfn, bok := proposalIndexedFuncType(bm, b.Type)
+		if b.Kind() == corewasm.HeapTypeIndex {
+			bfn, bok := proposalIndexedFuncType(bm, b.Type())
 			return aok && bok && proposalFuncTypesEquivalent(afn, am, bfn, bm, depth+1)
 		}
 	}

--- a/src/wago/valtype.go
+++ b/src/wago/valtype.go
@@ -90,8 +90,8 @@ func (t ValType) String() string {
 }
 
 func valTypeFromWasm(t wasm.ValType) ValType {
-	if t.Kind == wasm.ValRef && t.Ref.Heap.Kind == wasm.HeapAbs {
-		switch t.Ref.Heap.Abs {
+	if t.Kind() == wasm.ValRef && t.Ref().Heap().Kind() == wasm.HeapAbs {
+		switch t.Ref().Heap().Abs() {
 		case wasm.HeapAny, wasm.HeapNone:
 			return ValAnyRef
 		case wasm.HeapI31:


### PR DESCRIPTION
## Summary

- replace nested, pointer-bearing compiler type leaves with canonical pointer-free two-word scalar representations
- preserve full `uint32` type indexes and resolved definition coordinates without narrowing Wago's accepted domain
- preserve semantic equality while retaining non-semantic bare-reference encoding metadata for round trips
- add deterministic layout contracts and GC-heavy benchmarks for construction, decoding, validation, equality, structural identity, and frontend lowering

## Why

The former nested representation made common values expensive to copy and caused Go's collector to scan embedded `*DefType` pointers. A single `uint64` cannot faithfully encode every resolved definition coordinate plus tags without narrowing valid ranges, so this uses a deliberately boring 16-byte, two-word encoding. It remains pointer-free while preserving all existing Wasm semantics.

## Measured impact

| Type | Before | After |
|---|---:|---:|
| `HeapType` | 24 B | 16 B |
| `RefType` | 40 B | 16 B |
| `ValType` | 48 B | 16 B |
| `StorageType` | 64 B | 16 B |
| `FieldType` | 72 B | 16 B |
| `CompType` | 152 B | 96 B |
| `SubType` | 208 B | 152 B |

Representative focused results (`benchstat`, repeated samples):

- construction, 10K types × 64 fields: 9.975 ms / 43.945 MiB → 0.483 ms / 9.766 MiB
- equality, 64 fields: 1098 ns → 403 ns
- decode, 10 types × 64 fields: 48.3 µs / 50.5 KiB → 7.16 µs / 12.5 KiB
- validation, 10 types × 64 fields: 13.8 µs → 1.90 µs
- frontend lowering, 10K types × 1 field: 3.02 ms / 11.83 MiB → 2.27 ms / 8.98 MiB

Existing corpus family geomeans (`-count=10`):

- Decode: -25.61% time, -13.82% B/op, allocations unchanged
- Validate: -50.63% time, -19.42% B/op, allocations effectively unchanged
- Compile: -26.51% time, B/op and allocations unchanged

Binary size also decreased by about 57 KiB in both stripped and unstripped builds. Full methodology and layout details are documented in `docs/wasm-type-representation.md`.

## Validation

- `go test ./src/core/compiler/wasm`
- `go test ./src/core/compiler/frontend`
- `go test ./src/core/compiler/ir/...`
- `go test ./src/core/compiler/backend/...`
- `go test ./src/core/runtime/gc`
- `go test ./src/wago`
- `GOOS=linux GOARCH=arm64 go test ./src/core/compiler/backend/... ./src/wago -run '^$'`
- focused GC type benchmarks and existing Decode/Validate/Compile benchmarks with matching before/after parameters

`go test ./...` passes except for the staged official-spec cases in `src/wago`, which cannot run because `tests/spec-v3/test/core` is absent from this checkout. All other packages pass.

## Tradeoffs

- leaf descriptors are 16 bytes rather than forcing an unsafe or range-narrowing 8-byte encoding
- variable-length composite metadata remains in ordinary dense slices; arenas are intentionally deferred because leaf packing already captures substantial gains
- runtime `gc.TypeDesc` is unchanged, keeping compiler metadata and collector descriptor changes separate
