### PR TITLE
runtime: complete lifecycle, cache, and rolling-release hardening

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -47,7 +47,7 @@ jobs:
           sha=$(git rev-parse HEAD)
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "version=canary-${sha::7}" >> "$GITHUB_OUTPUT"
-          echo "tag=canary-${sha::7}" >> "$GITHUB_OUTPUT"
+          echo "tag=canary-$sha" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build canary (${{ matrix.goos }}/${{ matrix.goarch }})
@@ -109,7 +109,7 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          WAGO_VERSION: ${{ needs.prepare.outputs.version }}
+          WAGO_VERSION: canary@${{ needs.prepare.outputs.sha }}
         run: |
           scripts/build-release-assets.sh
           scripts/verify-channel-assets.sh . "${{ matrix.target }}"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -152,6 +152,11 @@ jobs:
           notes=$(printf 'Automated canary build of main at `%s`. All supported Normal targets are required; unsupported Tiny variants are omitted. Unstable — may break without notice.\n\n' \
             '${{ needs.prepare.outputs.sha }}'; sed -n '1,$p' .github/release-asset-naming.md)
           if gh release view "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            target=$(gh api "repos/${{ github.repository }}/releases/tags/${{ needs.prepare.outputs.tag }}" --jq '.target_commitish')
+            if [ "$target" != "${{ needs.prepare.outputs.sha }}" ]; then
+              echo "GitHub release ${{ needs.prepare.outputs.tag }} has an invalid target commit: $target" >&2
+              exit 1
+            fi
             gh release upload "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" --clobber "${assets[@]}"
             gh release edit "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" --notes "$notes"
             echo "canary release already exists for ${{ needs.prepare.outputs.sha }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -126,7 +126,7 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          WAGO_VERSION: ${{ needs.check.outputs.version }}
+          WAGO_VERSION: nightly@${{ needs.check.outputs.sha }}
         run: |
           scripts/build-release-assets.sh
           scripts/verify-channel-assets.sh . "${{ matrix.target }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
           sha=$(git rev-parse HEAD)
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "version=nightly-$(date -u +%Y%m%d)-${sha::7}" >> "$GITHUB_OUTPUT"
-          echo "tag=nightly-$(date -u +%Y%m%d)-${sha::7}" >> "$GITHUB_OUTPUT"
+          echo "tag=nightly-$(date -u +%Y%m%d)-$sha" >> "$GITHUB_OUTPUT"
       - name: Compare HEAD to the newest nightly release
         id: decide
         env:
@@ -175,6 +175,11 @@ jobs:
             '${{ needs.check.outputs.sha }}' '${{ needs.check.outputs.version }}' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
             sed -n '1,$p' .github/release-asset-naming.md)
           if gh release view "${{ needs.check.outputs.tag }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            target=$(gh api "repos/${{ github.repository }}/releases/tags/${{ needs.check.outputs.tag }}" --jq '.target_commitish')
