### PR TITLE
arm64: accelerate prepared integer entry

### DIFF
--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -69,6 +69,23 @@ func isIntValType(t wasm.ValType) bool {
 	return wasm.EqualValType(t, wasm.I32) || wasm.EqualValType(t, wasm.I64)
 }
 
+func preparedDirectIntSig(ft *wasm.CompType) bool {
+	if len(ft.Params) > 4 || len(ft.Results) > 1 {
+		return false
+	}
+	for _, typ := range ft.Params {
+		if !isIntValType(typ) {
+			return false
+		}
+	}
+	for _, typ := range ft.Results {
+		if !isIntValType(typ) {
+			return false
+		}
+	}
+	return true
+}
+
 func isFloatValType(t wasm.ValType) bool {
 	return wasm.EqualValType(t, wasm.F32) || wasm.EqualValType(t, wasm.F64)
 }

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -418,9 +418,10 @@ func asmCapForBody(bodyLen int) int {
 // the next function runs — so reset-and-reuse replaces per-function allocation.
 // Compile is sequential, so a single scratch is shared safely.
 type scratch struct {
-	stack   *stack   // the valent-block operand stack
-	asm     *a64.Asm // the AArch64 encoder byte buffer
-	fnState fn       // per-function compiler state, reused across the module
+	stack          *stack   // the valent-block operand stack
+	asm            *a64.Asm // the AArch64 encoder byte buffer
+	fnState        fn       // per-function compiler state, reused across the module
+	directPrepared bool
 
 	retSites      []int
 	ctrl          []ctrlFrame
@@ -452,6 +453,7 @@ func newScratch() *scratch {
 func (sc *scratch) reset() {
 	sc.stack.reset()
 	sc.asm.B = sc.asm.B[:0]
+	sc.directPrepared = false
 	sc.retSites = sc.retSites[:0]
 	sc.ctrl = sc.ctrl[:0]
 	for i := range sc.trapSites {
@@ -472,12 +474,21 @@ type workerState struct {
 // identify its owned bytes after the worker pool joins; relocs is independently
 // owned by the fn compiler state (it is not backed by scratch).
 type funcResult struct {
-	worker      int
-	start       int
-	end         int
-	internalOff int
-	relocs      []callReloc
-	err         error
+	worker         int
+	start          int
+	end            int
+	internalOff    int
+	directPrepared bool
+	relocs         []callReloc
+	err            error
+}
+
+func markDirectPrepared(bits []uint64, n, bit int) []uint64 {
+	if bits == nil {
+		bits = make([]uint64, (n+63)/64)
+	}
+	bits[bit>>6] |= uint64(1) << uint(bit&63)
+	return bits
 }
 
 // Frameless layout (WARP-style, SP-relative). X29/FP is only a frame-record anchor
@@ -783,6 +794,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 			}
 		}()
 		pressureDone := false
+		var directPrepared []uint64
 		pressureAt := shared.PressureThreshold(opts.MemoryPressureAt, codeCap)
 		for i := range m.Code {
 			// Align and reserve before lowering so the assembler can emit straight
@@ -813,6 +825,9 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 				return nil, fmt.Errorf("arm64: function %d: %w", i, err)
 			}
 			internalEntry[i] = len(code) + internalOff
+			if sc.directPrepared {
+				directPrepared = markDirectPrepared(directPrepared, n, i)
+			}
 			relocs[i] = rl
 			if !codeBuffer.CommitTail(fnCode) {
 				if err := codeBuffer.Append(fnCode); err != nil {
@@ -832,7 +847,7 @@ func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 			fmt.Fprint(os.Stderr, ms.String())
 		}
 		keepCodeBuffer = true
-		return &a64.CompiledModule{Code: code, CodeImage: codeBuffer, Entry: entry, InternalEntry: internalEntry}, nil
+		return &a64.CompiledModule{Code: code, CodeImage: codeBuffer, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared}, nil
 	}
 
 	return compileModuleParallel(m, opts, workers, codeCap, entry, internalEntry, relocs, allHints, modGlobals, hostAdapters, inlineTargets, calleePreservesPins, ms, guardMode, boundsFacts, importedFuncs)
@@ -880,7 +895,7 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 				}
 				start := len(ws.arena)
 				ws.arena = append(ws.arena, fnCode...)
-				results[i] = funcResult{worker: workerID, start: start, end: len(ws.arena), internalOff: internalOff, relocs: rl}
+				results[i] = funcResult{worker: workerID, start: start, end: len(ws.arena), internalOff: internalOff, directPrepared: ws.scratch.directPrepared, relocs: rl}
 				if opts.MemoryPressure != nil && pressureBytes.Add(int64(len(fnCode))) >= int64(pressureAt) {
 					pressureOnce.Do(opts.MemoryPressure)
 				}
@@ -893,6 +908,7 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 	}
 
 	code := make([]byte, 0, codeCap)
+	var directPrepared []uint64
 	for i := range results {
 		r := &results[i]
 		if pad := (16 - len(code)%16) % 16; pad != 0 {
@@ -900,6 +916,9 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 		}
 		entry[i] = len(code)
 		internalEntry[i] = len(code) + r.internalOff
+		if r.directPrepared {
+			directPrepared = markDirectPrepared(directPrepared, n, i)
+		}
 		relocs[i] = r.relocs
 		code = append(code, states[r.worker].arena[r.start:r.end]...)
 	}
@@ -909,7 +928,7 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 	if explainEnabled && ms != nil {
 		fmt.Fprint(os.Stderr, ms.String())
 	}
-	return &a64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry}, nil
+	return &a64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared}, nil
 }
 
 func patchCallRelocs(code []byte, entry, internalEntry []int, relocs [][]callReloc) error {
@@ -1376,6 +1395,11 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	}
 	hasCall := hints.hasCall
 	touchesMemory := hints.touchesMemory
