### PR TITLE
runtime: execute independent instances concurrently by default

### DIFF
--- a/bench/suite_test.go
+++ b/bench/suite_test.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	wago "github.com/wago-org/wago"
@@ -410,5 +412,79 @@ func BenchmarkExec(b *testing.B) {
 			})
 		}
 		in.Close()
+	}
+}
+
+// BenchmarkExecParallel compares the default instance-local execution lease
+// with the conservative process-wide lease across the executable corpus. Each
+// benchmark worker owns an instance because Instance reuses invocation buffers.
+func BenchmarkExecParallel(b *testing.B) {
+	modes := []struct {
+		name        string
+		independent bool
+	}{
+		{name: "independent", independent: true},
+		{name: "process", independent: false},
+	}
+	for _, m := range loadCorpus(b) {
+		if len(m.Exec) == 0 || !m.supports("Exec") {
+			continue
+		}
+		for _, mode := range modes {
+			cfg := wago.NewRuntimeConfig().WithIndependentInstanceExecution(mode.independent)
+			c, err := cfg.Compile(m.bytes)
+			if err != nil {
+				b.Fatalf("%s compile: %v", m.name(), err)
+			}
+			workers := runtime.GOMAXPROCS(0)
+			instances := make([]*wago.Instance, workers)
+			for i := range instances {
+				instances[i], err = wago.Instantiate(c, wago.InstantiateOptions{Imports: hostStubs(c)})
+				if err != nil {
+					b.Fatalf("%s instantiate: %v", m.name(), err)
+				}
+				if m.Init != "" {
+					if _, err := instances[i].Invoke(m.Init); err != nil {
+						b.Fatalf("%s init %s: %v", m.name(), m.Init, err)
+					}
+				}
+			}
+			for _, e := range m.Exec {
+				args := make([]uint64, len(e.Args))
+				for i, a := range e.Args {
+					args[i] = wago.I32(a)
+				}
+				functions := make([]*wago.PreparedFunction, len(instances))
+				for i := range functions {
+					functions[i], err = instances[i].PrepareFunction(e.Export)
+					if err != nil {
+						b.Fatalf("%s prepare %s: %v", m.name(), e.Export, err)
+					}
+					if _, err := functions[i].Invoke(args...); err != nil {
+						b.Fatalf("%s warmup %s: %v", m.name(), e.Export, err)
+					}
+				}
+				b.Run(mode.name+"/"+m.name()+"."+e.Export, func(b *testing.B) {
+					var next atomic.Uint32
+					b.ReportAllocs()
+					b.SetParallelism(1)
+					b.RunParallel(func(pb *testing.PB) {
+						index := int(next.Add(1) - 1)
+						fn := functions[index]
+						for pb.Next() {
+							if _, err := fn.Invoke(args...); err != nil {
+								b.Errorf("invoke: %v", err)
+								return
+							}
+						}
+					})
+				})
+			}
+			for _, in := range instances {
+				if err := in.Close(); err != nil {
+					b.Fatalf("%s close: %v", m.name(), err)
+				}
+			}
+		}
 	}
 }

--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -281,6 +281,18 @@ func (j *JobMemory) BindTrapCell(trap []byte) error {
 	return nil
 }
 
+// RebindTrapCell restores an active invocation's trap-cell pointer after a
+// nested entry changed basedata. Unlike BindTrapCell, it preserves a concurrent
+// interruption while clearing stale host-pending or ordinary trap state.
+func (j *JobMemory) RebindTrapCell(trap []byte) error {
+	if len(trap) < 4 {
+		return fmt.Errorf("trap cell requires at least 4 bytes")
+	}
+	clearTrapUnlessInterrupted(trap)
+	j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	return nil
+}
+
 // HasTrapCell reports whether basedata still names this invocation's trap cell.
 // Cross-instance entry replaces the pointer (and the fence alongside it), so
 // this one-word identity check is sufficient for the prepared-call fast path.

--- a/src/core/runtime/basedata_control_test.go
+++ b/src/core/runtime/basedata_control_test.go
@@ -106,6 +106,32 @@ func TestJobMemoryHasTrapCellDetectsCrossInstanceOverwrite(t *testing.T) {
 	}
 }
 
