### PR TITLE
runtime: harden lifecycle, ownership, and artifact reuse

### DIFF
--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -29,7 +29,7 @@ type Cache struct {
 	ReportError func(error)
 }
 
-const cacheKeyFormat = 1
+const cacheKeyFormat = 2
 
 var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	info, ok := debug.ReadBuildInfo()
@@ -50,6 +50,9 @@ func (cache Cache) LoadOrCompile(source []byte, config *wago.RuntimeConfig, rt *
 			if compiled.UnmarshalBinary(blob) == nil {
 				if module, err := rt.Module(compiled); err == nil {
 					return module, nil
+				} else {
+					_ = compiled.Close()
+					return nil, err
 				}
 			}
 		}
@@ -100,7 +103,9 @@ func (cache Cache) path(source []byte, config *wago.RuntimeConfig) (string, bool
 		encoded[len(encoded)-1] = 1
 	}
 	encoded = binary.LittleEndian.AppendUint32(encoded, config.MemoryLimitPages())
-	encoded = binary.LittleEndian.AppendUint64(encoded, uint64(config.FunctionWorkers()))
+	// FunctionWorkers is deliberately excluded: it controls only transient
+	// compilation scheduling, and serialized output is deterministic across
+	// worker policies. The key contains only semantic/codegen dimensions.
 
 	knobs := config.OptimizationInfos()
 	encoded = binary.LittleEndian.AppendUint32(encoded, uint32(len(knobs)))

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -14,6 +14,47 @@ import (
 	"github.com/wago-org/wago"
 )
 
+type rejectingCompileExtension struct {
+	err   error
+	calls *int
+}
+
+func (e rejectingCompileExtension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{ID: "test.reject-cache-bind"}
+}
+
+func (e rejectingCompileExtension) Register(reg *wago.Registry) error {
+	hooks, err := reg.ModuleCompiler()
+	if err != nil {
+		return err
+	}
+	hooks.After(func(*wago.CompileContext, *wago.Module) error {
+		(*e.calls)++
+		return e.err
+	})
+	return nil
+}
+
+type countingCompileExtension struct {
+	calls *int
+}
+
+func (e countingCompileExtension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{ID: "test.count-cache-compile"}
+}
+
+func (e countingCompileExtension) Register(reg *wago.Registry) error {
+	hooks, err := reg.ModuleCompiler()
+	if err != nil {
+		return err
+	}
+	hooks.Before(func(*wago.CompileContext, []byte) ([]byte, error) {
+		(*e.calls)++
+		return nil, nil
+	})
+	return nil
+}
+
 func TestLoadOrCompileCachesAndRepairsArtifact(t *testing.T) {
 	source := constantModule()
 	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
@@ -79,6 +120,63 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 	}
 }
 
