### PR TITLE
ci: validate documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.derive.outputs.code }}
+      docs: ${{ steps.derive.outputs.docs }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
@@ -49,8 +50,24 @@ jobs:
         id: derive
         run: |
           code='${{ steps.filter.outputs.code }}'
+          docs='${{ steps.filter.outputs.docs }}'
           echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "gate: code=$code"
+          echo "docs=$docs" >> "$GITHUB_OUTPUT"
+          echo "gate: code=$code docs=$docs"
+
+  docs:
+    name: Documentation
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: Validate documentation
+        run: make docs-check
 
   lint:
     name: Lint & format
@@ -560,7 +577,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [changes, lint, regression-corpus, race, platform-test, core-v2, tinygo, coverage, size]
+    needs: [changes, docs, lint, regression-corpus, race, platform-test, core-v2, tinygo, coverage, size]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
   docs:
     name: Documentation
     needs: changes
-    if: needs.changes.outputs.docs == 'true'
+    # Code-only changes can delete or rename a path referenced by unchanged
+    # documentation, so validate both documentation and executable changes.
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@
 # Actions workflow (.github/workflows/ci.yml) calls these same targets, so
 # `make lint` / `make test` reproduce CI exactly. Run `make` to list targets.
 #
-#   make lint   gofmt + go generate sync + go vet + staticcheck   (host, no act)
-#   make test   go build + go test                                (host, no act)
-#   make ci     replay the whole workflow in Docker via act       (scripts/ci-local.sh)
-#   make bench  run the benchmark suite (BENCH=<regex> to filter) (host)
+#   make lint        gofmt + generate sync + vet + staticcheck (host, no act)
+#   make docs-check  local Markdown paths and anchors           (host, no act)
+#   make test        go build + go test                         (host, no act)
+#   make ci          replay the whole workflow in Docker via act
+#   make bench       benchmark suite (BENCH=<regex> to filter)  (host)
 #
 # The bench-* targets run on a stable local machine, never CI: shared runners
 # make benchmark numbers noisy.
@@ -89,6 +90,10 @@ lint-staticcheck:
 .PHONY: lint-website-generator
 lint-website-generator:
 	node --test scripts/update-website-bench.test.mjs
+
+.PHONY: docs-check
+docs-check: ## Validate local paths and anchors in tracked Markdown files
+	go run ./tests/tools/docs-check
 
 .PHONY: test
 test: ## Build and run the test suite (host)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,8 +1,8 @@
 # Continuous integration
 
-Pull requests and pushes to `main` run `.github/workflows/ci.yml`. Markdown-only
-changes use the lightweight aggregation gate; every code or build change runs
-the complete native platform matrix:
+Pull requests and pushes to `main` run `.github/workflows/ci.yml`. Documentation
+changes run a lightweight, deterministic local-link and heading-anchor check;
+every code or build change runs the complete native platform matrix:
 
 | Runner | OS | Architecture | Standard suite | Guard pages | Corpus | SIMD |
 |---|---|---|---:|---:|---:|---:|
@@ -71,6 +71,14 @@ uploads their report fragments with the merged coverage profile. The final `CI`
 aggregation job is the stable branch-protection check and fails if any required
 matrix cell or supporting job fails.
 
+The change detector reports documentation and code changes independently. A
+documentation-only pull request runs `make docs-check` without starting the
+native matrix, while a mixed pull request runs both. The documentation checker
+uses only the Go standard library and the tracked repository files: it rejects
+missing relative targets, exact-case path mismatches, and missing Markdown
+heading fragments without contacting external sites. Run the same check locally
+with `make docs-check`.
+
 Nightly, canary, and tagged release workflows require Linux, Darwin, and Windows
 CLI builds for both amd64 and arm64, then publish every successful binary with
 its SHA-256 checksum. A push to `main` becomes a canary only after that commit's
@@ -122,6 +130,7 @@ checks tracked Go files only, so toolchains or diagnostics retained under `.git/
 do not contaminate `make lint`.
 
 ```sh
+make docs-check
 make lint
 make test
 make test-guard   # only on a supported guard-page target

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -71,13 +71,14 @@ uploads their report fragments with the merged coverage profile. The final `CI`
 aggregation job is the stable branch-protection check and fails if any required
 matrix cell or supporting job fails.
 
-The change detector reports documentation and code changes independently. A
-documentation-only pull request runs `make docs-check` without starting the
-native matrix, while a mixed pull request runs both. The documentation checker
-uses only the Go standard library and the tracked repository files: it rejects
-missing relative targets, exact-case path mismatches, and missing Markdown
-heading fragments without contacting external sites. Run the same check locally
-with `make docs-check`.
+The change detector reports documentation and code changes independently. Every
+change runs `make docs-check`, because a code-only refactor can remove a source
+path referenced by unchanged documentation. Documentation-only pull requests do
+not start the native matrix, while mixed pull requests run both checks. The
+documentation checker uses only the Go standard library and the tracked
+repository files: it rejects missing relative targets, exact-case path
+mismatches, and missing Markdown heading fragments without contacting external
+sites. Run the same check locally with `make docs-check`.
 
 Nightly, canary, and tagged release workflows require Linux, Darwin, and Windows
 CLI builds for both amd64 and arm64, then publish every successful binary with

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -113,3 +113,21 @@ func TestWindowsWABTInstallIsPinnedAndVerified(t *testing.T) {
 		}
 	}
 }