+func TestJobMemoryRebindTrapCellPreservesInterruption(t *testing.T) {
+	jm, err := NewJobMemory(65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jm.Close()
+	trap := make([]byte, TrapBufferBytes)
+	storeTrap(trap, uint32(TrapInterrupted))
+	if err := jm.RebindTrapCell(trap); err != nil {
+		t.Fatal(err)
+	}
+	if got := TrapCode(loadTrap(trap)); got != TrapInterrupted {
+		t.Fatalf("rebound trap = %v, want interrupted", got)
+	}
+	if !jm.HasTrapCell(trap) {
+		t.Fatal("rebound trap cell was not recognized")
+	}
+	storeTrap(trap, uint32(TrapLinMemOutOfBounds))
+	if err := jm.RebindTrapCell(trap); err != nil {
+		t.Fatal(err)
+	}
+	if got := TrapCode(loadTrap(trap)); got != TrapNone {
+		t.Fatalf("stale rebound trap = %v, want none", got)
+	}
+}
+
 func TestTrapMessagesStayCompactAndComplete(t *testing.T) {
 	if got := unsafe.Sizeof(trapMessages); got != 336 {
 		t.Fatalf("trap message storage = %d bytes, want 336", got)

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1378,7 +1378,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	if genericGCExecution || gcStructProduct.requiresHelpers() || gcArrayProduct.requiresHelpers() || gcStructProduct.requiresArrayHelpers() {
 		nativeGCABIVersion = gc.NativeABIVersion
 	}
-	c := &Compiled{code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Types: types, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, memoryDir: &compiledMemoryDirectory{exports: map[string]int{}, exactExports: true, staged: features.MultiMemory && (m.MemCount() > 1 || m.ImportedMemCount() > 0), stagedMemory64: features.Memory64 && usesMemory64}, boundsMode: boundsMode, stagedTable64: features.Table64 && usesTable64, GCTypeDescs: gcDescs, requiredFeatures: requiredByModule, dynamicImports: importedFuncs > 0, customInstructions: customInstructions, requiresBMI2: cm.RequiresBMI2, requiresAVX2: cm.RequiresAVX2, requiresAVX512: cm.RequiresAVX512, hasGCCodeTelemetry: cfg.gcCodeTelemetry}
+	c := &Compiled{code: code, Entry: entry, InternalEntry: internalEntry, NumImports: importedFuncs, Types: types, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, memoryDir: &compiledMemoryDirectory{exports: map[string]int{}, exactExports: true, staged: features.MultiMemory && (m.MemCount() > 1 || m.ImportedMemCount() > 0), stagedMemory64: features.Memory64 && usesMemory64}, boundsMode: boundsMode, stagedTable64: features.Table64 && usesTable64, independentInstances: cfg.independentInstances, GCTypeDescs: gcDescs, requiredFeatures: requiredByModule, dynamicImports: importedFuncs > 0, customInstructions: customInstructions, requiresBMI2: cm.RequiresBMI2, requiresAVX2: cm.RequiresAVX2, requiresAVX512: cm.RequiresAVX512, hasGCCodeTelemetry: cfg.gcCodeTelemetry}
 	if cfg.gcCodeTelemetry {
 		c.gcCodeTelemetry = railshotGCNativeCodeTelemetry(&gcCodeStats)
 		c.gcCodeTelemetry.TotalBytes = uint64(len(code))
@@ -4120,7 +4120,7 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 			return nil, err
 		}
 	} else {
-		privateScalar := invokePrivateEntryEnabled && cancel == nil && !in.nativeControlShared &&
+		privateScalar := invokePrivateEntryEnabled && cancel == nil && !in.nativeControlIsShared() &&
 			ic.entryMode != preparedEntryGeneral
 		entryMode := preparedEntryGeneral
 		if privateScalar {

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -218,21 +218,23 @@ func (m BoundsCheckMode) String() string {
 // RuntimeConfig configures compilation and execution. It is immutable — every
 // WithXxx returns a copy, so a base config can be shared and specialised safely.
 type RuntimeConfig struct {
-	features        CoreFeatures
-	optimizations   map[string]bool
-	maxMemoryPages  uint32
-	boundsChecks    BoundsCheckMode
-	noDeferBounds   bool // disable skipping of provably-redundant bounds checks (default: enabled)
-	functionWorkers int  // function validation/codegen: 0 adaptive; 1 serial; >1 forced maximum
-	gcCodeTelemetry bool // collect code-neutral per-family WasmGC native byte attribution
+	features             CoreFeatures
+	optimizations        map[string]bool
+	maxMemoryPages       uint32
+	boundsChecks         BoundsCheckMode
+	noDeferBounds        bool // disable skipping of provably-redundant bounds checks (default: enabled)
+	functionWorkers      int  // function validation/codegen: 0 adaptive; 1 serial; >1 forced maximum
+	gcCodeTelemetry      bool // collect code-neutral per-family WasmGC native byte attribution
+	independentInstances bool // allow unrelated instances to execute native code concurrently
 }
 
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
 
 // NewRuntimeConfig returns the default configuration: wago's supported feature
-// set, serial function validation/codegen, and the fastest available bounds-check
-// mode — signals-based (guard-page) when built with -tags wago_guardpage,
-// explicit otherwise. WAGO_BOUNDS overrides either way ("explicit" / "signals").
+// set, serial function validation/codegen, independent-instance execution, and
+// the fastest available bounds-check mode — signals-based (guard-page) when
+// built with -tags wago_guardpage, explicit otherwise. WAGO_BOUNDS overrides
+// either way ("explicit" / "signals").
 func NewRuntimeConfig() *RuntimeConfig {
 	bounds := BoundsChecksExplicit
 	if guardPageBuilt {
@@ -254,11 +256,12 @@ func NewRuntimeConfig() *RuntimeConfig {
 		}
 	}
 	return &RuntimeConfig{
-		features:        defaultCoreFeatures,
-		optimizations:   optimizations,
-		maxMemoryPages:  defaultMaxMemoryPages,
-		boundsChecks:    bounds,
-		functionWorkers: 1,
+		features:             defaultCoreFeatures,
+		optimizations:        optimizations,
+		maxMemoryPages:       defaultMaxMemoryPages,
+		boundsChecks:         bounds,
+		functionWorkers:      1,
+		independentInstances: true,
 	}
 }
 
@@ -367,6 +370,18 @@ func (c *RuntimeConfig) WithFunctionWorkers(workers int) *RuntimeConfig {
 	return &n
 }
 
+// WithIndependentInstanceExecution controls whether separately instantiated
+// modules may execute native code concurrently. It is enabled by default;
+// instances with cross-instance Wasm imports automatically use the process-wide
+// execution lease instead. Disable it to force that conservative lease, for
+// example when an extension maintains shared native state Wago cannot detect.
+func (c *RuntimeConfig) WithIndependentInstanceExecution(enabled bool) *RuntimeConfig {
+	n := *c
+	n.independentInstances = enabled
+
+	return &n
+}
+
 // WithCompileWorkers is retained for source compatibility.
 // Deprecated: use WithFunctionWorkers.
 func (c *RuntimeConfig) WithCompileWorkers(workers int) *RuntimeConfig {
@@ -410,6 +425,10 @@ func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }
 // adaptive, one serial, or a positive forced maximum.
 func (c *RuntimeConfig) FunctionWorkers() int { return c.functionWorkers }
 
+// IndependentInstanceExecution reports whether native calls use instance-local
+// execution leases instead of the process-wide cross-instance lease.
+func (c *RuntimeConfig) IndependentInstanceExecution() bool { return c.independentInstances }
+
 // CompileWorkers is retained for source compatibility.
 // Deprecated: use FunctionWorkers.
 func (c *RuntimeConfig) CompileWorkers() int { return c.FunctionWorkers() }
@@ -434,8 +453,8 @@ func (c *RuntimeConfig) MustCompile(wasmBytes []byte) *Compiled {
 }
 
 func (c *RuntimeConfig) String() string {
-	return fmt.Sprintf("RuntimeConfig{features: %s, optimizations: %d, bounds: %s, maxMemoryPages: %d, functionWorkers: %d}",
-		c.features, len(c.optimizations), c.boundsChecks, c.maxMemoryPages, c.functionWorkers)
+	return fmt.Sprintf("RuntimeConfig{features: %s, optimizations: %d, bounds: %s, maxMemoryPages: %d, functionWorkers: %d, independentInstances: %t}",
+		c.features, len(c.optimizations), c.boundsChecks, c.maxMemoryPages, c.functionWorkers, c.independentInstances)
 }
 
 // SupportedFeatures reports the WebAssembly feature set this wago build can

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -405,6 +405,9 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	if got := NewRuntimeConfig().WithCompileWorkers(3); got.CompileWorkers() != 3 || got.FunctionWorkers() != 3 {
 		t.Fatal("deprecated compile-worker aliases must preserve the function-worker policy")
 	}
+	if !NewRuntimeConfig().IndependentInstanceExecution() || NewRuntimeConfig().WithIndependentInstanceExecution(false).IndependentInstanceExecution() {
+		t.Fatal("independent instance execution must default on and support explicit opt-out")
+	}
 	wantFeatures := coreFeaturesWago
 	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
 		unsupported := CoreFeatureTailCall |

--- a/src/wago/cross_instance.go
+++ b/src/wago/cross_instance.go
@@ -795,6 +795,7 @@ func (in *Instance) ExportedTable(name string) (*Table, error) {
 	for table := in.table; table != nil; table = table.next {
 		if len(table.desc) != 0 && &table.desc[0] == &desc[0] {
 			in.lifeMu.Unlock()
+			in.markNativeControlShared()
 			return table, nil
 		}
 	}
@@ -807,6 +808,7 @@ func (in *Instance) ExportedTable(name string) (*Table, error) {
 	table := &Table{desc: desc, owner: owner, next: in.table}
 	in.table = table
 	in.lifeMu.Unlock()
+	in.markNativeControlShared()
 	return table, nil
 }
 
@@ -848,6 +850,9 @@ func (in *Instance) ExportedMemory(name string) (*Memory, error) {
 	}
 	if err := memory.share(owner, in.c.memoryDef(memoryIndex)); err != nil {
 		return nil, fmt.Errorf("export memory %q: %w", name, err)
+	}
+	if owns {
+		in.markNativeControlShared()
 	}
 	return memory, nil
 }
@@ -894,5 +899,6 @@ func (in *Instance) ExportedGlobalObject(name string) (*Global, error) {
 		g.owner = &globalOwner{store: store, instance: in, typ: g.Type, mutable: g.Mutable, valueType: exact, types: in.c.Types, hasValueType: true}
 	}
 	in.lifeMu.Unlock()
+	in.markNativeControlShared()
 	return g, nil
 }

--- a/src/wago/cross_instance.go
+++ b/src/wago/cross_instance.go
@@ -62,7 +62,7 @@ func (in *Instance) ExportedFunc(name string) (*InstanceExport, error) {
 		return nil, fmt.Errorf("export %q function index %d out of range", name, gfi)
 	}
 	sig := in.c.Funcs[li]
-	in.nativeControlShared = true
+	in.markNativeControlShared()
 	return &InstanceExport{inst: in, localIdx: li, params: sig.Params, results: sig.Results}, nil
 }
 
@@ -430,7 +430,7 @@ func (t *Table) retainProducerInstanceMode(in *Instance, finalization bool) bool
 		}
 		return false
 	}
-	in.nativeControlShared = true
+	in.markNativeControlShared()
 	if t.retained == nil {
 		t.retained = make(map[*Instance]*retainedInstanceRoot)
 	}
@@ -610,7 +610,7 @@ func (t *Table) retainDescriptorOwnersForFinalization(store *referenceStore, pro
 		if state == nil {
 			state = &retainedInstanceRoot{}
 			t.retained[owner] = state
-			owner.nativeControlShared = true
+			owner.markNativeControlShared()
 		} else {
 			release = append(release, owner)
 		}
@@ -653,7 +653,7 @@ func (t *Table) retainDescriptorOwnersForFinalization(store *referenceStore, pro
 			if state == nil {
 				state = &retainedInstanceRoot{}
 				t.retained[proxy] = state
-				proxy.nativeControlShared = true
+				proxy.markNativeControlShared()
 			} else {
 				release = append(release, proxy)
 			}

--- a/src/wago/cross_instance_test.go
+++ b/src/wago/cross_instance_test.go
@@ -674,6 +674,54 @@ func TestCrossInstanceFunctionImportRetainsProducerResources(t *testing.T) {
 	}
 }
 
+func TestIndependentInstanceExecutionFallsBackForCrossInstanceFunction(t *testing.T) {
+	producer, err := Instantiate(MustCompile(benchAddOneModule()), InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate producer: %v", err)
+	}
+	defer producer.Close()
+	target, err := producer.ExportedFunc("f")
+	if err != nil {
+		t.Fatalf("export function: %v", err)
+	}
+	consumerCode, err := NewRuntimeConfig().Compile(benchReturningImportModule())
+	if err != nil {
+		t.Fatalf("compile consumer: %v", err)
+	}
+	consumer, err := Instantiate(consumerCode, InstantiateOptions{Imports: Imports{"env.f": target}})
+	if err != nil {
+		t.Fatalf("instantiate consumer: %v", err)
+	}
+	defer consumer.Close()
+	if consumer.usesIndependentExecution() {
+		t.Fatal("cross-instance function import used an instance-local execution lease")
+	}
+}
+
+func TestProcessLeaseAllowsCrossInstanceFunction(t *testing.T) {
+	producer, err := Instantiate(MustCompile(benchAddOneModule()), InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate producer: %v", err)
+	}
+	defer producer.Close()
+	target, err := producer.ExportedFunc("f")
+	if err != nil {
+		t.Fatalf("export function: %v", err)
+	}
+	consumerCode, err := NewRuntimeConfig().WithIndependentInstanceExecution(false).Compile(benchReturningImportModule())
+	if err != nil {
+		t.Fatalf("compile consumer: %v", err)
+	}
+	consumer, err := Instantiate(consumerCode, InstantiateOptions{Imports: Imports{"env.f": target}})
+	if err != nil {
+		t.Fatalf("instantiate consumer: %v", err)
+	}
+	defer consumer.Close()
+	if consumer.usesIndependentExecution() {
+		t.Fatal("explicit opt-out used an instance-local execution lease")
+	}
+}
+
 func TestCrossInstanceCallNoArgs(t *testing.T) {
 	modA := wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}))),

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -321,7 +321,7 @@ func (g *Global) retainDescriptorOwnerForFinalization(store *referenceStore, pro
 		if state == nil {
 			state = &retainedInstanceRoot{precise: true}
 			o.retained[owner] = state
-			owner.nativeControlShared = true
+			owner.markNativeControlShared()
 		} else {
 			state.precise = true
 			release = append(release, owner)
@@ -346,7 +346,7 @@ func (g *Global) retainDescriptorOwnerForFinalization(store *referenceStore, pro
 			if state == nil {
 				state = &retainedInstanceRoot{}
 				o.retained[proxy] = state
-				proxy.nativeControlShared = true
+				proxy.markNativeControlShared()
 			} else {
 				release = append(release, proxy)
 			}
@@ -723,7 +723,7 @@ func (g *Global) setValueNoLease(v Value) error {
 				release = append(release, retainedOwner)
 			} else {
 				o.retained[retainedOwner] = &retainedInstanceRoot{precise: true}
-				retainedOwner.nativeControlShared = true
+				retainedOwner.markNativeControlShared()
 			}
 		}
 	}
@@ -1103,6 +1103,10 @@ type Compiled struct {
 	requiresBMI2       bool
 	requiresAVX2       bool
 	requiresAVX512     bool
+	// independentInstances allows instances without cross-instance Wasm imports
+	// to use instance-local native execution leases. It is intentionally not
+	// serialized because it is runtime policy rather than a module property.
+	independentInstances bool
 }
 
 // The sign bit of a fresh compilation's internal-entry offset carries the

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -129,7 +129,7 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 				panic(invalidHostReference{err: err})
 			}
 			active.jm.SetStackFence(active.eng.StackLimit())
