### PR TITLE
runtime: reduce scalar invocation overhead

### DIFF
--- a/docs/arm64-port.md
+++ b/docs/arm64-port.md
@@ -225,9 +225,10 @@ earlier this session; not part of the arm64 branch.)
   `guardmem` twins, and Darwin explicit-bounds `mem` twins now cover wrapper calls,
   explicit trap-cell unwinds, and sync host-call parking/resume.
 - **Package selectors**: `src/wago/railshot_{amd64,arm64}.go` keep the backend concrete
-  inside each arch package while avoiding a public facade package. `hostpolicy_arm64.go`
-  forces host imports through the sync dispatcher until the legacy async host-log path is
-  deliberately ported or retired.
+  inside each arch package while avoiding a public facade package. Host-control mode is
+  architecture-independent: actual host bindings, transitive parked cross-instance
+  targets, mutable imported funcref tables, GC helpers, dynamic ref tests, and atomic
+  waits select the synchronous dispatcher; host-free modules retain direct native entry.
 - **Tests**: `arm64/compilesmoke_arm64_test.go` (codegen runs), `arm64/portexec_arm64_test.go`
   (ported code executes), `arm64/_beachhead/exec_arm64_test.go` (hand-beachhead fib exec).
   Runtime arm64 native-call tests now build for both Linux and Darwin, so Apple Silicon

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4051,17 +4051,30 @@ func (in *Instance) invoke(export string, args []uint64, cancel context.Context)
 	if in.importsFuncrefStorage() || in.table != nil {
 		defer in.reconcileFuncrefRoots()
 	}
-	stopCancel := noOpCancellationWatch
 	if cancel != nil {
-		stopCancel = in.startCancellationWatch(cancel, in.trap)
+		stopCancel := in.startCancellationWatch(cancel, in.trap)
+		defer stopCancel()
 	}
