### PR TITLE
security: bound source archive extraction

### DIFF
--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -498,7 +498,11 @@ func (i *installer) downloadChecked(url, target string) error {
 }
 
 func (i *installer) download(url, target string) error {
-	response, err := i.httpClient.Get(url)
+	request, err := http.NewRequestWithContext(i.installContext(), http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	response, err := i.httpClient.Do(request)
 	if err != nil {
 		return err
 	}

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -50,6 +51,7 @@ type installer struct {
 	pathAdded           bool
 	pathRefresh         bool
 	pathInitiallyReady  bool
+	ctx                 context.Context
 }
 
 type pathTarget struct {
@@ -62,10 +64,13 @@ type pathTarget struct {
 
 func runInstaller() error {
 	clearPipedCmdHeader()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 	i, err := newInstaller(os.Stderr)
 	if err != nil {
 		return err
 	}
+	i.ctx = ctx
 	err = i.run()
 	if i.progressActive {
 		i.stopProgress()
@@ -566,12 +571,19 @@ func (i *installer) fetchSourceArchiveAfterGitFailure(target, archiveURL string,
 	if err := i.download(archiveURL, archive); err != nil {
 		return "", fmt.Errorf("fetch source with Git (%v: %s) or archive: %w", gitErr, strings.TrimSpace(string(gitLog)), err)
 	}
-	if err := sourcearchive.Extract(archive, target); err != nil {
+	if err := sourcearchive.ExtractContext(i.installContext(), archive, target); err != nil {
 		return "", fmt.Errorf("unpack source archive: %w", err)
 	}
 	i.sourceMethod = "archive"
 	i.done("Fetched Wago source")
 	return target, nil
+}
+
+func (i *installer) installContext() context.Context {
+	if i.ctx == nil {
+		return context.Background()
+	}
+	return i.ctx
 }
 
 func installerSourceRef(version string) string {

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -318,6 +319,75 @@ func TestInstallerCanonicalRollingArchiveFallbackUsesExactCommit(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(target, "go.mod")); err != nil {
 		t.Fatalf("extracted source: %v", err)
 	}
+}
+
+func TestInstallerArchiveCancellationCleansTemporaryTree(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writer := zip.NewWriter(w)
+		for _, entry := range []struct {
+			name string
+			data string
+		}{
+			{name: "wago-root/go.mod", data: "module example.invalid/wago\n"},
+			{name: "wago-root/large", data: strings.Repeat("x", 1<<20)},
+		} {
+			destination, err := writer.Create(entry.name)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if _, err := destination.Write([]byte(entry.data)); err != nil {
+				t.Error(err)
+				return
+			}
+		}
+		if err := writer.Close(); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer server.Close()
+
+	temporary := t.TempDir()
+	target := filepath.Join(temporary, "src")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	i := &installer{
+		out:        &bytes.Buffer{},
+		httpClient: server.Client(),
+		tmpDir:     temporary,
+		ctx:        &cancelWhenStagingExists{Context: ctx, cancel: cancel, target: target},
+	}
+	_, err := i.fetchSourceArchiveAfterGitFailure(target, server.URL, []byte("git unavailable"), errors.New("git failed"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("archive fallback error = %v, want context canceled", err)
+	}
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Fatalf("canceled archive target remains: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(temporary, ".src-extract-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("canceled archive staging paths remain: %v", matches)
+	}
+}
+
+type cancelWhenStagingExists struct {
+	context.Context
+	cancel context.CancelFunc
+	target string
+}
+
+func (ctx *cancelWhenStagingExists) Err() error {
+	if err := ctx.Context.Err(); err != nil {
+		return err
+	}
+	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(ctx.target), "."+filepath.Base(ctx.target)+"-extract-*"))
+	if len(matches) != 0 {
+		ctx.cancel()
+	}
+	return ctx.Context.Err()
 }
 
 func TestInstallerDownloadsNewestChannelManager(t *testing.T) {

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -373,6 +373,36 @@ func TestInstallerArchiveCancellationCleansTemporaryTree(t *testing.T) {
 	}
 }
 
+func TestInstallerArchiveDownloadCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		cancel()
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+	t.Cleanup(cancel)
+
+	temporary := t.TempDir()
+	target := filepath.Join(temporary, "src")
+	i := &installer{
+		out:        &bytes.Buffer{},
+		httpClient: server.Client(),
+		tmpDir:     temporary,
+		ctx:        ctx,
+	}
+	_, err := i.fetchSourceArchiveAfterGitFailure(target, server.URL, []byte("git unavailable"), errors.New("git failed"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("archive fallback error = %v, want context canceled", err)
+	}
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Fatalf("canceled archive target remains: %v", err)
+	}
+}
+
 type cancelWhenStagingExists struct {
 	context.Context
 	cancel context.CancelFunc

--- a/cli/manager/internal/version/source.go
+++ b/cli/manager/internal/version/source.go
@@ -228,7 +228,7 @@ func checkoutWagoSourceArchiveContext(ctx context.Context, ref, temp, source str
 	if err := downloadSourceArchiveContext(ctx, sourceArchiveURL(ref), archive); err != nil {
 		return err
 	}
-	return sourcearchive.Extract(archive, source)
+	return sourcearchive.ExtractContext(ctx, archive, source)
 }
 
 func downloadSourceArchiveContext(ctx context.Context, address, target string) error {

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -14,9 +14,10 @@ limits instead of the process default client:
 - dial, TLS-handshake, response-header, idle-connection, and
   `Expect: 100-continue` waits have independent transport timeouts.
 
-A parent command cancellation is propagated to active manager requests and to
-Git/TinyGo/Go subprocesses used by source-build fallback. In-memory bodies are
-explicitly bounded: registry and GitHub release JSON use a 4 MiB limit, OAuth
+A parent command cancellation is propagated to active manager requests,
+installer downloads, and Git/TinyGo/Go subprocesses used by source-build
+fallback. In-memory bodies are explicitly bounded: registry and GitHub release
+JSON use a 4 MiB limit, OAuth
 responses use 1 MiB, release checksums use 4 KiB, and non-success response
 capture uses an independent 64 KiB limit. Declared oversized bodies are rejected
 before reading; chunked or dishonest responses are stopped after the configured
@@ -50,8 +51,9 @@ Downloaded source ZIPs are preflighted completely before filesystem mutation.
 Extraction permits one top-level directory and strict regular files/directories
 only. It rejects traversal, duplicate and case-colliding paths,
 file/directory conflicts, non-portable names, encrypted entries, mixed or special
-file modes, unsupported compression, mismatched local headers or data
-descriptors, ZIP64 metadata, data ranges that reach the central directory, and
+file modes, unsupported ZIP versions, compression, or general-purpose flags,
+mismatched local headers or data descriptors, ZIP64 metadata, and local-record
+gaps, overlaps, prefixes, or data ranges that reach the central directory, and
 archives beyond 20,000 entries, 16,000 files,
 4,000 unique directories, 16 MiB of central-directory metadata, 64 relative path
 components, 255 bytes per component, 1,024 path bytes, 128 MiB per file, or 512
@@ -59,15 +61,17 @@ MiB expanded content. Directories must have trailing slashes and zero declared
 content. Stored files must have equal compressed and uncompressed sizes. The
 stripped archive root must contain an exactly spelled regular `go.mod` file.
 
-Path components are restricted to portable printable ASCII. A single byte scan
-validates each path, each complete relative path is canonicalized at most once,
+Path components are restricted to portable printable ASCII, including rejection
+of Windows DOS device aliases such as `CON`, `CONIN$`, and `CONOUT$`. A single
+byte scan validates each path, each complete relative path is canonicalized at most once,
 and parent nodes are derived by slicing at slash offsets. The preflight therefore
 scales linearly with accepted path metadata rather than repeatedly allocating
 and joining every parent prefix. On Go 1.26.5/linux-amd64 on a Ryzen 7 7800X3D,
 the 16,000-file, 63-shared-directory production-shaped benchmark improved from
 1.103 seconds, 1,078,897,384 bytes, and 2,048,079 allocations per operation to
-138 milliseconds, 19,593,424 bytes, and 64,135 allocations per operation after
-strict central/local metadata agreement and data-descriptor preflight.
+150 milliseconds, 20,184,512 bytes, and 64,200 allocations per operation after
+strict central/local metadata agreement, exact local-record coverage, and
+data-descriptor preflight.
 
 The fixed-memory central-directory scanner and Go ZIP reader share one opened
 regular-file descriptor, preventing pathname replacement between validation and

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -50,8 +50,9 @@ Downloaded source ZIPs are preflighted completely before filesystem mutation.
 Extraction permits one top-level directory and strict regular files/directories
 only. It rejects traversal, duplicate and case-colliding paths,
 file/directory conflicts, non-portable names, encrypted entries, mixed or special
-file modes, unsupported compression, malformed local headers, data ranges that
-reach the central directory, and archives beyond 20,000 entries, 16,000 files,
+file modes, unsupported compression, mismatched local headers or data
+descriptors, ZIP64 metadata, data ranges that reach the central directory, and
+archives beyond 20,000 entries, 16,000 files,
 4,000 unique directories, 16 MiB of central-directory metadata, 64 relative path
 components, 255 bytes per component, 1,024 path bytes, 128 MiB per file, or 512
 MiB expanded content. Directories must have trailing slashes and zero declared
@@ -65,7 +66,8 @@ scales linearly with accepted path metadata rather than repeatedly allocating
 and joining every parent prefix. On Go 1.26.5/linux-amd64 on a Ryzen 7 7800X3D,
 the 16,000-file, 63-shared-directory production-shaped benchmark improved from
 1.103 seconds, 1,078,897,384 bytes, and 2,048,079 allocations per operation to
-102 milliseconds, 19,494,096 bytes, and 48,128 allocations per operation.
+138 milliseconds, 19,593,424 bytes, and 64,135 allocations per operation after
+strict central/local metadata agreement and data-descriptor preflight.
 
 The fixed-memory central-directory scanner and Go ZIP reader share one opened
 regular-file descriptor, preventing pathname replacement between validation and
@@ -73,9 +75,9 @@ extraction. The descriptor is closed before publication. Decompressed bytes are
 counted against the declared and aggregate limits instead of trusting ZIP
 metadata. Extraction occurs in a private sibling staging directory, observes
 manager and installer command cancellation, and publishes the complete tree with
-an atomic no-replace rename. Every failure removes the staging tree, and cleanup
-or close failures are surfaced rather than discarded. ZIP entry and metadata
-limits remain checked before Go's ZIP reader allocates per-entry objects.
+an atomic no-replace rename. Every failure attempts to remove the staging tree,
+and cleanup or close failures are surfaced rather than discarded. ZIP entry and
+metadata limits remain checked before Go's ZIP reader allocates per-entry objects.
 
 The August 2026 limit check used 3,521 tracked files, 441 unique directories,
 467,141 central-directory bytes, 52,815,053 total bytes, a 16,243,226-byte

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -50,17 +50,26 @@ Downloaded source ZIPs are preflighted completely before filesystem mutation.
 Extraction permits one top-level directory and regular files/directories only;
 it rejects traversal, duplicate and case-colliding paths, file/directory
 conflicts, non-portable names, and archives beyond 20,000 entries, 16,000 files,
-4,000 unique directories, 64 relative path components, 255 bytes per component,
-1,024 path bytes, 128 MiB per file, or 512 MiB expanded content. Decompressed
-bytes are counted against the declared and aggregate limits instead of trusting
-ZIP metadata. Extraction occurs in a private sibling staging directory, observes
-command cancellation, and publishes the complete tree by rename only after a
-regular `go.mod` is present; every failure removes the staging tree.
+4,000 unique directories, 16 MiB of central-directory metadata, 64 relative path
+components, 255 bytes per component, 1,024 path bytes, 128 MiB per file, or 512
+MiB expanded content. Path components are restricted to portable printable
+ASCII. Decompressed bytes are counted against the declared and aggregate limits
+instead of trusting ZIP metadata. Extraction occurs in a private sibling staging
+directory, observes command cancellation, and publishes the complete tree with
+an atomic no-replace rename only after a regular `go.mod` is present; every
+failure removes the staging tree. ZIP entry and metadata limits are checked with
+a fixed-memory central-directory scan before Go's ZIP reader allocates per-entry
+objects.
 
 The August 2026 limit check used 3,521 tracked files, 441 unique directories,
-52,815,053 total bytes, a 16,243,226-byte largest file, 100 path bytes, and eight
-path components on `main`; each extraction ceiling therefore retains substantial
-headroom over the source tree it protects.
+467,141 central-directory bytes, 52,815,053 total bytes, a 16,243,226-byte
+largest file, 100 path bytes, and eight path components on `main`; each
+extraction ceiling therefore retains substantial headroom over the source tree
+it protects.
+
+The platform no-replace helpers remain no-cgo. On linux/amd64, the stripped,
+trimmed standard manager measured 9,052,322 bytes before these follow-up guards
+and 9,064,610 bytes after them, a 12,288-byte increase.
 
 The destination is published only after the complete stream has the expected
 length and digest, the executable mode is set, the file is synced, and it is

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -46,6 +46,22 @@ which leaves substantial headroom over current stripped Wago binaries without
 allowing an endpoint to consume unbounded disk or memory. Source archives use a
 separate 256 MiB streaming limit.
 
+Downloaded source ZIPs are preflighted completely before filesystem mutation.
+Extraction permits one top-level directory and regular files/directories only;
+it rejects traversal, duplicate and case-colliding paths, file/directory
+conflicts, non-portable names, and archives beyond 20,000 entries, 16,000 files,
+4,000 unique directories, 64 relative path components, 255 bytes per component,
+1,024 path bytes, 128 MiB per file, or 512 MiB expanded content. Decompressed
+bytes are counted against the declared and aggregate limits instead of trusting
+ZIP metadata. Extraction occurs in a private sibling staging directory, observes
+command cancellation, and publishes the complete tree by rename only after a
+regular `go.mod` is present; every failure removes the staging tree.
+
+The August 2026 limit check used 3,521 tracked files, 441 unique directories,
+52,815,053 total bytes, a 16,243,226-byte largest file, 100 path bytes, and eight
+path components on `main`; each extraction ceiling therefore retains substantial
+headroom over the source tree it protects.
+
 The destination is published only after the complete stream has the expected
 length and digest, the executable mode is set, the file is synced, and it is
 closed. Cancellation, malformed checksums, network interruption, oversized

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -60,10 +60,14 @@ components, 255 bytes per component, 1,024 path bytes, 128 MiB per file, or 512
 MiB expanded content. Directories must have trailing slashes and zero declared
 content. Stored files must have equal compressed and uncompressed sizes. The
 stripped archive root must contain an exactly spelled regular `go.mod` file.
+GitHub zipballs currently label ordinary directory and Deflate entries as ZIP
+version 1.0, so supported Store/Deflate entries retain that compatibility while
+versions above 2.0 and their unsupported features remain rejected independently.
 
 Path components are restricted to portable printable ASCII, including rejection
-of Windows DOS device aliases such as `CON`, `CONIN$`, and `CONOUT$`. A single
-byte scan validates each path, each complete relative path is canonicalized at most once,
+of Windows DOS device aliases such as `CON`, `CONIN$`, and `CONOUT$`, even when
+spaces precede an extension. A single byte scan validates each path, each complete
+relative path is canonicalized at most once,
 and parent nodes are derived by slicing at slash offsets. The preflight therefore
 scales linearly with accepted path metadata rather than repeatedly allocating
 and joining every parent prefix. On Go 1.26.5/linux-amd64 on a Ryzen 7 7800X3D,

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -47,19 +47,35 @@ allowing an endpoint to consume unbounded disk or memory. Source archives use a
 separate 256 MiB streaming limit.
 
 Downloaded source ZIPs are preflighted completely before filesystem mutation.
-Extraction permits one top-level directory and regular files/directories only;
-it rejects traversal, duplicate and case-colliding paths, file/directory
-conflicts, non-portable names, and archives beyond 20,000 entries, 16,000 files,
+Extraction permits one top-level directory and strict regular files/directories
+only. It rejects traversal, duplicate and case-colliding paths,
+file/directory conflicts, non-portable names, encrypted entries, mixed or special
+file modes, unsupported compression, malformed local headers, data ranges that
+reach the central directory, and archives beyond 20,000 entries, 16,000 files,
 4,000 unique directories, 16 MiB of central-directory metadata, 64 relative path
 components, 255 bytes per component, 1,024 path bytes, 128 MiB per file, or 512
-MiB expanded content. Path components are restricted to portable printable
-ASCII. Decompressed bytes are counted against the declared and aggregate limits
-instead of trusting ZIP metadata. Extraction occurs in a private sibling staging
-directory, observes command cancellation, and publishes the complete tree with
-an atomic no-replace rename only after a regular `go.mod` is present; every
-failure removes the staging tree. ZIP entry and metadata limits are checked with
-a fixed-memory central-directory scan before Go's ZIP reader allocates per-entry
-objects.
+MiB expanded content. Directories must have trailing slashes and zero declared
+content. Stored files must have equal compressed and uncompressed sizes. The
+stripped archive root must contain an exactly spelled regular `go.mod` file.
+
+Path components are restricted to portable printable ASCII. A single byte scan
+validates each path, each complete relative path is canonicalized at most once,
+and parent nodes are derived by slicing at slash offsets. The preflight therefore
+scales linearly with accepted path metadata rather than repeatedly allocating
+and joining every parent prefix. On Go 1.26.5/linux-amd64 on a Ryzen 7 7800X3D,
+the 16,000-file, 63-shared-directory production-shaped benchmark improved from
+1.103 seconds, 1,078,897,384 bytes, and 2,048,079 allocations per operation to
+102 milliseconds, 19,494,096 bytes, and 48,128 allocations per operation.
+
+The fixed-memory central-directory scanner and Go ZIP reader share one opened
+regular-file descriptor, preventing pathname replacement between validation and
+extraction. The descriptor is closed before publication. Decompressed bytes are
+counted against the declared and aggregate limits instead of trusting ZIP
+metadata. Extraction occurs in a private sibling staging directory, observes
+manager and installer command cancellation, and publishes the complete tree with
+an atomic no-replace rename. Every failure removes the staging tree, and cleanup
+or close failures are surfaced rather than discarded. ZIP entry and metadata
+limits remain checked before Go's ZIP reader allocates per-entry objects.
 
 The August 2026 limit check used 3,521 tracked files, 441 unique directories,
 467,141 central-directory bytes, 52,815,053 total bytes, a 16,243,226-byte

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/wago-org/wago
 
 go 1.22
+
+require golang.org/x/sys v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/sourcearchive/archive.go
+++ b/internal/sourcearchive/archive.go
@@ -4,6 +4,7 @@ package sourcearchive
 import (
 	"archive/zip"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -151,7 +152,7 @@ func extractWithOperations(ctx context.Context, archive, target string, limits e
 		return err
 	}
 
-	entries, err := preflight(ctx, reader.File, directory.offset, limits)
+	entries, err := preflight(ctx, archiveFile, reader.File, directory, limits)
 	if err != nil {
 		return err
 	}
@@ -222,6 +223,9 @@ func extractWithOperations(ctx context.Context, archive, target string, limits e
 	if err := closeArchive(); err != nil {
 		return err
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := publishDirectoryNoReplace(staging, target); err != nil {
 		return fmt.Errorf("publish source archive: %w", err)
 	}
@@ -238,7 +242,7 @@ func validateLimits(limits extractionLimits) error {
 	return nil
 }
 
-func preflight(ctx context.Context, files []*zip.File, directoryOffset int64, limits extractionLimits) ([]archiveEntry, error) {
+func preflight(ctx context.Context, readerAt io.ReaderAt, files []*zip.File, directory zipDirectory, limits extractionLimits) ([]archiveEntry, error) {
 	if len(files) == 0 {
 		return nil, errors.New("source archive is empty")
 	}
@@ -254,6 +258,10 @@ func preflight(ctx context.Context, files []*zip.File, directoryOffset int64, li
 	rootGoMod := false
 	regularFiles := 0
 	var declared uint64
+	central := newZipDirectoryCursor(readerAt, directory)
+	nameBuffer := make([]byte, limits.pathBytes+1)
+	localRecordBuffer := make([]byte, zipFileHeaderBytes+limits.pathBytes+1)
+	descriptorBuffer := make([]byte, zipDataDescriptorBytes)
 	for _, file := range files {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -262,8 +270,12 @@ func preflight(ctx context.Context, files []*zip.File, directoryOffset int64, li
 		if err != nil {
 			return nil, err
 		}
+		localOffset, err := central.next(file, nameBuffer)
+		if err != nil {
+			return nil, err
+		}
 		nameEndsInSlash := strings.HasSuffix(file.Name, "/")
-		dir, err := validateZipEntryMetadata(file, nameEndsInSlash, directoryOffset)
+		dir, err := validateZipEntryMetadata(file, nameEndsInSlash, readerAt, localOffset, directory.offset, localRecordBuffer, descriptorBuffer)
 		if err != nil {
 			return nil, err
 		}
@@ -357,6 +369,9 @@ func preflight(ctx context.Context, files []*zip.File, directoryOffset int64, li
 	}
 	if root == "" {
 		return nil, errors.New("source archive is empty")
+	}
+	if central.remaining != 0 {
+		return nil, errors.New("source archive central directory changed during preflight")
 	}
 	if !rootGoMod {
 		return nil, errors.New("source archive does not contain a regular go.mod file at the exact root path")
@@ -483,7 +498,7 @@ func canonicalPortablePath(path string) string {
 	return canonical.String()
 }
 
-func validateZipEntryMetadata(file *zip.File, nameEndsInSlash bool, directoryOffset int64) (bool, error) {
+func validateZipEntryMetadata(file *zip.File, nameEndsInSlash bool, readerAt io.ReaderAt, localOffset, directoryOffset int64, localRecordBuffer, descriptorBuffer []byte) (bool, error) {
 	mode := file.Mode()
 	kind := mode.Type()
 	if nameEndsInSlash {
@@ -514,11 +529,115 @@ func validateZipEntryMetadata(file *zip.File, nameEndsInSlash bool, directoryOff
 	if err != nil {
 		return false, fmt.Errorf("source archive path %q has a malformed local file header: %w", file.Name, err)
 	}
+	localRecordBytes := zipFileHeaderBytes + len(file.Name)
+	if localRecordBytes > len(localRecordBuffer) {
+		return false, fmt.Errorf("source archive path %q exceeds the local metadata buffer", file.Name)
+	}
+	localRecord := localRecordBuffer[:localRecordBytes]
+	localHeader := localRecord[:zipFileHeaderBytes]
+	if localOffset < 0 || directoryOffset < localOffset || int64(len(localRecord)) > directoryOffset-localOffset {
+		return false, fmt.Errorf("source archive path %q has a local file header outside the file-data region", file.Name)
+	}
+	if err := readZipMetadataAt(readerAt, localRecord, localOffset); err != nil {
+		return false, fmt.Errorf("read source archive path %q local file header: %w", file.Name, err)
+	}
+	if binary.LittleEndian.Uint32(localHeader[0:4]) != zipFileHeaderSignature {
+		return false, fmt.Errorf("source archive path %q has a malformed local file header", file.Name)
+	}
+	localFlags := binary.LittleEndian.Uint16(localHeader[6:8])
+	if localFlags != file.Flags {
+		return false, fmt.Errorf("source archive path %q local file header flags do not match the central directory", file.Name)
+	}
+	if binary.LittleEndian.Uint16(localHeader[8:10]) != file.Method {
+		return false, fmt.Errorf("source archive path %q local file header compression method does not match the central directory", file.Name)
+	}
+	localCompressed := binary.LittleEndian.Uint32(localHeader[18:22])
+	localUncompressed := binary.LittleEndian.Uint32(localHeader[22:26])
+	if localCompressed == ^uint32(0) || localUncompressed == ^uint32(0) {
+		return false, errors.New("source archive uses unsupported ZIP64 entry metadata")
+	}
+	nameBytes := int64(binary.LittleEndian.Uint16(localHeader[26:28]))
+	extraBytes := int64(binary.LittleEndian.Uint16(localHeader[28:30]))
+	wantDataOffset := localOffset + int64(len(localHeader)) + nameBytes + extraBytes
+	if wantDataOffset < localOffset || wantDataOffset != dataOffset || nameBytes != int64(len(file.Name)) {
+		return false, fmt.Errorf("source archive path %q local file header name or extra metadata is inconsistent", file.Name)
+	}
+	for index := range file.Name {
+		if localRecord[zipFileHeaderBytes+index] != file.Name[index] {
+			return false, fmt.Errorf("source archive path %q local file header name does not match the central directory", file.Name)
+		}
+	}
+	if extraBytes != 0 {
+		localExtra := io.NewSectionReader(readerAt, localOffset+int64(len(localHeader))+nameBytes, extraBytes)
+		if err := validateZipExtraFields(localExtra, uint64(extraBytes), "local file header"); err != nil {
+			return false, err
+		}
+	}
+	localCRC := binary.LittleEndian.Uint32(localHeader[14:18])
+	if localFlags&zipDataDescriptorFlag == 0 {
+		if localCRC != file.CRC32 || uint64(localCompressed) != file.CompressedSize64 || uint64(localUncompressed) != file.UncompressedSize64 {
+			return false, fmt.Errorf("source archive path %q local file header sizes or checksum do not match the central directory", file.Name)
+		}
+	} else {
+		allZero := localCRC == 0 && localCompressed == 0 && localUncompressed == 0
+		allCentral := localCRC == file.CRC32 && uint64(localCompressed) == file.CompressedSize64 && uint64(localUncompressed) == file.UncompressedSize64
+		if !allZero && !allCentral {
+			return false, fmt.Errorf("source archive path %q local file header sizes or checksum do not match the central directory", file.Name)
+		}
+	}
 	if dataOffset < 0 || directoryOffset < 0 || dataOffset > directoryOffset ||
 		file.CompressedSize64 > uint64(directoryOffset-dataOffset) {
 		return false, fmt.Errorf("source archive path %q has compressed data outside the file-data region", file.Name)
 	}
+	dataEnd := dataOffset + int64(file.CompressedSize64)
+	if localFlags&zipDataDescriptorFlag != 0 {
+		if err := validateZipDataDescriptor(readerAt, dataEnd, directoryOffset, file, descriptorBuffer); err != nil {
+			return false, err
+		}
+	}
 	return nameEndsInSlash, nil
+}
+
+func validateZipDataDescriptor(readerAt io.ReaderAt, offset, directoryOffset int64, file *zip.File, descriptorBuffer []byte) error {
+	if len(descriptorBuffer) < zipDataDescriptorBytes {
+		return errors.New("source archive data descriptor buffer is too small")
+	}
+	descriptor := descriptorBuffer[:zipDataDescriptorBytes]
+	if offset < 0 || directoryOffset < offset || zipDataDescriptorUnsignedBytes > directoryOffset-offset {
+		return fmt.Errorf("source archive path %q has a data descriptor outside the file-data region", file.Name)
+	}
+	readBytes := zipDataDescriptorBytes
+	if int64(readBytes) > directoryOffset-offset {
+		readBytes = zipDataDescriptorUnsignedBytes
+	}
+	if err := readZipMetadataAt(readerAt, descriptor[:readBytes], offset); err != nil {
+		return fmt.Errorf("read source archive path %q data descriptor: %w", file.Name, err)
+	}
+	signed := binary.LittleEndian.Uint32(descriptor[0:4]) == zipDataDescriptorSignature
+	valueOffset := 0
+	if signed {
+		if readBytes != zipDataDescriptorBytes {
+			return fmt.Errorf("source archive path %q has a truncated data descriptor", file.Name)
+		}
+		valueOffset = 4
+	}
+	if binary.LittleEndian.Uint32(descriptor[valueOffset:valueOffset+4]) != file.CRC32 ||
+		uint64(binary.LittleEndian.Uint32(descriptor[valueOffset+4:valueOffset+8])) != file.CompressedSize64 ||
+		uint64(binary.LittleEndian.Uint32(descriptor[valueOffset+8:valueOffset+12])) != file.UncompressedSize64 {
+		return fmt.Errorf("source archive path %q data descriptor does not match the central directory", file.Name)
+	}
+	return nil
+}
+
+func readZipMetadataAt(readerAt io.ReaderAt, destination []byte, offset int64) error {
+	read, err := readerAt.ReadAt(destination, offset)
+	if err != nil {
+		return err
+	}
+	if read != len(destination) {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 
 func containedDestination(root, relative string) (string, error) {

--- a/internal/sourcearchive/archive.go
+++ b/internal/sourcearchive/archive.go
@@ -3,89 +3,370 @@ package sourcearchive
 
 import (
 	"archive/zip"
+	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
+type extractionLimits struct {
+	entries        int
+	files          int
+	directories    int
+	pathBytes      int
+	pathDepth      int
+	componentBytes int
+	fileBytes      uint64
+	expandedBytes  uint64
+}
+
+type archiveEntry struct {
+	file     *zip.File
+	relative string
+	dir      bool
+}
+
 // Extract expands archive into target while removing the archive's single
-// top-level directory. It rejects traversal, multiple roots, and oversized
-// expanded content.
+// top-level directory. It rejects traversal, multiple roots, unsupported or
+// colliding paths, and work beyond the package's bounded extraction policy.
+// The target must not exist and is published atomically only after validation
+// and extraction succeed.
 func Extract(archive, target string) error {
+	return ExtractContext(context.Background(), archive, target)
+}
+
+// ExtractContext is Extract with cancellation. Cancellation and every other
+// failure remove the private staging tree without publishing a partial target.
+func ExtractContext(ctx context.Context, archive, target string) error {
+	return extractWithLimits(ctx, archive, target, productionExtractionLimits())
+}
+
+func productionExtractionLimits() extractionLimits {
+	return extractionLimits{
+		entries:        20_000,
+		files:          16_000,
+		directories:    4_000,
+		pathBytes:      1_024,
+		pathDepth:      64,
+		componentBytes: 255,
+		fileBytes:      128 << 20,
+		expandedBytes:  512 << 20,
+	}
+}
+
+func extractWithLimits(ctx context.Context, archive, target string, limits extractionLimits) error {
+	if ctx == nil {
+		return errors.New("source archive extraction requires a context")
+	}
+	if err := validateLimits(limits); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	reader, err := zip.OpenReader(archive)
 	if err != nil {
 		return err
 	}
 	defer reader.Close()
 
-	root := ""
-	for _, entry := range reader.File {
-		name := filepath.ToSlash(entry.Name)
-		part := strings.SplitN(name, "/", 2)[0]
-		if part == "" || part == "." || part == ".." {
-			return errors.New("source archive contains an invalid root")
-		}
-		if root == "" {
-			root = part
-		} else if root != part {
-			return errors.New("source archive contains multiple roots")
-		}
+	entries, err := preflight(ctx, reader.File, limits)
+	if err != nil {
+		return err
 	}
-	if root == "" {
-		return errors.New("source archive is empty")
+	target = filepath.Clean(target)
+	if target == "." || filepath.Base(target) == string(filepath.Separator) {
+		return errors.New("source archive target must name a new directory")
 	}
+	if _, err := os.Lstat(target); err == nil {
+		return errors.New("source archive target already exists")
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	staging, err := os.MkdirTemp(parent, "."+filepath.Base(target)+"-extract-*")
+	if err != nil {
+		return err
+	}
+	publish := false
+	defer func() {
+		if !publish {
+			_ = os.RemoveAll(staging)
+		}
+	}()
 
-	const maxExpandedSize = 512 << 20
-	var expanded uint64
-	for _, entry := range reader.File {
-		name := filepath.ToSlash(entry.Name)
-		relative := strings.TrimPrefix(name, root+"/")
-		if relative == "" {
-			continue
+	var actual uint64
+	buffer := make([]byte, 32<<10)
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		destination := filepath.Join(target, filepath.FromSlash(relative))
-		if !strings.HasPrefix(filepath.Clean(destination), filepath.Clean(target)+string(os.PathSeparator)) {
-			return errors.New("source archive path escapes destination")
+		destination, err := containedDestination(staging, entry.relative)
+		if err != nil {
+			return err
 		}
-		if entry.FileInfo().IsDir() {
+		if entry.dir {
 			if err := os.MkdirAll(destination, 0o755); err != nil {
 				return err
 			}
 			continue
 		}
-		expanded += entry.UncompressedSize64
-		if expanded > maxExpandedSize {
-			return errors.New("source archive expands beyond 512 MiB limit")
-		}
 		if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
 			return err
 		}
-		source, err := entry.Open()
+		copied, err := extractFile(ctx, entry.file, destination, buffer)
+		actual += copied
+		if actual > limits.expandedBytes {
+			return fmt.Errorf("source archive actual content exceeds %s limit", byteLimit(limits.expandedBytes))
+		}
 		if err != nil {
 			return err
-		}
-		destinationFile, err := os.OpenFile(destination, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, entry.Mode().Perm())
-		if err != nil {
-			source.Close()
-			return err
-		}
-		_, copyErr := io.Copy(destinationFile, source)
-		closeErr := destinationFile.Close()
-		sourceErr := source.Close()
-		if copyErr != nil {
-			return copyErr
-		}
-		if closeErr != nil {
-			return closeErr
-		}
-		if sourceErr != nil {
-			return sourceErr
 		}
 	}
-	if _, err := os.Stat(filepath.Join(target, "go.mod")); err != nil {
-		return errors.New("source archive does not contain go.mod")
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	info, err := os.Stat(filepath.Join(staging, "go.mod"))
+	if err != nil || !info.Mode().IsRegular() {
+		return errors.New("source archive does not contain a regular go.mod file")
+	}
+	if err := os.Rename(staging, target); err != nil {
+		return fmt.Errorf("publish source archive: %w", err)
+	}
+	publish = true
+	return nil
+}
+
+func validateLimits(limits extractionLimits) error {
+	if limits.entries <= 0 || limits.files <= 0 || limits.directories <= 0 ||
+		limits.pathBytes <= 0 || limits.pathDepth <= 0 || limits.componentBytes <= 0 ||
+		limits.fileBytes == 0 || limits.expandedBytes == 0 {
+		return errors.New("source archive extraction limits must be positive")
 	}
 	return nil
+}
+
+func preflight(ctx context.Context, files []*zip.File, limits extractionLimits) ([]archiveEntry, error) {
+	if len(files) == 0 {
+		return nil, errors.New("source archive is empty")
+	}
+	if len(files) > limits.entries {
+		return nil, fmt.Errorf("source archive contains more than %d entries", limits.entries)
+	}
+	entries := make([]archiveEntry, 0, len(files))
+	entryPaths := make(map[string]string, len(files))
+	treeKinds := make(map[string]bool, len(files)) // true means directory.
+	treePaths := make(map[string]string, len(files))
+	directories := make(map[string]struct{})
+	root := ""
+	rootEntry := false
+	regularFiles := 0
+	var declared uint64
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		name, components, err := validateArchivePath(file.Name, limits)
+		if err != nil {
+			return nil, err
+		}
+		if root == "" {
+			root = components[0]
+		} else if root != components[0] {
+			return nil, errors.New("source archive contains multiple roots")
+		}
+		dir := file.FileInfo().IsDir()
+		if !dir && !file.Mode().IsRegular() {
+			return nil, fmt.Errorf("source archive path %q has unsupported file type %s", name, file.Mode().Type())
+		}
+		if len(components) == 1 {
+			if !dir {
+				return nil, errors.New("source archive root must be a directory")
+			}
+			if rootEntry {
+				return nil, errors.New("source archive contains a duplicate root directory")
+			}
+			rootEntry = true
+			continue
+		}
+		relative := strings.Join(components[1:], "/")
+		folded := strings.ToLower(relative)
+		if previous, ok := entryPaths[folded]; ok {
+			if previous == relative {
+				return nil, fmt.Errorf("source archive contains duplicate path %q", relative)
+			}
+			return nil, fmt.Errorf("source archive contains case-colliding paths %q and %q", previous, relative)
+		}
+		entryPaths[folded] = relative
+
+		parents := components[1 : len(components)-1]
+		for index := range parents {
+			parent := strings.Join(parents[:index+1], "/")
+			key := strings.ToLower(parent)
+			if previous, ok := treePaths[key]; ok && previous != parent {
+				return nil, fmt.Errorf("source archive contains case-colliding paths %q and %q", previous, parent)
+			}
+			if kind, ok := treeKinds[key]; ok && !kind {
+				return nil, fmt.Errorf("source archive path %q is nested below a file", relative)
+			}
+			treePaths[key] = parent
+			treeKinds[key] = true
+			directories[key] = struct{}{}
+		}
+		if previous, ok := treePaths[folded]; ok && previous != relative {
+			return nil, fmt.Errorf("source archive contains case-colliding paths %q and %q", previous, relative)
+		}
+		if kind, ok := treeKinds[folded]; ok && kind != dir {
+			return nil, fmt.Errorf("source archive path %q is both a file and directory", relative)
+		}
+		treePaths[folded] = relative
+		treeKinds[folded] = dir
+		if dir {
+			directories[folded] = struct{}{}
+		} else {
+			regularFiles++
+			if regularFiles > limits.files {
+				return nil, fmt.Errorf("source archive contains more than %d files", limits.files)
+			}
+			if file.UncompressedSize64 > limits.fileBytes {
+				return nil, fmt.Errorf("source archive file %q exceeds %s limit", relative, byteLimit(limits.fileBytes))
+			}
+			if file.UncompressedSize64 > limits.expandedBytes || declared > limits.expandedBytes-file.UncompressedSize64 {
+				return nil, fmt.Errorf("source archive expands beyond %s limit", byteLimit(limits.expandedBytes))
+			}
+			declared += file.UncompressedSize64
+		}
+		if len(directories) > limits.directories {
+			return nil, fmt.Errorf("source archive contains more than %d directories", limits.directories)
+		}
+		entries = append(entries, archiveEntry{file: file, relative: relative, dir: dir})
+	}
+	if root == "" {
+		return nil, errors.New("source archive is empty")
+	}
+	return entries, nil
+}
+
+func validateArchivePath(raw string, limits extractionLimits) (string, []string, error) {
+	if raw == "" || strings.ContainsRune(raw, 0) || strings.Contains(raw, "\\") || strings.HasPrefix(raw, "/") {
+		return "", nil, errors.New("source archive contains an invalid path")
+	}
+	name := strings.TrimSuffix(raw, "/")
+	if len(name) > limits.pathBytes {
+		return "", nil, fmt.Errorf("source archive path exceeds %d-byte limit", limits.pathBytes)
+	}
+	components := strings.Split(name, "/")
+	if len(components) > limits.pathDepth+1 { // Include the stripped archive root.
+		return "", nil, fmt.Errorf("source archive path exceeds %d-component depth limit", limits.pathDepth)
+	}
+	for _, component := range components {
+		if component == "" || component == "." || component == ".." {
+			return "", nil, errors.New("source archive contains an invalid path component")
+		}
+		if len(component) > limits.componentBytes {
+			return "", nil, fmt.Errorf("source archive path component exceeds %d-byte limit", limits.componentBytes)
+		}
+		if !portablePathComponent(component) {
+			return "", nil, fmt.Errorf("source archive path component %q is not portable", component)
+		}
+	}
+	return name, components, nil
+}
+
+func portablePathComponent(component string) bool {
+	if strings.HasSuffix(component, ".") || strings.HasSuffix(component, " ") || strings.ContainsAny(component, `<>:"|?*`) {
+		return false
+	}
+	for _, char := range component {
+		if char < 0x20 {
+			return false
+		}
+	}
+	base := component
+	if dot := strings.IndexByte(base, '.'); dot >= 0 {
+		base = base[:dot]
+	}
+	switch strings.ToUpper(base) {
+	case "CON", "PRN", "AUX", "NUL",
+		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+		return false
+	}
+	return true
+}
+
+func containedDestination(root, relative string) (string, error) {
+	destination := filepath.Join(root, filepath.FromSlash(relative))
+	contained, err := filepath.Rel(root, destination)
+	if err != nil || filepath.IsAbs(contained) || contained == ".." || strings.HasPrefix(contained, ".."+string(filepath.Separator)) {
+		return "", errors.New("source archive path escapes destination")
+	}
+	return destination, nil
+}
+
+func extractFile(ctx context.Context, entry *zip.File, destination string, buffer []byte) (uint64, error) {
+	source, err := entry.Open()
+	if err != nil {
+		return 0, err
+	}
+	destinationFile, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, entry.Mode().Perm())
+	if err != nil {
+		_ = source.Close()
+		return 0, err
+	}
+	limited := &io.LimitedReader{R: source, N: int64(entry.UncompressedSize64) + 1}
+	var copied uint64
+	for {
+		if err := ctx.Err(); err != nil {
+			return copied, closeExtractedFile(destinationFile, source, err)
+		}
+		read, readErr := limited.Read(buffer)
+		if read > 0 {
+			written, writeErr := destinationFile.Write(buffer[:read])
+			copied += uint64(written)
+			if writeErr != nil {
+				return copied, closeExtractedFile(destinationFile, source, writeErr)
+			}
+			if written != read {
+				return copied, closeExtractedFile(destinationFile, source, io.ErrShortWrite)
+			}
+		}
+		if readErr != nil {
+			if readErr != io.EOF {
+				return copied, closeExtractedFile(destinationFile, source, readErr)
+			}
+			break
+		}
+	}
+	if copied != entry.UncompressedSize64 {
+		return copied, closeExtractedFile(destinationFile, source,
+			fmt.Errorf("source archive file %q expanded to %d bytes, declared %d", entry.Name, copied, entry.UncompressedSize64))
+	}
+	if err := closeExtractedFile(destinationFile, source, nil); err != nil {
+		return copied, err
+	}
+	return copied, nil
+}
+
+func closeExtractedFile(destination *os.File, source io.Closer, extractionErr error) error {
+	if err := destination.Close(); extractionErr == nil {
+		extractionErr = err
+	}
+	if err := source.Close(); extractionErr == nil {
+		extractionErr = err
+	}
+	return extractionErr
+}
+
+func byteLimit(value uint64) string {
+	if value%(1<<20) == 0 {
+		return fmt.Sprintf("%d MiB", value>>20)
+	}
+	return fmt.Sprintf("%d-byte", value)
 }

--- a/internal/sourcearchive/archive.go
+++ b/internal/sourcearchive/archive.go
@@ -16,6 +16,7 @@ type extractionLimits struct {
 	entries        int
 	files          int
 	directories    int
+	metadataBytes  uint64
 	pathBytes      int
 	pathDepth      int
 	componentBytes int
@@ -49,6 +50,7 @@ func productionExtractionLimits() extractionLimits {
 		entries:        20_000,
 		files:          16_000,
 		directories:    4_000,
+		metadataBytes:  16 << 20,
 		pathBytes:      1_024,
 		pathDepth:      64,
 		componentBytes: 255,
@@ -65,6 +67,9 @@ func extractWithLimits(ctx context.Context, archive, target string, limits extra
 		return err
 	}
 	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := inspectZipDirectory(ctx, archive, limits); err != nil {
 		return err
 	}
 	reader, err := zip.OpenReader(archive)
@@ -136,7 +141,7 @@ func extractWithLimits(ctx context.Context, archive, target string, limits extra
 	if err != nil || !info.Mode().IsRegular() {
 		return errors.New("source archive does not contain a regular go.mod file")
 	}
-	if err := os.Rename(staging, target); err != nil {
+	if err := publishDirectoryNoReplace(staging, target); err != nil {
 		return fmt.Errorf("publish source archive: %w", err)
 	}
 	publish = true
@@ -144,7 +149,7 @@ func extractWithLimits(ctx context.Context, archive, target string, limits extra
 }
 
 func validateLimits(limits extractionLimits) error {
-	if limits.entries <= 0 || limits.files <= 0 || limits.directories <= 0 ||
+	if limits.entries <= 0 || limits.files <= 0 || limits.directories <= 0 || limits.metadataBytes == 0 ||
 		limits.pathBytes <= 0 || limits.pathDepth <= 0 || limits.componentBytes <= 0 ||
 		limits.fileBytes == 0 || limits.expandedBytes == 0 {
 		return errors.New("source archive extraction limits must be positive")
@@ -283,8 +288,8 @@ func portablePathComponent(component string) bool {
 	if strings.HasSuffix(component, ".") || strings.HasSuffix(component, " ") || strings.ContainsAny(component, `<>:"|?*`) {
 		return false
 	}
-	for _, char := range component {
-		if char < 0x20 {
+	for index := 0; index < len(component); index++ {
+		if component[index] < 0x20 || component[index] > 0x7e {
 			return false
 		}
 	}

--- a/internal/sourcearchive/archive.go
+++ b/internal/sourcearchive/archive.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +29,36 @@ type archiveEntry struct {
 	file     *zip.File
 	relative string
 	dir      bool
+}
+
+type archiveReadCloser interface {
+	io.ReaderAt
+	Stat() (fs.FileInfo, error)
+	Close() error
+}
+
+type extractionOperations struct {
+	openArchive func(string) (archiveReadCloser, error)
+	removeAll   func(string) error
+}
+
+type pathNodeKey struct {
+	parent    int
+	component string
+}
+
+type pathNode struct {
+	id        int
+	component string
+	spelling  string
+	directory bool
+	explicit  bool
+}
+
+type validatedArchivePath struct {
+	name     string
+	root     string
+	relative string
 }
 
 // Extract expands archive into target while removing the archive's single
@@ -60,8 +91,22 @@ func productionExtractionLimits() extractionLimits {
 }
 
 func extractWithLimits(ctx context.Context, archive, target string, limits extractionLimits) error {
+	return extractWithOperations(ctx, archive, target, limits, defaultExtractionOperations())
+}
+
+func defaultExtractionOperations() extractionOperations {
+	return extractionOperations{
+		openArchive: func(path string) (archiveReadCloser, error) { return os.Open(path) },
+		removeAll:   os.RemoveAll,
+	}
+}
+
+func extractWithOperations(ctx context.Context, archive, target string, limits extractionLimits, operations extractionOperations) (returnErr error) {
 	if ctx == nil {
 		return errors.New("source archive extraction requires a context")
+	}
+	if operations.openArchive == nil || operations.removeAll == nil {
+		return errors.New("source archive extraction operations must be configured")
 	}
 	if err := validateLimits(limits); err != nil {
 		return err
@@ -69,16 +114,44 @@ func extractWithLimits(ctx context.Context, archive, target string, limits extra
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := inspectZipDirectory(ctx, archive, limits); err != nil {
-		return err
-	}
-	reader, err := zip.OpenReader(archive)
+	archiveFile, err := operations.openArchive(archive)
 	if err != nil {
 		return err
 	}
-	defer reader.Close()
+	archiveOpen := true
+	closeArchive := func() error {
+		if !archiveOpen {
+			return nil
+		}
+		archiveOpen = false
+		if err := archiveFile.Close(); err != nil {
+			return fmt.Errorf("close source archive: %w", err)
+		}
+		return nil
+	}
+	defer func() {
+		if archiveOpen {
+			returnErr = errors.Join(returnErr, closeArchive())
+		}
+	}()
 
-	entries, err := preflight(ctx, reader.File, limits)
+	info, err := archiveFile.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source archive: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("source archive must be a regular file")
+	}
+	directory, err := inspectZipDirectory(ctx, archiveFile, info.Size(), limits)
+	if err != nil {
+		return err
+	}
+	reader, err := zip.NewReader(archiveFile, info.Size())
+	if err != nil {
+		return err
+	}
+
+	entries, err := preflight(ctx, reader.File, directory.offset, limits)
 	if err != nil {
 		return err
 	}
@@ -99,10 +172,12 @@ func extractWithLimits(ctx context.Context, archive, target string, limits extra
 	if err != nil {
 		return err
 	}
-	publish := false
+	published := false
 	defer func() {
-		if !publish {
-			_ = os.RemoveAll(staging)
+		if !published {
+			if cleanupErr := operations.removeAll(staging); cleanupErr != nil {
+				returnErr = errors.Join(returnErr, fmt.Errorf("clean source archive staging: %w", cleanupErr))
+			}
 		}
 	}()
 
@@ -137,14 +212,20 @@ func extractWithLimits(ctx context.Context, archive, target string, limits extra
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	info, err := os.Stat(filepath.Join(staging, "go.mod"))
-	if err != nil || !info.Mode().IsRegular() {
+	info, err = os.Lstat(filepath.Join(staging, "go.mod"))
+	if err != nil {
+		return fmt.Errorf("verify extracted root go.mod: %w", err)
+	}
+	if !info.Mode().IsRegular() {
 		return errors.New("source archive does not contain a regular go.mod file")
+	}
+	if err := closeArchive(); err != nil {
+		return err
 	}
 	if err := publishDirectoryNoReplace(staging, target); err != nil {
 		return fmt.Errorf("publish source archive: %w", err)
 	}
-	publish = true
+	published = true
 	return nil
 }
 
@@ -157,7 +238,7 @@ func validateLimits(limits extractionLimits) error {
 	return nil
 }
 
-func preflight(ctx context.Context, files []*zip.File, limits extractionLimits) ([]archiveEntry, error) {
+func preflight(ctx context.Context, files []*zip.File, directoryOffset int64, limits extractionLimits) ([]archiveEntry, error) {
 	if len(files) == 0 {
 		return nil, errors.New("source archive is empty")
 	}
@@ -165,32 +246,33 @@ func preflight(ctx context.Context, files []*zip.File, limits extractionLimits) 
 		return nil, fmt.Errorf("source archive contains more than %d entries", limits.entries)
 	}
 	entries := make([]archiveEntry, 0, len(files))
-	entryPaths := make(map[string]string, len(files))
-	treeKinds := make(map[string]bool, len(files)) // true means directory.
-	treePaths := make(map[string]string, len(files))
-	directories := make(map[string]struct{})
+	nodes := make(map[pathNodeKey]*pathNode, len(files)+limits.directories)
+	nextNodeID := 1
+	directories := 0
 	root := ""
 	rootEntry := false
+	rootGoMod := false
 	regularFiles := 0
 	var declared uint64
 	for _, file := range files {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		name, components, err := validateArchivePath(file.Name, limits)
+		path, err := validateArchivePath(file.Name, limits)
+		if err != nil {
+			return nil, err
+		}
+		nameEndsInSlash := strings.HasSuffix(file.Name, "/")
+		dir, err := validateZipEntryMetadata(file, nameEndsInSlash, directoryOffset)
 		if err != nil {
 			return nil, err
 		}
 		if root == "" {
-			root = components[0]
-		} else if root != components[0] {
+			root = path.root
+		} else if root != path.root {
 			return nil, errors.New("source archive contains multiple roots")
 		}
-		dir := file.FileInfo().IsDir()
-		if !dir && !file.Mode().IsRegular() {
-			return nil, fmt.Errorf("source archive path %q has unsupported file type %s", name, file.Mode().Type())
-		}
-		if len(components) == 1 {
+		if path.relative == "" {
 			if !dir {
 				return nil, errors.New("source archive root must be a directory")
 			}
@@ -200,40 +282,58 @@ func preflight(ctx context.Context, files []*zip.File, limits extractionLimits) 
 			rootEntry = true
 			continue
 		}
-		relative := strings.Join(components[1:], "/")
-		folded := strings.ToLower(relative)
-		if previous, ok := entryPaths[folded]; ok {
-			if previous == relative {
-				return nil, fmt.Errorf("source archive contains duplicate path %q", relative)
+		relative := path.relative
+		canonical := canonicalPortablePath(relative)
+		parentID := 0
+		componentStart := 0
+		for {
+			slash := strings.IndexByte(canonical[componentStart:], '/')
+			componentEnd := len(canonical)
+			final := true
+			if slash >= 0 {
+				componentEnd = componentStart + slash
+				final = false
 			}
-			return nil, fmt.Errorf("source archive contains case-colliding paths %q and %q", previous, relative)
+			key := pathNodeKey{parent: parentID, component: canonical[componentStart:componentEnd]}
+			component := relative[componentStart:componentEnd]
+			spelling := relative[:componentEnd]
+			node, found := nodes[key]
+			if found && node.component != component {
+				return nil, fmt.Errorf("source archive contains case-colliding paths %q and %q", node.spelling, spelling)
+			}
+			wantDirectory := !final || dir
+			if found {
+				if !final && !node.directory {
+					return nil, fmt.Errorf("source archive path %q is nested below a file", relative)
+				}
+				if final {
+					if node.explicit {
+						return nil, fmt.Errorf("source archive contains duplicate path %q", relative)
+					}
+					if node.directory != wantDirectory {
+						return nil, fmt.Errorf("source archive path %q is both a file and directory", relative)
+					}
+					node.explicit = true
+				}
+			} else {
+				node = &pathNode{id: nextNodeID, component: component, spelling: spelling, directory: wantDirectory, explicit: final}
+				nextNodeID++
+				nodes[key] = node
+				if wantDirectory {
+					directories++
+				}
+			}
+			parentID = node.id
+			if final {
+				break
+			}
+			componentStart = componentEnd + 1
 		}
-		entryPaths[folded] = relative
 
-		parents := components[1 : len(components)-1]
-		for index := range parents {
-			parent := strings.Join(parents[:index+1], "/")
-			key := strings.ToLower(parent)
-			if previous, ok := treePaths[key]; ok && previous != parent {
-				return nil, fmt.Errorf("source archive contains case-colliding paths %q and %q", previous, parent)
-			}
-			if kind, ok := treeKinds[key]; ok && !kind {
-				return nil, fmt.Errorf("source archive path %q is nested below a file", relative)
-			}
-			treePaths[key] = parent
-			treeKinds[key] = true
-			directories[key] = struct{}{}
-		}
-		if previous, ok := treePaths[folded]; ok && previous != relative {
-			return nil, fmt.Errorf("source archive contains case-colliding paths %q and %q", previous, relative)
-		}
-		if kind, ok := treeKinds[folded]; ok && kind != dir {
-			return nil, fmt.Errorf("source archive path %q is both a file and directory", relative)
-		}
-		treePaths[folded] = relative
-		treeKinds[folded] = dir
 		if dir {
-			directories[folded] = struct{}{}
+			if relative == "go.mod" {
+				return nil, errors.New("source archive root go.mod must be a regular file")
+			}
 		} else {
 			regularFiles++
 			if regularFiles > limits.files {
@@ -246,8 +346,11 @@ func preflight(ctx context.Context, files []*zip.File, limits extractionLimits) 
 				return nil, fmt.Errorf("source archive expands beyond %s limit", byteLimit(limits.expandedBytes))
 			}
 			declared += file.UncompressedSize64
+			if relative == "go.mod" {
+				rootGoMod = true
+			}
 		}
-		if len(directories) > limits.directories {
+		if directories > limits.directories {
 			return nil, fmt.Errorf("source archive contains more than %d directories", limits.directories)
 		}
 		entries = append(entries, archiveEntry{file: file, relative: relative, dir: dir})
@@ -255,40 +358,72 @@ func preflight(ctx context.Context, files []*zip.File, limits extractionLimits) 
 	if root == "" {
 		return nil, errors.New("source archive is empty")
 	}
+	if !rootGoMod {
+		return nil, errors.New("source archive does not contain a regular go.mod file at the exact root path")
+	}
 	return entries, nil
 }
 
-func validateArchivePath(raw string, limits extractionLimits) (string, []string, error) {
-	if raw == "" || strings.ContainsRune(raw, 0) || strings.Contains(raw, "\\") || strings.HasPrefix(raw, "/") {
-		return "", nil, errors.New("source archive contains an invalid path")
+func validateArchivePath(raw string, limits extractionLimits) (validatedArchivePath, error) {
+	if raw == "" {
+		return validatedArchivePath{}, errors.New("source archive contains an invalid path")
 	}
-	name := strings.TrimSuffix(raw, "/")
+	name := raw
+	if name[len(name)-1] == '/' {
+		name = name[:len(name)-1]
+	}
 	if len(name) > limits.pathBytes {
-		return "", nil, fmt.Errorf("source archive path exceeds %d-byte limit", limits.pathBytes)
+		return validatedArchivePath{}, fmt.Errorf("source archive path exceeds %d-byte limit", limits.pathBytes)
 	}
-	components := strings.Split(name, "/")
-	if len(components) > limits.pathDepth+1 { // Include the stripped archive root.
-		return "", nil, fmt.Errorf("source archive path exceeds %d-component depth limit", limits.pathDepth)
-	}
-	for _, component := range components {
-		if component == "" || component == "." || component == ".." {
-			return "", nil, errors.New("source archive contains an invalid path component")
+	componentStart := 0
+	components := 0
+	rootEnd := -1
+	for index := 0; index <= len(name); index++ {
+		if index != len(name) {
+			if name[index] == 0 || name[index] == '\\' {
+				return validatedArchivePath{}, errors.New("source archive contains an invalid path")
+			}
+			if name[index] != '/' {
+				continue
+			}
+		}
+		if componentStart == index {
+			return validatedArchivePath{}, errors.New("source archive contains an invalid path component")
+		}
+		component := name[componentStart:index]
+		if component == "." || component == ".." {
+			return validatedArchivePath{}, errors.New("source archive contains an invalid path component")
 		}
 		if len(component) > limits.componentBytes {
-			return "", nil, fmt.Errorf("source archive path component exceeds %d-byte limit", limits.componentBytes)
+			return validatedArchivePath{}, fmt.Errorf("source archive path component exceeds %d-byte limit", limits.componentBytes)
 		}
 		if !portablePathComponent(component) {
-			return "", nil, fmt.Errorf("source archive path component %q is not portable", component)
+			return validatedArchivePath{}, fmt.Errorf("source archive path component %q is not portable", component)
 		}
+		components++
+		if components > limits.pathDepth+1 { // Include the stripped archive root.
+			return validatedArchivePath{}, fmt.Errorf("source archive path exceeds %d-component depth limit", limits.pathDepth)
+		}
+		if rootEnd < 0 && index < len(name) {
+			rootEnd = index
+		}
+		componentStart = index + 1
 	}
-	return name, components, nil
+	if rootEnd < 0 {
+		return validatedArchivePath{name: name, root: name}, nil
+	}
+	return validatedArchivePath{name: name, root: name[:rootEnd], relative: name[rootEnd+1:]}, nil
 }
 
 func portablePathComponent(component string) bool {
-	if strings.HasSuffix(component, ".") || strings.HasSuffix(component, " ") || strings.ContainsAny(component, `<>:"|?*`) {
+	if component == "." || component == ".." || component[len(component)-1] == '.' || component[len(component)-1] == ' ' {
 		return false
 	}
 	for index := 0; index < len(component); index++ {
+		switch component[index] {
+		case '<', '>', ':', '"', '|', '?', '*':
+			return false
+		}
 		if component[index] < 0x20 || component[index] > 0x7e {
 			return false
 		}
@@ -297,13 +432,93 @@ func portablePathComponent(component string) bool {
 	if dot := strings.IndexByte(base, '.'); dot >= 0 {
 		base = base[:dot]
 	}
-	switch strings.ToUpper(base) {
-	case "CON", "PRN", "AUX", "NUL",
-		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+	if len(base) == 3 && (equalFoldASCII(base, "CON") || equalFoldASCII(base, "PRN") ||
+		equalFoldASCII(base, "AUX") || equalFoldASCII(base, "NUL")) {
+		return false
+	}
+	if len(base) == 4 && base[3] >= '1' && base[3] <= '9' &&
+		(equalFoldASCII(base[:3], "COM") || equalFoldASCII(base[:3], "LPT")) {
 		return false
 	}
 	return true
+}
+
+func equalFoldASCII(left, right string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		value := left[index]
+		if value >= 'a' && value <= 'z' {
+			value -= 'a' - 'A'
+		}
+		if value != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalPortablePath(path string) string {
+	firstUpper := -1
+	for index := range path {
+		if path[index] >= 'A' && path[index] <= 'Z' {
+			firstUpper = index
+			break
+		}
+	}
+	if firstUpper < 0 {
+		return path
+	}
+	var canonical strings.Builder
+	canonical.Grow(len(path))
+	canonical.WriteString(path[:firstUpper])
+	for index := firstUpper; index < len(path); index++ {
+		value := path[index]
+		if value >= 'A' && value <= 'Z' {
+			value += 'a' - 'A'
+		}
+		canonical.WriteByte(value)
+	}
+	return canonical.String()
+}
+
+func validateZipEntryMetadata(file *zip.File, nameEndsInSlash bool, directoryOffset int64) (bool, error) {
+	mode := file.Mode()
+	kind := mode.Type()
+	if nameEndsInSlash {
+		if kind != fs.ModeDir {
+			return false, fmt.Errorf("source archive directory %q has unsupported file type %s", file.Name, kind)
+		}
+		if file.UncompressedSize64 != 0 {
+			return false, fmt.Errorf("source archive directory %q declares nonzero content", file.Name)
+		}
+	} else {
+		if kind&fs.ModeDir != 0 {
+			return false, fmt.Errorf("source archive directory %q must end in a slash", file.Name)
+		}
+		if !mode.IsRegular() {
+			return false, fmt.Errorf("source archive path %q has unsupported file type %s", file.Name, kind)
+		}
+	}
+	if file.Flags&(1|1<<6) != 0 {
+		return false, fmt.Errorf("source archive path %q is encrypted", file.Name)
+	}
+	if file.Method != zip.Store && file.Method != zip.Deflate {
+		return false, fmt.Errorf("source archive path %q uses unsupported compression method %d", file.Name, file.Method)
+	}
+	if file.Method == zip.Store && file.CompressedSize64 != file.UncompressedSize64 {
+		return false, fmt.Errorf("source archive stored path %q has mismatched compressed and uncompressed sizes", file.Name)
+	}
+	dataOffset, err := file.DataOffset()
+	if err != nil {
+		return false, fmt.Errorf("source archive path %q has a malformed local file header: %w", file.Name, err)
+	}
+	if dataOffset < 0 || directoryOffset < 0 || dataOffset > directoryOffset ||
+		file.CompressedSize64 > uint64(directoryOffset-dataOffset) {
+		return false, fmt.Errorf("source archive path %q has compressed data outside the file-data region", file.Name)
+	}
+	return nameEndsInSlash, nil
 }
 
 func containedDestination(root, relative string) (string, error) {
@@ -360,13 +575,7 @@ func extractFile(ctx context.Context, entry *zip.File, destination string, buffe
 }
 
 func closeExtractedFile(destination *os.File, source io.Closer, extractionErr error) error {
-	if err := destination.Close(); extractionErr == nil {
-		extractionErr = err
-	}
-	if err := source.Close(); extractionErr == nil {
-		extractionErr = err
-	}
-	return extractionErr
+	return errors.Join(extractionErr, destination.Close(), source.Close())
 }
 
 func byteLimit(value uint64) string {

--- a/internal/sourcearchive/archive.go
+++ b/internal/sourcearchive/archive.go
@@ -262,6 +262,7 @@ func preflight(ctx context.Context, readerAt io.ReaderAt, files []*zip.File, dir
 	nameBuffer := make([]byte, limits.pathBytes+1)
 	localRecordBuffer := make([]byte, zipFileHeaderBytes+limits.pathBytes+1)
 	descriptorBuffer := make([]byte, zipDataDescriptorBytes)
+	localRecordEnds := make(map[int64]int64, len(files))
 	for _, file := range files {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -275,10 +276,14 @@ func preflight(ctx context.Context, readerAt io.ReaderAt, files []*zip.File, dir
 			return nil, err
 		}
 		nameEndsInSlash := strings.HasSuffix(file.Name, "/")
-		dir, err := validateZipEntryMetadata(file, nameEndsInSlash, readerAt, localOffset, directory.offset, localRecordBuffer, descriptorBuffer)
+		dir, localEnd, err := validateZipEntryMetadata(file, nameEndsInSlash, readerAt, localOffset, directory.offset, localRecordBuffer, descriptorBuffer)
 		if err != nil {
 			return nil, err
 		}
+		if _, exists := localRecordEnds[localOffset]; exists {
+			return nil, fmt.Errorf("source archive path %q reuses a local file record", file.Name)
+		}
+		localRecordEnds[localOffset] = localEnd
 		if root == "" {
 			root = path.root
 		} else if root != path.root {
@@ -373,6 +378,9 @@ func preflight(ctx context.Context, readerAt io.ReaderAt, files []*zip.File, dir
 	if central.remaining != 0 {
 		return nil, errors.New("source archive central directory changed during preflight")
 	}
+	if err := validateLocalRecordCoverage(localRecordEnds, directory.offset); err != nil {
+		return nil, err
+	}
 	if !rootGoMod {
 		return nil, errors.New("source archive does not contain a regular go.mod file at the exact root path")
 	}
@@ -455,6 +463,9 @@ func portablePathComponent(component string) bool {
 		(equalFoldASCII(base[:3], "COM") || equalFoldASCII(base[:3], "LPT")) {
 		return false
 	}
+	if equalFoldASCII(base, "CONIN$") || equalFoldASCII(base, "CONOUT$") {
+		return false
+	}
 	return true
 }
 
@@ -498,133 +509,165 @@ func canonicalPortablePath(path string) string {
 	return canonical.String()
 }
 
-func validateZipEntryMetadata(file *zip.File, nameEndsInSlash bool, readerAt io.ReaderAt, localOffset, directoryOffset int64, localRecordBuffer, descriptorBuffer []byte) (bool, error) {
+func validateZipEntryMetadata(file *zip.File, nameEndsInSlash bool, readerAt io.ReaderAt, localOffset, directoryOffset int64, localRecordBuffer, descriptorBuffer []byte) (bool, int64, error) {
 	mode := file.Mode()
 	kind := mode.Type()
 	if nameEndsInSlash {
 		if kind != fs.ModeDir {
-			return false, fmt.Errorf("source archive directory %q has unsupported file type %s", file.Name, kind)
+			return false, 0, fmt.Errorf("source archive directory %q has unsupported file type %s", file.Name, kind)
 		}
 		if file.UncompressedSize64 != 0 {
-			return false, fmt.Errorf("source archive directory %q declares nonzero content", file.Name)
+			return false, 0, fmt.Errorf("source archive directory %q declares nonzero content", file.Name)
 		}
 	} else {
 		if kind&fs.ModeDir != 0 {
-			return false, fmt.Errorf("source archive directory %q must end in a slash", file.Name)
+			return false, 0, fmt.Errorf("source archive directory %q must end in a slash", file.Name)
 		}
 		if !mode.IsRegular() {
-			return false, fmt.Errorf("source archive path %q has unsupported file type %s", file.Name, kind)
+			return false, 0, fmt.Errorf("source archive path %q has unsupported file type %s", file.Name, kind)
 		}
 	}
-	if file.Flags&(1|1<<6) != 0 {
-		return false, fmt.Errorf("source archive path %q is encrypted", file.Name)
+	if file.Flags&(zipEncryptedFlag|zipStrongEncryptionFlag) != 0 {
+		return false, 0, fmt.Errorf("source archive path %q is encrypted", file.Name)
 	}
 	if file.Method != zip.Store && file.Method != zip.Deflate {
-		return false, fmt.Errorf("source archive path %q uses unsupported compression method %d", file.Name, file.Method)
+		return false, 0, fmt.Errorf("source archive path %q uses unsupported compression method %d", file.Name, file.Method)
+	}
+	allowedFlags := uint16(zipDataDescriptorFlag | zipUTF8Flag)
+	if file.Method == zip.Deflate {
+		allowedFlags |= zipDeflateOptionFlags
+	}
+	if unsupported := file.Flags &^ allowedFlags; unsupported != 0 {
+		return false, 0, fmt.Errorf("source archive path %q uses unsupported general-purpose flags %#x", file.Name, unsupported)
+	}
+	if file.ReaderVersion > zipVersion20 {
+		return false, 0, fmt.Errorf("source archive path %q requires unsupported ZIP version %d.%d", file.Name, file.ReaderVersion/10, file.ReaderVersion%10)
 	}
 	if file.Method == zip.Store && file.CompressedSize64 != file.UncompressedSize64 {
-		return false, fmt.Errorf("source archive stored path %q has mismatched compressed and uncompressed sizes", file.Name)
+		return false, 0, fmt.Errorf("source archive stored path %q has mismatched compressed and uncompressed sizes", file.Name)
 	}
 	dataOffset, err := file.DataOffset()
 	if err != nil {
-		return false, fmt.Errorf("source archive path %q has a malformed local file header: %w", file.Name, err)
+		return false, 0, fmt.Errorf("source archive path %q has a malformed local file header: %w", file.Name, err)
 	}
 	localRecordBytes := zipFileHeaderBytes + len(file.Name)
 	if localRecordBytes > len(localRecordBuffer) {
-		return false, fmt.Errorf("source archive path %q exceeds the local metadata buffer", file.Name)
+		return false, 0, fmt.Errorf("source archive path %q exceeds the local metadata buffer", file.Name)
 	}
 	localRecord := localRecordBuffer[:localRecordBytes]
 	localHeader := localRecord[:zipFileHeaderBytes]
 	if localOffset < 0 || directoryOffset < localOffset || int64(len(localRecord)) > directoryOffset-localOffset {
-		return false, fmt.Errorf("source archive path %q has a local file header outside the file-data region", file.Name)
+		return false, 0, fmt.Errorf("source archive path %q has a local file header outside the file-data region", file.Name)
 	}
 	if err := readZipMetadataAt(readerAt, localRecord, localOffset); err != nil {
-		return false, fmt.Errorf("read source archive path %q local file header: %w", file.Name, err)
+		return false, 0, fmt.Errorf("read source archive path %q local file header: %w", file.Name, err)
 	}
 	if binary.LittleEndian.Uint32(localHeader[0:4]) != zipFileHeaderSignature {
-		return false, fmt.Errorf("source archive path %q has a malformed local file header", file.Name)
+		return false, 0, fmt.Errorf("source archive path %q has a malformed local file header", file.Name)
+	}
+	if binary.LittleEndian.Uint16(localHeader[4:6]) != file.ReaderVersion {
+		return false, 0, fmt.Errorf("source archive path %q local file header ZIP version does not match the central directory", file.Name)
 	}
 	localFlags := binary.LittleEndian.Uint16(localHeader[6:8])
 	if localFlags != file.Flags {
-		return false, fmt.Errorf("source archive path %q local file header flags do not match the central directory", file.Name)
+		return false, 0, fmt.Errorf("source archive path %q local file header flags do not match the central directory", file.Name)
 	}
 	if binary.LittleEndian.Uint16(localHeader[8:10]) != file.Method {
-		return false, fmt.Errorf("source archive path %q local file header compression method does not match the central directory", file.Name)
+		return false, 0, fmt.Errorf("source archive path %q local file header compression method does not match the central directory", file.Name)
 	}
 	localCompressed := binary.LittleEndian.Uint32(localHeader[18:22])
 	localUncompressed := binary.LittleEndian.Uint32(localHeader[22:26])
 	if localCompressed == ^uint32(0) || localUncompressed == ^uint32(0) {
-		return false, errors.New("source archive uses unsupported ZIP64 entry metadata")
+		return false, 0, errors.New("source archive uses unsupported ZIP64 entry metadata")
 	}
 	nameBytes := int64(binary.LittleEndian.Uint16(localHeader[26:28]))
 	extraBytes := int64(binary.LittleEndian.Uint16(localHeader[28:30]))
 	wantDataOffset := localOffset + int64(len(localHeader)) + nameBytes + extraBytes
 	if wantDataOffset < localOffset || wantDataOffset != dataOffset || nameBytes != int64(len(file.Name)) {
-		return false, fmt.Errorf("source archive path %q local file header name or extra metadata is inconsistent", file.Name)
+		return false, 0, fmt.Errorf("source archive path %q local file header name or extra metadata is inconsistent", file.Name)
 	}
 	for index := range file.Name {
 		if localRecord[zipFileHeaderBytes+index] != file.Name[index] {
-			return false, fmt.Errorf("source archive path %q local file header name does not match the central directory", file.Name)
+			return false, 0, fmt.Errorf("source archive path %q local file header name does not match the central directory", file.Name)
 		}
 	}
 	if extraBytes != 0 {
 		localExtra := io.NewSectionReader(readerAt, localOffset+int64(len(localHeader))+nameBytes, extraBytes)
 		if err := validateZipExtraFields(localExtra, uint64(extraBytes), "local file header"); err != nil {
-			return false, err
+			return false, 0, err
 		}
 	}
 	localCRC := binary.LittleEndian.Uint32(localHeader[14:18])
 	if localFlags&zipDataDescriptorFlag == 0 {
 		if localCRC != file.CRC32 || uint64(localCompressed) != file.CompressedSize64 || uint64(localUncompressed) != file.UncompressedSize64 {
-			return false, fmt.Errorf("source archive path %q local file header sizes or checksum do not match the central directory", file.Name)
+			return false, 0, fmt.Errorf("source archive path %q local file header sizes or checksum do not match the central directory", file.Name)
 		}
 	} else {
 		allZero := localCRC == 0 && localCompressed == 0 && localUncompressed == 0
 		allCentral := localCRC == file.CRC32 && uint64(localCompressed) == file.CompressedSize64 && uint64(localUncompressed) == file.UncompressedSize64
 		if !allZero && !allCentral {
-			return false, fmt.Errorf("source archive path %q local file header sizes or checksum do not match the central directory", file.Name)
+			return false, 0, fmt.Errorf("source archive path %q local file header sizes or checksum do not match the central directory", file.Name)
 		}
 	}
 	if dataOffset < 0 || directoryOffset < 0 || dataOffset > directoryOffset ||
 		file.CompressedSize64 > uint64(directoryOffset-dataOffset) {
-		return false, fmt.Errorf("source archive path %q has compressed data outside the file-data region", file.Name)
+		return false, 0, fmt.Errorf("source archive path %q has compressed data outside the file-data region", file.Name)
 	}
 	dataEnd := dataOffset + int64(file.CompressedSize64)
 	if localFlags&zipDataDescriptorFlag != 0 {
-		if err := validateZipDataDescriptor(readerAt, dataEnd, directoryOffset, file, descriptorBuffer); err != nil {
-			return false, err
+		descriptorEnd, err := validateZipDataDescriptor(readerAt, dataEnd, directoryOffset, file, descriptorBuffer)
+		if err != nil {
+			return false, 0, err
 		}
+		dataEnd = descriptorEnd
 	}
-	return nameEndsInSlash, nil
+	return nameEndsInSlash, dataEnd, nil
 }
 
-func validateZipDataDescriptor(readerAt io.ReaderAt, offset, directoryOffset int64, file *zip.File, descriptorBuffer []byte) error {
+func validateZipDataDescriptor(readerAt io.ReaderAt, offset, directoryOffset int64, file *zip.File, descriptorBuffer []byte) (int64, error) {
 	if len(descriptorBuffer) < zipDataDescriptorBytes {
-		return errors.New("source archive data descriptor buffer is too small")
+		return 0, errors.New("source archive data descriptor buffer is too small")
 	}
 	descriptor := descriptorBuffer[:zipDataDescriptorBytes]
 	if offset < 0 || directoryOffset < offset || zipDataDescriptorUnsignedBytes > directoryOffset-offset {
-		return fmt.Errorf("source archive path %q has a data descriptor outside the file-data region", file.Name)
+		return 0, fmt.Errorf("source archive path %q has a data descriptor outside the file-data region", file.Name)
 	}
 	readBytes := zipDataDescriptorBytes
 	if int64(readBytes) > directoryOffset-offset {
 		readBytes = zipDataDescriptorUnsignedBytes
 	}
 	if err := readZipMetadataAt(readerAt, descriptor[:readBytes], offset); err != nil {
-		return fmt.Errorf("read source archive path %q data descriptor: %w", file.Name, err)
+		return 0, fmt.Errorf("read source archive path %q data descriptor: %w", file.Name, err)
 	}
 	signed := binary.LittleEndian.Uint32(descriptor[0:4]) == zipDataDescriptorSignature
 	valueOffset := 0
 	if signed {
 		if readBytes != zipDataDescriptorBytes {
-			return fmt.Errorf("source archive path %q has a truncated data descriptor", file.Name)
+			return 0, fmt.Errorf("source archive path %q has a truncated data descriptor", file.Name)
 		}
 		valueOffset = 4
 	}
 	if binary.LittleEndian.Uint32(descriptor[valueOffset:valueOffset+4]) != file.CRC32 ||
 		uint64(binary.LittleEndian.Uint32(descriptor[valueOffset+4:valueOffset+8])) != file.CompressedSize64 ||
 		uint64(binary.LittleEndian.Uint32(descriptor[valueOffset+8:valueOffset+12])) != file.UncompressedSize64 {
-		return fmt.Errorf("source archive path %q data descriptor does not match the central directory", file.Name)
+		return 0, fmt.Errorf("source archive path %q data descriptor does not match the central directory", file.Name)
+	}
+	return offset + int64(valueOffset+zipDataDescriptorUnsignedBytes), nil
+}
+
+func validateLocalRecordCoverage(recordEnds map[int64]int64, directoryOffset int64) error {
+	offset := int64(0)
+	visited := 0
+	for offset < directoryOffset {
+		end, ok := recordEnds[offset]
+		if !ok || end <= offset || end > directoryOffset {
+			return errors.New("source archive file-data region contains gaps, overlaps, or unsupported records")
+		}
+		offset = end
+		visited++
+	}
+	if offset != directoryOffset || visited != len(recordEnds) {
+		return errors.New("source archive file-data region contains gaps, overlaps, or unsupported records")
 	}
 	return nil
 }

--- a/internal/sourcearchive/archive.go
+++ b/internal/sourcearchive/archive.go
@@ -455,6 +455,9 @@ func portablePathComponent(component string) bool {
 	if dot := strings.IndexByte(base, '.'); dot >= 0 {
 		base = base[:dot]
 	}
+	for len(base) > 0 && base[len(base)-1] == ' ' {
+		base = base[:len(base)-1]
+	}
 	if len(base) == 3 && (equalFoldASCII(base, "CON") || equalFoldASCII(base, "PRN") ||
 		equalFoldASCII(base, "AUX") || equalFoldASCII(base, "NUL")) {
 		return false
@@ -603,10 +606,8 @@ func validateZipEntryMetadata(file *zip.File, nameEndsInSlash bool, readerAt io.
 			return false, 0, fmt.Errorf("source archive path %q local file header sizes or checksum do not match the central directory", file.Name)
 		}
 	} else {
-		allZero := localCRC == 0 && localCompressed == 0 && localUncompressed == 0
-		allCentral := localCRC == file.CRC32 && uint64(localCompressed) == file.CompressedSize64 && uint64(localUncompressed) == file.UncompressedSize64
-		if !allZero && !allCentral {
-			return false, 0, fmt.Errorf("source archive path %q local file header sizes or checksum do not match the central directory", file.Name)
+		if localCRC != 0 || localCompressed != 0 || localUncompressed != 0 {
+			return false, 0, fmt.Errorf("source archive path %q local file header sizes and checksum must be zero when using a data descriptor", file.Name)
 		}
 	}
 	if dataOffset < 0 || directoryOffset < 0 || dataOffset > directoryOffset ||

--- a/internal/sourcearchive/archive_benchmark_test.go
+++ b/internal/sourcearchive/archive_benchmark_test.go
@@ -34,7 +34,7 @@ func BenchmarkPreflightDeepPathsProduction(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		entries, err := preflight(context.Background(), reader.File, directory.offset, limits)
+		entries, err := preflight(context.Background(), file, reader.File, directory, limits)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/sourcearchive/archive_benchmark_test.go
+++ b/internal/sourcearchive/archive_benchmark_test.go
@@ -1,0 +1,78 @@
+package sourcearchive
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func BenchmarkPreflightDeepPathsProduction(b *testing.B) {
+	limits := productionExtractionLimits()
+	archive := writeProductionPathArchive(b, limits.files)
+	file, err := os.Open(archive)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = file.Close() })
+	info, err := file.Stat()
+	if err != nil {
+		b.Fatal(err)
+	}
+	directory, err := locateZipDirectory(file, info.Size(), limits)
+	if err != nil {
+		b.Fatal(err)
+	}
+	reader, err := zip.NewReader(file, info.Size())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		entries, err := preflight(context.Background(), reader.File, directory.offset, limits)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(entries) != limits.files {
+			b.Fatalf("preflight entries = %d, want %d", len(entries), limits.files)
+		}
+	}
+}
+
+func writeProductionPathArchive(tb testing.TB, files int) string {
+	tb.Helper()
+	directories := make([]string, 63)
+	for index := range directories {
+		directories[index] = fmt.Sprintf("D%013d", index)
+	}
+	deepPrefix := "ROOT/" + strings.Join(directories, "/") + "/"
+	archive := filepath.Join(tb.TempDir(), "production-paths.zip")
+	file, err := os.Create(archive)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	writeEmpty := func(name string) {
+		header := &zip.FileHeader{Name: name, Method: zip.Store}
+		header.SetMode(0o644)
+		if _, err := writer.CreateHeader(header); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	writeEmpty("ROOT/go.mod")
+	for index := 1; index < files; index++ {
+		writeEmpty(deepPrefix + fmt.Sprintf("F%012d", index))
+	}
+	if err := writer.Close(); err != nil {
+		tb.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		tb.Fatal(err)
+	}
+	return archive
+}

--- a/internal/sourcearchive/archive_test.go
+++ b/internal/sourcearchive/archive_test.go
@@ -172,7 +172,7 @@ func TestPreflightDeepPathsHasBoundedAllocations(t *testing.T) {
 		t.Fatal(err)
 	}
 	allocations := testing.AllocsPerRun(3, func() {
-		entries, err := preflight(context.Background(), reader.File, directory.offset, limits)
+		entries, err := preflight(context.Background(), file, reader.File, directory, limits)
 		if err != nil {
 			panic(err)
 		}
@@ -281,9 +281,19 @@ type closeErrorArchive struct {
 	closeCount *atomic.Int32
 }
 
+type cancelOnCloseArchive struct {
+	*os.File
+	cancel context.CancelFunc
+}
+
 func (archive *closeErrorArchive) Close() error {
 	archive.closeCount.Add(1)
 	return errors.Join(archive.File.Close(), archive.err)
+}
+
+func (archive *cancelOnCloseArchive) Close() error {
+	archive.cancel()
+	return archive.File.Close()
 }
 
 func TestArchiveCloseFailurePreventsPublicationAndCleansStaging(t *testing.T) {
@@ -305,6 +315,27 @@ func TestArchiveCloseFailurePreventsPublicationAndCleansStaging(t *testing.T) {
 	}
 	if closeCount.Load() != 1 {
 		t.Fatalf("archive close count = %d, want 1", closeCount.Load())
+	}
+	assertAbsent(t, target)
+	assertNoStaging(t, target)
+}
+
+func TestCancellationDuringArchiveClosePreventsPublication(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n"}})
+	target := filepath.Join(t.TempDir(), "out")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	operations := defaultExtractionOperations()
+	operations.openArchive = func(path string) (archiveReadCloser, error) {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		return &cancelOnCloseArchive{File: file, cancel: cancel}, nil
+	}
+	err := extractWithOperations(ctx, archive, target, productionExtractionLimits(), operations)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Extract error = %v, want context canceled", err)
 	}
 	assertAbsent(t, target)
 	assertNoStaging(t, target)
@@ -344,11 +375,43 @@ func TestExtractRejectsStrictMetadataBeforeFilesystemMutation(t *testing.T) {
 				binary.LittleEndian.PutUint16(data[local+6:], binary.LittleEndian.Uint16(data[local+6:])|1)
 			})
 		}, want: "is encrypted"},
+		{name: "local encrypted flag mismatch", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
+				binary.LittleEndian.PutUint16(data[local+6:], binary.LittleEndian.Uint16(data[local+6:])|1)
+			})
+		}, want: "local file header flags"},
+		{name: "local compression mismatch", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
+				binary.LittleEndian.PutUint16(data[local+8:], 99)
+			})
+		}, want: "local file header compression method"},
+		{name: "local name mismatch", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
+				copy(data[local+30:], []byte("../badxx"))
+			})
+		}, want: "local file header name"},
+		{name: "local stored size mismatch", bad: zipEntry{name: "root/bad", data: "x", store: true}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
+				binary.LittleEndian.PutUint32(data[local+18:], 2)
+			})
+		}, want: "local file header sizes"},
 		{name: "malformed local header", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
 			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
 				binary.LittleEndian.PutUint32(data[local:], 0)
 			})
 		}, want: "malformed local file header"},
+		{name: "malformed data descriptor", bad: zipEntry{name: "root/bad", data: "x", store: true}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, local, _ int) {
+				nameBytes := int(binary.LittleEndian.Uint16(data[local+26:]))
+				extraBytes := int(binary.LittleEndian.Uint16(data[local+28:]))
+				compressedBytes := int(binary.LittleEndian.Uint32(data[central+20:]))
+				descriptor := local + 30 + nameBytes + extraBytes + compressedBytes
+				if binary.LittleEndian.Uint32(data[descriptor:]) != zipDataDescriptorSignature {
+					t.Fatal("test ZIP data descriptor has no signature")
+				}
+				data[descriptor+4] ^= 0xff
+			})
+		}, want: "data descriptor"},
 		{name: "compressed range enters directory", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
 			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, local, directory int) {
 				nameBytes := int(binary.LittleEndian.Uint16(data[local+26:]))
@@ -373,6 +436,108 @@ func TestExtractRejectsStrictMetadataBeforeFilesystemMutation(t *testing.T) {
 				test.mutate(t, archive)
 			}
 			assertPreflightFailureBeforeMutation(t, archive, test.want)
+		})
+	}
+}
+
+func TestExtractRejectsPerEntryZIP64BeforeFilesystemMutation(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n", store: true}})
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	central := bytes.Index(data, []byte("PK\x01\x02"))
+	end := bytes.LastIndex(data, []byte("PK\x05\x06"))
+	if central < 0 || end < 0 {
+		t.Fatal("ZIP central directory records not found")
+	}
+	compressed := binary.LittleEndian.Uint32(data[central+20:])
+	uncompressed := binary.LittleEndian.Uint32(data[central+24:])
+	nameBytes := int(binary.LittleEndian.Uint16(data[central+28:]))
+	extraBytes := binary.LittleEndian.Uint16(data[central+30:])
+	zip64 := make([]byte, 20)
+	binary.LittleEndian.PutUint16(zip64[0:], zip64ExtraFieldTag)
+	binary.LittleEndian.PutUint16(zip64[2:], 16)
+	binary.LittleEndian.PutUint64(zip64[4:], uint64(uncompressed))
+	binary.LittleEndian.PutUint64(zip64[12:], uint64(compressed))
+	binary.LittleEndian.PutUint32(data[central+20:], ^uint32(0))
+	binary.LittleEndian.PutUint32(data[central+24:], ^uint32(0))
+	binary.LittleEndian.PutUint16(data[central+30:], extraBytes+uint16(len(zip64)))
+	insert := central + zipDirectoryHeaderBytes + nameBytes
+	mutated := make([]byte, 0, len(data)+len(zip64))
+	mutated = append(mutated, data[:insert]...)
+	mutated = append(mutated, zip64...)
+	mutated = append(mutated, data[insert:]...)
+	newEnd := end + len(zip64)
+	directoryBytes := binary.LittleEndian.Uint32(mutated[newEnd+12:])
+	binary.LittleEndian.PutUint32(mutated[newEnd+12:], directoryBytes+uint32(len(zip64)))
+	if err := os.WriteFile(archive, mutated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assertPreflightFailureBeforeMutation(t, archive, "ZIP64 entry metadata")
+}
+
+func TestExtractRejectsLocalZIP64ExtraBeforeFilesystemMutation(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n", store: true}})
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	central := bytes.Index(data, []byte("PK\x01\x02"))
+	end := bytes.LastIndex(data, []byte("PK\x05\x06"))
+	if central < 0 || end < 0 {
+		t.Fatal("ZIP central directory records not found")
+	}
+	local := int(binary.LittleEndian.Uint32(data[central+42:]))
+	nameBytes := int(binary.LittleEndian.Uint16(data[local+26:]))
+	extraBytes := binary.LittleEndian.Uint16(data[local+28:])
+	zip64 := []byte{byte(zip64ExtraFieldTag), byte(zip64ExtraFieldTag >> 8), 0, 0}
+	binary.LittleEndian.PutUint16(data[local+28:], extraBytes+uint16(len(zip64)))
+	insert := local + zipFileHeaderBytes + nameBytes
+	mutated := make([]byte, 0, len(data)+len(zip64))
+	mutated = append(mutated, data[:insert]...)
+	mutated = append(mutated, zip64...)
+	mutated = append(mutated, data[insert:]...)
+	newEnd := end + len(zip64)
+	directoryOffset := binary.LittleEndian.Uint32(mutated[newEnd+16:])
+	binary.LittleEndian.PutUint32(mutated[newEnd+16:], directoryOffset+uint32(len(zip64)))
+	if err := os.WriteFile(archive, mutated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assertPreflightFailureBeforeMutation(t, archive, "ZIP64 entry metadata")
+}
+
+func TestValidateZipDataDescriptorAcceptsSignedAndUnsignedForms(t *testing.T) {
+	const (
+		checksum          = 0x12345678
+		compressedBytes   = 17
+		uncompressedBytes = 29
+	)
+	file := &zip.File{FileHeader: zip.FileHeader{
+		CRC32:              checksum,
+		CompressedSize64:   compressedBytes,
+		UncompressedSize64: uncompressedBytes,
+	}}
+	for _, signed := range []bool{false, true} {
+		name := "unsigned"
+		valueOffset := 0
+		descriptorBytes := zipDataDescriptorUnsignedBytes
+		if signed {
+			name = "signed"
+			valueOffset = 4
+			descriptorBytes = zipDataDescriptorBytes
+		}
+		t.Run(name, func(t *testing.T) {
+			descriptor := make([]byte, descriptorBytes)
+			if signed {
+				binary.LittleEndian.PutUint32(descriptor[0:4], zipDataDescriptorSignature)
+			}
+			binary.LittleEndian.PutUint32(descriptor[valueOffset:valueOffset+4], checksum)
+			binary.LittleEndian.PutUint32(descriptor[valueOffset+4:valueOffset+8], compressedBytes)
+			binary.LittleEndian.PutUint32(descriptor[valueOffset+8:valueOffset+12], uncompressedBytes)
+			if err := validateZipDataDescriptor(bytes.NewReader(descriptor), 0, int64(len(descriptor)), file, make([]byte, zipDataDescriptorBytes)); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }

--- a/internal/sourcearchive/archive_test.go
+++ b/internal/sourcearchive/archive_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -150,6 +151,276 @@ func TestExtractMissingGoModCleansStaging(t *testing.T) {
 	assertNoStaging(t, target)
 }
 
+func TestPreflightDeepPathsHasBoundedAllocations(t *testing.T) {
+	limits := productionExtractionLimits()
+	archive := writeProductionPathArchive(t, 256)
+	file, err := os.Open(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory, err := locateZipDirectory(file, info.Size(), limits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := zip.NewReader(file, info.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	allocations := testing.AllocsPerRun(3, func() {
+		entries, err := preflight(context.Background(), reader.File, directory.offset, limits)
+		if err != nil {
+			panic(err)
+		}
+		if len(entries) != 256 {
+			panic("wrong preflight entry count")
+		}
+	})
+	if allocations >= 5_000 {
+		t.Fatalf("preflight allocations = %.0f, want fewer than 5000", allocations)
+	}
+}
+
+func TestExtractOpensArchiveOnce(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n"}})
+	target := filepath.Join(t.TempDir(), "out")
+	operations := defaultExtractionOperations()
+	openArchive := operations.openArchive
+	openCount := 0
+	cleanupCount := 0
+	operations.openArchive = func(path string) (archiveReadCloser, error) {
+		openCount++
+		return openArchive(path)
+	}
+	operations.removeAll = func(path string) error {
+		cleanupCount++
+		return os.RemoveAll(path)
+	}
+	if err := extractWithOperations(context.Background(), archive, target, productionExtractionLimits(), operations); err != nil {
+		t.Fatal(err)
+	}
+	if openCount != 1 {
+		t.Fatalf("archive open count = %d, want 1", openCount)
+	}
+	if cleanupCount != 0 {
+		t.Fatalf("cleanup count after publication = %d, want 0", cleanupCount)
+	}
+}
+
+func TestExtractUsesOpenedArchiveAfterPathReplacement(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module original.example/test\n"}})
+	replacement := writeArchive(t, []zipEntry{{name: "replacement/README.md", data: "wrong archive\n"}})
+	target := filepath.Join(t.TempDir(), "out")
+	operations := defaultExtractionOperations()
+	operations.openArchive = func(path string) (archiveReadCloser, error) {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		original := path + ".opened"
+		if err := os.Rename(path, original); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		if err := os.Rename(replacement, path); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		return file, nil
+	}
+	if err := extractWithOperations(context.Background(), archive, target, productionExtractionLimits(), operations); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(target, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "module original.example/test\n" {
+		t.Fatalf("extracted go.mod = %q", data)
+	}
+}
+
+func TestZipInsecurePathErrorClosesOpenedArchive(t *testing.T) {
+	t.Setenv("GODEBUG", "zipinsecurepath=0")
+	archive := writeArchive(t, []zipEntry{
+		{name: "root/go.mod", data: "module example.com/test\n"},
+		{name: `root\bad`, data: "bad"},
+	})
+	target := filepath.Join(t.TempDir(), "out")
+	operations := defaultExtractionOperations()
+	var closed atomic.Bool
+	operations.openArchive = func(path string) (archiveReadCloser, error) {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		return &trackedArchive{File: file, closed: &closed}, nil
+	}
+	err := extractWithOperations(context.Background(), archive, target, productionExtractionLimits(), operations)
+	if !errors.Is(err, zip.ErrInsecurePath) {
+		t.Fatalf("Extract error = %v, want zip.ErrInsecurePath", err)
+	}
+	if !closed.Load() {
+		t.Fatal("archive was not closed after zip.ErrInsecurePath")
+	}
+	assertAbsent(t, target)
+}
+
+type trackedArchive struct {
+	*os.File
+	closed *atomic.Bool
+}
+
+type closeErrorArchive struct {
+	*os.File
+	err        error
+	closeCount *atomic.Int32
+}
+
+func (archive *closeErrorArchive) Close() error {
+	archive.closeCount.Add(1)
+	return errors.Join(archive.File.Close(), archive.err)
+}
+
+func TestArchiveCloseFailurePreventsPublicationAndCleansStaging(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n"}})
+	target := filepath.Join(t.TempDir(), "out")
+	closeFailure := errors.New("injected archive close failure")
+	var closeCount atomic.Int32
+	operations := defaultExtractionOperations()
+	operations.openArchive = func(path string) (archiveReadCloser, error) {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		return &closeErrorArchive{File: file, err: closeFailure, closeCount: &closeCount}, nil
+	}
+	err := extractWithOperations(context.Background(), archive, target, productionExtractionLimits(), operations)
+	if !errors.Is(err, closeFailure) {
+		t.Fatalf("Extract error = %v, want close failure", err)
+	}
+	if closeCount.Load() != 1 {
+		t.Fatalf("archive close count = %d, want 1", closeCount.Load())
+	}
+	assertAbsent(t, target)
+	assertNoStaging(t, target)
+}
+
+func (archive *trackedArchive) Close() error {
+	archive.closed.Store(true)
+	return archive.File.Close()
+}
+
+func TestExtractRejectsStrictMetadataBeforeFilesystemMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		bad    zipEntry
+		mutate func(*testing.T, string)
+		want   string
+	}{
+		{name: "trailing slash symlink", bad: zipEntry{name: "root/bad/", mode: os.ModeSymlink | 0o777}, want: "unsupported file type"},
+		{name: "trailing slash device", bad: zipEntry{name: "root/bad/", mode: os.ModeDevice | 0o600}, want: "unsupported file type"},
+		{name: "trailing slash named pipe", bad: zipEntry{name: "root/bad/", mode: os.ModeNamedPipe | 0o600}, want: "unsupported file type"},
+		{name: "trailing slash socket", bad: zipEntry{name: "root/bad/", mode: os.ModeSocket | 0o600}, want: "unsupported file type"},
+		{name: "mode directory without slash", bad: zipEntry{name: "root/bad", mode: os.ModeDir | 0o755}, want: "must end in a slash"},
+		{name: "directory with content", bad: zipEntry{name: "root/bad/", dir: true}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad/", func(data []byte, central, _, _ int) {
+				binary.LittleEndian.PutUint32(data[central+24:], 1)
+			})
+		}, want: "declares nonzero content"},
+		{name: "unsupported compression", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, local, _ int) {
+				binary.LittleEndian.PutUint16(data[central+10:], 99)
+				binary.LittleEndian.PutUint16(data[local+8:], 99)
+			})
+		}, want: "unsupported compression method"},
+		{name: "encrypted", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, local, _ int) {
+				binary.LittleEndian.PutUint16(data[central+8:], binary.LittleEndian.Uint16(data[central+8:])|1)
+				binary.LittleEndian.PutUint16(data[local+6:], binary.LittleEndian.Uint16(data[local+6:])|1)
+			})
+		}, want: "is encrypted"},
+		{name: "malformed local header", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
+				binary.LittleEndian.PutUint32(data[local:], 0)
+			})
+		}, want: "malformed local file header"},
+		{name: "compressed range enters directory", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, local, directory int) {
+				nameBytes := int(binary.LittleEndian.Uint16(data[local+26:]))
+				extraBytes := int(binary.LittleEndian.Uint16(data[local+28:]))
+				dataOffset := local + 30 + nameBytes + extraBytes
+				binary.LittleEndian.PutUint32(data[central+20:], uint32(directory-dataOffset+1))
+			})
+		}, want: "compressed data outside"},
+		{name: "stored size mismatch", bad: zipEntry{name: "root/bad", data: "x", store: true}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, _, _ int) {
+				binary.LittleEndian.PutUint32(data[central+20:], 2)
+			})
+		}, want: "mismatched compressed and uncompressed sizes"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archive := writeArchive(t, []zipEntry{
+				{name: "root/go.mod", data: "module example.com/test\n"},
+				test.bad,
+			})
+			if test.mutate != nil {
+				test.mutate(t, archive)
+			}
+			assertPreflightFailureBeforeMutation(t, archive, test.want)
+		})
+	}
+}
+
+func TestExtractRequiresExactRootGoModBeforeFilesystemMutation(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []zipEntry
+		want    string
+	}{
+		{name: "missing", entries: []zipEntry{{name: "root/README.md"}}, want: "regular go.mod file at the exact root path"},
+		{name: "uppercase", entries: []zipEntry{{name: "root/GO.MOD"}}, want: "regular go.mod file at the exact root path"},
+		{name: "mixed case", entries: []zipEntry{{name: "root/Go.Mod"}}, want: "regular go.mod file at the exact root path"},
+		{name: "directory", entries: []zipEntry{{name: "root/go.mod/", dir: true}}, want: "root go.mod must be a regular file"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archive := writeArchive(t, test.entries)
+			assertPreflightFailureBeforeMutation(t, archive, test.want)
+		})
+	}
+}
+
+func TestCleanupFailureIsJoinedWithExtractionFailure(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n", store: true}})
+	mutateZipEntry(t, archive, "root/go.mod", func(data []byte, _, local, _ int) {
+		nameBytes := int(binary.LittleEndian.Uint16(data[local+26:]))
+		extraBytes := int(binary.LittleEndian.Uint16(data[local+28:]))
+		data[local+30+nameBytes+extraBytes] ^= 0xff
+	})
+	target := filepath.Join(t.TempDir(), "parent", "out")
+	cleanupFailure := errors.New("injected cleanup failure")
+	operations := defaultExtractionOperations()
+	operations.removeAll = func(path string) error {
+		err := os.RemoveAll(path)
+		return errors.Join(err, cleanupFailure)
+	}
+	err := extractWithOperations(context.Background(), archive, target, productionExtractionLimits(), operations)
+	if !errors.Is(err, zip.ErrChecksum) {
+		t.Fatalf("Extract error = %v, want zip.ErrChecksum", err)
+	}
+	if !errors.Is(err, cleanupFailure) {
+		t.Fatalf("Extract error = %v, want cleanup failure", err)
+	}
+	assertAbsent(t, target)
+	assertNoStaging(t, target)
+}
+
 func TestExtractCancellationLeavesNoTargetOrStaging(t *testing.T) {
 	archive := writeArchive(t, []zipEntry{
 		{name: "root/go.mod", data: "module example.com/test\n"},
@@ -222,6 +493,7 @@ type zipEntry struct {
 	data    string
 	dir     bool
 	mode    os.FileMode
+	store   bool
 	nonUTF8 bool
 }
 
@@ -234,7 +506,11 @@ func writeArchive(t *testing.T, entries []zipEntry) string {
 	}
 	writer := zip.NewWriter(file)
 	for _, entry := range entries {
-		header := &zip.FileHeader{Name: entry.name, Method: zip.Deflate, NonUTF8: entry.nonUTF8}
+		method := uint16(zip.Deflate)
+		if entry.store {
+			method = zip.Store
+		}
+		header := &zip.FileHeader{Name: entry.name, Method: method, NonUTF8: entry.nonUTF8}
 		if entry.dir {
 			header.Name = strings.TrimSuffix(header.Name, "/") + "/"
 			header.SetMode(os.ModeDir | 0o755)
@@ -258,6 +534,47 @@ func writeArchive(t *testing.T, entries []zipEntry) string {
 		t.Fatal(err)
 	}
 	return archive
+}
+
+func mutateZipEntry(t *testing.T, archive, name string, mutate func(data []byte, central, local, directory int)) {
+	t.Helper()
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := bytes.Index(data, []byte("PK\x01\x02"))
+	if directory < 0 {
+		t.Fatal("ZIP central directory not found")
+	}
+	for central := directory; central+46 <= len(data) && binary.LittleEndian.Uint32(data[central:]) == zipDirectoryHeaderSignature; {
+		nameBytes := int(binary.LittleEndian.Uint16(data[central+28:]))
+		extraBytes := int(binary.LittleEndian.Uint16(data[central+30:]))
+		commentBytes := int(binary.LittleEndian.Uint16(data[central+32:]))
+		if central+46+nameBytes > len(data) {
+			t.Fatal("truncated test ZIP central directory")
+		}
+		if string(data[central+46:central+46+nameBytes]) == name {
+			local := int(binary.LittleEndian.Uint32(data[central+42:]))
+			mutate(data, central, local, directory)
+			if err := os.WriteFile(archive, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		central += 46 + nameBytes + extraBytes + commentBytes
+	}
+	t.Fatalf("ZIP entry %q not found", name)
+}
+
+func assertPreflightFailureBeforeMutation(t *testing.T, archive, want string) {
+	t.Helper()
+	parent := filepath.Join(t.TempDir(), "must-not-exist")
+	target := filepath.Join(parent, "out")
+	err := Extract(archive, target)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("Extract error = %v, want containing %q", err, want)
+	}
+	assertAbsent(t, parent)
 }
 
 func assertAbsent(t *testing.T, path string) {

--- a/internal/sourcearchive/archive_test.go
+++ b/internal/sourcearchive/archive_test.go
@@ -52,8 +52,12 @@ func TestExtractPreflightRejectsUnsafeOrUnboundedArchives(t *testing.T) {
 		{name: "path depth", entries: []zipEntry{{name: "root/a/b/go.mod"}}, limits: withPathDepth(base, 2), want: "depth limit"},
 		{name: "component bytes", entries: []zipEntry{{name: "root/long/go.mod"}}, limits: withComponentBytes(base, 3), want: "component exceeds 3-byte"},
 		{name: "nonportable component", entries: []zipEntry{{name: "root/CON/go.mod"}}, limits: base, want: "not portable"},
+		{name: "console device base trailing space", entries: []zipEntry{{name: "root/CON .txt/go.mod"}}, limits: base, want: "not portable"},
+		{name: "printer device base trailing space", entries: []zipEntry{{name: "root/LPT1 .log/go.mod"}}, limits: base, want: "not portable"},
 		{name: "console input device", entries: []zipEntry{{name: "root/CONIN$/go.mod"}}, limits: base, want: "not portable"},
+		{name: "console input device base trailing space", entries: []zipEntry{{name: "root/CONIN$ .txt/go.mod"}}, limits: base, want: "not portable"},
 		{name: "console output device extension", entries: []zipEntry{{name: "root/CONOUT$.txt/go.mod"}}, limits: base, want: "not portable"},
+		{name: "console output device base trailing space", entries: []zipEntry{{name: "root/CONOUT$ .txt/go.mod"}}, limits: base, want: "not portable"},
 		{name: "non-ASCII component", entries: []zipEntry{{name: "root/café/go.mod"}}, limits: base, want: "not portable"},
 		{name: "invalid UTF-8 component", entries: []zipEntry{{name: "root/\xff/go.mod", nonUTF8: true}}, limits: base, want: "not portable"},
 		{name: "file size", entries: []zipEntry{{name: "root/go.mod", data: strings.Repeat("x", 33)}}, limits: base, want: "file \"go.mod\" exceeds 32-byte"},
@@ -413,7 +417,12 @@ func TestExtractRejectsStrictMetadataBeforeFilesystemMutation(t *testing.T) {
 			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
 				binary.LittleEndian.PutUint32(data[local+18:], 2)
 			})
-		}, want: "local file header sizes"},
+		}, want: "must be zero when using a data descriptor"},
+		{name: "populated descriptor local fields", bad: zipEntry{name: "root/bad", data: "x", store: true}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, local, _ int) {
+				copy(data[local+14:local+26], data[central+16:central+28])
+			})
+		}, want: "must be zero when using a data descriptor"},
 		{name: "malformed local header", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
 			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
 				binary.LittleEndian.PutUint32(data[local:], 0)
@@ -465,6 +474,24 @@ func TestExtractAcceptsDeflateOptionFlags(t *testing.T) {
 		binary.LittleEndian.PutUint16(data[central+8:], binary.LittleEndian.Uint16(data[central+8:])|zipDeflateOptionFlags)
 		binary.LittleEndian.PutUint16(data[local+6:], binary.LittleEndian.Uint16(data[local+6:])|zipDeflateOptionFlags)
 	})
+	target := filepath.Join(t.TempDir(), "out")
+	if err := Extract(archive, target); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExtractAcceptsZIPVersion10ForGitHubCompatibility(t *testing.T) {
+	const githubZIPVersion = 10
+	archive := writeArchive(t, []zipEntry{
+		{name: "root/", dir: true},
+		{name: "root/go.mod", data: "module example.com/test\n"},
+	})
+	for _, name := range []string{"root/", "root/go.mod"} {
+		mutateZipEntry(t, archive, name, func(data []byte, central, local, _ int) {
+			binary.LittleEndian.PutUint16(data[central+6:], githubZIPVersion)
+			binary.LittleEndian.PutUint16(data[local+4:], githubZIPVersion)
+		})
+	}
 	target := filepath.Join(t.TempDir(), "out")
 	if err := Extract(archive, target); err != nil {
 		t.Fatal(err)

--- a/internal/sourcearchive/archive_test.go
+++ b/internal/sourcearchive/archive_test.go
@@ -33,7 +33,7 @@ func TestExtractPublishesValidSingleRootArchive(t *testing.T) {
 }
 
 func TestExtractPreflightRejectsUnsafeOrUnboundedArchives(t *testing.T) {
-	base := extractionLimits{entries: 10, files: 10, directories: 10, pathBytes: 80, pathDepth: 5, componentBytes: 32, fileBytes: 32, expandedBytes: 64}
+	base := extractionLimits{entries: 10, files: 10, directories: 10, metadataBytes: 4 << 10, pathBytes: 80, pathDepth: 5, componentBytes: 32, fileBytes: 32, expandedBytes: 64}
 	tests := []struct {
 		name    string
 		entries []zipEntry
@@ -46,10 +46,13 @@ func TestExtractPreflightRejectsUnsafeOrUnboundedArchives(t *testing.T) {
 		{name: "entries", entries: []zipEntry{{name: "root/go.mod"}, {name: "root/a"}, {name: "root/b"}}, limits: withEntries(base, 2), want: "more than 2 entries"},
 		{name: "files", entries: []zipEntry{{name: "root/go.mod"}, {name: "root/a"}}, limits: withFiles(base, 1), want: "more than 1 files"},
 		{name: "directories", entries: []zipEntry{{name: "root/a/b/go.mod"}}, limits: withDirectories(base, 1), want: "more than 1 directories"},
+		{name: "metadata bytes", entries: []zipEntry{{name: "root/go.mod"}}, limits: withMetadataBytes(base, 1), want: "central directory exceeds 1-byte"},
 		{name: "path bytes", entries: []zipEntry{{name: "root/very-long-name/go.mod"}}, limits: withPathBytes(base, 12), want: "path exceeds 12-byte"},
 		{name: "path depth", entries: []zipEntry{{name: "root/a/b/go.mod"}}, limits: withPathDepth(base, 2), want: "depth limit"},
 		{name: "component bytes", entries: []zipEntry{{name: "root/long/go.mod"}}, limits: withComponentBytes(base, 3), want: "component exceeds 3-byte"},
 		{name: "nonportable component", entries: []zipEntry{{name: "root/CON/go.mod"}}, limits: base, want: "not portable"},
+		{name: "non-ASCII component", entries: []zipEntry{{name: "root/café/go.mod"}}, limits: base, want: "not portable"},
+		{name: "invalid UTF-8 component", entries: []zipEntry{{name: "root/\xff/go.mod", nonUTF8: true}}, limits: base, want: "not portable"},
 		{name: "file size", entries: []zipEntry{{name: "root/go.mod", data: strings.Repeat("x", 33)}}, limits: base, want: "file \"go.mod\" exceeds 32-byte"},
 		{name: "expanded size", entries: []zipEntry{{name: "root/go.mod", data: strings.Repeat("x", 32)}, {name: "root/a", data: strings.Repeat("x", 32)}, {name: "root/b", data: "x"}}, limits: base, want: "expands beyond 64-byte"},
 		{name: "duplicate", entries: []zipEntry{{name: "root/go.mod"}, {name: "root/go.mod"}}, limits: base, want: "duplicate path"},
@@ -70,6 +73,47 @@ func TestExtractPreflightRejectsUnsafeOrUnboundedArchives(t *testing.T) {
 			assertNoStaging(t, target)
 		})
 	}
+}
+
+func TestExtractRejectsForgedCentralDirectoryEntryCount(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod"}, {name: "root/a"}, {name: "root/b"}})
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	end := bytes.LastIndex(data, []byte("PK\x05\x06"))
+	if end < 0 {
+		t.Fatal("ZIP central directory end not found")
+	}
+	binary.LittleEndian.PutUint16(data[end+8:], 1)
+	binary.LittleEndian.PutUint16(data[end+10:], 1)
+	if err := os.WriteFile(archive, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "out")
+	err = Extract(archive, target)
+	if err == nil || !strings.Contains(err.Error(), "declares 1 entries but contains 3") {
+		t.Fatalf("Extract error = %v, want forged entry-count rejection", err)
+	}
+	assertAbsent(t, target)
+}
+
+func TestExtractRejectsPrependedZipPayload(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod"}})
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append([]byte("self-extracting-prefix"), data...)
+	if err := os.WriteFile(archive, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "out")
+	err = Extract(archive, target)
+	if err == nil || !strings.Contains(err.Error(), "unsupported data before") {
+		t.Fatalf("Extract error = %v, want prepended-data rejection", err)
+	}
+	assertAbsent(t, target)
 }
 
 func TestExtractRejectsDishonestExpandedSizeAndCleansStaging(t *testing.T) {
@@ -152,11 +196,33 @@ func TestExtractRefusesExistingTarget(t *testing.T) {
 	}
 }
 
+func TestPublishDoesNotReplaceTargetCreatedAfterInitialCheck(t *testing.T) {
+	parent := t.TempDir()
+	staging := filepath.Join(parent, "staging")
+	target := filepath.Join(parent, "target")
+	if err := os.Mkdir(staging, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := publishDirectoryNoReplace(staging, target); err == nil {
+		t.Fatal("no-replace publication replaced an existing target")
+	}
+	if _, err := os.Stat(staging); err != nil {
+		t.Fatalf("failed publication removed staging: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("failed publication removed target: %v", err)
+	}
+}
+
 type zipEntry struct {
-	name string
-	data string
-	dir  bool
-	mode os.FileMode
+	name    string
+	data    string
+	dir     bool
+	mode    os.FileMode
+	nonUTF8 bool
 }
 
 func writeArchive(t *testing.T, entries []zipEntry) string {
@@ -168,7 +234,7 @@ func writeArchive(t *testing.T, entries []zipEntry) string {
 	}
 	writer := zip.NewWriter(file)
 	for _, entry := range entries {
-		header := &zip.FileHeader{Name: entry.name, Method: zip.Deflate}
+		header := &zip.FileHeader{Name: entry.name, Method: zip.Deflate, NonUTF8: entry.nonUTF8}
 		if entry.dir {
 			header.Name = strings.TrimSuffix(header.Name, "/") + "/"
 			header.SetMode(os.ModeDir | 0o755)
@@ -222,6 +288,10 @@ func withFiles(limits extractionLimits, value int) extractionLimits {
 }
 func withDirectories(limits extractionLimits, value int) extractionLimits {
 	limits.directories = value
+	return limits
+}
+func withMetadataBytes(limits extractionLimits, value uint64) extractionLimits {
+	limits.metadataBytes = value
 	return limits
 }
 func withPathBytes(limits extractionLimits, value int) extractionLimits {

--- a/internal/sourcearchive/archive_test.go
+++ b/internal/sourcearchive/archive_test.go
@@ -2,30 +2,237 @@ package sourcearchive
 
 import (
 	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestExtractRejectsTraversal(t *testing.T) {
+func TestExtractPublishesValidSingleRootArchive(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{
+		{name: "root/", dir: true},
+		{name: "root/go.mod", data: "module example.com/test\n"},
+		{name: "root/cmd/tool/main.go", data: "package main\n"},
+	})
+	target := filepath.Join(t.TempDir(), "out")
+	if err := Extract(archive, target); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(target, "cmd", "tool", "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "package main\n" {
+		t.Fatalf("main.go = %q", data)
+	}
+	assertNoStaging(t, target)
+}
+
+func TestExtractPreflightRejectsUnsafeOrUnboundedArchives(t *testing.T) {
+	base := extractionLimits{entries: 10, files: 10, directories: 10, pathBytes: 80, pathDepth: 5, componentBytes: 32, fileBytes: 32, expandedBytes: 64}
+	tests := []struct {
+		name    string
+		entries []zipEntry
+		limits  extractionLimits
+		want    string
+	}{
+		{name: "traversal", entries: []zipEntry{{name: "root/../../escape", data: "bad"}}, limits: base, want: "invalid path component"},
+		{name: "backslash traversal", entries: []zipEntry{{name: `root\..\escape`, data: "bad"}}, limits: base, want: "invalid path"},
+		{name: "multiple roots", entries: []zipEntry{{name: "one/go.mod"}, {name: "two/file"}}, limits: base, want: "multiple roots"},
+		{name: "entries", entries: []zipEntry{{name: "root/go.mod"}, {name: "root/a"}, {name: "root/b"}}, limits: withEntries(base, 2), want: "more than 2 entries"},
+		{name: "files", entries: []zipEntry{{name: "root/go.mod"}, {name: "root/a"}}, limits: withFiles(base, 1), want: "more than 1 files"},
+		{name: "directories", entries: []zipEntry{{name: "root/a/b/go.mod"}}, limits: withDirectories(base, 1), want: "more than 1 directories"},
+		{name: "path bytes", entries: []zipEntry{{name: "root/very-long-name/go.mod"}}, limits: withPathBytes(base, 12), want: "path exceeds 12-byte"},
+		{name: "path depth", entries: []zipEntry{{name: "root/a/b/go.mod"}}, limits: withPathDepth(base, 2), want: "depth limit"},
+		{name: "component bytes", entries: []zipEntry{{name: "root/long/go.mod"}}, limits: withComponentBytes(base, 3), want: "component exceeds 3-byte"},
+		{name: "nonportable component", entries: []zipEntry{{name: "root/CON/go.mod"}}, limits: base, want: "not portable"},
+		{name: "file size", entries: []zipEntry{{name: "root/go.mod", data: strings.Repeat("x", 33)}}, limits: base, want: "file \"go.mod\" exceeds 32-byte"},
+		{name: "expanded size", entries: []zipEntry{{name: "root/go.mod", data: strings.Repeat("x", 32)}, {name: "root/a", data: strings.Repeat("x", 32)}, {name: "root/b", data: "x"}}, limits: base, want: "expands beyond 64-byte"},
+		{name: "duplicate", entries: []zipEntry{{name: "root/go.mod"}, {name: "root/go.mod"}}, limits: base, want: "duplicate path"},
+		{name: "case collision", entries: []zipEntry{{name: "root/go.mod"}, {name: "root/GO.MOD"}}, limits: base, want: "case-colliding"},
+		{name: "implicit directory case collision", entries: []zipEntry{{name: "root/a/one"}, {name: "root/A/two"}}, limits: base, want: "case-colliding"},
+		{name: "file directory conflict", entries: []zipEntry{{name: "root/a", data: "x"}, {name: "root/a/go.mod"}}, limits: base, want: "nested below a file"},
+		{name: "symlink", entries: []zipEntry{{name: "root/go.mod"}, {name: "root/link", mode: os.ModeSymlink | 0o777}}, limits: base, want: "unsupported file type"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archive := writeArchive(t, test.entries)
+			target := filepath.Join(t.TempDir(), "out")
+			err := extractWithLimits(context.Background(), archive, target, test.limits)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Extract error = %v, want containing %q", err, test.want)
+			}
+			assertAbsent(t, target)
+			assertNoStaging(t, target)
+		})
+	}
+}
+
+func TestExtractRejectsDishonestExpandedSizeAndCleansStaging(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n"}})
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	central := bytes.Index(data, []byte("PK\x01\x02"))
+	if central < 0 {
+		t.Fatal("ZIP central directory not found")
+	}
+	binary.LittleEndian.PutUint32(data[central+24:], 1)
+	if err := os.WriteFile(archive, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "out")
+	err = Extract(archive, target)
+	if err == nil {
+		t.Fatal("dishonest expanded size unexpectedly succeeded")
+	}
+	assertAbsent(t, target)
+	assertNoStaging(t, target)
+}
+
+func TestExtractMissingGoModCleansStaging(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/README.md", data: "missing module\n"}})
+	target := filepath.Join(t.TempDir(), "out")
+	err := Extract(archive, target)
+	if err == nil || !strings.Contains(err.Error(), "regular go.mod") {
+		t.Fatalf("Extract error = %v, want missing go.mod", err)
+	}
+	assertAbsent(t, target)
+	assertNoStaging(t, target)
+}
+
+func TestExtractCancellationLeavesNoTargetOrStaging(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{
+		{name: "root/go.mod", data: "module example.com/test\n"},
+		{name: "root/large", data: strings.Repeat("x", 1<<20)},
+	})
+	ctx := &cancelAfterChecks{Context: context.Background(), remaining: 8}
+	target := filepath.Join(t.TempDir(), "out")
+	err := ExtractContext(ctx, archive, target)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Extract error = %v, want context canceled", err)
+	}
+	assertAbsent(t, target)
+	assertNoStaging(t, target)
+}
+
+type cancelAfterChecks struct {
+	context.Context
+	remaining int
+}
+
+func (ctx *cancelAfterChecks) Err() error {
+	ctx.remaining--
+	if ctx.remaining <= 0 {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestExtractRefusesExistingTarget(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n"}})
+	target := filepath.Join(t.TempDir(), "out")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(target, "keep")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Extract(archive, target); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("Extract error = %v, want existing-target rejection", err)
+	}
+	if data, err := os.ReadFile(marker); err != nil || string(data) != "keep" {
+		t.Fatalf("existing target changed: data %q, error %v", data, err)
+	}
+}
+
+type zipEntry struct {
+	name string
+	data string
+	dir  bool
+	mode os.FileMode
+}
+
+func writeArchive(t *testing.T, entries []zipEntry) string {
+	t.Helper()
 	archive := filepath.Join(t.TempDir(), "source.zip")
 	file, err := os.Create(archive)
 	if err != nil {
 		t.Fatal(err)
 	}
 	writer := zip.NewWriter(file)
-	entry, err := writer.Create("root/../../escape")
-	if err != nil {
-		t.Fatal(err)
+	for _, entry := range entries {
+		header := &zip.FileHeader{Name: entry.name, Method: zip.Deflate}
+		if entry.dir {
+			header.Name = strings.TrimSuffix(header.Name, "/") + "/"
+			header.SetMode(os.ModeDir | 0o755)
+		} else if entry.mode != 0 {
+			header.SetMode(entry.mode)
+		} else {
+			header.SetMode(0o644)
+		}
+		destination, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := destination.Write([]byte(entry.data)); err != nil {
+			t.Fatal(err)
+		}
 	}
-	_, _ = entry.Write([]byte("bad"))
 	if err := writer.Close(); err != nil {
 		t.Fatal(err)
 	}
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := Extract(archive, filepath.Join(t.TempDir(), "out")); err == nil {
-		t.Fatal("traversing source archive unexpectedly succeeded")
+	return archive
+}
+
+func assertAbsent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("path %s exists after failed extraction: %v", path, err)
 	}
+}
+
+func assertNoStaging(t *testing.T, target string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(target), "."+filepath.Base(target)+"-extract-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("staging paths remain: %v", matches)
+	}
+}
+
+func withEntries(limits extractionLimits, value int) extractionLimits {
+	limits.entries = value
+	return limits
+}
+func withFiles(limits extractionLimits, value int) extractionLimits {
+	limits.files = value
+	return limits
+}
+func withDirectories(limits extractionLimits, value int) extractionLimits {
+	limits.directories = value
+	return limits
+}
+func withPathBytes(limits extractionLimits, value int) extractionLimits {
+	limits.pathBytes = value
+	return limits
+}
+func withPathDepth(limits extractionLimits, value int) extractionLimits {
+	limits.pathDepth = value
+	return limits
+}
+func withComponentBytes(limits extractionLimits, value int) extractionLimits {
+	limits.componentBytes = value
+	return limits
 }

--- a/internal/sourcearchive/archive_test.go
+++ b/internal/sourcearchive/archive_test.go
@@ -52,6 +52,8 @@ func TestExtractPreflightRejectsUnsafeOrUnboundedArchives(t *testing.T) {
 		{name: "path depth", entries: []zipEntry{{name: "root/a/b/go.mod"}}, limits: withPathDepth(base, 2), want: "depth limit"},
 		{name: "component bytes", entries: []zipEntry{{name: "root/long/go.mod"}}, limits: withComponentBytes(base, 3), want: "component exceeds 3-byte"},
 		{name: "nonportable component", entries: []zipEntry{{name: "root/CON/go.mod"}}, limits: base, want: "not portable"},
+		{name: "console input device", entries: []zipEntry{{name: "root/CONIN$/go.mod"}}, limits: base, want: "not portable"},
+		{name: "console output device extension", entries: []zipEntry{{name: "root/CONOUT$.txt/go.mod"}}, limits: base, want: "not portable"},
 		{name: "non-ASCII component", entries: []zipEntry{{name: "root/café/go.mod"}}, limits: base, want: "not portable"},
 		{name: "invalid UTF-8 component", entries: []zipEntry{{name: "root/\xff/go.mod", nonUTF8: true}}, limits: base, want: "not portable"},
 		{name: "file size", entries: []zipEntry{{name: "root/go.mod", data: strings.Repeat("x", 33)}}, limits: base, want: "file \"go.mod\" exceeds 32-byte"},
@@ -375,6 +377,23 @@ func TestExtractRejectsStrictMetadataBeforeFilesystemMutation(t *testing.T) {
 				binary.LittleEndian.PutUint16(data[local+6:], binary.LittleEndian.Uint16(data[local+6:])|1)
 			})
 		}, want: "is encrypted"},
+		{name: "patched data flag", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, local, _ int) {
+				binary.LittleEndian.PutUint16(data[central+8:], binary.LittleEndian.Uint16(data[central+8:])|zipPatchedDataFlag)
+				binary.LittleEndian.PutUint16(data[local+6:], binary.LittleEndian.Uint16(data[local+6:])|zipPatchedDataFlag)
+			})
+		}, want: "unsupported general-purpose flags"},
+		{name: "unsupported ZIP version", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, central, local, _ int) {
+				binary.LittleEndian.PutUint16(data[central+6:], 45)
+				binary.LittleEndian.PutUint16(data[local+4:], 45)
+			})
+		}, want: "unsupported ZIP version"},
+		{name: "local ZIP version mismatch", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
+			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
+				binary.LittleEndian.PutUint16(data[local+4:], 10)
+			})
+		}, want: "local file header ZIP version"},
 		{name: "local encrypted flag mismatch", bad: zipEntry{name: "root/bad", data: "x"}, mutate: func(t *testing.T, archive string) {
 			mutateZipEntry(t, archive, "root/bad", func(data []byte, _, local, _ int) {
 				binary.LittleEndian.PutUint16(data[local+6:], binary.LittleEndian.Uint16(data[local+6:])|1)
@@ -437,6 +456,18 @@ func TestExtractRejectsStrictMetadataBeforeFilesystemMutation(t *testing.T) {
 			}
 			assertPreflightFailureBeforeMutation(t, archive, test.want)
 		})
+	}
+}
+
+func TestExtractAcceptsDeflateOptionFlags(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n"}})
+	mutateZipEntry(t, archive, "root/go.mod", func(data []byte, central, local, _ int) {
+		binary.LittleEndian.PutUint16(data[central+8:], binary.LittleEndian.Uint16(data[central+8:])|zipDeflateOptionFlags)
+		binary.LittleEndian.PutUint16(data[local+6:], binary.LittleEndian.Uint16(data[local+6:])|zipDeflateOptionFlags)
+	})
+	target := filepath.Join(t.TempDir(), "out")
+	if err := Extract(archive, target); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -535,10 +566,84 @@ func TestValidateZipDataDescriptorAcceptsSignedAndUnsignedForms(t *testing.T) {
 			binary.LittleEndian.PutUint32(descriptor[valueOffset:valueOffset+4], checksum)
 			binary.LittleEndian.PutUint32(descriptor[valueOffset+4:valueOffset+8], compressedBytes)
 			binary.LittleEndian.PutUint32(descriptor[valueOffset+8:valueOffset+12], uncompressedBytes)
-			if err := validateZipDataDescriptor(bytes.NewReader(descriptor), 0, int64(len(descriptor)), file, make([]byte, zipDataDescriptorBytes)); err != nil {
+			end, err := validateZipDataDescriptor(bytes.NewReader(descriptor), 0, int64(len(descriptor)), file, make([]byte, zipDataDescriptorBytes))
+			if err != nil {
 				t.Fatal(err)
 			}
+			if end != int64(descriptorBytes) {
+				t.Fatalf("descriptor end = %d, want %d", end, descriptorBytes)
+			}
 		})
+	}
+}
+
+func TestExtractRejectsZIP64WidthDescriptorBeforeFilesystemMutation(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", store: true}})
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	central := bytes.Index(data, []byte("PK\x01\x02"))
+	end := bytes.LastIndex(data, []byte("PK\x05\x06"))
+	if central < 0 || end < 0 {
+		t.Fatal("ZIP central directory records not found")
+	}
+	local := int(binary.LittleEndian.Uint32(data[central+42:]))
+	nameBytes := int(binary.LittleEndian.Uint16(data[local+26:]))
+	extraBytes := int(binary.LittleEndian.Uint16(data[local+28:]))
+	compressedBytes := int(binary.LittleEndian.Uint32(data[central+20:]))
+	descriptor := local + zipFileHeaderBytes + nameBytes + extraBytes + compressedBytes
+	if binary.LittleEndian.Uint32(data[descriptor:]) != zipDataDescriptorSignature {
+		t.Fatal("test ZIP data descriptor has no signature")
+	}
+	mutated := make([]byte, 0, len(data)+8)
+	mutated = append(mutated, data[:descriptor+12]...)
+	mutated = append(mutated, 0, 0, 0, 0)
+	mutated = append(mutated, data[descriptor+12:descriptor+16]...)
+	mutated = append(mutated, 0, 0, 0, 0)
+	mutated = append(mutated, data[descriptor+16:]...)
+	newEnd := end + 8
+	directoryOffset := binary.LittleEndian.Uint32(mutated[newEnd+16:])
+	binary.LittleEndian.PutUint32(mutated[newEnd+16:], directoryOffset+8)
+	if err := os.WriteFile(archive, mutated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assertPreflightFailureBeforeMutation(t, archive, "gaps, overlaps, or unsupported records")
+}
+
+func TestExtractAcceptsUnsignedDataDescriptor(t *testing.T) {
+	archive := writeArchive(t, []zipEntry{{name: "root/go.mod", data: "module example.com/test\n", store: true}})
+	data, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	central := bytes.Index(data, []byte("PK\x01\x02"))
+	end := bytes.LastIndex(data, []byte("PK\x05\x06"))
+	if central < 0 || end < 0 {
+		t.Fatal("ZIP central directory records not found")
+	}
+	local := int(binary.LittleEndian.Uint32(data[central+42:]))
+	nameBytes := int(binary.LittleEndian.Uint16(data[local+26:]))
+	extraBytes := int(binary.LittleEndian.Uint16(data[local+28:]))
+	compressedBytes := int(binary.LittleEndian.Uint32(data[central+20:]))
+	descriptor := local + zipFileHeaderBytes + nameBytes + extraBytes + compressedBytes
+	if binary.LittleEndian.Uint32(data[descriptor:]) != zipDataDescriptorSignature {
+		t.Fatal("test ZIP data descriptor has no signature")
+	}
+	mutated := append([]byte(nil), data[:descriptor]...)
+	mutated = append(mutated, data[descriptor+4:]...)
+	newEnd := end - 4
+	directoryOffset := binary.LittleEndian.Uint32(mutated[newEnd+16:])
+	binary.LittleEndian.PutUint32(mutated[newEnd+16:], directoryOffset-4)
+	if err := os.WriteFile(archive, mutated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "out")
+	if err := Extract(archive, target); err != nil {
+		t.Fatal(err)
+	}
+	if contents, err := os.ReadFile(filepath.Join(target, "go.mod")); err != nil || string(contents) != "module example.com/test\n" {
+		t.Fatalf("go.mod = %q, error %v", contents, err)
 	}
 }
 

--- a/internal/sourcearchive/directory.go
+++ b/internal/sourcearchive/directory.go
@@ -23,6 +23,12 @@ const (
 	zipDataDescriptorSignature     = 0x08074b50
 	zipDataDescriptorBytes         = 16
 	zipDataDescriptorUnsignedBytes = 12
+	zipVersion20                   = 20
+	zipEncryptedFlag               = 1 << 0
+	zipDeflateOptionFlags          = 1<<1 | 1<<2
+	zipPatchedDataFlag             = 1 << 5
+	zipStrongEncryptionFlag        = 1 << 6
+	zipUTF8Flag                    = 1 << 11
 )
 
 type zipDirectory struct {
@@ -121,7 +127,8 @@ func (cursor *zipDirectoryCursor) next(file *zip.File, nameBuffer []byte) (int64
 	if recordBytes > cursor.remaining || nameBytes != uint64(len(file.Name)) || nameBytes > uint64(len(nameBuffer)) {
 		return 0, errors.New("source archive central directory changed during preflight")
 	}
-	if binary.LittleEndian.Uint16(cursor.header[8:10]) != file.Flags ||
+	if binary.LittleEndian.Uint16(cursor.header[6:8]) != file.ReaderVersion ||
+		binary.LittleEndian.Uint16(cursor.header[8:10]) != file.Flags ||
 		binary.LittleEndian.Uint16(cursor.header[10:12]) != file.Method ||
 		binary.LittleEndian.Uint32(cursor.header[16:20]) != file.CRC32 ||
 		uint64(binary.LittleEndian.Uint32(cursor.header[20:24])) != file.CompressedSize64 ||

--- a/internal/sourcearchive/directory.go
+++ b/internal/sourcearchive/directory.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 )
 
 const (
@@ -26,61 +25,52 @@ type zipDirectory struct {
 
 // inspectZipDirectory bounds central-directory parsing before archive/zip
 // constructs one zip.File and its variable metadata for every entry.
-func inspectZipDirectory(ctx context.Context, archive string, limits extractionLimits) error {
-	file, err := os.Open(archive)
+func inspectZipDirectory(ctx context.Context, readerAt io.ReaderAt, size int64, limits extractionLimits) (zipDirectory, error) {
+	directory, err := locateZipDirectory(readerAt, size, limits)
 	if err != nil {
-		return err
+		return zipDirectory{}, err
 	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return err
-	}
-	directory, err := locateZipDirectory(file, info.Size(), limits)
-	if err != nil {
-		return err
-	}
-	section := io.NewSectionReader(file, directory.offset, int64(directory.size))
+	section := io.NewSectionReader(readerAt, directory.offset, int64(directory.size))
 	reader := bufio.NewReaderSize(section, 32<<10)
 	remaining := directory.size
 	var records uint64
 	var header [zipDirectoryHeaderBytes]byte
 	for remaining != 0 {
 		if err := ctx.Err(); err != nil {
-			return err
+			return zipDirectory{}, err
 		}
 		if records >= uint64(limits.entries) {
-			return fmt.Errorf("source archive contains more than %d entries", limits.entries)
+			return zipDirectory{}, fmt.Errorf("source archive contains more than %d entries", limits.entries)
 		}
 		if remaining < zipDirectoryHeaderBytes {
-			return errors.New("source archive has a malformed central directory")
+			return zipDirectory{}, errors.New("source archive has a malformed central directory")
 		}
 		if _, err := io.ReadFull(reader, header[:]); err != nil {
-			return fmt.Errorf("read source archive central directory: %w", err)
+			return zipDirectory{}, fmt.Errorf("read source archive central directory: %w", err)
 		}
 		if binary.LittleEndian.Uint32(header[:4]) != zipDirectoryHeaderSignature {
-			return errors.New("source archive has a malformed central directory header")
+			return zipDirectory{}, errors.New("source archive has a malformed central directory header")
 		}
 		variable := uint64(binary.LittleEndian.Uint16(header[28:30])) +
 			uint64(binary.LittleEndian.Uint16(header[30:32])) +
 			uint64(binary.LittleEndian.Uint16(header[32:34]))
 		recordBytes := uint64(zipDirectoryHeaderBytes) + variable
 		if recordBytes > remaining {
-			return errors.New("source archive has truncated central directory metadata")
+			return zipDirectory{}, errors.New("source archive has truncated central directory metadata")
 		}
 		if _, err := io.CopyN(io.Discard, reader, int64(variable)); err != nil {
-			return fmt.Errorf("read source archive central directory metadata: %w", err)
+			return zipDirectory{}, fmt.Errorf("read source archive central directory metadata: %w", err)
 		}
 		remaining -= recordBytes
 		records++
 	}
 	if records != directory.records {
-		return fmt.Errorf("source archive central directory declares %d entries but contains %d", directory.records, records)
+		return zipDirectory{}, fmt.Errorf("source archive central directory declares %d entries but contains %d", directory.records, records)
 	}
-	return nil
+	return directory, nil
 }
 
-func locateZipDirectory(file *os.File, size int64, limits extractionLimits) (zipDirectory, error) {
+func locateZipDirectory(readerAt io.ReaderAt, size int64, limits extractionLimits) (zipDirectory, error) {
 	if size < zipDirectoryEndBytes {
 		return zipDirectory{}, errors.New("source archive has no central directory")
 	}
@@ -89,7 +79,7 @@ func locateZipDirectory(file *os.File, size int64, limits extractionLimits) (zip
 		tailBytes = size
 	}
 	tail := make([]byte, int(tailBytes))
-	if _, err := file.ReadAt(tail, size-tailBytes); err != nil {
+	if _, err := readerAt.ReadAt(tail, size-tailBytes); err != nil {
 		return zipDirectory{}, err
 	}
 	end := -1

--- a/internal/sourcearchive/directory.go
+++ b/internal/sourcearchive/directory.go
@@ -1,0 +1,135 @@
+package sourcearchive
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	zipDirectoryHeaderSignature = 0x02014b50
+	zipDirectoryHeaderBytes     = 46
+	zipDirectoryEndSignature    = 0x06054b50
+	zipDirectoryEndBytes        = 22
+	zipMaximumCommentBytes      = 1<<16 - 1
+)
+
+type zipDirectory struct {
+	offset  int64
+	size    uint64
+	records uint64
+}
+
+// inspectZipDirectory bounds central-directory parsing before archive/zip
+// constructs one zip.File and its variable metadata for every entry.
+func inspectZipDirectory(ctx context.Context, archive string, limits extractionLimits) error {
+	file, err := os.Open(archive)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	directory, err := locateZipDirectory(file, info.Size(), limits)
+	if err != nil {
+		return err
+	}
+	section := io.NewSectionReader(file, directory.offset, int64(directory.size))
+	reader := bufio.NewReaderSize(section, 32<<10)
+	remaining := directory.size
+	var records uint64
+	var header [zipDirectoryHeaderBytes]byte
+	for remaining != 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if records >= uint64(limits.entries) {
+			return fmt.Errorf("source archive contains more than %d entries", limits.entries)
+		}
+		if remaining < zipDirectoryHeaderBytes {
+			return errors.New("source archive has a malformed central directory")
+		}
+		if _, err := io.ReadFull(reader, header[:]); err != nil {
+			return fmt.Errorf("read source archive central directory: %w", err)
+		}
+		if binary.LittleEndian.Uint32(header[:4]) != zipDirectoryHeaderSignature {
+			return errors.New("source archive has a malformed central directory header")
+		}
+		variable := uint64(binary.LittleEndian.Uint16(header[28:30])) +
+			uint64(binary.LittleEndian.Uint16(header[30:32])) +
+			uint64(binary.LittleEndian.Uint16(header[32:34]))
+		recordBytes := uint64(zipDirectoryHeaderBytes) + variable
+		if recordBytes > remaining {
+			return errors.New("source archive has truncated central directory metadata")
+		}
+		if _, err := io.CopyN(io.Discard, reader, int64(variable)); err != nil {
+			return fmt.Errorf("read source archive central directory metadata: %w", err)
+		}
+		remaining -= recordBytes
+		records++
+	}
+	if records != directory.records {
+		return fmt.Errorf("source archive central directory declares %d entries but contains %d", directory.records, records)
+	}
+	return nil
+}
+
+func locateZipDirectory(file *os.File, size int64, limits extractionLimits) (zipDirectory, error) {
+	if size < zipDirectoryEndBytes {
+		return zipDirectory{}, errors.New("source archive has no central directory")
+	}
+	tailBytes := int64(zipDirectoryEndBytes + zipMaximumCommentBytes)
+	if tailBytes > size {
+		tailBytes = size
+	}
+	tail := make([]byte, int(tailBytes))
+	if _, err := file.ReadAt(tail, size-tailBytes); err != nil {
+		return zipDirectory{}, err
+	}
+	end := -1
+	for index := len(tail) - zipDirectoryEndBytes; index >= 0; index-- {
+		if binary.LittleEndian.Uint32(tail[index:index+4]) != zipDirectoryEndSignature {
+			continue
+		}
+		commentBytes := int(binary.LittleEndian.Uint16(tail[index+20 : index+22]))
+		if index+zipDirectoryEndBytes+commentBytes == len(tail) {
+			end = index
+			break
+		}
+	}
+	if end < 0 {
+		return zipDirectory{}, errors.New("source archive has no valid central directory end")
+	}
+	recordsThisDisk := uint64(binary.LittleEndian.Uint16(tail[end+8 : end+10]))
+	records := uint64(binary.LittleEndian.Uint16(tail[end+10 : end+12]))
+	directoryBytes := uint64(binary.LittleEndian.Uint32(tail[end+12 : end+16]))
+	directoryOffset := uint64(binary.LittleEndian.Uint32(tail[end+16 : end+20]))
+	if records > uint64(limits.entries) {
+		return zipDirectory{}, fmt.Errorf("source archive contains more than %d entries", limits.entries)
+	}
+	if directoryBytes > limits.metadataBytes {
+		return zipDirectory{}, fmt.Errorf("source archive central directory exceeds %s limit", byteLimit(limits.metadataBytes))
+	}
+	if records == 0xffff || directoryBytes == 0xffffffff || directoryOffset == 0xffffffff {
+		return zipDirectory{}, errors.New("source archive ZIP64 metadata exceeds the supported extraction policy")
+	}
+	if binary.LittleEndian.Uint16(tail[end+4:end+6]) != 0 ||
+		binary.LittleEndian.Uint16(tail[end+6:end+8]) != 0 || recordsThisDisk != records {
+		return zipDirectory{}, errors.New("source archive uses unsupported multi-disk metadata")
+	}
+	endOffset := size - tailBytes + int64(end)
+	if directoryBytes > uint64(endOffset) || directoryOffset > uint64(endOffset)-directoryBytes {
+		return zipDirectory{}, errors.New("source archive central directory lies outside the archive")
+	}
+	baseOffset := endOffset - int64(directoryBytes) - int64(directoryOffset)
+	if baseOffset != 0 {
+		return zipDirectory{}, errors.New("source archive contains unsupported data before the ZIP payload")
+	}
+	return zipDirectory{offset: int64(directoryOffset), size: directoryBytes, records: records}, nil
+}

--- a/internal/sourcearchive/directory.go
+++ b/internal/sourcearchive/directory.go
@@ -1,6 +1,7 @@
 package sourcearchive
 
 import (
+	"archive/zip"
 	"bufio"
 	"context"
 	"encoding/binary"
@@ -10,17 +11,30 @@ import (
 )
 
 const (
-	zipDirectoryHeaderSignature = 0x02014b50
-	zipDirectoryHeaderBytes     = 46
-	zipDirectoryEndSignature    = 0x06054b50
-	zipDirectoryEndBytes        = 22
-	zipMaximumCommentBytes      = 1<<16 - 1
+	zipFileHeaderSignature         = 0x04034b50
+	zipFileHeaderBytes             = 30
+	zipDirectoryHeaderSignature    = 0x02014b50
+	zipDirectoryHeaderBytes        = 46
+	zipDirectoryEndSignature       = 0x06054b50
+	zipDirectoryEndBytes           = 22
+	zipMaximumCommentBytes         = 1<<16 - 1
+	zip64ExtraFieldTag             = 0x0001
+	zipDataDescriptorFlag          = 1 << 3
+	zipDataDescriptorSignature     = 0x08074b50
+	zipDataDescriptorBytes         = 16
+	zipDataDescriptorUnsignedBytes = 12
 )
 
 type zipDirectory struct {
 	offset  int64
 	size    uint64
 	records uint64
+}
+
+type zipDirectoryCursor struct {
+	reader    *bufio.Reader
+	remaining uint64
+	header    [zipDirectoryHeaderBytes]byte
 }
 
 // inspectZipDirectory bounds central-directory parsing before archive/zip
@@ -51,14 +65,29 @@ func inspectZipDirectory(ctx context.Context, readerAt io.ReaderAt, size int64, 
 		if binary.LittleEndian.Uint32(header[:4]) != zipDirectoryHeaderSignature {
 			return zipDirectory{}, errors.New("source archive has a malformed central directory header")
 		}
-		variable := uint64(binary.LittleEndian.Uint16(header[28:30])) +
-			uint64(binary.LittleEndian.Uint16(header[30:32])) +
-			uint64(binary.LittleEndian.Uint16(header[32:34]))
+		nameBytes := uint64(binary.LittleEndian.Uint16(header[28:30]))
+		extraBytes := uint64(binary.LittleEndian.Uint16(header[30:32]))
+		commentBytes := uint64(binary.LittleEndian.Uint16(header[32:34]))
+		variable := nameBytes + extraBytes + commentBytes
 		recordBytes := uint64(zipDirectoryHeaderBytes) + variable
 		if recordBytes > remaining {
 			return zipDirectory{}, errors.New("source archive has truncated central directory metadata")
 		}
-		if _, err := io.CopyN(io.Discard, reader, int64(variable)); err != nil {
+		if binary.LittleEndian.Uint32(header[20:24]) == ^uint32(0) ||
+			binary.LittleEndian.Uint32(header[24:28]) == ^uint32(0) ||
+			binary.LittleEndian.Uint32(header[42:46]) == ^uint32(0) {
+			return zipDirectory{}, errors.New("source archive uses unsupported ZIP64 entry metadata")
+		}
+		if binary.LittleEndian.Uint16(header[34:36]) != 0 {
+			return zipDirectory{}, errors.New("source archive uses unsupported multi-disk entry metadata")
+		}
+		if err := discardZipMetadata(reader, nameBytes); err != nil {
+			return zipDirectory{}, fmt.Errorf("read source archive central directory metadata: %w", err)
+		}
+		if err := validateZipExtraFields(reader, extraBytes, "central directory"); err != nil {
+			return zipDirectory{}, err
+		}
+		if err := discardZipMetadata(reader, commentBytes); err != nil {
 			return zipDirectory{}, fmt.Errorf("read source archive central directory metadata: %w", err)
 		}
 		remaining -= recordBytes
@@ -68,6 +97,88 @@ func inspectZipDirectory(ctx context.Context, readerAt io.ReaderAt, size int64, 
 		return zipDirectory{}, fmt.Errorf("source archive central directory declares %d entries but contains %d", directory.records, records)
 	}
 	return directory, nil
+}
+
+func newZipDirectoryCursor(readerAt io.ReaderAt, directory zipDirectory) *zipDirectoryCursor {
+	section := io.NewSectionReader(readerAt, directory.offset, int64(directory.size))
+	return &zipDirectoryCursor{reader: bufio.NewReaderSize(section, 32<<10), remaining: directory.size}
+}
+
+func (cursor *zipDirectoryCursor) next(file *zip.File, nameBuffer []byte) (int64, error) {
+	if cursor.remaining < zipDirectoryHeaderBytes {
+		return 0, errors.New("source archive central directory changed during preflight")
+	}
+	if _, err := io.ReadFull(cursor.reader, cursor.header[:]); err != nil {
+		return 0, fmt.Errorf("read source archive central directory during preflight: %w", err)
+	}
+	if binary.LittleEndian.Uint32(cursor.header[0:4]) != zipDirectoryHeaderSignature {
+		return 0, errors.New("source archive central directory changed during preflight")
+	}
+	nameBytes := uint64(binary.LittleEndian.Uint16(cursor.header[28:30]))
+	extraBytes := uint64(binary.LittleEndian.Uint16(cursor.header[30:32]))
+	commentBytes := uint64(binary.LittleEndian.Uint16(cursor.header[32:34]))
+	recordBytes := uint64(zipDirectoryHeaderBytes) + nameBytes + extraBytes + commentBytes
+	if recordBytes > cursor.remaining || nameBytes != uint64(len(file.Name)) || nameBytes > uint64(len(nameBuffer)) {
+		return 0, errors.New("source archive central directory changed during preflight")
+	}
+	if binary.LittleEndian.Uint16(cursor.header[8:10]) != file.Flags ||
+		binary.LittleEndian.Uint16(cursor.header[10:12]) != file.Method ||
+		binary.LittleEndian.Uint32(cursor.header[16:20]) != file.CRC32 ||
+		uint64(binary.LittleEndian.Uint32(cursor.header[20:24])) != file.CompressedSize64 ||
+		uint64(binary.LittleEndian.Uint32(cursor.header[24:28])) != file.UncompressedSize64 {
+		return 0, errors.New("source archive central directory changed during preflight")
+	}
+	name := nameBuffer[:nameBytes]
+	if _, err := io.ReadFull(cursor.reader, name); err != nil {
+		return 0, fmt.Errorf("read source archive central directory name: %w", err)
+	}
+	for index := range name {
+		if name[index] != file.Name[index] {
+			return 0, errors.New("source archive central directory changed during preflight")
+		}
+	}
+	if err := validateZipExtraFields(cursor.reader, extraBytes, "central directory"); err != nil {
+		return 0, err
+	}
+	if err := discardZipMetadata(cursor.reader, commentBytes); err != nil {
+		return 0, fmt.Errorf("read source archive central directory comment: %w", err)
+	}
+	cursor.remaining -= recordBytes
+	return int64(binary.LittleEndian.Uint32(cursor.header[42:46])), nil
+}
+
+func validateZipExtraFields(reader io.Reader, remaining uint64, location string) error {
+	var header [4]byte
+	for remaining != 0 {
+		if remaining < uint64(len(header)) {
+			return fmt.Errorf("source archive has malformed %s extra metadata", location)
+		}
+		if _, err := io.ReadFull(reader, header[:]); err != nil {
+			return fmt.Errorf("read source archive %s extra metadata: %w", location, err)
+		}
+		remaining -= uint64(len(header))
+		tag := binary.LittleEndian.Uint16(header[0:2])
+		fieldBytes := uint64(binary.LittleEndian.Uint16(header[2:4]))
+		if fieldBytes > remaining {
+			return fmt.Errorf("source archive has malformed %s extra metadata", location)
+		}
+		if tag == zip64ExtraFieldTag {
+			return errors.New("source archive uses unsupported ZIP64 entry metadata")
+		}
+		if err := discardZipMetadata(reader, fieldBytes); err != nil {
+			return fmt.Errorf("read source archive %s extra metadata: %w", location, err)
+		}
+		remaining -= fieldBytes
+	}
+	return nil
+}
+
+func discardZipMetadata(reader io.Reader, size uint64) error {
+	if size == 0 {
+		return nil
+	}
+	_, err := io.CopyN(io.Discard, reader, int64(size))
+	return err
 }
 
 func locateZipDirectory(readerAt io.ReaderAt, size int64, limits extractionLimits) (zipDirectory, error) {

--- a/internal/sourcearchive/publish_darwin.go
+++ b/internal/sourcearchive/publish_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package sourcearchive
+
+import "golang.org/x/sys/unix"
+
+func publishDirectoryNoReplace(source, target string) error {
+	return unix.RenamexNp(source, target, unix.RENAME_EXCL)
+}

--- a/internal/sourcearchive/publish_linux.go
+++ b/internal/sourcearchive/publish_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package sourcearchive
+
+import "golang.org/x/sys/unix"
+
+func publishDirectoryNoReplace(source, target string) error {
+	return unix.Renameat2(unix.AT_FDCWD, source, unix.AT_FDCWD, target, unix.RENAME_NOREPLACE)
+}

--- a/internal/sourcearchive/publish_unsupported.go
+++ b/internal/sourcearchive/publish_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux && !windows
+
+package sourcearchive
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func publishDirectoryNoReplace(_, _ string) error {
+	return fmt.Errorf("atomic no-replace source publication is unsupported on %s", runtime.GOOS)
+}

--- a/internal/sourcearchive/publish_windows.go
+++ b/internal/sourcearchive/publish_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package sourcearchive
+
+import "syscall"
+
+func publishDirectoryNoReplace(source, target string) error {
+	sourcePointer, err := syscall.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	targetPointer, err := syscall.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	return syscall.MoveFile(sourcePointer, targetPointer)
+}


### PR DESCRIPTION
## Summary

- preflight source ZIP metadata before any filesystem mutation with linear path work
- parse the fixed-memory directory scan and archive/zip view through one regular-file descriptor
- cross-check central and local headers, validate data descriptors, and reject all ZIP64 entry metadata
- reject encrypted, unsupported, malformed, special-mode, size-inconsistent, and out-of-range entries
- require an exactly spelled regular root go.mod before staging
- count actual decompressed bytes, surface close and cleanup failures, and preserve atomic no-replace publication
- propagate Ctrl+C cancellation through both manager and installer archive fallback paths

## Security invariants

Accepted paths remain portable printable ASCII and retain the existing duplicate, case-collision, file/directory-conflict, root, depth, component, count, and size rules. Each path is scanned once, canonicalized at most once, and represented by component-sliced canonical nodes.

The archive pathname is opened exactly once. The descriptor remains open through preflight and extraction, is closed exactly once before publication, and is closed on every error including zip.ErrInsecurePath. Central-directory metadata, local headers, signed or unsigned data descriptors, and the exact root go.mod requirement are validated before target-parent or staging creation. ZIP64 metadata is rejected at the EOCD, central-entry, and local-entry levels.

Extraction still occurs in a private sibling tree and publishes with the existing OS-native atomic no-replace operation. Cancellation is checked again after archive close and immediately before publication. Failed cleanup and archive/file close errors are returned rather than discarded.

## Benchmark

Go 1.26.5, linux/amd64, Ryzen 7 7800X3D; 16,000 files with 63 shared uppercase directories and zero expanded bytes:

- before: 1,102,951,489 ns/op, 1,078,897,384 B/op, 2,048,079 allocs/op
- after strict local-record validation: 138,082,584 ns/op, 19,593,424 B/op, 64,135 allocs/op

## Validation

- go test -count=1 -race ./internal/sourcearchive
- go test -count=1 ./internal/sourcearchive ./cli/manager/internal/version ./cli/installer
- go test -count=1 -tags wago_runtime ./cli/...
- go vet ./internal/sourcearchive ./cli/manager/internal/version ./cli/installer
- Go 1.22.12 affected-package tests
- make tinygo-build
- make tinygo-test
- repository release-asset builds for Linux, Darwin, and Windows on amd64 and arm64
- real GitHub-generated 15 MiB Wago source ZIP extraction
- make docs-check and make lint

The unconfigured local go test -count=1 ./... run reaches only the interpreter-gated staged Core 3 cases; the pinned official interpreter cannot be built locally because dune installation requires unavailable sudo credentials. The PR native CI matrix provisions that toolchain.

## Limits

Production ceilings are unchanged: 20,000 entries, 16,000 files, 4,000 directories, 16 MiB central-directory metadata, 64 relative components, 1,024 path bytes, 255 bytes per component, 128 MiB per file, and 512 MiB aggregate expanded content.

Fixes #405.