+
+func TestDocsChangesRunDocumentationValidation(t *testing.T) {
+	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(workflow)
+	for _, required := range []string{
+		`docs: ${{ steps.derive.outputs.docs }}`,
+		`if: needs.changes.outputs.docs == 'true'`,
+		`run: make docs-check`,
+		`needs: [changes, docs, lint, regression-corpus`,
+	} {
+		if !strings.Contains(contents, required) {
+			t.Errorf("CI workflow is missing docs-validation policy %q", required)
+		}
+	}
+}

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -122,7 +122,7 @@ func TestDocsChangesRunDocumentationValidation(t *testing.T) {
 	contents := string(workflow)
 	for _, required := range []string{
 		`docs: ${{ steps.derive.outputs.docs }}`,
-		`if: needs.changes.outputs.docs == 'true'`,
+		`if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.code == 'true'`,
 		`run: make docs-check`,
 		`needs: [changes, docs, lint, regression-corpus`,
 	} {

--- a/tests/tools/docs-check/main.go
+++ b/tests/tools/docs-check/main.go
@@ -1,0 +1,376 @@
+// Command docs-check validates repository-local links in tracked Markdown files.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+type problem struct {
+	path    string
+	line    int
+	message string
+}
+
+type link struct {
+	line        int
+	destination string
+}
+
+var htmlLink = regexp.MustCompile(`(?i)(?:href|src)\s*=\s*["']([^"']+)["']`)
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+
+	absRoot, err := filepath.Abs(*root)
+	if err != nil {
+		fatal(err)
+	}
+	files, err := trackedMarkdown(absRoot)
+	if err != nil {
+		fatal(err)
+	}
+	problems := checkFiles(absRoot, files)
+	for _, p := range problems {
+		fmt.Fprintf(os.Stderr, "%s:%d: %s\n", filepath.ToSlash(p.path), p.line, p.message)
+	}
+	if len(problems) != 0 {
+		os.Exit(1)
+	}
+	fmt.Printf("docs-check: validated %d Markdown files\n", len(files))
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "docs-check:", err)
+	os.Exit(1)
+}
+
+func trackedMarkdown(root string) ([]string, error) {
+	cmd := exec.Command("git", "-C", root, "ls-files", "-z", "--", "*.md")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list tracked Markdown files: %w", err)
+	}
+	var files []string
+	for _, name := range bytes.Split(out, []byte{0}) {
+		if len(name) != 0 {
+			files = append(files, string(name))
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func checkFiles(root string, files []string) []problem {
+	anchorCache := make(map[string]map[string]struct{})
+	var problems []problem
+	for _, name := range files {
+		contents, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			problems = append(problems, problem{name, 1, err.Error()})
+			continue
+		}
+		for _, found := range extractLinks(string(contents)) {
+			if p := checkLink(root, name, found, anchorCache); p != nil {
+				problems = append(problems, *p)
+			}
+		}
+	}
+	sort.Slice(problems, func(i, j int) bool {
+		if problems[i].path != problems[j].path {
+			return problems[i].path < problems[j].path
+		}
+		if problems[i].line != problems[j].line {
+			return problems[i].line < problems[j].line
+		}
+		return problems[i].message < problems[j].message
+	})
+	return problems
+}
+
+func checkLink(root, source string, found link, anchorCache map[string]map[string]struct{}) *problem {
+	destination := strings.TrimSpace(found.destination)
+	if destination == "" || strings.HasPrefix(destination, "//") {
+		return nil
+	}
+	parsed, err := url.Parse(destination)
+	if err != nil {
+		return &problem{source, found.line, fmt.Sprintf("invalid link %q: %v", destination, err)}
+	}
+	if parsed.Scheme != "" || parsed.Host != "" || strings.HasPrefix(parsed.Path, "/") {
+		return nil
+	}
+	path, err := url.PathUnescape(parsed.Path)
+	if err != nil {
+		return &problem{source, found.line, fmt.Sprintf("invalid escaped path in %q", destination)}
+	}
+	target := source
+	if path != "" {
+		target = filepath.ToSlash(filepath.Clean(filepath.Join(filepath.Dir(source), filepath.FromSlash(path))))
+	}
+	if target == ".." || strings.HasPrefix(target, "../") {
+		return &problem{source, found.line, fmt.Sprintf("local link escapes the repository: %q", destination)}
+	}
+	if err := exactPath(root, target); err != nil {
+		return &problem{source, found.line, fmt.Sprintf("broken local link %q: %v", destination, err)}
+	}
+	if parsed.Fragment == "" || !strings.EqualFold(filepath.Ext(target), ".md") {
+		return nil
+	}
+	anchors, ok := anchorCache[target]
+	if !ok {
+		contents, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(target)))
+		if readErr != nil {
+			return &problem{source, found.line, fmt.Sprintf("read link target %q: %v", destination, readErr)}
+		}
+		anchors = markdownAnchors(string(contents))
+		anchorCache[target] = anchors
+	}
+	if _, ok := anchors[parsed.Fragment]; !ok {
+		return &problem{source, found.line, fmt.Sprintf("missing Markdown anchor %q in %s", parsed.Fragment, target)}
+	}
+	return nil
+}
+
+func exactPath(root, relative string) error {
+	current := root
+	for _, part := range strings.Split(filepath.Clean(filepath.FromSlash(relative)), string(filepath.Separator)) {
+		if part == "." || part == "" {
+			continue
+		}
+		entries, err := os.ReadDir(current)
+		if err != nil {
+			return err
+		}
+		matched := false
+		folded := ""
+		for _, entry := range entries {
+			if entry.Name() == part {
+				matched = true
+				break
+			}
+			if strings.EqualFold(entry.Name(), part) {
+				folded = entry.Name()
+			}
+		}
+		if !matched {
+			if folded != "" {
+				return fmt.Errorf("path case mismatch: wrote %q, repository has %q", part, folded)
+			}
+			return os.ErrNotExist
+		}
+		current = filepath.Join(current, part)
+	}
+	return nil
+}
+
+func extractLinks(markdown string) []link {
+	var links []link
+	scanner := bufio.NewScanner(strings.NewReader(markdown))
+	inFence := false
+	fenceChar := byte(0)
+	fenceLen := 0
+	for lineNo := 1; scanner.Scan(); lineNo++ {
+		lineText := scanner.Text()
+		trimmed := strings.TrimLeft(lineText, " \t")
+		if char, length, ok := fence(trimmed); ok {
+			if !inFence {
+				inFence, fenceChar, fenceLen = true, char, length
+			} else if char == fenceChar && length >= fenceLen {
+				inFence = false
+			}
+			continue
+		}
+		if inFence {
+			continue
+		}
+		lineText = stripInlineCode(lineText)
+		for _, destination := range inlineDestinations(lineText) {
+			links = append(links, link{lineNo, destination})
+		}
+		if destination, ok := referenceDestination(lineText); ok {
+			links = append(links, link{lineNo, destination})
+		}
+		for _, match := range htmlLink.FindAllStringSubmatch(lineText, -1) {
+			links = append(links, link{lineNo, match[1]})
+		}
+	}
+	return links
+}
+
+func fence(trimmed string) (byte, int, bool) {
+	if len(trimmed) < 3 || (trimmed[0] != '`' && trimmed[0] != '~') {
+		return 0, 0, false
+	}
+	char := trimmed[0]
+	i := 1
+	for i < len(trimmed) && trimmed[i] == char {
+		i++
+	}
+	return char, i, i >= 3
+}
+
+func stripInlineCode(line string) string {
+	result := []byte(line)
+	for i := 0; i < len(result); {
+		if result[i] != '`' {
+			i++
+			continue
+		}
+		start := i
+		for i < len(result) && result[i] == '`' {
+			i++
+		}
+		ticks := i - start
+		end := bytes.Index(result[i:], bytes.Repeat([]byte{'`'}, ticks))
+		if end < 0 {
+			break
+		}
+		end += i + ticks
+		for j := start; j < end; j++ {
+			result[j] = ' '
+		}
+		i = end
+	}
+	return string(result)
+}
+
+func inlineDestinations(line string) []string {
+	var destinations []string
+	for offset := 0; offset < len(line); {
+		rel := strings.Index(line[offset:], "](")
+		if rel < 0 {
+			break
+		}
+		start := offset + rel + 2
+		for start < len(line) && (line[start] == ' ' || line[start] == '\t') {
+			start++
+		}
+		if start >= len(line) {
+			break
+		}
+		if line[start] == '<' {
+			end := strings.IndexByte(line[start+1:], '>')
+			if end >= 0 {
+				destinations = append(destinations, line[start+1:start+1+end])
+				offset = start + end + 2
+				continue
+			}
+		}
+		end := start
+		escaped := false
+		for end < len(line) {
+			char := line[end]
+			if !escaped && (char == ')' || char == ' ' || char == '\t') {
+				break
+			}
+			if char == '\\' && !escaped {
+				escaped = true
+			} else {
+				escaped = false
+			}
+			end++
+		}
+		if end > start {
+			destinations = append(destinations, strings.ReplaceAll(line[start:end], `\)`, `)`))
+		}
+		offset = end + 1
+	}
+	return destinations
+}
+
+func referenceDestination(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "[") {
+		return "", false
+	}
+	marker := strings.Index(trimmed, "]:")
+	if marker < 1 {
+		return "", false
+	}
+	destination := strings.TrimSpace(trimmed[marker+2:])
+	if strings.HasPrefix(destination, "<") {
+		if end := strings.IndexByte(destination[1:], '>'); end >= 0 {
+			return destination[1 : end+1], true
+		}
+	}
+	if fields := strings.Fields(destination); len(fields) != 0 {
+		return fields[0], true
+	}
+	return "", false
+}
+
+func markdownAnchors(markdown string) map[string]struct{} {
+	anchors := make(map[string]struct{})
+	counts := make(map[string]int)
+	scanner := bufio.NewScanner(strings.NewReader(markdown))
+	inFence := false
+	fenceChar := byte(0)
+	fenceLen := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimLeft(line, " \t")
+		if char, length, ok := fence(trimmed); ok {
+			if !inFence {
+				inFence, fenceChar, fenceLen = true, char, length
+			} else if char == fenceChar && length >= fenceLen {
+				inFence = false
+			}
+			continue
+		}
+		if inFence {
+			continue
+		}
+		heading, ok := atxHeading(trimmed)
+		if !ok {
+			continue
+		}
+		base := githubSlug(heading)
+		anchor := base
+		if count := counts[base]; count != 0 {
+			anchor = fmt.Sprintf("%s-%d", base, count)
+		}
+		counts[base]++
+		anchors[anchor] = struct{}{}
+	}
+	return anchors
+}
+
+func atxHeading(trimmed string) (string, bool) {
+	i := 0
+	for i < len(trimmed) && trimmed[i] == '#' {
+		i++
+	}
+	if i == 0 || i > 6 || i == len(trimmed) || (trimmed[i] != ' ' && trimmed[i] != '\t') {
+		return "", false
+	}
+	heading := strings.TrimSpace(trimmed[i:])
+	heading = strings.TrimSpace(strings.TrimRight(heading, "#"))
+	return heading, true
+}
+
+func githubSlug(heading string) string {
+	var slug strings.Builder
+	for _, r := range strings.ToLower(heading) {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '_', r == '-', unicode.IsSpace(r):
+			if unicode.IsSpace(r) {
+				slug.WriteByte('-')
+			} else {
+				slug.WriteRune(r)
+			}
+		}
+	}
+	return slug.String()
+}

