### PR TITLE
gc: hoist native ABI checks and share resolver stubs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,15 +13,15 @@ on amd64 and arm64. Linux and Darwin/arm64 additionally support signal-backed
 guard-page bounds checks; all six targets support explicit bounds checks and
 cooperative cancellation safepoints.
 
-<!-- artifact:codec-version 34 -->
+<!-- artifact:codec-version 35 -->
 
-Compiled artifact v33 is a strict ordered section stream: a fixed header and
+Compiled artifact v35 is a strict ordered section stream: a fixed header and
 section count followed by length-delimited native-code and metadata sections.
 Unknown, duplicate, reordered, truncated, over-limit, and non-canonical section
 encodings fail closed. `Compiled.WriteTo` streams code without constructing a
 second full image; `Compiled.ReadFromWithLimits` reads code directly into an RW
 mapping, bounds code and metadata independently, validates all metadata, and
-seals that same mapping RX on first use. Version 32 and older artifacts are
+seals that same mapping RX on first use. Version 34 and older artifacts are
 intentionally rejected; Wago was unreleased, so there is no compatibility
 decoder or dual-format ambiguity.
 
@@ -68,7 +68,7 @@ callsite; amd64 adds hidden operand spill offsets, compact safepoint IDs, frame
 size, adapter return, and recursive call return-PC maps. The synchronous helper
 control frame publishes parked RSP, and Go exposes validated off-heap slots from
 each walked frame directly as mutable collector roots. Throughput/Tiny stress
-collection and the root walker remain zero-allocation after warm-up. Codec v34
+collection and the root walker remain zero-allocation after warm-up. Codec v35
 persists and strictly revalidates the map, including dynamic-import stack
 adjustments. Direct tail calls discard their caller frame. Numeric host callbacks
 use a bounded suspended-activation stack plus separate nested foreign stacks, and
@@ -102,17 +102,26 @@ cross-Runtime compact-handle sharing remains impossible. `CaptureDomain` separat
 collector domain and persists every member, internal function/global/table edge,
 memory32/memory64 and tag aliases, typed live passive roots, and one stable-ID heap
 graph in `WGDN` v3 with strict v1/v2 loading; restore publishes the complete member
-slice only after transactional graph reconstruction. Codec v34 persists helper admission and
-the 16-byte `v128` storage contract, but never compact handles.
+slice only after transactional graph reconstruction. Codec v35 persists helper admission,
+the required native-GC ABI version, and the 16-byte `v128` storage contract, but never compact handles.
 Snapshot v4 persists reachable local-global object graphs with stable IDs and
 two-pass cycle/sharing reconstruction; snapshot v5 adds one owned local
 collector-reference table, while snapshot v6 adds multiple heterogeneous local
 tables with indexed lengths, barriers, sharing, and exact structural root
 validation. AMD64 final scalar struct/array accesses and initialized final-struct
-allocation use collector native ABI v3: a stable allocation/collection/card-refreshed
-view at basedata offset 280 validates handle, space, object extent, canonical type,
-array bounds, remembered membership, any existing object-card interval, and the
-transactional native-allocation epoch before direct heap access. Final abstract
+allocation use collector native ABI v6. Artifact loading validates the Go/native
+layout and v35 records the required ABI; instantiation validates the immutable
+instance view, local canonical-type map, collector identity, collector version, and
+handle stride before publishing basedata offset 280. Native accesses then trust those
+immutable facts while reloading and validating mutable handle ranges/liveness, heap
+space and backing extents, object extents and canonical types, array bounds,
+remembered membership, any existing object-card interval, and the transactional
+native-allocation epoch. A module-owned 229-byte noncollecting resolver leaf replaces
+repeated inline resolver bodies at modules with at least two candidate sites; one-site
+modules retain inline code. Bounded straight-line reuse may retain one derived object
+address only while its unchanged compact local remains the root and no call,
+allocation, collection, host transition, control/EH edge, local mutation, or other
+invalidating opcode can intervene. Final abstract
 reference stores may bypass helpers only when no metadata growth is required;
 vector, non-final, bulk, cardless/unremembered, and Tiny barrier paths remain
 helper-bound. Arm64 builds lower struct/array/i31 and dynamic cast/test helpers
@@ -352,13 +361,18 @@ copy the target pointer context into its home basedata and restore the exact cal
 context on normal return.
 
 Every native-visible address must be stable for the duration in which native code
-can consume it. Most runtime state is off-heap. Native GC ABI v3 is the narrow
+can consume it. Most runtime state is off-heap. Native GC ABI v6 is the narrow
 exception: standard Go and the release TinyGo conservative collector are non-moving;
 typed Collector/Instance fields retain the view, heap/handle/card backing, fixed
-32-handle allocation state, epoch, nursery bump, and semantic counter. Generated
-code reloads relocatable slice pointers after helper allocation, collection, or
-card-backing refresh rather than caching them across safepoints. Native allocation
-reserves identities only; collection cancels unused reservations before tracing.
+32-handle allocation state, epoch, nursery bump, and semantic counter. Production
+code validates immutable view shape at artifact/collector/instantiation boundaries;
+`wagodebug` additionally revalidates it at each Go-to-native entry. Generated code
+reloads relocatable slice pointers after helper allocation, collection, or
+card-backing refresh rather than caching them across safepoints. The only raw-address
+reuse is a compiler-owned one-entry certificate within a mechanically safepoint-free
+straight-line region; every may-collect, host-reentry, control/EH, tail, local-write,
+or unknown edge invalidates it before lowering. Native allocation reserves identities
+only; collection cancels unused reservations before tracing.
 
 ### Off-heap allocation
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -117,9 +117,12 @@ immutable facts while reloading and validating mutable handle ranges/liveness, h
 space and backing extents, object extents and canonical types, array bounds,
 remembered membership, any existing object-card interval, and the transactional
 native-allocation epoch. A module-owned 229-byte noncollecting resolver leaf replaces
-repeated inline resolver bodies at modules with at least two candidate sites; one-site
-modules retain inline code. Bounded straight-line reuse may retain one derived object
-address only while its unchanged compact local remains the root and no call,
+repeated inline resolver bodies at modules with at least two candidate scalar sites;
+one-site modules retain inline code. A single-function module with reuse enabled is
+lowered inline first and adds the island only when at least two actual resolutions
+remain, so one-object repeated runs avoid the fixed leaf while distinct objects retain
+sharing. Bounded straight-line reuse may retain one derived object address only while
+its unchanged compact local remains the root and no call,
 allocation, collection, host transition, control/EH edge, local mutation, or other
 invalidating opcode can intervene. Final abstract
 reference stores may bypass helpers only when no metadata growth is required;

--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -274,8 +274,8 @@ compile as one resolution plus seven reuses and shrink 821→452 bytes; eight di
 objects in one function still select sharing and shrink 1,806→949 bytes. Ten CPU-0-
 pinned 500 ms runtime samples measured medians of 317.0 ns/op default, 341.85 ns/op
 with reuse disabled, and 340.6 ns/op fully inline, all 0 B/op and 0 allocs/op. A
-same-command stripped plugin-complete TinyGo build grew 2,096,928→2,106,840 bytes
-(+9,912, +0.473%); `compiledCodeCache` remains 64 bytes and collector/instance/native-
+same-command stripped plugin-complete TinyGo build grew 2,096,928→2,106,824 bytes
+(+9,896, +0.472%); `compiledCodeCache` remains 64 bytes and collector/instance/native-
 view layouts do not grow. Differential controls are
 `WAGO_AMD64_NO_GC_SHARED_STUBS=1` and
 `WAGO_AMD64_NO_GC_RESOLVE_REUSE=1`; permanent attribution is

--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -260,19 +260,23 @@ space, object-extent, canonical-type, bounds, ownership, barrier, lifecycle, tra
 root, EH, tail, snapshot, and host-reentry semantics remain dynamic. `wagodebug`
 retains a coarse Go-to-native immutable-view assertion.
 
-A module-owned 229-byte noncollecting compact-handle resolver leaf is selected only
-at two or more candidate direct scalar/length sites; one-site modules keep the
-351-byte inline crossover instead of growing to 453 bytes. Eight sites shrink
-1,669→821 bytes and 128 sites shrink 24,349→7,301 bytes. A one-entry derived-address
-certificate keeps the compact local as the root and survives only mechanically
-safepoint-free straight-line leaves; calls, helper/host transitions, allocations,
-control/EH/tail edges, local writes, and unknown opcodes invalidate it. Eight repeated
-accesses compile as one resolution plus seven reuses and shrink 821→565 bytes. Ten
-CPU-0-pinned 500 ms runtime samples measured medians of 310.0 ns/op default,
-328.1 ns/op with reuse disabled, and 324.0 ns/op fully inline, all 0 B/op and
-0 allocs/op. A same-command stripped plugin-complete TinyGo build grew
-2,096,928→2,102,160 bytes (+5,232, +0.250%); `compiledCodeCache` remains 64 bytes
-and collector/instance/native-view layouts do not grow. Differential controls are
+A module-owned 229-byte noncollecting compact-handle resolver leaf is selected at
+two or more candidate direct scalar sites. One-site modules keep the 351-byte inline
+crossover instead of growing to 453 bytes. With reuse enabled, a single-function
+module is first lowered inline and selects the island only when at least two actual
+resolutions remain; this avoids charging the fixed island after address-certificate
+reuse collapses a repeated run. With reuse disabled, eight sites shrink 1,669→821
+bytes and 128 sites shrink 24,349→7,301 bytes. A one-entry derived-address certificate
+keeps the compact local as the root and survives only mechanically safepoint-free
+straight-line leaves; calls, helper/host transitions, allocations, control/EH/tail
+edges, local writes, and unknown opcodes invalidate it. Eight repeated accesses
+compile as one resolution plus seven reuses and shrink 821→452 bytes; eight distinct
+objects in one function still select sharing and shrink 1,806→949 bytes. Ten CPU-0-
+pinned 500 ms runtime samples measured medians of 317.0 ns/op default, 341.85 ns/op
+with reuse disabled, and 340.6 ns/op fully inline, all 0 B/op and 0 allocs/op. A
+same-command stripped plugin-complete TinyGo build grew 2,096,928→2,106,840 bytes
+(+9,912, +0.473%); `compiledCodeCache` remains 64 bytes and collector/instance/native-
+view layouts do not grow. Differential controls are
 `WAGO_AMD64_NO_GC_SHARED_STUBS=1` and
 `WAGO_AMD64_NO_GC_RESOLVE_REUSE=1`; permanent attribution is
 `BenchmarkGCResolverCodeSize` plus `BenchmarkGCNativeResolverReuse`.

--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -250,6 +250,33 @@ bytes, neutral-to-slightly slower execution) were measured and reverted. Static
 site count alone is not a dynamic-hotness signal; executed transition/stub
 instrumentation precedes further load-forwarding work.
 