+	// A private prepared entry establishes X26 and preserves the full Go
+	// callee-saved set, so small integer functions need not be leaves. Keep host
+	// imports, memory caches, module-pinned globals, and EH state on the adapter.
+	directPrepared := regABIEnabled && preparedDirectIntSig(ft) && !touchesMemory && len(modGlobals) == 0 && !hints.moduleEH &&
+		m.ImportedFuncCount() == 0 && m.MemCount() == 0 && len(c.BodyBytes) <= 96 && nLocals <= 8
 	// Auto-inlining: collect the callees this caller will splice (before the pin
 	// setup below, which the plan can influence). A spliced memory-touching callee
 	// runs its linear-memory ops in THIS caller's frame, so fold it into
@@ -1503,6 +1527,7 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	var globalScores []uint32
 	var globalElig []bool
 	if regABI {
+		sc.directPrepared = directPrepared
 		globalScores = hints.globalScore
 		if hasCall {
 			globalElig = hints.globalElig

--- a/src/core/runtime/engine_int_arm64.go
+++ b/src/core/runtime/engine_int_arm64.go
@@ -1,0 +1,25 @@
+//go:build arm64 && !tinygo && (linux || darwin || windows)
+
+package runtime
+
+func enterNativeInt(code, linMem, a0, a1, a2, a3, foreignStackTop uintptr) uintptr
+
+func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) uint64 {
+	return uint64(enterNativeInt(code, linMemBase, uintptr(a0), uintptr(a1), uintptr(a2), uintptr(a3), e.stackTop))
+}
+
+func PreparedIntTrapCode(trap []byte) TrapCode {
+	if len(trap) < 4 {
+		return TrapNone
+	}
+	return TrapCode(loadTrap(trap))
+}
+
+func ConsumePreparedIntTrap(trap []byte) error {
+	tc := PreparedIntTrapCode(trap)
+	if tc == TrapNone {
+		return nil
+	}
+	storeTrap(trap, 0)
+	return trapErrorFromBuffer(tc, trap)
+}

--- a/src/core/runtime/engine_int_arm64.s
+++ b/src/core/runtime/engine_int_arm64.s
@@ -1,0 +1,46 @@
+//go:build (linux || darwin || windows) && arm64 && !tinygo
+
+#include "textflag.h"
+
+// func enterNativeInt(code, linMem, a0, a1, a2, a3, foreignStackTop uintptr) uintptr
+TEXT ·enterNativeInt(SB), NOSPLIT, $0-64
+	MOVD code+0(FP), R9
+	MOVD foreignStackTop+48(FP), R10
+	SUB  $112, R10, R10
+	MOVD RSP, R11
+	MOVD R11, 0(R10)
+	STP  (R19, R20), 8(R10)
+	STP  (R21, R22), 24(R10)
+	STP  (R23, R24), 40(R10)
+	STP  (R25, R26), 56(R10)
+	STP  (R27, g), 72(R10)
+	STP  (R29, R30), 88(R10)
+
+	MOVD linMem+8(FP), R26
+	MOVD a0+16(FP), R0
+	MOVD a1+24(FP), R1
+	MOVD a2+32(FP), R2
+	MOVD a3+40(FP), R3
+	MOVD R10, RSP
+	MOVD ZR, R22
+	MOVD ZR, R29
+	MOVD R10, -24(R26)
+	BL   callNativeInt
+
+afterNativeIntCall:
+	LDP  8(RSP), (R19, R20)
+	LDP  24(RSP), (R21, R22)
+	LDP  40(RSP), (R23, R24)
+	LDP  56(RSP), (R25, R26)
+	LDP  72(RSP), (R27, g)
+	LDP  88(RSP), (R29, R30)
+	MOVD 0(RSP), R11
+	MOVD R11, RSP
+	MOVD R0, ret+56(FP)
+	RET
+
+callNativeInt:
+	MOVD R30, R11
+	MOVD R11, -32(R26)
+	BL   (R9)
+	B    afterNativeIntCall

--- a/src/wago/prepared_direct_arm64.go
+++ b/src/wago/prepared_direct_arm64.go
@@ -1,4 +1,4 @@
-//go:build amd64 && !tinygo
+//go:build arm64 && !tinygo
 
 package wago
 
@@ -10,7 +10,7 @@ import (
 )
 
 const preparedDirectIntSupported = true
-const preparedDirectIntPrivateSupported = false
+const preparedDirectIntPrivateSupported = true
 
 func (fn *PreparedFunction) invokeDirectInt(args []uint64) ([]uint64, error) {
 	in := fn.in
@@ -42,6 +42,11 @@ func (fn *PreparedFunction) invokeDirectInt(args []uint64) ([]uint64, error) {
 		if fn.scalarWideMask&1 == 0 {
 			a0 = uint64(uint32(a0))
 		}
+	}
+	if !fn.isolatedFast {
+		nativeExecutionMu.Lock()
+		nativeExecutionEpoch++
+		defer nativeExecutionMu.Unlock()
 	}
 	result := in.eng.EnterPreparedInt(fn.directEntry, in.jm.LinMemBase(), a0, a1, a2, a3)
 	if wruntime.PreparedIntTrapCode(in.trap) != wruntime.TrapNone {

--- a/src/wago/prepared_direct_arm64.go
+++ b/src/wago/prepared_direct_arm64.go
@@ -1,4 +1,4 @@
-//go:build arm64 && !tinygo
+//go:build arm64 && !tinygo && (linux || darwin || windows)
 
 package wago
 

--- a/src/wago/prepared_direct_arm64_test.go
+++ b/src/wago/prepared_direct_arm64_test.go
@@ -1,0 +1,41 @@
+//go:build arm64 && !tinygo
+
+package wago
+
+import "testing"
+
+func TestPreparedDirectARM64CallIndirectAndTrapRecovery(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), callIndirectModule(2, 1, 2))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.directPreparedAt(0) {
+		t.Fatal("call_indirect caller did not select the ARM64 direct prepared entry")
+	}
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareFunction("caller")
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if !fn.directIntFast || fn.isolatedFast {
+		t.Fatalf("direct/private selection = %v/%v, want true/false", fn.directIntFast, fn.isolatedFast)
+	}
+	for _, tc := range []struct {
+		idx, want uint64
+	}{{0, 13}, {1, 7}} {
+		got, err := fn.Invoke(tc.idx, 10, 3)
+		if err != nil || len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("caller(%d,10,3) = %v, %v; want %d", tc.idx, got, err, tc.want)
+		}
+	}
+	if _, err := fn.Invoke(2, 10, 3); err == nil {
+		t.Fatal("out-of-bounds direct prepared call_indirect did not trap")
+	}
+	if got, err := fn.Invoke(0, 20, 22); err != nil || len(got) != 1 || got[0] != 42 {
+		t.Fatalf("call after trap = %v, %v; want 42", got, err)
+	}
+}

