### PR TITLE
arm64: reduce local register traffic

### DIFF
--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -148,6 +148,12 @@ type fn struct {
 	pinnedLocalMask  regMask
 	fpinnedLocalMask regMask
 
+	// Bounded straight-line local intervals. A nonzero last-get offset plus the
+	// score marks eligibility; locals[x].reg exists only while the cache is live.
+	intervalLast  []uint32
+	intervalScore []uint32
+	intervalOwner [32]int
+
 	// WARP STACK_REG lazy-spill model for pinned locals in CALL-MAKING functions
 	// (usesCalls). locals[i].state tracks whether the live value of pinned local i is
 	// in its register (dirty), in both register+slot (clean), or only in its slot.
@@ -187,16 +193,17 @@ type fn struct {
 	// spillFloor temporarily reserves a low spill-slot range while wide-stack
 	// canonicalization stages values above both their old homes and destinations.
 	spillFloor       int
-	subRspAt         int   // byte offset of the prologue's frame-alloc MOVZ (patched with frameSize)
-	addRspAt         int   // byte offset of the epilogue's frame-free MOVZ (patched with frameSize)
-	tailFrameSites   []int // tail-transfer frame-free MOVZ sites (patched with frameSize)
-	frameElided      bool  // simple register-only internal entry leaves SP unchanged
-	adapterReturnOff int   // register-ABI wrapper continuation used by cross-tail reuse
-	guardMode        bool  // elide inline bounds checks; rely on guard-page + SIGSEGV trap
-	boundsFacts      bool  // P6.1 straight-line bounds-check elision enabled (explicit mode)
-	interruptible    bool  // emit context-cancellation polls at entries and loop headers
-	lazyZero         bool  // defer declared-local zeroing for small call+memory functions
-	skipFence        bool  // call-free leaf with a provably small frame: no stack-fence check
+	subRspAt         int    // byte offset of the prologue's frame-alloc MOVZ (patched with frameSize)
+	addRspAt         int    // byte offset of the epilogue's frame-free MOVZ (patched with frameSize)
+	tailFrameSites   []int  // tail-transfer frame-free MOVZ sites (patched with frameSize)
+	frameElided      bool   // simple register-only internal entry leaves SP unchanged
+	adapterReturnOff int    // register-ABI wrapper continuation used by cross-tail reuse
+	guardMode        bool   // elide inline bounds checks; rely on guard-page + SIGSEGV trap
+	boundsFacts      bool   // P6.1 straight-line bounds-check elision enabled (explicit mode)
+	interruptible    bool   // emit context-cancellation polls at entries and loop headers
+	lazyZero         bool   // defer declared-local zeroing for small call+memory functions
+	entryInitialized uint64 // locals proven assigned before their first entry-prefix read
+	skipFence        bool   // call-free leaf with a provably small frame: no stack-fence check
 
 	// memSizeReg caches the linear-memory size in bytes ([linMemReg-bdCurBytes]) in a
 	// dedicated register for the whole module (WARP's REGS::memSize=R27, which
@@ -1001,6 +1008,7 @@ func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHint
 		return nil, nil, fmt.Errorf("function hint globals overflow")
 	}
 	localScores := make([]uint32, totalLocals)
+	localLastGets := make([]uint32, totalLocals)
 	denseGlobals := uint64(n)*uint64(nGlobals) <= 1<<20
 	var globalScores []uint32
 	var globalEligibility []bool
@@ -1033,6 +1041,7 @@ func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHint
 			h = funcHintsWithStorage(localScores[localAt:localAt+nLocals], nil, nil)
 			h.globalAccum = &sparseAccum
 		}
+		h.localLastGet = localLastGets[localAt : localAt+nLocals]
 		h.nLocals = nLocals
 		var err error
 		h, err = scanFuncBodyInto(m.Code[i], nLocals, nGlobals, uint32(importedFuncs+i), m.BranchHintsForFunc(uint32(importedFuncs+i)), h, &eligibilityTracker, m)
@@ -1325,7 +1334,11 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	f := &sc.fnState
 	localType, localSlot, locals := f.localType, f.localSlot, f.locals
 	mt0, _ := m.MemoryType(0)
-	*f = fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, gcTypeLayouts: gcTypeLayouts, transient: sc.transient, traceFuncIdx: uint32(globalIdx), tracePCBase: c.LocalDeclBytes, customInstructions: customInstructions, nParams: len(ft.Params), nLocals: nLocals, localType: localType, localSlot: localSlot, locals: locals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, gcStructHelpers: gcStructHelpers, gcArrayHelpers: gcArrayHelpers, gcFrameRoots: gcFrameRoots, moduleEH: hints.moduleEH, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stagedTailDescriptors: true, stats: stats, branchHints: m.BranchHintsForFunc(uint32(globalIdx)), branchHintLocalDecl: c.LocalDeclBytes, calleePreservesPins: calleePreservesPins, threadedMemory0: mt0.Shared}
+	entryInitialized := hints.entryInitialized
+	if !entryInitElisionEnabled || gcFrameRoots != nil && gcFrameRoots.Candidate {
+		entryInitialized = 0
+	}
+	*f = fn{a: sc.asm, s: sc.stack, sc: sc, m: m, ft: ft, gcTypeLayouts: gcTypeLayouts, transient: sc.transient, traceFuncIdx: uint32(globalIdx), tracePCBase: c.LocalDeclBytes, customInstructions: customInstructions, nParams: len(ft.Params), nLocals: nLocals, localType: localType, localSlot: localSlot, locals: locals, guardMode: guardMode, boundsFacts: boundsFacts, interruptible: interruptible, gcStructHelpers: gcStructHelpers, gcArrayHelpers: gcArrayHelpers, gcFrameRoots: gcFrameRoots, moduleEH: hints.moduleEH, regMerge: regMergeEnabled, globalCellReg: regNone, memSizeReg: regNone, immutableLocalTable: hints.immutableLocalTable, immutableTableType: hints.immutableTableType, immutableTableTyped: hints.immutableTableTyped, monomorphicTarget: hints.monomorphicTarget, importBindings: importBindings, stagedTailDescriptors: true, stats: stats, branchHints: m.BranchHintsForFunc(uint32(globalIdx)), branchHintLocalDecl: c.LocalDeclBytes, calleePreservesPins: calleePreservesPins, threadedMemory0: mt0.Shared, entryInitialized: entryInitialized}
 	defer func() {
 		sc.ctrl = f.ctrl
 		sc.transient = f.transient
@@ -1496,6 +1509,11 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 		}
 	}
 	f.installModuleGlobals(modGlobals)