+func TestLoadOrCompilePropagatesCachedModuleBindingFailureOnce(t *testing.T) {
+	source := constantModule()
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	producer := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	module, err := cache.LoadOrCompile(source, config, producer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Compiled().Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := producer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rejected := errors.New("cached artifact rejected")
+	var calls int
+	consumer := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	if err := consumer.Use(rejectingCompileExtension{err: rejected, calls: &calls}, wago.WithPluginGrants(wago.PluginCompileHooks)); err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+	if _, err := cache.LoadOrCompile(source, config, consumer); !errors.Is(err, rejected) {
+		t.Fatalf("LoadOrCompile error = %v, want cached binding rejection", err)
+	}
+	if calls != 1 {
+		t.Fatalf("AfterCompile called %d times, want exactly once", calls)
+	}
+}
+
+func TestLoadOrCompileReusesArtifactAcrossWorkerPolicies(t *testing.T) {
+	source := constantModule()
+	serial := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit).WithFunctionWorkers(1)
+	parallel := serial.WithFunctionWorkers(4)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	var compileCalls int
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(serial))
+	if err := rt.Use(countingCompileExtension{calls: &compileCalls}, wago.WithPluginGrants(wago.PluginCompileHooks)); err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	first, err := cache.LoadOrCompile(source, serial, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Compiled().Close()
+	second, err := cache.LoadOrCompile(source, parallel, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Compiled().Close()
+	if compileCalls != 1 {
+		t.Fatalf("source compiled %d times across worker policies, want one warm hit", compileCalls)
+	}
+}
+
 func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	source := constantModule()
 	dir := t.TempDir()
@@ -112,8 +210,8 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	if basePath == optimizationPath {
 		t.Fatal("optimization selection did not change artifact key")
 	}
-	if basePath == workersPath {
-		t.Fatal("function-worker policy did not change artifact key")
+	if basePath != workersPath {
+		t.Fatal("scheduling-only function-worker policy changed artifact key")
 	}
 	if basePath == boundsPath {
 		t.Fatal("bounds-check mode did not change artifact key")

--- a/docs/function-workers.md
+++ b/docs/function-workers.md
@@ -29,6 +29,14 @@ effective count for a particular module.
 aliases. New code should use `WithFunctionWorkers` and `FunctionWorkers`, because
 the policy covers validation as well as native code generation.
 
+Function-worker policy affects only transient scheduling. It is excluded from
+the automatic artifact-cache identity because serial, adaptive, and forced
+worker counts produce identical serialized artifacts. Core features, bounds
+behavior, memory limits, optimization selections, platform, source bytes, and
+the immutable runtime build identity remain key dimensions because they can
+change generated code or its interpretation; logging and progress settings are
+likewise excluded.
+
 ## CLI
 
 Both compilation through `run` and validation-only workflows accept the same

--- a/src/wago/extension.go
+++ b/src/wago/extension.go
@@ -228,9 +228,41 @@ const (
 	ErrPermissionDenied      = extErr("wago: permission denied")
 	ErrManagedImportLifetime = extErr("wago: managed instance cannot inherit a borrowed import")
 	ErrMissingImport         = extErr("wago: missing import")
+	ErrForeignModule         = extErr("wago: module belongs to a different runtime")
 	ErrInvalidHandle         = extErr("wago: invalid handle")
 	ErrExtensionConflict     = extErr("wago: extension conflict")
 )
+
+// cloneExtensionInfo returns a caller-owned snapshot of extension metadata.
+// ExtensionInfo is retained after registration and exposed through inspection,
+// so neither boundary may share mutable containers with extension code or
+// callers.
+func cloneExtensionInfo(info ExtensionInfo) ExtensionInfo {
+	info.Authors = cloneSlice(info.Authors)
+	info.Tags = cloneSlice(info.Tags)
+	info.Requires = cloneSlice(info.Requires)
+	info.Before = cloneSlice(info.Before)
+	info.After = cloneSlice(info.After)
+	info.RequiresCapabilities = cloneSlice(info.RequiresCapabilities)
+	info.Compat.Platforms = cloneSlice(info.Compat.Platforms)
+	if info.Compat.Engines != nil {
+		engines := make(map[string]string, len(info.Compat.Engines))
+		for engine, constraint := range info.Compat.Engines {
+			engines[engine] = constraint
+		}
+		info.Compat.Engines = engines
+	}
+	return info
+}
+
+func cloneSlice[T any](values []T) []T {
+	if values == nil {
+		return nil
+	}
+	cloned := make([]T, len(values))
+	copy(cloned, values)
+	return cloned
+}
 
 // ExtensionError attributes a failure to a specific extension and operation while
 // preserving the underlying error for errors.Is/As.

--- a/src/wago/gc_host_bridge_test.go
+++ b/src/wago/gc_host_bridge_test.go
@@ -86,7 +86,11 @@ func TestRuntimeGCHostFuncRefRejectsUnownedAndForeignDomains(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := plainRT.Instantiate(context.Background(), &Module{c: compiled}, WithImports(Imports{"host.echo": plain})); err == nil || !strings.Contains(err.Error(), "NewGCHostFuncRef") {
+	plainMod, err := plainRT.Module(compiled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := plainRT.Instantiate(context.Background(), plainMod, WithImports(Imports{"host.echo": plain})); err == nil || !strings.Contains(err.Error(), "NewGCHostFuncRef") {
 		t.Fatalf("plain GC host import error = %v", err)
 	}
 	_ = plain.Close()

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -230,8 +230,19 @@ func (m *Module) Compiled() *Compiled { return m.c }
 // Exports returns the module's exported function names, sorted.
 func (m *Module) Exports() []string { return m.c.ExportedFunctions() }
 
-// Imports returns the module's declared imports with extension-derived metadata.
-func (m *Module) Imports() []ImportSpec { return append([]ImportSpec(nil), m.imports...) }
+// Imports returns a caller-owned snapshot of the module's declared imports with
+// extension-derived metadata. Mutating the result never changes module state.
+func (m *Module) Imports() []ImportSpec {
+	imports := make([]ImportSpec, len(m.imports))
+	for i := range m.imports {
+		imports[i] = m.imports[i]
+		imports[i].Params = cloneSlice(m.imports[i].Params)
+		imports[i].Results = cloneSlice(m.imports[i].Results)
+		imports[i].ParamTypes = cloneSlice(m.imports[i].ParamTypes)
+		imports[i].ResultTypes = cloneSlice(m.imports[i].ResultTypes)
+	}
+	return imports
+}
 
 // RequiredCapabilities returns the capabilities the module's function imports
 // require, deduplicated in first-seen order.

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -43,7 +43,7 @@ func planPlugins(configs []PluginConfig) ([]plannedExtension, error) {
 		if !ok {
 			return nil, fmt.Errorf("wago: plugin %q is not compiled into this binary", cfg.Name)
 		}
-		info := ext.Info()
+		info := cloneExtensionInfo(ext.Info())
 		if info.ID == "" {
 			return nil, fmt.Errorf("wago: plugin %q has no extension ID", cfg.Name)
 		}
@@ -273,7 +273,7 @@ func resolvePluginOrder(configs []PluginConfig) ([]PluginConfig, error) {
 		if !ok {
 			return nil, fmt.Errorf("wago: plugin %q is not compiled into this binary", cfg.Name)
 		}
-		byName[cfg.Name], infos[cfg.Name] = cfg, ext.Info()
+		byName[cfg.Name], infos[cfg.Name] = cfg, cloneExtensionInfo(ext.Info())
 	}
 	edges := make(map[string]map[string]struct{}, len(configs))
 	indegree := make(map[string]int, len(configs))
@@ -394,7 +394,7 @@ func (rt *Runtime) commitPluginPlan(plan []plannedExtension) error {
 		for _, activate := range p.reg.activate {
 			activate(rt)
 		}
-		rt.exts = append(rt.exts, p.info)
+		rt.exts = append(rt.exts, cloneExtensionInfo(p.info))
 		rt.extensions[p.info.ID] = p.ext
 	}
 	return nil

--- a/src/wago/policy_test.go
+++ b/src/wago/policy_test.go
@@ -11,7 +11,7 @@ import (
 // memoryModule builds a module declaring (and exporting) a memory of minP..maxP
 // pages. Exporting it keeps MemMaxPages at maxP (an unexported, non-growing
 // memory is pinned to its minimum).
-func memoryModule(t *testing.T, minP, maxP int) *Module {
+func memoryModule(t *testing.T, rt *Runtime, minP, maxP int) *Module {
 	t.Helper()
 	memType := append([]byte{0x01}, wasmtest.ULEB(uint32(minP))...) // flags 0x01: has max
 	memType = append(memType, wasmtest.ULEB(uint32(maxP))...)
@@ -19,7 +19,7 @@ func memoryModule(t *testing.T, minP, maxP int) *Module {
 		wasmtest.Section(5, wasmtest.Vec(memType)),
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("memory", 2, 0))),
 	)
-	m, err := NewRuntime().Compile(mod)
+	m, err := rt.Compile(mod)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestPolicyCapabilityAllowDeny(t *testing.T) {
 
 func TestPolicyMemoryLimit(t *testing.T) {
 	rt := NewRuntime()
-	mod := memoryModule(t, 2, 4) // min 2 pages, max 4 pages -> 256 KiB max
+	mod := memoryModule(t, rt, 2, 4) // min 2 pages, max 4 pages -> 256 KiB max
 	// 128 KiB limit is below the module's 256 KiB max → denied.
 	if _, err := rt.Instantiate(context.Background(), mod, WithPolicy(Policy{MaxMemoryBytes: 128 << 10})); !errors.Is(err, ErrPermissionDenied) {
 		t.Fatalf("instantiate over memory limit = %v, want ErrPermissionDenied", err)

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -127,7 +127,7 @@ func (rt *Runtime) Use(ext Extension, opts ...UseOption) error {
 	if ext == nil {
 		return fmt.Errorf("wago: Use: nil extension")
 	}
-	info := ext.Info()
+	info := cloneExtensionInfo(ext.Info())
 	if info.ID == "" {
 		return fmt.Errorf("wago: Use: extension has no ID")
 	}
@@ -273,9 +273,23 @@ func (rt *Runtime) Use(ext Extension, opts ...UseOption) error {
 // as a *Module, resolving its imports against the registered extensions and
 // running any AfterCompile hooks.
 func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
+	rt.mu.Lock()
+	if rt.closed {
+		rt.mu.Unlock()
+		return nil, fmt.Errorf("wago: Compile on a closed runtime")
+	}
+	beforeCompile := append([]func(*CompileContext, []byte) ([]byte, error)(nil), rt.hooks.beforeCompile...)
+	afterCompile := append([]func(*CompileContext, *Module) error(nil), rt.hooks.afterCompile...)
+	instructions := make(map[string]*registeredInstruction, len(rt.instructions))
+	for key, ins := range rt.instructions {
+		instructions[key] = ins
+	}
+	cfg := rt.cfg
+	rt.mu.Unlock()
+
 	ctx := &CompileContext{Runtime: rt, Metadata: map[string]any{}}
 	source := wasmBytes
-	for _, fn := range rt.hooks.beforeCompile {
+	for _, fn := range beforeCompile {
 		next, err := fn(ctx, source)
 		if err != nil {
 			return nil, err
@@ -284,13 +298,6 @@ func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
 			source = next
 		}
 	}
-	rt.mu.Lock()
-	instructions := make(map[string]*registeredInstruction, len(rt.instructions))
-	for key, ins := range rt.instructions {
-		instructions[key] = ins
-	}
-	cfg := rt.cfg
-	rt.mu.Unlock()
 	c, err := compileWithConfigAndInstructions(cfg, source, instructions)
 	if err != nil {
 		return nil, err
@@ -312,8 +319,8 @@ func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
 			funcIndex++
 		}
 	}
-	if len(rt.hooks.afterCompile) > 0 {
-		for _, fn := range rt.hooks.afterCompile {
+	if len(afterCompile) > 0 {
+		for _, fn := range afterCompile {
 			if err := fn(ctx, mod); err != nil {
 				return nil, err
 			}
@@ -413,6 +420,9 @@ func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...Instant
 func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin InstantiateOrigin, opts ...InstantiateOption) (*Instance, error) {
 	if mod == nil {
 		return nil, fmt.Errorf("wago: Instantiate: nil module")
+	}
+	if mod.rt != rt {
+		return nil, fmt.Errorf("wago: Instantiate: %w; rebind it with Runtime.Module", ErrForeignModule)
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -528,11 +538,17 @@ func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc G
 	return inst, nil
 }
 
-// Extensions returns the registered extensions in registration order.
+// Extensions returns caller-owned snapshots of the registered extensions in
+// registration order. Mutating nested slices or maps does not affect runtime
+// state.
 func (rt *Runtime) Extensions() []ExtensionInfo {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	return append([]ExtensionInfo(nil), rt.exts...)
+	extensions := make([]ExtensionInfo, len(rt.exts))
+	for i := range rt.exts {
+		extensions[i] = cloneExtensionInfo(rt.exts[i])
+	}
+	return extensions
 }
 
 // Capabilities returns the capabilities declared by registered extensions,
@@ -564,23 +580,29 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 	pluginStops := append([]registeredPluginStop(nil), rt.pluginStops...)
 	store := rt.refStore
 	rt.mu.Unlock()
+	defer store.closeRuntime()
 
 	var errs []error
 	for i := len(pluginStops) - 1; i >= 0; i-- {
-		if err := pluginStops[i].stop(ctx); err != nil {
+		var stopErr error
+		panicErr := callHookSafely("plugin Stop", func() { stopErr = pluginStops[i].stop(ctx) })
+		if err := joinPrimary(stopErr, panicErr); err != nil {
 			errs = append(errs, &PluginError{Plugin: pluginStops[i].name, Phase: PluginPhaseStop, Err: err})
 		}
 	}
 	for i := len(internalClose) - 1; i >= 0; i-- {
-		if err := internalClose[i](); err != nil {
+		var closeErr error
+		panicErr := callHookSafely("internal runtime close", func() { closeErr = internalClose[i]() })
+		if err := joinPrimary(closeErr, panicErr); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	rctx := &RuntimeContext{Runtime: rt}
 	for i := len(hooks) - 1; i >= 0; i-- {
-		hooks[i](rctx)
+		if err := callHookSafely("OnRuntimeClose", func() { hooks[i](rctx) }); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	store.closeRuntime()
 	return errors.Join(errs...)
 }
 

--- a/src/wago/runtime_issue_batch_test.go
+++ b/src/wago/runtime_issue_batch_test.go
@@ -1,0 +1,243 @@
+package wago
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func TestRuntimeCompileRejectsClosedRuntimeBeforeHooks(t *testing.T) {
+	rt := NewRuntime()
+	var beforeCalls int
+	rt.hooks.BeforeCompile(func(*CompileContext, []byte) ([]byte, error) {
+		beforeCalls++
+		return nil, nil
+	})
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.Compile(wasmtest.Module()); err == nil || !strings.Contains(err.Error(), "closed runtime") {
+		t.Fatalf("Compile after Close = %v, want closed-runtime error", err)
+	}
+	if beforeCalls != 0 {
+		t.Fatalf("BeforeCompile ran %d times after close", beforeCalls)
+	}
+}
+
+func TestRuntimeCompileAdmittedBeforeCloseMayComplete(t *testing.T) {
+	rt := NewRuntime()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	rt.hooks.BeforeCompile(func(*CompileContext, []byte) ([]byte, error) {
+		close(entered)
+		<-release
+		return nil, nil
+	})
+	compileDone := make(chan error, 1)
+	go func() {
+		_, err := rt.Compile(wasmtest.Module())
+		compileDone <- err
+	}()
+	<-entered
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+	if err := <-compileDone; err != nil {
+		t.Fatalf("compile admitted before Close = %v", err)
+	}
+}
+
+func TestRuntimeCloseIsolatesCallbackPanicsAndClosesStore(t *testing.T) {
+	stopPanic := errors.New("stop panic")
+	internalPanic := errors.New("internal panic")
+	hookPanic := errors.New("hook panic")
+	var events []string
+	rt := NewRuntime()
+	rt.pluginStops = []registeredPluginStop{
+		{name: "continues", stop: func(context.Context) error { events = append(events, "stop:continues"); return nil }},
+		{name: "panics", stop: func(context.Context) error { events = append(events, "stop:panics"); panic(stopPanic) }},
+	}
+	rt.hooks.internalClose = []func() error{
+		func() error { events = append(events, "internal:continues"); return nil },
+		func() error { events = append(events, "internal:panics"); panic(internalPanic) },
+	}
+	rt.hooks.onRuntimeClose = []func(*RuntimeContext){
+		func(*RuntimeContext) { events = append(events, "hook:continues") },
+		func(*RuntimeContext) { events = append(events, "hook:panics"); panic(hookPanic) },
+	}
+
+	err := rt.Close()
+	for _, want := range []error{stopPanic, internalPanic, hookPanic} {
+		if !errors.Is(err, want) {
+			t.Fatalf("Close error = %v, want wrapped %v", err, want)
+		}
+	}
+	wantEvents := []string{
+		"stop:panics", "stop:continues",
+		"internal:panics", "internal:continues",
+		"hook:panics", "hook:continues",
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("close events = %v, want %v", events, wantEvents)
+	}
+	rt.refStore.mu.Lock()
+	storeClosed := rt.refStore.runtimeClosed
+	rt.refStore.mu.Unlock()
+	if !storeClosed {
+		t.Fatal("reference store remained open after callback panics")
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatalf("second Close = %v", err)
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("idempotent Close reran callbacks: %v", events)
+	}
+}
+
+func TestRuntimeRejectsForeignModuleAndAllowsExplicitRebind(t *testing.T) {
+	rtA := NewRuntime()
+	modA, err := rtA.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled := modA.Compiled()
+	defer compiled.Close()
+	if err := rtA.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rtB := NewRuntime()
+	defer rtB.Close()
+	var beforeInstantiate int
+	rtB.hooks.BeforeInstantiate(func(*InstantiateContext) error {
+		beforeInstantiate++
+		return nil
+	})
+	if _, err := rtB.Instantiate(context.Background(), modA); !errors.Is(err, ErrForeignModule) {
+		t.Fatalf("foreign Instantiate error = %v, want ErrForeignModule", err)
+	}
+	if beforeInstantiate != 0 {
+		t.Fatalf("foreign module reached %d instantiate hooks", beforeInstantiate)
+	}
+
+	modB, err := rtB.Module(compiled)
+	if err != nil {
+		t.Fatalf("explicit rebind: %v", err)
+	}
+	instance, err := rtB.Instantiate(context.Background(), modB)
+	if err != nil {
+		t.Fatalf("Instantiate rebound module: %v", err)
+	}
+	if err := instance.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if beforeInstantiate != 1 {
+		t.Fatalf("rebound module reached %d instantiate hooks, want 1", beforeInstantiate)
+	}
+}
+
+type mutableInfoExtension struct {
+	info ExtensionInfo
+}
+
+func (e *mutableInfoExtension) Info() ExtensionInfo    { return e.info }
+func (*mutableInfoExtension) Register(*Registry) error { return nil }
+
+func TestInspectionSnapshotsDeepCopyMutableContainers(t *testing.T) {
+	rt := NewRuntime()
+	ext := &mutableInfoExtension{info: ExtensionInfo{
+		ID: "test.mutable-info", Authors: []string{"author"}, Tags: []string{"tag"},
+		Requires: []string{"required"}, Before: []string{"before"}, After: []string{"after"},
+		RequiresCapabilities: []PluginCapability{PluginHostImports},
+		Compat:               Compatibility{Engines: map[string]string{"wago": "*"}, Platforms: []string{"linux/amd64"}},
+	}}
+	if err := rt.Use(ext); err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	baseline, err := json.Marshal(rt.Extensions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ext.info.Authors[0] = "changed"
+	ext.info.Tags[0] = "changed"
+	ext.info.Requires[0] = "changed"
+	ext.info.Before[0] = "changed"
+	ext.info.After[0] = "changed"
+	ext.info.RequiresCapabilities[0] = PluginCoreRuntime
+	ext.info.Compat.Platforms[0] = "changed"
+	ext.info.Compat.Engines["wago"] = "changed"
+	returned := rt.Extensions()
+	returned[0].Authors[0] = "caller"
+	returned[0].Tags[0] = "caller"
+	returned[0].Requires[0] = "caller"
+	returned[0].Before[0] = "caller"
+	returned[0].After[0] = "caller"
+	returned[0].RequiresCapabilities[0] = PluginCoreRuntime
+	returned[0].Compat.Platforms[0] = "caller"
+	returned[0].Compat.Engines["wago"] = "caller"
+	after, err := json.Marshal(rt.Extensions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(baseline) {
+		t.Fatalf("extension snapshot mutated:\n got %s\nwant %s", after, baseline)
+	}
+
+	mod := callsEnvF(t, rt)
+	importBaseline, err := json.Marshal(mod.Imports())
+	if err != nil {
+		t.Fatal(err)
+	}
+	imports := mod.Imports()
+	imports[0].Params[0] = ValV128
+	imports[0].Results[0] = ValV128
+	imports[0].ParamTypes[0] = ValueTypeDescriptor{Kind: ValueTypeV128}
+	imports[0].ResultTypes[0] = ValueTypeDescriptor{Kind: ValueTypeV128}
+	importAfter, err := json.Marshal(mod.Imports())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(importAfter) != string(importBaseline) {
+		t.Fatalf("import snapshot mutated:\n got %s\nwant %s", importAfter, importBaseline)
+	}
+}
+
+func TestInspectionCloneCoverageTracksMutableFields(t *testing.T) {
+	assertMutableFields(t, reflect.TypeOf(ImportSpec{}), map[string]bool{
+		"Params": true, "Results": true, "ParamTypes": true, "ResultTypes": true,
+	})
+	assertMutableFields(t, reflect.TypeOf(ExtensionInfo{}), map[string]bool{
+		"Authors": true, "Tags": true, "Requires": true, "Before": true,
+		"After": true, "RequiresCapabilities": true,
+	})
+	assertMutableFields(t, reflect.TypeOf(Compatibility{}), map[string]bool{
+		"Engines": true, "Platforms": true,
+	})
+
+	empty := cloneExtensionInfo(ExtensionInfo{Authors: []string{}, Compat: Compatibility{Engines: map[string]string{}, Platforms: []string{}}})
+	if empty.Authors == nil || empty.Compat.Engines == nil || empty.Compat.Platforms == nil {
+		t.Fatal("clone collapsed non-nil empty containers")
+	}
+}
+
+func assertMutableFields(t *testing.T, typ reflect.Type, want map[string]bool) {
+	t.Helper()
+	got := map[string]bool{}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Map || field.Type.Kind() == reflect.Pointer {
+			got[field.Name] = true
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mutable fields in %s = %v, update clone coverage for %v", typ.Name(), got, want)
+	}
+}

--- a/src/wago/runtime_regression_test.go
+++ b/src/wago/runtime_regression_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"math"
 	"os"
 	"path/filepath"
@@ -457,7 +458,7 @@ func TestHugeCallStackUnwindsToStartTrap(t *testing.T) {
 	}
 }
 
-func TestCrossRuntimeInstantiationUsesStructuralImportTypes(t *testing.T) {
+func TestCrossRuntimeInstantiationRequiresExplicitRebind(t *testing.T) {
 	funcImport := append(wasmtest.Name("env"), wasmtest.Name("proxy")...)
 	funcImport = append(funcImport, 0x00, 0x02) // function import, type index 2
 	mod := wasmtest.Module(
@@ -485,9 +486,16 @@ func TestCrossRuntimeInstantiationUsesStructuralImportTypes(t *testing.T) {
 	if err := rt2.Use(crossRuntimeImportExt{}); err != nil {
 		t.Fatalf("register runtime 2 import: %v", err)
 	}
-	in, err := rt2.Instantiate(context.Background(), compiled)
+	if _, err := rt2.Instantiate(context.Background(), compiled); !errors.Is(err, ErrForeignModule) {
+		t.Fatalf("foreign module error = %v, want ErrForeignModule", err)
+	}
+	rebound, err := rt2.Module(compiled.Compiled())
 	if err != nil {
-		t.Fatalf("cross-runtime instantiate with structurally identical import: %v", err)
+		t.Fatalf("rebind in runtime 2: %v", err)
+	}
+	in, err := rt2.Instantiate(context.Background(), rebound)
+	if err != nil {
+		t.Fatalf("instantiate explicitly rebound module: %v", err)
 	}
 	defer in.Close()
 	got, err := in.Invoke("f", I32(37))

--- a/wago.go
+++ b/wago.go
@@ -210,6 +210,7 @@ const (
 	ElemModeDeclarative                        = impl.ElemModeDeclarative
 	ElemModePassive                            = impl.ElemModePassive
 	ErrExtensionConflict                       = impl.ErrExtensionConflict
+	ErrForeignModule                           = impl.ErrForeignModule
 	ErrInvalidHandle                           = impl.ErrInvalidHandle
 	ErrManagedImportLifetime                   = impl.ErrManagedImportLifetime
 	ErrMissingImport                           = impl.ErrMissingImport


### PR DESCRIPTION
## Summary

Hardens six related runtime, inspection, and artifact-cache boundaries found during the current issue audit.

- reject compilation after runtime shutdown admission
- reject modules owned by another runtime and expose `ErrForeignModule`; callers can explicitly rebind compiled code with `Runtime.Module`
- isolate plugin, internal-service, and runtime-close callback panics so later cleanup and reference-store teardown still run
- snapshot extension metadata at registration and recursively clone nested module/extension inspection data
- propagate cached-artifact runtime binding failures exactly once and deterministically close rejected decoded artifacts
- remove scheduling-only `FunctionWorkers` from artifact identity and bump the cache-key format

## Impact

Runtime lifecycle and policy decisions now use one consistent owner and admission point. Shutdown remains best-effort across extension failures. Inspection results are caller-owned snapshots. Cache hits no longer bypass binding policy or split byte-identical artifacts by worker count.

Existing tests that relied on implicit cross-runtime module use now assert rejection followed by explicit rebinding.

## Validation

- `go test ./... -count=1`
- `go test ./src/wago ./cli/runtime/internal/artifactcache -count=1`
- focused runtime/cache regressions under `go test -race`
- `go generate .`
- `git diff --check`

Closes #388
Closes #390
Closes #393
Closes #400
Closes #401
Closes #416