### PR TITLE
compiler: remove redundant compile-path body walks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -233,9 +233,11 @@ current optimization priorities. The Core 3.0 implementation ledger is
 - 🚧 **P7 — compile path**: post-#96 profiling rejected validator/codegen
   entanglement as the first move. The existing requirements scan now also
   produces module footprint facts, passive-segment state bounds, and atomic
-  wait-helper selection, removing two later whole-body walks. Identical-commit
-  full-compile A/Bs on darwin/arm64 show latency improvements of 7.70–9.90% on
-  ruby, esbuild, sqlite3, and json-as, with allocation traffic and peak RSS
+  wait-helper selection, indexed-function ref-test/cast requirements, and the
+  ARM64 GC ref-test helper obligation, removing four later whole-body walks.
+  Identical-commit full-compile A/Bs on darwin/arm64 show 7.70–9.90% for the
+  first summary fusion and a further 9.99–13.94% for the ref-operation fusion
+  on ruby, esbuild, sqlite3, and json-as, with allocation traffic and peak RSS
   neutral. Fusing support admission and backend hints remains premise-gated on
   preserving validation/error order and per-architecture code identity.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -229,8 +229,15 @@ current optimization priorities. The Core 3.0 implementation ledger is
   forwarding, and a CPUID-gated BMI2 path remain.
 <!-- roadmap:P4 status=planned -->
 - [ ] **P4 — restricted pending `local.set`/`tee`** *(gated on P1 counters)*