+	intervalRegion := pinLocals && regABI && !hasCall && !hints.hasControlFlow &&
+		!hints.usesBulkMem && len(inlinedCallees) == 0 && f.prepareIntervalRegion(c.BodyBytes, hints)
+	if intervalRegion {
+		gpPool = nil // regional assignments supersede whole-function GP pins
+	}
 	f.assignPinnedLocals(hints.localScore, globalScores, globalElig, hints.sparseGlobals, gpPool, hasCall, pinLocals)
 	for i := range f.locals {
 		if r := f.locals[i].reg; r >= X2 && r <= X7 {
@@ -1783,9 +1801,13 @@ func (f *fn) assignPinnedLocals(scores, globalScores []uint32, globalElig []bool
 	// preserve the low 64 bits, so a v128 pin is confined to the call-free class.
 	pinV128 := v128LocalPinsEnabled && !hasCall
 	fc := f.tmpInts[:0]
+	hotV128Candidates := 0
 	for i := 0; i < f.nLocals; i++ {
 		if f.localType[i].isFloat() || (pinV128 && f.localType[i] == mtV128) {
 			fc = append(fc, i)
+			if f.localType[i] == mtV128 && scores[i] > 0 {
+				hotV128Candidates++
+			}
 		}
 	}
 	slices.SortFunc(fc, func(a, b int) int {
@@ -1796,10 +1818,18 @@ func (f *fn) assignPinnedLocals(scores, globalScores []uint32, globalElig []bool
 	})
 	f.tmpInts = fc
 	fpPinLimit := len(pinnedFLocalRegs)
+	deepV128Pins := false
 	if legacyFPPinsEnabled && fpPinLimit > 4 {
 		fpPinLimit = 4
 	} else if !extendedFPPinsEnabled && fpPinLimit > basePinnedFLocalRegs {
 		fpPinLimit = basePinnedFLocalRegs
+	} else if !hasCall && hotV128Candidates >= 24 {
+		// Wide vector kernels have short expression trees but large named v128
+		// state. Keeping that state resident is worth the smaller transient pool;
+		// scalar-float kernels retain the measured 15-pin cap below.
+		fpPinLimit = len(pinnedFLocalRegs)
+		deepV128Pins = true
+		f.stats.peep("deep-v128-local-pins")
 	} else if !hasCall && fpPinLimit > callFreePinnedFLocalRegs {
 		// Call-free numeric loops still need room for wide expression trees. Past
 		// this point nbody loses more to transient-register pressure than it gains
@@ -1827,6 +1857,9 @@ func (f *fn) assignPinnedLocals(scores, globalScores []uint32, globalElig []bool
 	}
 	for k, i := range fc {
 		if k >= fpPinLimit {
+			break
+		}
+		if deepV128Pins && scores[i] == 0 {
 			break
 		}
 		f.locals[i].reg = pinnedFLocalRegs[k]
@@ -2056,6 +2089,10 @@ func (f *fn) zeroDeclaredLocals() {
 		a := f.a
 		// AArch64 has a zero register (XZR): store it directly, no scratch to clear.
 		for i := f.nParams; i < f.nLocals; i++ {
+			if i < 64 && f.entryInitialized&(uint64(1)<<uint(i)) != 0 {
+				f.stats.peep("entry-init-elide")
+				continue
+			}
 			if pr, _, ok := f.pinReg(i); ok && f.localType[i] == mtV128 {
 				a.NeonEor16b(pr, pr, pr) // zero the whole 128-bit pin register
 			} else if pr, isFloat, ok := f.pinReg(i); ok && !isFloat {

--- a/src/core/compiler/backend/railshot/arm64/driver.go
+++ b/src/core/compiler/backend/railshot/arm64/driver.go
@@ -160,6 +160,12 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 		}
 		x := uint32(int(x32) + f.localBase) // localBase remaps an inlined callee's locals; 0 otherwise
 		var value *elem
+		f.activateIntervalLocal(int(x), r.Offset(), true)
+		if reg, ok := f.takeFinalIntervalGet(int(x), r.Offset()); ok {
+			value = f.pushReg(reg, f.localType[x])
+			value.st.gcRoot = f.gcFrameLocal(int(x))
+			break
+		}
 		if f.localConstZero(int(x)) {
 			if pr, _, ok := f.pinReg(int(x)); ok {
 				f.recoverLocal(int(x)) // materialize the lazy zero into the pinned register
@@ -190,7 +196,7 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 				return err
 			}
 		}
-		f.setLocal(int(x)+f.localBase, op == 0x22) // localBase remaps an inlined callee's locals; 0 otherwise
+		f.setLocal(r, int(x)+f.localBase, op == 0x22) // localBase remaps an inlined callee's locals; 0 otherwise
 	case 0x23: // global.get
 		return f.globalGet(r)
 	case 0x24: // global.set
@@ -1116,7 +1122,7 @@ func subtreeRefsLocal(e *elem, x int) bool {
 	return false
 }
 
-func (f *fn) setLocal(x int, tee bool) {
+func (f *fn) setLocal(reader *wasm.Reader, x int, tee bool) {
 	if f.bcKind == 1 && f.bcIdx == uint32(x) {
 		f.invalidateBoundsCert() // the certified base local changed value
 	}
@@ -1139,6 +1145,9 @@ func (f *fn) setLocal(x int, tee bool) {
 		}
 	}
 	f.realizeLocalRefs(x, skipFrom)
+	if reader != nil {
+		f.activateIntervalLocal(x, reader.Offset(), false)
+	}
 	if pr, isFloat, ok := f.pinReg(x); ok && !isFloat {
 		// Register-pinned local: compute/load directly into the local's register.
 		// condenseInto may temporarily mark pr as an owned result for deferred

--- a/src/core/compiler/backend/railshot/arm64/hints.go
+++ b/src/core/compiler/backend/railshot/arm64/hints.go
@@ -65,6 +65,13 @@ type funcHints struct {
 	// per enclosing loop level.
 	localScore  []uint32
 	globalScore []uint32
+	// localLastGet records the byte offset immediately after each local's final
+	// local.get. It lets the bounded regional cache return a register as soon as
+	// that local's lifetime ends without rescanning the body during compilation.
+	localLastGet []uint32
+	// entryInitialized marks locals whose first access in the straight-line entry
+	// prefix is local.set/tee, making their declared zero unobservable.
+	entryInitialized uint64
 
 	// globalElig[g]: global g is accessed inside a loop whose subtree contains NO
 	// call. Value-pinning such a global in a call-making function is a win: the
@@ -87,6 +94,7 @@ type funcHints struct {
 
 func newFuncHints(nLocals, nGlobals int) funcHints {
 	h := funcHintsWithStorage(make([]uint32, nLocals), make([]uint32, nGlobals), make([]bool, nGlobals))
+	h.localLastGet = make([]uint32, nLocals)
 	h.nLocals = nLocals
 	return h
 }
@@ -476,7 +484,7 @@ func scanBodyBytesWithHints(body []byte, localDeclBytes uint32, nLocals int, nGl
 func scanBodyBytesInto(body []byte, localDeclBytes uint32, nLocals int, nGlobals int, selfIdx uint32, branchHints []wasm.BranchHint, h funcHints, elig *globalEligibilityTracker, m *wasm.Module) (funcHints, error) {
 	elig.reset()
 	r := wasm.ReaderFrom(body)
-	s := byteBodyScanner{r: byteScanReader{Reader: r}, h: h, nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, localDeclBytes: localDeclBytes, branchHints: branchHints, elig: elig, m: m}
+	s := byteBodyScanner{r: byteScanReader{Reader: r}, h: h, nLocals: nLocals, nGlobals: nGlobals, selfIdx: selfIdx, localDeclBytes: localDeclBytes, branchHints: branchHints, elig: elig, m: m, entryPrefix: true}
 	called, term, err := s.scanExpr(0, 0, -1, false, 1)
 	if err != nil {
 		return s.h, err
@@ -500,6 +508,8 @@ type byteBodyScanner struct {
 	branchHints    []wasm.BranchHint
 	elig           *globalEligibilityTracker
 	m              *wasm.Module
+	entryPrefix    bool
+	entrySeen      uint64
 }
 
 func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAtElse bool, pathWeight int64) (bool, byte, error) {
@@ -515,6 +525,7 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 		switch op {
 		case 0x00, 0x02, 0x03, 0x04, 0x05, 0x0c, 0x0d, 0x0e, 0x0f, 0x1f:
 			s.h.hasControlFlow = true
+			s.entryPrefix = false
 			if op == 0x03 {
 				s.h.hasLoop = true
 			}
@@ -616,8 +627,20 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 			s.noteStackArenaOp(op, &imm)
 			idx := imm.Index
 			if int(idx) < s.nLocals {
+				if s.entryPrefix && idx < 64 {
+					bit := uint64(1) << idx
+					if s.entrySeen&bit == 0 {
+						s.entrySeen |= bit
+						if op != 0x20 {
+							s.h.entryInitialized |= bit
+						}
+					}
+				}
 				if op == 0x20 {
 					addHotness(s.h.localScore, idx, pathWeight*loopWeight(loopDepth))
+					if int(idx) < len(s.h.localLastGet) {
+						s.h.localLastGet[idx] = uint32(s.r.off())
+					}
 				} else {
 					addHotness(s.h.localScore, idx, 2*pathWeight*loopWeight(loopDepth))
 				}

--- a/src/core/compiler/backend/railshot/arm64/inline.go
+++ b/src/core/compiler/backend/railshot/arm64/inline.go
@@ -703,7 +703,7 @@ func (f *fn) bindInlineParams(t *inlineTarget, base int) {
 	// The p args are the top operands (deepest = param 0). Pop each into its param
 	// local. setLocal takes the absolute index (localBase is still 0 here).
 	for i := t.params - 1; i >= 0; i-- {
-		f.setLocal(base+i, false)
+		f.setLocal(nil, base+i, false)
 	}
 	if t.nLocals > t.params {
 		z := f.allocReg(0)

--- a/src/core/compiler/backend/railshot/arm64/interval_region.go
+++ b/src/core/compiler/backend/railshot/arm64/interval_region.go
@@ -1,0 +1,154 @@
+//go:build arm64
+
+package arm64
+
+const (
+	minIntervalRegionBody   = 128
+	minIntervalRegionLocals = 32
+	maxIntervalRegionBody   = 16 << 10
+	maxIntervalRegionLocals = 256
+	maxIntervalRegionRegs   = 18
+)
+
+var intervalRegionOrder = [...]Reg{
+	X19, X20, X21, X22, X23, X24, X25, X27,
+	X9, X10, X11, X12, X13, X14, X15, X8,
+	X7, X6, X5, X4, X3, X2,
+}
+
+// prepareIntervalRegion discovers profitable integer-local lifetimes in one
+// call-free straight-line body. Storage is worker scratch and capped by body and
+// local counts; unsupported shapes keep the existing whole-function allocator.
+func (f *fn) prepareIntervalRegion(body []byte, hints funcHints) bool {
+	if !intervalRegionPinsEnabled || len(body) < minIntervalRegionBody || len(body) > maxIntervalRegionBody ||
+		f.nLocals < minIntervalRegionLocals || f.nLocals > maxIntervalRegionLocals || f.moduleEH ||
+		len(hints.localScore) != f.nLocals || len(hints.localLastGet) != f.nLocals {
+		return false
+	}
+
+	kept := 0
+	for x := 0; x < f.nLocals; x++ {
+		if (f.localType[x] == mtI32 || f.localType[x] == mtI64) && hints.localLastGet[x] != 0 && hints.localScore[x] >= 2 {
+			kept++
+		}
+	}
+	if kept == 0 {
+		return false
+	}
+	f.intervalLast, f.intervalScore = hints.localLastGet, hints.localScore
+	for i := range f.intervalOwner {
+		f.intervalOwner[i] = -1
+	}
+	f.stats.peep("interval-region")
+	return true
+}
+
+// activateIntervalLocal restores an assigned regional local when a register is
+// free. A busy file is left to ordinary lowering; spilling merely to recreate
+// the cache would defeat its purpose.
+func (f *fn) activateIntervalLocal(x, pos int, load bool) {
+	if x < 0 || x >= len(f.intervalLast) || f.intervalLast[x] == 0 || f.intervalScore[x] < 2 ||
+		(f.localType[x] != mtI32 && f.localType[x] != mtI64) || uint32(pos) > f.intervalLast[x] || f.locals[x].reg != regNone {
+		return
+	}
+	reg := f.claimIntervalReg(x)
+	if reg == regNone {
+		return
+	}
+	f.invalidateGlobalsCache()
+	f.invalidateStoreForward()
+	if load {
+		f.ld64(reg, SP, f.localOff(x))
+		f.locals[x].state = lsStackReg
+	}
+	f.locals[x].reg = reg
+	f.intervalOwner[reg] = x
+	f.pinnedLocalMask = f.pinnedLocalMask.add(reg)
+	f.stats.peep("interval-region-reactivate")
+}
+
+func (f *fn) claimIntervalReg(x int) Reg {
+	active := 0
+	for _, owner := range f.intervalOwner {
+		if owner >= 0 {
+			active++
+		}
+	}
+	if active < maxIntervalRegionRegs {
+		for _, reg := range intervalRegionOrder {
+			if !f.reserved.has(reg) && !f.pinned.has(reg) && !f.pinnedLocalMask.has(reg) &&
+				f.regUser[reg] == nil && f.intervalOwner[reg] < 0 {
+				return reg
+			}
+		}
+		return regNone
+	}
+	return f.evictIntervalLocalBelow(0, int(f.intervalScore[x]))
+}
+
+// takeFinalIntervalGet transfers a dying local's register directly to the
+// operand stack. Older borrowed references are realized before ownership moves.
+func (f *fn) takeFinalIntervalGet(x, pos int) (Reg, bool) {
+	if x < 0 || x >= len(f.intervalLast) || f.intervalLast[x] != uint32(pos) || f.locals[x].reg == regNone {
+		return regNone, false
+	}
+	f.realizeLocalRefs(x, nil)
+	reg := f.locals[x].reg
+	f.locals[x].reg = regNone
+	f.locals[x].state = lsMem
+	f.intervalOwner[reg] = -1
+	f.pinnedLocalMask = f.pinnedLocalMask.remove(reg)
+	return reg, true
+}
+
+func (f *fn) evictIntervalLocal(avoid regMask) Reg {
+	return f.evictIntervalLocalBelow(avoid, int(^uint(0)>>1))
+}
+
+func (f *fn) evictIntervalLocalBelow(avoid regMask, scoreLimit int) Reg {
+	if len(f.intervalLast) == 0 {
+		return regNone
+	}
+	best, bestScore := -1, int(^uint(0)>>1)
+	for reg, x := range f.intervalOwner {
+		if x < 0 || avoid.has(Reg(reg)) || f.pinned.has(Reg(reg)) || f.intervalLocalHasMemBorrow(x) {
+			continue
+		}
+		score := int(f.intervalScore[x])
+		if score < scoreLimit && score < bestScore {
+			best, bestScore = x, score
+		}
+	}
+	if best < 0 {
+		return regNone
+	}
+	reg := f.locals[best].reg
+	if f.locals[best].state == lsReg {
+		f.st64(SP, f.localOff(best), reg)
+	}
+	f.demoteIntervalLocalRefs(best)
+	f.locals[best].reg = regNone
+	f.locals[best].state = lsMem
+	f.intervalOwner[reg] = -1
+	f.pinnedLocalMask = f.pinnedLocalMask.remove(reg)
+	f.stats.peep("interval-region-evict")
+	return reg
+}
+
+func (f *fn) intervalLocalHasMemBorrow(x int) bool {
+	for e := f.s.head.next; e != f.s.head; e = e.next {
+		if e.kind == ekValue && e.st.kind == stMemRef && e.st.memBorrow() == x {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fn) demoteIntervalLocalRefs(x int) {
+	for e := f.s.head.next; e != f.s.head; e = e.next {
+		if e.kind == ekValue && e.st.kind == stLocalReg && e.st.idx == x {
+			e.st.kind = stLocalRef
+			e.st.reg = regNone
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/interval_region_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/interval_region_arm64_test.go
@@ -1,0 +1,76 @@
+//go:build (linux || darwin) && arm64
+
+package arm64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func intervalRegionModuleArm64(t *testing.T) *wasm.Module {
+	body := []byte{0x01, 0x20, 0x7f}            // thirty-two i32 locals
+	body = append(body, 0x41, 0x00, 0x21, 0x00) // sum = 0
+	for x := byte(1); x < 32; x++ {
+		body = append(body,
+			0x41, x, 0x21, x, // local[x] = x
+			0x20, 0x00, 0x20, x, 0x6a, 0x21, 0x00, // sum += local[x]
+		)
+	}
+	body = append(body, 0x20, 0x00, 0x0b)
+	return mod1(t, nil, []wasm.ValType{wasm.I32}, body)
+}
+
+func TestIntervalRegionDynamicReuseArm64(t *testing.T) {
+	saved := intervalRegionPinsEnabled
+	defer func() { intervalRegionPinsEnabled = saved }()
+	m := intervalRegionModuleArm64(t)
+
+	intervalRegionPinsEnabled = true
+	on := compileWithStats(t, m, false).Funcs[0]
+	if got := runArm64(t, m); got != 496 {
+		t.Fatalf("enabled result = %d, want 496", got)
+	}
+	if on.Peephole["interval-region"] != 1 {
+		t.Fatalf("interval-region = %d, want 1 (all: %v)", on.Peephole["interval-region"], on.Peephole)
+	}
+	if on.Peephole["interval-region-reactivate"] == 0 {
+		t.Fatalf("dynamic regional cache did not reuse a register: %v", on.Peephole)
+	}
+
+	intervalRegionPinsEnabled = false
+	off := compileWithStats(t, m, false).Funcs[0]
+	if on.CodeBytes >= off.CodeBytes {
+		t.Fatalf("regional code = %d bytes, whole-function code = %d; want smaller", on.CodeBytes, off.CodeBytes)
+	}
+	if got := runArm64(t, m); got != 496 {
+		t.Fatalf("disabled result = %d, want 496", got)
+	}
+}
+
+func TestEntryInitializedLocalSkipsZeroArm64(t *testing.T) {
+	saved := entryInitElisionEnabled
+	defer func() { entryInitElisionEnabled = saved }()
+	body := []byte{
+		0x01, 0x01, 0x7f, // one i32 local
+		0x41, 0x07, 0x21, 0x00, // local[0] = 7
+		0x20, 0x00, 0x0b, // return local[0]
+	}
+	m := mod1(t, nil, []wasm.ValType{wasm.I32}, body)
+	entryInitElisionEnabled = true
+	on := compileWithStats(t, m, false).Funcs[0]
+	if got := on.Peephole["entry-init-elide"]; got != 1 {
+		t.Fatalf("entry-init-elide = %d, want 1 (all: %v)", got, on.Peephole)
+	}
+	if got := runArm64(t, m); got != 7 {
+		t.Fatalf("result = %d, want 7", got)
+	}
+	entryInitElisionEnabled = false
+	off := compileWithStats(t, m, false).Funcs[0]
+	if got := off.Peephole["entry-init-elide"]; got != 0 {
+		t.Fatalf("disabled entry-init-elide = %d, want 0", got)
+	}
+	if got := runArm64(t, m); got != 7 {
+		t.Fatalf("disabled result = %d, want 7", got)
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/localstate.go
+++ b/src/core/compiler/backend/railshot/arm64/localstate.go
@@ -151,7 +151,7 @@ func (f *fn) recoverLocal(x int) {
 
 // markLocalDirty records that pinned local x was just written (value only in reg).
 func (f *fn) markLocalDirty(x int) {
-	if f.usesCalls || f.lazyZero {
+	if f.usesCalls || f.lazyZero || len(f.intervalLast) != 0 {
 		f.locals[x].state = lsReg
 	}
 }

--- a/src/core/compiler/backend/railshot/arm64/regalloc.go
+++ b/src/core/compiler/backend/railshot/arm64/regalloc.go
@@ -64,6 +64,11 @@ func (f *fn) allocRegOrNone(avoid regMask) Reg {
 			return r
 		}
 	}
+	// Regional pins are a cache, not a hard reservation. Under pressure, evict a
+	// non-borrowed cached local before spilling a live operand-stack value.
+	if r := f.evictIntervalLocal(avoid); r != regNone {
+		return r
+	}
 	// Spill a victim: the deepest (bottom-most) stack value in a register — it is
 	// used furthest in the future, WARP's spill heuristic approximated by depth.
 	for e := f.s.head.next; e != f.s.head; e = e.next {

--- a/src/core/compiler/backend/railshot/arm64/simd.go
+++ b/src/core/compiler/backend/railshot/arm64/simd.go
@@ -294,15 +294,68 @@ func (f *fn) i8x16Swizzle() {
 	f.pushVReg(dst)
 }
 
-func (f *fn) i8x16Shuffle(lanes [16]byte) {
+var (
+	i8x16Rotate16 = [16]byte{2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13}
+	i8x16Rotate8  = [16]byte{1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12}
+	i8x16Zip1D    = [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23}
+	i8x16Zip2D    = [16]byte{8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31}
+	i8x16Zip1S    = [16]byte{0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23}
+	i8x16Zip2S    = [16]byte{8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31}
+)
+
+func (f *fn) i8x16Shuffle(r *wasm.Reader, lanes [16]byte) error {
+	// One-instruction shuffle forms can write a following pinned local directly.
+	// REV32 and ZIP read their complete inputs before committing the destination,
+	// so aliasing dst with either input is safe. Rotate-8 stays on the fresh-result
+	// path because its USHR+SLI sequence needs the original source twice.
+	directSink := v128ShuffleSinkEnabled && (lanes == i8x16Rotate16 || lanes == i8x16Zip1D || lanes == i8x16Zip2D || lanes == i8x16Zip1S || lanes == i8x16Zip2S)
+	if directSink {
+		if done, err := f.tryV128Sink2LocalSet(r, func(dst Reg) {
+			f.stats.peep("v128-shuffle-sink")
+			b := f.popValue()
+			a := f.popValue()
+			s1, o1 := f.operandRegV128(a)
+			if lanes == i8x16Rotate16 {
+				f.a.NeonRev32H(dst, s1)
+				if o1 && dst != s1 {
+					f.releaseF(s1)
+				}
+				if b.st.kind == stReg {
+					f.releaseF(b.st.reg)
+				}
+				return
+			}
+			f.fpinned = f.fpinned.add(s1)
+			s2, o2 := f.operandRegV128(b)
+			f.fpinned = f.fpinned.add(s2)
+			switch lanes {
+			case i8x16Zip1D:
+				f.a.NeonZip1D(dst, s1, s2)
+			case i8x16Zip2D:
+				f.a.NeonZip2D(dst, s1, s2)
+			case i8x16Zip1S:
+				f.a.NeonZip1S(dst, s1, s2)
+			case i8x16Zip2S:
+				f.a.NeonZip2S(dst, s1, s2)
+			}
+			f.fpinned = f.fpinned.remove(s1).remove(s2)
+			if o1 && dst != s1 {
+				f.releaseF(s1)
+			}
+			if o2 && dst != s2 {
+				f.releaseF(s2)
+			}
+		}); done || err != nil {
+			return err
+		}
+	}
+
 	// AssemblyScript spells BLAKE's per-i32 rotate-right-by-16 and -8 as
 	// one-input byte shuffles. Lower those masks directly: REV32.8H swaps the
 	// halfwords in every i32 lane, while USHR+SLI rotates every lane by 8.
 	// The second wasm operand is unselected by both masks, so only its consumed
 	// owned register (if any) needs releasing.
-	rotate16 := [16]byte{2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13}
-	rotate8 := [16]byte{1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12}
-	if lanes == rotate16 || lanes == rotate8 {
+	if lanes == i8x16Rotate16 || lanes == i8x16Rotate8 {
 		bElem := f.popValue()
 		if bElem.st.kind == stReg {
 			f.releaseF(bElem.st.reg)
@@ -311,7 +364,7 @@ func (f *fn) i8x16Shuffle(lanes [16]byte) {
 		src, owned := f.operandRegV128(aElem)
 		f.fpinned = f.fpinned.add(src)
 		dst := f.allocFReg(maskOf(src))
-		if lanes == rotate16 {
+		if lanes == i8x16Rotate16 {
 			f.a.NeonRev32H(dst, src)
 		} else {
 			f.a.NeonUshrS(dst, src, 8)
@@ -323,16 +376,12 @@ func (f *fn) i8x16Shuffle(lanes [16]byte) {
 		}
 		f.stats.peep("simd-shuffle-rotr")
 		f.pushVReg(dst)
-		return
+		return nil
 	}
 
 	// BLAKE's message schedule also uses the four canonical ZIP masks. They map
 	// directly to ZIP1/ZIP2 at 64- or 32-bit lane widths.
-	zip1D := [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23}
-	zip2D := [16]byte{8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31}
-	zip1S := [16]byte{0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23}
-	zip2S := [16]byte{8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31}
-	if lanes == zip1D || lanes == zip2D || lanes == zip1S || lanes == zip2S {
+	if lanes == i8x16Zip1D || lanes == i8x16Zip2D || lanes == i8x16Zip1S || lanes == i8x16Zip2S {
 		bElem := f.popValue()
 		aElem := f.popValue()
 		xa, aOwned := f.operandRegV128(aElem)
@@ -341,13 +390,13 @@ func (f *fn) i8x16Shuffle(lanes [16]byte) {
 		f.fpinned = f.fpinned.add(xb)
 		dst := f.allocFReg(maskOf(xa, xb))
 		switch lanes {
-		case zip1D:
+		case i8x16Zip1D:
 			f.a.NeonZip1D(dst, xa, xb)
-		case zip2D:
+		case i8x16Zip2D:
 			f.a.NeonZip2D(dst, xa, xb)
-		case zip1S:
+		case i8x16Zip1S:
 			f.a.NeonZip1S(dst, xa, xb)
-		case zip2S:
+		case i8x16Zip2S:
 			f.a.NeonZip2S(dst, xa, xb)
 		}
 		f.fpinned = f.fpinned.remove(xa).remove(xb)
@@ -359,7 +408,7 @@ func (f *fn) i8x16Shuffle(lanes [16]byte) {
 		}
 		f.stats.peep("simd-shuffle-zip")
 		f.pushVReg(dst)
-		return
+		return nil
 	}
 
 	var aMask, bMask [16]byte
@@ -396,28 +445,58 @@ func (f *fn) i8x16Shuffle(lanes [16]byte) {
 	f.a.NeonOrr16b(xa, xa, xb)
 	f.releaseF(xb)
 	f.pushVReg(xa)
+	return nil
 }
 
 // v128Bin lowers a two-operand v128 op. When the op is immediately consumed by
 // `local.set/tee $x` into a register-pinned v128 local, tryV128BinLocalSet emits
 // it in place into $x's V register (one instruction, no accumulator copy and no
-// result-to-pin copy). Otherwise it falls back to the eager form: an owned
-// writable copy of the left operand that the op accumulates into.
+// result-to-pin copy). Otherwise it reads both operands in place and reuses an
+// owned operand register for the result when possible. If both operands are
+// borrowed pinned locals, a fresh destination is enough: NEON's three-register
+// form does not require copying either source first.
 func (f *fn) v128Bin(r *wasm.Reader, op func(dst, s1, s2 Reg)) error {
 	if done, err := f.tryV128BinLocalSet(r, op); done || err != nil {
 		return err
 	}
+	if !v128DirectResultEnabled {
+		b := f.popValue()
+		a := f.popValue()
+		xa := f.materializeV128(a)
+		f.fpinned = f.fpinned.add(xa)
+		xb, bOwned := f.operandRegV128(b)
+		f.fpinned = f.fpinned.remove(xa)
+		op(xa, xa, xb)
+		if bOwned {
+			f.releaseF(xb)
+		}
+		f.pushVReg(xa)
+		return nil
+	}
 	b := f.popValue()
 	a := f.popValue()
-	xa := f.materializeV128(a) // owned writable copy: op writes s1
-	f.fpinned = f.fpinned.add(xa)
-	xb, bOwned := f.operandRegV128(b) // read-only source: a pinned local is used in place
-	f.fpinned = f.fpinned.remove(xa)
-	op(xa, xa, xb)
-	if bOwned {
-		f.releaseF(xb)
+	s1, o1 := f.operandRegV128(a)
+	f.fpinned = f.fpinned.add(s1)
+	s2, o2 := f.operandRegV128(b)
+	f.fpinned = f.fpinned.add(s2)
+	dst := s1
+	if !o1 {
+		f.stats.peep("v128-direct-result")
+		if o2 {
+			dst = s2
+		} else {
+			dst = f.allocFReg(maskOf(s1, s2))
+		}
 	}
-	f.pushVReg(xa)
+	op(dst, s1, s2)
+	f.fpinned = f.fpinned.remove(s1).remove(s2)
+	if o1 && dst != s1 {
+		f.releaseF(s1)
+	}
+	if o2 && dst != s2 {
+		f.releaseF(s2)
+	}
+	f.pushVReg(dst)
 	return nil
 }
 
@@ -506,9 +585,22 @@ func (f *fn) v128Unary(r *wasm.Reader, op func(dst, src Reg)) error {
 		return err
 	}
 	a := f.popValue()
-	x := f.materializeV128(a)
-	op(x, x)
-	f.pushVReg(x)
+	if !v128DirectResultEnabled {
+		x := f.materializeV128(a)
+		op(x, x)
+		f.pushVReg(x)
+		return nil
+	}
+	src, owned := f.operandRegV128(a)
+	dst := src
+	if !owned {
+		f.stats.peep("v128-direct-result")
+		f.fpinned = f.fpinned.add(src)
+		dst = f.allocFReg(maskOf(src))
+		f.fpinned = f.fpinned.remove(src)
+	}
+	op(dst, src)
+	f.pushVReg(dst)
 	return nil
 }
 
@@ -834,6 +926,55 @@ func (f *fn) v128Shift(r *wasm.Reader, op func(dst, s1, s2 Reg), opImm func(dst,
 	}); done || err != nil {
 		return err
 	}
+	if !v128DirectResultEnabled {
+		return f.v128ShiftLegacy(op, opImm, countMask, laneSize, right)
+	}
+	countElem := f.popValue()
+	if countElem.st.kind == stConst {
+		value := f.popValue()
+		src, owned := f.operandRegV128(value)
+		dst := src
+		if shift := uint8(countElem.st.cval & int64(countMask)); shift != 0 {
+			if !owned {
+				f.stats.peep("v128-direct-result")
+				f.fpinned = f.fpinned.add(src)
+				dst = f.allocFReg(maskOf(src))
+				f.fpinned = f.fpinned.remove(src)
+			}
+			opImm(dst, src, shift)
+		} else if !owned {
+			dst = f.allocFReg(maskOf(src))
+			f.a.NeonMov16b(dst, src)
+		}
+		f.stats.peep("simd-shift-imm")
+		f.pushVReg(dst)
+		return nil
+	}
+	count := f.materialize(countElem)
+	f.andImm(count, int64(countMask), false) // Wasm shifts use count modulo lane width.
+	if right {
+		f.a.Sub64(count, ZR, count) // NEON USHL/SSHL use negative counts for right shifts.
+	}
+
+	value := f.popValue()
+	src, owned := f.operandRegV128(value)
+	f.fpinned = f.fpinned.add(src)
+	countX := f.v128SplatScalar(count, laneSize)
+	f.release(count)
+	f.fpinned = f.fpinned.add(countX)
+	dst := src
+	if !owned {
+		f.stats.peep("v128-direct-result")
+		dst = f.allocFReg(maskOf(src, countX))
+	}
+	op(dst, src, countX)
+	f.fpinned = f.fpinned.remove(src).remove(countX)
+	f.releaseF(countX)
+	f.pushVReg(dst)
+	return nil
+}
+
+func (f *fn) v128ShiftLegacy(op func(dst, s1, s2 Reg), opImm func(dst, src Reg, shift uint8), countMask int32, laneSize int, right bool) error {
 	countElem := f.popValue()
 	if countElem.st.kind == stConst {
 		value := f.popValue()
@@ -846,17 +987,15 @@ func (f *fn) v128Shift(r *wasm.Reader, op func(dst, s1, s2 Reg), opImm func(dst,
 		return nil
 	}
 	count := f.materialize(countElem)
-	f.andImm(count, int64(countMask), false) // Wasm shifts use count modulo lane width.
+	f.andImm(count, int64(countMask), false)
 	if right {
-		f.a.Sub64(count, ZR, count) // NEON USHL/SSHL use negative counts for right shifts.
+		f.a.Sub64(count, ZR, count)
 	}
-
 	value := f.popValue()
 	x := f.materializeV128(value)
 	f.fpinned = f.fpinned.add(x)
 	countX := f.v128SplatScalar(count, laneSize)
 	f.release(count)
-
 	op(x, x, countX)
 	f.releaseF(countX)
 	f.fpinned = f.fpinned.remove(x)
@@ -2105,7 +2244,7 @@ func (f *fn) emitFD(r *wasm.Reader) error {
 			}
 			lanes[i] = lane
 		}
-		f.i8x16Shuffle(lanes)
+		return f.i8x16Shuffle(r, lanes)
 	case 14: // i8x16.swizzle
 		f.i8x16Swizzle()
 	case 256: // i8x16.relaxed_swizzle: deterministic raw TBL semantics.

--- a/src/core/compiler/backend/railshot/arm64/simd_exec_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/simd_exec_arm64_test.go
@@ -789,6 +789,36 @@ func TestSIMDNarrowSinkAlias(t *testing.T) {
 	}
 }
 
+func TestSIMDShuffleSinkAlias(t *testing.T) {
+	a := i32x4Bytes(0x11223344, 0x55667788, 0x10203040, 0x50607080)
+	b := i32x4Bytes(-0x66554434, 0x12345678, 0x23456789, 0x3456789a)
+	for _, tc := range []struct {
+		name string
+		mask [16]byte
+		lane byte
+		want uint32
+	}{
+		{"rotate16-self-alias", i8x16Rotate16, 0, 0x33441122},
+		{"zip1s-self-alias", i8x16Zip1S, 1, 0x99aabbcc},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte{0x01, 0x02, 0x7b}
+			body = append(body, simdConst(a)...)
+			body = append(body, 0x21, 0x00)
+			body = append(body, simdConst(b)...)
+			body = append(body, 0x21, 0x01)
+			body = append(body, 0x20, 0x00, 0x20, 0x01, 0xfd, 0x0d)
+			body = append(body, tc.mask[:]...)
+			body = append(body, 0x21, 0x00, 0x20, 0x00)
+			body = append(body, simdOp(27)...)
+			body = append(body, tc.lane, 0x0b)
+			if got := runArm64I32(t, body); got != tc.want {
+				t.Fatalf("lane %d = %#x, want %#x", tc.lane, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestSIMDPMinMaxSinkAlias covers the pmin/pmax fallback where an operand IS the
 // pinned dst (`local.set $x (pmin (get $y) (get $x))`): dst cannot serve as the
 // FCMP/BSL selector, so the sink must use a scratch mask and copy the result in.

--- a/src/core/compiler/backend/railshot/arm64/stats.go
+++ b/src/core/compiler/backend/railshot/arm64/stats.go
@@ -53,6 +53,19 @@ var (
 	// simdSuperoptEnabled gates exact bounded selection of multi-op Wasm SIMD
 	// sequences. WAGO_NO_SIMD_SUPEROPT=1 is the A/B oracle.
 	simdSuperoptEnabled = os.Getenv("WAGO_NO_SIMD_SUPEROPT") != "1"
+	// v128DirectResultEnabled lets NEON's non-destructive destination forms read
+	// pinned locals directly instead of copying a source into an accumulator.
+	v128DirectResultEnabled = os.Getenv("WAGO_ARM64_NO_V128_DIRECT_RESULTS") != "1"
+	// v128ShuffleSinkEnabled writes one-instruction REV32/ZIP shuffles directly
+	// into a following pinned local. The kill switch is the A/B oracle.
+	v128ShuffleSinkEnabled = os.Getenv("WAGO_ARM64_NO_V128_SHUFFLE_SINK") != "1"
+	// intervalRegionPinsEnabled reuses GP registers across integer-local
+	// lifetimes in bounded call-free straight-line functions. The cache is
+	// pressure-spillable and releases a register at the local's final get.
+	intervalRegionPinsEnabled = os.Getenv("WAGO_ARM64_INTERVAL_REGIONS") != "0"
+	// entryInitElisionEnabled skips zero-initialization for declared locals whose
+	// first straight-line access is a set/tee. The kill switch is the A/B oracle.
+	entryInitElisionEnabled = os.Getenv("WAGO_ARM64_NO_ENTRY_INIT_ELISION") != "1"
 
 	// fcmpFuseEnabled gates float compare→branch fusion (FCMP + B.cond instead of
 	// FCMP + CSET + branch). WAGO_NO_FCMP_FUSE=1 is the A/B oracle.

--- a/src/core/compiler/backend/railshot/arm64/stats_test.go
+++ b/src/core/compiler/backend/railshot/arm64/stats_test.go
@@ -27,6 +27,10 @@ func compileWithStats(t *testing.T, m *wasm.Module, guard bool) *ModuleStats {
 func TestCodegenStatsPeepholesArm64(t *testing.T) {
 	i32 := []wasm.ValType{wasm.I32}
 	i32x2 := []wasm.ValType{wasm.I32, wasm.I32}
+	v128x2 := []wasm.ValType{wasm.V128, wasm.V128}
+	shuffleSinkBody := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0xfd, 0x0d}
+	shuffleSinkBody = append(shuffleSinkBody, i8x16Rotate16[:]...)
+	shuffleSinkBody = append(shuffleSinkBody, 0x21, 0x00, 0x20, 0x00, 0x0b)
 	cases := []struct {
 		name string
 		in   []wasm.ValType
@@ -113,6 +117,20 @@ func TestCodegenStatsPeepholesArm64(t *testing.T) {
 			name: "float-minmax-local-sink", in: []wasm.ValType{wasm.F64, wasm.F64}, out: []wasm.ValType{wasm.F64},
 			body: []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0xa4, 0x21, 0x00, 0x20, 0x00, 0x0b},
 			peep: "float-minmax-local-sink",
+		},
+		{
+			// NEON can compute add(dst, p0, p1) without first copying the
+			// borrowed pinned p0 into an owned accumulator.
+			name: "v128-three-operand-result", in: v128x2, out: []wasm.ValType{wasm.V128},
+			body: []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0xfd, 0xae, 0x01, 0x0b},
+			peep: "v128-direct-result",
+		},
+		{
+			// A one-instruction rotate-by-16 shuffle consumed by local.set can
+			// write the pinned destination directly, including self-aliasing.
+			name: "v128-shuffle-local-sink", in: v128x2, out: []wasm.ValType{wasm.V128},
+			body: shuffleSinkBody,
+			peep: "v128-shuffle-sink",
 		},
 		{
 			name: "extend-wrap-elim", in: i32, out: i32,


### PR DESCRIPTION
## Summary

- add a bounded, lifetime-aware GP register region for integer locals in large call-free straight-line ARM64 functions
- elide declared-local zero stores when the entry prefix provably overwrites the local before its first read
- keep more hot `v128` state resident in vector-heavy leaf functions
- let NEON operations read pinned vector locals directly and sink REV32/ZIP results into pinned destinations
- add explain counters, A/B kill switches, dynamic-reuse tests, and SIMD aliasing coverage

## Root cause

The BLAKE kernels expose two related ARM64 codegen costs: wide scalar helpers repeatedly round-trip short-lived integer locals through the frame, while vector helpers copy pinned `v128` operands into writable temporaries even though NEON supports distinct source and destination registers. Wide vector helpers also exceeded the conservative whole-function pin budget.

The integer cache is capped at 18 registers and limited to bounded, call-free, straight-line bodies. Registers are activated on demand, recycled after the final get, and evicted under pressure. Vector-heavy leaf functions receive deeper residency only when at least 24 hot `v128` locals justify it.

## Measurements

Apple M4 Max, `GOMAXPROCS=1`, repeated one-second runs:

| Benchmark | Before | After | Ratio |
| --- | ---: | ---: | ---: |
| scalar BLAKE execution | 435,665 ns/op | 404,684 ns/op | 1.077x |
| SIMD BLAKE execution | 552,698 ns/op | 430,795 ns/op | 1.283x |
| vector direct-result interleaved A/B | 446,228 ns/op | 431,516 ns/op | 1.034x |

Runtime remains `0 B/op`, `0 allocs/op`.

The final vector placement pass is compile-cost neutral: 658,676 ns/op disabled versus 657,025 ns/op enabled, with 231 allocs/op and about 475 KB/op in both modes.

Hot native helper sizes:

- function 7: 8,536 -> 6,920 bytes
- function 8: 8,056 -> 6,472 bytes

## Validation

- `go test ./src/... -count=1`
- `go test -tags wago_guardpage . -run '^TestCorpus(Differential)?$' -count=1`
- guard-page corpus differential with the new vector paths disabled
- repeated BLAKE, JSON SIMD, and UTF SIMD execution controls
- `git diff --check`

The optimization paths retain environment A/B switches:

- `WAGO_ARM64_INTERVAL_REGIONS=0`
- `WAGO_ARM64_NO_ENTRY_INIT_ELISION=1`
- `WAGO_ARM64_NO_V128_DIRECT_RESULTS=1`
- `WAGO_ARM64_NO_V128_SHUFFLE_SINK=1`

Docs are unchanged because this is an internal code-generation optimization with no developer workflow impact.
