### PR TITLE
wasm: enable selected Core 3 features by default

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,8 +11,11 @@ Status: ✅ done · 🚧 partial · ⬜ planned · ❌ not planned.
 `CoreFeaturesV2` is the static WebAssembly 2.0 release group. `CoreFeaturesV3`
 describes the mandatory WebAssembly Core 3.0 scope, and `SupportedFeatures()`
 reports the executable build/host set. The compatibility default remains the
-Release 2 feature set plus completed extended constants; callers opt into the
-full Release 3 surface with `WithCoreFeatures(CoreFeaturesV3)`. On
+Release 2 feature set plus completed extended constants on incomplete backends.
+Complete Core 3 backends additionally default on tail calls, typed function
+references, multi-memory, memory64, and table64. WasmGC and exception handling
+remain opt-in; callers select the full Release 3 surface with
+`WithCoreFeatures(CoreFeaturesV3)`. On
 linux/amd64 explicit/signal builds and Linux/Darwin arm64 explicit/signal builds,
 every Core 3 family is admitted. ARM64 signal mode uses guard faults for eligible
 memory-0 memory32 accesses and retains explicit checks for indexed memories and
@@ -27,7 +30,7 @@ retains full-u64 explicit checks inside the signal-backed product.
 `memory64` and typed function references including `call_ref` are implemented
 on those explicitly admitted Core 3 products; this is not a claim for every Wago
 target. `SupportedFeatures()` remains the executable build/host authority.
