### PR TITLE
runtime: complete lifecycle and cache hardening

### DIFF
--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -39,6 +40,8 @@ var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	return buildIdentity(info)
 })
 
+var closeDecodedArtifact = func(compiled *wago.Compiled) error { return compiled.Close() }
+
 // LoadOrCompile loads a matching artifact or compiles source and saves the
 // result. Cache read/write failures never prevent execution; compilation and
 // artifact validation errors retain their normal behavior.
@@ -50,6 +53,11 @@ func (cache Cache) LoadOrCompile(source []byte, config *wago.RuntimeConfig, rt *
 			if compiled.UnmarshalBinary(blob) == nil {
 				if module, err := rt.Module(compiled); err == nil {
 					return module, nil
+				} else {
+					if closeErr := closeDecodedArtifact(compiled); closeErr != nil {
+						return nil, errors.Join(err, fmt.Errorf("release rejected cached artifact: %w", closeErr))
+					}
+					return nil, err
 				}
 			}
 		}

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -30,7 +30,7 @@ type Cache struct {
 	ReportError func(error)
 }
 
-const cacheKeyFormat = 1
+const cacheKeyFormat = 2
 
 var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	info, ok := debug.ReadBuildInfo()
@@ -108,7 +108,9 @@ func (cache Cache) path(source []byte, config *wago.RuntimeConfig) (string, bool
 		encoded[len(encoded)-1] = 1
 	}
 	encoded = binary.LittleEndian.AppendUint32(encoded, config.MemoryLimitPages())
-	encoded = binary.LittleEndian.AppendUint64(encoded, uint64(config.FunctionWorkers()))
+	// FunctionWorkers is deliberately excluded: it controls only transient
+	// compilation scheduling, and serialized output is deterministic across
+	// worker policies. The key contains only semantic/codegen dimensions.
 
 	knobs := config.OptimizationInfos()
 	encoded = binary.LittleEndian.AppendUint32(encoded, uint32(len(knobs)))

--- a/cli/runtime/internal/artifactcache/cache_binding_test.go
+++ b/cli/runtime/internal/artifactcache/cache_binding_test.go
@@ -1,0 +1,99 @@
+package artifactcache
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago"
+)
+
+type rejectingCompileExtension struct {
+	err   error
+	calls *int
+}
+
+func (e rejectingCompileExtension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{ID: "test.reject-cache-bind"}
+}
+
+func (e rejectingCompileExtension) Register(reg *wago.Registry) error {
+	hooks, err := reg.ModuleCompiler()
+	if err != nil {
+		return err
+	}
+	hooks.After(func(*wago.CompileContext, *wago.Module) error {
+		(*e.calls)++
+		return e.err
+	})
+	return nil
+}
+
+func TestLoadOrCompilePropagatesCachedModuleBindingFailureOnce(t *testing.T) {
+	source := constantModule()
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	producer := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	module, err := cache.LoadOrCompile(source, config, producer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Compiled().Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := producer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rejected := errors.New("cached artifact rejected")
+	var calls int
+	consumer := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	if err := consumer.Use(rejectingCompileExtension{err: rejected, calls: &calls}, wago.WithPluginGrants(wago.PluginCompileHooks)); err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+	oldClose := closeDecodedArtifact
+	var closedArtifacts int
+	closeDecodedArtifact = func(compiled *wago.Compiled) error {
+		closedArtifacts++
+		if err := compiled.Close(); err != nil {
+			return err
+		}
+		if _, err := wago.Instantiate(compiled); err == nil {
+			t.Error("rejected decoded artifact remained instantiable after cleanup")
+		}
+		return nil
+	}
+	t.Cleanup(func() { closeDecodedArtifact = oldClose })
+	if _, err := cache.LoadOrCompile(source, config, consumer); !errors.Is(err, rejected) {
+		t.Fatalf("LoadOrCompile error = %v, want cached binding rejection", err)
+	}
+	if calls != 1 {
+		t.Fatalf("AfterCompile called %d times, want exactly once", calls)
+	}
+	if closedArtifacts != 1 {
+		t.Fatalf("rejected decoded artifacts closed %d times, want exactly once", closedArtifacts)
+	}
+}
+
+func TestLoadOrCompileRejectsCachedArtifactOnClosedRuntime(t *testing.T) {
+	source := constantModule()
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	producer := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	module, err := cache.LoadOrCompile(source, config, producer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Compiled().Close()
+	if err := producer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	closed := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	if err := closed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cache.LoadOrCompile(source, config, closed); err == nil || !strings.Contains(err.Error(), "closed runtime") {
+		t.Fatalf("cached load into closed runtime = %v, want closed-runtime error", err)
+	}
+}

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -112,8 +112,8 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	if basePath == optimizationPath {
 		t.Fatal("optimization selection did not change artifact key")
 	}
-	if basePath == workersPath {
-		t.Fatal("function-worker policy did not change artifact key")
+	if basePath != workersPath {
+		t.Fatal("scheduling-only function-worker policy changed artifact key")
 	}
 	if basePath == boundsPath {
 		t.Fatal("bounds-check mode did not change artifact key")

--- a/cli/runtime/internal/artifactcache/cache_workers_test.go
+++ b/cli/runtime/internal/artifactcache/cache_workers_test.go
@@ -1,0 +1,137 @@
+package artifactcache
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/wago-org/wago"
+)
+
+type countingCompileExtension struct {
+	calls *int
+}
+
+func (e countingCompileExtension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{ID: "test.count-cache-compile"}
+}
+
+func (e countingCompileExtension) Register(reg *wago.Registry) error {
+	hooks, err := reg.ModuleCompiler()
+	if err != nil {
+		return err
+	}
+	hooks.Before(func(*wago.CompileContext, []byte) ([]byte, error) {
+		(*e.calls)++
+		return nil, nil
+	})
+	return nil
+}
+
+func TestArtifactsAreDeterministicAcrossWorkerPolicies(t *testing.T) {
+	policies := []int{0, 1, 2, 4, runtime.GOMAXPROCS(0) + 1}
+	corpus := [][]byte{wagoEmptyModule(), constantModule(), memoryModule()}
+	for sourceIndex, source := range corpus {
+		var baseline []byte
+		var baselineEntries []int
+		for _, workers := range policies {
+			config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit).WithFunctionWorkers(workers)
+			compiled, err := wago.Compile(config, source)
+			if err != nil {
+				t.Fatalf("source %d workers %d: %v", sourceIndex, workers, err)
+			}
+			artifact, err := compiled.MarshalBinary()
+			if err != nil {
+				compiled.Close()
+				t.Fatalf("source %d workers %d marshal: %v", sourceIndex, workers, err)
+			}
+			entries := append([]int(nil), compiled.Entry...)
+			if err := compiled.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if baseline == nil {
+				baseline = artifact
+				baselineEntries = entries
+				continue
+			}
+			if !bytes.Equal(artifact, baseline) || !slices.Equal(entries, baselineEntries) {
+				t.Fatalf("source %d workers %d changed serialized/native metadata", sourceIndex, workers)
+			}
+		}
+	}
+}
+
+func TestLoadOrCompileReusesArtifactAcrossWorkerPolicies(t *testing.T) {
+	source := constantModule()
+	policies := []int{0, 1, 2, 4, runtime.GOMAXPROCS(0) + 1}
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	var compileCalls int
+	base := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(base))
+	if err := rt.Use(countingCompileExtension{calls: &compileCalls}, wago.WithPluginGrants(wago.PluginCompileHooks)); err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	for _, workers := range policies {
+		module, err := cache.LoadOrCompile(source, base.WithFunctionWorkers(workers), rt)
+		if err != nil {
+			t.Fatalf("workers %d: %v", workers, err)
+		}
+		defer module.Compiled().Close()
+	}
+	if compileCalls != 1 {
+		t.Fatalf("source compiled %d times across worker policies, want one warm hit", compileCalls)
+	}
+}
+
+func TestLoadOrCompileReusesArtifactAcrossProcess(t *testing.T) {
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("cross-process")}
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	module, err := cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Compiled().Close()
+	defer rt.Close()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestArtifactCacheSubprocessHelper$")
+	cmd.Env = append(os.Environ(), "WAGO_ARTIFACT_CACHE_HELPER=1", "WAGO_ARTIFACT_CACHE_DIR="+cache.Dir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("subprocess warm cache reuse: %v\n%s", err, output)
+	}
+}
+
+func TestArtifactCacheSubprocessHelper(t *testing.T) {
+	if os.Getenv("WAGO_ARTIFACT_CACHE_HELPER") != "1" {
+		return
+	}
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit).WithFunctionWorkers(runtime.GOMAXPROCS(0) + 1)
+	cache := Cache{Dir: os.Getenv("WAGO_ARTIFACT_CACHE_DIR"), Identity: []byte("cross-process")}
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	var compileCalls int
+	if err := rt.Use(countingCompileExtension{calls: &compileCalls}, wago.WithPluginGrants(wago.PluginCompileHooks)); err != nil {
+		t.Fatal(err)
+	}
+	module, err := cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Compiled().Close()
+	defer rt.Close()
+	if compileCalls != 0 {
+		t.Fatalf("subprocess compiled source %d times, want warm artifact reuse", compileCalls)
+	}
+}
+
+func wagoEmptyModule() []byte {
+	return []byte{'\x00', 'a', 's', 'm', 1, 0, 0, 0}
+}
+
+func memoryModule() []byte {
+	// (module (memory 1 2))
+	return []byte{'\x00', 'a', 's', 'm', 1, 0, 0, 0, 5, 4, 1, 1, 1, 2}
+}