--- a/src/wago/prepared_direct_arm64_test.go
+++ b/src/wago/prepared_direct_arm64_test.go
@@ -1,4 +1,4 @@
-//go:build arm64 && !tinygo
+//go:build arm64 && !tinygo && (linux || darwin || windows)
 
 package wago
 

--- a/src/wago/prepared_direct_other.go
+++ b/src/wago/prepared_direct_other.go
@@ -1,10 +1,11 @@
-//go:build !amd64 || tinygo
+//go:build (!amd64 && !arm64) || tinygo
 
 package wago
 
 import "fmt"
 
 const preparedDirectIntSupported = false
+const preparedDirectIntPrivateSupported = false
 
 func (fn *PreparedFunction) invokeDirectInt([]uint64) ([]uint64, error) {
 	return nil, fmt.Errorf("wago: direct prepared integer entry is unavailable on this architecture")

--- a/src/wago/prepared_direct_other.go
+++ b/src/wago/prepared_direct_other.go
@@ -1,4 +1,4 @@
-//go:build (!amd64 && !arm64) || tinygo
+//go:build (!amd64 && !arm64) || tinygo || (arm64 && !(linux || darwin || windows))
 
 package wago
 

--- a/src/wago/prepared_function.go
+++ b/src/wago/prepared_function.go
@@ -123,7 +123,7 @@ func (in *Instance) PrepareFunction(export string) (*PreparedFunction, error) {
 	if scalarFast && preparedPrivateEntryEnabled && in.preparedPrivateEligible() {
 		fn.privateFast = true
 		fn.isolatedFast = preparedIsolatedEntryEnabled && in.preparedIsolatedEligible()
-		if fn.isolatedFast && preparedDirectIntSupported && preparedDirectIntEnabled && preparedDirectIntSignature(sig) && in.c.directPreparedAt(ic.li) {
+		if (fn.isolatedFast || preparedDirectIntPrivateSupported) && preparedDirectIntSupported && preparedDirectIntEnabled && preparedDirectIntSignature(sig) && in.c.directPreparedAt(ic.li) {
 			fn.directIntFast = true
 			fn.directEntry = in.base + uintptr(internalEntryOffset(in.c.InternalEntry[ic.li]))
 		}

--- a/src/wago/prepared_function_test.go
+++ b/src/wago/prepared_function_test.go
@@ -76,7 +76,7 @@ func TestPreparedFunctionPrivateFastPath(t *testing.T) {
 		if fn.isolatedFast != wantIsolated {
 			t.Fatalf("isolated fast enabled=%v: got %v, want %v", enabled, fn.isolatedFast, wantIsolated)
 		}
-		wantDirect := wantIsolated && preparedDirectIntSupported && preparedDirectIntSignature(in.c.Funcs[0]) && in.c.directPreparedAt(0)
+		wantDirect := wantFast && (wantIsolated || preparedDirectIntPrivateSupported) && preparedDirectIntSupported && preparedDirectIntSignature(in.c.Funcs[0]) && in.c.directPreparedAt(0)
 		if fn.directIntFast != wantDirect {
 			t.Fatalf("direct int enabled=%v: got %v, want %v", enabled, fn.directIntFast, wantDirect)
 		}


### PR DESCRIPTION
## What changed

- add an ARM64 foreign-stack trampoline for direct prepared integer entry
- emit ARM64 direct-prepared metadata for small integer functions that do not require memory, imports, module-pinned globals, or exception state
- allow private table-backed entries to use the direct path under the existing native execution serialization
- retain stack-fence behavior, cold trap recovery, and post-trap reuse
- add focused coverage for polymorphic `call_indirect`, out-of-bounds traps, and subsequent successful calls

## Why

The ARM64 `dispatch.apply` comparison looked like a `call_indirect` lowering gap, but the amortized in-Wasm ISA benchmark already ran indirect calls faster than wazero. The dominant cost was the host-to-Wasm boundary: ARM64 had no counterpart to AMD64's direct prepared-integer entry, despite the encoder already reserving the metadata.

On an Apple M4 Max, repeated paired measurements moved `BenchmarkExec/dispatch.apply` from approximately 34.4 ns/op to 20.8 ns/op, while wazero measured approximately 21.4 ns/op. The path remains allocation-free. `tiny.add` moved from approximately 30.2 ns/op to 17.5 ns/op.

## Validation

- `go test -race ./src/core/runtime ./src/core/compiler/backend/railshot/arm64 ./src/wago -count=1`
- `go test ./... -count=1`
- `make test-guard`
- `make lint`
- `tinygo test -scheduler=tasks -run '^TestPreparedFunction' ./src/wago/`
- Linux/ARM64 and Windows/ARM64 cross-compilation
- 10-run focused before/after benchmark comparison