-Release 1 and Release 2 defaults remain unchanged. This official-suite result is
+Explicit `CoreFeaturesV1` and `CoreFeaturesV2` selections remain unchanged. This official-suite result is
 not an unrestricted WasmGC claim. Shape-independent struct/array helper admission now also compiles, links,
 and starts the 3,225,249-byte MoonBit Starshine CLI smoke payload (SHA-256
 `3a92309ca48f80594c88ea6c3508982d6fc34953c018ce31786382e08a18d046`).

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ wago fib.wasm 20
 wago run --core 3 --invoke main generated-wasmgc.wasm
 ```
 
-The CLI preserves the WebAssembly 2 compatibility default. Pass `--core 3` to
-compile and execute modules with the complete opt-in `CoreFeaturesV3` set.
+On complete backends, the CLI defaults on tail calls, typed function references,
+multi-memory, memory64, and table64. WasmGC and exception handling remain opt-in:
+pass `--core 3` for the complete `CoreFeaturesV3` set, or `--core 2` for the
+strict Release 2 set.
 
 Validate or precompile a module:
 
@@ -307,8 +309,9 @@ Wago supports the WebAssembly 1.0 core language and the implemented
 WebAssembly 2.0 release features, including multi-value, reference types, bulk
 memory, extended constant expressions, and SIMD. Native runtime paths, CI, and
 release assets cover Linux, macOS, and Windows on amd64 and arm64. Linux amd64
-is the primary performance target; the complete opt-in Core 3 feature set is
-currently admitted on linux/amd64, linux/arm64, and darwin/arm64.
+is the primary performance target. Selected Core 3 families default on for
+linux/amd64, linux/arm64, and darwin/arm64; the complete set is available there
+with `--core 3`.
 
 Wago is JIT-only. Unsupported or disabled features fail during decode or
 validation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,7 +69,9 @@ in full — 57/57 applicable files, 0 failing assertions (see [SPECTEST.md](SPEC
   plugin; WASI host capabilities remain in the separate `wago-org/wasi` module.
 
 **Tooling**
-- [x] `wago` CLI: `run` / `validate` / `version`, typed args, and explicit `--core 3` opt-in while preserving the Release 2 default
+- [x] `wago` CLI: `run` / `validate` / `version`, typed args, automatic selected
+  Core 3 defaults on complete backends, and explicit `--core 2` / `--core 3`
+  release selection
 - [x] Public API: `Run`/`RunValues`, `Compile`/`Compiled`, `Instance`, plus
   opt-in serial/adaptive/forced function-worker policy for validation and codegen
 - [x] Workers plugin: the separate `github.com/wago-org/workers` extension
@@ -108,7 +110,9 @@ current optimization priorities. The Core 3.0 implementation ledger is
   categories; native Linux/Darwin arm64 runs are now required in CI.
 - [x] Complete mandatory extended constants, relaxed SIMD, tails, typed function
   references, GC, exception handling, multi-memory, memory64, and table64 on the
-  primary product. Release 1/2 defaults remain unchanged; Core 3 is opt-in.
+  primary product. Tail calls, typed function references, multi-memory, memory64,
+  and table64 now default on for complete backends; GC and exceptions remain
+  opt-in through the full Core 3 selection.
 - [x] Add exact linux/amd64 and Linux/Darwin arm64 WasmGC roots across local
   direct/indirect/reference calls, recursion, bounded host re-entry,
   mutable/shared GC globals, local/shared collector-reference tables, EH payload
@@ -370,8 +374,9 @@ and 58,038 passing assertions with zero failures, skips, or gap categories. The
 final integration includes prior-local-global constant offsets, typed element
 initializers, generic `array.new_data`/`array.new_elem`, imported/exported tags,
 `spectest.table64`, shared-memory co-tenant serialization, and reference
-argument/result ownership. Release 1/2 defaults remain unchanged; Core 3 is an
-explicit opt-in outside the versioned spec harness.
+argument/result ownership. A later default-policy pass promoted the lower-risk
+tail, typed-reference, and indexed/wide memory/table families on complete
+backends while retaining GC and exceptions as explicit Core 3 opt-ins.
 
 ## Iteration 75 generated WasmGC smoke hardening
 

--- a/cli/internal/handoff/runtime_commands.go
+++ b/cli/internal/handoff/runtime_commands.go
@@ -20,7 +20,7 @@ func RuntimeCommands() []*command.Cmd {
 		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
 		{Name: "watch", Short: "w", Bool: true, Help: "rerun when the module changes"},
 		{Name: "watch-interval", Arg: "<duration>", Help: "watch polling interval (default 200ms)"},
-		{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 (default) | 3"},
+		{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 | 3 (default: best supported)"},
 		parallel,
 	}
 	runFlags = append(runFlags, profileFlags...)

--- a/cli/internal/settings/catalog.go
+++ b/cli/internal/settings/catalog.go
@@ -181,10 +181,13 @@ func validateValues(kind boolSettingKind, values map[string]bool) error {
 		prefix = "optimizations."
 		label = "optimization"
 	}
-	for name := range values {
+	for name, enabled := range values {
 		setting, ok := Lookup(prefix + name)
-		if !ok || setting.kind != kind || !setting.Available {
+		if !ok || setting.kind != kind {
 			return fmt.Errorf("unknown %s setting %q", label, name)
+		}
+		if enabled && !setting.Available {
+			return fmt.Errorf("%s setting %q is unavailable", label, name)
 		}
 	}
 	return nil

--- a/cli/internal/settings/compilation.go
+++ b/cli/internal/settings/compilation.go
@@ -111,7 +111,10 @@ func (selection CompilationSelection) RuntimeConfig() *wago.RuntimeConfig {
 		WithDeferBoundsChecks(selection.DeferredBoundsChecking).
 		WithFunctionWorkers(selection.FunctionWorkers).
 		WithOptimizations(selection.Optimizations)
-	if selection.Core == 3 {
+	switch selection.Core {
+	case 2:
+		config = config.WithCoreFeatures(wago.CoreFeaturesV2)
+	case 3:
 		config = config.WithCoreFeatures(wago.CoreFeaturesV3)
 	}
 	for name, enabled := range selection.Features {
@@ -124,7 +127,9 @@ func (selection CompilationSelection) RuntimeConfig() *wago.RuntimeConfig {
 
 func resolveCore(value string) (int, error) {
 	switch value {
-	case "", "2":
+	case "":
+		return 0, nil
+	case "2":
 		return 2, nil
 	case "3":
 		return 3, nil

--- a/cli/internal/settings/compilation_test.go
+++ b/cli/internal/settings/compilation_test.go
@@ -51,3 +51,24 @@ func TestResolveCompilationFiltersTargetOptimizations(t *testing.T) {
 		t.Fatalf("supported runtime config: %v", err)
 	}
 }
+
+func TestCoreSelectionDefaultsAndExplicitRelease2(t *testing.T) {
+	selection, err := ResolveCompilationFrom(Default(), false, CompilationRequest{Arch: runtime.GOARCH})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selection.Core != 0 {
+		t.Fatalf("automatic core selection = %d, want 0", selection.Core)
+	}
+	if got := selection.RuntimeConfig().CoreFeatures(); got != wago.NewRuntimeConfig().CoreFeatures() {
+		t.Fatalf("automatic features = %s, want runtime default %s", got, wago.NewRuntimeConfig().CoreFeatures())
+	}
+
+	selection, err = ResolveCompilationFrom(Default(), false, CompilationRequest{Arch: runtime.GOARCH, Core: "2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := selection.RuntimeConfig().CoreFeatures(); got != wago.CoreFeaturesV2 {
+		t.Fatalf("explicit Core 2 features = %s, want %s", got, wago.CoreFeaturesV2)
+	}
+}

--- a/cli/internal/settings/store.go
+++ b/cli/internal/settings/store.go
@@ -106,11 +106,14 @@ func LoadFile(path string) (Config, error) {
 		return Config{}, fmt.Errorf("unsupported settings version %d (want %d)", stored.Version, Version)
 	}
 	for name, value := range stored.Features {
-		if setting, ok := Lookup("features." + name); !ok || !setting.Available {
+		setting, ok := Lookup("features." + name)
+		if !ok {
 			return Config{}, fmt.Errorf("unknown feature setting %q", name)
-		} else {
-			setting.SetValue(&config, value)
 		}
+		if value && !setting.Available {
+			return Config{}, fmt.Errorf("feature setting %q is unavailable", name)
+		}
+		setting.SetValue(&config, value)
 	}
 	for name, value := range stored.Optimizations {
 		if setting, ok := Lookup("optimizations." + name); !ok || !setting.Available {

--- a/cli/internal/settings/store_test.go
+++ b/cli/internal/settings/store_test.go
@@ -81,6 +81,28 @@ func TestSettingsRejectPreviewAndUnknown(t *testing.T) {
 	}
 }
 
+func TestUnavailableFeaturesMayRemainDisabled(t *testing.T) {
+	var unavailable BoolSetting
+	for _, setting := range allFeatures() {
+		if !setting.Available {
+			unavailable = setting
+			break
+		}
+	}
+	if unavailable.Key == "" {
+		t.Skip("all features are available on this platform")
+	}
+
+	values := map[string]bool{unavailable.name: false}
+	if err := ValidateFeatureValues(values); err != nil {
+		t.Fatalf("disabled unavailable feature should be portable: %v", err)
+	}
+	values[unavailable.name] = true
+	if err := ValidateFeatureValues(values); err == nil || !strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("enabled unavailable feature should be rejected clearly, got %v", err)
+	}
+}
+
 func TestResetRestoresBuiltInValue(t *testing.T) {
 	config := Default()
 	if err := Set(&config, "features.simd", "off", false); err != nil {

--- a/cli/internal/settings/store_test.go
+++ b/cli/internal/settings/store_test.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,6 +101,22 @@ func TestUnavailableFeaturesMayRemainDisabled(t *testing.T) {
 	values[unavailable.name] = true
 	if err := ValidateFeatureValues(values); err == nil || !strings.Contains(err.Error(), "unavailable") {
 		t.Fatalf("enabled unavailable feature should be rejected clearly, got %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "settings.json")
+	contents := fmt.Sprintf(`{"version":1,"features":{"%s":false},"runtime":{}}`, unavailable.name)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadFile(path); err != nil {
+		t.Fatalf("loading a disabled unavailable feature should be portable: %v", err)
+	}
+	contents = fmt.Sprintf(`{"version":1,"features":{"%s":true},"runtime":{}}`, unavailable.name)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadFile(path); err == nil || !strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("loading an enabled unavailable feature should fail clearly, got %v", err)
 	}
 }
 

--- a/cli/manager/command_environment.go
+++ b/cli/manager/command_environment.go
@@ -65,8 +65,12 @@ func (commandEnvironment) Compile(options compilecmd.Options) {
 		fatal("compile: %v", err)
 	}
 	if automation.DryRun() {
+		var core any = selection.Core
+		if selection.Core == 0 {
+			core = "auto"
+		}
 		plan := map[string]any{
-			"input": options.Input, "output": output, "target": target.String(), "core": selection.Core,
+			"input": options.Input, "output": output, "target": target.String(), "core": core,
 			"functionWorkers": selection.FunctionWorkers, "deferredBoundsChecking": selection.DeferredBoundsChecking,
 		}
 		if options.Invoke != "" {

--- a/cli/manager/commands/compile/command.go
+++ b/cli/manager/commands/compile/command.go
@@ -34,7 +34,7 @@ func Command(environment Environment) *command.Cmd {
 		{Name: "output", Short: "o", Arg: "<file>", Help: "output executable path"},
 		{Name: "target", Arg: "<os/arch>", Help: "target platform (default: current platform)"},
 		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
-		{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 (default) | 3"},
+		{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 | 3 (default: best supported)"},
 		internalparallel.Flag(),
 		{Name: "plugin", Arg: "<names>", Help: "comma-separated extra plugins to enable"},
 		{Name: "plugins", Arg: "<names>", Help: "alias for --plugin"},

--- a/cli/manager/commands/config/command_test.go
+++ b/cli/manager/commands/config/command_test.go
@@ -40,7 +40,7 @@ func TestConfigRootFlagsProvideOneShotActions(t *testing.T) {
 		{[]string{"--set", "runtime.parallel=auto"}, options.Set, "runtime.parallel", "auto", false, false, false},
 		{[]string{"--set", "simd=off", "--json"}, options.Set, "simd", "off", false, false, false},
 		{[]string{"--list", "--experimental"}, options.List, "", "", true, false, false},
-		{[]string{"--enable", "tail-call", "--experimental"}, options.Set, "tail-call", "on", true, false, false},
+		{[]string{"--enable", "gc", "--experimental"}, options.Set, "gc", "on", true, false, false},
 	} {
 		environment := &testEnvironment{}
 		Command(environment).Dispatch("wago config", test.args)
@@ -54,7 +54,7 @@ func TestConfigRootFlagsProvideOneShotActions(t *testing.T) {
 
 func TestConfigSetRequiresExplicitExperimentalFlag(t *testing.T) {
 	environment := &testEnvironment{}
-	Command(environment).Child("set").Dispatch("wago config set", []string{"tail-call", "on", "--experimental"})
+	Command(environment).Child("set").Dispatch("wago config set", []string{"gc", "on", "--experimental"})
 	if !environment.request.Experimental {
 		t.Fatal("config set did not forward --experimental")
 	}

--- a/cli/manager/internal/config/settings_test.go
+++ b/cli/manager/internal/config/settings_test.go
@@ -26,22 +26,22 @@ func TestExperimentalPreviewIsGeneratedFromRuntimeFeatures(t *testing.T) {
 	catalog := settings.Experimental()
 	found := false
 	for _, setting := range catalog {
-		if setting.Key == "features.tail-call" {
+		if setting.Key == "features.gc" {
 			found = true
 			if !setting.Experimental {
-				t.Fatal("tail calls should remain experimental")
+				t.Fatal("WasmGC should remain experimental")
 			}
 		}
 	}
 	if !found {
-		t.Fatal("tail-call preview is missing")
+		t.Fatal("WasmGC preview is missing")
 	}
 }
 
 func TestPrintIncludesExperimentalSectionOnRequest(t *testing.T) {
 	var output bytes.Buffer
 	Print(&output, settings.Default(), true, settings.ScopeLocal, "./wago.json", []settings.Override{{Key: "features.simd", Base: "false", Value: "true"}})
-	for _, want := range []string{"Wago configuration", "WebAssembly features", "Compiler optimizations", "Experimental preview", "tail-call", "override"} {
+	for _, want := range []string{"Wago configuration", "WebAssembly features", "Compiler optimizations", "Experimental preview", "gc", "override"} {
 		if !strings.Contains(output.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, output.String())
 		}

--- a/cli/runtime/commands/run/command.go
+++ b/cli/runtime/commands/run/command.go
@@ -29,7 +29,7 @@ func Command(environment Environment) *command.Cmd {
 		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
 		{Name: "watch", Short: "w", Bool: true, Help: "rerun when the module changes"},
 		{Name: "watch-interval", Arg: "<duration>", Help: "watch polling interval (default 200ms)"},
-		{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 (default) | 3"},
+		{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 | 3 (default: best supported)"},
 		ParallelFlag(),
 	}
 	flags = append(flags, environment.ProfileFlags()...)
@@ -44,7 +44,8 @@ func Command(environment Environment) *command.Cmd {
 		},
 		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
 			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64\n" +
-			"Use --core 3 for the complete opt-in WebAssembly Core 3 feature set. Use -p for\n" +
+			"Selected Core 3 features default on where supported; use --core 2 for strict Release 2\n" +
+			"or --core 3 for the complete release. Use -p for\n" +
 			"adaptive validation/compile parallelism, or -p8 / -p 8 / --parallel=8 to force a\n" +
 			"worker maximum. Optimization knobs are listed in `wago run --help`.",
 		Run: implementation.Run,

--- a/cli/standalone/standalone.go
+++ b/cli/standalone/standalone.go
@@ -109,7 +109,9 @@ func runtimeConfig(options Options) (*wago.RuntimeConfig, error) {
 	config := wago.NewRuntimeConfig().WithDeferBoundsChecks(options.DeferBoundsChecks).WithFunctionWorkers(options.FunctionWorkers)
 	config = config.WithOptimizations(options.OptimizationKnobs)
 	switch options.Core {
-	case 0, 2:
+	case 0:
+	case 2:
+		config = config.WithCoreFeatures(wago.CoreFeaturesV2)
 	case 3:
 		config = config.WithCoreFeatures(wago.CoreFeaturesV3)
 	default:

--- a/cli/standalone/standalone_test.go
+++ b/cli/standalone/standalone_test.go
@@ -92,6 +92,9 @@ func TestRuntimeConfigUsesBakedFunctionWorkers(t *testing.T) {
 	if got := config.FunctionWorkers(); got != 4 {
 		t.Fatalf("function workers = %d, want 4", got)
 	}
+	if got := config.CoreFeatures(); got != wago.CoreFeaturesV2 {
+		t.Fatalf("baked Core 2 features = %s, want %s", got, wago.CoreFeaturesV2)
+	}
 }
 
 func emptyStartModule() []byte {

--- a/docs/research/wasm3-default-feature-audit.md
+++ b/docs/research/wasm3-default-feature-audit.md
@@ -1,0 +1,76 @@
+# WebAssembly Core 3.0 default-feature audit
+
+Date: 2026-08-11
+
+## Scope and conformance boundary
+
+The final Core 3.0 change history names eight binary/runtime feature families:
+extended constant expressions, tail calls, exception handling, multiple
+memories, 64-bit address spaces, typeful references, garbage collection, and
+relaxed vector instructions. Profiles and custom annotations are two additional
+Release 3.0 sections, but profiles describe coherent language subsets and
+custom annotations affect the text format rather than binary execution.
+([Core 3.0 change history](https://webassembly.github.io/spec/core/appendix/changes.html#release-3-0))
+
+The specification's implementation-limitations appendix says a conforming
+implementation cannot omit individual features. Therefore a Wago default made
+from a subset of these families should be described as “selected Core 3
+features enabled by default,” not as the complete Core 3 language. The existing
+explicit `CoreFeaturesV3` group remains the right meaning for the complete
+release surface.
+([Core 3.0 implementation limitations](https://webassembly.github.io/spec/core/appendix/implementation.html))
+
+## Feature risk
+
+| Family | Normative surface | Default-admission risk | Assessment |
+|---|---|---:|---|
+| Extended constant expressions | Adds integer add/sub/mul and access to preceding immutable globals in constant expressions. ([spec change history](https://webassembly.github.io/spec/core/appendix/changes.html#extended-constant-expressions), [proposal source](https://github.com/WebAssembly/spec/tree/main/proposals/extended-const)) | Low | Additive and confined to validation/evaluation of module initializers. This is the clearest default-on candidate. |
+| Tail calls | Adds `return_call` and `return_call_indirect`. ([spec change history](https://webassembly.github.io/spec/core/appendix/changes.html#tail-calls), [proposal source](https://github.com/WebAssembly/spec/tree/main/proposals/tail-call)) | Low–moderate | Additive control instructions with no new stored value family. Correctness still depends on genuine frame replacement across internal, indirect, host, and cross-instance boundaries. |
+| Relaxed vector instructions | Adds relaxed SIMD operations whose result may be implementation-dependent. ([spec change history](https://webassembly.github.io/spec/core/appendix/changes.html#relaxed-vector-instructions), [proposal source](https://github.com/WebAssembly/spec/tree/main/proposals/relaxed-simd)) | Low–moderate | Additive opcodes and no new ownership model. Enable only where SIMD is executable. The Full profile permits the specified result alternatives; the Deterministic profile fixes their behavior. ([profiles](https://webassembly.github.io/spec/core/appendix/profiles.html#defined-profiles)) |
+| Multiple memories | Permits multiple imported/defined/exported memories and adds memory indices to memory instructions and data segments. ([spec change history](https://webassembly.github.io/spec/core/appendix/changes.html#multiple-memories), [proposal source](https://github.com/WebAssembly/spec/tree/main/proposals/multi-memory)) | Moderate | No new value kind, but expands the instance memory model from one implicit memory to an indexed directory. Bounds, import aliasing, growth, bulk operations, codec state, and teardown must all be per-memory. |
+| 64-bit address space | Allows `i64` address types for memories and tables, changing the operand types of their operations. ([spec change history](https://webassembly.github.io/spec/core/appendix/changes.html#bit-address-space), [proposal source](https://github.com/WebAssembly/spec/tree/main/proposals/memory64)) | Moderate–high | Expands bounds arithmetic, reservations, overflow handling, ABI lowering, and metadata. It does not itself add managed ownership, but a single truncation bug is security-relevant. |
+| Typeful references | Generalizes reference types, adds subtyping, `call_ref`, null branches, non-defaultable-local tracking, and table initializers. ([spec change history](https://webassembly.github.io/spec/core/appendix/changes.html#typeful-references), [proposal source](https://github.com/WebAssembly/spec/tree/main/proposals/function-references)) | Moderate–high | Extends validation and runtime type identity across modules. Function references remain opaque store references, so exact function/type/store ownership matters even without WasmGC. ([Core 3 types](https://webassembly.github.io/spec/core/syntax/types.html#reference-types)) |
+| Exception handling | Adds tags, exception references, `throw`, `throw_ref`, `try_table`, and unwinding. ([spec change history](https://webassembly.github.io/spec/core/appendix/changes.html#exception-handling), [proposal source](https://github.com/WebAssembly/spec/tree/main/proposals/exception-handling)) | High | Expands the control and runtime object model. Confidence requires payload rooting and correct unwinding through native, host, tail-call, and cross-instance boundaries, plus tag identity at link time. |
+| Garbage collection | Adds recursive/sub types, managed structs and arrays, i31 values, casts/tests, allocation, mutation, and bulk array operations. ([spec change history](https://webassembly.github.io/spec/core/appendix/changes.html#garbage-collection), [proposal source](https://github.com/WebAssembly/spec/tree/main/proposals/gc)) | Highest | Introduces a managed heap, lifetime tracing, barriers, exact roots, richer subtype identity, and embedder ownership. The spec explicitly classifies aggregate heap types as dynamically allocated managed data. ([Core 3 heap types](https://webassembly.github.io/spec/core/syntax/types.html#heap-types)) |
+
+Profiles are not version switches. The specification describes them as static,
+coherent subsets, says the Full profile contains the complete language, and
+says profiles are not intended for language versioning. Wago should therefore
+keep feature admission separate from any future Full-versus-Deterministic
+execution-policy choice.
+([Core 3 profiles](https://webassembly.github.io/spec/core/appendix/profiles.html))
+
+## Recommendation
+
+For the compatibility default, enable the additive families that do not create
+a new managed ownership model and for which Wago already has native backend and
+official-suite coverage:
+
+1. extended constant expressions;
+2. tail calls;
+3. relaxed SIMD when SIMD itself is supported by the current build/host;
+4. multiple memories;
+5. memory64/table64; and
+6. typeful/function references.
+
+Keep exception handling and WasmGC opt-in for now. Both are final Core 3
+features, but they cross the most runtime ownership boundaries; WasmGC in
+particular should not become a compatibility default until Wago's confidence
+extends beyond the official conformance corpus to representative generated
+programs, collection during every native/host/cross-instance boundary, and
+stable public ownership behavior. Exception handling can graduate separately
+once its exception-reference lifetime and host-boundary contract are considered
+part of the stable default runtime model.
+
+This selection must not weaken `SupportedFeatures()` as the executable
+build/host authority. Unsupported architecture or bounds-mode combinations
+should reject clearly rather than silently accepting a feature bit that cannot
+execute.
+
+## Official sources
+
+- [WebAssembly Core Specification, Release 3.0](https://webassembly.github.io/spec/core/)
+- [Release 3.0 change inventory](https://webassembly.github.io/spec/core/appendix/changes.html#release-3-0)
+- [Implementation limitations and full-feature conformance rule](https://webassembly.github.io/spec/core/appendix/implementation.html)
+- [Defined profiles](https://webassembly.github.io/spec/core/appendix/profiles.html#defined-profiles)
+- [Official proposal snapshots integrated into the specification](https://github.com/WebAssembly/spec/tree/main/proposals)

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -918,8 +918,9 @@ M9 extends the same 40-byte canonical descriptor ABI to null plus two provider d
 ## Iteration 74 integrated Core 3 ABI
 
 The complete Release 3 harness uses the same bounded native ABI rather than a
-parallel conformance-only executor. `CoreFeaturesV3` is an explicit admission
-choice; the Release 2-compatible default remains unchanged. Typed element
+parallel conformance-only executor. At this iteration, `CoreFeaturesV3` was an
+explicit admission choice; a later policy pass promoted selected lower-risk
+families on complete backends. Typed element
 initializers persist either a canonical local function identity or a validated
 immutable-global source. Imported/exported tags carry store identity through the
 existing tag directory, whose codec count is bounded by the artifact reader

--- a/docs/wasm3.md
+++ b/docs/wasm3.md
@@ -181,9 +181,11 @@ on linux/amd64 and Linux/Darwin arm64 explicit and signal-backed products.
 green in both linux/amd64 bounds modes and under Linux/arm64 QEMU explicit
 bounds; native Linux/Darwin arm64 explicit and `spec3-signals` conformance runs
 are required by CI. ARM64 signal mode guard-checks eligible memory-0 memory32
-accesses while indexed memories and memory64 retain explicit checks. The compatibility default deliberately remains the
-Release 2 feature set plus extended constants; callers opt into Core 3 with
-`WithCoreFeatures(CoreFeaturesV3)`, and the versioned spec harness does so when
+accesses while indexed memories and memory64 retain explicit checks. On complete
+backends, the compatibility default adds tails, typed function references,
+multi-memory, memory64, and table64 to the Release 2 plus extended-constants
+surface. GC and exception handling remain opt-in; callers request the complete
+release with `WithCoreFeatures(CoreFeaturesV3)`, and the versioned spec harness does so when
 `WAGO_SPEC_VERSION=3.0`. Unsupported build/platform requests return
 `UnsupportedFeatureError` with the exact requested bits, admitted bits, and
 `GOOS/GOARCH` platform. In particular, `memory64` and typed function references
@@ -5048,12 +5050,13 @@ WebAssembly Core 3.0 is complete for the pinned official linux/amd64
 explicit-bounds product. `make spec3` exits successfully with 2,226 passing
 modules and 58,038 passing assertions, zero failed or skipped modules/assertions,
 and zero gap counters. `tests/spec-v3-baseline.json` records the same zero-gap
-result. Release 1 and Release 2 compatibility defaults remain unchanged, and the
-runtime remains pure Go/no-cgo.
+result. Explicit Release 1 and Release 2 feature groups remain unchanged, and
+the runtime remains pure Go/no-cgo.
 
-`coreFeaturesWago` is the implementation ceiling, while `defaultCoreFeatures`
-retains the prior default admission set. Applications must explicitly request
-`CoreFeaturesV3`; the spec harness does so only for `WAGO_SPEC_VERSION=3.0`.
+`coreFeaturesWago` is the implementation ceiling. `defaultCoreFeatures()` adds
+the selected lower-risk Core 3 families only on complete backends; applications
+must still request `CoreFeaturesV3` for GC, exception handling, and the complete
+release. The spec harness does so for `WAGO_SPEC_VERSION=3.0`.
 Persisted artifacts retain structural/type metadata, but feature-dependent live
 product state is admitted after reload only when its required structural sidecar
 is completely represented; otherwise codec load or instantiation remains

--- a/src/core/compiler/backend/railshot/arm64/adapter_elision_test.go
+++ b/src/core/compiler/backend/railshot/arm64/adapter_elision_test.go
@@ -1,4 +1,4 @@
-//go:build arm64
+//go:build (linux || darwin) && arm64
 
 package arm64
 

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -2667,7 +2667,7 @@ func (c *Compiled) validate() error {
 		return err
 	}
 	required := c.requiredFeatures
-	unsupported := required &^ defaultCoreFeatures
+	unsupported := required &^ coreFeaturesWithoutSidecar
 	var staged CoreFeatures
 	if c.memoryDir != nil {
 		if c.memoryDir.staged {

--- a/src/wago/cancellation_test.go
+++ b/src/wago/cancellation_test.go
@@ -85,12 +85,14 @@ func TestInvokeContextInterruptsHostCallLoop(t *testing.T) {
 		)),
 	)
 	calls := 0
+	var cancelledAt time.Time
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	c := MustCompile(mod)
 	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.tick": HostFunc(func(_ HostModule, _, r []uint64) {
 		calls++
 		if calls == 1<<20+1 {
+			cancelledAt = time.Now()
 			cancel()
 		}
 		r[0] = I32(0)
@@ -100,11 +102,10 @@ func TestInvokeContextInterruptsHostCallLoop(t *testing.T) {
 	}
 	defer in.Close()
 
-	started := time.Now()
 	if _, err := in.InvokeContext(ctx, "spin"); !errors.Is(err, context.Canceled) {
 		t.Fatalf("spin error = %v, want context cancellation (a re-entry-cap error here is the regression)", err)
 	}
-	if elapsed := time.Since(started); elapsed > 5*time.Second {
+	if elapsed := time.Since(cancelledAt); elapsed > 5*time.Second {
 		t.Fatalf("cancellation took %v, want bounded interruption", elapsed)
 	}
 	// Prove the loop sailed past the historical 1<<20 host-call re-entry cap:

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -90,11 +90,14 @@ const (
 		CoreFeatureTable64
 
 	// coreFeaturesWago is the optional set wago's backend lowers and the ceiling
-	// validated by WithCoreFeatures. Core 3 features are opt-in so existing users
-	// retain the Release 2-compatible default behavior.
+	// validated by WithCoreFeatures.
 	coreFeaturesWago = CoreFeaturesV3 | CoreFeatureExtendedConst | CoreFeatureThreads
 
-	defaultCoreFeatures = CoreFeatureMutableGlobal |
+	// coreFeaturesWithoutSidecar is the set whose compiled representation needs
+	// no feature-specific structural sidecar. Keep this separate from the runtime
+	// default: Core 3 products still validate their persisted metadata even where
+	// they are admitted by default.
+	coreFeaturesWithoutSidecar = CoreFeatureMutableGlobal |
 		CoreFeatureSignExtensionOps |
 		CoreFeatureMultiValue |
 		CoreFeatureBulkMemoryOperations |
@@ -103,6 +106,15 @@ const (
 		CoreFeatureSIMD |
 		CoreFeatureExtendedConst |
 		CoreFeatureExtendedConstExpressions
+
+	// defaultCore3Features contains the finalized Core 3 families that extend
+	// validation and execution without making managed-object lifetime or native
+	// exception unwinding part of every runtime's default contract.
+	defaultCore3Features = CoreFeatureTailCall |
+		CoreFeatureTypedFunctionReferences |
+		CoreFeatureMultiMemory |
+		CoreFeatureMemory64 |
+		CoreFeatureTable64
 )
 
 // IsEnabled returns true if all bits in feature are set.
@@ -152,13 +164,13 @@ var featureRegistry = []FeatureInfo{
 	{Feature: CoreFeatureSIMD, Name: "simd", Label: "SIMD", Description: "128-bit vector instructions"},
 	{Feature: CoreFeatureExtendedConst, Name: "extended-constant-expressions", Label: "Extended constants", Description: "integer arithmetic in constant expressions"},
 	{Feature: CoreFeatureExtendedConstExpressions, Name: "extended-const-expressions", Label: "Extended constant expressions", Description: "imported globals in constant expressions"},
-	{Feature: CoreFeatureTailCall, Name: "tail-call", Label: "Tail calls", Description: "return_call, return_call_indirect, and return_call_ref", Experimental: true},
-	{Feature: CoreFeatureTypedFunctionReferences, Name: "typed-function-references", Label: "Typed function references", Description: "typed references, call_ref, and related casts", Experimental: true},
+	{Feature: CoreFeatureTailCall, Name: "tail-call", Label: "Tail calls", Description: "return_call, return_call_indirect, and return_call_ref"},
+	{Feature: CoreFeatureTypedFunctionReferences, Name: "typed-function-references", Label: "Typed function references", Description: "typed references, call_ref, and related casts"},
 	{Feature: CoreFeatureGC, Name: "gc", Label: "Garbage collection", Description: "struct, array, i31, and managed reference instructions", Experimental: true},
 	{Feature: CoreFeatureExceptionHandling, Name: "exception-handling", Label: "Exception handling", Description: "tags, throw, and try_table", Experimental: true},
-	{Feature: CoreFeatureMultiMemory, Name: "multi-memory", Label: "Multiple memories", Description: "multiple memories and indexed memory instructions", Experimental: true},
-	{Feature: CoreFeatureMemory64, Name: "memory64", Label: "64-bit memory", Description: "64-bit linear-memory limits and addresses", Experimental: true},
-	{Feature: CoreFeatureTable64, Name: "table64", Label: "64-bit tables", Description: "64-bit table limits and indexes", Experimental: true},
+	{Feature: CoreFeatureMultiMemory, Name: "multi-memory", Label: "Multiple memories", Description: "multiple memories and indexed memory instructions"},
+	{Feature: CoreFeatureMemory64, Name: "memory64", Label: "64-bit memory", Description: "64-bit linear-memory limits and addresses"},
+	{Feature: CoreFeatureTable64, Name: "table64", Label: "64-bit tables", Description: "64-bit table limits and indexes"},
 	{Feature: CoreFeatureThreads, Name: "threads", Label: "Threads and atomics", Description: "shared memory and atomic memory instructions", Experimental: true},
 }
 
@@ -172,7 +184,7 @@ func FeatureInfos() []FeatureInfo {
 	supported := platformCoreFeatures()
 	result := make([]FeatureInfo, len(featureRegistry))
 	for index, feature := range featureRegistry {
-		feature.Default = defaultCoreFeatures.IsEnabled(feature.Feature)
+		feature.Default = defaultCoreFeatures().IsEnabled(feature.Feature)
 		feature.Available = supported.IsEnabled(feature.Feature)
 		result[index] = feature
 	}
@@ -230,8 +242,8 @@ type RuntimeConfig struct {
 
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
 
-// NewRuntimeConfig returns the default configuration: wago's supported feature
-// set, serial function validation/codegen, independent-instance execution, and
+// NewRuntimeConfig returns the default configuration: wago's selected feature
+// set for this build, serial function validation/codegen, independent-instance execution, and
 // the fastest available bounds-check mode — signals-based (guard-page) when
 // built with -tags wago_guardpage, explicit otherwise. WAGO_BOUNDS overrides
 // either way ("explicit" / "signals").
@@ -256,7 +268,7 @@ func NewRuntimeConfig() *RuntimeConfig {
 		}
 	}
 	return &RuntimeConfig{
-		features:             defaultCoreFeatures,
+		features:             defaultCoreFeatures(),
 		optimizations:        optimizations,
 		maxMemoryPages:       defaultMaxMemoryPages,
 		boundsChecks:         bounds,
@@ -489,6 +501,14 @@ func platformCoreFeatures() CoreFeatures {
 		supported &^= CoreFeatureThreads
 	}
 	return supported
+}
+
+// defaultCoreFeatures admits selected finalized Core 3 families on backends that
+// implement the complete product. Other targets retain the portable Release 2
+// plus extended-constant surface instead of silently accepting partial support.
+// GC, exception handling, and the separate threads proposal remain opt-in.
+func defaultCoreFeatures() CoreFeatures {
+	return coreFeaturesWithoutSidecar | (defaultCore3Features & platformCoreFeatures())
 }
 
 func SupportedFeatures() CoreFeatures {

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -316,6 +316,42 @@ func TestCoreFeaturesV3ReleaseScopeAndAdmission(t *testing.T) {
 	}
 }
 
+func TestDefaultCoreFeaturePolicy(t *testing.T) {
+	want := coreFeaturesWithoutSidecar
+	if supportsCompleteCore3Backend(runtime.GOOS, runtime.GOARCH) {
+		want |= defaultCore3Features
+	}
+	if got := NewRuntimeConfig().CoreFeatures(); got != want {
+		t.Fatalf("default features = %s, want %s", got, want)
+	}
+	if want.IsEnabled(CoreFeatureGC | CoreFeatureExceptionHandling | CoreFeatureThreads) {
+		t.Fatalf("default unexpectedly includes ownership-sensitive opt-in features: %s", want)
+	}
+	for _, info := range FeatureInfos() {
+		expected := want.IsEnabled(info.Feature)
+		if got := info.Default; got != expected {
+			t.Errorf("feature %q default = %v, want %v", info.Name, got, expected)
+		}
+	}
+
+	if !supportsCompleteCore3Backend(runtime.GOOS, runtime.GOARCH) {
+		return
+	}
+	module := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x12, 0x01, 0x0b}), // return_call 1
+			wasmtest.Code([]byte{0x0b}),
+		)),
+	)
+	compiled, err := Compile(nil, module)
+	if err != nil {
+		t.Fatalf("default compile of selected Core 3 tail call: %v", err)
+	}
+	_ = compiled.Close()
+}
+
 func TestFeatureRegistryCoversEveryRuntimeFeature(t *testing.T) {
 	seen := map[string]bool{}
 	var registered CoreFeatures

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -461,6 +461,9 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	if !hostSupportsSIMD() {
 		wantFeatures &^= CoreFeatureSIMD
 	}
+	if !supportsThreadsBackend(runtime.GOOS, runtime.GOARCH) {
+		wantFeatures &^= CoreFeatureThreads
+	}
 	if SupportedFeatures() != wantFeatures {
 		t.Fatal("SupportedFeatures mismatch")
 	}

--- a/src/wago/cross_instance_tail_amd64_test.go
+++ b/src/wago/cross_instance_tail_amd64_test.go
@@ -124,7 +124,7 @@ func TestStagedDirectReturnCallDynamicHostDispatch(t *testing.T) {
 }
 
 func TestStagedDirectCrossInstanceReturnCall(t *testing.T) {
-	if _, err := Compile(nil, directCrossTailConsumerModule()); err == nil || !strings.Contains(err.Error(), "tail-call disabled") {
+	if _, err := compatibilityDefaultConfig().Compile(directCrossTailConsumerModule()); err == nil || !strings.Contains(err.Error(), "tail-call disabled") {
 		t.Fatalf("public direct cross-tail compile error = %v, want fail-closed feature rejection", err)
 	}
 	compiled, err := compileStagedTail(directCrossTailConsumerModule())
@@ -321,7 +321,7 @@ func instantiateDirectCrossTailFloat(t testing.TB) (*Instance, *Instance) {
 }
 
 func TestStagedDirectCrossInstanceReturnCallMixedFloat(t *testing.T) {
-	if _, err := Compile(nil, directCrossTailFloatConsumerModule()); err == nil || !strings.Contains(err.Error(), "tail-call disabled") {
+	if _, err := compatibilityDefaultConfig().Compile(directCrossTailFloatConsumerModule()); err == nil || !strings.Contains(err.Error(), "tail-call disabled") {
 		t.Fatalf("public float direct-tail compile error = %v", err)
 	}
 	producer, consumer := instantiateDirectCrossTailFloat(t)
@@ -422,7 +422,7 @@ func unprovenFloatResultCrossTailModule(imported bool) []byte {
 }
 
 func TestStagedDirectCrossInstanceReturnCallFloatParamIntegerResult(t *testing.T) {
-	if _, err := Compile(nil, floatParamIntegerResultCrossTailModule(true)); err == nil || !strings.Contains(err.Error(), "tail-call disabled") {
+	if _, err := compatibilityDefaultConfig().Compile(floatParamIntegerResultCrossTailModule(true)); err == nil || !strings.Contains(err.Error(), "tail-call disabled") {
 		t.Fatalf("public float-param direct-tail compile error = %v", err)
 	}
 	producerCompiled, err := compileStagedTail(floatParamIntegerResultCrossTailModule(false))

--- a/src/wago/engine_regression_test.go
+++ b/src/wago/engine_regression_test.go
@@ -273,7 +273,7 @@ func instantiateEngineFixture(t *testing.T, name string, imports Imports) *Insta
 	return in
 }
 
-func TestTailCallProposalFailsClosed(t *testing.T) {
+func TestTailCallFeatureDisableFailsClosed(t *testing.T) {
 	mod := wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
 		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
@@ -282,7 +282,7 @@ func TestTailCallProposalFailsClosed(t *testing.T) {
 			wasmtest.Code([]byte{0x12, 0x00, 0x0b}), // return_call 0
 		)),
 	)
-	compiled, err := Compile(nil, mod)
+	compiled, err := Compile(compatibilityDefaultConfig(), mod)
 	if compiled != nil {
 		_ = compiled.Close()
 		t.Fatal("unsupported tail-call module compiled")
@@ -292,7 +292,7 @@ func TestTailCallProposalFailsClosed(t *testing.T) {
 	}
 }
 
-func TestTypedFunctionReferenceProposalFailsClosed(t *testing.T) {
+func TestTypedFunctionReferenceFeatureDisableFailsClosed(t *testing.T) {
 	mod := wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
 		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
@@ -305,7 +305,7 @@ func TestTypedFunctionReferenceProposalFailsClosed(t *testing.T) {
 			wasmtest.Code([]byte{0xd2, 0x00, 0x14, 0x00, 0x0b}), // ref.func 0; call_ref type 0
 		)),
 	)
-	compiled, err := Compile(nil, mod)
+	compiled, err := Compile(compatibilityDefaultConfig(), mod)
 	if compiled != nil {
 		_ = compiled.Close()
 		t.Fatal("unsupported typed-function-reference module compiled")

--- a/src/wago/example_test.go
+++ b/src/wago/example_test.go
@@ -51,7 +51,7 @@ func ExampleSupportedFeatures() {
 func ExampleRuntimeConfig_WithFeature() {
 	cfg := wago.NewRuntimeConfig().WithFeature(wago.CoreFeatureBulkMemoryOperations, false)
 	fmt.Println(cfg.CoreFeatures())
-	// Output: multi-value|mutable-global|nontrapping-float-to-int-conversion|reference-types|sign-extension-ops|simd|extended-constant-expressions|extended-const-expressions
+	// Output: multi-value|mutable-global|nontrapping-float-to-int-conversion|reference-types|sign-extension-ops|simd|extended-constant-expressions|extended-const-expressions|tail-call|typed-function-references|multi-memory|memory64|table64
 }
 
 func ExampleCoreFeatures_IsEnabled() {

--- a/src/wago/exception_funcref_product_amd64_test.go
+++ b/src/wago/exception_funcref_product_amd64_test.go
@@ -68,7 +68,7 @@ func compileStagedExceptionFuncrefProduct(t testing.TB, data []byte) *Compiled {
 
 func TestStagedExceptionFuncrefProductIdentityLifetimeAndGates(t *testing.T) {
 	data := stagedExceptionFuncrefProductModule([]byte{0x64, 0x00}, 0x03, 0x00, true)
-	if _, err := Compile(NewRuntimeConfig(), data); err == nil || !strings.Contains(err.Error(), "disabled") {
+	if _, err := Compile(NewRuntimeConfig(), data); err == nil || (!strings.Contains(err.Error(), "disabled") && !strings.Contains(err.Error(), "exn")) {
 		t.Fatalf("public compile = %v, want a closed public Core 3 feature gate", err)
 	}
 	c := compileStagedExceptionFuncrefProduct(t, data)

--- a/src/wago/exception_funcref_product_arm64_test.go
+++ b/src/wago/exception_funcref_product_arm64_test.go
@@ -68,7 +68,7 @@ func compileStagedExceptionFuncrefProduct(t testing.TB, data []byte) *Compiled {
 
 func TestStagedExceptionFuncrefProductIdentityLifetimeAndGates(t *testing.T) {
 	data := stagedExceptionFuncrefProductModule([]byte{0x64, 0x00}, 0x03, 0x00, true)
-	if _, err := Compile(NewRuntimeConfig(), data); err == nil || !strings.Contains(err.Error(), "disabled") {
+	if _, err := Compile(NewRuntimeConfig(), data); err == nil || (!strings.Contains(err.Error(), "disabled") && !strings.Contains(err.Error(), "exn")) {
 		t.Fatalf("public compile = %v, want a closed public Core 3 feature gate", err)
 	}
 	c := compileStagedExceptionFuncrefProduct(t, data)

--- a/src/wago/feature_policy_test.go
+++ b/src/wago/feature_policy_test.go
@@ -1,0 +1,8 @@
+package wago
+
+// compatibilityDefaultConfig preserves the pre-promotion feature mask for tests
+// whose purpose is to prove that a proposal fails closed when its bit is off.
+// Those tests must not rely on the process-wide default policy.
+func compatibilityDefaultConfig() *RuntimeConfig {
+	return NewRuntimeConfig().WithCoreFeatures(coreFeaturesWithoutSidecar)
+}

--- a/src/wago/global_test.go
+++ b/src/wago/global_test.go
@@ -215,9 +215,9 @@ func TestCompileAcceptsImportedReferenceGlobalWithInstantiationOwnerGate(t *test
 	}
 }
 
-func TestCompileRejectsWasm3DecodedProposalFeatureBeforeLegacyDecode(t *testing.T) {
+func TestCompileRejectsDisabledWasm3FeatureBeforeLegacyDecode(t *testing.T) {
 	mod := wasmtest.Module(wasmtest.Section(5, wasmtest.Vec([]byte{0x04, 0x00}))) // memory64 min 0
-	if _, err := Compile(nil, mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte("compile: unsupported memory memory64 (memory64 disabled) at memory 0")) {
+	if _, err := compatibilityDefaultConfig().Compile(mod); err == nil || !bytes.Contains([]byte(err.Error()), []byte("compile: unsupported memory memory64 (memory64 disabled) at memory 0")) {
 		t.Fatalf("Compile memory64 error = %v, want frontend support-pass rejection", err)
 	}
 }

--- a/src/wago/memory64_exec_amd64_test.go
+++ b/src/wago/memory64_exec_amd64_test.go
@@ -300,7 +300,7 @@ func compileStagedMemory64(data []byte) (*Compiled, error) {
 
 func TestStagedMemory64LocalExecutionAndProductRoundTrip(t *testing.T) {
 	module := boundedMemory64Module(3)
-	if _, err := Compile(nil, module); err == nil || !strings.Contains(err.Error(), "memory64") {
+	if _, err := compatibilityDefaultConfig().Compile(module); err == nil || !strings.Contains(err.Error(), "memory64") {
 		t.Fatalf("public memory64 compile error = %v, want fail-closed feature rejection", err)
 	}
 	compiled, err := compileStagedMemory64(module)
@@ -1011,7 +1011,7 @@ func TestStagedMemory64InstanceExportImportLifecycle(t *testing.T) {
 	}
 
 	consumerModule := memory64ImportModule(1, &max4)
-	if _, err := Compile(nil, consumerModule); err == nil || !strings.Contains(err.Error(), "memory64") {
+	if _, err := compatibilityDefaultConfig().Compile(consumerModule); err == nil || !strings.Contains(err.Error(), "memory64") {
 		t.Fatalf("public memory64 import compile = %v, want fail-closed feature rejection", err)
 	}
 	consumerCompiled, err := compileStagedMemory64(consumerModule)

--- a/src/wago/multi_memory_exec_amd64_test.go
+++ b/src/wago/multi_memory_exec_amd64_test.go
@@ -446,7 +446,7 @@ func TestStagedMultiMemoryLocalAndImportedExecution(t *testing.T) {
 		}
 	})
 
-	if _, err := Compile(nil, localMultiMemoryExecModule()); err == nil {
+	if _, err := compatibilityDefaultConfig().Compile(localMultiMemoryExecModule()); err == nil {
 		t.Fatal("public multi-memory compile unexpectedly succeeded")
 	}
 	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV2 | CoreFeatureMultiMemory)

--- a/src/wago/multi_memory_native_call_amd64_test.go
+++ b/src/wago/multi_memory_native_call_amd64_test.go
@@ -606,7 +606,7 @@ func TestStagedMultiMemoryNativeSameMemoryImportedGlobalTableComposition(t *test
 	if _, err := chain.middle.c.MarshalBinary(); err != nil {
 		t.Fatalf("marshal global+table structural module: %v", err)
 	}
-	if _, err := Compile(nil, sameMemoryNativeGlobalTableTenantModule("A", 20)); err == nil {
+	if _, err := compatibilityDefaultConfig().Compile(sameMemoryNativeGlobalTableTenantModule("A", 20)); err == nil {
 		t.Fatal("public compile admitted global+table staged multi-memory composition")
 	}
 	returnCall := sameMemoryNativeGlobalTableTenantModule("A", 20)
@@ -730,7 +730,7 @@ func TestStagedMultiMemoryNativeSameMemoryImportedTableComposition(t *testing.T)
 	if _, err := chain.middle.c.MarshalBinary(); err != nil {
 		t.Fatalf("marshal table-composed structural module: %v", err)
 	}
-	if _, err := Compile(nil, sameMemoryNativeTableTenantModule("A", 20)); err == nil {
+	if _, err := compatibilityDefaultConfig().Compile(sameMemoryNativeTableTenantModule("A", 20)); err == nil {
 		t.Fatal("public compile admitted imported-table staged multi-memory composition")
 	}
 	returnCall := sameMemoryNativeTableTenantModule("A", 20)
@@ -841,7 +841,7 @@ func TestStagedMultiMemoryNativeSameMemoryImportedGlobalComposition(t *testing.T
 	if _, err := chain.middle.c.MarshalBinary(); err != nil {
 		t.Fatalf("marshal composed structural module: %v", err)
 	}
-	if _, err := Compile(nil, sameMemoryNativeGlobalTenantModule("A", 20)); err == nil {
+	if _, err := compatibilityDefaultConfig().Compile(sameMemoryNativeGlobalTenantModule("A", 20)); err == nil {
 		t.Fatal("public compile admitted imported-global same-memory native composition")
 	}
 	ownerStep, _ := chain.owner.ExportedFunc("step")
@@ -962,7 +962,7 @@ func TestStagedMultiMemoryNativeContextProductAndGates(t *testing.T) {
 		t.Fatalf("public reload of multi-memory module: %v", err)
 	}
 	defer loaded.Close()
-	if _, err := Compile(nil, sameMemoryNativeTenantModule("A", 20)); err == nil {
+	if _, err := compatibilityDefaultConfig().Compile(sameMemoryNativeTenantModule("A", 20)); err == nil {
 		t.Fatal("public default compile admitted staged multi-memory native calls")
 	}
 

--- a/src/wago/multi_memory_official_amd64_test.go
+++ b/src/wago/multi_memory_official_amd64_test.go
@@ -80,7 +80,7 @@ func stagedOfficialMultiMemoryModules(t *testing.T, base string) [][]byte {
 
 func stagedCompactConsumerRoundTrip(t *testing.T, data []byte, wantImports []string) *Compiled {
 	t.Helper()
-	if _, err := Compile(nil, data); err == nil || !strings.Contains(err.Error(), "compact imports") {
+	if _, err := compatibilityDefaultConfig().Compile(data); err == nil || !strings.Contains(err.Error(), "compact imports") {
 		t.Fatalf("default compile error = %v, want fail-closed compact-import rejection", err)
 	}
 	compiled := stagedMultiMemoryCompile(t, data)

--- a/src/wago/table64_exec_amd64_test.go
+++ b/src/wago/table64_exec_amd64_test.go
@@ -618,7 +618,7 @@ func compileStagedTable64(data []byte) (*Compiled, error) {
 
 func TestStagedTable64LocalGetSetSizeAndProductRoundTrip(t *testing.T) {
 	module := boundedTable64Module(4)
-	if _, err := Compile(nil, module); err == nil || !strings.Contains(err.Error(), "table64") {
+	if _, err := compatibilityDefaultConfig().Compile(module); err == nil || !strings.Contains(err.Error(), "table64") {
 		t.Fatalf("public table64 compile error = %v", err)
 	}
 	compiled, err := compileStagedTable64(module)

--- a/src/wago/tail_call_official_amd64_test.go
+++ b/src/wago/tail_call_official_amd64_test.go
@@ -64,7 +64,7 @@ func TestStagedOfficialReturnCall(t *testing.T) {
 				continue
 			}
 			if counts.Commands == 1 {
-				if public, err := Compile(nil, data); err == nil {
+				if public, err := compatibilityDefaultConfig().Compile(data); err == nil {
 					_ = public.Close()
 					counts.Failures++
 					t.Errorf("return_call.wast:%d public compile unexpectedly admitted tail calls", cmd.Line)

--- a/src/wago/threads_atomic_test.go
+++ b/src/wago/threads_atomic_test.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin || windows) && (amd64 || arm64) && !tinygo
+//go:build (linux || darwin) && (amd64 || arm64) && !tinygo
 
 package wago
 

--- a/src/wago/typed_cross_instance_tail_amd64_test.go
+++ b/src/wago/typed_cross_instance_tail_amd64_test.go
@@ -50,7 +50,7 @@ func typedReferenceResultTailModule() []byte {
 
 func TestStagedTypedReferenceResultReturnCallRef(t *testing.T) {
 	module := typedReferenceResultTailModule()
-	if _, err := Compile(nil, module); err == nil || !strings.Contains(err.Error(), "typed") {
+	if _, err := compatibilityDefaultConfig().Compile(module); err == nil || !strings.Contains(err.Error(), "typed") {
 		t.Fatalf("public reference-result tail compile error = %v, want fail-closed feature rejection", err)
 	}
 	compiled := stagedTypedTailCompile(t, module)
@@ -180,7 +180,7 @@ func typedCrossTailPairConsumerModule() []byte {
 }
 
 func TestStagedTypedCrossInstanceReturnCallRefRootTransfer(t *testing.T) {
-	if _, err := Compile(nil, typedCrossTailConsumerModule()); err == nil || !strings.Contains(err.Error(), "typed") {
+	if _, err := compatibilityDefaultConfig().Compile(typedCrossTailConsumerModule()); err == nil || !strings.Contains(err.Error(), "typed") {
 		t.Fatalf("public typed-tail compile error = %v, want fail-closed feature rejection", err)
 	}
 	producer, consumer := instantiateTypedCrossTail(t)

--- a/src/wago/typed_reference_assertion_test.go
+++ b/src/wago/typed_reference_assertion_test.go
@@ -137,7 +137,7 @@ func replayProposalAssertionsFile(t *testing.T, dir, base string) (counts propos
 		t.Fatalf("create spectest.memory: %v", err)
 	}
 	state := &proposalReplayState{
-		rt:            NewRuntime(),
+		rt:            NewRuntime(WithRuntimeConfig(compatibilityDefaultConfig())),
 		standard:      proposalSpectestImports(table, memory),
 		standardTypes: proposalSpectestTypes(),
 		named:         make(map[string]*proposalReplayModule),

--- a/src/wago/typed_storage_test.go
+++ b/src/wago/typed_storage_test.go
@@ -150,7 +150,7 @@ func TestStagedTypedStorageExactImports(t *testing.T) {
 	mismatch := wasmtest.FuncType([]wasm.ValType{wasm.I64}, []wasm.ValType{wasm.I64})
 
 	t.Run("public gate remains closed", func(t *testing.T) {
-		_, err := Compile(typedTableModule([][]byte{equivalent}, 0, false, true))
+		_, err := compatibilityDefaultConfig().Compile(typedTableModule([][]byte{equivalent}, 0, false, true))
 		if err == nil || !strings.Contains(err.Error(), "typed-function-references disabled") {
 			t.Fatalf("public typed table compile error = %v", err)
 		}

--- a/src/wago/typed_table_dynamic_amd64_test.go
+++ b/src/wago/typed_table_dynamic_amd64_test.go
@@ -159,8 +159,9 @@ func TestTypedFunctionReferenceDynamicTableLifecycle(t *testing.T) {
 		t.Fatal("local typed table owner overwrite did not release closed consumer")
 	}
 
-	// Public admission remains closed even though the staged end-to-end path runs.
-	if _, err := Compile(nil, producerModule); err == nil {
+	// Explicitly disabling typed references remains fail-closed even though the
+	// default and staged end-to-end paths run.
+	if _, err := compatibilityDefaultConfig().Compile(producerModule); err == nil {
 		t.Fatal("public typed-reference table compile unexpectedly succeeded")
 	}
 }

--- a/src/wago/unsupported_proposal_test.go
+++ b/src/wago/unsupported_proposal_test.go
@@ -38,6 +38,7 @@ type proposalFixtureFile struct {
 
 func TestUnsupportedProposalCorporaFailClosed(t *testing.T) {
 	root := filepath.Clean("../../tests/regressions/spectest-proposals")
+	config := compatibilityDefaultConfig()
 	type proposalWant struct {
 		files, accepted, unsupported, invalid, negativeInstantiation, malformedBinary, malformedText int
 	}
@@ -94,7 +95,7 @@ func TestUnsupportedProposalCorporaFailClosed(t *testing.T) {
 						t.Errorf("%s:%d read %s: %v", filepath.Base(jsonPath), cmd.Line, cmd.Filename, err)
 						continue
 					}
-					compiled, compileErr := Compile(nil, data)
+					compiled, compileErr := Compile(config, data)
 					if compileErr != nil && compiled != nil {
 						t.Errorf("%s:%d compile returned both artifact and error: %v", filepath.Base(jsonPath), cmd.Line, compileErr)
 						_ = compiled.Close()


### PR DESCRIPTION
Why:
- completed Core 3 backends already pass the pinned zero-gap suite
- low-risk finalized families should not require an experimental opt-in

What:
- default tail calls, typed function references, multi-memory, memory64, and table64 on complete backends
- keep WasmGC, exception handling, and threads opt-in
- make CLI auto-selection follow the platform default while --core 2 and --core 3 remain exact
- separate artifact-sidecar validation from runtime default policy and make disabled-feature tests explicit

Proof:
- go test ./...
- native linux/amd64: go test ./src/wago -count=1 with pinned wg-3.0 corpus

Docs:
- FEATURES.md, README.md, ROADMAP.md, docs/wasm3.md, docs/runtime-abi.md
- docs/research/wasm3-default-feature-audit.md