--- a/docs/artifact-cache.md
+++ b/docs/artifact-cache.md
@@ -41,8 +41,11 @@ fixed-order configuration values:
 - accepted Core feature bits;
 - bounds-check and deferred-bounds policy;
 - maximum memory pages;
-- function-worker policy; and
 - the ordered compiler-optimization bit set.
+
+Function-worker policy is excluded because it changes transient scheduling, not
+the serialized artifact. Logging and progress settings are excluded for the
+same non-semantic reason.
 
 The binary key format has an explicit version and domain prefix. Changing the
 meaning or order of any encoded field requires incrementing `cacheKeyFormat`.

--- a/docs/function-workers.md
+++ b/docs/function-workers.md
@@ -29,6 +29,14 @@ effective count for a particular module.
 aliases. New code should use `WithFunctionWorkers` and `FunctionWorkers`, because
 the policy covers validation as well as native code generation.
 
+Function-worker policy affects only transient scheduling. It is excluded from
+the automatic artifact-cache identity because serial, adaptive, and forced
+worker counts produce identical serialized artifacts. Core features, bounds
+behavior, memory limits, optimization selections, platform, source bytes, and
+the immutable runtime build identity remain key dimensions because they can
+change generated code or its interpretation; logging and progress settings are
+likewise excluded.
+
 ## CLI
 
 Both compilation through `run` and validation-only workflows accept the same

--- a/src/wago/extension.go
+++ b/src/wago/extension.go
@@ -232,6 +232,37 @@ const (
 	ErrExtensionConflict     = extErr("wago: extension conflict")
 )
 