-<!-- roadmap:P7 status=planned -->
-- [ ] **P7 — compile path** *(premise re-measured post-#96)*: fused validate+compile
+<!-- roadmap:P7 status=partial -->
+- 🚧 **P7 — compile path**: post-#96 profiling rejected validator/codegen
+  entanglement as the first move. The existing requirements scan now also
+  produces module footprint facts, passive-segment state bounds, and atomic
+  wait-helper selection, removing two later whole-body walks. Identical-commit
+  full-compile A/Bs on darwin/arm64 show latency improvements of 7.70–9.90% on
+  ruby, esbuild, sqlite3, and json-as, with allocation traffic and peak RSS
+  neutral. Fusing support admission and backend hints remains premise-gated on
+  preserving validation/error order and per-architecture code identity.
 
 **Runtime & product** (no-ir-plan P8 — parallel track, feature value)
 - [x] **Synchronous host-import results** — returning host imports use the no-cgo

--- a/docs/code-image-pipeline-plan.md
+++ b/docs/code-image-pipeline-plan.md
@@ -1,6 +1,6 @@
 # Code-image and artifact pipeline
 
-Status: complete on `codex/code-image-pipeline`.
+Status: phases 1-4 complete on `main`; direct serial emission follow-up complete.
 
 Tracking issues: #316, #330, #331.
 
@@ -45,6 +45,60 @@ during compilation. Steady-state execution, artifact bytes, and machine-code
 bytes are intentionally unchanged. The ordinary instantiate benchmark is also
 unchanged because it amortizes the one-time transition across all iterations.
 
+The original phase 1 image was off heap, but each function was still encoded
+into reusable heap scratch and copied once into that image. The direct-emission
+follow-up makes the writable image tail the serial assembler's output buffer and
+commits it transactionally. If a function exceeds the reserved tail, the
+assembler moves to heap and the compiler safely falls back to `Append`; a
+capacity estimate can still affect performance, never correctness.
+
+On the same Apple M4 Max, five 500 ms samples of the public serial compile path
+measured:
+
+| Module | Full compile before | Direct emission | Delta | Go heap before | Direct emission | Delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| many_funcs | 314.4 us | 306.2 us | 1.027x faster | 217,203 B/op | 216,644 B/op | 1.003x less |
+| json-as | 1.468 ms | 1.387 ms | 1.058x faster | 400,023 B/op | 355,959 B/op | 1.124x less |
+| sqlite3 | 90.79 ms | 88.43 ms | 1.027x faster | 7,092,716 B/op | 6,615,945 B/op | 1.072x less |
+| ruby | 1.069 s | 1.029 s | 1.039x faster | 40,137,960 B/op | 37,394,792 B/op | 1.073x less |
+| esbuild | 709.3 ms | 688.9 ms | 1.030x faster | 46,570,752 B/op | 42,765,200 B/op | 1.089x less |
+
+The ruby and esbuild latency changes reached significance in these five-sample
+runs (`p=0.032` and `p=0.016`); the smaller corpora did not. Five fresh esbuild
+processes reduced median peak RSS from 138,706,944 to 136,527,872 bytes, 1.016x
+less. The completed-function `CodeBuffer.Append` copy disappeared from the CPU
+profile; first-touch page cost moved into encoder stores, explaining why the
+latency gain is much smaller than the removed copy's former 33.4% CPU-profile
+share. Native code size stayed byte-for-byte unchanged. Twelve interleaved
+execution samples were also unchanged: fib_iter was 66.72 vs 66.40 ns/op
+(`p=0.590`) and json-as serialization was 19.04 vs 19.01 us/op (`p=0.671`),
+both at zero B/op and zero allocations/op.
+
+The review gate was repeated after rebasing the complete branch onto
+`5a5327bf`. Median allocation counts moved from 403 to 400 allocs/op on
+many_funcs, 1,350 to 1,339 on json-as, 37,369 to 37,355 on sqlite3, 252,216 to
+252,198 on ruby, and 81,198 to 81,182 on esbuild. A first-load-only json-as
+benchmark recompiled before each timed first instantiation and alternated ten
+200-iteration samples: the median was 29.86 us on main and 27.64 us on the
+branch (7.45% lower), with both sides at 199 allocs/op and approximately 6,033
+B/op. Sample variance was high, so this is evidence against a regression, not a
+claimed first-load speedup. The compile-produced mappings were also exactly the
+same page-rounded sizes (32,768 bytes for many_funcs and 81,920 for json-as).
+
+Artifact and native-code bytes were byte-identical; the raw sizes below apply
+to both main and the branch. Direct emission removes the completed-function
+copy (zero such copy on the branch); the code-image size is the conservative
+upper bound on bytes formerly copied because it also includes alignment and
+module-level code.
+
+| Module | Native code bytes | `.wago` bytes |
+| --- | ---: | ---: |
+| many_funcs | 28,984 | 34,636 |
+| json-as | 77,388 | 86,000 |
+| sqlite3 | 4,029,344 | 4,207,097 |
+| ruby | 44,146,196 | 49,584,314 |
+| esbuild | 31,506,684 | 35,097,196 |
+
 ## Ownership model
 
 The neutral `core/codeimage.Image` interface transfers an image between the
@@ -78,6 +132,8 @@ flushes the instruction cache.
 - [x] Transfer ownership without growing decoded-module footprint.
 - [x] Prove first instantiation retains the exact code address.
 - [x] Preserve byte-identical code, codec output, and execution behavior.
+- [x] Emit each serial function directly into the writable image tail.
+- [x] Retain a checked heap-copy fallback for a tail-capacity underestimate.
 
 ### Phase 2: bounded parallel join investigation
 

--- a/docs/no-ir-plan.md
+++ b/docs/no-ir-plan.md
@@ -343,6 +343,40 @@ differential-fuzzed old-vs-fused on accept/reject agreement. Keep the
 standalone validator as the API surface either way. Add compile-side stats
 (allocs, arena high-water) to P1's stats while in here.
 
+Current remeasurement confirms that standalone validation is not the best
+first fusion seam: it accounts for roughly 10–14% of full compile time on the
+large corpus modules, while body summaries are redundantly rebuilt around it.
+The first retained P7 slice deepens `analyzeModuleRequirements` into the shared
+summary pass: its existing body decode now also records `ModuleFacts`, passive
+segment state bounds, and atomic wait-helper selection. The standalone
+validator and its error precedence remain unchanged.
+
+Identical-commit darwin/arm64 A/Bs (`-benchtime=500ms -count=10`) measured the
+following median full-compile changes:
+
+| Module | Latency | Allocated bytes | Allocations |
+|---|---:|---:|---:|
+| many_funcs | -2.68% | neutral | neutral |
+| json-as | -9.90% | neutral | neutral |
+| sqlite3 | -7.70% | neutral | neutral |
+| ruby | -7.74% | neutral | neutral |
+| esbuild | -9.00% | neutral | neutral |
+
+All latency comparisons were significant at `p <= 0.001` with ten samples per
+side. Allocated bytes and allocation counts were statistically unchanged;
+esbuild was independently repeated at two iterations per sample to retain all
+ten timing samples. A future support/hint fusion must beat this same gate
+without duplicating feature admission logic inside `wago` or changing which
+phase owns malformed-module diagnostics. `WAGO_FUSED_VALIDATE` remains
+reserved; this slice needs no kill switch because it removes redundant pure
+analysis while retaining the reference validator and frontend admission pass.
+
+Seven interleaved fresh-process compile-only runs kept median peak RSS neutral:
+ruby moved from 136,364,032 to 136,495,104 bytes (+0.10%), while esbuild moved
+from 114,622,464 to 114,458,624 bytes (-0.14%). Native code size and SHA-256
+stayed byte-identical for all five benchmark modules, so execution time and
+generated code size are unchanged by construction.
+
 ### P8. Runtime & product track (original plan; feature value, not exec perf)
 
 The list below is retained as the original July plan. Current disposition:

--- a/docs/no-ir-plan.md
+++ b/docs/no-ir-plan.md
@@ -377,6 +377,40 @@ from 114,622,464 to 114,458,624 bytes (-0.14%). Native code size and SHA-256
 stayed byte-identical for all five benchmark modules, so execution time and
 generated code size are unchanged by construction.
 
+The second retained P7 slice folds indexed-function `ref.test`/`ref.cast`
+requirements and ARM64 GC ref-test helper selection into the same summary
+decode. These booleans previously required two additional full body walks. An
+identical-commit darwin/arm64 A/B (`-benchtime=500ms -count=10`) measured this
+increment independently from the first summary fusion:
+
+| Module | Latency | Allocated bytes | Allocations |
+|---|---:|---:|---:|
+| many_funcs | -6.28% | neutral | neutral |
+| json-as | -13.94% | neutral | neutral |
+| sqlite3 | -9.99% | neutral | neutral |
+| ruby | -10.15% | neutral | neutral |
+| esbuild | -12.44% | neutral | neutral |
+
+All latency comparisons were significant at `p < 0.001`. The post-fusion Ruby
+profile attributes the remaining full-compile CPU chiefly to native emission,
+standalone validation (13.73%), backend hints (8.96%), and frontend admission
+(5.60%). Those remaining walks own type correctness, architecture-specific
+code-quality policy, or product diagnostics; they are not folded into the
+requirements summary without a separate differential design and code-identity
+gate.
+
+Seven interleaved fresh-process runs kept this second slice's median peak RSS
+neutral as well: ruby moved from 136,445,952 to 136,347,648 bytes (-0.07%) and
+esbuild from 114,556,928 to 114,491,392 bytes (-0.06%). Native code size and
+SHA-256 again stayed byte-identical across all five benchmark modules.
+
+Across the complete three-commit compile-path branch rebased onto current main,
+the identical-origin A/B improves full compile latency by 8.55% on many_funcs
+and 18.74–23.25% on the four large modules. Allocated bytes fall 6.72–10.86%
+on those large modules; the summary-fusion commits themselves are
+allocation-neutral, while the byte reduction comes from serial direct-to-image
+emission.
+
 ### P8. Runtime & product track (original plan; feature value, not exec perf)
 
 The list below is retained as the original July plan. Current disposition:

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -908,6 +908,22 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		pressureAt := shared.PressureThreshold(opts.MemoryPressureAt, codeCap)
 		var directPrepared []uint64
 		for i := range m.Code {
+			// Align and reserve before lowering so the assembler can emit straight
+			// into the module-owned image. If an unusually large function outgrows
+			// the mapping tail, CommitTail rejects the detached slice and Append
+			// preserves the old capacity-underestimate fallback.
+			if pad := (16 - len(codeBuffer.Bytes())%16) % 16; pad != 0 {
+				if err := codeBuffer.AppendZeros(pad); err != nil {
+					return nil, fmt.Errorf("amd64: grow code image: %w", err)
+				}
+			}
+			code := codeBuffer.Bytes()
+			entry[i] = len(code)
+			tail, err := codeBuffer.AppendTail(asmCapForBody(len(m.Code[i].BodyBytes)))
+			if err != nil {
+				return nil, fmt.Errorf("amd64: grow code image: %w", err)
+			}
+			sc.asm.B = tail
 			hints := allHints[i]
 			var st *CodegenStats
 			if ms != nil {
@@ -920,21 +936,15 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 				return nil, fmt.Errorf("amd64: function %d: %w", i, err)
 			}
 			requiresBMI2 = requiresBMI2 || sc.asm.UsesBMI2
-			// 16-byte align each function (append zeros without a temp allocation).
-			if pad := (16 - len(codeBuffer.Bytes())%16) % 16; pad != 0 {
-				if err := codeBuffer.AppendZeros(pad); err != nil {
-					return nil, fmt.Errorf("amd64: grow code image: %w", err)
-				}
-			}
-			code := codeBuffer.Bytes()
-			entry[i] = len(code)
 			internalEntry[i] = len(code) + internalOff
 			if sc.directPrepared {
 				directPrepared = markDirectPrepared(directPrepared, n, i)
 			}
 			relocs[i] = rl
-			if err := codeBuffer.Append(fnCode); err != nil {
-				return nil, fmt.Errorf("amd64: grow code image: %w", err)
+			if !codeBuffer.CommitTail(fnCode) {
+				if err := codeBuffer.Append(fnCode); err != nil {
+					return nil, fmt.Errorf("amd64: grow code image: %w", err)
+				}
 			}
 			if !pressureDone && opts.MemoryPressure != nil && len(codeBuffer.Bytes()) >= pressureAt {
 				pressureDone = true

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -777,6 +777,22 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 		pressureDone := false
 		pressureAt := shared.PressureThreshold(opts.MemoryPressureAt, codeCap)
 		for i := range m.Code {
+			// Align and reserve before lowering so the assembler can emit straight
+			// into the module-owned image. If an unusually large function outgrows
+			// the mapping tail, CommitTail rejects the detached slice and Append
+			// preserves the old capacity-underestimate fallback.
+			if pad := (16 - len(codeBuffer.Bytes())%16) % 16; pad != 0 {
+				if err := codeBuffer.AppendZeros(pad); err != nil {
+					return nil, fmt.Errorf("arm64: grow code image: %w", err)
+				}
+			}
+			code := codeBuffer.Bytes()
+			entry[i] = len(code)
+			tail, err := codeBuffer.AppendTail(asmCapForBody(len(m.Code[i].BodyBytes)))
+			if err != nil {
+				return nil, fmt.Errorf("arm64: grow code image: %w", err)
+			}
+			sc.asm.B = tail
 			hints := allHints[i]
 			var st *CodegenStats
 			if ms != nil {
@@ -788,17 +804,12 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 			if err != nil {
 				return nil, fmt.Errorf("arm64: function %d: %w", i, err)
 			}
-			if pad := (16 - len(codeBuffer.Bytes())%16) % 16; pad != 0 {
-				if err := codeBuffer.AppendZeros(pad); err != nil {
-					return nil, fmt.Errorf("arm64: grow code image: %w", err)
-				}
-			}
-			code := codeBuffer.Bytes()
-			entry[i] = len(code)
 			internalEntry[i] = len(code) + internalOff
 			relocs[i] = rl
-			if err := codeBuffer.Append(fnCode); err != nil {
-				return nil, fmt.Errorf("arm64: grow code image: %w", err)
+			if !codeBuffer.CommitTail(fnCode) {
+				if err := codeBuffer.Append(fnCode); err != nil {
+					return nil, fmt.Errorf("arm64: grow code image: %w", err)
+				}
 			}
 			if !pressureDone && opts.MemoryPressure != nil && len(codeBuffer.Bytes()) >= pressureAt {
 				pressureDone = true

--- a/src/core/runtime/code_buffer.go
+++ b/src/core/runtime/code_buffer.go
@@ -69,6 +69,40 @@ func (b *CodeBuffer) AppendSpace(n int) ([]byte, error) {
 	return b.mem[start:b.n:b.n], nil
 }
 
+// AppendTail returns a zero-length writable slice at the logical end of the
+// image with at least minCapacity bytes available. The caller may append into
+// the slice, then pass the result to CommitTail. Calling another mutating
+// CodeBuffer method invalidates the returned slice.
+//
+// This lets a serial compiler emit directly into the final code image instead
+// of first building a heap-backed function and copying it with Append.
+func (b *CodeBuffer) AppendTail(minCapacity int) ([]byte, error) {
+	if minCapacity < 0 {
+		return nil, fmt.Errorf("jit: negative code tail capacity %d", minCapacity)
+	}
+	if err := b.grow(minCapacity); err != nil {
+		return nil, err
+	}
+	return b.mem[b.n:b.n:len(b.mem)], nil
+}
+
+// CommitTail advances the logical image over code emitted into the slice from
+// AppendTail. It returns false without changing the image if code was moved to
+// another allocation while growing; callers can then fall back to Append.
+func (b *CodeBuffer) CommitTail(code []byte) bool {
+	if b == nil || b.closed || b.sealed || len(code) > len(b.mem)-b.n {
+		return false
+	}
+	if len(code) == 0 {
+		return true
+	}
+	if b.n == len(b.mem) || unsafe.SliceData(code) != unsafe.SliceData(b.mem[b.n:]) {
+		return false
+	}
+	b.n += len(code)
+	return true
+}
+
 // Bytes returns the exact logical image. It is writable until Seal succeeds
 // and read-only afterward. Callers must not retain it after Close.
 func (b *CodeBuffer) Bytes() []byte {

--- a/src/core/runtime/code_buffer_test.go
+++ b/src/core/runtime/code_buffer_test.go
@@ -61,6 +61,49 @@ func TestCodeBufferGrowSealClose(t *testing.T) {
 	}
 }
 
+func TestCodeBufferAppendTail(t *testing.T) {
+	b, err := NewCodeBuffer(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	if err := b.Append([]byte{1, 2, 3}); err != nil {
+		t.Fatal(err)
+	}
+	tail, err := b.AppendTail(5000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tail) != 0 || cap(tail) < 5000 {
+		t.Fatalf("AppendTail = len %d cap %d, want len 0 cap >= 5000", len(tail), cap(tail))
+	}
+	code := append(tail, 4, 5, 6, 7)
+	if !b.CommitTail(code) {
+		t.Fatal("CommitTail rejected code emitted into the reserved tail")
+	}
+	if got, want := b.Bytes(), []byte{1, 2, 3, 4, 5, 6, 7}; !bytes.Equal(got, want) {
+		t.Fatalf("Bytes = %v, want %v", got, want)
+	}
+
+	before := append([]byte(nil), b.Bytes()...)
+	if b.CommitTail([]byte{8, 9}) {
+		t.Fatal("CommitTail accepted a detached allocation")
+	}
+	if got := b.Bytes(); !bytes.Equal(got, before) {
+		t.Fatalf("rejected CommitTail changed Bytes: %v", got)
+	}
+	if err := b.Append([]byte{8, 9}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := b.Bytes(), []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}; !bytes.Equal(got, want) {
+		t.Fatalf("Append fallback after rejected CommitTail = %v, want %v", got, want)
+	}
+	if _, err := b.AppendTail(-1); err == nil {
+		t.Fatal("AppendTail accepted a negative capacity")
+	}
+}
+
 func BenchmarkCodeImageTransition(b *testing.B) {
 	code := bytes.Repeat([]byte{0x90}, 1<<20)
 	b.Run("copy-and-seal", func(b *testing.B) {

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1104,7 +1104,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 		functionIndex++
 	}
 	customInstructions := resolveInstructionLowerings(m, instructions)
-	atomicWaitHelpers := moduleUsesAtomicWaitHelpers(m)
+	atomicWaitHelpers := requirements.atomicWaitHelpers
 	structuralProduct := stagedStructuralTypeProduct(0)
 	gcTypeSubtypingProduct := stagedGCTypeSubtypingProduct(0)
 	gcStructProduct := stagedGCStructProduct(0)
@@ -1319,10 +1319,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	if err := configureStagedGCArrayTypeDescs(gcArrayProduct, gcDescs); err != nil {
 		return nil, fmt.Errorf("gc array descriptors: %w", err)
 	}
-	moduleFacts, err := frontend.AnalyzeModuleFacts(m)
-	if err != nil {
-		return nil, fmt.Errorf("compile module facts: %w", err)
-	}
+	moduleFacts := requirements.moduleFacts
 	if err := frontend.RejectUnsupportedWithFeaturesAndFacts(m, features, moduleFacts); err != nil {
 		return nil, fmt.Errorf("compile: %w", err)
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1187,7 +1187,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 		// recognizers select optimizations, not semantic admission boundaries.
 		gcStructProduct = stagedGCStructGeneric
 	}
-	if goruntime.GOARCH == "arm64" && !gcStructProduct.requiresHelpers() && moduleUsesArm64GCRefTestHelper(m) {
+	if goruntime.GOARCH == "arm64" && !gcStructProduct.requiresHelpers() && requirements.arm64GCRefTestHelper {
 		// ARM64 lowers collector-reference ref.test through the generic checked
 		// helper. Provision the collector and helper dispatch even when a narrower
 		// metadata-only product recognized the module.
@@ -1342,7 +1342,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	pressureAt, pressure := compileMemoryPressure(len(wasmBytes))
 	genericGCExecution := gcStructProduct == stagedGCStructGeneric || gcArrayProduct == stagedGCArrayProductNewData || gcArrayProduct == stagedGCArrayProductNewElem || gcArrayProduct == stagedGCArrayProductGeneric
 	gcFrameRoots := newGCFrameRootPlan(m, genericGCExecution)
-	indexedFunctionRefTest, indexedFunctionRefCast := moduleUsesIndexedFunctionRefTestOrCast(m)
+	indexedFunctionRefTest, indexedFunctionRefCast := requirements.indexedFuncRefTest, requirements.indexedFuncRefCast
 	indexedFunctionRefOps := indexedFunctionRefTest || indexedFunctionRefCast
 	dynamicFuncRefTest := indexedFunctionRefTest && !gcTypeSubtypingProduct.usesRefTest() && !gcTypeSubtypingProduct.usesRuntimeFunctionIdentity()
 	gcFunctionRefTest := gcTypeSubtypingProduct.usesRefTest() || gcTypeSubtypingProduct.usesRuntimeFunctionIdentity() || indexedFunctionRefOps
@@ -1976,45 +1976,6 @@ func isUnsupportedProposalError(err error) bool {
 	} {
 		if strings.Contains(message, marker) {
 			return true
-		}
-	}
-	return false
-}
-
-func moduleUsesArm64GCRefTestHelper(m *wasm.Module) bool {
-	if m == nil {
-		return false
-	}
-	for i := range m.Code {
-		r := wasm.NewReader(m.Code[i].BodyBytes)
-		for r.HasNext() {
-			op, err := r.Byte()
-			if err != nil {
-				return false
-			}
-			if op == 0xfb {
-				peek := *r
-				sub, subErr := peek.U32()
-				if subErr != nil {
-					return false
-				}
-				if sub == 20 || sub == 21 {
-					heap, heapErr := peek.S33()
-					if heapErr != nil {
-						return false
-					}
-					if heap >= 0 {
-						if _, isFunc := m.TypeFunc(uint32(heap)); !isFunc {
-							return true
-						}
-					} else if heap != -16 && heap != -17 && heap != -13 && heap != -14 {
-						return true
-					}
-				}
-			}
-			if _, err := wasm.ClassifyInstructionImmediate(r, op); err != nil {
-				return false
-			}
 		}
 	}
 	return false

--- a/src/wago/feature_usage.go
+++ b/src/wago/feature_usage.go
@@ -6,11 +6,14 @@ import (
 )
 
 type moduleRequirements struct {
-	features          CoreFeatures
-	elemStateCount    int
-	dataStateCount    int
-	moduleFacts       *frontend.ModuleFacts
-	atomicWaitHelpers bool
+	features             CoreFeatures
+	elemStateCount       int
+	dataStateCount       int
+	moduleFacts          *frontend.ModuleFacts
+	atomicWaitHelpers    bool
+	indexedFuncRefTest   bool
+	indexedFuncRefCast   bool
+	arm64GCRefTestHelper bool
 }
 
 // moduleRequiredFeatures records optional core features that remain execution
@@ -35,6 +38,8 @@ func analyzeModuleRequirements(m *wasm.Module) moduleRequirements {
 		MemoryExported: make([]bool, m.MemCount()),
 	}
 	atomicWaitHelpers := false
+	indexedFuncRefTest, indexedFuncRefCast := false, false
+	arm64GCRefTestHelper := false
 	if frontend.ModuleNonCodeRequiresSIMD(m) {
 		out |= CoreFeatureSIMD
 	}
@@ -170,7 +175,7 @@ func analyzeModuleRequirements(m *wasm.Module) moduleRequirements {
 			out |= requiredFeaturesForValType(local.Type)
 		}
 		if len(fn.BodyBytes) != 0 {
-			out |= requiredFeaturesAndSegmentCountsForBodyBytes(fn.BodyBytes, &elemStateCount, &dataStateCount, moduleFacts, &atomicWaitHelpers)
+			out |= requiredFeaturesAndSegmentCountsForBodyBytes(fn.BodyBytes, &elemStateCount, &dataStateCount, moduleFacts, &atomicWaitHelpers, m, &indexedFuncRefTest, &indexedFuncRefCast, &arm64GCRefTestHelper)
 		} else if len(fn.Body.Instrs) != 0 {
 			programmaticCode = true
 			instrsModuleRequirements(fn.Body.Instrs, &elemStateCount, &dataStateCount, moduleFacts, &atomicWaitHelpers)
@@ -180,11 +185,14 @@ func analyzeModuleRequirements(m *wasm.Module) moduleRequirements {
 		out |= CoreFeatureSIMD
 	}
 	return moduleRequirements{
-		features:          out,
-		elemStateCount:    elemStateCount,
-		dataStateCount:    dataStateCount,
-		moduleFacts:       moduleFacts,
-		atomicWaitHelpers: atomicWaitHelpers,
+		features:             out,
+		elemStateCount:       elemStateCount,
+		dataStateCount:       dataStateCount,
+		moduleFacts:          moduleFacts,
+		atomicWaitHelpers:    atomicWaitHelpers,
+		indexedFuncRefTest:   indexedFuncRefTest,
+		indexedFuncRefCast:   indexedFuncRefCast,
+		arm64GCRefTestHelper: arm64GCRefTestHelper,
 	}
 }
 
@@ -281,10 +289,10 @@ func requiredFeaturesForValType(typ wasm.ValType) CoreFeatures {
 
 func requiredFeaturesForBodyBytes(body []byte) CoreFeatures {
 	elemStateCount, dataStateCount := 0, 0
-	return requiredFeaturesAndSegmentCountsForBodyBytes(body, &elemStateCount, &dataStateCount, nil, nil)
+	return requiredFeaturesAndSegmentCountsForBodyBytes(body, &elemStateCount, &dataStateCount, nil, nil, nil, nil, nil, nil)
 }
 
-func requiredFeaturesAndSegmentCountsForBodyBytes(body []byte, elemStateCount, dataStateCount *int, facts *frontend.ModuleFacts, atomicWaitHelpers *bool) CoreFeatures {
+func requiredFeaturesAndSegmentCountsForBodyBytes(body []byte, elemStateCount, dataStateCount *int, facts *frontend.ModuleFacts, atomicWaitHelpers *bool, m *wasm.Module, indexedFuncRefTest, indexedFuncRefCast, arm64GCRefTestHelper *bool) CoreFeatures {
 	var out CoreFeatures
 	r := wasm.NewReader(body)
 	for r.HasNext() {
@@ -428,18 +436,65 @@ func requiredFeaturesAndSegmentCountsForBodyBytes(body []byte, elemStateCount, d
 			}
 			continue
 		}
+		var probe wasm.Reader
+		if op == 0xfb {
+			probe = *r
+		}
 		imm, err := wasm.ClassifyInstructionImmediate(r, op)
 		if err != nil {
 			break
 		}
 		segmentStateCount(imm.Kind, imm.Index, imm.Index2, elemStateCount, dataStateCount)
 		recordModuleRequirementFact(imm.Kind, imm.Index, facts, atomicWaitHelpers)
+		if op == 0xfb {
+			recordRefTypeRequirements(m, imm.Kind, &probe, indexedFuncRefTest, indexedFuncRefCast, arm64GCRefTestHelper)
+		}
 		out |= requiredFeaturesForInstructionKind(imm.Kind)
 		if imm.Kind == wasm.InstrCallIndirect && imm.Index2 != 0 {
 			out |= CoreFeatureReferenceTypes
 		}
 	}
 	return out
+}
+
+func recordRefTypeRequirements(m *wasm.Module, kind wasm.InstrKind, probe *wasm.Reader, refTest, refCast, arm64GCRefTestHelper *bool) {
+	if m == nil || (kind != wasm.InstrRefTest && kind != wasm.InstrRefCast) {
+		return
+	}
+	subopcode, err := probe.U32()
+	if err != nil || (subopcode != 20 && subopcode != 21 && subopcode != 22 && subopcode != 23) {
+		return
+	}
+	heap, err := probe.S33()
+	if err != nil {
+		return
+	}
+	if kind == wasm.InstrRefTest && (subopcode == 20 || subopcode == 21) && arm64GCRefTestHelper != nil {
+		if heap >= 0 {
+			if _, isFunc := m.TypeFunc(uint32(heap)); !isFunc {
+				*arm64GCRefTestHelper = true
+			}
+		} else {
+			switch heap {
+			case -16, -17, -13, -14:
+			default:
+				*arm64GCRefTestHelper = true
+			}
+		}
+	}
+	if heap < 0 {
+		return
+	}
+	if _, ok := m.TypeFunc(uint32(heap)); !ok {
+		return
+	}
+	if kind == wasm.InstrRefTest {
+		if refTest != nil {
+			*refTest = true
+		}
+	} else if refCast != nil {
+		*refCast = true
+	}
 }
 
 func instrsModuleRequirements(instrs []wasm.Instruction, elemCount, dataCount *int, facts *frontend.ModuleFacts, atomicWaitHelpers *bool) {

--- a/src/wago/feature_usage.go
+++ b/src/wago/feature_usage.go
@@ -6,9 +6,11 @@ import (
 )
 
 type moduleRequirements struct {
-	features       CoreFeatures
-	elemStateCount int
-	dataStateCount int
+	features          CoreFeatures
+	elemStateCount    int
+	dataStateCount    int
+	moduleFacts       *frontend.ModuleFacts
+	atomicWaitHelpers bool
 }
 
 // moduleRequiredFeatures records optional core features that remain execution
@@ -26,6 +28,13 @@ func analyzeModuleRequirements(m *wasm.Module) moduleRequirements {
 	var out CoreFeatures
 	programmaticCode := false
 	elemStateCount, dataStateCount := 0, 0
+	moduleFacts := &frontend.ModuleFacts{
+		TableGrowUsed:  make([]bool, m.TableCount()),
+		TableExported:  make([]bool, m.TableCount()),
+		MemoryGrowUsed: make([]bool, m.MemCount()),
+		MemoryExported: make([]bool, m.MemCount()),
+	}
+	atomicWaitHelpers := false
 	if frontend.ModuleNonCodeRequiresSIMD(m) {
 		out |= CoreFeatureSIMD
 	}
@@ -72,12 +81,23 @@ func analyzeModuleRequirements(m *wasm.Module) moduleRequirements {
 	}
 	for _, g := range m.Globals {
 		out |= requiredFeaturesForValType(g.Type.Type)
-		out |= requiredFeaturesForConstExpr(g.Init, m.ImportedGlobalCount())
+		features, usesRefFunc := analyzeConstExprRequirements(g.Init, m.ImportedGlobalCount())
+		out |= features
+		moduleFacts.UsesRefFunc = moduleFacts.UsesRefFunc || usesRefFunc
 	}
 	for _, ex := range m.Exports {
-		if ex.Index.Kind == wasm.ExternGlobal {
+		switch ex.Index.Kind {
+		case wasm.ExternGlobal:
 			if gt, ok := m.GlobalTypeByIndex(uint32(ex.Index.Index)); ok && gt.Mutable {
 				out |= CoreFeatureMutableGlobal
+			}
+		case wasm.ExternTable:
+			if uint64(ex.Index.Index) < uint64(len(moduleFacts.TableExported)) {
+				moduleFacts.TableExported[ex.Index.Index] = true
+			}
+		case wasm.ExternMem:
+			if uint64(ex.Index.Index) < uint64(len(moduleFacts.MemoryExported)) {
+				moduleFacts.MemoryExported[ex.Index.Index] = true
 			}
 		}
 	}
@@ -121,8 +141,11 @@ func analyzeModuleRequirements(m *wasm.Module) moduleRequirements {
 			out |= requiredFeaturesForConstExpr(elem.Mode.Offset, m.ImportedGlobalCount())
 		}
 		for _, expr := range elem.Kind.Exprs {
-			out |= requiredFeaturesForConstExpr(expr, m.ImportedGlobalCount())
+			features, usesRefFunc := analyzeConstExprRequirements(expr, m.ImportedGlobalCount())
+			out |= features
+			moduleFacts.UsesRefFunc = moduleFacts.UsesRefFunc || usesRefFunc
 		}
+		moduleFacts.UsesRefFunc = moduleFacts.UsesRefFunc || (elem.Kind.Kind == wasm.ElemFuncs && len(elem.Kind.Funcs) != 0)
 		if elem.Mode.Kind != wasm.ElemActive {
 			out |= CoreFeatureBulkMemoryOperations
 		}
@@ -147,45 +170,64 @@ func analyzeModuleRequirements(m *wasm.Module) moduleRequirements {
 			out |= requiredFeaturesForValType(local.Type)
 		}
 		if len(fn.BodyBytes) != 0 {
-			out |= requiredFeaturesAndSegmentCountsForBodyBytes(fn.BodyBytes, &elemStateCount, &dataStateCount)
+			out |= requiredFeaturesAndSegmentCountsForBodyBytes(fn.BodyBytes, &elemStateCount, &dataStateCount, moduleFacts, &atomicWaitHelpers)
 		} else if len(fn.Body.Instrs) != 0 {
 			programmaticCode = true
-			instrsSegmentStateCounts(fn.Body.Instrs, &elemStateCount, &dataStateCount)
+			instrsModuleRequirements(fn.Body.Instrs, &elemStateCount, &dataStateCount, moduleFacts, &atomicWaitHelpers)
 		}
 	}
 	if programmaticCode && frontend.ModuleRequiresSIMD(m) {
 		out |= CoreFeatureSIMD
 	}
-	return moduleRequirements{features: out, elemStateCount: elemStateCount, dataStateCount: dataStateCount}
+	return moduleRequirements{
+		features:          out,
+		elemStateCount:    elemStateCount,
+		dataStateCount:    dataStateCount,
+		moduleFacts:       moduleFacts,
+		atomicWaitHelpers: atomicWaitHelpers,
+	}
 }
 
 func requiredFeaturesForConstExpr(expr wasm.Expr, importedGlobals int) CoreFeatures {
+	features, _ := analyzeConstExprRequirements(expr, importedGlobals)
+	return features
+}
+
+func analyzeConstExprRequirements(expr wasm.Expr, importedGlobals int) (CoreFeatures, bool) {
 	body := expr.BodyBytes
 	if len(body) == 0 {
 		encoded, err := wasm.EncodeExpr(expr)
 		if err != nil {
-			return 0
+			return 0, true
 		}
 		body = encoded
 	}
-	return requiredFeaturesForConstExprBytes(body, importedGlobals)
+	return analyzeConstExprBytes(body, importedGlobals)
 }
 
 func requiredFeaturesForConstExprBytes(body []byte, importedGlobals int) CoreFeatures {
+	features, _ := analyzeConstExprBytes(body, importedGlobals)
+	return features
+}
+
+func analyzeConstExprBytes(body []byte, importedGlobals int) (CoreFeatures, bool) {
 	r := wasm.NewReader(body)
 	var out CoreFeatures
+	usesRefFunc := false
 	usesArithmetic, usesPriorLocal := false, false
 	for r.HasNext() {
 		op, err := r.Byte()
 		if err != nil {
-			break
+			return out, true
 		}
 		imm, err := wasm.ClassifyInstructionImmediate(r, op)
 		if err != nil {
-			break
+			return out, true
 		}
 		out |= requiredFeaturesForInstructionKind(imm.Kind)
 		switch imm.Kind {
+		case wasm.InstrRefFunc:
+			usesRefFunc = true
 		case wasm.InstrGlobalGet:
 			if int(imm.Index) >= importedGlobals {
 				usesPriorLocal = true
@@ -200,7 +242,7 @@ func requiredFeaturesForConstExprBytes(body []byte, importedGlobals int) CoreFea
 	} else if usesArithmetic {
 		out |= CoreFeatureExtendedConst
 	}
-	return out
+	return out, usesRefFunc
 }
 
 func requiredFeaturesForValTypes(types []wasm.ValType) CoreFeatures {
@@ -239,31 +281,10 @@ func requiredFeaturesForValType(typ wasm.ValType) CoreFeatures {
 
 func requiredFeaturesForBodyBytes(body []byte) CoreFeatures {
 	elemStateCount, dataStateCount := 0, 0
-	return requiredFeaturesAndSegmentCountsForBodyBytes(body, &elemStateCount, &dataStateCount)
+	return requiredFeaturesAndSegmentCountsForBodyBytes(body, &elemStateCount, &dataStateCount, nil, nil)
 }
 
-func moduleUsesAtomicWaitHelpers(m *wasm.Module) bool {
-	for i := range m.Code {
-		r := wasm.NewReader(m.Code[i].BodyBytes)
-		for r.HasNext() {
-			op, err := r.Byte()
-			if err != nil {
-				break
-			}
-			imm, err := wasm.ClassifyInstructionImmediate(r, op)
-			if err != nil {
-				break
-			}
-			switch imm.Kind {
-			case wasm.InstrMemoryAtomicNotify, wasm.InstrMemoryAtomicWait32, wasm.InstrMemoryAtomicWait64:
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func requiredFeaturesAndSegmentCountsForBodyBytes(body []byte, elemStateCount, dataStateCount *int) CoreFeatures {
+func requiredFeaturesAndSegmentCountsForBodyBytes(body []byte, elemStateCount, dataStateCount *int, facts *frontend.ModuleFacts, atomicWaitHelpers *bool) CoreFeatures {
 	var out CoreFeatures
 	r := wasm.NewReader(body)
 	for r.HasNext() {
@@ -316,6 +337,9 @@ func requiredFeaturesAndSegmentCountsForBodyBytes(body []byte, elemStateCount, d
 				return out
 			}
 			out |= CoreFeatureReferenceTypes
+			if op == 0xd2 && facts != nil {
+				facts.UsesRefFunc = true
+			}
 			continue
 		case 0x41:
 			if _, err := r.I32(); err != nil {
@@ -409,12 +433,48 @@ func requiredFeaturesAndSegmentCountsForBodyBytes(body []byte, elemStateCount, d
 			break
 		}
 		segmentStateCount(imm.Kind, imm.Index, imm.Index2, elemStateCount, dataStateCount)
+		recordModuleRequirementFact(imm.Kind, imm.Index, facts, atomicWaitHelpers)
 		out |= requiredFeaturesForInstructionKind(imm.Kind)
 		if imm.Kind == wasm.InstrCallIndirect && imm.Index2 != 0 {
 			out |= CoreFeatureReferenceTypes
 		}
 	}
 	return out
+}
+
+func instrsModuleRequirements(instrs []wasm.Instruction, elemCount, dataCount *int, facts *frontend.ModuleFacts, atomicWaitHelpers *bool) {
+	for i := range instrs {
+		in := &instrs[i]
+		segmentStateCount(in.Kind, in.Index, in.Index2, elemCount, dataCount)
+		recordModuleRequirementFact(in.Kind, in.Index, facts, atomicWaitHelpers)
+		instrsModuleRequirements(in.Body().Instrs, elemCount, dataCount, facts, atomicWaitHelpers)
+		instrsModuleRequirements(in.Then(), elemCount, dataCount, facts, atomicWaitHelpers)
+		instrsModuleRequirements(in.Else(), elemCount, dataCount, facts, atomicWaitHelpers)
+	}
+}
+
+func recordModuleRequirementFact(kind wasm.InstrKind, index uint32, facts *frontend.ModuleFacts, atomicWaitHelpers *bool) {
+	if atomicWaitHelpers != nil {
+		switch kind {
+		case wasm.InstrMemoryAtomicNotify, wasm.InstrMemoryAtomicWait32, wasm.InstrMemoryAtomicWait64:
+			*atomicWaitHelpers = true
+		}
+	}
+	if facts == nil {
+		return
+	}
+	switch kind {
+	case wasm.InstrTableGrow:
+		if uint64(index) < uint64(len(facts.TableGrowUsed)) {
+			facts.TableGrowUsed[index] = true
+		}
+	case wasm.InstrMemoryGrow:
+		if uint64(index) < uint64(len(facts.MemoryGrowUsed)) {
+			facts.MemoryGrowUsed[index] = true
+		}
+	case wasm.InstrRefFunc:
+		facts.UsesRefFunc = true
+	}
 }
 
 func requiredFeaturesForInstructionKind(kind wasm.InstrKind) CoreFeatures {

--- a/src/wago/feature_usage_fusion_test.go
+++ b/src/wago/feature_usage_fusion_test.go
@@ -79,6 +79,39 @@ func TestAnalyzeModuleRequirementsFusesAtomicWaitHelpers(t *testing.T) {
 	}
 }
 
+func TestAnalyzeModuleRequirementsFusesIndexedFunctionRefOps(t *testing.T) {
+	m := &wasm.Module{
+		Types: []wasm.RecType{{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompFunc}}}}},
+		Code: []wasm.Func{{BodyBytes: []byte{
+			0xfb, 0x14, 0x00, // ref.test (ref null 0)
+			0xfb, 0x16, 0x00, // ref.cast (ref null 0)
+			0x0b,
+		}}},
+	}
+	requirements := analyzeModuleRequirements(m)
+	if !requirements.indexedFuncRefTest || !requirements.indexedFuncRefCast || requirements.arm64GCRefTestHelper {
+		t.Fatalf("function ref requirements = test:%v cast:%v helper:%v, want true/true/false", requirements.indexedFuncRefTest, requirements.indexedFuncRefCast, requirements.arm64GCRefTestHelper)
+	}
+
+	abstract := &wasm.Module{Code: []wasm.Func{{BodyBytes: []byte{
+		0xfb, 0x14, 0x70, // ref.test funcref
+		0x0b,
+	}}}}
+	requirements = analyzeModuleRequirements(abstract)
+	if requirements.indexedFuncRefTest || requirements.indexedFuncRefCast {
+		t.Fatalf("abstract ref op selected indexed function metadata: %+v", requirements)
+	}
+
+	gcHeap := &wasm.Module{
+		Types: []wasm.RecType{{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompStruct}}}}},
+		Code:  []wasm.Func{{BodyBytes: []byte{0xfb, 0x14, 0x00, 0x0b}}},
+	}
+	requirements = analyzeModuleRequirements(gcHeap)
+	if !requirements.arm64GCRefTestHelper || requirements.indexedFuncRefTest || requirements.indexedFuncRefCast {
+		t.Fatalf("gc ref.test requirements = test:%v cast:%v helper:%v, want false/false/true", requirements.indexedFuncRefTest, requirements.indexedFuncRefCast, requirements.arm64GCRefTestHelper)
+	}
+}
+
 func TestAnalyzeModuleRequirementsFusesDeclarationRefFunc(t *testing.T) {
 	for _, init := range []wasm.Expr{
 		{BodyBytes: []byte{0xd2, 0x00, 0x0b}},

--- a/src/wago/feature_usage_fusion_test.go
+++ b/src/wago/feature_usage_fusion_test.go
@@ -1,0 +1,116 @@
+package wago
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/frontend"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func TestAnalyzeModuleRequirementsFusesModuleFacts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code wasm.Func
+	}{
+		{
+			name: "byte-backed",
+			code: wasm.Func{BodyBytes: []byte{
+				0xfc, 0x0f, 0x01, // table.grow 1
+				0x40, 0x00, // memory.grow 0
+				0xd2, 0x00, // ref.func 0
+				0x0b,
+			}},
+		},
+		{
+			name: "instruction-backed",
+			code: wasm.Func{Body: wasm.Expr{Instrs: []wasm.Instruction{
+				{Kind: wasm.InstrTableGrow, Index: 1},
+				{Kind: wasm.InstrMemoryGrow, Index: 0},
+				{Kind: wasm.InstrRefFunc, Index: 0},
+			}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &wasm.Module{
+				Tables:   []wasm.Table{{}, {}},
+				Memories: []wasm.MemType{{}},
+				Exports: []wasm.Export{
+					{Index: wasm.ExternIdx{Kind: wasm.ExternTable, Index: 0}},
+					{Index: wasm.ExternIdx{Kind: wasm.ExternMem, Index: 0}},
+				},
+				Code: []wasm.Func{tc.code},
+			}
+			want, err := frontend.AnalyzeModuleFacts(m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := analyzeModuleRequirements(m).moduleFacts
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("fused module facts = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestAnalyzeModuleRequirementsFusesAtomicWaitHelpers(t *testing.T) {
+	byteBacked := &wasm.Module{Code: []wasm.Func{{BodyBytes: []byte{
+		0xfe, 0x00, 0x00, 0x00, // memory.atomic.notify align=0 offset=0
+		0x0b,
+	}}}}
+	if !analyzeModuleRequirements(byteBacked).atomicWaitHelpers {
+		t.Fatal("byte-backed atomic notify did not select wait helpers")
+	}
+
+	instructionBacked := &wasm.Module{Code: []wasm.Func{{Body: wasm.Expr{Instrs: []wasm.Instruction{
+		{Kind: wasm.InstrMemoryAtomicWait32},
+	}}}}}
+	if !analyzeModuleRequirements(instructionBacked).atomicWaitHelpers {
+		t.Fatal("instruction-backed atomic wait did not select wait helpers")
+	}
+
+	directOnly := &wasm.Module{Code: []wasm.Func{{BodyBytes: []byte{
+		0xfe, 0x10, 0x00, 0x00, // i32.atomic.load align=0 offset=0
+		0x0b,
+	}}}}
+	if analyzeModuleRequirements(directOnly).atomicWaitHelpers {
+		t.Fatal("direct atomic instruction selected wait helpers")
+	}
+}
+
+func TestAnalyzeModuleRequirementsFusesDeclarationRefFunc(t *testing.T) {
+	for _, init := range []wasm.Expr{
+		{BodyBytes: []byte{0xd2, 0x00, 0x0b}},
+		{Instrs: []wasm.Instruction{{Kind: wasm.InstrRefFunc, Index: 0}}},
+	} {
+		m := &wasm.Module{Globals: []wasm.Global{{Init: init}}}
+		want, err := frontend.AnalyzeModuleFacts(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := analyzeModuleRequirements(m).moduleFacts
+		if !reflect.DeepEqual(got, want) || !got.UsesRefFunc {
+			t.Fatalf("fused declaration facts = %+v, want %+v", got, want)
+		}
+	}
+}
+
+func TestAnalyzeModuleRequirementsIgnoresInvalidFactIndexesBeforeValidation(t *testing.T) {
+	m := &wasm.Module{
+		Tables:   []wasm.Table{{}},
+		Memories: []wasm.MemType{{}},
+		Exports: []wasm.Export{
+			{Index: wasm.ExternIdx{Kind: wasm.ExternTable, Index: math.MaxUint32}},
+			{Index: wasm.ExternIdx{Kind: wasm.ExternMem, Index: math.MaxUint32}},
+		},
+		Code: []wasm.Func{{Body: wasm.Expr{Instrs: []wasm.Instruction{
+			{Kind: wasm.InstrTableGrow, Index: math.MaxUint32},
+			{Kind: wasm.InstrMemoryGrow, Index: math.MaxUint32},
+		}}}},
+	}
+	facts := analyzeModuleRequirements(m).moduleFacts
+	if facts.TableExported[0] || facts.MemoryExported[0] || facts.TableGrowUsed[0] || facts.MemoryGrowUsed[0] {
+		t.Fatalf("invalid indexes polluted fused facts: %+v", facts)
+	}
+}

--- a/src/wago/gc_struct_product.go
+++ b/src/wago/gc_struct_product.go
@@ -251,50 +251,6 @@ func moduleUsesGCExternConversion(m *wasm.Module) bool {
 	return false
 }
 
-func moduleUsesIndexedFunctionRefTestOrCast(m *wasm.Module) (refTest, refCast bool) {
-	if m == nil {
-		return false, false
-	}
-	for i := range m.Code {
-		r := wasm.NewReader(m.Code[i].BodyBytes)
-		for r.HasNext() {
-			op, err := r.Byte()
-			if err != nil {
-				return false, false
-			}
-			probe := *r
-			imm, err := wasm.ClassifyInstructionImmediate(r, op)
-			if err != nil {
-				return false, false
-			}
-			if op != 0xfb || (imm.Kind != wasm.InstrRefTest && imm.Kind != wasm.InstrRefCast) {
-				continue
-			}
-			sub, err := probe.U32()
-			if err != nil || (sub != 20 && sub != 21 && sub != 22 && sub != 23) {
-				continue
-			}
-			heap, err := probe.S33()
-			if err != nil || heap < 0 {
-				continue
-			}
-			if _, ok := m.TypeFunc(uint32(heap)); !ok {
-				continue
-			}
-			switch imm.Kind {
-			case wasm.InstrRefTest:
-				refTest = true
-			case wasm.InstrRefCast:
-				refCast = true
-			}
-			if refTest && refCast {
-				return true, true
-			}
-		}
-	}
-	return refTest, refCast
-}
-
 func moduleHasGCHeapType(m *wasm.Module) bool {
 	if m == nil {
 		return false


### PR DESCRIPTION
## Summary

This PR removes four redundant whole-module body walks from the compile path and eliminates the serial function-code copy into the final executable image.

- serial compilation now reserves and emits directly into the final writable code image, with the existing append path retained when an encoder outgrows its reservation
- the existing module-requirements scan now also produces footprint facts, passive-segment state bounds, and atomic wait-helper selection
- the same scan records indexed-function `ref.test` / `ref.cast` obligations and ARM64 GC ref-test helper provisioning
- validation, frontend admission/error ordering, backend hints, generated code, and public APIs remain unchanged

The work is split into three atomic commits so each optimization remains reviewable and bisectable.

## Performance

Identical current-main A/B on Darwin/ARM64, Apple M4 Max:

`go test -run '^$' -bench '^BenchmarkCompileFull$/(many_funcs|json-as|sqlite3|ruby|esbuild)$' -benchmem -benchtime=500ms -count=10 ./bench`

| Module | main | PR | Delta |
|---|---:|---:|---:|
| many_funcs | 326.9 µs | 298.9 µs | -8.55% |
| json-as | 1.541 ms | 1.183 ms | -23.25% |
| sqlite3 | 93.45 ms | 75.73 ms | -18.96% |
| ruby | 1093.2 ms | 888.3 ms | -18.74% |
| esbuild | 735.4 ms | 581.5 ms | -20.92% |

All latency comparisons are significant at `p < 0.001` (`n=10` per side).

Allocated bytes fall by 6.72–10.86% on the four large modules (6.63% geomean across all five). Allocation counts fall slightly; the two summary-fusion commits themselves are allocation-neutral. Fresh-process RSS for the summary fusions remained neutral.

Native code size and SHA-256 are byte-identical for all five modules, so there is no execution-time or generated-code-size delta.

## Validation

- `go test ./...`
- `go vet ./...`
- compiler/frontend/runtime focused suites
- focused race coverage for summary and dynamic function-reference paths
- full `src/wago` guard-page suite
- corpus execution in explicit and guard-page modes
- guard-page corpus differential execution
- Linux AMD64, Linux ARM64, and Windows AMD64 cross-builds
- native-code size/SHA-256 identity across all five benchmark modules
- 10-sample full-compile A/B and interleaved fresh-process RSS measurements

The P7 decision and measurements are recorded in `ROADMAP.md` and `docs/no-ir-plan.md`.

## AI assistance

AI assistance was used to profile the compile path, draft tests and documentation, and perform a structured pre-review. Every changed line and measurement was reviewed and validated locally.