-			if err := active.jm.BindTrapCell(active.trap); err != nil {
+			if err := active.jm.RebindTrapCell(active.trap); err != nil {
 				panic(invalidHostReference{err: err})
 			}
 			// bindNativeContext restores the instance's immutable context image,

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -101,11 +101,8 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 		panic(invalidHostReference{err: err})
 	}
 	var localMu *sync.Mutex
-	var localState *instancePluginState
 	epoch := nativeExecutionEpoch
 	if active.usesIndependentExecution() {
-		localState = active.ensurePluginState()
-		epoch = localState.nativeExecutionEpoch
 		localMu = active.independentNativeExecutionMu()
 		localMu.Unlock()
 	} else {
@@ -123,7 +120,11 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 			nativeExecutionMu.Lock()
 		}
 		active.clearGCHostResultRoots(activation)
-		if (localState != nil && localState.nativeExecutionEpoch != epoch) || (localState == nil && nativeExecutionEpoch != epoch) {
+		// Public calls on one instance are serialized, but synchronous host code
+		// may re-enter the parked instance while its local lease is released.
+		// Always restore local context; the process lease can retain its epoch
+		// shortcut because competing entries advance the shared epoch.
+		if localMu != nil || nativeExecutionEpoch != epoch {
 			if err := active.bindNativeContext(); err != nil {
 				panic(invalidHostReference{err: err})
 			}

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -100,17 +100,30 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 		active.popGCHostActivation(activation)
 		panic(invalidHostReference{err: err})
 	}
+	var localMu *sync.Mutex
+	var localState *instancePluginState
 	epoch := nativeExecutionEpoch
-	nativeExecutionMu.Unlock()
+	if active.usesIndependentExecution() {
+		localState = active.ensurePluginState()
+		epoch = localState.nativeExecutionEpoch
+		localMu = active.independentNativeExecutionMu()
+		localMu.Unlock()
+	} else {
+		nativeExecutionMu.Unlock()
+	}
 	// Keep the parked activation and any GC host-result roots published until the
 	// native execution lease is reacquired. A competing entry may collect while
 	// arbitrary host code runs, but cannot observe the unrooted handoff window
 	// between host result validation and the caller's resumed native frame.
 	defer active.popGCHostActivation(activation)
 	defer func() {
-		nativeExecutionMu.Lock()
+		if localMu != nil {
+			localMu.Lock()
+		} else {
+			nativeExecutionMu.Lock()
+		}
 		active.clearGCHostResultRoots(activation)
-		if nativeExecutionEpoch != epoch {
+		if (localState != nil && localState.nativeExecutionEpoch != epoch) || (localState == nil && nativeExecutionEpoch != epoch) {
 			if err := active.bindNativeContext(); err != nil {
 				panic(invalidHostReference{err: err})
 			}

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -129,21 +129,20 @@ type hostCallWaiter struct {
 }
 
 type instancePluginState struct {
-	hostScope            hostCallScope
-	invokeMu             sync.Mutex // serializes unrelated public calls across parked host callbacks
-	nativeExecutionMu    sync.Mutex // serializes native entry for an independent instance
-	nativeExecutionEpoch uint64     // guarded by nativeExecutionMu or memoryDir.nativeMu
-	invocationID         invocationID
-	close                atomic.Pointer[instanceCloseState]
-	gcConfig             *GCConfig
-	origin               InstantiateOrigin
-	gcPublic             atomic.Pointer[gcPublicState]
-	gcArrayElements      atomic.Pointer[gcArrayElementState]
-	gcRefTestTable       atomic.Pointer[gcRefTestTableState]
-	gcGlobalRoots        [3]gcGlobalRootMapping
-	gcGlobalRootCount    uint8
-	tagIdentityBase      uintptr      // arena-owned bounded native u64 directory for staged EH
-	tagExports           map[int]*Tag // lazy stable identity handles for exported local tags
+	hostScope         hostCallScope
+	invokeMu          sync.Mutex // serializes unrelated public calls across parked host callbacks
+	nativeExecutionMu sync.Mutex // serializes native entry for an independent instance
+	invocationID      invocationID
+	close             atomic.Pointer[instanceCloseState]
+	gcConfig          *GCConfig
+	origin            InstantiateOrigin
+	gcGlobalRootCount uint8
+	gcPublic          atomic.Pointer[gcPublicState]
+	gcArrayElements   atomic.Pointer[gcArrayElementState]
+	gcRefTestTable    atomic.Pointer[gcRefTestTableState]
+	gcGlobalRoots     [3]gcGlobalRootMapping
+	tagIdentityBase   uintptr      // arena-owned bounded native u64 directory for staged EH
+	tagExports        map[int]*Tag // lazy stable identity handles for exported local tags
 }
 
 type instanceCloseState struct {

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -129,19 +129,21 @@ type hostCallWaiter struct {
 }
 
 type instancePluginState struct {
-	hostScope         hostCallScope
-	invokeMu          sync.Mutex // serializes unrelated public calls across parked host callbacks
-	invocationID      invocationID
-	close             atomic.Pointer[instanceCloseState]
-	gcConfig          *GCConfig
-	origin            InstantiateOrigin
-	gcPublic          atomic.Pointer[gcPublicState]
-	gcArrayElements   atomic.Pointer[gcArrayElementState]
-	gcRefTestTable    atomic.Pointer[gcRefTestTableState]
-	gcGlobalRoots     [3]gcGlobalRootMapping
-	gcGlobalRootCount uint8
-	tagIdentityBase   uintptr      // arena-owned bounded native u64 directory for staged EH
-	tagExports        map[int]*Tag // lazy stable identity handles for exported local tags
+	hostScope            hostCallScope
+	invokeMu             sync.Mutex // serializes unrelated public calls across parked host callbacks
+	nativeExecutionMu    sync.Mutex // serializes native entry for an independent instance
+	nativeExecutionEpoch uint64     // guarded by nativeExecutionMu or memoryDir.nativeMu
+	invocationID         invocationID
+	close                atomic.Pointer[instanceCloseState]
+	gcConfig             *GCConfig
+	origin               InstantiateOrigin
+	gcPublic             atomic.Pointer[gcPublicState]
+	gcArrayElements      atomic.Pointer[gcArrayElementState]
+	gcRefTestTable       atomic.Pointer[gcRefTestTableState]
+	gcGlobalRoots        [3]gcGlobalRootMapping
+	gcGlobalRootCount    uint8
+	tagIdentityBase      uintptr      // arena-owned bounded native u64 directory for staged EH
+	tagExports           map[int]*Tag // lazy stable identity handles for exported local tags
 }
 
 type instanceCloseState struct {

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -45,6 +45,68 @@ func TestIndependentInstanceExecutionBypassesProcessLease(t *testing.T) {
 	}
 }
 
+func TestIndependentInstanceExecutionFallsBackForExportedState(t *testing.T) {
+	tests := []struct {
+		name   string
+		module []byte
+		export func(*Instance) error
+	}{
+		{
+			name: "memory",
+			module: wasmtest.Module(
+				wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
+				wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("state", 2, 0))),
+			),
+			export: func(in *Instance) error {
+				_, err := in.ExportedMemory("state")
+				return err
+			},
+		},
+		{
+			name: "table",
+			module: wasmtest.Module(
+				wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x00, 0x01})),
+				wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("state", 1, 0))),
+			),
+			export: func(in *Instance) error {
+				_, err := in.ExportedTable("state")
+				return err
+			},
+		},
+		{
+			name: "global",
+			module: wasmtest.Module(
+				wasmtest.Section(6, wasmtest.Vec(wasmtest.GlobalEntry(wasm.I32, true, []byte{0x41, 0x00, 0x0b}))),
+				wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("state", 3, 0))),
+			),
+			export: func(in *Instance) error {
+				_, err := in.ExportedGlobalObject("state")
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			compiled := MustCompile(test.module)
+			defer compiled.Close()
+			in, err := Instantiate(compiled, InstantiateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			if !in.usesIndependentExecution() {
+				t.Fatal("fresh instance did not use independent execution")
+			}
+			if err := test.export(in); err != nil {
+				t.Fatal(err)
+			}
+			if in.usesIndependentExecution() {
+				t.Fatal("exported cross-instance state retained independent execution")
+			}
+		})
+	}
+}
+
 // returningImportModule builds a module whose func 0 is an import of type `sig`
 // (env.f) and func 1 (exported "g") has body `body`. Optional extra sections
 // (e.g. a memory) are appended before the export section.

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -2,11 +2,48 @@ package wago
 
 import (
 	"encoding/binary"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/wasmtest"
 )
