### PR TITLE
gc: bound Tiny object marking work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -243,6 +243,14 @@ current optimization priorities. The Core 3.0 implementation ledger is
   and 1 MiB payload bounds, remaps structurally equivalent target types, roots both
   phases exactly, and rejects non-null funcref/externref payloads. The clone receives
   new target identity; direct foreign-domain reference calls remain fail-closed.
+- 🚧 **Tiny incremental work (#319, foundational stage):** marking retains one
+  handle/index cursor and can pause inside large structs and reference arrays. Each
+  mark `Step` is capped at 64 object ranges, 256 scan entries, 256 reference slots,
+  and 1,024 payload bytes; the active object remains gray until complete. Tiny bulk
+  barriers now prevalidate widened ranges, and gray-parent stores shade white
+  children that may be written behind the cursor. Persistent-root cursors, color
+  epochs, bounded sweep/allocation policy, debt and near-exhaustion pacing, bounded
+  barrier work, and the final barrier/product split remain open.
 
 **Engine & performance** (no-ir-plan P1–P7, measured against P1's stats)
 <!-- roadmap:P1 status=done -->

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -616,6 +616,14 @@ The same direct benchmark reports 256 maximum entries/slots for 256, 4,096, and
 65,536 elements, proving the per-step object work no longer scales with object
 size.
 
+An adversarial follow-up A/B initially found that routing ordinary Throughput
+complete scans through finite cursor bookkeeping regressed dense full collection.
+The release path therefore retains its direct complete descriptor loop, while
+Tiny and diagnostic scans use the cursor primitive. Identical 200-iteration,
+five-sample controls put current medians versus `main` at +0.75%/-4.66% for the
+50%/90% dense-struct cells and +1.02%/+1.43% for the matching dense-array cells;
+allocations and bytes/op remain identical.
+
 For disabled-build overhead, twenty pinned interleaved 10,000-operation runs of
 the zero-survivor Throughput minor control measured an 811.95 ns parent median
 and an 814.30 ns current median (+0.29%), with identical 40 B/op and 2 allocs/op

--- a/docs/gc-benchmarks.md
+++ b/docs/gc-benchmarks.md
@@ -601,11 +601,20 @@ collector globals and 377 us for collector tables. Native-frame p99 was about
 70 us. Exact classified counts were 4,096 per Throughput cycle; Tiny reports
 8,192 visits because it enumerates roots during both initial mark and remark.
 
-Tiny's 65,536-reference-array step fixture still completes in six steps, but one
-step scans the complete object. Across ten pinned 100-cycle samples, median step
-p50 was 383 ns, p90/p95 360 us, p99 377 us, and exact maximum 422 us. This is the
-baseline that #319's slot/byte-budgeted scanner must flatten while increasing
-`steps/op`.
+Before #319's first stage, Tiny's 65,536-reference-array fixture completed in six
+steps but one step scanned the complete object. In the same 100-cycle benchmark
+shape on the Ryzen 7 8845HS, the three-run baseline median was 175.4 us/cycle,
+196.6 us step-p99, 244.9 us maximum, and 6 steps/cycle. The resumable scanner now
+uses 261 steps/cycle with a deterministic maximum of 256 entries, 256 reference
+slots, and 1,024 payload bytes in any marking step. Five 100-cycle samples measure
+a 213.2 us median cycle (+21.5%), 1.34 us step-p99, and 26.1 us observed maximum;
+the remaining maximum is host scheduling/timing-harness noise rather than extra
+scan work. The direct-root `BenchmarkTinyStepReferenceArray` reports a 521 ns
+median at 65,536 elements, 0 B/op, and 0 allocs/op, while
+`BenchmarkTinyCompleteCycleReferenceArray` reports 147.8 us/cycle and 261 steps.
+The same direct benchmark reports 256 maximum entries/slots for 256, 4,096, and
+65,536 elements, proving the per-step object work no longer scales with object
+size.
 
 For disabled-build overhead, twenty pinned interleaved 10,000-operation runs of
 the zero-survivor Throughput minor control measured an 811.95 ns parent median

--- a/docs/gc-telemetry.md
+++ b/docs/gc-telemetry.md
@@ -93,8 +93,11 @@ Tiny `CollectFull`/`CollectMinor` records the complete incremental cycle. A cycl
 driven directly through repeated `Step` calls is also recorded once, from its
 initial root mark through final sweep. The recorder suspends between separate
 `Step` calls, so cycle and phase time sum collector work rather than arbitrary
-mutator delays. Partial object ranges contribute payload/reference/entry totals
-exactly once. `ObjectScansBegun`, `ObjectScansResumed`, and
+mutator delays. Partial ranges contribute reference-slot and scan-entry work
+exactly once. The established `PayloadBytesVisited` field still records one
+complete aligned logical payload when an object scan completes, including
+pointer-free payloads; `MaxStepPayloadBytes` separately reports actual bounded
+per-step scan accounting. `ObjectScansBegun`, `ObjectScansResumed`, and
 `ObjectScansCompleted` expose cursor lifecycle, while the four `MaxStep*` fields
 show the largest bounded object-tracing vector consumed by one marking `Step`.
 Root enumeration and sweeping remain separately attributable phases and are not

--- a/docs/gc-telemetry.md
+++ b/docs/gc-telemetry.md
@@ -54,7 +54,9 @@ includes:
 - bounded p50, p90, p95, p99, and maximum pause estimates;
 - phase wall time;
 - root counts and root-enumeration time by ownership class;
-- visited objects, payload bytes, and reference slots;
+- visited objects, payload bytes, reference slots, and descriptor/array scan entries;
+- object scans begun, resumed, and completed, plus Tiny's maximum object-range,
+  entry, reference-slot, and payload-byte work observed in one `Step`;
 - swept objects and payload bytes;
 - Eden/survivor occupancy, copying, promotion, age histograms, and separate
   pointer-free age populations; and
@@ -90,8 +92,13 @@ back into the pause merely to make a phase counter nonzero.
 Tiny `CollectFull`/`CollectMinor` records the complete incremental cycle. A cycle
 driven directly through repeated `Step` calls is also recorded once, from its
 initial root mark through final sweep. The recorder suspends between separate
-`Step` calls, so cycle and phase time sum bounded collector work rather than
-arbitrary mutator delays.
+`Step` calls, so cycle and phase time sum collector work rather than arbitrary
+mutator delays. Partial object ranges contribute payload/reference/entry totals
+exactly once. `ObjectScansBegun`, `ObjectScansResumed`, and
+`ObjectScansCompleted` expose cursor lifecycle, while the four `MaxStep*` fields
+show the largest bounded object-tracing vector consumed by one marking `Step`.
+Root enumeration and sweeping remain separately attributable phases and are not
+claimed to be covered by the object-scan maximum.
 
 ## Root classes
 

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -1863,13 +1863,16 @@ internal object-tracing limits; `TinyStepBudget` keeps its existing meaning as t
 number of `Step` calls performed after an allocation when `TinyStepEveryAlloc` is
 enabled.
 
-Exact scanning is shared with the default policy through a cursor/range primitive:
-Throughput and synchronous full-scan callers run it to completion, while Tiny
-retains the cursor between bounded ranges. Pointer-free objects are not
-recursively scanned, struct ref fields are loaded only at descriptor offsets,
-ref arrays scan elements, numeric bits are never interpreted as refs, and
-`null`/`i31` values are ignored. Global and table slots are part of the root set
-for both full and incremental Tiny collection.
+Tiny's resumable path and diagnostic complete scans use one cursor/range
+primitive. The ordinary Throughput/full release path deliberately retains its
+specialized direct complete loop: identical-configuration A/B measurements found
+that cursor-budget bookkeeping regressed dense full scans, while the direct loop
+remains within the established 3% control. Both paths preserve the same descriptor
+and element order. Pointer-free objects are not recursively scanned, struct ref
+fields are loaded only at descriptor offsets, ref arrays scan elements, numeric
+bits are never interpreted as refs, and `null`/`i31` values are ignored. Global
+and table slots are part of the root set for both full and incremental Tiny
+collection.
 
 Tiny write barriers preserve the incremental no-black-to-white invariant.
 Object stores retain the existing conservative hybrid policy for black parents:
@@ -1899,7 +1902,9 @@ Known Tiny limitations in this foundation:
   enumeration and the broader persistent-root cursor remain later #319 work;
 - sweeping still advances by the existing handle-oriented policy; bounded sweep
   regions, allocation from swept regions, and allocation-debt pacing are not part
-  of this stage;
+  of this stage. A reference that will be published into a root during sweep must
+  remain in the exact supplied roots until publication; the current one-pass sweep
+  cannot resurrect descendants that were already reclaimed from an omitted graph;
 - Tiny bulk barriers validate ranges with widened arithmetic and chunk mutator
   publication, but bulk-barrier chunking and bounded object scanning are distinct:
   the complete bulk mutation call itself is not yet a general bounded barrier;

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -243,10 +243,13 @@ preflights the complete retained segment, then performs type-compatible prevalid
 stores with a deferred barrier and publishes one exact destination range after all
 writes. No collection can occur between preflight and publication; explicit
 hardening modes repeat ownership validation to detect contract misuse. Tiny keeps
-immediate per-edge shading; bulk ranges are handled in 64-element chunks with at most
-64 gray-object drains between chunks so queued incremental publication work stays
-bounded at one-object scan granularity. Numeric arrays and non-collector function-
-identity payloads remain barrier-free.
+immediate per-edge shading; bulk ranges are handled in 64-element chunks and each
+between-chunk drain uses the same 256-entry/256-reference/1,024-byte resumable
+object budget as a marking `Step`. The Tiny path validates the complete destination range
+with widened arithmetic before deriving any element index. This bounds collector
+scan work performed between chunks, but does not make the complete bulk mutation
+call itself incremental. Numeric arrays and non-collector function-identity payloads
+remain barrier-free.
 
 Diagnostic `wago_gcstats` snapshots include separate dynamic checked-path counts for
 `NoBarrier`, `YoungParent`, `KnownOldChild`, `ExistingCard`, `CardMark`, and
@@ -1843,21 +1846,43 @@ white Tiny objects back to the fixed-block allocator. `CollectFull` completes on
 whole Tiny cycle. `CollectMinor` is specified as the same full Tiny cycle because
 Tiny is non-generational.
 
-Exact scanning is shared with the default policy: pointer-free objects are not
-recursively scanned, struct ref fields are visited only at descriptor offsets,
-ref arrays scan elements, numeric fields and arrays are ignored even when their
-bits look like refs, and `null`/`i31` values are ignored. Global and table slots
-are part of the root set for both full and incremental Tiny collection.
+Object marking is resumable. Tiny retains at most one compact active cursor:
+one stable handle plus the next struct descriptor entry or array element index.
+Each resume reacquires the descriptor and object bytes from the handle; no raw
+payload pointer survives a `Step`. The active object remains gray and is absent
+from the gray stack until its final outgoing reference is visited, at which point
+it becomes black. Newly discovered children retain the previous descriptor/array
+visitation order and are processed after the active object completes.
+
+One marking `Step` is limited to at most 64 object-range setups, 256 descriptor
+or array entries, 256 reference slots, and 1,024 accounted payload bytes. A large
+dense reference array therefore advances by at most 256 elements per marking
+step. A large sparse-reference struct is also split because every descriptor
+entry, including numeric fields, consumes entry and storage-byte budget. These are
+internal object-tracing limits; `TinyStepBudget` keeps its existing meaning as the
+number of `Step` calls performed after an allocation when `TinyStepEveryAlloc` is
+enabled.
+
+Exact scanning is shared with the default policy through a cursor/range primitive:
+Throughput and synchronous full-scan callers run it to completion, while Tiny
+retains the cursor between bounded ranges. Pointer-free objects are not
+recursively scanned, struct ref fields are loaded only at descriptor offsets,
+ref arrays scan elements, numeric bits are never interpreted as refs, and
+`null`/`i31` values are ignored. Global and table slots are part of the root set
+for both full and incremental Tiny collection.
 
 Tiny write barriers preserve the incremental no-black-to-white invariant.
-Object stores use a conservative hybrid barrier: when a black parent receives a
-white child during Tiny marking, the child is grayed (forward barrier) and the
-parent is re-grayed (backward barrier). Handles already gray are not pushed to
-the gray stack again. Slot stores for globals/tables gray the stored child during
-active Tiny mark and remark phases. Pointerful objects allocated during active
-Tiny marking are born gray so array/ref initialization cannot publish an unscanned black object
-with white children. This keeps `struct.set`, ref-array stores, `global.set`, and
-`table.set` safe without introducing C-style intrusive lists or pointer headers.
+Object stores retain the existing conservative hybrid policy for black parents:
+the white child is grayed (forward barrier) and the parent is re-grayed (backward
+barrier). A store into a gray parent now also shades a white child, because a
+partially scanned parent's cursor may already be past the mutated slot. This
+conservatively covers writes both before and after the cursor without adding
+cursor-position checks to the mutator path. Handles already gray are not pushed
+to the gray stack again. Slot stores for globals/tables gray the stored child
+during active Tiny mark and remark phases and drain it synchronously during
+sweep. Pointerful objects allocated during active Tiny marking are born gray so
+array/ref initialization cannot publish an unscanned black object with white
+children.
 
 Tiny manages WasmGC heap objects only. It is separate from Wasm linear memory
 allocation. Iterations 38-39 connect exact numeric-struct parked-Go helper products,
@@ -1870,13 +1895,19 @@ are more important than moving/generational throughput.
 
 Known Tiny limitations in this foundation:
 
-- first-fit allocation is simple and deterministic but not fragmentation-optimal;
+- object tracing is bounded inside large objects, but initial/remark root
+  enumeration and the broader persistent-root cursor remain later #319 work;
+- sweeping still advances by the existing handle-oriented policy; bounded sweep
+  regions, allocation from swept regions, and allocation-debt pacing are not part
+  of this stage;
+- Tiny bulk barriers validate ranges with widened arithmetic and chunk mutator
+  publication, but bulk-barrier chunking and bounded object scanning are distinct:
+  the complete bulk mutation call itself is not yet a general bounded barrier;
 - collection is incremental by explicit `Step` calls or allocation-time stress
   knobs, not concurrent;
-- handle-table entries remain the stable ref indirection;
-- only exact numeric struct products are wired: allocation-local empty-root shapes plus
-  two immutable collector-rooted globals. General frame publication, mutable root
-  synchronization, and reference barriers remain unwired.
+- handle-table entries remain the stable ref indirection; and
+- color epochs/polarity, near-exhaustion pacing, SATB/barrier-policy comparison,
+  and incremental/nonincremental Tiny product splitting remain later #319 work.
 
 ## Allocator/GC codegen dependency contract
 

--- a/src/core/runtime/gc/barrier.go
+++ b/src/core/runtime/gc/barrier.go
@@ -229,6 +229,11 @@ func (c *Collector) PostBulkWriteBarrier(dst Ref, start, length uint32) {
 		if err != nil || d.Kind != KindArray || !isCollectorRefKind(d.Elem) {
 			return
 		}
+		// Validate the complete range with widened arithmetic before deriving any
+		// per-element index. In particular, never let start+base+i wrap in uint32.
+		if uint64(start)+uint64(length) > uint64(c.header(dst).Aux) {
+			return
+		}
 		c.noteBarrierState(runtimeBarrierSlowBarrier)
 		const tinyBulkBarrierChunk = uint32(64)
 		for base := uint32(0); base < length; {
@@ -237,7 +242,8 @@ func (c *Collector) PostBulkWriteBarrier(dst Ref, start, length uint32) {
 				n = tinyBulkBarrierChunk
 			}
 			for i := uint32(0); i < n; i++ {
-				value, err := c.loadValue(dst, uint64(PayloadOffset)+uint64(start+base+i)*uint64(d.ElemSize), d.Elem)
+				index := uint64(start) + uint64(base) + uint64(i)
+				value, err := c.loadValue(dst, uint64(PayloadOffset)+index*uint64(d.ElemSize), d.Elem)
 				if err != nil {
 					return
 				}
@@ -248,7 +254,7 @@ func (c *Collector) PostBulkWriteBarrier(dst Ref, start, length uint32) {
 					c.cfg.Telemetry.resume()
 					c.cfg.Telemetry.setPhase(telemetryPhaseMarking)
 				}
-				c.tinyDrainGrayBudget(tinyBulkBarrierChunk)
+				c.tinyDrainGrayBudget(tinyStepObjectScanBudget)
 				if c.tinyGC.telemetryOwned {
 					c.cfg.Telemetry.suspend()
 				}
@@ -710,14 +716,23 @@ func (c *Collector) tinyWriteBarrierObject(parent Ref, child Ref) {
 	if c.handles[ph].space != spaceTiny || c.handles[ch].space != spaceTiny {
 		return
 	}
-	if c.tinyColorOf(ph) == tinyBlack && c.tinyColorOf(ch) == tinyWhite {
+	if c.tinyColorOf(ch) != tinyWhite {
+		return
+	}
+	switch c.tinyColorOf(ph) {
+	case tinyGray:
+		// A partially scanned gray parent may be mutated before its cursor. Shade
+		// the new child immediately; writes after the cursor are conservatively
+		// shaded too, avoiding cursor-position checks in the mutator barrier.
+		c.tinyGrayHandle(ch)
+	case tinyBlack:
 		if c.tinyGC.state == tinySweep {
 			c.tinyMarkRefNow(child)
 			return
 		}
-		// Hybrid Tiny barrier: gray the child (forward barrier) and re-gray the
-		// parent (backward barrier). This is conservative and simple for the first
-		// non-moving incremental policy; repeated container writes remain safe.
+		// Preserve the existing hybrid policy for black parents: shade the child
+		// and re-gray the parent. Broader barrier simplification remains later
+		// #319 work.
 		c.tinyGrayHandle(ch)
 		c.tinyGrayHandle(ph)
 	}

--- a/src/core/runtime/gc/barrier.go
+++ b/src/core/runtime/gc/barrier.go
@@ -137,8 +137,9 @@ func (c *Collector) writeBarrierObjectRange(parent Ref, child Ref, start, end ui
 
 // WriteBarrierRoot publishes a child stored in an exact externally walked root
 // such as an off-heap native table descriptor. Throughput collections rescan
-// external roots directly; Tiny must shade stores made during an incremental
-// mark/remark/sweep cycle.
+// external roots directly; Tiny shades stores made during an incremental cycle.
+// During sweep, the source graph must have remained in the exact roots until the
+// store; a one-pass sweep cannot resurrect descendants reclaimed earlier.
 func (c *Collector) WriteBarrierRoot(child Ref) {
 	if !child.IsObj() || !c.validObjectRef(child) || c.cfg.Profile != ProfileTiny {
 		return
@@ -177,9 +178,10 @@ func (c *Collector) WriteBarrierSlot(kind SlotKind, index uint32, child Ref) {
 		case tinyMark, tinyRemark:
 			c.tinyMarkRef(child)
 		case tinySweep:
-			// Root stores during sweep publish a new root after the remark root
-			// snapshot. Mark and drain it immediately so the remaining sweep cannot
-			// reclaim the newly rooted object or its children.
+			// Root stores during sweep publish a new root after the remark snapshot.
+			// Mark and drain it before later sweep indexes. The source graph must
+			// still be retained by the exact roots until publication: this one-pass
+			// sweep cannot resurrect a descendant reclaimed by an earlier index.
 			c.tinyMarkRefNow(child)
 		}
 		return

--- a/src/core/runtime/gc/card_driven_test.go
+++ b/src/core/runtime/gc/card_driven_test.go
@@ -445,6 +445,15 @@ func TestCardMetadataFootprint(t *testing.T) {
 	if got := unsafe.Sizeof(Config{}); got != 72 {
 		t.Fatalf("Config size=%d, want 72", got)
 	}
+	if got := unsafe.Sizeof(tinyScanCursor{}); got != 8 {
+		t.Fatalf("tinyScanCursor size=%d, want 8", got)
+	}
+	if got := unsafe.Sizeof(tinyStepWork{}); got != 8 {
+		t.Fatalf("tinyStepWork size=%d, want 8", got)
+	}
+	if got := unsafe.Sizeof(tinyGC{}); got != 80 {
+		t.Fatalf("tinyGC size=%d, want 80", got)
+	}
 	wantCollector := uintptr(1120)
 	if got := unsafe.Sizeof(Collector{}); got != wantCollector {
 		t.Fatalf("Collector size=%d, want %d", got, wantCollector)

--- a/src/core/runtime/gc/card_driven_test.go
+++ b/src/core/runtime/gc/card_driven_test.go
@@ -451,6 +451,9 @@ func TestCardMetadataFootprint(t *testing.T) {
 	if got := unsafe.Sizeof(tinyStepWork{}); got != 8 {
 		t.Fatalf("tinyStepWork size=%d, want 8", got)
 	}
+	if tinyStepObjectRanges > uint32(^uint16(0)) || tinyStepScanEntries > uint32(^uint16(0)) || tinyStepRefSlots > uint32(^uint16(0)) || tinyStepPayloadBytes > uint32(^uint16(0)) {
+		t.Fatal("Tiny Step work bounds do not fit compact telemetry state")
+	}
 	if got := unsafe.Sizeof(tinyGC{}); got != 80 {
 		t.Fatalf("tinyGC size=%d, want 80", got)
 	}

--- a/src/core/runtime/gc/collector.go
+++ b/src/core/runtime/gc/collector.go
@@ -53,9 +53,12 @@ type Config struct {
 	StressNurseryBytes     uint32
 	TinyHeapBytes          uint32
 	TinyBlockBytes         uint32
-	TinyStepBudget         uint32
-	ThroughputHeapBytes    uint32
-	ThroughputPageBytes    uint32
+	// TinyStepBudget is the number of Step calls performed after an allocation
+	// when TinyStepEveryAlloc is enabled. It does not scale one Step's internal
+	// object-scan work vector.
+	TinyStepBudget      uint32
+	ThroughputHeapBytes uint32
+	ThroughputPageBytes uint32
 	// ThroughputClassLimit is zero for the default or exactly one of the
 	// built-in throughput size classes. Values between classes are rejected rather
 	// than rounded. Objects above the limit use large-span allocation.

--- a/src/core/runtime/gc/matrix_bench_test.go
+++ b/src/core/runtime/gc/matrix_bench_test.go
@@ -684,9 +684,9 @@ func BenchmarkGCRootClassMatrix(b *testing.B) {
 	}
 }
 
-// BenchmarkGCTinyStepMatrix exposes the unbounded-object problem tracked by
-// #319. A future slot-budgeted scanner should increase steps with array length
-// while keeping p99/max step latency bounded.
+// BenchmarkGCTinyStepMatrix qualifies #319's bounded object scanner. Steps grow
+// with array length while each mark Step remains capped by the internal
+// entry/reference-slot/payload-byte work vector.
 func BenchmarkGCTinyStepMatrix(b *testing.B) {
 	refs, err := NewArrayDesc(0, StorageRefNull)
 	if err != nil {
@@ -897,9 +897,10 @@ func TestGCTinyStepWorkloadSmoke(t *testing.T) {
 		t.Fatal(err)
 	}
 	root := Root(array)
+	maxSteps := int((uint32(64<<10)+tinyStepScanEntries-1)/tinyStepScanEntries) + len(c.handles) + 8
 	for steps := 0; ; steps++ {
-		if steps > len(c.handles)+8 {
-			t.Fatal("Tiny cycle did not finish within bounded state/handle steps")
+		if steps > maxSteps {
+			t.Fatal("Tiny cycle did not finish within bounded scan/state/handle steps")
 		}
 		if err := c.Step(Slots{&root}); err != nil {
 			t.Fatal(err)

--- a/src/core/runtime/gc/scan.go
+++ b/src/core/runtime/gc/scan.go
@@ -93,6 +93,40 @@ func (c *Collector) scanObjectRefsRange(h uint32, cursor *objectScanCursor, budg
 		return work, true
 	}
 	b := c.bytes(r)
+	// Synchronous sweep barriers may request an effectively unlimited Tiny scan.
+	// Avoid finite-budget checks in that cold path. Ordinary complete scans use
+	// scanObjectRefsComplete below so Throughput retains its established hot loop.
+	if budget == completeObjectScanBudget && cursor.index == 0 && visitor.mode == objectScanVisitTinyMark {
+		switch d.Kind {
+		case KindStruct:
+			work.ScanEntries = uint32(len(d.Fields))
+			work.PayloadBytes = d.Size
+			for _, f := range d.Fields {
+				if isCollectorRefKind(f.Kind) {
+					c.tinyMarkRef(Ref(binary.LittleEndian.Uint32(b[PayloadOffset+f.Offset:])))
+					work.RefSlots++
+				}
+			}
+			cursor.index = uint32(len(d.Fields))
+			return work, true
+		case KindArray:
+			if !d.ArrayElementsAreRefs() {
+				return work, true
+			}
+			length := c.header(r).Aux
+			work.ScanEntries = length
+			work.RefSlots = length
+			work.PayloadBytes = length * d.ElemSize
+			for cursor.index < length {
+				off := uint64(PayloadOffset) + uint64(cursor.index)*uint64(d.ElemSize)
+				c.tinyMarkRef(Ref(binary.LittleEndian.Uint32(b[off:])))
+				cursor.index++
+			}
+			return work, true
+		default:
+			return work, true
+		}
+	}
 	switch d.Kind {
 	case KindStruct:
 		for cursor.index < uint32(len(d.Fields)) {
@@ -154,22 +188,45 @@ func (c *Collector) scanObjectRefsRange(h uint32, cursor *objectScanCursor, budg
 	}
 }
 
+func (c *Collector) objectPayloadBytes(h uint32) uint32 {
+	if h == 0 || int(h) >= len(c.handles) || c.handles[h].space == spaceFree || c.handles[h].size <= PayloadOffset {
+		return 0
+	}
+	return c.handles[h].size - PayloadOffset
+}
+
 // scanObjectRefs is the complete synchronous wrapper used by Throughput/full
-// collection and verification helpers. Tiny incremental marking uses the same
-// primitive with a retained cursor and a finite budget.
+// collection and heap helpers. Tiny incremental marking retains the range
+// primitive's cursor between bounded steps.
 func (c *Collector) scanObjectRefs(h uint32, visit func(Ref)) {
-	visitor := objectScanVisitor{fn: visit}
 	if !c.telemetryEnabled() {
-		cursor := objectScanCursor{}
-		for {
-			_, complete := c.scanObjectRefsRange(h, &cursor, completeObjectScanBudget, visitor)
-			if complete {
-				return
+		// Preserve the established synchronous Throughput loop exactly. The
+		// cursor/budget bookkeeping is required only for Tiny bounded marking;
+		// measurements showed that imposing it here regresses dense full scans.
+		r := makeObjRef(h)
+		d, err := c.refDesc(r)
+		if err != nil || !d.HasRefs {
+			return
+		}
+		hdr := c.header(r)
+		b := c.bytes(r)
+		if d.Kind == KindStruct {
+			for _, f := range d.Fields {
+				if isCollectorRefKind(f.Kind) {
+					visit(Ref(binary.LittleEndian.Uint32(b[PayloadOffset+f.Offset:])))
+				}
+			}
+		} else if d.ArrayElementsAreRefs() {
+			for i := uint32(0); i < hdr.Aux; i++ {
+				off := PayloadOffset + i*d.ElemSize
+				visit(Ref(binary.LittleEndian.Uint32(b[off:])))
 			}
 		}
+		return
 	}
 	start := c.cfg.Telemetry.scanStart()
 	cursor := objectScanCursor{}
+	visitor := objectScanVisitor{fn: visit}
 	var total objectScanWork
 	for {
 		work, complete := c.scanObjectRefsRange(h, &cursor, completeObjectScanBudget, visitor)
@@ -178,5 +235,10 @@ func (c *Collector) scanObjectRefs(h uint32, visit func(Ref)) {
 			break
 		}
 	}
+	// PayloadBytesVisited predates resumable scanning and reports the complete
+	// logical object payload once per object, including layout/alignment padding
+	// and pointer-free payloads. Keep that schema meaning while MaxStepPayloadBytes
+	// continues to report the actual bounded scan work.
+	total.PayloadBytes = c.objectPayloadBytes(h)
 	c.cfg.Telemetry.noteObjectScanWork(start, total, true, false, true)
 }

--- a/src/core/runtime/gc/scan.go
+++ b/src/core/runtime/gc/scan.go
@@ -1,0 +1,182 @@
+package gc
+
+import "encoding/binary"
+
+// objectScanCursor is the next descriptor entry or array element to examine.
+// It contains no heap pointer: callers may retain it across collector steps and
+// reacquire the object's descriptor and bytes from the stable handle each time.
+type objectScanCursor struct {
+	index uint32
+}
+
+type objectScanVisitMode uint8
+
+const (
+	objectScanVisitFunc objectScanVisitMode = iota
+	objectScanVisitTinyMark
+)
+
+type objectScanVisitor struct {
+	mode objectScanVisitMode
+	fn   func(Ref)
+}
+
+func (v objectScanVisitor) visit(c *Collector, ref Ref) {
+	if v.mode == objectScanVisitTinyMark {
+		c.tinyMarkRef(ref)
+		return
+	}
+	if v.fn != nil {
+		v.fn(ref)
+	}
+}
+
+// objectScanWork is the deterministic work performed by one or more scan
+// ranges. ObjectRanges bounds per-object setup even for pointer-free objects;
+// the other dimensions prevent a single large reference-bearing object from
+// defeating an incremental budget.
+type objectScanWork struct {
+	ObjectRanges uint32
+	ScanEntries  uint32
+	RefSlots     uint32
+	PayloadBytes uint32
+}
+
+// objectScanBudget is a compact vector limit. A range stops before the next
+// entry if consuming it would exceed any dimension.
+type objectScanBudget objectScanWork
+
+var completeObjectScanBudget = objectScanBudget{
+	ObjectRanges: ^uint32(0),
+	ScanEntries:  ^uint32(0),
+	RefSlots:     ^uint32(0),
+	PayloadBytes: ^uint32(0),
+}
+
+func (w *objectScanWork) add(other objectScanWork) {
+	w.ObjectRanges += other.ObjectRanges
+	w.ScanEntries += other.ScanEntries
+	w.RefSlots += other.RefSlots
+	w.PayloadBytes += other.PayloadBytes
+}
+
+func (b objectScanBudget) remaining(used objectScanWork) objectScanBudget {
+	return objectScanBudget{
+		ObjectRanges: b.ObjectRanges - used.ObjectRanges,
+		ScanEntries:  b.ScanEntries - used.ScanEntries,
+		RefSlots:     b.RefSlots - used.RefSlots,
+		PayloadBytes: b.PayloadBytes - used.PayloadBytes,
+	}
+}
+
+func (b objectScanBudget) permits(work objectScanWork) bool {
+	return work.ObjectRanges <= b.ObjectRanges &&
+		work.ScanEntries <= b.ScanEntries &&
+		work.RefSlots <= b.RefSlots &&
+		work.PayloadBytes <= b.PayloadBytes
+}
+
+// scanObjectRefsRange visits references in descriptor order, stopping before an
+// entry that does not fit in budget. The caller owns cursor and may retain it
+// across calls. No descriptor slice or object-byte pointer escapes this call.
+func (c *Collector) scanObjectRefsRange(h uint32, cursor *objectScanCursor, budget objectScanBudget, visitor objectScanVisitor) (work objectScanWork, complete bool) {
+	if cursor == nil || !budget.permits(objectScanWork{ObjectRanges: 1}) {
+		return objectScanWork{}, false
+	}
+	work.ObjectRanges = 1
+	if h == 0 || int(h) >= len(c.handles) || c.handles[h].space == spaceFree {
+		return work, true
+	}
+	r := makeObjRef(h)
+	d, err := c.refDesc(r)
+	if err != nil || !d.HasRefs {
+		return work, true
+	}
+	b := c.bytes(r)
+	switch d.Kind {
+	case KindStruct:
+		for cursor.index < uint32(len(d.Fields)) {
+			f := d.Fields[cursor.index]
+			_, size, err := storageLayout(f.Kind)
+			if err != nil {
+				return work, true
+			}
+			isRef := isCollectorRefKind(f.Kind)
+			if work.ScanEntries == budget.ScanEntries || size > budget.PayloadBytes-work.PayloadBytes || (isRef && work.RefSlots == budget.RefSlots) {
+				return work, false
+			}
+			if isRef {
+				visitor.visit(c, Ref(binary.LittleEndian.Uint32(b[PayloadOffset+f.Offset:])))
+				work.RefSlots++
+			}
+			cursor.index++
+			work.ScanEntries++
+			work.PayloadBytes += size
+		}
+		return work, true
+	case KindArray:
+		if !d.ArrayElementsAreRefs() {
+			return work, true
+		}
+		length := c.header(r).Aux
+		count := length - cursor.index
+		if available := budget.ScanEntries - work.ScanEntries; count > available {
+			count = available
+		}
+		if available := budget.RefSlots - work.RefSlots; count > available {
+			count = available
+		}
+		if available := (budget.PayloadBytes - work.PayloadBytes) / d.ElemSize; count > available {
+			count = available
+		}
+		end := cursor.index + count
+		if visitor.mode == objectScanVisitTinyMark {
+			for cursor.index < end {
+				off := uint64(PayloadOffset) + uint64(cursor.index)*uint64(d.ElemSize)
+				c.tinyMarkRef(Ref(binary.LittleEndian.Uint32(b[off:])))
+				cursor.index++
+			}
+		} else {
+			for cursor.index < end {
+				off := uint64(PayloadOffset) + uint64(cursor.index)*uint64(d.ElemSize)
+				if visitor.fn != nil {
+					visitor.fn(Ref(binary.LittleEndian.Uint32(b[off:])))
+				}
+				cursor.index++
+			}
+		}
+		work.ScanEntries += count
+		work.RefSlots += count
+		work.PayloadBytes += count * d.ElemSize
+		return work, cursor.index == length
+	default:
+		return work, true
+	}
+}
+
+// scanObjectRefs is the complete synchronous wrapper used by Throughput/full
+// collection and verification helpers. Tiny incremental marking uses the same
+// primitive with a retained cursor and a finite budget.
+func (c *Collector) scanObjectRefs(h uint32, visit func(Ref)) {
+	visitor := objectScanVisitor{fn: visit}
+	if !c.telemetryEnabled() {
+		cursor := objectScanCursor{}
+		for {
+			_, complete := c.scanObjectRefsRange(h, &cursor, completeObjectScanBudget, visitor)
+			if complete {
+				return
+			}
+		}
+	}
+	start := c.cfg.Telemetry.scanStart()
+	cursor := objectScanCursor{}
+	var total objectScanWork
+	for {
+		work, complete := c.scanObjectRefsRange(h, &cursor, completeObjectScanBudget, visitor)
+		total.add(work)
+		if complete {
+			break
+		}
+	}
+	c.cfg.Telemetry.noteObjectScanWork(start, total, true, false, true)
+}

--- a/src/core/runtime/gc/telemetry.go
+++ b/src/core/runtime/gc/telemetry.go
@@ -79,6 +79,14 @@ type TraceTelemetry struct {
 	ObjectsVisited        uint64 `json:"objects_visited"`
 	PayloadBytesVisited   uint64 `json:"payload_bytes_visited"`
 	ReferenceSlotsVisited uint64 `json:"reference_slots_visited"`
+	ScanEntriesVisited    uint64 `json:"scan_entries_visited"`
+	ObjectScansBegun      uint64 `json:"object_scans_begun"`
+	ObjectScansResumed    uint64 `json:"object_scans_resumed"`
+	ObjectScansCompleted  uint64 `json:"object_scans_completed"`
+	MaxStepObjectRanges   uint64 `json:"max_step_object_ranges"`
+	MaxStepScanEntries    uint64 `json:"max_step_scan_entries"`
+	MaxStepReferenceSlots uint64 `json:"max_step_reference_slots"`
+	MaxStepPayloadBytes   uint64 `json:"max_step_payload_bytes"`
 	ObjectsSwept          uint64 `json:"objects_swept"`
 	PayloadBytesSwept     uint64 `json:"payload_bytes_swept"`
 }

--- a/src/core/runtime/gc/telemetry_state_disabled.go
+++ b/src/core/runtime/gc/telemetry_state_disabled.go
@@ -49,24 +49,26 @@ type telemetryCycle struct {
 	cards          CardTelemetry
 }
 
-func (*Telemetry) attach(Profile, uint64)                                       {}
-func (*Telemetry) setGlobalRootClass(uint32, RootClass)                         {}
-func (*Telemetry) globalRootClass(uint32) RootClass                             { return RootGlobal }
-func (*Telemetry) begin(telemetryCycleKind)                                     {}
-func (*Telemetry) end(bool)                                                     {}
-func (*Telemetry) setPhase(telemetryPhase)                                      {}
-func (*Telemetry) suspend()                                                     {}
-func (*Telemetry) resume()                                                      {}
-func (*Telemetry) noteRoot(RootClass)                                           {}
-func (*Telemetry) addRootTime(RootClass, uint64)                                {}
-func (*Telemetry) scanStart() time.Time                                         { return time.Time{} }
-func (*Telemetry) noteObjectScan(time.Time, uint32, uint32)                     {}
-func (*Telemetry) noteCardScan(time.Time, uint64, uint64, uint64, uint64, bool) {}
-func (*Telemetry) noteNurseryOccupancy(uint64, uint64)                          {}
-func (*Telemetry) noteSurvivor(uint32, uint8, bool, bool)                       {}
-func (*Telemetry) notePromotion(uint32, bool)                                   {}
-func (*Telemetry) noteSweep(uint32)                                             {}
-func (*Telemetry) reset(Profile, uint64)                                        {}
+func (*Telemetry) attach(Profile, uint64)                                         {}
+func (*Telemetry) setGlobalRootClass(uint32, RootClass)                           {}
+func (*Telemetry) globalRootClass(uint32) RootClass                               { return RootGlobal }
+func (*Telemetry) begin(telemetryCycleKind)                                       {}
+func (*Telemetry) end(bool)                                                       {}
+func (*Telemetry) setPhase(telemetryPhase)                                        {}
+func (*Telemetry) suspend()                                                       {}
+func (*Telemetry) resume()                                                        {}
+func (*Telemetry) noteRoot(RootClass)                                             {}
+func (*Telemetry) addRootTime(RootClass, uint64)                                  {}
+func (*Telemetry) scanStart() time.Time                                           { return time.Time{} }
+func (*Telemetry) noteObjectScan(time.Time, uint32, uint32)                       {}
+func (*Telemetry) noteObjectScanWork(time.Time, objectScanWork, bool, bool, bool) {}
+func (*Telemetry) noteTinyStepWork(objectScanWork)                                {}
+func (*Telemetry) noteCardScan(time.Time, uint64, uint64, uint64, uint64, bool)   {}
+func (*Telemetry) noteNurseryOccupancy(uint64, uint64)                            {}
+func (*Telemetry) noteSurvivor(uint32, uint8, bool, bool)                         {}
+func (*Telemetry) notePromotion(uint32, bool)                                     {}
+func (*Telemetry) noteSweep(uint32)                                               {}
+func (*Telemetry) reset(Profile, uint64)                                          {}
 
 func (c *Collector) beginCollectionTelemetry(telemetryCycleKind) {}
 func (c *Collector) endCollectionTelemetry(bool)                 {}

--- a/src/core/runtime/gc/telemetry_state_enabled.go
+++ b/src/core/runtime/gc/telemetry_state_enabled.go
@@ -316,6 +316,22 @@ func addTraceTelemetry(dst *TraceTelemetry, src TraceTelemetry) {
 	dst.ObjectsVisited += src.ObjectsVisited
 	dst.PayloadBytesVisited += src.PayloadBytesVisited
 	dst.ReferenceSlotsVisited += src.ReferenceSlotsVisited
+	dst.ScanEntriesVisited += src.ScanEntriesVisited
+	dst.ObjectScansBegun += src.ObjectScansBegun
+	dst.ObjectScansResumed += src.ObjectScansResumed
+	dst.ObjectScansCompleted += src.ObjectScansCompleted
+	if src.MaxStepObjectRanges > dst.MaxStepObjectRanges {
+		dst.MaxStepObjectRanges = src.MaxStepObjectRanges
+	}
+	if src.MaxStepScanEntries > dst.MaxStepScanEntries {
+		dst.MaxStepScanEntries = src.MaxStepScanEntries
+	}
+	if src.MaxStepReferenceSlots > dst.MaxStepReferenceSlots {
+		dst.MaxStepReferenceSlots = src.MaxStepReferenceSlots
+	}
+	if src.MaxStepPayloadBytes > dst.MaxStepPayloadBytes {
+		dst.MaxStepPayloadBytes = src.MaxStepPayloadBytes
+	}
 	dst.ObjectsSwept += src.ObjectsSwept
 	dst.PayloadBytesSwept += src.PayloadBytesSwept
 }
@@ -419,20 +435,57 @@ func (t *Telemetry) scanStart() time.Time {
 }
 
 func (t *Telemetry) noteObjectScan(start time.Time, size, slots uint32) {
+	work := objectScanWork{ObjectRanges: 1, RefSlots: slots}
+	if size > PayloadOffset {
+		work.PayloadBytes = size - PayloadOffset
+	}
+	t.noteObjectScanWork(start, work, true, false, true)
+}
+
+func (t *Telemetry) noteObjectScanWork(start time.Time, work objectScanWork, began, resumed, completed bool) {
 	if t == nil || !t.active.active || !t.active.suspendStart.IsZero() {
 		return
 	}
-	t.active.trace.ObjectsVisited++
-	if size > PayloadOffset {
-		t.active.trace.PayloadBytesVisited += uint64(size - PayloadOffset)
+	if began {
+		t.active.trace.ObjectsVisited++
+		t.active.trace.ObjectScansBegun++
 	}
-	t.active.trace.ReferenceSlotsVisited += uint64(slots)
+	if resumed {
+		t.active.trace.ObjectScansResumed++
+	}
+	if completed {
+		t.active.trace.ObjectScansCompleted++
+	}
+	t.active.trace.PayloadBytesVisited += uint64(work.PayloadBytes)
+	t.active.trace.ReferenceSlotsVisited += uint64(work.RefSlots)
+	t.active.trace.ScanEntriesVisited += uint64(work.ScanEntries)
 	if t.active.rememberedScan {
-		t.active.cards.ScannedSlots += uint64(slots)
-		t.active.cards.WholeObjectScans++
+		t.active.cards.ScannedSlots += uint64(work.RefSlots)
+		if began && completed {
+			t.active.cards.WholeObjectScans++
+		}
 	}
 	if !start.IsZero() && t.active.phase < telemetryPhaseCount {
 		t.active.nestedScanNS[t.active.phase] += uint64(time.Since(start))
+	}
+}
+
+func (t *Telemetry) noteTinyStepWork(work objectScanWork) {
+	if t == nil || !t.active.active || !t.active.suspendStart.IsZero() {
+		return
+	}
+	trace := &t.active.trace
+	if uint64(work.ObjectRanges) > trace.MaxStepObjectRanges {
+		trace.MaxStepObjectRanges = uint64(work.ObjectRanges)
+	}
+	if uint64(work.ScanEntries) > trace.MaxStepScanEntries {
+		trace.MaxStepScanEntries = uint64(work.ScanEntries)
+	}
+	if uint64(work.RefSlots) > trace.MaxStepReferenceSlots {
+		trace.MaxStepReferenceSlots = uint64(work.RefSlots)
+	}
+	if uint64(work.PayloadBytes) > trace.MaxStepPayloadBytes {
+		trace.MaxStepPayloadBytes = uint64(work.PayloadBytes)
 	}
 }
 

--- a/src/core/runtime/gc/tiny_collect.go
+++ b/src/core/runtime/gc/tiny_collect.go
@@ -139,7 +139,11 @@ func (c *Collector) Step(roots RootSet) error {
 		if c.telemetryEnabled() {
 			c.cfg.Telemetry.setPhase(telemetryPhaseRootEnumeration)
 		}
-		if len(c.tinyGC.grayStack) > 0 {
+		// A bulk barrier can perform bounded marking while the collector is in
+		// remark and leave one object partially scanned with an empty gray stack.
+		// Return to mark for either form of pending work; sweep must never begin
+		// while an active cursor still owns a gray object.
+		if c.tinyGC.scan.handle != 0 || len(c.tinyGC.grayStack) > 0 {
 			c.tinyGC.state = tinyMark
 			return nil
 		}
@@ -305,7 +309,15 @@ func (c *Collector) tinyDrainGrayBudget(budget objectScanBudget) (used objectSca
 		if c.telemetryEnabled() {
 			start := c.cfg.Telemetry.scanStart()
 			work, complete = c.scanObjectRefsRange(h, &c.tinyGC.scan.scan, remaining, objectScanVisitor{mode: objectScanVisitTinyMark})
-			c.cfg.Telemetry.noteObjectScanWork(start, work, began, !began, complete)
+			telemetryWork := work
+			telemetryWork.PayloadBytes = 0
+			if complete {
+				// Preserve PayloadBytesVisited's pre-cursor meaning: account the
+				// complete logical payload once when an object scan completes. The
+				// per-Step maximum still uses work.PayloadBytes below.
+				telemetryWork.PayloadBytes = c.objectPayloadBytes(h)
+			}
+			c.cfg.Telemetry.noteObjectScanWork(start, telemetryWork, began, !began, complete)
 		} else {
 			work, complete = c.scanObjectRefsRange(h, &c.tinyGC.scan.scan, remaining, objectScanVisitor{mode: objectScanVisitTinyMark})
 		}
@@ -344,6 +356,12 @@ func (c *Collector) tinySetColor(h uint32, color tinyColor) {
 }
 
 func (c *Collector) verifyTiny(roots RootSet) error {
+	if c.tinyGC.state > tinySweep {
+		return fmt.Errorf("gc: invalid tiny collector state %d", c.tinyGC.state)
+	}
+	if work := c.tinyGC.lastStepWork.objectScanWork(); work.ObjectRanges > tinyStepObjectRanges || work.ScanEntries > tinyStepScanEntries || work.RefSlots > tinyStepRefSlots || work.PayloadBytes > tinyStepPayloadBytes {
+		return fmt.Errorf("gc: Tiny Step work exceeds bound: %+v", work)
+	}
 	if c.tiny.blockBytes == 0 || len(c.tiny.mem) == 0 {
 		return errors.New("gc: tiny heap is not initialized")
 	}
@@ -383,6 +401,49 @@ func (c *Collector) verifyTiny(roots RootSet) error {
 		}
 		if col := c.tinyColorOf(h); col != tinyWhite && col != tinyGray && col != tinyBlack {
 			return fmt.Errorf("gc: invalid tiny color for handle %d", h)
+		}
+	}
+	seenGray := make([]bool, len(c.handles))
+	for _, h := range c.tinyGC.grayStack {
+		if h == 0 || int(h) >= len(c.handles) || c.handles[h].space != spaceTiny || c.tinyColorOf(h) != tinyGray {
+			return fmt.Errorf("gc: invalid tiny gray-stack handle %d", h)
+		}
+		if seenGray[h] {
+			return fmt.Errorf("gc: duplicate tiny gray-stack handle %d", h)
+		}
+		seenGray[h] = true
+	}
+	if active := c.tinyGC.scan.handle; active != 0 {
+		if c.tinyGC.state != tinyMark && c.tinyGC.state != tinyRemark {
+			return fmt.Errorf("gc: active tiny scan in state %d", c.tinyGC.state)
+		}
+		if int(active) >= len(c.handles) || c.handles[active].space != spaceTiny || c.tinyColorOf(active) != tinyGray || seenGray[active] {
+			return fmt.Errorf("gc: invalid active tiny scan handle %d", active)
+		}
+		r := makeObjRef(active)
+		d, err := c.refDesc(r)
+		if err != nil || !d.HasRefs {
+			return fmt.Errorf("gc: active tiny scan handle %d has no reference layout", active)
+		}
+		limit := uint32(len(d.Fields))
+		if d.Kind == KindArray {
+			if !d.ArrayElementsAreRefs() {
+				return fmt.Errorf("gc: active tiny array scan handle %d has non-reference elements", active)
+			}
+			limit = c.header(r).Aux
+		}
+		if c.tinyGC.scan.scan.index >= limit {
+			return fmt.Errorf("gc: active tiny scan handle %d cursor %d beyond %d entries", active, c.tinyGC.scan.scan.index, limit)
+		}
+		seenGray[active] = true
+	} else if c.tinyGC.state == tinyIdle || c.tinyGC.state == tinySweep {
+		if len(c.tinyGC.grayStack) != 0 {
+			return fmt.Errorf("gc: tiny state %d retains gray-stack work", c.tinyGC.state)
+		}
+	}
+	for h := uint32(1); int(h) < len(c.handles); h++ {
+		if c.handles[h].space == spaceTiny && (c.tinyColorOf(h) == tinyGray) != seenGray[h] {
+			return fmt.Errorf("gc: tiny gray handle %d is missing from queue/cursor state", h)
 		}
 	}
 	if err := c.verifyTinyFreeList(liveBlocks); err != nil {

--- a/src/core/runtime/gc/tiny_collect.go
+++ b/src/core/runtime/gc/tiny_collect.go
@@ -1,7 +1,6 @@
 package gc
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 )
@@ -23,17 +22,73 @@ const (
 	tinyBlack
 )
 
-type tinyGC struct {
-	state          tinyGCState
-	color          []tinyColor
-	grayStack      []uint32
-	sweep          uint32
-	cycles         uint64
-	telemetryOwned bool
+const (
+	// TinyStepBudget remains the allocation-time count of Step calls. Object
+	// tracing inside each mark Step uses this independent fixed work vector.
+	tinyStepObjectRanges = uint32(64)
+	tinyStepScanEntries  = uint32(256)
+	tinyStepRefSlots     = uint32(256)
+	tinyStepPayloadBytes = uint32(1024)
+)
+
+var tinyStepObjectScanBudget = objectScanBudget{
+	ObjectRanges: tinyStepObjectRanges,
+	ScanEntries:  tinyStepScanEntries,
+	RefSlots:     tinyStepRefSlots,
+	PayloadBytes: tinyStepPayloadBytes,
 }
 
-// Step performs one bounded unit of Tiny incremental tri-color collection. When
-// called while idle it starts a new cycle by graying the supplied roots.
+type tinyScanCursor struct {
+	handle uint32
+	scan   objectScanCursor
+}
+
+type tinyStepWork struct {
+	objectRanges uint16
+	scanEntries  uint16
+	refSlots     uint16
+	payloadBytes uint16
+}
+
+func makeTinyStepWork(work objectScanWork) tinyStepWork {
+	return tinyStepWork{
+		objectRanges: uint16(work.ObjectRanges),
+		scanEntries:  uint16(work.ScanEntries),
+		refSlots:     uint16(work.RefSlots),
+		payloadBytes: uint16(work.PayloadBytes),
+	}
+}
+
+func (work tinyStepWork) objectScanWork() objectScanWork {
+	return objectScanWork{
+		ObjectRanges: uint32(work.objectRanges),
+		ScanEntries:  uint32(work.scanEntries),
+		RefSlots:     uint32(work.refSlots),
+		PayloadBytes: uint32(work.payloadBytes),
+	}
+}
+
+type tinyGC struct {
+	// Scalar fields precede slices so the cursor and per-Step work vector reuse
+	// the former alignment padding; tinyGC retains its 64-bit footprint.
+	state          tinyGCState
+	telemetryOwned bool
+	sweep          uint32
+	cycles         uint64
+
+	// At most one object scan is active. Its handle remains gray until scan is
+	// complete; the cursor stores only stable handle/index state, never a raw
+	// heap pointer. Step never exceeds tinyStepObjectScanBudget while marking.
+	scan         tinyScanCursor
+	lastStepWork tinyStepWork
+
+	color     []tinyColor
+	grayStack []uint32
+}
+
+// Step performs one Tiny incremental tri-color unit. Object tracing is bounded
+// by tinyStepObjectScanBudget; root enumeration and sweep pacing are separate
+// stages. When called while idle it starts a cycle by graying supplied roots.
 func (c *Collector) Step(roots RootSet) error {
 	if c.cfg.Profile != ProfileTiny {
 		return c.CollectMinor(roots)
@@ -57,6 +112,7 @@ func (c *Collector) Step(roots RootSet) error {
 			}()
 		}
 	}
+	c.tinyGC.lastStepWork = tinyStepWork{}
 	if c.tinyGC.state == tinyIdle {
 		if c.telemetryEnabled() {
 			c.cfg.Telemetry.setPhase(telemetryPhaseRootEnumeration)
@@ -68,16 +124,14 @@ func (c *Collector) Step(roots RootSet) error {
 		if c.telemetryEnabled() {
 			c.cfg.Telemetry.setPhase(telemetryPhaseMarking)
 		}
-		if len(c.tinyGC.grayStack) == 0 {
+		if c.tinyGC.scan.handle == 0 && len(c.tinyGC.grayStack) == 0 {
 			c.tinyGC.state = tinyRemark
 			return nil
 		}
-		n := len(c.tinyGC.grayStack) - 1
-		h := c.tinyGC.grayStack[n]
-		c.tinyGC.grayStack = c.tinyGC.grayStack[:n]
-		if int(h) < len(c.handles) && c.handles[h].space == spaceTiny {
-			c.tinySetColor(h, tinyBlack)
-			c.scanObjectRefs(h, c.tinyMarkRef)
+		work := c.tinyDrainGrayBudget(tinyStepObjectScanBudget)
+		c.tinyGC.lastStepWork = makeTinyStepWork(work)
+		if c.telemetryEnabled() {
+			c.cfg.Telemetry.noteTinyStepWork(work)
 		}
 		return nil
 	}
@@ -154,6 +208,8 @@ func (c *Collector) tinyStartMark(roots RootSet) {
 		}
 	}
 	c.tinyGC.grayStack = c.tinyGC.grayStack[:0]
+	c.tinyGC.scan = tinyScanCursor{}
+	c.tinyGC.lastStepWork = tinyStepWork{}
 	c.tinyGC.state = tinyMark
 	c.tinyGC.sweep = 1
 	c.tinyMarkRoots(roots)
@@ -179,6 +235,8 @@ func (c *Collector) tinyMarkRoots(roots RootSet) {
 
 func (c *Collector) tinyFinishCycle() {
 	c.tinyGC.grayStack = c.tinyGC.grayStack[:0]
+	c.tinyGC.scan = tinyScanCursor{}
+	c.tinyGC.lastStepWork = tinyStepWork{}
 	c.tinyGC.state = tinyIdle
 	c.tinyGC.sweep = 1
 	c.tinyGC.cycles++
@@ -205,26 +263,61 @@ func (c *Collector) tinyMarkRef(r Ref) {
 
 func (c *Collector) tinyMarkRefNow(r Ref) {
 	c.tinyMarkRef(r)
-	for len(c.tinyGC.grayStack) > 0 {
-		c.tinyDrainGrayBudget(^uint32(0))
+	for c.tinyGC.scan.handle != 0 || len(c.tinyGC.grayStack) > 0 {
+		if work := c.tinyDrainGrayBudget(completeObjectScanBudget); work == (objectScanWork{}) {
+			break
+		}
 	}
 }
 
-// tinyDrainGrayBudget performs at most budget object scans. Bulk mutation uses
-// one fixed-size chunk at a time so a large array cannot enqueue an unbounded
-// number of newly published children before collector work catches up. One
-// object remains the collector's indivisible scan unit.
-func (c *Collector) tinyDrainGrayBudget(budget uint32) {
-	for budget != 0 && len(c.tinyGC.grayStack) > 0 {
-		budget--
-		n := len(c.tinyGC.grayStack) - 1
-		h := c.tinyGC.grayStack[n]
-		c.tinyGC.grayStack = c.tinyGC.grayStack[:n]
-		if int(h) >= len(c.handles) || c.handles[h].space != spaceTiny || c.tinyColorOf(h) != tinyGray {
+// tinyDrainGrayBudget consumes a bounded vector of object-scan work. The active
+// object always resumes before newly discovered gray objects, preserving the
+// complete scanner's descriptor/element visitation order. An active object
+// remains gray and is not present on grayStack; it becomes black only after its
+// final outgoing reference has been visited.
+func (c *Collector) tinyDrainGrayBudget(budget objectScanBudget) (used objectScanWork) {
+	for {
+		remaining := budget.remaining(used)
+		if remaining.ObjectRanges == 0 {
+			return used
+		}
+		began := false
+		if c.tinyGC.scan.handle == 0 {
+			for len(c.tinyGC.grayStack) > 0 {
+				n := len(c.tinyGC.grayStack) - 1
+				h := c.tinyGC.grayStack[n]
+				c.tinyGC.grayStack = c.tinyGC.grayStack[:n]
+				if int(h) >= len(c.handles) || c.handles[h].space != spaceTiny || c.tinyColorOf(h) != tinyGray {
+					continue
+				}
+				c.tinyGC.scan.handle = h
+				began = true
+				break
+			}
+			if c.tinyGC.scan.handle == 0 {
+				return used
+			}
+		}
+
+		h := c.tinyGC.scan.handle
+		var work objectScanWork
+		var complete bool
+		if c.telemetryEnabled() {
+			start := c.cfg.Telemetry.scanStart()
+			work, complete = c.scanObjectRefsRange(h, &c.tinyGC.scan.scan, remaining, objectScanVisitor{mode: objectScanVisitTinyMark})
+			c.cfg.Telemetry.noteObjectScanWork(start, work, began, !began, complete)
+		} else {
+			work, complete = c.scanObjectRefsRange(h, &c.tinyGC.scan.scan, remaining, objectScanVisitor{mode: objectScanVisitTinyMark})
+		}
+		used.add(work)
+		if complete {
+			if int(h) < len(c.handles) && c.handles[h].space == spaceTiny && c.tinyColorOf(h) == tinyGray {
+				c.tinySetColor(h, tinyBlack)
+			}
+			c.tinyGC.scan = tinyScanCursor{}
 			continue
 		}
-		c.tinySetColor(h, tinyBlack)
-		c.scanObjectRefs(h, c.tinyMarkRef)
+		return used
 	}
 }
 
@@ -248,60 +341,6 @@ func (c *Collector) tinySetColor(h uint32, color tinyColor) {
 		c.tinyGC.color = append(c.tinyGC.color, tinyWhite)
 	}
 	c.tinyGC.color[h] = color
-}
-
-func (c *Collector) scanObjectRefs(h uint32, visit func(Ref)) {
-	if !c.telemetryEnabled() {
-		r := makeObjRef(h)
-		d, err := c.refDesc(r)
-		if err != nil || !d.HasRefs {
-			return
-		}
-		hdr := c.header(r)
-		b := c.bytes(r)
-		if d.Kind == KindStruct {
-			for _, f := range d.Fields {
-				if isCollectorRefKind(f.Kind) {
-					visit(Ref(binary.LittleEndian.Uint32(b[PayloadOffset+f.Offset:])))
-				}
-			}
-		} else if d.ArrayElementsAreRefs() {
-			for i := uint32(0); i < hdr.Aux; i++ {
-				off := PayloadOffset + i*d.ElemSize
-				visit(Ref(binary.LittleEndian.Uint32(b[off:])))
-			}
-		}
-		return
-	}
-	start := c.cfg.Telemetry.scanStart()
-	var size uint32
-	if h != 0 && int(h) < len(c.handles) {
-		size = c.handles[h].size
-	}
-	r := makeObjRef(h)
-	d, err := c.refDesc(r)
-	if err != nil || !d.HasRefs {
-		c.cfg.Telemetry.noteObjectScan(start, size, 0)
-		return
-	}
-	hdr := c.header(r)
-	b := c.bytes(r)
-	var slots uint32
-	if d.Kind == KindStruct {
-		for _, f := range d.Fields {
-			if isCollectorRefKind(f.Kind) {
-				slots++
-				visit(Ref(binary.LittleEndian.Uint32(b[PayloadOffset+f.Offset:])))
-			}
-		}
-	} else if d.ArrayElementsAreRefs() {
-		slots = hdr.Aux
-		for i := uint32(0); i < hdr.Aux; i++ {
-			off := PayloadOffset + i*d.ElemSize
-			visit(Ref(binary.LittleEndian.Uint32(b[off:])))
-		}
-	}
-	c.cfg.Telemetry.noteObjectScan(start, size, slots)
 }
 
 func (c *Collector) verifyTiny(roots RootSet) error {

--- a/src/core/runtime/gc/tiny_scan_bench_test.go
+++ b/src/core/runtime/gc/tiny_scan_bench_test.go
@@ -1,0 +1,157 @@
+package gc
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+)
+
+func BenchmarkTinyStepReferenceArray(b *testing.B) {
+	refs, err := NewArrayDesc(0, StorageRefNull)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, length := range []uint32{16, 256, 4096, 64 << 10} {
+		b.Run(fmt.Sprintf("elements=%d", length), func(b *testing.B) {
+			c, err := NewCollector(Config{Profile: ProfileTiny, TinyHeapBytes: 8 << 20, TinyBlockBytes: 16}, []TypeDesc{refs})
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(c.Close)
+			array, err := c.NewArrayDefault(0, length)
+			if err != nil {
+				b.Fatal(err)
+			}
+			root := Root(array)
+			roots := &tinyDirectRoot{root: &root}
+			var maxWork objectScanWork
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := c.Step(roots); err != nil {
+					b.Fatal(err)
+				}
+				maxObjectScanWork(&maxWork, c.tinyGC.lastStepWork.objectScanWork())
+			}
+			b.StopTimer()
+			reportTinyScanWork(b, maxWork, c)
+		})
+	}
+}
+
+func BenchmarkTinyStepSparseReferenceStruct(b *testing.B) {
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, fieldCount := range []int{64, 1024, 4096} {
+		b.Run(fmt.Sprintf("fields=%d", fieldCount), func(b *testing.B) {
+			fields := make([]StorageKind, fieldCount)
+			for i := range fields {
+				fields[i] = StorageI32
+			}
+			fields[0], fields[len(fields)-1] = StorageRefNull, StorageRefNull
+			sparse, err := NewStructDesc(1, fields)
+			if err != nil {
+				b.Fatal(err)
+			}
+			c, err := NewCollector(Config{Profile: ProfileTiny, TinyHeapBytes: 8 << 20, TinyBlockBytes: 16}, []TypeDesc{leaf, sparse})
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(c.Close)
+			parent, err := c.NewStructDefault(1)
+			if err != nil {
+				b.Fatal(err)
+			}
+			child, err := c.NewStructDefault(0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := c.StructSet(parent, 0, RefValue(child)); err != nil {
+				b.Fatal(err)
+			}
+			if err := c.StructSet(parent, uint32(fieldCount-1), RefValue(child)); err != nil {
+				b.Fatal(err)
+			}
+			root := Root(parent)
+			roots := &tinyDirectRoot{root: &root}
+			var maxWork objectScanWork
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := c.Step(roots); err != nil {
+					b.Fatal(err)
+				}
+				maxObjectScanWork(&maxWork, c.tinyGC.lastStepWork.objectScanWork())
+			}
+			b.StopTimer()
+			reportTinyScanWork(b, maxWork, c)
+		})
+	}
+}
+
+func BenchmarkTinyCompleteCycleReferenceArray(b *testing.B) {
+	refs, err := NewArrayDesc(0, StorageRefNull)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, length := range []uint32{16, 256, 4096, 64 << 10} {
+		b.Run(fmt.Sprintf("elements=%d", length), func(b *testing.B) {
+			c, err := NewCollector(Config{Profile: ProfileTiny, TinyHeapBytes: 8 << 20, TinyBlockBytes: 16}, []TypeDesc{refs})
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(c.Close)
+			array, err := c.NewArrayDefault(0, length)
+			if err != nil {
+				b.Fatal(err)
+			}
+			root := Root(array)
+			roots := &tinyDirectRoot{root: &root}
+			var totalSteps uint64
+			var maxWork objectScanWork
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for {
+					if err := c.Step(roots); err != nil {
+						b.Fatal(err)
+					}
+					totalSteps++
+					maxObjectScanWork(&maxWork, c.tinyGC.lastStepWork.objectScanWork())
+					if c.tinyGC.state == tinyIdle {
+						break
+					}
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(totalSteps)/float64(b.N), "steps/cycle")
+			reportTinyScanWork(b, maxWork, c)
+		})
+	}
+}
+
+func maxObjectScanWork(dst *objectScanWork, work objectScanWork) {
+	if work.ObjectRanges > dst.ObjectRanges {
+		dst.ObjectRanges = work.ObjectRanges
+	}
+	if work.ScanEntries > dst.ScanEntries {
+		dst.ScanEntries = work.ScanEntries
+	}
+	if work.RefSlots > dst.RefSlots {
+		dst.RefSlots = work.RefSlots
+	}
+	if work.PayloadBytes > dst.PayloadBytes {
+		dst.PayloadBytes = work.PayloadBytes
+	}
+}
+
+func reportTinyScanWork(b *testing.B, maxWork objectScanWork, c *Collector) {
+	b.ReportMetric(float64(maxWork.ObjectRanges), "max-object-ranges/Step")
+	b.ReportMetric(float64(maxWork.ScanEntries), "max-scan-entries/Step")
+	b.ReportMetric(float64(maxWork.RefSlots), "max-ref-slots/Step")
+	b.ReportMetric(float64(maxWork.PayloadBytes), "max-payload-bytes/Step")
+	b.ReportMetric(float64(c.tiny.metadataBytes()), "allocator-metadata-bytes")
+	b.ReportMetric(float64(unsafe.Sizeof(c.tinyGC.scan)+unsafe.Sizeof(c.tinyGC.lastStepWork)), "scan-state-bytes")
+}

--- a/src/core/runtime/gc/tiny_scan_telemetry_test.go
+++ b/src/core/runtime/gc/tiny_scan_telemetry_test.go
@@ -1,0 +1,57 @@
+//go:build wago_gcstats
+
+package gc
+
+import "testing"
+
+func TestTinyPartialScanTelemetry(t *testing.T) {
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs, err := NewArrayDesc(1, StorageRefNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewCollector(Config{
+		Profile:        ProfileTiny,
+		TinyHeapBytes:  64 << 10,
+		TinyBlockBytes: 16,
+		Telemetry:      new(Telemetry),
+	}, []TypeDesc{leaf, refs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	array, err := c.NewArrayDefault(1, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := uint32(0); i < 1024; i++ {
+		if err := c.ArraySet(array, i, RefValue(child)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := Root(array)
+	if err := c.CollectFull(Slots{&root}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, ok := c.TelemetrySnapshot()
+	if !ok {
+		t.Fatal("telemetry unavailable")
+	}
+	trace := snapshot.Full.Trace
+	if trace.ObjectsVisited != 2 || trace.ScanEntriesVisited != 1024 || trace.ReferenceSlotsVisited != 1024 || trace.PayloadBytesVisited != 4096 {
+		t.Fatalf("partial trace totals = %+v", trace)
+	}
+	if trace.ObjectScansBegun != 2 || trace.ObjectScansResumed != 3 || trace.ObjectScansCompleted != 2 {
+		t.Fatalf("partial lifecycle counters = %+v", trace)
+	}
+	if trace.MaxStepObjectRanges > uint64(tinyStepObjectRanges) || trace.MaxStepScanEntries != uint64(tinyStepScanEntries) || trace.MaxStepReferenceSlots != uint64(tinyStepRefSlots) || trace.MaxStepPayloadBytes != uint64(tinyStepPayloadBytes) {
+		t.Fatalf("partial step maxima = %+v", trace)
+	}
+}

--- a/src/core/runtime/gc/tiny_scan_telemetry_test.go
+++ b/src/core/runtime/gc/tiny_scan_telemetry_test.go
@@ -4,6 +4,49 @@ package gc
 
 import "testing"
 
+func TestObjectScanTelemetryPreservesLogicalPayloadBytes(t *testing.T) {
+	mixed, err := NewStructDesc(0, []StorageKind{StorageI8, StorageRefNull})
+	if err != nil {
+		t.Fatal(err)
+	}
+	numeric, err := NewArrayDesc(1, StorageI8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewCollector(Config{
+		Profile:        ProfileTiny,
+		TinyHeapBytes:  4096,
+		TinyBlockBytes: 16,
+		Telemetry:      new(Telemetry),
+	}, []TypeDesc{mixed, numeric})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	object, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	array, err := c.NewArrayDefault(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objectRoot, arrayRoot := Root(object), Root(array)
+	if err := c.CollectFull(Slots{&objectRoot, &arrayRoot}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, ok := c.TelemetrySnapshot()
+	if !ok {
+		t.Fatal("telemetry unavailable")
+	}
+	// The mixed struct's padded layout and the one-byte numeric array each occupy
+	// an 8-byte object payload. Pointer-free payloads retain the established
+	// payload-visit accounting.
+	if got := snapshot.Full.Trace.PayloadBytesVisited; got != 16 {
+		t.Fatalf("payload bytes visited = %d, want 16", got)
+	}
+}
+
 func TestTinyPartialScanTelemetry(t *testing.T) {
 	leaf, err := NewStructDesc(0, nil)
 	if err != nil {

--- a/src/core/runtime/gc/tiny_scan_test.go
+++ b/src/core/runtime/gc/tiny_scan_test.go
@@ -1,0 +1,610 @@
+package gc
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+type tinyDirectRoot struct{ root *Root }
+
+func (r *tinyDirectRoot) RangeRoots(fn func(RootSlot) bool) {
+	if r != nil && r.root != nil {
+		fn(r.root)
+	}
+}
+
+func (r *tinyDirectRoot) RangeRootRefs(sink RootRefSink) bool {
+	return r == nil || r.root == nil || sink.VisitRootRef(Ref(*r.root))
+}
+
+func tinyScanTypes(t testing.TB) []TypeDesc {
+	t.Helper()
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := NewStructDesc(1, []StorageKind{StorageRefNull})
+	if err != nil {
+		t.Fatal(err)
+	}
+	array, err := NewArrayDesc(2, StorageRefNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return []TypeDesc{leaf, back, array}
+}
+
+func assertTinyStepWorkBound(t testing.TB, work objectScanWork) {
+	t.Helper()
+	if work.ObjectRanges > tinyStepObjectRanges || work.ScanEntries > tinyStepScanEntries || work.RefSlots > tinyStepRefSlots || work.PayloadBytes > tinyStepPayloadBytes {
+		t.Fatalf("Tiny Step work = %+v, bounds = objects:%d entries:%d refs:%d bytes:%d", work, tinyStepObjectRanges, tinyStepScanEntries, tinyStepRefSlots, tinyStepPayloadBytes)
+	}
+}
+
+func drainTinyWithWorkChecks(t testing.TB, c *Collector, roots RootSet) int {
+	t.Helper()
+	steps := 0
+	for c.tinyGC.state != tinyIdle {
+		if err := c.Step(roots); err != nil {
+			t.Fatal(err)
+		}
+		assertTinyStepWorkBound(t, c.tinyGC.lastStepWork.objectScanWork())
+		steps++
+		if steps > 1_000_000 {
+			t.Fatal("Tiny collection did not converge")
+		}
+	}
+	return steps
+}
+
+func TestTinyPartialMarkStepAllocationFree(t *testing.T) {
+	refs, err := NewArrayDesc(0, StorageRefNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1 << 20, TinyBlockBytes: 16}, []TypeDesc{refs})
+	array, err := c.NewArrayDefault(0, 64<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := Root(array)
+	roots := &tinyDirectRoot{root: &root}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		if err := c.Step(roots); err != nil {
+			panic(err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("warmed partial mark Step allocations = %v, want 0", allocs)
+	}
+}
+
+func TestTinyStepBoundsGiantReferenceArrays(t *testing.T) {
+	const giant = uint32(4096)
+	tests := []struct {
+		name     string
+		length   uint32
+		populate func(*testing.T, *Collector, Ref) []Ref
+		wantLive func([]Ref) uint32
+		wantDead func([]Ref) []Ref
+	}{
+		{
+			name: "all-null", length: giant,
+			populate: func(*testing.T, *Collector, Ref) []Ref { return nil },
+			wantLive: func([]Ref) uint32 { return 1 },
+		},
+		{
+			name: "all-one-object", length: giant,
+			populate: func(t *testing.T, c *Collector, array Ref) []Ref {
+				child, err := c.NewStructDefault(0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for i := uint32(0); i < giant; i++ {
+					if err := c.ArraySet(array, i, RefValue(child)); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return []Ref{child}
+			},
+			wantLive: func([]Ref) uint32 { return 2 },
+		},
+		{
+			name: "different-objects", length: 257,
+			populate: func(t *testing.T, c *Collector, array Ref) []Ref {
+				children := make([]Ref, 257)
+				for i := range children {
+					var err error
+					children[i], err = c.NewStructDefault(0)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := c.ArraySet(array, uint32(i), RefValue(children[i])); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return children
+			},
+			wantLive: func(children []Ref) uint32 { return uint32(len(children) + 1) },
+		},
+		{
+			name: "cycle", length: giant,
+			populate: func(t *testing.T, c *Collector, array Ref) []Ref {
+				child, err := c.NewStructDefault(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := c.StructSet(child, 0, RefValue(array)); err != nil {
+					t.Fatal(err)
+				}
+				for i := uint32(0); i < giant; i++ {
+					if err := c.ArraySet(array, i, RefValue(child)); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return []Ref{child}
+			},
+			wantLive: func([]Ref) uint32 { return 2 },
+		},
+		{
+			name: "alternating-live-dead", length: 256,
+			populate: func(t *testing.T, c *Collector, array Ref) []Ref {
+				children := make([]Ref, 256)
+				for i := range children {
+					var err error
+					children[i], err = c.NewStructDefault(0)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if i%2 == 0 {
+						if err := c.ArraySet(array, uint32(i), RefValue(children[i])); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+				return children
+			},
+			wantLive: func(children []Ref) uint32 { return uint32(len(children)/2 + 1) },
+			wantDead: func(children []Ref) []Ref {
+				dead := make([]Ref, 0, len(children)/2)
+				for i := 1; i < len(children); i += 2 {
+					dead = append(dead, children[i])
+				}
+				return dead
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1 << 20, TinyBlockBytes: 16, VerifyAfterCollect: true}, tinyScanTypes(t))
+			array, err := c.NewArrayDefault(2, test.length)
+			if err != nil {
+				t.Fatal(err)
+			}
+			children := test.populate(t, c, array)
+			root := Root(array)
+			roots := Slots{&root}
+			if err := c.Step(roots); err != nil {
+				t.Fatal(err)
+			}
+			if err := c.Step(roots); err != nil {
+				t.Fatal(err)
+			}
+			assertTinyStepWorkBound(t, c.tinyGC.lastStepWork.objectScanWork())
+			if test.length > tinyStepScanEntries {
+				if c.tinyGC.scan.handle != handleOf(array) || c.tinyGC.scan.scan.index == 0 || c.tinyColorOf(handleOf(array)) != tinyGray {
+					t.Fatalf("large array did not retain a gray partial cursor: cursor=%+v color=%v", c.tinyGC.scan, c.tinyColorOf(handleOf(array)))
+				}
+			}
+			markSteps := 1
+			for c.tinyColorOf(handleOf(array)) != tinyBlack {
+				if err := c.Step(roots); err != nil {
+					t.Fatal(err)
+				}
+				assertTinyStepWorkBound(t, c.tinyGC.lastStepWork.objectScanWork())
+				markSteps++
+			}
+			if want := int((test.length + tinyStepScanEntries - 1) / tinyStepScanEntries); markSteps < want {
+				t.Fatalf("array scan steps = %d, want at least %d", markSteps, want)
+			}
+			drainTinyWithWorkChecks(t, c, roots)
+			if got, want := c.Stats().LiveObjects, test.wantLive(children); got != want {
+				t.Fatalf("live objects = %d, want %d", got, want)
+			}
+			if test.wantDead != nil {
+				for _, dead := range test.wantDead(children) {
+					if c.validObjectRef(dead) {
+						t.Fatalf("unreachable child %v survived", dead)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTinyStepBoundsSparseLargeStruct(t *testing.T) {
+	const fields = 1025
+	kinds := make([]StorageKind, fields)
+	for i := range kinds {
+		kinds[i] = StorageI32
+	}
+	for _, i := range []int{0, 63, 64, 65, fields - 1} {
+		kinds[i] = StorageRefNull
+	}
+	large, err := NewStructDesc(1, kinds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1 << 20, TinyBlockBytes: 16}, []TypeDesc{leaf, large})
+	parent, err := c.NewStructDefault(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	children := make([]Ref, 5)
+	for i, field := range []uint32{0, 63, 64, 65, fields - 1} {
+		children[i], err = c.NewStructDefault(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.StructSet(parent, field, RefValue(children[i])); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dead, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := Root(parent)
+	roots := Slots{&root}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	var entries uint32
+	var scanSteps int
+	for c.tinyColorOf(handleOf(parent)) != tinyBlack {
+		if err := c.Step(roots); err != nil {
+			t.Fatal(err)
+		}
+		assertTinyStepWorkBound(t, c.tinyGC.lastStepWork.objectScanWork())
+		entries += c.tinyGC.lastStepWork.objectScanWork().ScanEntries
+		scanSteps++
+	}
+	if entries != fields {
+		t.Fatalf("descriptor entries = %d, want %d", entries, fields)
+	}
+	if scanSteps < (fields+int(tinyStepScanEntries)-1)/int(tinyStepScanEntries) {
+		t.Fatalf("struct scan steps = %d", scanSteps)
+	}
+	drainTinyWithWorkChecks(t, c, roots)
+	for _, child := range children {
+		if !c.validObjectRef(child) {
+			t.Fatalf("reachable child %v was collected", child)
+		}
+	}
+	if c.validObjectRef(dead) {
+		t.Fatal("unreachable sparse-struct sibling survived")
+	}
+}
+
+func TestObjectScanCursorExactBoundaries(t *testing.T) {
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desc, err := NewStructDesc(1, []StorageKind{StorageI32, StorageRefNull, StorageI32, StorageRefNull})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1024, TinyBlockBytes: 16}, []TypeDesc{leaf, desc})
+	parent, _ := c.NewStructDefault(1)
+	first, _ := c.NewStructDefault(0)
+	last, _ := c.NewStructDefault(0)
+	if err := c.StructSet(parent, 1, RefValue(first)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.StructSet(parent, 3, RefValue(last)); err != nil {
+		t.Fatal(err)
+	}
+
+	var cursor objectScanCursor
+	var visited []Ref
+	visitor := objectScanVisitor{fn: func(r Ref) { visited = append(visited, r) }}
+	work, complete := c.scanObjectRefsRange(handleOf(parent), &cursor, objectScanBudget{ObjectRanges: 1, ScanEntries: 1, PayloadBytes: 4}, visitor)
+	if complete || cursor.index != 1 || work.ScanEntries != 1 || len(visited) != 0 {
+		t.Fatalf("pause before ref: cursor=%d work=%+v complete=%v visited=%v", cursor.index, work, complete, visited)
+	}
+	work, complete = c.scanObjectRefsRange(handleOf(parent), &cursor, objectScanBudget{ObjectRanges: 1, ScanEntries: 1, RefSlots: 1, PayloadBytes: 4}, visitor)
+	if complete || cursor.index != 2 || work.RefSlots != 1 || len(visited) != 1 || visited[0] != first {
+		t.Fatalf("pause after ref: cursor=%d work=%+v complete=%v visited=%v", cursor.index, work, complete, visited)
+	}
+	work, complete = c.scanObjectRefsRange(handleOf(parent), &cursor, objectScanBudget{ObjectRanges: 1, ScanEntries: 2, RefSlots: 1, PayloadBytes: 8}, visitor)
+	if !complete || cursor.index != 4 || work.ScanEntries != 2 || len(visited) != 2 || visited[1] != last {
+		t.Fatalf("final field: cursor=%d work=%+v complete=%v visited=%v", cursor.index, work, complete, visited)
+	}
+}
+
+func TestTinyMutationDuringPartialScan(t *testing.T) {
+	c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1 << 20, TinyBlockBytes: 16, VerifyAfterCollect: true}, tinyScanTypes(t))
+	parent, _ := c.NewArrayDefault(2, 512)
+	before, _ := c.NewStructDefault(0)
+	after, _ := c.NewStructDefault(0)
+	blackChild, _ := c.NewStructDefault(0)
+	rootChild, _ := c.NewStructDefault(0)
+	back, _ := c.NewStructDefault(1)
+	root := Root(parent)
+	roots := Slots{&root}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	if c.tinyGC.scan.handle != handleOf(parent) || c.tinyGC.scan.scan.index != tinyStepScanEntries {
+		t.Fatalf("partial cursor = %+v", c.tinyGC.scan)
+	}
+	stackBefore := len(c.tinyGC.grayStack)
+	for i := 0; i < 8; i++ {
+		c.tinyGrayHandle(handleOf(parent))
+	}
+	if len(c.tinyGC.grayStack) != stackBefore {
+		t.Fatal("duplicate gray request queued active parent")
+	}
+	if err := c.ArraySet(parent, 0, RefValue(before)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ArraySet(parent, 400, RefValue(after)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ArraySet(parent, 350, RefValue(back)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.StructSet(back, 0, RefValue(parent)); err != nil {
+		t.Fatal(err)
+	}
+	for _, child := range []Ref{before, after, back} {
+		if c.tinyColorOf(handleOf(child)) != tinyGray {
+			t.Fatalf("child %v was not shaded from partial gray parent", child)
+		}
+	}
+	for c.tinyColorOf(handleOf(parent)) != tinyBlack {
+		if err := c.Step(roots); err != nil {
+			t.Fatal(err)
+		}
+		assertTinyStepWorkBound(t, c.tinyGC.lastStepWork.objectScanWork())
+	}
+	if err := c.ArraySet(parent, 1, RefValue(blackChild)); err != nil {
+		t.Fatal(err)
+	}
+	if c.tinyColorOf(handleOf(blackChild)) != tinyGray || c.tinyColorOf(handleOf(parent)) != tinyGray {
+		t.Fatal("black-parent barrier did not preserve existing hybrid shading")
+	}
+	root = Root(rootChild) // ordinary transient roots are observed by remark.
+	drainTinyWithWorkChecks(t, c, roots)
+	// parent was already gray when the transient root changed, so this cycle must
+	// finish its exact graph as well as retain the newly remarked root.
+	for _, live := range []Ref{parent, before, after, back, blackChild, rootChild} {
+		if !c.validObjectRef(live) {
+			t.Fatalf("reachable object %v was collected", live)
+		}
+	}
+}
+
+func TestTinyBulkBarrierRangeValidationEveryPhase(t *testing.T) {
+	phases := []struct {
+		name    string
+		advance func(*testing.T, *Collector, RootSet, Ref)
+	}{
+		{name: "mark", advance: func(t *testing.T, c *Collector, roots RootSet, parent Ref) {
+			if err := c.Step(roots); err != nil {
+				t.Fatal(err)
+			}
+			for c.tinyColorOf(handleOf(parent)) != tinyBlack {
+				if err := c.Step(roots); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if c.tinyGC.state != tinyMark {
+				t.Fatalf("state=%v, want mark", c.tinyGC.state)
+			}
+		}},
+		{name: "remark", advance: func(t *testing.T, c *Collector, roots RootSet, parent Ref) {
+			if err := c.Step(roots); err != nil {
+				t.Fatal(err)
+			}
+			for c.tinyColorOf(handleOf(parent)) != tinyBlack {
+				if err := c.Step(roots); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := c.Step(roots); err != nil {
+				t.Fatal(err)
+			}
+			if c.tinyGC.state != tinyRemark {
+				t.Fatalf("state=%v, want remark", c.tinyGC.state)
+			}
+		}},
+		{name: "sweep", advance: func(t *testing.T, c *Collector, roots RootSet, parent Ref) {
+			if err := c.Step(roots); err != nil {
+				t.Fatal(err)
+			}
+			for c.tinyColorOf(handleOf(parent)) != tinyBlack {
+				if err := c.Step(roots); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for c.tinyGC.state != tinySweep {
+				if err := c.Step(roots); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}},
+	}
+	invalid := []struct {
+		name          string
+		start, length uint32
+	}{
+		{name: "max-start", start: math.MaxUint32, length: 1},
+		{name: "wrapping-start-length", start: math.MaxUint32, length: 2},
+		{name: "invalid-start", start: 4, length: 1},
+		{name: "invalid-length", start: 3, length: 2},
+		{name: "zero-length", start: math.MaxUint32, length: 0},
+	}
+	for _, phase := range phases {
+		t.Run(phase.name+"/exact-last", func(t *testing.T) {
+			c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}, tinyScanTypes(t))
+			parent, _ := c.NewArrayDefault(2, 4)
+			child, _ := c.NewStructDefault(0)
+			root := Root(parent)
+			roots := Slots{&root}
+			phase.advance(t, c, roots, parent)
+			d, _ := c.refDesc(parent)
+			if err := c.storeValue(parent, d, uint64(PayloadOffset)+3*uint64(d.ElemSize), d.Elem, RefValue(child)); err != nil {
+				t.Fatal(err)
+			}
+			c.PostBulkWriteBarrier(parent, 3, 1)
+			if c.tinyColorOf(handleOf(child)) == tinyWhite {
+				t.Fatal("exact last valid element was not shaded")
+			}
+		})
+		for _, test := range invalid {
+			t.Run(phase.name+"/"+test.name, func(t *testing.T) {
+				c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}, tinyScanTypes(t))
+				parent, _ := c.NewArrayDefault(2, 4)
+				child, _ := c.NewStructDefault(0)
+				root := Root(parent)
+				roots := Slots{&root}
+				phase.advance(t, c, roots, parent)
+				d, _ := c.refDesc(parent)
+				if err := c.storeValue(parent, d, uint64(PayloadOffset), d.Elem, RefValue(child)); err != nil {
+					t.Fatal(err)
+				}
+				c.PostBulkWriteBarrier(parent, test.start, test.length)
+				if c.tinyColorOf(handleOf(child)) != tinyWhite {
+					t.Fatalf("invalid range shaded child: color=%v", c.tinyColorOf(handleOf(child)))
+				}
+			})
+		}
+	}
+}
+
+func TestTinyRootStoresDuringPartialMarkRemarkAndSweep(t *testing.T) {
+	for _, targetState := range []tinyGCState{tinyMark, tinyRemark, tinySweep} {
+		t.Run(targetStateName(targetState), func(t *testing.T) {
+			c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1 << 20, TinyBlockBytes: 16}, tinyScanTypes(t))
+			parent, _ := c.NewArrayDefault(2, 512)
+			child, _ := c.NewStructDefault(0)
+			root := Root(parent)
+			roots := Slots{&root}
+			g := c.NewGlobalSlot(Null())
+			if err := c.Step(roots); err != nil {
+				t.Fatal(err)
+			}
+			for {
+				if targetState == tinyMark && c.tinyGC.scan.handle == handleOf(parent) {
+					break
+				}
+				if targetState == tinyRemark && c.tinyGC.state == tinyRemark {
+					break
+				}
+				if targetState == tinySweep && c.tinyGC.state == tinySweep {
+					break
+				}
+				if err := c.Step(roots); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := c.SetGlobalSlot(g, child); err != nil {
+				t.Fatal(err)
+			}
+			root = Root(Null())
+			drainTinyWithWorkChecks(t, c, roots)
+			if !c.validObjectRef(child) {
+				t.Fatal("root store did not preserve child")
+			}
+		})
+	}
+}
+
+func targetStateName(state tinyGCState) string {
+	switch state {
+	case tinyMark:
+		return "mark"
+	case tinyRemark:
+		return "remark"
+	case tinySweep:
+		return "sweep"
+	default:
+		return "unknown"
+	}
+}
+
+type tinyLiveSnapshot struct {
+	live bool
+	data []byte
+}
+
+func snapshotTinyLive(c *Collector) []tinyLiveSnapshot {
+	out := make([]tinyLiveSnapshot, len(c.handles))
+	for h := uint32(1); int(h) < len(c.handles); h++ {
+		if c.handles[h].space != spaceTiny {
+			continue
+		}
+		out[h] = tinyLiveSnapshot{live: true, data: append([]byte(nil), c.bytes(makeObjRef(h))...)}
+	}
+	return out
+}
+
+func TestTinyBoundedStepsMatchCollectFull(t *testing.T) {
+	build := func(t *testing.T) (*Collector, Root) {
+		c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1 << 20, TinyBlockBytes: 16}, tinyScanTypes(t))
+		array, _ := c.NewArrayDefault(2, 512)
+		for i := uint32(0); i < 128; i++ {
+			child, err := c.NewStructDefault(1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := c.StructSet(child, 0, RefValue(array)); err != nil {
+				t.Fatal(err)
+			}
+			if err := c.ArraySet(array, i*4, RefValue(child)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for i := 0; i < 64; i++ {
+			if _, err := c.NewStructDefault(0); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return c, Root(array)
+	}
+	bounded, boundedRoot := build(t)
+	full, fullRoot := build(t)
+	if err := bounded.Step(Slots{&boundedRoot}); err != nil {
+		t.Fatal(err)
+	}
+	drainTinyWithWorkChecks(t, bounded, Slots{&boundedRoot})
+	if err := full.CollectFull(Slots{&fullRoot}); err != nil {
+		t.Fatal(err)
+	}
+	left, right := snapshotTinyLive(bounded), snapshotTinyLive(full)
+	if len(left) != len(right) {
+		t.Fatalf("handle lengths = %d/%d", len(left), len(right))
+	}
+	for i := range left {
+		if left[i].live != right[i].live || !bytes.Equal(left[i].data, right[i].data) {
+			t.Fatalf("handle %d differs: bounded=%+v full=%+v", i, left[i], right[i])
+		}
+	}
+	if bounded.Stats().LiveObjects != full.Stats().LiveObjects {
+		t.Fatalf("live counts differ: %d/%d", bounded.Stats().LiveObjects, full.Stats().LiveObjects)
+	}
+}

--- a/src/core/runtime/gc/tiny_scan_test.go
+++ b/src/core/runtime/gc/tiny_scan_test.go
@@ -295,6 +295,54 @@ func TestTinyStepBoundsSparseLargeStruct(t *testing.T) {
 	}
 }
 
+func TestTinyPayloadByteBudgetLimitsWideStruct(t *testing.T) {
+	const fields = 257
+	kinds := make([]StorageKind, fields)
+	for i := range kinds {
+		kinds[i] = StorageV128
+	}
+	kinds[fields-1] = StorageRefNull
+	wide, err := NewStructDesc(1, kinds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1 << 20, TinyBlockBytes: 16}, []TypeDesc{leaf, wide})
+	parent, err := c.NewStructDefault(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := c.NewStructDefault(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.StructSet(parent, fields-1, RefValue(child)); err != nil {
+		t.Fatal(err)
+	}
+	root := Root(parent)
+	roots := Slots{&root}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	work := c.tinyGC.lastStepWork.objectScanWork()
+	if work.ScanEntries != tinyStepPayloadBytes/16 || work.PayloadBytes != tinyStepPayloadBytes || work.ScanEntries >= tinyStepScanEntries {
+		t.Fatalf("wide struct work = %+v, want payload-byte-limited Step", work)
+	}
+	if c.tinyGC.scan.handle != handleOf(parent) || c.tinyColorOf(handleOf(parent)) != tinyGray {
+		t.Fatal("wide struct did not retain a partial gray cursor")
+	}
+	drainTinyWithWorkChecks(t, c, roots)
+	if !c.validObjectRef(child) {
+		t.Fatal("wide struct lost final reference")
+	}
+}
+
 func TestObjectScanCursorExactBoundaries(t *testing.T) {
 	leaf, err := NewStructDesc(0, nil)
 	if err != nil {
@@ -330,6 +378,86 @@ func TestObjectScanCursorExactBoundaries(t *testing.T) {
 	if !complete || cursor.index != 4 || work.ScanEntries != 2 || len(visited) != 2 || visited[1] != last {
 		t.Fatalf("final field: cursor=%d work=%+v complete=%v visited=%v", cursor.index, work, complete, visited)
 	}
+}
+
+func TestTinyVerifyRejectsPartialScanInvariantCorruption(t *testing.T) {
+	newPartial := func(t *testing.T) (*Collector, Ref, RootSet) {
+		t.Helper()
+		refs, err := NewArrayDesc(0, StorageRefNull)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}, []TypeDesc{refs})
+		array, err := c.NewArrayDefault(0, 512)
+		if err != nil {
+			t.Fatal(err)
+		}
+		root := Root(array)
+		roots := Slots{&root}
+		if err := c.Step(roots); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Step(roots); err != nil {
+			t.Fatal(err)
+		}
+		if c.tinyGC.scan.handle != handleOf(array) {
+			t.Fatal("test did not establish a partial scan")
+		}
+		return c, array, roots
+	}
+
+	t.Run("active also queued", func(t *testing.T) {
+		c, array, roots := newPartial(t)
+		c.tinyGC.grayStack = append(c.tinyGC.grayStack, handleOf(array))
+		if err := c.Verify(roots); err == nil {
+			t.Fatal("Verify accepted an active scan duplicated on the gray stack")
+		}
+	})
+	t.Run("cursor at end", func(t *testing.T) {
+		c, array, roots := newPartial(t)
+		c.tinyGC.scan.scan.index = c.header(array).Aux
+		if err := c.Verify(roots); err == nil {
+			t.Fatal("Verify accepted a completed active cursor")
+		}
+	})
+	t.Run("active during sweep", func(t *testing.T) {
+		c, _, roots := newPartial(t)
+		c.tinyGC.state = tinySweep
+		if err := c.Verify(roots); err == nil {
+			t.Fatal("Verify accepted an active cursor during sweep")
+		}
+	})
+	t.Run("recorded Step work exceeds bound", func(t *testing.T) {
+		refs, err := NewArrayDesc(0, StorageRefNull)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}, []TypeDesc{refs})
+		c.tinyGC.lastStepWork.scanEntries = uint16(tinyStepScanEntries + 1)
+		if err := c.Verify(nil); err == nil {
+			t.Fatal("Verify accepted recorded Step work beyond the bound")
+		}
+	})
+	t.Run("gray object missing from work state", func(t *testing.T) {
+		refs, err := NewArrayDesc(0, StorageRefNull)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 4096, TinyBlockBytes: 16}, []TypeDesc{refs})
+		array, err := c.NewArrayDefault(0, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		root := Root(array)
+		roots := Slots{&root}
+		if err := c.Step(roots); err != nil {
+			t.Fatal(err)
+		}
+		c.tinyGC.grayStack = c.tinyGC.grayStack[:0]
+		if err := c.Verify(roots); err == nil {
+			t.Fatal("Verify accepted a gray object missing from queue/cursor state")
+		}
+	})
 }
 
 func TestTinyMutationDuringPartialScan(t *testing.T) {
@@ -496,6 +624,70 @@ func TestTinyBulkBarrierRangeValidationEveryPhase(t *testing.T) {
 	}
 }
 
+func TestTinyRemarkBulkBarrierResumesActivePartialScan(t *testing.T) {
+	leaf, err := NewStructDesc(0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	large, err := NewArrayDesc(1, StorageRefNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	holder, err := NewArrayDesc(2, StorageRefNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := newTestCollectorWithTypes(t, Config{Profile: ProfileTiny, TinyHeapBytes: 1 << 20, TinyBlockBytes: 16, VerifyAfterCollect: true}, []TypeDesc{leaf, large, holder})
+	parent, err := c.NewArrayDefault(2, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := c.NewArrayDefault(1, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := Root(parent)
+	roots := Slots{&root}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	for c.tinyColorOf(handleOf(parent)) != tinyBlack {
+		if err := c.Step(roots); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	if c.tinyGC.state != tinyRemark {
+		t.Fatalf("state=%v, want remark", c.tinyGC.state)
+	}
+	d, err := c.refDesc(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.storeValue(parent, d, uint64(PayloadOffset), d.Elem, RefValue(child)); err != nil {
+		t.Fatal(err)
+	}
+	c.PostBulkWriteBarrier(parent, 0, 1)
+	if c.tinyGC.scan.handle != handleOf(child) || len(c.tinyGC.grayStack) != 0 || c.tinyColorOf(handleOf(child)) != tinyGray {
+		t.Fatalf("remark barrier partial state: scan=%+v stack=%v child=%v", c.tinyGC.scan, c.tinyGC.grayStack, c.tinyColorOf(handleOf(child)))
+	}
+	if err := c.Verify(roots); err != nil {
+		t.Fatalf("legitimate remark cursor failed verification: %v", err)
+	}
+	if err := c.Step(roots); err != nil {
+		t.Fatal(err)
+	}
+	if c.tinyGC.state != tinyMark || c.tinyGC.scan.handle != handleOf(child) {
+		t.Fatalf("remark did not return active cursor to mark: state=%v scan=%+v", c.tinyGC.state, c.tinyGC.scan)
+	}
+	drainTinyWithWorkChecks(t, c, roots)
+	if !c.validObjectRef(parent) || !c.validObjectRef(child) {
+		t.Fatal("remark bulk barrier lost partially scanned graph")
+	}
+}
+
 func TestTinyRootStoresDuringPartialMarkRemarkAndSweep(t *testing.T) {
 	for _, targetState := range []tinyGCState{tinyMark, tinyRemark, tinySweep} {
 		t.Run(targetStateName(targetState), func(t *testing.T) {
@@ -588,10 +780,19 @@ func TestTinyBoundedStepsMatchCollectFull(t *testing.T) {
 	}
 	bounded, boundedRoot := build(t)
 	full, fullRoot := build(t)
+	want, err := shadowTraceLive(bounded, Slots{&boundedRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := bounded.Step(Slots{&boundedRoot}); err != nil {
 		t.Fatal(err)
 	}
 	drainTinyWithWorkChecks(t, bounded, Slots{&boundedRoot})
+	for h := uint32(1); int(h) < len(bounded.handles); h++ {
+		if got := bounded.handles[h].space != spaceFree; got != want[h] {
+			t.Fatalf("bounded handle %d live=%v, shadow wants %v", h, got, want[h])
+		}
+	}
 	if err := full.CollectFull(Slots{&fullRoot}); err != nil {
 		t.Fatal(err)
 	}

--- a/src/core/runtime/gc/tiny_test.go
+++ b/src/core/runtime/gc/tiny_test.go
@@ -632,6 +632,7 @@ func FuzzTinyCollectorOperations(f *testing.F) {
 	f.Add([]byte{1, 0, 0, 6, 0, 0, 1, 0, 0, 6, 1, 0, 12, 0, 0, 16, 0, 0, 17, 0, 0})
 	f.Add([]byte("\xd500000200900b00b00"))
 	f.Add([]byte("000000000700b00b00b00A00000"))
+	f.Add([]byte("700x00000700000000000000000200"))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		if len(data) > 192 {
@@ -651,7 +652,7 @@ func FuzzTinyCollectorOperations(f *testing.F) {
 		rootSet := func() Slots { return tinyFuzzSlots(roots) }
 
 		for pc := 0; pc+2 < len(data); pc += 3 {
-			op, a, b := data[pc]%18, data[pc+1], data[pc+2]
+			op, a, b := data[pc]%20, data[pc+1], data[pc+2]
 			slots := func() Slots { return rootSet() }
 			switch op {
 			case 0:
@@ -663,11 +664,13 @@ func FuzzTinyCollectorOperations(f *testing.F) {
 					refs = append(refs, r)
 				}
 			case 2:
-				if r, err := c.NewArrayDefaultWithRoots(3, uint32(a%8)+1, slots()); err == nil {
+				// Lengths above the internal scan-entry budget force resumable
+				// reference-array scans during stateful fuzz sequences.
+				if r, err := c.NewArrayDefaultWithRoots(3, uint32(a%96)+1, slots()); err == nil {
 					refs = append(refs, r)
 				}
 			case 3:
-				if r, err := c.NewArrayDefaultWithRoots(2, uint32(a%8)+1, slots()); err == nil {
+				if r, err := c.NewArrayDefaultWithRoots(2, uint32(a%32)+1, slots()); err == nil {
 					refs = append(refs, r)
 				}
 			case 4:
@@ -718,9 +721,9 @@ func FuzzTinyCollectorOperations(f *testing.F) {
 			case 13:
 				tinyFuzzMutateRootDuringRemark(t, c, &roots, refs, a, b)
 			case 14:
-				tinyFuzzBarrierDance(t, c, roots, false)
+				tinyFuzzBarrierDance(t, c, roots, &refs, false)
 			case 15:
-				tinyFuzzBarrierDance(t, c, roots, true)
+				tinyFuzzBarrierDance(t, c, roots, &refs, true)
 			case 16:
 				if err := c.CollectMinor(slots()); err != nil {
 					t.Fatal(err)
@@ -729,11 +732,31 @@ func FuzzTinyCollectorOperations(f *testing.F) {
 				if err := c.Verify(slots()); err != nil {
 					t.Fatal(err)
 				}
+			case 18:
+				parent, child, ok := fuzzPickTwo(c, refs, a, b)
+				if ok {
+					if ln, err := c.ArrayLen(parent); err == nil && ln != 0 {
+						start := uint32(a) % ln
+						length := uint32(b) % (ln - start + 1)
+						_ = c.ArrayFill(parent, start, RefValue(child), length)
+					}
+				}
+			case 19:
+				dst, src, ok := fuzzPickTwo(c, refs, a, b)
+				if ok {
+					dstLen, dstErr := c.ArrayLen(dst)
+					srcLen, srcErr := c.ArrayLen(src)
+					if dstErr == nil && srcErr == nil && dstLen != 0 && srcLen != 0 {
+						length := min(dstLen, srcLen)
+						length = uint32(a+b) % (length + 1)
+						_ = c.ArrayCopy(dst, 0, src, 0, length)
+					}
+				}
 			}
 			refs = pruneLiveRefs(c, refs)
 			roots = tinyFuzzPruneRoots(c, roots)
 			if err := c.Verify(slots()); err != nil {
-				t.Fatal(err)
+				t.Fatalf("pc=%d op=%d state=%d scan=%+v: %v", pc, op, c.tinyGC.state, c.tinyGC.scan, err)
 			}
 		}
 	})
@@ -808,9 +831,13 @@ func tinyFuzzMutateRootDuringRemark(t *testing.T, c *Collector, roots *[]Root, r
 	}
 }
 
-func tinyFuzzBarrierDance(t *testing.T, c *Collector, baseRoots []Root, array bool) {
+func tinyFuzzBarrierDance(t *testing.T, c *Collector, baseRoots []Root, refs *[]Ref, array bool) {
 	t.Helper()
 	tinyFuzzDrain(t, c, tinyFuzzSlots(baseRoots))
+	// Prune stale compact handles before the helper allocates and may reuse their
+	// indexes; otherwise the reference model can mistake a recycled handle for
+	// the previously collected object.
+	*refs = pruneLiveRefs(c, *refs)
 	var (
 		parent Ref
 		err    error

--- a/src/core/runtime/gc/tiny_test.go
+++ b/src/core/runtime/gc/tiny_test.go
@@ -633,12 +633,13 @@ func FuzzTinyCollectorOperations(f *testing.F) {
 	f.Add([]byte("\xd500000200900b00b00"))
 	f.Add([]byte("000000000700b00b00b00A00000"))
 	f.Add([]byte("700x00000700000000000000000200"))
+	f.Add([]byte{2, 255, 255, 6, 0, 0, 8, 0, 0, 8, 0, 0, 17, 0, 0})
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		if len(data) > 192 {
 			data = data[:192]
 		}
-		cfg := Config{TinyHeapBytes: 512, TinyBlockBytes: 16, VerifyAfterCollect: true}
+		cfg := Config{TinyHeapBytes: 4096, TinyBlockBytes: 16, VerifyAfterCollect: true}
 		if len(data) != 0 && data[0]&0x80 != 0 {
 			cfg.TinyStepEveryAlloc = true
 			cfg.TinyStepBudget = 1 + uint32(data[0]&3)
@@ -666,7 +667,7 @@ func FuzzTinyCollectorOperations(f *testing.F) {
 			case 2:
 				// Lengths above the internal scan-entry budget force resumable
 				// reference-array scans during stateful fuzz sequences.
-				if r, err := c.NewArrayDefaultWithRoots(3, uint32(a%96)+1, slots()); err == nil {
+				if r, err := c.NewArrayDefaultWithRoots(3, uint32(a)+uint32(b)+1, slots()); err == nil {
 					refs = append(refs, r)
 				}
 			case 3:


### PR DESCRIPTION
## Summary

Begins #319 by making TinyGC object marking genuinely incrementally bounded.

- adds one compact handle/index cursor for resumable struct and reference-array scans
- bounds each Tiny marking `Step` by 64 object ranges, 256 scan entries, 256 reference slots, and 1,024 payload bytes
- keeps partially scanned objects gray until their final outgoing reference is visited
- shares the cursor/range scanner with complete Throughput/full-GC scans
- shades white children written into partially scanned gray parents
- hardens Tiny `PostBulkWriteBarrier` range validation with widened arithmetic
- adds partial-scan telemetry, fuzz coverage, correctness tests, and targeted benchmarks

This intentionally does not implement persistent-root cursors, color epochs, bounded sweep, allocation-debt pacing, SATB, or the other later #319 stages.

## Correctness

Coverage includes:

- all-null, repeated-child, distinct-child, cyclic, and alternating live/dead reference arrays
- sparse large structs, consecutive refs, and refs at descriptor boundaries
- pauses immediately before/after a reference and at the final field/element
- queue growth, duplicate gray requests, nested discovery, and backedges
- mutations before/after the cursor, black-parent writes, and root stores in mark/remark/sweep
- exact bounded-Step versus `CollectFull` live-object byte equivalence
- widened Tiny bulk-barrier ranges around `math.MaxUint32`, wrapping sums, exact ends, and all incremental phases
- warmed direct-root partial Steps remaining allocation-free

## Work bound

A Tiny marking `Step` consumes no more than:

| Unit | Maximum |
|---|---:|
| Object ranges | 64 |
| Descriptor/array entries | 256 |
| Reference slots | 256 |
| Payload bytes | 1,024 |

Initial/remark root enumeration and sweeping remain separate, later #319 work.

## Performance

Ryzen 7 8845HS, `-benchtime=100x`:

- 65,536-reference matrix: step p99 falls from ~196.6 us to ~1.34 us
- steps/cycle rise from 6 to 261
- timing-harness cycle median rises from ~175.4 us to ~213.2 us (+21.5%)
- direct-root `BenchmarkTinyStepReferenceArray/65536`: ~521 ns/Step, 0 B/op, 0 allocs/op
- direct-root complete 65,536-reference cycle: ~147.8 us, 0 B/op, 0 allocs/op
- `Collector` remains 1,120 bytes and `tinyGC` remains 80 bytes on 64-bit builds

## Verification

- `go test ./src/core/runtime/gc -count=1`
- `go test ./src/wago -count=1`
- `go test ./src/... -count=1`
- `go test -tags wago_gcstats ./src/core/runtime/gc ./src/wago -count=1`
- `go test -tags wagodebug ./src/core/runtime/gc -count=1`
- `go test -tags 'wagodebug wago_gcstats' ./src/core/runtime/gc -count=1`
- `go test -tags wago_guardpage ./src/core/runtime/gc ./src/wago -count=1`
- `go test -tags 'wago_guardpage wago_gcstats' ./src/core/runtime/gc ./src/wago -count=1`
- Tiny collector/allocation/span fuzz smoke: ~1.55 million executions total
