### PR TITLE
cli: harden release downloads and credential persistence

### DIFF
--- a/cli/manager/command_environment.go
+++ b/cli/manager/command_environment.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,7 +44,14 @@ import (
 
 // commandEnvironment adapts manager-owned domain modules to command packages.
 // Parsing, validation, and command-level orchestration stay in command.go.
-type commandEnvironment struct{}
+type commandEnvironment struct{ ctx context.Context }
+
+func (e commandEnvironment) context() context.Context {
+	if e.ctx != nil {
+		return e.ctx
+	}
+	return context.Background()
+}
 
 func (commandEnvironment) Compile(options compilecmd.Options) {
 	if err := managerplugin.Select(options.Global, options.Local, options.Bare); err != nil {
@@ -304,7 +312,7 @@ func (e commandEnvironment) CachePrune(options cacheprune.Options) {
 	fmt.Printf("Pruned %d old cache %s (%s)\n", result.Removed, noun, managercache.FormatBytes(result.Bytes))
 }
 
-func (commandEnvironment) Login(options authlogin.Options) {
+func (e commandEnvironment) Login(options authlogin.Options) {
 	if automation.DryRun() {
 		method := "interactive"
 		switch {
@@ -320,28 +328,28 @@ func (commandEnvironment) Login(options authlogin.Options) {
 		automation.PrintPlan("log in", map[string]any{"registry": "plugins.wago.sh", "method": method})
 		return
 	}
-	registry.Login(registry.LoginRequest{
+	registry.LoginContext(e.context(), registry.LoginRequest{
 		Link: options.Link, Code: options.Code, WithToken: options.WithToken, Token: options.Token,
 	})
 }
 
-func (commandEnvironment) Logout() {
+func (e commandEnvironment) Logout() {
 	if automation.DryRun() {
 		automation.PrintPlan("log out", map[string]any{"registry": "plugins.wago.sh"})
 		return
 	}
-	registry.Logout()
+	registry.LogoutContext(e.context())
 }
-func (commandEnvironment) Whoami() { registry.Whoami() }
+func (e commandEnvironment) Whoami() { registry.WhoamiContext(e.context()) }
 
-func (commandEnvironment) Add(options pluginadd.Options) {
+func (e commandEnvironment) Add(options pluginadd.Options) {
 	requireUnlocked("add plugins")
 	if automation.DryRun() {
 		automation.PrintPlan("add plugins", map[string]any{"packages": options.Modules, "scope": scopeName(options.Global, options.Local), "force": options.Force})
 		return
 	}
 	managerplugin.Add(managerplugin.AddRequest{
-		Modules: options.Modules, Global: options.Global, Local: options.Local,
+		Context: e.context(), Modules: options.Modules, Global: options.Global, Local: options.Local,
 		Force: options.Force, Verbose: options.Verbose,
 		Capabilities: options.Capabilities, GrantAll: options.GrantAll, DenyAll: options.DenyAll,
 	})
@@ -368,14 +376,14 @@ func (commandEnvironment) Grant(options grant.Options) {
 	})
 }
 
-func (commandEnvironment) UpdatePlugins(options pluginupdate.Options) {
+func (e commandEnvironment) UpdatePlugins(options pluginupdate.Options) {
 	requireUnlocked("update plugins")
 	if automation.DryRun() {
 		automation.PrintPlan("update plugins", map[string]any{"package": options.Module, "scope": scopeName(options.Global, options.Local), "force": options.Force})
 		return
 	}
 	managerplugin.Update(managerplugin.MutationRequest{
-		Name: options.Module, Global: options.Global, Local: options.Local,
+		Context: e.context(), Name: options.Module, Global: options.Global, Local: options.Local,
 		Force: options.Force, Verbose: options.Verbose,
 	})
 }
@@ -397,31 +405,31 @@ func (commandEnvironment) RebuildPlugins(options pluginrebuild.Options) {
 	managerplugin.RebuildRuntime(maintenanceRequest("", options.Global, options.Local, options.Verbose))
 }
 
-func (commandEnvironment) Publish(options publish.Options) {
+func (e commandEnvironment) Publish(options publish.Options) {
 	if automation.DryRun() {
 		automation.PrintPlan("publish plugin", map[string]any{"manifest": options.Manifest, "commit": options.Commit, "category": options.Category, "tags": options.Tags})
 		return
 	}
-	registry.Publish(registry.PublishRequest{
+	registry.PublishContext(e.context(), registry.PublishRequest{
 		Manifest: options.Manifest, Commit: options.Commit, Notes: options.Notes,
 		Category: options.Category, Tags: options.Tags,
 	})
 }
 
-func (commandEnvironment) Unpublish(options unpublish.Options) {
+func (e commandEnvironment) Unpublish(options unpublish.Options) {
 	if automation.DryRun() {
 		automation.PrintPlan("unpublish plugin", map[string]any{"target": options.Target})
 		return
 	}
-	registry.Unpublish(registry.UnpublishRequest{Target: options.Target, Yes: options.Yes})
+	registry.UnpublishContext(e.context(), registry.UnpublishRequest{Target: options.Target, Yes: options.Yes})
 }
 
-func (commandEnvironment) Deprecate(options deprecate.Options) {
+func (e commandEnvironment) Deprecate(options deprecate.Options) {
 	if automation.DryRun() {
 		automation.PrintPlan("change plugin deprecation", map[string]any{"target": options.Target, "message": options.Message, "undo": options.Undo})
 		return
 	}
-	registry.Deprecate(registry.DeprecateRequest{
+	registry.DeprecateContext(e.context(), registry.DeprecateRequest{
 		Target: options.Target, Message: options.Message, Undo: options.Undo,
 	})
 }
@@ -443,7 +451,7 @@ func (commandEnvironment) dirs() wagopaths.Dirs {
 }
 
 func (e commandEnvironment) toolchain() managerversion.Toolchain {
-	return managerversion.Toolchain{Dirs: e.dirs()}
+	return managerversion.Toolchain{Dirs: e.dirs(), Context: e.context()}
 }
 
 func (e commandEnvironment) List()    { e.toolchain().List() }
@@ -491,12 +499,12 @@ func (e commandEnvironment) UninstallAllVersions() {
 	e.toolchain().UninstallAll()
 }
 
-func (commandEnvironment) Update(force bool) {
+func (e commandEnvironment) Update(force bool) {
 	if automation.DryRun() {
 		automation.PrintPlan("update Wago", map[string]any{"component": "manager", "force": force})
 		return
 	}
-	managerself.Update(versionString(), managerself.ExecutablePath(), force)
+	managerself.UpdateContext(e.context(), versionString(), managerself.ExecutablePath(), force)
 }
 
 func (e commandEnvironment) UpdateEverything(options updatecmd.Options) {
@@ -509,7 +517,7 @@ func (e commandEnvironment) UpdateEverything(options updatecmd.Options) {
 	}
 	activeRuntime := managerversion.ActiveVersion(e.dirs())
 	if options.Manager {
-		managerself.Update(versionString(), managerself.ExecutablePath(), options.Force)
+		managerself.UpdateContext(e.context(), versionString(), managerself.ExecutablePath(), options.Force)
 	}
 	if options.Runtime {
 		channel := options.Channel
@@ -540,7 +548,7 @@ func (e commandEnvironment) UpdateEverything(options updatecmd.Options) {
 		if len(dependencies) == 0 {
 			fmt.Fprintln(os.Stdout, dim("no plugins enabled; skipping plugin update"))
 		} else {
-			managerplugin.Update(managerplugin.MutationRequest{Global: global, Local: local, Verbose: options.Verbose, Force: options.Force})
+			managerplugin.Update(managerplugin.MutationRequest{Context: e.context(), Global: global, Local: local, Verbose: options.Verbose, Force: options.Force})
 		}
 	}
 }

--- a/cli/manager/command_registry.go
+++ b/cli/manager/command_registry.go
@@ -1,6 +1,8 @@
 package manager
 
 import (
+	"context"
+
 	"github.com/wago-org/wago/cli/internal/command"
 	"github.com/wago-org/wago/cli/internal/handoff"
 	authcmd "github.com/wago-org/wago/cli/manager/commands/auth"
@@ -26,7 +28,11 @@ import (
 )
 
 func buildCommandRegistry() *command.Cmd {
-	environment := commandEnvironment{}
+	return buildCommandRegistryContext(context.Background())
+}
+
+func buildCommandRegistryContext(ctx context.Context) *command.Cmd {
+	environment := commandEnvironment{ctx: ctx}
 	return &command.Cmd{
 		Name: "wago",
 		Children: []*command.Cmd{

--- a/cli/manager/internal/plugin/build.go
+++ b/cli/manager/internal/plugin/build.go
@@ -5,6 +5,7 @@
 package plugin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ import (
 
 // pkgOpts are the shared flags for the consume-side pkg commands.
 type pkgOpts struct {
+	ctx          context.Context
 	global       bool // operate on the ~/.wago set instead of the project
 	force        bool // ignore the build cache / fetch latest
 	verbose      bool // stream the underlying `go` output
@@ -45,7 +47,9 @@ func pkgAddMany(specs []string, o pkgOpts) {
 	}
 	progress.Title(title)
 	progress.Begin("Resolving packages")
-	packages, err := ResolvePackages(specs, registry.ResolveModule)
+	packages, err := ResolvePackages(specs, func(name string) (string, error) {
+		return registry.ResolveModuleContext(pluginContext(o.ctx), name)
+	})
 	if err != nil {
 		progress.Fail("Package resolution failed")
 		fatal("add: %v", err)
@@ -80,7 +84,7 @@ func pkgAddMany(specs []string, o pkgOpts) {
 				if automation.JSON() {
 					fatal("add: package %s was not found", getSpec)
 				}
-				printPackageNotFound(os.Stderr, pkg.Module, registry.Closest(pkg.Module))
+				printPackageNotFound(os.Stderr, pkg.Module, registry.ClosestContext(pluginContext(o.ctx), pkg.Module))
 				os.Exit(1)
 			}
 			progress.Fail("Package download failed")
@@ -139,7 +143,7 @@ func pkgAddMany(specs []string, o pkgOpts) {
 		progress.Finish(fmt.Sprintf("Built Wago with %d package%s", len(packages), plural(len(packages))))
 	}
 	for _, pkg := range packages {
-		registry.RecordInstall(pkg.Module, pkg.Resolved)
+		registry.RecordInstallContext(pluginContext(o.ctx), pkg.Module, pkg.Resolved)
 	}
 	// Then review capabilities — on a first install, or when the package's
 	// required capabilities have changed since the lockfile recorded them.
@@ -376,7 +380,7 @@ func pkgUpdate(target string, o pkgOpts) {
 	targets := deps
 	if target != "" {
 		if !strings.Contains(target, "/") && !strings.Contains(target, ".") {
-			if m, err := registry.ResolveModule(target); err == nil {
+			if m, err := registry.ResolveModuleContext(pluginContext(o.ctx), target); err == nil {
 				target = m
 			}
 		} else {
@@ -429,6 +433,13 @@ func pkgUpdate(target string, o pkgOpts) {
 		fatal("plugin update: %v", err)
 	}
 	fmt.Printf("%s updated %d plugin%s  %s\n", cyan("✓"), len(pending), plural(len(pending)), bin)
+}
+
+func pluginContext(ctx context.Context) context.Context {
+	if ctx != nil {
+		return ctx
+	}
+	return context.Background()
 }
 
 func pluginUpdateRequired(current, locked, latest string, force bool) bool {

--- a/cli/manager/internal/plugin/build/module.go
+++ b/cli/manager/internal/plugin/build/module.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"github.com/wago-org/wago/cli/internal/automation"
 
 	"github.com/wago-org/wago/cli/internal/ui"
+	"github.com/wago-org/wago/internal/atomicfile"
 )
 
 // buildModuleName is the generated module's path. It never leaves the machine.
@@ -304,8 +306,16 @@ func ensureBinary(dir string, deps []string, force, verbose bool, config Config)
 	// -buildvcs=false: the generated build module is a local throwaway; VCS
 	// stamping is meaningless and would otherwise fail when .wago sits inside an
 	// unrelated or partial git work tree.
-	staged := bin + ".tmp"
-	_ = os.Remove(staged)
+	temporary, err := atomicfile.CreateTemp(bin)
+	if err != nil {
+		return "", false, fmt.Errorf("prepare plugin build: %w", err)
+	}
+	staged := temporary.Name()
+	if err := temporary.Close(); err != nil {
+		_ = os.Remove(staged)
+		return "", false, fmt.Errorf("prepare plugin build: %w", err)
+	}
+	defer os.Remove(staged)
 	buildStep := []string{"build", "-buildvcs=false"}
 	if tag := config.BuildTag; tag != "" {
 		buildStep = append(buildStep, "-tags", tag)
@@ -323,14 +333,15 @@ func ensureBinary(dir string, deps []string, force, verbose bool, config Config)
 			return "", false, fmt.Errorf("go %s: %w", step[0], err)
 		}
 	}
-	if runtime.GOOS == "windows" {
-		_ = os.Remove(bin)
-	}
-	if err := os.Rename(staged, bin); err != nil {
-		_ = os.Remove(staged)
+	if err := atomicfile.CommitTempFile(staged, bin, atomicfile.Options{Mode: 0o755, Sync: true}); err != nil {
 		return "", false, fmt.Errorf("install plugin build: %w", err)
 	}
-	_ = os.WriteFile(hashFile, []byte(want), 0o644)
+	if err := atomicfile.ReplaceFile(hashFile, atomicfile.Options{Mode: 0o644}, func(writer io.Writer) error {
+		_, err := io.WriteString(writer, want)
+		return err
+	}); err != nil {
+		return "", false, fmt.Errorf("publish plugin build hash: %w", err)
+	}
 	return bin, false, nil
 }
 

--- a/cli/manager/internal/plugin/plugin.go
+++ b/cli/manager/internal/plugin/plugin.go
@@ -3,6 +3,7 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 )
 
 type AddRequest struct {
+	Context        context.Context
 	Modules        []string
 	Global, Local  bool
 	Force, Verbose bool
@@ -21,6 +23,7 @@ type AddRequest struct {
 }
 
 type MutationRequest struct {
+	Context       context.Context
 	Name          string
 	Global, Local bool
 	Force         bool
@@ -49,6 +52,7 @@ func managerVersion() string { return configuredManagerVersion }
 
 func Add(request AddRequest) {
 	pkgAddMany(request.Modules, pkgOpts{
+		ctx:          request.Context,
 		global:       mustMutationScope(request.Global, request.Local),
 		force:        request.Force,
 		verbose:      request.Verbose,
@@ -68,6 +72,7 @@ func Grant(request MutationRequest) {
 
 func Update(request MutationRequest) {
 	pkgUpdate(normalizeModuleRef(request.Name), pkgOpts{
+		ctx:     request.Context,
 		global:  mustMutationScope(request.Global, request.Local),
 		force:   request.Force,
 		verbose: request.Verbose,

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,10 @@ import (
 )
 
 func registryLogin(options LoginRequest) {
+	registryLoginContext(context.Background(), options)
+}
+
+func registryLoginContext(ctx context.Context, options LoginRequest) {
 	withToken := options.WithToken
 	code := options.Code
 	link := options.Link
@@ -36,24 +41,24 @@ func registryLogin(options LoginRequest) {
 			fatal("login: no token on stdin")
 		}
 	case code:
-		token = githubDeviceLogin(base)
+		token = githubDeviceLoginContext(ctx, base)
 	case link:
-		token = browserLogin(base)
+		token = browserLoginContext(ctx, base)
 	default:
 		var ok bool
-		token, ok = chooseLoginMethod(base)
+		token, ok = chooseLoginMethodContext(ctx, base)
 		if !ok {
 			return
 		}
 	}
-	me, err := fetchMe(token)
+	me, err := fetchMeContext(ctx, token)
 	if err != nil {
 		if errors.Is(err, errUnauthorized) {
 			fatal("login: the registry rejected that token")
 		}
 		fatal("login: %v", err)
 	}
-	if err := saveCredentials(base, token, me.Login); err != nil {
+	if err := saveCredentialsContext(ctx, base, token, me.Login); err != nil {
 		fatal("login: saving credentials: %v", err)
 	}
 	fmt.Printf("%s Logged in as %s\n", cyan("✓"), bold(me.Login))
@@ -77,6 +82,10 @@ func loginMethodPicker() *tui.Picker {
 // chooseLoginMethod asks how to log in using the shared radio selector. Link is
 // selected by default and remains the fallback for non-interactive callers.
 func chooseLoginMethod(base string) (string, bool) {
+	return chooseLoginMethodContext(context.Background(), base)
+}
+
+func chooseLoginMethodContext(ctx context.Context, base string) (string, bool) {
 	p := loginMethodPicker()
 	submitted, cancelled := tui.Run(p)
 	if cancelled {
@@ -88,9 +97,9 @@ func chooseLoginMethod(base string) (string, bool) {
 	}
 	switch method {
 	case "code":
-		return githubDeviceLogin(base), true
+		return githubDeviceLoginContext(ctx, base), true
 	default:
-		return browserLogin(base), true
+		return browserLoginContext(ctx, base), true
 	}
 }
 
@@ -98,6 +107,10 @@ func chooseLoginMethod(base string) (string, bool) {
 // opens the browser to the registry's CLI-login endpoint, and waits for the
 // /callback redirect carrying the plaintext token. It fatals on error or timeout.
 func browserLogin(base string) string {
+	return browserLoginContext(context.Background(), base)
+}
+
+func browserLoginContext(ctx context.Context, base string) string {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		fatal("login: cannot open a loopback listener: %v", err)
@@ -146,6 +159,9 @@ func browserLogin(base string) string {
 			fatal("login: no token received from the registry")
 		}
 		return res.token
+	case <-ctx.Done():
+		fatal("login: %v", ctx.Err())
+		return ""
 	case <-time.After(2 * time.Minute):
 		fatal("login: timed out waiting for the browser callback")
 		return ""
@@ -163,8 +179,12 @@ func browserLogin(base string) string {
 // the GitHub token to the registry (POST /api/auth/github/exchange), which
 // verifies the token belongs to its app and returns a wago token.
 func githubDeviceLogin(base string) string {
+	return githubDeviceLoginContext(context.Background(), base)
+}
+
+func githubDeviceLoginContext(ctx context.Context, base string) string {
 	// 1. Ask the registry which GitHub OAuth app to authenticate against.
-	status, data, err := apiRequest(http.MethodGet, "/api/auth/github/client", "", nil)
+	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/auth/github/client", "", nil)
 	if err != nil {
 		fatal("login: fetching GitHub client config: %v", err)
 	}
@@ -191,7 +211,7 @@ func githubDeviceLogin(base string) string {
 		Interval        int    `json:"interval"`
 		Error           string `json:"error"`
 	}
-	if err := PostForm("https://github.com/login/device/code",
+	if err := PostFormContext(ctx, "https://github.com/login/device/code",
 		url.Values{"client_id": {cfg.ClientID}, "scope": {cfg.Scope}}, &dc); err != nil {
 		fatal("login: requesting device code from GitHub: %v", err)
 	}
@@ -228,12 +248,18 @@ func githubDeviceLogin(base string) string {
 	var ghToken string
 	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
 	for time.Now().Before(deadline) {
-		time.Sleep(time.Duration(interval) * time.Second)
+		timer := time.NewTimer(time.Duration(interval) * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			fatal("login: %v", ctx.Err())
+		case <-timer.C:
+		}
 		var tr struct {
 			AccessToken string `json:"access_token"`
 			Error       string `json:"error"`
 		}
-		if err := PostForm("https://github.com/login/oauth/access_token", url.Values{
+		if err := PostFormContext(ctx, "https://github.com/login/oauth/access_token", url.Values{
 			"client_id":   {cfg.ClientID},
 			"device_code": {dc.DeviceCode},
 			"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
@@ -262,7 +288,7 @@ func githubDeviceLogin(base string) string {
 	}
 
 	// 4. Exchange the GitHub token for a wago API token.
-	status, data, err = apiRequest(http.MethodPost, "/api/auth/github/exchange", "",
+	status, data, err = apiRequestContext(ctx, http.MethodPost, "/api/auth/github/exchange", "",
 		map[string]string{"access_token": ghToken})
 	if err != nil {
 		fatal("login: exchanging GitHub token: %v", err)
@@ -284,13 +310,20 @@ func githubDeviceLogin(base string) string {
 
 // registryLogout deletes stored credentials for the current registry.
 func registryLogout() {
+	registryLogoutContext(context.Background())
+}
+
+func registryLogoutContext(ctx context.Context) {
 	base := registryBase()
-	creds, _ := loadCredentials()
+	creds, err := loadCredentials()
+	if err != nil {
+		fatal("logout: reading credentials: %v", err)
+	}
 	if _, ok := creds[base]; !ok {
 		fmt.Printf("%s Not logged in to %s\n", dim("·"), base)
 		return
 	}
-	if err := deleteCredentials(base); err != nil {
+	if err := deleteCredentialsContext(ctx, base); err != nil {
 		fatal("logout: %v", err)
 	}
 	fmt.Printf("%s Logged out of %s\n", cyan("✓"), base)
@@ -299,6 +332,10 @@ func registryLogout() {
 // registryWhoami prints the login of the current token, or a friendly hint when
 // there is no valid session.
 func registryWhoami() {
+	registryWhoamiContext(context.Background())
+}
+
+func registryWhoamiContext(ctx context.Context) {
 	token := resolveToken()
 	if token == "" {
 		if automation.JSON() {
@@ -308,7 +345,7 @@ func registryWhoami() {
 		fmt.Println("not logged in (run: wago auth login)")
 		return
 	}
-	me, err := fetchMe(token)
+	me, err := fetchMeContext(ctx, token)
 	if err != nil {
 		if errors.Is(err, errUnauthorized) {
 			if automation.JSON() {

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -79,12 +79,8 @@ func loginMethodPicker() *tui.Picker {
 	})
 }
 
-// chooseLoginMethod asks how to log in using the shared radio selector. Link is
-// selected by default and remains the fallback for non-interactive callers.
-func chooseLoginMethod(base string) (string, bool) {
-	return chooseLoginMethodContext(context.Background(), base)
-}
-
+// chooseLoginMethodContext asks how to log in using the shared radio selector.
+// Link is selected by default and remains the fallback for non-interactive callers.
 func chooseLoginMethodContext(ctx context.Context, base string) (string, bool) {
 	p := loginMethodPicker()
 	submitted, cancelled := tui.Run(p)
@@ -103,13 +99,10 @@ func chooseLoginMethodContext(ctx context.Context, base string) (string, bool) {
 	}
 }
 
-// browserLogin runs the loopback OAuth flow: it listens on a free localhost port,
-// opens the browser to the registry's CLI-login endpoint, and waits for the
-// /callback redirect carrying the plaintext token. It fatals on error or timeout.
-func browserLogin(base string) string {
-	return browserLoginContext(context.Background(), base)
-}
-
+// browserLoginContext runs the loopback OAuth flow: it listens on a free
+// localhost port, opens the browser to the registry's CLI-login endpoint, and
+// waits for the /callback redirect carrying the plaintext token. It fatals on
+// error or timeout.
 func browserLoginContext(ctx context.Context, base string) string {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -168,20 +161,6 @@ func browserLoginContext(ctx context.Context, base string) string {
 	}
 }
 
-// githubDeviceLogin runs GitHub's OAuth device flow (RFC 8628) and exchanges the
-// resulting GitHub token for a wago API token. It's the login path for
-// headless/remote machines: the user enters a code at github.com/login/device
-// instead of relying on a localhost redirect.
-//
-// The registry advertises its GitHub OAuth client_id (GET /api/auth/github/client)
-// so a self-hosted registry with its own OAuth app works without recompiling the
-// CLI. The CLI talks to GitHub directly for the device + access token, then hands
-// the GitHub token to the registry (POST /api/auth/github/exchange), which
-// verifies the token belongs to its app and returns a wago token.
-func githubDeviceLogin(base string) string {
-	return githubDeviceLoginContext(context.Background(), base)
-}
-
 const (
 	defaultDeviceFlowLifetime = 15 * time.Minute
 	maximumDeviceFlowLifetime = 20 * time.Minute
@@ -209,6 +188,16 @@ func deviceFlowTiming(expiresIn, interval int) (lifetime, pollInterval time.Dura
 	return lifetime, pollInterval
 }
 
+// githubDeviceLoginContext runs GitHub's OAuth device flow (RFC 8628) and
+// exchanges the resulting GitHub token for a wago API token. It's the login path
+// for headless/remote machines: the user enters a code at github.com/login/device
+// instead of relying on a localhost redirect.
+//
+// The registry advertises its GitHub OAuth client_id (GET /api/auth/github/client)
+// so a self-hosted registry with its own OAuth app works without recompiling the
+// CLI. The CLI talks to GitHub directly for the device + access token, then hands
+// the GitHub token to the registry (POST /api/auth/github/exchange), which
+// verifies the token belongs to its app and returns a wago token.
 func githubDeviceLoginContext(ctx context.Context, base string) string {
 	// 1. Ask the registry which GitHub OAuth app to authenticate against.
 	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/auth/github/client", "", nil)

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -182,6 +182,33 @@ func githubDeviceLogin(base string) string {
 	return githubDeviceLoginContext(context.Background(), base)
 }
 
+const (
+	defaultDeviceFlowLifetime = 15 * time.Minute
+	maximumDeviceFlowLifetime = 20 * time.Minute
+	defaultDevicePollInterval = 5 * time.Second
+	maximumDevicePollInterval = 60 * time.Second
+)
+
+func deviceFlowTiming(expiresIn, interval int) (lifetime, pollInterval time.Duration) {
+	lifetime = defaultDeviceFlowLifetime
+	if expiresIn > 0 {
+		if expiresIn > int(maximumDeviceFlowLifetime/time.Second) {
+			lifetime = maximumDeviceFlowLifetime
+		} else {
+			lifetime = time.Duration(expiresIn) * time.Second
+		}
+	}
+	pollInterval = defaultDevicePollInterval
+	if interval > 0 {
+		if interval > int(maximumDevicePollInterval/time.Second) {
+			pollInterval = maximumDevicePollInterval
+		} else {
+			pollInterval = time.Duration(interval) * time.Second
+		}
+	}
+	return lifetime, pollInterval
+}
+
 func githubDeviceLoginContext(ctx context.Context, base string) string {
 	// 1. Ask the registry which GitHub OAuth app to authenticate against.
 	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/auth/github/client", "", nil)
@@ -225,14 +252,7 @@ func githubDeviceLoginContext(ctx context.Context, base string) string {
 		fatal("login: GitHub returned an incomplete device authorization response")
 	}
 
-	interval := dc.Interval
-	if interval <= 0 {
-		interval = 5 // RFC 8628 §3.5 default
-	}
-	expiresIn := dc.ExpiresIn
-	if expiresIn <= 0 {
-		expiresIn = 15 * 60
-	}
+	lifetime, pollInterval := deviceFlowTiming(dc.ExpiresIn, dc.Interval)
 	verifyURI := dc.VerificationURI
 	if verifyURI == "" {
 		verifyURI = "https://github.com/login/device"
@@ -246,14 +266,18 @@ func githubDeviceLoginContext(ctx context.Context, base string) string {
 
 	// 3. Poll GitHub for the access token until the user authorizes or it expires.
 	var ghToken string
-	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
+	deadline := time.Now().Add(lifetime)
 	for time.Now().Before(deadline) {
-		timer := time.NewTimer(time.Duration(interval) * time.Second)
+		wait := min(pollInterval, time.Until(deadline))
+		timer := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
 			fatal("login: %v", ctx.Err())
 		case <-timer.C:
+		}
+		if !time.Now().Before(deadline) {
+			break
 		}
 		var tr struct {
 			AccessToken string `json:"access_token"`
@@ -274,7 +298,9 @@ func githubDeviceLoginContext(ctx context.Context, base string) string {
 		case "authorization_pending":
 			// not authorized yet — keep polling
 		case "slow_down":
-			interval += 5 // RFC 8628 §3.5: back off by 5s on slow_down
+			// RFC 8628 §3.5 asks for a five-second backoff. Keep the
+			// server-controlled interval within the command's bounded policy.
+			pollInterval = min(pollInterval+5*time.Second, maximumDevicePollInterval)
 		case "access_denied":
 			fatal("login: authorization was denied on GitHub")
 		case "expired_token":
@@ -315,16 +341,13 @@ func registryLogout() {
 
 func registryLogoutContext(ctx context.Context) {
 	base := registryBase()
-	creds, err := loadCredentials()
+	removed, err := deleteCredentialsResultContext(ctx, base)
 	if err != nil {
-		fatal("logout: reading credentials: %v", err)
+		fatal("logout: %v", err)
 	}
-	if _, ok := creds[base]; !ok {
+	if !removed {
 		fmt.Printf("%s Not logged in to %s\n", dim("·"), base)
 		return
-	}
-	if err := deleteCredentialsContext(ctx, base); err != nil {
-		fatal("logout: %v", err)
 	}
 	fmt.Printf("%s Logged out of %s\n", cyan("✓"), base)
 }

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -12,6 +12,14 @@ import (
 	"time"
 
 	"github.com/wago-org/wago/cli/internal/automation"
+	"github.com/wago-org/wago/internal/httpclient"
+)
+
+const registryResponseLimit int64 = 4 << 20
+
+var (
+	registryResponseMaximum = registryResponseLimit
+	registryHTTP            = httpclient.NewAPI()
 )
 
 // errUnauthorized marks a 401 from the registry (used to distinguish "not logged
@@ -31,6 +39,10 @@ type meResponse struct {
 // bearer token (when non-empty) and an optional JSON body, returning the status
 // code and raw response bytes.
 func apiRequest(method, path, token string, body any) (int, []byte, error) {
+	return apiRequestContext(context.Background(), method, path, token, body)
+}
+
+func apiRequestContext(ctx context.Context, method, path, token string, body any) (int, []byte, error) {
 	if err := automation.RequireOnline("registry request"); err != nil {
 		return 0, nil, err
 	}
@@ -42,7 +54,7 @@ func apiRequest(method, path, token string, body any) (int, []byte, error) {
 		}
 		reader = bytes.NewReader(b)
 	}
-	req, err := http.NewRequest(method, registryBase()+path, reader)
+	req, err := http.NewRequestWithContext(ctx, method, registryBase()+path, reader)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -52,22 +64,18 @@ func apiRequest(method, path, token string, body any) (int, []byte, error) {
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return 0, nil, err
-	}
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return resp.StatusCode, nil, err
-	}
-	return resp.StatusCode, data, nil
+	response, err := registryHTTP.Bytes(ctx, req, registryResponseMaximum)
+	return response.StatusCode, response.Body, err
 }
 
 // recordRegistryInstall reports one successfully installed plugin to the public
 // registry. Metrics must never make `wago add` fail, and the short timeout keeps
 // full-module installs usable when the registry is offline.
 func recordRegistryInstall(module, version string) {
+	recordRegistryInstallContext(context.Background(), module, version)
+}
+
+func recordRegistryInstallContext(parent context.Context, module, version string) {
 	if automation.Offline() {
 		return
 	}
@@ -75,7 +83,7 @@ func recordRegistryInstall(module, version string) {
 	if err != nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 	path := "/api/packages/" + url.PathEscape(module) + "/installs"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registryBase()+path, bytes.NewReader(body))
@@ -83,12 +91,7 @@ func recordRegistryInstall(module, version string) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return
-	}
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
+	_, _ = registryHTTP.Bytes(ctx, req, 4<<10)
 }
 
 // apiError extracts the {"error":...} message from a response body, falling back
@@ -105,7 +108,11 @@ func apiError(status int, data []byte) string {
 
 // fetchMe calls GET /api/me and returns the user, or errUnauthorized on a 401.
 func fetchMe(token string) (meResponse, error) {
-	status, data, err := apiRequest(http.MethodGet, "/api/me", token, nil)
+	return fetchMeContext(context.Background(), token)
+}
+
+func fetchMeContext(ctx context.Context, token string) (meResponse, error) {
+	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/me", token, nil)
 	if err != nil {
 		return meResponse{}, err
 	}

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -1,11 +1,16 @@
 package registry
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/wago-org/wago/internal/httpclient"
 )
 
 func TestRegistryHTTPHelpers(t *testing.T) {
@@ -50,6 +55,43 @@ func TestRegistryHTTPHelpers(t *testing.T) {
 	}
 	if got := apiError(http.StatusBadRequest, []byte("not json")); got != "server returned status 400" {
 		t.Fatalf("apiError fallback = %q", got)
+	}
+}
+
+func TestRegistryRequestIsBoundedAndCancelable(t *testing.T) {
+	oldMaximum := registryResponseMaximum
+	registryResponseMaximum = 32
+	t.Cleanup(func() { registryResponseMaximum = oldMaximum })
+
+	oversized := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.(http.Flusher).Flush()
+		_, _ = w.Write([]byte(strings.Repeat("x", 33)))
+	}))
+	defer oversized.Close()
+	t.Setenv("WAGO_REGISTRY", oversized.URL)
+	if _, _, err := apiRequestContext(context.Background(), http.MethodGet, "/oversized", "", nil); !errors.Is(err, httpclient.ErrBodyTooLarge) {
+		t.Fatalf("oversized registry response = %v", err)
+	}
+
+	stalled := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		<-request.Context().Done()
+	}))
+	defer stalled.Close()
+	t.Setenv("WAGO_REGISTRY", stalled.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := apiRequestContext(ctx, http.MethodGet, "/stalled", "", nil)
+		done <- err
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled registry response = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled registry request did not return")
 	}
 }
 

--- a/cli/manager/internal/registry/config.go
+++ b/cli/manager/internal/registry/config.go
@@ -9,11 +9,17 @@ package registry
 // XDG config directory on Linux, unless WAGO_HOME overrides both.
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
+	"github.com/wago-org/wago/internal/atomicfile"
+	"github.com/wago-org/wago/internal/filelock"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
@@ -116,42 +122,99 @@ func loadCredentials() (map[string]credential, error) {
 	return creds, nil
 }
 
-// saveCredentials records token+login for base, preserving other registries'
-// entries, and writes the file with 0600 permissions.
+// saveCredentials records token+login for base while holding the cross-process
+// credential-store lock, preserving other registries' latest entries.
 func saveCredentials(base, token, login string) error {
-	creds, err := loadCredentials()
-	if err != nil {
-		return err
-	}
-	creds[base] = credential{Token: token, Login: login}
-	return writeCredentials(creds)
+	return saveCredentialsContext(context.Background(), base, token, login)
+}
+
+func saveCredentialsContext(ctx context.Context, base, token, login string) error {
+	return mutateCredentials(ctx, func(creds map[string]credential) bool {
+		creds[base] = credential{Token: token, Login: login}
+		return true
+	})
 }
 
 // deleteCredentials removes the stored entry for base (a no-op if none exists).
 func deleteCredentials(base string) error {
-	creds, err := loadCredentials()
+	return deleteCredentialsContext(context.Background(), base)
+}
+
+func deleteCredentialsContext(ctx context.Context, base string) error {
+	return mutateCredentials(ctx, func(creds map[string]credential) bool {
+		if _, ok := creds[base]; !ok {
+			return false
+		}
+		delete(creds, base)
+		return true
+	})
+}
+
+func mutateCredentials(ctx context.Context, mutate func(map[string]credential) bool) error {
+	path := credentialsPath()
+	if err := prepareCredentialDirectory(filepath.Dir(path)); err != nil {
+		return err
+	}
+	lock, err := filelock.Acquire(ctx, path+".lock")
 	if err != nil {
 		return err
 	}
-	if _, ok := creds[base]; !ok {
-		return nil
+	creds, operationErr := loadCredentials()
+	if operationErr == nil && mutate(creds) {
+		operationErr = writeCredentialsLocked(path, creds)
 	}
-	delete(creds, base)
-	return writeCredentials(creds)
+	return errors.Join(operationErr, lock.Close())
 }
 
-// writeCredentials serializes the credential map to disk (0600), creating the
-// parent directory if needed.
+// writeCredentials replaces the complete credential map under the same lock
+// used by mutations. Existing malformed data is rejected rather than silently
+// overwritten.
 func writeCredentials(creds map[string]credential) error {
 	path := credentialsPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	if err := prepareCredentialDirectory(filepath.Dir(path)); err != nil {
 		return err
 	}
+	lock, err := filelock.Acquire(context.Background(), path+".lock")
+	if err != nil {
+		return err
+	}
+	_, operationErr := loadCredentials()
+	if operationErr == nil {
+		operationErr = writeCredentialsLocked(path, creds)
+	}
+	return errors.Join(operationErr, lock.Close())
+}
+
+var (
+	replaceCredentialFile = atomicfile.ReplaceFile
+	credentialAtomicHooks *atomicfile.Hooks
+)
+
+func writeCredentialsLocked(path string, creds map[string]credential) error {
 	data, err := json.MarshalIndent(creds, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(data, '\n'), 0o600)
+	data = append(data, '\n')
+	return replaceCredentialFile(path, atomicfile.Options{Mode: 0o600, Sync: true, Hooks: credentialAtomicHooks}, func(writer io.Writer) error {
+		_, err := writer.Write(data)
+		return err
+	})
+}
+
+func prepareCredentialDirectory(directory string) error {
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return err
+	}
+	// Windows mode bits do not provide ACL-equivalent privacy guarantees. The
+	// file remains atomically replaced there, while native ACL hardening is a
+	// separate platform concern.
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(directory, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // resolveToken returns the API token for the current registry: WAGO_TOKEN wins,

--- a/cli/manager/internal/registry/config.go
+++ b/cli/manager/internal/registry/config.go
@@ -119,6 +119,9 @@ func loadCredentials() (map[string]credential, error) {
 	if err := json.Unmarshal(data, &creds); err != nil {
 		return nil, err
 	}
+	if creds == nil {
+		return nil, errors.New("credential store must be a JSON object")
+	}
 	return creds, nil
 }
 
@@ -129,10 +132,11 @@ func saveCredentials(base, token, login string) error {
 }
 
 func saveCredentialsContext(ctx context.Context, base, token, login string) error {
-	return mutateCredentials(ctx, func(creds map[string]credential) bool {
+	_, err := mutateCredentials(ctx, func(creds map[string]credential) bool {
 		creds[base] = credential{Token: token, Login: login}
 		return true
 	})
+	return err
 }
 
 // deleteCredentials removes the stored entry for base (a no-op if none exists).
@@ -141,6 +145,11 @@ func deleteCredentials(base string) error {
 }
 
 func deleteCredentialsContext(ctx context.Context, base string) error {
+	_, err := deleteCredentialsResultContext(ctx, base)
+	return err
+}
+
+func deleteCredentialsResultContext(ctx context.Context, base string) (bool, error) {
 	return mutateCredentials(ctx, func(creds map[string]credential) bool {
 		if _, ok := creds[base]; !ok {
 			return false
@@ -150,20 +159,30 @@ func deleteCredentialsContext(ctx context.Context, base string) error {
 	})
 }
 
-func mutateCredentials(ctx context.Context, mutate func(map[string]credential) bool) error {
+func mutateCredentials(ctx context.Context, mutate func(map[string]credential) bool) (bool, error) {
+	if ctx == nil {
+		return false, errors.New("nil credential mutation context")
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
 	path := credentialsPath()
 	if err := prepareCredentialDirectory(filepath.Dir(path)); err != nil {
-		return err
+		return false, err
 	}
 	lock, err := filelock.Acquire(ctx, path+".lock")
 	if err != nil {
-		return err
+		return false, err
 	}
 	creds, operationErr := loadCredentials()
-	if operationErr == nil && mutate(creds) {
-		operationErr = writeCredentialsLocked(path, creds)
+	changed := false
+	if operationErr == nil {
+		changed = mutate(creds)
+		if changed {
+			operationErr = writeCredentialsLocked(path, creds)
+		}
 	}
-	return errors.Join(operationErr, lock.Close())
+	return changed, errors.Join(operationErr, lock.Close())
 }
 
 // writeCredentials replaces the complete credential map under the same lock
@@ -191,6 +210,9 @@ var (
 )
 
 func writeCredentialsLocked(path string, creds map[string]credential) error {
+	if creds == nil {
+		return errors.New("credential store must be a JSON object")
+	}
 	data, err := json.MarshalIndent(creds, "", "  ")
 	if err != nil {
 		return err

--- a/cli/manager/internal/registry/config_hardening_test.go
+++ b/cli/manager/internal/registry/config_hardening_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/wago-org/wago/internal/atomicfile"
@@ -279,6 +280,12 @@ func TestCredentialTemporaryFileIsPrivateAndReadersSeeCompleteJSON(t *testing.T)
 			}
 			data, err := os.ReadFile(credentialsPath())
 			if err != nil {
+				// MoveFileEx can briefly exclude readers while replacing a file on
+				// Windows. That is a transient sharing condition, not a partial
+				// credential document.
+				if runtime.GOOS == "windows" && (errors.Is(err, syscall.Errno(5)) || errors.Is(err, syscall.Errno(32))) {
+					continue
+				}
 				readerDone <- err
 				return
 			}

--- a/cli/manager/internal/registry/config_hardening_test.go
+++ b/cli/manager/internal/registry/config_hardening_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -15,6 +16,60 @@ import (
 
 	"github.com/wago-org/wago/internal/atomicfile"
 )
+
+func TestCredentialMutationRejectsPreCanceledContextWithoutCreatingStore(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("WAGO_HOME", root)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := saveCredentialsContext(ctx, "https://one.test", "token", "one"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-canceled credential save = %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(credentialsPath())); !os.IsNotExist(err) {
+		t.Fatalf("pre-canceled credential save created store: %v", err)
+	}
+}
+
+func TestCredentialMutationRejectsNullStoreWithoutOverwritingIt(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(credentialsPath(), []byte("null\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveCredentials("https://one.test", "token", "one"); err == nil {
+		t.Fatal("credential save accepted a null store")
+	}
+	data, err := os.ReadFile(credentialsPath())
+	if err != nil || string(data) != "null\n" {
+		t.Fatalf("null credential store changed to %q: %v", data, err)
+	}
+	assertNoCredentialTemps(t)
+}
+
+func TestCredentialMutationRejectsSymlinkDestination(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "target.json")
+	original := []byte("{}\n")
+	if err := os.WriteFile(target, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, credentialsPath()); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := saveCredentials("https://one.test", "token", "one"); err == nil {
+		t.Fatal("credential save accepted a symlink destination")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != string(original) {
+		t.Fatalf("credential symlink target changed to %q: %v", data, err)
+	}
+	assertNoCredentialTemps(t)
+}
 
 func TestCredentialUpdateRepairsPrivateMode(t *testing.T) {
 	root := t.TempDir()

--- a/cli/manager/internal/registry/config_hardening_test.go
+++ b/cli/manager/internal/registry/config_hardening_test.go
@@ -1,0 +1,255 @@
+package registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/wago-org/wago/internal/atomicfile"
+)
+
+func TestCredentialUpdateRepairsPrivateMode(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("WAGO_HOME", root)
+	if err := saveCredentials("https://one.test", "token-one", "one"); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" {
+		return
+	}
+	if err := os.Chmod(credentialsPath(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveCredentials("https://two.test", "token-two", "two"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(credentialsPath())
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("credential mode = %v, %v", info, err)
+	}
+	directory, err := os.Stat(filepath.Dir(credentialsPath()))
+	if err != nil || directory.Mode().Perm() != 0o700 {
+		t.Fatalf("credential directory mode = %v, %v", directory, err)
+	}
+}
+
+func TestConcurrentCredentialMutationsPreserveUnrelatedEntries(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	var wait sync.WaitGroup
+	errorsChannel := make(chan error, 2)
+	for _, item := range []struct{ base, token string }{
+		{"https://one.test", "token-one"},
+		{"https://two.test", "token-two"},
+	} {
+		item := item
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			errorsChannel <- saveCredentials(item.base, item.token, item.base)
+		}()
+	}
+	wait.Wait()
+	close(errorsChannel)
+	for err := range errorsChannel {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	creds, err := loadCredentials()
+	if err != nil || creds["https://one.test"].Token != "token-one" || creds["https://two.test"].Token != "token-two" {
+		t.Fatalf("credentials = %#v, %v", creds, err)
+	}
+
+	if err := saveCredentials("https://delete.test", "delete", "delete"); err != nil {
+		t.Fatal(err)
+	}
+	errorsChannel = make(chan error, 2)
+	wait.Add(2)
+	go func() {
+		defer wait.Done()
+		errorsChannel <- saveCredentials("https://one.test", "updated", "one")
+	}()
+	go func() {
+		defer wait.Done()
+		errorsChannel <- deleteCredentials("https://delete.test")
+	}()
+	wait.Wait()
+	close(errorsChannel)
+	for err := range errorsChannel {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	creds, err = loadCredentials()
+	if err != nil || creds["https://one.test"].Token != "updated" {
+		t.Fatalf("serialized save/delete = %#v, %v", creds, err)
+	}
+	if _, exists := creds["https://delete.test"]; exists {
+		t.Fatal("concurrent delete was lost")
+	}
+}
+
+func TestCredentialProcessesSerialize(t *testing.T) {
+	if os.Getenv("WAGO_TEST_CREDENTIAL_HELPER") == "1" {
+		if err := saveCredentials(os.Getenv("WAGO_TEST_BASE"), os.Getenv("WAGO_TEST_TOKEN"), "helper"); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	root := t.TempDir()
+	const count = 4
+	commands := make([]*exec.Cmd, count)
+	outputs := make([]bytes.Buffer, count)
+	for index := range count {
+		commands[index] = exec.Command(os.Args[0], "-test.run=^TestCredentialProcessesSerialize$")
+		commands[index].Env = append(os.Environ(),
+			"WAGO_TEST_CREDENTIAL_HELPER=1",
+			"WAGO_HOME="+root,
+			"WAGO_TEST_BASE=https://registry-"+string(rune('a'+index))+".test",
+			"WAGO_TEST_TOKEN=token-"+string(rune('a'+index)),
+		)
+		commands[index].Stdout = &outputs[index]
+		commands[index].Stderr = &outputs[index]
+		if err := commands[index].Start(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for index, command := range commands {
+		if err := command.Wait(); err != nil {
+			t.Fatalf("credential helper: %v\n%s", err, outputs[index].String())
+		}
+	}
+	t.Setenv("WAGO_HOME", root)
+	creds, err := loadCredentials()
+	if err != nil || len(creds) != count {
+		t.Fatalf("cross-process credentials = %#v, %v", creds, err)
+	}
+}
+
+func TestCredentialPublicationFailuresPreserveOldFile(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	if err := saveCredentials("https://old.test", "old-token", "old"); err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.ReadFile(credentialsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	injected := errors.New("injected credential publication failure")
+	tests := []struct {
+		name    string
+		replace func(string, atomicfile.Options, func(io.Writer) error) error
+		hooks   *atomicfile.Hooks
+	}{
+		{name: "write", replace: func(path string, options atomicfile.Options, write func(io.Writer) error) error {
+			return atomicfile.ReplaceFile(path, options, func(writer io.Writer) error {
+				_, _ = io.WriteString(writer, "token-bearing partial")
+				return injected
+			})
+		}},
+		{name: "sync", hooks: &atomicfile.Hooks{Sync: func(*os.File) error { return injected }}},
+		{name: "close", hooks: &atomicfile.Hooks{Close: func(file *os.File) error {
+			_ = file.Close()
+			return injected
+		}}},
+		{name: "replace", hooks: &atomicfile.Hooks{Replace: func(_, _ string) error { return injected }}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oldReplace, oldHooks := replaceCredentialFile, credentialAtomicHooks
+			t.Cleanup(func() {
+				replaceCredentialFile, credentialAtomicHooks = oldReplace, oldHooks
+			})
+			if test.replace != nil {
+				replaceCredentialFile = test.replace
+			}
+			credentialAtomicHooks = test.hooks
+			err := saveCredentials("https://new.test", "super-secret-token", "new")
+			if err == nil {
+				t.Fatal("injected failure was not returned")
+			}
+			if strings.Contains(err.Error(), "super-secret-token") {
+				t.Fatalf("error leaked token: %v", err)
+			}
+			got, readErr := os.ReadFile(credentialsPath())
+			if readErr != nil || string(got) != string(original) {
+				t.Fatalf("old credentials changed: %q, %v", got, readErr)
+			}
+			assertNoCredentialTemps(t)
+		})
+	}
+}
+
+func TestCredentialTemporaryFileIsPrivateAndReadersSeeCompleteJSON(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	oldReplace := replaceCredentialFile
+	t.Cleanup(func() { replaceCredentialFile = oldReplace })
+	checked := false
+	replaceCredentialFile = func(path string, options atomicfile.Options, write func(io.Writer) error) error {
+		return atomicfile.ReplaceFile(path, options, func(writer io.Writer) error {
+			if file, ok := writer.(*os.File); ok && runtime.GOOS != "windows" {
+				info, err := file.Stat()
+				if err != nil || info.Mode().Perm() != 0o600 {
+					t.Fatalf("temporary credential mode = %v, %v", info, err)
+				}
+				checked = true
+			}
+			return write(writer)
+		})
+	}
+	if err := saveCredentials("https://one.test", "one", "one"); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && !checked {
+		t.Fatal("temporary credential file was not inspected")
+	}
+
+	readerDone := make(chan error, 1)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				readerDone <- nil
+				return
+			default:
+			}
+			data, err := os.ReadFile(credentialsPath())
+			if err != nil {
+				readerDone <- err
+				return
+			}
+			var creds map[string]credential
+			if err := json.Unmarshal(data, &creds); err != nil {
+				readerDone <- err
+				return
+			}
+		}
+	}()
+	for index := range 50 {
+		if err := saveCredentials("https://one.test", strings.Repeat("x", 1024)+string(rune(index)), "one"); err != nil {
+			close(stop)
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	if err := <-readerDone; err != nil {
+		t.Fatalf("reader observed incomplete credentials: %v", err)
+	}
+}
+
+func assertNoCredentialTemps(t *testing.T) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(credentialsPath()), ".wago-atomic-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("credential temporary debris = %v, %v", matches, err)
+	}
+}

--- a/cli/manager/internal/registry/oauth.go
+++ b/cli/manager/internal/registry/oauth.go
@@ -1,10 +1,11 @@
 package registry
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"io"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os/exec"
@@ -14,33 +15,37 @@ import (
 	"github.com/wago-org/wago/cli/internal/automation"
 )
 
+var oauthResponseMaximum int64 = 1 << 20
+
 const SuccessHTML = `<!doctype html><html><head><meta charset="utf-8">` +
 	`<title>wago — logged in</title></head>` +
 	`<body style="font-family:system-ui,sans-serif;text-align:center;padding:4rem">` +
 	`<h1>You're logged in ✓</h1><p>You can close this tab and return to your terminal.</p>` +
 	`</body></html>`
 
-// PostForm sends a GitHub OAuth form request and decodes its JSON response.
+// PostForm sends a GitHub OAuth form request and decodes its bounded JSON response.
 func PostForm(endpoint string, form url.Values, output any) error {
+	return PostFormContext(context.Background(), endpoint, form, output)
+}
+
+func PostFormContext(ctx context.Context, endpoint string, form url.Values, output any) error {
 	if err := automation.RequireOnline("authentication request"); err != nil {
 		return err
 	}
-	request, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return err
 	}
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	response, err := http.DefaultClient.Do(request)
+	response, err := registryHTTP.Bytes(ctx, request, oauthResponseMaximum)
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
-	if err != nil {
-		return err
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("OAuth endpoint returned %s", response.Status)
 	}
-	return json.Unmarshal(data, output)
+	return json.Unmarshal(response.Body, output)
 }
 
 func OpenBrowser(target string) error {

--- a/cli/manager/internal/registry/oauth_test.go
+++ b/cli/manager/internal/registry/oauth_test.go
@@ -7,9 +7,30 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/internal/httpclient"
 )
+
+func TestDeviceFlowTimingIsBounded(t *testing.T) {
+	for _, test := range []struct {
+		name                string
+		expiresIn, interval int
+		wantLifetime        time.Duration
+		wantInterval        time.Duration
+	}{
+		{name: "defaults", wantLifetime: defaultDeviceFlowLifetime, wantInterval: defaultDevicePollInterval},
+		{name: "server values", expiresIn: 600, interval: 10, wantLifetime: 10 * time.Minute, wantInterval: 10 * time.Second},
+		{name: "huge values", expiresIn: int(^uint(0) >> 1), interval: int(^uint(0) >> 1), wantLifetime: maximumDeviceFlowLifetime, wantInterval: maximumDevicePollInterval},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lifetime, interval := deviceFlowTiming(test.expiresIn, test.interval)
+			if lifetime != test.wantLifetime || interval != test.wantInterval {
+				t.Fatalf("device timing = %v/%v, want %v/%v", lifetime, interval, test.wantLifetime, test.wantInterval)
+			}
+		})
+	}
+}
 
 func TestOAuthHelpers(t *testing.T) {
 	state, err := RandomState()

--- a/cli/manager/internal/registry/oauth_test.go
+++ b/cli/manager/internal/registry/oauth_test.go
@@ -1,11 +1,14 @@
 package registry
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/wago-org/wago/internal/httpclient"
 )
 
 func TestOAuthHelpers(t *testing.T) {
@@ -22,6 +25,17 @@ func TestOAuthHelpers(t *testing.T) {
 	}
 	if err := PostForm(server.URL, url.Values{"scope": {"read write"}}, &reply); err != nil || !reply.OK {
 		t.Fatalf("PostForm = %+v, %v", reply, err)
+	}
+	oldMaximum := oauthResponseMaximum
+	oauthResponseMaximum = 16
+	t.Cleanup(func() { oauthResponseMaximum = oldMaximum })
+	oversized := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.(http.Flusher).Flush()
+		_, _ = w.Write([]byte(strings.Repeat("x", 17)))
+	}))
+	defer oversized.Close()
+	if err := PostForm(oversized.URL, url.Values{}, &reply); !errors.Is(err, httpclient.ErrBodyTooLarge) {
+		t.Fatalf("oversized OAuth response = %v", err)
 	}
 	if !strings.Contains(SuccessHTML, "logged in") {
 		t.Fatal("login success HTML missing confirmation")

--- a/cli/manager/internal/registry/packages.go
+++ b/cli/manager/internal/registry/packages.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,7 +12,11 @@ import (
 // closestModule returns the nearest package id in the registry when it is a
 // plausible typo. Suggestions are best-effort and never block installation.
 func closestModule(module string) string {
-	status, data, err := apiRequest(http.MethodGet, "/api/packages", "", nil)
+	return closestModuleContext(context.Background(), module)
+}
+
+func closestModuleContext(ctx context.Context, module string) string {
+	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/packages", "", nil)
 	if err != nil || status != http.StatusOK {
 		return ""
 	}
@@ -61,7 +66,11 @@ func editDistance(a, b string) int {
 }
 
 func resolveRegistryModule(name string) (string, error) {
-	status, data, err := apiRequest(http.MethodGet, "/api/packages/"+url.PathEscape(name), "", nil)
+	return resolveRegistryModuleContext(context.Background(), name)
+}
+
+func resolveRegistryModuleContext(ctx context.Context, name string) (string, error) {
+	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/packages/"+url.PathEscape(name), "", nil)
 	if err != nil {
 		return "", err
 	}

--- a/cli/manager/internal/registry/publish.go
+++ b/cli/manager/internal/registry/publish.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +13,10 @@ import (
 )
 
 func registryPublish(options PublishRequest) {
+	registryPublishContext(context.Background(), options)
+}
+
+func registryPublishContext(ctx context.Context, options PublishRequest) {
 	manifestPath := options.Manifest
 	var ver string
 	commit := options.Commit
@@ -80,7 +85,7 @@ func registryPublish(options PublishRequest) {
 		body["unpackedKB"] = kb
 	}
 
-	status, data, err := apiRequest(http.MethodPost, "/api/publish", token, body)
+	status, data, err := apiRequestContext(ctx, http.MethodPost, "/api/publish", token, body)
 	if err != nil {
 		fatal("publish: %v", err)
 	}
@@ -102,6 +107,10 @@ func registryPublish(options PublishRequest) {
 // registryUnpublish removes a whole package, or a single version when the
 // argument carries an @version suffix. It confirms first unless --yes is given.
 func registryUnpublish(options UnpublishRequest) {
+	registryUnpublishContext(context.Background(), options)
+}
+
+func registryUnpublishContext(ctx context.Context, options UnpublishRequest) {
 	yes := options.Yes
 	token := resolveToken()
 	if token == "" {
@@ -121,7 +130,7 @@ func registryUnpublish(options UnpublishRequest) {
 	if ver != "" {
 		path += "/versions/" + url.PathEscape(ver)
 	}
-	status, data, err := apiRequest(http.MethodDelete, path, token, nil)
+	status, data, err := apiRequestContext(ctx, http.MethodDelete, path, token, nil)
 	if err != nil {
 		fatal("unpublish: %v", err)
 	}
@@ -142,6 +151,10 @@ func registryUnpublish(options UnpublishRequest) {
 // registryDeprecate marks a package (or a specific @version) deprecated, or
 // reverses it with --undo. --message sets the deprecation notice.
 func registryDeprecate(options DeprecateRequest) {
+	registryDeprecateContext(context.Background(), options)
+}
+
+func registryDeprecateContext(ctx context.Context, options DeprecateRequest) {
 	undo := options.Undo
 	message := options.Message
 	token := resolveToken()
@@ -156,7 +169,7 @@ func registryDeprecate(options DeprecateRequest) {
 
 	body := map[string]any{"message": message, "version": ver, "undo": undo}
 	path := "/api/packages/" + url.PathEscape(name) + "/deprecate"
-	status, data, err := apiRequest(http.MethodPost, path, token, body)
+	status, data, err := apiRequestContext(ctx, http.MethodPost, path, token, body)
 	if err != nil {
 		fatal("deprecate: %v", err)
 	}

--- a/cli/manager/internal/registry/registry.go
+++ b/cli/manager/internal/registry/registry.go
@@ -2,6 +2,8 @@
 // registry credentials for the Wago manager.
 package registry
 
+import "context"
+
 type LoginRequest struct {
 	Link, Code, WithToken bool
 	Token                 string
@@ -21,12 +23,36 @@ type DeprecateRequest struct {
 	Undo            bool
 }
 
-func Login(request LoginRequest)                { registryLogin(request) }
-func Logout()                                   { registryLogout() }
-func Whoami()                                   { registryWhoami() }
-func Publish(request PublishRequest)            { registryPublish(request) }
-func Unpublish(request UnpublishRequest)        { registryUnpublish(request) }
-func Deprecate(request DeprecateRequest)        { registryDeprecate(request) }
-func ResolveModule(name string) (string, error) { return resolveRegistryModule(name) }
-func RecordInstall(module, version string)      { recordRegistryInstall(module, version) }
-func Closest(module string) string              { return closestModule(module) }
+func Login(request LoginRequest)         { registryLogin(request) }
+func Logout()                            { registryLogout() }
+func Whoami()                            { registryWhoami() }
+func Publish(request PublishRequest)     { registryPublish(request) }
+func Unpublish(request UnpublishRequest) { registryUnpublish(request) }
+func Deprecate(request DeprecateRequest) { registryDeprecate(request) }
+func ResolveModule(name string) (string, error) {
+	return resolveRegistryModule(name)
+}
+func RecordInstall(module, version string) { recordRegistryInstall(module, version) }
+func RecordInstallContext(ctx context.Context, module, version string) {
+	recordRegistryInstallContext(ctx, module, version)
+}
+func Closest(module string) string { return closestModule(module) }
+
+func LoginContext(ctx context.Context, request LoginRequest) { registryLoginContext(ctx, request) }
+func LogoutContext(ctx context.Context)                      { registryLogoutContext(ctx) }
+func WhoamiContext(ctx context.Context)                      { registryWhoamiContext(ctx) }
+func PublishContext(ctx context.Context, request PublishRequest) {
+	registryPublishContext(ctx, request)
+}
+func UnpublishContext(ctx context.Context, request UnpublishRequest) {
+	registryUnpublishContext(ctx, request)
+}
+func DeprecateContext(ctx context.Context, request DeprecateRequest) {
+	registryDeprecateContext(ctx, request)
+}
+func ResolveModuleContext(ctx context.Context, name string) (string, error) {
+	return resolveRegistryModuleContext(ctx, name)
+}
+func ClosestContext(ctx context.Context, module string) string {
+	return closestModuleContext(ctx, module)
+}

--- a/cli/manager/internal/self/manager.go
+++ b/cli/manager/internal/self/manager.go
@@ -2,6 +2,7 @@
 package self
 
 import (
+	"context"
 	"io"
 
 	"github.com/wago-org/wago/internal/wagopaths"
@@ -13,6 +14,10 @@ func ExecutablePath() string {
 
 func Update(current, executable string, force bool) {
 	selfUpdate(current, executable, force)
+}
+
+func UpdateContext(ctx context.Context, current, executable string, force bool) {
+	selfUpdateContext(ctx, current, executable, force)
 }
 
 func RequestedMode(value string, yes bool) (Mode, bool) {

--- a/cli/manager/internal/self/replace/replace_windows.go
+++ b/cli/manager/internal/self/replace/replace_windows.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/wago-org/wago/internal/atomicfile"
 )
 
 const (
@@ -69,7 +71,7 @@ func containsPath(parent, child string) bool {
 }
 
 func Executable(executable, staged string) (bool, error) {
-	if err := os.Rename(staged, executable); err == nil {
+	if err := atomicfile.ReplaceExisting(staged, executable); err == nil {
 		return false, nil
 	}
 	return true, scheduleMove(staged, executable, moveFileReplaceExisting|moveFileDelayUntilReboot)

--- a/cli/manager/internal/self/self.go
+++ b/cli/manager/internal/self/self.go
@@ -11,6 +11,7 @@ import (
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
 	selfreplace "github.com/wago-org/wago/cli/manager/internal/self/replace"
 	managerversion "github.com/wago-org/wago/cli/manager/internal/version"
+	"github.com/wago-org/wago/internal/atomicfile"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
@@ -113,18 +114,19 @@ func selfUpdateUsing(
 ) {
 	progress := managerprogress.NewProgress(os.Stderr)
 	progress.Title("Updating Wago")
-	staged := executable + ".new"
-	_ = os.Remove(staged)
 	channel := Channel(current)
 
 	resolved, sourceOnly, err := resolve(channel, progress)
 	if err != nil {
-		_ = os.Remove(staged)
 		fatal("self update: %v", err)
 	}
 	if !force && managerversion.SameRelease(current, resolved) {
 		progress.Finish("Wago is already up to date (" + managerversion.DisplayRelease(resolved) + ")")
 		return
+	}
+	staged, err := createSelfUpdateStage(executable)
+	if err != nil {
+		fatal("self update: prepare replacement: %v", err)
 	}
 	if err := install(resolved, staged, sourceOnly, progress); err != nil {
 		_ = os.Remove(staged)
@@ -141,6 +143,19 @@ func selfUpdateUsing(
 	}
 	progress.Finish("Updated Wago to " + managerversion.DisplayRelease(resolved))
 	printDetail(progress.Writer(), "location", displayPath(executable))
+}
+
+func createSelfUpdateStage(executable string) (string, error) {
+	file, err := atomicfile.CreateTemp(executable)
+	if err != nil {
+		return "", err
+	}
+	staged := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(staged)
+		return "", err
+	}
+	return staged, nil
 }
 
 func selfUninstall(

--- a/cli/manager/internal/self/self.go
+++ b/cli/manager/internal/self/self.go
@@ -1,6 +1,7 @@
 package self
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -90,13 +91,33 @@ var (
 )
 
 func selfUpdate(current, executable string, force bool) {
+	selfUpdateUsing(current, executable, force, resolveManagerUpdate, installManagerPayload)
+}
+
+func selfUpdateContext(ctx context.Context, current, executable string, force bool) {
+	selfUpdateUsing(current, executable, force,
+		func(channel string, progress *managerprogress.Progress) (string, bool, error) {
+			return managerversion.ResolveManagerUpdateContext(ctx, channel, progress)
+		},
+		func(resolved, destination string, sourceOnly bool, progress *managerprogress.Progress) error {
+			return managerversion.InstallManagerPayloadContext(ctx, resolved, destination, sourceOnly, progress)
+		},
+	)
+}
+
+func selfUpdateUsing(
+	current, executable string,
+	force bool,
+	resolve func(string, *managerprogress.Progress) (string, bool, error),
+	install func(string, string, bool, *managerprogress.Progress) error,
+) {
 	progress := managerprogress.NewProgress(os.Stderr)
 	progress.Title("Updating Wago")
 	staged := executable + ".new"
 	_ = os.Remove(staged)
 	channel := Channel(current)
 
-	resolved, sourceOnly, err := resolveManagerUpdate(channel, progress)
+	resolved, sourceOnly, err := resolve(channel, progress)
 	if err != nil {
 		_ = os.Remove(staged)
 		fatal("self update: %v", err)
@@ -105,7 +126,7 @@ func selfUpdate(current, executable string, force bool) {
 		progress.Finish("Wago is already up to date (" + managerversion.DisplayRelease(resolved) + ")")
 		return
 	}
-	if err := installManagerPayload(resolved, staged, sourceOnly, progress); err != nil {
+	if err := install(resolved, staged, sourceOnly, progress); err != nil {
 		_ = os.Remove(staged)
 		fatal("self update: %v", err)
 	}

--- a/cli/manager/internal/self/self_test.go
+++ b/cli/manager/internal/self/self_test.go
@@ -24,6 +24,32 @@ func setTestHome(t *testing.T, home string) {
 	}
 }
 
+func TestSelfUpdateStagesAreUniqueAndSameDirectory(t *testing.T) {
+	directory := t.TempDir()
+	executable := filepath.Join(directory, "wago")
+	if err := os.WriteFile(executable, []byte("manager"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	first, err := createSelfUpdateStage(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(first)
+	second, err := createSelfUpdateStage(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(second)
+	if first == second {
+		t.Fatalf("self-update stages collided at %q", first)
+	}
+	for _, staged := range []string{first, second} {
+		if filepath.Dir(staged) != directory {
+			t.Fatalf("self-update stage %q is not beside executable", staged)
+		}
+	}
+}
+
 func TestSelfUpdateSkipsMatchingManagerCommit(t *testing.T) {
 	executable := filepath.Join(t.TempDir(), "wago")
 	if err := os.WriteFile(executable, []byte("manager"), 0o755); err != nil {

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -76,9 +76,11 @@ func fetchReleases() ([]remoteRelease, error) {
 	return fetchReleasesContext(context.Background())
 }
 
+const discoveryPageLimit = 10
+
 func fetchReleasesContext(ctx context.Context) ([]remoteRelease, error) {
 	var releases []remoteRelease
-	for page := 1; ; page++ {
+	for page := 1; page <= discoveryPageLimit; page++ {
 		address := fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=100&page=%d", releaseAPI(), page)
 		response, err := getReleaseBytes(ctx, "release discovery", address, releaseMetadataMaximum)
 		if err != nil {
@@ -91,11 +93,15 @@ func fetchReleasesContext(ctx context.Context) ([]remoteRelease, error) {
 		if err := json.Unmarshal(response.Body, &batch); err != nil {
 			return nil, err
 		}
+		if len(batch) > 100 {
+			return nil, fmt.Errorf("GitHub returned too many releases on page %d", page)
+		}
 		releases = append(releases, batch...)
 		if len(batch) < 100 {
 			return releases, nil
 		}
 	}
+	return nil, fmt.Errorf("GitHub release discovery exceeded %d pages", discoveryPageLimit)
 }
 
 // vmUpdate resolves the moving channel before touching the installed runtime.
@@ -337,7 +343,7 @@ func fetchMainCommits() ([]remoteCommit, error) {
 
 func fetchMainCommitsContext(ctx context.Context) ([]remoteCommit, error) {
 	var commits []remoteCommit
-	for page := 1; ; page++ {
+	for page := 1; page <= discoveryPageLimit; page++ {
 		address := fmt.Sprintf("%s/repos/wago-org/wago/commits?sha=main&per_page=100&page=%d", releaseAPI(), page)
 		response, err := getReleaseBytes(ctx, "main commit discovery", address, releaseMetadataMaximum)
 		if err != nil {
@@ -350,11 +356,15 @@ func fetchMainCommitsContext(ctx context.Context) ([]remoteCommit, error) {
 		if err := json.Unmarshal(response.Body, &batch); err != nil {
 			return nil, err
 		}
+		if len(batch) > 100 {
+			return nil, fmt.Errorf("GitHub returned too many commits on page %d", page)
+		}
 		commits = append(commits, batch...)
 		if len(batch) < 100 {
 			return commits, nil
 		}
 	}
+	return nil, fmt.Errorf("GitHub commit discovery exceeded %d pages", discoveryPageLimit)
 }
 
 func latestChannelRelease(channel string) (string, error) {

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -15,18 +15,6 @@ import (
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
-func latestRelease() string {
-	release, err := latestStableRelease()
-	if err != nil {
-		fatal("version latest: %v", err)
-	}
-	return release
-}
-
-func latestStableRelease() (string, error) {
-	return latestStableReleaseContext(context.Background())
-}
-
 func latestStableReleaseContext(ctx context.Context) (string, error) {
 	response, err := getReleaseBytes(ctx, "release discovery", releaseAPI()+"/repos/wago-org/wago/releases/latest", releaseMetadataMaximum)
 	if err != nil {
@@ -42,10 +30,6 @@ func latestStableReleaseContext(ctx context.Context) (string, error) {
 		return "", errors.New("GitHub returned an invalid latest release")
 	}
 	return release.TagName, nil
-}
-
-func vmBrowse(d wagopaths.Dirs, profileValue, buildValue, use string) {
-	vmBrowseContext(context.Background(), d, profileValue, buildValue, use)
 }
 
 func vmBrowseContext(ctx context.Context, d wagopaths.Dirs, profileValue, buildValue, use string) {

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wago-org/wago/cli/internal/automation"
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
@@ -24,32 +24,36 @@ func latestRelease() string {
 }
 
 func latestStableRelease() (string, error) {
-	if err := automation.RequireOnline("release discovery"); err != nil {
-		return "", err
-	}
-	resp, err := http.Get(releaseAPI() + "/repos/wago-org/wago/releases/latest")
+	return latestStableReleaseContext(context.Background())
+}
+
+func latestStableReleaseContext(ctx context.Context) (string, error) {
+	response, err := getReleaseBytes(ctx, "release discovery", releaseAPI()+"/repos/wago-org/wago/releases/latest", releaseMetadataMaximum)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub returned %s", resp.Status)
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub returned %s", response.Status)
 	}
 	var release struct {
 		TagName string `json:"tag_name"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil || release.TagName == "" {
+	if err := json.Unmarshal(response.Body, &release); err != nil || release.TagName == "" {
 		return "", errors.New("GitHub returned an invalid latest release")
 	}
 	return release.TagName, nil
 }
 
 func vmBrowse(d wagopaths.Dirs, profileValue, buildValue, use string) {
-	releases, err := fetchReleases()
+	vmBrowseContext(context.Background(), d, profileValue, buildValue, use)
+}
+
+func vmBrowseContext(ctx context.Context, d wagopaths.Dirs, profileValue, buildValue, use string) {
+	releases, err := fetchReleasesContext(ctx)
 	if err != nil {
 		fatal("version browse: unable to fetch releases: %v", err)
 	}
-	commits, err := fetchMainCommits()
+	commits, err := fetchMainCommitsContext(ctx)
 	if err != nil {
 		fatal("version browse: unable to fetch main commits: %v", err)
 	}
@@ -58,32 +62,34 @@ func vmBrowse(d wagopaths.Dirs, profileValue, buildValue, use string) {
 		return
 	}
 	if choice == "latest" {
-		vmInstall(d, latestRelease(), profile, build, use)
+		release, err := latestStableReleaseContext(ctx)
+		if err != nil {
+			fatal("version latest: %v", err)
+		}
+		vmInstallContext(ctx, d, release, profile, build, use)
 		return
 	}
-	vmInstall(d, choice, profile, build, use)
+	vmInstallContext(ctx, d, choice, profile, build, use)
 }
 
 func fetchReleases() ([]remoteRelease, error) {
-	if err := automation.RequireOnline("release discovery"); err != nil {
-		return nil, err
-	}
+	return fetchReleasesContext(context.Background())
+}
+
+func fetchReleasesContext(ctx context.Context) ([]remoteRelease, error) {
 	var releases []remoteRelease
 	for page := 1; ; page++ {
-		url := fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=100&page=%d", releaseAPI(), page)
-		resp, err := http.Get(url)
+		address := fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=100&page=%d", releaseAPI(), page)
+		response, err := getReleaseBytes(ctx, "release discovery", address, releaseMetadataMaximum)
 		if err != nil {
 			return nil, err
 		}
-		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
-			return nil, fmt.Errorf("GitHub returned %s", resp.Status)
+		if response.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GitHub returned %s", response.Status)
 		}
 		var batch []remoteRelease
-		decodeErr := json.NewDecoder(resp.Body).Decode(&batch)
-		resp.Body.Close()
-		if decodeErr != nil {
-			return nil, decodeErr
+		if err := json.Unmarshal(response.Body, &batch); err != nil {
+			return nil, err
 		}
 		releases = append(releases, batch...)
 		if len(batch) < 100 {
@@ -96,18 +102,22 @@ func fetchReleases() ([]remoteRelease, error) {
 // Matching commits are left intact unless force is set; replacements use a
 // sibling temporary file so a failed update preserves the installed binary.
 var (
-	resolveUpdateRunnerVersion = resolveRunnerVersion
-	installUpdateRunnerPayload = installRunnerPayload
+	resolveUpdateRunnerVersionContext = resolveRunnerVersionContext
+	installUpdateRunnerPayloadContext = installRunnerPayloadContext
 )
 
 func vmUpdate(d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, use string, force bool) {
+	vmUpdateContext(context.Background(), d, ver, profile, build, use, force)
+}
+
+func vmUpdateContext(ctx context.Context, d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, use string, force bool) {
 	dest := d.RuntimeBinary(ver, string(profile), string(build))
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		fatal("version update: %v", err)
 	}
 	progress := managerprogress.NewProgress(os.Stderr)
 	progress.Title("Updating " + installedWagoLabel(ver, ver, profile, build))
-	resolved, sourceOnly, err := resolveUpdateRunnerVersion(ver, progress)
+	resolved, sourceOnly, err := resolveUpdateRunnerVersionContext(ctx, ver, progress)
 	if err != nil {
 		fatal("version update: %v", err)
 	}
@@ -116,7 +126,7 @@ func vmUpdate(d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wag
 		offerUseUpdated(d, ver, profile, build, use)
 		return
 	}
-	if err := installUpdateRunnerPayload(resolved, profile, build, dest, sourceOnly, progress); err != nil {
+	if err := installUpdateRunnerPayloadContext(ctx, resolved, profile, build, dest, sourceOnly, progress); err != nil {
 		fatal("version update: %v", err)
 	}
 	progress.Finish("Updated " + installedWagoLabel(ver, resolved, profile, build))
@@ -161,11 +171,15 @@ func commitFromVersion(version string) string {
 }
 
 func resolveRunnerVersion(ver string, progress *managerprogress.Progress) (resolved string, sourceOnly bool, err error) {
+	return resolveRunnerVersionContext(context.Background(), ver, progress)
+}
+
+func resolveRunnerVersionContext(ctx context.Context, ver string, progress *managerprogress.Progress) (resolved string, sourceOnly bool, err error) {
 	if ver == "canary" {
 		if progress != nil {
 			progress.Begin("resolving main commit")
 		}
-		sha, resolveErr := latestMainCommit()
+		sha, resolveErr := latestMainCommitContext(ctx)
 		if resolveErr != nil {
 			if progress != nil {
 				progress.Fail("could not resolve main commit")
@@ -184,7 +198,7 @@ func resolveRunnerVersion(ver string, progress *managerprogress.Progress) (resol
 	if progress != nil {
 		progress.Begin("resolving release")
 	}
-	resolved, err = latestChannelRelease(ver)
+	resolved, err = latestChannelReleaseContext(ctx, ver)
 	if err == nil {
 		if progress != nil {
 			progress.Done("resolved " + releasePickerLabel(resolved))
@@ -215,8 +229,12 @@ func canonicalReleaseRef(version string) string {
 }
 
 func installRunnerPayload(ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
+	return installRunnerPayloadContext(context.Background(), ref, profile, build, dest, sourceOnly, progress)
+}
+
+func installRunnerPayloadContext(ctx context.Context, ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
 	if !sourceOnly {
-		err := downloadBinaryWithProgress(releaseBase(), canaryCommitVersion(ref), profile, build, dest, progress)
+		err := downloadBinaryWithProgressContext(ctx, releaseBase(), canaryCommitVersion(ref), profile, build, dest, progress)
 		if err == nil {
 			return nil
 		}
@@ -224,31 +242,39 @@ func installRunnerPayload(ref string, profile wagopaths.Profile, build wagopaths
 			return err
 		}
 	}
-	return buildRunnerSource(ref, profile, build, dest, progress)
+	return buildRunnerSource(ctx, ref, profile, build, dest, progress)
 }
 
 func installManagerUpdate(channel, dest string, progress *managerprogress.Progress) (string, error) {
-	resolved, sourceOnly, err := resolveManagerUpdate(channel, progress)
+	return installManagerUpdateContext(context.Background(), channel, dest, progress)
+}
+
+func installManagerUpdateContext(ctx context.Context, channel, dest string, progress *managerprogress.Progress) (string, error) {
+	resolved, sourceOnly, err := resolveManagerUpdateContext(ctx, channel, progress)
 	if err != nil {
 		return "", err
 	}
-	if err := installManagerPayload(resolved, dest, sourceOnly, progress); err != nil {
+	if err := installManagerPayloadContext(ctx, resolved, dest, sourceOnly, progress); err != nil {
 		return "", err
 	}
 	return resolved, nil
 }
 
 func resolveManagerUpdate(channel string, progress *managerprogress.Progress) (resolved string, sourceOnly bool, err error) {
+	return resolveManagerUpdateContext(context.Background(), channel, progress)
+}
+
+func resolveManagerUpdateContext(ctx context.Context, channel string, progress *managerprogress.Progress) (resolved string, sourceOnly bool, err error) {
 	if channel == "latest" {
 		if progress != nil {
 			progress.Begin("resolving latest release")
 		}
-		resolved, err = latestStableRelease()
+		resolved, err = latestStableReleaseContext(ctx)
 		if err == nil && progress != nil {
 			progress.Done("resolved " + releasePickerLabel(resolved))
 		}
 	} else {
-		resolved, sourceOnly, err = resolveRunnerVersion(channel, progress)
+		resolved, sourceOnly, err = resolveRunnerVersionContext(ctx, channel, progress)
 	}
 	if err != nil {
 		return "", false, err
@@ -257,8 +283,13 @@ func resolveManagerUpdate(channel string, progress *managerprogress.Progress) (r
 }
 
 func installManagerPayload(resolved, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
+	return installManagerPayloadContext(context.Background(), resolved, dest, sourceOnly, progress)
+}
+
+func installManagerPayloadContext(ctx context.Context, resolved, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
 	if !sourceOnly {
-		err := downloadReleaseAssetWithProgress(
+		err := downloadReleaseAssetWithProgressContext(
+			ctx,
 			releaseBase(),
 			canaryCommitVersion(resolved),
 			managerAsset(),
@@ -272,26 +303,26 @@ func installManagerPayload(resolved, dest string, sourceOnly bool, progress *man
 			return err
 		}
 	}
-	if err := buildManagerSource(resolved, dest, progress); err != nil {
+	if err := buildManagerSource(ctx, resolved, dest, progress); err != nil {
 		return err
 	}
 	return nil
 }
 
 func latestMainCommit() (string, error) {
-	if err := automation.RequireOnline("main commit discovery"); err != nil {
-		return "", err
-	}
-	resp, err := http.Get(releaseAPI() + "/repos/wago-org/wago/commits/main")
+	return latestMainCommitContext(context.Background())
+}
+
+func latestMainCommitContext(ctx context.Context) (string, error) {
+	response, err := getReleaseBytes(ctx, "main commit discovery", releaseAPI()+"/repos/wago-org/wago/commits/main", releaseMetadataMaximum)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub returned %s", resp.Status)
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub returned %s", response.Status)
 	}
 	var commit remoteCommit
-	if err := json.NewDecoder(resp.Body).Decode(&commit); err != nil {
+	if err := json.Unmarshal(response.Body, &commit); err != nil {
 		return "", err
 	}
 	if !validCommitSHA(strings.ToLower(commit.SHA)) {
@@ -301,25 +332,23 @@ func latestMainCommit() (string, error) {
 }
 
 func fetchMainCommits() ([]remoteCommit, error) {
-	if err := automation.RequireOnline("main commit discovery"); err != nil {
-		return nil, err
-	}
+	return fetchMainCommitsContext(context.Background())
+}
+
+func fetchMainCommitsContext(ctx context.Context) ([]remoteCommit, error) {
 	var commits []remoteCommit
 	for page := 1; ; page++ {
-		url := fmt.Sprintf("%s/repos/wago-org/wago/commits?sha=main&per_page=100&page=%d", releaseAPI(), page)
-		resp, err := http.Get(url)
+		address := fmt.Sprintf("%s/repos/wago-org/wago/commits?sha=main&per_page=100&page=%d", releaseAPI(), page)
+		response, err := getReleaseBytes(ctx, "main commit discovery", address, releaseMetadataMaximum)
 		if err != nil {
 			return nil, err
 		}
-		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
-			return nil, fmt.Errorf("GitHub returned %s", resp.Status)
+		if response.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GitHub returned %s", response.Status)
 		}
 		var batch []remoteCommit
-		decodeErr := json.NewDecoder(resp.Body).Decode(&batch)
-		resp.Body.Close()
-		if decodeErr != nil {
-			return nil, decodeErr
+		if err := json.Unmarshal(response.Body, &batch); err != nil {
+			return nil, err
 		}
 		commits = append(commits, batch...)
 		if len(batch) < 100 {
@@ -329,21 +358,21 @@ func fetchMainCommits() ([]remoteCommit, error) {
 }
 
 func latestChannelRelease(channel string) (string, error) {
-	if err := automation.RequireOnline("release channel discovery"); err != nil {
-		return "", err
-	}
-	resp, err := http.Get(releaseAPI() + "/repos/wago-org/wago/releases?per_page=100")
+	return latestChannelReleaseContext(context.Background(), channel)
+}
+
+func latestChannelReleaseContext(ctx context.Context, channel string) (string, error) {
+	response, err := getReleaseBytes(ctx, "release channel discovery", releaseAPI()+"/repos/wago-org/wago/releases?per_page=100", releaseMetadataMaximum)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub returned %s", resp.Status)
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub returned %s", response.Status)
 	}
 	var releases []struct {
 		TagName string `json:"tag_name"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+	if err := json.Unmarshal(response.Body, &releases); err != nil {
 		return "", err
 	}
 	prefix := channel + "-"

--- a/cli/manager/internal/version/download.go
+++ b/cli/manager/internal/version/download.go
@@ -1,8 +1,9 @@
 package version
 
 import (
-	"bytes"
+	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -12,9 +13,20 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/wago-org/wago/cli/internal/automation"
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
+	"github.com/wago-org/wago/internal/atomicfile"
+	"github.com/wago-org/wago/internal/httpclient"
 	"github.com/wago-org/wago/internal/wagopaths"
+)
+
+// releaseAssetLimit is deliberately much larger than current stripped Wago
+// executables while still bounding a compromised release endpoint. Downloads
+// remain O(copy-buffer) memory and may consume at most this much temporary disk.
+const releaseAssetLimit int64 = 512 << 20
+
+var (
+	releaseAssetMaximum = releaseAssetLimit
+	errChecksumFormat   = errors.New("invalid release checksum format")
 )
 
 type httpStatusError struct {
@@ -33,44 +45,44 @@ func releaseAssetUnavailable(err error) bool {
 }
 
 // downloadBinary fetches the host-platform wago binary for ver from baseURL,
-// verifies its SHA-256 against the sibling ".sha256" file, and writes it to dest
-// (0755). It writes nothing on a checksum mismatch.
+// verifies its SHA-256 against the sibling ".sha256" file, and atomically
+// publishes it to dest with executable permissions.
 func downloadBinary(baseURL, ver string, profile wagopaths.Profile, build wagopaths.Build, dest string) error {
-	return downloadBinaryWithProgress(baseURL, ver, profile, build, dest, nil)
+	return downloadBinaryContext(context.Background(), baseURL, ver, profile, build, dest)
+}
+
+func downloadBinaryContext(ctx context.Context, baseURL, ver string, profile wagopaths.Profile, build wagopaths.Build, dest string) error {
+	return downloadBinaryWithProgressContext(ctx, baseURL, ver, profile, build, dest, nil)
 }
 
 func downloadBinaryWithProgress(baseURL, ver string, profile wagopaths.Profile, build wagopaths.Build, dest string, progress *managerprogress.Progress) error {
+	return downloadBinaryWithProgressContext(context.Background(), baseURL, ver, profile, build, dest, progress)
+}
+
+func downloadBinaryWithProgressContext(ctx context.Context, baseURL, ver string, profile wagopaths.Profile, build wagopaths.Build, dest string, progress *managerprogress.Progress) error {
 	asset := versionAsset(profile, build)
-	return downloadReleaseAssetWithProgress(baseURL, ver, asset, dest, progress)
+	return downloadReleaseAssetWithProgressContext(ctx, baseURL, ver, asset, dest, progress)
 }
 
 func downloadReleaseAssetWithProgress(baseURL, ver, asset, dest string, progress *managerprogress.Progress) error {
-	url := fmt.Sprintf("%s/%s/%s", strings.TrimRight(baseURL, "/"), ver, asset)
+	return downloadReleaseAssetWithProgressContext(context.Background(), baseURL, ver, asset, dest, progress)
+}
+
+func downloadReleaseAssetWithProgressContext(ctx context.Context, baseURL, ver, asset, dest string, progress *managerprogress.Progress) error {
+	address := fmt.Sprintf("%s/%s/%s", strings.TrimRight(baseURL, "/"), ver, asset)
 
 	if progress != nil {
-		progress.Begin("downloading " + asset)
-	}
-	body, err := httpGetBytesProgress(url, func(current, total int64) {
-		if progress != nil {
-			progress.Percent("downloading "+asset, current, total)
-		}
-	})
-	if err != nil {
-		if progress != nil {
-			if releaseAssetUnavailable(err) {
-				progress.Done("release asset unavailable; using source")
-			} else {
-				progress.Fail("download failed")
-			}
-		}
-		return err
-	}
-	if progress != nil {
-		progress.Done("downloaded " + asset)
 		progress.Begin("fetching checksum")
 	}
-	sumRaw, err := httpGetBytes(url + ".sha256")
+	checksumResponse, err := getReleaseBytes(ctx, "release checksum download", address+".sha256", checksumBodyMaximum)
 	if err != nil {
+		if progress != nil {
+			progress.Fail("checksum download failed")
+		}
+		return fmt.Errorf("fetch checksum: %w", err)
+	}
+	if checksumResponse.StatusCode != http.StatusOK {
+		err := &httpStatusError{url: address + ".sha256", code: checksumResponse.StatusCode, status: checksumResponse.Status}
 		if progress != nil {
 			if releaseAssetUnavailable(err) {
 				progress.Done("checksum unavailable; using source")
@@ -80,42 +92,132 @@ func downloadReleaseAssetWithProgress(baseURL, ver, asset, dest string, progress
 		}
 		return fmt.Errorf("fetch checksum: %w", err)
 	}
+	want, err := parseReleaseChecksum(checksumResponse.Body, asset)
+	if err != nil {
+		if progress != nil {
+			progress.Fail("invalid checksum")
+		}
+		return fmt.Errorf("parse checksum for %s: %w", asset, err)
+	}
 	if progress != nil {
 		progress.Done("fetched checksum")
-		progress.Begin("verifying SHA-256")
+		progress.Begin("downloading " + asset)
 	}
-	want := strings.TrimSpace(string(sumRaw))
-	if fields := strings.Fields(want); len(fields) > 0 {
-		want = fields[0] // accept "<hash>  <filename>" form
-	}
-	got := sha256.Sum256(body)
-	if !strings.EqualFold(hex.EncodeToString(got[:]), want) {
+
+	response, err := openReleaseStream(ctx, "release download", address)
+	if err != nil {
 		if progress != nil {
-			progress.Fail("checksum verification failed")
-		}
-		return fmt.Errorf("checksum mismatch for %s (want %s, got %x)", asset, want, got)
-	}
-	if progress != nil {
-		progress.Done("verified SHA-256")
-		progress.Begin("installing executable")
-	}
-	tmp := dest + ".tmp"
-	if err := os.WriteFile(tmp, body, 0o755); err != nil {
-		if progress != nil {
-			progress.Fail("could not write executable")
+			progress.Fail("download failed")
 		}
 		return err
 	}
-	if err := os.Rename(tmp, dest); err != nil {
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		_, readErr := httpclient.ReadBounded(response.Body, response.ContentLength, httpclient.DefaultErrorBodyLimit, address)
+		if readErr != nil && !errors.Is(readErr, httpclient.ErrBodyTooLarge) {
+			return readErr
+		}
+		err := &httpStatusError{url: address, code: response.StatusCode, status: response.Status}
 		if progress != nil {
-			progress.Fail("could not install executable")
+			if releaseAssetUnavailable(err) {
+				progress.Done("release asset unavailable; using source")
+			} else {
+				progress.Fail("download failed")
+			}
+		}
+		return err
+	}
+	if response.ContentLength > releaseAssetMaximum {
+		if progress != nil {
+			progress.Fail("download exceeds size limit")
+		}
+		return &httpclient.BodyTooLargeError{URL: address, Limit: releaseAssetMaximum, ContentLength: response.ContentLength}
+	}
+
+	err = atomicfile.ReplaceFile(dest, atomicfile.Options{Mode: 0o755, Sync: true}, func(writer io.Writer) error {
+		hash := sha256.New()
+		output := io.MultiWriter(writer, hash)
+		limited := &io.LimitedReader{R: response.Body, N: releaseAssetMaximum + 1}
+		buffer := make([]byte, 64<<10)
+		var current int64
+		for {
+			read, readErr := limited.Read(buffer)
+			if read > 0 {
+				written, writeErr := output.Write(buffer[:read])
+				current += int64(written)
+				if progress != nil {
+					progress.Percent("downloading "+asset, current, response.ContentLength)
+				}
+				if writeErr != nil {
+					return writeErr
+				}
+				if written != read {
+					return io.ErrShortWrite
+				}
+			}
+			if readErr == io.EOF {
+				break
+			}
+			if readErr != nil {
+				return readErr
+			}
+		}
+		if current > releaseAssetMaximum {
+			return &httpclient.BodyTooLargeError{URL: address, Limit: releaseAssetMaximum, ContentLength: -1}
+		}
+		if response.ContentLength >= 0 && current != response.ContentLength {
+			return io.ErrUnexpectedEOF
+		}
+		got := hash.Sum(nil)
+		if subtle.ConstantTimeCompare(got, want[:]) != 1 {
+			return fmt.Errorf("checksum mismatch for %s (want %x, got %x)", asset, want, got)
+		}
+		return nil
+	})
+	if err != nil {
+		if progress != nil {
+			if errors.Is(err, httpclient.ErrBodyTooLarge) {
+				progress.Fail("download exceeds size limit")
+			} else if strings.Contains(err.Error(), "checksum mismatch") {
+				progress.Fail("checksum verification failed")
+			} else {
+				progress.Fail("download failed")
+			}
 		}
 		return err
 	}
 	if progress != nil {
+		progress.Done("downloaded and verified " + asset)
 		progress.Done("installed executable")
 	}
 	return nil
+}
+
+func parseReleaseChecksum(data []byte, asset string) ([sha256.Size]byte, error) {
+	var digest [sha256.Size]byte
+	line := strings.TrimSuffix(string(data), "\n")
+	line = strings.TrimSuffix(line, "\r")
+	if line == "" || strings.ContainsAny(line, "\r\n") {
+		return digest, errChecksumFormat
+	}
+	separator := strings.IndexAny(line, " \t")
+	if separator != 64 || len(line) <= separator {
+		return digest, errChecksumFormat
+	}
+	digestText := line[:separator]
+	remainder := strings.TrimLeft(line[separator:], " \t")
+	if strings.HasPrefix(remainder, "*") {
+		remainder = remainder[1:]
+	}
+	if remainder != asset || strings.ContainsAny(remainder, " \t") {
+		return digest, errChecksumFormat
+	}
+	decoded, err := hex.DecodeString(digestText)
+	if err != nil || len(decoded) != sha256.Size {
+		return digest, errChecksumFormat
+	}
+	copy(digest[:], decoded)
+	return digest, nil
 }
 
 func versionAsset(profile wagopaths.Profile, build wagopaths.Build) string {
@@ -130,37 +232,20 @@ func httpGetBytes(url string) ([]byte, error) {
 	return httpGetBytesProgress(url, nil)
 }
 
+// httpGetBytesProgress remains for small metadata tests/callers only. Release
+// executables use the dedicated streaming path above.
 func httpGetBytesProgress(url string, progress func(current, total int64)) ([]byte, error) {
-	if err := automation.RequireOnline("release download"); err != nil {
-		return nil, err
-	}
-	resp, err := http.Get(url)
+	response, err := getReleaseBytes(context.Background(), "release metadata download", url, releaseMetadataMaximum)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpStatusError{url: url, code: resp.StatusCode, status: resp.Status}
+	if response.StatusCode != http.StatusOK {
+		return nil, &httpStatusError{url: url, code: response.StatusCode, status: response.Status}
 	}
-	var body bytes.Buffer
-	buf := make([]byte, 32*1024)
-	var current int64
-	for {
-		n, readErr := resp.Body.Read(buf)
-		if n > 0 {
-			_, _ = body.Write(buf[:n])
-			current += int64(n)
-			if progress != nil {
-				progress(current, resp.ContentLength)
-			}
-		}
-		if readErr == io.EOF {
-			return body.Bytes(), nil
-		}
-		if readErr != nil {
-			return nil, readErr
-		}
+	if progress != nil {
+		progress(int64(len(response.Body)), int64(len(response.Body)))
 	}
+	return response.Body, nil
 }
 
 // releaseBase is the base URL for release binary assets, overridable for testing.

--- a/cli/manager/internal/version/download.go
+++ b/cli/manager/internal/version/download.go
@@ -113,10 +113,8 @@ func downloadReleaseAssetWithProgressContext(ctx context.Context, baseURL, ver, 
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		_, readErr := httpclient.ReadBounded(response.Body, response.ContentLength, httpclient.DefaultErrorBodyLimit, address)
-		if readErr != nil && !errors.Is(readErr, httpclient.ErrBodyTooLarge) {
-			return readErr
-		}
+		// The status is sufficient for release fallback/error handling. Do not
+		// wait for an unused error body under the much longer streaming timeout.
 		err := &httpStatusError{url: address, code: response.StatusCode, status: response.Status}
 		if progress != nil {
 			if releaseAssetUnavailable(err) {
@@ -143,16 +141,25 @@ func downloadReleaseAssetWithProgressContext(ctx context.Context, baseURL, ver, 
 		for {
 			read, readErr := limited.Read(buffer)
 			if read > 0 {
-				written, writeErr := output.Write(buffer[:read])
-				current += int64(written)
-				if progress != nil {
-					progress.Percent("downloading "+asset, current, response.ContentLength)
+				allowed := read
+				if remaining := releaseAssetMaximum - current; int64(allowed) > remaining {
+					allowed = int(remaining)
 				}
-				if writeErr != nil {
-					return writeErr
+				if allowed > 0 {
+					written, writeErr := output.Write(buffer[:allowed])
+					current += int64(written)
+					if progress != nil {
+						progress.Percent("downloading "+asset, current, response.ContentLength)
+					}
+					if writeErr != nil {
+						return writeErr
+					}
+					if written != allowed {
+						return io.ErrShortWrite
+					}
 				}
-				if written != read {
-					return io.ErrShortWrite
+				if allowed != read {
+					return &httpclient.BodyTooLargeError{URL: address, Limit: releaseAssetMaximum, ContentLength: -1}
 				}
 			}
 			if readErr == io.EOF {
@@ -161,9 +168,6 @@ func downloadReleaseAssetWithProgressContext(ctx context.Context, baseURL, ver, 
 			if readErr != nil {
 				return readErr
 			}
-		}
-		if current > releaseAssetMaximum {
-			return &httpclient.BodyTooLargeError{URL: address, Limit: releaseAssetMaximum, ContentLength: -1}
 		}
 		if response.ContentLength >= 0 && current != response.ContentLength {
 			return io.ErrUnexpectedEOF
@@ -209,7 +213,14 @@ func parseReleaseChecksum(data []byte, asset string) ([sha256.Size]byte, error) 
 	if strings.HasPrefix(remainder, "*") {
 		remainder = remainder[1:]
 	}
-	if remainder != asset || strings.ContainsAny(remainder, " \t") {
+	// The release workflow invokes checksum tools with paths such as
+	// "./wago-linux-amd64", while downloaded assets are addressed by basename.
+	// Accept only that harmless current-directory prefix in addition to the
+	// exact asset name; arbitrary directories remain invalid.
+	if remainder != asset && remainder != "./"+asset {
+		return digest, errChecksumFormat
+	}
+	if strings.ContainsAny(remainder, " \t") {
 		return digest, errChecksumFormat
 	}
 	decoded, err := hex.DecodeString(digestText)

--- a/cli/manager/internal/version/download.go
+++ b/cli/manager/internal/version/download.go
@@ -55,17 +55,9 @@ func downloadBinaryContext(ctx context.Context, baseURL, ver string, profile wag
 	return downloadBinaryWithProgressContext(ctx, baseURL, ver, profile, build, dest, nil)
 }
 
-func downloadBinaryWithProgress(baseURL, ver string, profile wagopaths.Profile, build wagopaths.Build, dest string, progress *managerprogress.Progress) error {
-	return downloadBinaryWithProgressContext(context.Background(), baseURL, ver, profile, build, dest, progress)
-}
-
 func downloadBinaryWithProgressContext(ctx context.Context, baseURL, ver string, profile wagopaths.Profile, build wagopaths.Build, dest string, progress *managerprogress.Progress) error {
 	asset := versionAsset(profile, build)
 	return downloadReleaseAssetWithProgressContext(ctx, baseURL, ver, asset, dest, progress)
-}
-
-func downloadReleaseAssetWithProgress(baseURL, ver, asset, dest string, progress *managerprogress.Progress) error {
-	return downloadReleaseAssetWithProgressContext(context.Background(), baseURL, ver, asset, dest, progress)
 }
 
 func downloadReleaseAssetWithProgressContext(ctx context.Context, baseURL, ver, asset, dest string, progress *managerprogress.Progress) error {
@@ -210,9 +202,7 @@ func parseReleaseChecksum(data []byte, asset string) ([sha256.Size]byte, error) 
 	}
 	digestText := line[:separator]
 	remainder := strings.TrimLeft(line[separator:], " \t")
-	if strings.HasPrefix(remainder, "*") {
-		remainder = remainder[1:]
-	}
+	remainder = strings.TrimPrefix(remainder, "*")
 	// The release workflow invokes checksum tools with paths such as
 	// "./wago-linux-amd64", while downloaded assets are addressed by basename.
 	// Accept only that harmless current-directory prefix in addition to the
@@ -237,10 +227,6 @@ func versionAsset(profile wagopaths.Profile, build wagopaths.Build) string {
 
 func managerAsset() string {
 	return "wago-" + runtime.GOOS + "-" + runtime.GOARCH
-}
-
-func httpGetBytes(url string) ([]byte, error) {
-	return httpGetBytesProgress(url, nil)
 }
 
 // httpGetBytesProgress remains for small metadata tests/callers only. Release

--- a/cli/manager/internal/version/download_hardening_test.go
+++ b/cli/manager/internal/version/download_hardening_test.go
@@ -1,0 +1,329 @@
+package version
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/internal/httpclient"
+)
+
+func TestParseReleaseChecksumStrict(t *testing.T) {
+	asset := "wago-linux-amd64"
+	digest := strings.Repeat("a", 64)
+	for _, valid := range []string{
+		digest + "  " + asset + "\n",
+		strings.ToUpper(digest) + " *" + asset + "\r\n",
+	} {
+		got, err := parseReleaseChecksum([]byte(valid), asset)
+		if err != nil || hex.EncodeToString(got[:]) != strings.ToLower(digest) {
+			t.Fatalf("valid checksum %q = %x, %v", valid, got, err)
+		}
+	}
+	for name, invalid := range map[string]string{
+		"digest only":    digest + "\n",
+		"truncated":      digest[:63] + "  " + asset + "\n",
+		"non-hex":        strings.Repeat("z", 64) + "  " + asset + "\n",
+		"wrong filename": digest + "  other\n",
+		"multiple":       digest + "  " + asset + "\n" + digest + "  " + asset + "\n",
+		"extra field":    digest + "  " + asset + " extra\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseReleaseChecksum([]byte(invalid), asset); !errors.Is(err, errChecksumFormat) {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func FuzzParseReleaseChecksum(f *testing.F) {
+	f.Add([]byte(strings.Repeat("0", 64)+"  asset\n"), "asset")
+	f.Add([]byte("bad"), "asset")
+	f.Fuzz(func(t *testing.T, data []byte, asset string) {
+		digest, err := parseReleaseChecksum(data, asset)
+		if err == nil {
+			if len(data) > int(checksumBodyLimit) {
+				t.Fatal("oversized checksum parsed")
+			}
+			if len(hex.EncodeToString(digest[:])) != 64 {
+				t.Fatal("parsed digest has wrong length")
+			}
+		}
+	})
+}
+
+func TestDownloadReleaseAssetRejectsOversizedChecksumBeforeAsset(t *testing.T) {
+	asset := "wago-test"
+	oldMaximum := checksumBodyMaximum
+	checksumBodyMaximum = 16
+	t.Cleanup(func() { checksumBodyMaximum = oldMaximum })
+	var assetRequested atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.HasSuffix(request.URL.Path, ".sha256") {
+			writer.(http.Flusher).Flush()
+			_, _ = writer.Write([]byte(strings.Repeat("x", 17)))
+			return
+		}
+		assetRequested.Store(true)
+	}))
+	defer server.Close()
+	destination := filepath.Join(t.TempDir(), "wago")
+	if err := os.WriteFile(destination, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := downloadReleaseAssetWithProgressContext(context.Background(), server.URL, "v1", asset, destination, nil)
+	if !errors.Is(err, httpclient.ErrBodyTooLarge) {
+		t.Fatalf("checksum error = %v", err)
+	}
+	if assetRequested.Load() {
+		t.Fatal("asset was requested before checksum validation")
+	}
+	data, readErr := os.ReadFile(destination)
+	if readErr != nil || string(data) != "old" {
+		t.Fatalf("destination = %q, %v", data, readErr)
+	}
+}
+
+func TestDownloadReleaseAssetStreamsVerifiesAndReplaces(t *testing.T) {
+	payload := strings.Repeat("streamed-release-asset", 1<<12)
+	asset := "wago-test"
+	server := releaseServer(t, asset, []byte(payload), "")
+	destination := filepath.Join(t.TempDir(), "wago")
+	if err := os.WriteFile(destination, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := downloadReleaseAssetWithProgressContext(context.Background(), server.URL, "v1", asset, destination, nil); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil || string(data) != payload {
+		t.Fatalf("destination bytes = %d, %v", len(data), err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(destination)
+		if err != nil || info.Mode().Perm() != 0o755 {
+			t.Fatalf("destination mode = %v, %v", info, err)
+		}
+	}
+	assertNoDownloadTemps(t, destination)
+}
+
+func TestDownloadReleaseAssetFailuresPreserveDestination(t *testing.T) {
+	asset := "wago-test"
+	payload := []byte(strings.Repeat("payload", 32))
+	oldMaximum := releaseAssetMaximum
+	releaseAssetMaximum = 128
+	t.Cleanup(func() { releaseAssetMaximum = oldMaximum })
+
+	tests := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request)
+		cancel  bool
+	}{
+		{name: "malformed checksum", handler: func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, ".sha256") {
+				_, _ = writer.Write([]byte("bad\n"))
+				return
+			}
+			_, _ = writer.Write(payload)
+		}},
+		{name: "multiple hashes", handler: func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, ".sha256") {
+				sum := sha256.Sum256(payload)
+				line := fmt.Sprintf("%x  %s\n", sum, asset)
+				_, _ = writer.Write([]byte(line + line))
+				return
+			}
+			_, _ = writer.Write(payload)
+		}},
+		{name: "hash mismatch", handler: func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, ".sha256") {
+				_, _ = writer.Write([]byte(strings.Repeat("0", 64) + "  " + asset + "\n"))
+				return
+			}
+			_, _ = writer.Write(payload[:64])
+		}},
+		{name: "declared oversized", handler: func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, ".sha256") {
+				writeChecksum(writer, payload, asset)
+				return
+			}
+			writer.Header().Set("Content-Length", "129")
+			writer.WriteHeader(http.StatusOK)
+		}},
+		{name: "chunked oversized", handler: func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, ".sha256") {
+				writeChecksum(writer, payload, asset)
+				return
+			}
+			writer.(http.Flusher).Flush()
+			_, _ = writer.Write(make([]byte, 129))
+		}},
+		{name: "network interruption", handler: func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, ".sha256") {
+				writeChecksum(writer, payload[:100], asset)
+				return
+			}
+			writer.Header().Set("Content-Length", "100")
+			_, _ = writer.Write(payload[:32])
+			writer.(http.Flusher).Flush()
+			panic(http.ErrAbortHandler)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(test.handler))
+			defer server.Close()
+			directory := t.TempDir()
+			destination := filepath.Join(directory, "wago")
+			if err := os.WriteFile(destination, []byte("old"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			err := downloadReleaseAssetWithProgressContext(context.Background(), server.URL, "v1", asset, destination, nil)
+			if err == nil {
+				t.Fatal("download failure was accepted")
+			}
+			if strings.Contains(test.name, "oversized") && !errors.Is(err, httpclient.ErrBodyTooLarge) {
+				t.Fatalf("oversized error = %v", err)
+			}
+			data, readErr := os.ReadFile(destination)
+			if readErr != nil || string(data) != "old" {
+				t.Fatalf("old destination = %q, %v (download error %v)", data, readErr, err)
+			}
+			assertNoDownloadTemps(t, destination)
+		})
+	}
+}
+
+func TestDownloadReleaseAssetCancellationPreservesDestination(t *testing.T) {
+	asset := "wago-test"
+	payload := []byte(strings.Repeat("x", 256))
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.HasSuffix(request.URL.Path, ".sha256") {
+			writeChecksum(writer, payload, asset)
+			return
+		}
+		writer.Header().Set("Content-Length", fmt.Sprint(len(payload)))
+		_, _ = writer.Write(payload[:32])
+		writer.(http.Flusher).Flush()
+		close(started)
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+	destination := filepath.Join(t.TempDir(), "wago")
+	if err := os.WriteFile(destination, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- downloadReleaseAssetWithProgressContext(ctx, server.URL, "v1", asset, destination, nil)
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancellation error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled download did not return")
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil || string(data) != "old" {
+		t.Fatalf("old destination = %q, %v", data, err)
+	}
+	assertNoDownloadTemps(t, destination)
+}
+
+func TestConcurrentReleaseDownloadsDoNotCollide(t *testing.T) {
+	asset := "wago-test"
+	payload := []byte(strings.Repeat("concurrent", 4096))
+	server := releaseServer(t, asset, payload, "")
+	destination := filepath.Join(t.TempDir(), "wago")
+	const count = 8
+	var wait sync.WaitGroup
+	errorsChannel := make(chan error, count)
+	for range count {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			errorsChannel <- downloadReleaseAssetWithProgressContext(context.Background(), server.URL, "v1", asset, destination, nil)
+		}()
+	}
+	wait.Wait()
+	close(errorsChannel)
+	for err := range errorsChannel {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil || string(data) != string(payload) {
+		t.Fatalf("destination = %d bytes, %v", len(data), err)
+	}
+	assertNoDownloadTemps(t, destination)
+}
+
+func BenchmarkReleaseDownloadStreaming(b *testing.B) {
+	for _, size := range []int{1 << 20, 16 << 20} {
+		b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
+			payload := []byte(strings.Repeat("x", size))
+			asset := "wago-test"
+			server := releaseServer(b, asset, payload, "")
+			destination := filepath.Join(b.TempDir(), "wago")
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				if err := downloadReleaseAssetWithProgressContext(context.Background(), server.URL, "v1", asset, destination, nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func releaseServer(t testing.TB, asset string, payload []byte, checksum string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.HasSuffix(request.URL.Path, ".sha256") {
+			if checksum != "" {
+				_, _ = writer.Write([]byte(checksum))
+			} else {
+				writeChecksum(writer, payload, asset)
+			}
+			return
+		}
+		writer.Header().Set("Content-Length", fmt.Sprint(len(payload)))
+		_, _ = writer.Write(payload)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func writeChecksum(writer http.ResponseWriter, payload []byte, asset string) {
+	sum := sha256.Sum256(payload)
+	_, _ = fmt.Fprintf(writer, "%x  %s\n", sum, asset)
+}
+
+func assertNoDownloadTemps(t *testing.T, destination string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(destination), ".wago-atomic-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("temporary downloads remain: %v, %v", matches, err)
+	}
+}

--- a/cli/manager/internal/version/download_hardening_test.go
+++ b/cli/manager/internal/version/download_hardening_test.go
@@ -25,7 +25,9 @@ func TestParseReleaseChecksumStrict(t *testing.T) {
 	digest := strings.Repeat("a", 64)
 	for _, valid := range []string{
 		digest + "  " + asset + "\n",
+		digest + "  ./" + asset + "\n",
 		strings.ToUpper(digest) + " *" + asset + "\r\n",
+		strings.ToUpper(digest) + " *./" + asset + "\r\n",
 	} {
 		got, err := parseReleaseChecksum([]byte(valid), asset)
 		if err != nil || hex.EncodeToString(got[:]) != strings.ToLower(digest) {
@@ -37,6 +39,8 @@ func TestParseReleaseChecksumStrict(t *testing.T) {
 		"truncated":      digest[:63] + "  " + asset + "\n",
 		"non-hex":        strings.Repeat("z", 64) + "  " + asset + "\n",
 		"wrong filename": digest + "  other\n",
+		"nested path":    digest + "  releases/" + asset + "\n",
+		"parent path":    digest + "  ../" + asset + "\n",
 		"multiple":       digest + "  " + asset + "\n" + digest + "  " + asset + "\n",
 		"extra field":    digest + "  " + asset + " extra\n",
 	} {
@@ -118,6 +122,30 @@ func TestDownloadReleaseAssetStreamsVerifiesAndReplaces(t *testing.T) {
 		}
 	}
 	assertNoDownloadTemps(t, destination)
+}
+
+func TestDownloadReleaseAssetAcceptsExactUnknownLengthLimit(t *testing.T) {
+	asset := "wago-test"
+	payload := []byte(strings.Repeat("x", 128))
+	oldMaximum := releaseAssetMaximum
+	releaseAssetMaximum = int64(len(payload))
+	t.Cleanup(func() { releaseAssetMaximum = oldMaximum })
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.HasSuffix(request.URL.Path, ".sha256") {
+			writeChecksum(writer, payload, asset)
+			return
+		}
+		writer.(http.Flusher).Flush()
+		_, _ = writer.Write(payload)
+	}))
+	defer server.Close()
+	destination := filepath.Join(t.TempDir(), "wago")
+	if err := downloadReleaseAssetWithProgressContext(context.Background(), server.URL, "v1", asset, destination, nil); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(destination); err != nil || string(data) != string(payload) {
+		t.Fatalf("exact-limit release asset = %d bytes, %v", len(data), err)
+	}
 }
 
 func TestDownloadReleaseAssetFailuresPreserveDestination(t *testing.T) {

--- a/cli/manager/internal/version/http.go
+++ b/cli/manager/internal/version/http.go
@@ -1,0 +1,43 @@
+package version
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/wago-org/wago/cli/internal/automation"
+	"github.com/wago-org/wago/internal/httpclient"
+)
+
+const (
+	releaseMetadataLimit int64 = 4 << 20
+	checksumBodyLimit    int64 = 4 << 10
+)
+
+var (
+	releaseMetadataHTTP    = httpclient.NewMetadata()
+	releaseStreamHTTP      = httpclient.NewStreaming()
+	releaseMetadataMaximum = releaseMetadataLimit
+	checksumBodyMaximum    = checksumBodyLimit
+)
+
+func getReleaseBytes(ctx context.Context, operation, address string, limit int64) (httpclient.Response, error) {
+	if err := automation.RequireOnline(operation); err != nil {
+		return httpclient.Response{}, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		return httpclient.Response{}, err
+	}
+	return releaseMetadataHTTP.Bytes(ctx, request, limit)
+}
+
+func openReleaseStream(ctx context.Context, operation, address string) (*http.Response, error) {
+	if err := automation.RequireOnline(operation); err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		return nil, err
+	}
+	return releaseStreamHTTP.Open(ctx, request)
+}

--- a/cli/manager/internal/version/install.go
+++ b/cli/manager/internal/version/install.go
@@ -10,10 +10,6 @@ import (
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
-func vmInstall(d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, use string) {
-	vmInstallContext(context.Background(), d, ver, profile, build, use)
-}
-
 func vmInstallContext(ctx context.Context, d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, use string) {
 	installVersionContext(ctx, d, ver, profile, build, true, true, use)
 }
@@ -67,10 +63,6 @@ func installVersionContext(ctx context.Context, d wagopaths.Dirs, ver string, pr
 	if offer {
 		finishVersionInstall(d, installName, profile, build, use)
 	}
-}
-
-func vmInstallRequested(d wagopaths.Dirs, args []string, latest, nightly, canary bool, profileValue, buildValue, use string) {
-	vmInstallRequestedContext(context.Background(), d, args, latest, nightly, canary, profileValue, buildValue, use)
 }
 
 func vmInstallRequestedContext(ctx context.Context, d wagopaths.Dirs, args []string, latest, nightly, canary bool, profileValue, buildValue, use string) {

--- a/cli/manager/internal/version/install.go
+++ b/cli/manager/internal/version/install.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,14 +11,26 @@ import (
 )
 
 func vmInstall(d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, use string) {
-	installVersion(d, ver, profile, build, true, true, use)
+	vmInstallContext(context.Background(), d, ver, profile, build, use)
+}
+
+func vmInstallContext(ctx context.Context, d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, use string) {
+	installVersionContext(ctx, d, ver, profile, build, true, true, use)
 }
 
 func vmInstallForSwitch(d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build) {
-	installVersion(d, ver, profile, build, false, false, "no")
+	vmInstallForSwitchContext(context.Background(), d, ver, profile, build)
+}
+
+func vmInstallForSwitchContext(ctx context.Context, d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build) {
+	installVersionContext(ctx, d, ver, profile, build, false, false, "no")
 }
 
 func installVersion(d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, offer, showLocation bool, use string) {
+	installVersionContext(context.Background(), d, ver, profile, build, offer, showLocation, use)
+}
+
+func installVersionContext(ctx context.Context, d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, offer, showLocation bool, use string) {
 	installName := canaryCommitVersion(ver)
 	dest := d.RuntimeBinary(installName, string(profile), string(build))
 	if installedPath, _, _, installed := installedRuntime(d, installName, profile, build); installed {
@@ -40,11 +53,11 @@ func installVersion(d wagopaths.Dirs, ver string, profile wagopaths.Profile, bui
 	}
 	progress := managerprogress.NewProgress(os.Stderr)
 	progress.Title("Setting Up")
-	resolved, sourceOnly, err := resolveRunnerVersion(ver, progress)
+	resolved, sourceOnly, err := resolveRunnerVersionContext(ctx, ver, progress)
 	if err != nil {
 		fatal("version install: %v", err)
 	}
-	if err := installRunnerPayload(resolved, profile, build, dest, sourceOnly, progress); err != nil {
+	if err := installRunnerPayloadContext(ctx, resolved, profile, build, dest, sourceOnly, progress); err != nil {
 		fatal("version install: %v", err)
 	}
 	progress.Finish("Installed " + installedWagoLabel(installName, canaryCommitVersion(resolved), profile, build))
@@ -57,6 +70,10 @@ func installVersion(d wagopaths.Dirs, ver string, profile wagopaths.Profile, bui
 }
 
 func vmInstallRequested(d wagopaths.Dirs, args []string, latest, nightly, canary bool, profileValue, buildValue, use string) {
+	vmInstallRequestedContext(context.Background(), d, args, latest, nightly, canary, profileValue, buildValue, use)
+}
+
+func vmInstallRequestedContext(ctx context.Context, d wagopaths.Dirs, args []string, latest, nightly, canary bool, profileValue, buildValue, use string) {
 	if len(args) > 1 || (len(args) == 1 && (latest || nightly || canary)) || (latest && (nightly || canary)) || (nightly && canary) {
 		fatal("version install: choose one version or channel")
 	}
@@ -67,7 +84,7 @@ func vmInstallRequested(d wagopaths.Dirs, args []string, latest, nightly, canary
 		fatal("version install: %v", err)
 	}
 	if len(args) == 0 && !latest && !nightly && !canary {
-		vmBrowse(d, profileValue, buildValue, use)
+		vmBrowseContext(ctx, d, profileValue, buildValue, use)
 		return
 	}
 	profile, build, ok := chooseInstallVariant(profileValue, buildValue)
@@ -75,18 +92,22 @@ func vmInstallRequested(d wagopaths.Dirs, args []string, latest, nightly, canary
 		return
 	}
 	if latest {
-		vmInstall(d, latestRelease(), profile, build, use)
+		release, err := latestStableReleaseContext(ctx)
+		if err != nil {
+			fatal("version latest: %v", err)
+		}
+		vmInstallContext(ctx, d, release, profile, build, use)
 		return
 	}
 	if nightly {
-		vmInstall(d, "nightly", profile, build, use)
+		vmInstallContext(ctx, d, "nightly", profile, build, use)
 		return
 	}
 	if canary {
-		vmInstall(d, "canary", profile, build, use)
+		vmInstallContext(ctx, d, "canary", profile, build, use)
 		return
 	}
-	vmInstall(d, args[0], profile, build, use)
+	vmInstallContext(ctx, d, args[0], profile, build, use)
 }
 
 func requestedProfile(value string) (wagopaths.Profile, error) {

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -1,17 +1,22 @@
 package version
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/wago-org/wago/internal/httpclient"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
@@ -76,6 +81,43 @@ func TestMainCommitBrowsingPaginatesAndResolvesTip(t *testing.T) {
 	releases, err := fetchReleases()
 	if err != nil || len(releases) != 101 {
 		t.Fatalf("fetchReleases = %d releases, %v", len(releases), err)
+	}
+}
+
+func TestReleaseMetadataIsBoundedAndCancelable(t *testing.T) {
+	oldMaximum := releaseMetadataMaximum
+	releaseMetadataMaximum = 32
+	t.Cleanup(func() { releaseMetadataMaximum = oldMaximum })
+
+	oversized := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.(http.Flusher).Flush()
+		_, _ = w.Write([]byte(strings.Repeat("x", 33)))
+	}))
+	defer oversized.Close()
+	t.Setenv("WAGO_RELEASE_API", oversized.URL)
+	if _, err := latestMainCommitContext(context.Background()); !errors.Is(err, httpclient.ErrBodyTooLarge) {
+		t.Fatalf("oversized release metadata = %v", err)
+	}
+
+	stalled := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		<-request.Context().Done()
+	}))
+	defer stalled.Close()
+	t.Setenv("WAGO_RELEASE_API", stalled.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := latestMainCommitContext(ctx)
+		done <- err
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled release metadata = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled release metadata request did not return")
 	}
 }
 

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -84,6 +84,43 @@ func TestMainCommitBrowsingPaginatesAndResolvesTip(t *testing.T) {
 	}
 }
 
+func TestReleaseDiscoveryBoundsTotalPagination(t *testing.T) {
+	releases := make([]remoteRelease, 100)
+	commits := make([]remoteCommit, 100)
+	for index := range releases {
+		releases[index].TagName = fmt.Sprintf("v%d.0.0", index)
+		commits[index].SHA = fmt.Sprintf("%040x", index+1)
+	}
+	releaseRequests, commitRequests := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/repos/wago-org/wago/releases":
+			releaseRequests++
+			_ = json.NewEncoder(writer).Encode(releases)
+		case "/repos/wago-org/wago/commits":
+			commitRequests++
+			_ = json.NewEncoder(writer).Encode(commits)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_RELEASE_API", server.URL)
+
+	if _, err := fetchReleasesContext(context.Background()); err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("unbounded release pagination error = %v", err)
+	}
+	if releaseRequests != discoveryPageLimit {
+		t.Fatalf("release page requests = %d, want %d", releaseRequests, discoveryPageLimit)
+	}
+	if _, err := fetchMainCommitsContext(context.Background()); err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("unbounded commit pagination error = %v", err)
+	}
+	if commitRequests != discoveryPageLimit {
+		t.Fatalf("commit page requests = %d, want %d", commitRequests, discoveryPageLimit)
+	}
+}
+
 func TestReleaseMetadataIsBoundedAndCancelable(t *testing.T) {
 	oldMaximum := releaseMetadataMaximum
 	releaseMetadataMaximum = 32

--- a/cli/manager/internal/version/source.go
+++ b/cli/manager/internal/version/source.go
@@ -113,10 +113,6 @@ func buildRunnerFromSourceContext(ctx context.Context, ref string, profile wagop
 	return finishSourceBuild(tempRunner, dest, progress, "built "+string(profile)+" runtime with Go")
 }
 
-func buildManagerFromSource(ref, dest string, progress *managerprogress.Progress) error {
-	return buildManagerFromSourceContext(context.Background(), ref, dest, progress)
-}
-
 func buildManagerFromSourceContext(ctx context.Context, ref, dest string, progress *managerprogress.Progress) error {
 	temp, source, stamp, err := checkoutWagoSourceContext(ctx, ref, progress)
 	if err != nil {
@@ -155,16 +151,8 @@ func buildManagerFromSourceContext(ctx context.Context, ref, dest string, progre
 	return finishSourceBuild(tempManager, dest, progress, "built Wago with Go")
 }
 
-func checkoutWagoSource(ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
-	return checkoutWagoSourceContext(context.Background(), ref, progress)
-}
-
 func checkoutWagoSourceContext(ctx context.Context, ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
 	return checkoutWagoSourceInContext(ctx, "", ref, progress)
-}
-
-func checkoutWagoSourceIn(parent, ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
-	return checkoutWagoSourceInContext(context.Background(), parent, ref, progress)
 }
 
 func checkoutWagoSourceInContext(ctx context.Context, parent, ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
@@ -235,20 +223,12 @@ func checkoutWagoSourceWithGit(ctx context.Context, ref, source string) error {
 	return nil
 }
 
-func checkoutWagoSourceArchive(ref, temp, source string) error {
-	return checkoutWagoSourceArchiveContext(context.Background(), ref, temp, source)
-}
-
 func checkoutWagoSourceArchiveContext(ctx context.Context, ref, temp, source string) error {
 	archive := filepath.Join(temp, "source.zip")
 	if err := downloadSourceArchiveContext(ctx, sourceArchiveURL(ref), archive); err != nil {
 		return err
 	}
 	return sourcearchive.Extract(archive, source)
-}
-
-func downloadSourceArchive(address, target string) error {
-	return downloadSourceArchiveContext(context.Background(), address, target)
 }
 
 func downloadSourceArchiveContext(ctx context.Context, address, target string) error {

--- a/cli/manager/internal/version/source.go
+++ b/cli/manager/internal/version/source.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,9 +20,12 @@ import (
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
+const sourceArchiveLimit int64 = 256 << 20
+
 var (
-	buildRunnerSource  = buildRunnerFromSourceContext
-	buildManagerSource = buildManagerFromSourceContext
+	buildRunnerSource    = buildRunnerFromSourceContext
+	buildManagerSource   = buildManagerFromSourceContext
+	sourceArchiveMaximum = sourceArchiveLimit
 )
 
 func sourceRepository() string {
@@ -77,10 +81,13 @@ func buildRunnerFromSourceContext(ctx context.Context, ref string, profile wagop
 			args = append(args, "-tags", tags)
 		}
 		args = append(args, "-o", tempRunner, "./cli/wago")
-		output, buildErr := runSourceCommand(source, nil, "tinygo", args...)
+		output, buildErr := runSourceCommand(ctx, source, nil, "tinygo", args...)
 		if buildErr != nil {
 			if progress != nil {
 				progress.Fail("TinyGo source build failed")
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
 			}
 			return commandFailure("tinygo build", buildErr, output)
 		}
@@ -93,10 +100,13 @@ func buildRunnerFromSourceContext(ctx context.Context, ref string, profile wagop
 		args = append(args, "-tags", tags)
 	}
 	args = append(args, "-o", tempRunner, "./cli/wago")
-	output, err := runSourceCommand(source, append(os.Environ(), "CGO_ENABLED=0"), "go", args...)
+	output, err := runSourceCommand(ctx, source, append(os.Environ(), "CGO_ENABLED=0"), "go", args...)
 	if err != nil {
 		if progress != nil {
 			progress.Fail("source build failed")
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		return commandFailure("go build", err, output)
 	}
@@ -132,10 +142,13 @@ func buildManagerFromSourceContext(ctx context.Context, ref, dest string, progre
 		"-ldflags", "-s -w -X main.version=" + stamp,
 		"-o", tempManager, "./cli/wago",
 	}
-	output, err := runSourceCommand(source, append(os.Environ(), "CGO_ENABLED=0"), "go", args...)
+	output, err := runSourceCommand(ctx, source, append(os.Environ(), "CGO_ENABLED=0"), "go", args...)
 	if err != nil {
 		if progress != nil {
 			progress.Fail("manager source build failed")
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		return commandFailure("go build", err, output)
 	}
@@ -155,6 +168,12 @@ func checkoutWagoSourceIn(parent, ref string, progress *managerprogress.Progress
 }
 
 func checkoutWagoSourceInContext(ctx context.Context, parent, ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
+	if ctx == nil {
+		return "", "", "", errors.New("nil source checkout context")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", "", "", err
+	}
 	if err := automation.RequireOnline("source checkout"); err != nil {
 		return "", "", "", err
 	}
@@ -167,9 +186,16 @@ func checkoutWagoSourceInContext(ctx context.Context, parent, ref string, progre
 		progress.Begin("fetching source")
 	}
 	stamp = ref
-	gitErr := checkoutWagoSourceWithGit(ref, source)
+	gitErr := checkoutWagoSourceWithGit(ctx, ref, source)
 	if gitErr != nil {
 		_ = os.RemoveAll(source)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if progress != nil {
+				progress.Fail("source fetch canceled")
+			}
+			_ = os.RemoveAll(temp)
+			return "", "", "", ctxErr
+		}
 		if progress != nil {
 			progress.Begin("fetching source archive")
 		}
@@ -190,7 +216,7 @@ func checkoutWagoSourceInContext(ctx context.Context, parent, ref string, progre
 	return temp, source, stamp, nil
 }
 
-func checkoutWagoSourceWithGit(ref, source string) error {
+func checkoutWagoSourceWithGit(ctx context.Context, ref, source string) error {
 	if sha, canaryCommit := canaryCommitSHA(ref); canaryCommit {
 		commands := [][]string{
 			{"init", "--quiet", source},
@@ -199,11 +225,11 @@ func checkoutWagoSourceWithGit(ref, source string) error {
 			{"-C", source, "checkout", "--quiet", "--detach", "FETCH_HEAD"},
 		}
 		for _, args := range commands {
-			if output, err := runSourceCommand("", nil, "git", args...); err != nil {
+			if output, err := runSourceCommand(ctx, "", nil, "git", args...); err != nil {
 				return commandFailure("git "+args[0], err, output)
 			}
 		}
-	} else if output, err := runSourceCommand("", nil, "git", "clone", "--depth", "1", "--single-branch", "--branch", ref, "--", sourceRepository(), source); err != nil {
+	} else if output, err := runSourceCommand(ctx, "", nil, "git", "clone", "--depth", "1", "--single-branch", "--branch", ref, "--", sourceRepository(), source); err != nil {
 		return commandFailure("git clone", err, output)
 	}
 	return nil
@@ -234,9 +260,8 @@ func downloadSourceArchiveContext(ctx context.Context, address, target string) e
 	if response.StatusCode != http.StatusOK {
 		return &httpStatusError{url: address, code: response.StatusCode, status: response.Status}
 	}
-	const maxDownloadSize int64 = 256 << 20
-	if response.ContentLength > maxDownloadSize {
-		return &httpclient.BodyTooLargeError{URL: address, Limit: maxDownloadSize, ContentLength: response.ContentLength}
+	if response.ContentLength > sourceArchiveMaximum {
+		return &httpclient.BodyTooLargeError{URL: address, Limit: sourceArchiveMaximum, ContentLength: response.ContentLength}
 	}
 	file, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
@@ -248,13 +273,22 @@ func downloadSourceArchiveContext(ctx context.Context, address, target string) e
 			_ = os.Remove(target)
 		}
 	}()
-	written, copyErr := io.Copy(file, io.LimitReader(response.Body, maxDownloadSize+1))
+	written, copyErr := io.Copy(file, io.LimitReader(response.Body, sourceArchiveMaximum))
+	if copyErr == nil && response.ContentLength >= 0 && written != response.ContentLength {
+		copyErr = io.ErrUnexpectedEOF
+	}
+	if copyErr == nil && written == sourceArchiveMaximum {
+		var extra [1]byte
+		read, readErr := io.ReadFull(response.Body, extra[:])
+		if read != 0 {
+			copyErr = &httpclient.BodyTooLargeError{URL: address, Limit: sourceArchiveMaximum, ContentLength: -1}
+		} else if readErr != nil && readErr != io.EOF {
+			copyErr = readErr
+		}
+	}
 	closeErr := file.Close()
 	if copyErr != nil {
 		return copyErr
-	}
-	if written > maxDownloadSize {
-		return &httpclient.BodyTooLargeError{URL: address, Limit: maxDownloadSize, ContentLength: -1}
 	}
 	if closeErr != nil {
 		return closeErr
@@ -264,11 +298,15 @@ func downloadSourceArchiveContext(ctx context.Context, address, target string) e
 }
 
 func syncInstalledSource(ref, dest string, progress *managerprogress.Progress) error {
+	return syncInstalledSourceContext(context.Background(), ref, dest, progress)
+}
+
+func syncInstalledSourceContext(ctx context.Context, ref, dest string, progress *managerprogress.Progress) error {
 	parent := filepath.Dir(dest)
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return err
 	}
-	temp, source, _, err := checkoutWagoSourceInContext(context.Background(), parent, ref, progress)
+	temp, source, _, err := checkoutWagoSourceInContext(ctx, parent, ref, progress)
 	if err != nil {
 		return err
 	}
@@ -325,8 +363,11 @@ func sourceBuildTag(profile wagopaths.Profile) string {
 
 var runSourceCommand = executeSourceCommand
 
-func executeSourceCommand(dir string, env []string, name string, args ...string) ([]byte, error) {
-	command := exec.Command(name, args...)
+func executeSourceCommand(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("nil source command context")
+	}
+	command := exec.CommandContext(ctx, name, args...)
 	command.Dir = dir
 	if env != nil {
 		command.Env = env

--- a/cli/manager/internal/version/source.go
+++ b/cli/manager/internal/version/source.go
@@ -1,7 +1,7 @@
 package version
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,13 +13,15 @@ import (
 
 	"github.com/wago-org/wago/cli/internal/automation"
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
+	"github.com/wago-org/wago/internal/atomicfile"
+	"github.com/wago-org/wago/internal/httpclient"
 	"github.com/wago-org/wago/internal/sourcearchive"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
 var (
-	buildRunnerSource  = buildRunnerFromSource
-	buildManagerSource = buildManagerFromSource
+	buildRunnerSource  = buildRunnerFromSourceContext
+	buildManagerSource = buildManagerFromSourceContext
 )
 
 func sourceRepository() string {
@@ -40,13 +42,26 @@ func sourceArchiveURL(ref string) string {
 }
 
 func buildRunnerFromSource(ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, progress *managerprogress.Progress) error {
-	temp, source, stamp, err := checkoutWagoSource(ref, progress)
+	return buildRunnerFromSourceContext(context.Background(), ref, profile, build, dest, progress)
+}
+
+func buildRunnerFromSourceContext(ctx context.Context, ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, progress *managerprogress.Progress) error {
+	temp, source, stamp, err := checkoutWagoSourceContext(ctx, ref, progress)
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(temp)
 
-	tempRunner := dest + ".tmp"
+	tempFile, err := atomicfile.CreateTemp(dest)
+	if err != nil {
+		return err
+	}
+	tempRunner := tempFile.Name()
+	if err := tempFile.Close(); err != nil {
+		_ = os.Remove(tempRunner)
+		return err
+	}
+	defer os.Remove(tempRunner)
 	if progress != nil {
 		progress.Begin("building " + string(profile) + " runtime from source")
 	}
@@ -89,13 +104,26 @@ func buildRunnerFromSource(ref string, profile wagopaths.Profile, build wagopath
 }
 
 func buildManagerFromSource(ref, dest string, progress *managerprogress.Progress) error {
-	temp, source, stamp, err := checkoutWagoSource(ref, progress)
+	return buildManagerFromSourceContext(context.Background(), ref, dest, progress)
+}
+
+func buildManagerFromSourceContext(ctx context.Context, ref, dest string, progress *managerprogress.Progress) error {
+	temp, source, stamp, err := checkoutWagoSourceContext(ctx, ref, progress)
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(temp)
 
-	tempManager := dest + ".tmp"
+	tempFile, err := atomicfile.CreateTemp(dest)
+	if err != nil {
+		return err
+	}
+	tempManager := tempFile.Name()
+	if err := tempFile.Close(); err != nil {
+		_ = os.Remove(tempManager)
+		return err
+	}
+	defer os.Remove(tempManager)
 	if progress != nil {
 		progress.Begin("building Wago from source")
 	}
@@ -115,10 +143,18 @@ func buildManagerFromSource(ref, dest string, progress *managerprogress.Progress
 }
 
 func checkoutWagoSource(ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
-	return checkoutWagoSourceIn("", ref, progress)
+	return checkoutWagoSourceContext(context.Background(), ref, progress)
+}
+
+func checkoutWagoSourceContext(ctx context.Context, ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
+	return checkoutWagoSourceInContext(ctx, "", ref, progress)
 }
 
 func checkoutWagoSourceIn(parent, ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
+	return checkoutWagoSourceInContext(context.Background(), parent, ref, progress)
+}
+
+func checkoutWagoSourceInContext(ctx context.Context, parent, ref string, progress *managerprogress.Progress) (temp, source, stamp string, err error) {
 	if err := automation.RequireOnline("source checkout"); err != nil {
 		return "", "", "", err
 	}
@@ -137,7 +173,7 @@ func checkoutWagoSourceIn(parent, ref string, progress *managerprogress.Progress
 		if progress != nil {
 			progress.Begin("fetching source archive")
 		}
-		if archiveErr := checkoutWagoSourceArchive(ref, temp, source); archiveErr != nil {
+		if archiveErr := checkoutWagoSourceArchiveContext(ctx, ref, temp, source); archiveErr != nil {
 			if progress != nil {
 				progress.Fail("could not fetch source")
 			}
@@ -174,15 +210,23 @@ func checkoutWagoSourceWithGit(ref, source string) error {
 }
 
 func checkoutWagoSourceArchive(ref, temp, source string) error {
+	return checkoutWagoSourceArchiveContext(context.Background(), ref, temp, source)
+}
+
+func checkoutWagoSourceArchiveContext(ctx context.Context, ref, temp, source string) error {
 	archive := filepath.Join(temp, "source.zip")
-	if err := downloadSourceArchive(sourceArchiveURL(ref), archive); err != nil {
+	if err := downloadSourceArchiveContext(ctx, sourceArchiveURL(ref), archive); err != nil {
 		return err
 	}
 	return sourcearchive.Extract(archive, source)
 }
 
 func downloadSourceArchive(address, target string) error {
-	response, err := http.Get(address)
+	return downloadSourceArchiveContext(context.Background(), address, target)
+}
+
+func downloadSourceArchiveContext(ctx context.Context, address, target string) error {
+	response, err := openReleaseStream(ctx, "source archive download", address)
 	if err != nil {
 		return err
 	}
@@ -190,20 +234,33 @@ func downloadSourceArchive(address, target string) error {
 	if response.StatusCode != http.StatusOK {
 		return &httpStatusError{url: address, code: response.StatusCode, status: response.Status}
 	}
-	file, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	const maxDownloadSize int64 = 256 << 20
+	if response.ContentLength > maxDownloadSize {
+		return &httpclient.BodyTooLargeError{URL: address, Limit: maxDownloadSize, ContentLength: response.ContentLength}
+	}
+	file, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
-	const maxDownloadSize = 256 << 20
+	remove := true
+	defer func() {
+		if remove {
+			_ = os.Remove(target)
+		}
+	}()
 	written, copyErr := io.Copy(file, io.LimitReader(response.Body, maxDownloadSize+1))
 	closeErr := file.Close()
 	if copyErr != nil {
 		return copyErr
 	}
 	if written > maxDownloadSize {
-		return errors.New("source archive exceeds 256 MiB limit")
+		return &httpclient.BodyTooLargeError{URL: address, Limit: maxDownloadSize, ContentLength: -1}
 	}
-	return closeErr
+	if closeErr != nil {
+		return closeErr
+	}
+	remove = false
+	return nil
 }
 
 func syncInstalledSource(ref, dest string, progress *managerprogress.Progress) error {
@@ -211,7 +268,7 @@ func syncInstalledSource(ref, dest string, progress *managerprogress.Progress) e
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return err
 	}
-	temp, source, _, err := checkoutWagoSourceIn(parent, ref, progress)
+	temp, source, _, err := checkoutWagoSourceInContext(context.Background(), parent, ref, progress)
 	if err != nil {
 		return err
 	}
@@ -278,10 +335,7 @@ func executeSourceCommand(dir string, env []string, name string, args ...string)
 }
 
 func finishSourceBuild(tempRunner, dest string, progress *managerprogress.Progress, message string) error {
-	if err := os.Chmod(tempRunner, 0o755); err != nil {
-		return err
-	}
-	if err := os.Rename(tempRunner, dest); err != nil {
+	if err := atomicfile.CommitTempFile(tempRunner, dest, atomicfile.Options{Mode: 0o755, Sync: true}); err != nil {
 		return err
 	}
 	if progress != nil {

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -3,6 +3,7 @@ package version
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
+	"github.com/wago-org/wago/internal/atomicfile"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
@@ -26,7 +28,7 @@ func TestMissingReleaseAssetFallsBackToSource(t *testing.T) {
 	var gotRef string
 	var gotProfile wagopaths.Profile
 	var gotBuild wagopaths.Build
-	buildRunnerSource = func(ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, _ *managerprogress.Progress) error {
+	buildRunnerSource = func(_ context.Context, ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, _ *managerprogress.Progress) error {
 		gotRef, gotProfile = ref, profile
 		gotBuild = build
 		return os.WriteFile(dest, []byte("source runner"), 0o755)
@@ -61,7 +63,7 @@ func TestMissingManagerAssetFallsBackToSource(t *testing.T) {
 	old := buildManagerSource
 	t.Cleanup(func() { buildManagerSource = old })
 	var gotRef string
-	buildManagerSource = func(ref, dest string, _ *managerprogress.Progress) error {
+	buildManagerSource = func(_ context.Context, ref, dest string, _ *managerprogress.Progress) error {
 		gotRef = ref
 		return os.WriteFile(dest, []byte("source manager"), 0o755)
 	}
@@ -82,7 +84,8 @@ func TestMissingManagerAssetFallsBackToSource(t *testing.T) {
 func TestChecksumMismatchDoesNotBuildFromSource(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ".sha256") {
-			_, _ = w.Write([]byte("deadbeef\n"))
+			asset := strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, ".sha256"), "/v1.0.0/")
+			_, _ = w.Write([]byte(strings.Repeat("0", 64) + "  " + asset + "\n"))
 			return
 		}
 		_, _ = w.Write([]byte("runner"))
@@ -93,7 +96,7 @@ func TestChecksumMismatchDoesNotBuildFromSource(t *testing.T) {
 	old := buildRunnerSource
 	t.Cleanup(func() { buildRunnerSource = old })
 	called := false
-	buildRunnerSource = func(string, wagopaths.Profile, wagopaths.Build, string, *managerprogress.Progress) error {
+	buildRunnerSource = func(context.Context, string, wagopaths.Profile, wagopaths.Build, string, *managerprogress.Progress) error {
 		called = true
 		return nil
 	}
@@ -129,7 +132,7 @@ func TestCanaryCommitMissingReleaseBuildsExactSource(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
 	target := canaryCommitTarget(sha)
 	var gotRef string
-	buildRunnerSource = func(ref string, _ wagopaths.Profile, _ wagopaths.Build, dest string, _ *managerprogress.Progress) error {
+	buildRunnerSource = func(_ context.Context, ref string, _ wagopaths.Profile, _ wagopaths.Build, dest string, _ *managerprogress.Progress) error {
 		gotRef = ref
 		return os.WriteFile(dest, []byte("source runner"), 0o755)
 	}
@@ -172,6 +175,36 @@ func TestBuildRunnerFromSourceUsesProfileTag(t *testing.T) {
 	}
 	if body, err := os.ReadFile(dest); err != nil || string(body) != "built" {
 		t.Fatalf("built runner = %q, %v", body, err)
+	}
+}
+
+func TestFinishSourceBuildReplacesExisting(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "wago")
+	if err := os.WriteFile(destination, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	temporary, err := atomicfile.CreateTemp(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := temporary.Name()
+	if _, err := temporary.Write([]byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := temporary.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := finishSourceBuild(name, destination, nil, "built"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil || string(data) != "new" {
+		t.Fatalf("source build destination = %q, %v", data, err)
+	}
+	matches, err := filepath.Glob(filepath.Join(directory, ".wago-atomic-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("source build temporary debris = %v, %v", matches, err)
 	}
 }
 

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,11 +13,136 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
 	"github.com/wago-org/wago/internal/atomicfile"
+	"github.com/wago-org/wago/internal/httpclient"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
+
+func TestExecuteSourceCommandCancellation(t *testing.T) {
+	if os.Getenv("WAGO_TEST_SOURCE_COMMAND_HELPER") == "1" {
+		time.Sleep(10 * time.Second)
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := executeSourceCommand(ctx, "", append(os.Environ(), "WAGO_TEST_SOURCE_COMMAND_HELPER=1"), os.Args[0], "-test.run=^TestExecuteSourceCommandCancellation$")
+		done <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("canceled source command returned no error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled source command did not stop")
+	}
+}
+
+func TestSourceCheckoutRejectsNilContext(t *testing.T) {
+	if _, _, _, err := checkoutWagoSourceInContext(nil, t.TempDir(), "v1.2.3", nil); err == nil {
+		t.Fatal("source checkout accepted a nil context")
+	}
+}
+
+func TestSourceCheckoutCancellationStopsGitWithoutArchiveFallback(t *testing.T) {
+	old := runSourceCommand
+	t.Cleanup(func() { runSourceCommand = old })
+	started := make(chan struct{})
+	runSourceCommand = func(ctx context.Context, _ string, _ []string, _ string, _ ...string) ([]byte, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	parent := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		temp, _, _, err := checkoutWagoSourceInContext(ctx, parent, "v1.2.3", nil)
+		if temp != "" {
+			done <- fmt.Errorf("canceled checkout returned temp %q", temp)
+			return
+		}
+		done <- err
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled source checkout = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled source checkout did not return")
+	}
+	matches, err := filepath.Glob(filepath.Join(parent, ".wago-source-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("canceled source checkout left temporary directories: %v, %v", matches, err)
+	}
+}
+
+func TestDownloadSourceArchiveIsSizeBounded(t *testing.T) {
+	oldMaximum := sourceArchiveMaximum
+	sourceArchiveMaximum = 8
+	t.Cleanup(func() { sourceArchiveMaximum = oldMaximum })
+
+	for _, test := range []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{name: "declared", handler: func(writer http.ResponseWriter, _ *http.Request) {
+			writer.Header().Set("Content-Length", "9")
+			writer.WriteHeader(http.StatusOK)
+		}},
+		{name: "chunked", handler: func(writer http.ResponseWriter, _ *http.Request) {
+			writer.(http.Flusher).Flush()
+			_, _ = writer.Write([]byte("123456789"))
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(test.handler)
+			defer server.Close()
+			target := filepath.Join(t.TempDir(), "source.zip")
+			if err := downloadSourceArchiveContext(context.Background(), server.URL, target); !errors.Is(err, httpclient.ErrBodyTooLarge) {
+				t.Fatalf("oversized source archive = %v", err)
+			}
+			if _, err := os.Stat(target); !os.IsNotExist(err) {
+				t.Fatalf("oversized source archive left target: %v", err)
+			}
+		})
+	}
+
+	truncated := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Length", "8")
+		_, _ = writer.Write([]byte("1234"))
+	}))
+	defer truncated.Close()
+	truncatedTarget := filepath.Join(t.TempDir(), "source.zip")
+	if err := downloadSourceArchiveContext(context.Background(), truncated.URL, truncatedTarget); err == nil {
+		t.Fatal("truncated source archive was accepted")
+	}
+	if _, err := os.Stat(truncatedTarget); !os.IsNotExist(err) {
+		t.Fatalf("truncated source archive left target: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.(http.Flusher).Flush()
+		_, _ = writer.Write([]byte("12345678"))
+	}))
+	defer server.Close()
+	target := filepath.Join(t.TempDir(), "source.zip")
+	if err := downloadSourceArchiveContext(context.Background(), server.URL, target); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(target); err != nil || string(data) != "12345678" {
+		t.Fatalf("exact-limit source archive = %q, %v", data, err)
+	}
+}
 
 func TestMissingReleaseAssetFallsBackToSource(t *testing.T) {
 	server := httptest.NewServer(http.NotFoundHandler())
@@ -149,7 +275,7 @@ func TestBuildRunnerFromSourceUsesProfileTag(t *testing.T) {
 	old := runSourceCommand
 	t.Cleanup(func() { runSourceCommand = old })
 	var commands []string
-	runSourceCommand = func(_ string, _ []string, name string, args ...string) ([]byte, error) {
+	runSourceCommand = func(_ context.Context, _ string, _ []string, name string, args ...string) ([]byte, error) {
 		commands = append(commands, name+" "+strings.Join(args, " "))
 		switch name {
 		case "git":
@@ -230,7 +356,7 @@ func TestBuildRunnerFromSourceFallsBackToArchiveWithoutGit(t *testing.T) {
 	old := runSourceCommand
 	t.Cleanup(func() { runSourceCommand = old })
 	var commands []string
-	runSourceCommand = func(dir string, _ []string, name string, args ...string) ([]byte, error) {
+	runSourceCommand = func(_ context.Context, dir string, _ []string, name string, args ...string) ([]byte, error) {
 		commands = append(commands, name+" "+strings.Join(args, " "))
 		if name == "git" {
 			return nil, errors.New(`exec: "git": executable file not found in %PATH%`)
@@ -277,7 +403,7 @@ func TestBuildRunnerFromSourceChecksOutExactCanaryCommit(t *testing.T) {
 	t.Cleanup(func() { runSourceCommand = old })
 	const sha = "deadbee123456789012345678901234567890123"
 	var commands []string
-	runSourceCommand = func(_ string, _ []string, name string, args ...string) ([]byte, error) {
+	runSourceCommand = func(_ context.Context, _ string, _ []string, name string, args ...string) ([]byte, error) {
 		commands = append(commands, name+" "+strings.Join(args, " "))
 		if name == "go" {
 			output := args[slices.Index(args, "-o")+1]
@@ -308,7 +434,7 @@ func TestSyncInstalledSourceReplacesManagedCheckoutAtExactCanaryCommit(t *testin
 	t.Cleanup(func() { runSourceCommand = old })
 	const sha = "880e153000000000000000000000000000000000"
 	var commands []string
-	runSourceCommand = func(_ string, _ []string, name string, args ...string) ([]byte, error) {
+	runSourceCommand = func(_ context.Context, _ string, _ []string, name string, args ...string) ([]byte, error) {
 		commands = append(commands, name+" "+strings.Join(args, " "))
 		if name == "git" && len(args) >= 3 && args[0] == "init" {
 			source := args[len(args)-1]

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -45,7 +45,8 @@ func TestExecuteSourceCommandCancellation(t *testing.T) {
 }
 
 func TestSourceCheckoutRejectsNilContext(t *testing.T) {
-	if _, _, _, err := checkoutWagoSourceInContext(nil, t.TempDir(), "v1.2.3", nil); err == nil {
+	var nilContext context.Context
+	if _, _, _, err := checkoutWagoSourceInContext(nilContext, t.TempDir(), "v1.2.3", nil); err == nil {
 		t.Fatal("source checkout accepted a nil context")
 	}
 }

--- a/cli/manager/internal/version/toolchain.go
+++ b/cli/manager/internal/version/toolchain.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/wago-org/wago/cli/internal/automation"
@@ -8,7 +9,15 @@ import (
 )
 
 type Toolchain struct {
-	Dirs wagopaths.Dirs
+	Dirs    wagopaths.Dirs
+	Context context.Context
+}
+
+func (t Toolchain) context() context.Context {
+	if t.Context != nil {
+		return t.Context
+	}
+	return context.Background()
 }
 
 type InstallRequest struct {
@@ -32,8 +41,8 @@ func (t Toolchain) Which()           { vmWhich(t.Dirs) }
 func (t Toolchain) ChooseInstalled() { vmChooseInstalled(t.Dirs) }
 
 func (t Toolchain) Install(request InstallRequest) {
-	vmInstallRequested(
-		t.Dirs, request.Versions, request.Latest, request.Nightly, request.Canary,
+	vmInstallRequestedContext(
+		t.context(), t.Dirs, request.Versions, request.Latest, request.Nightly, request.Canary,
 		request.Profile, request.Build,
 		request.Use,
 	)
@@ -59,7 +68,7 @@ func (t Toolchain) Switch(name, profileValue, buildValue string) {
 		}
 	}
 	if _, _, _, installed := installedRuntime(t.Dirs, name, profile, build); !installed {
-		vmInstallForSwitch(t.Dirs, name, profile, build)
+		vmInstallForSwitchContext(t.context(), t.Dirs, name, profile, build)
 	}
 	vmSwitchTo(t.Dirs, name, profile, build)
 }
@@ -101,7 +110,7 @@ func (t Toolchain) Update(request UpdateRequest) {
 	if name == "" {
 		fatal("version update: %v", fmt.Errorf("no release channel selected"))
 	}
-	vmUpdate(t.Dirs, name, profile, build, request.Use, request.Force)
+	vmUpdateContext(t.context(), t.Dirs, name, profile, build, request.Use, request.Force)
 }
 
 func (t Toolchain) UninstallAll() {

--- a/cli/manager/internal/version/update_test.go
+++ b/cli/manager/internal/version/update_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,18 +54,18 @@ func TestVersionUpdateSkipsMatchingInstalledCommitUnlessForced(t *testing.T) {
 	if err := os.WriteFile(dest, []byte("runtime"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	oldResolve, oldInstall, oldOutput := resolveUpdateRunnerVersion, installUpdateRunnerPayload, runtimeVersionOutput
+	oldResolve, oldInstall, oldOutput := resolveUpdateRunnerVersionContext, installUpdateRunnerPayloadContext, runtimeVersionOutput
 	t.Cleanup(func() {
-		resolveUpdateRunnerVersion, installUpdateRunnerPayload, runtimeVersionOutput = oldResolve, oldInstall, oldOutput
+		resolveUpdateRunnerVersionContext, installUpdateRunnerPayloadContext, runtimeVersionOutput = oldResolve, oldInstall, oldOutput
 	})
-	resolveUpdateRunnerVersion = func(string, *managerprogress.Progress) (string, bool, error) {
+	resolveUpdateRunnerVersionContext = func(context.Context, string, *managerprogress.Progress) (string, bool, error) {
 		return "canary@deadbee123456789012345678901234567890123", false, nil
 	}
 	runtimeVersionOutput = func(string) ([]byte, error) {
 		return []byte("Wago\n  release      canary-deadbee\n"), nil
 	}
 	installs := 0
-	installUpdateRunnerPayload = func(string, wagopaths.Profile, wagopaths.Build, string, bool, *managerprogress.Progress) error {
+	installUpdateRunnerPayloadContext = func(context.Context, string, wagopaths.Profile, wagopaths.Build, string, bool, *managerprogress.Progress) error {
 		installs++
 		return nil
 	}

--- a/cli/manager/internal/version/version.go
+++ b/cli/manager/internal/version/version.go
@@ -58,6 +58,10 @@ func SyncInstalledSource(ref, dest string, progress *managerprogress.Progress) e
 	return syncInstalledSource(ref, dest, progress)
 }
 
+func SyncInstalledSourceContext(ctx context.Context, ref, dest string, progress *managerprogress.Progress) error {
+	return syncInstalledSourceContext(ctx, ref, dest, progress)
+}
+
 func SetActiveInstallation(d wagopaths.Dirs, name string, profile wagopaths.Profile, build wagopaths.Build) error {
 	return setActiveInstallation(d, name, profile, build)
 }

--- a/cli/manager/internal/version/version.go
+++ b/cli/manager/internal/version/version.go
@@ -3,6 +3,7 @@
 package version
 
 import (
+	"context"
 	"io"
 
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
@@ -25,16 +26,32 @@ func InstallManagerUpdate(channel, dest string, progress *managerprogress.Progre
 	return installManagerUpdate(channel, dest, progress)
 }
 
+func InstallManagerUpdateContext(ctx context.Context, channel, dest string, progress *managerprogress.Progress) (string, error) {
+	return installManagerUpdateContext(ctx, channel, dest, progress)
+}
+
 func ResolveManagerUpdate(channel string, progress *managerprogress.Progress) (string, bool, error) {
 	return resolveManagerUpdate(channel, progress)
+}
+
+func ResolveManagerUpdateContext(ctx context.Context, channel string, progress *managerprogress.Progress) (string, bool, error) {
+	return resolveManagerUpdateContext(ctx, channel, progress)
 }
 
 func InstallManagerPayload(resolved, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
 	return installManagerPayload(resolved, dest, sourceOnly, progress)
 }
 
+func InstallManagerPayloadContext(ctx context.Context, resolved, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
+	return installManagerPayloadContext(ctx, resolved, dest, sourceOnly, progress)
+}
+
 func InstallRunnerPayload(ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
 	return installRunnerPayload(ref, profile, build, dest, sourceOnly, progress)
+}
+
+func InstallRunnerPayloadContext(ctx context.Context, ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
+	return installRunnerPayloadContext(ctx, ref, profile, build, dest, sourceOnly, progress)
 }
 
 func SyncInstalledSource(ref, dest string, progress *managerprogress.Progress) error {

--- a/cli/manager/main.go
+++ b/cli/manager/main.go
@@ -1,11 +1,13 @@
 package manager
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -40,6 +42,9 @@ func versionString() string {
 // installation so every profile retains the same management commands.
 func Main(v string) {
 	version = v
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	managerRoot = buildCommandRegistryContext(ctx)
 	managerplugin.ConfigureManagerVersion(versionString())
 	args, err := automation.ParseLeading(os.Args[1:])
 	if err != nil {

--- a/cli/manager/main.go
+++ b/cli/manager/main.go
@@ -44,6 +44,14 @@ func Main(v string) {
 	version = v
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
+	// NotifyContext suppresses the default interrupt action while registered.
+	// Restore it after the first signal so context-aware work can unwind, while
+	// a second Ctrl-C still terminates commands that have not reached a context
+	// cancellation point.
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
 	managerRoot = buildCommandRegistryContext(ctx)
 	managerplugin.ConfigureManagerVersion(versionString())
 	args, err := automation.ParseLeading(os.Args[1:])

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/wago-org/wago"
+	"github.com/wago-org/wago/internal/atomicfile"
 )
 
 // Cache is a best-effort store for regenerable .wago artifacts. The runtime
@@ -21,6 +24,9 @@ import (
 type Cache struct {
 	Dir      string
 	Identity []byte
+	// ReportError observes best-effort publication failures. When nil, failures
+	// are reported on stderr so persistent cache misses are diagnosable.
+	ReportError func(error)
 }
 
 const cacheKeyFormat = 1
@@ -61,7 +67,13 @@ func (cache Cache) LoadOrCompile(source []byte, config *wago.RuntimeConfig, rt *
 		// Some valid compilation modes intentionally cannot be serialized.
 		return module, nil
 	}
-	_ = writeAtomic(path, artifact)
+	if err := publishArtifact(path, artifact); err != nil {
+		if cache.ReportError != nil {
+			cache.ReportError(err)
+		} else {
+			fmt.Fprintf(os.Stderr, "wago: artifact cache publication failed: %v\n", err)
+		}
+	}
 	return module, nil
 }
 
@@ -203,27 +215,11 @@ func writeUint64(h interface{ Write([]byte) (int, error) }, value uint64) {
 	h.Write(encoded[:])
 }
 
+var publishArtifact = writeAtomic
+
 func writeAtomic(path string, artifact []byte) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	return atomicfile.ReplaceFile(path, atomicfile.Options{Mode: 0o644}, func(writer io.Writer) error {
+		_, err := writer.Write(artifact)
 		return err
-	}
-	temp, err := os.CreateTemp(dir, ".wago-*")
-	if err != nil {
-		return err
-	}
-	tempName := temp.Name()
-	defer os.Remove(tempName)
-	if err := temp.Chmod(0o644); err != nil {
-		temp.Close()
-		return err
-	}
-	if _, err := temp.Write(artifact); err != nil {
-		temp.Close()
-		return err
-	}
-	if err := temp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tempName, path)
+	})
 }

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -52,6 +53,29 @@ func TestLoadOrCompileCachesAndRepairsArtifact(t *testing.T) {
 	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), ".wago-*"))
 	if err != nil || len(matches) != 0 {
 		t.Fatalf("temporary artifacts remain: %v (err %v)", matches, err)
+	}
+}
+
+func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
+	source := constantModule()
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	var reported error
+	cache.ReportError = func(err error) { reported = err }
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	defer rt.Close()
+
+	injected := errors.New("injected cache publication failure")
+	oldPublish := publishArtifact
+	publishArtifact = func(string, []byte) error { return injected }
+	t.Cleanup(func() { publishArtifact = oldPublish })
+
+	module, err := cache.LoadOrCompile(source, config, rt)
+	if err != nil || module == nil {
+		t.Fatalf("LoadOrCompile = %v, %v", module, err)
+	}
+	if !errors.Is(reported, injected) {
+		t.Fatalf("reported error = %v", reported)
 	}
 }
 

--- a/docs/artifact-cache.md
+++ b/docs/artifact-cache.md
@@ -52,7 +52,14 @@ registry order is interpreted under the build identity that owns that registry.
 The final SHA-256 key remains hexadecimal in the filesystem path. Artifact
 loading keeps its existing version, ABI, target, and malformed-input checks;
 cache corruption remains a safe miss followed by recompilation and atomic
-replacement.
+replacement. Publication uses a unique same-directory temporary file and a
+platform-specific replace-existing operation, including `MoveFileExW` on
+Windows. Existing symlink, directory, and non-regular destinations are rejected;
+failed writes leave the prior regular artifact intact and remove the temporary
+file. Because cache entries are regenerable, publication does not promise
+power-loss durability or sync the parent directory. Publication failures remain
+best-effort for execution but are reported (or delivered to `Cache.ReportError`)
+so a persistent miss is diagnosable.
 
 ## Validation
 

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -1,23 +1,25 @@
-# CLI release hardening
+# CLI release and credential hardening
 
 Wago's manager applies explicit resource and publication policies to networked
-release operations.
+release, registry, and authentication operations.
 
 ## HTTP policies
 
 The shared internal HTTP client uses request contexts plus operation-class
 limits instead of the process default client:
 
+- small registry/API/OAuth JSON requests have a 30-second overall deadline;
 - release metadata and checksums have a 45-second overall deadline;
 - bounded release/source streams have a 30-minute overall deadline; and
 - dial, TLS-handshake, response-header, idle-connection, and
   `Expect: 100-continue` waits have independent transport timeouts.
 
-A parent command cancellation is propagated to active manager release requests.
-In-memory GitHub release JSON uses a 4 MiB limit, release checksums use 4 KiB,
-and non-success response capture uses an independent 64 KiB limit. Declared
-oversized bodies are rejected before reading; chunked or dishonest responses are
-stopped after the configured limit.
+A parent command cancellation is propagated to active manager requests. In-memory
+bodies are explicitly bounded: registry and GitHub release JSON use a 4 MiB
+limit, OAuth responses use 1 MiB, release checksums use 4 KiB, and non-success
+response capture uses an independent 64 KiB limit. Declared oversized bodies are
+rejected before reading; chunked or dishonest responses are stopped after the
+configured limit.
 
 ## Release downloads
 
@@ -44,3 +46,27 @@ replacement.
 File contents are synced before release publication, but Wago does not claim
 perfect power-loss durability because the parent directory is not synced on all
 platforms.
+
+## Registry credentials
+
+Registry credentials remain a plaintext fallback store containing long-lived
+bearer tokens. Every mutation:
+
+1. acquires an OS-backed exclusive lock associated with `credentials.json`;
+2. re-reads and validates the latest JSON while locked;
+3. applies the save or delete to that current state;
+4. writes a unique same-directory temporary file created as `0600`;
+5. syncs and closes it; and
+6. atomically replaces the prior regular file.
+
+This serializes separate Wago processes and prevents unrelated registry entries
+from being lost. Malformed existing data is reported rather than overwritten.
+Failures before replacement preserve the previous complete credential file and
+remove token-bearing temporary files.
+
+On Unix-like systems Wago repairs the configuration directory to `0700` and a
+successfully updated credential file to `0600`, including files that were
+previously more permissive. On Windows the same locking and atomic replacement
+rules apply, but POSIX mode bits are not equivalent to Windows ACL guarantees;
+this implementation does not claim ACL hardening beyond the current user's
+normal filesystem protections.

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -1,0 +1,46 @@
+# CLI release hardening
+
+Wago's manager applies explicit resource and publication policies to networked
+release operations.
+
+## HTTP policies
+
+The shared internal HTTP client uses request contexts plus operation-class
+limits instead of the process default client:
+
+- release metadata and checksums have a 45-second overall deadline;
+- bounded release/source streams have a 30-minute overall deadline; and
+- dial, TLS-handshake, response-header, idle-connection, and
+  `Expect: 100-continue` waits have independent transport timeouts.
+
+A parent command cancellation is propagated to active manager release requests.
+In-memory GitHub release JSON uses a 4 MiB limit, release checksums use 4 KiB,
+and non-success response capture uses an independent 64 KiB limit. Declared
+oversized bodies are rejected before reading; chunked or dishonest responses are
+stopped after the configured limit.
+
+## Release downloads
+
+Executable checksums are fetched before assets. The parser accepts exactly one
+64-hexadecimal SHA-256 record naming the expected asset. The executable is then
+streamed through a 64 KiB copy buffer into a unique same-directory temporary
+file while SHA-256 and progress are updated. Executables are limited to 512 MiB,
+which leaves substantial headroom over current stripped Wago binaries without
+allowing an endpoint to consume unbounded disk or memory. Source archives use a
+separate 256 MiB streaming limit.
+
+The destination is published only after the complete stream has the expected
+length and digest, the executable mode is set, the file is synced, and it is
+closed. Cancellation, malformed checksums, network interruption, oversized
+content, hash mismatch, write/sync/close failure, and replacement failure leave
+the previous destination unchanged and remove temporary files.
+
+Publication rejects destination symlinks, directories, and non-regular files.
+Unix uses same-filesystem rename replacement; Windows uses `MoveFileExW` with
+replace-existing and write-through flags. Running-manager self-replacement keeps
+its specialized delayed-restart fallback when Windows prevents immediate
+replacement.
+
+File contents are synced before release publication, but Wago does not claim
+perfect power-loss durability because the parent directory is not synced on all
+platforms.

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -14,17 +14,23 @@ limits instead of the process default client:
 - dial, TLS-handshake, response-header, idle-connection, and
   `Expect: 100-continue` waits have independent transport timeouts.
 
-A parent command cancellation is propagated to active manager requests. In-memory
-bodies are explicitly bounded: registry and GitHub release JSON use a 4 MiB
-limit, OAuth responses use 1 MiB, release checksums use 4 KiB, and non-success
-response capture uses an independent 64 KiB limit. Declared oversized bodies are
-rejected before reading; chunked or dishonest responses are stopped after the
-configured limit.
+A parent command cancellation is propagated to active manager requests and to
+Git/TinyGo/Go subprocesses used by source-build fallback. In-memory bodies are
+explicitly bounded: registry and GitHub release JSON use a 4 MiB limit, OAuth
+responses use 1 MiB, release checksums use 4 KiB, and non-success response
+capture uses an independent 64 KiB limit. Declared oversized bodies are rejected
+before reading; chunked or dishonest responses are stopped after the configured
+limit. Release/commit browsing is capped at ten 100-item pages so repeated full
+pages cannot accumulate metadata indefinitely. OAuth device-flow lifetimes and
+server-provided polling intervals are also capped.
 
 ## Release downloads
 
 Executable checksums are fetched before assets. The parser accepts exactly one
-64-hexadecimal SHA-256 record naming the expected asset. The executable is then
+64-hexadecimal SHA-256 record naming the expected asset; the checksum tools'
+harmless `./` filename prefix is accepted for existing releases, while arbitrary
+parent or nested paths are rejected. New release workflows emit basename-only
+records. The executable is then
 streamed through a 64 KiB copy buffer into a unique same-directory temporary
 file while SHA-256 and progress are updated. Executables are limited to 512 MiB,
 which leaves substantial headroom over current stripped Wago binaries without
@@ -39,8 +45,8 @@ the previous destination unchanged and remove temporary files.
 
 Publication rejects destination symlinks, directories, and non-regular files.
 Unix uses same-filesystem rename replacement; Windows uses `MoveFileExW` with
-replace-existing and write-through flags. Running-manager self-replacement keeps
-its specialized delayed-restart fallback when Windows prevents immediate
+replace-existing and write-through flags. Running-manager self-replacement uses a unique same-directory staging path and
+keeps its specialized delayed-restart fallback when Windows prevents immediate
 replacement.
 
 File contents are synced before release publication, but Wago does not claim
@@ -50,7 +56,7 @@ platforms.
 ## Registry credentials
 
 Registry credentials remain a plaintext fallback store containing long-lived
-bearer tokens. Every mutation:
+bearer tokens. Every mutation, including the decision whether logout has anything to remove:
 
 1. acquires an OS-backed exclusive lock associated with `credentials.json`;
 2. re-reads and validates the latest JSON while locked;

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -45,9 +45,10 @@ the previous destination unchanged and remove temporary files.
 
 Publication rejects destination symlinks, directories, and non-regular files.
 Unix uses same-filesystem rename replacement; Windows uses `MoveFileExW` with
-replace-existing and write-through flags. Running-manager self-replacement uses a unique same-directory staging path and
-keeps its specialized delayed-restart fallback when Windows prevents immediate
-replacement.
+replace-existing and write-through flags and briefly retries sharing conflicts
+from readers or concurrent publishers. Running-manager self-replacement uses a
+unique same-directory staging path and keeps its specialized delayed-restart
+fallback when Windows prevents immediate replacement.
 
 File contents are synced before release publication, but Wago does not claim
 perfect power-loss durability because the parent directory is not synced on all

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,215 @@
+// Package atomicfile publishes complete files through unique same-directory
+// temporary files and platform-correct replace-existing operations.
+package atomicfile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Options controls construction and publication. Sync flushes file contents
+// before the atomic replacement; it does not promise parent-directory durability.
+type Options struct {
+	Mode  fs.FileMode
+	Sync  bool
+	Hooks *Hooks
+}
+
+// Hooks supports deterministic failure testing at pre-commit boundaries.
+// Production callers must leave Hooks nil.
+type Hooks struct {
+	Sync    func(*os.File) error
+	Close   func(*os.File) error
+	Replace func(source, destination string) error
+}
+
+// ReplaceFile writes a unique restrictive temporary file in the destination
+// directory, finalizes it, and atomically replaces destination. Existing
+// directories, symlinks, and non-regular files are rejected.
+func ReplaceFile(destination string, options Options, write func(io.Writer) error) error {
+	if write == nil {
+		return errors.New("atomic file writer is nil")
+	}
+	if err := validateDestination(destination); err != nil {
+		return err
+	}
+	file, err := createTemp(destination)
+	if err != nil {
+		return err
+	}
+	temporary := file.Name()
+	closed := false
+	committed := false
+	defer func() {
+		if !closed {
+			_ = file.Close()
+		}
+		if !committed {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if err := write(file); err != nil {
+		return fmt.Errorf("write temporary file: %w", err)
+	}
+	if err := finalize(file, options); err != nil {
+		closed = true
+		return err
+	}
+	closed = true
+	if err := validateDestination(destination); err != nil {
+		return err
+	}
+	if err := replace(options, temporary, destination); err != nil {
+		return fmt.Errorf("replace %s: %w", destination, err)
+	}
+	committed = true
+	return nil
+}
+
+// CreateTemp creates a unique 0600 temporary file beside destination. It is
+// intended for tools such as the Go compiler that require an output pathname.
+// The caller must close it and either pass its name to CommitTempFile or remove it.
+func CreateTemp(destination string) (*os.File, error) {
+	if err := validateDestination(destination); err != nil {
+		return nil, err
+	}
+	return createTemp(destination)
+}
+
+// CommitTempFile finalizes an existing same-directory regular temporary file
+// and atomically replaces destination. The temporary file is removed on every
+// pre-commit failure.
+func CommitTempFile(temporary, destination string, options Options) error {
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if filepath.Clean(filepath.Dir(temporary)) != filepath.Clean(filepath.Dir(destination)) {
+		return errors.New("atomic temporary file must be in the destination directory")
+	}
+	if err := validateDestination(destination); err != nil {
+		return err
+	}
+	if err := validateRegular(temporary, "temporary file"); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(temporary, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	if err := validateOpenFile(file, temporary); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := finalize(file, options); err != nil {
+		return err
+	}
+	if err := validateDestination(destination); err != nil {
+		return err
+	}
+	if err := replace(options, temporary, destination); err != nil {
+		return fmt.Errorf("replace %s: %w", destination, err)
+	}
+	committed = true
+	return nil
+}
+
+// ReplaceExisting performs the platform replacement operation. Callers that
+// need temp creation, type checks, cleanup, permissions, or syncing should use
+// ReplaceFile or CommitTempFile instead.
+func ReplaceExisting(source, destination string) error {
+	return replaceExisting(source, destination)
+}
+
+func createTemp(destination string) (*os.File, error) {
+	directory := filepath.Dir(destination)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return nil, err
+	}
+	return os.CreateTemp(directory, ".wago-atomic-*")
+}
+
+func finalize(file *os.File, options Options) error {
+	mode := options.Mode.Perm()
+	if mode == 0 {
+		mode = 0o600
+	}
+	if err := file.Chmod(mode); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("set temporary file mode: %w", err)
+	}
+	if options.Sync {
+		syncFile := (*os.File).Sync
+		if options.Hooks != nil && options.Hooks.Sync != nil {
+			syncFile = options.Hooks.Sync
+		}
+		if err := syncFile(file); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("sync temporary file: %w", err)
+		}
+	}
+	closeFile := (*os.File).Close
+	if options.Hooks != nil && options.Hooks.Close != nil {
+		closeFile = options.Hooks.Close
+	}
+	if err := closeFile(file); err != nil {
+		return fmt.Errorf("close temporary file: %w", err)
+	}
+	return nil
+}
+
+func replace(options Options, source, destination string) error {
+	if options.Hooks != nil && options.Hooks.Replace != nil {
+		return options.Hooks.Replace(source, destination)
+	}
+	return replaceExisting(source, destination)
+}
+
+func validateDestination(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect destination %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("destination %s is a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("destination %s is not a regular file", path)
+	}
+	return nil
+}
+
+func validateRegular(path, label string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("%s %s is not a regular file", label, path)
+	}
+	return nil
+}
+
+func validateOpenFile(file *os.File, path string) error {
+	opened, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	linked, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !opened.Mode().IsRegular() || linked.Mode()&os.ModeSymlink != 0 || !os.SameFile(opened, linked) {
+		return fmt.Errorf("temporary file %s changed before publication", path)
+	}
+	return nil
+}

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -154,11 +154,16 @@ func finalize(file *os.File, options Options) error {
 			return fmt.Errorf("sync temporary file: %w", err)
 		}
 	}
-	closeFile := (*os.File).Close
 	if options.Hooks != nil && options.Hooks.Close != nil {
-		closeFile = options.Hooks.Close
+		if err := options.Hooks.Close(file); err != nil {
+			// A failure injector must not be able to leave the descriptor open.
+			// This matters on Windows, where an open temporary file cannot be
+			// removed or moved reliably during cleanup.
+			_ = file.Close()
+			return fmt.Errorf("close temporary file: %w", err)
+		}
 	}
-	if err := closeFile(file); err != nil {
+	if err := file.Close(); err != nil {
 		return fmt.Errorf("close temporary file: %w", err)
 	}
 	return nil

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,223 @@
+package atomicfile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestReplaceFileCreatesAndReplaces(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "value")
+	if err := ReplaceFile(path, Options{Mode: 0o640, Sync: true}, func(writer io.Writer) error {
+		_, err := io.WriteString(writer, "first")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ReplaceFile(path, Options{Mode: 0o640}, func(writer io.Writer) error {
+		_, err := io.WriteString(writer, "replacement")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "replacement" {
+		t.Fatalf("destination = %q, %v", data, err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil || info.Mode().Perm() != 0o640 {
+			t.Fatalf("mode = %v, %v", info, err)
+		}
+	}
+	assertNoTemps(t, directory)
+}
+
+func TestReplaceFileFailuresPreserveDestination(t *testing.T) {
+	injected := errors.New("injected failure")
+	tests := []struct {
+		name    string
+		write   func(io.Writer) error
+		options Options
+	}{
+		{name: "write", write: func(writer io.Writer) error {
+			_, _ = io.WriteString(writer, "secret partial")
+			return injected
+		}},
+		{name: "sync", write: writeString("new"), options: Options{Sync: true, Hooks: &Hooks{Sync: func(file *os.File) error {
+			return injected
+		}}}},
+		{name: "close", write: writeString("new"), options: Options{Hooks: &Hooks{Close: func(file *os.File) error {
+			_ = file.Close()
+			return injected
+		}}}},
+		{name: "replace", write: writeString("new"), options: Options{Hooks: &Hooks{Replace: func(_, _ string) error {
+			return injected
+		}}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			path := filepath.Join(directory, "value")
+			if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			options := test.options
+			options.Mode = 0o600
+			err := ReplaceFile(path, options, test.write)
+			if err == nil {
+				t.Fatal("failure was not returned")
+			}
+			data, readErr := os.ReadFile(path)
+			if readErr != nil || string(data) != "old" {
+				t.Fatalf("old destination = %q, %v", data, readErr)
+			}
+			assertNoTemps(t, directory)
+		})
+	}
+}
+
+func TestReplaceFileRejectsDirectoryAndSymlink(t *testing.T) {
+	directory := t.TempDir()
+	if err := ReplaceFile(directory, Options{}, writeString("x")); err == nil {
+		t.Fatal("directory destination accepted")
+	}
+	target := filepath.Join(directory, "target")
+	link := filepath.Join(directory, "link")
+	if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := ReplaceFile(link, Options{}, writeString("replacement")); err == nil {
+		t.Fatal("symlink destination accepted")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != "target" {
+		t.Fatalf("symlink target changed: %q, %v", data, err)
+	}
+}
+
+func TestCreateTempUsesUniqueSameDirectoryNames(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "value")
+	const count = 16
+	names := make(chan string, count)
+	errorsChannel := make(chan error, count)
+	var wait sync.WaitGroup
+	for range count {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			file, err := CreateTemp(destination)
+			if err != nil {
+				errorsChannel <- err
+				return
+			}
+			name := file.Name()
+			_ = file.Close()
+			names <- name
+			_ = os.Remove(name)
+		}()
+	}
+	wait.Wait()
+	close(names)
+	close(errorsChannel)
+	for err := range errorsChannel {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for name := range names {
+		if filepath.Dir(name) != directory || seen[name] {
+			t.Fatalf("invalid/non-unique temporary path %q", name)
+		}
+		seen[name] = true
+	}
+	if len(seen) != count {
+		t.Fatalf("unique names = %d, want %d", len(seen), count)
+	}
+}
+
+func TestCommitTempFileReplacesExisting(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "value")
+	if err := os.WriteFile(destination, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	temporary, err := CreateTemp(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := temporary.Name()
+	if _, err := temporary.Write([]byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := temporary.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := CommitTempFile(name, destination, Options{Mode: 0o600, Sync: true}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil || string(data) != "new" {
+		t.Fatalf("destination = %q, %v", data, err)
+	}
+	assertNoTemps(t, directory)
+}
+
+func FuzzReplaceFileContents(f *testing.F) {
+	f.Add([]byte("one"))
+	f.Add([]byte{})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		directory := t.TempDir()
+		path := filepath.Join(directory, "value")
+		if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := ReplaceFile(path, Options{Mode: 0o600}, func(writer io.Writer) error {
+			_, err := writer.Write(data)
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != string(data) {
+			t.Fatalf("contents differ: %v", err)
+		}
+	})
+}
+
+func writeString(value string) func(io.Writer) error {
+	return func(writer io.Writer) error {
+		_, err := io.WriteString(writer, value)
+		return err
+	}
+}
+
+func assertNoTemps(t *testing.T, directory string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(directory, ".wago-atomic-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("temporary debris = %v, %v", matches, err)
+	}
+}
+
+func ExampleReplaceFile() {
+	directory, _ := os.MkdirTemp("", "atomic-example-")
+	defer os.RemoveAll(directory)
+	path := filepath.Join(directory, "value")
+	_ = ReplaceFile(path, Options{Mode: 0o600}, writeString("complete"))
+	data, _ := os.ReadFile(path)
+	fmt.Println(string(data))
+	// Output: complete
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -86,6 +86,30 @@ func TestReplaceFileFailuresPreserveDestination(t *testing.T) {
 	}
 }
 
+func TestCloseFailureStillClosesAndCleansTemporary(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "value")
+	injected := errors.New("injected close failure")
+	var temporary *os.File
+	err := ReplaceFile(destination, Options{Hooks: &Hooks{Close: func(file *os.File) error {
+		temporary = file
+		return injected
+	}}}, writeString("new"))
+	if !errors.Is(err, injected) {
+		t.Fatalf("close failure = %v", err)
+	}
+	if temporary == nil {
+		t.Fatal("close hook did not receive temporary file")
+	}
+	if _, err := temporary.Stat(); err == nil {
+		t.Fatal("temporary descriptor remained open after close failure")
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Fatalf("destination was published after close failure: %v", err)
+	}
+	assertNoTemps(t, directory)
+}
+
 func TestReplaceFileRejectsDirectoryAndSymlink(t *testing.T) {
 	directory := t.TempDir()
 	if err := ReplaceFile(directory, Options{}, writeString("x")); err == nil {

--- a/internal/atomicfile/replace_unix.go
+++ b/internal/atomicfile/replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package atomicfile
+
+import "os"
+
+func replaceExisting(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/internal/atomicfile/replace_windows.go
+++ b/internal/atomicfile/replace_windows.go
@@ -3,13 +3,19 @@
 package atomicfile
 
 import (
+	"errors"
 	"syscall"
+	"time"
 	"unsafe"
 )
 
 const (
-	moveFileReplaceExisting = 0x1
-	moveFileWriteThrough    = 0x8
+	moveFileReplaceExisting      = 0x1
+	moveFileWriteThrough         = 0x8
+	windowsErrorSharingViolation = syscall.Errno(32)
+	windowsErrorLockViolation    = syscall.Errno(33)
+	windowsReplaceRetryDelay     = 10 * time.Millisecond
+	windowsReplaceRetryTimeout   = 2 * time.Second
 )
 
 var moveFileEx = syscall.NewLazyDLL("kernel32.dll").NewProc("MoveFileExW")
@@ -23,13 +29,25 @@ func replaceExisting(source, destination string) error {
 	if err != nil {
 		return err
 	}
-	result, _, callErr := moveFileEx.Call(
-		uintptr(unsafe.Pointer(sourcePointer)),
-		uintptr(unsafe.Pointer(destinationPointer)),
-		moveFileReplaceExisting|moveFileWriteThrough,
-	)
-	if result == 0 {
-		return callErr
+	deadline := time.Now().Add(windowsReplaceRetryTimeout)
+	for {
+		result, _, callErr := moveFileEx.Call(
+			uintptr(unsafe.Pointer(sourcePointer)),
+			uintptr(unsafe.Pointer(destinationPointer)),
+			moveFileReplaceExisting|moveFileWriteThrough,
+		)
+		if result != 0 {
+			return nil
+		}
+		if !retryableWindowsReplaceError(callErr) || !time.Now().Before(deadline) {
+			return callErr
+		}
+		time.Sleep(windowsReplaceRetryDelay)
 	}
-	return nil
+}
+
+func retryableWindowsReplaceError(err error) bool {
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windowsErrorSharingViolation) ||
+		errors.Is(err, windowsErrorLockViolation)
 }

--- a/internal/atomicfile/replace_windows.go
+++ b/internal/atomicfile/replace_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	moveFileReplaceExisting = 0x1
+	moveFileWriteThrough    = 0x8
+)
+
+var moveFileEx = syscall.NewLazyDLL("kernel32.dll").NewProc("MoveFileExW")
+
+func replaceExisting(source, destination string) error {
+	sourcePointer, err := syscall.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationPointer, err := syscall.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	result, _, callErr := moveFileEx.Call(
+		uintptr(unsafe.Pointer(sourcePointer)),
+		uintptr(unsafe.Pointer(destinationPointer)),
+		moveFileReplaceExisting|moveFileWriteThrough,
+	)
+	if result == 0 {
+		return callErr
+	}
+	return nil
+}

--- a/internal/atomicfile/replace_windows_test.go
+++ b/internal/atomicfile/replace_windows_test.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestWindowsReplaceExistingFile(t *testing.T) {
@@ -19,6 +21,54 @@ func TestWindowsReplaceExistingFile(t *testing.T) {
 		return err
 	}); err != nil {
 		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "new" {
+		t.Fatalf("replacement = %q, %v", data, err)
+	}
+}
+
+func TestWindowsReplaceRetriesSharingViolation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "existing.exe")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pathPointer, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := syscall.CreateFile(
+		pathPointer,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- ReplaceFile(path, Options{Mode: 0o755}, func(writer io.Writer) error {
+			_, err := writer.Write([]byte("new"))
+			return err
+		})
+	}()
+	// Windows readers do not necessarily share delete access. Keep the old file
+	// open long enough to force at least one replacement attempt to contend.
+	time.Sleep(50 * time.Millisecond)
+	if err := syscall.CloseHandle(reader); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(windowsReplaceRetryTimeout + time.Second):
+		t.Fatal("replacement did not complete after reader closed")
 	}
 	data, err := os.ReadFile(path)
 	if err != nil || string(data) != "new" {

--- a/internal/atomicfile/replace_windows_test.go
+++ b/internal/atomicfile/replace_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsReplaceExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "existing.exe")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ReplaceFile(path, Options{Mode: 0o755, Sync: true}, func(writer io.Writer) error {
+		_, err := writer.Write([]byte("new"))
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "new" {
+		t.Fatalf("replacement = %q, %v", data, err)
+	}
+}

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,69 @@
+// Package filelock provides small cross-process advisory file locks.
+package filelock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const pollInterval = 10 * time.Millisecond
+
+// Lock is an acquired exclusive lock. Close releases it.
+type Lock struct {
+	file *os.File
+}
+
+// Acquire opens path with restrictive permissions and waits for an exclusive
+// cross-process lock until ctx is canceled.
+func Acquire(ctx context.Context, path string) (*Lock, error) {
+	if ctx == nil {
+		return nil, errors.New("nil lock context")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	for {
+		locked, err := tryLock(file)
+		if err != nil {
+			_ = file.Close()
+			return nil, fmt.Errorf("lock %s: %w", path, err)
+		}
+		if locked {
+			return &Lock{file: file}, nil
+		}
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			_ = file.Close()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// Close releases the lock and closes its file descriptor.
+func (lock *Lock) Close() error {
+	if lock == nil || lock.file == nil {
+		return nil
+	}
+	file := lock.file
+	lock.file = nil
+	unlockErr := unlock(file)
+	closeErr := file.Close()
+	return errors.Join(unlockErr, closeErr)
+}

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -23,6 +23,9 @@ func Acquire(ctx context.Context, path string) (*Lock, error) {
 	if ctx == nil {
 		return nil, errors.New("nil lock context")
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, err
 	}
@@ -35,6 +38,10 @@ func Acquire(ctx context.Context, path string) (*Lock, error) {
 		return nil, err
 	}
 	for {
+		if err := ctx.Err(); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
 		locked, err := tryLock(file)
 		if err != nil {
 			_ = file.Close()

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -1,0 +1,34 @@
+package filelock
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLockSerializesAndHonorsCancellation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.lock")
+	first, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := Acquire(ctx, path); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("contended acquire = %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -3,10 +3,23 @@ package filelock
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestLockRejectsPreCanceledContextWithoutCreatingFiles(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "credentials")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Acquire(ctx, filepath.Join(directory, "credentials.lock")); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-canceled acquire = %v", err)
+	}
+	if _, err := os.Stat(directory); !os.IsNotExist(err) {
+		t.Fatalf("pre-canceled acquire created lock directory: %v", err)
+	}
+}
 
 func TestLockSerializesAndHonorsCancellation(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "credentials.lock")

--- a/internal/filelock/filelock_unix.go
+++ b/internal/filelock/filelock_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package filelock
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func tryLock(file *os.File) (bool, error) {
+	err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlock(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/filelock/filelock_windows.go
+++ b/internal/filelock/filelock_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package filelock
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	lockfileExclusiveLock   = 0x00000002
+	lockfileFailImmediately = 0x00000001
+	errorLockViolation      = syscall.Errno(33)
+	errorSharingViolation   = syscall.Errno(32)
+)
+
+var (
+	lockFileEx   = syscall.NewLazyDLL("kernel32.dll").NewProc("LockFileEx")
+	unlockFileEx = syscall.NewLazyDLL("kernel32.dll").NewProc("UnlockFileEx")
+)
+
+func tryLock(file *os.File) (bool, error) {
+	var overlapped syscall.Overlapped
+	result, _, callErr := lockFileEx.Call(
+		file.Fd(),
+		lockfileExclusiveLock|lockfileFailImmediately,
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if result != 0 {
+		return true, nil
+	}
+	if errors.Is(callErr, errorLockViolation) || errors.Is(callErr, errorSharingViolation) {
+		return false, nil
+	}
+	return false, callErr
+}
+
+func unlock(file *os.File) error {
+	var overlapped syscall.Overlapped
+	result, _, callErr := unlockFileEx.Call(
+		file.Fd(),
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if result == 0 {
+		return callErr
+	}
+	return nil
+}

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -1,0 +1,193 @@
+// Package httpclient provides the bounded, context-aware HTTP policies used by
+// Wago's command-line network operations.
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+const DefaultErrorBodyLimit int64 = 64 << 10
+
+var ErrBodyTooLarge = errors.New("HTTP response body exceeds limit")
+
+// BodyTooLargeError reports a response that exceeded its configured in-memory
+// or streaming limit.
+type BodyTooLargeError struct {
+	URL           string
+	Limit         int64
+	ContentLength int64
+}
+
+func (e *BodyTooLargeError) Error() string {
+	if e.ContentLength >= 0 {
+		return fmt.Sprintf("HTTP response from %s is too large: %d bytes exceeds %d-byte limit", e.URL, e.ContentLength, e.Limit)
+	}
+	return fmt.Sprintf("HTTP response from %s exceeds %d-byte limit", e.URL, e.Limit)
+}
+
+func (e *BodyTooLargeError) Unwrap() error { return ErrBodyTooLarge }
+
+// Config configures one operation class. Timeout is the overall operation
+// deadline; transport fields independently bound connection and header stalls.
+type Config struct {
+	HTTPClient            *http.Client
+	Timeout               time.Duration
+	ErrorBodyLimit        int64
+	DialTimeout           time.Duration
+	TLSHandshakeTimeout   time.Duration
+	ResponseHeaderTimeout time.Duration
+	IdleConnTimeout       time.Duration
+	ExpectContinueTimeout time.Duration
+}
+
+// Client applies one explicit timeout/transport policy. It is safe for
+// concurrent use.
+type Client struct {
+	httpClient     *http.Client
+	timeout        time.Duration
+	errorBodyLimit int64
+}
+
+// Response is a fully read, bounded response.
+type Response struct {
+	StatusCode int
+	Status     string
+	Header     http.Header
+	Body       []byte
+}
+
+func New(config Config) *Client {
+	if config.ErrorBodyLimit <= 0 {
+		config.ErrorBodyLimit = DefaultErrorBodyLimit
+	}
+	if config.DialTimeout <= 0 {
+		config.DialTimeout = 10 * time.Second
+	}
+	if config.TLSHandshakeTimeout <= 0 {
+		config.TLSHandshakeTimeout = 10 * time.Second
+	}
+	if config.ResponseHeaderTimeout <= 0 {
+		config.ResponseHeaderTimeout = 15 * time.Second
+	}
+	if config.IdleConnTimeout <= 0 {
+		config.IdleConnTimeout = 90 * time.Second
+	}
+	if config.ExpectContinueTimeout <= 0 {
+		config.ExpectContinueTimeout = time.Second
+	}
+	client := config.HTTPClient
+	if client == nil {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = (&net.Dialer{
+			Timeout:   config.DialTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext
+		transport.TLSHandshakeTimeout = config.TLSHandshakeTimeout
+		transport.ResponseHeaderTimeout = config.ResponseHeaderTimeout
+		transport.IdleConnTimeout = config.IdleConnTimeout
+		transport.ExpectContinueTimeout = config.ExpectContinueTimeout
+		client = &http.Client{Transport: transport}
+	}
+	return &Client{httpClient: client, timeout: config.Timeout, errorBodyLimit: config.ErrorBodyLimit}
+}
+
+// NewAPI returns the policy for small registry/API/OAuth JSON operations.
+func NewAPI() *Client {
+	return New(Config{Timeout: 30 * time.Second, ResponseHeaderTimeout: 15 * time.Second})
+}
+
+// NewMetadata returns the policy for release metadata and checksums.
+func NewMetadata() *Client {
+	return New(Config{Timeout: 45 * time.Second, ResponseHeaderTimeout: 20 * time.Second})
+}
+
+// NewStreaming returns the policy for bounded release/source-archive streams.
+// The longer overall timeout accommodates slow links; connect, TLS, and header
+// waits remain independently bounded.
+func NewStreaming() *Client {
+	return New(Config{Timeout: 30 * time.Minute, ResponseHeaderTimeout: 30 * time.Second})
+}
+
+// Open executes request with the supplied parent context and this client's
+// overall deadline. Closing the returned body releases the deadline context.
+func (c *Client) Open(ctx context.Context, request *http.Request) (*http.Response, error) {
+	if ctx == nil {
+		return nil, errors.New("nil HTTP request context")
+	}
+	operationContext := ctx
+	cancel := func() {}
+	if c.timeout > 0 {
+		operationContext, cancel = context.WithTimeout(ctx, c.timeout)
+	}
+	request = request.Clone(operationContext)
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	response.Body = &cancelReadCloser{ReadCloser: response.Body, cancel: cancel}
+	return response, nil
+}
+
+// Bytes executes and completely reads a small response. Successful responses
+// use limit; non-success responses use the independently bounded error-body
+// limit. The response body is always closed.
+func (c *Client) Bytes(ctx context.Context, request *http.Request, limit int64) (Response, error) {
+	response, err := c.Open(ctx, request)
+	if err != nil {
+		return Response{}, err
+	}
+	defer response.Body.Close()
+	result := Response{
+		StatusCode: response.StatusCode,
+		Status:     response.Status,
+		Header:     response.Header.Clone(),
+	}
+	bodyLimit := limit
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		bodyLimit = c.errorBodyLimit
+	}
+	result.Body, err = ReadBounded(response.Body, response.ContentLength, bodyLimit, request.URL.String())
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// ReadBounded reads at most limit bytes. It rejects an oversized declared
+// Content-Length before reading and also enforces the limit for chunked or
+// dishonest responses.
+func ReadBounded(body io.Reader, contentLength, limit int64, source string) ([]byte, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("invalid HTTP body limit %d", limit)
+	}
+	if contentLength > limit {
+		return nil, &BodyTooLargeError{URL: source, Limit: limit, ContentLength: contentLength}
+	}
+	limited := io.LimitReader(body, limit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, &BodyTooLargeError{URL: source, Limit: limit, ContentLength: -1}
+	}
+	return data, nil
+}
+
+type cancelReadCloser struct {
+	io.ReadCloser
+	cancel func()
+}
+
+func (body *cancelReadCloser) Close() error {
+	err := body.ReadCloser.Close()
+	body.cancel()
+	return err
+}

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -1,0 +1,183 @@
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClientBoundsHeaderAndBodyStalls(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "headers",
+			handler: func(_ http.ResponseWriter, request *http.Request) {
+				<-request.Context().Done()
+			},
+		},
+		{
+			name: "body",
+			handler: func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(http.StatusOK)
+				_, _ = writer.Write([]byte("x"))
+				writer.(http.Flusher).Flush()
+				<-request.Context().Done()
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(test.handler)
+			defer server.Close()
+			client := New(Config{Timeout: 75 * time.Millisecond})
+			request, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			started := time.Now()
+			_, err = client.Bytes(context.Background(), request, 16)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("error = %v, want context deadline", err)
+			}
+			if elapsed := time.Since(started); elapsed > time.Second {
+				t.Fatalf("stalled request took %v", elapsed)
+			}
+		})
+	}
+}
+
+func TestClientParentCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+	client := New(Config{Timeout: time.Minute})
+	ctx, cancel := context.WithCancel(context.Background())
+	request, _ := http.NewRequest(http.MethodGet, server.URL, nil)
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Bytes(ctx, request, 16)
+		done <- err
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled request did not return")
+	}
+}
+
+func TestReadBoundedLimits(t *testing.T) {
+	const limit = int64(8)
+	if got, err := ReadBounded(strings.NewReader("12345678"), -1, limit, "test"); err != nil || string(got) != "12345678" {
+		t.Fatalf("exact limit = %q, %v", got, err)
+	}
+	for name, length := range map[string]int64{"declared": 9, "unknown": -1} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ReadBounded(strings.NewReader("123456789"), length, limit, "test")
+			if !errors.Is(err, ErrBodyTooLarge) {
+				t.Fatalf("error = %v, want ErrBodyTooLarge", err)
+			}
+		})
+	}
+}
+
+func TestClientUsesIndependentErrorBodyLimit(t *testing.T) {
+	client := New(Config{HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusBadGateway,
+			Status:        "502 Bad Gateway",
+			Header:        make(http.Header),
+			Body:          io.NopCloser(strings.NewReader(strings.Repeat("x", 33))),
+			ContentLength: -1,
+			Request:       request,
+		}, nil
+	})}, Timeout: time.Second, ErrorBodyLimit: 32})
+	request, _ := http.NewRequest(http.MethodGet, "https://example.invalid", nil)
+	response, err := client.Bytes(context.Background(), request, 1<<20)
+	if response.StatusCode != http.StatusBadGateway || !errors.Is(err, ErrBodyTooLarge) {
+		t.Fatalf("response = %#v, error = %v", response, err)
+	}
+}
+
+func TestClientRejectsDeclaredOversizeWithoutReadingAndCloses(t *testing.T) {
+	body := &trackedBody{Reader: strings.NewReader("ignored")}
+	client := New(Config{HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header),
+			Body: body, ContentLength: 65, Request: request,
+		}, nil
+	})}, Timeout: time.Second})
+	request, _ := http.NewRequest(http.MethodGet, "https://example.invalid", nil)
+	_, err := client.Bytes(context.Background(), request, 64)
+	if !errors.Is(err, ErrBodyTooLarge) {
+		t.Fatalf("error = %v", err)
+	}
+	if body.reads.Load() != 0 || !body.closed.Load() {
+		t.Fatalf("body reads=%d closed=%v", body.reads.Load(), body.closed.Load())
+	}
+}
+
+func BenchmarkClientBytes1KiB(b *testing.B) {
+	payload := strings.Repeat("x", 1024)
+	client := New(Config{HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header),
+			Body: io.NopCloser(strings.NewReader(payload)), ContentLength: int64(len(payload)), Request: request,
+		}, nil
+	})}, Timeout: time.Second})
+	request, _ := http.NewRequest(http.MethodGet, "https://example.invalid", nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	for range b.N {
+		if _, err := client.Bytes(context.Background(), request, 2<<10); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func FuzzReadBounded(f *testing.F) {
+	f.Add([]byte("small"), uint8(8))
+	f.Add([]byte("too large"), uint8(3))
+	f.Fuzz(func(t *testing.T, data []byte, rawLimit uint8) {
+		limit := int64(rawLimit)
+		got, err := ReadBounded(strings.NewReader(string(data)), -1, limit, "fuzz")
+		if int64(len(data)) <= limit {
+			if err != nil || string(got) != string(data) {
+				t.Fatalf("bounded read = %q, %v", got, err)
+			}
+		} else if !errors.Is(err, ErrBodyTooLarge) {
+			t.Fatalf("oversized error = %v", err)
+		}
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return fn(request) }
+
+type trackedBody struct {
+	io.Reader
+	reads  atomic.Int32
+	closed atomic.Bool
+}
+
+func (body *trackedBody) Read(buffer []byte) (int, error) {
+	body.reads.Add(1)
+	return body.Reader.Read(buffer)
+}
+func (body *trackedBody) Close() error {
+	body.closed.Store(true)
+	return nil
+}

--- a/scripts/build-release-assets.sh
+++ b/scripts/build-release-assets.sh
@@ -83,9 +83,11 @@ for asset in \
   if [[ ! -s "$asset" ]]; then
     continue
   fi
+  asset_dir="$(dirname "$asset")"
+  asset_name="$(basename "$asset")"
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$asset" > "${asset}.sha256"
+    (cd "$asset_dir" && sha256sum "$asset_name" > "${asset_name}.sha256")
   else
-    shasum -a 256 "$asset" > "${asset}.sha256"
+    (cd "$asset_dir" && shasum -a 256 "$asset_name" > "${asset_name}.sha256")
   fi
 done


### PR DESCRIPTION
## Summary

- add shared bounded, context-aware HTTP policies for release, registry, and OAuth operations
- stream release assets through fixed-size buffers, verify strict SHA-256 records, and publish only complete verified executables
- centralize same-directory atomic replace-existing behavior across Unix and Windows for updater, source-build, plugin-build, cache, and credential paths
- serialize registry credential mutations across processes and publish private `0600` files atomically
- propagate cancellation through source Git/Go/TinyGo subprocesses and bound aggregate release discovery and OAuth device-flow waits

## Safety properties

- stalled requests have explicit connection, header, and overall deadlines
- in-memory response bodies and streamed transfers have endpoint-specific limits
- failed or canceled updates preserve the previously installed executable
- concurrent writers use unique temporary files
- Windows replacement uses `MoveFileExW` replace-existing semantics
- credential save/logout decisions happen while holding an OS-backed cross-process lock
- malformed, null, directory, and symlink credential destinations are rejected without overwriting prior contents

## Review fixes

A second-pass audit found and corrected several edge cases before opening this PR:

- release-generated checksum files used `./asset`, which the initial strict parser rejected
- self-update still used a fixed `.new` staging path
- source-build subprocesses ignored command cancellation
- repeated full metadata pages and server-provided OAuth timing values could extend work excessively
- oversized streams wrote one detection byte beyond their documented disk cap
- logout checked credential existence before acquiring the transaction lock
- a JSON `null` credential store could produce a nil-map panic

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `tinygo test ./cli/runtime/internal/artifactcache`
- repeated focused updater, registry, atomic-file, file-lock, and self-update tests
- `git diff --check`
- shell syntax and checksum-format checks for release scripts
- production builds for Linux amd64/arm64, Darwin amd64/arm64, and Windows amd64/arm64
- affected package test cross-compilation for Windows amd64/arm64

## Memory

For a 16 MiB release asset, the streamed implementation allocates roughly 100–160 KiB per operation instead of approximately 42 MiB. Allocation volume remains approximately flat as asset size increases.

Closes #402
Closes #403
Closes #404
Closes #408
