### PR TITLE
gc: make throughput size-class lookup constant-time

### DIFF
--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -216,7 +216,7 @@ func TestThroughputClassForMatchesLinearReference(t *testing.T) {
 		}
 	}
 
-	boundarySizes := []uint32{0, 1, 15, 16, 17}
+	boundarySizes := []uint32{0, 1, 15, 16, 17, ^uint32(0) - 15, ^uint32(0)}
 	for _, classSize := range throughputClassSizes {
 		boundarySizes = append(boundarySizes, classSize-1, classSize, classSize+1)
 	}
@@ -260,6 +260,19 @@ func BenchmarkThroughputClassFor(b *testing.B) {
 			benchmarkThroughputClass = got
 		})
 	}
+	b.Run("mixed", func(b *testing.B) {
+		h := throughputHeap{classLimit: 32768}
+		index, got := 0, 0
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			got += benchmarkThroughputClassFor(&h, throughputClassSizes[index])
+			index++
+			if index == len(throughputClassSizes) {
+				index = 0
+			}
+		}
+		benchmarkThroughputClass = got + index
+	})
 }
 
 var benchmarkThroughputLargeSpan int

--- a/src/core/runtime/gc/profile_throughput_test.go
+++ b/src/core/runtime/gc/profile_throughput_test.go
@@ -191,6 +191,77 @@ func TestThroughputClassLimitMustBeSupportedSizeClass(t *testing.T) {
 	}
 }
 