--- a/tests/tools/docs-check/main.go
+++ b/tests/tools/docs-check/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"flag"
 	"fmt"
@@ -177,12 +176,11 @@ func exactPath(root, relative string) error {
 
 func extractLinks(markdown string) []link {
 	var links []link
-	scanner := bufio.NewScanner(strings.NewReader(markdown))
 	inFence := false
 	fenceChar := byte(0)
 	fenceLen := 0
-	for lineNo := 1; scanner.Scan(); lineNo++ {
-		lineText := scanner.Text()
+	for index, lineText := range strings.Split(markdown, "\n") {
+		lineNo := index + 1
 		trimmed := strings.TrimLeft(lineText, " \t")
 		if char, length, ok := fence(trimmed); ok {
 			if !inFence {
@@ -269,16 +267,33 @@ func inlineDestinations(line string) []string {
 			}
 		}
 		end := start
+		depth := 0
 		escaped := false
+	scanDestination:
 		for end < len(line) {
 			char := line[end]
-			if !escaped && (char == ')' || char == ' ' || char == '\t') {
-				break
-			}
-			if char == '\\' && !escaped {
-				escaped = true
-			} else {
+			if escaped {
 				escaped = false
+				end++
+				continue
+			}
+			if char == '\\' {
+				escaped = true
+				end++
+				continue
+			}
+			switch char {
+			case '(':
+				depth++
+			case ')':
+				if depth == 0 {
+					break scanDestination
+				}
+				depth--
+			case ' ', '\t':
+				if depth == 0 {
+					break scanDestination
+				}
 			}
 			end++
 		}
@@ -314,12 +329,10 @@ func referenceDestination(line string) (string, bool) {
 func markdownAnchors(markdown string) map[string]struct{} {
 	anchors := make(map[string]struct{})
 	counts := make(map[string]int)
-	scanner := bufio.NewScanner(strings.NewReader(markdown))
 	inFence := false
 	fenceChar := byte(0)
 	fenceLen := 0
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range strings.Split(markdown, "\n") {
 		trimmed := strings.TrimLeft(line, " \t")
 		if char, length, ok := fence(trimmed); ok {
 			if !inFence {

--- a/tests/tools/docs-check/main_test.go
+++ b/tests/tools/docs-check/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckFilesAcceptsValidLocalLinks(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "README.md", strings.Join([]string{
+		"# Home",
+		"[guide](docs/guide.md#details)",
+		"[same](#home)",
+		"[source](src/example.go)",
+		"[reference]: docs/guide.md#details",
+		`<a href="LICENSE">license</a>`,
+	}, "\n"))
+	writeFile(t, root, "docs/guide.md", "# Details\n")
+	writeFile(t, root, "src/example.go", "package example\n")
+	writeFile(t, root, "LICENSE", "test\n")
+
+	if problems := checkFiles(root, []string{"README.md", "docs/guide.md"}); len(problems) != 0 {
+		t.Fatalf("unexpected problems: %+v", problems)
+	}
+}
+
+func TestCheckFilesRejectsBrokenPathAnchorAndCase(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "README.md", strings.Join([]string{
+		"[missing](docs/missing.md)",
+		"[anchor](docs/guide.md#missing)",
+		"[case](Docs/guide.md)",
+	}, "\n"))
+	writeFile(t, root, "docs/guide.md", "# Present\n")
+
+	problems := checkFiles(root, []string{"README.md", "docs/guide.md"})
+	if len(problems) != 3 {
+		t.Fatalf("got %d problems, want 3: %+v", len(problems), problems)
+	}
+	joined := problems[0].message + "\n" + problems[1].message + "\n" + problems[2].message
+	for _, want := range []string{"file does not exist", "missing Markdown anchor", "path case mismatch"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("problems do not contain %q: %s", want, joined)
+		}
+	}
+}
+
+func TestExtractLinksSkipsCodeAndExternalLinks(t *testing.T) {
+	markdown := strings.Join([]string{
+		"[local](guide.md)",
+		"`[inline](ignored.md)`",
+		"```md",
+		"[fenced](ignored.md)",
+		"```",
+		"[web](https://example.com/missing)",
+	}, "\n")
+	links := extractLinks(markdown)
+	if len(links) != 2 {
+		t.Fatalf("got links %+v", links)
+	}
+	if links[0].destination != "guide.md" || links[1].destination != "https://example.com/missing" {
+		t.Fatalf("unexpected links: %+v", links)
+	}
+}
+
+func TestMarkdownAnchorsMatchGitHubDuplicates(t *testing.T) {
+	anchors := markdownAnchors("# Review Focus\n## Review Focus\n")
+	for _, want := range []string{"review-focus", "review-focus-1"} {
+		if _, ok := anchors[want]; !ok {
+			t.Errorf("missing anchor %q in %+v", want, anchors)
+		}
+	}
+}
+
+func writeFile(t *testing.T, root, name, contents string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tests/tools/docs-check/main_test.go
+++ b/tests/tools/docs-check/main_test.go
@@ -14,10 +14,12 @@ func TestCheckFilesAcceptsValidLocalLinks(t *testing.T) {
 		"[guide](docs/guide.md#details)",
 		"[same](#home)",
 		"[source](src/example.go)",
+		"[parentheses](docs/guide_(v2).md)",
 		"[reference]: docs/guide.md#details",
 		`<a href="LICENSE">license</a>`,
 	}, "\n"))
 	writeFile(t, root, "docs/guide.md", "# Details\n")
+	writeFile(t, root, "docs/guide_(v2).md", "# Version 2\n")
 	writeFile(t, root, "src/example.go", "package example\n")
 	writeFile(t, root, "LICENSE", "test\n")
 


### PR DESCRIPTION
## Summary

- add a dependency-free checker for tracked Markdown paths and GitHub-style heading anchors
- run documentation validation for documentation, mixed, and code-only changes
- include the documentation job in the stable CI aggregate
- document the local `make docs-check` workflow

## Why

Documentation-only changes previously skipped every substantive validation job. Code-only refactors could also remove source paths referenced by unchanged documentation.

Fixes #415.

## Validation

- `GOCACHE=/tmp/wago-review-go-cache go test -count=1 ./tests/tools/docs-check ./tests/cipolicy`
- `GOCACHE=/tmp/wago-review-go-cache go vet ./tests/tools/docs-check ./tests/cipolicy`
- `GOCACHE=/tmp/wago-review-go-cache make docs-check` (100 tracked Markdown files)
- `git diff --check`

Docs updated: `docs/ci.md`. No benchmark or memory measurement applies because this changes CI tooling only.