+            if [ "$target" != "${{ needs.check.outputs.sha }}" ]; then
+              echo "GitHub release ${{ needs.check.outputs.tag }} has an invalid target commit: $target" >&2
+              exit 1
+            fi
             gh release upload "${{ needs.check.outputs.tag }}" --repo "${{ github.repository }}" --clobber "${assets[@]}"
             gh release edit "${{ needs.check.outputs.tag }}" --repo "${{ github.repository }}" --notes "$notes"
           else

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -424,9 +425,31 @@ func (catalog installerReleaseCatalog) Latest() (installbootstrap.Release, error
 }
 
 func (catalog installerReleaseCatalog) Releases() ([]installbootstrap.Release, error) {
+	const pageLimit = 10
 	var releases []installbootstrap.Release
-	err := catalog.installer.getJSON(catalog.installer.releaseAPI+"?per_page=100", &releases)
-	return releases, err
+	base, err := url.Parse(catalog.installer.releaseAPI)
+	if err != nil {
+		return nil, fmt.Errorf("parse release catalog URL: %w", err)
+	}
+	for page := 1; page <= pageLimit; page++ {
+		var batch []installbootstrap.Release
+		address := *base
+		query := address.Query()
+		query.Set("per_page", "100")
+		query.Set("page", strconv.Itoa(page))
+		address.RawQuery = query.Encode()
+		if err := catalog.installer.getJSON(address.String(), &batch); err != nil {
+			return nil, err
+		}
+		if len(batch) > 100 {
+			return nil, fmt.Errorf("release catalog returned too many releases on page %d", page)
+		}
+		releases = append(releases, batch...)
+		if len(batch) < 100 {
+			return releases, nil
+		}
+	}
+	return nil, fmt.Errorf("release catalog exceeded %d pages", pageLimit)
 }
 
 func (i *installer) getJSON(url string, value any) error {

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -41,6 +41,7 @@ type installer struct {
 	httpClient          *http.Client
 	tmpDir              string
 	managerTag          string
+	managerSourceRef    string
 	managerFromRelease  bool
 	sourceMethod        string
 	progressActive      bool
@@ -380,14 +381,16 @@ func reinstallLabel(mode string) string {
 }
 
 func (i *installer) downloadManager(target string) error {
-	tag, base := i.version, ""
+	resolved := installbootstrap.ResolvedRelease{Tag: i.version, SourceRef: installerSourceRef(i.version)}
+	base := ""
 	if os.Getenv("WAGO_MANAGER_URL") == "" {
 		var err error
-		tag, base, err = i.resolveRelease()
+		resolved, base, err = i.resolveRelease()
 		if err != nil {
 			return err
 		}
 	}
+	tag := resolved.Tag
 	asset, err := installbootstrap.Asset("wago", runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return err
@@ -403,17 +406,17 @@ func (i *installer) downloadManager(target string) error {
 	if err := os.Chmod(target, 0o755); err != nil {
 		return err
 	}
-	i.managerTag, i.managerFromRelease = tag, true
+	i.managerTag, i.managerSourceRef, i.managerFromRelease = tag, resolved.SourceRef, true
 	i.done("Downloaded Wago manager " + tag)
 	return nil
 }
 
-func (i *installer) resolveRelease() (string, string, error) {
-	tag, err := installbootstrap.Resolve(i.version, installerReleaseCatalog{i})
+func (i *installer) resolveRelease() (installbootstrap.ResolvedRelease, string, error) {
+	resolved, err := installbootstrap.ResolveRelease(i.version, installerReleaseCatalog{i})
 	if err != nil {
-		return "", "", err
+		return installbootstrap.ResolvedRelease{}, "", err
 	}
-	return tag, i.releaseDownloadBase + "/download/" + tag, nil
+	return resolved, i.releaseDownloadBase + "/download/" + resolved.Tag, nil
 }
 
 type installerReleaseCatalog struct{ installer *installer }
@@ -520,16 +523,13 @@ var runInstallerGit = func(args ...string) ([]byte, error) {
 
 func (i *installer) fetchSource() (string, error) {
 	target := filepath.Join(i.tmpDir, "src")
-	_, canonicalSHA, canonicalCommit := installerRollingCommit(i.version)
 	sourceVersion := installerSourceRef(i.version)
+	if i.managerFromRelease && i.managerSourceRef != "" {
+		sourceVersion = i.managerSourceRef
+	}
 	archiveURL := i.archiveURL
-	if i.managerFromRelease && !canonicalCommit {
-		sourceVersion = i.managerTag
-		if os.Getenv("WAGO_ARCHIVE_URL") == "" {
-			archiveURL = installerSourceArchiveURL(envOr("WAGO_RELEASE_REPO", "wago-org/wago"), sourceVersion)
-		}
-	} else if canonicalCommit && os.Getenv("WAGO_ARCHIVE_URL") == "" {
-		archiveURL = installerSourceArchiveURL(envOr("WAGO_RELEASE_REPO", "wago-org/wago"), canonicalSHA)
+	if os.Getenv("WAGO_ARCHIVE_URL") == "" {
+		archiveURL = installerSourceArchiveURL(envOr("WAGO_RELEASE_REPO", "wago-org/wago"), sourceVersion)
 	}
 	i.begin("Fetching Wago source")
 	gitLog, gitErr := i.fetchSourceWithGit(target, sourceVersion)
@@ -543,7 +543,8 @@ func (i *installer) fetchSource() (string, error) {
 }
 
 func (i *installer) fetchSourceWithGit(target, sourceVersion string) ([]byte, error) {
-	if _, sha, canonical := installerRollingCommit(i.version); canonical {
+	if fullInstallerCommitSHA(sourceVersion) {
+		sha := sourceVersion
 		commands := [][]string{
 			{"-c", "init.defaultBranch=main", "init", target},
 			{"-C", target, "fetch", "--quiet", "--depth", "1", i.repoURL, sha},
@@ -578,6 +579,18 @@ func installerSourceRef(version string) string {
 		return sha
 	}
 	return version
+}
+
+func fullInstallerCommitSHA(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, char := range strings.ToLower(value) {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return false
+		}
+	}
+	return true
 }
 
 func installerRollingCommit(version string) (channel, sha string, canonical bool) {

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -71,6 +71,10 @@ func runInstaller() error {
 	return err
 }
 
+var installerSourceArchiveURL = func(repo, ref string) string {
+	return "https://api.github.com/repos/" + repo + "/zipball/" + ref
+}
+
 func newInstaller(out io.Writer) (*installer, error) {
 	home, err := os.UserHomeDir()
 	if value := firstEnv("HOME", "USERPROFILE"); value != "" {
@@ -79,7 +83,11 @@ func newInstaller(out io.Writer) (*installer, error) {
 	if err != nil && home == "" {
 		return nil, errors.New("home directory is not available")
 	}
-	version := envOr("WAGO_VERSION", "main")
+	requestedVersion := envOr("WAGO_VERSION", version)
+	if requestedVersion == "" || requestedVersion == "dev" {
+		requestedVersion = "main"
+	}
+	archiveRef := installerSourceRef(requestedVersion)
 	releaseRepo := envOr("WAGO_RELEASE_REPO", "wago-org/wago")
 	binDir := os.Getenv("WAGO_BIN_DIR")
 	binExplicit := binDir != ""
@@ -91,9 +99,9 @@ func newInstaller(out io.Writer) (*installer, error) {
 	i := &installer{
 		out:                 out,
 		home:                home,
-		version:             version,
+		version:             requestedVersion,
 		repoURL:             envOr("WAGO_REPO_URL", "https://github.com/wago-org/wago.git"),
-		archiveURL:          envOr("WAGO_ARCHIVE_URL", "https://api.github.com/repos/wago-org/wago/zipball/"+version),
+		archiveURL:          envOr("WAGO_ARCHIVE_URL", installerSourceArchiveURL(releaseRepo, archiveRef)),
 		releaseAPI:          envOr("WAGO_RELEASES_API_URL", "https://api.github.com/repos/"+releaseRepo+"/releases"),
 		releaseDownloadBase: envOr("WAGO_RELEASE_DOWNLOAD_BASE", "https://github.com/"+releaseRepo+"/releases"),
 		binDir:              filepath.Clean(binDir),
@@ -483,24 +491,52 @@ func (i *installer) download(url, target string) error {
 	return closeErr
 }
 
+var runInstallerGit = func(args ...string) ([]byte, error) {
+	return exec.Command("git", args...).CombinedOutput()
+}
+
 func (i *installer) fetchSource() (string, error) {
 	target := filepath.Join(i.tmpDir, "src")
-	sourceVersion := i.version
+	_, canonicalSHA, canonicalCommit := installerRollingCommit(i.version)
+	sourceVersion := installerSourceRef(i.version)
 	archiveURL := i.archiveURL
-	if i.managerFromRelease {
+	if i.managerFromRelease && !canonicalCommit {
 		sourceVersion = i.managerTag
 		if os.Getenv("WAGO_ARCHIVE_URL") == "" {
-			archiveURL = "https://api.github.com/repos/" + envOr("WAGO_RELEASE_REPO", "wago-org/wago") + "/zipball/" + sourceVersion
+			archiveURL = installerSourceArchiveURL(envOr("WAGO_RELEASE_REPO", "wago-org/wago"), sourceVersion)
 		}
+	} else if canonicalCommit && os.Getenv("WAGO_ARCHIVE_URL") == "" {
+		archiveURL = installerSourceArchiveURL(envOr("WAGO_RELEASE_REPO", "wago-org/wago"), canonicalSHA)
 	}
 	i.begin("Fetching Wago source")
-	gitLog, gitErr := exec.Command("git", "clone", "--depth", "1", "--branch", sourceVersion, i.repoURL, target).CombinedOutput()
+	gitLog, gitErr := i.fetchSourceWithGit(target, sourceVersion)
 	if gitErr == nil {
 		i.sourceMethod = "git"
 		i.done("Fetched Wago source")
 		return target, nil
 	}
 	_ = os.RemoveAll(target)
+	return i.fetchSourceArchiveAfterGitFailure(target, archiveURL, gitLog, gitErr)
+}
+
+func (i *installer) fetchSourceWithGit(target, sourceVersion string) ([]byte, error) {
+	if _, sha, canonical := installerRollingCommit(i.version); canonical {
+		commands := [][]string{
+			{"-c", "init.defaultBranch=main", "init", target},
+			{"-C", target, "fetch", "--quiet", "--depth", "1", i.repoURL, sha},
+			{"-C", target, "checkout", "--quiet", "--detach", "FETCH_HEAD"},
+		}
+		for _, args := range commands {
+			if output, err := runInstallerGit(args...); err != nil {
+				return output, err
+			}
+		}
+		return nil, nil
+	}
+	return runInstallerGit("clone", "--depth", "1", "--branch", sourceVersion, i.repoURL, target)
+}
+
+func (i *installer) fetchSourceArchiveAfterGitFailure(target, archiveURL string, gitLog []byte, gitErr error) (string, error) {
 	i.retry("Git fetch failed; trying source archive")
 	archive := filepath.Join(i.tmpDir, "source.zip")
 	if err := i.download(archiveURL, archive); err != nil {
@@ -512,6 +548,26 @@ func (i *installer) fetchSource() (string, error) {
 	i.sourceMethod = "archive"
 	i.done("Fetched Wago source")
 	return target, nil
+}
+
+func installerSourceRef(version string) string {
+	if _, sha, canonical := installerRollingCommit(version); canonical {
+		return sha
+	}
+	return version
+}
+
+func installerRollingCommit(version string) (channel, sha string, canonical bool) {
+	channel, sha, found := strings.Cut(strings.ToLower(strings.TrimSpace(version)), "@")
+	if !found || (channel != "canary" && channel != "nightly") || len(sha) != 40 {
+		return "", "", false
+	}
+	for _, char := range sha {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return "", "", false
+		}
+	}
+	return channel, sha, true
 }
 
 func (i *installer) buildManager(sourceDir, target string) error {

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -239,7 +239,8 @@ func (i *installer) resolveReleaseForTest(version string) (string, string, error
 	previous := i.version
 	i.version = version
 	defer func() { i.version = previous }()
-	return i.resolveRelease()
+	resolved, base, err := i.resolveRelease()
+	return resolved.Tag, base, err
 }
 
 func TestInstallerCanonicalRollingGitFetchUsesExactDetachedCommit(t *testing.T) {

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -196,6 +196,52 @@ func TestInstallerDownloadsExactCanonicalRollingManager(t *testing.T) {
 	}
 }
 
+func TestInstallerCanonicalRollingManagerResolutionPaginates(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("scope") != "installer" || r.URL.Query().Get("per_page") != "100" {
+			t.Fatalf("release query = %q", r.URL.RawQuery)
+		}
+		requests++
+		if r.URL.Query().Get("page") == "1" {
+			for index := 0; index < 100; index++ {
+				if index != 0 {
+					_, _ = fmt.Fprint(w, ",")
+				}
+				if index == 0 {
+					_, _ = fmt.Fprint(w, "[")
+				}
+				_, _ = fmt.Fprintf(w, `{"tag_name":"v1.0.%d"}`, index)
+			}
+			_, _ = fmt.Fprint(w, "]")
+			return
+		}
+		_, _ = fmt.Fprintf(w, `[{"tag_name":"canary-exact","target_commitish":%q,"published_at":"2026-08-03T00:00:00Z"}]`, sha)
+	}))
+	defer server.Close()
+
+	i := &installer{releaseAPI: server.URL + "/releases?scope=installer&per_page=1&page=99", httpClient: server.Client()}
+	tag, _, err := i.resolveReleaseForTest("canary@" + sha)
+	if err != nil || tag != "canary-exact" {
+		t.Fatalf("resolve canonical manager = %q, %v", tag, err)
+	}
+	if requests != 2 {
+		t.Fatalf("release requests = %d, want 2", requests)
+	}
+}
+
+func (i *installer) resolveReleaseForTest(version string) (string, string, error) {
+	previous := i.version
+	i.version = version
+	defer func() { i.version = previous }()
+	return i.resolveRelease()
+}
+
 func TestInstallerCanonicalRollingGitFetchUsesExactDetachedCommit(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
 	previous := runInstallerGit

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"archive/zip"
 	"bytes"
 	"crypto/sha256"
 	"errors"
@@ -110,6 +111,21 @@ func TestMovePathDoesNotMaskOrdinaryRenameErrors(t *testing.T) {
 	}
 }
 
+func TestInstallerUsesEmbeddedReleaseIdentityByDefault(t *testing.T) {
+	previous := version
+	version = "canary@deadbee123456789012345678901234567890123"
+	t.Cleanup(func() { version = previous })
+	t.Setenv("WAGO_VERSION", "")
+	var output bytes.Buffer
+	installer, err := newInstaller(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installer.version != version {
+		t.Fatalf("installer version = %q, want embedded %q", installer.version, version)
+	}
+}
+
 func TestInstallerDryRunPresentation(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	t.Setenv("HOME", filepath.Join(string(os.PathSeparator), "home", "wago"))
@@ -132,6 +148,128 @@ func TestInstallerDryRunPresentation(t *testing.T) {
 		"Dry run · no changes made.\n"
 	if got := output.String(); got != want {
 		t.Fatalf("dry-run output:\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
+func TestInstallerDownloadsExactCanonicalRollingManager(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	payload := []byte("exact released manager")
+	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
+	asset := "wago-" + runtime.GOOS + "-" + runtime.GOARCH
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases":
+			_, _ = fmt.Fprintf(w, `[
+  {"tag_name":"canary-draft","target_commitish":%q,"published_at":"2026-08-05T00:00:00Z","draft":true},
+  {"tag_name":"canary-wrong","target_commitish":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","published_at":"2026-08-04T00:00:00Z"},
+  {"tag_name":"canary-exact","target_commitish":%q,"published_at":"2026-08-03T00:00:00Z"}
+]`, sha, sha)
+		case "/download/canary-exact/" + asset:
+			_, _ = w.Write(payload)
+		case "/download/canary-exact/" + asset + ".sha256":
+			_, _ = fmt.Fprintf(w, "%s  %s\n", hash, asset)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("WAGO_VERSION", "canary@"+sha)
+	t.Setenv("WAGO_RELEASES_API_URL", server.URL+"/releases")
+	t.Setenv("WAGO_RELEASE_DOWNLOAD_BASE", server.URL)
+	var output bytes.Buffer
+	installer, err := newInstaller(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installer.tmpDir = t.TempDir()
+	target := filepath.Join(installer.tmpDir, executableName("wago"))
+	if err := installer.downloadManager(target); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("manager = %q, %v", got, err)
+	}
+	if installer.managerTag != "canary-exact" || !installer.managerFromRelease {
+		t.Fatalf("manager resolution = %q, %v", installer.managerTag, installer.managerFromRelease)
+	}
+}
+
+func TestInstallerCanonicalRollingGitFetchUsesExactDetachedCommit(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	previous := runInstallerGit
+	var commands [][]string
+	runInstallerGit = func(args ...string) ([]byte, error) {
+		commands = append(commands, append([]string(nil), args...))
+		return nil, nil
+	}
+	t.Cleanup(func() { runInstallerGit = previous })
+
+	target := filepath.Join(t.TempDir(), "src")
+	i := &installer{version: "canary@" + sha, repoURL: "https://example.invalid/wago.git"}
+	if output, err := i.fetchSourceWithGit(target, sha); err != nil || output != nil {
+		t.Fatalf("fetchSourceWithGit = %q, %v", output, err)
+	}
+	want := [][]string{
+		{"-c", "init.defaultBranch=main", "init", target},
+		{"-C", target, "fetch", "--quiet", "--depth", "1", i.repoURL, sha},
+		{"-C", target, "checkout", "--quiet", "--detach", "FETCH_HEAD"},
+	}
+	if fmt.Sprint(commands) != fmt.Sprint(want) {
+		t.Fatalf("git commands = %v, want %v", commands, want)
+	}
+}
+
+func TestInstallerCanonicalRollingArchiveFallbackUsesExactCommit(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	var requested string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = r.URL.Path
+		w.Header().Set("Content-Type", "application/zip")
+		writer := zip.NewWriter(w)
+		entry, err := writer.Create("wago-root/go.mod")
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		_, _ = entry.Write([]byte("module example.invalid/wago\n"))
+		if err := writer.Close(); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer server.Close()
+
+	previousGit := runInstallerGit
+	previousArchiveURL := installerSourceArchiveURL
+	runInstallerGit = func(...string) ([]byte, error) { return []byte("git unavailable"), errors.New("git failed") }
+	installerSourceArchiveURL = func(_, ref string) string { return server.URL + "/zipball/" + ref }
+	t.Cleanup(func() {
+		runInstallerGit = previousGit
+		installerSourceArchiveURL = previousArchiveURL
+	})
+	t.Setenv("WAGO_RELEASE_API", server.URL)
+	t.Setenv("WAGO_ARCHIVE_URL", "")
+	i := &installer{
+		out:        &bytes.Buffer{},
+		version:    "nightly@" + sha,
+		repoURL:    "https://example.invalid/wago.git",
+		archiveURL: server.URL + "/wrong-ref",
+		httpClient: server.Client(),
+		tmpDir:     t.TempDir(),
+	}
+	target, err := i.fetchSource()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requested != "/zipball/"+sha {
+		t.Fatalf("archive request = %q", requested)
+	}
+	if i.sourceMethod != "archive" {
+		t.Fatalf("source method = %q", i.sourceMethod)
+	}
+	if _, err := os.Stat(filepath.Join(target, "go.mod")); err != nil {
+		t.Fatalf("extracted source: %v", err)
 	}
 }
 

--- a/cli/manager/internal/self/release.go
+++ b/cli/manager/internal/self/release.go
@@ -17,7 +17,7 @@ func Channel(current string) string {
 
 func pinnedChannel(version string) string {
 	for _, channel := range []string{"canary", "nightly"} {
-		if strings.HasPrefix(version, channel+"-") {
+		if strings.HasPrefix(version, channel+"-") || strings.HasPrefix(version, channel+"@") {
 			return channel
 		}
 	}

--- a/cli/manager/internal/self/release_test.go
+++ b/cli/manager/internal/self/release_test.go
@@ -4,13 +4,15 @@ import "testing"
 
 func TestChannelPreservesReleaseTrack(t *testing.T) {
 	tests := map[string]string{
-		"canary":                   "canary",
-		"canary-7d8c58a":           "canary",
+		"canary":         "canary",
+		"canary-7d8c58a": "canary",
+		"canary@7d8c58a000000000000000000000000000000000": "canary",
 		"nightly":                  "nightly",
 		"nightly-20260728-7d8c58a": "nightly",
-		"v0.2.0":                   "latest",
-		"0.0.0":                    "canary",
-		"7d8c58a":                  "canary",
+		"nightly@7d8c58a000000000000000000000000000000000": "nightly",
+		"v0.2.0":  "latest",
+		"0.0.0":   "canary",
+		"7d8c58a": "canary",
 	}
 	for version, want := range tests {
 		if got := Channel(version); got != want {

--- a/cli/manager/internal/self/self_test.go
+++ b/cli/manager/internal/self/self_test.go
@@ -68,11 +68,12 @@ func TestSelfUpdateSkipsMatchingManagerCommit(t *testing.T) {
 		return os.WriteFile(dest, []byte("updated manager"), 0o755)
 	}
 
-	selfUpdate("canary-2ff00dd", executable, false)
+	current := "canary@2ff00ddd12345678901234567890123456789012"
+	selfUpdate(current, executable, false)
 	if installs != 0 {
 		t.Fatalf("matching manager update installed %d payloads, want 0", installs)
 	}
-	selfUpdate("canary-2ff00dd", executable, true)
+	selfUpdate(current, executable, true)
 	if installs != 1 {
 		t.Fatalf("forced manager update installed %d payloads, want 1", installs)
 	}

--- a/cli/manager/internal/version/diagnostics.go
+++ b/cli/manager/internal/version/diagnostics.go
@@ -4,9 +4,9 @@ import "strings"
 
 func DiagnosticChannel(activeVersion, release string) string {
 	switch {
-	case activeVersion == "canary", strings.HasPrefix(release, "canary-"):
+	case activeVersion == "canary", strings.HasPrefix(release, "canary-"), strings.HasPrefix(release, "canary@"):
 		return "canary"
-	case activeVersion == "nightly", strings.HasPrefix(release, "nightly-"):
+	case activeVersion == "nightly", strings.HasPrefix(release, "nightly-"), strings.HasPrefix(release, "nightly@"):
 		return "nightly"
 	case activeVersion == "latest":
 		return "latest"

--- a/cli/manager/internal/version/diagnostics_test.go
+++ b/cli/manager/internal/version/diagnostics_test.go
@@ -8,8 +8,10 @@ func TestDiagnosticChannel(t *testing.T) {
 	}{
 		{"canary", "deadbee", "canary"},
 		{"", "canary-20260729-deadbee", "canary"},
+		{"", "canary@deadbee123456789012345678901234567890123", "canary"},
 		{"nightly", "deadbee", "nightly"},
 		{"", "nightly-20260729-deadbee", "nightly"},
+		{"", "nightly@deadbee123456789012345678901234567890123", "nightly"},
 		{"latest", "v1.0.0", "latest"},
 		{"", "v1.0.0", "stable"},
 		{"local", "deadbee", "local"},

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,28 +65,81 @@ const discoveryPageLimit = 10
 
 func fetchReleasesContext(ctx context.Context) ([]remoteRelease, error) {
 	var releases []remoteRelease
+	err := forEachReleasePage(ctx, "release discovery", func(batch []remoteRelease) bool {
+		releases = append(releases, batch...)
+		return true
+	})
+	return releases, err
+}
+
+func forEachReleasePage(ctx context.Context, operation string, visit func([]remoteRelease) bool) error {
+	address := fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=100&page=1", releaseAPI())
+	seen := make(map[string]struct{}, discoveryPageLimit)
 	for page := 1; page <= discoveryPageLimit; page++ {
-		address := fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=100&page=%d", releaseAPI(), page)
-		response, err := getReleaseBytes(ctx, "release discovery", address, releaseMetadataMaximum)
+		if _, duplicate := seen[address]; duplicate {
+			return fmt.Errorf("GitHub release pagination loop at page %d", page)
+		}
+		seen[address] = struct{}{}
+		response, err := getReleaseBytes(ctx, operation, address, releaseMetadataMaximum)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if response.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("GitHub returned %s", response.Status)
+			return fmt.Errorf("GitHub returned %s", response.Status)
 		}
 		var batch []remoteRelease
 		if err := json.Unmarshal(response.Body, &batch); err != nil {
-			return nil, err
+			return err
 		}
 		if len(batch) > 100 {
-			return nil, fmt.Errorf("GitHub returned too many releases on page %d", page)
+			return fmt.Errorf("GitHub returned too many releases on page %d", page)
 		}
-		releases = append(releases, batch...)
+		if !visit(batch) {
+			return nil
+		}
+		next, found, err := releaseNextLink(response.Header, address)
+		if err != nil {
+			return err
+		}
+		if found {
+			address = next
+			continue
+		}
 		if len(batch) < 100 {
-			return releases, nil
+			return nil
+		}
+		address = fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=100&page=%d", releaseAPI(), page+1)
+	}
+	return fmt.Errorf("GitHub release discovery exceeded %d pages", discoveryPageLimit)
+}
+
+func releaseNextLink(header http.Header, current string) (string, bool, error) {
+	for _, value := range header.Values("Link") {
+		for _, entry := range strings.Split(value, ",") {
+			entry = strings.TrimSpace(entry)
+			left, parameters, found := strings.Cut(entry, ";")
+			if !found || !strings.Contains(parameters, `rel="next"`) {
+				continue
+			}
+			if len(left) < 3 || left[0] != '<' || left[len(left)-1] != '>' {
+				return "", false, fmt.Errorf("GitHub returned a malformed release pagination link")
+			}
+			base, err := url.Parse(current)
+			if err != nil {
+				return "", false, err
+			}
+			reference, err := url.Parse(left[1 : len(left)-1])
+			if err != nil {
+				return "", false, fmt.Errorf("GitHub returned a malformed release pagination link: %w", err)
+			}
+			next := base.ResolveReference(reference)
+			if next.Scheme != base.Scheme || next.Host != base.Host || next.Path != base.Path {
+				return "", false, fmt.Errorf("GitHub returned an invalid release pagination target")
+			}
+			return next.String(), true, nil
 		}
 	}
-	return nil, fmt.Errorf("GitHub release discovery exceeded %d pages", discoveryPageLimit)
+	return "", false, nil
 }
 
 // vmUpdate resolves the moving channel before touching the installed runtime.
@@ -132,32 +186,17 @@ func installedCommitMatches(path, resolved string) bool {
 }
 
 func sameRelease(installed, resolved string) bool {
-	if installed != "" && installed == resolved {
+	lowerInstalled := strings.ToLower(strings.TrimSpace(installed))
+	rollingStamp := strings.HasPrefix(lowerInstalled, "canary@") || strings.HasPrefix(lowerInstalled, "nightly@")
+	if installed != "" && installed == resolved && channelRelease(installed) == "" && !isRollingChannel(installed) && !rollingStamp {
 		return true
 	}
-	installedCommit, resolvedCommit := commitFromVersion(installed), commitFromVersion(resolved)
-	return installedCommit != "" && resolvedCommit != "" &&
-		(strings.HasPrefix(installedCommit, resolvedCommit) || strings.HasPrefix(resolvedCommit, installedCommit))
-}
-
-func commitFromVersion(version string) string {
-	if sha, ok := canaryCommitSHA(version); ok {
-		return sha
-	}
-	if channelRelease(version) == "" {
-		return ""
-	}
-	parts := strings.Split(version, "-")
-	commit := parts[len(parts)-1]
-	if len(commit) < 7 {
-		return ""
-	}
-	for _, character := range strings.ToLower(commit) {
-		if !strings.ContainsRune("0123456789abcdef", character) {
-			return ""
-		}
-	}
-	return strings.ToLower(commit)
+	installedChannel, installedCommit, installedCanonical := rollingCommitSHA(installed)
+	resolvedChannel, resolvedCommit, resolvedCanonical := rollingCommitSHA(resolved)
+	// Only canonical object IDs are safe freshness identities. Legacy abbreviated
+	// stamps are deliberately treated as stale: prefix equality can collide, and
+	// an offline local comparison cannot prove what object an abbreviation named.
+	return installedCanonical && resolvedCanonical && installedChannel == resolvedChannel && installedCommit == resolvedCommit
 }
 
 func resolveRunnerVersion(ver string, progress *managerprogress.Progress) (resolved string, sourceOnly bool, err error) {
@@ -178,7 +217,7 @@ func resolveRunnerVersionContext(ctx context.Context, ver string, progress *mana
 		}
 		resolved = canaryCommitTarget(sha)
 		if progress != nil {
-			progress.Done("resolved " + canaryCommitVersion(resolved))
+			progress.Done("resolved " + releasePickerLabel(resolved))
 		}
 		return resolved, false, nil
 	}
@@ -196,10 +235,18 @@ func resolveRunnerVersionContext(ctx context.Context, ver string, progress *mana
 		return resolved, false, nil
 	}
 	if errors.Is(err, errNoPublishedRelease) {
-		if progress != nil {
-			progress.Done("no published release; using source")
+		sha, resolveErr := latestMainCommitContext(ctx)
+		if resolveErr != nil {
+			if progress != nil {
+				progress.Fail("could not resolve source commit")
+			}
+			return "", false, resolveErr
 		}
-		return "main", true, nil
+		resolved = ver + "@" + sha
+		if progress != nil {
+			progress.Done("no published release; using " + releasePickerLabel(resolved) + " source")
+		}
+		return resolved, true, nil
 	}
 	if progress != nil {
 		progress.Fail("could not resolve release")
@@ -224,7 +271,7 @@ func installRunnerPayload(ref string, profile wagopaths.Profile, build wagopaths
 
 func installRunnerPayloadContext(ctx context.Context, ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
 	if !sourceOnly {
-		err := downloadBinaryWithProgressContext(ctx, releaseBase(), canaryCommitVersion(ref), profile, build, dest, progress)
+		err := downloadBinaryWithProgressContext(ctx, releaseBase(), releaseAssetVersion(ref), profile, build, dest, progress)
 		if err == nil {
 			return nil
 		}
@@ -281,7 +328,7 @@ func installManagerPayloadContext(ctx context.Context, resolved, dest string, so
 		err := downloadReleaseAssetWithProgressContext(
 			ctx,
 			releaseBase(),
-			canaryCommitVersion(resolved),
+			releaseAssetVersion(resolved),
 			managerAsset(),
 			dest,
 			progress,
@@ -356,26 +403,34 @@ func latestChannelRelease(channel string) (string, error) {
 }
 
 func latestChannelReleaseContext(ctx context.Context, channel string) (string, error) {
-	response, err := getReleaseBytes(ctx, "release channel discovery", releaseAPI()+"/repos/wago-org/wago/releases?per_page=100", releaseMetadataMaximum)
+	prefix := channel + "-"
+	var resolved string
+	var resolveErr error
+	err := forEachReleasePage(ctx, "release channel discovery", func(releases []remoteRelease) bool {
+		for _, release := range releases {
+			if release.Draft || !strings.HasPrefix(release.TagName, prefix) {
+				continue
+			}
+			sha := strings.ToLower(strings.TrimSpace(release.TargetCommitish))
+			if !validCommitSHA(sha) {
+				resolveErr = fmt.Errorf("GitHub release %q has an invalid target commit", release.TagName)
+				return false
+			}
+			resolved = release.TagName + "@" + sha
+			return false
+		}
+		return true
+	})
 	if err != nil {
 		return "", err
 	}
-	if response.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub returned %s", response.Status)
+	if resolveErr != nil {
+		return "", resolveErr
 	}
-	var releases []struct {
-		TagName string `json:"tag_name"`
+	if resolved == "" {
+		return "", fmt.Errorf("%w: %s", errNoPublishedRelease, channel)
 	}
-	if err := json.Unmarshal(response.Body, &releases); err != nil {
-		return "", err
-	}
-	prefix := channel + "-"
-	for _, release := range releases {
-		if strings.HasPrefix(release.TagName, prefix) {
-			return release.TagName, nil
-		}
-	}
-	return "", fmt.Errorf("%w: %s", errNoPublishedRelease, channel)
+	return resolved, nil
 }
 
 var errNoPublishedRelease = errors.New("no published release")

--- a/cli/manager/internal/version/install.go
+++ b/cli/manager/internal/version/install.go
@@ -27,7 +27,7 @@ func installVersion(d wagopaths.Dirs, ver string, profile wagopaths.Profile, bui
 }
 
 func installVersionContext(ctx context.Context, d wagopaths.Dirs, ver string, profile wagopaths.Profile, build wagopaths.Build, offer, showLocation bool, use string) {
-	installName := canaryCommitVersion(ver)
+	installName := releaseAssetVersion(ver)
 	dest := d.RuntimeBinary(installName, string(profile), string(build))
 	if installedPath, _, _, installed := installedRuntime(d, installName, profile, build); installed {
 		// A rolling channel (canary/nightly) re-fetches even when present — the
@@ -56,7 +56,7 @@ func installVersionContext(ctx context.Context, d wagopaths.Dirs, ver string, pr
 	if err := installRunnerPayloadContext(ctx, resolved, profile, build, dest, sourceOnly, progress); err != nil {
 		fatal("version install: %v", err)
 	}
-	progress.Finish("Installed " + installedWagoLabel(installName, canaryCommitVersion(resolved), profile, build))
+	progress.Finish("Installed " + installedWagoLabel(installName, resolved, profile, build))
 	if showLocation {
 		printDetail(progress.Writer(), "location", displayPath(dest))
 	}

--- a/cli/manager/internal/version/lifecycle_test.go
+++ b/cli/manager/internal/version/lifecycle_test.go
@@ -434,7 +434,7 @@ func TestInstallPickerHidesImmutableChannelTagsAtTopLevel(t *testing.T) {
 		t.Fatalf("channelReleaseNames = %v, want %v", got, want)
 	}
 	releases := []remoteRelease{
-		{TagName: "nightly-20260728-7d8c58a", PublishedAt: "2026-07-28T08:31:22Z"},
+		{TagName: "nightly-20260728-7d8c58a", TargetCommitish: "7d8c58a123456789012345678901234567890123", PublishedAt: "2026-07-28T08:31:22Z"},
 		{TagName: "v0.1.4", PublishedAt: "2026-06-30T12:00:00Z"},
 		{TagName: "canary-cafef00", PublishedAt: "2026-07-28T00:48:44Z"},
 		{TagName: "nightly-20260711-abcdef0", PublishedAt: "2026-07-11T08:31:22Z"},
@@ -454,15 +454,15 @@ func TestInstallPickerHidesImmutableChannelTagsAtTopLevel(t *testing.T) {
 		t.Fatalf("latest picker children = %v, want %v", got, want)
 	}
 	nightly := items[1].Children[1]
-	if nightly.Label != "nightly-7d8c58a" || nightly.Value != "nightly-20260728-7d8c58a" || nightly.Description != "07/28/2026  1d ago" {
+	if nightly.Label != "nightly-7d8c58a" || nightly.Value != "nightly-20260728-7d8c58a@7d8c58a123456789012345678901234567890123" || nightly.Description != "07/28/2026  1d ago" {
 		t.Fatalf("nightly picker item = %#v", nightly)
 	}
 	canary := items[0].Children[1]
 	if canary.Label != "canary-cafef00" || canary.Description != "07/28/2026  1d ago" {
 		t.Fatalf("canary picker item = %#v", canary)
 	}
-	if got := canaryCommitVersion(canary.Value); got != "canary-cafef00" {
-		t.Fatalf("canary commit install name = %q", got)
+	if got := releaseAssetVersion(canary.Value); got != "canary-cafef00123456789012345678901234567890123" {
+		t.Fatalf("canary commit release asset = %q", got)
 	}
 	if got := releasePickerLabel("canary"); got != "canary" {
 		t.Fatalf("releasePickerLabel(canary) = %q", got)

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -26,14 +26,190 @@ func TestLatestChannelRelease(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		_, _ = w.Write([]byte(`[{"tag_name":"nightly-20260712-deadbee"},{"tag_name":"canary-cafef00"}]`))
+		_, _ = w.Write([]byte(`[{"tag_name":"nightly-20260712-deadbee","target_commitish":"deadbee123456789012345678901234567890123"},{"tag_name":"canary-cafef00","target_commitish":"cafef00123456789012345678901234567890123"}]`))
 	}))
 	defer srv.Close()
 	t.Setenv("WAGO_RELEASE_API", srv.URL)
 
 	got, err := latestChannelRelease("nightly")
-	if err != nil || got != "nightly-20260712-deadbee" {
+	if err != nil || got != "nightly-20260712-deadbee@deadbee123456789012345678901234567890123" {
 		t.Fatalf("latestChannelRelease(nightly) = %q, %v", got, err)
+	}
+}
+
+func TestLatestChannelReleasePaginates(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/wago-org/wago/releases" {
+			http.NotFound(w, r)
+			return
+		}
+		requests++
+		if r.URL.Query().Get("page") == "1" {
+			releases := make([]remoteRelease, 100)
+			for i := range releases {
+				releases[i].TagName = fmt.Sprintf("v1.0.%d", i)
+			}
+			_ = json.NewEncoder(w).Encode(releases)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "nightly-20260812-deadbee", TargetCommitish: "deadbee123456789012345678901234567890123"}})
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	got, err := latestChannelReleaseContext(context.Background(), "nightly")
+	if err != nil || got != "nightly-20260812-deadbee@deadbee123456789012345678901234567890123" {
+		t.Fatalf("latestChannelReleaseContext = %q, %v", got, err)
+	}
+	if requests != 2 {
+		t.Fatalf("release page requests = %d, want 2", requests)
+	}
+}
+
+func TestLatestChannelReleaseUsesLinkPaginationAndSkipsDrafts(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/wago-org/wago/releases?cursor=next>; rel="next"`, "http://"+r.Host))
+			_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "nightly-draft", Draft: true, TargetCommitish: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}})
+		case "next":
+			_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "nightly-20260812-deadbee", TargetCommitish: "deadbee123456789012345678901234567890123"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	got, err := latestChannelReleaseContext(context.Background(), "nightly")
+	if err != nil || got != "nightly-20260812-deadbee@deadbee123456789012345678901234567890123" {
+		t.Fatalf("latestChannelReleaseContext = %q, %v", got, err)
+	}
+	if requests != 2 {
+		t.Fatalf("release page requests = %d, want 2", requests)
+	}
+}
+
+func TestReleasePaginationRejectsMalformedAndCrossOriginTargets(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		link func(*httptest.Server) string
+		want string
+	}{
+		{name: "malformed", link: func(*httptest.Server) string { return `not-a-url; rel="next"` }, want: "malformed"},
+		{name: "cross origin", link: func(*httptest.Server) string {
+			return `<https://example.invalid/repos/wago-org/wago/releases?page=2>; rel="next"`
+		}, want: "invalid"},
+		{name: "different path", link: func(server *httptest.Server) string {
+			return `<` + server.URL + `/repos/wago-org/other/releases?page=2>; rel="next"`
+		}, want: "invalid"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Link", test.link(server))
+				_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "v1.0.0"}})
+			}))
+			defer server.Close()
+			t.Setenv("WAGO_RELEASE_API", server.URL)
+			if _, err := latestChannelReleaseContext(context.Background(), "nightly"); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("pagination target error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLatestChannelReleaseRejectsPaginationLoop(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, "http://"+r.Host+r.URL.RequestURI()))
+		_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "v1.0.0"}})
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	if _, err := latestChannelReleaseContext(context.Background(), "nightly"); err == nil || !strings.Contains(err.Error(), "loop") {
+		t.Fatalf("channel pagination loop error = %v", err)
+	}
+}
+
+func TestLatestChannelReleaseRejectsInvalidTargetCommit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "nightly-20260812-deadbee", TargetCommitish: "main"}})
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	if _, err := latestChannelReleaseContext(context.Background(), "nightly"); err == nil || !strings.Contains(err.Error(), "invalid target commit") {
+		t.Fatalf("invalid channel target error = %v", err)
+	}
+}
+
+func TestLatestChannelReleaseCancellationBetweenPages(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/wago-org/wago/releases?page=2>; rel="next"`, "http://"+r.Host))
+			_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "v1.0.0"}})
+			cancel()
+			return
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	if _, err := latestChannelReleaseContext(ctx, "nightly"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled channel pagination = %v", err)
+	}
+	if requests > 2 {
+		t.Fatalf("release page requests = %d, want at most 2", requests)
+	}
+}
+
+func TestRollingChannelWithoutPublishedReleaseUsesCanonicalMainSource(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/wago-org/wago/releases":
+			_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "v1.0.0"}})
+		case "/repos/wago-org/wago/commits/main":
+			_ = json.NewEncoder(w).Encode(remoteCommit{SHA: sha})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	resolved, sourceOnly, err := resolveRunnerVersionContext(context.Background(), "nightly", nil)
+	if err != nil || !sourceOnly || resolved != "nightly@"+sha {
+		t.Fatalf("resolveRunnerVersionContext = %q, %v, %v", resolved, sourceOnly, err)
+	}
+}
+
+func TestLatestChannelReleaseBoundsPagination(t *testing.T) {
+	releases := make([]remoteRelease, 100)
+	for i := range releases {
+		releases[i].TagName = fmt.Sprintf("v1.0.%d", i)
+	}
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	if _, err := latestChannelReleaseContext(context.Background(), "nightly"); err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("channel pagination error = %v", err)
+	}
+	if requests != discoveryPageLimit {
+		t.Fatalf("release page requests = %d, want %d", requests, discoveryPageLimit)
 	}
 }
 

--- a/cli/manager/internal/version/releases.go
+++ b/cli/manager/internal/version/releases.go
@@ -141,15 +141,15 @@ func canaryCommitTarget(sha string) string {
 // stamp such as "nightly@<sha>" or a resolved release such as
 // "nightly-20260812-deadbee@<sha>".
 func rollingCommitSHA(target string) (channel, sha string, found bool) {
-	prefix, sha, found := strings.Cut(target, "@")
-	if !found {
+	prefix, sha, found := strings.Cut(strings.ToLower(strings.TrimSpace(target)), "@")
+	if !found || strings.Contains(sha, "@") {
 		return "", "", false
 	}
 	channel = prefix
 	if releaseChannel := channelRelease(prefix); releaseChannel != "" {
 		channel = releaseChannel
 	}
-	sha = strings.ToLower(strings.TrimSpace(sha))
+	sha = strings.TrimSpace(sha)
 	return channel, sha, rollingChannels[channel] && validCommitSHA(sha)
 }
 
@@ -181,7 +181,8 @@ func validCommitSHA(sha string) bool {
 // resolved dated rolling release retains the published tag before @SHA.
 func releaseAssetVersion(target string) string {
 	if channel, sha, ok := rollingCommitSHA(target); ok {
-		if tag, _, tagged := strings.Cut(target, "@"); tagged && channelRelease(tag) == channel {
+		normalized := strings.ToLower(strings.TrimSpace(target))
+		if tag, _, tagged := strings.Cut(normalized, "@"); tagged && channelRelease(tag) == channel {
 			return tag
 		}
 		return channel + "-" + sha
@@ -198,7 +199,8 @@ func rollingVersionStamp(target string) string {
 
 func releasePickerLabel(tag string) string {
 	if channel, sha, canonical := rollingCommitSHA(tag); canonical {
-		if releaseTag, _, tagged := strings.Cut(tag, "@"); tagged && channelRelease(releaseTag) == channel {
+		normalized := strings.ToLower(strings.TrimSpace(tag))
+		if releaseTag, _, tagged := strings.Cut(normalized, "@"); tagged && channelRelease(releaseTag) == channel {
 			tag = releaseTag
 		} else {
 			return channel + "-" + sha[:7]

--- a/cli/manager/internal/version/releases.go
+++ b/cli/manager/internal/version/releases.go
@@ -11,8 +11,10 @@ import (
 )
 
 type remoteRelease struct {
-	TagName     string `json:"tag_name"`
-	PublishedAt string `json:"published_at"`
+	TagName         string `json:"tag_name"`
+	TargetCommitish string `json:"target_commitish"`
+	PublishedAt     string `json:"published_at"`
+	Draft           bool   `json:"draft"`
 }
 
 type remoteCommit struct {
@@ -78,6 +80,9 @@ func stableReleaseNames(tags []string) []string {
 func releasePickerItems(releases []remoteRelease, channel string, now time.Time) []tui.Item {
 	items := make([]tui.Item, 0, len(releases))
 	for _, release := range releases {
+		if release.Draft {
+			continue
+		}
 		if channel == "" {
 			if release.TagName == "" || isRollingChannel(release.TagName) || channelRelease(release.TagName) != "" {
 				continue
@@ -86,10 +91,18 @@ func releasePickerItems(releases []remoteRelease, channel string, now time.Time)
 			continue
 		}
 		label := releasePickerLabel(release.TagName)
+		value := release.TagName
+		if channel != "" {
+			var canonical bool
+			value, canonical = canonicalRollingRelease(release)
+			if !canonical {
+				continue
+			}
+		}
 		items = append(items, tui.Item{
 			Label:       label,
 			Description: releasePickerDescription(release, now),
-			Value:       release.TagName,
+			Value:       value,
 		})
 	}
 	if channel == "" {
@@ -124,9 +137,31 @@ func canaryCommitTarget(sha string) string {
 	return "canary@" + strings.ToLower(strings.TrimSpace(sha))
 }
 
-func canaryCommitSHA(target string) (string, bool) {
-	sha, found := strings.CutPrefix(target, "canary@")
-	return sha, found && validCommitSHA(sha)
+// rollingCommitSHA extracts the canonical commit identity from either a build
+// stamp such as "nightly@<sha>" or a resolved release such as
+// "nightly-20260812-deadbee@<sha>".
+func rollingCommitSHA(target string) (channel, sha string, found bool) {
+	prefix, sha, found := strings.Cut(target, "@")
+	if !found {
+		return "", "", false
+	}
+	channel = prefix
+	if releaseChannel := channelRelease(prefix); releaseChannel != "" {
+		channel = releaseChannel
+	}
+	sha = strings.ToLower(strings.TrimSpace(sha))
+	return channel, sha, rollingChannels[channel] && validCommitSHA(sha)
+}
+
+func canonicalRollingRelease(release remoteRelease) (string, bool) {
+	if release.Draft || channelRelease(release.TagName) == "" {
+		return "", false
+	}
+	sha := strings.ToLower(strings.TrimSpace(release.TargetCommitish))
+	if !validCommitSHA(sha) {
+		return "", false
+	}
+	return release.TagName + "@" + sha, true
 }
 
 func validCommitSHA(sha string) bool {
@@ -141,23 +176,46 @@ func validCommitSHA(sha string) bool {
 	return true
 }
 
-func canaryCommitVersion(target string) string {
-	if sha, ok := canaryCommitSHA(target); ok {
-		return "canary-" + sha[:7]
+// releaseAssetVersion returns the immutable GitHub release tag used for an
+// asset lookup. Exact commit releases use the full object ID in the tag; a
+// resolved dated rolling release retains the published tag before @SHA.
+func releaseAssetVersion(target string) string {
+	if channel, sha, ok := rollingCommitSHA(target); ok {
+		if tag, _, tagged := strings.Cut(target, "@"); tagged && channelRelease(tag) == channel {
+			return tag
+		}
+		return channel + "-" + sha
+	}
+	return target
+}
+
+func rollingVersionStamp(target string) string {
+	if channel, sha, ok := rollingCommitSHA(target); ok {
+		return channel + "@" + sha
 	}
 	return target
 }
 
 func releasePickerLabel(tag string) string {
+	if channel, sha, canonical := rollingCommitSHA(tag); canonical {
+		if releaseTag, _, tagged := strings.Cut(tag, "@"); tagged && channelRelease(releaseTag) == channel {
+			tag = releaseTag
+		} else {
+			return channel + "-" + sha[:7]
+		}
+	}
 	if isRollingChannel(tag) || tag == "latest" {
 		return tag
 	}
-	if channelRelease(tag) != "" {
+	if channel := channelRelease(tag); channel != "" {
 		parts := strings.Split(tag, "-")
 		if len(parts) >= 3 && len(parts[1]) == 8 {
 			if _, ok := ParseNumeric(parts[1]); ok {
 				return parts[0] + "-" + strings.Join(parts[2:], "-")
 			}
+		}
+		if commit := parts[len(parts)-1]; validCommitSHA(strings.ToLower(commit)) {
+			return channel + "-" + strings.ToLower(commit[:7])
 		}
 		return tag
 	}

--- a/cli/manager/internal/version/selection.go
+++ b/cli/manager/internal/version/selection.go
@@ -310,7 +310,10 @@ func installedWagoLabel(requested, resolved string, profile wagopaths.Profile, b
 	if isRollingChannel(requested) {
 		channel = requested
 	} else {
-		channel = channelRelease(resolved)
+		channel, _, _ = rollingCommitSHA(resolved)
+		if channel == "" {
+			channel = channelRelease(resolved)
+		}
 		if channel == "" {
 			channel = channelRelease(requested)
 		}
@@ -326,6 +329,9 @@ func installedWagoLabel(requested, resolved string, profile wagopaths.Profile, b
 }
 
 func releaseCommit(release string) string {
+	if _, sha, canonical := rollingCommitSHA(release); canonical {
+		return sha[:7]
+	}
 	if channelRelease(release) == "" {
 		return ""
 	}

--- a/cli/manager/internal/version/source.go
+++ b/cli/manager/internal/version/source.go
@@ -39,7 +39,7 @@ func sourceArchiveURL(ref string) string {
 	if value := os.Getenv("WAGO_ARCHIVE_URL"); value != "" {
 		return value
 	}
-	if sha, canaryCommit := canaryCommitSHA(ref); canaryCommit {
+	if _, sha, rollingCommit := rollingCommitSHA(ref); rollingCommit {
 		ref = sha
 	}
 	return strings.TrimRight(releaseAPI(), "/") + "/repos/wago-org/wago/zipball/" + url.PathEscape(ref)
@@ -195,8 +195,8 @@ func checkoutWagoSourceInContext(ctx context.Context, parent, ref string, progre
 			return "", "", "", fmt.Errorf("fetch source with Git (%v) or archive: %w", gitErr, archiveErr)
 		}
 	}
-	if _, canaryCommit := canaryCommitSHA(ref); canaryCommit {
-		stamp = canaryCommitVersion(ref)
+	if _, _, rollingCommit := rollingCommitSHA(ref); rollingCommit {
+		stamp = rollingVersionStamp(ref)
 	}
 	if progress != nil {
 		progress.Done("fetched source")
@@ -205,7 +205,7 @@ func checkoutWagoSourceInContext(ctx context.Context, parent, ref string, progre
 }
 
 func checkoutWagoSourceWithGit(ctx context.Context, ref, source string) error {
-	if sha, canaryCommit := canaryCommitSHA(ref); canaryCommit {
+	if _, sha, rollingCommit := rollingCommitSHA(ref); rollingCommit {
 		commands := [][]string{
 			{"init", "--quiet", source},
 			{"-C", source, "remote", "add", "origin", sourceRepository()},

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -458,7 +458,7 @@ func TestBuildRunnerFromSourceChecksOutExactCanaryCommit(t *testing.T) {
 		"git -C", "remote add origin",
 		"fetch --quiet --depth 1 origin " + sha,
 		"checkout --quiet --detach FETCH_HEAD",
-		"go build", "-X main.version=canary-deadbee",
+		"go build", "-X main.version=canary@" + sha,
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("source commands missing %q:\n%s", want, joined)

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -272,6 +272,42 @@ func TestCanaryCommitMissingReleaseBuildsExactSource(t *testing.T) {
 	}
 }
 
+func TestRollingReleaseMissingAssetsPreserveExactSourceIdentity(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	t.Setenv("WAGO_RELEASE_BASE", server.URL)
+
+	const sha = "deadbee123456789012345678901234567890123"
+	targets := []string{
+		"canary@" + sha,
+		"nightly-20260812-" + sha + "@" + sha,
+	}
+	for _, target := range targets {
+		t.Run(target[:strings.IndexByte(target, '@')], func(t *testing.T) {
+			oldRunner, oldManager := buildRunnerSource, buildManagerSource
+			t.Cleanup(func() { buildRunnerSource, buildManagerSource = oldRunner, oldManager })
+			var runnerRef, managerRef string
+			buildRunnerSource = func(_ context.Context, ref string, _ wagopaths.Profile, _ wagopaths.Build, dest string, _ *managerprogress.Progress) error {
+				runnerRef = ref
+				return os.WriteFile(dest, []byte("source runner"), 0o755)
+			}
+			buildManagerSource = func(_ context.Context, ref, dest string, _ *managerprogress.Progress) error {
+				managerRef = ref
+				return os.WriteFile(dest, []byte("source manager"), 0o755)
+			}
+			if err := installRunnerPayload(target, wagopaths.ProfileStandard, wagopaths.BuildNormal, filepath.Join(t.TempDir(), "runner"), false, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := installManagerPayload(target, filepath.Join(t.TempDir(), "manager"), false, nil); err != nil {
+				t.Fatal(err)
+			}
+			if runnerRef != target || managerRef != target {
+				t.Fatalf("fallback identities = runner %q manager %q, want %q", runnerRef, managerRef, target)
+			}
+		})
+	}
+}
+
 func TestBuildRunnerFromSourceUsesProfileTag(t *testing.T) {
 	old := runSourceCommand
 	t.Cleanup(func() { runSourceCommand = old })

--- a/cli/manager/internal/version/update_test.go
+++ b/cli/manager/internal/version/update_test.go
@@ -56,6 +56,8 @@ func TestRollingCommitIdentityRequiresCanonicalSHA(t *testing.T) {
 	}{
 		{"canary@deadbee123456789012345678901234567890123", "canary", "deadbee123456789012345678901234567890123", true},
 		{"nightly-20260731-cafef00@cafef00123456789012345678901234567890123", "nightly", "cafef00123456789012345678901234567890123", true},
+		{" CANARY@DEADBEE123456789012345678901234567890123 ", "canary", "deadbee123456789012345678901234567890123", true},
+		{"canary@deadbee123456789012345678901234567890123@junk", "", "", false},
 		{"canary-deadbee", "", "", false},
 		{"nightly-20260731-cafef00", "", "", false},
 		{"v0.2.0", "", "", false},
@@ -64,6 +66,13 @@ func TestRollingCommitIdentityRequiresCanonicalSHA(t *testing.T) {
 		if channel != test.channel || sha != test.sha || canonical != test.canonical {
 			t.Errorf("rollingCommitSHA(%q) = %q, %q, %v", test.version, channel, sha, canonical)
 		}
+	}
+	canonical := " NIGHTLY-20260731-CAFEF00@CAFEF00123456789012345678901234567890123 "
+	if got := releaseAssetVersion(canonical); got != "nightly-20260731-cafef00" {
+		t.Fatalf("releaseAssetVersion(%q) = %q", canonical, got)
+	}
+	if got := releasePickerLabel(canonical); got != "nightly-cafef00" {
+		t.Fatalf("releasePickerLabel(%q) = %q", canonical, got)
 	}
 }
 

--- a/cli/manager/internal/version/update_test.go
+++ b/cli/manager/internal/version/update_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
-func TestInstalledCommitMatchesShortAndFullHashes(t *testing.T) {
+func TestInstalledCommitMatchesOnlyCanonicalHashes(t *testing.T) {
 	runtime := filepath.Join(t.TempDir(), "wago-runtime")
 	if err := os.WriteFile(runtime, []byte("runtime"), 0o755); err != nil {
 		t.Fatal(err)
@@ -20,23 +20,49 @@ func TestInstalledCommitMatchesShortAndFullHashes(t *testing.T) {
 	runtimeVersionOutput = func(string) ([]byte, error) {
 		return []byte("Wago\n  release      canary-deadbee\n"), nil
 	}
-	if !installedCommitMatches(runtime, "canary@deadbee123456789012345678901234567890123") {
-		t.Fatal("matching short and full canary hashes were not recognized")
+	if installedCommitMatches(runtime, "canary@deadbee123456789012345678901234567890123") {
+		t.Fatal("legacy abbreviated canary hash was treated as canonical")
 	}
 	if installedCommitMatches(runtime, "canary@cafef00123456789012345678901234567890123") {
 		t.Fatal("different canary hashes matched")
 	}
+	runtimeVersionOutput = func(string) ([]byte, error) {
+		return []byte("Wago\n  release      canary@DEADBEE123456789012345678901234567890123\n"), nil
+	}
+	if !installedCommitMatches(runtime, "canary@deadbee123456789012345678901234567890123") {
+		t.Fatal("equal canonical canary hashes did not match")
+	}
 }
 
-func TestCommitFromVersionUnderstandsRollingReleaseNames(t *testing.T) {
-	for _, test := range []struct{ version, want string }{
-		{"canary@deadbee123456789012345678901234567890123", "deadbee123456789012345678901234567890123"},
-		{"canary-deadbee", "deadbee"},
-		{"nightly-20260731-cafef00", "cafef00"},
-		{"v0.2.0", ""},
+func TestSameReleaseRejectsMalformedRollingIdentityEvenWhenTextMatches(t *testing.T) {
+	for _, version := range []string{
+		"canary@deadbee",
+		"nightly@deadbee12345678901234567890123456789012z",
+		"canary",
 	} {
-		if got := commitFromVersion(test.version); got != test.want {
-			t.Errorf("commitFromVersion(%q) = %q, want %q", test.version, got, test.want)
+		if sameRelease(version, version) {
+			t.Errorf("sameRelease(%q, %q) accepted malformed or moving rolling identity", version, version)
+		}
+	}
+	if !sameRelease("v1.2.3", "v1.2.3") {
+		t.Fatal("equal stable releases did not match")
+	}
+}
+
+func TestRollingCommitIdentityRequiresCanonicalSHA(t *testing.T) {
+	for _, test := range []struct {
+		version, channel, sha string
+		canonical             bool
+	}{
+		{"canary@deadbee123456789012345678901234567890123", "canary", "deadbee123456789012345678901234567890123", true},
+		{"nightly-20260731-cafef00@cafef00123456789012345678901234567890123", "nightly", "cafef00123456789012345678901234567890123", true},
+		{"canary-deadbee", "", "", false},
+		{"nightly-20260731-cafef00", "", "", false},
+		{"v0.2.0", "", "", false},
+	} {
+		channel, sha, canonical := rollingCommitSHA(test.version)
+		if channel != test.channel || sha != test.sha || canonical != test.canonical {
+			t.Errorf("rollingCommitSHA(%q) = %q, %q, %v", test.version, channel, sha, canonical)
 		}
 	}
 }
@@ -62,7 +88,7 @@ func TestVersionUpdateSkipsMatchingInstalledCommitUnlessForced(t *testing.T) {
 		return "canary@deadbee123456789012345678901234567890123", false, nil
 	}
 	runtimeVersionOutput = func(string) ([]byte, error) {
-		return []byte("Wago\n  release      canary-deadbee\n"), nil
+		return []byte("Wago\n  release      canary@deadbee123456789012345678901234567890123\n"), nil
 	}
 	installs := 0
 	installUpdateRunnerPayloadContext = func(context.Context, string, wagopaths.Profile, wagopaths.Build, string, bool, *managerprogress.Progress) error {

--- a/cli/manager/internal/version/version.go
+++ b/cli/manager/internal/version/version.go
@@ -75,7 +75,7 @@ func PromptYesNo(in io.Reader, out io.Writer, prompt string) bool {
 }
 
 func DisplayRelease(ref string) string {
-	return releasePickerLabel(canaryCommitVersion(ref))
+	return releasePickerLabel(ref)
 }
 
 func SameRelease(installed, resolved string) bool {

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -43,17 +43,29 @@ var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 // result. Cache read/write failures never prevent execution; compilation and
 // artifact validation errors retain their normal behavior.
 func (cache Cache) LoadOrCompile(source []byte, config *wago.RuntimeConfig, rt *wago.Runtime) (*wago.Module, error) {
+	if rt == nil {
+		return nil, fmt.Errorf("wago: artifact cache requires a runtime")
+	}
+	if config == nil {
+		return rt.Compile(source)
+	}
+	// Runtime.Compile is authoritative. The explicit config parameter is retained
+	// for source compatibility, but a mismatched caller value must never select an
+	// artifact compiled under policy the destination runtime did not request.
+	config = rt.Config()
+	if config.GCCodeTelemetry() || config.BoundsChecks() == wago.BoundsChecksSignalsBased {
+		// Telemetry is intentionally compile-only and absent from serialized
+		// artifacts. Signals-based native code is also deliberately nonserializable.
+		return rt.Compile(source)
+	}
 	path, cacheable := cache.path(source, config)
 	if cacheable {
-		if blob, err := os.ReadFile(path); err == nil {
-			compiled := &wago.Compiled{}
-			if compiled.UnmarshalBinary(blob) == nil {
-				module, bindErr := rt.AdoptModule(compiled)
-				if bindErr == nil {
-					return module, nil
-				}
-				return nil, bindErr
+		if compiled, hit := loadArtifact(path); hit {
+			module, bindErr := rt.AdoptModule(compiled)
+			if bindErr == nil {
+				return module, nil
 			}
+			return nil, bindErr
 		}
 	}
 
@@ -64,12 +76,7 @@ func (cache Cache) LoadOrCompile(source []byte, config *wago.RuntimeConfig, rt *
 	if !cacheable {
 		return module, nil
 	}
-	artifact, err := module.Compiled().MarshalBinary()
-	if err != nil {
-		// Some valid compilation modes intentionally cannot be serialized.
-		return module, nil
-	}
-	if err := publishArtifact(path, artifact); err != nil {
+	if err := publishArtifact(path, module.Compiled()); err != nil {
 		if cache.ReportError != nil {
 			cache.ReportError(err)
 		} else {
@@ -218,9 +225,37 @@ func writeUint64(h interface{ Write([]byte) (int, error) }, value uint64) {
 
 var publishArtifact = writeAtomic
 
-func writeAtomic(path string, artifact []byte) error {
+func loadArtifact(path string) (*wago.Compiled, bool) {
+	linked, err := os.Lstat(path)
+	if err != nil || linked.Mode()&os.ModeSymlink != 0 || !linked.Mode().IsRegular() {
+		return nil, false
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(linked, opened) {
+		return nil, false
+	}
+	limits := wago.DefaultArtifactLimits()
+	maximum := limits.MaxCodeBytes + limits.MaxMetadataBytes + 64
+	if opened.Size() < 0 || opened.Size() > maximum {
+		return nil, false
+	}
+	compiled := &wago.Compiled{}
+	read, err := compiled.ReadFromWithLimits(file, limits)
+	if err != nil || read != opened.Size() {
+		_ = compiled.Close()
+		return nil, false
+	}
+	return compiled, true
+}
+
+func writeAtomic(path string, compiled *wago.Compiled) error {
 	return atomicfile.ReplaceFile(path, atomicfile.Options{Mode: 0o644}, func(writer io.Writer) error {
-		_, err := writer.Write(artifact)
+		_, err := compiled.WriteTo(writer)
 		return err
 	})
 }

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -29,7 +29,7 @@ type Cache struct {
 	ReportError func(error)
 }
 
-const cacheKeyFormat = 1
+const cacheKeyFormat = 2
 
 var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	info, ok := debug.ReadBuildInfo()
@@ -48,9 +48,11 @@ func (cache Cache) LoadOrCompile(source []byte, config *wago.RuntimeConfig, rt *
 		if blob, err := os.ReadFile(path); err == nil {
 			compiled := &wago.Compiled{}
 			if compiled.UnmarshalBinary(blob) == nil {
-				if module, err := rt.Module(compiled); err == nil {
+				module, bindErr := rt.AdoptModule(compiled)
+				if bindErr == nil {
 					return module, nil
 				}
+				return nil, bindErr
 			}
 		}
 	}
@@ -100,7 +102,6 @@ func (cache Cache) path(source []byte, config *wago.RuntimeConfig) (string, bool
 		encoded[len(encoded)-1] = 1
 	}
 	encoded = binary.LittleEndian.AppendUint32(encoded, config.MemoryLimitPages())
-	encoded = binary.LittleEndian.AppendUint64(encoded, uint64(config.FunctionWorkers()))
 
 	knobs := config.OptimizationInfos()
 	encoded = binary.LittleEndian.AppendUint32(encoded, uint32(len(knobs)))

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -42,13 +42,13 @@ var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 // LoadOrCompile loads a matching artifact or compiles source and saves the
 // result. Cache read/write failures never prevent execution; compilation and
 // artifact validation errors retain their normal behavior.
-func (cache Cache) LoadOrCompile(source []byte, config *wago.RuntimeConfig, rt *wago.Runtime) (*wago.Module, error) {
+func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.Runtime) (*wago.Module, error) {
 	if rt == nil {
 		return nil, fmt.Errorf("wago: artifact cache requires a runtime")
 	}
 	// Runtime.Compile is authoritative. The explicit config parameter is retained
 	// for source compatibility, but cannot select code under a different policy.
-	config = rt.Config()
+	config := rt.Config()
 	if config == nil {
 		return nil, fmt.Errorf("wago: artifact cache runtime has no configuration")
 	}

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -46,30 +46,38 @@ func (cache Cache) LoadOrCompile(source []byte, config *wago.RuntimeConfig, rt *
 	if rt == nil {
 		return nil, fmt.Errorf("wago: artifact cache requires a runtime")
 	}
-	if config == nil {
-		return rt.Compile(source)
-	}
 	// Runtime.Compile is authoritative. The explicit config parameter is retained
-	// for source compatibility, but a mismatched caller value must never select an
-	// artifact compiled under policy the destination runtime did not request.
+	// for source compatibility, but cannot select code under a different policy.
 	config = rt.Config()
-	if config.GCCodeTelemetry() || config.BoundsChecks() == wago.BoundsChecksSignalsBased {
-		// Telemetry is intentionally compile-only and absent from serialized
-		// artifacts. Signals-based native code is also deliberately nonserializable.
-		return rt.Compile(source)
+	if config == nil {
+		return nil, fmt.Errorf("wago: artifact cache runtime has no configuration")
 	}
-	path, cacheable := cache.path(source, config)
+	// Validate before lookup, bypass, or plugin preparation: a warm entry must not
+	// admit a configuration that a cold Runtime.Compile rejects.
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	prepared, err := rt.PrepareCompile(source)
+	if err != nil {
+		return nil, err
+	}
+	defer prepared.Close()
+
+	cacheableGeneration := prepared.Cacheable()
+	if config.GCCodeTelemetry() || config.BoundsChecks() == wago.BoundsChecksSignalsBased {
+		// Telemetry is compile-only and absent from serialized artifacts. Signals-
+		// based native code is also deliberately nonserializable.
+		cacheableGeneration = false
+	}
+	path, cacheable := cache.path(prepared.Source(), config)
+	cacheable = cacheable && cacheableGeneration
 	if cacheable {
 		if compiled, hit := loadArtifact(path); hit {
-			module, bindErr := rt.AdoptModule(compiled)
-			if bindErr == nil {
-				return module, nil
-			}
-			return nil, bindErr
+			return prepared.Adopt(compiled)
 		}
 	}
 
-	module, err := rt.Compile(source)
+	module, err := prepared.Compile()
 	if err != nil {
 		return nil, err
 	}

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -239,6 +239,10 @@ func loadArtifact(path string) (*wago.Compiled, bool) {
 	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(linked, opened) {
 		return nil, false
 	}
+	return loadOpenedArtifact(path, file, opened)
+}
+
+func loadOpenedArtifact(path string, file *os.File, opened os.FileInfo) (*wago.Compiled, bool) {
 	limits := wago.DefaultArtifactLimits()
 	maximum := limits.MaxCodeBytes + limits.MaxMetadataBytes + 64
 	if opened.Size() < 0 || opened.Size() > maximum {
@@ -246,7 +250,18 @@ func loadArtifact(path string) (*wago.Compiled, bool) {
 	}
 	compiled := &wago.Compiled{}
 	read, err := compiled.ReadFromWithLimits(file, limits)
-	if err != nil || read != opened.Size() {
+	if err != nil {
+		_ = compiled.Close()
+		return nil, false
+	}
+	var trailing [1]byte
+	trailingBytes, trailingErr := file.Read(trailing[:])
+	finalOpened, statErr := file.Stat()
+	finalLinked, linkErr := os.Lstat(path)
+	if read != opened.Size() || trailingBytes != 0 || trailingErr != io.EOF ||
+		statErr != nil || finalOpened.Size() != read || !finalOpened.Mode().IsRegular() ||
+		linkErr != nil || finalLinked.Mode()&os.ModeSymlink != 0 || !finalLinked.Mode().IsRegular() ||
+		!os.SameFile(finalLinked, finalOpened) {
 		_ = compiled.Close()
 		return nil, false
 	}

--- a/cli/runtime/internal/artifactcache/cache_semantics_test.go
+++ b/cli/runtime/internal/artifactcache/cache_semantics_test.go
@@ -1,0 +1,218 @@
+//go:build !tinygo
+
+package artifactcache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago"
+)
+
+func TestLoadOrCompileValidatesDestinationConfigBeforeWarmLookup(t *testing.T) {
+	source := constantModule()
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	valid := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	seedRuntime := wago.NewRuntime(wago.WithRuntimeConfig(valid))
+	seed, err := cache.LoadOrCompile(source, valid, seedRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedRuntime.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		cfg  *wago.RuntimeConfig
+		want string
+	}{
+		{name: "negative workers", cfg: valid.WithFunctionWorkers(-1), want: "function workers must be non-negative"},
+		{name: "unknown optimization", cfg: valid.WithOptimization("test-does-not-exist", true), want: "unknown"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rt := wago.NewRuntime(wago.WithRuntimeConfig(test.cfg))
+			defer rt.Close()
+			if _, err := cache.LoadOrCompile(source, valid, rt); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("LoadOrCompile error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLoadOrCompileValidatesUnsupportedBMI2BeforeWarmLookup(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("bmi2-rorx is amd64-only")
+	}
+	base := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit).WithOptimization("bmi2-rorx", false)
+	unsupported := base.WithOptimization("bmi2-rorx", true)
+	if err := unsupported.Validate(); err == nil || !strings.Contains(err.Error(), "requires BMI2") {
+		t.Skip("host supports BMI2")
+	}
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	seedRuntime := wago.NewRuntime(wago.WithRuntimeConfig(base))
+	seed, err := cache.LoadOrCompile(constantModule(), base, seedRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedRuntime.Close(); err != nil {
+		t.Fatal(err)
+	}
+	seedPath, _ := cache.path(constantModule(), base)
+	warmPath, _ := cache.path(constantModule(), unsupported)
+	artifact, err := os.ReadFile(seedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(warmPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(warmPath, artifact, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(unsupported))
+	defer rt.Close()
+	if _, err := cache.LoadOrCompile(constantModule(), base, rt); err == nil || !strings.Contains(err.Error(), "requires BMI2") {
+		t.Fatalf("LoadOrCompile BMI2 error = %v", err)
+	}
+}
+
+func TestLoadOrCompileTransformGenerationsCannotReuseWrongCode(t *testing.T) {
+	input := constantModule()
+	cfg := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	for _, value := range []byte{11, 22} {
+		transformed := constantModule()
+		transformed[len(transformed)-2] = value
+		rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+		loadCachePlugin(t, rt, "example.com/cache/transform/"+string(rune('a'+value)), []wago.AuthorityRequest{{
+			Name: wago.AuthorityModuleSourceTransform, Mode: wago.AuthorityRequired, Reason: "replace source",
+		}}, func(reg *wago.Registrar) error {
+			transformer, err := reg.ModuleSourceTransformer()
+			if err != nil {
+				return err
+			}
+			return transformer.Transform(func(wago.ModuleSourceContext, []byte) ([]byte, error) {
+				return append([]byte(nil), transformed...), nil
+			})
+		})
+		mod, err := cache.LoadOrCompile(input, cfg, rt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		in, err := rt.Instantiate(context.Background(), mod)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := in.Call(context.Background(), "answer")
+		if err != nil || len(got) != 1 || got[0].I32() != int32(value) {
+			t.Fatalf("transformed answer = %v, %v; want %d", got, err, value)
+		}
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := mod.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := rt.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	matches, err := filepath.Glob(filepath.Join(cache.Dir, "*", "*.wago"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("transform generations published artifacts %v, err %v", matches, err)
+	}
+}
+
+func TestLoadOrCompileWarmHitRunsCompileObserver(t *testing.T) {
+	source := constantModule()
+	cfg := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	seedRuntime := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	seed, err := cache.LoadOrCompile(source, cfg, seedRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedRuntime.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	loadCachePlugin(t, rt, "example.com/cache/observer", []wago.AuthorityRequest{{
+		Name: wago.AuthorityModuleCompileObserve, Mode: wago.AuthorityRequired, Reason: "observe warm adoption",
+	}}, func(reg *wago.Registrar) error {
+		observer, err := reg.ModuleCompileObserver()
+		if err != nil {
+			return err
+		}
+		return observer.Observe(func(event wago.ModuleCompiledEvent) {
+			calls++
+			if event.Compilation.IsZero() || event.SourceDigest.IsZero() {
+				t.Error("warm compile event lost compilation/source identity")
+			}
+		})
+	})
+	mod, err := cache.LoadOrCompile(source, cfg, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("compile observer calls = %d, want 1", calls)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadOrCompileCustomInstructionsAreNonCacheable(t *testing.T) {
+	source := constantModule()
+	cfg := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	loadCachePlugin(t, rt, "example.com/cache/instruction", []wago.AuthorityRequest{{
+		Name: wago.AuthorityCompilerInstructionDefine, Mode: wago.AuthorityRequired, Reason: "define instruction", Scope: wago.AuthorityScope{Modules: []string{"test.cache"}},
+	}}, func(reg *wago.Registrar) error {
+		instructions, err := reg.CompilerInstructions()
+		if err != nil {
+			return err
+		}
+		return instructions.Define(wago.InstructionSpec{
+			Module: "test.cache", Name: "identity", Input: []int32{32}, Output: []int32{32},
+			Handler: func(_ wago.InstructionContext, args []wago.Bits) ([]wago.Bits, error) { return args, nil },
+		})
+	})
+	for range 2 {
+		mod, err := cache.LoadOrCompile(source, cfg, rt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := mod.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(filepath.Join(cache.Dir, "*", "*.wago"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("custom-instruction generation published artifacts %v, err %v", matches, err)
+	}
+}

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"testing"
 
 	"github.com/wago-org/wago"
@@ -79,6 +80,82 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 	}
 }
 
+type rejectingCompileExtension struct {
+	calls *int
+	err   error
+}
+
+func (e rejectingCompileExtension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{ID: "test.cache-reject"}
+}
+
+func (e rejectingCompileExtension) Register(reg *wago.Registry) error {
+	reg.Hooks().AfterCompile(func(*wago.CompileContext, *wago.Module) error {
+		*e.calls++
+		if *e.calls == 1 {
+			return e.err
+		}
+		return nil
+	})
+	return nil
+}
+
+func TestCacheHitPropagatesAfterCompileErrorExactlyOnce(t *testing.T) {
+	source := constantModule()
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	seedRuntime := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	module, err := cache.LoadOrCompile(source, config, seedRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Compiled().Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedRuntime.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rejected := errors.New("cached artifact rejected")
+	calls := 0
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	defer rt.Close()
+	if err := rt.Use(rejectingCompileExtension{calls: &calls, err: rejected}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cache.LoadOrCompile(source, config, rt); !errors.Is(err, rejected) {
+		t.Fatalf("cache binding error = %v, want %v", err, rejected)
+	}
+	if calls != 1 {
+		t.Fatalf("AfterCompile calls = %d, want 1", calls)
+	}
+}
+
+func TestCacheHitPropagatesRuntimeBindingError(t *testing.T) {
+	source := constantModule()
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	seedRuntime := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	module, err := cache.LoadOrCompile(source, config, seedRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedRuntime.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	closedRuntime := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	if err := closedRuntime.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cache.LoadOrCompile(source, config, closedRuntime); err == nil || !strings.Contains(err.Error(), "closed runtime") {
+		t.Fatalf("cache binding error = %v", err)
+	}
+}
+
 func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	source := constantModule()
 	dir := t.TempDir()
@@ -112,8 +189,8 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	if basePath == optimizationPath {
 		t.Fatal("optimization selection did not change artifact key")
 	}
-	if basePath == workersPath {
-		t.Fatal("function-worker policy did not change artifact key")
+	if basePath != workersPath {
+		t.Fatal("function-worker scheduling policy changed artifact key")
 	}
 	if basePath == boundsPath {
 		t.Fatal("bounds-check mode did not change artifact key")

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -57,6 +57,40 @@ func TestLoadOrCompileCachesAndRepairsArtifact(t *testing.T) {
 	}
 }
 
+func TestLoadArtifactRejectsSymlinkAndOversizeEntry(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.wago")
+	if err := os.WriteFile(target, []byte("not an artifact"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.wago")
+	if err := os.Symlink(target, link); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		t.Fatal(err)
+	}
+	if compiled, hit := loadArtifact(link); hit || compiled != nil {
+		t.Fatalf("symlink cache entry loaded: %v, %v", compiled, hit)
+	}
+
+	oversize := filepath.Join(dir, "oversize.wago")
+	limits := wago.DefaultArtifactLimits()
+	file, err := os.Create(oversize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(oversize, limits.MaxCodeBytes+limits.MaxMetadataBytes+65); err != nil {
+		t.Fatal(err)
+	}
+	if compiled, hit := loadArtifact(oversize); hit || compiled != nil {
+		t.Fatalf("oversize cache entry loaded: %v, %v", compiled, hit)
+	}
+}
+
 func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 	source := constantModule()
 	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
@@ -68,7 +102,7 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 
 	injected := errors.New("injected cache publication failure")
 	oldPublish := publishArtifact
-	publishArtifact = func(string, []byte) error { return injected }
+	publishArtifact = func(string, *wago.Compiled) error { return injected }
 	t.Cleanup(func() { publishArtifact = oldPublish })
 
 	module, err := cache.LoadOrCompile(source, config, rt)
@@ -154,6 +188,99 @@ func TestCacheHitPropagatesRuntimeBindingError(t *testing.T) {
 	if _, err := cache.LoadOrCompile(source, config, closedRuntime); err == nil || !strings.Contains(err.Error(), "closed runtime") {
 		t.Fatalf("cache binding error = %v", err)
 	}
+}
+
+func TestLoadOrCompileUsesDestinationRuntimeConfig(t *testing.T) {
+	source := constantModule()
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	runtimeConfig := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	callerConfig := runtimeConfig.WithMemoryLimitPages(runtimeConfig.MemoryLimitPages() - 1)
+	callerPath, ok := cache.path(source, callerConfig)
+	if !ok {
+		t.Fatal("caller cache key unavailable")
+	}
+	runtimePath, ok := cache.path(source, runtimeConfig)
+	if !ok || runtimePath == callerPath {
+		t.Fatalf("runtime cache key = %q, caller key = %q", runtimePath, callerPath)
+	}
+
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(runtimeConfig))
+	module, err := cache.LoadOrCompile(source, callerConfig, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(runtimePath); err != nil {
+		t.Fatalf("runtime-config artifact was not published: %v", err)
+	}
+	if _, err := os.Stat(callerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("mismatched caller-config artifact exists: %v", err)
+	}
+}
+
+func TestLoadOrCompileBypassesArtifactsForCompileOnlyTelemetry(t *testing.T) {
+	source := constantModule()
+	base := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	seedRuntime := wago.NewRuntime(wago.WithRuntimeConfig(base))
+	seed, err := cache.LoadOrCompile(source, base, seedRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedRuntime.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	telemetry := base.WithGCCodeTelemetry(true)
+	var compileCalls int
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(telemetry))
+	if err := rt.Use(telemetryCountingExtension{calls: &compileCalls}, wago.WithPluginGrants(wago.PluginCompileHooks)); err != nil {
+		t.Fatal(err)
+	}
+	module, err := cache.LoadOrCompile(source, telemetry, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compileCalls != 1 {
+		t.Fatalf("compile-only telemetry used a warm artifact; compile calls = %d", compileCalls)
+	}
+	if _, ok := module.Compiled().GCNativeCodeTelemetry(); !ok {
+		t.Fatal("fresh telemetry compile did not retain requested attribution")
+	}
+	if err := module.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type telemetryCountingExtension struct {
+	calls *int
+}
+
+func (e telemetryCountingExtension) Info() wago.ExtensionInfo {
+	return wago.ExtensionInfo{ID: "test.telemetry-cache-compile"}
+}
+
+func (e telemetryCountingExtension) Register(reg *wago.Registry) error {
+	hooks, err := reg.ModuleCompiler()
+	if err != nil {
+		return err
+	}
+	hooks.Before(func(*wago.CompileContext, []byte) ([]byte, error) {
+		(*e.calls)++
+		return nil, nil
+	})
+	return nil
 }
 
 func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -1,6 +1,7 @@
 package artifactcache
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -171,24 +172,33 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 	}
 }
 
-type rejectingCompileExtension struct {
-	calls *int
-	err   error
-}
+type cachePlugin func(*wago.Registrar) error
 
-func (e rejectingCompileExtension) Info() wago.ExtensionInfo {
-	return wago.ExtensionInfo{ID: "test.cache-reject"}
-}
+func (f cachePlugin) Register(reg *wago.Registrar) error { return f(reg) }
 
-func (e rejectingCompileExtension) Register(reg *wago.Registry) error {
-	reg.Hooks().AfterCompile(func(*wago.CompileContext, *wago.Module) error {
-		*e.calls++
-		if *e.calls == 1 {
-			return e.err
+func loadCachePlugin(t testing.TB, rt *wago.Runtime, id string, authorities []wago.AuthorityRequest, register cachePlugin) {
+	t.Helper()
+	definition := wago.PluginDefinition{
+		ID: id, Version: "1.0.0",
+		Provenance:  wago.PluginProvenance{Repository: "https://example.com/" + id, License: "MIT"},
+		Authorities: authorities,
+	}
+	digest, err := wago.DefinitionDigest(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection := wago.PluginSelection{ID: id, DefinitionDigest: digest, Direct: true, Dependencies: map[string]string{}}
+	for _, authority := range authorities {
+		if authority.Mode == wago.AuthorityRequired {
+			selection.Grants = append(selection.Grants, wago.AuthorityGrant{Name: authority.Name, Scope: authority.Scope})
 		}
-		return nil
-	})
-	return nil
+	}
+	if err := rt.LoadPlugins(context.Background(), wago.PluginSet{
+		Providers:  []wago.PluginProvider{{Definition: definition, New: func() wago.Plugin { return register }}},
+		Selections: []wago.PluginSelection{selection},
+	}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestCacheHitPropagatesAfterCompileErrorExactlyOnce(t *testing.T) {
@@ -200,7 +210,7 @@ func TestCacheHitPropagatesAfterCompileErrorExactlyOnce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := module.Compiled().Close(); err != nil {
+	if err := module.Close(); err != nil {
 		t.Fatal(err)
 	}
 	if err := seedRuntime.Close(); err != nil {
@@ -211,9 +221,20 @@ func TestCacheHitPropagatesAfterCompileErrorExactlyOnce(t *testing.T) {
 	calls := 0
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
 	defer rt.Close()
-	if err := rt.Use(rejectingCompileExtension{calls: &calls, err: rejected}); err != nil {
-		t.Fatal(err)
-	}
+	loadCachePlugin(t, rt, "example.com/cache/reject", []wago.AuthorityRequest{{
+		Name: wago.AuthorityModuleCompileObserve, Mode: wago.AuthorityRequired, Reason: "reject adopted artifacts",
+	}}, func(reg *wago.Registrar) error {
+		observer, err := reg.ModuleCompileObserver()
+		if err != nil {
+			return err
+		}
+		return observer.Observe(func(wago.ModuleCompiledEvent) {
+			calls++
+			if calls == 1 {
+				panic(rejected)
+			}
+		})
+	})
 	if _, err := cache.LoadOrCompile(source, config, rt); !errors.Is(err, rejected) {
 		t.Fatalf("cache binding error = %v, want %v", err, rejected)
 	}
@@ -299,9 +320,18 @@ func TestLoadOrCompileBypassesArtifactsForCompileOnlyTelemetry(t *testing.T) {
 	telemetry := base.WithGCCodeTelemetry(true)
 	var compileCalls int
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(telemetry))
-	if err := rt.Use(telemetryCountingExtension{calls: &compileCalls}, wago.WithPluginGrants(wago.PluginCompileHooks)); err != nil {
-		t.Fatal(err)
-	}
+	loadCachePlugin(t, rt, "example.com/cache/telemetry", []wago.AuthorityRequest{{
+		Name: wago.AuthorityModuleSourceTransform, Mode: wago.AuthorityRequired, Reason: "count fresh compiles",
+	}}, func(reg *wago.Registrar) error {
+		transformer, err := reg.ModuleSourceTransformer()
+		if err != nil {
+			return err
+		}
+		return transformer.Transform(func(wago.ModuleSourceContext, []byte) ([]byte, error) {
+			compileCalls++
+			return nil, nil
+		})
+	})
 	module, err := cache.LoadOrCompile(source, telemetry, rt)
 	if err != nil {
 		t.Fatal(err)
@@ -318,26 +348,6 @@ func TestLoadOrCompileBypassesArtifactsForCompileOnlyTelemetry(t *testing.T) {
 	if err := rt.Close(); err != nil {
 		t.Fatal(err)
 	}
-}
-
-type telemetryCountingExtension struct {
-	calls *int
-}
-
-func (e telemetryCountingExtension) Info() wago.ExtensionInfo {
-	return wago.ExtensionInfo{ID: "test.telemetry-cache-compile"}
-}
-
-func (e telemetryCountingExtension) Register(reg *wago.Registry) error {
-	hooks, err := reg.ModuleCompiler()
-	if err != nil {
-		return err
-	}
-	hooks.Before(func(*wago.CompileContext, []byte) ([]byte, error) {
-		(*e.calls)++
-		return nil, nil
-	})
-	return nil
 }
 
 func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -91,6 +91,63 @@ func TestLoadArtifactRejectsSymlinkAndOversizeEntry(t *testing.T) {
 	}
 }
 
+func TestLoadOpenedArtifactRejectsReplacementAndGrowth(t *testing.T) {
+	source := constantModule()
+	compiled, err := wago.Compile(wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := compiled.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name        string
+		skipWindows bool
+		mutate      func(string, *os.File) error
+	}{
+		{name: "replacement", skipWindows: true, mutate: func(path string, _ *os.File) error {
+			replacement := path + ".replacement"
+			if err := os.WriteFile(replacement, artifact, 0o644); err != nil {
+				return err
+			}
+			return os.Rename(replacement, path)
+		}},
+		{name: "growth", mutate: func(_ string, file *os.File) error {
+			return os.Truncate(file.Name(), int64(len(artifact)+1))
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.skipWindows && runtime.GOOS == "windows" {
+				t.Skip("Windows does not replace an open cache entry by rename")
+			}
+			path := filepath.Join(t.TempDir(), "entry.wago")
+			if err := os.WriteFile(path, artifact, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			file, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			opened, err := file.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := test.mutate(path, file); err != nil {
+				t.Fatal(err)
+			}
+			if loaded, hit := loadOpenedArtifact(path, file, opened); hit || loaded != nil {
+				t.Fatalf("mutated cache entry loaded: %v, %v", loaded, hit)
+			}
+		})
+	}
+}
+
 func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 	source := constantModule()
 	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)

--- a/cli/runtime/internal/artifactcache/cache_workers_test.go
+++ b/cli/runtime/internal/artifactcache/cache_workers_test.go
@@ -1,0 +1,137 @@
+//go:build !tinygo
+
+package artifactcache
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/wago-org/wago"
+)
+
+func TestArtifactsAreDeterministicAcrossWorkerPolicies(t *testing.T) {
+	policies := []int{0, 1, 2, 4, runtime.GOMAXPROCS(0) + 1}
+	corpus := [][]byte{wagoEmptyModule(), constantModule(), memoryModule()}
+	for sourceIndex, source := range corpus {
+		var baseline []byte
+		var baselineEntries []int
+		for _, workers := range policies {
+			config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit).WithFunctionWorkers(workers)
+			compiled, err := wago.Compile(config, source)
+			if err != nil {
+				t.Fatalf("source %d workers %d: %v", sourceIndex, workers, err)
+			}
+			artifact, err := compiled.MarshalBinary()
+			if err != nil {
+				_ = compiled.Close()
+				t.Fatalf("source %d workers %d marshal: %v", sourceIndex, workers, err)
+			}
+			entries := append([]int(nil), compiled.Entry...)
+			if err := compiled.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if baseline == nil {
+				baseline = artifact
+				baselineEntries = entries
+				continue
+			}
+			if !bytes.Equal(artifact, baseline) || !slices.Equal(entries, baselineEntries) {
+				t.Fatalf("source %d workers %d changed serialized/native metadata", sourceIndex, workers)
+			}
+		}
+	}
+}
+
+func TestLoadOrCompileReusesArtifactAcrossWorkerPolicies(t *testing.T) {
+	source := constantModule()
+	policies := []int{0, 1, 2, 4, runtime.GOMAXPROCS(0) + 1}
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+	base := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	for _, workers := range policies {
+		rt := wago.NewRuntime(wago.WithRuntimeConfig(base.WithFunctionWorkers(workers)))
+		module, err := cache.LoadOrCompile(source, base, rt)
+		if err != nil {
+			t.Fatalf("workers %d: %v", workers, err)
+		}
+		if err := module.Close(); err != nil {
+			t.Fatalf("workers %d close: %v", workers, err)
+		}
+		if err := rt.Close(); err != nil {
+			t.Fatalf("workers %d runtime close: %v", workers, err)
+		}
+	}
+	matches, err := filepath.Glob(filepath.Join(cache.Dir, "*", "*.wago"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("worker-policy artifacts = %v, %v; want one shared artifact", matches, err)
+	}
+}
+
+func TestLoadOrCompileReusesArtifactAcrossProcess(t *testing.T) {
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("cross-process")}
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	module, err := cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestArtifactCacheSubprocessHelper$")
+	cmd.Env = append(os.Environ(), "WAGO_ARTIFACT_CACHE_HELPER=1", "WAGO_ARTIFACT_CACHE_DIR="+cache.Dir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("subprocess warm cache reuse: %v\n%s", err, output)
+	}
+}
+
+func TestArtifactCacheSubprocessHelper(t *testing.T) {
+	if os.Getenv("WAGO_ARTIFACT_CACHE_HELPER") != "1" {
+		return
+	}
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit).WithFunctionWorkers(runtime.GOMAXPROCS(0) + 1)
+	cache := Cache{Dir: os.Getenv("WAGO_ARTIFACT_CACHE_DIR"), Identity: []byte("cross-process")}
+	path, ok := cache.path(constantModule(), config)
+	if !ok {
+		t.Fatal("subprocess cache key unavailable")
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("warm artifact unavailable: %v", err)
+	}
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	module, err := cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) {
+		t.Fatalf("warm subprocess rewrote artifact: before=%v after=%v", before, after)
+	}
+}
+
+func wagoEmptyModule() []byte {
+	return []byte{'\x00', 'a', 's', 'm', 1, 0, 0, 0}
+}
+
+func memoryModule() []byte {
+	// (module (memory 1 2))
+	return []byte{'\x00', 'a', 's', 'm', 1, 0, 0, 0, 5, 4, 1, 1, 1, 2}
+}

--- a/cli/runtime/internal/version/release.go
+++ b/cli/runtime/internal/version/release.go
@@ -4,9 +4,9 @@ import "strings"
 
 func diagnosticChannel(activeVersion, release string) string {
 	switch {
-	case activeVersion == "canary", strings.HasPrefix(release, "canary-"):
+	case activeVersion == "canary", strings.HasPrefix(release, "canary-"), strings.HasPrefix(release, "canary@"):
 		return "canary"
-	case activeVersion == "nightly", strings.HasPrefix(release, "nightly-"):
+	case activeVersion == "nightly", strings.HasPrefix(release, "nightly-"), strings.HasPrefix(release, "nightly@"):
 		return "nightly"
 	case activeVersion == "latest":
 		return "latest"

--- a/cli/runtime/internal/version/report_test.go
+++ b/cli/runtime/internal/version/report_test.go
@@ -83,8 +83,10 @@ func TestDiagnosticChannel(t *testing.T) {
 	}{
 		{"canary", "deadbee", "canary"},
 		{"", "canary-20260729-deadbee", "canary"},
+		{"", "canary@deadbee123456789012345678901234567890123", "canary"},
 		{"nightly", "deadbee", "nightly"},
 		{"", "nightly-20260729-deadbee", "nightly"},
+		{"", "nightly@deadbee123456789012345678901234567890123", "nightly"},
 		{"latest", "v1.0.0", "latest"},
 		{"", "v1.0.0", "stable"},
 		{"local", "deadbee", "local"},

--- a/docs/artifact-cache.md
+++ b/docs/artifact-cache.md
@@ -45,7 +45,13 @@ fixed-order configuration values:
 
 Function-worker policy is intentionally excluded: it controls only bounded
 compiler scheduling, while validation order, generated native code, and
-serialized artifact bytes remain deterministic across worker counts.
+serialized artifact bytes remain deterministic across worker counts. Cache
+lookup always uses the destination runtime's effective configuration—the
+caller's compatibility parameter cannot select code compiled under a different
+runtime policy. The compile-only GC native-code telemetry option bypasses the
+cache entirely because that attribution is deliberately not serialized and a
+warm artifact cannot satisfy the request. Signals-based compilation also
+bypasses the cache because guard-page native code is intentionally nonserializable.
 
 The binary key format has an explicit version and domain prefix. Changing the
 meaning or order of any encoded field requires incrementing `cacheKeyFormat`.
@@ -53,11 +59,13 @@ Optimization names are not serialized into the hot cache-key path; their stable
 registry order is interpreted under the build identity that owns that registry.
 
 The final SHA-256 key remains hexadecimal in the filesystem path. Artifact
-loading keeps its existing version, ABI, target, and malformed-input checks;
-cache corruption remains a safe miss followed by recompilation and atomic
-replacement. Once an artifact decodes successfully, runtime binding and
-`AfterCompile` policy errors are returned directly rather than being converted
-into cache misses; the decoded mapping is closed on that failure path.
+loading keeps its existing version, ABI, target, section-size, file-type, and
+malformed-input checks; cache entries are streamed into bounded code/metadata
+sections rather than first buffered as an unbounded whole file. Cache corruption
+remains a safe miss followed by recompilation and atomic replacement. Once an
+artifact decodes successfully, runtime binding and `AfterCompile` policy errors
+are returned directly rather than being converted into cache misses; the decoded
+mapping is closed on that failure path.
 Publication uses a unique same-directory temporary file and a
 platform-specific replace-existing operation, including `MoveFileExW` on
 Windows. Existing symlink, directory, and non-regular destinations are rejected;

--- a/docs/artifact-cache.md
+++ b/docs/artifact-cache.md
@@ -61,8 +61,11 @@ registry order is interpreted under the build identity that owns that registry.
 The final SHA-256 key remains hexadecimal in the filesystem path. Artifact
 loading keeps its existing version, ABI, target, section-size, file-type, and
 malformed-input checks; cache entries are streamed into bounded code/metadata
-sections rather than first buffered as an unbounded whole file. Cache corruption
-remains a safe miss followed by recompilation and atomic replacement. Once an
+sections rather than first buffered as an unbounded whole file. After decoding,
+the loader verifies EOF, the final opened-file size, and that the cache path still
+names the same regular file, so concurrent replacement or growth remains a safe
+miss. Cache corruption remains a safe miss followed by recompilation and atomic
+replacement. Once an
 artifact decodes successfully, runtime binding and `AfterCompile` policy errors
 are returned directly rather than being converted into cache misses; the decoded
 mapping is closed on that failure path.

--- a/docs/artifact-cache.md
+++ b/docs/artifact-cache.md
@@ -40,9 +40,12 @@ fixed-order configuration values:
 - target GOOS and GOARCH;
 - accepted Core feature bits;
 - bounds-check and deferred-bounds policy;
-- maximum memory pages;
-- function-worker policy; and
+- maximum memory pages; and
 - the ordered compiler-optimization bit set.
+
+Function-worker policy is intentionally excluded: it controls only bounded
+compiler scheduling, while validation order, generated native code, and
+serialized artifact bytes remain deterministic across worker counts.
 
 The binary key format has an explicit version and domain prefix. Changing the
 meaning or order of any encoded field requires incrementing `cacheKeyFormat`.
@@ -52,7 +55,10 @@ registry order is interpreted under the build identity that owns that registry.
 The final SHA-256 key remains hexadecimal in the filesystem path. Artifact
 loading keeps its existing version, ABI, target, and malformed-input checks;
 cache corruption remains a safe miss followed by recompilation and atomic
-replacement. Publication uses a unique same-directory temporary file and a
+replacement. Once an artifact decodes successfully, runtime binding and
+`AfterCompile` policy errors are returned directly rather than being converted
+into cache misses; the decoded mapping is closed on that failure path.
+Publication uses a unique same-directory temporary file and a
 platform-specific replace-existing operation, including `MoveFileExW` on
 Windows. Existing symlink, directory, and non-regular destinations are rejected;
 failed writes leave the prior regular artifact intact and remove the temporary

--- a/docs/artifact-cache.md
+++ b/docs/artifact-cache.md
@@ -46,12 +46,22 @@ fixed-order configuration values:
 Function-worker policy is intentionally excluded: it controls only bounded
 compiler scheduling, while validation order, generated native code, and
 serialized artifact bytes remain deterministic across worker counts. Cache
-lookup always uses the destination runtime's effective configuration—the
-caller's compatibility parameter cannot select code compiled under a different
-runtime policy. The compile-only GC native-code telemetry option bypasses the
-cache entirely because that attribution is deliberately not serialized and a
-warm artifact cannot satisfy the request. Signals-based compilation also
-bypasses the cache because guard-page native code is intentionally nonserializable.
+lookup validates and uses the destination runtime's effective configuration
+before lookup or bypass decisions—the caller's compatibility parameter cannot
+select code compiled under a different runtime policy, and a warm entry cannot
+admit a configuration that a cold compile rejects.
+
+One `PreparedCompile` owns each lookup. Source transforms run exactly once before
+key selection, and compile observers see the same `CompilationIdentity` on cold
+compilation and warm artifact adoption. Generations with source transforms or
+custom compiler instructions currently bypass serialized reuse because those
+plugin semantics do not yet expose a deterministic fingerprint. Observer-only
+generations remain cacheable and still receive warm-hit events.
+
+The compile-only GC native-code telemetry option bypasses the cache entirely
+because that attribution is deliberately not serialized and a warm artifact
+cannot satisfy the request. Signals-based compilation also bypasses the cache
+because guard-page native code is intentionally nonserializable.
 
 The binary key format has an explicit version and domain prefix. Changing the
 meaning or order of any encoded field requires incrementing `cacheKeyFormat`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -76,8 +76,10 @@ CLI builds for both amd64 and arm64, then publish every successful binary with
 its SHA-256 checksum. A push to `main` becomes a canary only after that commit's
 `CI` workflow succeeds; failed or cancelled CI runs do not publish a canary.
 Manual canary runs build the current `main` tip. Nightly and canary use unique
-never-retargeted prerelease tags; the CLI resolves the newest `nightly-*` or
-`canary-*` tag when a channel is installed. Every target publishes a
+never-retargeted prerelease tags; canary tags contain the full 40-hex commit ID,
+and both channels stamp binaries with their canonical full commit identity. The
+CLI resolves the newest `nightly-*` or `canary-*` tag when a channel is
+installed. Every target publishes a
 standard-Go CLI plus Normal builds of the Standard and Minimal runtimes.
 Linux also requires Tiny builds of both profiles; other platforms publish
 each feature-complete Tiny profile supported by their TinyGo port. Normal favors

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -21,10 +21,19 @@ responses use 1 MiB, release checksums use 4 KiB, and non-success response
 capture uses an independent 64 KiB limit. Declared oversized bodies are rejected
 before reading; chunked or dishonest responses are stopped after the configured
 limit. Release/commit browsing is capped at ten 100-item pages so repeated full
-pages cannot accumulate metadata indefinitely. OAuth device-flow lifetimes and
-server-provided polling intervals are also capped.
+pages cannot accumulate metadata indefinitely. Rolling-channel lookup follows
+validated same-origin GitHub `Link` pagination within that budget, skips draft
+releases, and requires the selected release to expose a canonical 40-hex commit
+target. OAuth device-flow lifetimes and server-provided polling intervals are
+also capped.
 
 ## Release downloads
+
+Canary and nightly binaries now stamp `canary@<full-sha>` or
+`nightly@<full-sha>` as their comparison identity; user-facing labels remain
+abbreviated. Canary release tags also use the full commit ID. Legacy abbreviated
+stamps are treated as stale rather than compared by prefix, so a colliding short
+hash cannot suppress an update.
 
 Executable checksums are fetched before assets. The parser accepts exactly one
 64-hexadecimal SHA-256 record naming the expected asset; the checksum tools'

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -203,9 +203,9 @@ instruction generation across lookup: transforms run exactly once, and warm
 adoption emits compile success under the same immutable generation. A prepared
 compilation must terminate through `Compile`, `Adopt`, or `Close` before runtime
 shutdown can tear down its plugin generation. `PreparedCompile.Source()` is a
-borrowed immutable view: after successful `Compile`, the returned `Module` owns
-source storage retained by decoded metadata, so callers must not mutate that
-backing array until the Module closes.
+read-only view of runtime-owned transformed bytes. Transformer return slices are
+snapshotted after each callback; after successful `Compile`, the returned
+`Module` retains that source storage until it closes.
 
 `Module.Close` emits one close event with the final module identity, clears the
 wrapper identity, and rejects later runtime instantiation through that wrapper.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -197,12 +197,27 @@ comparable. A successful `Runtime.Compile` event carries an opaque
 `ModuleSourceDigest` of the final bytes after every transformer. A transformer
 can compare it with `DigestModuleSource` without compile observers receiving the
 source itself. The precompiled `Runtime.Module` path reports a zero digest
-because its original source is unavailable. `Module.Close` emits one close event
-with the final module identity, clears the wrapper identity, and rejects later
-runtime instantiation through that wrapper; it does not close or take ownership
-of `Module.Compiled()`. Plugins can therefore move metadata into module- and
-instance-identity maps and release it deterministically without retaining a
-`Runtime`, `Module`, `Compiled`, or `Instance` through an identity.
+because its original source is unavailable. Artifact integrations use
+`Runtime.PrepareCompile` to retain one admitted transform/observer/import/custom-
+instruction generation across lookup: transforms run exactly once, and warm
+adoption emits compile success under the same immutable generation. A prepared
+compilation must terminate through `Compile`, `Adopt`, or `Close` before runtime
+shutdown can tear down its plugin generation. `PreparedCompile.Source()` is a
+borrowed immutable view: after successful `Compile`, the returned `Module` owns
+source storage retained by decoded metadata, so callers must not mutate that
+backing array until the Module closes.
+
+`Module.Close` emits one close event with the final module identity, clears the
+wrapper identity, and rejects later runtime instantiation through that wrapper.
+Modules returned by `Runtime.Compile` or `Runtime.AdoptModule` own their
+`Compiled` artifact; `Runtime.Module` remains the explicit borrowing path.
+Existing instances retain their executable mapping until they close. A module-
+close observer may call `Module.Close` or `Runtime.Close` reentrantly; those calls
+publish closure without waiting on the active observer, and runtime teardown
+drains the admitted module-close generation before stopping providers. Plugins
+can therefore move metadata into module- and instance-identity maps and release
+it deterministically without retaining a `Runtime`, `Module`, `Compiled`, or
+`Instance` through an identity.
 The instantiate interceptor's `After` phase is fallible and runs after an exact
 instance identity exists but before the Wasm start function and success
 observers. Failure closes the partial instance through normal close observation
@@ -351,10 +366,19 @@ handle's logical close. If another instance retains an exported function, the
 manager's instance and declared-memory reservations remain charged until that
 last importer closes and physical resources are released.
 
-`Runtime.Close` and `Runtime.CloseContext` are synchronous drains. Do not call
-either from a host callback, Contract callback, lifecycle hook, or observer
-currently running on that same Runtime: shutdown waits for the current operation
-to return. Initiate close from the owning goroutine after the callback returns.
+`Runtime.Close` publishes the shutdown gate immediately. When no runtime
+operation is admitted it waits for teardown; from an admitted host callback,
+Contract callback, lifecycle hook, or observer it uses the nonwaiting path so the
+callback can return without self-deadlock. `Runtime.Closed` exposes completion,
+and `Runtime.WaitClosed(ctx)` returns the final joined teardown error. Callbacks
+must not wait on their own runtime's completion before returning.
+
+`Runtime.CloseContext` starts the same single teardown and waits selectably. Its
+context bounds the caller's wait and is passed to plugin `Stop`; teardown still
+publishes one final result for every later `WaitClosed` caller. Once the gate is
+published, new compile, module binding, direct/managed instantiation, and managed
+fork operations fail closed, while already admitted operations finish or unwind
+before their plugin generation is released.
 
 The package-level low-level `Compile`, `Instantiate`, and `Invoke` APIs are
 outside the Runtime plugin lifecycle. Native process crashes and forced

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -342,43 +342,53 @@ Resource-owning plugins key state by the exact `*wago.Instance`. Attach state in
 an instantiate observer, associate synchronous host calls through the separately
 granted caller resolver, and retire state from the close observer.
 
-`BeforeClose` is the authoritative logical disposal event. The invocation gate
-has already closed, so no new public call can begin. It does not promise that
-native code, arena memory, or retained references have already been physically
-released; active invocations can defer physical teardown. Concurrent close
-calls share one logical close, every hook runs once, and hook failures are
-joined without skipping remaining cleanup.
+`BeforeClose` is the logical close event. The invocation gate has already
+closed, so no new public call can begin. `AfterClose` is the terminal disposal
+observer: it runs only after construction and admitted invocations have
+quiesced, immediately before physical release can proceed. Concurrent close
+calls share one logical close, every hook runs once, and callback panics are
+reported as bounded `ErrCallbackPanic` errors without retaining panic values or
+skipping remaining cleanup. A close callback may reenter `Instance.Close`; the
+reentrant call returns promptly instead of waiting on itself.
 
 A Runtime-owned instance is tracked immediately after construction, before its
 post-create hooks or Wasm start function run. An ordinary invocation trap,
 cancellation, or `HostExit` does not dispose an instance. A start-function
 failure does: instantiation never succeeded, so Wago closes the partial instance
-before returning. `Runtime.Close` logically closes every tracked direct and
-managed instance in reverse creation order before plugin `Stop` callbacks run,
-preventing new calls. It then lets `Stop` cancel admitted work and waits for
-in-flight Runtime operations, callback admission, invocation, and
-managed-instance quiescence before returning.
-A direct caller retains its handle, but only as an idempotent closed handle;
-calling `Close` again is safe.
+through the normal lifecycle before returning. Direct instances are logically
+closed before plugin `Stop`. Managed-instance shutdown is three phase: close
+manager admission, run plugin `Stop` while existing workers and dependent
+contracts remain usable, then close and drain managed instances before revoking
+provider state. A direct caller retains its handle only as an idempotent closed
+handle; calling `Close` again is safe.
 
 Managed-instance limits account for physical ownership, not just the managed
 handle's logical close. If another instance retains an exported function, the
 manager's instance and declared-memory reservations remain charged until that
 last importer closes and physical resources are released.
 
-`Runtime.Close` publishes the shutdown gate immediately. When no runtime
-operation is admitted it waits for teardown; from an admitted host callback,
-Contract callback, lifecycle hook, or observer it uses the nonwaiting path so the
-callback can return without self-deadlock. `Runtime.Closed` exposes completion,
-and `Runtime.WaitClosed(ctx)` returns the final joined teardown error. Callbacks
-must not wait on their own runtime's completion before returning.
+`Runtime.Close` is always initiation-only: it publishes the shutdown gate and
+returns promptly, including while plugin loading or a callback is active.
+`Runtime.Closed` exposes completion, and `Runtime.WaitClosed(ctx)` returns the
+single final joined teardown error. Callbacks must not wait on their own
+runtime's completion before returning.
 
 `Runtime.CloseContext` starts the same single teardown and waits selectably. Its
-context bounds the caller's wait and is passed to plugin `Stop`; teardown still
-publishes one final result for every later `WaitClosed` caller. Once the gate is
-published, new compile, module binding, direct/managed instantiation, and managed
-fork operations fail closed, while already admitted operations finish or unwind
-before their plugin generation is released.
+context bounds both plugin-loading waits and final completion, and the initiating
+context is passed to plugin `Stop`; teardown still publishes one final result for
+every later `WaitClosed` caller. Startup rollback is mandatory even if the load
+context is canceled. Once shutdown is published, new compile, module binding,
+direct/managed instantiation, invocation, and managed fork operations fail
+closed. Already-admitted instantiation and invocation generations retain explicit
+plugin-operation reservations, so their terminal observers and host callbacks
+can finish after ordinary callback admission closes; provider teardown waits for
+those reservations to drain.
+
+Shutdown callbacks, including runtime-close observers, plugin `Stop`, manager
+close/drain operations, internal close callbacks, contract/handle revocation, and
+reference-store closure, are panic-contained. Errors match `ErrCallbackPanic`,
+carry bounded phase attribution, and never include the recovered panic value or
+stack.
 
 The package-level low-level `Compile`, `Instantiate`, and `Invoke` APIs are
 outside the Runtime plugin lifecycle. Native process crashes and forced

--- a/internal/installbootstrap/release.go
+++ b/internal/installbootstrap/release.go
@@ -32,6 +32,7 @@ type Catalog interface {
 // canary, nightly means the newest nightly, latest follows the latest release,
 // and explicit release tags pass through without a catalog request.
 func Resolve(version string, catalog Catalog) (string, error) {
+	version = strings.TrimSpace(version)
 	switch {
 	case version == "latest":
 		item, err := catalog.Latest()
@@ -79,7 +80,9 @@ func Resolve(version string, catalog Catalog) (string, error) {
 }
 
 func IsReleaseTag(version string) bool {
-	return strings.HasPrefix(version, "v") || strings.HasPrefix(version, "canary-") || strings.HasPrefix(version, "nightly-")
+	version = strings.TrimSpace(version)
+	return version != "" && !strings.Contains(version, "@") &&
+		(strings.HasPrefix(version, "v") || strings.HasPrefix(version, "canary-") || strings.HasPrefix(version, "nightly-"))
 }
 
 func rollingCommit(version string) (channel, sha string, ok bool) {

--- a/internal/installbootstrap/release.go
+++ b/internal/installbootstrap/release.go
@@ -15,8 +15,10 @@ import (
 )
 
 type Release struct {
-	TagName     string `json:"tag_name"`
-	PublishedAt string `json:"published_at"`
+	TagName         string `json:"tag_name"`
+	TargetCommitish string `json:"target_commitish"`
+	PublishedAt     string `json:"published_at"`
+	Draft           bool   `json:"draft"`
 }
 
 // Catalog is the release-discovery seam. GitHub HTTP and in-memory tests are
@@ -43,6 +45,19 @@ func Resolve(version string, catalog Catalog) (string, error) {
 	case IsReleaseTag(version):
 		return version, nil
 	}
+	if channel, sha, canonical := rollingCommit(version); canonical {
+		releases, err := catalog.Releases()
+		if err != nil {
+			return "", err
+		}
+		sort.SliceStable(releases, func(a, b int) bool { return releases[a].PublishedAt > releases[b].PublishedAt })
+		for _, item := range releases {
+			if !item.Draft && strings.HasPrefix(item.TagName, channel+"-") && strings.EqualFold(item.TargetCommitish, sha) {
+				return item.TagName, nil
+			}
+		}
+		return "", fmt.Errorf("no %s installer release found for commit %s", channel, sha)
+	}
 	channel := version
 	if version == "main" {
 		channel = "canary"
@@ -56,7 +71,7 @@ func Resolve(version string, catalog Catalog) (string, error) {
 	}
 	sort.SliceStable(releases, func(a, b int) bool { return releases[a].PublishedAt > releases[b].PublishedAt })
 	for _, item := range releases {
-		if strings.HasPrefix(item.TagName, channel+"-") {
+		if !item.Draft && strings.HasPrefix(item.TagName, channel+"-") {
 			return item.TagName, nil
 		}
 	}
@@ -65,6 +80,19 @@ func Resolve(version string, catalog Catalog) (string, error) {
 
 func IsReleaseTag(version string) bool {
 	return strings.HasPrefix(version, "v") || strings.HasPrefix(version, "canary-") || strings.HasPrefix(version, "nightly-")
+}
+
+func rollingCommit(version string) (channel, sha string, ok bool) {
+	channel, sha, found := strings.Cut(strings.ToLower(strings.TrimSpace(version)), "@")
+	if !found || (channel != "canary" && channel != "nightly") || len(sha) != 40 {
+		return "", "", false
+	}
+	for _, char := range sha {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return "", "", false
+		}
+	}
+	return channel, sha, true
 }
 
 func Asset(prefix, goos, goarch string) (string, error) {

--- a/internal/installbootstrap/release.go
+++ b/internal/installbootstrap/release.go
@@ -21,6 +21,14 @@ type Release struct {
 	Draft           bool   `json:"draft"`
 }
 
+// ResolvedRelease preserves the immutable identity selected during discovery.
+// Tag is the exact release asset namespace; SourceRef is the exact Git/archive
+// reference and never degrades to a mutable channel after resolution.
+type ResolvedRelease struct {
+	Tag       string
+	SourceRef string
+}
+
 // Catalog is the release-discovery seam. GitHub HTTP and in-memory tests are
 // the two adapters; release selection itself remains local and deterministic.
 type Catalog interface {
@@ -32,51 +40,79 @@ type Catalog interface {
 // canary, nightly means the newest nightly, latest follows the latest release,
 // and explicit release tags pass through without a catalog request.
 func Resolve(version string, catalog Catalog) (string, error) {
+	resolved, err := ResolveRelease(version, catalog)
+	return resolved.Tag, err
+}
+
+// ResolveRelease selects the exact release and source identity named by
+// version. Once discovery knows a full commit SHA or stable tag, every fallback
+// uses that immutable reference rather than the original mutable channel.
+func ResolveRelease(version string, catalog Catalog) (ResolvedRelease, error) {
 	version = strings.TrimSpace(version)
 	switch {
 	case version == "latest":
 		item, err := catalog.Latest()
 		if err != nil {
-			return "", err
+			return ResolvedRelease{}, err
 		}
-		if item.TagName == "" {
-			return "", errors.New("release response did not contain a tag")
-		}
-		return item.TagName, nil
+		return resolvedRelease(item)
 	case IsReleaseTag(version):
-		return version, nil
+		return ResolvedRelease{Tag: version, SourceRef: version}, nil
 	}
 	if channel, sha, canonical := rollingCommit(version); canonical {
 		releases, err := catalog.Releases()
 		if err != nil {
-			return "", err
+			return ResolvedRelease{}, err
 		}
 		sort.SliceStable(releases, func(a, b int) bool { return releases[a].PublishedAt > releases[b].PublishedAt })
 		for _, item := range releases {
 			if !item.Draft && strings.HasPrefix(item.TagName, channel+"-") && strings.EqualFold(item.TargetCommitish, sha) {
-				return item.TagName, nil
+				return ResolvedRelease{Tag: item.TagName, SourceRef: strings.ToLower(sha)}, nil
 			}
 		}
-		return "", fmt.Errorf("no %s installer release found for commit %s", channel, sha)
+		return ResolvedRelease{}, fmt.Errorf("no %s installer release found for commit %s", channel, sha)
 	}
 	channel := version
 	if version == "main" {
 		channel = "canary"
 	}
 	if channel != "canary" && channel != "nightly" {
-		return "", errors.New("custom source ref requires a source build")
+		return ResolvedRelease{}, errors.New("custom source ref requires a source build")
 	}
 	releases, err := catalog.Releases()
 	if err != nil {
-		return "", err
+		return ResolvedRelease{}, err
 	}
 	sort.SliceStable(releases, func(a, b int) bool { return releases[a].PublishedAt > releases[b].PublishedAt })
 	for _, item := range releases {
 		if !item.Draft && strings.HasPrefix(item.TagName, channel+"-") {
-			return item.TagName, nil
+			return resolvedRelease(item)
 		}
 	}
-	return "", fmt.Errorf("no %s installer release found", channel)
+	return ResolvedRelease{}, fmt.Errorf("no %s installer release found", channel)
+}
+
+func resolvedRelease(item Release) (ResolvedRelease, error) {
+	if item.TagName == "" {
+		return ResolvedRelease{}, errors.New("release response did not contain a tag")
+	}
+	ref := strings.ToLower(strings.TrimSpace(item.TargetCommitish))
+	if !fullCommitSHA(ref) {
+		ref = item.TagName
+	}
+	return ResolvedRelease{Tag: item.TagName, SourceRef: ref}, nil
+}
+
+func fullCommitSHA(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, char := range value {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return false
+		}
+	}
+	return true
 }
 
 func IsReleaseTag(version string) bool {

--- a/internal/installbootstrap/release_test.go
+++ b/internal/installbootstrap/release_test.go
@@ -32,7 +32,7 @@ func TestResolveReleaseContract(t *testing.T) {
 	for _, test := range []struct{ version, want string }{
 		{"latest", "v1.2.3"}, {"main", "canary-new"}, {"canary", "canary-new"},
 		{"canary@" + canarySHA, "canary-new"}, {"nightly", "nightly-new"},
-		{"v9.0.0", "v9.0.0"}, {"canary-pinned", "canary-pinned"},
+		{" v9.0.0 ", "v9.0.0"}, {"canary-pinned", "canary-pinned"},
 	} {
 		got, err := Resolve(test.version, catalog)
 		if err != nil || got != test.want {
@@ -44,6 +44,12 @@ func TestResolveReleaseContract(t *testing.T) {
 	}
 	if _, err := Resolve("nightly@cccccccccccccccccccccccccccccccccccccccc", catalog); err == nil {
 		t.Fatal("unpublished canonical commit resolved as a release")
+	}
+	if _, err := Resolve("nightly-20260812-deadbee@cccccccccccccccccccccccccccccccccccccccc", catalog); err == nil {
+		t.Fatal("tag plus unverified commit suffix bypassed release resolution")
+	}
+	if IsReleaseTag("canary-deadbee@cccccccccccccccccccccccccccccccccccccccc") {
+		t.Fatal("release tag accepted an appended commit identity")
 	}
 }
 

--- a/internal/installbootstrap/release_test.go
+++ b/internal/installbootstrap/release_test.go
@@ -51,6 +51,18 @@ func TestResolveReleaseContract(t *testing.T) {
 	if IsReleaseTag("canary-deadbee@cccccccccccccccccccccccccccccccccccccccc") {
 		t.Fatal("release tag accepted an appended commit identity")
 	}
+	resolved, err := ResolveRelease("canary@"+canarySHA, catalog)
+	if err != nil || resolved.Tag != "canary-new" || resolved.SourceRef != canarySHA {
+		t.Fatalf("ResolveRelease canonical = %+v, %v", resolved, err)
+	}
+	resolved, err = ResolveRelease("main", catalog)
+	if err != nil || resolved.Tag != "canary-new" || resolved.SourceRef != canarySHA {
+		t.Fatalf("ResolveRelease channel = %+v, %v", resolved, err)
+	}
+	resolved, err = ResolveRelease("v9.0.0", catalog)
+	if err != nil || resolved.Tag != "v9.0.0" || resolved.SourceRef != "v9.0.0" {
+		t.Fatalf("ResolveRelease stable = %+v, %v", resolved, err)
+	}
 }
 
 func TestAssetAndChecksumContract(t *testing.T) {

--- a/internal/installbootstrap/release_test.go
+++ b/internal/installbootstrap/release_test.go
@@ -19,17 +19,20 @@ func (catalog memoryCatalog) Releases() ([]Release, error) {
 }
 
 func TestResolveReleaseContract(t *testing.T) {
+	const canarySHA = "deadbee123456789012345678901234567890123"
 	catalog := memoryCatalog{
 		latest: Release{TagName: "v1.2.3"},
 		releases: []Release{
-			{TagName: "canary-old", PublishedAt: "2026-08-01T00:00:00Z"},
-			{TagName: "nightly-new", PublishedAt: "2026-08-04T00:00:00Z"},
-			{TagName: "canary-new", PublishedAt: "2026-08-03T00:00:00Z"},
+			{TagName: "canary-draft", TargetCommitish: canarySHA, PublishedAt: "2026-08-05T00:00:00Z", Draft: true},
+			{TagName: "canary-old", TargetCommitish: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", PublishedAt: "2026-08-01T00:00:00Z"},
+			{TagName: "nightly-new", TargetCommitish: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", PublishedAt: "2026-08-04T00:00:00Z"},
+			{TagName: "canary-new", TargetCommitish: canarySHA, PublishedAt: "2026-08-03T00:00:00Z"},
 		},
 	}
 	for _, test := range []struct{ version, want string }{
 		{"latest", "v1.2.3"}, {"main", "canary-new"}, {"canary", "canary-new"},
-		{"nightly", "nightly-new"}, {"v9.0.0", "v9.0.0"}, {"canary-pinned", "canary-pinned"},
+		{"canary@" + canarySHA, "canary-new"}, {"nightly", "nightly-new"},
+		{"v9.0.0", "v9.0.0"}, {"canary-pinned", "canary-pinned"},
 	} {
 		got, err := Resolve(test.version, catalog)
 		if err != nil || got != test.want {
@@ -38,6 +41,9 @@ func TestResolveReleaseContract(t *testing.T) {
 	}
 	if _, err := Resolve("feature/ref", catalog); err == nil {
 		t.Fatal("custom source ref resolved as a release")
+	}
+	if _, err := Resolve("nightly@cccccccccccccccccccccccccccccccccccccccc", catalog); err == nil {
+		t.Fatal("unpublished canonical commit resolved as a release")
 	}
 }
 

--- a/plugin/contracts_test.go
+++ b/plugin/contracts_test.go
@@ -64,6 +64,9 @@ func TestTypedContractRequiredOptionalAndMany(t *testing.T) {
 	if err := rt.Close(); err != nil {
 		t.Fatal(err)
 	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	if err := ref.With(func([]int) error { return nil }); !errors.Is(err, wago.ErrPermissionDenied) {
 		t.Fatalf("after close=%v", err)
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4002,6 +4002,15 @@ func (in *Instance) InvokeContext(ctx context.Context, export string, args ...ui
 }
 
 func (in *Instance) invoke(export string, args []uint64, cancel context.Context) ([]uint64, error) {
+	return in.invokeEntry(export, args, cancel, false)
+}
+
+func (in *Instance) invokeAdmitted(export string, args []uint64, cancel context.Context, reservation *pluginOperationReservation) ([]uint64, error) {
+	state := in.ensurePluginState()
+	return in.invokeWithToken(export, args, cancel, state.invocationID, true, true, reservation)
+}
+
+func (in *Instance) invokeEntry(export string, args []uint64, cancel context.Context, alreadyAdmitted bool) ([]uint64, error) {
 	// Close hooks run after the invocation gate is published and may probe that
 	// later calls fail closed. Check the gate before waiting for the per-instance
 	// serialization lock so such a probe cannot deadlock behind the activation
@@ -4018,10 +4027,10 @@ func (in *Instance) invoke(export string, args []uint64, cancel context.Context)
 		state.invocationID = 0
 		state.invokeMu.Unlock()
 	}()
-	return in.invokeWithToken(export, args, cancel, id, true)
+	return in.invokeWithToken(export, args, cancel, id, true, alreadyAdmitted, nil)
 }
 
-func (in *Instance) invokeWithToken(export string, args []uint64, cancel context.Context, id invocationID, gateHeld bool) ([]uint64, error) {
+func (in *Instance) invokeWithToken(export string, args []uint64, cancel context.Context, id invocationID, gateHeld, alreadyAdmitted bool, reservation *pluginOperationReservation) ([]uint64, error) {
 	reentry := !gateHeld && isNativeActive(in, id)
 	if !reentry && !gateHeld {
 		state := in.ensurePluginState()
@@ -4039,10 +4048,14 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 		}
 		defer restore()
 	}
-	if err := in.beginInvocation(); err != nil {
-		return nil, fmt.Errorf("invoke %q: %w", export, err)
+	if !alreadyAdmitted {
+		if err := in.beginInvocation(); err != nil {
+			return nil, fmt.Errorf("invoke %q: %w", export, err)
+		}
+		defer in.endInvocation()
 	}
-	defer in.endInvocation()
+	previousReservation := in.swapInvocationReservation(reservation)
+	defer in.swapInvocationReservation(previousReservation)
 	if threadedMu := in.lockThreadedInstanceState(); threadedMu != nil {
 		defer threadedMu.Unlock()
 	}

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -485,6 +485,10 @@ func (c *RuntimeConfig) DeferBoundsChecks() bool { return !c.noDeferBounds }
 // MemoryLimitPages reports the configured maximum linear-memory size in pages.
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }
 
+// GCCodeTelemetry reports whether fresh compilation should retain code-neutral
+// WasmGC native-byte attribution. Serialized artifacts do not contain it.
+func (c *RuntimeConfig) GCCodeTelemetry() bool { return c.gcCodeTelemetry }
+
 // FunctionWorkers reports the configured function-pipeline worker policy: zero
 // adaptive, one serial, or a positive forced maximum.
 func (c *RuntimeConfig) FunctionWorkers() int { return c.functionWorkers }

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -475,6 +475,15 @@ func (c *RuntimeConfig) optimizationValues() map[string]bool {
 	return values
 }
 
+func (c *RuntimeConfig) clone() *RuntimeConfig {
+	if c == nil {
+		return NewRuntimeConfig()
+	}
+	clone := *c
+	clone.optimizations = c.optimizationValues()
+	return &clone
+}
+
 // BoundsChecks reports the configured bounds-check mode.
 func (c *RuntimeConfig) BoundsChecks() BoundsCheckMode { return c.boundsChecks }
 

--- a/src/wago/extension.go
+++ b/src/wago/extension.go
@@ -274,6 +274,7 @@ const (
 	ErrMissingImport         = pluginErr("wago: missing import")
 	ErrInvalidHandle         = pluginErr("wago: invalid handle")
 	ErrPluginConflict        = pluginErr("wago: plugin conflict")
+	ErrForeignModule         = pluginErr("wago: module belongs to a different runtime")
 )
 
 // DefinitionDigest returns the lowercase SHA-256 of the canonical JSON form of

--- a/src/wago/extension.go
+++ b/src/wago/extension.go
@@ -270,6 +270,7 @@ func (e pluginErr) Error() string { return string(e) }
 
 const (
 	ErrPermissionDenied      = pluginErr("wago: permission denied")
+	ErrCallbackPanic         = pluginErr("wago: callback panicked")
 	ErrManagedImportLifetime = pluginErr("wago: managed instance cannot inherit a borrowed import")
 	ErrMissingImport         = pluginErr("wago: missing import")
 	ErrInvalidHandle         = pluginErr("wago: invalid handle")

--- a/src/wago/externref.go
+++ b/src/wago/externref.go
@@ -63,7 +63,7 @@ func (in *Instance) ExternRefValue(ref ExternRef) (any, bool) {
 	if ref.IsNull() {
 		return nil, true
 	}
-	if in == nil || in.refStore == nil {
+	if in == nil || in.refStore == nil || in.rt != nil && in.rt.isClosed() {
 		return nil, false
 	}
 	return in.refStore.resolveExternref(ref.token)

--- a/src/wago/externref_test.go
+++ b/src/wago/externref_test.go
@@ -302,6 +302,9 @@ func TestExternrefGenerationAndStoreTeardown(t *testing.T) {
 	if err := rt.Close(); err != nil {
 		t.Fatalf("Runtime.Close: %v", err)
 	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatalf("Runtime.WaitClosed: %v", err)
+	}
 	if len(rt.refStore.externrefs) != 0 || rt.refStore.externKey != 0 {
 		t.Fatalf("closed runtime retained externrefs: slots=%d key=%#x", len(rt.refStore.externrefs), rt.refStore.externKey)
 	}

--- a/src/wago/failed_global_transfer_test.go
+++ b/src/wago/failed_global_transfer_test.go
@@ -158,6 +158,7 @@ func TestFailedInstantiationTransfersImportedGlobalRoots(t *testing.T) {
 		_ = global.Close()
 		_ = producer.Close()
 		_ = rt.Close()
+		_ = rt.WaitClosed(context.Background())
 		if !root.resourcesClosed {
 			t.Fatal("producer remained live after container and token roots were released")
 		}

--- a/src/wago/failed_instantiation_reference_store_test.go
+++ b/src/wago/failed_instantiation_reference_store_test.go
@@ -45,8 +45,8 @@ func TestFailedInstantiationTerminatesReferenceStoreRegistration(t *testing.T) {
 	}
 	rt.refStore.mu.Unlock()
 
-	if err := rt.Close(); err != nil {
-		t.Fatalf("Runtime.Close: %v", err)
+	if err := rt.CloseContext(context.Background()); err != nil {
+		t.Fatalf("Runtime.CloseContext: %v", err)
 	}
 	rt.refStore.mu.Lock()
 	defer rt.refStore.mu.Unlock()

--- a/src/wago/global_overwrite_retention_test.go
+++ b/src/wago/global_overwrite_retention_test.go
@@ -128,6 +128,7 @@ func TestGlobalOverwriteReplacesProducerAndBoundsRepeatedWrites(t *testing.T) {
 	_ = producerB.Close()
 	_ = global.Close()
 	_ = rt.Close()
+	_ = rt.WaitClosed(context.Background())
 	assertRetainedInstanceState(t, "producer A after store teardown", producerA, 0, false)
 	assertRetainedInstanceState(t, "producer B after store teardown", producerB, 0, false)
 }
@@ -174,6 +175,7 @@ func TestGlobalOverwriteRacesCloseWithoutDoubleRelease(t *testing.T) {
 		}
 		_ = producer.Close()
 		_ = rt.Close()
+		_ = rt.WaitClosed(context.Background())
 		assertRetainedInstanceState(t, "racing producer teardown", producer, 0, false)
 	}
 }

--- a/src/wago/global_synchronization_test.go
+++ b/src/wago/global_synchronization_test.go
@@ -269,7 +269,9 @@ func TestGlobalSynchronizationFuncrefReplacementVersusGuestCall(t *testing.T) {
 	_ = producerA.Close()
 	_ = producerB.Close()
 	_ = global.Close()
-	_ = rt.Close()
+	if err := rt.CloseContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	assertRetainedInstanceState(t, "funcref producer A teardown", producerA, 0, false)
 	assertRetainedInstanceState(t, "funcref producer B teardown", producerB, 0, false)
 }

--- a/src/wago/hooks.go
+++ b/src/wago/hooks.go
@@ -8,6 +8,7 @@ import (
 )
 
 type hookRegistry struct {
+	operationGates      []*pluginCallGate
 	onRuntimeClose      []func(RuntimeCloseEvent)
 	internalClose       []func() error
 	internalBeforeClose []func(*Instance)
@@ -112,18 +113,21 @@ type ModuleCompileErrorEvent struct {
 }
 type ModuleCloseEvent struct{ Module ModuleView }
 type InstantiationRequest struct {
-	Module ModuleView
-	Origin InstantiateOrigin
+	Module      ModuleView
+	Origin      InstantiateOrigin
+	reservation *pluginOperationReservation
 }
 type InstantiationEvent struct {
-	Module   ModuleView
-	Instance InstanceIdentity
-	Origin   InstantiateOrigin
+	Module      ModuleView
+	Instance    InstanceIdentity
+	Origin      InstantiateOrigin
+	reservation *pluginOperationReservation
 }
 type InstantiationErrorEvent struct {
-	Module ModuleView
-	Origin InstantiateOrigin
-	Err    error
+	Module      ModuleView
+	Origin      InstantiateOrigin
+	Err         error
+	reservation *pluginOperationReservation
 }
 type InstanceCloseEvent struct {
 	Module   ModuleView
@@ -134,19 +138,21 @@ type operationIdentityToken struct{ _ byte }
 type OperationIdentity struct{ value *operationIdentityToken }
 
 type InvocationRequest struct {
-	Operation OperationIdentity
-	Instance  InstanceIdentity
-	Export    string
-	Args      []Value
-	Start     time.Time
+	Operation   OperationIdentity
+	Instance    InstanceIdentity
+	Export      string
+	Args        []Value
+	Start       time.Time
+	reservation *pluginOperationReservation
 }
 type InvocationEvent struct {
-	Operation OperationIdentity
-	Instance  InstanceIdentity
-	Export    string
-	Results   []Value
-	Err       error
-	Start     time.Time
+	Operation   OperationIdentity
+	Instance    InstanceIdentity
+	Export      string
+	Results     []Value
+	Err         error
+	Start       time.Time
+	reservation *pluginOperationReservation
 }
 
 type InstantiateOrigin uint8
@@ -161,6 +167,7 @@ func (h *hookRegistry) clone() *hookRegistry {
 		return &hookRegistry{}
 	}
 	return &hookRegistry{
+		operationGates:      append([]*pluginCallGate(nil), h.operationGates...),
 		onRuntimeClose:      append([]func(RuntimeCloseEvent){}, h.onRuntimeClose...),
 		internalClose:       append([]func() error{}, h.internalClose...),
 		internalBeforeClose: append([]func(*Instance){}, h.internalBeforeClose...),
@@ -183,6 +190,7 @@ func (h *hookRegistry) appendGated(src *hookRegistry, gate *pluginCallGate) {
 	if src == nil {
 		return
 	}
+	h.operationGates = append(h.operationGates, gate)
 	for _, fn := range src.onRuntimeClose {
 		fn := fn
 		h.onRuntimeClose = append(h.onRuntimeClose, func(event RuntimeCloseEvent) { withPluginHook(gate, func() { fn(event) }) })
@@ -209,22 +217,24 @@ func (h *hookRegistry) appendGated(src *hookRegistry, gate *pluginCallGate) {
 	for _, fn := range src.beforeInstantiate {
 		fn := fn
 		h.beforeInstantiate = append(h.beforeInstantiate, func(request InstantiationRequest) error {
-			return withPluginHookError(gate, func() error { return fn(request) })
+			return withReservedPluginHookError(gate, request.reservation, func() error { return fn(request) })
 		})
 	}
 	for _, fn := range src.afterCreate {
 		fn := fn
 		h.afterCreate = append(h.afterCreate, func(event InstantiationEvent) error {
-			return withPluginHookError(gate, func() error { return fn(event) })
+			return withReservedPluginHookError(gate, event.reservation, func() error { return fn(event) })
 		})
 	}
 	for _, fn := range src.afterInstantiate {
 		fn := fn
-		h.afterInstantiate = append(h.afterInstantiate, func(event InstantiationEvent) { withPluginHook(gate, func() { fn(event) }) })
+		h.afterInstantiate = append(h.afterInstantiate, func(event InstantiationEvent) { withReservedPluginHook(gate, event.reservation, func() { fn(event) }) })
 	}
 	for _, fn := range src.onInstantiateError {
 		fn := fn
-		h.onInstantiateError = append(h.onInstantiateError, func(event InstantiationErrorEvent) { withPluginHook(gate, func() { fn(event) }) })
+		h.onInstantiateError = append(h.onInstantiateError, func(event InstantiationErrorEvent) {
+			withReservedPluginHook(gate, event.reservation, func() { fn(event) })
+		})
 	}
 	for _, fn := range src.beforeClose {
 		fn := fn
@@ -237,12 +247,12 @@ func (h *hookRegistry) appendGated(src *hookRegistry, gate *pluginCallGate) {
 	for _, fn := range src.beforeInvoke {
 		fn := fn
 		h.beforeInvoke = append(h.beforeInvoke, func(request InvocationRequest) error {
-			return withPluginHookError(gate, func() error { return fn(request) })
+			return withReservedPluginHookError(gate, request.reservation, func() error { return fn(request) })
 		})
 	}
 	for _, fn := range src.afterInvoke {
 		fn := fn
-		h.afterInvoke = append(h.afterInvoke, func(event InvocationEvent) { withPluginHook(gate, func() { fn(event) }) })
+		h.afterInvoke = append(h.afterInvoke, func(event InvocationEvent) { withReservedPluginHook(gate, event.reservation, func() { fn(event) }) })
 	}
 }
 
@@ -262,8 +272,33 @@ func withPluginHookError(gate *pluginCallGate, fn func() error) error {
 	return fn()
 }
 
+func withReservedPluginHook(gate *pluginCallGate, reservation *pluginOperationReservation, fn func()) {
+	if reservation != nil && reservation.allows(gate) {
+		fn()
+		return
+	}
+	withPluginHook(gate, fn)
+}
+
+func withReservedPluginHookError(gate *pluginCallGate, reservation *pluginOperationReservation, fn func() error) error {
+	if reservation != nil && reservation.allows(gate) {
+		return fn()
+	}
+	return withPluginHookError(gate, fn)
+}
+
 func callHookSafely(phase string, fn func()) (err error) {
 	return callSafely(phase+" hook", fn)
+}
+
+func callShutdownSafely(label string, fn func()) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = fmt.Errorf("wago: %s: %w", label, ErrCallbackPanic)
+		}
+	}()
+	fn()
+	return nil
 }
 
 func callSafely(label string, fn func()) (err error) {

--- a/src/wago/hooks.go
+++ b/src/wago/hooks.go
@@ -156,6 +156,29 @@ const (
 	InstantiateManaged
 )
 
+func (h *hookRegistry) clone() *hookRegistry {
+	if h == nil {
+		return &hookRegistry{}
+	}
+	return &hookRegistry{
+		onRuntimeClose:      append([]func(RuntimeCloseEvent){}, h.onRuntimeClose...),
+		internalClose:       append([]func() error{}, h.internalClose...),
+		internalBeforeClose: append([]func(*Instance){}, h.internalBeforeClose...),
+		beforeCompile:       append([]func(ModuleSourceContext, []byte) ([]byte, error){}, h.beforeCompile...),
+		afterCompile:        append([]func(ModuleCompiledEvent){}, h.afterCompile...),
+		onCompileError:      append([]func(ModuleCompileErrorEvent){}, h.onCompileError...),
+		onModuleClose:       append([]func(ModuleCloseEvent){}, h.onModuleClose...),
+		beforeInstantiate:   append([]func(InstantiationRequest) error{}, h.beforeInstantiate...),
+		afterCreate:         append([]func(InstantiationEvent) error{}, h.afterCreate...),
+		afterInstantiate:    append([]func(InstantiationEvent){}, h.afterInstantiate...),
+		onInstantiateError:  append([]func(InstantiationErrorEvent){}, h.onInstantiateError...),
+		beforeClose:         append([]func(InstanceCloseEvent){}, h.beforeClose...),
+		afterClose:          append([]func(InstanceCloseEvent){}, h.afterClose...),
+		beforeInvoke:        append([]func(InvocationRequest) error{}, h.beforeInvoke...),
+		afterInvoke:         append([]func(InvocationEvent){}, h.afterInvoke...),
+	}
+}
+
 func (h *hookRegistry) appendGated(src *hookRegistry, gate *pluginCallGate) {
 	if src == nil {
 		return

--- a/src/wago/hooks_test.go
+++ b/src/wago/hooks_test.go
@@ -373,6 +373,9 @@ func TestCoreRuntimeAccessActivatesAndRevokesWithRuntime(t *testing.T) {
 	if err := rt.Close(); err != nil {
 		t.Fatal(err)
 	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := access.Compile(wasmtest.Module()); !errors.Is(err, ErrPermissionDenied) {
 		t.Fatalf("Compile after close = %v, want permission denied", err)
 	}

--- a/src/wago/host_funcref_global_test.go
+++ b/src/wago/host_funcref_global_test.go
@@ -117,8 +117,8 @@ func TestHostCreatedFuncRefGlobalSharesOwnedTokenAndCallableIdentity(t *testing.
 	if err := caller.Close(); err != nil {
 		t.Fatalf("Close caller: %v", err)
 	}
-	if err := rt.Close(); err != nil {
-		t.Fatalf("Runtime.Close: %v", err)
+	if err := rt.CloseContext(context.Background()); err != nil {
+		t.Fatalf("Runtime.CloseContext: %v", err)
 	}
 	if err := owner.Close(); err != nil {
 		t.Fatalf("Close host owner: %v", err)

--- a/src/wago/host_funcref_owner_test.go
+++ b/src/wago/host_funcref_owner_test.go
@@ -90,7 +90,7 @@ func TestOwnedHostFuncrefEgressRoundTripAndCloseOrdering(t *testing.T) {
 	if err := consumer.Close(); err != nil {
 		t.Fatalf("Close consumer: %v", err)
 	}
-	if err := rt.Close(); err != nil {
+	if err := rt.CloseContext(context.Background()); err != nil {
 		t.Fatalf("Close runtime: %v", err)
 	}
 	if err := owner.Close(); err != nil {

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -31,11 +31,13 @@ type HostModule interface {
 func (in *Instance) InvokeFromHost(ctx context.Context, caller HostModule, export string, args ...uint64) (results []uint64, err error) {
 	var active *Instance
 	var id invocationID
+	var reservation *pluginOperationReservation
 	switch h := caller.(type) {
 	case instanceHostModule:
 		if h.valid() {
 			active = h.in
 			id = h.invocationID
+			reservation = h.reservation
 		}
 	}
 	if active == nil || id == 0 {
@@ -50,7 +52,7 @@ func (in *Instance) InvokeFromHost(ctx context.Context, caller HostModule, expor
 	if nativeCancellationSupported() && ctx != nil && ctx.Done() != nil {
 		cancel = ctx
 	}
-	results, err = in.invokeWithToken(export, args, cancel, id, false)
+	results, err = in.invokeWithToken(export, args, cancel, id, false, false, reservation)
 	return results, contextInterruptError(ctx, err)
 }
 
@@ -153,11 +155,15 @@ type instancePluginState struct {
 }
 
 type instanceCloseState struct {
-	done          chan struct{}
-	quiesced      chan struct{}
-	quiescedOnce  sync.Once
-	result        error
-	interruptStop func()
+	done           chan struct{}
+	quiesced       chan struct{}
+	quiescedOnce   sync.Once
+	result         error
+	interruptStop  func()
+	hooks          *hookRegistry
+	event          *InstanceCloseEvent
+	terminalOnce   sync.Once
+	terminalResult error
 }
 
 func (in *Instance) instantiateOrigin() InstantiateOrigin {
@@ -168,10 +174,14 @@ func (in *Instance) instantiateOrigin() InstantiateOrigin {
 }
 
 func (s *hostCallScope) begin(in *Instance) instanceHostModule {
+	return s.beginReserved(in, currentInvocationReservation(in))
+}
+
+func (s *hostCallScope) beginReserved(in *Instance, reservation *pluginOperationReservation) instanceHostModule {
 	parent := s.active.Load()
 	generation := uint64(newInvocationID())
 	s.active.Store(generation)
-	return instanceHostModule{in: in, scope: s, generation: generation, parentGeneration: parent, invocationID: in.currentInvocationID()}
+	return instanceHostModule{in: in, scope: s, generation: generation, parentGeneration: parent, invocationID: in.currentInvocationID(), reservation: reservation}
 }
 
 func (s *hostCallScope) end(generation, parent uint64) {
@@ -200,7 +210,11 @@ func (in *Instance) ensurePluginState() *instancePluginState {
 }
 
 func (in *Instance) beginHostCallScope() instanceHostModule {
-	return in.ensurePluginState().hostScope.begin(in)
+	return in.beginHostCallScopeReserved(currentInvocationReservation(in))
+}
+
+func (in *Instance) beginHostCallScopeReserved(reservation *pluginOperationReservation) instanceHostModule {
+	return in.ensurePluginState().hostScope.beginReserved(in, reservation)
 }
 
 func (in *Instance) currentInvocationID() invocationID {
@@ -555,6 +569,7 @@ type instanceHostModule struct {
 	generation       uint64
 	parentGeneration uint64
 	invocationID     invocationID
+	reservation      *pluginOperationReservation
 }
 
 func (h instanceHostModule) valid() bool {

--- a/src/wago/instance.go
+++ b/src/wago/instance.go
@@ -21,48 +21,50 @@ func offHeapPtr(addr uintptr) unsafe.Pointer {
 
 // Instance is ready for repeated Invoke calls.
 type Instance struct {
-	c                      *Compiled
-	eng                    *runtime.Engine
-	jm                     *runtime.JobMemory
-	memory                 *Memory // the memory object (owned or host-imported)
-	ar                     *runtime.Arena
-	base                   uintptr
-	hosts                  map[string]HostFunc
-	imports                Imports // the imports as provided to Instantiate
-	hostLog                []byte
-	ctrl                   []byte                              // sync host-call control frame (nil in async mode)
-	syncHosts              []HostFunc                          // per import-func-index host, sync mode only
-	hostCall               runtime.HostCall                    // active instance's bound host imports
-	pluginState            atomic.Pointer[instancePluginState] // allocated only after privileged instance services activate
-	globals                []byte                              // pointer table handed to JIT code
-	globalCells            []*Global
-	table                  *Table        // lazily created importer-owned local export-handle chain
-	tableDescPtr           uintptr       // local/imported descriptor address; arena/table ownership keeps it live
-	tableDescLen           int           // descriptor byte length for safe slice reconstruction
-	funcRefDescs           []byte        // canonical funcref descriptor handles for this instance's function index space
-	passiveDataDesc        []byte        // per-instance data-segment descriptors; active slots start dropped
-	thunkMem               []byte        // executable mapping for host-func-in-table log thunks (nil if none)
-	gc                     *gc.Collector // nil for modules with no Wasm GC descriptors/runtime use
-	gcTypeMap              *gcTypeMapping
-	gcNativeView           *gc.NativeInstanceView
-	serArgs, results, trap []byte
-	resultVals             []uint64       // reusable Invoke result buffer (valid until the next call)
-	ic                     [4]invokeCache // tiny fixed export resolution cache
-	icNext                 uint8          // round-robin replacement cursor
-	refStore               *referenceStore
-	lifeMu                 sync.Mutex
-	resourceRefs           int
-	invocationState        atomic.Uint32 // high bit closes entry; low bits count active public invocations
-	closed                 bool          // logical close; retained references may defer physical release
-	finalizing             bool          // one goroutine owns quiescent finalization
-	resourcesClosed        bool
-	physicalFinalizer      func()
-	ownsMem                bool                     // false when memory 0 is host-imported (don't close it)
-	memoryDir              *instanceMemoryDirectory // allocated only for indexed memory execution
-	syncMode               bool                     // true when host imports use the synchronous re-entry protocol
-	executionFlags         atomic.Uint32            // independent eligibility and cross-instance native-control sharing
-	nativeContext          uintptr                  // arena-backed context bytes rebound before every native entry
-	instructionState       instructionState
+	c                       *Compiled
+	eng                     *runtime.Engine
+	jm                      *runtime.JobMemory
+	memory                  *Memory // the memory object (owned or host-imported)
+	ar                      *runtime.Arena
+	base                    uintptr
+	hosts                   map[string]HostFunc
+	imports                 Imports // the imports as provided to Instantiate
+	hostLog                 []byte
+	ctrl                    []byte                              // sync host-call control frame (nil in async mode)
+	syncHosts               []HostFunc                          // per import-func-index host, sync mode only
+	hostCall                runtime.HostCall                    // active instance's bound host imports
+	pluginState             atomic.Pointer[instancePluginState] // allocated only after privileged instance services activate
+	globals                 []byte                              // pointer table handed to JIT code
+	globalCells             []*Global
+	table                   *Table        // lazily created importer-owned local export-handle chain
+	tableDescPtr            uintptr       // local/imported descriptor address; arena/table ownership keeps it live
+	tableDescLen            int           // descriptor byte length for safe slice reconstruction
+	funcRefDescs            []byte        // canonical funcref descriptor handles for this instance's function index space
+	passiveDataDesc         []byte        // per-instance data-segment descriptors; active slots start dropped
+	thunkMem                []byte        // executable mapping for host-func-in-table log thunks (nil if none)
+	gc                      *gc.Collector // nil for modules with no Wasm GC descriptors/runtime use
+	gcTypeMap               *gcTypeMapping
+	gcNativeView            *gc.NativeInstanceView
+	serArgs, results, trap  []byte
+	resultVals              []uint64       // reusable Invoke result buffer (valid until the next call)
+	ic                      [4]invokeCache // tiny fixed export resolution cache
+	icNext                  uint8          // round-robin replacement cursor
+	refStore                *referenceStore
+	lifeMu                  sync.Mutex
+	resourceRefs            int
+	invocationState         atomic.Uint32 // high bit closes entry; low bits count active public invocations
+	closed                  bool          // logical close; retained references may defer physical release
+	finalizing              bool          // one goroutine owns quiescent finalization
+	resourcesClosed         bool
+	physicalFinalizer       func()
+	ownsMem                 bool                     // false when memory 0 is host-imported (don't close it)
+	memoryDir               *instanceMemoryDirectory // allocated only for indexed memory execution
+	syncMode                bool                     // true when host imports use the synchronous re-entry protocol
+	constructionActive      bool                     // registration through terminal instantiation observation
+	constructionReservation *pluginOperationReservation
+	executionFlags          atomic.Uint32 // independent eligibility and cross-instance native-control sharing
+	nativeContext           uintptr       // arena-backed context bytes rebound before every native entry
+	instructionState        instructionState
 
 	// rt is set when the instance is created through Runtime.Instantiate, so
 	// Instance.Call and Instance.Close can fire lifecycle hooks. It is nil for

--- a/src/wago/instance_call.go
+++ b/src/wago/instance_call.go
@@ -21,6 +21,17 @@ import (
 // by compiler feature support. v128
 // parameters/results are not expressible as a Value; use Invoke for those.
 func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]Value, error) {
+	if err := in.beginInvocation(); err != nil {
+		return nil, fmt.Errorf("call %q: %w", export, err)
+	}
+	defer in.endInvocation()
+	state := in.ensurePluginState()
+	state.invokeMu.Lock()
+	state.invocationID = newInvocationID()
+	defer func() {
+		state.invocationID = 0
+		state.invokeMu.Unlock()
+	}()
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -53,18 +64,24 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 		cancel = ctx
 	}
 
-	// Fast path: no runtime or no invoke hooks — invoke directly, zero overhead.
+	// Fast path: no runtime or no invoke hooks — invoke directly under the one
+	// already-admitted invocation lease, with no plugin reservation allocation.
 	if in.rt == nil {
-		out, err := in.callInner(export, slots, results, cancel)
+		out, err := in.callInnerAdmitted(export, slots, results, cancel, nil)
 		return out, contextInterruptError(ctx, err)
 	}
 	hooks := in.rt.loadHooks()
 	if len(hooks.beforeInvoke) == 0 && len(hooks.afterInvoke) == 0 {
-		out, err := in.callInner(export, slots, results, cancel)
+		out, err := in.callInnerAdmitted(export, slots, results, cancel, nil)
 		return out, contextInterruptError(ctx, err)
 	}
+	reservation, err := reservePluginOperation(hooks.operationGates)
+	if err != nil {
+		return nil, err
+	}
+	defer reservation.release()
 
-	request := InvocationRequest{Operation: OperationIdentity{value: &operationIdentityToken{}}, Instance: InstanceIdentity{value: in}, Export: export, Args: append([]Value(nil), args...), Start: time.Now()}
+	request := InvocationRequest{Operation: OperationIdentity{value: &operationIdentityToken{}}, Instance: InstanceIdentity{value: in}, Export: export, Args: append([]Value(nil), args...), Start: time.Now(), reservation: reservation}
 	emitAfter := func(event InvocationEvent) error {
 		var hookErrs []error
 		for _, fn := range hooks.afterInvoke {
@@ -86,12 +103,12 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 		if err := joinPrimary(interceptErr, panicErr); err != nil {
 			// A BeforeInvoke veto aborts the call; report it to AfterInvoke too so
 			// paired hooks can unwind.
-			return nil, joinPrimary(err, emitAfter(InvocationEvent{Operation: request.Operation, Instance: request.Instance, Export: export, Err: err, Start: request.Start}))
+			return nil, joinPrimary(err, emitAfter(InvocationEvent{Operation: request.Operation, Instance: request.Instance, Export: export, Err: err, Start: request.Start, reservation: reservation}))
 		}
 	}
-	out, err := in.callInner(export, slots, results, cancel)
+	out, err := in.callInnerAdmitted(export, slots, results, cancel, reservation)
 	err = contextInterruptError(ctx, err)
-	err = joinPrimary(err, emitAfter(InvocationEvent{Operation: request.Operation, Instance: request.Instance, Export: export, Results: out, Err: err, Start: request.Start}))
+	err = joinPrimary(err, emitAfter(InvocationEvent{Operation: request.Operation, Instance: request.Instance, Export: export, Results: out, Err: err, Start: request.Start, reservation: reservation}))
 	return out, err
 }
 
@@ -111,9 +128,10 @@ func contextInterruptError(ctx context.Context, err error) error {
 	return err
 }
 
-// callInner performs the actual invocation and result decoding.
-func (in *Instance) callInner(export string, slots []uint64, results []ValType, cancel context.Context) ([]Value, error) {
-	raw, err := in.invoke(export, slots, cancel)
+// callInnerAdmitted performs the actual invocation and result decoding under
+// the invocation lease already held by Call.
+func (in *Instance) callInnerAdmitted(export string, slots []uint64, results []ValType, cancel context.Context, reservation *pluginOperationReservation) ([]Value, error) {
+	raw, err := in.invokeAdmitted(export, slots, cancel, reservation)
 	if err != nil {
 		return nil, err
 	}

--- a/src/wago/instance_call.go
+++ b/src/wago/instance_call.go
@@ -54,7 +54,12 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 	}
 
 	// Fast path: no runtime or no invoke hooks — invoke directly, zero overhead.
-	if in.rt == nil || (len(in.rt.hooks.beforeInvoke) == 0 && len(in.rt.hooks.afterInvoke) == 0) {
+	if in.rt == nil {
+		out, err := in.callInner(export, slots, results, cancel)
+		return out, contextInterruptError(ctx, err)
+	}
+	hooks := in.rt.loadHooks()
+	if len(hooks.beforeInvoke) == 0 && len(hooks.afterInvoke) == 0 {
 		out, err := in.callInner(export, slots, results, cancel)
 		return out, contextInterruptError(ctx, err)
 	}
@@ -62,7 +67,7 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 	request := InvocationRequest{Operation: OperationIdentity{value: &operationIdentityToken{}}, Instance: InstanceIdentity{value: in}, Export: export, Args: append([]Value(nil), args...), Start: time.Now()}
 	emitAfter := func(event InvocationEvent) error {
 		var hookErrs []error
-		for _, fn := range in.rt.hooks.afterInvoke {
+		for _, fn := range hooks.afterInvoke {
 			observer := fn
 			copyEvent := event
 			copyEvent.Results = append([]Value(nil), event.Results...)
@@ -72,7 +77,7 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 		}
 		return errors.Join(hookErrs...)
 	}
-	for _, fn := range in.rt.hooks.beforeInvoke {
+	for _, fn := range hooks.beforeInvoke {
 		interceptor := fn
 		copyRequest := request
 		copyRequest.Args = append([]Value(nil), request.Args...)

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -24,16 +24,19 @@ func (in *Instance) Close() (err error) {
 	}
 	state, owner := in.beginClose()
 	if !owner {
-		<-state.done
-		return state.result
+		select {
+		case <-state.done:
+			return state.result
+		default:
+			// A callback may reenter Close while the lifecycle owner is still
+			// active. Returning promptly avoids self-deadlock; external callers
+			// that need completion use closeAndWait or Runtime.WaitClosed.
+			return nil
+		}
 	}
 	defer func() {
-		if recovered := recover(); recovered != nil {
-			if panicErr, ok := recovered.(error); ok {
-				err = joinPrimary(err, fmt.Errorf("wago: instance close panicked: %w", panicErr))
-			} else {
-				err = joinPrimary(err, fmt.Errorf("wago: instance close panicked: %v", recovered))
-			}
+		if recover() != nil {
+			err = joinPrimary(err, fmt.Errorf("wago: instance close: %w", ErrCallbackPanic))
 		}
 		state.result = err
 		close(state.done)
@@ -56,7 +59,7 @@ func (in *Instance) beginClose() (*instanceCloseState, bool) {
 func (in *Instance) closeOnce() error {
 	var errs []error
 	appendStep := func(phase string, fn func()) {
-		if err := callHookSafely(phase, fn); err != nil {
+		if err := callShutdownSafely(phase, fn); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -93,6 +96,8 @@ func (in *Instance) closeOnce() error {
 	if hooks != nil && (len(hooks.beforeClose) != 0 || len(hooks.afterClose) != 0) {
 		event := InstanceCloseEvent{Module: ModuleView{compiled: in.c, identity: in.moduleIdentity}, Instance: InstanceIdentity{value: in}, Origin: in.instantiateOrigin()}
 		closeEvent = &event
+		closeState := in.ensurePluginState().close.Load()
+		closeState.hooks, closeState.event = hooks, closeEvent
 		for i := len(hooks.beforeClose) - 1; i >= 0; i-- {
 			fn := hooks.beforeClose[i]
 			appendStep("BeforeClose", func() { fn(*closeEvent) })
@@ -100,9 +105,9 @@ func (in *Instance) closeOnce() error {
 	}
 
 	// An activation parked in host code may have resumed and mutated an imported
-	// table/global while hooks ran. Root transfer is therefore deferred to
-	// tryFinalize after the active count reaches zero. closed enables that final
-	// transition only after BeforeClose is completely finished.
+	// table/global while hooks ran. Mark logical closure now, but defer terminal
+	// disposal observation and physical release until every admitted invocation
+	// and the construction lifecycle have quiesced.
 	in.lifeMu.Lock()
 	in.closed = true
 	store := in.refStore
@@ -110,12 +115,6 @@ func (in *Instance) closeOnce() error {
 
 	appendStep("close reference store instance", func() { in.referenceLifetime().notifyStore(store, referenceLifetimeClosed) })
 	appendStep("finalize instance resources", in.tryFinalize)
-	if closeEvent != nil {
-		for i := len(hooks.afterClose) - 1; i >= 0; i-- {
-			fn := hooks.afterClose[i]
-			appendStep("AfterClose", func() { fn(*closeEvent) })
-		}
-	}
 	return errors.Join(errs...)
 }
 
@@ -127,12 +126,15 @@ func (in *Instance) closeAndWait() error {
 	if in == nil {
 		return nil
 	}
-	err := in.Close()
+	if err := in.Close(); err != nil {
+		return err
+	}
 	state := in.ensurePluginState().close.Load()
 	if state != nil {
 		<-state.quiesced
+		return joinPrimary(state.result, state.terminalResult)
 	}
-	return err
+	return nil
 }
 
 func (in *Instance) isLogicallyClosed() bool {
@@ -155,6 +157,25 @@ func (in *Instance) beginInvocation() error {
 	if in == nil {
 		return fmt.Errorf("instance is nil")
 	}
+	if in.rt != nil {
+		in.rt.mu.Lock()
+		if in.rt.state == runtimeClosed || in.rt.state == runtimeClosing && in.instantiateOrigin() != InstantiateManaged {
+			in.rt.mu.Unlock()
+			return fmt.Errorf("instance runtime is closed")
+		}
+		in.rt.activeOperations++
+		in.rt.mu.Unlock()
+	}
+	admitted := false
+	defer func() {
+		if admitted || in.rt == nil {
+			return
+		}
+		in.rt.mu.Lock()
+		in.rt.activeOperations--
+		in.rt.stateCond.Broadcast()
+		in.rt.mu.Unlock()
+	}()
 	for {
 		state := in.invocationState.Load()
 		if state&instanceInvocationClosed != 0 {
@@ -164,6 +185,7 @@ func (in *Instance) beginInvocation() error {
 			return fmt.Errorf("instance has too many active invocations")
 		}
 		if in.invocationState.CompareAndSwap(state, state+1) {
+			admitted = true
 			return nil
 		}
 	}
@@ -182,6 +204,16 @@ func (in *Instance) endInvocation() {
 		if !in.invocationState.CompareAndSwap(state, next) {
 			continue
 		}
+		if in.rt != nil {
+			in.rt.mu.Lock()
+			if in.rt.activeOperations == 0 {
+				in.rt.mu.Unlock()
+				panic("wago: runtime invocation operation underflow")
+			}
+			in.rt.activeOperations--
+			in.rt.stateCond.Broadcast()
+			in.rt.mu.Unlock()
+		}
 		if next == instanceInvocationClosed {
 			if closeState := in.ensurePluginState().close.Load(); closeState != nil {
 				closeState.quiescedOnce.Do(func() { close(closeState.quiesced) })
@@ -195,12 +227,74 @@ func (in *Instance) endInvocation() {
 // tryFinalize delegates the reference-lifetime transition. Keeping this small
 // call point lets resource-root and invocation paths remain direct.
 func (in *Instance) tryFinalize() {
-	if in != nil && in.invocationState.Load()&instanceInvocationClosed != 0 && in.invocationState.Load()&instanceInvocationCount == 0 {
-		if closeState := in.ensurePluginState().close.Load(); closeState != nil {
+	if in == nil || in.constructionIsActive() || in.invocationState.Load()&instanceInvocationClosed == 0 || in.invocationState.Load()&instanceInvocationCount != 0 {
+		return
+	}
+	if closeState := in.ensurePluginState().close.Load(); closeState != nil {
+		closeState.terminalOnce.Do(func() {
+			if closeState.hooks != nil && closeState.event != nil {
+				var errs []error
+				for i := len(closeState.hooks.afterClose) - 1; i >= 0; i-- {
+					fn := closeState.hooks.afterClose[i]
+					if err := callShutdownSafely("AfterClose", func() { fn(*closeState.event) }); err != nil {
+						errs = append(errs, err)
+					}
+				}
+				closeState.terminalResult = errors.Join(errs...)
+			}
 			closeState.quiescedOnce.Do(func() { close(closeState.quiesced) })
-		}
+		})
 	}
 	in.referenceLifetime().finalize()
+}
+
+func (in *Instance) constructionIsActive() bool {
+	if in == nil {
+		return false
+	}
+	in.lifeMu.Lock()
+	active := in.constructionActive
+	in.lifeMu.Unlock()
+	return active
+}
+
+func (in *Instance) beginConstruction(reservation *pluginOperationReservation) {
+	if in == nil {
+		return
+	}
+	in.lifeMu.Lock()
+	if in.constructionActive {
+		in.lifeMu.Unlock()
+		panic("wago: instance construction lifetime already started")
+	}
+	in.constructionActive = true
+	in.constructionReservation = reservation
+	in.lifeMu.Unlock()
+}
+
+func (in *Instance) endConstruction() {
+	if in == nil {
+		return
+	}
+	in.lifeMu.Lock()
+	if !in.constructionActive {
+		in.lifeMu.Unlock()
+		panic("wago: instance construction lifetime is not active")
+	}
+	in.constructionActive = false
+	in.constructionReservation = nil
+	in.lifeMu.Unlock()
+	in.tryFinalize()
+}
+
+func (in *Instance) constructionReservationSnapshot() *pluginOperationReservation {
+	if in == nil {
+		return nil
+	}
+	in.lifeMu.Lock()
+	reservation := in.constructionReservation
+	in.lifeMu.Unlock()
+	return reservation
 }
 
 // releaseResources performs the physical teardown after tryFinalize has claimed

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -80,19 +80,21 @@ func (in *Instance) closeOnce() error {
 	}
 	in.lifeMu.Unlock()
 
+	var hooks *hookRegistry
 	if in.rt != nil {
-		for i := len(in.rt.hooks.internalBeforeClose) - 1; i >= 0; i-- {
-			fn := in.rt.hooks.internalBeforeClose[i]
+		hooks = in.rt.loadHooks()
+		for i := len(hooks.internalBeforeClose) - 1; i >= 0; i-- {
+			fn := hooks.internalBeforeClose[i]
 			appendStep("internal BeforeClose", func() { fn(in) })
 		}
 	}
 
 	var closeEvent *InstanceCloseEvent
-	if in.rt != nil && (len(in.rt.hooks.beforeClose) != 0 || len(in.rt.hooks.afterClose) != 0) {
+	if hooks != nil && (len(hooks.beforeClose) != 0 || len(hooks.afterClose) != 0) {
 		event := InstanceCloseEvent{Module: ModuleView{compiled: in.c, identity: in.moduleIdentity}, Instance: InstanceIdentity{value: in}, Origin: in.instantiateOrigin()}
 		closeEvent = &event
-		for i := len(in.rt.hooks.beforeClose) - 1; i >= 0; i-- {
-			fn := in.rt.hooks.beforeClose[i]
+		for i := len(hooks.beforeClose) - 1; i >= 0; i-- {
+			fn := hooks.beforeClose[i]
 			appendStep("BeforeClose", func() { fn(*closeEvent) })
 		}
 	}
@@ -109,8 +111,8 @@ func (in *Instance) closeOnce() error {
 	appendStep("close reference store instance", func() { in.referenceLifetime().notifyStore(store, referenceLifetimeClosed) })
 	appendStep("finalize instance resources", in.tryFinalize)
 	if closeEvent != nil {
-		for i := len(in.rt.hooks.afterClose) - 1; i >= 0; i-- {
-			fn := in.rt.hooks.afterClose[i]
+		for i := len(hooks.afterClose) - 1; i >= 0; i-- {
+			fn := hooks.afterClose[i]
 			appendStep("AfterClose", func() { fn(*closeEvent) })
 		}
 	}

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -17,10 +17,12 @@ import (
 // ordering. Synchronous host dispatch releases the lease while arbitrary Go code
 // runs, then reacquires it and rebinds the exact parked callee before resume.
 var (
-	nativeExecutionMu    sync.Mutex
-	nativeExecutionEpoch uint64 // guarded by nativeExecutionMu; advances on every public native entry
-	nativeActiveMu       sync.Mutex
-	nativeActive         = map[nativeActivation]uint32{}
+	nativeExecutionMu       sync.Mutex
+	nativeExecutionEpoch    uint64 // guarded by nativeExecutionMu; advances on every public native entry
+	nativeActiveMu          sync.Mutex
+	nativeActive            = map[nativeActivation]uint32{}
+	invocationReservationMu sync.Mutex
+	invocationReservations  = map[nativeActivation]*pluginOperationReservation{}
 )
 
 const (
@@ -68,6 +70,39 @@ func isNativeActive(in *Instance, id invocationID) bool {
 	active := id != 0 && nativeActive[nativeActivation{in: in, id: id}] != 0
 	nativeActiveMu.Unlock()
 	return active
+}
+
+func (in *Instance) swapInvocationReservation(next *pluginOperationReservation) *pluginOperationReservation {
+	if in == nil {
+		return nil
+	}
+	activation := nativeActivation{in: in, id: in.currentInvocationID()}
+	if activation.id == 0 {
+		return nil
+	}
+	invocationReservationMu.Lock()
+	previous := invocationReservations[activation]
+	if next == nil {
+		delete(invocationReservations, activation)
+	} else {
+		invocationReservations[activation] = next
+	}
+	invocationReservationMu.Unlock()
+	return previous
+}
+
+func currentInvocationReservation(in *Instance) *pluginOperationReservation {
+	if in == nil {
+		return nil
+	}
+	activation := nativeActivation{in: in, id: in.currentInvocationID()}
+	if activation.id == 0 {
+		return nil
+	}
+	invocationReservationMu.Lock()
+	reservation := invocationReservations[activation]
+	invocationReservationMu.Unlock()
+	return reservation
 }
 
 type executionLease struct{ local *sync.Mutex }

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -23,6 +23,7 @@ type InstantiateOptions struct {
 	forceSyncHost        bool
 	afterCreate          func(*Instance) error
 	moduleIdentity       ModuleIdentity
+	operationReservation *pluginOperationReservation
 	independentInstances bool
 	hasExecutionPolicy   bool
 }
@@ -1387,11 +1388,15 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 		}
 	}
 	if opts.runtime != nil {
+		in.beginConstruction(opts.operationReservation)
 		if err := opts.runtime.registerInstance(in); err != nil {
+			in.endConstruction()
 			return nil, err
 		}
 		// Once a Runtime-owned Instance exists, every later failure must dispose it
-		// through the normal lifecycle before the instantiation error escapes.
+		// through the normal lifecycle before the instantiation error escapes. The
+		// construction lifetime remains active through rollback and is released only
+		// after all terminal instantiation observers return.
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				result = nil
@@ -1401,11 +1406,11 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 					err = fmt.Errorf("wago: instantiation panicked after instance creation: %v", recovered)
 				}
 			}
-			if b.success {
-				return
+			if !b.success {
+				b.success = true // the normal Close path now owns all instance resources
+				err = joinPrimary(err, in.Close())
 			}
-			b.success = true // the normal Close path now owns all instance resources
-			err = joinPrimary(err, in.Close())
+			in.endConstruction()
 		}()
 	}
 	if opts.store != nil {
@@ -1466,7 +1471,7 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 			if err != nil {
 				return nil, fmt.Errorf("start function %q: %w", key, err)
 			}
-			caller := in.beginHostCallScope()
+			caller := in.beginHostCallScopeReserved(in.constructionReservationSnapshot())
 			if err := callImportedStart(fn, caller); err != nil {
 				return nil, fmt.Errorf("start function %q: %w", key, err)
 			}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -17,12 +17,14 @@ type InstantiateOptions struct {
 	GC      GCConfig
 	store   *referenceStore
 
-	runtime        *Runtime
-	origin         InstantiateOrigin
-	pluginGC       *GCConfig
-	forceSyncHost  bool
-	afterCreate    func(*Instance) error
-	moduleIdentity ModuleIdentity
+	runtime              *Runtime
+	origin               InstantiateOrigin
+	pluginGC             *GCConfig
+	forceSyncHost        bool
+	afterCreate          func(*Instance) error
+	moduleIdentity       ModuleIdentity
+	independentInstances bool
+	hasExecutionPolicy   bool
 }
 
 // Instantiable is the set of sources Instantiate accepts. The interface is
@@ -98,10 +100,17 @@ type instanceBuilder struct {
 	tableAttachments    tableImportAttachments
 	globalAttachments   globalImportAttachments
 	tagAttachments      tagImportAttachments
+	moduleUse           *Module
 }
 
 // instantiateCore maps code and applies explicit instance options.
 func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
+	return instantiateCoreWithModuleLease(c, opts, nil)
+}
+
+func instantiateCoreWithModuleLease(c *Compiled, opts InstantiateOptions, moduleUse *Module) (*Instance, error) {
+	b := instanceBuilder{c: c, opts: opts, imports: opts.Imports, moduleUse: moduleUse}
+	defer b.releaseModuleUse()
 	if c == nil {
 		return nil, errors.New("wago: instantiate: nil compiled module")
 	}
@@ -114,8 +123,15 @@ func instantiateCore(c *Compiled, opts InstantiateOptions) (*Instance, error) {
 	if err := c.preflightImportBindings(opts.Imports); err != nil {
 		return nil, err
 	}
-	b := instanceBuilder{c: c, opts: opts, imports: opts.Imports}
 	return b.instantiate()
+}
+
+func (b *instanceBuilder) releaseModuleUse() {
+	if b.moduleUse == nil {
+		return
+	}
+	b.moduleUse.endUse()
+	b.moduleUse = nil
 }
 
 func (b *instanceBuilder) validateCompiled() error {
@@ -125,8 +141,8 @@ func (b *instanceBuilder) validateCompiled() error {
 	return b.c.validateCached()
 }
 
-func (c *Compiled) allowsIndependentInstanceExecution(imports Imports) bool {
-	if !c.independentInstances {
+func (c *Compiled) allowsIndependentInstanceExecution(imports Imports, enabled bool) bool {
+	if !enabled {
 		return false
 	}
 	if c.memoryImportCount() != 0 || c.tableImportCount() != 0 || len(c.GlobalImports) != 0 {
@@ -536,6 +552,10 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 		closeMem()
 		runtime.ReleaseEngine(eng)
 	}()
+	// The builder now owns a compiled-code reference. Release the Module lease
+	// before lifecycle and start callbacks; Module.Close may close the Compiled
+	// while this reference keeps its native mapping live.
+	b.releaseModuleUse()
 	var hostLog, ctrl []byte
 	var syncHosts []HostFunc
 	if syncMode {
@@ -1288,7 +1308,11 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 		nativeContext:  nativeContextPtr,
 		moduleIdentity: opts.moduleIdentity,
 	}
-	if c.allowsIndependentInstanceExecution(imports) {
+	independentInstances := c.independentInstances
+	if opts.hasExecutionPolicy {
+		independentInstances = opts.independentInstances
+	}
+	if c.allowsIndependentInstanceExecution(imports, independentInstances) {
 		in.executionFlags.Store(executionFlagIndependent)
 	}
 	b.registeredInstance = in

--- a/src/wago/lifecycle_disposal_test.go
+++ b/src/wago/lifecycle_disposal_test.go
@@ -319,20 +319,25 @@ func TestRuntimeCloseWaitsForPendingManagedInstantiation(t *testing.T) {
 		instantiateDone <- instantiateResult{managed: managed, err: err}
 	}()
 	<-startEntered
-	runtimeDone := make(chan error, 1)
-	go func() { runtimeDone <- rt.Close() }()
+	if err := rt.Close(); err != nil {
+		t.Fatalf("Runtime.Close: %v", err)
+	}
+	done := rt.Closed()
+	if done == nil {
+		t.Fatal("Runtime.Close did not publish completion")
+	}
 	select {
-	case err := <-runtimeDone:
-		t.Fatalf("Runtime.Close returned before pending managed instantiation cleanup: %v", err)
-	case <-time.After(25 * time.Millisecond):
+	case <-done:
+		t.Fatal("runtime teardown completed before pending managed instantiation cleanup")
+	default:
 	}
 	close(releaseStart)
 	result := <-instantiateDone
 	if result.managed != nil || result.err == nil {
 		t.Fatalf("pending Instantiate = %v, %v; want nil, error", result.managed, result.err)
 	}
-	if err := <-runtimeDone; err != nil {
-		t.Fatalf("Runtime.Close: %v", err)
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatalf("Runtime.WaitClosed: %v", err)
 	}
 	if resolved == nil || closed != resolved {
 		t.Fatalf("resolved/closed instances = %p/%p", resolved, closed)

--- a/src/wago/lifecycle_disposal_test.go
+++ b/src/wago/lifecycle_disposal_test.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/wago-org/wago/tests/wasmtest"
 )
@@ -217,6 +216,9 @@ func TestExactInstanceLifecycleManagedExplicitAndRuntimeClose(t *testing.T) {
 	if err := rt.Close(); err != nil {
 		t.Fatalf("Runtime.Close: %v", err)
 	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatalf("Runtime.WaitClosed: %v", err)
+	}
 	if second.Instance() != nil {
 		t.Fatal("runtime close retained managed instance")
 	}
@@ -256,19 +258,20 @@ func TestRuntimeCloseWaitsForActiveManagedClose(t *testing.T) {
 	managedDone := make(chan error, 1)
 	go func() { managedDone <- managed.Close() }()
 	<-entered
-	runtimeDone := make(chan error, 1)
-	go func() { runtimeDone <- rt.Close() }()
+	if err := rt.Close(); err != nil {
+		t.Fatalf("Runtime.Close: %v", err)
+	}
 	select {
-	case err := <-runtimeDone:
-		t.Fatalf("Runtime.Close returned before active managed close: %v", err)
-	case <-time.After(25 * time.Millisecond):
+	case <-rt.Closed():
+		t.Fatal("Runtime teardown completed before active managed close")
+	default:
 	}
 	close(release)
 	if err := <-managedDone; err != nil {
 		t.Fatalf("ManagedInstance.Close: %v", err)
 	}
-	if err := <-runtimeDone; err != nil {
-		t.Fatalf("Runtime.Close: %v", err)
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatalf("Runtime.WaitClosed: %v", err)
 	}
 	if before.Load() != 1 || after.Load() != 1 {
 		t.Fatalf("hook counts = %d/%d, want 1/1", before.Load(), after.Load())
@@ -347,7 +350,6 @@ func TestRuntimeCloseWaitsForPendingManagedInstantiation(t *testing.T) {
 func TestConcurrentInstanceCloseWaitsAndRunsOnce(t *testing.T) {
 	entered := make(chan struct{})
 	release := make(chan struct{})
-	closePanic := errors.New("concurrent close hook panic")
 	var before, after atomic.Int32
 	p := &disposalTestPlugin{
 		id:       "test.lifecycle.concurrent-close",
@@ -356,7 +358,7 @@ func TestConcurrentInstanceCloseWaitsAndRunsOnce(t *testing.T) {
 			before.Add(1)
 			close(entered)
 			<-release
-			panic(closePanic)
+			panic("concurrent close hook panic")
 		}},
 		afterClose: []func(*InstanceContext){func(*InstanceContext) { after.Add(1) }},
 	}
@@ -380,23 +382,18 @@ func TestConcurrentInstanceCloseWaitsAndRunsOnce(t *testing.T) {
 	}
 	close(start)
 	<-entered
-	select {
-	case err := <-results:
-		t.Fatalf("Close returned before lifecycle completion: %v", err)
-	case <-time.After(25 * time.Millisecond):
-	}
 	close(release)
-	var first error
+	var panicResults int
 	for i := 0; i < callers; i++ {
 		err := <-results
-		if !errors.Is(err, closePanic) {
-			t.Fatalf("Close[%d] = %v, want close hook panic", i, err)
+		if errors.Is(err, ErrCallbackPanic) {
+			panicResults++
+		} else if err != nil {
+			t.Fatalf("Close[%d] = %v, want nil or ErrCallbackPanic", i, err)
 		}
-		if i == 0 {
-			first = err
-		} else if err != first {
-			t.Fatalf("Close[%d] result identity differs: %v != %v", i, err, first)
-		}
+	}
+	if panicResults == 0 {
+		t.Fatal("close lifecycle owner did not report ErrCallbackPanic")
 	}
 	if before.Load() != 1 || after.Load() != 1 {
 		t.Fatalf("hook counts = %d/%d, want 1/1", before.Load(), after.Load())
@@ -404,7 +401,6 @@ func TestConcurrentInstanceCloseWaitsAndRunsOnce(t *testing.T) {
 }
 
 func TestPanickingCloseHookDoesNotSkipCleanup(t *testing.T) {
-	panicErr := errors.New("close hook exploded")
 	var mu sync.Mutex
 	var events []string
 	record := func(event string) {
@@ -417,7 +413,7 @@ func TestPanickingCloseHookDoesNotSkipCleanup(t *testing.T) {
 		requires: []PluginCapability{PluginInstanceHooks},
 		beforeClose: []func(*InstanceContext){
 			func(*InstanceContext) { record("before-first") },
-			func(*InstanceContext) { record("before-panic"); panic(panicErr) },
+			func(*InstanceContext) { record("before-panic"); panic("close hook exploded") },
 			func(*InstanceContext) { record("before-last") },
 		},
 		afterClose: []func(*InstanceContext){
@@ -435,8 +431,8 @@ func TestPanickingCloseHookDoesNotSkipCleanup(t *testing.T) {
 		t.Fatalf("Instantiate: %v", err)
 	}
 	closeErr := in.Close()
-	if !errors.Is(closeErr, panicErr) {
-		t.Fatalf("Close error = %v, want panic error", closeErr)
+	if !errors.Is(closeErr, ErrCallbackPanic) {
+		t.Fatalf("Close error = %v, want ErrCallbackPanic", closeErr)
 	}
 	if second := in.Close(); second != closeErr {
 		t.Fatalf("second Close error identity = %v, want same %v", second, closeErr)
@@ -551,7 +547,6 @@ func TestFailedLocalStartResolvesAndClosesExactInstance(t *testing.T) {
 
 func TestAfterInstantiateFailureClosesAndJoinsCleanupError(t *testing.T) {
 	instantiateErr := errors.New("attach failed")
-	cleanupErr := errors.New("detach panicked")
 	var before, after int
 	var observed error
 	p := &disposalTestPlugin{
@@ -563,7 +558,7 @@ func TestAfterInstantiateFailureClosesAndJoinsCleanupError(t *testing.T) {
 		onInstErr: []func(*InstantiateContext, error){func(_ *InstantiateContext, err error) { observed = err }},
 		beforeClose: []func(*InstanceContext){func(*InstanceContext) {
 			before++
-			panic(cleanupErr)
+			panic("detach panicked")
 		}},
 		afterClose: []func(*InstanceContext){func(*InstanceContext) { after++ }},
 	}
@@ -576,11 +571,11 @@ func TestAfterInstantiateFailureClosesAndJoinsCleanupError(t *testing.T) {
 	if in != nil {
 		t.Fatalf("Instantiate returned failed instance %p", in)
 	}
-	if !errors.Is(err, instantiateErr) || !errors.Is(err, cleanupErr) {
-		t.Fatalf("Instantiate error = %v, want original and cleanup errors", err)
+	if !errors.Is(err, instantiateErr) || !errors.Is(err, ErrCallbackPanic) {
+		t.Fatalf("Instantiate error = %v, want original and callback panic errors", err)
 	}
-	if !errors.Is(observed, instantiateErr) || !errors.Is(observed, cleanupErr) {
-		t.Fatalf("OnInstantiateError = %v, want original and cleanup errors", observed)
+	if !errors.Is(observed, instantiateErr) || !errors.Is(observed, ErrCallbackPanic) {
+		t.Fatalf("OnInstantiateError = %v, want original and callback panic errors", observed)
 	}
 	if before != 1 || after != 1 {
 		t.Fatalf("close hook counts = %d/%d, want 1/1", before, after)
@@ -807,6 +802,9 @@ func TestManagedForkLifecycleAndRuntimeOwnership(t *testing.T) {
 	}
 	if err := rt.Close(); err != nil {
 		t.Fatalf("Runtime.Close: %v", err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatalf("Runtime.WaitClosed: %v", err)
 	}
 	if child.Instance() != nil {
 		t.Fatal("runtime close retained forked managed instance")

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -175,7 +175,7 @@ func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*Managed
 	if err != nil {
 		return nil, err
 	}
-	end, err := m.rt.beginOperation("managed Fork", true)
+	hooks, reservation, end, err := m.rt.beginOperationGeneration("managed Fork", true)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,6 @@ func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*Managed
 	m.mu.Unlock()
 	defer m.pending.Done()
 	rt.mu.Lock()
-	hooks := rt.loadHooks()
 	bindings := rt.snapshotModuleBindingsLocked(hooks)
 	rt.mu.Unlock()
 	state := parent.pluginState.Load()
@@ -217,7 +216,7 @@ func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*Managed
 	if hasGC {
 		gc = *state.gcConfig
 	}
-	child, err := rt.instantiateWithHooksOrigin(buildModule(parent.c, bindings), imports, gc, hasGC, false, InstantiateManaged, hooks)
+	child, err := rt.instantiateWithHooksOrigin(buildModule(parent.c, bindings), imports, gc, hasGC, false, InstantiateManaged, hooks, reservation)
 	if err != nil {
 		m.mu.Lock()
 		m.live--
@@ -310,8 +309,12 @@ func validateVoidTableEntry(in *Instance, index uint32) error {
 // InvokeVoidTable invokes a validated () -> () table entry on this managed
 // instance. Calls on one instance must be serialized by the owning plugin.
 func (m *ManagedInstance) InvokeVoidTable(ctx context.Context, index uint32) error {
-	in := m.Instance()
-	manager := m.manager
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.mu.Lock()
+	in, manager := m.value, m.manager
+	m.mu.Unlock()
 	if in == nil || manager == nil {
 		return fmt.Errorf("wago: managed instance is closed")
 	}
@@ -468,47 +471,47 @@ func (m *InstanceManager) releaseReservation(memoryBytes uint64) {
 }
 
 func (m *InstanceManager) closeLogical() error {
-	m.mu.Lock()
-	if m.closed {
-		m.mu.Unlock()
+	if m == nil {
 		return nil
 	}
-	m.closed = true
-	list := make([]*ManagedInstance, 0, len(m.instances))
-	for owned := range m.instances {
-		list = append(list, owned)
-	}
-	m.mu.Unlock()
-	// No new creation can increment pending after closed is set under m.mu.
-	// Wait for in-flight creations to either fail or close themselves in adopt.
-	m.pending.Wait()
-	var errs []error
-	draining := make([]*Instance, 0, len(list))
-	for _, owned := range list {
-		in, err := owned.closeLogical()
-		if err != nil {
-			errs = append(errs, err)
-		}
-		if in != nil {
-			draining = append(draining, in)
-		}
-	}
 	m.mu.Lock()
-	m.draining = draining
-	m.instances = nil
-	m.byInstance = nil
+	m.closed = true
 	m.mu.Unlock()
-	return errors.Join(errs...)
+	// Phase 1 closes only creation/fork admission. Existing managed instances
+	// remain usable by Plugin.Stop; phase 3 closes and drains them afterward.
+	return nil
 }
 
 func (m *InstanceManager) drain() error {
 	if m == nil {
 		return nil
 	}
+	// closed was published under m.mu before this wait, so no later pending.Add
+	// can race the Wait. In-flight creators either fail or close their partial
+	// instance in adopt before signaling Done.
+	m.pending.Wait()
 	m.mu.Lock()
-	list := append([]*Instance(nil), m.draining...)
+	owned := make([]*ManagedInstance, 0, len(m.instances))
+	for instance := range m.instances {
+		owned = append(owned, instance)
+	}
 	m.mu.Unlock()
 	var errs []error
+	list := make([]*Instance, 0, len(owned))
+	for _, managed := range owned {
+		in, err := managed.closeLogical()
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if in != nil {
+			list = append(list, in)
+		}
+	}
+	m.mu.Lock()
+	list = append(list, m.draining...)
+	m.instances = nil
+	m.byInstance = nil
+	m.mu.Unlock()
 	for _, in := range list {
 		state := in.ensurePluginState().close.Load()
 		if state != nil {

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -207,13 +207,17 @@ func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*Managed
 	rt := m.rt
 	m.mu.Unlock()
 	defer m.pending.Done()
+	rt.mu.Lock()
+	hooks := rt.loadHooks()
+	bindings := rt.snapshotModuleBindingsLocked(hooks)
+	rt.mu.Unlock()
 	state := parent.pluginState.Load()
 	var gc GCConfig
 	hasGC := state != nil && state.gcConfig != nil
 	if hasGC {
 		gc = *state.gcConfig
 	}
-	child, err := rt.instantiateWithHooksOrigin(rt.buildModule(parent.c), imports, gc, hasGC, false, InstantiateManaged)
+	child, err := rt.instantiateWithHooksOrigin(buildModule(parent.c, bindings), imports, gc, hasGC, false, InstantiateManaged, hooks)
 	if err != nil {
 		m.mu.Lock()
 		m.live--

--- a/src/wago/managed_instances_test.go
+++ b/src/wago/managed_instances_test.go
@@ -42,6 +42,9 @@ func TestManagedInstancesAreRuntimeOwned(t *testing.T) {
 	if err := rt.Close(); err != nil {
 		t.Fatalf("Runtime.Close: %v", err)
 	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatalf("Runtime.WaitClosed: %v", err)
+	}
 	if owned.Instance() != nil {
 		t.Fatal("runtime close retained managed instance")
 	}

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -299,8 +299,6 @@ func (m *Module) moduleIdentity() ModuleIdentity {
 	return ModuleIdentity{value: m.identity.Load()}
 }
 
-func (m *Module) isClosed() bool { return m == nil || m.closed.Load() }
-
 // Compiled returns the underlying low-level compiled module.
 func (m *Module) Compiled() *Compiled { return m.c }
 

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -2,6 +2,7 @@ package wago
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -16,10 +17,20 @@ type Module struct {
 	imports []ImportSpec
 	reqCaps []Capability
 
-	identity  atomic.Pointer[moduleIdentityToken]
-	closed    atomic.Bool
-	closeOnce sync.Once
-	closeErr  error
+	identity             atomic.Pointer[moduleIdentityToken]
+	ownsCompiled         bool
+	independentInstances bool
+	lifeMu               sync.Mutex
+	closed               atomic.Bool
+	uses                 uint32
+	usesDone             chan struct{}
+	closeState           atomic.Pointer[moduleCloseState]
+	closeCallbacks       atomic.Uint32
+}
+
+type moduleCloseState struct {
+	done   chan struct{}
+	result error
 }
 
 // ImportKind classifies what a module imports.
@@ -166,14 +177,47 @@ type ModuleMetadata struct {
 	Tags                 []TagMetadata
 }
 
-// buildModule wraps a freshly compiled module, resolving each import against the
-// runtime's selected plugins to attach signatures, capabilities, and
-// provided-state.
+type moduleBindings struct {
+	rt                   *Runtime
+	imports              Imports
+	importMeta           map[string]*registeredImport
+	independentInstances bool
+	moduleIdentity       bool
+}
+
+// snapshotModuleBindingsLocked captures one immutable import-policy generation.
+// The caller must hold rt.mu.
+func (rt *Runtime) snapshotModuleBindingsLocked(hooks *hookRegistry) moduleBindings {
+	cfg := rt.cfg.clone()
+	bindings := moduleBindings{
+		rt:                   rt,
+		imports:              make(Imports, len(rt.imports)),
+		importMeta:           make(map[string]*registeredImport, len(rt.importMeta)),
+		independentInstances: cfg.IndependentInstanceExecution(),
+		moduleIdentity:       hooks.needsModuleIdentity(),
+	}
+	for key, value := range rt.imports {
+		bindings.imports[key] = value
+	}
+	for key, value := range rt.importMeta {
+		bindings.importMeta[key] = cloneRegisteredImport(value)
+	}
+	return bindings
+}
+
+// buildModule wraps a compiled module with the runtime's current binding
+// generation. Callers that already hold rt.mu should snapshot directly instead.
 func (rt *Runtime) buildModule(c *Compiled) *Module {
-	m := &Module{rt: rt, c: c}
 	rt.mu.Lock()
-	defer rt.mu.Unlock()
-	if rt.hooks.needsModuleIdentity() {
+	hooks := rt.loadHooks()
+	bindings := rt.snapshotModuleBindingsLocked(hooks)
+	rt.mu.Unlock()
+	return buildModule(c, bindings)
+}
+
+func buildModule(c *Compiled, bindings moduleBindings) *Module {
+	m := &Module{rt: bindings.rt, c: c, independentInstances: bindings.independentInstances}
+	if bindings.moduleIdentity {
 		m.identity.Store(&moduleIdentityToken{})
 	}
 
@@ -186,10 +230,10 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 			spec.Results = append([]ValType(nil), c.importFuncSigs[i].Results...)
 			spec.ParamTypes, spec.ResultTypes, _ = exactFuncSignature(c.importFuncSigs[i], c.Types)
 		}
-		if _, ok := rt.imports[key]; ok {
+		if _, ok := bindings.imports[key]; ok {
 			spec.Provided = true
 		}
-		if meta := rt.importMeta[key]; meta != nil {
+		if meta := bindings.importMeta[key]; meta != nil {
 			spec.Capability, spec.HasCapability = meta.cap, meta.hasCap
 			spec.Docs = meta.docs
 			if meta.hasCap && !capSeen[meta.cap] {
@@ -204,7 +248,7 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 		exact, exactErr := exactValueType(gi.Type, gi.HasValueType, gi.ValueTypeIndex, c.ValueTypes, c.Types)
 		m.imports = append(m.imports, ImportSpec{
 			Module: gi.Module, Name: gi.Name, Kind: ImportGlobal, Index: i,
-			Type: gi.Type, ValueType: exact, HasValueType: exactErr == nil, Mutable: gi.Mutable, Provided: rt.imports[key] != nil,
+			Type: gi.Type, ValueType: exact, HasValueType: exactErr == nil, Mutable: gi.Mutable, Provided: bindings.imports[key] != nil,
 		})
 	}
 	for i := 0; i < c.memoryImportCount(); i++ {
@@ -213,7 +257,7 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 		m.imports = append(m.imports, ImportSpec{
 			Module: mod, Name: name, Kind: ImportMemory, Index: i,
 			MemoryMin: def.Min, MemoryMax: def.Max, HasMax: def.HasMax, Addr64: def.Addr64, Shared: def.Shared,
-			Provided: rt.imports[def.ImportKey] != nil,
+			Provided: bindings.imports[def.ImportKey] != nil,
 		})
 	}
 	for i := 0; i < c.tableImportCount(); i++ {
@@ -223,7 +267,7 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 		m.imports = append(m.imports, ImportSpec{
 			Module: mod, Name: name, Kind: ImportTable, Index: i,
 			Type: def.Type, ValueType: exact, HasValueType: exactErr == nil, Min: def.Min, Max: def.Max, HasMax: def.HasMax, Addr64: def.Addr64,
-			Provided: rt.imports[def.Key] != nil,
+			Provided: bindings.imports[def.Key] != nil,
 		})
 	}
 	if c.memoryDir != nil {
@@ -232,7 +276,7 @@ func (rt *Runtime) buildModule(c *Compiled) *Module {
 			mod, name := splitImportKey(def.ImportKey)
 			sig := c.Types[def.TypeIndex]
 			params, _ := valTypesFromDescriptors(sig.Params, c.Types)
-			m.imports = append(m.imports, ImportSpec{Module: mod, Name: name, Kind: ImportTag, Index: i, Params: params, ParamTypes: append([]ValueTypeDescriptor(nil), sig.Params...), Provided: rt.imports[def.ImportKey] != nil})
+			m.imports = append(m.imports, ImportSpec{Module: mod, Name: name, Kind: ImportTag, Index: i, Params: params, ParamTypes: append([]ValueTypeDescriptor(nil), sig.Params...), Provided: bindings.imports[def.ImportKey] != nil})
 		}
 	}
 	return m
@@ -263,8 +307,9 @@ func (m *Module) Compiled() *Compiled { return m.c }
 // Exports returns the module's exported function names, sorted.
 func (m *Module) Exports() []string { return m.c.ExportedFunctions() }
 
-// Imports returns the module's declared imports with plugin-derived metadata.
-func (m *Module) Imports() []ImportSpec { return append([]ImportSpec(nil), m.imports...) }
+// Imports returns caller-owned snapshots of the module's declared imports with
+// plugin-derived metadata. Mutating the result does not affect the Module.
+func (m *Module) Imports() []ImportSpec { return cloneImportSpecs(m.imports) }
 
 // RequiredCapabilities returns the capabilities the module's function imports
 // require, deduplicated in first-seen order.
@@ -386,35 +431,110 @@ func exportsByIndex(exports map[string]int, count int) [][]string {
 }
 
 // Close ends this runtime-bound module's lifecycle and notifies module-close
-// observers exactly once. It prevents new Runtime.Instantiate calls through the
-// wrapper, but does not close or otherwise take ownership of the caller-visible
-// Compiled artifact. Existing instances keep their own execution references.
-func (m *Module) Close() error {
+// observers exactly once. Modules returned by Runtime.Compile or AdoptModule own
+// their Compiled value; Runtime.Module wrappers borrow caller-owned code. Existing
+// instances retain executable mappings until they close. Close calls made while
+// module-close observers are active return without self-waiting; callers after
+// observer completion receive the published final result.
+func (m *Module) Close() (err error) {
 	if m == nil {
 		return nil
 	}
-	m.closeOnce.Do(func() {
-		m.closed.Store(true)
-		if m.rt != nil {
-			m.rt.moduleCloseMu.RLock()
-			defer m.rt.moduleCloseMu.RUnlock()
+	state, owner := m.beginClose()
+	if !owner {
+		if m.closeCallbacks.Load() != 0 {
+			return nil
 		}
-		if m.rt != nil && m.rt.allowsLifecycleCallbacks() && len(m.rt.hooks.onModuleClose) != 0 {
+		<-state.done
+		return state.result
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if panicErr, ok := recovered.(error); ok {
+				err = joinPrimary(err, fmt.Errorf("wago: module close panicked: %w", panicErr))
+			} else {
+				err = joinPrimary(err, fmt.Errorf("wago: module close panicked: %v", recovered))
+			}
+		}
+		state.result = err
+		close(state.done)
+	}()
+	return m.closeOwned()
+}
+
+func (m *Module) beginClose() (*moduleCloseState, bool) {
+	if active := m.closeState.Load(); active != nil {
+		return active, false
+	}
+	candidate := &moduleCloseState{done: make(chan struct{})}
+	if m.closeState.CompareAndSwap(nil, candidate) {
+		return candidate, true
+	}
+	return m.closeState.Load(), false
+}
+
+func (m *Module) closeOwned() error {
+	m.lifeMu.Lock()
+	m.closed.Store(true)
+	var usesDone <-chan struct{}
+	if m.uses != 0 {
+		m.usesDone = make(chan struct{})
+		usesDone = m.usesDone
+	}
+	m.lifeMu.Unlock()
+	if usesDone != nil {
+		<-usesDone
+	}
+
+	var errs []error
+	if hooks, end := m.rt.beginModuleCloseCallbacks(); end != nil {
+		defer end()
+		if len(hooks.onModuleClose) != 0 {
 			event := ModuleCloseEvent{Module: moduleView(m)}
-			var errs []error
-			for i := len(m.rt.hooks.onModuleClose) - 1; i >= 0; i-- {
-				observer := m.rt.hooks.onModuleClose[i]
+			m.closeCallbacks.Add(1)
+			for i := len(hooks.onModuleClose) - 1; i >= 0; i-- {
+				observer := hooks.onModuleClose[i]
 				if err := callHookSafely("ModuleCloseObserver", func() { observer(event) }); err != nil {
 					errs = append(errs, err)
 				}
 			}
-			m.closeErr = errors.Join(errs...)
+			m.closeCallbacks.Add(^uint32(0))
 		}
-		// A retained ModuleIdentity must not retain Compiled or the Module wrapper.
-		// Clear the wrapper's copy only after observers receive the final identity.
-		m.identity.Store(nil)
-	})
-	return m.closeErr
+	}
+	m.identity.Store(nil)
+	if m.ownsCompiled && m.c != nil {
+		errs = append(errs, m.c.Close())
+	}
+	return errors.Join(errs...)
+}
+
+// beginUse admits one operation that reads the compiled module. Admission is
+// atomic with Close publishing the module's closed state.
+func (m *Module) beginUse() bool {
+	if m == nil {
+		return false
+	}
+	m.lifeMu.Lock()
+	defer m.lifeMu.Unlock()
+	if m.closed.Load() {
+		return false
+	}
+	m.uses++
+	return true
+}
+
+func (m *Module) endUse() {
+	m.lifeMu.Lock()
+	if m.uses == 0 {
+		m.lifeMu.Unlock()
+		panic("wago: module use lease underflow")
+	}
+	m.uses--
+	if m.uses == 0 && m.usesDone != nil {
+		close(m.usesDone)
+		m.usesDone = nil
+	}
+	m.lifeMu.Unlock()
 }
 
 // splitImportKey splits a "module.name" key at the first dot.

--- a/src/wago/persistent_funcref_copy_test.go
+++ b/src/wago/persistent_funcref_copy_test.go
@@ -201,7 +201,9 @@ func TestPersistentFuncrefGlobalToGlobalRetainsActualProducer(t *testing.T) {
 		t.Fatalf("G2 retained roots after overwrite = %d, want 0", retained)
 	}
 	_ = g2.Close()
-	_ = rt.Close()
+	if err := rt.CloseContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	if producer.hasPhysicalResources() || producer.resourceRefs != 0 {
 		t.Fatalf("producer after G2/root token teardown: live=%v roots=%d", producer.hasPhysicalResources(), producer.resourceRefs)
 	}
@@ -461,7 +463,7 @@ func TestPersistentFuncrefPublicIngressAndCrossInstanceResult(t *testing.T) {
 	_ = producer.Close()
 	_ = relay.Close()
 	_ = writer.Close()
-	if err := rt.Close(); err != nil {
+	if err := rt.CloseContext(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if len(rt.refStore.byToken) != 0 {

--- a/src/wago/plugin_call_gate.go
+++ b/src/wago/plugin_call_gate.go
@@ -13,10 +13,65 @@ const pluginCallGateClosed = uint64(1) << 63
 // plugin-owned blockers, and then drains admitted calls before teardown proceeds.
 // A reference that outlives its Runtime cannot enter stopped plugin code.
 type pluginCallGate struct {
-	state       atomic.Uint64 // high bit closes admission; low bits count calls
+	state       atomic.Uint64 // high bit closes admission; low bits count calls or operation reservations
 	drained     chan struct{}
 	drainOnce   sync.Once
 	inactiveErr error
+}
+
+// pluginOperationReservation pins the exact plugin generation selected when a
+// runtime operation was admitted. Individual callbacks belonging to that
+// operation may continue after ordinary callback admission closes, while
+// unrelated callbacks still fail closed. A retained reservation keeps every
+// participating plugin alive until the operation's terminal callback returns.
+type pluginOperationReservation struct {
+	gates []*pluginCallGate
+	refs  atomic.Int32
+}
+
+func reservePluginOperation(gates []*pluginCallGate) (*pluginOperationReservation, error) {
+	if len(gates) == 0 {
+		return nil, nil
+	}
+	reservation := &pluginOperationReservation{gates: gates}
+	reservation.refs.Store(1)
+	for index, gate := range gates {
+		if err := gate.enter(); err != nil {
+			for prior := index - 1; prior >= 0; prior-- {
+				gates[prior].release()
+			}
+			return nil, err
+		}
+	}
+	return reservation, nil
+}
+
+func (r *pluginOperationReservation) release() {
+	if r == nil {
+		return
+	}
+	refs := r.refs.Add(-1)
+	if refs < 0 {
+		panic("wago: plugin operation reservation underflow")
+	}
+	if refs != 0 {
+		return
+	}
+	for index := len(r.gates) - 1; index >= 0; index-- {
+		r.gates[index].release()
+	}
+}
+
+func (r *pluginOperationReservation) allows(gate *pluginCallGate) bool {
+	if r == nil || gate == nil || r.refs.Load() == 0 {
+		return false
+	}
+	for _, candidate := range r.gates {
+		if candidate == gate {
+			return true
+		}
+	}
+	return false
 }
 
 func newPluginCallGate(plugin string) *pluginCallGate {
@@ -46,6 +101,10 @@ func (g *pluginCallGate) enter() error {
 
 func (g *pluginCallGate) wrap(fn HostFunc) HostFunc {
 	return func(module HostModule, params, results []uint64) {
+		if caller, ok := module.(instanceHostModule); ok && caller.reservation != nil && caller.reservation.allows(g) {
+			fn(module, params, results)
+			return
+		}
 		if err := g.enter(); err != nil {
 			panic(HostTrap{Err: err})
 		}

--- a/src/wago/plugin_lifecycle_hardening_test.go
+++ b/src/wago/plugin_lifecycle_hardening_test.go
@@ -58,18 +58,17 @@ func TestLoadPluginsExclusiveAndCloseWaitsForStart(t *testing.T) {
 	if _, err := rt.Compile(wasmtest.Module()); err == nil || !strings.Contains(err.Error(), "plugins are loading") {
 		t.Fatalf("Compile during Start = %v", err)
 	}
-	closeDone := make(chan error, 1)
-	go func() { closeDone <- rt.Close() }()
-	select {
-	case err := <-closeDone:
-		t.Fatalf("Close returned before Start: %v", err)
-	case <-time.After(25 * time.Millisecond):
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if rt.Closed() == nil {
+		t.Fatal("Close did not publish shutdown while Start was active")
 	}
 	close(release)
 	if err := <-loadDone; err != nil {
 		t.Fatal(err)
 	}
-	if err := <-closeDone; err != nil {
+	if err := rt.WaitClosed(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -229,6 +228,9 @@ func TestConsumerStopCanInvokeProviderManagedInstance(t *testing.T) {
 	if err := rt.Close(); err != nil {
 		t.Fatal(err)
 	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	if stoppedValue != 7 {
 		t.Fatalf("consumer Stop value = %d, want 7", stoppedValue)
 	}
@@ -311,7 +313,7 @@ func TestRuntimeCloseCompletionPublishesSameError(t *testing.T) {
 	close(release)
 	err1 := <-first
 	err2 := rt.WaitClosed(context.Background())
-	if !errors.Is(err1, stopErr) || !errors.Is(err2, stopErr) || err1.Error() != err2.Error() {
+	if err1 != nil || !errors.Is(err2, stopErr) {
 		t.Fatalf("Close/WaitClosed results = %v / %v", err1, err2)
 	}
 }
@@ -355,6 +357,9 @@ func TestRuntimeCloseObserverAndInstancesPrecedePluginStop(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(events, []string{"runtime", "instance", "stop"}) {
@@ -403,6 +408,9 @@ func TestRuntimeCloseClosesInstancesInReverseCreationOrder(t *testing.T) {
 		created = append(created, InstanceIdentity{value: in})
 	}
 	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	want := []InstanceIdentity{created[2], created[1], created[0]}
@@ -492,17 +500,18 @@ func TestRuntimeStopCanReleaseBlockedPublicInvoke(t *testing.T) {
 	invokeDone := make(chan error, 1)
 	go func() { _, err := in.Invoke("call"); invokeDone <- err }()
 	<-entered
-	closeDone := make(chan error, 1)
-	go func() { closeDone <- rt.Close() }()
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
 	select {
-	case err := <-closeDone:
-		if err != nil {
-			t.Fatal(err)
-		}
+	case <-release:
 	case <-time.After(time.Second):
 		t.Fatal("Runtime.Close did not run Stop to release a blocked public Invoke")
 	}
 	<-invokeDone // interruption or successful unwind are both valid
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestRuntimeStopCanReleaseBlockedImportedStart(t *testing.T) {
@@ -554,21 +563,22 @@ func TestRuntimeStopCanReleaseBlockedImportedStart(t *testing.T) {
 	instantiateDone := make(chan error, 1)
 	go func() { _, err := rt.Instantiate(context.Background(), mod); instantiateDone <- err }()
 	<-entered
-	closeDone := make(chan error, 1)
-	go func() { closeDone <- rt.Close() }()
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
 	select {
-	case err := <-closeDone:
-		if err != nil {
-			t.Fatal(err)
-		}
+	case <-release:
 	case <-time.After(time.Second):
 		t.Fatal("Runtime.Close did not run Stop to release a blocked imported start")
 	}
 	if err := <-instantiateDone; err == nil || !strings.Contains(err.Error(), "closed") {
 		t.Fatalf("Instantiate racing Runtime.Close = %v, want closed failure", err)
 	}
-	if got := afterInstantiate.Load(); got != 0 {
-		t.Fatalf("AfterInstantiate ran %d time(s) after plugin Stop", got)
+	if got := afterInstantiate.Load(); got != 1 {
+		t.Fatalf("admitted AfterInstantiate ran %d time(s), want 1", got)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -653,6 +663,59 @@ func TestRuntimeCloseDrainsManagedForkBeforeManagerTeardown(t *testing.T) {
 	}
 }
 
+func TestAdmittedImportedStartKeepsPluginGenerationUntilTerminalObserver(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	afterReturned, stopped := make(chan struct{}), make(chan struct{})
+	def := testDefinition("example.com/close/reserved-start")
+	def.Authorities = []AuthorityRequest{
+		{Name: AuthorityHostImportDefine, Mode: AuthorityRequired, Reason: "block imported start", Scope: AuthorityScope{Modules: []string{"env"}}},
+		{Name: AuthorityInstanceInstantiateObserve, Mode: AuthorityRequired, Reason: "prove terminal generation retention"},
+	}
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(r *Registrar) error {
+			hosts, _ := r.HostImports()
+			module, _ := hosts.Module("env")
+			module.Func("f", func(HostModule, []uint64, []uint64) { close(entered); <-release })
+			observer, _ := r.InstanceInstantiateObserver()
+			if err := observer.After(func(InstantiationEvent) { close(afterReturned) }); err != nil {
+				return err
+			}
+			return r.Lifecycle(PluginLifecycle{Stop: func(context.Context) error { close(stopped); return nil }})
+		})
+	}}
+	rt := NewRuntime()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	mod, err := rt.Compile(blockingImportedStartModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	instantiateDone := make(chan error, 1)
+	go func() { _, err := rt.Instantiate(context.Background(), mod); instantiateDone <- err }()
+	<-entered
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("plugin Stop did not run")
+	}
+	close(release)
+	if err := <-instantiateDone; err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("Instantiate racing close = %v, want closed failure", err)
+	}
+	select {
+	case <-afterReturned:
+	case <-time.After(time.Second):
+		t.Fatal("admitted terminal observer did not run after Stop")
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func blockingImportedStartModule() []byte {
 	return wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
@@ -716,16 +779,17 @@ func TestRetainedCrossInstanceCallCannotEnterPluginAfterStop(t *testing.T) {
 	callDone := make(chan error, 1)
 	go func() { _, err := consumer.Invoke("call"); callDone <- err }()
 	<-entered
-	closeDone := make(chan error, 1)
-	go func() { closeDone <- rt.Close() }()
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
 	select {
-	case <-time.After(25 * time.Millisecond):
-	case err := <-closeDone:
-		t.Fatalf("Runtime.Close returned while a retained plugin callback was active: %v", err)
+	case <-rt.Closed():
+		t.Fatal("Runtime teardown completed while a retained plugin callback was active")
+	default:
 	}
 	close(release)
 	<-callDone // runtime interruption or normal unwind are both valid
-	if err := <-closeDone; err != nil {
+	if err := rt.WaitClosed(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if !stopped.Load() {

--- a/src/wago/plugin_lifecycle_hardening_test.go
+++ b/src/wago/plugin_lifecycle_hardening_test.go
@@ -276,7 +276,7 @@ func TestStartFailureNeverPublishesCommittedPlan(t *testing.T) {
 	}
 }
 
-func TestRuntimeCloseIsJoinableWithSameError(t *testing.T) {
+func TestRuntimeCloseCompletionPublishesSameError(t *testing.T) {
 	stopErr := errors.New("same close result")
 	entered, release := make(chan struct{}), make(chan struct{})
 	def := testDefinition("example.com/close/join")
@@ -296,17 +296,23 @@ func TestRuntimeCloseIsJoinableWithSameError(t *testing.T) {
 	first := make(chan error, 1)
 	go func() { first <- rt.Close() }()
 	<-entered
-	second := make(chan error, 1)
-	go func() { second <- rt.Close() }()
+	if err := rt.Close(); err != nil {
+		t.Fatalf("concurrent Close = %v", err)
+	}
+	done := rt.Closed()
+	if done == nil {
+		t.Fatal("concurrent Close did not expose completion")
+	}
 	select {
-	case err := <-second:
-		t.Fatalf("joined Close returned early: %v", err)
-	case <-time.After(25 * time.Millisecond):
+	case <-done:
+		t.Fatal("shutdown completed before Stop returned")
+	default:
 	}
 	close(release)
-	err1, err2 := <-first, <-second
+	err1 := <-first
+	err2 := rt.WaitClosed(context.Background())
 	if !errors.Is(err1, stopErr) || !errors.Is(err2, stopErr) || err1.Error() != err2.Error() {
-		t.Fatalf("Close results = %v / %v", err1, err2)
+		t.Fatalf("Close/WaitClosed results = %v / %v", err1, err2)
 	}
 }
 
@@ -563,6 +569,87 @@ func TestRuntimeStopCanReleaseBlockedImportedStart(t *testing.T) {
 	}
 	if got := afterInstantiate.Load(); got != 0 {
 		t.Fatalf("AfterInstantiate ran %d time(s) after plugin Stop", got)
+	}
+}
+
+func TestRuntimeCloseDrainsManagedForkBeforeManagerTeardown(t *testing.T) {
+	def := testDefinition("example.com/close/managed-fork")
+	def.Authorities = []AuthorityRequest{
+		{Name: AuthorityHostImportDefine, Mode: AuthorityRequired, Reason: "fork caller", Scope: AuthorityScope{Modules: []string{"env"}}},
+		{Name: AuthorityInstanceManage, Mode: AuthorityRequired, Reason: "own fork", Scope: AuthorityScope{MaxInstances: 1, MaxMemoryBytes: 64 << 10}},
+		{Name: AuthorityInstanceInstantiateIntercept, Mode: AuthorityRequired, Reason: "hold admitted fork"},
+	}
+	entered, release := make(chan struct{}), make(chan struct{})
+	forkResult := make(chan error, 1)
+	var manager *InstanceManager
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			var err error
+			manager, err = reg.ManagedInstances()
+			if err != nil {
+				return err
+			}
+			hosts, err := reg.HostImports()
+			if err != nil {
+				return err
+			}
+			module, err := hosts.Module("env")
+			if err != nil {
+				return err
+			}
+			module.Func("f", func(caller HostModule, _, _ []uint64) {
+				child, err := manager.Fork(context.Background(), caller)
+				if child != nil {
+					err = errors.Join(err, child.Close())
+				}
+				forkResult <- err
+			})
+			interceptor, err := reg.InstanceInstantiateInterceptor()
+			if err != nil {
+				return err
+			}
+			return interceptor.Before(func(request InstantiationRequest) error {
+				if request.Origin == InstantiateManaged {
+					close(entered)
+					<-release
+				}
+				return nil
+			})
+		})
+	}}
+	rt := NewRuntime()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	mod, err := rt.Compile(voidImportCallModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callDone := make(chan error, 1)
+	go func() { _, err := parent.Call(context.Background(), "call"); callDone <- err }()
+	<-entered
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-rt.Closed():
+		t.Fatal("runtime teardown completed while managed fork was admitted")
+	default:
+	}
+	close(release)
+	if err := <-forkResult; err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("managed fork racing close = %v, want closed failure", err)
+	}
+	<-callDone // interrupted or successful host-call unwind are both valid.
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -141,6 +141,11 @@ func (rt *Runtime) beginFailedPluginRollback() {
 	if rt.state == runtimeLoading {
 		rt.state = runtimeClosing
 	}
+	select {
+	case <-rt.loadingDone:
+	default:
+		close(rt.loadingDone)
+	}
 	rt.stateCond.Broadcast()
 	rt.mu.Unlock()
 }
@@ -162,6 +167,7 @@ func (rt *Runtime) beginPluginLoad() error {
 	}
 	rt.pluginsLoadAttempted = true
 	rt.state = runtimeLoading
+	rt.loadingDone = make(chan struct{})
 	return nil
 }
 
@@ -169,6 +175,11 @@ func (rt *Runtime) finishPluginLoad() {
 	rt.mu.Lock()
 	if rt.state == runtimeLoading {
 		rt.state = runtimeReady
+	}
+	select {
+	case <-rt.loadingDone:
+	default:
+		close(rt.loadingDone)
 	}
 	rt.stateCond.Broadcast()
 	rt.mu.Unlock()

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -746,13 +746,15 @@ func (rt *Runtime) commitPluginPlan(plan []plannedPlugin) error {
 		return err
 	}
 	needsInstructionABI := false
+	hooks := rt.hooks.clone()
 	for _, p := range plan {
 		id := p.provider.Definition.ID
 		needsInstructionABI = needsInstructionABI || len(p.reg.instructions) != 0
 		for _, imp := range p.reg.imports {
-			rt.imports[imp.key()] = p.reg.callGate.wrap(imp.fn)
-			rt.importMeta[imp.key()] = imp
-			rt.importOwner[imp.key()] = id
+			key := imp.key()
+			rt.imports[key] = p.reg.callGate.wrap(imp.fn)
+			rt.importMeta[key] = cloneRegisteredImport(imp)
+			rt.importOwner[key] = id
 			rt.moduleOwner[imp.module] = id
 		}
 		for _, cap := range p.reg.caps {
@@ -772,7 +774,7 @@ func (rt *Runtime) commitPluginPlan(plan []plannedPlugin) error {
 				return &PluginError{Plugin: id, Phase: PluginPhaseCommit, Err: err}
 			}
 		}
-		rt.hooks.appendGated(p.reg.hooks, p.reg.callGate)
+		hooks.appendGated(p.reg.hooks, p.reg.callGate)
 		for _, activate := range p.reg.activate {
 			activate(rt)
 		}
@@ -780,13 +782,17 @@ func (rt *Runtime) commitPluginPlan(plan []plannedPlugin) error {
 	}
 	if needsInstructionABI {
 		for _, imp := range instructionABIImports() {
-			rt.imports[imp.key()] = imp.fn
-			rt.importMeta[imp.key()] = imp
-			rt.importOwner[imp.key()] = "wago:core"
+			key := imp.key()
+			rt.imports[key] = imp.fn
+			rt.importMeta[key] = cloneRegisteredImport(imp)
+			rt.importOwner[key] = "wago:core"
 			rt.moduleOwner[imp.module] = "wago:core"
 		}
 	}
 	rt.pluginRuns = pluginRunsFor(plan)
+	// Publish only after every handle, contract, import, and manager used by the
+	// complete generation has activated.
+	rt.storeHooks(hooks)
 	return nil
 }
 

--- a/src/wago/plugin_vnext_test.go
+++ b/src/wago/plugin_vnext_test.go
@@ -848,7 +848,7 @@ func TestModuleCompiledEventCarriesOnlyTheFinalTransformedSourceDigest(t *testin
 	}
 }
 
-func TestModuleCloseObserverEmitsOnceWithoutClosingCompiled(t *testing.T) {
+func TestModuleCloseObserverEmitsOnceAndClosesRuntimeCompiled(t *testing.T) {
 	def := testDefinition("example.com/module/lifecycle")
 	def.Authorities = []AuthorityRequest{
 		{Name: AuthorityModuleCompileObserve, Mode: AuthorityRequired, Reason: "correlate the module"},
@@ -922,15 +922,8 @@ func TestModuleCloseObserverEmitsOnceWithoutClosingCompiled(t *testing.T) {
 	if _, err := rt.Instantiate(context.Background(), mod); err == nil || !strings.Contains(err.Error(), "module is closed") {
 		t.Fatalf("Runtime.Instantiate after Module.Close error=%v", err)
 	}
-	instance, err := Instantiate(compiled)
-	if err != nil {
-		t.Fatalf("Module.Close closed caller-owned Compiled: %v", err)
-	}
-	if err := instance.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := compiled.Close(); err != nil {
-		t.Fatal(err)
+	if _, err := Instantiate(compiled); err == nil || !strings.Contains(err.Error(), "compiled module is closed") {
+		t.Fatalf("Runtime.Compile Module.Close retained owned Compiled: %v", err)
 	}
 }
 

--- a/src/wago/plugin_vnext_test.go
+++ b/src/wago/plugin_vnext_test.go
@@ -475,23 +475,24 @@ func TestLifecycleRollbackReverseStopAndContractLease(t *testing.T) {
 	doneCall := make(chan error, 1)
 	go func() { doneCall <- ref.Call(func(any) error { close(entered); <-release; return nil }) }()
 	<-entered
-	closed := make(chan error, 1)
-	go func() { closed <- rt.Close() }()
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < 1000; i++ {
 		if err := ref.Call(func(any) error { return nil }); err != nil {
 			break
 		}
 	}
 	select {
-	case err := <-closed:
-		t.Fatalf("close returned early: %v", err)
+	case <-rt.Closed():
+		t.Fatal("runtime teardown completed while a contract call was active")
 	default:
 	}
 	close(release)
 	if err := <-doneCall; err != nil {
 		t.Fatal(err)
 	}
-	if err := <-closed; err != nil {
+	if err := rt.WaitClosed(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if err := ref.Call(func(any) error { return nil }); !errors.Is(err, ErrPermissionDenied) {
@@ -1010,6 +1011,9 @@ func TestGuestArgumentsAreRuntimeScopedAndRevoked(t *testing.T) {
 	if err := rt.Close(); err != nil {
 		t.Fatal(err)
 	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := access.Args(); !errors.Is(err, ErrPermissionDenied) {
 		t.Fatalf("after close=%v", err)
 	}
@@ -1031,6 +1035,9 @@ func TestGuestArgumentsEmptyIsActiveAndRevoked(t *testing.T) {
 		t.Fatalf("empty args=%#v err=%v", args, err)
 	}
 	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := access.Args(); !errors.Is(err, ErrPermissionDenied) {
@@ -1243,8 +1250,11 @@ func TestObserverPanicsAreContainedAndTeardownContinues(t *testing.T) {
 	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
 		t.Fatal(err)
 	}
-	err := rt.Close()
-	if err == nil || !strings.Contains(err.Error(), "RuntimeCloseObserver hook panicked") {
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	err := rt.WaitClosed(context.Background())
+	if !errors.Is(err, ErrCallbackPanic) {
 		t.Fatalf("close error=%v", err)
 	}
 	if !reflect.DeepEqual(events, []string{"second", "first"}) {

--- a/src/wago/reexport_test.go
+++ b/src/wago/reexport_test.go
@@ -260,6 +260,9 @@ func TestImportedFunctionReexportIssuesFirstFuncrefAfterProducerClose(t *testing
 	if err := rt.Close(); err != nil {
 		t.Fatalf("Close runtime: %v", err)
 	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatalf("WaitClosed runtime: %v", err)
+	}
 	if producer.hasPhysicalResources() || producer.resourceRefs != 0 {
 		t.Fatalf("producer after final token teardown: live=%v roots=%d", producer.hasPhysicalResources(), producer.resourceRefs)
 	}

--- a/src/wago/reference_lifetime.go
+++ b/src/wago/reference_lifetime.go
@@ -37,7 +37,7 @@ func (lifetime referenceLifetime) finalize() {
 		return
 	}
 	in.lifeMu.Lock()
-	if !in.closed || in.finalizing || in.resourcesClosed || in.invocationState.Load()&instanceInvocationCount != 0 {
+	if !in.closed || in.finalizing || in.resourcesClosed || in.constructionActive || in.invocationState.Load()&instanceInvocationCount != 0 {
 		in.lifeMu.Unlock()
 		return
 	}
@@ -51,7 +51,7 @@ func (lifetime referenceLifetime) finalize() {
 
 	in.lifeMu.Lock()
 	in.finalizing = false
-	if in.resourcesClosed || !in.closed || in.resourceRefs != 0 || in.invocationState.Load()&instanceInvocationCount != 0 {
+	if in.resourcesClosed || !in.closed || in.resourceRefs != 0 || in.constructionActive || in.invocationState.Load()&instanceInvocationCount != 0 {
 		in.lifeMu.Unlock()
 		return
 	}

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -167,6 +167,16 @@ type registeredImport struct {
 
 func (i *registeredImport) key() string { return i.module + "." + i.name }
 
+func cloneRegisteredImport(imp *registeredImport) *registeredImport {
+	if imp == nil {
+		return nil
+	}
+	clone := *imp
+	clone.params = append([]ValType(nil), imp.params...)
+	clone.results = append([]ValType(nil), imp.results...)
+	return &clone
+}
+
 // ImportModuleBuilder scopes declarations to one exact Wasm module.
 type ImportModuleBuilder struct {
 	reg    *Registrar

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -374,9 +374,13 @@ func (rt *Runtime) prepareCompile(wasmBytes []byte, allowLoading bool) (*Prepare
 		if err := joinPrimary(transformErr, panicErr); err != nil {
 			return fail(emitCompileError(hooks, compilation, err))
 		}
-		if next != nil {
-			source = next
+		if next == nil {
+			next = source
 		}
+		// A transformer may retain either its input or returned slice. Snapshot
+		// after every callback so the admitted generation cannot be mutated later
+		// through plugin-owned storage.
+		source = append([]byte(nil), next...)
 	}
 	return &PreparedCompile{
 		rt: rt, end: end, compilation: compilation, source: source, cfg: cfg,
@@ -385,10 +389,11 @@ func (rt *Runtime) prepareCompile(wasmBytes []byte, allowLoading bool) (*Prepare
 	}, nil
 }
 
-// Source returns the transformed source for this preparation. The returned
-// bytes must remain immutable until the preparation is closed or adopted. If
-// Compile succeeds, ownership transfers to the returned Module and the bytes
-// must remain immutable until that Module closes.
+// Source returns the admitted transformed source for this preparation. Callers
+// receive a read-only view and must not mutate it. Transformer return slices are
+// snapshotted; without transforms, the view retains PrepareCompile's input under
+// the same ownership contract as Compile. A successful Compile may retain that
+// storage until the returned Module closes.
 func (p *PreparedCompile) Source() []byte {
 	if p == nil {
 		return nil

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -32,6 +32,7 @@ type Runtime struct {
 	mu                    sync.Mutex
 	stateCond             *sync.Cond
 	state                 runtimeState
+	loadingDone           chan struct{}
 	pluginsLoadAttempted  bool
 	operational           bool
 	activeOperations      uint64
@@ -122,6 +123,8 @@ func NewRuntime(opts ...RuntimeOption) *Runtime {
 		instances:    map[*Instance]uint64{},
 	}
 	rt.stateCond = sync.NewCond(&rt.mu)
+	rt.loadingDone = make(chan struct{})
+	close(rt.loadingDone)
 	for _, opt := range opts {
 		opt(rt)
 	}
@@ -170,6 +173,47 @@ func (rt *Runtime) storeHooks(hooks *hookRegistry) {
 // phase after the complete plan has activated.
 func (rt *Runtime) beginOperation(label string, allowLoading bool) (func(), error) {
 	return rt.beginOperationKind(label, allowLoading, false)
+}
+
+func (rt *Runtime) beginOperationGeneration(label string, allowLoading bool) (*hookRegistry, *pluginOperationReservation, func(), error) {
+	if rt == nil {
+		return nil, nil, nil, fmt.Errorf("wago: %s on a nil runtime", label)
+	}
+	rt.mu.Lock()
+	switch rt.state {
+	case runtimeLoading:
+		if !allowLoading {
+			rt.mu.Unlock()
+			return nil, nil, nil, fmt.Errorf("wago: %s while plugins are loading", label)
+		}
+	case runtimeClosing, runtimeClosed:
+		rt.mu.Unlock()
+		return nil, nil, nil, fmt.Errorf("wago: %s on a closed runtime", label)
+	}
+	hooks := rt.loadHooks()
+	reservation, err := reservePluginOperation(hooks.operationGates)
+	if err != nil {
+		rt.mu.Unlock()
+		return nil, nil, nil, err
+	}
+	rt.operational = true
+	rt.activeOperations++
+	rt.mu.Unlock()
+	var once sync.Once
+	end := func() {
+		once.Do(func() {
+			reservation.release()
+			rt.mu.Lock()
+			if rt.activeOperations == 0 {
+				rt.mu.Unlock()
+				panic("wago: runtime operation lease underflow")
+			}
+			rt.activeOperations--
+			rt.stateCond.Broadcast()
+			rt.mu.Unlock()
+		})
+	}
+	return hooks, reservation, end, nil
 }
 
 func (rt *Runtime) beginCompileOperation(label string, allowLoading bool) (func(), error) {
@@ -645,7 +689,7 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	if mod.rt != rt {
 		return nil, fmt.Errorf("wago: Instantiate: %w", ErrForeignModule)
 	}
-	end, err := rt.beginOperation("Instantiate", allowLoading)
+	hooks, reservation, end, err := rt.beginOperationGeneration("Instantiate", allowLoading)
 	if err != nil {
 		return nil, err
 	}
@@ -684,7 +728,6 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 		}
 	}
 	policy := rt.overridePolicy
-	hooks := rt.loadHooks()
 	rt.mu.Unlock()
 
 	for k, v := range cfg.imports {
@@ -712,7 +755,7 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	// retained code ownership before start-time host callbacks.
 	mod.endUse()
 	usingModule = false
-	in, err := rt.instantiateWithHooksOrigin(mod, merged, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks)
+	in, err := rt.instantiateWithHooksOrigin(mod, merged, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks, reservation)
 	if err == nil && rt.isClosed() {
 		err = joinPrimary(fmt.Errorf("wago: runtime closed during instantiation"), in.Close())
 		in = nil
@@ -730,11 +773,12 @@ func applyInstantiateOptions(opts []InstantiateOption) instantiateConfig {
 
 // instantiateWithHooksOrigin runs the Runtime-aware instantiation path and emits
 // plugin lifecycle callbacks around the low-level instantiator.
-func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc GCConfig, hasGC, forceSyncHost bool, origin InstantiateOrigin, hooks *hookRegistry) (*Instance, error) {
+func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc GCConfig, hasGC, forceSyncHost bool, origin InstantiateOrigin, hooks *hookRegistry, reservation *pluginOperationReservation) (*Instance, error) {
 	iopts := InstantiateOptions{
 		Imports: imports, store: rt.refStore, runtime: rt, origin: origin,
 		forceSyncHost:        forceSyncHost || rt.callerResolverActive.Load(),
 		moduleIdentity:       mod.moduleIdentity(),
+		operationReservation: reservation,
 		independentInstances: mod.independentInstances,
 		hasExecutionPolicy:   true,
 	}
@@ -748,12 +792,14 @@ func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc G
 		return instantiateCoreWithModuleUse(mod, iopts)
 	}
 
-	request := InstantiationRequest{Module: moduleView(mod), Origin: origin}
+	request := InstantiationRequest{Module: moduleView(mod), Origin: origin, reservation: reservation}
 	emitError := func(original error) error {
 		var hookErrs []error
 		for _, fn := range hooks.onInstantiateError {
 			observer := fn
-			if panicErr := callHookSafely("OnInstantiateError", func() { observer(InstantiationErrorEvent{Module: request.Module, Origin: origin, Err: original}) }); panicErr != nil {
+			if panicErr := callHookSafely("OnInstantiateError", func() {
+				observer(InstantiationErrorEvent{Module: request.Module, Origin: origin, Err: original, reservation: reservation})
+			}); panicErr != nil {
 				hookErrs = append(hookErrs, panicErr)
 			}
 		}
@@ -769,7 +815,7 @@ func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc G
 		}
 	}
 	iopts.afterCreate = func(inst *Instance) error {
-		event := InstantiationEvent{Module: request.Module, Instance: InstanceIdentity{value: inst}, Origin: origin}
+		event := InstantiationEvent{Module: request.Module, Instance: InstanceIdentity{value: inst}, Origin: origin, reservation: reservation}
 		for _, fn := range hooks.afterCreate {
 			interceptor := fn
 			var hookErr error
@@ -786,7 +832,7 @@ func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc G
 	}
 	for _, fn := range hooks.afterInstantiate {
 		observer := fn
-		event := InstantiationEvent{Module: request.Module, Instance: InstanceIdentity{value: inst}, Origin: origin}
+		event := InstantiationEvent{Module: request.Module, Instance: InstanceIdentity{value: inst}, Origin: origin, reservation: reservation}
 		if err := callHookSafely("InstanceInstantiateObserver", func() { observer(event) }); err != nil {
 			failed := joinPrimary(err, inst.Close())
 			return nil, emitError(failed)
@@ -848,36 +894,31 @@ func (rt *Runtime) ProvidedImports() []ImportSpec {
 	return specs
 }
 
-// Close publishes the shutdown gate immediately. If called from an admitted
-// runtime operation, it starts teardown asynchronously and returns so callbacks
-// can unwind without self-deadlock. Closed and WaitClosed expose deterministic
-// completion and the final joined error.
+// Close publishes shutdown and returns promptly. It never waits for teardown,
+// so plugin callbacks, host imports, contract calls, invoke hooks, and close
+// observers may initiate Runtime closure without self-deadlock. Use
+// CloseContext or WaitClosed when completion and the joined teardown error are
+// required.
 func (rt *Runtime) Close() error {
 	if rt == nil {
 		return nil
 	}
 	rt.mu.Lock()
-	for rt.state == runtimeLoading {
-		rt.stateCond.Wait()
-	}
 	if rt.closeState != nil {
-		state := rt.closeState
-		closed := rt.state == runtimeClosed
 		rt.mu.Unlock()
-		if closed {
-			return state.result
-		}
 		return nil
 	}
-	active := rt.activeOperations != 0
-	state, hooks, internalClose, pluginRuns, store := rt.startCloseLocked()
+	state := rt.publishCloseLocked()
+	if rt.stateWasLoadingLocked() {
+		loadingDone := rt.loadingDone
+		rt.mu.Unlock()
+		go rt.finishCloseAfterLoading(context.Background(), state, loadingDone)
+		return nil
+	}
+	hooks, internalClose, pluginRuns, store := rt.snapshotCloseLocked()
 	rt.mu.Unlock()
 	go rt.finishClose(context.Background(), state, hooks, internalClose, pluginRuns, store)
-	if active {
-		return nil
-	}
-	<-state.done
-	return state.result
+	return nil
 }
 
 // Closed returns a channel closed after teardown completes and the final result
@@ -933,18 +974,18 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 		return err
 	}
 	rt.mu.Lock()
-	for rt.state == runtimeLoading {
-		rt.stateCond.Wait()
-	}
 	state := rt.closeState
 	if state == nil {
-		var hooks []func(RuntimeCloseEvent)
-		var internalClose []func() error
-		var pluginRuns []registeredPluginRun
-		var store *referenceStore
-		state, hooks, internalClose, pluginRuns, store = rt.startCloseLocked()
-		rt.mu.Unlock()
-		go rt.finishClose(ctx, state, hooks, internalClose, pluginRuns, store)
+		state = rt.publishCloseLocked()
+		if rt.stateWasLoadingLocked() {
+			loadingDone := rt.loadingDone
+			rt.mu.Unlock()
+			go rt.finishCloseAfterLoading(ctx, state, loadingDone)
+		} else {
+			hooks, internalClose, pluginRuns, store := rt.snapshotCloseLocked()
+			rt.mu.Unlock()
+			go rt.finishClose(ctx, state, hooks, internalClose, pluginRuns, store)
+		}
 	} else {
 		rt.mu.Unlock()
 	}
@@ -956,18 +997,53 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 	}
 }
 
-// startCloseLocked publishes shutdown and snapshots teardown state. rt.mu is
-// held by the caller.
-func (rt *Runtime) startCloseLocked() (*runtimeCloseState, []func(RuntimeCloseEvent), []func() error, []registeredPluginRun, *referenceStore) {
+// publishCloseLocked publishes shutdown without waiting or running callbacks.
+// rt.mu is held by the caller.
+func (rt *Runtime) publishCloseLocked() *runtimeCloseState {
+	wasLoading := rt.state == runtimeLoading
 	state := &runtimeCloseState{done: make(chan struct{})}
 	rt.closeState = state
 	rt.state = runtimeClosing
+	if wasLoading {
+		// loadingDone remains owned by the plugin-loading transaction. The close
+		// worker waits for its committed generation to finish starting or rolling
+		// back before taking the teardown snapshot.
+		rt.operational = true
+	}
+	return state
+}
+
+func (rt *Runtime) stateWasLoadingLocked() bool {
+	select {
+	case <-rt.loadingDone:
+		return false
+	default:
+		return true
+	}
+}
+
+func (rt *Runtime) snapshotCloseLocked() ([]func(RuntimeCloseEvent), []func() error, []registeredPluginRun, *referenceStore) {
 	hooks := rt.loadHooks()
-	return state,
-		append([]func(RuntimeCloseEvent){}, hooks.onRuntimeClose...),
+	return append([]func(RuntimeCloseEvent){}, hooks.onRuntimeClose...),
 		append([]func() error(nil), hooks.internalClose...),
 		append([]registeredPluginRun(nil), rt.pluginRuns...),
 		rt.refStore
+}
+
+// startCloseLocked publishes shutdown and snapshots teardown state. rt.mu is
+// held by the caller and plugin loading has completed.
+func (rt *Runtime) startCloseLocked() (*runtimeCloseState, []func(RuntimeCloseEvent), []func() error, []registeredPluginRun, *referenceStore) {
+	state := rt.publishCloseLocked()
+	hooks, internalClose, pluginRuns, store := rt.snapshotCloseLocked()
+	return state, hooks, internalClose, pluginRuns, store
+}
+
+func (rt *Runtime) finishCloseAfterLoading(ctx context.Context, state *runtimeCloseState, loadingDone <-chan struct{}) {
+	<-loadingDone
+	rt.mu.Lock()
+	hooks, internalClose, pluginRuns, store := rt.snapshotCloseLocked()
+	rt.mu.Unlock()
+	rt.finishClose(ctx, state, hooks, internalClose, pluginRuns, store)
 }
 
 func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, hooks []func(RuntimeCloseEvent), internalClose []func() error, pluginRuns []registeredPluginRun, store *referenceStore) {
@@ -982,7 +1058,7 @@ func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, ho
 	rt.mu.Unlock()
 	for i := len(hooks) - 1; i >= 0; i-- {
 		observer := hooks[i]
-		if err := callHookSafely("RuntimeCloseObserver", func() { observer(RuntimeCloseEvent{}) }); err != nil {
+		if err := callShutdownSafely("RuntimeCloseObserver", func() { observer(RuntimeCloseEvent{}) }); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -1002,8 +1078,16 @@ func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, ho
 		}
 	}
 	for i := len(pluginRuns) - 1; i >= 0; i-- {
-		pluginRuns[i].deactivateProviders()
 		errs = append(errs, closePluginRun(ctx, pluginRuns[i])...)
+	}
+	for i := len(pluginRuns) - 1; i >= 0; i-- {
+		for j := len(pluginRuns[i].provided) - 1; j >= 0; j-- {
+			var revokeErr error
+			panicErr := callShutdownSafely("provided contract revoke", func() { revokeErr = pluginRuns[i].provided[j].revoke() })
+			if err := joinPrimary(revokeErr, panicErr); err != nil {
+				errs = append(errs, err)
+			}
+		}
 	}
 	rt.mu.Lock()
 	for rt.activeOperations != 0 {
@@ -1013,15 +1097,22 @@ func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, ho
 	for i := len(instances) - 1; i >= 0; i-- {
 		closeState := instances[i].ensurePluginState().close.Load()
 		if closeState != nil {
-			<-closeState.quiesced
+			<-closeState.done
+			if closeState.result != nil {
+				errs = append(errs, closeState.result)
+			}
 		}
 	}
 	for i := len(internalClose) - 1; i >= 0; i-- {
-		if err := internalClose[i](); err != nil {
+		var closeErr error
+		panicErr := callShutdownSafely("internal runtime close", func() { closeErr = internalClose[i]() })
+		if err := joinPrimary(closeErr, panicErr); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	store.closeRuntime()
+	if err := callShutdownSafely("reference store close", store.closeRuntime); err != nil {
+		errs = append(errs, err)
+	}
 	result := errors.Join(errs...)
 	rt.mu.Lock()
 	rt.state = runtimeClosed
@@ -1032,7 +1123,27 @@ func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, ho
 }
 
 func (rt *Runtime) rollbackCommittedPluginPlan(ctx context.Context) error {
-	err := rt.CloseContext(ctx)
+	// Startup rollback is mandatory even when the loading context is already
+	// canceled. That context is still delivered to Stop as its cancellation
+	// signal, while rollback itself waits independently for complete teardown.
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rt.mu.Lock()
+	state := rt.closeState
+	if state == nil {
+		var hooks []func(RuntimeCloseEvent)
+		var internalClose []func() error
+		var pluginRuns []registeredPluginRun
+		var store *referenceStore
+		state, hooks, internalClose, pluginRuns, store = rt.startCloseLocked()
+		rt.mu.Unlock()
+		go rt.finishClose(ctx, state, hooks, internalClose, pluginRuns, store)
+	} else {
+		rt.mu.Unlock()
+	}
+	<-state.done
+	err := state.result
 	rt.mu.Lock()
 	rt.plugins = nil
 	rt.imports = Imports{}
@@ -1052,27 +1163,18 @@ func (rt *Runtime) rollbackCommittedPluginPlan(ctx context.Context) error {
 	return err
 }
 
-func (run registeredPluginRun) deactivateProviders() {
-	for _, slot := range run.provided {
-		slot.deactivate()
-	}
-}
-
 func closePluginRun(ctx context.Context, run registeredPluginRun) (errs []error) {
-	for i := len(run.provided) - 1; i >= 0; i-- {
-		if err := run.provided[i].revoke(); err != nil {
-			errs = append(errs, err)
-		}
-	}
 	for i := len(run.closeInstances) - 1; i >= 0; i-- {
-		if err := run.closeInstances[i](); err != nil {
+		var closeErr error
+		panicErr := callShutdownSafely("manager close admission", func() { closeErr = run.closeInstances[i]() })
+		if err := joinPrimary(closeErr, panicErr); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	run.callbacks.deactivate()
 	if run.shouldStop && run.lifecycle.Stop != nil {
 		var stopErr error
-		panicErr := callSafely("plugin Stop", func() { stopErr = run.lifecycle.Stop(ctx) })
+		panicErr := callShutdownSafely("plugin Stop", func() { stopErr = run.lifecycle.Stop(ctx) })
 		if err := joinPrimary(stopErr, panicErr); err != nil {
 			errs = append(errs, &PluginError{Plugin: run.name, Phase: PluginPhaseStop, Err: err})
 		}
@@ -1081,17 +1183,23 @@ func closePluginRun(ctx context.Context, run registeredPluginRun) (errs []error)
 		errs = append(errs, err)
 	}
 	for i := len(run.drainInstances) - 1; i >= 0; i-- {
-		if err := run.drainInstances[i](); err != nil {
+		var drainErr error
+		panicErr := callShutdownSafely("manager drain", func() { drainErr = run.drainInstances[i]() })
+		if err := joinPrimary(drainErr, panicErr); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	for i := len(run.consumed) - 1; i >= 0; i-- {
-		if err := run.consumed[i].revoke(); err != nil {
+		var revokeErr error
+		panicErr := callShutdownSafely("consumed contract revoke", func() { revokeErr = run.consumed[i].revoke() })
+		if err := joinPrimary(revokeErr, panicErr); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	for i := len(run.handles) - 1; i >= 0; i-- {
-		if err := run.handles[i](); err != nil {
+		var closeErr error
+		panicErr := callShutdownSafely("plugin handle revoke", func() { closeErr = run.handles[i]() })
+		if err := joinPrimary(closeErr, panicErr); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -29,24 +29,25 @@ const (
 // host imports into it, and it threads those through Compile/Instantiate. The
 // package-level Compile/Instantiate remain available as the low-level API.
 type Runtime struct {
-	mu                   sync.Mutex
-	stateCond            *sync.Cond
-	state                runtimeState
-	pluginsLoadAttempted bool
-	operational          bool
-	activeOperations     uint64
-	closeState           *runtimeCloseState
-	instances            map[*Instance]uint64
-	instanceSequence     uint64
-	moduleCloseMu        sync.RWMutex
-	moduleCloseBarrier   struct{}
-	cfg                  *RuntimeConfig
-	overridePolicy       ImportOverridePolicy
-	managedActive        atomic.Bool
-	callerResolverActive atomic.Bool
-	hooks                *hookRegistry
-	refStore             *referenceStore
-	guestArguments       []string
+	mu                    sync.Mutex
+	stateCond             *sync.Cond
+	state                 runtimeState
+	pluginsLoadAttempted  bool
+	operational           bool
+	activeOperations      uint64
+	compileOperations     uint64
+	moduleCloseOperations uint64
+	closeState            *runtimeCloseState
+	instances             map[*Instance]uint64
+	instanceSequence      uint64
+	cfg                   *RuntimeConfig
+	overridePolicy        ImportOverridePolicy
+	managedActive         atomic.Bool
+	callerResolverActive  atomic.Bool
+	hooks                 *hookRegistry
+	publishedHooks        atomic.Pointer[hookRegistry]
+	refStore              *referenceStore
+	guestArguments        []string
 
 	plugins      []PluginDefinition
 	imports      Imports                      // "module.name" -> host fn (any)
@@ -91,7 +92,7 @@ type RuntimeOption func(*Runtime)
 // WithRuntimeConfig sets the compile/instantiate configuration (feature gating,
 // bounds-check mode). Defaults to NewRuntimeConfig.
 func WithRuntimeConfig(cfg *RuntimeConfig) RuntimeOption {
-	return func(rt *Runtime) { rt.cfg = cfg }
+	return func(rt *Runtime) { rt.cfg = cfg.clone() }
 }
 
 // WithImportOverridePolicy sets how import collisions are resolved.
@@ -127,7 +128,40 @@ func NewRuntime(opts ...RuntimeOption) *Runtime {
 	if rt.cfg == nil {
 		rt.cfg = NewRuntimeConfig()
 	}
+	rt.publishedHooks.Store(rt.hooks)
 	return rt
+}
+
+// Config returns a caller-owned snapshot of the runtime's effective compile and
+// execution configuration.
+func (rt *Runtime) Config() *RuntimeConfig {
+	if rt == nil {
+		return nil
+	}
+	rt.mu.Lock()
+	cfg := rt.cfg.clone()
+	rt.mu.Unlock()
+	return cfg
+}
+
+func (rt *Runtime) loadHooks() *hookRegistry {
+	if rt == nil {
+		return &hookRegistry{}
+	}
+	if hooks := rt.publishedHooks.Load(); hooks != nil {
+		return hooks
+	}
+	return &hookRegistry{}
+}
+
+// storeHooks publishes one complete immutable hook generation. The caller must
+// hold rt.mu while changing the production generation.
+func (rt *Runtime) storeHooks(hooks *hookRegistry) {
+	if hooks == nil {
+		hooks = &hookRegistry{}
+	}
+	rt.hooks = hooks
+	rt.publishedHooks.Store(hooks)
 }
 
 // beginOperation permanently seals plugin loading on first public runtime use
@@ -135,6 +169,14 @@ func NewRuntime(opts ...RuntimeOption) *Runtime {
 // excludes public callers; committed authority handles may opt into the Start
 // phase after the complete plan has activated.
 func (rt *Runtime) beginOperation(label string, allowLoading bool) (func(), error) {
+	return rt.beginOperationKind(label, allowLoading, false)
+}
+
+func (rt *Runtime) beginCompileOperation(label string, allowLoading bool) (func(), error) {
+	return rt.beginOperationKind(label, allowLoading, true)
+}
+
+func (rt *Runtime) beginOperationKind(label string, allowLoading, compile bool) (func(), error) {
 	if rt == nil {
 		return nil, fmt.Errorf("wago: %s on a nil runtime", label)
 	}
@@ -151,13 +193,21 @@ func (rt *Runtime) beginOperation(label string, allowLoading bool) (func(), erro
 	}
 	rt.operational = true
 	rt.activeOperations++
+	if compile {
+		rt.compileOperations++
+	}
 	rt.mu.Unlock()
 	var once sync.Once
 	return func() {
 		once.Do(func() {
 			rt.mu.Lock()
-			if rt.activeOperations > 0 {
-				rt.activeOperations--
+			if rt.activeOperations == 0 || compile && rt.compileOperations == 0 {
+				rt.mu.Unlock()
+				panic("wago: runtime operation lease underflow")
+			}
+			rt.activeOperations--
+			if compile {
+				rt.compileOperations--
 			}
 			rt.stateCond.Broadcast()
 			rt.mu.Unlock()
@@ -213,14 +263,30 @@ func (rt *Runtime) unregisterInstance(in *Instance) {
 	rt.mu.Unlock()
 }
 
-func (rt *Runtime) allowsLifecycleCallbacks() bool {
+func (rt *Runtime) beginModuleCloseCallbacks() (*hookRegistry, func()) {
 	if rt == nil {
-		return false
+		return nil, nil
 	}
 	rt.mu.Lock()
-	active := rt.state != runtimeClosing && rt.state != runtimeClosed
+	if rt.state == runtimeClosing || rt.state == runtimeClosed {
+		rt.mu.Unlock()
+		return nil, nil
+	}
+	hooks := rt.loadHooks()
+	rt.activeOperations++
+	rt.moduleCloseOperations++
 	rt.mu.Unlock()
-	return active
+	return hooks, func() {
+		rt.mu.Lock()
+		if rt.activeOperations == 0 || rt.moduleCloseOperations == 0 {
+			rt.mu.Unlock()
+			panic("wago: module close operation lease underflow")
+		}
+		rt.activeOperations--
+		rt.moduleCloseOperations--
+		rt.stateCond.Broadcast()
+		rt.mu.Unlock()
+	}
 }
 
 func (rt *Runtime) isClosed() bool {
@@ -244,61 +310,203 @@ func (rt *Runtime) compilePlugin(wasmBytes []byte) (*Module, error) {
 	return rt.compile(wasmBytes, true)
 }
 
-func (rt *Runtime) compile(wasmBytes []byte, allowLoading bool) (*Module, error) {
-	end, err := rt.beginOperation("Compile", allowLoading)
+// PreparedCompile is one admitted runtime compilation generation. Preparation
+// validates configuration, snapshots hooks/imports/custom instructions, and runs
+// source transforms exactly once. Compile, Adopt, or Close releases the shutdown
+// admission exactly once.
+type PreparedCompile struct {
+	mu           sync.Mutex
+	rt           *Runtime
+	end          func()
+	compilation  CompilationIdentity
+	source       []byte
+	cfg          *RuntimeConfig
+	bindings     moduleBindings
+	hooks        *hookRegistry
+	instructions map[string]*registeredInstruction
+	cacheable    bool
+	consumed     bool
+	finished     bool
+}
+
+// PrepareCompile admits and prepares one public compilation.
+func (rt *Runtime) PrepareCompile(wasmBytes []byte) (*PreparedCompile, error) {
+	return rt.prepareCompile(wasmBytes, false)
+}
+
+func (rt *Runtime) prepareCompile(wasmBytes []byte, allowLoading bool) (*PreparedCompile, error) {
+	end, err := rt.beginCompileOperation("Compile", allowLoading)
 	if err != nil {
 		return nil, err
 	}
-	defer end()
+	fail := func(err error) (*PreparedCompile, error) {
+		end()
+		return nil, err
+	}
+
+	rt.mu.Lock()
+	cfg := rt.cfg.clone()
+	hooks := rt.loadHooks()
+	bindings := rt.snapshotModuleBindingsLocked(hooks)
+	instructions := make(map[string]*registeredInstruction, len(rt.instructions))
+	for key, ins := range rt.instructions {
+		instructions[key] = ins
+	}
+	rt.mu.Unlock()
+	if err := cfg.Validate(); err != nil {
+		return fail(err)
+	}
+
 	var compilation CompilationIdentity
-	if len(rt.hooks.beforeCompile) != 0 || len(rt.hooks.afterCompile) != 0 || len(rt.hooks.onCompileError) != 0 {
+	if len(hooks.beforeCompile) != 0 || len(hooks.afterCompile) != 0 || len(hooks.onCompileError) != 0 {
 		compilation = CompilationIdentity{value: &compilationIdentityToken{}}
 	}
 	ctx := ModuleSourceContext{Compilation: compilation}
-	emitError := func(original error) error {
-		var hookErrs []error
-		for _, fn := range rt.hooks.onCompileError {
-			if panicErr := callHookSafely("ModuleCompileObserver.OnError", func() {
-				fn(ModuleCompileErrorEvent{Compilation: compilation, Err: original})
-			}); panicErr != nil {
-				hookErrs = append(hookErrs, panicErr)
-			}
-		}
-		return joinPrimary(original, hookErrs...)
-	}
 	source := wasmBytes
-	if len(rt.hooks.beforeCompile) != 0 {
+	if len(hooks.beforeCompile) != 0 {
 		source = append([]byte(nil), wasmBytes...)
 	}
-	for _, fn := range rt.hooks.beforeCompile {
+	for _, fn := range hooks.beforeCompile {
 		transform := fn
 		var next []byte
 		var transformErr error
 		panicErr := callHookSafely("ModuleSourceTransformer", func() { next, transformErr = transform(ctx, source) })
 		if err := joinPrimary(transformErr, panicErr); err != nil {
-			return nil, emitError(err)
+			return fail(emitCompileError(hooks, compilation, err))
 		}
 		if next != nil {
 			source = next
 		}
 	}
-	rt.mu.Lock()
-	instructions := make(map[string]*registeredInstruction, len(rt.instructions))
-	for key, ins := range rt.instructions {
-		instructions[key] = ins
+	return &PreparedCompile{
+		rt: rt, end: end, compilation: compilation, source: source, cfg: cfg,
+		bindings: bindings, hooks: hooks, instructions: instructions,
+		cacheable: len(hooks.beforeCompile) == 0 && len(instructions) == 0,
+	}, nil
+}
+
+// Source returns the transformed source for this preparation. The returned
+// bytes must remain immutable until the preparation is closed or adopted. If
+// Compile succeeds, ownership transfers to the returned Module and the bytes
+// must remain immutable until that Module closes.
+func (p *PreparedCompile) Source() []byte {
+	if p == nil {
+		return nil
 	}
-	cfg := rt.cfg
-	rt.mu.Unlock()
-	c, err := compileWithConfigAndInstructions(cfg, source, instructions)
+	return p.source
+}
+
+// Cacheable reports whether this compiler generation has a trustworthy
+// deterministic serialized-artifact identity.
+func (p *PreparedCompile) Cacheable() bool { return p != nil && p.cacheable }
+
+func (p *PreparedCompile) consume() error {
+	if p == nil {
+		return fmt.Errorf("wago: nil prepared compile")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.consumed {
+		return fmt.Errorf("wago: prepared compile already consumed")
+	}
+	p.consumed = true
+	return nil
+}
+
+func (p *PreparedCompile) finish() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	if p.finished {
+		p.mu.Unlock()
+		return
+	}
+	p.finished = true
+	end := p.end
+	p.end = nil
+	p.mu.Unlock()
+	if end != nil {
+		end()
+	}
+}
+
+// Compile compiles the prepared source and adopts ownership into the returned
+// Module.
+func (p *PreparedCompile) Compile() (*Module, error) {
+	if err := p.consume(); err != nil {
+		return nil, err
+	}
+	defer p.finish()
+	c, err := compileWithConfigAndInstructions(p.cfg, p.source, p.instructions)
 	if err != nil {
-		return nil, emitError(err)
+		return nil, emitCompileError(p.hooks, p.compilation, err)
 	}
-	mod := rt.buildModule(c)
+	return p.finishCompile(c)
+}
+
+// Adopt binds a freshly decoded artifact to this preparation and transfers its
+// ownership. A failed adoption closes the artifact exactly once.
+func (p *PreparedCompile) Adopt(c *Compiled) (*Module, error) {
+	if err := p.consume(); err != nil {
+		return nil, err
+	}
+	defer p.finish()
+	if c == nil {
+		return nil, fmt.Errorf("wago: nil compiled artifact")
+	}
+	return p.finishCompile(c)
+}
+
+func (p *PreparedCompile) finishCompile(c *Compiled) (*Module, error) {
+	mod := buildModule(c, p.bindings)
+	p.rt.restoreStructuredImportNames(mod, p.source)
+	if len(p.hooks.afterCompile) != 0 {
+		event := ModuleCompiledEvent{Compilation: p.compilation, Module: moduleView(mod), SourceDigest: DigestModuleSource(p.source)}
+		for _, fn := range p.hooks.afterCompile {
+			observer := fn
+			if err := callHookSafely("ModuleCompileObserver", func() { observer(event) }); err != nil {
+				return nil, emitCompileError(p.hooks, p.compilation, joinPrimary(err, c.Close()))
+			}
+		}
+	}
+	mod.ownsCompiled = true
+	return mod, nil
+}
+
+// Close abandons an unused preparation. It is idempotent.
+func (p *PreparedCompile) Close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	if p.consumed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.consumed = true
+	p.mu.Unlock()
+	p.finish()
+	return nil
+}
+
+func emitCompileError(hooks *hookRegistry, compilation CompilationIdentity, original error) error {
+	var hookErrs []error
+	for _, fn := range hooks.onCompileError {
+		observer := fn
+		if panicErr := callHookSafely("ModuleCompileObserver.OnError", func() {
+			observer(ModuleCompileErrorEvent{Compilation: compilation, Err: original})
+		}); panicErr != nil {
+			hookErrs = append(hookErrs, panicErr)
+		}
+	}
+	return joinPrimary(original, hookErrs...)
+}
+
+func (rt *Runtime) restoreStructuredImportNames(mod *Module, source []byte) {
 	// The historical Imports key joins module and field with a dot. Both Wasm
-	// names may themselves contain dots, so recover the exact pair from the
-	// validated source for structured metadata and component-model linking.
-	// The flat key remains unchanged for backwards-compatible Imports lookup.
-	if decoded, decodeErr := wasm.DecodeModule(source); decodeErr == nil {
+	// names may contain dots, so recover the exact pair from validated source.
+	if decoded, err := wasm.DecodeModule(source); err == nil {
 		funcIndex := 0
 		for i := range decoded.Imports {
 			im := &decoded.Imports[i]
@@ -310,53 +518,60 @@ func (rt *Runtime) compile(wasmBytes []byte, allowLoading bool) (*Module, error)
 			funcIndex++
 		}
 	}
-	if len(rt.hooks.afterCompile) > 0 {
-		sourceDigest := DigestModuleSource(source)
-		for _, fn := range rt.hooks.afterCompile {
-			if err := callHookSafely("ModuleCompileObserver", func() {
-				fn(ModuleCompiledEvent{Compilation: compilation, Module: moduleView(mod), SourceDigest: sourceDigest})
-			}); err != nil {
-				return nil, emitError(joinPrimary(err, mod.Close(), c.Close()))
-			}
-		}
+}
+
+func (rt *Runtime) compile(wasmBytes []byte, allowLoading bool) (*Module, error) {
+	prepared, err := rt.prepareCompile(wasmBytes, allowLoading)
+	if err != nil {
+		return nil, err
 	}
-	return mod, nil
+	return prepared.Compile()
 }
 
 // Module binds an already compiled artifact to this runtime's plugin imports
 // and lifecycle. It is the precompiled counterpart of Runtime.Compile.
 func (rt *Runtime) Module(c *Compiled) (*Module, error) {
+	return rt.bindModule(c, false)
+}
+
+// AdoptModule binds a decoded artifact and transfers ownership to the returned
+// Module. If binding fails, the artifact is closed before returning.
+func (rt *Runtime) AdoptModule(c *Compiled) (*Module, error) {
+	mod, err := rt.bindModule(c, true)
+	if err != nil && c != nil {
+		_ = c.Close()
+	}
+	return mod, err
+}
+
+func (rt *Runtime) bindModule(c *Compiled, ownsCompiled bool) (*Module, error) {
 	if rt == nil || c == nil {
 		return nil, fmt.Errorf("wago: nil runtime or compiled module")
 	}
-	end, err := rt.beginOperation("Module", false)
+	end, err := rt.beginCompileOperation("Module", false)
 	if err != nil {
 		return nil, err
 	}
 	defer end()
+	rt.mu.Lock()
+	hooks := rt.loadHooks()
+	bindings := rt.snapshotModuleBindingsLocked(hooks)
+	rt.mu.Unlock()
 	var compilation CompilationIdentity
-	if len(rt.hooks.afterCompile) != 0 || len(rt.hooks.onCompileError) != 0 {
+	if len(hooks.afterCompile) != 0 || len(hooks.onCompileError) != 0 {
 		compilation = CompilationIdentity{value: &compilationIdentityToken{}}
 	}
-	emitError := func(original error) error {
-		var hookErrs []error
-		for _, fn := range rt.hooks.onCompileError {
-			if panicErr := callHookSafely("ModuleCompileObserver.OnError", func() {
-				fn(ModuleCompileErrorEvent{Compilation: compilation, Err: original})
-			}); panicErr != nil {
-				hookErrs = append(hookErrs, panicErr)
-			}
-		}
-		return joinPrimary(original, hookErrs...)
-	}
-	mod := rt.buildModule(c)
-	if len(rt.hooks.afterCompile) > 0 {
-		for _, fn := range rt.hooks.afterCompile {
-			if err := callHookSafely("ModuleCompileObserver", func() { fn(ModuleCompiledEvent{Compilation: compilation, Module: moduleView(mod)}) }); err != nil {
-				return nil, emitError(joinPrimary(err, mod.Close()))
+	mod := buildModule(c, bindings)
+	if len(hooks.afterCompile) != 0 {
+		event := ModuleCompiledEvent{Compilation: compilation, Module: moduleView(mod)}
+		for _, fn := range hooks.afterCompile {
+			observer := fn
+			if err := callHookSafely("ModuleCompileObserver", func() { observer(event) }); err != nil {
+				return nil, emitCompileError(hooks, compilation, joinPrimary(err, mod.Close()))
 			}
 		}
 	}
+	mod.ownsCompiled = ownsCompiled
 	return mod, nil
 }
 
@@ -417,20 +632,28 @@ func (rt *Runtime) Instantiate(ctx context.Context, mod *Module, opts ...Instant
 }
 
 func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin InstantiateOrigin, allowLoading bool, opts ...InstantiateOption) (*Instance, error) {
+	if mod == nil {
+		return nil, fmt.Errorf("wago: Instantiate: nil module")
+	}
+	// Runtime ownership is intrinsic to the wrapper and takes precedence over
+	// destination policy or closed-state behavior.
+	if mod.rt != rt {
+		return nil, fmt.Errorf("wago: Instantiate: %w", ErrForeignModule)
+	}
 	end, err := rt.beginOperation("Instantiate", allowLoading)
 	if err != nil {
 		return nil, err
 	}
 	defer end()
-	if mod == nil {
-		return nil, fmt.Errorf("wago: Instantiate: nil module")
-	}
-	if mod.isClosed() {
+	if !mod.beginUse() {
 		return nil, fmt.Errorf("wago: Instantiate: module is closed")
 	}
-	if mod.rt != rt {
-		return nil, fmt.Errorf("wago: Instantiate: module belongs to a different runtime")
-	}
+	usingModule := true
+	defer func() {
+		if usingModule {
+			mod.endUse()
+		}
+	}()
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -446,7 +669,8 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	}
 
 	rt.mu.Lock()
-	// Merge plugin imports first, then per-call imports on top.
+	// Merge plugin imports first, then per-call imports on top. Hooks, imports,
+	// and execution policy come from one admitted immutable generation.
 	var merged Imports
 	if n := len(rt.imports) + len(cfg.imports); n != 0 {
 		merged = make(Imports, n)
@@ -455,6 +679,7 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 		}
 	}
 	policy := rt.overridePolicy
+	hooks := rt.loadHooks()
 	rt.mu.Unlock()
 
 	for k, v := range cfg.imports {
@@ -477,7 +702,12 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 		}
 	}
 
-	in, err := rt.instantiateWithHooksOrigin(mod, merged, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin)
+	// Lifecycle callbacks may close their Module. End the inspection lease before
+	// callbacks; low-level instantiation acquires a fresh lease and transfers it to
+	// retained code ownership before start-time host callbacks.
+	mod.endUse()
+	usingModule = false
+	in, err := rt.instantiateWithHooksOrigin(mod, merged, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks)
 	if err == nil && rt.isClosed() {
 		err = joinPrimary(fmt.Errorf("wago: runtime closed during instantiation"), in.Close())
 		in = nil
@@ -495,68 +725,76 @@ func applyInstantiateOptions(opts []InstantiateOption) instantiateConfig {
 
 // instantiateWithHooksOrigin runs the Runtime-aware instantiation path and emits
 // plugin lifecycle callbacks around the low-level instantiator.
-func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc GCConfig, hasGC, forceSyncHost bool, origin InstantiateOrigin) (*Instance, error) {
+func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc GCConfig, hasGC, forceSyncHost bool, origin InstantiateOrigin, hooks *hookRegistry) (*Instance, error) {
 	iopts := InstantiateOptions{
 		Imports: imports, store: rt.refStore, runtime: rt, origin: origin,
-		forceSyncHost:  forceSyncHost || rt.callerResolverActive.Load(),
-		moduleIdentity: mod.moduleIdentity(),
+		forceSyncHost:        forceSyncHost || rt.callerResolverActive.Load(),
+		moduleIdentity:       mod.moduleIdentity(),
+		independentInstances: mod.independentInstances,
+		hasExecutionPolicy:   true,
 	}
 	if hasGC {
 		iopts.GC = gc
 		iopts.pluginGC = &gc
 	}
 
-	// Keep the no-lifecycle-hook path allocation-free. The instance still retains
-	// rt so invoke/close hooks registered before later calls can be observed.
-	if len(rt.hooks.beforeInstantiate) == 0 && len(rt.hooks.afterCreate) == 0 && len(rt.hooks.afterInstantiate) == 0 && len(rt.hooks.onInstantiateError) == 0 {
-		inst, err := instantiateCore(mod.c, iopts)
-		if err != nil {
-			return nil, err
-		}
-		return inst, nil
+	// Keep the no-lifecycle-hook path allocation-free.
+	if len(hooks.beforeInstantiate) == 0 && len(hooks.afterCreate) == 0 && len(hooks.afterInstantiate) == 0 && len(hooks.onInstantiateError) == 0 {
+		return instantiateCoreWithModuleUse(mod, iopts)
 	}
 
 	request := InstantiationRequest{Module: moduleView(mod), Origin: origin}
 	emitError := func(original error) error {
 		var hookErrs []error
-		for _, fn := range rt.hooks.onInstantiateError {
-			if panicErr := callHookSafely("OnInstantiateError", func() { fn(InstantiationErrorEvent{Module: request.Module, Origin: origin, Err: original}) }); panicErr != nil {
+		for _, fn := range hooks.onInstantiateError {
+			observer := fn
+			if panicErr := callHookSafely("OnInstantiateError", func() { observer(InstantiationErrorEvent{Module: request.Module, Origin: origin, Err: original}) }); panicErr != nil {
 				hookErrs = append(hookErrs, panicErr)
 			}
 		}
 		return joinPrimary(original, hookErrs...)
 	}
 
-	for _, fn := range rt.hooks.beforeInstantiate {
+	for _, fn := range hooks.beforeInstantiate {
+		interceptor := fn
 		var hookErr error
-		panicErr := callHookSafely("BeforeInstantiate", func() { hookErr = fn(request) })
+		panicErr := callHookSafely("BeforeInstantiate", func() { hookErr = interceptor(request) })
 		if err := joinPrimary(hookErr, panicErr); err != nil {
 			return nil, emitError(err)
 		}
 	}
 	iopts.afterCreate = func(inst *Instance) error {
 		event := InstantiationEvent{Module: request.Module, Instance: InstanceIdentity{value: inst}, Origin: origin}
-		for _, fn := range rt.hooks.afterCreate {
+		for _, fn := range hooks.afterCreate {
+			interceptor := fn
 			var hookErr error
-			panicErr := callHookSafely("InstanceInstantiateInterceptor.After", func() { hookErr = fn(event) })
+			panicErr := callHookSafely("InstanceInstantiateInterceptor.After", func() { hookErr = interceptor(event) })
 			if err := joinPrimary(hookErr, panicErr); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
-	inst, err := instantiateCore(mod.c, iopts)
+	inst, err := instantiateCoreWithModuleUse(mod, iopts)
 	if err != nil {
 		return nil, emitError(err)
 	}
-	for _, fn := range rt.hooks.afterInstantiate {
+	for _, fn := range hooks.afterInstantiate {
+		observer := fn
 		event := InstantiationEvent{Module: request.Module, Instance: InstanceIdentity{value: inst}, Origin: origin}
-		if err := callHookSafely("InstanceInstantiateObserver", func() { fn(event) }); err != nil {
+		if err := callHookSafely("InstanceInstantiateObserver", func() { observer(event) }); err != nil {
 			failed := joinPrimary(err, inst.Close())
 			return nil, emitError(failed)
 		}
 	}
 	return inst, nil
+}
+
+func instantiateCoreWithModuleUse(mod *Module, opts InstantiateOptions) (*Instance, error) {
+	if !mod.beginUse() {
+		return nil, fmt.Errorf("wago: Instantiate: module is closed")
+	}
+	return instantiateCoreWithModuleLease(mod.c, opts, mod)
 }
 
 // Plugins returns immutable definitions in dependency-resolved activation order.
@@ -605,21 +843,13 @@ func (rt *Runtime) ProvidedImports() []ImportSpec {
 	return specs
 }
 
-// Close stops plugins and marks the runtime unusable. It closes every instance
-// created through this Runtime; callers retain only idempotent closed handles.
-func (rt *Runtime) Close() error { return rt.CloseContext(context.Background()) }
-
-// CloseContext is idempotent and joinable: concurrent callers wait for and
-// receive the same complete shutdown result. The first caller's context is used
-// for plugin Stop callbacks; later callers do not cancel an active shutdown.
-// It must not be called synchronously from a callback or hook running on this
-// Runtime because shutdown waits for the current operation to return.
-func (rt *Runtime) CloseContext(ctx context.Context) error {
+// Close publishes the shutdown gate immediately. If called from an admitted
+// runtime operation, it starts teardown asynchronously and returns so callbacks
+// can unwind without self-deadlock. Closed and WaitClosed expose deterministic
+// completion and the final joined error.
+func (rt *Runtime) Close() error {
 	if rt == nil {
 		return nil
-	}
-	if ctx == nil {
-		ctx = context.Background()
 	}
 	rt.mu.Lock()
 	for rt.state == runtimeLoading {
@@ -627,31 +857,138 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 	}
 	if rt.closeState != nil {
 		state := rt.closeState
+		closed := rt.state == runtimeClosed
 		rt.mu.Unlock()
-		<-state.done
-		return state.result
+		if closed {
+			return state.result
+		}
+		return nil
 	}
+	active := rt.activeOperations != 0
+	state, hooks, internalClose, pluginRuns, store := rt.startCloseLocked()
+	rt.mu.Unlock()
+	go rt.finishClose(context.Background(), state, hooks, internalClose, pluginRuns, store)
+	if active {
+		return nil
+	}
+	<-state.done
+	return state.result
+}
+
+// Closed returns a channel closed after teardown completes and the final result
+// is published. It returns nil until shutdown has started.
+func (rt *Runtime) Closed() <-chan struct{} {
+	if rt == nil {
+		return nil
+	}
+	rt.mu.Lock()
+	state := rt.closeState
+	rt.mu.Unlock()
+	if state == nil {
+		return nil
+	}
+	return state.done
+}
+
+// WaitClosed waits for an already-started shutdown and returns its final joined
+// error. It does not initiate shutdown.
+func (rt *Runtime) WaitClosed(ctx context.Context) error {
+	if rt == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rt.mu.Lock()
+	state := rt.closeState
+	rt.mu.Unlock()
+	if state == nil {
+		return fmt.Errorf("wago: runtime shutdown has not started")
+	}
+	select {
+	case <-state.done:
+		return state.result
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// CloseContext starts shutdown and waits selectably for completion. The first
+// caller's context is passed to plugin Stop callbacks; teardown continues to its
+// single final result even if this waiter later times out. Shutdown callbacks
+// that need reentrant closure must call Close, not WaitClosed or CloseContext.
+func (rt *Runtime) CloseContext(ctx context.Context) error {
+	if rt == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rt.mu.Lock()
+	for rt.state == runtimeLoading {
+		rt.stateCond.Wait()
+	}
+	state := rt.closeState
+	if state == nil {
+		var hooks []func(RuntimeCloseEvent)
+		var internalClose []func() error
+		var pluginRuns []registeredPluginRun
+		var store *referenceStore
+		state, hooks, internalClose, pluginRuns, store = rt.startCloseLocked()
+		rt.mu.Unlock()
+		go rt.finishClose(ctx, state, hooks, internalClose, pluginRuns, store)
+	} else {
+		rt.mu.Unlock()
+	}
+	select {
+	case <-state.done:
+		return state.result
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// startCloseLocked publishes shutdown and snapshots teardown state. rt.mu is
+// held by the caller.
+func (rt *Runtime) startCloseLocked() (*runtimeCloseState, []func(RuntimeCloseEvent), []func() error, []registeredPluginRun, *referenceStore) {
 	state := &runtimeCloseState{done: make(chan struct{})}
 	rt.closeState = state
 	rt.state = runtimeClosing
-	hooks := rt.hooks.onRuntimeClose
-	internalClose := append([]func() error(nil), rt.hooks.internalClose...)
-	pluginRuns := append([]registeredPluginRun(nil), rt.pluginRuns...)
-	store := rt.refStore
-	rt.mu.Unlock()
+	hooks := rt.loadHooks()
+	return state,
+		append([]func(RuntimeCloseEvent){}, hooks.onRuntimeClose...),
+		append([]func() error(nil), hooks.internalClose...),
+		append([]registeredPluginRun(nil), rt.pluginRuns...),
+		rt.refStore
+}
 
+func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, hooks []func(RuntimeCloseEvent), internalClose []func() error, pluginRuns []registeredPluginRun, store *referenceStore) {
 	var errs []error
+	// Compile preparations can retain transformed source, custom instruction
+	// implementations, and compile observers between PrepareCompile and their
+	// terminal action. Drain them before any plugin teardown callback can run.
+	rt.mu.Lock()
+	for rt.compileOperations != 0 {
+		rt.stateCond.Wait()
+	}
+	rt.mu.Unlock()
 	for i := len(hooks) - 1; i >= 0; i-- {
 		observer := hooks[i]
 		if err := callHookSafely("RuntimeCloseObserver", func() { observer(RuntimeCloseEvent{}) }); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	// A Module.Close already inside an observer finishes before teardown. New
-	// module closes see runtimeClosing and suppress callbacks into stopped code.
-	rt.moduleCloseMu.Lock()
-	_ = rt.moduleCloseBarrier
-	rt.moduleCloseMu.Unlock()
+	// A Module.Close admitted before shutdown may still be running observers.
+	// Drain those callbacks before closing instances or stopping their providers;
+	// new module closes see runtimeClosing and suppress lifecycle callbacks.
+	rt.mu.Lock()
+	for rt.moduleCloseOperations != 0 {
+		rt.stateCond.Wait()
+	}
+	rt.mu.Unlock()
 
 	instances := rt.directInstancesSnapshot()
 	for i := len(instances) - 1; i >= 0; i-- {
@@ -669,9 +1006,9 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 	}
 	rt.mu.Unlock()
 	for i := len(instances) - 1; i >= 0; i-- {
-		state := instances[i].ensurePluginState().close.Load()
-		if state != nil {
-			<-state.quiesced
+		closeState := instances[i].ensurePluginState().close.Load()
+		if closeState != nil {
+			<-closeState.quiesced
 		}
 	}
 	for i := len(internalClose) - 1; i >= 0; i-- {
@@ -687,7 +1024,6 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 	close(state.done)
 	rt.stateCond.Broadcast()
 	rt.mu.Unlock()
-	return result
 }
 
 func (rt *Runtime) rollbackCommittedPluginPlan(ctx context.Context) error {
@@ -701,7 +1037,7 @@ func (rt *Runtime) rollbackCommittedPluginPlan(ctx context.Context) error {
 	rt.caps = map[Capability]string{}
 	rt.capOrder = nil
 	rt.instructions = map[string]*registeredInstruction{}
-	rt.hooks = &hookRegistry{}
+	rt.storeHooks(&hookRegistry{})
 	rt.pluginRuns = nil
 	rt.managedActive.Store(false)
 	rt.callerResolverActive.Store(false)

--- a/src/wago/runtime_close_panic_test.go
+++ b/src/wago/runtime_close_panic_test.go
@@ -1,0 +1,58 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeCloseSanitizesShutdownPanicsAndContinues(t *testing.T) {
+	secret := strings.Repeat("secret-token-", 1024)
+	var events []string
+	def := testDefinition("example.com/close/panic")
+	def.Authorities = []AuthorityRequest{{Name: AuthorityRuntimeCloseObserve, Mode: AuthorityRequired, Reason: "panic containment"}}
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			observer, err := reg.RuntimeCloseObserver()
+			if err != nil {
+				return err
+			}
+			if err := observer.Observe(
+				func(RuntimeCloseEvent) { events = append(events, "continues") },
+				func(RuntimeCloseEvent) { events = append(events, "panics"); panic(secret) },
+			); err != nil {
+				return err
+			}
+			return reg.Lifecycle(PluginLifecycle{Stop: func(context.Context) error {
+				events = append(events, "stop")
+				panic(secret)
+			}})
+		})
+	}}
+	rt := NewRuntime()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	err := rt.WaitClosed(context.Background())
+	if !errors.Is(err, ErrCallbackPanic) {
+		t.Fatalf("WaitClosed error = %v, want ErrCallbackPanic", err)
+	}
+	firstResult := err.Error()
+	if strings.Contains(firstResult, secret) {
+		t.Fatal("shutdown error retained recovered panic value")
+	}
+	if len(firstResult) > 512 {
+		t.Fatalf("shutdown panic report is unbounded: %d bytes", len(firstResult))
+	}
+	want := "[panics continues stop]"
+	if got := strings.Join(events, " "); "["+got+"]" != want {
+		t.Fatalf("shutdown events = %v, want %s", events, want)
+	}
+	if err := rt.WaitClosed(context.Background()); err == nil || err.Error() != firstResult {
+		t.Fatalf("second WaitClosed = %v, want %q", err, firstResult)
+	}
+}

--- a/src/wago/runtime_hardening_test.go
+++ b/src/wago/runtime_hardening_test.go
@@ -14,6 +14,10 @@ import (
 
 func TestRuntimeConfigOwnsConstructionSnapshot(t *testing.T) {
 	base := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit)
+	// Default optimization maps are immutable process snapshots on current main.
+	// Detach this same-package adversarial mutation from that shared cache before
+	// verifying Runtime ingestion ownership.
+	base.optimizations = base.optimizationValues()
 	rt := NewRuntime(WithRuntimeConfig(base))
 	base.optimizations["mutated-after-construction"] = true
 	base.functionWorkers = -1

--- a/src/wago/runtime_hardening_test.go
+++ b/src/wago/runtime_hardening_test.go
@@ -350,7 +350,7 @@ func TestRuntimeClosedAndWaitClosedObserveFinalError(t *testing.T) {
 		t.Fatalf("canceled WaitClosed = %v", err)
 	}
 	close(release)
-	if err := <-owner; !errors.Is(err, stopErr) {
+	if err := <-owner; err != nil {
 		t.Fatalf("owner Close = %v", err)
 	}
 	if err := rt.WaitClosed(context.Background()); !errors.Is(err, stopErr) {

--- a/src/wago/runtime_hardening_test.go
+++ b/src/wago/runtime_hardening_test.go
@@ -1,0 +1,560 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func TestRuntimeConfigOwnsConstructionSnapshot(t *testing.T) {
+	base := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit)
+	rt := NewRuntime(WithRuntimeConfig(base))
+	base.optimizations["mutated-after-construction"] = true
+	base.functionWorkers = -1
+	cfg := rt.Config()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("runtime config aliased caller mutation: %v", err)
+	}
+	if _, ok := cfg.optimizations["mutated-after-construction"]; ok || cfg.FunctionWorkers() < 0 {
+		t.Fatal("runtime config retained caller-owned state")
+	}
+	cfg.optimizations["mutated-returned-snapshot"] = true
+	if _, ok := rt.Config().optimizations["mutated-returned-snapshot"]; ok {
+		t.Fatal("Config returned mutable runtime state")
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPreparedCompilePreservesGenerationAndWarmAdoption(t *testing.T) {
+	def := testDefinition("example.com/compile/prepared")
+	def.Authorities = []AuthorityRequest{
+		{Name: AuthorityModuleSourceTransform, Mode: AuthorityRequired, Reason: "transform source"},
+		{Name: AuthorityModuleCompileObserve, Mode: AuthorityRequired, Reason: "observe compilation"},
+	}
+	original := wasmtest.Module()
+	transformed := wasmtest.Module(wasmtest.Section(0, append(wasmtest.Name("prepared"), 1)))
+	var sourceID, compiledID CompilationIdentity
+	compileCalls := 0
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			transformer, err := reg.ModuleSourceTransformer()
+			if err != nil {
+				return err
+			}
+			if err := transformer.Transform(func(ctx ModuleSourceContext, source []byte) ([]byte, error) {
+				compileCalls++
+				sourceID = ctx.Compilation
+				return append([]byte(nil), transformed...), nil
+			}); err != nil {
+				return err
+			}
+			observer, err := reg.ModuleCompileObserver()
+			if err != nil {
+				return err
+			}
+			return observer.Observe(func(event ModuleCompiledEvent) { compiledID = event.Compilation })
+		})
+	}}
+	rt := NewRuntime()
+	defer rt.Close()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := rt.PrepareCompile(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Cacheable() {
+		t.Fatal("source-transform generation reported cacheable")
+	}
+	if !reflect.DeepEqual(prepared.Source(), transformed) || compileCalls != 1 {
+		t.Fatalf("prepared source/calls = %x/%d", prepared.Source(), compileCalls)
+	}
+	compiled, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), transformed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod, err := prepared.Adopt(compiled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sourceID.IsZero() || compiledID != sourceID || compileCalls != 1 {
+		t.Fatalf("compile identity/calls = %v/%v/%d", sourceID, compiledID, compileCalls)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepared.Compile(); err == nil || !strings.Contains(err.Error(), "already consumed") {
+		t.Fatalf("second prepared consume = %v", err)
+	}
+}
+
+func TestPreparedCompileTerminalOperationsRaceExactlyOnce(t *testing.T) {
+	rt := NewRuntime()
+	prepared, err := rt.PrepareCompile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled, err := Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	type terminalResult struct {
+		operation string
+		err       error
+	}
+	start := make(chan struct{})
+	results := make(chan terminalResult, 3)
+	go func() {
+		<-start
+		mod, err := prepared.Compile()
+		if mod != nil {
+			err = errors.Join(err, mod.Close())
+		}
+		results <- terminalResult{operation: "Compile", err: err}
+	}()
+	go func() {
+		<-start
+		mod, err := prepared.Adopt(compiled)
+		if mod != nil {
+			err = errors.Join(err, mod.Close())
+		}
+		results <- terminalResult{operation: "Adopt", err: err}
+	}()
+	go func() {
+		<-start
+		results <- terminalResult{operation: "Close", err: prepared.Close()}
+	}()
+	close(start)
+	consumeSuccesses := 0
+	for range 3 {
+		result := <-results
+		if result.err == nil {
+			if result.operation != "Close" {
+				consumeSuccesses++
+			}
+			continue
+		}
+		if result.operation == "Close" || !strings.Contains(result.err.Error(), "already consumed") {
+			t.Fatalf("%s terminal race error = %v", result.operation, result.err)
+		}
+	}
+	if consumeSuccesses > 1 {
+		t.Fatalf("terminal race successful consumes = %d, want at most one", consumeSuccesses)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPreparedCompileAdoptNilConsumesPreparation(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	prepared, err := rt.PrepareCompile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepared.Adopt(nil); err == nil || !strings.Contains(err.Error(), "nil compiled artifact") {
+		t.Fatalf("Adopt(nil) = %v", err)
+	}
+	if _, err := prepared.Compile(); err == nil || !strings.Contains(err.Error(), "already consumed") {
+		t.Fatalf("Compile after Adopt(nil) = %v", err)
+	}
+}
+
+func TestPreparedCompileCloseReleasesShutdownAdmission(t *testing.T) {
+	rt := NewRuntime()
+	prepared, err := rt.PrepareCompile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	done := rt.Closed()
+	select {
+	case <-done:
+		t.Fatal("shutdown completed while prepared compile retained its generation")
+	default:
+	}
+	if err := prepared.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeCloseFromImportedStartIsReentrant(t *testing.T) {
+	rt := NewRuntime()
+	mod, err := rt.Compile(importedStartModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Close()
+	callbackReturned := make(chan struct{})
+	instantiateDone := make(chan error, 1)
+	go func() {
+		in, err := rt.Instantiate(context.Background(), mod, WithImports(Imports{
+			"env.start": HostFunc(func(HostModule, []uint64, []uint64) {
+				if err := rt.Close(); err != nil {
+					t.Errorf("reentrant Close: %v", err)
+				}
+				close(callbackReturned)
+			}),
+		}))
+		if in != nil {
+			_ = in.Close()
+		}
+		instantiateDone <- err
+	}()
+	select {
+	case <-callbackReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reentrant Close deadlocked")
+	}
+	if err := <-instantiateDone; err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("Instantiate racing reentrant Close = %v", err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeCloseContextPreCanceledHasNoSideEffects(t *testing.T) {
+	rt := NewRuntime()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := rt.CloseContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("CloseContext = %v, want context.Canceled", err)
+	}
+	if rt.Closed() != nil {
+		t.Fatal("pre-canceled CloseContext published shutdown")
+	}
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatalf("runtime unusable after pre-canceled close: %v", err)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeCloseContextTimeoutStillPublishesFinalCompletion(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	def := testDefinition("example.com/close/context-timeout")
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			return reg.Lifecycle(PluginLifecycle{Stop: func(context.Context) error {
+				close(entered)
+				<-release
+				return nil
+			}})
+		})
+	}}
+	rt := NewRuntime()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() { result <- rt.CloseContext(ctx) }()
+	<-entered
+	if err := <-result; !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("CloseContext = %v, want deadline", err)
+	}
+	close(release)
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeClosedAndWaitClosedObserveFinalError(t *testing.T) {
+	stopErr := errors.New("stop failed")
+	entered, release := make(chan struct{}), make(chan struct{})
+	def := testDefinition("example.com/close/final-error")
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			return reg.Lifecycle(PluginLifecycle{Stop: func(context.Context) error {
+				close(entered)
+				<-release
+				return stopErr
+			}})
+		})
+	}}
+	rt := NewRuntime()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	owner := make(chan error, 1)
+	go func() { owner <- rt.Close() }()
+	<-entered
+	done := rt.Closed()
+	if done == nil {
+		t.Fatal("Closed returned nil after shutdown started")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := rt.WaitClosed(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled WaitClosed = %v", err)
+	}
+	close(release)
+	if err := <-owner; !errors.Is(err, stopErr) {
+		t.Fatalf("owner Close = %v", err)
+	}
+	if err := rt.WaitClosed(context.Background()); !errors.Is(err, stopErr) {
+		t.Fatalf("final WaitClosed = %v", err)
+	}
+	select {
+	case <-done:
+	default:
+		t.Fatal("Closed did not complete")
+	}
+}
+
+func TestRuntimeCompileOwnsAndModuleBorrowsCompiled(t *testing.T) {
+	rt := NewRuntime()
+	owned, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownedCompiled := owned.Compiled()
+	if err := owned.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Instantiate(ownedCompiled); err == nil || !strings.Contains(err.Error(), "compiled module is closed") {
+		t.Fatalf("Runtime.Compile module did not close owned code: %v", err)
+	}
+
+	borrowedCompiled, err := Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	borrowed, err := rt.Module(borrowedCompiled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := borrowed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	in, err := Instantiate(borrowedCompiled)
+	if err != nil {
+		t.Fatalf("Runtime.Module closed borrowed code: %v", err)
+	}
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := borrowedCompiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeRejectsForeignModuleBeforeDestinationClosedState(t *testing.T) {
+	a := NewRuntime()
+	mod, err := a.Compile(wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x0b}))),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := NewRuntime()
+	if err := b.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Instantiate(context.Background(), mod); !errors.Is(err, ErrForeignModule) {
+		t.Fatalf("foreign module error = %v", err)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeBindingReappliesDestinationExecutionPolicy(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithIndependentInstanceExecution(true), wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	serial := NewRuntime(WithRuntimeConfig(NewRuntimeConfig().WithIndependentInstanceExecution(false)))
+	mod, err := serial.Module(compiled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := serial.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if in.usesIndependentExecution() {
+		t.Fatal("destination runtime serial policy was not applied")
+	}
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := serial.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeRegisteredImportMetadataIsOwned(t *testing.T) {
+	def := testDefinition("example.com/import/snapshot")
+	def.Authorities = []AuthorityRequest{{Name: AuthorityHostImportDefine, Mode: AuthorityRequired, Reason: "define env", Scope: AuthorityScope{Modules: []string{"env"}}}}
+	var builder *ImportFuncBuilder
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			hosts, err := reg.HostImports()
+			if err != nil {
+				return err
+			}
+			module, err := hosts.Module("env")
+			if err != nil {
+				return err
+			}
+			builder = module.Func("f", func(HostModule, []uint64, []uint64) {}).Params(ValI32).Results(ValI64).Docs("original")
+			return nil
+		})
+	}}
+	rt := NewRuntime()
+	defer rt.Close()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	builder.Params(ValV128).Results(ValV128).Capability("mutated").Docs("mutated")
+	imports := rt.ProvidedImports()
+	if len(imports) != 1 || !reflect.DeepEqual(imports[0].Params, []ValType{ValI32}) || !reflect.DeepEqual(imports[0].Results, []ValType{ValI64}) || imports[0].HasCapability || imports[0].Docs != "original" {
+		t.Fatalf("registered import metadata aliased plugin builder: %#v", imports)
+	}
+}
+
+func TestModuleCloseObserverCanReenterClose(t *testing.T) {
+	def := testDefinition("example.com/module/reentrant-close")
+	def.Authorities = []AuthorityRequest{{Name: AuthorityModuleCloseObserve, Mode: AuthorityRequired, Reason: "reenter close"}}
+	var mod *Module
+	callbackReturned := make(chan struct{})
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			observer, err := reg.ModuleCloseObserver()
+			if err != nil {
+				return err
+			}
+			return observer.Observe(func(ModuleCloseEvent) {
+				if err := mod.Close(); err != nil {
+					t.Errorf("reentrant Module.Close: %v", err)
+				}
+				close(callbackReturned)
+			})
+		})
+	}}
+	rt := NewRuntime()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	var err error
+	mod, err = rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- mod.Close() }()
+	select {
+	case <-callbackReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reentrant Module.Close deadlocked")
+	}
+	if err := <-closeDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestModuleCloseObserverCanCloseRuntime(t *testing.T) {
+	def := testDefinition("example.com/module/close-runtime")
+	def.Authorities = []AuthorityRequest{{Name: AuthorityModuleCloseObserve, Mode: AuthorityRequired, Reason: "close runtime"}}
+	callbackReturned := make(chan struct{})
+	var rt *Runtime
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			observer, err := reg.ModuleCloseObserver()
+			if err != nil {
+				return err
+			}
+			return observer.Observe(func(ModuleCloseEvent) {
+				if err := rt.Close(); err != nil {
+					t.Errorf("Runtime.Close from module observer: %v", err)
+				}
+				close(callbackReturned)
+			})
+		})
+	}}
+	rt = NewRuntime()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- mod.Close() }()
+	select {
+	case <-callbackReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Close from module observer deadlocked")
+	}
+	if err := <-closeDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeModuleImportsReturnsDeepSnapshot(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I64})
+	mod, err := rt.Compile(returningImportModule(sig, []byte{0x00, 0x42, 0x00, 0x0b}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mod.Imports()
+	first[0].Params[0] = ValV128
+	first[0].Results[0] = ValV128
+	first[0].ParamTypes[0].Kind = ValueTypeV128
+	first[0].ResultTypes[0].Kind = ValueTypeV128
+	second := mod.Imports()
+	if second[0].Params[0] != ValI32 || second[0].Results[0] != ValI64 || second[0].ParamTypes[0].Kind != ValueTypeI32 || second[0].ResultTypes[0].Kind != ValueTypeI64 {
+		t.Fatalf("caller mutation changed module imports: %#v", second)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/src/wago/runtime_hardening_test.go
+++ b/src/wago/runtime_hardening_test.go
@@ -97,6 +97,44 @@ func TestPreparedCompilePreservesGenerationAndWarmAdoption(t *testing.T) {
 	}
 }
 
+func TestPreparedCompileOwnsTransformedSourceSnapshot(t *testing.T) {
+	def := testDefinition("example.com/compile/source-snapshot")
+	def.Authorities = []AuthorityRequest{{Name: AuthorityModuleSourceTransform, Mode: AuthorityRequired, Reason: "return plugin-owned source"}}
+	transformed := wasmtest.Module(wasmtest.Section(0, wasmtest.Name("snapshot")))
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(reg *Registrar) error {
+			transformer, err := reg.ModuleSourceTransformer()
+			if err != nil {
+				return err
+			}
+			return transformer.Transform(func(ModuleSourceContext, []byte) ([]byte, error) { return transformed, nil })
+		})
+	}}
+	rt := NewRuntime()
+	defer rt.Close()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := rt.PrepareCompile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := append([]byte(nil), prepared.Source()...)
+	for i := range transformed {
+		transformed[i] ^= 0xff
+	}
+	if !reflect.DeepEqual(prepared.Source(), want) {
+		t.Fatal("prepared source aliased transformer-owned storage")
+	}
+	mod, err := prepared.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mod.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPreparedCompileTerminalOperationsRaceExactlyOnce(t *testing.T) {
 	rt := NewRuntime()
 	prepared, err := rt.PrepareCompile(wasmtest.Module())

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -53,6 +53,36 @@ func TestWorkflowActionsUseImmutableCommits(t *testing.T) {
 	}
 }
 
+func TestRollingReleaseWorkflowsUseImmutableTagsAndTargets(t *testing.T) {
+	for _, path := range []string{"../../.github/workflows/canary.yml", "../../.github/workflows/nightly.yml"} {
+		workflow, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		contents := string(workflow)
+		for _, required := range []string{
+			`target=$(gh api "repos/${{ github.repository }}/releases/tags/`,
+			`has an invalid target commit`,
+			`if [ "$target" != "${{ needs.`,
+		} {
+			if !strings.Contains(contents, required) {
+				t.Errorf("%s is missing immutable existing-release validation %q", filepath.Base(path), required)
+			}
+		}
+	}
+	nightly, err := os.ReadFile(filepath.Clean("../../.github/workflows/nightly.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(nightly)
+	if !strings.Contains(contents, `echo "tag=nightly-$(date -u +%Y%m%d)-$sha"`) {
+		t.Fatal("nightly release tag must contain the full immutable commit SHA")
+	}
+	if strings.Contains(contents, `echo "tag=nightly-$(date -u +%Y%m%d)-${sha::7}"`) {
+		t.Fatal("nightly release tag still uses an abbreviated commit SHA")
+	}
+}
+
 func TestWindowsWABTInstallIsPinnedAndVerified(t *testing.T) {
 	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
 	if err != nil {

--- a/wago.go
+++ b/wago.go
@@ -258,6 +258,7 @@ const (
 	ElemModeActive                             = impl.ElemModeActive
 	ElemModeDeclarative                        = impl.ElemModeDeclarative
 	ElemModePassive                            = impl.ElemModePassive
+	ErrCallbackPanic                           = impl.ErrCallbackPanic
 	ErrForeignModule                           = impl.ErrForeignModule
 	ErrInvalidHandle                           = impl.ErrInvalidHandle
 	ErrManagedImportLifetime                   = impl.ErrManagedImportLifetime

--- a/wago.go
+++ b/wago.go
@@ -151,6 +151,7 @@ type (
 	PluginSelection                = impl.PluginSelection
 	PluginSet                      = impl.PluginSet
 	Policy                         = impl.Policy
+	PreparedCompile                = impl.PreparedCompile
 	PreparedFunction               = impl.PreparedFunction
 	ProviderCatalogDocument        = impl.ProviderCatalogDocument
 	ProviderCatalogEntry           = impl.ProviderCatalogEntry
@@ -257,6 +258,7 @@ const (
 	ElemModeActive                             = impl.ElemModeActive
 	ElemModeDeclarative                        = impl.ElemModeDeclarative
 	ElemModePassive                            = impl.ElemModePassive
+	ErrForeignModule                           = impl.ErrForeignModule
 	ErrInvalidHandle                           = impl.ErrInvalidHandle
 	ErrManagedImportLifetime                   = impl.ErrManagedImportLifetime
 	ErrMissingImport                           = impl.ErrMissingImport


### PR DESCRIPTION
## Summary

Supersedes #424 and #425 with the complete runtime/cache solution plus the rolling-release correctness fixes from the same audit.

### Runtime and API

- reject compile/module binding after shutdown and wait for admitted operations before provider teardown;
- publish immutable hook generations so compile, instantiate, invoke, close, managed-fork, and shutdown paths observe one callback generation;
- snapshot import policy at compile/module-binding admission;
- make `Runtime.Compile` modules own native code through deterministic `Module.Close`, while `Runtime.Module` borrows and `Runtime.AdoptModule` transfers ownership;
- serialize `Module.Close` with concurrent instantiation so admitted work finishes safely and later work fails closed;
- reject foreign runtime-bound modules with `ErrForeignModule`, retaining explicit `Runtime.Module` rebinding;
- isolate shutdown callback panics behind bounded `ErrCallbackPanic` errors while continuing plugin, internal-service, hook, managed-instance, token, and final reference-store cleanup;
- deep-copy extension/import inspection metadata at ingestion and return boundaries;
- publish hook generations with copy-on-write rather than mutating callback slices read by active operations.

### Artifact cache

- propagate decoded-artifact runtime binding failures exactly once instead of recompiling;
- adopt and deterministically close decoded artifacts on binding rejection;
- remove scheduling-only `FunctionWorkers` from cache identity and bump the cache-key format;
- prove byte/native-metadata determinism across worker policies and warm reuse across processes.

### Rolling releases

- paginate rolling-channel discovery through validated GitHub `Link` targets with cancellation, loop detection, and a ten-page aggregate bound;
- skip drafts and require canonical full `target_commitish` identities;
- stamp and compare canary/nightly versions as `channel@<40-hex-sha>` with exact equality, treating legacy abbreviations conservatively as stale;
- preserve exact commit identity through manager, installer, archive, and Git source fallbacks instead of building moving `main` references;
- stamp canary/nightly workflows with the full resolved SHA.

## Regression coverage

- compile/close admission ordering and one-generation import/hook snapshots;
- concurrent `Module.Close`/instantiate ownership transfer;
- runtime-close panic containment with retained managed-instance and reference-token cleanup;
- foreign-module rejection before policy, hooks, binding, and destination closed-state checks;
- concurrent hook publication under compile/instantiate/invoke/close/runtime-close activity;
- caller/plugin mutation of nested inspection snapshots under the race detector;
- cached binding rejection, closed-runtime errors, corruption repair, worker-policy equality, and subprocess warm reuse;
- rolling release page 2+, drafts, loops, cancellation, malformed/cross-origin/wrong-path links, page bounds, invalid target commits, legacy abbreviations, exact source checkout, and archive fallback.

## Validation

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `go vet -tags wago_runtime ./cli/...`
- Go 1.22 `go test ./...` and vet, including runtime-tagged CLI vet
- `make tinygo-test`
- TinyGo artifact-cache tests
- affected-package staticcheck: only the pre-existing `src/wago/runtime.go` `scopedHostCalls` U1000 remains
- Linux, Darwin, and Windows amd64/arm64 cross-builds for `./...` and runtime-tagged CLI packages
- `go generate ./...` reproduced `wago.go` and `schema.json`
- `actionlint`, release/install shell syntax checks, and `git diff --check`

## Scope and follow-ups

This intentionally does not implement plugin activation rollback or the `PluginStarter.Start`/`Runtime.Close` race tracked separately by #391 and #392.

Closes #388.
Closes #389.
Closes #390.
Closes #393.
Closes #394.
Closes #400.
Closes #401.
Closes #411.
Closes #413.
Closes #416.
