### PR TITLE
amd64: sink comparisons into byte stores

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -1048,10 +1048,14 @@ the eager call-spill model, float `call; local.set` fusion (int-only today), mix
 parallel staging (`emitMixedRegisterCall` still does full `flush()` + slot staging).
 (Plan P5.1–.2.)
 
-### R3. Store-narrowing peephole  · S · ⬜
-`setcc; movzx; store8` keeps a dead `movzx` (sieve's inner loop). Ships standalone if
-trivial, otherwise falls out of `stFlags` for free — don't build scaffolding twice.
-(Plan P2.5/P3.)
+### R3. Store-narrowing peephole  · S · ✅
+Integer comparisons consumed immediately by `i32.store8` now remain in flags and
+emit `setcc` directly into a scratch low byte, omitting the dead `movzx`. The rule
+selects 173 explicit-mode and 165 guard-mode sites across 11 corpus modules,
+removing 684 and 569 native bytes respectively. On a pinned Ryzen 7 7800X3D,
+sieve improves from 81.15 to 81.01 µs/op (-0.17%, p=0.000, n=12), while SQLite
+and Ruby compilation remain flat at 1.0001x geomean with effectively unchanged
+allocation volume. `WAGO_NO_STORE8_FLAGS=1` is the differential oracle. (Plan P2.5/P3.)
 
 ### R4. json serialize gap — ✅ RESOLVED (2026-07-02)
 Closed by #99 + #100: guard-mode ser 190→**93ns (beats WARP's 97)**; deser 175ns

--- a/docs/singlepass-optimization-research-and-issues-2026-08.md
+++ b/docs/singlepass-optimization-research-and-issues-2026-08.md
@@ -150,10 +150,10 @@ the useful semantic list.
 
 ### Public optimizer catalog on current main
 
-The 42 registered definitions are:
+The 43 registered definitions are:
 
 ```text
-bounds-facts, st-flags, reg-merge, tee-sink, unary-sink,
+bounds-facts, st-flags, store8-flags, reg-merge, tee-sink, unary-sink,
 three-op-sink, olddest-rhs-sink, branch-fold, store-load-fwd, uxtw-add,
 entry-arg-pins, x8-pin, deep-fp-pins, ext-fp-pins, call-next-use,
 affine-lea, tree-order, assoc-tree, bmi2-rorx, leaf-scratch-pins,
@@ -167,7 +167,7 @@ stack-reg
 
 ### Complete current peephole/explain event vocabulary
 
-These 94 names are the union emitted by current AMD64 and ARM64 source. Candidate
+These 95 names are the union emitted by current AMD64 and ARM64 source. Candidate
 and bookkeeping events are included deliberately so the audit trail is complete:
 
 ```text
@@ -193,7 +193,7 @@ select-flags, select-local-sink, simd-and-anytrue, simd-anytrue-vptest,
 simd-local-forward, simd-mem-fold, simd-not-and, simd-rotr-imm,
 simd-shift-imm, simd-shuffle-native, simd-shuffle-rotr,
 simd-shuffle-same, simd-shuffle-zip, simd-tee-store-elide,
-small-frame-adjust, store-imm, store-load-fwd, strength-reduce,
+small-frame-adjust, store-imm, store-load-fwd, store8-flags, strength-reduce,
 swar-mask-test, swar-pack4, swar-parse4, swar-widen4, tree-order,
 tree-order-candidate, uxtw-add, v128-local-sink, xor-byte-mask
 ```

--- a/schema.json
+++ b/schema.json
@@ -205,6 +205,7 @@
               "stack-reg",
               "store-forward",
               "store-load-fwd",
+              "store8-flags",
               "tee-sink",
               "three-op-sink",
               "tree-order",

--- a/src/core/compiler/backend/railshot/amd64/knobs.go
+++ b/src/core/compiler/backend/railshot/amd64/knobs.go
@@ -9,6 +9,7 @@ import "github.com/wago-org/wago/src/core/compiler/optimization"
 var optimizationBindings = optimization.NewBindings("amd64",
 	optimization.Bind("bounds-facts", &boundsFactsEnabled),
 	optimization.Bind("st-flags", &stFlagsEnabled),
+	optimization.Bind("store8-flags", &store8FlagsEnabled),
 	optimization.Bind("reg-merge", &regMergeEnabled),
 	optimization.Bind("tee-sink", &teeLocalSinkEnabled),
 	optimization.Bind("unary-sink", &unaryLocalSinkEnabled),

--- a/src/core/compiler/backend/railshot/amd64/memory.go
+++ b/src/core/compiler/backend/railshot/amd64/memory.go
@@ -615,6 +615,25 @@ func (f *fn) memStore(r *wasm.Reader, size int) error {
 		}
 		return nil
 	}
+	// An integer comparison immediately consumed by an 8-bit store needs only its
+	// low byte. Keep SETcc's upper-register garbage dead and omit MOVZX; the byte
+	// store cannot observe it. Pending loads were materialized above, preserving
+	// pre-store reads and trap order before this dedicated sink condenses the tree.
+	if top := f.s.back(); size == 1 && store8FlagsEnabled && isFusableCompare(top) && !top.typ.isFloat() {
+		vreg := f.allocReg(0)
+		f.pinned = f.pinned.add(vreg)
+		cc := f.condenseToFlags(top)
+		f.stats.reclassifyPeep("cmp-branch-fuse", "store8-flags")
+		f.a.SetccReg8(cc, vreg)
+		ea, eaOwned, _, disp := f.memAddr(off32, size, true)
+		f.a.StoreIdx(RBX, ea, vreg, disp, size)
+		f.pinned = f.pinned.remove(vreg)
+		if eaOwned {
+			f.release(ea)
+		}
+		f.release(vreg)
+		return nil
+	}
 	// Both the value and the address are immediate read-only uses here, so a
 	// pinned local feeds the store in place — no copy (nothing between the reads
 	// and the StoreIdx can write a local).

--- a/src/core/compiler/backend/railshot/amd64/memory.go
+++ b/src/core/compiler/backend/railshot/amd64/memory.go
@@ -620,7 +620,11 @@ func (f *fn) memStore(r *wasm.Reader, size int) error {
 	// store cannot observe it. Pending loads were materialized above, preserving
 	// pre-store reads and trap order before this dedicated sink condenses the tree.
 	if top := f.s.back(); size == 1 && store8FlagsEnabled && isFusableCompare(top) && !top.typ.isFloat() {
-		vreg := f.allocReg(0)
+		// condenseToFlags may recursively lower div/rem or a variable shift. Those
+		// paths temporarily claim and then unpin x86's fixed-role registers; because
+		// the pin mask is not reference-counted, nesting would drop this outer
+		// reservation. Keep the byte result in a neutral scratch instead.
+		vreg := f.allocReg(maskOf(RAX, RDX, RCX))
 		f.pinned = f.pinned.add(vreg)
 		cc := f.condenseToFlags(top)
 		f.stats.reclassifyPeep("cmp-branch-fuse", "store8-flags")

--- a/src/core/compiler/backend/railshot/amd64/stats.go
+++ b/src/core/compiler/backend/railshot/amd64/stats.go
@@ -43,6 +43,9 @@ var (
 	// storing $c with a flag-neutral SETcc after the CMP. WAGO_NO_STFLAGS=1 is the
 	// A/B oracle + kill switch for this flag-desync-sensitive path.
 	stFlagsEnabled = os.Getenv("WAGO_NO_STFLAGS") != "1"
+	// store8FlagsEnabled gates direct low-byte comparison results consumed by an
+	// i32.store8. WAGO_NO_STORE8_FLAGS=1 is the A/B oracle.
+	store8FlagsEnabled = os.Getenv("WAGO_NO_STORE8_FLAGS") != "1"
 	// swarMaskTestEnabled gates direct packed-word mask-test fusion.
 	// WAGO_NO_SWAR_MASK_TEST=1 is the A/B oracle.
 	swarMaskTestEnabled = os.Getenv("WAGO_NO_SWAR_MASK_TEST") != "1"
@@ -318,6 +321,20 @@ func (s *CodegenStats) peep(name string) {
 		s.Peephole = make(map[string]int)
 	}
 	s.Peephole[name]++
+}
+
+// reclassifyPeep moves one already-recorded selection event to a more specific
+// sink. It is used only on the opt-in explain path; ordinary compilation has a
+// nil stats receiver and returns immediately.
+func (s *CodegenStats) reclassifyPeep(from, to string) {
+	if s == nil {
+		return
+	}
+	s.Peephole[from]--
+	if s.Peephole[from] == 0 {
+		delete(s.Peephole, from)
+	}
+	s.Peephole[to]++
 }
 
 // ModuleGlobalPinInfo describes one module-wide global→register reservation.

--- a/src/core/compiler/backend/railshot/amd64/store8_flags_test.go
+++ b/src/core/compiler/backend/railshot/amd64/store8_flags_test.go
@@ -1,0 +1,75 @@
+//go:build (linux || darwin || windows) && amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func store8CompareModule(t *testing.T) *wasm.Module {
+	t.Helper()
+	// mem[$addr] = byte($x <s $y); return mem[$addr]
+	return modMem(t, 1,
+		[]wasm.ValType{wasm.I32, wasm.I32, wasm.I32},
+		[]wasm.ValType{wasm.I32},
+		[]byte{
+			0x00,
+			0x20, 0x00,
+			0x20, 0x01,
+			0x20, 0x02,
+			0x48,
+			0x3a, 0x00, 0x00,
+			0x20, 0x00,
+			0x2d, 0x00, 0x00,
+			0x0b,
+		})
+}
+
+func TestStore8FlagsSink(t *testing.T) {
+	m := store8CompareModule(t)
+	for _, guard := range []bool{false, true} {
+		t.Run(map[bool]string{false: "explicit", true: "guard"}[guard], func(t *testing.T) {
+			s := compileWithStats(t, m, guard).Funcs[0]
+			if got := s.Peephole["store8-flags"]; got != 1 {
+				t.Fatalf("store8-flags = %d, want 1 (all: %v)", got, s.Peephole)
+			}
+			if got := s.Peephole["compare-setcc"]; got != 0 {
+				t.Fatalf("compare-setcc = %d, want 0 after byte-store sink", got)
+			}
+			if got := s.Peephole["cmp-branch-fuse"]; got != 0 {
+				t.Fatalf("cmp-branch-fuse = %d, want 0 after event reclassification", got)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		x, y uint64
+		want byte
+	}{
+		{x: 3, y: 5, want: 1},
+		{x: 5, y: 3, want: 0},
+		{x: uint64(uint32(0x80000000)), y: 0, want: 1},
+	} {
+		_, mem, err := runMemAmd64(t, m, nil, 37, tc.x, tc.y)
+		if err != nil {
+			t.Fatalf("run(%#x, %#x): %v", tc.x, tc.y, err)
+		}
+		if got := mem[37]; got != tc.want {
+			t.Fatalf("run(%#x, %#x) stored %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestStore8FlagsKillSwitch(t *testing.T) {
+	defer func(prev bool) { store8FlagsEnabled = prev }(store8FlagsEnabled)
+	store8FlagsEnabled = false
+	s := compileWithStats(t, store8CompareModule(t), false).Funcs[0]
+	if got := s.Peephole["store8-flags"]; got != 0 {
+		t.Fatalf("store8-flags = %d, want 0 with kill switch", got)
+	}
+	if got := s.Peephole["compare-setcc"]; got != 1 {
+		t.Fatalf("compare-setcc = %d, want 1 with kill switch", got)
+	}
+}

--- a/src/core/compiler/backend/railshot/amd64/store8_flags_test.go
+++ b/src/core/compiler/backend/railshot/amd64/store8_flags_test.go
@@ -73,3 +73,45 @@ func TestStore8FlagsKillSwitch(t *testing.T) {
 		t.Fatalf("compare-setcc = %d, want 1 with kill switch", got)
 	}
 }
+
+func TestStore8FlagsNestedFixedRegisterPressure(t *testing.T) {
+	// Four pending loads occupy the remaining freely allocatable registers,
+	// making the byte-result scratch land in RAX. The nested div then borrows
+	// RAX/RDX while condensing the comparison. The store address remains deferred
+	// until after SETcc, so losing the outer RAX reservation lets address
+	// generation clobber AL before the byte store.
+	body := []byte{0x00}
+	for off := byte(0); off < 4; off++ {
+		body = append(body,
+			0x20, 0x00, // local.get loadBase
+			0x41, off, // i32.const off
+			0x6a,             // i32.add
+			0x2d, 0x00, 0x00, // i32.load8_u (deferred)
+		)
+	}
+	body = append(body,
+		0x20, 0x01, 0x41, 0x25, 0x6a, // address = storeBase + 37
+		0x20, 0x02, 0x20, 0x03, 0x6e, // x / y (fixed RAX/RDX)
+		0x20, 0x04, 0x49, // (x / y) <u z
+		0x3a, 0x00, 0x00, // i32.store8
+	)
+	for range 4 {
+		body = append(body, 0x1a) // drop the pressure loads
+	}
+	body = append(body,
+		0x20, 0x01, 0x41, 0x25, 0x6a,
+		0x2d, 0x00, 0x00, // return stored byte
+		0x0b,
+	)
+
+	m := modMem(t, 1,
+		[]wasm.ValType{wasm.I32, wasm.I32, wasm.I32, wasm.I32, wasm.I32},
+		[]wasm.ValType{wasm.I32}, body)
+	got, mem, err := runMemAmd64(t, m, nil, 0, 100, 100, 5, 30)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got != 1 || mem[137] != 1 {
+		t.Fatalf("fixed-register pressure corrupted store8 flags: result=%d mem[137]=%d, want 1", got, mem[137])
+	}
+}

--- a/src/core/compiler/optimization/catalog.go
+++ b/src/core/compiler/optimization/catalog.go
@@ -162,6 +162,7 @@ func (b *Bindings) Apply(overrides map[string]bool) (func(), error) {
 var catalog = []Definition{
 	both("bounds-facts", "Bounds facts", "straight-line bounds-check elision"),
 	both("st-flags", "Flags results", "keep comparison results in the flags register"),
+	amd64("store8-flags", "Byte-store flags", "sink comparison results directly into byte stores"),
 	both("reg-merge", "Register merge", "keep block results in registers across joins"),
 	both("tee-sink", "Tee sinking", "sink local.tee expressions into local registers"),
 	both("unary-sink", "Unary sinking", "sink unary and conversion expressions in place"),

--- a/src/core/encoder/amd64/asm.go
+++ b/src/core/encoder/amd64/asm.go
@@ -704,14 +704,20 @@ func (a *Asm) Cmovcc(cc Cond, dst, src Reg, w bool) {
 }
 
 func (a *Asm) SetccReg(c Cond, dst Reg) {
-	if dst >= 4 {
-		a.emit(rex(false, false, false, dst >= 8))
-	}
-	a.emit(0x0F, 0x90|byte(c), 0xC0|byte(dst&7))
+	a.SetccReg8(c, dst)
 	if dst >= 4 {
 		a.emit(rex(false, dst >= 8, false, dst >= 8))
 	}
 	a.emit(0x0F, 0xB6, 0xC0|((byte(dst)&7)<<3)|byte(dst&7))
+}
+
+// SetccReg8 writes only dst's low byte. Callers may use it when the next sink
+// observes exactly that byte; the rest of dst remains unspecified.
+func (a *Asm) SetccReg8(c Cond, dst Reg) {
+	if dst >= 4 {
+		a.emit(rex(false, false, false, dst >= 8))
+	}
+	a.emit(0x0F, 0x90|byte(c), 0xC0|byte(dst&7))
 }
 
 // nopSeqs[n] is the canonical n-byte NOP (Intel SDM recommended multi-byte

--- a/src/core/encoder/amd64/asm_base_test.go
+++ b/src/core/encoder/amd64/asm_base_test.go
@@ -108,6 +108,7 @@ func TestIntegerMemoryAndControlEncodings(t *testing.T) {
 		{"conditional move", func(a *Asm) { a.Cmovcc(CondGE, R8, R9, true) }, []byte{0x4d, 0x0f, 0x4d, 0xc1}},
 		{"setcc register", func(a *Asm) { a.SetccReg(CondNE, R8) }, []byte{0x41, 0x0f, 0x95, 0xc0, 0x45, 0x0f, 0xb6, 0xc0}},
 		{"setcc low byte", func(a *Asm) { a.SetccReg8(CondNE, R8) }, []byte{0x41, 0x0f, 0x95, 0xc0}},
+		{"setcc low byte bare rex", func(a *Asm) { a.SetccReg8(CondNE, RSI) }, []byte{0x40, 0x0f, 0x95, 0xc6}},
 		{"jump register", func(a *Asm) { a.JmpReg(R9) }, []byte{0x41, 0xff, 0xe1}},
 		{"neg", func(a *Asm) { a.Neg(R8, true) }, []byte{0x49, 0xf7, 0xd8}},
 	}

--- a/src/core/encoder/amd64/asm_base_test.go
+++ b/src/core/encoder/amd64/asm_base_test.go
@@ -107,6 +107,7 @@ func TestIntegerMemoryAndControlEncodings(t *testing.T) {
 		{"multiply high", func(a *Asm) { a.IMulHigh(R8, false) }, []byte{0x41, 0xf7, 0xe8}},
 		{"conditional move", func(a *Asm) { a.Cmovcc(CondGE, R8, R9, true) }, []byte{0x4d, 0x0f, 0x4d, 0xc1}},
 		{"setcc register", func(a *Asm) { a.SetccReg(CondNE, R8) }, []byte{0x41, 0x0f, 0x95, 0xc0, 0x45, 0x0f, 0xb6, 0xc0}},
+		{"setcc low byte", func(a *Asm) { a.SetccReg8(CondNE, R8) }, []byte{0x41, 0x0f, 0x95, 0xc0}},
 		{"jump register", func(a *Asm) { a.JmpReg(R9) }, []byte{0x41, 0xff, 0xe1}},
 		{"neg", func(a *Asm) { a.Neg(R8, true) }, []byte{0x49, 0xf7, 0xd8}},
 	}


### PR DESCRIPTION
## Summary

- keep integer comparison results in flags when immediately consumed by `i32.store8`
- emit `setcc` into a scratch low byte without the dead `movzx`
- add an AMD64 optimization knob, explain counter, encoder coverage, execution tests, and a kill switch

## Measured result

Pinned Ryzen 7 7800X3D, CPU 7, `GOMAXPROCS=1`:

- corpus coverage: 173 explicit-mode and 165 guard-mode sites across 11 modules
- native code: -684 bytes explicit, -569 bytes guard
- `Exec/sieve.count`: 81.15 us/op to 81.01 us/op, 0.9983x, p=0.000, n=12
- `Compile/sqlite3` + `Compile/ruby`: 1.0001x geomean, no significant row; allocation volume effectively unchanged

The initial implementation regressed Ruby compilation by 1.83% because it refactored every comparison through an extra helper. This version restores the ordinary compare path exactly and pays only at matched store sinks.

## Validation

- `go test ./src/core/encoder/amd64 ./src/core/compiler/backend/railshot/amd64`
- `go vet ./src/core/compiler/backend/railshot/amd64`
- `go test ./src/core/compiler/optimization ./src/wago`
- `WAGO_CORPUS_TIMEOUT=20s make test-corpus` on AMD64: explicit and guard-page suites pass
- `WAGO_NO_STORE8_FLAGS=1` differential oracle exercised
