### PR TITLE
fix memory bounds after host reentry

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -14,6 +14,16 @@ import (
 	"github.com/wago-org/wago/src/core/runtime/abi"
 )
 
+// refreshCachedMemoryBoundAfterExternalCall reestablishes the memory-zero
+// bounds cache after a continuation resumes from code outside this compilation
+// context. The external code may have grown an aliased memory, and a
+// cross-instance continuation must read from the restored caller basedata.
+func (f *fn) refreshCachedMemoryBoundAfterExternalCall() {
+	if f.memSizeReg != regNone {
+		f.a.Load64(f.memSizeReg, RBX, -bdCurBytes)
+	}
+}
+
 // regABIEnabled turns on the register-based internal-call ABI (default on;
 // WAGO_Amd64_NOREGABI=1 forces the wrapper ABI everywhere, for A/B measurement).
 var regABIEnabled = os.Getenv("WAGO_Amd64_NOREGABI") != "1"
@@ -629,9 +639,7 @@ func (f *fn) emitTailDynamicImportJump(ft *wasm.CompType, b ImportBinding) {
 	f.a.Load64(RBX, RSP, 0)
 	f.a.Load64(R10, RSP, 8)
 	f.copyInstanceContext(RBX, R10)
-	if f.memSizeReg != regNone {
-		f.a.Load64(f.memSizeReg, RBX, -bdCurBytes)
-	}
+	f.refreshCachedMemoryBoundAfterExternalCall()
 	f.deriveModuleGlobals()
 	if len(ft.Results) > 0 {
 		if isFloatValType(ft.Results[0]) {
@@ -707,9 +715,7 @@ func (f *fn) emitTailCrossDirectJump(ft *wasm.CompType, b ImportBinding) {
 	trampoline := f.a.Len()
 	f.a.PatchRel32(trampolineSite, trampoline)
 	f.a.Load64(RBX, RSP, 0)
-	if f.memSizeReg != regNone {
-		f.a.Load64(f.memSizeReg, RBX, -bdCurBytes)
-	}
+	f.refreshCachedMemoryBoundAfterExternalCall()
 	f.deriveModuleGlobals()
 	if len(ft.Results) > 0 {
 		if isFloatValType(ft.Results[0]) {
@@ -1142,6 +1148,10 @@ func (f *fn) callHostSync(importIdx int, ft *wasm.CompType) error {
 		}
 		value.st.gcRoot = gcFrameRefType(f.m, ft.Results[j])
 	}
+	// Arbitrary host code can synchronously re-enter this instance and grow its
+	// memory. Reload after reconstructing the operand stack so the continuation
+	// cannot retain the parked activation's pre-call size.
+	f.refreshCachedMemoryBoundAfterExternalCall()
 	return nil
 }
 
@@ -1409,6 +1419,10 @@ func (f *fn) emitCrossInstanceCall(b ImportBinding, ft *wasm.CompType) error {
 	if b.Dynamic {
 		f.copyInstanceContext(RBX, R9)
 	}
+	// A dynamic target may be arbitrary host code that synchronously re-enters
+	// this caller and grows its memory. R15 was saved before that call, so reload
+	// from the restored caller context instead of reviving the stale bound.
+	f.refreshCachedMemoryBoundAfterExternalCall()
 
 	f.reloadLocalsForCall() // non-STACK_REG model only
 	f.deriveModuleGlobals() // cross-instance callee may have written shared global cells
@@ -2370,9 +2384,7 @@ func (f *fn) emitTailCrossWrapperJump(ft *wasm.CompType) {
 	f.a.Load64(RBX, RSP, 0)
 	f.a.Load64(R10, RSP, 8)
 	f.copyInstanceContext(RBX, R10)
-	if f.memSizeReg != regNone {
-		f.a.Load64(f.memSizeReg, RBX, -bdCurBytes)
-	}
+	f.refreshCachedMemoryBoundAfterExternalCall()
 	f.deriveModuleGlobals()
 	if len(ft.Results) > 0 {
 		if mtOf(ft.Results[0]).isFloat() {

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -15,6 +15,16 @@ import (
 	"github.com/wago-org/wago/src/core/runtime/abi"
 )
 
+// refreshCachedMemoryBoundAfterExternalCall reestablishes the memory-zero
+// bounds cache after a continuation resumes from code outside this compilation
+// context. The external code may have grown an aliased memory, and a
+// cross-instance continuation must read from the restored caller basedata.
+func (f *fn) refreshCachedMemoryBoundAfterExternalCall() {
+	if f.memSizeReg != regNone {
+		f.ld64(f.memSizeReg, linMemReg, -int32(bdCurBytes))
+	}
+}
+
 // regABIEnabled turns on the register-based internal-call ABI (default on;
 // WAGO_ARM64_NOREGABI=1 forces the wrapper ABI everywhere, for A/B measurement).
 var regABIEnabled = os.Getenv("WAGO_ARM64_NOREGABI") != "1"
@@ -432,9 +442,7 @@ func (f *fn) emitTailDynamicImportJump(ft *wasm.CompType, b ImportBinding) error
 	f.ld64(X11, SP, 16)
 	f.copyInstanceContext(X10, X11)
 	f.a.MovReg64(linMemReg, X10)
-	if f.memSizeReg != regNone {
-		f.ld64(f.memSizeReg, linMemReg, -bdCurBytes)
-	}
+	f.refreshCachedMemoryBoundAfterExternalCall()
 	f.deriveModuleGlobals()
 	f.derivePinnedGlobals()
 	if len(ft.Results) > 0 {
@@ -686,9 +694,7 @@ func (f *fn) emitTailDescriptorWrapperJump(ft *wasm.CompType) {
 	f.ld64(X11, SP, 16)
 	f.copyInstanceContext(X10, X11)
 	f.a.MovReg64(linMemReg, X10)
-	if f.memSizeReg != regNone {
-		f.ld64(f.memSizeReg, linMemReg, -bdCurBytes)
-	}
+	f.refreshCachedMemoryBoundAfterExternalCall()
 	f.deriveModuleGlobals()
 	f.derivePinnedGlobals()
 	if len(ft.Results) > 0 {
@@ -1064,6 +1070,10 @@ func (f *fn) callHostSync(importIdx int, ft *wasm.CompType) error {
 		}
 		value.st.gcRoot = f.tracksGCFrameRoots() && arm64GCFrameRefType(f.m, ft.Results[j])
 	}
+	// Arbitrary host code can synchronously re-enter this instance and grow its
+	// memory. Reload after reconstructing the operand stack so the continuation
+	// cannot retain the parked activation's pre-call size.
+	f.refreshCachedMemoryBoundAfterExternalCall()
 	return nil
 }
 
@@ -1323,6 +1333,10 @@ func (f *fn) emitCrossInstanceCall(b ImportBinding, ft *wasm.CompType) error {
 	if b.Dynamic {
 		f.copyInstanceContext(linMemReg, X16)
 	}
+	// A dynamic target may be arbitrary host code that synchronously re-enters
+	// this caller and grows its memory. Reload from the restored caller context
+	// before its continuation resumes.
+	f.refreshCachedMemoryBoundAfterExternalCall()
 
 	f.reloadLocalsForCall() // non-STACK_REG model only
 	f.deriveModuleGlobals() // cross-instance callee may have written shared global cells

--- a/src/wago/shared_memory_basedata_test.go
+++ b/src/wago/shared_memory_basedata_test.go
@@ -4,7 +4,10 @@ package wago
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 )
 
 // Shared-memory importers capture their per-instance basedata pointers and
@@ -145,7 +148,138 @@ func TestSharedMemoryIndirectCallSwitchesPrivateContext(t *testing.T) {
 	}
 }
 
-func mustCompileWat(rt *Runtime, t *testing.T, wat string) *Module {
+func TestHostReentryRefreshesMemorySizeAfterNestedGrow(t *testing.T) {
+	rt := NewRuntime(WithRuntimeConfig(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit)))
+	defer rt.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var instance *Instance
+	instance, err := rt.Instantiate(ctx, mustCompileWat(rt, t, `(module
+		(import "env" "reenter" (func $reenter (result i32)))
+		(memory (export "memory") 1 3)
+		(func (export "grow") (result i32)
+			(memory.grow (i32.const 1)))
+		(func (export "outer") (result i32 i32 i32 i32 i32 i32 i32)
+			(call $reenter) drop
+			memory.size
+			(i32.store (i32.const 65536) (i32.const 42))
+			(i32.load (i32.const 65536))
+			(memory.fill (i32.const 65540) (i32.const 127) (i32.const 4))
+			(memory.copy (i32.const 65544) (i32.const 65540) (i32.const 4))
+			(i32.load8_u (i32.const 65547))
+			(call $reenter)
+			(call $reenter)
+			memory.size
+			(i32.store (i32.const 131072) (i32.const 99))
+			(i32.load (i32.const 131072))))`), WithImports(Imports{
+		"env.reenter": HostFunc(func(caller HostModule, _, results []uint64) {
+			grown, callErr := instance.InvokeFromHost(ctx, caller, "grow")
+			if callErr != nil {
+				panic(HostTrap{Err: callErr})
+			}
+			if len(grown) != 1 {
+				panic(HostTrap{Err: fmt.Errorf("nested memory.grow = %v, want one result", grown)})
+			}
+			if got := len(instance.Memory().Bytes()); got < 2*65536 || got > 3*65536 {
+				panic(HostTrap{Err: fmt.Errorf("memory after nested grow = %d bytes", got)})
+			}
+			if got := len(caller.Memory()); got < 2*65536 || got > 3*65536 {
+				panic(HostTrap{Err: fmt.Errorf("caller memory after nested grow = %d bytes", got)})
+			}
+			results[0] = grown[0]
+		}),
+	}), WithSynchronousHostCalls())
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer instance.Close()
+
+	got, err := instance.InvokeContext(ctx, "outer")
+	if err != nil {
+		t.Fatalf("outer after nested memory.grow: %v", err)
+	}
+	want := []int32{2, 42, 127, 2, -1, 3, 99}
+	if len(got) != len(want) {
+		t.Fatalf("outer = %v, want %v", got, want)
+	}
+	for i := range want {
+		if value := AsI32(got[i]); value != want[i] {
+			t.Fatalf("outer result %d = %d, want %d (all results %v)", i, value, want[i], got)
+		}
+	}
+}
+
+func BenchmarkExternalCallMemoryContinuation(b *testing.B) {
+	for _, tc := range []struct {
+		name          string
+		crossInstance bool
+		memoryAccess  bool
+		calls         int
+	}{
+		{name: "host-noop", calls: 1},
+		{name: "host-then-load", memoryAccess: true, calls: 1},
+		{name: "cross-instance", crossInstance: true, calls: 1},
+		{name: "host-64-sites", calls: 64},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			rt := NewRuntime(WithRuntimeConfig(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit)))
+			defer rt.Close()
+
+			var body strings.Builder
+			for range tc.calls {
+				body.WriteString("(call $external)\n")
+			}
+			if tc.memoryAccess {
+				body.WriteString("(i32.load (i32.const 0))")
+			} else {
+				body.WriteString("(i32.const 0)")
+			}
+			mod := mustCompileWat(rt, b, fmt.Sprintf(`(module
+				(import "env" "external" (func $external))
+				(memory 1 1)
+				(func (export "run") (result i32)
+					%s))`, body.String()))
+			var external any = HostFunc(func(HostModule, []uint64, []uint64) {})
+			var callee *Instance
+			if tc.crossInstance {
+				calleeMod := mustCompileWat(rt, b, `(module (func (export "external")))`)
+				var err error
+				callee, err = rt.Instantiate(context.Background(), calleeMod)
+				if err != nil {
+					b.Fatalf("instantiate callee: %v", err)
+				}
+				defer callee.Close()
+				external, err = callee.ExportedFunc("external")
+				if err != nil {
+					b.Fatalf("export callee: %v", err)
+				}
+			}
+			in, err := rt.Instantiate(context.Background(), mod, WithImports(Imports{"env.external": external}), WithSynchronousHostCalls())
+			if err != nil {
+				b.Fatalf("instantiate caller: %v", err)
+			}
+			defer in.Close()
+			if _, err := in.Invoke("run"); err != nil {
+				b.Fatalf("warm invoke: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				result, err := in.Invoke("run")
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchResultSink = result
+			}
+			b.ReportMetric(float64(mod.c.CodeSize()), "code-B")
+			b.ReportMetric(float64(tc.calls), "external-calls/op")
+		})
+	}
+}
+
+func mustCompileWat(rt *Runtime, t testing.TB, wat string) *Module {
 	t.Helper()
 	m, err := rt.Compile(watToWasm(t, wat))
 	if err != nil {


### PR DESCRIPTION
Fix stale linear-memory bounds after synchronous host re-entry grows shared memory.

- reload the cached memory size after sync host calls
- reload it after restoring dynamic cross-instance caller context
- cover nested guest re-entry + memory.grow with an amd64 runtime regression
- keep the arm64 path in parity

Validation:
- focused regression passes 20 consecutive runs
- amd64 compiler package passes
- arm64 compiler/runtime packages cross-compile
- the WASI Preview 2 corpus passes all 35 Wasmtime-reference fixtures with this fix

The broader src/wago package includes staged spec tests that require the absent tests/spec-v3 checkout; those fail at corpus discovery in this worktree.