+
+func TestIndependentInstanceExecutionBypassesProcessLease(t *testing.T) {
+	sig := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	body := []byte{0x00, 0x10, 0x00, 0x0b} // call 0; end
+	c, err := NewRuntimeConfig().Compile(returningImportModule(sig, body))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, _, results []uint64) {
+		results[0] = I32(7)
+	})}})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	nativeExecutionMu.Lock()
+	defer nativeExecutionMu.Unlock()
+	done := make(chan error, 1)
+	go func() {
+		results, invokeErr := in.Invoke("g")
+		if invokeErr == nil && (len(results) != 1 || AsI32(results[0]) != 7) {
+			invokeErr = errors.New("unexpected independent invocation result")
+		}
+		done <- invokeErr
+	}()
+	select {
+	case invokeErr := <-done:
+		if invokeErr != nil {
+			t.Fatalf("invoke: %v", invokeErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("independent invocation waited for the process-wide native execution lease")
+	}
+}
 
 // returningImportModule builds a module whose func 0 is an import of type `sig`
 // (env.f) and func 1 (exported "g") has body `body`. Optional extra sections

--- a/src/wago/instance.go
+++ b/src/wago/instance.go
@@ -59,7 +59,7 @@ type Instance struct {
 	ownsMem                bool                     // false when memory 0 is host-imported (don't close it)
 	memoryDir              *instanceMemoryDirectory // allocated only for indexed memory execution
 	syncMode               bool                     // true when host imports use the synchronous re-entry protocol
-	nativeControlShared    bool                     // entered from another instance; prepared control fields may be overwritten
+	executionFlags         atomic.Uint32            // independent eligibility and cross-instance native-control sharing
 	nativeContext          uintptr                  // arena-backed context bytes rebound before every native entry
 	instructionState       instructionState
 

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -80,7 +80,6 @@ func (in *Instance) beginNativeEntry() (executionLease, error) {
 	if in.usesIndependentExecution() {
 		mu := in.independentNativeExecutionMu()
 		mu.Lock()
-		in.ensurePluginState().nativeExecutionEpoch++
 		if err := in.bindAndValidateNativeContext(); err != nil {
 			mu.Unlock()
 

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -23,6 +23,11 @@ var (
 	nativeActive         = map[nativeActivation]uint32{}
 )
 
+const (
+	executionFlagIndependent uint32 = 1 << iota
+	executionFlagNativeControlShared
+)
+
 type invocationID uint64
 
 var nextInvocationID atomic.Uint64
@@ -72,6 +77,18 @@ type executionLease struct{ local *sync.Mutex }
 // size/growth fields remain backing-owned; invocation control is refreshed by
 // the engine entry/resume paths.
 func (in *Instance) beginNativeEntry() (executionLease, error) {
+	if in.usesIndependentExecution() {
+		mu := in.independentNativeExecutionMu()
+		mu.Lock()
+		in.ensurePluginState().nativeExecutionEpoch++
+		if err := in.bindAndValidateNativeContext(); err != nil {
+			mu.Unlock()
+
+			return executionLease{}, err
+		}
+
+		return executionLease{local: mu}, nil
+	}
 	if in.c.threadedMemory0() {
 		mu := &in.memoryDir.nativeMu
 		mu.Lock()
@@ -145,6 +162,31 @@ func (l executionLease) unlockExecution() {
 	nativeExecutionMu.Unlock()
 }
 
+func (in *Instance) independentNativeExecutionMu() *sync.Mutex {
+	if in.memoryDir != nil {
+		return &in.memoryDir.nativeMu
+	}
+
+	return &in.ensurePluginState().nativeExecutionMu
+}
+
+func (in *Instance) usesIndependentExecution() bool {
+	if in == nil {
+		return false
+	}
+	flags := in.executionFlags.Load()
+
+	return flags&executionFlagIndependent != 0 && flags&executionFlagNativeControlShared == 0
+}
+
+func (in *Instance) markNativeControlShared() {
+	in.executionFlags.Or(executionFlagNativeControlShared)
+}
+
+func (in *Instance) nativeControlIsShared() bool {
+	return in != nil && in.executionFlags.Load()&executionFlagNativeControlShared != 0
+}
+
 func (in *Instance) lockThreadedInstanceState() *sync.Mutex {
 	if in == nil || in.c == nil || !in.c.threadedMemory0() {
 		return nil
@@ -154,6 +196,12 @@ func (in *Instance) lockThreadedInstanceState() *sync.Mutex {
 }
 
 func (in *Instance) lockInstanceNativeStateForHostAccess() func() {
+	if in.usesIndependentExecution() {
+		mu := in.independentNativeExecutionMu()
+		mu.Lock()
+
+		return mu.Unlock
+	}
 	if in != nil && in.c != nil && in.c.threadedMemory0() {
 		in.memoryDir.nativeMu.Lock()
 		return in.memoryDir.nativeMu.Unlock
@@ -203,7 +251,7 @@ const (
 
 func (in *Instance) preparedEntryMode() preparedEntryMode {
 	if in == nil || in.c == nil || in.c.boundsMode == BoundsChecksSignalsBased ||
-		in.memoryDir != nil || in.nativeControlShared || in.syncMode {
+		in.memoryDir != nil || in.nativeControlIsShared() || in.syncMode {
 		return preparedEntryGeneral
 	}
 	if in.memory != nil {

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -180,7 +180,13 @@ func (in *Instance) usesIndependentExecution() bool {
 }
 
 func (in *Instance) markNativeControlShared() {
-	in.executionFlags.Or(executionFlagNativeControlShared)
+	for {
+		flags := in.executionFlags.Load()
+		if flags&executionFlagNativeControlShared != 0 ||
+			in.executionFlags.CompareAndSwap(flags, flags|executionFlagNativeControlShared) {
+			return
+		}
+	}
 }
 
 func (in *Instance) nativeControlIsShared() bool {

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -156,6 +156,22 @@ func (b *instanceBuilder) validateCompiled() error {
 	return b.c.validateCached()
 }
 
+func (c *Compiled) allowsIndependentInstanceExecution(imports Imports) bool {
+	if !c.independentInstances {
+		return false
+	}
+	if c.memoryImportCount() != 0 || c.tableImportCount() != 0 || len(c.GlobalImports) != 0 {
+		return false
+	}
+	for _, key := range c.Imports {
+		if _, ok := imports[key].(*InstanceExport); ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (c *Compiled) arenaNeedForImports(imports Imports, syncMode bool) int {
 	need := c.instantiateArenaNeed
 	baselineHostBytes := 0
@@ -1382,6 +1398,9 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, hosts: imports.hostFuncs(), imports: imports, hostLog: hostLog, syncMode: syncMode, ctrl: ctrl, syncHosts: syncHosts, globals: globals, globalCells: globalCells, tableDescPtr: tableDescPtr, tableDescLen: len(tableDesc), funcRefDescs: funcRefDescs, passiveDataDesc: passiveDataDesc, thunkMem: thunkMem, gc: b.collector, gcTypeMap: b.gcTypeMap, gcNativeView: gcNativeView,
 		serArgs: serArgs, results: results, trap: trap, resultVals: make([]uint64, c.maxResultSlots), rt: opts.runtime,
 		nativeContext: nativeContextPtr,
+	}
+	if c.allowsIndependentInstanceExecution(imports) {
+		in.executionFlags.Store(executionFlagIndependent)
 	}
 	b.registeredInstance = in
 	if in.syncMode {

--- a/src/wago/prepared_function_test.go
+++ b/src/wago/prepared_function_test.go
@@ -184,7 +184,7 @@ func TestPreparedFunctionIsolatedEligibility(t *testing.T) {
 	}
 	if !in.preparedIsolatedEligible() {
 		t.Fatalf("plain scalar instance should be isolated: private=%v dir=%v sharedctx=%v sync=%v memory=%v owns=%v globals=%d table=%#x gc=%v imports=%d refs=%v",
-			in.preparedPrivateEligible(), in.memoryDir != nil, in.nativeControlShared, in.syncMode, in.memory != nil, in.ownsMem,
+			in.preparedPrivateEligible(), in.memoryDir != nil, in.nativeControlIsShared(), in.syncMode, in.memory != nil, in.ownsMem,
 			len(in.globalCells), in.tableDescPtr, in.gc != nil, in.c.NumImports, in.c.NeedsFuncRefDescs)
 	}
 
@@ -307,7 +307,7 @@ func TestInvokeScalarUsesIsolatedEntry(t *testing.T) {
 
 	// Attachment can make native control shared after this export was cached.
 	// The cached scalar shape must then fall back to rebinding under the lease.
-	in.nativeControlShared = true
+	in.markNativeControlShared()
 	done = make(chan result, 1)
 	nativeExecutionMu.Lock()
 	go func() {


### PR DESCRIPTION
## Problem

The process-wide native execution lease serializes unrelated instances, preventing isolated workloads from scaling across cores.

## Change

- Use instance-local native execution leases by default.
- Detect cross-instance Wasm functions, memories, tables, and globals and fall back to the process-wide lease automatically.
- Keep `WithIndependentInstanceExecution(false)` as a conservative mode for extensions with shared native state Wago cannot detect.
- Preserve nested host re-entry, GC roots, close interruption, and shared native-control safety.
- Add a corpus-parallel benchmark comparing both lease modes.

## ARM64 results

Linux ARM64, 12 CPUs, guard-page bounds, five 300 ms samples; medians:

| Corpus | Independent | Process lease | Throughput gain |
| --- | ---: | ---: | ---: |
| nbody | 13,266 ns/op | 159,494 ns/op | 12.02x |
| spectral norm | 33,781 ns/op | 385,740 ns/op | 11.42x |
| quicksort | 6,362 ns/op | 80,828 ns/op | 12.71x |
| SHA-256 | 2,591 ns/op | 28,534 ns/op | 11.01x |
| ray tracing | 26,411 ns/op | 307,198 ns/op | 11.63x |

Independent rows remain at 0 B/op and 0 allocs/op.

## Validation

- `GOWORK=off go test ./... -skip TestRuntimeRegressionPortResourceFootprintRemainsBounded -count=1`
- `GOWORK=off go test ./... -count=1` in the benchmark module
- Focused race and guard-page tests for independent execution, linked fallback, host re-entry, close interruption, and instance footprint