+func linearThroughputClassFor(size, limit uint32) int {
+	for i, classSize := range throughputClassSizes {
+		if size <= classSize && classSize <= limit {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestThroughputClassForMatchesLinearReference(t *testing.T) {
+	limits := make([]uint32, 1, len(throughputClassSizes)+1)
+	for _, limit := range throughputClassSizes {
+		limits = append(limits, limit)
+	}
+	maxSize := throughputClassSizes[len(throughputClassSizes)-1] + 1
+	for _, limit := range limits {
+		h := throughputHeap{classLimit: limit}
+		for size := uint32(0); size <= maxSize; size++ {
+			want := linearThroughputClassFor(size, limit)
+			if got := h.classFor(size); got != want {
+				t.Fatalf("classFor(size=%d, limit=%d) = %d, want %d", size, limit, got, want)
+			}
+		}
+	}
+
+	boundarySizes := []uint32{0, 1, 15, 16, 17}
+	for _, classSize := range throughputClassSizes {
+		boundarySizes = append(boundarySizes, classSize-1, classSize, classSize+1)
+	}
+	for limit := uint32(0); limit <= throughputClassSizes[len(throughputClassSizes)-1]+1; limit++ {
+		h := throughputHeap{classLimit: limit}
+		for _, size := range boundarySizes {
+			want := linearThroughputClassFor(size, limit)
+			if got := h.classFor(size); got != want {
+				t.Fatalf("classFor(size=%d, malformed limit=%d) = %d, want %d", size, limit, got, want)
+			}
+		}
+	}
+}
+
+var benchmarkThroughputClass int
+
+//go:noinline
+func benchmarkThroughputClassFor(h *throughputHeap, size uint32) int {
+	return h.classFor(size)
+}
+
+func BenchmarkThroughputClassFor(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		size  uint32
+		limit uint32
+	}{
+		{name: "small", size: 32, limit: 4096},
+		{name: "common", size: 96, limit: 4096},
+		{name: "middle", size: 768, limit: 4096},
+		{name: "default-limit", size: 4096, limit: 4096},
+		{name: "maximum-limit", size: 32768, limit: 32768},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			h := throughputHeap{classLimit: tc.limit}
+			got := 0
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				got += benchmarkThroughputClassFor(&h, tc.size)
+			}
+			benchmarkThroughputClass = got
+		})
+	}
+}
+
 var benchmarkThroughputLargeSpan int
 
 func newThroughputLargeSpanMissFixture(spans int) throughputHeap {

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -254,11 +254,15 @@ func (h *throughputHeap) free(e handleEntry) error {
 	return nil
 }
 
+// Keep the mapper out of line: duplicating it in allocator callers grows hot
+// code and regresses promotion despite faster isolated lookups.
+//
+//go:noinline
 func (h *throughputHeap) classFor(size uint32) int {
 	if size <= 128 {
 		class := 0
 		switch {
-		case size <= throughputClassSizes[0]:
+		case size <= 32:
 		case size <= 64:
 			class = int((size-1)>>4) - 1
 		case size <= 96:
@@ -271,27 +275,23 @@ func (h *throughputHeap) classFor(size uint32) int {
 		}
 		return -1
 	}
-	if size > throughputClassSizes[len(throughputClassSizes)-1] {
+	if size > 32768 {
 		return -1
 	}
 
-	var class int
-	switch {
-	case size <= 4096:
+	exponent := bits.Len32(size - 1)
+	class := exponent + 2
+	if size <= 4096 {
 		// Classes through 4 KiB alternate powers of two and 1.5x.
-		exponent := bits.Len32(size - 1)
-		upper := uint32(1) << exponent
 		class = 2 * (exponent - 5)
-		if size <= upper-(upper>>2) {
+		if size <= uint32(3)<<(exponent-2) {
 			class--
 		}
-	default:
-		class = bits.Len32(size-1) + 2
 	}
-	if throughputClassSizes[class] > h.classLimit {
-		return -1
+	if throughputClassSizes[class] <= h.classLimit {
+		return class
 	}
-	return class
+	return -1
 }
 
 func supportedThroughputClassLimit(limit uint32) bool {

--- a/src/core/runtime/gc/throughput_alloc.go
+++ b/src/core/runtime/gc/throughput_alloc.go
@@ -3,6 +3,7 @@ package gc
 import (
 	"errors"
 	"fmt"
+	"math/bits"
 )
 
 var errThroughputHeapExhausted = errors.New("gc: throughput heap exhausted")
@@ -254,12 +255,43 @@ func (h *throughputHeap) free(e handleEntry) error {
 }
 
 func (h *throughputHeap) classFor(size uint32) int {
-	for i, sz := range throughputClassSizes {
-		if size <= sz && sz <= h.classLimit {
-			return i
+	if size <= 128 {
+		class := 0
+		switch {
+		case size <= throughputClassSizes[0]:
+		case size <= 64:
+			class = int((size-1)>>4) - 1
+		case size <= 96:
+			class = 3
+		default:
+			class = 4
 		}
+		if throughputClassSizes[class] <= h.classLimit {
+			return class
+		}
+		return -1
 	}
-	return -1
+	if size > throughputClassSizes[len(throughputClassSizes)-1] {
+		return -1
+	}
+
+	var class int
+	switch {
+	case size <= 4096:
+		// Classes through 4 KiB alternate powers of two and 1.5x.
+		exponent := bits.Len32(size - 1)
+		upper := uint32(1) << exponent
+		class = 2 * (exponent - 5)
+		if size <= upper-(upper>>2) {
+			class--
+		}
+	default:
+		class = bits.Len32(size-1) + 2
+	}
+	if throughputClassSizes[class] > h.classLimit {
+		return -1
+	}
+	return class
 }
 
 func supportedThroughputClassLimit(limit uint32) bool {


### PR DESCRIPTION
## Summary

- replace the Throughput allocator's linear 18-entry size-class scan with direct constant-time mapping
- preserve exact class-limit behavior for every supported class and reject oversized inputs before bit arithmetic
- keep the mapper out of allocator callers after adversarial benchmarking showed that full inlining regressed end-to-end promotion
- add exhaustive equivalence coverage, maximum-`uint32` cases, representative fixed-class benchmarks, and a mixed-class benchmark

This is the first focused allocator slice of #312; it does not close the remaining large-span, free-record, sweeping, or locality work.

## Why

Every old-space size-class allocation and promotion checkpoint rediscovered a class by walking the ordered class table. The cost rose with allocation size, reaching the full 18 comparisons at the maximum class.

The retained mapper exploits the existing class progression: small classes use direct fixed branches, classes through 4 KiB alternate powers of two and 1.5x, and larger classes are powers of two. The linear implementation remains as a test-only oracle.

## Correctness

`TestThroughputClassForMatchesLinearReference` compares the new mapper with the former linear behavior:

- every byte size through the maximum class plus one;
- every supported class limit, including zero/uninitialized state;
- every class boundary and adjacent value under every possible limit through 32,769; and
- near-overflow and maximum `uint32` inputs.

No heap, handle, object, serialized, snapshot, or native ABI layout changes.

## Measurements

Linux/amd64, Ryzen 7 8845HS, Go 1.24.4, `GOMAXPROCS=1`, pinned to CPU 2. Ten interleaved/reversed-order samples, 300 ms each:

| Lookup | Before | After | Delta |
|---|---:|---:|---:|
| 32-byte class | 2.336 ns | 2.322 ns | -0.6% |
| 96-byte class | 2.603 ns | 2.696 ns | +3.6%, overlapping ranges |
| 768-byte class | 3.907 ns | 3.006 ns | -23.1% |
| 4 KiB default limit | 5.168 ns | 2.949 ns | -42.9% |
| 32 KiB maximum limit | 6.854 ns | 2.893 ns | -57.8% |
| all classes mixed | 4.706 ns | 3.159 ns | -32.9% |
| lookup geomean | 3.978 ns | 2.824 ns | -29.0% |

All cases remain 0 B/op and 0 allocs/op.

Fifteen pinned interleaved/reversed-order `BenchmarkForcePromoteTransactional` samples measured 85.07 ns before and 84.81 ns after (-0.3% median; paired median +0.23%), treated as unchanged.

With identical test sources, the GC test binary is 1,568 bytes smaller. Direct symbol sizes change as follows:

- `throughputHeap.alloc`: 1,680 -> 1,535 bytes
- `throughputHeap.checkpointAlloc`: 811 -> 666 bytes
- one shared `throughputHeap.classFor`: +268 bytes

The three symbols therefore shrink by 22 bytes in total; file-level savings include linker alignment.

## Adversarial review

After the first commit, I tested and rejected two faster-looking alternatives:

- fully inlining the mapper improved isolated lookup numbers but regressed pinned transactional promotion by about 3.3%; and
- an inline small-class table plus out-of-line large mapper regressed promotion by about 12% and grew the equivalent test binary by about 2.1 KiB.

Both were reverted. The retained out-of-line mapper keeps caller text compact and leaves end-to-end promotion unchanged.

## Validation

Passed:

- `go test ./src/core/runtime/gc -count=100 -shuffle=on`
- `go test -race ./src/core/runtime/gc -count=10`
- `go test -tags 'wagodebug wagostress wago_guardpage' ./src/core/runtime/gc -count=10`
- `go test ./src/core/runtime/gc -gcflags=all='-d=checkptr=2' -count=10`
- `FuzzCollectorOperations`: more than 2.4 million executions across two post-change runs
- `go vet ./src/core/runtime/gc`
- `make lint` (`staticcheck` was not installed, so the Makefile skipped it)
- GC package cross-builds for all six supported OS/architecture targets, plus linux/386
- every repository package except execution of `src/wago`'s staged spec cases
- compile-only `go test ./src/wago -run '^$'`
- `(cd bench && go test ./...)`

A full `go test ./...` reached only unrelated staged Core 3 failures: the locally installed WABT cannot parse the pinned GC/EH/memory64 syntax and `WAGO_SPEC_INTERPRETER` is unset. All other packages passed.

## Documentation

Unchanged. This is an internal allocator optimization and does not change developer workflow, public API, supported features, or benchmark procedure.

## AI assistance

AI assistance was used to explore mappings, generate adversarial boundary cases, and review benchmark/code-size tradeoffs; every retained change and rejected variant was tested directly.