+// cloneExtensionInfo returns a caller-owned snapshot of extension metadata.
+// ExtensionInfo is retained after registration and exposed through inspection,
+// so neither boundary may share mutable containers with extension code or
+// callers.
+func cloneExtensionInfo(info ExtensionInfo) ExtensionInfo {
+	info.Authors = cloneSlice(info.Authors)
+	info.Tags = cloneSlice(info.Tags)
+	info.Requires = cloneSlice(info.Requires)
+	info.Before = cloneSlice(info.Before)
+	info.After = cloneSlice(info.After)
+	info.RequiresCapabilities = cloneSlice(info.RequiresCapabilities)
+	info.Compat.Platforms = cloneSlice(info.Compat.Platforms)
+	if info.Compat.Engines != nil {
+		engines := make(map[string]string, len(info.Compat.Engines))
+		for engine, constraint := range info.Compat.Engines {
+			engines[engine] = constraint
+		}
+		info.Compat.Engines = engines
+	}
+	return info
+}
+
+func cloneSlice[T any](values []T) []T {
+	if values == nil {
+		return nil
+	}
+	cloned := make([]T, len(values))
+	copy(cloned, values)
+	return cloned
+}
+
 // ExtensionError attributes a failure to a specific extension and operation while
 // preserving the underlying error for errors.Is/As.
 type ExtensionError struct {

--- a/src/wago/gc_host_bridge_test.go
+++ b/src/wago/gc_host_bridge_test.go
@@ -86,7 +86,11 @@ func TestRuntimeGCHostFuncRefRejectsUnownedAndForeignDomains(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := plainRT.Instantiate(context.Background(), &Module{c: compiled}, WithImports(Imports{"host.echo": plain})); err == nil || !strings.Contains(err.Error(), "NewGCHostFuncRef") {
+	plainMod, err := plainRT.Module(compiled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := plainRT.Instantiate(context.Background(), plainMod, WithImports(Imports{"host.echo": plain})); err == nil || !strings.Contains(err.Error(), "NewGCHostFuncRef") {
 		t.Fatalf("plain GC host import error = %v", err)
 	}
 	_ = plain.Close()

--- a/src/wago/hooks.go
+++ b/src/wago/hooks.go
@@ -6,6 +6,10 @@ import (
 	"time"
 )
 
+// ErrCallbackPanic identifies a panic recovered at an untrusted runtime-close
+// callback boundary. Panic values and stacks are deliberately not retained.
+const ErrCallbackPanic = extErr("wago: callback panicked")
+
 // HookRegistry collects lifecycle callbacks contributed by extensions: runtime
 // close, compile, instantiate, instance close, and invoke. Hooks fire on the
 // Runtime-aware paths (rt.Compile, rt.Instantiate, Instance.Call, and
@@ -186,6 +190,19 @@ func callHookSafely(phase string, fn func()) (err error) {
 			} else {
 				err = fmt.Errorf("wago: %s hook panicked: %v", phase, recovered)
 			}
+		}
+	}()
+	fn()
+	return nil
+}
+
+func callRuntimeCloseSafely(phase string, fn func()) (err error) {
+	defer func() {
+		if recover() != nil {
+			// Runtime-shutdown callbacks are plugin boundaries. Panic values and
+			// stacks may contain credentials or attacker-sized data, so expose only
+			// the bounded phase label and a stable sentinel through normal errors.
+			err = fmt.Errorf("wago: %s: %w", phase, ErrCallbackPanic)
 		}
 	}()
 	fn()

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -155,13 +155,41 @@ type ModuleMetadata struct {
 	Tags                 []TagMetadata
 }
 
-// buildModule wraps a freshly compiled module, resolving each import against the
-// runtime's registered extensions to attach signatures, capabilities, and
-// provided-state.
+type moduleBindings struct {
+	rt         *Runtime
+	imports    Imports
+	importMeta map[string]*registeredImport
+}
+
+// snapshotModuleBindingsLocked captures the immutable import-policy generation
+// used to bind one module. The caller must hold rt.mu.
+func (rt *Runtime) snapshotModuleBindingsLocked() moduleBindings {
+	bindings := moduleBindings{
+		rt:         rt,
+		imports:    make(Imports, len(rt.imports)),
+		importMeta: make(map[string]*registeredImport, len(rt.importMeta)),
+	}
+	for key, value := range rt.imports {
+		bindings.imports[key] = value
+	}
+	for key, value := range rt.importMeta {
+		bindings.importMeta[key] = value
+	}
+	return bindings
+}
+
+// buildModule wraps a freshly compiled module using the runtime's current
+// import-policy generation. Compile and Module use a snapshot captured at their
+// admission boundary instead.
 func (rt *Runtime) buildModule(c *Compiled) *Module {
-	m := &Module{rt: rt, c: c}
 	rt.mu.Lock()
-	defer rt.mu.Unlock()
+	bindings := rt.snapshotModuleBindingsLocked()
+	rt.mu.Unlock()
+	return buildModule(c, bindings)
+}
+
+func buildModule(c *Compiled, bindings moduleBindings) *Module {
+	m := &Module{rt: bindings.rt, c: c}
 
 	capSeen := map[Capability]bool{}
 	for i, key := range c.Imports { // function imports, in "module.name" form
@@ -172,10 +200,10 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 			spec.Results = append([]ValType(nil), c.importFuncSigs[i].Results...)
 			spec.ParamTypes, spec.ResultTypes, _ = exactFuncSignature(c.importFuncSigs[i], c.Types)
 		}
-		if _, ok := rt.imports[key]; ok {
+		if _, ok := bindings.imports[key]; ok {
 			spec.Provided = true
 		}
-		if meta := rt.importMeta[key]; meta != nil {
+		if meta := bindings.importMeta[key]; meta != nil {
 			spec.Capability, spec.HasCapability = meta.cap, meta.hasCap
 			spec.Docs = meta.docs
 			if meta.hasCap && !capSeen[meta.cap] {
@@ -190,7 +218,7 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 		exact, exactErr := exactValueType(gi.Type, gi.HasValueType, gi.ValueTypeIndex, c.ValueTypes, c.Types)
 		m.imports = append(m.imports, ImportSpec{
 			Module: gi.Module, Name: gi.Name, Kind: ImportGlobal, Index: i,
-			Type: gi.Type, ValueType: exact, HasValueType: exactErr == nil, Mutable: gi.Mutable, Provided: rt.imports[key] != nil,
+			Type: gi.Type, ValueType: exact, HasValueType: exactErr == nil, Mutable: gi.Mutable, Provided: bindings.imports[key] != nil,
 		})
 	}
 	for i := 0; i < c.memoryImportCount(); i++ {
@@ -199,7 +227,7 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 		m.imports = append(m.imports, ImportSpec{
 			Module: mod, Name: name, Kind: ImportMemory, Index: i,
 			MemoryMin: def.Min, MemoryMax: def.Max, HasMax: def.HasMax, Addr64: def.Addr64, Shared: def.Shared,
-			Provided: rt.imports[def.ImportKey] != nil,
+			Provided: bindings.imports[def.ImportKey] != nil,
 		})
 	}
 	for i := 0; i < c.tableImportCount(); i++ {
@@ -209,7 +237,7 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 		m.imports = append(m.imports, ImportSpec{
 			Module: mod, Name: name, Kind: ImportTable, Index: i,
 			Type: def.Type, ValueType: exact, HasValueType: exactErr == nil, Min: def.Min, Max: def.Max, HasMax: def.HasMax, Addr64: def.Addr64,
-			Provided: rt.imports[def.Key] != nil,
+			Provided: bindings.imports[def.Key] != nil,
 		})
 	}
 	if c.memoryDir != nil {
@@ -218,7 +246,7 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 			mod, name := splitImportKey(def.ImportKey)
 			sig := c.Types[def.TypeIndex]
 			params, _ := valTypesFromDescriptors(sig.Params, c.Types)
-			m.imports = append(m.imports, ImportSpec{Module: mod, Name: name, Kind: ImportTag, Index: i, Params: params, ParamTypes: append([]ValueTypeDescriptor(nil), sig.Params...), Provided: rt.imports[def.ImportKey] != nil})
+			m.imports = append(m.imports, ImportSpec{Module: mod, Name: name, Kind: ImportTag, Index: i, Params: params, ParamTypes: append([]ValueTypeDescriptor(nil), sig.Params...), Provided: bindings.imports[def.ImportKey] != nil})
 		}
 	}
 	return m

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -258,8 +258,19 @@ func (m *Module) Compiled() *Compiled { return m.c }
 // Exports returns the module's exported function names, sorted.
 func (m *Module) Exports() []string { return m.c.ExportedFunctions() }
 
-// Imports returns the module's declared imports with extension-derived metadata.
-func (m *Module) Imports() []ImportSpec { return append([]ImportSpec(nil), m.imports...) }
+// Imports returns a caller-owned snapshot of the module's declared imports with
+// extension-derived metadata. Mutating the result never changes module state.
+func (m *Module) Imports() []ImportSpec {
+	imports := make([]ImportSpec, len(m.imports))
+	for i := range m.imports {
+		imports[i] = m.imports[i]
+		imports[i].Params = cloneSlice(m.imports[i].Params)
+		imports[i].Results = cloneSlice(m.imports[i].Results)
+		imports[i].ParamTypes = cloneSlice(m.imports[i].ParamTypes)
+		imports[i].ResultTypes = cloneSlice(m.imports[i].ResultTypes)
+	}
+	return imports
+}
 
 // RequiredCapabilities returns the capabilities the module's function imports
 // require, deduplicated in first-seen order.

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -43,7 +43,7 @@ func planPlugins(configs []PluginConfig) ([]plannedExtension, error) {
 		if !ok {
 			return nil, fmt.Errorf("wago: plugin %q is not compiled into this binary", cfg.Name)
 		}
-		info := ext.Info()
+		info := cloneExtensionInfo(ext.Info())
 		if info.ID == "" {
 			return nil, fmt.Errorf("wago: plugin %q has no extension ID", cfg.Name)
 		}
@@ -273,7 +273,7 @@ func resolvePluginOrder(configs []PluginConfig) ([]PluginConfig, error) {
 		if !ok {
 			return nil, fmt.Errorf("wago: plugin %q is not compiled into this binary", cfg.Name)
 		}
-		byName[cfg.Name], infos[cfg.Name] = cfg, ext.Info()
+		byName[cfg.Name], infos[cfg.Name] = cfg, cloneExtensionInfo(ext.Info())
 	}
 	edges := make(map[string]map[string]struct{}, len(configs))
 	indegree := make(map[string]int, len(configs))
@@ -394,7 +394,7 @@ func (rt *Runtime) commitPluginPlan(plan []plannedExtension) error {
 		for _, activate := range p.reg.activate {
 			activate(rt)
 		}
-		rt.exts = append(rt.exts, p.info)
+		rt.exts = append(rt.exts, cloneExtensionInfo(p.info))
 		rt.extensions[p.info.ID] = p.ext
 	}
 	return nil

--- a/src/wago/policy_test.go
+++ b/src/wago/policy_test.go
@@ -11,7 +11,7 @@ import (
 // memoryModule builds a module declaring (and exporting) a memory of minP..maxP
 // pages. Exporting it keeps MemMaxPages at maxP (an unexported, non-growing
 // memory is pinned to its minimum).
-func memoryModule(t *testing.T, minP, maxP int) *Module {
+func memoryModule(t *testing.T, rt *Runtime, minP, maxP int) *Module {
 	t.Helper()
 	memType := append([]byte{0x01}, wasmtest.ULEB(uint32(minP))...) // flags 0x01: has max
 	memType = append(memType, wasmtest.ULEB(uint32(maxP))...)
@@ -19,7 +19,7 @@ func memoryModule(t *testing.T, minP, maxP int) *Module {
 		wasmtest.Section(5, wasmtest.Vec(memType)),
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("memory", 2, 0))),
 	)
-	m, err := NewRuntime().Compile(mod)
+	m, err := rt.Compile(mod)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestPolicyCapabilityAllowDeny(t *testing.T) {
 
 func TestPolicyMemoryLimit(t *testing.T) {
 	rt := NewRuntime()
-	mod := memoryModule(t, 2, 4) // min 2 pages, max 4 pages -> 256 KiB max
+	mod := memoryModule(t, rt, 2, 4) // min 2 pages, max 4 pages -> 256 KiB max
 	// 128 KiB limit is below the module's 256 KiB max → denied.
 	if _, err := rt.Instantiate(context.Background(), mod, WithPolicy(Policy{MaxMemoryBytes: 128 << 10})); !errors.Is(err, ErrPermissionDenied) {
 		t.Fatalf("instantiate over memory limit = %v, want ErrPermissionDenied", err)

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -30,6 +30,7 @@ const (
 // package-level Compile/Instantiate remain available as the low-level API.
 type Runtime struct {
 	mu                   sync.Mutex
+	compileOps           sync.WaitGroup
 	cfg                  *RuntimeConfig
 	overridePolicy       ImportOverridePolicy
 	managedActive        atomic.Bool
@@ -273,9 +274,26 @@ func (rt *Runtime) Use(ext Extension, opts ...UseOption) error {
 // as a *Module, resolving its imports against the registered extensions and
 // running any AfterCompile hooks.
 func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
+	rt.mu.Lock()
+	if rt.closed {
+		rt.mu.Unlock()
+		return nil, fmt.Errorf("wago: Compile on a closed runtime")
+	}
+	beforeCompile := append([]func(*CompileContext, []byte) ([]byte, error)(nil), rt.hooks.beforeCompile...)
+	afterCompile := append([]func(*CompileContext, *Module) error(nil), rt.hooks.afterCompile...)
+	bindings := rt.snapshotModuleBindingsLocked()
+	instructions := make(map[string]*registeredInstruction, len(rt.instructions))
+	for key, ins := range rt.instructions {
+		instructions[key] = ins
+	}
+	cfg := rt.cfg
+	rt.compileOps.Add(1)
+	rt.mu.Unlock()
+	defer rt.compileOps.Done()
+
 	ctx := &CompileContext{Runtime: rt, Metadata: map[string]any{}}
 	source := wasmBytes
-	for _, fn := range rt.hooks.beforeCompile {
+	for _, fn := range beforeCompile {
 		next, err := fn(ctx, source)
 		if err != nil {
 			return nil, err
@@ -284,18 +302,11 @@ func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
 			source = next
 		}
 	}
-	rt.mu.Lock()
-	instructions := make(map[string]*registeredInstruction, len(rt.instructions))
-	for key, ins := range rt.instructions {
-		instructions[key] = ins
-	}
-	cfg := rt.cfg
-	rt.mu.Unlock()
 	c, err := compileWithConfigAndInstructions(cfg, source, instructions)
 	if err != nil {
 		return nil, err
 	}
-	mod := rt.buildModule(c)
+	mod := buildModule(c, bindings)
 	// The historical Imports key joins module and field with a dot. Both Wasm
 	// names may themselves contain dots, so recover the exact pair from the
 	// validated source for structured metadata and component-model linking.
@@ -312,8 +323,8 @@ func (rt *Runtime) Compile(wasmBytes []byte) (*Module, error) {
 			funcIndex++
 		}
 	}
-	if len(rt.hooks.afterCompile) > 0 {
-		for _, fn := range rt.hooks.afterCompile {
+	if len(afterCompile) > 0 {
+		for _, fn := range afterCompile {
 			if err := fn(ctx, mod); err != nil {
 				return nil, err
 			}
@@ -338,15 +349,20 @@ func (rt *Runtime) Module(c *Compiled) (*Module, error) {
 		return nil, fmt.Errorf("wago: nil runtime or compiled module")
 	}
 	rt.mu.Lock()
-	closed := rt.closed
-	rt.mu.Unlock()
-	if closed {
+	if rt.closed {
+		rt.mu.Unlock()
 		return nil, fmt.Errorf("wago: Module on a closed runtime")
 	}
-	mod := rt.buildModule(c)
-	if len(rt.hooks.afterCompile) > 0 {
+	bindings := rt.snapshotModuleBindingsLocked()
+	afterCompile := append([]func(*CompileContext, *Module) error(nil), rt.hooks.afterCompile...)
+	rt.compileOps.Add(1)
+	rt.mu.Unlock()
+	defer rt.compileOps.Done()
+
+	mod := buildModule(c, bindings)
+	if len(afterCompile) > 0 {
 		ctx := &CompileContext{Runtime: rt, Metadata: map[string]any{}}
-		for _, fn := range rt.hooks.afterCompile {
+		for _, fn := range afterCompile {
 			if err := fn(ctx, mod); err != nil {
 				return nil, err
 			}
@@ -551,7 +567,9 @@ func (rt *Runtime) Capabilities() []Capability {
 func (rt *Runtime) Close() error { return rt.CloseContext(context.Background()) }
 
 // CloseContext stops plugins in reverse load order, then closes internal
-// services and runtime hooks. It is idempotent.
+// services and runtime hooks. It is idempotent. It waits for compile operations
+// admitted before shutdown; compile hooks must therefore not call Close or
+// CloseContext synchronously on their own Runtime.
 func (rt *Runtime) CloseContext(ctx context.Context) error {
 	rt.mu.Lock()
 	if rt.closed {
@@ -564,6 +582,11 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 	pluginStops := append([]registeredPluginStop(nil), rt.pluginStops...)
 	store := rt.refStore
 	rt.mu.Unlock()
+	// No compile operation can be admitted after closed is published above.
+	// Wait for operations admitted before shutdown before tearing down the plugin
+	// hooks, instruction providers, and internal services they may still use.
+	rt.compileOps.Wait()
+	defer store.closeRuntime()
 
 	var errs []error
 	for i := len(pluginStops) - 1; i >= 0; i-- {
@@ -580,7 +603,6 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 	for i := len(hooks) - 1; i >= 0; i-- {
 		hooks[i](rctx)
 	}
-	store.closeRuntime()
 	return errors.Join(errs...)
 }
 

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -590,18 +590,24 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 
 	var errs []error
 	for i := len(pluginStops) - 1; i >= 0; i-- {
-		if err := pluginStops[i].stop(ctx); err != nil {
+		var stopErr error
+		panicErr := callRuntimeCloseSafely("plugin Stop", func() { stopErr = pluginStops[i].stop(ctx) })
+		if err := joinPrimary(stopErr, panicErr); err != nil {
 			errs = append(errs, &PluginError{Plugin: pluginStops[i].name, Phase: PluginPhaseStop, Err: err})
 		}
 	}
 	for i := len(internalClose) - 1; i >= 0; i-- {
-		if err := internalClose[i](); err != nil {
+		var closeErr error
+		panicErr := callRuntimeCloseSafely("internal runtime close", func() { closeErr = internalClose[i]() })
+		if err := joinPrimary(closeErr, panicErr); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	rctx := &RuntimeContext{Runtime: rt}
 	for i := len(hooks) - 1; i >= 0; i-- {
-		hooks[i](rctx)
+		if err := callRuntimeCloseSafely("OnRuntimeClose", func() { hooks[i](rctx) }); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -132,7 +132,7 @@ func (rt *Runtime) Use(ext Extension, opts ...UseOption) error {
 	if ext == nil {
 		return fmt.Errorf("wago: Use: nil extension")
 	}
-	info := ext.Info()
+	info := cloneExtensionInfo(ext.Info())
 	if info.ID == "" {
 		return fmt.Errorf("wago: Use: extension has no ID")
 	}
@@ -551,11 +551,17 @@ func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc G
 	return inst, nil
 }
 
-// Extensions returns the registered extensions in registration order.
+// Extensions returns caller-owned snapshots of the registered extensions in
+// registration order. Mutating nested slices or maps does not affect runtime
+// state.
 func (rt *Runtime) Extensions() []ExtensionInfo {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	return append([]ExtensionInfo(nil), rt.exts...)
+	extensions := make([]ExtensionInfo, len(rt.exts))
+	for i := range rt.exts {
+		extensions[i] = cloneExtensionInfo(rt.exts[i])
+	}
+	return extensions
 }
 
 // Capabilities returns the capabilities declared by registered extensions,

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -57,6 +57,10 @@ type registeredPluginStop struct {
 	stop func(context.Context) error
 }
 
+// ErrForeignModule reports an attempt to instantiate a Module through a Runtime
+// other than the one that bound its imports and lifecycle policy.
+const ErrForeignModule = extErr("wago: module belongs to a different runtime")
+
 // RuntimeOption configures a Runtime at construction.
 type RuntimeOption func(*Runtime)
 
@@ -429,6 +433,9 @@ func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...Instant
 func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin InstantiateOrigin, opts ...InstantiateOption) (*Instance, error) {
 	if mod == nil {
 		return nil, fmt.Errorf("wago: Instantiate: nil module")
+	}
+	if mod.rt != rt {
+		return nil, fmt.Errorf("wago: Instantiate: %w; rebind it with Runtime.Module", ErrForeignModule)
 	}
 	if ctx == nil {
 		ctx = context.Background()

--- a/src/wago/runtime_close_panic_test.go
+++ b/src/wago/runtime_close_panic_test.go
@@ -1,0 +1,101 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeCloseSanitizesPanicsAndReleasesManagedResources(t *testing.T) {
+	secret := strings.Repeat("secret-token-", 1024)
+	stopPanic := errors.New(secret + "stop")
+	internalPanic := errors.New(secret + "internal")
+	hookPanic := errors.New(secret + "hook")
+	var events []string
+	rt := NewRuntime()
+	manager := newPendingInstanceManager("test.manager", CapabilityBudget{})
+	manager.activate(rt)
+	owner, err := rt.NewHostFuncRef(HostFunc(func(_ HostModule, _ []uint64, results []uint64) {
+		results[0] = I32(42)
+	}), FuncSig{Results: []ValType{ValI32}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod, err := rt.Compile(funcrefImportedRefFuncModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	managed, err := manager.Instantiate(context.Background(), mod, WithImports(Imports{"env.target": owner}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := managed.Instance().Call(context.Background(), "get")
+	if err != nil || len(result) != 1 || result[0].FuncRef().IsNull() {
+		t.Fatalf("get retained token = %v, %v", result, err)
+	}
+	rt.refStore.mu.Lock()
+	retainedTokens := len(rt.refStore.byToken)
+	rt.refStore.mu.Unlock()
+	if retainedTokens == 0 {
+		t.Fatal("test setup did not retain a funcref token")
+	}
+	rt.pluginStops = []registeredPluginStop{
+		{name: "continues", stop: func(context.Context) error { events = append(events, "stop:continues"); return nil }},
+		{name: "panics", stop: func(context.Context) error { events = append(events, "stop:panics"); panic(stopPanic) }},
+	}
+	rt.hooks.internalClose = []func() error{
+		manager.close,
+		func() error { events = append(events, "internal:continues"); return nil },
+		func() error { events = append(events, "internal:panics"); panic(internalPanic) },
+	}
+	rt.hooks.onRuntimeClose = []func(*RuntimeContext){
+		func(*RuntimeContext) { events = append(events, "hook:continues") },
+		func(*RuntimeContext) { events = append(events, "hook:panics"); panic(hookPanic) },
+	}
+
+	err = rt.Close()
+	if !errors.Is(err, ErrCallbackPanic) {
+		t.Fatalf("Close error = %v, want ErrCallbackPanic", err)
+	}
+	for _, panicErr := range []error{stopPanic, internalPanic, hookPanic} {
+		if errors.Is(err, panicErr) || strings.Contains(err.Error(), panicErr.Error()) {
+			t.Fatalf("Close error retained secret panic value: %v", err)
+		}
+	}
+	if len(err.Error()) > 512 {
+		t.Fatalf("Close panic report is unbounded: %d bytes", len(err.Error()))
+	}
+	wantEvents := []string{
+		"stop:panics", "stop:continues",
+		"internal:panics", "internal:continues",
+		"hook:panics", "hook:continues",
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("close events = %v, want %v", events, wantEvents)
+	}
+	if managed.Instance() != nil {
+		t.Fatal("managed instance remained open after callback panics")
+	}
+	if err := owner.Close(); err != nil {
+		t.Fatalf("host token owner remained retained after Close: %v", err)
+	}
+	rt.refStore.mu.Lock()
+	storeClosed := rt.refStore.runtimeClosed
+	liveInstances := rt.refStore.liveInstances
+	instances := len(rt.refStore.instances)
+	funcrefTokens := len(rt.refStore.byToken)
+	gcTokens := len(rt.refStore.gcByToken)
+	rt.refStore.mu.Unlock()
+	if !storeClosed || liveInstances != 0 || instances != 0 || funcrefTokens != 0 || gcTokens != 0 {
+		t.Fatalf("reference resources after Close: closed=%v live=%d instances=%d funcrefs=%d gc=%d",
+			storeClosed, liveInstances, instances, funcrefTokens, gcTokens)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatalf("second Close = %v", err)
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("idempotent Close reran callbacks: %v", events)
+	}
+}

--- a/src/wago/runtime_compile_close_test.go
+++ b/src/wago/runtime_compile_close_test.go
@@ -1,0 +1,157 @@
+package wago
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func waitRuntimeClosed(t *testing.T, rt *Runtime) {
+	t.Helper()
+	for {
+		rt.mu.Lock()
+		closed := rt.closed
+		rt.mu.Unlock()
+		if closed {
+			return
+		}
+		runtime.Gosched()
+	}
+}
+
+func TestRuntimeCompileRejectsClosedRuntimeBeforeHooks(t *testing.T) {
+	rt := NewRuntime()
+	var beforeCalls int
+	rt.hooks.BeforeCompile(func(*CompileContext, []byte) ([]byte, error) {
+		beforeCalls++
+		return nil, nil
+	})
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.Compile(wasmtest.Module()); err == nil || !strings.Contains(err.Error(), "closed runtime") {
+		t.Fatalf("Compile after Close = %v, want closed-runtime error", err)
+	}
+	if beforeCalls != 0 {
+		t.Fatalf("BeforeCompile ran %d times after close", beforeCalls)
+	}
+}
+
+func TestRuntimeCloseWaitsForAdmittedCompileBeforePluginTeardown(t *testing.T) {
+	rt := NewRuntime()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	afterCompile := make(chan struct{})
+	stopped := make(chan struct{})
+	rt.hooks.BeforeCompile(func(*CompileContext, []byte) ([]byte, error) {
+		close(entered)
+		<-release
+		return nil, nil
+	})
+	rt.hooks.AfterCompile(func(*CompileContext, *Module) error {
+		close(afterCompile)
+		return nil
+	})
+	rt.pluginStops = []registeredPluginStop{{name: "compiler", stop: func(context.Context) error {
+		select {
+		case <-afterCompile:
+		default:
+			t.Error("plugin stopped before admitted compile finished its AfterCompile hook")
+		}
+		close(stopped)
+		return nil
+	}}}
+
+	compileDone := make(chan error, 1)
+	go func() {
+		_, err := rt.Compile(wasmtest.Module())
+		compileDone <- err
+	}()
+	<-entered
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- rt.Close() }()
+	waitRuntimeClosed(t, rt)
+	select {
+	case <-stopped:
+		t.Fatal("plugin stopped while an admitted compile was still active")
+	default:
+	}
+	close(release)
+	if err := <-compileDone; err != nil {
+		t.Fatalf("compile admitted before Close = %v", err)
+	}
+	if err := <-closeDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeCompileUsesOneAdmissionSnapshot(t *testing.T) {
+	rt := NewRuntime()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	rt.hooks.BeforeCompile(func(*CompileContext, []byte) ([]byte, error) {
+		close(entered)
+		<-release
+		return nil, nil
+	})
+
+	moduleDone := make(chan *Module, 1)
+	errDone := make(chan error, 1)
+	go func() {
+		mod, err := rt.Compile(returningImportModule(
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+			[]byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b},
+		))
+		moduleDone <- mod
+		errDone <- err
+	}()
+	<-entered
+	if err := rt.Use(tripleExt{}); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+	mod := <-moduleDone
+	if err := <-errDone; err != nil {
+		t.Fatal(err)
+	}
+	imports := mod.Imports()
+	if len(imports) != 1 || imports[0].Provided || imports[0].HasCapability {
+		t.Fatalf("admitted compile observed later import generation: %+v", imports)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeCompileCloseRaceHasOnlyAdmittedOrClosedOutcomes(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		rt := NewRuntime()
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		var compileErr, closeErr error
+		go func() {
+			defer wg.Done()
+			<-start
+			_, compileErr = rt.Compile(wasmtest.Module())
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			closeErr = rt.Close()
+		}()
+		close(start)
+		wg.Wait()
+		if closeErr != nil {
+			t.Fatalf("iteration %d Close = %v", i, closeErr)
+		}
+		if compileErr != nil && !strings.Contains(compileErr.Error(), "closed runtime") {
+			t.Fatalf("iteration %d Compile = %v", i, compileErr)
+		}
+	}
+}

--- a/src/wago/runtime_foreign_module_test.go
+++ b/src/wago/runtime_foreign_module_test.go
@@ -1,0 +1,102 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+type namedNoopExtension string
+
+func (e namedNoopExtension) Info() ExtensionInfo    { return ExtensionInfo{ID: string(e)} }
+func (namedNoopExtension) Register(*Registry) error { return nil }
+
+func TestRuntimeRejectsForeignModuleBeforePolicyHooksAndClosedState(t *testing.T) {
+	rtA := NewRuntime()
+	if err := rtA.Use(tripleExt{}); err != nil {
+		t.Fatal(err)
+	}
+	modA := callsEnvF(t, rtA)
+	compiled := modA.Compiled()
+	defer compiled.Close()
+	if err := rtA.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rtB := NewRuntime()
+	if err := rtB.Use(tripleExt{}); err != nil {
+		t.Fatal(err)
+	}
+	var beforeInstantiate int
+	rtB.hooks.BeforeInstantiate(func(*InstantiateContext) error {
+		beforeInstantiate++
+		return nil
+	})
+	denySourceCapability := Policy{DeniedCapabilities: []Capability{CapMetricsWrite}}
+	if _, err := rtB.Instantiate(context.Background(), modA, WithPolicy(denySourceCapability)); !errors.Is(err, ErrForeignModule) {
+		t.Fatalf("foreign Instantiate error = %v, want ErrForeignModule before capability policy", err)
+	}
+	if beforeInstantiate != 0 {
+		t.Fatalf("foreign module reached %d instantiate hooks", beforeInstantiate)
+	}
+	if err := rtB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rtB.Instantiate(context.Background(), modA); !errors.Is(err, ErrForeignModule) {
+		t.Fatalf("foreign Instantiate on closed destination = %v, want ErrForeignModule", err)
+	}
+
+	rtC := NewRuntime()
+	defer rtC.Close()
+	modC, err := rtC.Module(compiled)
+	if err != nil {
+		t.Fatalf("explicit rebind: %v", err)
+	}
+	instance, err := rtC.Instantiate(context.Background(), modC, WithImports(Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] })}))
+	if err != nil {
+		t.Fatalf("Instantiate rebound module: %v", err)
+	}
+	if err := instance.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeRejectsForeignModuleDuringConcurrentUse(t *testing.T) {
+	source := NewRuntime()
+	mod, err := source.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Compiled().Close()
+	destination := NewRuntime()
+	defer destination.Close()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			if err := destination.Use(namedNoopExtension(fmt.Sprintf("test.concurrent.%d", i))); err != nil {
+				t.Errorf("Use %d: %v", i, err)
+			}
+		}(i)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := destination.Instantiate(context.Background(), mod); !errors.Is(err, ErrForeignModule) {
+				t.Errorf("concurrent foreign Instantiate = %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if err := source.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/src/wago/runtime_inspection_snapshot_test.go
+++ b/src/wago/runtime_inspection_snapshot_test.go
@@ -1,0 +1,159 @@
+package wago
+
+import (
+	"encoding/json"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+type mutableInfoExtension struct {
+	info ExtensionInfo
+}
+
+func (e *mutableInfoExtension) Info() ExtensionInfo    { return e.info }
+func (*mutableInfoExtension) Register(*Registry) error { return nil }
+
+func populatedMutableInfo() ExtensionInfo {
+	return ExtensionInfo{
+		ID: "test.mutable-info", Authors: []string{"author"}, Tags: []string{"tag"},
+		Requires: []string{"required"}, Before: []string{"before"}, After: []string{"after"},
+		RequiresCapabilities: []PluginCapability{PluginHostImports},
+		Compat:               Compatibility{Engines: map[string]string{"wago": "*"}, Platforms: []string{"linux/amd64"}},
+	}
+}
+
+func mutateExtensionInfo(info *ExtensionInfo, value string) {
+	info.Authors[0] = value
+	info.Tags[0] = value
+	info.Requires[0] = value
+	info.Before[0] = value
+	info.After[0] = value
+	info.RequiresCapabilities[0] = PluginCoreRuntime
+	info.Compat.Platforms[0] = value
+	info.Compat.Engines["wago"] = value
+}
+
+func TestInspectionSnapshotsDeepCopyMutableContainers(t *testing.T) {
+	rt := NewRuntime()
+	ext := &mutableInfoExtension{info: populatedMutableInfo()}
+	if err := rt.Use(ext); err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	baseline, err := json.Marshal(rt.Extensions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mutateExtensionInfo(&ext.info, "extension")
+	returned := rt.Extensions()
+	mutateExtensionInfo(&returned[0], "caller")
+	after, err := json.Marshal(rt.Extensions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(baseline) {
+		t.Fatalf("extension snapshot mutated:\n got %s\nwant %s", after, baseline)
+	}
+
+	mod := callsEnvF(t, rt)
+	importBaseline, err := json.Marshal(mod.Imports())
+	if err != nil {
+		t.Fatal(err)
+	}
+	imports := mod.Imports()
+	imports[0].Params[0] = ValV128
+	imports[0].Results[0] = ValV128
+	imports[0].ParamTypes[0] = ValueTypeDescriptor{Kind: ValueTypeV128}
+	imports[0].ResultTypes[0] = ValueTypeDescriptor{Kind: ValueTypeV128}
+	importAfter, err := json.Marshal(mod.Imports())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(importAfter) != string(importBaseline) {
+		t.Fatalf("import snapshot mutated:\n got %s\nwant %s", importAfter, importBaseline)
+	}
+
+	metadataBaseline, err := json.Marshal(mod.Metadata())
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata := mod.Metadata()
+	metadata.Functions[0].Params[0] = ValV128
+	metadata.Functions[0].Exports = append(metadata.Functions[0].Exports, "caller")
+	metadataAfter, err := json.Marshal(mod.Metadata())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(metadataAfter) != string(metadataBaseline) {
+		t.Fatalf("module metadata snapshot mutated:\n got %s\nwant %s", metadataAfter, metadataBaseline)
+	}
+}
+
+func TestInspectionSnapshotsAreRaceFreeAgainstCallerMutation(t *testing.T) {
+	rt := NewRuntime()
+	ext := &mutableInfoExtension{info: populatedMutableInfo()}
+	if err := rt.Use(ext); err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			mutateExtensionInfo(&ext.info, "extension")
+		}
+	}()
+	for worker := 0; worker < 2; worker++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				infos := rt.Extensions()
+				mutateExtensionInfo(&infos[0], "caller")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestInspectionCloneCoverageTracksNestedMutableFields(t *testing.T) {
+	assertMutableFieldPaths(t, reflect.TypeOf(ImportSpec{}), []string{
+		"Params", "Results", "ParamTypes", "ResultTypes",
+	})
+	assertMutableFieldPaths(t, reflect.TypeOf(ExtensionInfo{}), []string{
+		"Authors", "Tags", "Compat.Engines", "Compat.Platforms", "Requires", "Before", "After", "RequiresCapabilities",
+	})
+
+	empty := cloneExtensionInfo(ExtensionInfo{Authors: []string{}, Compat: Compatibility{Engines: map[string]string{}, Platforms: []string{}}})
+	if empty.Authors == nil || empty.Compat.Engines == nil || empty.Compat.Platforms == nil {
+		t.Fatal("clone collapsed non-nil empty containers")
+	}
+}
+
+func assertMutableFieldPaths(t *testing.T, typ reflect.Type, want []string) {
+	t.Helper()
+	var got []string
+	var walk func(reflect.Type, string)
+	walk = func(current reflect.Type, prefix string) {
+		for i := 0; i < current.NumField(); i++ {
+			field := current.Field(i)
+			path := field.Name
+			if prefix != "" {
+				path = prefix + "." + path
+			}
+			switch field.Type.Kind() {
+			case reflect.Slice, reflect.Map, reflect.Pointer:
+				got = append(got, path)
+			case reflect.Struct:
+				walk(field.Type, path)
+			}
+		}
+	}
+	walk(typ, "")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mutable fields in %s = %v, update clone coverage for %v", typ.Name(), got, want)
+	}
+}

--- a/src/wago/runtime_regression_test.go
+++ b/src/wago/runtime_regression_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"math"
 	"os"
 	"path/filepath"
@@ -457,7 +458,7 @@ func TestHugeCallStackUnwindsToStartTrap(t *testing.T) {
 	}
 }
 
-func TestCrossRuntimeInstantiationUsesStructuralImportTypes(t *testing.T) {
+func TestCrossRuntimeInstantiationRequiresExplicitRebind(t *testing.T) {
 	funcImport := append(wasmtest.Name("env"), wasmtest.Name("proxy")...)
 	funcImport = append(funcImport, 0x00, 0x02) // function import, type index 2
 	mod := wasmtest.Module(
@@ -485,9 +486,16 @@ func TestCrossRuntimeInstantiationUsesStructuralImportTypes(t *testing.T) {
 	if err := rt2.Use(crossRuntimeImportExt{}); err != nil {
 		t.Fatalf("register runtime 2 import: %v", err)
 	}
-	in, err := rt2.Instantiate(context.Background(), compiled)
+	if _, err := rt2.Instantiate(context.Background(), compiled); !errors.Is(err, ErrForeignModule) {
+		t.Fatalf("foreign module error = %v, want ErrForeignModule", err)
+	}
+	rebound, err := rt2.Module(compiled.Compiled())
 	if err != nil {
-		t.Fatalf("cross-runtime instantiate with structurally identical import: %v", err)
+		t.Fatalf("rebind in runtime 2: %v", err)
+	}
+	in, err := rt2.Instantiate(context.Background(), rebound)
+	if err != nil {
+		t.Fatalf("instantiate explicitly rebound module: %v", err)
 	}
 	defer in.Close()
 	got, err := in.Invoke("f", I32(37))

--- a/wago.go
+++ b/wago.go
@@ -209,7 +209,9 @@ const (
 	ElemModeActive                             = impl.ElemModeActive
 	ElemModeDeclarative                        = impl.ElemModeDeclarative
 	ElemModePassive                            = impl.ElemModePassive
+	ErrCallbackPanic                           = impl.ErrCallbackPanic
 	ErrExtensionConflict                       = impl.ErrExtensionConflict
+	ErrForeignModule                           = impl.ErrForeignModule
 	ErrInvalidHandle                           = impl.ErrInvalidHandle
 	ErrManagedImportLifetime                   = impl.ErrManagedImportLifetime
 	ErrMissingImport                           = impl.ErrMissingImport


### PR DESCRIPTION
Supersedes #424 with an atomic replacement built from current `main` and fixes every finding from its code review.

## What changed

- reject `Compile` after shutdown and snapshot hooks, instructions, configuration, imports, and capability metadata at one admission boundary;
- wait for admitted compile/module operations before stopping plugins and internal services;
- isolate shutdown callback panics behind a bounded `ErrCallbackPanic` without retaining panic values or stacks, while continuing cleanup;
- reject foreign `Module` values before policy, imports, or hooks and retain explicit `Runtime.Module` rebinding;
- bind decoded cache artifacts exactly once, close rejected native mappings deterministically, and propagate binding failures;
- remove scheduling-only function-worker policy from cache identity, bump the cache format, and reconcile cache documentation;
- deep-copy nested extension/import inspection metadata at registration, planning, storage, and return boundaries.

## Regression coverage

- deterministic compile/close lifecycle ordering and concurrent admission races;
- shutdown panics in plugin, internal, and runtime hook callbacks with retained managed-instance and funcref-token cleanup;
- capability mismatch, identical imports, closed source/destination runtimes, concurrent `Use`, and explicit rebinding;
- cached binding rejection, closed runtime, corrupt artifact repair, and decoded artifact ownership cleanup;
- worker policies `0`, `1`, `2`, `4`, and above `GOMAXPROCS` across a small corpus, byte/native-metadata equality, and subprocess warm reuse;
- concurrent caller mutation of inspection snapshots under the race detector plus recursive mutable-field guards.

## Validation

- `go test -race ./src/wago ./cli/runtime/internal/artifactcache -count=1`
- `go test ./... -count=1`
- `make lint` (`staticcheck` unavailable locally and skipped by the repository target)

Closes #388.
Closes #390.
Closes #393.
Closes #400.
Closes #401.
Closes #416.