+**Trusted native-GC ABI boundaries and bounded resolver reuse (2026-08-10, #307).**
+Collector ABI v6 is now validated against Go structure sizes/offsets at collector
+construction, recorded explicitly in codec v35 generic-GC artifacts, rejected on
+artifact mismatch, and validated with the immutable instance type-map/collector view
+before basedata publication. AMD64 no longer reloads instance/collector versions,
+local-map counts, or handle stride in every native GC access; mutable handle/backing,
+space, object-extent, canonical-type, bounds, ownership, barrier, lifecycle, trap,
+root, EH, tail, snapshot, and host-reentry semantics remain dynamic. `wagodebug`
+retains a coarse Go-to-native immutable-view assertion.
+
+A module-owned 229-byte noncollecting compact-handle resolver leaf is selected only
+at two or more candidate direct scalar/length sites; one-site modules keep the
+351-byte inline crossover instead of growing to 453 bytes. Eight sites shrink
+1,669→821 bytes and 128 sites shrink 24,349→7,301 bytes. A one-entry derived-address
+certificate keeps the compact local as the root and survives only mechanically
+safepoint-free straight-line leaves; calls, helper/host transitions, allocations,
+control/EH/tail edges, local writes, and unknown opcodes invalidate it. Eight repeated
+accesses compile as one resolution plus seven reuses and shrink 821→565 bytes. Ten
+CPU-0-pinned 500 ms runtime samples measured medians of 310.0 ns/op default,
+328.1 ns/op with reuse disabled, and 324.0 ns/op fully inline, all 0 B/op and
+0 allocs/op. A same-command stripped plugin-complete TinyGo build grew
+2,096,928→2,102,160 bytes (+5,232, +0.250%); `compiledCodeCache` remains 64 bytes
+and collector/instance/native-view layouts do not grow. Differential controls are
+`WAGO_AMD64_NO_GC_SHARED_STUBS=1` and
+`WAGO_AMD64_NO_GC_RESOLVE_REUSE=1`; permanent attribution is
+`BenchmarkGCResolverCodeSize` plus `BenchmarkGCNativeResolverReuse`.
+
 **Release unwind-table removal (2026-08-01).** TinyGo `-no-debug` Linux
 releases do not use DWARF `.eh_frame` data for panic text or Wago's native
 trap/signal path. In the historical monolithic CLI, removing that allocated

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,7 +106,8 @@ current optimization priorities. The Core 3.0 implementation ledger is
   direct/indirect/reference calls, recursion, bounded host re-entry,
   mutable/shared GC globals, local/shared collector-reference tables, EH payload
   records, local starts, and same-Runtime cross-instance calls. One-/two-word and
-  bounded flat masks cover up to 1,024 roots; codec v34 validates the native maps.
+  bounded flat masks cover up to 1,024 roots; codec v35 validates the native maps
+  and the required native-GC ABI version.
 - [x] Add snapshot v4 stable-ID heap graphs for objects reachable from owned local
   GC globals, preserving cycles and sharing without serializing compact handles.
 - [x] Add snapshot v5 roots for one owned local collector-reference table, then

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -386,7 +386,7 @@ A post-audit set of ten CPU-0-pinned 500 ms execution samples measured medians o
 0 allocs/op. Thus the retained path was 7.3% faster than shared-without-reuse and 6.9%
 faster than fully inline resolution on this repeated-access fixture. A same-command
 stripped `wago_runtime` TinyGo build was 2,096,928 bytes at the baseline SHA and
-2,106,840 bytes after the tertiary audit (+9,912, +0.473%); the fixed 64-byte
+2,106,824 bytes after the tertiary audit (+9,896, +0.472%); the fixed 64-byte
 compiled-code cache and runtime collector/instance/view layouts do not grow. This
 fixture proves the intended dense straight-line case; it does not claim every static
 shared-stub site is dynamically hot.

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -347,6 +347,46 @@ cycles, 533,396 B/op, and 8 allocs/op. The execution difference is below a
 pre-declared optimization threshold and is baseline evidence, not a reason to
 special-case static sites.
 
+### Issue #307 native-GC ABI/resolver attribution
+
+`BenchmarkGCResolverCodeSize` is the permanent compiler/JIT attribution fixture for
+immutable-ABI hoisting, the module-owned noncollecting resolver, low-site crossover,
+and bounded resolved-address reuse. Run it together with the process-level execution
+fixture:
+
+```sh
+go test ./src/core/compiler/backend/railshot/amd64 -run '^$' \
+  -bench '^BenchmarkGCResolverCodeSize$' -benchmem -count=10
+
+GOMAXPROCS=1 taskset -c 0 go test ./src/wago -run '^$' \
+  -bench '^BenchmarkGCNativeResolverReuse$' -benchmem -benchtime=500ms -count=10
+GOMAXPROCS=1 WAGO_AMD64_NO_GC_RESOLVE_REUSE=1 taskset -c 0 go test ./src/wago \
+  -run '^$' -bench '^BenchmarkGCNativeResolverReuse$' -benchmem -benchtime=500ms -count=10
+GOMAXPROCS=1 WAGO_AMD64_NO_GC_RESOLVE_REUSE=1 WAGO_AMD64_NO_GC_SHARED_STUBS=1 \
+  taskset -c 0 go test ./src/wago -run '^$' \
+  -bench '^BenchmarkGCNativeResolverReuse$' -benchmem -benchtime=500ms -count=10
+```
+
+On August 10, 2026, Ryzen 7 8845HS / Go 1.24.4 linux/amd64 code-size
+qualification measured a 229-byte shared resolver body. One candidate site remains
+inline at 351 native bytes because an unconditional island would produce 453 bytes.
+At eight sites the shared form is 821 versus 1,669 bytes (-50.8%); at 128 sites it is
+7,301 versus 24,349 bytes (-70.0%). Within the eight-site straight-line reuse fixture,
+one resolution plus seven certified reuses produces 565 bytes versus 821 bytes with
+eight resolutions (-31.2%). Module telemetry records shared body bytes/call sites,
+and per-function telemetry records emitted versus reused resolutions.
+
+Ten CPU-0-pinned 500 ms execution samples measured medians of 310.0 ns/op for the
+default shared+reuse path, 328.1 ns/op with reuse disabled, and 324.0 ns/op with both
+reuse and shared resolution disabled; all cases were 0 B/op and 0 allocs/op. Thus the
+retained combined path was 5.5% faster than shared-without-reuse and 4.3% faster than
+fully inline resolution on this repeated-access fixture. Two isolated ~0.8 us host
+outliers did not affect medians. A same-command stripped `wago_runtime` TinyGo build was
+2,096,928 bytes at the baseline SHA and 2,102,160 bytes for the candidate (+5,232,
++0.250%); the fixed 64-byte compiled-code cache and runtime collector/instance/view
+layouts do not grow. This fixture proves the intended dense straight-line case; it
+does not claim every static shared-stub site is dynamically hot.
+
 ### Issue #300 baseline report
 
 The following pinned linux/amd64 results use Go 1.24.4, Linux 6.12, one Ryzen 7

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -370,22 +370,26 @@ GOMAXPROCS=1 WAGO_AMD64_NO_GC_RESOLVE_REUSE=1 WAGO_AMD64_NO_GC_SHARED_STUBS=1 \
 On August 10, 2026, Ryzen 7 8845HS / Go 1.24.4 linux/amd64 code-size
 qualification measured a 229-byte shared resolver body. One candidate site remains
 inline at 351 native bytes because an unconditional island would produce 453 bytes.
-At eight sites the shared form is 821 versus 1,669 bytes (-50.8%); at 128 sites it is
-7,301 versus 24,349 bytes (-70.0%). Within the eight-site straight-line reuse fixture,
-one resolution plus seven certified reuses produces 565 bytes versus 821 bytes with
-eight resolutions (-31.2%). Module telemetry records shared body bytes/call sites,
-and per-function telemetry records emitted versus reused resolutions.
+With reuse disabled, eight sites use the shared form at 821 versus 1,669 bytes
+(-50.8%); 128 sites use 7,301 versus 24,349 bytes (-70.0%). With reuse enabled, a
+single-function module is first lowered inline and selects the island only if at
+least two emitted resolutions remain. The eight-site straight-line fixture therefore
+compiles as one resolution plus seven certified reuses at 452 bytes versus 821 bytes
+with eight shared resolutions (-44.9%). An eight-distinct-object, one-function audit
+still selects the island and measures 949 versus 1,806 inline bytes (-47.5%). Module
+telemetry records shared body bytes/call sites, and per-function telemetry records
+emitted versus reused resolutions.
 
-Ten CPU-0-pinned 500 ms execution samples measured medians of 310.0 ns/op for the
-default shared+reuse path, 328.1 ns/op with reuse disabled, and 324.0 ns/op with both
-reuse and shared resolution disabled; all cases were 0 B/op and 0 allocs/op. Thus the
-retained combined path was 5.5% faster than shared-without-reuse and 4.3% faster than
-fully inline resolution on this repeated-access fixture. Two isolated ~0.8 us host
-outliers did not affect medians. A same-command stripped `wago_runtime` TinyGo build was
-2,096,928 bytes at the baseline SHA and 2,102,160 bytes for the candidate (+5,232,
-+0.250%); the fixed 64-byte compiled-code cache and runtime collector/instance/view
-layouts do not grow. This fixture proves the intended dense straight-line case; it
-does not claim every static shared-stub site is dynamically hot.
+A post-audit set of ten CPU-0-pinned 500 ms execution samples measured medians of
+317.0 ns/op for the default inline+reuse path, 341.85 ns/op with reuse disabled, and
+340.6 ns/op with both reuse and shared resolution disabled; all cases were 0 B/op and
+0 allocs/op. Thus the retained path was 7.3% faster than shared-without-reuse and 6.9%
+faster than fully inline resolution on this repeated-access fixture. A same-command
+stripped `wago_runtime` TinyGo build was 2,096,928 bytes at the baseline SHA and
+2,106,840 bytes after the tertiary audit (+9,912, +0.473%); the fixed 64-byte
+compiled-code cache and runtime collector/instance/view layouts do not grow. This
+fixture proves the intended dense straight-line case; it does not claim every static
+shared-stub site is dynamically hot.
 
 ### Issue #300 baseline report
 

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -66,7 +66,7 @@ call graphs and recursion. Throughput collect-every-allocation/forced-major veri
 Tiny collect/step-every-allocation preserve references in every recursive caller
 while the deepest frame performs 1,000 allocations. Dead locals are omitted,
 hidden operand roots survive control merges, and malformed IDs, offsets,
-call-sites, and adapter returns fail closed. Codec v34 persists and revalidates
+call-sites, and adapter returns fail closed. Codec v35 persists and revalidates
 safepoint, spill, callsite, frame-size, local-start, and adapter-return metadata;
 repeated offset vectors share immutable storage after compilation and reload.
 It never persists collector handles, liveness work arenas, or live frames.
@@ -101,16 +101,36 @@ product, both at 0 B/op and 0 allocs/op. On July 31, 2026, five 500 ms samples o
 with 0 B/op and 0 allocs/op on the Ryzen 7 8845HS host.
 
 AMD64 final scalar struct/array get/set operations now bypass the parked helper
-through native collector ABI v3. Its 160-byte collector-owned stable view preserves
-the complete 128-byte v2 handle/space/generation/object-card prefix and appends
-allocation-state, epoch, nursery-bump, and semantic-counter pointers. Collection
-and relocating/large-space allocation republish the complete view; ordinary helper
-nursery allocation updates only handle metadata and generation, while card
-append/remove/clear republishes card metadata. One
-instance-owned view publishes the immutable local-to-canonical type
-map at basedata offset 280. Generated code reloads every pointer per access and
-checks ABI version, handle tag/range, space range, object extent, exact canonical
-type, and array index before touching payload bytes.
+through native collector ABI v6. Its 168-byte collector-owned stable view preserves
+the complete handle/space/generation/object-card prefix and appends allocation-state,
+epoch, nursery-bump, and semantic-counter pointers. Collection and relocating/large-
+space allocation republish the complete view; ordinary helper nursery allocation
+updates only handle metadata and generation, while card append/remove/clear republishes
+card metadata. One instance-owned view publishes the immutable local-to-canonical type
+map at basedata offset 280.
+
+The Go/native structure layout is validated when a collector is created. Codec v35
+records the required native-GC ABI for generic struct/array execution and rejects a
+missing or mismatched requirement while loading. Instantiation then validates the
+immutable instance version, collector identity, local-type map pointer/count,
+collector version, and handle stride before basedata publication. Production AMD64
+operations do not reload those immutable guards per access; `-tags wagodebug` retains
+a coarse Go-to-native entry assertion. Dynamic semantic checks are unchanged:
+generated code reloads mutable handle/backing pointers and counts, then checks compact
+handle tag/range/liveness, space and backing extents, object extent, exact canonical
+type, array bounds, ownership/barrier state, and trap order before touching payload.
+
+At modules with two or more candidate direct scalar/length sites, AMD64 emits one
+229-byte module-owned noncollecting compact-handle resolver leaf and patches local
+`CALL rel32` sites to it. One-site modules keep inline resolution because the measured
+crossover is unfavorable. The leaf cannot allocate, collect, enter Go, publish roots,
+or become a safepoint; local trap stubs retain exact source attribution. A separate
+one-entry derived-address certificate may reuse a successful resolution only across
+an unchanged compact local and a mechanically safepoint-free straight-line region.
+Calls, helper/host transitions, allocations, control/EH/tail edges, local writes,
+mutable-fact invalidation, and all unknown opcodes clear it before lowering. Controls:
+`WAGO_AMD64_NO_GC_SHARED_STUBS=1` and `WAGO_AMD64_NO_GC_RESOLVE_REUSE=1` restore
+inline/no-reuse differential paths.
 
 Shared AMD64 stubs additionally cover final casts, final cast-plus-array-length,
 final reference-array reads, and final cast-plus-reference-struct reads. Final
@@ -175,9 +195,9 @@ and 31.7 ms for linked instantiate/start. The cold Starshine link/JIT allocated
 166.2 MB in 565,697 allocations; this and the 74.8 MB/448,851-allocation compile
 front half are explicit optimization targets rather than footprint claims.
 
-Codec v34 persists generic helper admission, vector layout, and bounded native
-root maps; compact handles remain process-local. Snapshot format v4 separately
-serializes every object reachable from owned local GC globals using one-based
+Codec v35 persists generic helper admission, the required native-GC ABI version,
+vector layout, and bounded native root maps; compact handles remain process-local.
+Snapshot format v4 separately serializes every object reachable from owned local GC globals using one-based
 stable IDs, exact type IDs, array lengths, and typed field/element payloads.
 Snapshot v5 adds the live length and entries of one owned local collector-reference
 table. Snapshot v6 extends that record to multiple heterogeneous local tables with
@@ -420,7 +440,7 @@ immutable decoded subtype declarations and is discarded after code generation; i
 not retained by `Compiled` or serialized. `Compiled.GCTypeDescs` stores the runtime
 descriptor slice so `.wago` blobs can instantiate without re-decoding the Wasm type
 section. The descriptor slice index matches flattened `wasm.TypeIdx.Index`, including
-function sentinels used only to preserve indexes. Codec v34 retains the appended
+function sentinels used only to preserve indexes. Codec v35 retains the appended
 `StorageV128` kind, the 16-byte layout contract, and validated native
 safepoint/callsite root maps; older codec versions are rejected.
 
@@ -432,7 +452,7 @@ Iteration 38 added a separate exact numeric-local helper product with one alloca
 and a proven empty live-ref set. Iteration 39 added two collector-owned immutable global
 slots, not frame roots: each slot is installed before a later initializer allocation. The native-frame publication slice now records function-relative safepoint IDs, exact
 structured-CFG local liveness, hidden operand spills, and direct self-call return-PC maps for
-linux/amd64 local functions. Codec v34 persists and revalidates that metadata, including
+linux/amd64 local functions. Codec v35 persists and revalidates that metadata, including
 caller stack adjustments, and the runtime walks cross-function, recursive, and suspended host
 activations through mutable off-heap slots. Mutable module-local global slots synchronize before
 allocation. Private local `call_indirect` and tail-indirect calls now participate in exact frame walking,

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -120,12 +120,15 @@ generated code reloads mutable handle/backing pointers and counts, then checks c
 handle tag/range/liveness, space and backing extents, object extent, exact canonical
 type, array bounds, ownership/barrier state, and trap order before touching payload.
 
-At modules with two or more candidate direct scalar/length sites, AMD64 emits one
-229-byte module-owned noncollecting compact-handle resolver leaf and patches local
+At modules with two or more candidate direct scalar sites, AMD64 may emit one
+229-byte module-owned noncollecting compact-handle resolver leaf and patch local
 `CALL rel32` sites to it. One-site modules keep inline resolution because the measured
-crossover is unfavorable. The leaf cannot allocate, collect, enter Go, publish roots,
-or become a safepoint; local trap stubs retain exact source attribution. A separate
-one-entry derived-address certificate may reuse a successful resolution only across
+crossover is unfavorable. When reuse is enabled for a single-function module, the
+compiler first lowers inline and emits the island only if at least two actual handle
+resolutions remain; repeated accesses collapsed to one resolution do not pay the fixed
+island, while distinct objects still share it. The leaf cannot allocate, collect,
+enter Go, publish roots, or become a safepoint; local trap stubs retain exact source
+attribution. A separate one-entry derived-address certificate may reuse a successful resolution only across
 an unchanged compact local and a mechanically safepoint-free straight-line region.
 Calls, helper/host transitions, allocations, control/EH/tail edges, local writes,
 mutable-fact invalidation, and all unknown opcodes clear it before lowering. Controls:

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -38,6 +38,7 @@ type callReloc struct {
 	at       int  // byte offset of the rel32 field within this function's code
 	target   int  // target local-function index (into m.Code)
 	internal bool // target the callee's register-ABI internal entry (else offset 0)
+	gcStub   gcSharedStubKind
 }
 
 // intArgRegs is the integer argument/result register order for the internal
@@ -880,6 +881,7 @@ func (f *fn) emitTailRegisterJump(ft *wasm.CompType, emitJump func()) {
 // synchronous re-entry path instead (callHostSync). The caller (emitCall) routes
 // by result arity, so ft here always has zero results.
 func (f *fn) callHost(importIdx int, ft *wasm.CompType) error {
+	f.invalidateGCResolvedObject()
 	f.stats.call(callKindHost)
 	p := len(ft.Params)
 	f.flush()
@@ -968,6 +970,7 @@ func (f *fn) gcFramePrefixRoots(roots []*elem, n int) []bool {
 // globals are also synced around the call: the host may read or write the
 // instance's globals through their cells.
 func (f *fn) callHostSync(importIdx int, ft *wasm.CompType) error {
+	f.invalidateGCResolvedObject()
 	f.stats.call(callKindHostSync)
 	internalGC := uint32(importIdx)&(gcStructDispatchBit|shared.AtomicWaitDispatchBit) != 0
 	nativeStructType := f.nativeStructAllocType

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 	"slices"
@@ -47,6 +48,17 @@ var exactGCRefFactsEnabled = os.Getenv("WAGO_AMD64_NO_GC_REF_FACTS") != "1"
 // chunks for admitted struct and array constructors. Rooted Go helpers remain the
 // collection/refill path. Keep one differential kill switch for qualification.
 var nativeGCStructAllocEnabled = os.Getenv("WAGO_AMD64_NO_GC_NATIVE_ALLOC") != "1"
+
+// gcSharedStubsEnabled moves the common noncollecting compact-handle resolver
+// into one module-owned leaf stub. The local call edge retains exact trap/source
+// attribution. WAGO_AMD64_NO_GC_SHARED_STUBS=1 restores fully inline resolution
+// for differential qualification and low-site-count crossover measurement.
+var gcSharedStubsEnabled = os.Getenv("WAGO_AMD64_NO_GC_SHARED_STUBS") != "1"
+
+// gcResolveReuseEnabled retains one resolved object address only across a
+// compiler-proven straight-line, safepoint-free region. The compact local remains
+// the root and stable identity. WAGO_AMD64_NO_GC_RESOLVE_REUSE=1 disables reuse.
+var gcResolveReuseEnabled = os.Getenv("WAGO_AMD64_NO_GC_RESOLVE_REUSE") != "1"
 
 // immutableLocalTableEnabled specializes call_indirect when the one-pass module
 // scan proves table 0 is a private, never-mutated table of same-module functions
@@ -202,6 +214,8 @@ type fn struct {
 	localExactGCType []uint32      // exact non-null GC type + 1; zero means unknown
 	gcLastArrayLen   gcArrayLenFact
 	gcLastField      gcStructFieldFact
+	gcResolved       gcResolvedObject
+	gcSharedResolver bool
 	nLocalSlots      int // total local frame slots in 8-byte units
 
 	// WARP-style per-local storage metadata. localType remains as the compact
@@ -824,6 +838,14 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	if err != nil {
 		return nil, fmt.Errorf("amd64: %w", err)
 	}
+	resolverSites := 0
+	for i := range allHints {
+		resolverSites += allHints[i].gcResolverSites
+	}
+	useSharedGCResolver := gcSharedStubsEnabled && resolverSites >= 2
+	for i := range allHints {
+		allHints[i].gcSharedResolver = useSharedGCResolver
+	}
 	modGlobals := pickModuleGlobals(m, nGlobals, globalScores)
 	hostAdapters, err := shared.HostAdapterSet(m)
 	if err != nil {
@@ -952,17 +974,29 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 				opts.MemoryPressure()
 			}
 		}
-		// Patch call sites now that every function's entry offsets are known.
-		code := codeBuffer.Bytes()
-		for i := 0; i < n; i++ {
-			for _, rl := range relocs[i] {
-				site := entry[i] + rl.at
-				target := entry[rl.target]
-				if rl.internal {
-					target = internalEntry[rl.target]
+		// Append one module-owned cold leaf island after every function, then patch
+		// ordinary calls and shared-stub calls in one deterministic pass.
+		stubCode, stubOffsets := buildModuleGCSharedStubs(relocs)
+		stubBase := -1
+		if len(stubCode) != 0 {
+			if pad := (16 - len(codeBuffer.Bytes())%16) % 16; pad != 0 {
+				if err := codeBuffer.AppendZeros(pad); err != nil {
+					return nil, fmt.Errorf("amd64: grow GC stub island: %w", err)
 				}
-				binary.LittleEndian.PutUint32(code[site:], uint32(int32(target-(site+4))))
 			}
+			stubBase = len(codeBuffer.Bytes())
+			if err := codeBuffer.Append(stubCode); err != nil {
+				return nil, fmt.Errorf("amd64: append GC stub island: %w", err)
+			}
+			if ms != nil {
+				ms.GCSharedStubBytes = len(stubCode)
+				ms.GCSharedStubs = 1
+				ms.GCSharedStubCallSites = countGCSharedStubRelocs(relocs)
+			}
+		}
+		code := codeBuffer.Bytes()
+		if err := patchModuleRelocs(code, entry, internalEntry, relocs, stubBase, stubOffsets); err != nil {
+			return nil, err
 		}
 		if explainEnabled && ms != nil {
 			fmt.Fprint(os.Stderr, ms.String())
@@ -1051,15 +1085,22 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 		relocs[i] = r.relocs
 		code = append(code, states[r.worker].arena[r.start:r.end]...)
 	}
-	for i := 0; i < n; i++ {
-		for _, rl := range relocs[i] {
-			site := entry[i] + rl.at
-			target := entry[rl.target]
-			if rl.internal {
-				target = internalEntry[rl.target]
-			}
-			binary.LittleEndian.PutUint32(code[site:], uint32(int32(target-(site+4))))
+	stubCode, stubOffsets := buildModuleGCSharedStubs(relocs)
+	stubBase := -1
+	if len(stubCode) != 0 {
+		if pad := (16 - len(code)%16) % 16; pad != 0 {
+			code = append(code, alignPad[:pad]...)
 		}
+		stubBase = len(code)
+		code = append(code, stubCode...)
+		if ms != nil {
+			ms.GCSharedStubBytes = len(stubCode)
+			ms.GCSharedStubs = 1
+			ms.GCSharedStubCallSites = countGCSharedStubRelocs(relocs)
+		}
+	}
+	if err := patchModuleRelocs(code, entry, internalEntry, relocs, stubBase, stubOffsets); err != nil {
+		return nil, err
 	}
 	if explainEnabled && ms != nil {
 		fmt.Fprint(os.Stderr, ms.String())
@@ -1077,6 +1118,47 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 		}
 	}
 	return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, RequiresBMI2: requiresBMI2, RequiresAVX2: requiresAVX2, RequiresAVX512: requiresAVX512}, nil
+}
+
+func countGCSharedStubRelocs(relocs [][]callReloc) int {
+	count := 0
+	for i := range relocs {
+		for _, reloc := range relocs[i] {
+			if reloc.gcStub != gcSharedStubNone {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func patchModuleRelocs(code []byte, entry, internalEntry []int, relocs [][]callReloc, stubBase int, stubOffsets [gcSharedStubMax]int) error {
+	for i := range relocs {
+		for _, rl := range relocs[i] {
+			site := entry[i] + rl.at
+			target := 0
+			if rl.gcStub != gcSharedStubNone {
+				if stubBase < 0 || rl.gcStub >= gcSharedStubMax || stubOffsets[rl.gcStub] < 0 {
+					return fmt.Errorf("amd64: missing shared GC stub %d for function %d", rl.gcStub, i)
+				}
+				target = stubBase + stubOffsets[rl.gcStub]
+			} else {
+				if rl.target < 0 || rl.target >= len(entry) {
+					return fmt.Errorf("amd64: invalid call relocation target %d for function %d", rl.target, i)
+				}
+				target = entry[rl.target]
+				if rl.internal {
+					target = internalEntry[rl.target]
+				}
+			}
+			delta := target - (site + 4)
+			if int64(delta) < math.MinInt32 || int64(delta) > math.MaxInt32 {
+				return fmt.Errorf("amd64: relocation from %#x to %#x exceeds rel32 range", site, target)
+			}
+			binary.LittleEndian.PutUint32(code[site:], uint32(int32(delta)))
+		}
+	}
+	return nil
 }
 
 func firstFuncError(results []funcResult) (int, error) {
@@ -1554,7 +1636,7 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	f := &sc.fnState
 	localType, localSlot, localExactGCType, locals := f.localType, f.localSlot, f.localExactGCType, f.locals
 	mt0, _ := m.MemoryType(0)
-	*f = fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, gcTypeLayouts: gcTypeLayouts, transient: sc.transient, globalIdx: globalIdx, traceFuncIdx: uint32(globalIdx), tracePCBase: c.LocalDeclBytes, customInstructions: custom, nParams: len(ft.Params), nLocals: nLocals, localType: localType, localSlot: localSlot, localExactGCType: localExactGCType, locals: locals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled && !moduleEH, globalCellReg: regNone, memSizeReg: regNone, immutableTables: hints.immutableTables, stagedTailDescriptors: hints.hasTailCall, importBindings: importBindings, stats: stats, entryInitialized: entryInitialized, gcFrameRoots: gcFrameRoots, moduleEH: moduleEH, threadedMemory0: mt0.Shared}
+	*f = fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, gcTypeLayouts: gcTypeLayouts, transient: sc.transient, globalIdx: globalIdx, traceFuncIdx: uint32(globalIdx), tracePCBase: c.LocalDeclBytes, customInstructions: custom, nParams: len(ft.Params), nLocals: nLocals, localType: localType, localSlot: localSlot, localExactGCType: localExactGCType, locals: locals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, regMerge: regMergeEnabled && !moduleEH, globalCellReg: regNone, memSizeReg: regNone, immutableTables: hints.immutableTables, stagedTailDescriptors: hints.hasTailCall, importBindings: importBindings, stats: stats, entryInitialized: entryInitialized, gcFrameRoots: gcFrameRoots, moduleEH: moduleEH, threadedMemory0: mt0.Shared, gcSharedResolver: hints.gcSharedResolver}
 	// Retain the (possibly grown) control-frame backing for the next function.
 	defer func() {
 		sc.ctrl = f.ctrl
@@ -1589,6 +1671,7 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 			i++
 		}
 	}
+	f.seedFinalGCParameterTypes(ft.Params)
 	if cap(f.localSlot) < nLocals {
 		f.localSlot = make([]int, nLocals)
 	} else {

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -207,16 +207,17 @@ type fn struct {
 	wasmPC             uint32
 	customInstructions map[uint32]CustomInstruction
 
-	nParams          int
-	nLocals          int           // params + declared locals
-	localType        []machineType // per-local machine type
-	localSlot        []int         // per-local frame slot in 8-byte units; v128 occupies two
-	localExactGCType []uint32      // exact non-null GC type + 1; zero means unknown
-	gcLastArrayLen   gcArrayLenFact
-	gcLastField      gcStructFieldFact
-	gcResolved       gcResolvedObject
-	gcSharedResolver bool
-	nLocalSlots      int // total local frame slots in 8-byte units
+	nParams             int
+	nLocals             int           // params + declared locals
+	localType           []machineType // per-local machine type
+	localSlot           []int         // per-local frame slot in 8-byte units; v128 occupies two
+	localExactGCType    []uint32      // exact non-null GC type + 1; zero means unknown
+	gcLastArrayLen      gcArrayLenFact
+	gcLastField         gcStructFieldFact
+	gcResolved          gcResolvedObject
+	gcSharedResolver    bool
+	gcHandleResolutions int
+	nLocalSlots         int // total local frame slots in 8-byte units
 
 	// WARP-style per-local storage metadata. localType remains as the compact
 	// type table used by existing lowering; locals holds the assigned register and
@@ -834,7 +835,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	internalEntry := make([]int, n)
 	importedFuncs := m.ImportedFuncCount()
 	nGlobals := m.GlobalCount()
-	allHints, globalScores, err := computeModuleHints(m, nGlobals, importedFuncs)
+	allHints, globalScores, err := computeModuleHints(m, nGlobals, importedFuncs, opts.Codegen.Module.GCTypeLayouts)
 	if err != nil {
 		return nil, fmt.Errorf("amd64: %w", err)
 	}
@@ -842,7 +843,13 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	for i := range allHints {
 		resolverSites += allHints[i].gcResolverSites
 	}
-	useSharedGCResolver := gcSharedStubsEnabled && resolverSites >= 2
+	// A one-entry address certificate can collapse a single function's repeated
+	// candidate sites to one real resolution. Compile that narrow shape inline
+	// first and select the module island only when lowering proves at least two
+	// resolutions remain. Multi-function modules retain the measured static
+	// crossover because caches cannot cross function boundaries.
+	deferSingleFuncGCResolverDecision := gcSharedStubsEnabled && gcResolveReuseEnabled && n == 1 && resolverSites >= 2
+	useSharedGCResolver := gcSharedStubsEnabled && resolverSites >= 2 && !deferSingleFuncGCResolverDecision
 	for i := range allHints {
 		allHints[i].gcSharedResolver = useSharedGCResolver
 	}
@@ -867,8 +874,13 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 		ms = &ModuleStats{}
 	}
 	if ms != nil {
-		ms.Funcs = make([]*CodegenStats, n)
-		ms.ModuleGlobalPins = moduleGlobalPinInfos(modGlobals)
+		// A stats sink is reusable across compiles. Reset the complete module-level
+		// attribution, including optional analyses that may be unavailable for the
+		// next module, before installing this compile's deterministic destinations.
+		*ms = ModuleStats{
+			Funcs:            make([]*CodegenStats, n),
+			ModuleGlobalPins: moduleGlobalPinInfos(modGlobals),
+		}
 		// Inline-candidate detection (report only; no codegen change yet). Failure
 		// to analyze is non-fatal — it never blocks a compile.
 		if rep, ierr := AnalyzeInlineCandidates(m); ierr == nil {
@@ -954,6 +966,11 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 				ms.Funcs[i] = st
 			}
 			fnCode, rl, internalOff, err := compileFunc(m, opts.Codegen.Module.GCTypeLayouts, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.CustomInstructions, opts.GCFrameRoots.Function(i), st, inlineTargets, sc)
+			if err == nil && deferSingleFuncGCResolverDecision && sc.fnState.gcHandleResolutions >= 2 {
+				hints.gcSharedResolver = true
+				resetFuncStats(st)
+				fnCode, rl, internalOff, err = compileFunc(m, opts.Codegen.Module.GCTypeLayouts, i, hostAdapters[i], guardMode, boundsFacts, opts.Interruptible, modGlobals, hints, opts.ImportBindings, opts.SyncHostCalls, opts.GCTypeSubtypingRefTest, opts.GCStructHelpers, opts.GCArrayHelpers, opts.CustomInstructions, opts.GCFrameRoots.Function(i), st, inlineTargets, sc)
+			}
 			allHints[i] = funcHints{}
 			if err != nil {
 				return nil, fmt.Errorf("amd64: function %d: %w", i, err)
@@ -1133,12 +1150,22 @@ func countGCSharedStubRelocs(relocs [][]callReloc) int {
 }
 
 func patchModuleRelocs(code []byte, entry, internalEntry []int, relocs [][]callReloc, stubBase int, stubOffsets [gcSharedStubMax]int) error {
+	if len(entry) < len(relocs) {
+		return fmt.Errorf("amd64: relocation entry table has %d functions, want at least %d", len(entry), len(relocs))
+	}
 	for i := range relocs {
+		base := entry[i]
+		if base < 0 || base > len(code) {
+			return fmt.Errorf("amd64: invalid function %d entry %#x for %d-byte code image", i, base, len(code))
+		}
 		for _, rl := range relocs[i] {
-			site := entry[i] + rl.at
+			if rl.at < 0 || base > len(code)-4 || rl.at > len(code)-base-4 {
+				return fmt.Errorf("amd64: invalid relocation site %#x in function %d for %d-byte code image", rl.at, i, len(code))
+			}
+			site := base + rl.at
 			target := 0
 			if rl.gcStub != gcSharedStubNone {
-				if stubBase < 0 || rl.gcStub >= gcSharedStubMax || stubOffsets[rl.gcStub] < 0 {
+				if stubBase < 0 || stubBase > len(code) || rl.gcStub >= gcSharedStubMax || stubOffsets[rl.gcStub] < 0 || stubOffsets[rl.gcStub] > len(code)-stubBase {
 					return fmt.Errorf("amd64: missing shared GC stub %d for function %d", rl.gcStub, i)
 				}
 				target = stubBase + stubOffsets[rl.gcStub]
@@ -1148,11 +1175,17 @@ func patchModuleRelocs(code []byte, entry, internalEntry []int, relocs [][]callR
 				}
 				target = entry[rl.target]
 				if rl.internal {
+					if rl.target >= len(internalEntry) {
+						return fmt.Errorf("amd64: missing internal entry for call relocation target %d in function %d", rl.target, i)
+					}
 					target = internalEntry[rl.target]
 				}
+				if target < 0 || target > len(code) {
+					return fmt.Errorf("amd64: invalid call relocation target entry %#x for function %d", target, i)
+				}
 			}
-			delta := target - (site + 4)
-			if int64(delta) < math.MinInt32 || int64(delta) > math.MaxInt32 {
+			delta := int64(target) - int64(site+4)
+			if delta < math.MinInt32 || delta > math.MaxInt32 {
 				return fmt.Errorf("amd64: relocation from %#x to %#x exceeds rel32 range", site, target)
 			}
 			binary.LittleEndian.PutUint32(code[site:], uint32(int32(delta)))
@@ -1222,7 +1255,7 @@ func computeFuncHints(m *wasm.Module, funcIdx int, nGlobals int, importedFuncs i
 // those across functions — so summing here removes a second full-body
 // immediate-decoding pass per function (the standalone global-scores scan). The
 // standalone computeModuleGlobalScores is retained as the parity oracle in tests.
-func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHints, []int64, error) {
+func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int, gcTypeLayouts []codegen.GCTypeLayout) ([]funcHints, []int64, error) {
 	n := len(m.Code)
 	allHints := make([]funcHints, n)
 	localCounts := make([]int, n)
@@ -1287,7 +1320,7 @@ func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHint
 		h.localLastGet = localLastGets[localAt : localAt+nLocals]
 		h.nLocals = nLocals
 		var err error
-		h, err = scanFuncBodyIntoMemory64(m.Code[i], nLocals, nGlobals, uint32(importedFuncs+i), h, &eligibilityTracker, memory64)
+		h, err = scanFuncBodyIntoMemory64WithModule(m.Code[i], nLocals, nGlobals, uint32(importedFuncs+i), h, &eligibilityTracker, memory64, m, gcTypeLayouts)
 		if err != nil {
 			return nil, nil, fmt.Errorf("function %d hints: %w", i, err)
 		}
@@ -1671,7 +1704,8 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 			i++
 		}
 	}
-	f.seedFinalGCParameterTypes(ft.Params)
+	recBase, recLength, _ := nativeGCRecGroup(m, m.FuncTypes[funcIdx].Index)
+	f.seedFinalGCParameterTypes(ft.Params, recBase, recLength)
 	if cap(f.localSlot) < nLocals {
 		f.localSlot = make([]int, nLocals)
 	} else {

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -835,7 +835,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	internalEntry := make([]int, n)
 	importedFuncs := m.ImportedFuncCount()
 	nGlobals := m.GlobalCount()
-	allHints, globalScores, err := computeModuleHints(m, nGlobals, importedFuncs, opts.Codegen.Module.GCTypeLayouts)
+	allHints, globalScores, err := computeModuleHints(m, nGlobals, importedFuncs, opts.Codegen.Module.GCTypeLayouts, opts.GCStructHelpers)
 	if err != nil {
 		return nil, fmt.Errorf("amd64: %w", err)
 	}
@@ -1255,7 +1255,7 @@ func computeFuncHints(m *wasm.Module, funcIdx int, nGlobals int, importedFuncs i
 // those across functions — so summing here removes a second full-body
 // immediate-decoding pass per function (the standalone global-scores scan). The
 // standalone computeModuleGlobalScores is retained as the parity oracle in tests.
-func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int, gcTypeLayouts []codegen.GCTypeLayout) ([]funcHints, []int64, error) {
+func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int, gcTypeLayouts []codegen.GCTypeLayout, gcStructHelpers bool) ([]funcHints, []int64, error) {
 	n := len(m.Code)
 	allHints := make([]funcHints, n)
 	localCounts := make([]int, n)
@@ -1320,7 +1320,7 @@ func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int, gcTypeLayou
 		h.localLastGet = localLastGets[localAt : localAt+nLocals]
 		h.nLocals = nLocals
 		var err error
-		h, err = scanFuncBodyIntoMemory64WithModule(m.Code[i], nLocals, nGlobals, uint32(importedFuncs+i), h, &eligibilityTracker, memory64, m, gcTypeLayouts)
+		h, err = scanFuncBodyIntoMemory64WithModule(m.Code[i], nLocals, nGlobals, uint32(importedFuncs+i), h, &eligibilityTracker, memory64, m, gcTypeLayouts, gcStructHelpers)
 		if err != nil {
 			return nil, nil, fmt.Errorf("function %d hints: %w", i, err)
 		}

--- a/src/core/compiler/backend/railshot/amd64/driver.go
+++ b/src/core/compiler/backend/railshot/amd64/driver.go
@@ -31,6 +31,7 @@ func (f *fn) bodyLoop(r *wasm.Reader, minCtrl int) error {
 			return err
 		}
 		f.prepareStoreForward(op)
+		f.prepareGCResolvedObject(op)
 		switch op {
 		case 0x00: // unreachable
 			f.clearLocalExactGCTypes()
@@ -109,13 +110,16 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 		f.invalidateGCMutableLoadFacts()
 		return f.callIndirect(r)
 	case 0x12: // return_call
+		f.invalidateGCResolvedObject()
 		return f.returnCall(r)
 	case 0x13: // return_call_indirect
+		f.invalidateGCResolvedObject()
 		return f.returnCallIndirect(r)
 	case 0x14: // call_ref
 		f.invalidateGCMutableLoadFacts()
 		return f.callRef(r)
 	case 0x15: // return_call_ref
+		f.invalidateGCResolvedObject()
 		return f.returnCallRef(r)
 
 	case 0x1a: // drop

--- a/src/core/compiler/backend/railshot/amd64/gc_array.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_array.go
@@ -247,6 +247,9 @@ func (f *fn) emitGCArray(sub uint32, r *wasm.Reader) error {
 	case 15: // array.len
 		if _, typeIndex, exact := f.topExactGCLocal(); exact {
 			f.observeGCArrayLen(typeIndex)
+			if f.emitDirectGCArrayLen(typeIndex) {
+				return nil
+			}
 		}
 		object := wasm.RefVal(wasm.Ref(true, wasm.AbsHeap(wasm.HeapArray), false))
 		return f.callGCStructHelper(gcArrayLen, []wasm.ValType{object}, []wasm.ValType{wasm.I32})

--- a/src/core/compiler/backend/railshot/amd64/gc_direct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_direct.go
@@ -481,6 +481,7 @@ func (f *fn) emitDirectGCObject(object *elem, localType, requiredBytes uint32, l
 	} else {
 		obj, done = f.emitCheckedGCObject(object, localType, requiredBytes)
 	}
+	f.gcHandleResolutions++
 	f.stats.addGCHandleResolution()
 	if !gcResolveReuseEnabled || !hasLocal {
 		return obj, done

--- a/src/core/compiler/backend/railshot/amd64/gc_direct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_direct.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
+	x64 "github.com/wago-org/wago/src/core/encoder/amd64"
 	"github.com/wago-org/wago/src/core/runtime/abi"
 	"github.com/wago-org/wago/src/core/runtime/gc"
 )
@@ -14,6 +15,14 @@ import (
 // directGCScalar describes a pointer-free scalar storage location that can be
 // accessed without entering the parked Go helper. Reference and v128 storage
 // deliberately remain helper-bound until their barrier/vector paths are proven.
+type gcSharedStubKind uint8
+
+const (
+	gcSharedStubNone gcSharedStubKind = iota
+	gcSharedStubResolveObject
+	gcSharedStubMax
+)
+
 type directGCScalar struct {
 	size int
 	typ  machineType
@@ -337,6 +346,179 @@ func directGCArrayLayout(m *wasm.Module, typeIndex uint32) (directGCScalar, bool
 	return scalar, st.Final, ok
 }
 
+// buildModuleGCSharedStubs emits one compact module-owned island for every
+// referenced noncollecting GC leaf family. Offsets are relative to the returned
+// byte slice; callers add the island's module base before patching CALL rel32.
+func buildModuleGCSharedStubs(relocs [][]callReloc) ([]byte, [gcSharedStubMax]int) {
+	var used [gcSharedStubMax]bool
+	for i := range relocs {
+		for _, reloc := range relocs[i] {
+			if reloc.gcStub > gcSharedStubNone && reloc.gcStub < gcSharedStubMax {
+				used[reloc.gcStub] = true
+			}
+		}
+	}
+	var offsets [gcSharedStubMax]int
+	for i := range offsets {
+		offsets[i] = -1
+	}
+	if !used[gcSharedStubResolveObject] {
+		return nil, offsets
+	}
+	a := &x64.Asm{}
+	offsets[gcSharedStubResolveObject] = a.Len()
+	emitModuleGCResolveObjectStub(a)
+	return a.B, offsets
+}
+
+// emitModuleGCResolveObjectStub implements the AMD64 noncollecting GC leaf ABI:
+//
+//	EAX compact object ref, EDX static module-local type, ECX required bytes
+//	RAX resolved object header on success, EDX zero on success or trap code
+//	clobbers RAX,RCX,RDX,RDI,R8 and flags; preserves R9-R11 explicitly
+//	no Go transition, allocation, collection, root publication, or safepoint
+//
+// The compact reference remains in the caller's canonical local/stack root. A
+// returned raw address is valid only until the caller's next invalidating edge.
+func emitModuleGCResolveObjectStub(a *x64.Asm) {
+	a.Push(R9)
+	a.Push(R10)
+	a.Push(R11)
+	a.MovRegReg32(RDI, RCX) // required object extent
+
+	a.TestSelf(RAX, false)
+	nullFailure := a.JccPlaceholder(condE)
+	a.MovRegReg32(R10, RAX)
+	a.AluRI(4, R10, 1, false)
+	a.TestSelf(R10, false)
+	castFailures := []int{a.JccPlaceholder(condNE)}
+
+	// Immutable view/type-map shape was proved at artifact load + instantiation.
+	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
+	a.Load64(R10, R8, gc.NativeInstanceViewLocalTypesOffset)
+	a.ImulRI(RDX, 4, true)
+	a.LoadIdx(RDX, R10, RDX, 0, 4, false, false)
+	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
+
+	// Dynamic semantic validation remains exact: handle range/liveness, space,
+	// backing extent, object extent, and canonical runtime type.
+	a.ShiftImm(5, RAX, 1, false)
+	a.AluRM(cmpRMcode, RAX, R8, gc.NativeViewHandleCountOffset, false)
+	castFailures = append(castFailures, a.JccPlaceholder(condAE))
+	a.Load64(R9, R8, gc.NativeViewHandlesOffset)
+	a.ImulRI(RAX, gc.NativeHandleStride, true)
+	a.Add64(R9, RAX)
+
+	a.Load32(R10, R9, 16)
+	a.ShiftImm(5, R10, 16, false)
+	a.AluRI(4, R10, 0xff, false)
+	a.TestSelf(R10, false)
+	castFailures = append(castFailures, a.JccPlaceholder(condE))
+	a.AluRI(cmpDigit, R10, gc.NativeSpaceCount-1, false)
+	castFailures = append(castFailures, a.JccPlaceholder(condA))
+	a.ImulRI(R10, gc.NativeViewSpaceStride, true)
+	a.LeaDisp(R8, R8, gc.NativeViewSpacesOffset)
+	a.Add64(R8, R10)
+	a.Load64(R11, R8, gc.NativeSpaceBaseOffset)
+	a.Load32(R8, R8, gc.NativeSpaceBytesOffset)
+	a.Load32(RAX, R9, gc.NativeHandleOffsetOffset)
+	a.Cmp32(RAX, R8)
+	castFailures = append(castFailures, a.JccPlaceholder(condA))
+	a.Sub32(R8, RAX)
+	a.Load32(RCX, R9, gc.NativeHandleSizeOffset)
+	a.Cmp32(RCX, R8)
+	castFailures = append(castFailures, a.JccPlaceholder(condA))
+	a.Cmp32(RCX, RDI)
+	castFailures = append(castFailures, a.JccPlaceholder(condB))
+
+	a.Add64(R11, RAX)
+	a.Load32(RCX, R11, 0)
+	a.Cmp32(RCX, RDX)
+	castFailures = append(castFailures, a.JccPlaceholder(condNE))
+	a.Load32(RCX, R11, 4)
+	a.Cmp32(RCX, RDI)
+	castFailures = append(castFailures, a.JccPlaceholder(condB))
+	a.MovReg64(RAX, R11)
+	a.XorSelf32(RDX)
+	done := a.JmpPlaceholder()
+
+	nullAt := a.Len()
+	a.MovImm32(RDX, int32(trapNullReference))
+	a.XorSelf32(RAX)
+	nullDone := a.JmpPlaceholder()
+
+	castAt := a.Len()
+	a.MovImm32(RDX, int32(trapCastFailure))
+	a.XorSelf32(RAX)
+	for _, branch := range castFailures {
+		a.PatchRel32(branch, castAt)
+	}
+	a.PatchRel32(nullFailure, nullAt)
+	finish := a.Len()
+	a.PatchRel32(done, finish)
+	a.PatchRel32(nullDone, finish)
+	a.Pop(R11)
+	a.Pop(R10)
+	a.Pop(R9)
+	a.Ret()
+}
+
+func (f *fn) emitDirectGCObject(object *elem, localType, requiredBytes uint32, local int, hasLocal bool) (obj Reg, done func()) {
+	if gcResolveReuseEnabled && hasLocal && f.gcResolved.valid &&
+		f.gcResolved.local == local && f.gcResolved.typeIndex == localType &&
+		requiredBytes <= f.gcResolved.requiredBytes {
+		// Consume the repeated compact local.get while retaining the compact local
+		// itself as the exact root. No raw address is reconstructed.
+		ref := f.materialize(object)
+		f.release(ref)
+		f.stats.addGCHandleResolutionReuse()
+		f.stats.peep("gc-resolve-reuse")
+		return f.gcResolved.reg, func() {}
+	}
+	f.invalidateGCResolvedObject()
+	if f.gcSharedResolver {
+		obj, done = f.emitSharedCheckedGCObject(object, localType, requiredBytes)
+	} else {
+		obj, done = f.emitCheckedGCObject(object, localType, requiredBytes)
+	}
+	f.stats.addGCHandleResolution()
+	if !gcResolveReuseEnabled || !hasLocal {
+		return obj, done
+	}
+	cacheReg := f.gcResolvedRegister()
+	if cacheReg == regNone {
+		return obj, done
+	}
+	f.a.MovReg64(cacheReg, obj)
+	done()
+	f.pinned = f.pinned.add(cacheReg)
+	f.gcResolved = gcResolvedObject{valid: true, local: local, typeIndex: localType, requiredBytes: requiredBytes, reg: cacheReg}
+	return cacheReg, func() {}
+}
+
+func (f *fn) emitSharedCheckedGCObject(object *elem, localType, requiredBytes uint32) (obj Reg, done func()) {
+	ref := f.materialize(object)
+	if ref != RAX {
+		f.a.MovReg64(RAX, ref)
+	}
+	f.release(ref)
+	f.a.MovImm32(RDX, int32(localType))
+	f.a.MovImm32(RCX, int32(requiredBytes))
+	site := f.a.CallRel32()
+	f.relocs = append(f.relocs, callReloc{at: site, gcStub: gcSharedStubResolveObject})
+	f.stats.call("gcnative-leaf")
+	f.stats.peep("gc-shared-resolve-call")
+
+	f.a.TestSelf(RDX, false)
+	success := f.a.JccPlaceholder(condE)
+	f.a.AluRI(cmpDigit, RDX, int32(trapNullReference), false)
+	f.trapIf(condE, trapNullReference)
+	f.trapAlways(trapCastFailure)
+	f.a.PatchRel32(success, f.a.Len())
+	f.pinned = f.pinned.add(RAX)
+	return RAX, func() { f.pinned = f.pinned.remove(RAX) }
+}
+
 // emitCheckedGCObject resolves one compact object handle through the stable
 // versioned collector view and proves exact canonical type plus object bounds.
 // The caller must have raised spillFloor so consumed operand slots cannot be
@@ -358,15 +540,10 @@ func (f *fn) emitCheckedGCObject(object *elem, localType, requiredBytes uint32) 
 	f.a.TestSelf(tmp, false)
 	f.trapIf(condNE, trapCastFailure)
 
+	// Instantiation has already proved the immutable instance/collector ABI and
+	// exact module-local type-map shape. Reload only the immutable map pointer and
+	// the mutable collector view; semantic handle/object checks remain below.
 	f.a.Load64(view, RBX, -int32(abi.GCNativeViewPtrOffset))
-	f.a.TestSelf(view, true)
-	f.trapIf(condE, trapCastFailure)
-	f.a.Load32(tmp, view, gc.NativeInstanceViewVersionOffset)
-	f.a.AluRI(cmpDigit, tmp, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	f.a.Load32(tmp, view, gc.NativeInstanceViewLocalTypeCountOffset)
-	f.a.AluRI(cmpDigit, tmp, int32(localType), false)
-	f.trapIf(condBE, trapCastFailure)
 	f.a.Load64(tmp, view, gc.NativeInstanceViewLocalTypesOffset)
 	if uint64(localType)*4 > math.MaxInt32 {
 		panic("amd64: native GC local type table displacement overflow")
@@ -379,14 +556,6 @@ func (f *fn) emitCheckedGCObject(object *elem, localType, requiredBytes uint32) 
 	f.a.StoreRsp32(f.spillOff(domainSlot), tmp)
 
 	f.a.Load64(view, view, gc.NativeInstanceViewCollectorOffset)
-	f.a.TestSelf(view, true)
-	f.trapIf(condE, trapCastFailure)
-	f.a.Load32(tmp, view, gc.NativeViewVersionOffset)
-	f.a.AluRI(cmpDigit, tmp, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	f.a.Load32(tmp, view, gc.NativeViewHandleStrideOffset)
-	f.a.AluRI(cmpDigit, tmp, gc.NativeHandleStride, false)
-	f.trapIf(condNE, trapCastFailure)
 
 	f.a.ShiftImm(5, ref, 1, false) // compact handle index
 	// cmp ref,[view+HandleCount]; h >= count is invalid.
@@ -737,23 +906,7 @@ func (f *fn) emitNativeArrayAllocStub(site gcArrayAllocStubSite) {
 	addFallback := func(branch int) { fallback = append(fallback, branch) }
 
 	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
-	a.TestSelf(R8, true)
-	addFallback(a.JccPlaceholder(condE))
-	a.Load32(RAX, R8, gc.NativeInstanceViewVersionOffset)
-	a.AluRI(cmpDigit, RAX, int32(gc.NativeABIVersion), false)
-	addFallback(a.JccPlaceholder(condNE))
-	a.Load32(RAX, R8, gc.NativeInstanceViewLocalTypeCountOffset)
-	a.AluRI(cmpDigit, RAX, int32(site.typeIndex), false)
-	addFallback(a.JccPlaceholder(condBE))
 	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
-	a.TestSelf(R8, true)
-	addFallback(a.JccPlaceholder(condE))
-	a.Load32(RAX, R8, gc.NativeViewVersionOffset)
-	a.AluRI(cmpDigit, RAX, int32(gc.NativeABIVersion), false)
-	addFallback(a.JccPlaceholder(condNE))
-	a.Load32(RAX, R8, gc.NativeViewHandleStrideOffset)
-	a.AluRI(cmpDigit, RAX, gc.NativeHandleStride, false)
-	addFallback(a.JccPlaceholder(condNE))
 
 	a.Load64(R10, R8, gc.NativeViewStructAllocStateOffset)
 	a.TestSelf(R10, true)
@@ -1041,25 +1194,9 @@ func (f *fn) emitNativeStructAllocStub(typeIndex uint32) {
 	addFallback := func(site int) { fallback = append(fallback, site) }
 
 	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
-	a.TestSelf(R8, true)
-	addFallback(a.JccPlaceholder(condE))
-	a.Load32(RAX, R8, gc.NativeInstanceViewVersionOffset)
-	a.AluRI(cmpDigit, RAX, int32(gc.NativeABIVersion), false)
-	addFallback(a.JccPlaceholder(condNE))
-	a.Load32(RAX, R8, gc.NativeInstanceViewLocalTypeCountOffset)
-	a.AluRI(cmpDigit, RAX, int32(typeIndex), false)
-	addFallback(a.JccPlaceholder(condBE))
 	a.Load64(R10, R8, gc.NativeInstanceViewLocalTypesOffset)
 	a.Load32(RDX, R10, int32(typeIndex*4))
 	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
-	a.TestSelf(R8, true)
-	addFallback(a.JccPlaceholder(condE))
-	a.Load32(RAX, R8, gc.NativeViewVersionOffset)
-	a.AluRI(cmpDigit, RAX, int32(gc.NativeABIVersion), false)
-	addFallback(a.JccPlaceholder(condNE))
-	a.Load32(RAX, R8, gc.NativeViewHandleStrideOffset)
-	a.AluRI(cmpDigit, RAX, gc.NativeHandleStride, false)
-	addFallback(a.JccPlaceholder(condNE))
 
 	a.Load64(R10, R8, gc.NativeViewStructAllocStateOffset)
 	a.TestSelf(R10, true)
@@ -1258,30 +1395,14 @@ func (f *fn) emitNativeFinalCastArrayLenStub() {
 	a.TestSelf(R10, false)
 	f.trapIf(condNE, trapCastFailure)
 
-	// Resolve the module-local type to immutable Runtime-domain identity.
+	// Instantiation proved the immutable view ABI and local type-map shape.
 	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewLocalTypeCountOffset)
-	a.Cmp32(RDX, R10)
-	f.trapIf(condAE, trapCastFailure)
 	a.Load64(R10, R8, gc.NativeInstanceViewLocalTypesOffset)
 	a.ImulRI(RDX, 4, true)
 	a.LoadIdx(RDX, R10, RDX, 0, 4, false, false)
 
-	// Resolve and validate the compact handle against collector ABI v1.
+	// Resolve and semantically validate the compact handle through current backing.
 	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewHandleStrideOffset)
-	a.AluRI(cmpDigit, R10, gc.NativeHandleStride, false)
-	f.trapIf(condNE, trapCastFailure)
 	a.ShiftImm(5, RAX, 1, false)
 	a.AluRM(cmpRMcode, RAX, R8, gc.NativeViewHandleCountOffset, false)
 	f.trapIf(condAE, trapCastFailure)
@@ -1361,27 +1482,11 @@ func (f *fn) emitNativeFinalCastStub() {
 	f.trapIf(condNE, trapCastFailure)
 
 	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewLocalTypeCountOffset)
-	a.Cmp32(RDX, R10)
-	f.trapIf(condAE, trapCastFailure)
 	a.Load64(R10, R8, gc.NativeInstanceViewLocalTypesOffset)
 	a.ImulRI(RDX, 4, true)
 	a.LoadIdx(RDX, R10, RDX, 0, 4, false, false)
 
 	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewHandleStrideOffset)
-	a.AluRI(cmpDigit, R10, gc.NativeHandleStride, false)
-	f.trapIf(condNE, trapCastFailure)
 	a.ShiftImm(5, RAX, 1, false)
 	a.AluRM(cmpRMcode, RAX, R8, gc.NativeViewHandleCountOffset, false)
 	f.trapIf(condAE, trapCastFailure)
@@ -1455,27 +1560,11 @@ func (f *fn) emitNativeFinalArrayRefGetStub() {
 	f.trapIf(condNE, trapCastFailure)
 
 	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewLocalTypeCountOffset)
-	a.Cmp32(RDX, R10)
-	f.trapIf(condAE, trapCastFailure)
 	a.Load64(R10, R8, gc.NativeInstanceViewLocalTypesOffset)
 	a.ImulRI(RDX, 4, true)
 	a.LoadIdx(RDX, R10, RDX, 0, 4, false, false)
 
 	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewHandleStrideOffset)
-	a.AluRI(cmpDigit, R10, gc.NativeHandleStride, false)
-	f.trapIf(condNE, trapCastFailure)
 	a.ShiftImm(5, RAX, 1, false)
 	a.AluRM(cmpRMcode, RAX, R8, gc.NativeViewHandleCountOffset, false)
 	f.trapIf(condAE, trapCastFailure)
@@ -1567,27 +1656,11 @@ func (f *fn) emitNativeFinalCastStructRefResolverStub() {
 	f.trapIf(condNE, trapCastFailure)
 
 	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewLocalTypeCountOffset)
-	a.Cmp32(RDX, R10)
-	f.trapIf(condAE, trapCastFailure)
 	a.Load64(R10, R8, gc.NativeInstanceViewLocalTypesOffset)
 	a.ImulRI(RDX, 4, true)
 	a.LoadIdx(RDX, R10, RDX, 0, 4, false, false)
 
 	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewHandleStrideOffset)
-	a.AluRI(cmpDigit, R10, gc.NativeHandleStride, false)
-	f.trapIf(condNE, trapCastFailure)
 	a.ShiftImm(5, RAX, 1, false)
 	a.AluRM(cmpRMcode, RAX, R8, gc.NativeViewHandleCountOffset, false)
 	f.trapIf(condAE, trapCastFailure)
@@ -1671,27 +1744,11 @@ func (f *fn) emitNativeBarrierSafeStructRefSetStub() {
 	addFallback(a.JccPlaceholder(condNE))
 
 	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewLocalTypeCountOffset)
-	a.Cmp32(RDX, R10)
-	f.trapIf(condAE, trapCastFailure)
 	a.Load64(R10, R8, gc.NativeInstanceViewLocalTypesOffset)
 	a.ImulRI(RDX, 4, true)
 	a.LoadIdx(RDX, R10, RDX, 0, 4, false, false)
 
 	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewHandleStrideOffset)
-	a.AluRI(cmpDigit, R10, gc.NativeHandleStride, false)
-	f.trapIf(condNE, trapCastFailure)
 	a.ShiftImm(5, RAX, 1, false)
 	a.AluRM(cmpRMcode, RAX, R8, gc.NativeViewHandleCountOffset, false)
 	addFallback(a.JccPlaceholder(condAE))
@@ -1828,27 +1885,11 @@ func (f *fn) emitNativeCardSafeArrayRefSetStub() {
 	addFallback(a.JccPlaceholder(condNE))
 
 	a.Load64(R8, RBX, -int32(abi.GCNativeViewPtrOffset))
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeInstanceViewLocalTypeCountOffset)
-	a.Cmp32(RDX, R10)
-	f.trapIf(condAE, trapCastFailure)
 	a.Load64(R10, R8, gc.NativeInstanceViewLocalTypesOffset)
 	a.ImulRI(RDX, 4, true)
 	a.LoadIdx(RDX, R10, RDX, 0, 4, false, false)
 
 	a.Load64(R8, R8, gc.NativeInstanceViewCollectorOffset)
-	a.TestSelf(R8, true)
-	f.trapIf(condE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewVersionOffset)
-	a.AluRI(cmpDigit, R10, int32(gc.NativeABIVersion), false)
-	f.trapIf(condNE, trapCastFailure)
-	a.Load32(R10, R8, gc.NativeViewHandleStrideOffset)
-	a.AluRI(cmpDigit, R10, gc.NativeHandleStride, false)
-	f.trapIf(condNE, trapCastFailure)
 	a.ShiftImm(5, RAX, 1, false)
 	a.AluRM(cmpRMcode, RAX, R8, gc.NativeViewHandleCountOffset, false)
 	addFallback(a.JccPlaceholder(condAE))
@@ -1994,12 +2035,13 @@ func (f *fn) emitDirectGCStructGet(typeIndex, fieldIndex uint32, helper uint32) 
 	if !ok || !final {
 		return false
 	}
+	local, hasLocal := gcLocalProvenance(f.s.back())
 	f.flush()
 	oldFloor := f.spillFloor
 	f.spillFloor = f.curSpillSlot()
 	object := f.popValue()
 	required := gc.PayloadOffset + off + uint32(scalar.size)
-	obj, done := f.emitCheckedGCObject(object, typeIndex, required)
+	obj, done := f.emitDirectGCObject(object, typeIndex, required, local, hasLocal)
 	disp := int32(gc.PayloadOffset + off)
 	if scalar.typ.isFloat() {
 		x := f.allocFReg(0)
@@ -2023,13 +2065,15 @@ func (f *fn) emitDirectGCStructSet(typeIndex, fieldIndex uint32) bool {
 	if !ok || !final {
 		return false
 	}
+	valueRoot := f.s.back()
+	local, hasLocal := gcLocalProvenance(baseOfValentBlock(valueRoot).prev)
 	f.flush()
 	oldFloor := f.spillFloor
 	f.spillFloor = f.curSpillSlot()
 	value := f.popValue()
 	object := f.popValue()
 	required := gc.PayloadOffset + off + uint32(scalar.size)
-	obj, done := f.emitCheckedGCObject(object, typeIndex, required)
+	obj, done := f.emitDirectGCObject(object, typeIndex, required, local, hasLocal)
 	disp := int32(gc.PayloadOffset + off)
 	if scalar.typ.isFloat() {
 		x := f.materializeF(value)
@@ -2045,17 +2089,43 @@ func (f *fn) emitDirectGCStructSet(typeIndex, fieldIndex uint32) bool {
 	return true
 }
 
+func (f *fn) emitDirectGCArrayLen(typeIndex uint32) bool {
+	if layout, ok := f.gcTypeLayout(typeIndex, wasm.CompArray); ok {
+		if !layout.DirectLen {
+			return false
+		}
+	} else if target, ok := f.stagedArraySubtype(typeIndex); !ok || !target.Final {
+		// Legacy low-level tests may omit compiler-only #365 layouts. Production
+		// compilation always takes the precomputed metadata branch above.
+		return false
+	}
+	local, hasLocal := gcLocalProvenance(f.s.back())
+	f.flush()
+	oldFloor := f.spillFloor
+	f.spillFloor = f.curSpillSlot()
+	object := f.popValue()
+	obj, done := f.emitDirectGCObject(object, typeIndex, gc.HeaderSize, local, hasLocal)
+	result := f.allocReg(maskOf(obj))
+	f.a.Load32(result, obj, 8)
+	done()
+	f.spillFloor = oldFloor
+	f.pushReg(result, mtI32)
+	return true
+}
+
 func (f *fn) emitDirectGCArrayGet(typeIndex uint32, helper uint32) bool {
 	scalar, final, ok := f.directGCArrayLayout(typeIndex)
 	if !ok || !final {
 		return false
 	}
+	indexRoot := f.s.back()
+	local, hasLocal := gcLocalProvenance(baseOfValentBlock(indexRoot).prev)
 	f.flush()
 	oldFloor := f.spillFloor
 	f.spillFloor = f.curSpillSlot()
 	indexValue := f.popValue()
 	object := f.popValue()
-	obj, done := f.emitCheckedGCObject(object, typeIndex, gc.PayloadOffset)
+	obj, done := f.emitDirectGCObject(object, typeIndex, gc.PayloadOffset, local, hasLocal)
 	index := f.materialize(indexValue)
 	f.pinned = f.pinned.add(index)
 	tmp := f.allocReg(maskOf(obj, index))
@@ -2103,13 +2173,16 @@ func (f *fn) emitDirectGCArraySet(typeIndex uint32) bool {
 	if !ok || !final {
 		return false
 	}
+	valueRoot := f.s.back()
+	indexRoot := baseOfValentBlock(valueRoot).prev
+	local, hasLocal := gcLocalProvenance(baseOfValentBlock(indexRoot).prev)
 	f.flush()
 	oldFloor := f.spillFloor
 	f.spillFloor = f.curSpillSlot()
 	value := f.popValue()
 	indexValue := f.popValue()
 	object := f.popValue()
-	obj, done := f.emitCheckedGCObject(object, typeIndex, gc.PayloadOffset)
+	obj, done := f.emitDirectGCObject(object, typeIndex, gc.PayloadOffset, local, hasLocal)
 	index := f.materialize(indexValue)
 	f.pinned = f.pinned.add(index)
 	tmp := f.allocReg(maskOf(obj, index))

--- a/src/core/compiler/backend/railshot/amd64/gc_ref_facts.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_ref_facts.go
@@ -53,7 +53,7 @@ func (f *fn) markTopExactGCType(typeIndex uint32) {
 	}
 }
 
-func (f *fn) seedFinalGCParameterTypes(params []wasm.ValType) {
+func (f *fn) seedFinalGCParameterTypes(params []wasm.ValType, recBase, recLength uint32) {
 	if !exactGCRefFactsEnabled {
 		return
 	}
@@ -65,7 +65,14 @@ func (f *fn) seedFinalGCParameterTypes(params []wasm.ValType) {
 		var index uint32
 		switch heap.Kind() {
 		case wasm.HeapTypeIndex:
-			index = heap.Type().Index
+			typeIndex := heap.Type()
+			index = typeIndex.Index
+			if typeIndex.Rec {
+				if typeIndex.Index >= recLength || recBase > ^uint32(0)-typeIndex.Index {
+					continue
+				}
+				index = recBase + typeIndex.Index
+			}
 		case wasm.HeapDefType:
 			group, member, _, valid := heap.Def()
 			if !valid || int(group) >= len(f.m.Types) || member >= uint32(len(f.m.Types[group].SubTypes)) {

--- a/src/core/compiler/backend/railshot/amd64/gc_ref_facts.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_ref_facts.go
@@ -2,6 +2,8 @@
 
 package amd64
 
+import "github.com/wago-org/wago/src/core/compiler/wasm"
+
 type gcArrayLenFact struct {
 	valid     bool
 	local     int
@@ -14,6 +16,14 @@ type gcStructFieldFact struct {
 	local      int
 	typeIndex  uint32
 	fieldIndex uint32
+}
+
+type gcResolvedObject struct {
+	valid         bool
+	local         int
+	typeIndex     uint32
+	requiredBytes uint32
+	reg           Reg
 }
 
 // Exact non-null GC reference facts are deliberately compact and local. A
@@ -40,6 +50,37 @@ func markExactGCType(e *elem, typeIndex uint32) {
 func (f *fn) markTopExactGCType(typeIndex uint32) {
 	if exactGCRefFactsEnabled {
 		markExactGCType(f.s.back(), typeIndex)
+	}
+}
+
+func (f *fn) seedFinalGCParameterTypes(params []wasm.ValType) {
+	if !exactGCRefFactsEnabled {
+		return
+	}
+	for local, typ := range params {
+		if local >= len(f.localExactGCType) || typ.Kind() != wasm.ValRef || typ.Ref().Nullable() {
+			continue
+		}
+		heap := typ.Ref().Heap()
+		var index uint32
+		switch heap.Kind() {
+		case wasm.HeapTypeIndex:
+			index = heap.Type().Index
+		case wasm.HeapDefType:
+			group, member, _, valid := heap.Def()
+			if !valid || int(group) >= len(f.m.Types) || member >= uint32(len(f.m.Types[group].SubTypes)) {
+				continue
+			}
+			for i := uint32(0); i < group; i++ {
+				index += uint32(len(f.m.Types[i].SubTypes))
+			}
+			index += member
+		default:
+			continue
+		}
+		if target, ok := f.stagedGCType(index); ok && target.Final && (target.Comp.Kind == wasm.CompStruct || target.Comp.Kind == wasm.CompArray) {
+			f.localExactGCType[local] = index + 1
+		}
 	}
 }
 
@@ -71,6 +112,7 @@ func (f *fn) clearLocalExactGCTypes() {
 	}
 	f.gcLastArrayLen.valid = false
 	f.gcLastField.valid = false
+	f.invalidateGCResolvedObject()
 }
 
 func (f *fn) invalidateGCLoadFactsForLocal(local int) {
@@ -80,10 +122,68 @@ func (f *fn) invalidateGCLoadFactsForLocal(local int) {
 	if f.gcLastField.valid && f.gcLastField.local == local {
 		f.gcLastField.valid = false
 	}
+	if f.gcResolved.valid && f.gcResolved.local == local {
+		f.invalidateGCResolvedObject()
+	}
 }
 
 func (f *fn) invalidateGCMutableLoadFacts() {
 	f.gcLastField.valid = false
+	f.invalidateGCResolvedObject()
+}
+
+// prepareGCResolvedObject is the central straight-line invalidation gate. Only
+// leaves needed to carry an unchanged local into another GC operation and the
+// GC prefix itself retain the transient address. Every other opcode drops it
+// before lowering, conservatively covering arithmetic fixed-register uses,
+// memory/runtime operations, control transfers, exceptions, and unknown work.
+func (f *fn) prepareGCResolvedObject(op byte) {
+	if !f.gcResolved.valid {
+		return
+	}
+	switch op {
+	case 0x1a, // drop is register-neutral
+		0x20,                   // local.get
+		0x41, 0x42, 0x43, 0x44, // scalar constants used by array indexes
+		0xfb: // decoded subopcode performs the second-stage allowlist
+		return
+	default:
+		f.invalidateGCResolvedObject()
+	}
+}
+
+func (f *fn) prepareGCResolvedFB(sub uint32) {
+	if !f.gcResolved.valid {
+		return
+	}
+	switch sub {
+	case 2, 3, 4, 5, // struct.get/get_s/get_u/set
+		11, 12, 13, 14, 15: // array.get/get_s/get_u/set/len
+		return
+	default:
+		f.invalidateGCResolvedObject()
+	}
+}
+
+func (f *fn) invalidateGCResolvedObject() {
+	if !f.gcResolved.valid {
+		return
+	}
+	f.pinned = f.pinned.remove(f.gcResolved.reg)
+	f.gcResolved = gcResolvedObject{}
+}
+
+func (f *fn) gcResolvedRegister() Reg {
+	block := f.pinned.union(f.pinnedLocalMask).union(f.reserved)
+	// Restrict the transient cache to registers untouched by tiny leaf stubs and
+	// x86 fixed-role scalar operations. Do not spill a Wasm value merely to cache
+	// a derived address: register pressure rejects the optimization instead.
+	for _, reg := range [...]Reg{RBP, R12, R13, R14} {
+		if f.regUser[reg] == nil && !block.has(reg) {
+			return reg
+		}
+	}
+	return regNone
 }
 
 func gcLocalProvenance(e *elem) (int, bool) {

--- a/src/core/compiler/backend/railshot/amd64/gc_ref_facts_test.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_ref_facts_test.go
@@ -43,6 +43,22 @@ func exactGCRefFactModule(t *testing.T, controlBoundary bool) *wasm.Module {
 	return m
 }
 
+func TestFinalGCParameterFactsResolveRecursiveGroupIndex(t *testing.T) {
+	recParam := wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: 0, Rec: true}), false))
+	m := &wasm.Module{Types: []wasm.RecType{
+		{SubTypes: []wasm.SubType{{Final: true, Comp: wasm.CompType{Kind: wasm.CompFunc}}}},
+		{SubTypes: []wasm.SubType{
+			{Final: true, Comp: wasm.CompType{Kind: wasm.CompStruct}},
+			{Final: true, Comp: wasm.CompType{Kind: wasm.CompFunc, Params: []wasm.ValType{recParam}}},
+		}},
+	}}
+	f := fn{m: m, localExactGCType: make([]uint32, 1)}
+	f.seedFinalGCParameterTypes([]wasm.ValType{recParam}, 1, 2)
+	if got := f.localExactGCType[0]; got != 2 {
+		t.Fatalf("recursive final parameter fact = %d, want flattened type 1 encoded as 2", got)
+	}
+}
+
 func TestExactGCReferenceFactsElideProvenCast(t *testing.T) {
 	compile := func(m *wasm.Module) *CodegenStats {
 		var stats ModuleStats
@@ -205,9 +221,35 @@ func TestModuleSharedGCResolverStubReducesDenseSites(t *testing.T) {
 		}
 		return m
 	}
-	compile := func(m *wasm.Module, shared bool) (int, ModuleStats) {
+	distinctModule := func(sites int) *wasm.Module {
+		body := []byte{0x00}
+		funcType := []byte{0x60, byte(sites)}
+		for i := 0; i < sites; i++ {
+			funcType = append(funcType, 0x64, 0x00)
+			body = append(body, 0x20, byte(i), 0xfb, 0x02, 0x00, 0x00)
+		}
+		funcType = append(funcType, 0x01, 0x7f)
+		for i := 1; i < sites; i++ {
+			body = append(body, 0x6a)
+		}
+		body = append(body, 0x0b)
+		data := wasmtest.Module(
+			wasmtest.Section(1, wasmtest.Vec([]byte{0x5f, 0x01, 0x7f, 0x00}, funcType)),
+			wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+			wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+		)
+		m, err := wasm.DecodeModule(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := wasm.ValidateModule(m); err != nil {
+			t.Fatal(err)
+		}
+		return m
+	}
+	compile := func(m *wasm.Module, shared, reuse bool) (int, ModuleStats) {
 		savedShared, savedReuse := gcSharedStubsEnabled, gcResolveReuseEnabled
-		gcSharedStubsEnabled, gcResolveReuseEnabled = shared, false
+		gcSharedStubsEnabled, gcResolveReuseEnabled = shared, reuse
 		defer func() { gcSharedStubsEnabled, gcResolveReuseEnabled = savedShared, savedReuse }()
 		var stats ModuleStats
 		cm, err := CompileModuleWith(m, CompileOptions{GCStructHelpers: true, Stats: &stats})
@@ -218,15 +260,46 @@ func TestModuleSharedGCResolverStubReducesDenseSites(t *testing.T) {
 		return len(cm.Code), stats
 	}
 
-	oneOnBytes, oneOn := compile(module(1), true)
-	oneOffBytes, _ := compile(module(1), false)
+	oneOnBytes, oneOn := compile(module(1), true, false)
+	oneOffBytes, _ := compile(module(1), false, false)
 	if oneOn.GCSharedStubs != 0 || oneOn.GCSharedStubCallSites != 0 || oneOnBytes != oneOffBytes {
 		t.Fatalf("one-site crossover emitted shared resolver: bytes=%d/%d stats=%+v", oneOnBytes, oneOffBytes, oneOn)
 	}
 
+	// One direct scalar access plus one final reference-field access has two GC
+	// opcodes but only one module-resolver callsite. The conservative hint scan
+	// must not cross the measured two-real-site threshold.
+	mixedBody := []byte{
+		0x00,
+		0x20, 0x01, 0xfb, 0x02, 0x01, 0x00, 0x1a,
+		0x20, 0x00, 0xfb, 0x02, 0x00, 0x00,
+		0x0b,
+	}
+	mixedData := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			[]byte{0x5f, 0x01, 0x7f, 0x00},
+			[]byte{0x5f, 0x01, 0x6e, 0x00},
+			[]byte{0x60, 0x02, 0x64, 0x00, 0x64, 0x01, 0x01, 0x7f},
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(mixedBody))), mixedBody...))),
+	)
+	mixed, err := wasm.DecodeModule(mixedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wasm.ValidateModule(mixed); err != nil {
+		t.Fatal(err)
+	}
+	mixedOnBytes, mixedOn := compile(mixed, true, false)
+	mixedOffBytes, _ := compile(mixed, false, false)
+	if mixedOn.GCSharedStubs != 0 || mixedOn.GCSharedStubCallSites != 0 || mixedOnBytes != mixedOffBytes {
+		t.Fatalf("one-real-site mixed module emitted shared resolver: bytes=%d/%d stats=%+v", mixedOnBytes, mixedOffBytes, mixedOn)
+	}
+
 	const sites = 8
-	onBytes, on := compile(module(sites), true)
-	offBytes, off := compile(module(sites), false)
+	onBytes, on := compile(module(sites), true, false)
+	offBytes, off := compile(module(sites), false, false)
 	if on.GCSharedStubs != 1 || on.GCSharedStubCallSites != sites || on.GCSharedStubBytes == 0 {
 		t.Fatalf("shared resolver stats = bodies %d calls %d bytes %d", on.GCSharedStubs, on.GCSharedStubCallSites, on.GCSharedStubBytes)
 	}
@@ -235,6 +308,45 @@ func TestModuleSharedGCResolverStubReducesDenseSites(t *testing.T) {
 	}
 	if onBytes >= offBytes {
 		t.Fatalf("shared resolver code = %d bytes, inline = %d; want shared smaller", onBytes, offBytes)
+	}
+
+	reuseSharedBytes, reuseShared := compile(module(sites), true, true)
+	reuseInlineBytes, _ := compile(module(sites), false, true)
+	if reuseShared.GCSharedStubs != 0 || reuseShared.GCSharedStubCallSites != 0 || reuseSharedBytes != reuseInlineBytes {
+		t.Fatalf("one-function reuse emitted code-growing shared island: bytes=%d/%d stats=%+v", reuseSharedBytes, reuseInlineBytes, reuseShared)
+	}
+
+	distinctSharedBytes, distinctShared := compile(distinctModule(sites), true, true)
+	distinctInlineBytes, _ := compile(distinctModule(sites), false, true)
+	if distinctShared.GCSharedStubs != 1 || distinctShared.GCSharedStubCallSites != sites || distinctSharedBytes >= distinctInlineBytes {
+		t.Fatalf("distinct one-function sites did not select shared island: bytes=%d/%d stats=%+v", distinctSharedBytes, distinctInlineBytes, distinctShared)
+	}
+
+	// ModuleStats is a reusable sink; a later sparse compile must not retain the
+	// prior module's island attribution.
+	savedShared, savedReuse := gcSharedStubsEnabled, gcResolveReuseEnabled
+	gcSharedStubsEnabled, gcResolveReuseEnabled = true, false
+	defer func() { gcSharedStubsEnabled, gcResolveReuseEnabled = savedShared, savedReuse }()
+	var reused ModuleStats
+	dense, err := CompileModuleWith(module(sites), CompileOptions{GCStructHelpers: true, Stats: &reused})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dense.CodeImage != nil {
+		_ = dense.CodeImage.Close()
+	}
+	if reused.GCSharedStubs != 1 {
+		t.Fatalf("dense reusable stats = %+v", reused)
+	}
+	sparse, err := CompileModuleWith(module(1), CompileOptions{GCStructHelpers: true, Stats: &reused})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sparse.CodeImage != nil {
+		_ = sparse.CodeImage.Close()
+	}
+	if reused.GCSharedStubBytes != 0 || reused.GCSharedStubs != 0 || reused.GCSharedStubCallSites != 0 {
+		t.Fatalf("reused sparse stats retained shared island = %+v", reused)
 	}
 }
 

--- a/src/core/compiler/backend/railshot/amd64/gc_ref_facts_test.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_ref_facts_test.go
@@ -107,6 +107,137 @@ func gcReferenceFactStats(t *testing.T, composite, body []byte) *CodegenStats {
 	return stats.Funcs[0]
 }
 
+func gcResolveReuseStats(t *testing.T, composite, funcType, body []byte) *CodegenStats {
+	t.Helper()
+	data := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(composite, funcType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+	m, err := wasm.DecodeModule(data)
+	if err != nil {
+		t.Fatalf("decode GC resolve module: %v", err)
+	}
+	if err := wasm.ValidateModule(m); err != nil {
+		t.Fatalf("validate GC resolve module: %v", err)
+	}
+	var stats ModuleStats
+	if _, err := CompileModuleWith(m, CompileOptions{GCStructHelpers: true, GCArrayHelpers: true, Stats: &stats}); err != nil {
+		t.Fatalf("compile GC resolve module: %v", err)
+	}
+	return stats.Funcs[0]
+}
+
+func TestGCResolvedHandleReuseAndInvalidation(t *testing.T) {
+	refTo0I32 := []byte{0x60, 0x01, 0x64, 0x00, 0x01, 0x7f}
+	refTo0TwoI32 := []byte{0x60, 0x01, 0x64, 0x00, 0x02, 0x7f, 0x7f}
+	structBody := []byte{
+		0x00,
+		0x20, 0x00, 0xfb, 0x02, 0x00, 0x00,
+		0x20, 0x00, 0xfb, 0x02, 0x00, 0x00,
+		0x6a, 0x0b,
+	}
+	stats := gcResolveReuseStats(t, []byte{0x5f, 0x01, 0x7f, 0x00}, refTo0I32, structBody)
+	if stats.GCHandleResolutions != 1 || stats.GCHandleResolutionReuse != 1 {
+		t.Fatalf("straight-line resolutions = %d reused = %d, want 1/1", stats.GCHandleResolutions, stats.GCHandleResolutionReuse)
+	}
+
+	arrayBody := []byte{
+		0x00,
+		0x20, 0x00, 0xfb, 0x0f,
+		0x20, 0x00, 0x41, 0x00, 0xfb, 0x0b, 0x00,
+		0x0b,
+	}
+	stats = gcResolveReuseStats(t, []byte{0x5e, 0x7f, 0x00}, refTo0TwoI32, arrayBody)
+	if stats.GCHandleResolutions != 1 || stats.GCHandleResolutionReuse != 1 {
+		t.Fatalf("array len/get resolutions = %d reused = %d, want 1/1 (calls=%v peep=%v)", stats.GCHandleResolutions, stats.GCHandleResolutionReuse, stats.Calls, stats.Peephole)
+	}
+
+	savedDead := deadGCNewEnabled
+	deadGCNewEnabled = false
+	defer func() { deadGCNewEnabled = savedDead }()
+	allocationBody := []byte{
+		0x00,
+		0x20, 0x00, 0xfb, 0x02, 0x00, 0x00, 0x1a,
+		0xfb, 0x01, 0x00, 0x1a,
+		0x20, 0x00, 0xfb, 0x02, 0x00, 0x00,
+		0x0b,
+	}
+	stats = gcResolveReuseStats(t, []byte{0x5f, 0x01, 0x7f, 0x00}, refTo0I32, allocationBody)
+	if stats.GCHandleResolutions != 2 || stats.GCHandleResolutionReuse != 0 {
+		t.Fatalf("allocation-boundary resolutions = %d reused = %d, want 2/0", stats.GCHandleResolutions, stats.GCHandleResolutionReuse)
+	}
+
+	controlBody := []byte{
+		0x00,
+		0x20, 0x00, 0xfb, 0x02, 0x00, 0x00, 0x1a,
+		0x02, 0x40, 0x0b,
+		0x20, 0x00, 0xfb, 0x02, 0x00, 0x00,
+		0x0b,
+	}
+	stats = gcResolveReuseStats(t, []byte{0x5f, 0x01, 0x7f, 0x00}, refTo0I32, controlBody)
+	if stats.GCHandleResolutions != 2 || stats.GCHandleResolutionReuse != 0 {
+		t.Fatalf("control-boundary resolutions = %d reused = %d, want 2/0", stats.GCHandleResolutions, stats.GCHandleResolutionReuse)
+	}
+}
+
+func TestModuleSharedGCResolverStubReducesDenseSites(t *testing.T) {
+	module := func(sites int) *wasm.Module {
+		body := []byte{0x00}
+		for range sites {
+			body = append(body, 0x20, 0x00, 0xfb, 0x02, 0x00, 0x00, 0x1a)
+		}
+		body = append(body, 0x41, 0x00, 0x0b)
+		data := wasmtest.Module(
+			wasmtest.Section(1, wasmtest.Vec(
+				[]byte{0x5f, 0x01, 0x7f, 0x00},
+				[]byte{0x60, 0x01, 0x64, 0x00, 0x01, 0x7f},
+			)),
+			wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+			wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+		)
+		m, err := wasm.DecodeModule(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := wasm.ValidateModule(m); err != nil {
+			t.Fatal(err)
+		}
+		return m
+	}
+	compile := func(m *wasm.Module, shared bool) (int, ModuleStats) {
+		savedShared, savedReuse := gcSharedStubsEnabled, gcResolveReuseEnabled
+		gcSharedStubsEnabled, gcResolveReuseEnabled = shared, false
+		defer func() { gcSharedStubsEnabled, gcResolveReuseEnabled = savedShared, savedReuse }()
+		var stats ModuleStats
+		cm, err := CompileModuleWith(m, CompileOptions{GCStructHelpers: true, Stats: &stats})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cm.CodeImage.Close()
+		return len(cm.Code), stats
+	}
+
+	oneOnBytes, oneOn := compile(module(1), true)
+	oneOffBytes, _ := compile(module(1), false)
+	if oneOn.GCSharedStubs != 0 || oneOn.GCSharedStubCallSites != 0 || oneOnBytes != oneOffBytes {
+		t.Fatalf("one-site crossover emitted shared resolver: bytes=%d/%d stats=%+v", oneOnBytes, oneOffBytes, oneOn)
+	}
+
+	const sites = 8
+	onBytes, on := compile(module(sites), true)
+	offBytes, off := compile(module(sites), false)
+	if on.GCSharedStubs != 1 || on.GCSharedStubCallSites != sites || on.GCSharedStubBytes == 0 {
+		t.Fatalf("shared resolver stats = bodies %d calls %d bytes %d", on.GCSharedStubs, on.GCSharedStubCallSites, on.GCSharedStubBytes)
+	}
+	if off.GCSharedStubs != 0 || off.GCSharedStubCallSites != 0 || off.GCSharedStubBytes != 0 {
+		t.Fatalf("disabled shared resolver stats = bodies %d calls %d bytes %d", off.GCSharedStubs, off.GCSharedStubCallSites, off.GCSharedStubBytes)
+	}
+	if onBytes >= offBytes {
+		t.Fatalf("shared resolver code = %d bytes, inline = %d; want shared smaller", onBytes, offBytes)
+	}
+}
+
 func TestGCReferenceFactLoadOpportunityCounters(t *testing.T) {
 	arrayBody := []byte{
 		0x01, 0x01, 0x63, 0x00, // one (ref null 0) local

--- a/src/core/compiler/backend/railshot/amd64/gc_struct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_struct.go
@@ -39,6 +39,7 @@ func (f *fn) emitFB(r *wasm.Reader) error {
 	if err != nil {
 		return err
 	}
+	f.prepareGCResolvedFB(sub)
 	defer func() { f.recordGCOpcodeBytes(sub, f.a.Len()-before) }()
 	if sub >= 6 && sub <= 19 {
 		return f.emitGCArray(sub, r)

--- a/src/core/compiler/backend/railshot/amd64/gc_telemetry_bench_test.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_telemetry_bench_test.go
@@ -74,6 +74,83 @@ func BenchmarkGCStaticSiteCompilation(b *testing.B) {
 	}
 }
 
+func gcResolverDensityModule(tb testing.TB, sites int) *wasm.Module {
+	tb.Helper()
+	body := []byte{0x00}
+	for range sites {
+		body = append(body, 0x20, 0x00, 0xfb, 0x02, 0x00, 0x00, 0x1a)
+	}
+	body = append(body, 0x41, 0x00, 0x0b)
+	data := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			[]byte{0x5f, 0x01, 0x7f, 0x00},
+			[]byte{0x60, 0x01, 0x64, 0x00, 0x01, 0x7f},
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+	m, err := wasm.DecodeModule(data)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if err := wasm.ValidateModule(m); err != nil {
+		tb.Fatal(err)
+	}
+	return m
+}
+
+// BenchmarkGCResolverCodeSize permanently records the low/dense-site crossover
+// for the module-owned compact-handle resolver and the bounded reuse certificate.
+func BenchmarkGCResolverCodeSize(b *testing.B) {
+	for _, sites := range []int{1, 8, 128} {
+		m := gcResolverDensityModule(b, sites)
+		for _, shared := range []bool{false, true} {
+			b.Run(fmt.Sprintf("sites=%d/shared=%v", sites, shared), func(b *testing.B) {
+				savedShared, savedReuse := gcSharedStubsEnabled, gcResolveReuseEnabled
+				gcSharedStubsEnabled, gcResolveReuseEnabled = shared, false
+				defer func() { gcSharedStubsEnabled, gcResolveReuseEnabled = savedShared, savedReuse }()
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					var stats ModuleStats
+					compiled, err := CompileModuleWith(m, CompileOptions{Workers: 1, GCStructHelpers: true, Stats: &stats})
+					if err != nil {
+						b.Fatal(err)
+					}
+					b.ReportMetric(float64(len(compiled.Code)), "native-bytes/op")
+					b.ReportMetric(float64(stats.GCSharedStubBytes), "shared-stub-bytes/op")
+					b.ReportMetric(float64(stats.GCSharedStubCallSites), "shared-calls/op")
+					if compiled.CodeImage != nil {
+						_ = compiled.CodeImage.Close()
+					}
+				}
+			})
+		}
+	}
+	m := gcResolverDensityModule(b, 8)
+	for _, reuse := range []bool{false, true} {
+		b.Run(fmt.Sprintf("reuse=%v", reuse), func(b *testing.B) {
+			savedShared, savedReuse := gcSharedStubsEnabled, gcResolveReuseEnabled
+			gcSharedStubsEnabled, gcResolveReuseEnabled = true, reuse
+			defer func() { gcSharedStubsEnabled, gcResolveReuseEnabled = savedShared, savedReuse }()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var stats ModuleStats
+				compiled, err := CompileModuleWith(m, CompileOptions{Workers: 1, GCStructHelpers: true, Stats: &stats})
+				if err != nil {
+					b.Fatal(err)
+				}
+				function := stats.Funcs[0]
+				b.ReportMetric(float64(len(compiled.Code)), "native-bytes/op")
+				b.ReportMetric(float64(function.GCHandleResolutions), "resolutions/op")
+				b.ReportMetric(float64(function.GCHandleResolutionReuse), "reuses/op")
+				if compiled.CodeImage != nil {
+					_ = compiled.CodeImage.Close()
+				}
+			}
+		})
+	}
+}
+
 func TestGCStaticSiteTelemetrySmoke(t *testing.T) {
 	for _, sites := range []int{1, 128} {
 		m := gcStaticSiteModule(t, sites)

--- a/src/core/compiler/backend/railshot/amd64/hints.go
+++ b/src/core/compiler/backend/railshot/amd64/hints.go
@@ -211,27 +211,28 @@ func scanFuncBodyInto(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, h fun
 }
 
 func scanFuncBodyIntoMemory64(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool) (funcHints, error) {
-	return scanFuncBodyIntoMemory64WithModule(fn, nLocals, nGlobals, selfIdx, h, elig, memory64, nil, nil)
+	return scanFuncBodyIntoMemory64WithModule(fn, nLocals, nGlobals, selfIdx, h, elig, memory64, nil, nil, false)
 }
 
-func scanFuncBodyIntoMemory64WithModule(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout) (funcHints, error) {
+func scanFuncBodyIntoMemory64WithModule(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, gcStructHelpers bool) (funcHints, error) {
 	if len(fn.BodyBytes) != 0 {
-		return scanBodyBytesIntoMemory64WithModule(fn.BodyBytes, nLocals, nGlobals, selfIdx, h, elig, memory64, m, gcTypeLayouts)
+		return scanBodyBytesIntoMemory64WithModule(fn.BodyBytes, nLocals, nGlobals, selfIdx, h, elig, memory64, m, gcTypeLayouts, gcStructHelpers)
 	}
-	return scanBodyInto(fn.Body, nLocals, nGlobals, selfIdx, h, elig, m, gcTypeLayouts), nil
+	return scanBodyInto(fn.Body, nLocals, nGlobals, selfIdx, h, elig, m, gcTypeLayouts, gcStructHelpers), nil
 }
 
-func gcOrAtomicInstructionMayCall(kind wasm.InstrKind) bool {
+func gcOrAtomicInstructionMayCall(kind wasm.InstrKind, gcStructHelpers bool) bool {
 	switch kind {
 	case wasm.InstrStructNew, wasm.InstrStructNewDefault, wasm.InstrStructNewDesc, wasm.InstrStructNewDefaultDesc,
 		wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructAtomicGet, wasm.InstrStructAtomicGetS, wasm.InstrStructAtomicGetU, wasm.InstrStructSet,
 		wasm.InstrArrayNew, wasm.InstrArrayNewDefault, wasm.InstrArrayNewFixed, wasm.InstrArrayNewData, wasm.InstrArrayNewElem,
 		wasm.InstrArrayGet, wasm.InstrArrayGetS, wasm.InstrArrayGetU, wasm.InstrArraySet, wasm.InstrArrayLen,
 		wasm.InstrArrayFill, wasm.InstrArrayCopy, wasm.InstrArrayInitData, wasm.InstrArrayInitElem,
-		wasm.InstrRefGetDesc, wasm.InstrRefTest, wasm.InstrRefCast, wasm.InstrRefTestDesc, wasm.InstrRefCastDescEq, wasm.InstrBrOnCast, wasm.InstrBrOnCastFail,
-		wasm.InstrAnyConvertExtern, wasm.InstrExternConvertAny, wasm.InstrRefI31, wasm.InstrI31GetS, wasm.InstrI31GetU,
 		wasm.InstrMemoryAtomicNotify, wasm.InstrMemoryAtomicWait32, wasm.InstrMemoryAtomicWait64:
 		return true
+	case wasm.InstrRefGetDesc, wasm.InstrRefTest, wasm.InstrRefCast, wasm.InstrRefTestDesc, wasm.InstrRefCastDescEq, wasm.InstrBrOnCast, wasm.InstrBrOnCastFail,
+		wasm.InstrAnyConvertExtern, wasm.InstrExternConvertAny, wasm.InstrRefI31, wasm.InstrI31GetS, wasm.InstrI31GetU:
+		return gcStructHelpers
 	default:
 		return false
 	}
@@ -283,10 +284,10 @@ func directGCResolverInstruction(m *wasm.Module, gcTypeLayouts []codegen.GCTypeL
 func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 	h := newFuncHints(nLocals, nGlobals)
 	elig := newGlobalEligibilityTracker(nGlobals)
-	return scanBodyInto(body, nLocals, nGlobals, selfIdx, h, &elig, nil, nil)
+	return scanBodyInto(body, nLocals, nGlobals, selfIdx, h, &elig, nil, nil, false)
 }
 
-func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout) funcHints {
+func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, gcStructHelpers bool) funcHints {
 	elig.reset()
 	// walk returns whether the subtree contains a call. curLoop identifies the
 	// innermost enclosing loop whose globals are being considered for eligibility.
@@ -300,7 +301,7 @@ func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcH
 			case wasm.InstrTryTable, wasm.InstrThrow, wasm.InstrThrowRef:
 				h.moduleEH = true
 			}
-			if gcOrAtomicInstructionMayCall(in.Kind) {
+			if gcOrAtomicInstructionMayCall(in.Kind, gcStructHelpers) {
 				h.hasCall, sub = true, true
 			}
 			// Inline-candidacy control-flow signals (matches scanInlineFactsAST).
@@ -548,13 +549,13 @@ func scanBodyBytesMemory64(body []byte, nLocals int, nGlobals int, selfIdx uint3
 }
 
 func scanBodyBytesIntoMemory64(body []byte, nLocals int, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool) (funcHints, error) {
-	return scanBodyBytesIntoMemory64WithModule(body, nLocals, nGlobals, selfIdx, h, elig, memory64, nil, nil)
+	return scanBodyBytesIntoMemory64WithModule(body, nLocals, nGlobals, selfIdx, h, elig, memory64, nil, nil, false)
 }
 
-func scanBodyBytesIntoMemory64WithModule(body []byte, nLocals int, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout) (funcHints, error) {
+func scanBodyBytesIntoMemory64WithModule(body []byte, nLocals int, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, gcStructHelpers bool) (funcHints, error) {
 	elig.reset()
 	r := wasm.ReaderFrom(body)
-	s := byteBodyScanner{r: byteScanReader{Reader: r}, h: h, nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, elig: elig, entryPrefix: true, memory64: memory64, m: m, gcTypeLayouts: gcTypeLayouts}
+	s := byteBodyScanner{r: byteScanReader{Reader: r}, h: h, nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, elig: elig, entryPrefix: true, memory64: memory64, m: m, gcTypeLayouts: gcTypeLayouts, gcStructHelpers: gcStructHelpers}
 	called, term, err := s.scanExpr(0, 0, -1, false)
 	if err != nil {
 		return s.h, err
@@ -576,11 +577,12 @@ type byteBodyScanner struct {
 	selfIdx  uint32
 	elig     *globalEligibilityTracker
 
-	entryPrefix   bool
-	entrySeen     uint64
-	memory64      bool
-	m             *wasm.Module
-	gcTypeLayouts []codegen.GCTypeLayout
+	entryPrefix     bool
+	entrySeen       uint64
+	memory64        bool
+	m               *wasm.Module
+	gcTypeLayouts   []codegen.GCTypeLayout
+	gcStructHelpers bool
 }
 
 func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAtElse bool) (bool, byte, error) {
@@ -742,7 +744,7 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				return true, 0, err
 			}
 			s.noteStackArenaOp(op, &imm)
-			if gcOrAtomicInstructionMayCall(imm.Kind) {
+			if gcOrAtomicInstructionMayCall(imm.Kind, s.gcStructHelpers) {
 				s.h.hasCall, subHasCall = true, true
 			}
 			if op == 0xfb {

--- a/src/core/compiler/backend/railshot/amd64/hints.go
+++ b/src/core/compiler/backend/railshot/amd64/hints.go
@@ -31,13 +31,15 @@ func loopWeight(depth int) int64 {
 
 // funcHints is everything scanFuncBody yields.
 type funcHints struct {
-	nLocals       int
-	hasCall       bool // any direct or indirect call
-	hasTailCall   bool // any return_call/return_call_indirect/return_call_ref
-	callsSelf     bool // a direct call to the function's own index
-	touchesMemory bool // any linear-memory op
-	usesBulkMem   bool // memory.copy/fill (rep movs/stos clobber RDI/RSI/RCX)
-	mutatesTable  bool // table.set/init/copy/grow/fill; excludes immutable local-table call_indirect specialization
+	nLocals          int
+	hasCall          bool // any direct or indirect call
+	hasTailCall      bool // any return_call/return_call_indirect/return_call_ref
+	callsSelf        bool // a direct call to the function's own index
+	touchesMemory    bool // any linear-memory op
+	usesBulkMem      bool // memory.copy/fill (rep movs/stos clobber RDI/RSI/RCX)
+	mutatesTable     bool // table.set/init/copy/grow/fill; excludes immutable local-table call_indirect specialization
+	gcResolverSites  int  // conservative direct scalar/length resolver site count
+	gcSharedResolver bool // module decision: shared island beats one-site inline crossover
 
 	// Inline-candidacy signals, gathered in the same pre-scan so buildInlineTargets
 	// needs no second body walk. hasControlFlow matches scanInlineFactsBytes's set
@@ -665,6 +667,11 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				switch imm.Kind {
 				case wasm.InstrStructNew, wasm.InstrStructNewDefault, wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructSet:
 					s.h.hasCall, subHasCall = true, true
+				}
+				switch imm.Kind {
+				case wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructSet,
+					wasm.InstrArrayGet, wasm.InstrArrayGetS, wasm.InstrArrayGetU, wasm.InstrArraySet, wasm.InstrArrayLen:
+					s.h.gcResolverSites++
 				}
 				switch imm.Kind {
 				case wasm.InstrMemoryAtomicNotify, wasm.InstrMemoryAtomicWait32, wasm.InstrMemoryAtomicWait64:

--- a/src/core/compiler/backend/railshot/amd64/hints.go
+++ b/src/core/compiler/backend/railshot/amd64/hints.go
@@ -4,6 +4,7 @@ package amd64
 
 import (
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+	"github.com/wago-org/wago/src/core/compiler/codegen"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
@@ -210,10 +211,71 @@ func scanFuncBodyInto(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, h fun
 }
 
 func scanFuncBodyIntoMemory64(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool) (funcHints, error) {
+	return scanFuncBodyIntoMemory64WithModule(fn, nLocals, nGlobals, selfIdx, h, elig, memory64, nil, nil)
+}
+
+func scanFuncBodyIntoMemory64WithModule(fn wasm.Func, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout) (funcHints, error) {
 	if len(fn.BodyBytes) != 0 {
-		return scanBodyBytesIntoMemory64(fn.BodyBytes, nLocals, nGlobals, selfIdx, h, elig, memory64)
+		return scanBodyBytesIntoMemory64WithModule(fn.BodyBytes, nLocals, nGlobals, selfIdx, h, elig, memory64, m, gcTypeLayouts)
 	}
-	return scanBodyInto(fn.Body, nLocals, nGlobals, selfIdx, h, elig), nil
+	return scanBodyInto(fn.Body, nLocals, nGlobals, selfIdx, h, elig, m, gcTypeLayouts), nil
+}
+
+func gcOrAtomicInstructionMayCall(kind wasm.InstrKind) bool {
+	switch kind {
+	case wasm.InstrStructNew, wasm.InstrStructNewDefault, wasm.InstrStructNewDesc, wasm.InstrStructNewDefaultDesc,
+		wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructAtomicGet, wasm.InstrStructAtomicGetS, wasm.InstrStructAtomicGetU, wasm.InstrStructSet,
+		wasm.InstrArrayNew, wasm.InstrArrayNewDefault, wasm.InstrArrayNewFixed, wasm.InstrArrayNewData, wasm.InstrArrayNewElem,
+		wasm.InstrArrayGet, wasm.InstrArrayGetS, wasm.InstrArrayGetU, wasm.InstrArraySet, wasm.InstrArrayLen,
+		wasm.InstrArrayFill, wasm.InstrArrayCopy, wasm.InstrArrayInitData, wasm.InstrArrayInitElem,
+		wasm.InstrRefGetDesc, wasm.InstrRefTest, wasm.InstrRefCast, wasm.InstrRefTestDesc, wasm.InstrRefCastDescEq, wasm.InstrBrOnCast, wasm.InstrBrOnCastFail,
+		wasm.InstrAnyConvertExtern, wasm.InstrExternConvertAny, wasm.InstrRefI31, wasm.InstrI31GetS, wasm.InstrI31GetU,
+		wasm.InstrMemoryAtomicNotify, wasm.InstrMemoryAtomicWait32, wasm.InstrMemoryAtomicWait64:
+		return true
+	default:
+		return false
+	}
+}
+
+func directGCResolverInstruction(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, kind wasm.InstrKind, typeIndex, fieldIndex uint32) bool {
+	if m == nil {
+		switch kind {
+		case wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructSet,
+			wasm.InstrArrayGet, wasm.InstrArrayGetS, wasm.InstrArrayGetU, wasm.InstrArraySet, wasm.InstrArrayLen:
+			return true
+		default:
+			return false
+		}
+	}
+	switch kind {
+	case wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructSet:
+		if int(typeIndex) < len(gcTypeLayouts) {
+			layout := gcTypeLayouts[typeIndex]
+			if layout.Type != nil && layout.Type.Comp.Kind == wasm.CompStruct && int(fieldIndex) < len(layout.FieldLayout) {
+				_, ok := directGCScalarStorage(layout.Type.Comp.Fields[fieldIndex].Storage())
+				return ok && layout.Type.Final
+			}
+		}
+		_, _, final, ok := directGCStructLayout(m, typeIndex, fieldIndex)
+		return ok && final
+	case wasm.InstrArrayGet, wasm.InstrArrayGetS, wasm.InstrArrayGetU, wasm.InstrArraySet:
+		if int(typeIndex) < len(gcTypeLayouts) {
+			layout := gcTypeLayouts[typeIndex]
+			if layout.Type != nil && layout.Type.Comp.Kind == wasm.CompArray {
+				_, ok := directGCScalarStorage(layout.Type.Comp.Array.Storage())
+				return ok && layout.Type.Final
+			}
+		}
+		_, final, ok := directGCArrayLayout(m, typeIndex)
+		return ok && final
+	case wasm.InstrArrayLen:
+		// array.len has no type immediate. Exact-local dataflow may still select the
+		// direct path, but counting it here can turn one real site plus one abstract
+		// helper site into a code-growing shared island. Keep the crossover strict.
+		return false
+	default:
+		return false
+	}
 }
 
 // scanBody performs the AST pre-scan walk. selfIdx is the function's global
@@ -221,10 +283,10 @@ func scanFuncBodyIntoMemory64(fn wasm.Func, nLocals, nGlobals int, selfIdx uint3
 func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 	h := newFuncHints(nLocals, nGlobals)
 	elig := newGlobalEligibilityTracker(nGlobals)
-	return scanBodyInto(body, nLocals, nGlobals, selfIdx, h, &elig)
+	return scanBodyInto(body, nLocals, nGlobals, selfIdx, h, &elig, nil, nil)
 }
 
-func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker) funcHints {
+func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout) funcHints {
 	elig.reset()
 	// walk returns whether the subtree contains a call. curLoop identifies the
 	// innermost enclosing loop whose globals are being considered for eligibility.
@@ -238,9 +300,12 @@ func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcH
 			case wasm.InstrTryTable, wasm.InstrThrow, wasm.InstrThrowRef:
 				h.moduleEH = true
 			}
+			if gcOrAtomicInstructionMayCall(in.Kind) {
+				h.hasCall, sub = true, true
+			}
 			// Inline-candidacy control-flow signals (matches scanInlineFactsAST).
 			switch in.Kind {
-			case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf,
+			case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf, wasm.InstrTryTable,
 				wasm.InstrBr, wasm.InstrBrIf, wasm.InstrBrTable, wasm.InstrReturn:
 				h.hasControlFlow = true
 				if in.Kind == wasm.InstrLoop {
@@ -288,7 +353,7 @@ func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcH
 					}
 				}
 				elig.pop(loop)
-			case wasm.InstrBlock:
+			case wasm.InstrBlock, wasm.InstrTryTable:
 				if walk(in.Body().Instrs, depth, curLoop) {
 					sub = true
 				}
@@ -301,6 +366,14 @@ func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcH
 				}
 			case wasm.InstrMemoryCopy, wasm.InstrMemoryFill:
 				h.usesBulkMem, h.touchesMemory = true, true
+			case wasm.InstrStructNew, wasm.InstrStructNewDefault, wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructSet:
+				if directGCResolverInstruction(m, gcTypeLayouts, in.Kind, in.Index, in.Index2) {
+					h.gcResolverSites++
+				}
+			case wasm.InstrArrayGet, wasm.InstrArrayGetS, wasm.InstrArrayGetU, wasm.InstrArraySet, wasm.InstrArrayLen:
+				if directGCResolverInstruction(m, gcTypeLayouts, in.Kind, in.Index, in.Index2) {
+					h.gcResolverSites++
+				}
 			case wasm.InstrTableSet, wasm.InstrTableInit, wasm.InstrTableCopy,
 				wasm.InstrTableGrow, wasm.InstrTableFill:
 				h.mutatesTable = true
@@ -475,9 +548,13 @@ func scanBodyBytesMemory64(body []byte, nLocals int, nGlobals int, selfIdx uint3
 }
 
 func scanBodyBytesIntoMemory64(body []byte, nLocals int, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool) (funcHints, error) {
+	return scanBodyBytesIntoMemory64WithModule(body, nLocals, nGlobals, selfIdx, h, elig, memory64, nil, nil)
+}
+
+func scanBodyBytesIntoMemory64WithModule(body []byte, nLocals int, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker, memory64 bool, m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout) (funcHints, error) {
 	elig.reset()
 	r := wasm.ReaderFrom(body)
-	s := byteBodyScanner{r: byteScanReader{Reader: r}, h: h, nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, elig: elig, entryPrefix: true, memory64: memory64}
+	s := byteBodyScanner{r: byteScanReader{Reader: r}, h: h, nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, elig: elig, entryPrefix: true, memory64: memory64, m: m, gcTypeLayouts: gcTypeLayouts}
 	called, term, err := s.scanExpr(0, 0, -1, false)
 	if err != nil {
 		return s.h, err
@@ -499,9 +576,11 @@ type byteBodyScanner struct {
 	selfIdx  uint32
 	elig     *globalEligibilityTracker
 
-	entryPrefix bool
-	entrySeen   uint64
-	memory64    bool
+	entryPrefix   bool
+	entrySeen     uint64
+	memory64      bool
+	m             *wasm.Module
+	gcTypeLayouts []codegen.GCTypeLayout
 }
 
 func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAtElse bool) (bool, byte, error) {
@@ -663,19 +742,16 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				return true, 0, err
 			}
 			s.noteStackArenaOp(op, &imm)
+			if gcOrAtomicInstructionMayCall(imm.Kind) {
+				s.h.hasCall, subHasCall = true, true
+			}
 			if op == 0xfb {
-				switch imm.Kind {
-				case wasm.InstrStructNew, wasm.InstrStructNewDefault, wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructSet:
-					s.h.hasCall, subHasCall = true, true
-				}
 				switch imm.Kind {
 				case wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructSet,
 					wasm.InstrArrayGet, wasm.InstrArrayGetS, wasm.InstrArrayGetU, wasm.InstrArraySet, wasm.InstrArrayLen:
-					s.h.gcResolverSites++
-				}
-				switch imm.Kind {
-				case wasm.InstrMemoryAtomicNotify, wasm.InstrMemoryAtomicWait32, wasm.InstrMemoryAtomicWait64:
-					s.h.hasCall, subHasCall = true, true
+					if directGCResolverInstruction(s.m, s.gcTypeLayouts, imm.Kind, imm.Index, imm.Index2) {
+						s.h.gcResolverSites++
+					}
 				}
 			}
 			if imm.TouchesMemory {

--- a/src/core/compiler/backend/railshot/amd64/hints_test.go
+++ b/src/core/compiler/backend/railshot/amd64/hints_test.go
@@ -337,6 +337,33 @@ func TestModuleGlobalScoreScanSupportsASTBodies(t *testing.T) {
 // per-function hints scan. This pins that merged path to the standalone
 // computeModuleGlobalScores oracle: same aggregate scores, and each cached
 // funcHints must equal an independent computeFuncHints for that function.
+func TestGCHelperHintScannersMarkNativeCalls(t *testing.T) {
+	body := []byte{0x41, 0x00, 0xfb, 0x07, 0x00, 0x1a, 0x0b} // array.new_default 0; drop
+	byteHints, err := scanBodyBytes(body, 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	astHints := scanBody(wasm.Expr{Instrs: []wasm.Instruction{
+		{Kind: wasm.InstrI32Const},
+		{Kind: wasm.InstrArrayNewDefault, Index: 0},
+		{Kind: wasm.InstrDrop},
+	}}, 0, 0, 0)
+	if !byteHints.hasCall || !astHints.hasCall {
+		t.Fatalf("array helper call hints byte/AST = %v/%v, want true/true", byteHints.hasCall, astHints.hasCall)
+	}
+}
+
+func TestASTExceptionHintsReserveHandlerState(t *testing.T) {
+	ast := wasm.Expr{Instrs: []wasm.Instruction{
+		{Kind: wasm.InstrTryTable},
+		{Kind: wasm.InstrArrayNewDefault, Index: 0},
+	}}
+	h := scanBody(ast, 0, 0, 0)
+	if !h.moduleEH || !h.hasControlFlow || !h.hasCall {
+		t.Fatalf("AST exception hints = EH:%v control:%v call:%v, want all true", h.moduleEH, h.hasControlFlow, h.hasCall)
+	}
+}
+
 func TestComputeModuleHintsMatchesGlobalScoreOracle(t *testing.T) {
 	globals := make([]wasm.Global, 4)
 	for i := range globals {
@@ -358,7 +385,7 @@ func TestComputeModuleHintsMatchesGlobalScoreOracle(t *testing.T) {
 		m.Code = append(m.Code, wasm.Func{BodyBytes: b, Locals: wasm.Locals{Runs: []wasm.LocalRun{{Count: 1, Type: wasm.I32}}}})
 	}
 
-	allHints, agg, err := computeModuleHints(m, m.GlobalCount(), 0)
+	allHints, agg, err := computeModuleHints(m, m.GlobalCount(), 0, nil)
 	if err != nil {
 		t.Fatalf("computeModuleHints: %v", err)
 	}

--- a/src/core/compiler/backend/railshot/amd64/hints_test.go
+++ b/src/core/compiler/backend/railshot/amd64/hints_test.go
@@ -353,6 +353,15 @@ func TestGCHelperHintScannersMarkNativeCalls(t *testing.T) {
 	}
 }
 
+func TestGCReferenceHintRequiresHelperAdmission(t *testing.T) {
+	if gcOrAtomicInstructionMayCall(wasm.InstrRefTest, false) {
+		t.Fatal("helper-free ref.test was classified as a call")
+	}
+	if !gcOrAtomicInstructionMayCall(wasm.InstrRefTest, true) {
+		t.Fatal("generic ref.test helper call was not classified")
+	}
+}
+
 func TestASTExceptionHintsReserveHandlerState(t *testing.T) {
 	ast := wasm.Expr{Instrs: []wasm.Instruction{
 		{Kind: wasm.InstrTryTable},
@@ -385,7 +394,7 @@ func TestComputeModuleHintsMatchesGlobalScoreOracle(t *testing.T) {
 		m.Code = append(m.Code, wasm.Func{BodyBytes: b, Locals: wasm.Locals{Runs: []wasm.LocalRun{{Count: 1, Type: wasm.I32}}}})
 	}
 
-	allHints, agg, err := computeModuleHints(m, m.GlobalCount(), 0, nil)
+	allHints, agg, err := computeModuleHints(m, m.GlobalCount(), 0, nil, false)
 	if err != nil {
 		t.Fatalf("computeModuleHints: %v", err)
 	}

--- a/src/core/compiler/backend/railshot/amd64/immutable_table_test.go
+++ b/src/core/compiler/backend/railshot/amd64/immutable_table_test.go
@@ -70,7 +70,7 @@ func TestImmutableLocalTableCallIndirectSpecialization(t *testing.T) {
 	// An exported table can be mutated by another importing instance, so the
 	// specialization must not fire.
 	m.Exports = append(m.Exports, wasm.Export{Name: "table", Index: wasm.ExternIdx{Kind: wasm.ExternTable, Index: 0}})
-	hints, _, err := computeModuleHints(m, m.GlobalCount(), m.ImportedFuncCount())
+	hints, _, err := computeModuleHints(m, m.GlobalCount(), m.ImportedFuncCount(), nil)
 	if err != nil {
 		t.Fatalf("exported-table hints: %v", err)
 	}

--- a/src/core/compiler/backend/railshot/amd64/immutable_table_test.go
+++ b/src/core/compiler/backend/railshot/amd64/immutable_table_test.go
@@ -70,7 +70,7 @@ func TestImmutableLocalTableCallIndirectSpecialization(t *testing.T) {
 	// An exported table can be mutated by another importing instance, so the
 	// specialization must not fire.
 	m.Exports = append(m.Exports, wasm.Export{Name: "table", Index: wasm.ExternIdx{Kind: wasm.ExternTable, Index: 0}})
-	hints, _, err := computeModuleHints(m, m.GlobalCount(), m.ImportedFuncCount(), nil)
+	hints, _, err := computeModuleHints(m, m.GlobalCount(), m.ImportedFuncCount(), nil, false)
 	if err != nil {
 		t.Fatalf("exported-table hints: %v", err)
 	}

--- a/src/core/compiler/backend/railshot/amd64/reloc_test.go
+++ b/src/core/compiler/backend/railshot/amd64/reloc_test.go
@@ -1,0 +1,71 @@
+//go:build amd64
+
+package amd64
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestPatchModuleRelocsValidatesTablesAndSites(t *testing.T) {
+	var stubOffsets [gcSharedStubMax]int
+	for i := range stubOffsets {
+		stubOffsets[i] = -1
+	}
+	tests := []struct {
+		name          string
+		code          []byte
+		entry         []int
+		internalEntry []int
+		relocs        [][]callReloc
+		stubBase      int
+		want          string
+	}{
+		{name: "entry table", code: make([]byte, 8), relocs: make([][]callReloc, 1), want: "entry table"},
+		{name: "function entry", code: make([]byte, 8), entry: []int{9}, relocs: make([][]callReloc, 1), want: "invalid function 0 entry"},
+		{name: "negative site", code: make([]byte, 8), entry: []int{0}, relocs: [][]callReloc{{{at: -1}}}, want: "invalid relocation site"},
+		{name: "truncated site", code: make([]byte, 8), entry: []int{0}, relocs: [][]callReloc{{{at: 5}}}, want: "invalid relocation site"},
+		{name: "missing internal entry", code: make([]byte, 8), entry: []int{0}, relocs: [][]callReloc{{{at: 0, internal: true}}}, want: "missing internal entry"},
+		{name: "missing shared stub", code: make([]byte, 8), entry: []int{0}, relocs: [][]callReloc{{{at: 0, gcStub: gcSharedStubResolveObject}}}, stubBase: -1, want: "missing shared GC stub"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := patchModuleRelocs(tc.code, tc.entry, tc.internalEntry, tc.relocs, tc.stubBase, stubOffsets)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("patch error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPatchModuleRelocsPatchesOrdinaryInternalAndSharedCalls(t *testing.T) {
+	code := make([]byte, 64)
+	entry := []int{0, 32}
+	internalEntry := []int{8, 40}
+	var stubOffsets [gcSharedStubMax]int
+	for i := range stubOffsets {
+		stubOffsets[i] = -1
+	}
+	stubOffsets[gcSharedStubResolveObject] = 4
+	relocs := [][]callReloc{
+		{
+			{at: 0, target: 1},
+			{at: 4, target: 1, internal: true},
+			{at: 8, gcStub: gcSharedStubResolveObject},
+		},
+		nil,
+	}
+	if err := patchModuleRelocs(code, entry, internalEntry, relocs, 48, stubOffsets); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		site, target int
+	}{{0, 32}, {4, 40}, {8, 52}} {
+		got := int32(binary.LittleEndian.Uint32(code[tc.site:]))
+		want := int32(tc.target - (tc.site + 4))
+		if got != want {
+			t.Fatalf("site %#x delta = %d, want %d", tc.site, got, want)
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/amd64/sparse_hints_test.go
+++ b/src/core/compiler/backend/railshot/amd64/sparse_hints_test.go
@@ -12,7 +12,7 @@ func TestComputeModuleHintsRetainsSparseGlobalsPastDenseCutoff(t *testing.T) {
 	const count = 1025
 	body := []byte{0x03, 0x40, 0x23, 0x7b, 0x1a, 0x0b, 0x0b} // loop { global.get 123; drop }
 	m := sparseGlobalHintModule(count, body)
-	hints, aggregate, err := computeModuleHints(m, m.GlobalCount(), 0, nil)
+	hints, aggregate, err := computeModuleHints(m, m.GlobalCount(), 0, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/core/compiler/backend/railshot/amd64/sparse_hints_test.go
+++ b/src/core/compiler/backend/railshot/amd64/sparse_hints_test.go
@@ -12,7 +12,7 @@ func TestComputeModuleHintsRetainsSparseGlobalsPastDenseCutoff(t *testing.T) {
 	const count = 1025
 	body := []byte{0x03, 0x40, 0x23, 0x7b, 0x1a, 0x0b, 0x0b} // loop { global.get 123; drop }
 	m := sparseGlobalHintModule(count, body)
-	hints, aggregate, err := computeModuleHints(m, m.GlobalCount(), 0)
+	hints, aggregate, err := computeModuleHints(m, m.GlobalCount(), 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/core/compiler/backend/railshot/amd64/stats.go
+++ b/src/core/compiler/backend/railshot/amd64/stats.go
@@ -123,11 +123,13 @@ type CodegenStats struct {
 	MemRefsForcedByStore int // deferred loads forced out by a store (P2.1 target)
 
 	// Bounds / traps.
-	BoundsChecks          int // inline memory-OOB checks emitted (P6 elides these)
-	BoundsChecksElidable  int // subset of BoundsChecks a straight-line certificate covers (P6.1 sizing; count-only)
-	BoundsChecksInLoop    int // subset emitted inside a loop on a keyable base (P6.2 loop-precheck ceiling; count-only)
-	BoundsChecksHoistable int // subset on a loop-INVARIANT local base (not set in the loop) — the P6.2 hoistable target; count-only
-	TrapStubs             int // shared cold trap stubs emitted (one per trap code used)
+	BoundsChecks            int // inline memory-OOB checks emitted (P6 elides these)
+	BoundsChecksElidable    int // subset of BoundsChecks a straight-line certificate covers (P6.1 sizing; count-only)
+	BoundsChecksInLoop      int // subset emitted inside a loop on a keyable base (P6.2 loop-precheck ceiling; count-only)
+	BoundsChecksHoistable   int // subset on a loop-INVARIANT local base (not set in the loop) — the P6.2 hoistable target; count-only
+	TrapStubs               int // shared cold trap stubs emitted (one per trap code used)
+	GCHandleResolutions     int // dynamic compact-handle resolutions emitted
+	GCHandleResolutionReuse int // resolutions elided by bounded raw-address reuse
 
 	// Calls, by lowering kind: regabi / mixed / wrapper / host / indirect /
 	// crossinstance / importdispatch.
@@ -230,6 +232,16 @@ func (s *CodegenStats) addPinnedGlobalValue() {
 		s.PinnedGlobalsValue++
 	}
 }
+func (s *CodegenStats) addGCHandleResolution() {
+	if s != nil {
+		s.GCHandleResolutions++
+	}
+}
+func (s *CodegenStats) addGCHandleResolutionReuse() {
+	if s != nil {
+		s.GCHandleResolutionReuse++
+	}
+}
 func (s *CodegenStats) addGCAllocationBytes(n int) {
 	if s != nil && n > 0 {
 		s.GCCodeBytes.Allocation += n
@@ -314,9 +326,12 @@ type ModuleGlobalPinInfo = shared.ModuleGlobalPinInfo
 // ModuleStats aggregates one module's per-function stats plus the module-wide
 // decisions. The zero value is ready to collect into.
 type ModuleStats struct {
-	Funcs            []*CodegenStats
-	ModuleGlobalPins []ModuleGlobalPinInfo
-	Inline           *InlineReport // inline-candidate detection (nil if not analyzed)
+	Funcs                 []*CodegenStats
+	ModuleGlobalPins      []ModuleGlobalPinInfo
+	Inline                *InlineReport // inline-candidate detection (nil if not analyzed)
+	GCSharedStubBytes     int
+	GCSharedStubs         int
+	GCSharedStubCallSites int
 }
 
 // String renders the explain dump: a module summary line, the module-pinned
@@ -327,6 +342,9 @@ func (ms *ModuleStats) String() string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "=== codegen explain: %d function(s) ===\n", len(ms.Funcs))
+	if ms.GCSharedStubs != 0 || ms.GCSharedStubCallSites != 0 {
+		fmt.Fprintf(&b, "module GC leaf stubs: bodies=%d calls=%d bytes=%d\n", ms.GCSharedStubs, ms.GCSharedStubCallSites, ms.GCSharedStubBytes)
+	}
 	if len(ms.ModuleGlobalPins) == 0 {
 		fmt.Fprintf(&b, "module-pinned globals: none (K=0)\n")
 	} else {
@@ -364,6 +382,9 @@ func (s *CodegenStats) report() string {
 		s.Flushes, s.FlushBelows, s.Condenses, s.Spills, s.Reloads, s.MemRefsForcedByStore)
 	fmt.Fprintf(&b, "    mem:   bounds=%d elidable=%d inloop=%d hoistable=%d trapStubs=%d   pins: local=%d gval=%d\n",
 		s.BoundsChecks, s.BoundsChecksElidable, s.BoundsChecksInLoop, s.BoundsChecksHoistable, s.TrapStubs, s.PinnedLocals, s.PinnedGlobalsValue)
+	if s.GCHandleResolutions != 0 || s.GCHandleResolutionReuse != 0 {
+		fmt.Fprintf(&b, "    gcresolve: emitted=%d reused=%d\n", s.GCHandleResolutions, s.GCHandleResolutionReuse)
+	}
 	gcBytes := s.GCCodeBytes
 	if gcBytes.Allocation|gcBytes.HandleResolution|gcBytes.TypeCast|gcBytes.NullCheck|gcBytes.BoundsCheck|gcBytes.Barrier|gcBytes.SpillReload|gcBytes.HelperCall|gcBytes.SharedStub|gcBytes.TrapStub|gcBytes.RootMap != 0 {
 		fmt.Fprintf(&b, "    gcbytes: total=%d alloc=%d resolve=%d cast=%d null=%d bounds=%d barrier=%d spill=%d helper=%d shared=%d trap=%d rootmap=%d\n",

--- a/src/core/compiler/backend/railshot/arm64/hints.go
+++ b/src/core/compiler/backend/railshot/arm64/hints.go
@@ -209,6 +209,22 @@ func scanBody(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32) funcHints {
 	return scanBodyInto(body, nLocals, nGlobals, selfIdx, h, &elig)
 }
 
+func gcOrAtomicInstructionMayCall(kind wasm.InstrKind) bool {
+	switch kind {
+	case wasm.InstrStructNew, wasm.InstrStructNewDefault, wasm.InstrStructNewDesc, wasm.InstrStructNewDefaultDesc,
+		wasm.InstrStructGet, wasm.InstrStructGetS, wasm.InstrStructGetU, wasm.InstrStructAtomicGet, wasm.InstrStructAtomicGetS, wasm.InstrStructAtomicGetU, wasm.InstrStructSet,
+		wasm.InstrArrayNew, wasm.InstrArrayNewDefault, wasm.InstrArrayNewFixed, wasm.InstrArrayNewData, wasm.InstrArrayNewElem,
+		wasm.InstrArrayGet, wasm.InstrArrayGetS, wasm.InstrArrayGetU, wasm.InstrArraySet, wasm.InstrArrayLen,
+		wasm.InstrArrayFill, wasm.InstrArrayCopy, wasm.InstrArrayInitData, wasm.InstrArrayInitElem,
+		wasm.InstrRefGetDesc, wasm.InstrRefTest, wasm.InstrRefCast, wasm.InstrRefTestDesc, wasm.InstrRefCastDescEq, wasm.InstrBrOnCast, wasm.InstrBrOnCastFail,
+		wasm.InstrAnyConvertExtern, wasm.InstrExternConvertAny, wasm.InstrRefI31, wasm.InstrI31GetS, wasm.InstrI31GetU,
+		wasm.InstrMemoryAtomicNotify, wasm.InstrMemoryAtomicWait32, wasm.InstrMemoryAtomicWait64:
+		return true
+	default:
+		return false
+	}
+}
+
 func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcHints, elig *globalEligibilityTracker) funcHints {
 	elig.reset()
 	// walk returns whether the subtree contains a call. curLoop identifies the
@@ -219,13 +235,20 @@ func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcH
 		sub := false
 		for i := range instrs {
 			in := &instrs[i]
+			if gcOrAtomicInstructionMayCall(in.Kind) {
+				sub, h.hasCall = true, true
+			}
 			switch in.Kind {
-			case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf,
+			case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf, wasm.InstrTryTable,
 				wasm.InstrBr, wasm.InstrBrIf, wasm.InstrBrTable, wasm.InstrReturn:
 				h.hasControlFlow = true
 				if in.Kind == wasm.InstrLoop {
 					h.hasLoop = true
 				}
+			}
+			switch in.Kind {
+			case wasm.InstrTryTable, wasm.InstrThrow, wasm.InstrThrowRef:
+				h.moduleEH = true
 			}
 			switch in.Kind {
 			case wasm.InstrCall, wasm.InstrReturnCall, wasm.InstrCallRef, wasm.InstrReturnCallRef:
@@ -262,7 +285,7 @@ func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcH
 					}
 				}
 				elig.pop(loop)
-			case wasm.InstrBlock:
+			case wasm.InstrBlock, wasm.InstrTryTable:
 				if walk(in.Body().Instrs, depth, curLoop) {
 					sub = true
 				}

--- a/src/core/compiler/backend/railshot/arm64/hints_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/hints_arm64_test.go
@@ -30,6 +30,33 @@ func TestTableMutationHints(t *testing.T) {
 	}
 }
 
+func TestGCHelperHintScannersMarkNativeCalls(t *testing.T) {
+	body := []byte{0x41, 0x00, 0xfb, 0x07, 0x00, 0x1a, 0x0b} // array.new_default 0; drop
+	byteHints, err := scanBodyBytes(body, 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	astHints := scanBody(wasm.Expr{Instrs: []wasm.Instruction{
+		{Kind: wasm.InstrI32Const},
+		{Kind: wasm.InstrArrayNewDefault, Index: 0},
+		{Kind: wasm.InstrDrop},
+	}}, 0, 0, 0)
+	if !byteHints.hasCall || !astHints.hasCall {
+		t.Fatalf("array helper call hints byte/AST = %v/%v, want true/true", byteHints.hasCall, astHints.hasCall)
+	}
+}
+
+func TestASTExceptionHintsReserveHandlerState(t *testing.T) {
+	ast := wasm.Expr{Instrs: []wasm.Instruction{
+		{Kind: wasm.InstrTryTable},
+		{Kind: wasm.InstrArrayNewDefault, Index: 0},
+	}}
+	h := scanBody(ast, 0, 0, 0)
+	if !h.moduleEH || !h.hasControlFlow || !h.hasCall {
+		t.Fatalf("AST exception hints = EH:%v control:%v call:%v, want all true", h.moduleEH, h.hasControlFlow, h.hasCall)
+	}
+}
+
 func TestLoopHintReservesLoopScratchPins(t *testing.T) {
 	h, err := scanBodyBytes([]byte{0x03, 0x40, 0x0b, 0x0b}, 0, 0, 0)
 	if err != nil {

--- a/src/core/runtime/gc/collector.go
+++ b/src/core/runtime/gc/collector.go
@@ -159,6 +159,9 @@ const defaultLarge = 32 << 10
 var errCollectorClosed = errors.New("gc: collector closed")
 
 func NewCollector(config Config, types []TypeDesc) (*Collector, error) {
+	if err := ValidateNativeABI(); err != nil {
+		return nil, err
+	}
 	var err error
 	config, err = normalizeConfig(config)
 	if err != nil {

--- a/src/core/runtime/gc/native_view.go
+++ b/src/core/runtime/gc/native_view.go
@@ -1,11 +1,16 @@
 package gc
 
-import "unsafe"
+import (
+	"fmt"
+	"unsafe"
+)
 
 // NativeABIVersion identifies the checked collector metadata layout consumed by
-// generated code. Native code must compare this value before following any
-// pointer. The view is refreshed in place whenever a growable backing slice can
-// relocate; callers must still serialize access with collector mutation.
+// generated code. Artifact loading and instantiation must validate it before
+// publishing the basedata pointer; generated operations then trust that immutable
+// contract while reloading every mutable backing pointer/count they consume. The
+// view is refreshed in place whenever growable backing can relocate, and callers
+// must still serialize access with collector mutation.
 const NativeABIVersion uint32 = 6
 
 // Native handle-entry layout. These constants are part of NativeABIVersion and
@@ -115,6 +120,111 @@ func sliceData[T any](s []T) uintptr {
 	return uintptr(unsafe.Pointer(&s[0]))
 }
 
+// ValidateNativeABI verifies the Go layouts behind the native collector ABI.
+// It belongs at collector/artifact construction boundaries, never in generated
+// hot paths. Any mismatch is fail-closed before native code can follow a field.
+func ValidateNativeABI() error {
+	var entry handleEntry
+	if unsafe.Sizeof(entry) != NativeHandleStride ||
+		unsafe.Offsetof(entry.off) != NativeHandleOffsetOffset ||
+		unsafe.Offsetof(entry.size) != NativeHandleSizeOffset ||
+		unsafe.Offsetof(entry.cardSlot) != NativeHandleCardSlotOffset ||
+		unsafe.Offsetof(entry.space) != NativeHandleSpaceOffset ||
+		unsafe.Offsetof(entry.remembered) != NativeHandleRememberedOffset {
+		return fmt.Errorf("gc: native handle ABI layout mismatch")
+	}
+	var card objectCard
+	if unsafe.Sizeof(card) != NativeObjectCardStride ||
+		unsafe.Offsetof(card.handle) != NativeObjectCardHandleOffset ||
+		unsafe.Offsetof(card.index) != NativeObjectCardStartOffset ||
+		unsafe.Offsetof(card.end) != NativeObjectCardEndOffset ||
+		unsafe.Offsetof(card.next) != NativeObjectCardNextOffset {
+		return fmt.Errorf("gc: native object-card ABI layout mismatch")
+	}
+	var alloc nativeStructAllocState
+	if unsafe.Sizeof(alloc) != NativeStructAllocStateSize ||
+		unsafe.Offsetof(alloc.Epoch) != NativeStructAllocEpochOffset ||
+		unsafe.Offsetof(alloc.Cursor) != NativeStructAllocCursorOffset ||
+		unsafe.Offsetof(alloc.Count) != NativeStructAllocCountOffset ||
+		unsafe.Offsetof(alloc.HandleBase) != NativeStructAllocHandleBaseOffset ||
+		unsafe.Offsetof(alloc.ChunkStart) != NativeStructAllocChunkStartOffset ||
+		unsafe.Offsetof(alloc.ChunkCursor) != NativeStructAllocChunkCursorOffset ||
+		unsafe.Offsetof(alloc.ChunkEnd) != NativeStructAllocChunkEndOffset ||
+		unsafe.Offsetof(alloc.ChunkBump) != NativeStructAllocChunkBumpOffset ||
+		unsafe.Offsetof(alloc.Handles) != NativeStructAllocHandlesOffset {
+		return fmt.Errorf("gc: native allocation-state ABI layout mismatch")
+	}
+	var space NativeSpaceView
+	if unsafe.Sizeof(space) != NativeViewSpaceStride ||
+		unsafe.Offsetof(space.Base) != NativeSpaceBaseOffset ||
+		unsafe.Offsetof(space.Bytes) != NativeSpaceBytesOffset {
+		return fmt.Errorf("gc: native space ABI layout mismatch")
+	}
+	var view NativeCollectorView
+	if unsafe.Sizeof(view) != NativeCollectorViewSize ||
+		unsafe.Offsetof(view.Version) != NativeViewVersionOffset ||
+		unsafe.Offsetof(view.HandleStride) != NativeViewHandleStrideOffset ||
+		unsafe.Offsetof(view.Handles) != NativeViewHandlesOffset ||
+		unsafe.Offsetof(view.HandleCount) != NativeViewHandleCountOffset ||
+		unsafe.Offsetof(view.Spaces) != NativeViewSpacesOffset ||
+		unsafe.Offsetof(view.RefreshGeneration) != NativeViewRefreshGenerationOffset ||
+		unsafe.Offsetof(view.ObjectCards) != NativeViewObjectCardsOffset ||
+		unsafe.Offsetof(view.ObjectCardCount) != NativeViewObjectCardCountOffset ||
+		unsafe.Offsetof(view.NurseryAllocBytes) != NativeViewNurseryAllocBytesOffset ||
+		unsafe.Offsetof(view.StructAllocState) != NativeViewStructAllocStateOffset ||
+		unsafe.Offsetof(view.StructAllocEpoch) != NativeViewStructAllocEpochOffset ||
+		unsafe.Offsetof(view.NurseryBump) != NativeViewNurseryBumpOffset ||
+		unsafe.Offsetof(view.AllocationCount) != NativeViewAllocationCountOffset ||
+		unsafe.Offsetof(view.NurseryObjectMaxBytes) != NativeViewNurseryObjectMaxBytesOffset {
+		return fmt.Errorf("gc: native collector ABI layout mismatch")
+	}
+	var instance NativeInstanceView
+	if unsafe.Offsetof(instance.keepTypes) != NativeInstanceViewABISize ||
+		unsafe.Offsetof(instance.Version) != NativeInstanceViewVersionOffset ||
+		unsafe.Offsetof(instance.Collector) != NativeInstanceViewCollectorOffset ||
+		unsafe.Offsetof(instance.LocalTypes) != NativeInstanceViewLocalTypesOffset ||
+		unsafe.Offsetof(instance.LocalTypeCount) != NativeInstanceViewLocalTypeCountOffset {
+		return fmt.Errorf("gc: native instance ABI layout mismatch")
+	}
+	return nil
+}
+
+// ValidateNativeInstanceView proves the immutable per-instance/native collector
+// contract before native execution. Mutable handle, heap, card, and nursery
+// pointers are intentionally not cached or validated here; generated code must
+// continue reloading and semantically validating them at each access.
+func ValidateNativeInstanceView(view *NativeInstanceView, collector *Collector, localTypeCount uint32) error {
+	if err := ValidateNativeABI(); err != nil {
+		return err
+	}
+	if view == nil {
+		return fmt.Errorf("gc: native instance view is missing")
+	}
+	if collector == nil || collector.closed || collector.nativeView == nil {
+		return fmt.Errorf("gc: native collector view is unavailable")
+	}
+	if view.Version != NativeABIVersion {
+		return fmt.Errorf("gc: native instance ABI version %d unsupported (want %d)", view.Version, NativeABIVersion)
+	}
+	if view.LocalTypeCount != localTypeCount || uint32(len(view.keepTypes)) != localTypeCount {
+		return fmt.Errorf("gc: native local type map count %d does not match module count %d", view.LocalTypeCount, localTypeCount)
+	}
+	if view.LocalTypes != sliceData(view.keepTypes) {
+		return fmt.Errorf("gc: native local type map pointer does not match immutable backing")
+	}
+	collectorPointer := uintptr(unsafe.Pointer(collector.nativeView))
+	if view.Collector != collectorPointer {
+		return fmt.Errorf("gc: native collector view pointer does not match instance collector")
+	}
+	if collector.nativeView.Version != NativeABIVersion {
+		return fmt.Errorf("gc: native collector ABI version %d unsupported (want %d)", collector.nativeView.Version, NativeABIVersion)
+	}
+	if collector.nativeView.HandleStride != NativeHandleStride {
+		return fmt.Errorf("gc: native handle stride %d unsupported (want %d)", collector.nativeView.HandleStride, NativeHandleStride)
+	}
+	return nil
+}
+
 func (c *Collector) initNativeView() {
 	if c.nativeView == nil {
 		c.nativeView = &NativeCollectorView{}
@@ -194,14 +304,29 @@ func (c *Collector) NativeView() *NativeCollectorView {
 // NewNativeInstanceView constructs an instance-owned immutable type-map view.
 // localTypes must remain alive and unchanged for the view's lifetime.
 func NewNativeInstanceView(c *Collector, localTypes []TypeID) *NativeInstanceView {
-	if c == nil || c.nativeView == nil {
+	view, err := BuildNativeInstanceView(c, localTypes)
+	if err != nil {
 		return nil
 	}
-	return &NativeInstanceView{
+	return view
+}
+
+// BuildNativeInstanceView constructs and validates the immutable instance view.
+// Callers that install the pointer into basedata should use this error-returning
+// form so malformed internal state is rejected before native execution.
+func BuildNativeInstanceView(c *Collector, localTypes []TypeID) (*NativeInstanceView, error) {
+	if c == nil || c.nativeView == nil {
+		return nil, fmt.Errorf("gc: native collector view is unavailable")
+	}
+	view := &NativeInstanceView{
 		Version:        NativeABIVersion,
 		Collector:      uintptr(unsafe.Pointer(c.nativeView)),
 		LocalTypes:     sliceData(localTypes),
 		LocalTypeCount: uint32(len(localTypes)),
 		keepTypes:      localTypes,
 	}
+	if err := ValidateNativeInstanceView(view, c, uint32(len(localTypes))); err != nil {
+		return nil, err
+	}
+	return view, nil
 }

--- a/src/core/runtime/gc/native_view_test.go
+++ b/src/core/runtime/gc/native_view_test.go
@@ -113,11 +113,49 @@ func TestNativeInstanceViewPublishesImmutableTypeMap(t *testing.T) {
 	if view == nil || view.Version != NativeABIVersion || view.Collector == 0 || view.LocalTypes == 0 || view.LocalTypeCount != uint32(len(localTypes)) {
 		t.Fatalf("native instance view = %+v", view)
 	}
+	if err := ValidateNativeInstanceView(view, c, uint32(len(localTypes))); err != nil {
+		t.Fatalf("native instance view validation: %v", err)
+	}
 	if len(view.keepTypes) != len(localTypes) || &view.keepTypes[0] != &localTypes[0] {
 		t.Fatal("native instance view did not retain caller-owned type map")
 	}
 	empty := NewNativeInstanceView(c, nil)
 	if empty == nil || empty.LocalTypes != 0 || empty.LocalTypeCount != 0 || empty.Collector != view.Collector {
 		t.Fatalf("empty native instance view = %+v", empty)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*NativeInstanceView)
+	}{
+		{"version", func(v *NativeInstanceView) { v.Version++ }},
+		{"collector", func(v *NativeInstanceView) { v.Collector = 0 }},
+		{"type pointer", func(v *NativeInstanceView) { v.LocalTypes = 0 }},
+		{"type count", func(v *NativeInstanceView) { v.LocalTypeCount-- }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := *view
+			tc.mutate(&bad)
+			if err := ValidateNativeInstanceView(&bad, c, uint32(len(localTypes))); err == nil {
+				t.Fatal("malformed native instance view validated")
+			}
+		})
+	}
+
+	collectorView := c.NativeView()
+	version, stride := collectorView.Version, collectorView.HandleStride
+	collectorView.Version++
+	if err := ValidateNativeInstanceView(view, c, uint32(len(localTypes))); err == nil {
+		t.Fatal("collector ABI version mismatch validated")
+	}
+	collectorView.Version = version
+	collectorView.HandleStride++
+	if err := ValidateNativeInstanceView(view, c, uint32(len(localTypes))); err == nil {
+		t.Fatal("collector handle stride mismatch validated")
+	}
+	collectorView.HandleStride = stride
+	c.Close()
+	if err := ValidateNativeInstanceView(view, c, uint32(len(localTypes))); err == nil {
+		t.Fatal("closed collector native view validated")
 	}
 }

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4017,9 +4017,6 @@ func (in *Instance) invoke(export string, args []uint64, cancel context.Context)
 	if threadedMu := in.lockThreadedInstanceState(); threadedMu != nil {
 		defer threadedMu.Unlock()
 	}
-	if err := validateNativeGCEntry(in); err != nil {
-		return nil, fmt.Errorf("invoke %q: %w", export, err)
-	}
 	ic := in.findInvokeCache(export)
 	if ic == nil {
 		var err error
@@ -4143,9 +4140,6 @@ func (in *Instance) invokeLocalContext(li int, args []uint64, cancel context.Con
 // exactly as for a native dynamic import call. attachedResult permits first-time
 // funcref tokenization to transfer the attachment's finalization lifetime.
 func (in *Instance) invokeAttachedLocalContext(li int, args []uint64, cancel context.Context, activeTrap []byte, attachedResult bool) ([]uint64, error) {
-	if err := validateNativeGCEntry(in); err != nil {
-		return nil, fmt.Errorf("invoke function %d: %w", li, err)
-	}
 	if li < 0 || li >= len(in.c.Funcs) || li >= len(in.c.Entry) {
 		return nil, fmt.Errorf("invalid function index %d", li)
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1374,6 +1374,10 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	if err != nil {
 		return nil, fmt.Errorf("type metadata: %w", err)
 	}
+	nativeGCABIVersion := uint32(0)
+	if genericGCExecution || gcStructProduct.requiresHelpers() || gcArrayProduct.requiresHelpers() || gcStructProduct.requiresArrayHelpers() {
+		nativeGCABIVersion = gc.NativeABIVersion
+	}
 	c := &Compiled{code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Types: types, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, memoryDir: &compiledMemoryDirectory{exports: map[string]int{}, exactExports: true, staged: features.MultiMemory && (m.MemCount() > 1 || m.ImportedMemCount() > 0), stagedMemory64: features.Memory64 && usesMemory64}, boundsMode: boundsMode, stagedTable64: features.Table64 && usesTable64, GCTypeDescs: gcDescs, requiredFeatures: requiredByModule, dynamicImports: importedFuncs > 0, customInstructions: customInstructions, requiresBMI2: cm.RequiresBMI2, requiresAVX2: cm.RequiresAVX2, requiresAVX512: cm.RequiresAVX512, hasGCCodeTelemetry: cfg.gcCodeTelemetry}
 	if cfg.gcCodeTelemetry {
 		c.gcCodeTelemetry = railshotGCNativeCodeTelemetry(&gcCodeStats)
@@ -1876,6 +1880,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 		c.Data = append(c.Data, init)
 	}
 	compiled := installCompiledFinalizer(c)
+	compiled.codeCache.setNativeGCABIVersion(nativeGCABIVersion)
 	if cm.CodeImage != nil {
 		mapping, base, err := cm.CodeImage.Take()
 		if err != nil {
@@ -1936,7 +1941,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	}
 	if structuralProduct != 0 {
 		compiled.codeCache.stagedFeatures |= CoreFeatureGC
-		compiled.codeCache.collectorFreeStructuralMetadata = true
+		compiled.codeCache.gcMetadataFlags |= compiledGCMetadataCollectorFreeStructural
 	}
 	if gcTypeSubtypingProduct != 0 {
 		compiled.codeCache.stagedFeatures |= CoreFeatureGC
@@ -1955,7 +1960,9 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	if gcArrayProduct != 0 {
 		compiled.codeCache.stagedFeatures |= CoreFeatureGC
 		compiled.codeCache.gcArrayProduct = gcArrayProduct
-		compiled.codeCache.collectorFreeGCArrayMetadata = gcArrayProduct.metadataOnly()
+		if gcArrayProduct.metadataOnly() {
+			compiled.codeCache.gcMetadataFlags |= compiledGCMetadataCollectorFreeArray
+		}
 	}
 	if gcI31Product != 0 {
 		compiled.codeCache.stagedFeatures |= CoreFeatureGC
@@ -3089,6 +3096,17 @@ func (c *Compiled) validate() error {
 	if err := gc.ValidateTypeDescs(c.GCTypeDescs); err != nil {
 		return fmt.Errorf("compiled metadata invalid: GCTypeDescs: %w", err)
 	}
+	needsNativeGCABI := c.usesGenericGCExecution() || c.usesGCStructHelpers() || c.usesGCArrayHelpers()
+	if needsNativeGCABI {
+		if c.nativeGCABIRequirement() != gc.NativeABIVersion {
+			return fmt.Errorf("compiled metadata invalid: native GC ABI version %d unsupported (want %d)", c.nativeGCABIRequirement(), gc.NativeABIVersion)
+		}
+		if err := gc.ValidateNativeABI(); err != nil {
+			return fmt.Errorf("compiled metadata invalid: native GC ABI: %w", err)
+		}
+	} else if c.nativeGCABIRequirement() != 0 {
+		return fmt.Errorf("compiled metadata invalid: native GC ABI version %d recorded without native GC execution", c.nativeGCABIRequirement())
+	}
 	if err := c.validateArenaFootprint(); err != nil {
 		return err
 	}
@@ -3708,10 +3726,12 @@ const wagoMagic = "WAGO"
 // Version 33 replaces the positional outer stream with strict length-delimited
 // code and metadata sections. Version 34 binds generated constructors to native
 // collector ABI v6 and the static-array helper IDs; older native code is rejected
-// rather than silently mixing allocation ticket layouts.
+// rather than silently mixing allocation ticket layouts. Version 35 records the
+// required native-GC ABI for generic struct/array execution and rejects missing or
+// mismatched contracts before native code can run.
 // The codec never serializes live owners, collector handles, mappings, tokens,
 // active handlers, thunk addresses, or store identity.
-const wagoVersion = 34
+const wagoVersion = 35
 
 // MarshalBinary serializes the precompiled module to a ".wago" blob.
 //
@@ -3997,6 +4017,9 @@ func (in *Instance) invoke(export string, args []uint64, cancel context.Context)
 	if threadedMu := in.lockThreadedInstanceState(); threadedMu != nil {
 		defer threadedMu.Unlock()
 	}
+	if err := validateNativeGCEntry(in); err != nil {
+		return nil, fmt.Errorf("invoke %q: %w", export, err)
+	}
 	ic := in.findInvokeCache(export)
 	if ic == nil {
 		var err error
@@ -4120,6 +4143,9 @@ func (in *Instance) invokeLocalContext(li int, args []uint64, cancel context.Con
 // exactly as for a native dynamic import call. attachedResult permits first-time
 // funcref tokenization to transfer the attachment's finalization lifetime.
 func (in *Instance) invokeAttachedLocalContext(li int, args []uint64, cancel context.Context, activeTrap []byte, attachedResult bool) ([]uint64, error) {
+	if err := validateNativeGCEntry(in); err != nil {
+		return nil, fmt.Errorf("invoke function %d: %w", li, err)
+	}
 	if li < 0 || li >= len(in.c.Funcs) || li >= len(in.c.Entry) {
 		return nil, fmt.Errorf("invalid function index %d", li)
 	}

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -10,6 +10,7 @@ import (
 )
 
 type compiledCodeCacheFlags uint8
+type compiledGCMetadataFlags uint8
 
 const (
 	compiledCacheDynamicFuncRefTest compiledCodeCacheFlags = 1 << iota
@@ -21,20 +22,26 @@ const (
 	compiledCacheGCRootFailureMask  = compiledCodeCacheFlags(0xf0)
 )
 
+const (
+	compiledGCMetadataCollectorFreeStructural compiledGCMetadataFlags = 1 << iota
+	compiledGCMetadataCollectorFreeArray
+	compiledGCMetadataNativeABIShift = 2
+	compiledGCMetadataNativeABIMask  = compiledGCMetadataFlags(0xfc)
+)
+
 type compiledCodeCache struct {
-	mu                              sync.Mutex
-	mem                             []byte
-	base                            uintptr
-	refs                            int
-	closed                          bool
-	collectorFreeStructuralMetadata bool                         // exact staged products use struct descriptors only for function identity
-	collectorFreeGCArrayMetadata    bool                         // exact staged array declaration/binding products allocate no collector
-	gcTypeSubtypingProduct          stagedGCTypeSubtypingProduct // exact first gc/type-subtyping no-object product; never serialized
-	gcStructProduct                 stagedGCStructProduct        // exact products stay compile-only; codec v30 may restore generic helper admission
-	gcArrayProduct                  stagedGCArrayProduct         // exact products stay compile-only; codec v30 may restore generic helper admission
-	gcI31Product                    stagedGCI31Product           // exact non-allocating i31 boundary; never serialized
-	flags                           compiledCodeCacheFlags       // compact compile-only native dispatch and memory preferences
-	stagedFeatures                  CoreFeatures                 // exact admission is compile-only; codec v30 restores generic GC requirements
+	mu                     sync.Mutex
+	mem                    []byte
+	base                   uintptr
+	refs                   int
+	closed                 bool
+	gcMetadataFlags        compiledGCMetadataFlags      // collector-free markers plus native-GC ABI version
+	gcTypeSubtypingProduct stagedGCTypeSubtypingProduct // exact first gc/type-subtyping no-object product; never serialized
+	gcStructProduct        stagedGCStructProduct        // exact products stay compile-only; codec v30 may restore generic helper admission
+	gcArrayProduct         stagedGCArrayProduct         // exact products stay compile-only; codec v30 may restore generic helper admission
+	gcI31Product           stagedGCI31Product           // exact non-allocating i31 boundary; never serialized
+	flags                  compiledCodeCacheFlags       // compact compile-only native dispatch and memory preferences
+	stagedFeatures         CoreFeatures                 // exact admission is compile-only; codec v30 restores generic GC requirements
 }
 
 func installCompiledFinalizer(c *Compiled) *Compiled {
@@ -135,7 +142,7 @@ func (c *Compiled) stagedFeatures() CoreFeatures {
 }
 
 func (c *Compiled) collectorFreeStructuralMetadata() bool {
-	return c != nil && c.codeCache != nil && c.codeCache.collectorFreeStructuralMetadata
+	return c != nil && c.codeCache != nil && c.codeCache.gcMetadataFlags&compiledGCMetadataCollectorFreeStructural != 0
 }
 
 func (c *Compiled) stagedGCTypeSubtypingProduct() stagedGCTypeSubtypingProduct {
@@ -154,7 +161,7 @@ func (c *Compiled) usesGCArrayHelpers() bool {
 }
 
 func (c *Compiled) collectorFreeGCArrayMetadata() bool {
-	return c != nil && c.codeCache != nil && c.codeCache.collectorFreeGCArrayMetadata
+	return c != nil && c.codeCache != nil && c.codeCache.gcMetadataFlags&compiledGCMetadataCollectorFreeArray != 0
 }
 
 func (c *Compiled) stagedGCStructProduct() stagedGCStructProduct {
@@ -177,6 +184,21 @@ func (c *Compiled) usesGenericGCExecution() bool {
 	}
 	arrayProduct := c.stagedGCArrayProduct()
 	return c.stagedGCStructProduct() == stagedGCStructGeneric || arrayProduct == stagedGCArrayProductNewData || arrayProduct == stagedGCArrayProductNewElem || arrayProduct == stagedGCArrayProductGeneric
+}
+
+func (c *Compiled) nativeGCABIRequirement() uint32 {
+	if c == nil || c.codeCache == nil {
+		return 0
+	}
+	return uint32(c.codeCache.gcMetadataFlags&compiledGCMetadataNativeABIMask) >> compiledGCMetadataNativeABIShift
+}
+
+func (c *compiledCodeCache) setNativeGCABIVersion(version uint32) {
+	if c == nil || version > uint32(compiledGCMetadataNativeABIMask>>compiledGCMetadataNativeABIShift) {
+		panic("wago: native GC ABI version exceeds compact metadata field")
+	}
+	c.gcMetadataFlags = c.gcMetadataFlags&^compiledGCMetadataNativeABIMask |
+		compiledGCMetadataFlags(version<<compiledGCMetadataNativeABIShift)
 }
 
 // compiledGCFrameRoots is the immutable codec-v33 admission sidecar for bounded

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -339,6 +339,9 @@ func marshalCompiledMetadataMeasured(c *Compiled) ([]byte, ArtifactSectionSizes,
 	w.u64(required)
 	sizes.Features += int64(len(w.buf) - start)
 	start = len(w.buf)
+	if required&(compiledGCExecutionGenericStruct|compiledGCExecutionGenericArray) != 0 {
+		w.u32(c.nativeGCABIRequirement())
+	}
 	w.gcTypeDescs(c.GCTypeDescs)
 	if err := validateCompiledGCFrameRoots(c, c.genericGCFrameRoots()); err != nil {
 		return nil, sizes, err
@@ -905,6 +908,17 @@ func unmarshalCompiledMetadata(c *Compiled, data []byte) error {
 	gcExecution := required & compiledGCExecutionMask
 	c.requiresBMI2 = required&compiledCPUFeatureBMI2 != 0
 	c.requiredFeatures = CoreFeatures(required &^ (compiledAtomicWaitExecution | compiledGCExecutionMask | compiledCPUFeatureBMI2))
+	if gcExecution&(compiledGCExecutionGenericStruct|compiledGCExecutionGenericArray) != 0 {
+		nativeGCABIVersion, readErr := r.u32()
+		if readErr != nil {
+			return fmt.Errorf("generic GC native ABI version: %w", readErr)
+		}
+		if nativeGCABIVersion != gc.NativeABIVersion {
+			return fmt.Errorf("generic GC native ABI version %d unsupported (want %d)", nativeGCABIVersion, gc.NativeABIVersion)
+		}
+		c.ensureCodeCache()
+		c.codeCache.setNativeGCABIVersion(nativeGCABIVersion)
+	}
 	c.GCTypeDescs, err = r.gcTypeDescs()
 	if err != nil {
 		return err

--- a/src/wago/codec_hardening_test.go
+++ b/src/wago/codec_hardening_test.go
@@ -191,8 +191,8 @@ func TestCompiledCodecRoundTripsReferenceSignatures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	if blob[4] != wagoVersion || wagoVersion != 34 {
-		t.Fatalf("compiled codec version = %d, want native-allocation ABI version 34", blob[4])
+	if blob[4] != wagoVersion || wagoVersion != 35 {
+		t.Fatalf("compiled codec version = %d, want native-GC ABI contract version 35", blob[4])
 	}
 	for _, version := range []byte{19, 20, 30, 31} {
 		oldVersion := append([]byte(nil), blob...)

--- a/src/wago/codec_reference_test.go
+++ b/src/wago/codec_reference_test.go
@@ -8,13 +8,13 @@ import (
 	"testing"
 )
 
-func TestCompiledCodecV34VersionContract(t *testing.T) {
+func TestCompiledCodecV35VersionContract(t *testing.T) {
 	blob, err := (&Compiled{}).MarshalBinary()
 	if err != nil {
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	if got := blob[4]; got != 34 {
-		t.Fatalf("compiled codec version = %d, want 34", got)
+	if got := blob[4]; got != wagoVersion || wagoVersion != 35 {
+		t.Fatalf("compiled codec version = %d, want native-GC ABI contract version 35", got)
 	}
 
 	for _, version := range []byte{33, 32, 31, 30, 26, 25, 24, 23, 22} {
@@ -160,8 +160,8 @@ func TestCompiledCodecV21RequiredFeatureBitsAreExactAndFailClosed(t *testing.T) 
 		t.Fatalf("marshal forged generic-GC fixture: %v", err)
 	}
 	binary.LittleEndian.PutUint64(blob[len(blob)-9:len(blob)-1], compiledGCExecutionGenericArray)
-	if err := decoded.UnmarshalBinary(blob); err == nil || !strings.Contains(err.Error(), "require recorded GC heap metadata") {
-		t.Fatalf("forged generic GC execution error = %v, want fail-closed rejection", err)
+	if err := decoded.UnmarshalBinary(blob); err == nil || !strings.Contains(err.Error(), "generic GC native ABI version") {
+		t.Fatalf("forged generic GC execution error = %v, want fail-closed ABI rejection", err)
 	}
 }
 

--- a/src/wago/gc_exec_arm64_test.go
+++ b/src/wago/gc_exec_arm64_test.go
@@ -5,6 +5,7 @@ package wago
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -22,6 +23,36 @@ func arm64GCStructModule() []byte {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("roundtrip", 0, 0))),
 		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
 	)
+}
+
+func TestARM64GCNativeABIArtifactAndInstantiationPreflight(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), arm64GCStructModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	if got := compiled.nativeGCABIRequirement(); got != gc.NativeABIVersion {
+		t.Fatalf("native GC ABI = %d, want %d", got, gc.NativeABIVersion)
+	}
+	in, err := instantiateCore(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gc.ValidateNativeInstanceView(in.gcNativeView, in.gc, uint32(len(in.c.Types))); err != nil {
+		t.Fatalf("instantiated native GC view: %v", err)
+	}
+	_ = in.Close()
+
+	compiled.codeCache.setNativeGCABIVersion(gc.NativeABIVersion + 1)
+	blob, err := marshalCompiled(compiled)
+	compiled.codeCache.setNativeGCABIVersion(gc.NativeABIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var loaded Compiled
+	if err := loaded.UnmarshalBinary(blob); err == nil || !strings.Contains(err.Error(), "native ABI version") {
+		t.Fatalf("mismatched native GC artifact = %v", err)
+	}
 }
 
 func arm64GCReferenceConstructorModule() []byte {

--- a/src/wago/gc_native_entry_guard_debug.go
+++ b/src/wago/gc_native_entry_guard_debug.go
@@ -1,0 +1,27 @@
+//go:build wagodebug
+
+package wago
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/wago-org/wago/src/core/runtime/gc"
+)
+
+// validateNativeGCEntry retains a coarse hardened assertion at the untrusted
+// Go-to-native boundary without charging every production GC access. It checks
+// only immutable ABI/view facts; mutable collector backing remains dynamically
+// validated by generated semantic access code.
+func validateNativeGCEntry(in *Instance) error {
+	if in == nil || in.gcNativeView == nil {
+		return nil
+	}
+	if in.jm == nil || in.jm.GCNativeViewPtr() != uintptr(unsafe.Pointer(in.gcNativeView)) {
+		return fmt.Errorf("wagodebug: native GC basedata view pointer mismatch")
+	}
+	if err := gc.ValidateNativeInstanceView(in.gcNativeView, in.gc, uint32(len(in.c.Types))); err != nil {
+		return fmt.Errorf("wagodebug: native GC entry: %w", err)
+	}
+	return nil
+}

--- a/src/wago/gc_native_entry_guard_debug.go
+++ b/src/wago/gc_native_entry_guard_debug.go
@@ -9,6 +9,8 @@ import (
 	"github.com/wago-org/wago/src/core/runtime/gc"
 )
 
+const nativeGCEntryValidationEnabled = true
+
 // validateNativeGCEntry retains a coarse hardened assertion at the untrusted
 // Go-to-native boundary without charging every production GC access. It checks
 // only immutable ABI/view facts; mutable collector backing remains dynamically

--- a/src/wago/gc_native_entry_guard_debug_test.go
+++ b/src/wago/gc_native_entry_guard_debug_test.go
@@ -1,0 +1,27 @@
+//go:build linux && amd64 && !tinygo && !wago_guardpage && wagodebug
+
+package wago
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/runtime/gc"
+)
+
+func TestDebugNativeGCEntryGuardRejectsMutatedImmutableView(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), v128StructModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := instantiateCore(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	in.gcNativeView.Version = gc.NativeABIVersion + 1
+	if _, err := in.Invoke("default"); err == nil || !strings.Contains(err.Error(), "native GC entry") {
+		t.Fatalf("debug entry guard error = %v", err)
+	}
+}

--- a/src/wago/gc_native_entry_guard_debug_test.go
+++ b/src/wago/gc_native_entry_guard_debug_test.go
@@ -20,6 +20,13 @@ func TestDebugNativeGCEntryGuardRejectsMutatedImmutableView(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer in.Close()
+	// JobMemory basedata may still describe the last tenant until beginNativeEntry
+	// rebinds this instance's captured context. The guard belongs after that bind,
+	// not at the outer Invoke layer.
+	in.jm.SetGCNativeViewPtr(0)
+	if _, err := in.Invoke("default"); err != nil {
+		t.Fatalf("debug entry guard rejected rebindable stale basedata: %v", err)
+	}
 	in.gcNativeView.Version = gc.NativeABIVersion + 1
 	if _, err := in.Invoke("default"); err == nil || !strings.Contains(err.Error(), "native GC entry") {
 		t.Fatalf("debug entry guard error = %v", err)

--- a/src/wago/gc_native_entry_guard_release.go
+++ b/src/wago/gc_native_entry_guard_release.go
@@ -2,4 +2,6 @@
 
 package wago
 
+const nativeGCEntryValidationEnabled = false
+
 func validateNativeGCEntry(*Instance) error { return nil }

--- a/src/wago/gc_native_entry_guard_release.go
+++ b/src/wago/gc_native_entry_guard_release.go
@@ -1,0 +1,5 @@
+//go:build !wagodebug
+
+package wago
+
+func validateNativeGCEntry(*Instance) error { return nil }

--- a/src/wago/gc_native_hotpath_release_amd64_test.go
+++ b/src/wago/gc_native_hotpath_release_amd64_test.go
@@ -1,0 +1,38 @@
+//go:build linux && amd64 && !tinygo && !wago_guardpage && !wagodebug
+
+package wago
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/runtime/gc"
+)
+
+// TestNativeGCHotPathDoesNotRecheckImmutableABI proves the production hot path
+// consumes the trusted instantiation result rather than reloading version/count/
+// stride guards on every operation. Dynamic handle/backing/object/type checks are
+// still exercised by the allocation plus direct get.
+func TestNativeGCHotPathDoesNotRecheckImmutableABI(t *testing.T) {
+	compiled, err := compileStagedGCArray(stagedGCArrayNumericLocalBytes(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := instantiateCore(compiled, InstantiateOptions{GC: GCConfig{DisableCollection: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	collector := in.gc.NativeView()
+	in.gcNativeView.Version = gc.NativeABIVersion + 1
+	in.gcNativeView.LocalTypeCount = 0
+	collector.Version = gc.NativeABIVersion + 1
+	collector.HandleStride = gc.NativeHandleStride + 4
+	if got, err := in.Invoke("get", 1, 0); err != nil || len(got) != 1 || got[0] != 0 {
+		t.Fatalf("trusted immutable ABI hot path = %v, %v", got, err)
+	}
+	in.gcNativeView.Version = gc.NativeABIVersion
+	in.gcNativeView.LocalTypeCount = uint32(len(in.c.Types))
+	collector.Version = gc.NativeABIVersion
+	collector.HandleStride = gc.NativeHandleStride
+}

--- a/src/wago/gc_native_resolver_amd64_test.go
+++ b/src/wago/gc_native_resolver_amd64_test.go
@@ -1,0 +1,87 @@
+//go:build linux && amd64 && !tinygo && !wago_guardpage
+
+package wago
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func gcNativeResolverReuseModule() []byte {
+	body := []byte{
+		0x01, 0x01, 0x63, 0x00, // one nullable (ref 0) local
+		0xfb, 0x01, 0x00, 0x21, 0x00, // struct.new_default 0; local.set 0
+	}
+	for i := 0; i < 8; i++ {
+		body = append(body, 0x20, 0x00, 0xfb, 0x02, 0x00, 0x00)
+	}
+	for i := 1; i < 8; i++ {
+		body = append(body, 0x6a) // sum all zero-valued fields after the safe reuse region
+	}
+	body = append(body, 0x0b)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			[]byte{0x5f, 0x01, 0x7f, 0x00},
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
+func TestGCNativeResolverTelemetryAttributesModuleStub(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3).WithGCCodeTelemetry(true), gcNativeResolverReuseModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	telemetry, ok := compiled.GCNativeCodeTelemetry()
+	if !ok || telemetry.SharedStubBytes == 0 || telemetry.HandleResolutionBytes == 0 || telemetry.TotalBytes != uint64(compiled.CodeSize()) {
+		t.Fatalf("native resolver telemetry = %+v, enabled=%v", telemetry, ok)
+	}
+}
+
+func TestGCNativeResolverReuseExecution(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), gcNativeResolverReuseModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := instantiateCore(compiled, InstantiateOptions{GC: GCConfig{DisableCollection: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	for i := 0; i < 1000; i++ {
+		got, err := in.Invoke("run")
+		if err != nil || len(got) != 1 || got[0] != 0 {
+			t.Fatalf("iteration %d = %v, %v", i, got, err)
+		}
+	}
+}
+
+// BenchmarkGCNativeResolverReuse is intended for process-level differential
+// runs with WAGO_AMD64_NO_GC_RESOLVE_REUSE and WAGO_AMD64_NO_GC_SHARED_STUBS.
+func BenchmarkGCNativeResolverReuse(b *testing.B) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), gcNativeResolverReuseModule())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := instantiateCore(compiled, InstantiateOptions{GC: GCConfig{DisableCollection: true, ThroughputHeapBytes: 64 << 20}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer in.Close()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := in.Invoke("run")
+		if err != nil || len(got) != 1 || got[0] != 0 {
+			b.Fatalf("run = %v, %v", got, err)
+		}
+	}
+}

--- a/src/wago/gc_native_resolver_amd64_test.go
+++ b/src/wago/gc_native_resolver_amd64_test.go
@@ -32,8 +32,28 @@ func gcNativeResolverReuseModule() []byte {
 	)
 }
 
+func gcNativeResolverSharedModule() []byte {
+	body := []byte{
+		0x00,
+		0xfb, 0x01, 0x00, // struct.new_default 0
+		0xfb, 0x02, 0x00, 0x00, // struct.get 0 0
+		0x0b,
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			[]byte{0x5f, 0x01, 0x7f, 0x00},
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(1))),
+		wasmtest.Section(10, wasmtest.Vec(
+			append(wasmtest.ULEB(uint32(len(body))), body...),
+			append(wasmtest.ULEB(uint32(len(body))), body...),
+		)),
+	)
+}
+
 func TestGCNativeResolverTelemetryAttributesModuleStub(t *testing.T) {
-	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3).WithGCCodeTelemetry(true), gcNativeResolverReuseModule())
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3).WithGCCodeTelemetry(true), gcNativeResolverSharedModule())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/wago/gc_native_struct_alloc_amd64_test.go
+++ b/src/wago/gc_native_struct_alloc_amd64_test.go
@@ -72,8 +72,13 @@ func TestGCNativeStructAllocMalformedMetadataFallsBack(t *testing.T) {
 	view.StructAllocState = state
 	stride := view.HandleStride
 	view.HandleStride++
-	if got, err := fn.Invoke(lo+2, hi+2); err != nil || !reflect.DeepEqual(got, []uint64{lo + 2, hi + 2}) {
-		t.Fatalf("bad handle-stride fallback = %#x, %v", got, err)
+	got, invokeErr := fn.Invoke(lo+2, hi+2)
+	if nativeGCEntryValidationEnabled {
+		if invokeErr == nil {
+			t.Fatalf("wagodebug accepted mutated immutable handle stride: %#x", got)
+		}
+	} else if invokeErr != nil || !reflect.DeepEqual(got, []uint64{lo + 2, hi + 2}) {
+		t.Fatalf("trusted immutable handle stride hot path = %#x, %v", got, invokeErr)
 	}
 	view.HandleStride = stride
 }

--- a/src/wago/gc_native_view_amd64_test.go
+++ b/src/wago/gc_native_view_amd64_test.go
@@ -10,6 +10,29 @@ import (
 	"github.com/wago-org/wago/src/core/runtime/gc"
 )
 
+func TestCompiledGenericGCArtifactRejectsNativeABIMismatch(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), v128StructModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	if got := compiled.nativeGCABIRequirement(); got != gc.NativeABIVersion {
+		t.Fatalf("compiled native GC ABI = %d, want %d", got, gc.NativeABIVersion)
+	}
+	for _, version := range []uint32{0, gc.NativeABIVersion + 1} {
+		compiled.codeCache.setNativeGCABIVersion(version)
+		blob, err := marshalCompiled(compiled)
+		compiled.codeCache.setNativeGCABIVersion(gc.NativeABIVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var loaded Compiled
+		if err := loaded.UnmarshalBinary(blob); err == nil || !strings.Contains(err.Error(), "native ABI version") {
+			t.Fatalf("native GC ABI version %d load = %v", version, err)
+		}
+	}
+}
+
 func TestNativeGCViewVersionAndAllocationRefresh(t *testing.T) {
 	compiled, err := compileStagedGCArray(stagedGCArrayNumericLocalBytes(t))
 	if err != nil {
@@ -30,11 +53,15 @@ func TestNativeGCViewVersionAndAllocationRefresh(t *testing.T) {
 	}
 
 	in.gcNativeView.Version = gc.NativeABIVersion + 1
-	if _, err := in.Invoke("get", 1, 0); err == nil || !strings.Contains(err.Error(), "cast failure") {
-		t.Fatalf("instance-view version mismatch = %v", err)
+	if err := gc.ValidateNativeInstanceView(in.gcNativeView, in.gc, uint32(len(in.c.Types))); err == nil || !strings.Contains(err.Error(), "instance ABI version") {
+		t.Fatalf("instance-view preflight mismatch = %v", err)
 	}
 	in.gcNativeView.Version = gc.NativeABIVersion
 	collectorView.Version = gc.NativeABIVersion + 1
+	if err := gc.ValidateNativeInstanceView(in.gcNativeView, in.gc, uint32(len(in.c.Types))); err == nil || !strings.Contains(err.Error(), "collector ABI version") {
+		t.Fatalf("collector-view preflight mismatch = %v", err)
+	}
+	collectorView.Version = gc.NativeABIVersion
 	if got, err := in.Invoke("get", 1, 0); err != nil || len(got) != 1 || got[0] != 0 {
 		t.Fatalf("allocation-refreshed collector view = %v, %v", got, err)
 	}

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -30,7 +30,7 @@ func (in *Instance) beginNativeEntry() (executionLease, error) {
 	if in.c.threadedMemory0() {
 		mu := &in.memoryDir.nativeMu
 		mu.Lock()
-		if err := in.bindNativeContext(); err != nil {
+		if err := in.bindAndValidateNativeContext(); err != nil {
 			mu.Unlock()
 			return executionLease{}, err
 		}
@@ -38,11 +38,18 @@ func (in *Instance) beginNativeEntry() (executionLease, error) {
 	}
 	nativeExecutionMu.Lock()
 	nativeExecutionEpoch++
-	if err := in.bindNativeContext(); err != nil {
+	if err := in.bindAndValidateNativeContext(); err != nil {
 		nativeExecutionMu.Unlock()
 		return executionLease{}, err
 	}
 	return executionLease{}, nil
+}
+
+func (in *Instance) bindAndValidateNativeContext() error {
+	if err := in.bindNativeContext(); err != nil {
+		return err
+	}
+	return validateNativeGCEntry(in)
 }
 
 func (in *Instance) bindNativeContext() error {
@@ -169,6 +176,9 @@ func (in *Instance) callPreparedPrivate(entry uintptr, activeTrap []byte) error 
 	nativeExecutionMu.Lock()
 	nativeExecutionEpoch++
 	defer nativeExecutionMu.Unlock()
+	if err := validateNativeGCEntry(in); err != nil {
+		return err
+	}
 	if err := refreshNativeControl(true, in.eng, in.jm, activeTrap); err != nil {
 		return err
 	}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -1352,9 +1352,9 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 			}
 			gcNativeTypes[local] = domain
 		}
-		gcNativeView = gc.NewNativeInstanceView(b.collector, gcNativeTypes)
-		if gcNativeView == nil {
-			return nil, fmt.Errorf("instantiate: native GC metadata view is unavailable")
+		gcNativeView, err = gc.BuildNativeInstanceView(b.collector, gcNativeTypes)
+		if err != nil {
+			return nil, fmt.Errorf("instantiate: native GC metadata view: %w", err)
 		}
 		jm.SetGCNativeViewPtr(uintptr(unsafe.Pointer(gcNativeView)))
 	}

--- a/src/wago/memory_directory_test.go
+++ b/src/wago/memory_directory_test.go
@@ -26,8 +26,8 @@ func TestCompiledIndexedMemoryDirectoryCodecAndMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	if blob[4] != 34 {
-		t.Fatalf("codec version = %d, want 34", blob[4])
+	if blob[4] != wagoVersion {
+		t.Fatalf("codec version = %d, want %d", blob[4], wagoVersion)
 	}
 	var got Compiled
 	if err := unmarshalCompiled(&got, blob[5:]); err != nil {

--- a/src/wago/railshot_amd64.go
+++ b/src/wago/railshot_amd64.go
@@ -26,6 +26,7 @@ func railshotGCNativeCodeTelemetry(stats *railshotModuleStats) GCNativeCodeTelem
 	if stats == nil {
 		return out
 	}
+	out.SharedStubBytes = uint64(stats.GCSharedStubBytes)
 	for _, function := range stats.Funcs {
 		if function == nil {
 			continue

--- a/src/wago/table64_exec_amd64_test.go
+++ b/src/wago/table64_exec_amd64_test.go
@@ -640,8 +640,8 @@ func TestStagedTable64LocalGetSetSizeAndProductRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal table64: %v", err)
 	}
-	if blob[4] != 34 {
-		t.Fatalf("table64 codec version = %d, want 34", blob[4])
+	if blob[4] != wagoVersion {
+		t.Fatalf("table64 codec version = %d, want %d", blob[4], wagoVersion)
 	}
 	var public Compiled
 	if err := public.UnmarshalBinary(blob); err != nil {


### PR DESCRIPTION
Closes #307.

## Summary

- hoist immutable native-GC ABI checks to collector construction, artifact loading, and instance-view publication;
- record and fail closed on the native-GC ABI requirement in codec v35;
- keep every mutable semantic check dynamic: compact tag/range/liveness, current handle/space backing, object extent/type, array bounds, barriers/ownership, roots, lifecycle, EH/tails, snapshots, and host re-entry;
- add a `wagodebug` Go-to-native immutable-view assertion without charging production GC operations;
- replace repeated AMD64 direct scalar/length handle-resolution bodies with one 229-byte module leaf at the measured two-site crossover;
- retain local trap/source attribution and rel32 range checks;
- add one-entry raw-address reuse only while an unchanged compact local remains the root inside a mechanically safepoint-free straight-line region;
- invalidate reuse at calls, helpers/hosts, allocation, control/EH/tail edges, local writes, mutable-fact changes, and unknown/non-access GC opcodes;
- add ARM64 artifact/instantiation preflight coverage (ARM64 execution remains helper-lowered);
- add permanent code-size/runtime attribution, differential controls, tests, and docs.

## ABI and artifact boundary

`gc.ValidateNativeABI` checks the Go layouts consumed by native code, including handle entries, cards, allocation state, spaces, collector view, and instance view. `gc.BuildNativeInstanceView` validates collector identity, immutable type-map pointer/count, versions, and stride before basedata publication.

Generic struct/array artifacts now carry native ABI v6 in codec v35. Missing or mismatched requirements reject before execution. `compiledCodeCache` remains 64 bytes by packing the requirement with existing metadata markers.

## AMD64 codegen

The module resolver leaf:

- cannot allocate, collect, enter Go, publish roots, or become a safepoint;
- reloads mutable collector pointers/counts;
- validates handle range/liveness, space/backing extent, object extent, and canonical runtime type;
- returns only a resolved address plus a local trap class, leaving exact source trapping in each caller.

Controls:

- `WAGO_AMD64_NO_GC_SHARED_STUBS=1`
- `WAGO_AMD64_NO_GC_RESOLVE_REUSE=1`

## Measurements

Ryzen 7 8845HS, Go 1.24.4, linux/amd64:

| Fixture | Candidate | Differential | Delta |
|---|---:|---:|---:|
| one resolver site | 351 B inline-selected | 351 B inline | 0 |
| eight sites | 821 B shared | 1,669 B inline | -50.8% |
| 128 sites | 7,301 B shared | 24,349 B inline | -70.0% |
| eight-site reuse | 565 B, 1 resolve + 7 reuse | 821 B, 8 resolves | -31.2% |

Ten CPU-0-pinned 500 ms runtime samples:

- default shared + reuse: **310.0 ns/op median**;
- reuse disabled: **328.1 ns/op median**;
- shared + reuse disabled (fully inline): **324.0 ns/op median**;
- all: **0 B/op, 0 allocs/op**.

The default was 5.5% faster than shared-without-reuse and 4.3% faster than fully inline on the repeated-access fixture. Two isolated ~0.8 us host outliers did not affect medians.

A same-command stripped `wago_runtime` TinyGo build changed **2,096,928 -> 2,102,160 bytes** (+5,232, +0.250%). Collector, instance, native-view, and compiled-code-cache layouts do not grow.

## Qualification

Passed:

- `go test ./src/core/...`
- focused `src/wago` ABI, artifact, hot-path, resolver, telemetry, structural-corpus, and documentation tests
- `go test -race ./src/core/runtime/gc`
- focused `src/wago` race tests
- `-tags wagodebug`
- `-tags wago_gcstats`
- `-tags wago_guardpage`
- Linux ARM64 cross-build of Railshot and `src/wago`
- Darwin ARM64 cross-build of `src/wago`
- `git diff --check`

The complete `go test ./src/wago` run reaches no issue-specific failures, but remains red in this environment because the installed WABT cannot parse the pinned Core 3 fixtures and `WAGO_SPEC_INTERPRETER` is not configured. The failures are the existing official GC/EH/memory64/table64 fixture-conversion/accounting cases; focused corpus and changed-path tests pass.

## Commits

- `3b2daaf4` gc: trust validated native ABI boundaries
- `8e8657c6` docs: record issue 307 qualification
