### PR TITLE
runtime: reduce repeated instantiation overhead

### DIFF
--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -395,6 +395,11 @@ func (c *Compiled) releaseCode() {
 		cc.base = 0
 		c.code = nil
 	}
+	if cc.refs == 0 && cc.closed {
+		if c.validateMemo != nil {
+			c.validateMemo.structuralCallIdentities = nil
+		}
+	}
 }
 
 // replaceDecoded installs decoded state without orphaning an executable image.
@@ -441,6 +446,9 @@ func (c *Compiled) Close() error {
 	goruntime.SetFinalizer(c, nil)
 	if cc.refs != 0 {
 		return nil
+	}
+	if c.validateMemo != nil {
+		c.validateMemo.structuralCallIdentities = nil
 	}
 	if cc.mem == nil {
 		// Preserve compiler-produced metadata so a later Instantiate reaches the

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -1125,9 +1125,10 @@ func (c *Compiled) RequiresAVX2() bool { return c != nil && c.requiresAVX2 }
 func (c *Compiled) RequiresAVX512() bool { return c != nil && c.requiresAVX512 }
 
 type validateMemo struct {
-	once         sync.Once
-	err          error
-	gcFrameRoots *compiledGCFrameRoots // immutable compiled/codec native safepoint and callsite map
+	once                     sync.Once
+	err                      error
+	gcFrameRoots             *compiledGCFrameRoots // immutable compiled/codec native safepoint and callsite map
+	structuralCallIdentities *structuralCallIdentityCache
 }
 
 // validateCached returns the metadata-validation result, running the full check

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -727,6 +727,11 @@ func (s *referenceStore) acquireGCCollector(config gc.Config, c *Compiled, prefe
 }
 
 func (s *referenceStore) registerInstance(in *Instance) error {
+	if in != nil && in.c != nil {
+		if err := in.c.prepareStructuralCallIdentities(); err != nil {
+			return fmt.Errorf("wago: prepare structural call identities: %w", err)
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.runtimeClosed && !s.private {
@@ -752,9 +757,13 @@ func (s *referenceStore) registerInstance(in *Instance) error {
 	candidate := make(map[uint64]structuralTypeRegistration)
 	keys := make([]uint64, 0, len(in.c.FuncTypeID))
 	for i, key := range in.c.FuncTypeID {
-		canonical, err := compiledStructuralCallIdentity(in.c, i)
-		if err != nil {
-			return fmt.Errorf("wago: function %d exact type: %w", i, err)
+		canonical, cached := in.c.cachedStructuralCallIdentity(i)
+		if !cached {
+			var err error
+			canonical, err = compiledStructuralCallIdentity(in.c, i)
+			if err != nil {
+				return fmt.Errorf("wago: function %d exact type: %w", i, err)
+			}
 		}
 		exact := structuralTypeRegistration{canonical: canonical}
 		if prior, ok := candidate[key]; ok {

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -369,8 +369,8 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 		return nil, err
 	}
 	var cfg instantiateConfig
-	for _, opt := range opts {
-		opt(&cfg)
+	if len(opts) != 0 {
+		cfg = applyInstantiateOptions(opts)
 	}
 	if err := applyPolicy(mod, cfg.policy); err != nil {
 		return nil, err
@@ -382,9 +382,12 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 		return nil, fmt.Errorf("wago: Instantiate on a closed runtime")
 	}
 	// Merge extension imports first, then per-call imports on top.
-	merged := make(Imports, len(rt.imports)+len(cfg.imports))
-	for k, v := range rt.imports {
-		merged[k] = v
+	var merged Imports
+	if n := len(rt.imports) + len(cfg.imports); n != 0 {
+		merged = make(Imports, n)
+		for k, v := range rt.imports {
+			merged[k] = v
+		}
 	}
 	policy := rt.overridePolicy
 	rt.mu.Unlock()
@@ -410,6 +413,14 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	}
 
 	return rt.instantiateWithHooksOrigin(mod, merged, cfg.gc, cfg.hasGC, origin)
+}
+
+func applyInstantiateOptions(opts []InstantiateOption) instantiateConfig {
+	var cfg instantiateConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
 }
 
 // instantiateWithHooksOrigin runs the Runtime-aware instantiation path and emits

--- a/src/wago/structural_call_identity.go
+++ b/src/wago/structural_call_identity.go
@@ -2,6 +2,99 @@ package wago
 
 import "fmt"
 
+type structuralCallIdentityCache struct {
+	identities []byte
+	spans      []structuralCallIdentitySpan
+}
+
+type structuralCallIdentitySpan struct {
+	start uint32
+	end   uint32
+}
+
+var structuralCallIdentitySeenSentinel = &structuralCallIdentityCache{}
+
+const (
+	maxStructuralCallIdentityCacheBytes    = 64 << 10
+	structuralCallIdentityCacheHeaderBytes = 48
+	structuralCallIdentitySpanBytes        = 8
+	uncachedStructuralCallIdentityEnd      = ^uint32(0)
+)
+
+func (c *Compiled) prepareStructuralCallIdentities() error {
+	if c.validateMemo == nil || len(c.FuncTypeID) == 0 || len(c.Types) == 0 {
+		return nil
+	}
+	c.ensureCodeCache()
+	cc := c.codeCache
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	memo := c.validateMemo
+	if memo.structuralCallIdentities != nil && memo.structuralCallIdentities != structuralCallIdentitySeenSentinel {
+		return nil
+	}
+	if memo.structuralCallIdentities == nil {
+		memo.structuralCallIdentities = structuralCallIdentitySeenSentinel
+		return nil
+	}
+	spanBytes := uint64(len(c.Types)) * structuralCallIdentitySpanBytes
+	if spanBytes > maxStructuralCallIdentityCacheBytes-structuralCallIdentityCacheHeaderBytes {
+		// A non-nil empty cache records that this module exceeded the bounded
+		// retention budget. Registrations keep reconstructing identities exactly.
+		memo.structuralCallIdentities = &structuralCallIdentityCache{}
+		return nil
+	}
+	identityBudget := maxStructuralCallIdentityCacheBytes - structuralCallIdentityCacheHeaderBytes - int(spanBytes)
+	cache := &structuralCallIdentityCache{spans: make([]structuralCallIdentitySpan, len(c.Types))}
+	for i := range c.FuncTypeID {
+		sig, ok := compiledFunctionSignature(c, i)
+		if !ok || !sig.HasTypeIndex || int(sig.TypeIndex) >= len(c.Types) {
+			continue
+		}
+		if cache.spans[sig.TypeIndex].end != 0 {
+			continue
+		}
+		canonical, err := compiledStructuralCallIdentity(c, i)
+		if err != nil {
+			return fmt.Errorf("function %d exact type: %w", i, err)
+		}
+		if len(canonical) > identityBudget-len(cache.identities) {
+			cache.spans[sig.TypeIndex].end = uncachedStructuralCallIdentityEnd
+			continue
+		}
+		start := len(cache.identities)
+		cache.identities = append(cache.identities, canonical...)
+		if cap(cache.identities) > identityBudget {
+			bounded := make([]byte, len(cache.identities))
+			copy(bounded, cache.identities)
+			cache.identities = bounded
+		}
+		end := len(cache.identities)
+		cache.spans[sig.TypeIndex] = structuralCallIdentitySpan{start: uint32(start), end: uint32(end)}
+	}
+	memo.structuralCallIdentities = cache
+	return nil
+}
+
+func (c *Compiled) cachedStructuralCallIdentity(functionIndex int) ([]byte, bool) {
+	if c.validateMemo == nil || c.validateMemo.structuralCallIdentities == nil || c.validateMemo.structuralCallIdentities == structuralCallIdentitySeenSentinel {
+		return nil, false
+	}
+	cache := c.validateMemo.structuralCallIdentities
+	sig, ok := compiledFunctionSignature(c, functionIndex)
+	if !ok || !sig.HasTypeIndex || int(sig.TypeIndex) >= len(cache.spans) {
+		return nil, false
+	}
+	span := cache.spans[sig.TypeIndex]
+	if span.end == 0 || span.end == uncachedStructuralCallIdentityEnd {
+		return nil, false
+	}
+	if span.start > span.end || int(span.end) > len(cache.identities) {
+		return nil, false
+	}
+	return cache.identities[span.start:span.end], true
+}
+
 // compiledStructuralCallIdentity reconstructs the exact canonical byte program
 // underlying native structural-key generation from persisted compiled metadata.
 // The store compares these bytes after a fast-key match; no hash width is treated

--- a/src/wago/structural_type_store_test.go
+++ b/src/wago/structural_type_store_test.go
@@ -1,6 +1,7 @@
 package wago
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -8,6 +9,84 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/wasmtest"
 )
+
+func TestCompiledStructuralCallIdentityCacheLifecycle(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	module, err := rt.Compile(scalarFunctionModule(wasm.I64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled := module.Compiled()
+	want, err := compiledStructuralCallIdentity(compiled, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.validateMemo.structuralCallIdentities != nil {
+		t.Fatal("structural identity cache built before instantiation")
+	}
+
+	in, err := rt.Instantiate(context.Background(), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.validateMemo.structuralCallIdentities != structuralCallIdentitySeenSentinel {
+		t.Fatal("structural identity cache built for one-shot instantiation")
+	}
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	in, err = rt.Instantiate(context.Background(), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := compiled.cachedStructuralCallIdentity(0)
+	if !ok || !bytes.Equal(got, want) {
+		t.Fatalf("cached identity = %x, %v; want %x", got, ok, want)
+	}
+	cache := compiled.validateMemo.structuralCallIdentities
+	retained := structuralCallIdentityCacheHeaderBytes + cap(cache.spans)*structuralCallIdentitySpanBytes + cap(cache.identities)
+	if retained > maxStructuralCallIdentityCacheBytes {
+		t.Fatalf("identity cache retains %d bytes; budget %d", retained, maxStructuralCallIdentityCacheBytes)
+	}
+	if err := compiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if compiled.validateMemo.structuralCallIdentities == nil {
+		t.Fatal("Close released identity cache while an instance was live")
+	}
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if compiled.validateMemo.structuralCallIdentities != nil {
+		t.Fatal("identity cache retained after compiled module and final instance closed")
+	}
+}
+
+func TestCompiledStructuralCallIdentityCacheBudget(t *testing.T) {
+	typeCount := (maxStructuralCallIdentityCacheBytes-structuralCallIdentityCacheHeaderBytes)/structuralCallIdentitySpanBytes + 1
+	compiled := &Compiled{
+		Funcs:        []FuncSig{{HasTypeIndex: true}},
+		Types:        make([]DefinedTypeDescriptor, typeCount),
+		FuncTypeID:   []uint64{1},
+		validateMemo: &validateMemo{},
+		codeCache:    &compiledCodeCache{},
+	}
+	compiled.Types[0].Kind = CompositeTypeFunction
+	if err := compiled.prepareStructuralCallIdentities(); err != nil {
+		t.Fatal(err)
+	}
+	if err := compiled.prepareStructuralCallIdentities(); err != nil {
+		t.Fatal(err)
+	}
+	cache := compiled.validateMemo.structuralCallIdentities
+	if cache == nil {
+		t.Fatal("oversized module did not record disabled identity cache")
+	}
+	if len(cache.spans) != 0 || len(cache.identities) != 0 {
+		t.Fatalf("oversized module retained spans=%d identities=%d", len(cache.spans), len(cache.identities))
+	}
+}
 
 func compiledStoreType(key uint64, param ValueTypeKind) *Compiled {
 	abi := ValI32


### PR DESCRIPTION
## What changed

- skip `instantiateConfig` setup when no per-call options were supplied
- avoid allocating an imports map when neither runtime nor per-call imports exist
- pack exact structural call identities once a compiled module is instantiated repeatedly
- keep the first instantiation on the existing no-retention path
- release cached identity storage after `Compiled.Close` and the final instance close

## Why

Repeated instantiation rebuilt immutable structural call identities and allocated empty option/import state. This was visible even for tiny scalar modules and grew substantially for reference-heavy modules.

The identity cache is deliberately earned on the second instantiation. The cache itself does not alter the one-shot allocation profile, so modules used once do not retain variable identity state.

## Performance

Apple M4 Max, Darwin/arm64, `GOMAXPROCS=1`, medians from repeated uncontended runs:

| Benchmark | Before | After | Allocation delta |
| --- | ---: | ---: | ---: |
| Small scalar | 1,249 ns/op | 1,134 ns/op | 1,568 -> 1,296 B; 16 -> 9 allocs |
| Funcref ingress | 1,457 ns/op | 1,332 ns/op | 1,696 -> 1,424 B; 21 -> 14 allocs |
| Owned host funcref | 5,934 ns/op | 5,691 ns/op | 3,080 -> 2,992 B; 34 -> 28 allocs |
| Externref control | 1,986 ns/op | 1,336 ns/op | 1,984 -> 1,352 B; 40 -> 9 allocs |

Compile allocations are unchanged at 47,930 B/op and 81 allocations; the latest uncontended medians were 21,553 ns/op on the base and 20,440 ns/op on the branch, with no claimed compile-speed change because those samples overlap ordinary run noise. The generated machine-code path is unchanged. `compiledCodeCache` remains exactly 64 B, enforced by the existing AMD64 footprint guards.

Variable identity storage is created only after repeated use, follows compiled-code lifetime, and is capped at 64 KiB per compiled module with exact uncached reconstruction beyond the budget. Measured retained cache state is 72 B for the scalar fixture and 216 B for the externref-control fixture. The scalar cache-building instantiation measured 1,254 ns/op, 1,432 B, and 17 allocations; subsequent instantiations use the steady-state figures above.

## Validation

- `go test ./... -count=1`
- `(cd bench && go test ./... -count=1)`
- `go test -race ./src/wago -run 'TestCompiledStructuralCallIdentityCache|TestReferenceStoreResolvesNativeStructuralKeyCollisionsExactly|TestRuntimeRejectsForcedHashEqualDistinctNativeTarget' -count=1`
- post-rebase instantiation benchmark matrix on Darwin/arm64
- adversarial oversized-type cache-budget test

The collision-free store invariant remains authoritative: cached bytes are the same exact canonical identities previously rebuilt on every registration, not a relaxation to hash-only equality.

## AI assistance

Codex helped profile, implement, benchmark, test, and prepare this PR. Measurements and validation were rerun against the current `main` base before review.