-	defer stopCancel()
 	if in.syncMode {
 		if err := in.callNativeSyncWithTrapContext(entry, in.trap, cancel); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := in.callNativeAsync(entry, false); err != nil {
+		privateScalar := invokePrivateEntryEnabled && cancel == nil && !in.nativeControlShared &&
+			ic.entryMode != preparedEntryGeneral
+		entryMode := preparedEntryGeneral
+		if privateScalar {
+			entryMode = ic.entryMode
+		}
+		var err error
+		if entryMode == preparedEntryIsolated && preparedIsolatedEntryEnabled {
+			err = in.callPreparedIsolated(entry, in.trap)
+		} else if entryMode != preparedEntryGeneral {
+			err = in.callPreparedPrivate(entry, in.trap)
+		} else {
+			err = in.callNativeAsync(entry, false)
+		}
+		if err != nil {
 			return nil, err
 		}
 		if err := in.replayHostLog(); err != nil {
@@ -4428,6 +4441,11 @@ func (in *Instance) fillInvokeCache(export string) (*invokeCache, error) {
 			rw = append(rw, isWideValType(r))
 		}
 	}
+	entryMode := preparedEntryGeneral
+	if !hasReferenceValType(sig.Params) && !hasReferenceValType(sig.Results) &&
+		paramSlots <= 4 && resultSlots <= 1 {
+		entryMode = in.preparedEntryMode()
+	}
 	*slot = invokeCache{
 		export:            export,
 		valid:             true,
@@ -4437,6 +4455,7 @@ func (in *Instance) fillInvokeCache(export string) (*invokeCache, error) {
 		hasFuncRefParams:  hasReferenceValType(sig.Params),
 		hasFuncRefResults: hasReferenceValType(sig.Results),
 		resultWide:        rw,
+		entryMode:         entryMode,
 	}
 	return slot, nil
 }

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -2175,7 +2175,7 @@ func asyncReplayable(sig FuncSig) bool {
 }
 
 func (c *Compiled) importsRequireSync(imports Imports, force bool) bool {
-	if force || forceSyncHostImports || c.needsPublicFuncrefHostReentry() || c.usesGCStructHelpers() || c.usesGCArrayHelpers() || c.usesDynamicFuncRefTest() || c.usesAtomicWaitHelpers() {
+	if force || c.needsPublicFuncrefHostReentry() || c.usesGCStructHelpers() || c.usesGCArrayHelpers() || c.usesDynamicFuncRefTest() || c.usesAtomicWaitHelpers() {
 		return true
 	}
 	for _, key := range c.Imports {

--- a/src/wago/footprint_test.go
+++ b/src/wago/footprint_test.go
@@ -36,6 +36,24 @@ func TestNoImportSynchronousArenaNeedIncludesControlFrame(t *testing.T) {
 	}
 }
 
+func TestHostControlModeDependsOnModuleBoundaryNotArchitecture(t *testing.T) {
+	compiled := MustCompile(wasmtest.Module())
+	defer compiled.Close()
+	if compiled.importsRequireSync(nil, false) {
+		t.Fatal("host-free module unexpectedly requires synchronous host control")
+	}
+	if !compiled.importsRequireSync(nil, true) {
+		t.Fatal("explicit synchronous-host option was ignored")
+	}
+
+	importer := MustCompile(voidI32ImportCallerModule())
+	defer importer.Close()
+	imports := Imports{"env.log": HostFunc(func(HostModule, []uint64, []uint64) {})}
+	if !importer.importsRequireSync(imports, false) {
+		t.Fatal("actual host binding did not require synchronous host control")
+	}
+}
+
 func requireBoundedInstanceFootprint(t *testing.T, got uintptr) {
 	t.Helper()
 	// Go 1.22 and Go 1.26 lay out synchronization primitives differently.

--- a/src/wago/funcref_boundary_test.go
+++ b/src/wago/funcref_boundary_test.go
@@ -181,11 +181,7 @@ func TestRuntimeImportedFuncrefUsesProducerIdentityAndLifetime(t *testing.T) {
 	if importer.hostLog != nil {
 		t.Fatal("host-free cross-instance importer allocated an async host log")
 	}
-	if forceSyncHostImports {
-		if !importer.syncMode || importer.ctrl == nil {
-			t.Fatal("forced-sync architecture omitted the host control frame")
-		}
-	} else if importer.syncMode || importer.ctrl != nil {
+	if importer.syncMode || importer.ctrl != nil {
 		t.Fatal("host-free cross-instance importer allocated host-dispatch state")
 	}
 	consumerMod, err := rt.Compile(funcrefCallableConsumerModule())

--- a/src/wago/hostpolicy_amd64.go
+++ b/src/wago/hostpolicy_amd64.go
@@ -1,5 +1,0 @@
-//go:build amd64
-
-package wago
-
-const forceSyncHostImports = false

--- a/src/wago/hostpolicy_arm64.go
+++ b/src/wago/hostpolicy_arm64.go
@@ -1,5 +1,0 @@
-//go:build arm64
-
-package wago
-
-const forceSyncHostImports = true

--- a/src/wago/instance.go
+++ b/src/wago/instance.go
@@ -87,6 +87,7 @@ type instanceMemoryDirectory struct {
 type invokeCache struct {
 	export            string
 	valid             bool
+	entryMode         preparedEntryMode
 	li                int // local index, or -1-import index for an InstanceExport re-export
 	paramSlots        int
 	resultSlots       int

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -141,18 +141,37 @@ func (in *Instance) callNativeAsyncWithTrap(entry uintptr, prepared bool, active
 	return in.decorateTrap(callNative(in.c, in.eng, in.jm, true, entry, in.serArgs, activeTrap, in.results))
 }
 
+type preparedEntryMode uint8
+
+const (
+	preparedEntryGeneral preparedEntryMode = iota
+	preparedEntryPrivate
+	preparedEntryIsolated
+)
+
+func (in *Instance) preparedEntryMode() preparedEntryMode {
+	if in == nil || in.c == nil || in.c.boundsMode == BoundsChecksSignalsBased ||
+		in.memoryDir != nil || in.nativeControlShared || in.syncMode {
+		return preparedEntryGeneral
+	}
+	if in.memory != nil {
+		if !in.ownsMem {
+			return preparedEntryGeneral
+		}
+		_, shared := in.memory.importShape()
+		if shared {
+			return preparedEntryGeneral
+		}
+	}
+	if len(in.globalCells) == 0 && in.tableDescPtr == 0 && in.gc == nil &&
+		in.c.NumImports == 0 && !in.c.NeedsFuncRefDescs {
+		return preparedEntryIsolated
+	}
+	return preparedEntryPrivate
+}
+
 func (in *Instance) preparedPrivateEligible() bool {
-	if in == nil || in.memoryDir != nil || in.nativeControlShared || in.syncMode {
-		return false
-	}
-	if in.memory == nil {
-		return true
-	}
-	if !in.ownsMem {
-		return false
-	}
-	_, shared := in.memory.importShape()
-	return !shared
+	return in.preparedEntryMode() != preparedEntryGeneral
 }
 
 // preparedIsolatedEligible identifies instances whose native execution has no
@@ -160,9 +179,7 @@ func (in *Instance) preparedPrivateEligible() bool {
 // PreparedFunction already forbids concurrent calls on one Instance; each such
 // instance owns its Engine, stack, trap cell, argument/result buffers, and memory.
 func (in *Instance) preparedIsolatedEligible() bool {
-	return in != nil && in.preparedPrivateEligible() && in.c != nil &&
-		len(in.globalCells) == 0 && in.tableDescPtr == 0 && in.gc == nil &&
-		in.c.NumImports == 0 && !in.c.NeedsFuncRefDescs
+	return in.preparedEntryMode() == preparedEntryIsolated
 }
 
 func (in *Instance) callPreparedPrivate(entry uintptr, activeTrap []byte) error {

--- a/src/wago/prepared_call.go
+++ b/src/wago/prepared_call.go
@@ -27,6 +27,11 @@ var preparedPrivateEntryEnabled = os.Getenv("WAGO_PREPARED_PRIVATE_ENTRY") != "0
 // restores the serialized private entry for A/B.
 var preparedIsolatedEntryEnabled = os.Getenv("WAGO_PREPARED_ISOLATED_ENTRY") != "0"
 
+// invokePrivateEntryEnabled lets the bounded scalar Instance.Invoke path reuse
+// the same already-bound private entry as PreparedFunction. Export resolution
+// remains in Invoke; WAGO_INVOKE_PRIVATE_ENTRY=0 restores the general entry.
+var invokePrivateEntryEnabled = os.Getenv("WAGO_INVOKE_PRIVATE_ENTRY") != "0"
+
 // preparedDirectIntEnabled selects register-ABI entry for adapter-free integer
 // scalar leaves. WAGO_PREPARED_DIRECT_INT=0 restores the wrapper adapter.
 var preparedDirectIntEnabled = os.Getenv("WAGO_PREPARED_DIRECT_INT") != "0"

--- a/src/wago/prepared_function_test.go
+++ b/src/wago/prepared_function_test.go
@@ -145,7 +145,11 @@ func TestPreparedFunctionDirectIntArgumentsAndTrap(t *testing.T) {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("div", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0x6d, 0x0b}))),
 	)
-	in, err = Instantiate(MustCompile(div), InstantiateOptions{})
+	compiled, err = Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), div)
+	if err != nil {
+		t.Fatalf("compile div: %v", err)
+	}
+	in, err = Instantiate(compiled, InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate div: %v", err)
 	}

--- a/src/wago/prepared_function_test.go
+++ b/src/wago/prepared_function_test.go
@@ -90,7 +90,7 @@ func TestPreparedFunctionPrivateFastPath(t *testing.T) {
 }
 
 func TestPreparedFunctionDirectIntArgumentsAndTrap(t *testing.T) {
-	if forceSyncHostImports || !preparedDirectIntSupported {
+	if !preparedDirectIntSupported {
 		t.Log("architecture does not support direct prepared integer entry")
 		return
 	}
@@ -166,10 +166,6 @@ func TestPreparedFunctionDirectIntArgumentsAndTrap(t *testing.T) {
 }
 
 func TestPreparedFunctionIsolatedEligibility(t *testing.T) {
-	if forceSyncHostImports {
-		t.Log("architecture forces synchronous native entry")
-		return
-	}
 	in, err := Instantiate(MustCompile(benchAddOneModule()), InstantiateOptions{})
 	if err != nil {
 		t.Fatalf("instantiate: %v", err)
@@ -203,10 +199,6 @@ func TestPreparedFunctionIsolatedEligibility(t *testing.T) {
 }
 
 func TestPreparedFunctionIsolatedInstancesRunConcurrently(t *testing.T) {
-	if forceSyncHostImports {
-		t.Log("architecture forces synchronous native entry")
-		return
-	}
 	c := MustCompile(benchAddOneModule())
 	instances := make([]*Instance, 2)
 	prepared := make([]*PreparedFunction, 2)

--- a/src/wago/prepared_function_test.go
+++ b/src/wago/prepared_function_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/wasmtest"
@@ -171,6 +172,12 @@ func TestPreparedFunctionIsolatedEligibility(t *testing.T) {
 		t.Fatalf("instantiate: %v", err)
 	}
 	defer in.Close()
+	if in.c.boundsMode == BoundsChecksSignalsBased {
+		if in.preparedPrivateEligible() || in.preparedIsolatedEligible() {
+			t.Fatal("signals-based instance must use the guarded entry")
+		}
+		return
+	}
 	if !in.preparedIsolatedEligible() {
 		t.Fatalf("plain scalar instance should be isolated: private=%v dir=%v sharedctx=%v sync=%v memory=%v owns=%v globals=%d table=%#x gc=%v imports=%d refs=%v",
 			in.preparedPrivateEligible(), in.memoryDir != nil, in.nativeControlShared, in.syncMode, in.memory != nil, in.ownsMem,
@@ -200,6 +207,9 @@ func TestPreparedFunctionIsolatedEligibility(t *testing.T) {
 
 func TestPreparedFunctionIsolatedInstancesRunConcurrently(t *testing.T) {
 	c := MustCompile(benchAddOneModule())
+	if c.boundsMode == BoundsChecksSignalsBased {
+		t.Skip("signals-based execution requires the guarded entry")
+	}
 	instances := make([]*Instance, 2)
 	prepared := make([]*PreparedFunction, 2)
 	for i := range instances {
@@ -241,6 +251,75 @@ func TestPreparedFunctionIsolatedInstancesRunConcurrently(t *testing.T) {
 	close(errs)
 	for err := range errs {
 		t.Error(err)
+	}
+}
+
+func TestInvokeScalarUsesIsolatedEntry(t *testing.T) {
+	savedInvoke := invokePrivateEntryEnabled
+	savedIsolated := preparedIsolatedEntryEnabled
+	invokePrivateEntryEnabled = true
+	preparedIsolatedEntryEnabled = true
+	defer func() {
+		invokePrivateEntryEnabled = savedInvoke
+		preparedIsolatedEntryEnabled = savedIsolated
+	}()
+
+	in, err := Instantiate(MustCompile(benchAddOneModule()), InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	if !in.preparedIsolatedEligible() {
+		if in.c.boundsMode == BoundsChecksSignalsBased {
+			t.Skip("signals-based execution requires the guarded entry")
+		}
+		t.Fatal("plain scalar instance should be eligible for isolated entry")
+	}
+	if _, err := in.Invoke("f", I32(0)); err != nil {
+		t.Fatalf("warm invoke: %v", err)
+	}
+
+	type result struct {
+		values []uint64
+		err    error
+	}
+	done := make(chan result, 1)
+	nativeExecutionMu.Lock()
+	go func() {
+		values, err := in.Invoke("f", I32(41))
+		done <- result{values: values, err: err}
+	}()
+	select {
+	case got := <-done:
+		nativeExecutionMu.Unlock()
+		if got.err != nil || len(got.values) != 1 || AsI32(got.values[0]) != 42 {
+			t.Fatalf("isolated invoke = %v, %v", got.values, got.err)
+		}
+	case <-time.After(time.Second):
+		nativeExecutionMu.Unlock()
+		<-done
+		t.Fatal("isolated Invoke waited for the process-wide native execution lease")
+	}
+
+	// Attachment can make native control shared after this export was cached.
+	// The cached scalar shape must then fall back to rebinding under the lease.
+	in.nativeControlShared = true
+	done = make(chan result, 1)
+	nativeExecutionMu.Lock()
+	go func() {
+		values, err := in.Invoke("f", I32(42))
+		done <- result{values: values, err: err}
+	}()
+	select {
+	case got := <-done:
+		nativeExecutionMu.Unlock()
+		t.Fatalf("shared-control invoke bypassed the execution lease: %v, %v", got.values, got.err)
+	case <-time.After(20 * time.Millisecond):
+		nativeExecutionMu.Unlock()
+	}
+	got := <-done
+	if got.err != nil || len(got.values) != 1 || AsI32(got.values[0]) != 43 {
+		t.Fatalf("shared-control invoke = %v, %v", got.values, got.err)
 	}
 }
 

--- a/src/wago/threads_atomic_test.go
+++ b/src/wago/threads_atomic_test.go
@@ -267,7 +267,7 @@ func TestThreadsAtomicRMWAddExecutesOnSharedMemory(t *testing.T) {
 		t.Fatalf("instantiate shared atomic module: %v", err)
 	}
 	defer instance.Close()
-	if compiled.usesAtomicWaitHelpers() || (!forceSyncHostImports && len(instance.ctrl) != 0) {
+	if compiled.usesAtomicWaitHelpers() || len(instance.ctrl) != 0 {
 		t.Fatalf("direct-only atomic module retained wait bridge: helper=%v ctrl=%d", compiled.usesAtomicWaitHelpers(), len(instance.ctrl))
 	}
 


### PR DESCRIPTION
## What changed

- classify synchronous host-control requirements from the compiled module and its actual bindings instead of forcing every ARM64 instance through the host protocol
- omit the off-heap host-control frame for modules that cannot enter synchronous host dispatch
- cache conservative private/isolated scalar entry eligibility in existing invoke-cache padding
- let eligible cached `Instance.Invoke` calls reuse the prepared native entry
- keep cancellation, reference values, shared/threaded memory, dynamically shared control, and signals-based bounds checks on their general entry paths
- avoid the unconditional no-op cancellation defer

## Why

ARM64's architecture-wide synchronous-host policy made host-free modules pay host-control memory and execution costs they could never use. After removing that policy, ordinary cached scalar calls still spent most of their time rebinding general native-entry state even when the instance already met the stricter prepared-call isolation rules.

## Impact

Apple M4 Max measurements:

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `BenchmarkInvokeAddOne` | 70.9 ns/op | 48.7 ns/op | 1.46x faster |
| Prepared add-one | 60.9 ns/op | 29.6 ns/op | 2.06x faster |
| Host-free control footprint | 1,216 B | 0 B | -1,216 B/instance |

All measured invocation paths remain at `0 B/op` and `0 allocs/op`. Shared-memory public entry remains neutral at roughly 64-65 ns/op. `Instance` and `Compiled` Go object sizes are unchanged.

## Safety boundaries

The private scalar route is limited to explicit-bounds calls with no cancellation or reference parameters/results and at most four argument slots plus one result slot. Guard-page execution, shared memory, and cross-instance control rebinding retain their existing paths. Tests cover late attachment after the export cache is populated.

## Validation

- `go test ./...`
- `go test ./src/core/runtime ./src/wago -count=1`
- `go test -tags wago_guardpage ./src/core/runtime ./src/wago -count=1`
- explicit and guard-page corpus suites
- focused race tests for isolated invocation
- `make lint` / `go vet`
- Linux amd64, Linux arm64, and Windows arm64 cross-compiles
