### PR TITLE
security: keep registry credentials out of browser URLs

### DIFF
--- a/cli/internal/project/lock.go
+++ b/cli/internal/project/lock.go
@@ -352,7 +352,7 @@ func validateLockEntry(id string, entry LockEntry) error {
 	if _, err := semver.Parse(entry.Source.Version); err != nil {
 		return fmt.Errorf("source.version must be an exact v-prefixed Go module version: %w", err)
 	}
-	if !validGoChecksum(entry.Source.Checksum) {
+	if !ValidGoChecksum(entry.Source.Checksum) {
 		return errors.New("source.checksum must be a Go h1 checksum")
 	}
 	if id != entry.Source.Module && !strings.HasPrefix(id, entry.Source.Module+"/") {
@@ -399,7 +399,8 @@ func validateLockEntry(id string, entry LockEntry) error {
 	return validateBindings(entry.Contracts, entry.Bindings)
 }
 
-func validGoChecksum(checksum string) bool {
+// ValidGoChecksum reports whether checksum is a canonical Go h1 checksum.
+func ValidGoChecksum(checksum string) bool {
 	if !strings.HasPrefix(checksum, "h1:") {
 		return false
 	}

--- a/cli/internal/project/lock.go
+++ b/cli/internal/project/lock.go
@@ -401,10 +401,11 @@ func validateLockEntry(id string, entry LockEntry) error {
 
 // ValidGoChecksum reports whether checksum is a canonical Go h1 checksum.
 func ValidGoChecksum(checksum string) bool {
-	if !strings.HasPrefix(checksum, "h1:") {
+	const encodedSHA256Length = 44
+	if len(checksum) != len("h1:")+encodedSHA256Length || !strings.HasPrefix(checksum, "h1:") {
 		return false
 	}
-	digest, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(checksum, "h1:"))
+	digest, err := base64.StdEncoding.Strict().DecodeString(strings.TrimPrefix(checksum, "h1:"))
 	return err == nil && len(digest) == 32
 }
 

--- a/cli/internal/project/lock_test.go
+++ b/cli/internal/project/lock_test.go
@@ -285,6 +285,22 @@ func TestLockRejectsConflictingSharedSourceReleases(t *testing.T) {
 	}
 }
 
+func TestValidGoChecksumRequiresCanonicalBase64(t *testing.T) {
+	canonical := "h1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	nonCanonical := canonical[:len(canonical)-2] + "B="
+	if !ValidGoChecksum(canonical) {
+		t.Fatal("canonical Go checksum was rejected")
+	}
+	if ValidGoChecksum(nonCanonical) {
+		t.Fatal("Go checksum with nonzero Base64 padding bits was accepted")
+	}
+	for _, checksum := range []string{canonical + "A", strings.TrimSuffix(canonical, "=")} {
+		if ValidGoChecksum(checksum) {
+			t.Fatalf("wrong-length Go checksum %q was accepted", checksum)
+		}
+	}
+}
+
 func testLockEntry(direct bool, id string, dependencies map[string]string) LockEntry {
 	return LockEntry{
 		Direct:               direct,

--- a/cli/manager/commands/auth/login/command.go
+++ b/cli/manager/commands/auth/login/command.go
@@ -22,7 +22,7 @@ func Command(environment Environment) *command.Cmd {
 		Summary:    "log in to the registry",
 		Automation: command.DryRun,
 		Flags: []command.Flag{
-			{Name: "link", Short: "l", Bool: true, Help: "log in via a browser link on this machine"},
+			{Name: "link", Short: "l", Bool: true, Help: "open one-time authorization in a browser on this machine"},
 			{Name: "code", Short: "c", Bool: true, Help: "log in with a one-time code (headless/remote)"},
 			{Name: "token", Short: "t", Arg: "<t>", Help: "use this API token directly"},
 			{Name: "with-token", Bool: true, Help: "read an API token from stdin (for CI)"},

--- a/cli/manager/internal/plugin/catalog.go
+++ b/cli/manager/internal/plugin/catalog.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/wago-org/wago/cli/internal/automation"
 	"github.com/wago-org/wago/cli/internal/project"
+	"github.com/wago-org/wago/cli/manager/internal/registry"
+	"github.com/wago-org/wago/internal/httpclient"
 	"github.com/wago-org/wago/src/core/semver"
 	corewago "github.com/wago-org/wago/src/wago"
 )
@@ -42,12 +44,23 @@ type HTTPCatalog struct {
 	Client  HTTPDoer
 }
 
+type defaultCatalogHTTPClient struct{ client *httpclient.Client }
+
+func (client defaultCatalogHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	return client.client.Open(request.Context(), request)
+}
+
+var registryCatalogHTTP = defaultCatalogHTTPClient{client: httpclient.NewAPI()}
+
 func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraints []string) ([]CatalogRelease, error) {
 	if err := automation.RequireOnline("plugin catalog resolution"); err != nil {
 		return nil, err
 	}
+	if err := registry.ValidateBaseURL(catalog.BaseURL); err != nil {
+		return nil, err
+	}
 	if catalog.Client == nil {
-		catalog.Client = http.DefaultClient
+		catalog.Client = registryCatalogHTTP
 	}
 	baseEndpoint, err := url.Parse(strings.TrimRight(catalog.BaseURL, "/") + "/api/v1/plugins/candidates")
 	if err != nil {

--- a/cli/manager/internal/plugin/catalog.go
+++ b/cli/manager/internal/plugin/catalog.go
@@ -110,13 +110,16 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 			Limit      int              `json:"limit"`
 			NextOffset *int             `json:"nextOffset,omitempty"`
 		}
+		if err := registry.ValidateUniqueJSON(data); err != nil {
+			return nil, fmt.Errorf("resolve %s: catalog returned invalid metadata", id)
+		}
 		decoder := json.NewDecoder(bytes.NewReader(data))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(&envelope); err != nil {
-			return nil, fmt.Errorf("resolve %s: decode catalog metadata: %w", id, err)
+			return nil, fmt.Errorf("resolve %s: catalog returned invalid metadata", id)
 		}
 		if err := requireJSONEOF(decoder); err != nil {
-			return nil, fmt.Errorf("resolve %s: decode catalog metadata: %w", id, err)
+			return nil, fmt.Errorf("resolve %s: catalog returned invalid metadata", id)
 		}
 		if envelope.Total <= 0 || envelope.Offset != offset || envelope.Limit != pageLimit || len(envelope.Plugins) == 0 || len(envelope.Plugins) > pageLimit {
 			return nil, fmt.Errorf("resolve %s: catalog returned invalid page offset=%d limit=%d count=%d total=%d", id, envelope.Offset, envelope.Limit, len(envelope.Plugins), envelope.Total)
@@ -135,7 +138,7 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 			}
 			key := release.ID + "\x00" + release.Version + "\x00" + release.ReleaseFingerprint
 			if seenReleases[key] {
-				return nil, fmt.Errorf("resolve %s: catalog repeated release %s", id, release.Version)
+				return nil, fmt.Errorf("resolve %s: catalog repeated a release", id)
 			}
 			seenReleases[key] = true
 		}
@@ -680,35 +683,42 @@ func sameOrderedStrings(left, right []string) bool {
 
 func validateCatalogRelease(id string, constraints []string, release CatalogRelease) error {
 	if release.ID != id || release.Definition.ID != id {
-		return fmt.Errorf("catalog returned plugin %q with definition %q for requested %q", release.ID, release.Definition.ID, id)
+		return fmt.Errorf("plugin %s catalog identifiers do not match the request", id)
 	}
 	if err := project.ValidatePluginID(release.Source.Module); err != nil {
-		return fmt.Errorf("plugin %s source: %w", id, err)
+		return fmt.Errorf("plugin %s catalog source module is invalid", id)
 	}
 	if err := project.ValidatePluginID(release.Provider.ImportPath); err != nil {
-		return fmt.Errorf("plugin %s provider: %w", id, err)
+		return fmt.Errorf("plugin %s catalog provider import is invalid", id)
 	}
 	if release.Provider.ImportPath != release.Source.Module+"/register" {
-		return fmt.Errorf("plugin %s provider import %q must be the source module's register package", id, release.Provider.ImportPath)
+		return fmt.Errorf("plugin %s catalog provider does not match its source module", id)
 	}
-	if release.Source.Checksum == "" || release.Source.Version == "" {
-		return fmt.Errorf("plugin %s catalog metadata omits exact source version or checksum", id)
+	if !project.ValidGoChecksum(release.Source.Checksum) {
+		return fmt.Errorf("plugin %s catalog source checksum is invalid", id)
 	}
-	if !strings.HasPrefix(release.Source.Version, "v") {
-		return fmt.Errorf("plugin %s catalog source version %q is not an exact v-prefixed Go module version", id, release.Source.Version)
+	const maximumCatalogVersionLength = 200
+	if release.Source.Version == "" || len(release.Source.Version) > maximumCatalogVersionLength || !strings.HasPrefix(release.Source.Version, "v") {
+		return fmt.Errorf("plugin %s catalog source version is not an exact v-prefixed Go module version", id)
 	}
 	if _, err := semver.Parse(release.Source.Version); err != nil {
-		return fmt.Errorf("plugin %s catalog source version %q is invalid: %w", id, release.Source.Version, err)
+		return fmt.Errorf("plugin %s catalog source version is invalid", id)
+	}
+	if release.Version == "" || len(release.Version) > maximumCatalogVersionLength || len(release.Definition.Version) > maximumCatalogVersionLength {
+		return fmt.Errorf("plugin %s catalog version is invalid", id)
 	}
 	if release.Version != release.Definition.Version || strings.TrimPrefix(release.Source.Version, "v") != strings.TrimPrefix(release.Version, "v") {
 		return fmt.Errorf("plugin %s catalog, source, and definition versions disagree", id)
 	}
 	for _, requirement := range release.Definition.Requires {
 		if err := project.ValidatePluginID(requirement.ID); err != nil {
-			return fmt.Errorf("plugin %s requirement: %w", id, err)
+			return fmt.Errorf("plugin %s catalog requirement is invalid", id)
+		}
+		if strings.TrimSpace(requirement.Version) == "" {
+			return fmt.Errorf("plugin %s requirement version constraint is empty", id)
 		}
 		if err := project.ValidateConstraint(requirement.Version); err != nil {
-			return fmt.Errorf("plugin %s requirement %s: %w", id, requirement.ID, err)
+			return fmt.Errorf("plugin %s catalog requirement is invalid", id)
 		}
 	}
 	for _, constraint := range constraints {
@@ -717,12 +727,15 @@ func validateCatalogRelease(id string, constraints []string, release CatalogRele
 			return fmt.Errorf("plugin %s version %s does not satisfy %q", id, release.Version, constraint)
 		}
 	}
+	if !validSHA256(release.DefinitionDigest) {
+		return fmt.Errorf("plugin %s catalog definition digest is invalid", id)
+	}
 	digest, err := corewago.DefinitionDigest(release.Definition)
 	if err != nil {
-		return fmt.Errorf("plugin %s definition: %w", id, err)
+		return fmt.Errorf("plugin %s catalog definition is invalid", id)
 	}
 	if digest != release.DefinitionDigest {
-		return fmt.Errorf("plugin %s definition digest mismatch: catalog has %s, computed %s", id, release.DefinitionDigest, digest)
+		return fmt.Errorf("plugin %s definition digest mismatch", id)
 	}
 	if !validSHA256(release.ReleaseFingerprint) {
 		return fmt.Errorf("plugin %s has invalid release fingerprint", id)

--- a/cli/manager/internal/plugin/catalog.go
+++ b/cli/manager/internal/plugin/catalog.go
@@ -35,6 +35,14 @@ type CatalogRelease struct {
 	ReleaseFingerprint string                    `json:"releaseFingerprint"`
 }
 
+type catalogEnvelope struct {
+	Plugins    []CatalogRelease `json:"plugins"`
+	Total      int              `json:"total"`
+	Offset     int              `json:"offset"`
+	Limit      int              `json:"limit"`
+	NextOffset *int             `json:"nextOffset,omitempty"`
+}
+
 type HTTPDoer interface {
 	Do(*http.Request) (*http.Response, error)
 }
@@ -103,16 +111,15 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 		if response.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("resolve %s: %s", id, registry.ResponseError(response.StatusCode, data))
 		}
-		var envelope struct {
-			Plugins    []CatalogRelease `json:"plugins"`
-			Total      int              `json:"total"`
-			Offset     int              `json:"offset"`
-			Limit      int              `json:"limit"`
-			NextOffset *int             `json:"nextOffset,omitempty"`
-		}
-		if err := registry.ValidateUniqueJSON(data); err != nil {
+		if err := preflightCatalogPage(data, pageLimit); err != nil {
 			return nil, fmt.Errorf("resolve %s: catalog returned invalid metadata", id)
 		}
+		// configSchema is arbitrary JSON whose property names are case-sensitive;
+		// the surrounding catalog structs use encoding/json's folded field lookup.
+		if err := registry.ValidateUniqueFoldedJSON(data, "configSchema"); err != nil {
+			return nil, fmt.Errorf("resolve %s: catalog returned invalid metadata", id)
+		}
+		var envelope catalogEnvelope
 		decoder := json.NewDecoder(bytes.NewReader(data))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(&envelope); err != nil {
@@ -156,6 +163,84 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 	}
 	sortCatalogReleases(releases)
 	return releases, nil
+}
+
+func preflightCatalogPage(data []byte, maximumPlugins int) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	opening, err := decoder.Token()
+	if err != nil || opening != json.Delim('{') {
+		return errors.New("catalog page must be a JSON object")
+	}
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return errors.New("catalog page contains a non-string key")
+		}
+		if !strings.EqualFold(key, "plugins") {
+			if err := skipJSONValue(decoder); err != nil {
+				return err
+			}
+			continue
+		}
+		array, err := decoder.Token()
+		if err != nil || array != json.Delim('[') {
+			return errors.New("catalog plugins must be an array")
+		}
+		count := 0
+		for decoder.More() {
+			count++
+			if count > maximumPlugins {
+				return errors.New("catalog plugins exceed the page limit")
+			}
+			if err := skipJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return errors.New("catalog plugins array is incomplete")
+		}
+	}
+	closing, err := decoder.Token()
+	if err != nil || closing != json.Delim('}') {
+		return errors.New("catalog page object is incomplete")
+	}
+	return requireJSONEOF(decoder)
+}
+
+func skipJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	if delimiter != '{' && delimiter != '[' {
+		return errors.New("unexpected closing JSON delimiter")
+	}
+	depth := 1
+	for depth > 0 {
+		token, err = decoder.Token()
+		if err != nil {
+			return err
+		}
+		if delimiter, ok = token.(json.Delim); ok {
+			switch delimiter {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+	return nil
 }
 
 // MemoryCatalog is a deterministic in-memory adapter used by resolver tests.

--- a/cli/manager/internal/plugin/catalog.go
+++ b/cli/manager/internal/plugin/catalog.go
@@ -101,14 +101,7 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 			return nil, errors.New("plugin catalog response exceeds 4 MiB")
 		}
 		if response.StatusCode != http.StatusOK {
-			var failure struct {
-				Error string `json:"error"`
-			}
-			_ = json.Unmarshal(data, &failure)
-			if failure.Error == "" {
-				failure.Error = response.Status
-			}
-			return nil, fmt.Errorf("resolve %s: %s", id, failure.Error)
+			return nil, fmt.Errorf("resolve %s: %s", id, registry.ResponseError(response.StatusCode, data))
 		}
 		var envelope struct {
 			Plugins    []CatalogRelease `json:"plugins"`

--- a/cli/manager/internal/plugin/catalog.go
+++ b/cli/manager/internal/plugin/catalog.go
@@ -60,6 +60,11 @@ func (client defaultCatalogHTTPClient) Do(request *http.Request) (*http.Response
 
 var registryCatalogHTTP = defaultCatalogHTTPClient{client: httpclient.NewAPI()}
 
+const (
+	catalogPageLimit     = 256
+	maxCatalogCandidates = 1024
+)
+
 func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraints []string) ([]CatalogRelease, error) {
 	if err := automation.RequireOnline("plugin catalog resolution"); err != nil {
 		return nil, err
@@ -74,7 +79,6 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 	if err != nil {
 		return nil, err
 	}
-	const pageLimit = 256
 	constraints = sortedUnique(constraints)
 	var releases []CatalogRelease
 	seenReleases := map[string]bool{}
@@ -83,7 +87,7 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 		endpoint := *baseEndpoint
 		query := endpoint.Query()
 		query.Set("id", id)
-		query.Set("limit", fmt.Sprint(pageLimit))
+		query.Set("limit", fmt.Sprint(catalogPageLimit))
 		query.Set("offset", fmt.Sprint(offset))
 		for _, constraint := range constraints {
 			query.Add("range", constraint)
@@ -111,7 +115,7 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 		if response.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("resolve %s: %s", id, registry.ResponseError(response.StatusCode, data))
 		}
-		if err := preflightCatalogPage(data, pageLimit); err != nil {
+		if err := preflightCatalogPage(data, catalogPageLimit); err != nil {
 			return nil, fmt.Errorf("resolve %s: catalog returned invalid metadata", id)
 		}
 		// configSchema is arbitrary JSON whose property names are case-sensitive;
@@ -128,7 +132,7 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 		if err := requireJSONEOF(decoder); err != nil {
 			return nil, fmt.Errorf("resolve %s: catalog returned invalid metadata", id)
 		}
-		if envelope.Total <= 0 || envelope.Offset != offset || envelope.Limit != pageLimit || len(envelope.Plugins) == 0 || len(envelope.Plugins) > pageLimit {
+		if envelope.Total <= 0 || envelope.Offset != offset || envelope.Limit != catalogPageLimit || len(envelope.Plugins) == 0 || len(envelope.Plugins) > catalogPageLimit {
 			return nil, fmt.Errorf("resolve %s: catalog returned invalid page offset=%d limit=%d count=%d total=%d", id, envelope.Offset, envelope.Limit, len(envelope.Plugins), envelope.Total)
 		}
 		if wantTotal < 0 {
@@ -136,8 +140,8 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 		} else if envelope.Total != wantTotal {
 			return nil, fmt.Errorf("resolve %s: catalog total changed during pagination (%d to %d)", id, wantTotal, envelope.Total)
 		}
-		if envelope.Total > maxResolverSteps {
-			return nil, fmt.Errorf("resolve %s: catalog exposes %d candidates, exceeding resolver bound %d", id, envelope.Total, maxResolverSteps)
+		if envelope.Total > maxCatalogCandidates {
+			return nil, fmt.Errorf("resolve %s: catalog exposes %d candidates, exceeding catalog bound %d", id, envelope.Total, maxCatalogCandidates)
 		}
 		for _, release := range envelope.Plugins {
 			if err := validateCatalogRelease(id, constraints, release); err != nil {

--- a/cli/manager/internal/plugin/catalog.go
+++ b/cli/manager/internal/plugin/catalog.go
@@ -61,8 +61,13 @@ func (client defaultCatalogHTTPClient) Do(request *http.Request) (*http.Response
 var registryCatalogHTTP = defaultCatalogHTTPClient{client: httpclient.NewAPI()}
 
 const (
-	catalogPageLimit     = 256
-	maxCatalogCandidates = 1024
+	catalogPageLimit                 = 256
+	catalogResponseLimit       int64 = 4 << 20
+	maxCatalogPages                  = 4
+	maxCatalogBytes                  = maxCatalogPages * catalogResponseLimit
+	maxCatalogCandidates             = 1024
+	maxCatalogNestedCollection       = 128
+	maxCatalogStructureDepth         = 32
 )
 
 func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraints []string) ([]CatalogRelease, error) {
@@ -83,7 +88,13 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 	var releases []CatalogRelease
 	seenReleases := map[string]bool{}
 	wantTotal := -1
+	pages := 0
+	var catalogBytes int64
 	for offset := 0; ; {
+		if pages >= maxCatalogPages {
+			return nil, fmt.Errorf("resolve %s: catalog pagination exceeds %d-page bound", id, maxCatalogPages)
+		}
+		pages++
 		endpoint := *baseEndpoint
 		query := endpoint.Query()
 		query.Set("id", id)
@@ -101,7 +112,7 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 		if err != nil {
 			return nil, err
 		}
-		data, readErr := io.ReadAll(io.LimitReader(response.Body, (4<<20)+1))
+		data, readErr := io.ReadAll(io.LimitReader(response.Body, catalogResponseLimit+1))
 		closeErr := response.Body.Close()
 		if readErr != nil {
 			return nil, readErr
@@ -109,9 +120,14 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 		if closeErr != nil {
 			return nil, closeErr
 		}
-		if len(data) > 4<<20 {
+		pageBytes := int64(len(data))
+		if pageBytes > catalogResponseLimit {
 			return nil, errors.New("plugin catalog response exceeds 4 MiB")
 		}
+		if pageBytes > maxCatalogBytes-catalogBytes {
+			return nil, fmt.Errorf("resolve %s: catalog metadata exceeds %d MiB cumulative bound", id, maxCatalogBytes>>20)
+		}
+		catalogBytes += pageBytes
 		if response.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("resolve %s: %s", id, registry.ResponseError(response.StatusCode, data))
 		}
@@ -176,7 +192,12 @@ func preflightCatalogPage(data []byte, maximumPlugins int) error {
 	if err != nil || opening != json.Delim('{') {
 		return errors.New("catalog page must be a JSON object")
 	}
+	members := 0
 	for decoder.More() {
+		members++
+		if members > maxCatalogNestedCollection {
+			return errors.New("catalog object exceeds the nested collection limit")
+		}
 		keyToken, err := decoder.Token()
 		if err != nil {
 			return err
@@ -186,7 +207,7 @@ func preflightCatalogPage(data []byte, maximumPlugins int) error {
 			return errors.New("catalog page contains a non-string key")
 		}
 		if !strings.EqualFold(key, "plugins") {
-			if err := skipJSONValue(decoder); err != nil {
+			if err := preflightCatalogValue(decoder, 1, strings.EqualFold(key, "configSchema")); err != nil {
 				return err
 			}
 			continue
@@ -201,7 +222,7 @@ func preflightCatalogPage(data []byte, maximumPlugins int) error {
 			if count > maximumPlugins {
 				return errors.New("catalog plugins exceed the page limit")
 			}
-			if err := skipJSONValue(decoder); err != nil {
+			if err := preflightCatalogValue(decoder, 1, false); err != nil {
 				return err
 			}
 		}
@@ -215,6 +236,56 @@ func preflightCatalogPage(data []byte, maximumPlugins int) error {
 		return errors.New("catalog page object is incomplete")
 	}
 	return requireJSONEOF(decoder)
+}
+
+func preflightCatalogValue(decoder *json.Decoder, depth int, exactSchema bool) error {
+	if exactSchema {
+		return skipJSONValue(decoder)
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	if delimiter != '{' && delimiter != '[' {
+		return errors.New("unexpected closing JSON delimiter")
+	}
+	if depth > maxCatalogStructureDepth {
+		return errors.New("catalog metadata exceeds the structure depth limit")
+	}
+	items := 0
+	for decoder.More() {
+		items++
+		if items > maxCatalogNestedCollection {
+			return errors.New("catalog metadata exceeds the nested collection limit")
+		}
+		exactChild := false
+		if delimiter == '{' {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("catalog metadata contains a non-string object key")
+			}
+			exactChild = strings.EqualFold(key, "configSchema")
+		}
+		if err := preflightCatalogValue(decoder, depth+1, exactChild); err != nil {
+			return err
+		}
+	}
+	closing, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if delimiter == '{' && closing != json.Delim('}') || delimiter == '[' && closing != json.Delim(']') {
+		return errors.New("catalog metadata contains a mismatched closing delimiter")
+	}
+	return nil
 }
 
 func skipJSONValue(decoder *json.Decoder) error {
@@ -318,9 +389,12 @@ type ContractReview struct {
 }
 
 const (
-	maxResolvedPlugins = 1024
-	maxResolverSteps   = 100000
+	maxResolvedPlugins        = 1024
+	maxResolverSteps          = 100000
+	maxResolverCatalogQueries = 2048
 )
+
+var errCatalogQueryBudget = errors.New("plugin dependency resolution exceeded the catalog query budget")
 
 // ResolveCatalogGraph performs a deterministic, bounded global solve. Candidate
 // releases are tried newest-first, but a later transitive constraint can unwind
@@ -359,6 +433,7 @@ type catalogSolver struct {
 	direct   map[string]bool
 	previous project.LockDocument
 	steps    int
+	queries  int
 	lastErr  error
 }
 
@@ -383,6 +458,10 @@ func (solver *catalogSolver) solve(selected map[string]CatalogRelease, constrain
 		return plan, nil
 	}
 	ranges := sortedMapValues(constraints[id])
+	if solver.queries >= maxResolverCatalogQueries {
+		return ResolutionPlan{}, fmt.Errorf("%w of %d requests", errCatalogQueryBudget, maxResolverCatalogQueries)
+	}
+	solver.queries++
 	candidates, err := solver.catalog.Candidates(solver.ctx, id, ranges)
 	if err != nil {
 		solver.lastErr = err
@@ -425,7 +504,7 @@ func (solver *catalogSolver) solve(selected map[string]CatalogRelease, constrain
 		if err == nil {
 			return plan, nil
 		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || solver.steps > maxResolverSteps {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, errCatalogQueryBudget) || solver.steps > maxResolverSteps {
 			return ResolutionPlan{}, err
 		}
 	}
@@ -808,6 +887,11 @@ func validateCatalogRelease(id string, constraints []string, release CatalogRele
 		}
 		if err := project.ValidateConstraint(requirement.Version); err != nil {
 			return fmt.Errorf("plugin %s catalog requirement is invalid", id)
+		}
+	}
+	for _, constraint := range release.Definition.Compatibility.Engines {
+		if err := project.ValidateConstraint(constraint); err != nil {
+			return fmt.Errorf("plugin %s catalog engine compatibility is invalid", id)
 		}
 	}
 	for _, constraint := range constraints {

--- a/cli/manager/internal/plugin/catalog.go
+++ b/cli/manager/internal/plugin/catalog.go
@@ -68,7 +68,21 @@ const (
 	maxCatalogCandidates             = 1024
 	maxCatalogNestedCollection       = 128
 	maxCatalogStructureDepth         = 32
+	maxResolverCatalogBytes    int64 = 64 << 20
 )
+
+type catalogBudgetContextKey struct{}
+
+type catalogByteBudget struct{ remaining int64 }
+
+func withCatalogByteBudget(ctx context.Context, maximum int64) context.Context {
+	return context.WithValue(ctx, catalogBudgetContextKey{}, &catalogByteBudget{remaining: maximum})
+}
+
+func catalogByteBudgetFromContext(ctx context.Context) *catalogByteBudget {
+	budget, _ := ctx.Value(catalogBudgetContextKey{}).(*catalogByteBudget)
+	return budget
+}
 
 func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraints []string) ([]CatalogRelease, error) {
 	if err := automation.RequireOnline("plugin catalog resolution"); err != nil {
@@ -112,7 +126,12 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 		if err != nil {
 			return nil, err
 		}
-		data, readErr := io.ReadAll(io.LimitReader(response.Body, catalogResponseLimit+1))
+		readLimit := catalogResponseLimit
+		resolutionBudget := catalogByteBudgetFromContext(ctx)
+		if resolutionBudget != nil {
+			readLimit = min(readLimit, resolutionBudget.remaining)
+		}
+		data, readErr := io.ReadAll(io.LimitReader(response.Body, readLimit+1))
 		closeErr := response.Body.Close()
 		if readErr != nil {
 			return nil, readErr
@@ -121,8 +140,14 @@ func (catalog HTTPCatalog) Candidates(ctx context.Context, id string, constraint
 			return nil, closeErr
 		}
 		pageBytes := int64(len(data))
+		if pageBytes > readLimit && readLimit < catalogResponseLimit {
+			return nil, fmt.Errorf("resolve %s: catalog metadata exceeds %d MiB resolution bound", id, maxResolverCatalogBytes>>20)
+		}
 		if pageBytes > catalogResponseLimit {
 			return nil, errors.New("plugin catalog response exceeds 4 MiB")
+		}
+		if resolutionBudget != nil {
+			resolutionBudget.remaining -= pageBytes
 		}
 		if pageBytes > maxCatalogBytes-catalogBytes {
 			return nil, fmt.Errorf("resolve %s: catalog metadata exceeds %d MiB cumulative bound", id, maxCatalogBytes>>20)
@@ -419,7 +444,10 @@ func ResolveCatalogGraph(ctx context.Context, catalog Catalog, roots []project.P
 		contributions[root.ID]["@manifest"] = root.Constraint
 		direct[root.ID] = true
 	}
-	solver := catalogSolver{ctx: ctx, catalog: catalog, direct: direct, previous: previous}
+	solver := catalogSolver{
+		ctx: withCatalogByteBudget(ctx, maxResolverCatalogBytes), catalog: catalog,
+		direct: direct, previous: previous, cache: map[catalogQueryKey]catalogQueryResult{},
+	}
 	plan, err := solver.solve(map[string]CatalogRelease{}, contributions)
 	if err != nil {
 		return ResolutionPlan{}, err
@@ -435,6 +463,14 @@ type catalogSolver struct {
 	steps    int
 	queries  int
 	lastErr  error
+	cache    map[catalogQueryKey]catalogQueryResult
+}
+
+type catalogQueryKey struct{ id, constraints string }
+
+type catalogQueryResult struct {
+	candidates []CatalogRelease
+	err        error
 }
 
 func (solver *catalogSolver) solve(selected map[string]CatalogRelease, constraints map[string]map[string]string) (ResolutionPlan, error) {
@@ -458,15 +494,28 @@ func (solver *catalogSolver) solve(selected map[string]CatalogRelease, constrain
 		return plan, nil
 	}
 	ranges := sortedMapValues(constraints[id])
+	queryKey := catalogQueryKey{id: id, constraints: strings.Join(ranges, "\x00")}
+	if cached, ok := solver.cache[queryKey]; ok {
+		if cached.err != nil {
+			solver.lastErr = cached.err
+			return ResolutionPlan{}, cached.err
+		}
+		return solver.tryCandidates(id, cached.candidates, selected, constraints)
+	}
 	if solver.queries >= maxResolverCatalogQueries {
 		return ResolutionPlan{}, fmt.Errorf("%w of %d requests", errCatalogQueryBudget, maxResolverCatalogQueries)
 	}
 	solver.queries++
 	candidates, err := solver.catalog.Candidates(solver.ctx, id, ranges)
+	solver.cache[queryKey] = catalogQueryResult{candidates: candidates, err: err}
 	if err != nil {
 		solver.lastErr = err
 		return ResolutionPlan{}, err
 	}
+	return solver.tryCandidates(id, candidates, selected, constraints)
+}
+
+func (solver *catalogSolver) tryCandidates(id string, candidates []CatalogRelease, selected map[string]CatalogRelease, constraints map[string]map[string]string) (ResolutionPlan, error) {
 	for _, candidate := range candidates {
 		if err := sharedSourceReleaseConflict(selected, candidate); err != nil {
 			solver.lastErr = err

--- a/cli/manager/internal/plugin/catalog_test.go
+++ b/cli/manager/internal/plugin/catalog_test.go
@@ -3,9 +3,11 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -565,6 +567,39 @@ func TestResolveCatalogGraphPreservesNarrowRequiredGrant(t *testing.T) {
 	}
 }
 
+func TestResolveCatalogGraphBoundsCatalogQueriesDuringBacktracking(t *testing.T) {
+	rootID := "github.com/acme/root"
+	childID := "github.com/acme/child"
+	candidates := make([]CatalogRelease, maxResolverCatalogQueries)
+	for index := range candidates {
+		candidates[index] = CatalogRelease{
+			ID:      rootID,
+			Version: "1.0.0",
+			Definition: corewago.PluginDefinition{
+				ID:       rootID,
+				Requires: []corewago.PluginRequirement{{ID: childID, Version: "*"}},
+			},
+		}
+	}
+	calls := 0
+	catalog := catalogFunc(func(_ context.Context, id string, _ []string) ([]CatalogRelease, error) {
+		calls++
+		if id == rootID {
+			return candidates, nil
+		}
+		return nil, errors.New("no matching child")
+	})
+
+	_, err := ResolveCatalogGraph(context.Background(), catalog,
+		[]project.PluginRequirement{{ID: rootID, Constraint: "*"}}, project.NewLockDocument())
+	if !errors.Is(err, errCatalogQueryBudget) {
+		t.Fatalf("catalog query budget error = %v", err)
+	}
+	if calls != maxResolverCatalogQueries {
+		t.Fatalf("catalog calls = %d, want %d", calls, maxResolverCatalogQueries)
+	}
+}
+
 func TestHTTPCatalogUsesRepeatedRangesAndStrictMetadata(t *testing.T) {
 	newest := testCatalogRelease(t, "github.com/acme/plugin", "1.3.0")
 	oldest := testCatalogRelease(t, "github.com/acme/plugin", "1.2.0")
@@ -614,6 +649,39 @@ func TestHTTPCatalogRejectsExcessiveTotalBeforePagination(t *testing.T) {
 	}
 	if got := requests.Load(); got != 1 {
 		t.Fatalf("catalog requests = %d, want 1", got)
+	}
+}
+
+func TestHTTPCatalogRejectsSparsePaginationAtPageBudget(t *testing.T) {
+	releases := make([]CatalogRelease, maxCatalogPages)
+	for index := range releases {
+		releases[index] = testCatalogRelease(t, "github.com/acme/plugin", "1.2."+strconv.Itoa(index))
+	}
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		index := int(requests.Add(1) - 1)
+		if index >= len(releases) {
+			t.Errorf("unexpected catalog request %d", index+1)
+			http.Error(response, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"plugins":    []CatalogRelease{releases[index]},
+			"total":      maxCatalogCandidates,
+			"offset":     index,
+			"limit":      catalogPageLimit,
+			"nextOffset": index + 1,
+		})
+	}))
+	defer server.Close()
+
+	_, err := (HTTPCatalog{BaseURL: server.URL, Client: server.Client()}).Candidates(
+		context.Background(), releases[0].ID, []string{"*"})
+	if err == nil || !strings.Contains(err.Error(), "exceeds 4-page bound") {
+		t.Fatalf("sparse catalog pagination = %v", err)
+	}
+	if got := requests.Load(); got != maxCatalogPages {
+		t.Fatalf("catalog requests = %d, want %d", got, maxCatalogPages)
 	}
 }
 
@@ -668,6 +736,20 @@ func TestCatalogPreflightRejectsOversizedPageBeforeMaterialization(t *testing.T)
 	}
 }
 
+func TestCatalogPreflightRejectsOversizedNestedCollectionBeforeMaterialization(t *testing.T) {
+	data := oversizedCatalogNestedCollection(100_000)
+	if err := preflightCatalogPage(data, 256); err == nil || !strings.Contains(err.Error(), "nested collection limit") {
+		t.Fatalf("oversized nested catalog preflight = %v", err)
+	}
+}
+
+func TestCatalogPreflightPreservesArbitraryConfigSchemaCollections(t *testing.T) {
+	data := catalogConfigSchemaCollection(maxCatalogNestedCollection + 1)
+	if err := preflightCatalogPage(data, 256); err != nil {
+		t.Fatalf("config schema collection preflight = %v", err)
+	}
+}
+
 func BenchmarkCatalogPreflightOversizedPage(b *testing.B) {
 	data := oversizedCatalogPage(100_000)
 	b.ReportAllocs()
@@ -676,6 +758,15 @@ func BenchmarkCatalogPreflightOversizedPage(b *testing.B) {
 		if err := preflightCatalogPage(data, 256); err == nil {
 			b.Fatal("oversized catalog page succeeded")
 		}
+	}
+}
+
+func BenchmarkCatalogPreflightOversizedNestedCollection(b *testing.B) {
+	data := oversizedCatalogNestedCollection(100_000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = preflightCatalogPage(data, 256)
 	}
 }
 
@@ -690,6 +781,34 @@ func oversizedCatalogPage(entries int) []byte {
 		body.WriteString(`{}`)
 	}
 	body.WriteString(`],"total":1,"offset":0,"limit":256}`)
+	return []byte(body.String())
+}
+
+func oversizedCatalogNestedCollection(entries int) []byte {
+	var body strings.Builder
+	body.Grow(len(`{"plugins":[{"definition":{"authorities":[]}}],"total":1,"offset":0,"limit":256}`) + entries*3)
+	body.WriteString(`{"plugins":[{"definition":{"authorities":[`)
+	for index := range entries {
+		if index > 0 {
+			body.WriteByte(',')
+		}
+		body.WriteString(`{}`)
+	}
+	body.WriteString(`]}}],"total":1,"offset":0,"limit":256}`)
+	return []byte(body.String())
+}
+
+func catalogConfigSchemaCollection(entries int) []byte {
+	var body strings.Builder
+	body.Grow(len(`{"plugins":[{"definition":{"configSchema":{"examples":[]}}}],"total":1,"offset":0,"limit":256}`) + entries*3)
+	body.WriteString(`{"plugins":[{"definition":{"configSchema":{"examples":[`)
+	for index := range entries {
+		if index > 0 {
+			body.WriteByte(',')
+		}
+		body.WriteString(`{}`)
+	}
+	body.WriteString(`]}}}],"total":1,"offset":0,"limit":256}`)
 	return []byte(body.String())
 }
 
@@ -845,6 +964,15 @@ func TestCatalogRejectsUnprefixedSourceVersion(t *testing.T) {
 	}
 }
 
+func TestCatalogRejectsOversizedEngineConstraintBeforeDigestingDefinition(t *testing.T) {
+	release := testCatalogRelease(t, "github.com/acme/plugin", "1.2.3")
+	release.Definition.Compatibility.Engines["wago"] = strings.Repeat("*||", 100) + "*"
+	err := validateCatalogRelease(release.ID, []string{"*"}, release)
+	if err == nil || !strings.Contains(err.Error(), "engine compatibility") {
+		t.Fatalf("oversized engine constraint = %v", err)
+	}
+}
+
 func testCatalogRelease(t *testing.T, id, version string) CatalogRelease {
 	t.Helper()
 	release := CatalogRelease{
@@ -880,4 +1008,10 @@ func resignRelease(t *testing.T, release CatalogRelease) CatalogRelease {
 	}
 	release.DefinitionDigest = digest
 	return release
+}
+
+type catalogFunc func(context.Context, string, []string) ([]CatalogRelease, error)
+
+func (function catalogFunc) Candidates(ctx context.Context, id string, constraints []string) ([]CatalogRelease, error) {
+	return function(ctx, id, constraints)
 }

--- a/cli/manager/internal/plugin/catalog_test.go
+++ b/cli/manager/internal/plugin/catalog_test.go
@@ -591,6 +591,83 @@ func TestHTTPCatalogUsesRepeatedRangesAndStrictMetadata(t *testing.T) {
 	}
 }
 
+func TestHTTPCatalogPreservesCaseSensitiveConfigSchemaProperties(t *testing.T) {
+	release := testCatalogRelease(t, "github.com/acme/plugin", "1.2.3")
+	release.Definition.ConfigSchema = json.RawMessage(`{
+		"type":"object",
+		"properties":{"Foo":{"type":"string"},"foo":{"type":"string"}},
+		"additionalProperties":false
+	}`)
+	release = resignRelease(t, release)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"plugins": []CatalogRelease{release}, "total": 1, "offset": 0, "limit": 256,
+		})
+	}))
+	defer server.Close()
+
+	got, err := (HTTPCatalog{BaseURL: server.URL, Client: server.Client()}).Candidates(
+		context.Background(), release.ID, []string{"*"})
+	if err != nil || len(got) != 1 {
+		t.Fatalf("case-sensitive config schema catalog = %#v, %v", got, err)
+	}
+}
+
+func TestHTTPCatalogRejectsExactDuplicateConfigSchemaProperties(t *testing.T) {
+	release := testCatalogRelease(t, "github.com/acme/plugin", "1.2.3")
+	release.Definition.ConfigSchema = json.RawMessage(`{
+		"type":"object",
+		"properties":{"mode":{"type":"string"},"mode":{"type":"number"}},
+		"additionalProperties":false
+	}`)
+	release = resignRelease(t, release)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"plugins": []CatalogRelease{release}, "total": 1, "offset": 0, "limit": 256,
+		})
+	}))
+	defer server.Close()
+
+	_, err := (HTTPCatalog{BaseURL: server.URL, Client: server.Client()}).Candidates(
+		context.Background(), release.ID, []string{"*"})
+	if err == nil || !strings.Contains(err.Error(), "invalid metadata") {
+		t.Fatalf("duplicate config schema property = %v", err)
+	}
+}
+
+func TestCatalogPreflightRejectsOversizedPageBeforeMaterialization(t *testing.T) {
+	data := oversizedCatalogPage(100_000)
+	if err := preflightCatalogPage(data, 256); err == nil || !strings.Contains(err.Error(), "page limit") {
+		t.Fatalf("oversized catalog preflight = %v", err)
+	}
+}
+
+func BenchmarkCatalogPreflightOversizedPage(b *testing.B) {
+	data := oversizedCatalogPage(100_000)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for range b.N {
+		if err := preflightCatalogPage(data, 256); err == nil {
+			b.Fatal("oversized catalog page succeeded")
+		}
+	}
+}
+
+func oversizedCatalogPage(entries int) []byte {
+	var body strings.Builder
+	body.Grow(len(`{"plugins":[],"total":1,"offset":0,"limit":256}`) + entries*3)
+	body.WriteString(`{"plugins":[`)
+	for index := range entries {
+		if index > 0 {
+			body.WriteByte(',')
+		}
+		body.WriteString(`{}`)
+	}
+	body.WriteString(`],"total":1,"offset":0,"limit":256}`)
+	return []byte(body.String())
+}
+
 func TestHTTPCatalogRejectsAmbiguousMetadataWithoutReflection(t *testing.T) {
 	unsafe := "untrusted\x1b[2J" + strings.Repeat("x", 1024)
 	for _, test := range []struct {

--- a/cli/manager/internal/plugin/catalog_test.go
+++ b/cli/manager/internal/plugin/catalog_test.go
@@ -591,6 +591,41 @@ func TestHTTPCatalogUsesRepeatedRangesAndStrictMetadata(t *testing.T) {
 	}
 }
 
+func TestHTTPCatalogRejectsRemotePlaintextBeforeRequest(t *testing.T) {
+	_, err := (HTTPCatalog{BaseURL: "http://192.0.2.1"}).Candidates(
+		context.Background(), "github.com/acme/plugin", []string{"*"})
+	if err == nil || !strings.Contains(err.Error(), "HTTPS is required") {
+		t.Fatalf("remote plaintext catalog = %v", err)
+	}
+}
+
+func TestHTTPCatalogDefaultClientRefusesRedirects(t *testing.T) {
+	redirected := make(chan struct{}, 1)
+	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirected <- struct{}{}
+	}))
+	defer sink.Close()
+	registry := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Location", sink.URL)
+		writer.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer registry.Close()
+
+	_, err := (HTTPCatalog{BaseURL: registry.URL}).Candidates(
+		context.Background(), "github.com/acme/plugin", []string{"*"})
+	if err == nil {
+		t.Fatal("redirecting catalog succeeded")
+	}
+	select {
+	case <-redirected:
+		t.Fatal("catalog client followed redirect")
+	default:
+	}
+	if !strings.Contains(err.Error(), "307") {
+		t.Fatalf("redirecting catalog error = %v", err)
+	}
+}
+
 func TestCatalogRejectsUnprefixedSourceVersion(t *testing.T) {
 	release := testCatalogRelease(t, "github.com/acme/plugin", "1.2.3")
 	release.Source.Version = "1.2.3"

--- a/cli/manager/internal/plugin/catalog_test.go
+++ b/cli/manager/internal/plugin/catalog_test.go
@@ -591,6 +591,39 @@ func TestHTTPCatalogUsesRepeatedRangesAndStrictMetadata(t *testing.T) {
 	}
 }
 
+func TestHTTPCatalogRejectsAmbiguousMetadataWithoutReflection(t *testing.T) {
+	unsafe := "untrusted\x1b[2J" + strings.Repeat("x", 1024)
+	for _, test := range []struct {
+		name string
+		body func(http.ResponseWriter)
+	}{
+		{name: "duplicate field", body: func(writer http.ResponseWriter) {
+			_, _ = writer.Write([]byte(`{"plugins":[],"total":1,"Total":0,"offset":0,"limit":256}`))
+		}},
+		{name: "unknown field", body: func(writer http.ResponseWriter) {
+			_ = json.NewEncoder(writer).Encode(map[string]any{
+				"plugins": []CatalogRelease{}, "total": 1, "offset": 0, "limit": 256, unsafe: true,
+			})
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				test.body(writer)
+			}))
+			defer server.Close()
+
+			_, err := (HTTPCatalog{BaseURL: server.URL, Client: server.Client()}).Candidates(
+				context.Background(), "github.com/acme/plugin", []string{"*"})
+			if err == nil || !strings.Contains(err.Error(), "invalid metadata") {
+				t.Fatalf("ambiguous catalog metadata = %v", err)
+			}
+			if strings.Contains(err.Error(), unsafe) || len(err.Error()) > 512 {
+				t.Fatalf("unsafe catalog metadata error = %q", err)
+			}
+		})
+	}
+}
+
 func TestHTTPCatalogRejectsRemotePlaintextBeforeRequest(t *testing.T) {
 	_, err := (HTTPCatalog{BaseURL: "http://192.0.2.1"}).Candidates(
 		context.Background(), "github.com/acme/plugin", []string{"*"})
@@ -656,6 +689,44 @@ func TestHTTPCatalogErrorsAreTerminalSafeAndBounded(t *testing.T) {
 				if strings.Contains(err.Error(), test.message) || !strings.Contains(err.Error(), "status 400") {
 					t.Fatalf("unsafe catalog error = %q", err)
 				}
+			}
+		})
+	}
+}
+
+func TestCatalogMetadataErrorsAreTerminalSafeAndBounded(t *testing.T) {
+	const id = "github.com/acme/plugin"
+	unsafe := "untrusted\x1b[2J" + strings.Repeat("x", 1024)
+	for _, test := range []struct {
+		name   string
+		mutate func(*CatalogRelease)
+	}{
+		{name: "release id", mutate: func(release *CatalogRelease) { release.ID = unsafe }},
+		{name: "definition id", mutate: func(release *CatalogRelease) { release.Definition.ID = unsafe }},
+		{name: "source module", mutate: func(release *CatalogRelease) { release.Source.Module = unsafe }},
+		{name: "provider import", mutate: func(release *CatalogRelease) { release.Provider.ImportPath = unsafe }},
+		{name: "source checksum", mutate: func(release *CatalogRelease) { release.Source.Checksum = unsafe }},
+		{name: "source version", mutate: func(release *CatalogRelease) { release.Source.Version = "v" + unsafe }},
+		{name: "release version", mutate: func(release *CatalogRelease) { release.Version = unsafe }},
+		{name: "definition version", mutate: func(release *CatalogRelease) { release.Definition.Version = unsafe }},
+		{name: "requirement id", mutate: func(release *CatalogRelease) {
+			release.Definition.Requires = []corewago.PluginRequirement{{ID: unsafe, Version: "*"}}
+		}},
+		{name: "requirement version", mutate: func(release *CatalogRelease) {
+			release.Definition.Requires = []corewago.PluginRequirement{{ID: "github.com/acme/dependency", Version: unsafe}}
+		}},
+		{name: "definition metadata", mutate: func(release *CatalogRelease) { release.Definition.Name = unsafe }},
+		{name: "definition digest", mutate: func(release *CatalogRelease) { release.DefinitionDigest = unsafe }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			release := testCatalogRelease(t, id, "1.2.3")
+			test.mutate(&release)
+			err := validateCatalogRelease(id, []string{"*"}, release)
+			if err == nil {
+				t.Fatal("unsafe catalog metadata succeeded")
+			}
+			if strings.Contains(err.Error(), unsafe) || len(err.Error()) > 512 {
+				t.Fatalf("unsafe catalog error = %q", err)
 			}
 		})
 	}

--- a/cli/manager/internal/plugin/catalog_test.go
+++ b/cli/manager/internal/plugin/catalog_test.go
@@ -577,7 +577,7 @@ func TestResolveCatalogGraphBoundsCatalogQueriesDuringBacktracking(t *testing.T)
 			Version: "1.0.0",
 			Definition: corewago.PluginDefinition{
 				ID:       rootID,
-				Requires: []corewago.PluginRequirement{{ID: childID, Version: "*"}},
+				Requires: []corewago.PluginRequirement{{ID: childID, Version: "=1.0." + strconv.Itoa(index)}},
 			},
 		}
 	}
@@ -597,6 +597,37 @@ func TestResolveCatalogGraphBoundsCatalogQueriesDuringBacktracking(t *testing.T)
 	}
 	if calls != maxResolverCatalogQueries {
 		t.Fatalf("catalog calls = %d, want %d", calls, maxResolverCatalogQueries)
+	}
+}
+
+func TestResolveCatalogGraphCachesExactQueriesDuringBacktracking(t *testing.T) {
+	rootID := "github.com/acme/root"
+	childID := "github.com/acme/child"
+	candidates := make([]CatalogRelease, 8)
+	for index := range candidates {
+		candidates[index] = CatalogRelease{
+			ID: rootID, Version: "1.0.0",
+			Definition: corewago.PluginDefinition{
+				ID: rootID, Requires: []corewago.PluginRequirement{{ID: childID, Version: "*"}},
+			},
+		}
+	}
+	calls := 0
+	catalog := catalogFunc(func(_ context.Context, id string, _ []string) ([]CatalogRelease, error) {
+		calls++
+		if id == rootID {
+			return candidates, nil
+		}
+		return nil, errors.New("no matching child")
+	})
+
+	_, err := ResolveCatalogGraph(context.Background(), catalog,
+		[]project.PluginRequirement{{ID: rootID, Constraint: "*"}}, project.NewLockDocument())
+	if err == nil || !strings.Contains(err.Error(), "no matching child") {
+		t.Fatalf("cached catalog error = %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("catalog calls = %d, want one root and one cached child query", calls)
 	}
 }
 
@@ -682,6 +713,33 @@ func TestHTTPCatalogRejectsSparsePaginationAtPageBudget(t *testing.T) {
 	}
 	if got := requests.Load(); got != maxCatalogPages {
 		t.Fatalf("catalog requests = %d, want %d", got, maxCatalogPages)
+	}
+}
+
+func TestHTTPCatalogSharesResolutionByteBudgetAcrossQueries(t *testing.T) {
+	release := testCatalogRelease(t, "github.com/acme/plugin", "1.2.3")
+	body, err := json.Marshal(map[string]any{
+		"plugins": []CatalogRelease{release}, "total": 1, "offset": 0, "limit": catalogPageLimit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = response.Write(body)
+	}))
+	defer server.Close()
+	catalog := HTTPCatalog{BaseURL: server.URL, Client: server.Client()}
+	ctx := withCatalogByteBudget(context.Background(), int64(len(body)+len(body)/2))
+	if _, err := catalog.Candidates(ctx, release.ID, []string{"*"}); err != nil {
+		t.Fatalf("first catalog query = %v", err)
+	}
+	if _, err := catalog.Candidates(ctx, release.ID, []string{"*"}); err == nil || !strings.Contains(err.Error(), "resolution bound") {
+		t.Fatalf("cumulative catalog metadata = %v", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("catalog requests = %d, want 2", got)
 	}
 }
 

--- a/cli/manager/internal/plugin/catalog_test.go
+++ b/cli/manager/internal/plugin/catalog_test.go
@@ -626,6 +626,41 @@ func TestHTTPCatalogDefaultClientRefusesRedirects(t *testing.T) {
 	}
 }
 
+func TestHTTPCatalogErrorsAreTerminalSafeAndBounded(t *testing.T) {
+	for _, test := range []struct {
+		name, message string
+		wantMessage   bool
+	}{
+		{name: "ordinary", message: "ordinary failure", wantMessage: true},
+		{name: "newline", message: "failure\nforged"},
+		{name: "escape", message: "failure\x1b[2J"},
+		{name: "oversized", message: strings.Repeat("x", 1025)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(writer).Encode(map[string]string{"error": test.message})
+			}))
+			defer server.Close()
+
+			_, err := (HTTPCatalog{BaseURL: server.URL, Client: server.Client()}).Candidates(
+				context.Background(), "github.com/acme/plugin", []string{"*"})
+			if err == nil {
+				t.Fatal("failed catalog request succeeded")
+			}
+			if test.wantMessage {
+				if !strings.Contains(err.Error(), test.message) {
+					t.Fatalf("ordinary catalog error = %q", err)
+				}
+			} else {
+				if strings.Contains(err.Error(), test.message) || !strings.Contains(err.Error(), "status 400") {
+					t.Fatalf("unsafe catalog error = %q", err)
+				}
+			}
+		})
+	}
+}
+
 func TestCatalogRejectsUnprefixedSourceVersion(t *testing.T) {
 	release := testCatalogRelease(t, "github.com/acme/plugin", "1.2.3")
 	release.Source.Version = "1.2.3"

--- a/cli/manager/internal/plugin/catalog_test.go
+++ b/cli/manager/internal/plugin/catalog_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/wago-org/wago/cli/internal/automation"
@@ -591,6 +592,31 @@ func TestHTTPCatalogUsesRepeatedRangesAndStrictMetadata(t *testing.T) {
 	}
 }
 
+func TestHTTPCatalogRejectsExcessiveTotalBeforePagination(t *testing.T) {
+	release := testCatalogRelease(t, "github.com/acme/plugin", "1.2.3")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"plugins":    []CatalogRelease{release},
+			"total":      maxCatalogCandidates + 1,
+			"offset":     0,
+			"limit":      catalogPageLimit,
+			"nextOffset": 1,
+		})
+	}))
+	defer server.Close()
+
+	_, err := (HTTPCatalog{BaseURL: server.URL, Client: server.Client()}).Candidates(
+		context.Background(), release.ID, []string{"*"})
+	if err == nil || !strings.Contains(err.Error(), "exceeding catalog bound 1024") {
+		t.Fatalf("excessive catalog total = %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("catalog requests = %d, want 1", got)
+	}
+}
+
 func TestHTTPCatalogPreservesCaseSensitiveConfigSchemaProperties(t *testing.T) {
 	release := testCatalogRelease(t, "github.com/acme/plugin", "1.2.3")
 	release.Definition.ConfigSchema = json.RawMessage(`{
@@ -645,7 +671,6 @@ func TestCatalogPreflightRejectsOversizedPageBeforeMaterialization(t *testing.T)
 func BenchmarkCatalogPreflightOversizedPage(b *testing.B) {
 	data := oversizedCatalogPage(100_000)
 	b.ReportAllocs()
-	b.SetBytes(int64(len(data)))
 	b.ResetTimer()
 	for range b.N {
 		if err := preflightCatalogPage(data, 256); err == nil {

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -255,8 +255,11 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 		url.Values{"client_id": {cfg.ClientID}, "scope": {cfg.Scope}}, &dc); err != nil {
 		return "", fmt.Errorf("requesting device code from GitHub: %w", err)
 	}
-	if dc.Error == "device_flow_disabled" {
-		return "", errors.New("GitHub device flow is disabled for this OAuth app — enable \"Device Flow\" in its settings")
+	if dc.Error != "" {
+		if dc.Error == "device_flow_disabled" {
+			return "", errors.New("GitHub device flow is disabled for this OAuth app — enable \"Device Flow\" in its settings")
+		}
+		return "", errors.New("GitHub rejected the device authorization request")
 	}
 	if dc.DeviceCode == "" || dc.UserCode == "" {
 		return "", errors.New("GitHub returned an incomplete device authorization response")
@@ -311,6 +314,23 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 		}, &tr); err != nil {
 			return "", fmt.Errorf("polling GitHub for the token: %w", err)
 		}
+		if tr.Error != "" {
+			switch tr.Error {
+			case "authorization_pending":
+				// not authorized yet — keep polling
+			case "slow_down":
+				// RFC 8628 §3.5 asks for a five-second backoff. Keep the
+				// server-controlled interval within the command's bounded policy.
+				pollInterval = min(pollInterval+5*time.Second, maximumDevicePollInterval)
+			case "access_denied":
+				return "", errors.New("authorization was denied on GitHub")
+			case "expired_token":
+				return "", errors.New("the code expired before you authorized it — run `wago auth login --code` again")
+			default:
+				return "", errors.New("GitHub returned an unknown device authorization error")
+			}
+			continue
+		}
 		if tr.AccessToken != "" {
 			if err := validatePrintableASCIIField("GitHub access token", tr.AccessToken, maximumGitHubTokenLength); err != nil {
 				return "", err
@@ -318,20 +338,7 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 			ghToken = tr.AccessToken
 			break
 		}
-		switch tr.Error {
-		case "authorization_pending":
-			// not authorized yet — keep polling
-		case "slow_down":
-			// RFC 8628 §3.5 asks for a five-second backoff. Keep the
-			// server-controlled interval within the command's bounded policy.
-			pollInterval = min(pollInterval+5*time.Second, maximumDevicePollInterval)
-		case "access_denied":
-			return "", errors.New("authorization was denied on GitHub")
-		case "expired_token":
-			return "", errors.New("the code expired before you authorized it — run `wago auth login --code` again")
-		default:
-			return "", errors.New("GitHub returned an unknown device authorization error")
-		}
+		return "", errors.New("GitHub returned an incomplete device token response")
 	}
 	if ghToken == "" {
 		return "", errors.New("timed out waiting for GitHub authorization")
@@ -350,9 +357,13 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 	}
 	var xr struct {
 		Token string `json:"token"`
+		Error string `json:"error"`
 	}
 	if err := json.Unmarshal(data, &xr); err != nil {
 		return "", fmt.Errorf("parsing exchange response: %w", err)
+	}
+	if xr.Error != "" {
+		return "", errors.New("registry returned an error during the GitHub exchange")
 	}
 	if xr.Token == "" {
 		return "", errors.New("registry returned no token after the GitHub exchange")

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -50,7 +50,7 @@ func registryLoginContext(ctx context.Context, options LoginRequest) {
 			return
 		}
 	}
-	me, err := fetchMeContext(ctx, token)
+	me, err := fetchMeAtBaseContext(ctx, base, token)
 	if err != nil {
 		if errors.Is(err, errUnauthorized) {
 			fatal("login: the registry rejected that token")
@@ -226,17 +226,14 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 	}
 
 	lifetime, pollInterval := deviceFlowTiming(dc.ExpiresIn, dc.Interval)
-	verifyURI := dc.VerificationURI
-	if verifyURI == "" {
-		verifyURI = "https://github.com/login/device"
-	}
+	verifyURI := trustedDeviceVerificationURL(dc.VerificationURI, hooks.deviceCodeEndpoint)
 
 	// Print the one-time code before launching a browser so it remains available
 	// when GitHub does not provide a verification_uri_complete value.
 	fmt.Printf("\n  First, copy your one-time code:\n\n      %s\n\n", bold(dc.UserCode))
 	if openBrowser {
-		browserURL := dc.VerificationURIComplete
-		if browserURL == "" {
+		browserURL := trustedDeviceVerificationURL(dc.VerificationURIComplete, hooks.deviceCodeEndpoint)
+		if dc.VerificationURIComplete == "" || browserURL == "" {
 			browserURL = verifyURI
 		}
 		if err := hooks.openBrowser(browserURL); err != nil {
@@ -315,6 +312,24 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 		return "", errors.New("registry returned no token after the GitHub exchange")
 	}
 	return xr.Token, nil
+}
+
+func trustedDeviceVerificationURL(candidate, deviceCodeEndpoint string) string {
+	provider, err := url.Parse(deviceCodeEndpoint)
+	if err != nil || provider.Scheme == "" || provider.Host == "" || provider.User != nil {
+		return ""
+	}
+	fallback := &url.URL{Scheme: provider.Scheme, Host: provider.Host, Path: "/login/device"}
+	if candidate == "" {
+		return fallback.String()
+	}
+	target, err := url.Parse(candidate)
+	if err != nil || target.Opaque != "" || target.User != nil || target.Fragment != "" ||
+		!strings.EqualFold(target.Scheme, provider.Scheme) || !strings.EqualFold(target.Host, provider.Host) ||
+		target.Path != "/login/device" {
+		return fallback.String()
+	}
+	return target.String()
 }
 
 // registryLogout deletes stored credentials for the current registry.

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -32,7 +32,7 @@ func registryLoginContext(ctx context.Context, options LoginRequest) {
 		// use the provided token directly
 	case withToken:
 		var err error
-		token, err = readRegistryToken(os.Stdin)
+		token, err = readRegistryTokenContext(ctx, os.Stdin)
 		if err != nil {
 			fatal("login: reading token from stdin: %v", err)
 		}
@@ -79,6 +79,30 @@ func readRegistryToken(reader io.Reader) (string, error) {
 		return "", err
 	}
 	return token, nil
+}
+
+func readRegistryTokenContext(ctx context.Context, reader io.ReadCloser) (string, error) {
+	if ctx == nil {
+		return "", errors.New("nil registry token context")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	type result struct {
+		token string
+		err   error
+	}
+	resultChannel := make(chan result, 1)
+	go func() {
+		token, err := readRegistryToken(reader)
+		resultChannel <- result{token: token, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", errors.Join(ctx.Err(), reader.Close())
+	case result := <-resultChannel:
+		return result.token, result.err
+	}
 }
 
 func validateRegistryToken(token string) error {

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -31,13 +31,10 @@ func registryLoginContext(ctx context.Context, options LoginRequest) {
 	case token != "":
 		// use the provided token directly
 	case withToken:
-		b, err := io.ReadAll(os.Stdin)
+		var err error
+		token, err = readRegistryToken(os.Stdin)
 		if err != nil {
 			fatal("login: reading token from stdin: %v", err)
-		}
-		token = strings.TrimSpace(string(b))
-		if token == "" {
-			fatal("login: no token on stdin")
 		}
 	case code:
 		token = githubDeviceLoginContext(ctx, base)
@@ -50,6 +47,9 @@ func registryLoginContext(ctx context.Context, options LoginRequest) {
 			return
 		}
 	}
+	if err := validateRegistryToken(token); err != nil {
+		fatal("login: %v", err)
+	}
 	me, err := fetchMeAtBaseContext(ctx, base, token)
 	if err != nil {
 		if errors.Is(err, errUnauthorized) {
@@ -61,6 +61,31 @@ func registryLoginContext(ctx context.Context, options LoginRequest) {
 		fatal("login: saving credentials: %v", err)
 	}
 	fmt.Printf("%s Logged in as %s\n", cyan("✓"), bold(me.Login))
+}
+
+func readRegistryToken(reader io.Reader) (string, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maximumRegistryInputLength+1))
+	if err != nil {
+		return "", err
+	}
+	if len(data) > maximumRegistryInputLength {
+		return "", fmt.Errorf("registry token exceeds %d-byte limit", maximumRegistryTokenLength)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", errors.New("no token on stdin")
+	}
+	if err := validateRegistryToken(token); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+func validateRegistryToken(token string) error {
+	if token == "" {
+		return errors.New("registry token is empty")
+	}
+	return validatePrintableASCIIField("registry token", token, maximumRegistryTokenLength)
 }
 
 func loginMethodPicker() *tui.Picker {
@@ -106,10 +131,18 @@ func browserLoginContext(ctx context.Context, base string) string {
 }
 
 const (
-	defaultDeviceFlowLifetime = 15 * time.Minute
-	maximumDeviceFlowLifetime = 20 * time.Minute
-	defaultDevicePollInterval = 5 * time.Second
-	maximumDevicePollInterval = 60 * time.Second
+	defaultDeviceFlowLifetime  = 15 * time.Minute
+	maximumDeviceFlowLifetime  = 20 * time.Minute
+	defaultDevicePollInterval  = 5 * time.Second
+	maximumDevicePollInterval  = 60 * time.Second
+	maximumOAuthClientIDLength = 256
+	maximumOAuthScopeLength    = 128
+	maximumDeviceCodeLength    = 1024
+	maximumUserCodeLength      = 128
+	maximumGitHubTokenLength   = 16 << 10
+	maximumRegistryTokenLength = 64 << 10
+	maximumRegistryInputLength = maximumRegistryTokenLength + 2 // optional CRLF
+	maximumVerificationURLSize = 4 << 10
 )
 
 func deviceFlowTiming(expiresIn, interval int) (lifetime, pollInterval time.Duration) {
@@ -183,7 +216,7 @@ func githubDeviceTokenContext(ctx context.Context, base string, openBrowser bool
 
 func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser bool, hooks deviceFlowHooks) (string, error) {
 	// 1. Ask the registry which GitHub OAuth app to authenticate against.
-	status, data, err := apiRequestAtBaseContext(ctx, base, http.MethodGet, "/api/auth/github/client", "", nil)
+	status, data, err := apiRequestAtBaseLimitContext(ctx, base, http.MethodGet, "/api/auth/github/client", "", nil, registryAuthResponseLimit)
 	if err != nil {
 		return "", fmt.Errorf("fetching GitHub client config: %w", err)
 	}
@@ -199,6 +232,13 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 	}
 	if cfg.ClientID == "" {
 		return "", errors.New("registry did not advertise a GitHub client id")
+	}
+	if err := validatePrintableASCIIField("GitHub client id", cfg.ClientID, maximumOAuthClientIDLength); err != nil {
+		return "", err
+	}
+	cfg.Scope, err = allowedGitHubScopes(cfg.Scope)
+	if err != nil {
+		return "", err
 	}
 
 	// 2. Ask GitHub for a device + user code.
@@ -219,10 +259,13 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 		return "", errors.New("GitHub device flow is disabled for this OAuth app — enable \"Device Flow\" in its settings")
 	}
 	if dc.DeviceCode == "" || dc.UserCode == "" {
-		if dc.Error != "" {
-			return "", fmt.Errorf("GitHub: %s", dc.Error)
-		}
 		return "", errors.New("GitHub returned an incomplete device authorization response")
+	}
+	if err := validatePrintableASCIIField("GitHub device code", dc.DeviceCode, maximumDeviceCodeLength); err != nil {
+		return "", err
+	}
+	if err := validatePrintableASCIIField("GitHub user code", dc.UserCode, maximumUserCodeLength); err != nil {
+		return "", err
 	}
 
 	lifetime, pollInterval := deviceFlowTiming(dc.ExpiresIn, dc.Interval)
@@ -269,6 +312,9 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 			return "", fmt.Errorf("polling GitHub for the token: %w", err)
 		}
 		if tr.AccessToken != "" {
+			if err := validatePrintableASCIIField("GitHub access token", tr.AccessToken, maximumGitHubTokenLength); err != nil {
+				return "", err
+			}
 			ghToken = tr.AccessToken
 			break
 		}
@@ -292,8 +338,8 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 	}
 
 	// 4. Exchange the GitHub token for a wago API token.
-	status, data, err = apiRequestAtBaseContext(ctx, base, http.MethodPost, "/api/auth/github/exchange", "",
-		map[string]string{"access_token": ghToken})
+	status, data, err = apiRequestAtBaseLimitContext(ctx, base, http.MethodPost, "/api/auth/github/exchange", "",
+		map[string]string{"access_token": ghToken}, registryAuthResponseLimit)
 	if err != nil {
 		return "", fmt.Errorf("exchanging GitHub token: %w", err)
 	}
@@ -311,7 +357,44 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 	if xr.Token == "" {
 		return "", errors.New("registry returned no token after the GitHub exchange")
 	}
+	if err := validateRegistryToken(xr.Token); err != nil {
+		return "", err
+	}
 	return xr.Token, nil
+}
+
+func allowedGitHubScopes(scope string) (string, error) {
+	if err := validateTerminalTextField("registry GitHub scope", scope, maximumOAuthScopeLength); err != nil {
+		return "", err
+	}
+	requested := make(map[string]bool, 2)
+	for _, item := range strings.Fields(scope) {
+		switch item {
+		case "read:user", "user:email":
+			requested[item] = true
+		default:
+			return "", errors.New("registry requested an unsupported GitHub OAuth scope")
+		}
+	}
+	ordered := make([]string, 0, len(requested))
+	for _, item := range []string{"read:user", "user:email"} {
+		if requested[item] {
+			ordered = append(ordered, item)
+		}
+	}
+	return strings.Join(ordered, " "), nil
+}
+
+func validatePrintableASCIIField(name, value string, maximum int) error {
+	if len(value) > maximum {
+		return fmt.Errorf("%s exceeds %d-byte limit", name, maximum)
+	}
+	for index := range len(value) {
+		if value[index] < 0x21 || value[index] > 0x7e {
+			return fmt.Errorf("%s contains non-printable characters", name)
+		}
+	}
+	return nil
 }
 
 func trustedDeviceVerificationURL(candidate, deviceCodeEndpoint string) string {
@@ -321,6 +404,9 @@ func trustedDeviceVerificationURL(candidate, deviceCodeEndpoint string) string {
 	}
 	fallback := &url.URL{Scheme: provider.Scheme, Host: provider.Host, Path: "/login/device"}
 	if candidate == "" {
+		return fallback.String()
+	}
+	if len(candidate) > maximumVerificationURLSize {
 		return fallback.String()
 	}
 	target, err := url.Parse(candidate)

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -460,15 +460,16 @@ func registryLogout() {
 
 func registryLogoutContext(ctx context.Context) {
 	base := registryBase()
+	displayBase := registryDisplayBase(base)
 	removed, err := deleteCredentialsResultContext(ctx, base)
 	if err != nil {
 		fatal("logout: %v", err)
 	}
 	if !removed {
-		fmt.Printf("%s Not logged in to %s\n", dim("·"), base)
+		fmt.Printf("%s Not logged in to %s\n", dim("·"), displayBase)
 		return
 	}
-	fmt.Printf("%s Logged out of %s\n", cyan("✓"), base)
+	fmt.Printf("%s Logged out of %s\n", cyan("✓"), displayBase)
 }
 
 // registryWhoami prints the login of the current token, or a friendly hint when

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -68,7 +67,7 @@ func loginMethodPicker() *tui.Picker {
 	return tui.NewPicker("Choose login method", []tui.Item{
 		{
 			Label:       "Link",
-			Description: "Open a browser link on this machine",
+			Description: "Open one-time authorization in a browser",
 			Value:       "link",
 		},
 		{
@@ -99,66 +98,11 @@ func chooseLoginMethodContext(ctx context.Context, base string) (string, bool) {
 	}
 }
 
-// browserLoginContext runs the loopback OAuth flow: it listens on a free
-// localhost port, opens the browser to the registry's CLI-login endpoint, and
-// waits for the /callback redirect carrying the plaintext token. It fatals on
-// error or timeout.
+// browserLoginContext uses the same one-time device authorization as headless
+// login, but opens GitHub's verification URL after displaying the short-lived
+// user code. Long-lived credentials therefore never pass through a loopback URL.
 func browserLoginContext(ctx context.Context, base string) string {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		fatal("login: cannot open a loopback listener: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	state, err := RandomState()
-	if err != nil {
-		fatal("login: %v", err)
-	}
-
-	type result struct {
-		token string
-		err   error
-	}
-	resCh := make(chan result, 1)
-	mux := http.NewServeMux()
-	srv := &http.Server{Handler: mux}
-	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		q := r.URL.Query()
-		if q.Get("state") != state {
-			http.Error(w, "state mismatch — login aborted", http.StatusBadRequest)
-			resCh <- result{err: errors.New("state mismatch — login aborted (possible CSRF)")}
-			return
-		}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = io.WriteString(w, SuccessHTML)
-		resCh <- result{token: q.Get("token")}
-	})
-	go srv.Serve(ln)
-	defer srv.Close()
-
-	loginURL := fmt.Sprintf("%s/auth/cli/login?port=%d&state=%s", base, port, url.QueryEscape(state))
-	if err := OpenBrowser(loginURL); err != nil {
-		fmt.Printf("Open this URL in your browser to log in:\n\n  %s\n\n", cyan(loginURL))
-	} else {
-		fmt.Printf("%s Opening your browser to log in…\n", dim("→"))
-		fmt.Printf("  %s\n  %s\n", dim("if it doesn't open, visit:"), cyan(loginURL))
-	}
-
-	select {
-	case res := <-resCh:
-		if res.err != nil {
-			fatal("login: %v", res.err)
-		}
-		if res.token == "" {
-			fatal("login: no token received from the registry")
-		}
-		return res.token
-	case <-ctx.Done():
-		fatal("login: %v", ctx.Err())
-		return ""
-	case <-time.After(2 * time.Minute):
-		fatal("login: timed out waiting for the browser callback")
-		return ""
-	}
+	return githubDeviceLoginContextUsing(ctx, base, true)
 }
 
 const (
@@ -189,9 +133,9 @@ func deviceFlowTiming(expiresIn, interval int) (lifetime, pollInterval time.Dura
 }
 
 // githubDeviceLoginContext runs GitHub's OAuth device flow (RFC 8628) and
-// exchanges the resulting GitHub token for a wago API token. It's the login path
-// for headless/remote machines: the user enters a code at github.com/login/device
-// instead of relying on a localhost redirect.
+// exchanges the resulting GitHub token for a wago API token. Browser and
+// headless modes both enter a code at github.com/login/device instead of relying
+// on a localhost redirect; browser mode merely opens the verification URL.
 //
 // The registry advertises its GitHub OAuth client_id (GET /api/auth/github/client)
 // so a self-hosted registry with its own OAuth app works without recompiling the
@@ -199,46 +143,86 @@ func deviceFlowTiming(expiresIn, interval int) (lifetime, pollInterval time.Dura
 // the GitHub token to the registry (POST /api/auth/github/exchange), which
 // verifies the token belongs to its app and returns a wago token.
 func githubDeviceLoginContext(ctx context.Context, base string) string {
-	// 1. Ask the registry which GitHub OAuth app to authenticate against.
-	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/auth/github/client", "", nil)
+	return githubDeviceLoginContextUsing(ctx, base, false)
+}
+
+func githubDeviceLoginContextUsing(ctx context.Context, base string, openBrowser bool) string {
+	token, err := githubDeviceTokenContext(ctx, base, openBrowser)
 	if err != nil {
-		fatal("login: fetching GitHub client config: %v", err)
+		fatal("login: %v", err)
+	}
+	return token
+}
+
+type deviceFlowHooks struct {
+	deviceCodeEndpoint  string
+	accessTokenEndpoint string
+	openBrowser         func(string) error
+	wait                func(context.Context, time.Duration) error
+}
+
+func waitDevicePollContext(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func githubDeviceTokenContext(ctx context.Context, base string, openBrowser bool) (string, error) {
+	return githubDeviceTokenUsingContext(ctx, base, openBrowser, deviceFlowHooks{
+		deviceCodeEndpoint:  "https://github.com/login/device/code",
+		accessTokenEndpoint: "https://github.com/login/oauth/access_token",
+		openBrowser:         OpenBrowser,
+		wait:                waitDevicePollContext,
+	})
+}
+
+func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser bool, hooks deviceFlowHooks) (string, error) {
+	// 1. Ask the registry which GitHub OAuth app to authenticate against.
+	status, data, err := apiRequestAtBaseContext(ctx, base, http.MethodGet, "/api/auth/github/client", "", nil)
+	if err != nil {
+		return "", fmt.Errorf("fetching GitHub client config: %w", err)
 	}
 	if status != http.StatusOK {
-		fatal("login: fetching GitHub client config: %s", apiError(status, data))
+		return "", fmt.Errorf("fetching GitHub client config: %s", apiError(status, data))
 	}
 	var cfg struct {
 		ClientID string `json:"client_id"`
 		Scope    string `json:"scope"`
 	}
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		fatal("login: parsing GitHub client config: %v", err)
+		return "", fmt.Errorf("parsing GitHub client config: %w", err)
 	}
 	if cfg.ClientID == "" {
-		fatal("login: registry did not advertise a GitHub client id")
+		return "", errors.New("registry did not advertise a GitHub client id")
 	}
 
 	// 2. Ask GitHub for a device + user code.
 	var dc struct {
-		DeviceCode      string `json:"device_code"`
-		UserCode        string `json:"user_code"`
-		VerificationURI string `json:"verification_uri"`
-		ExpiresIn       int    `json:"expires_in"`
-		Interval        int    `json:"interval"`
-		Error           string `json:"error"`
+		DeviceCode              string `json:"device_code"`
+		UserCode                string `json:"user_code"`
+		VerificationURI         string `json:"verification_uri"`
+		VerificationURIComplete string `json:"verification_uri_complete"`
+		ExpiresIn               int    `json:"expires_in"`
+		Interval                int    `json:"interval"`
+		Error                   string `json:"error"`
 	}
-	if err := PostFormContext(ctx, "https://github.com/login/device/code",
+	if err := PostFormContext(ctx, hooks.deviceCodeEndpoint,
 		url.Values{"client_id": {cfg.ClientID}, "scope": {cfg.Scope}}, &dc); err != nil {
-		fatal("login: requesting device code from GitHub: %v", err)
+		return "", fmt.Errorf("requesting device code from GitHub: %w", err)
 	}
 	if dc.Error == "device_flow_disabled" {
-		fatal("login: GitHub device flow is disabled for this OAuth app — enable \"Device Flow\" in its settings")
+		return "", errors.New("GitHub device flow is disabled for this OAuth app — enable \"Device Flow\" in its settings")
 	}
 	if dc.DeviceCode == "" || dc.UserCode == "" {
 		if dc.Error != "" {
-			fatal("login: GitHub: %s", dc.Error)
+			return "", fmt.Errorf("GitHub: %s", dc.Error)
 		}
-		fatal("login: GitHub returned an incomplete device authorization response")
+		return "", errors.New("GitHub returned an incomplete device authorization response")
 	}
 
 	lifetime, pollInterval := deviceFlowTiming(dc.ExpiresIn, dc.Interval)
@@ -247,10 +231,22 @@ func githubDeviceLoginContext(ctx context.Context, base string) string {
 		verifyURI = "https://github.com/login/device"
 	}
 
-	// Keep the terminal still so the code can be copied before the user opens a
-	// browser. Unlike Link login, the device flow never launches one itself.
+	// Print the one-time code before launching a browser so it remains available
+	// when GitHub does not provide a verification_uri_complete value.
 	fmt.Printf("\n  First, copy your one-time code:\n\n      %s\n\n", bold(dc.UserCode))
-	fmt.Printf("  Then open %s and enter it.\n", cyan(verifyURI))
+	if openBrowser {
+		browserURL := dc.VerificationURIComplete
+		if browserURL == "" {
+			browserURL = verifyURI
+		}
+		if err := hooks.openBrowser(browserURL); err != nil {
+			fmt.Printf("  Then open %s and enter it.\n", cyan(verifyURI))
+		} else {
+			fmt.Printf("%s Opened %s in your browser.\n", dim("→"), cyan(browserURL))
+		}
+	} else {
+		fmt.Printf("  Then open %s and enter it.\n", cyan(verifyURI))
+	}
 	fmt.Printf("\n%s Waiting for you to authorize on GitHub…\n", dim("→"))
 
 	// 3. Poll GitHub for the access token until the user authorizes or it expires.
@@ -258,12 +254,8 @@ func githubDeviceLoginContext(ctx context.Context, base string) string {
 	deadline := time.Now().Add(lifetime)
 	for time.Now().Before(deadline) {
 		wait := min(pollInterval, time.Until(deadline))
-		timer := time.NewTimer(wait)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			fatal("login: %v", ctx.Err())
-		case <-timer.C:
+		if err := hooks.wait(ctx, wait); err != nil {
+			return "", err
 		}
 		if !time.Now().Before(deadline) {
 			break
@@ -272,12 +264,12 @@ func githubDeviceLoginContext(ctx context.Context, base string) string {
 			AccessToken string `json:"access_token"`
 			Error       string `json:"error"`
 		}
-		if err := PostFormContext(ctx, "https://github.com/login/oauth/access_token", url.Values{
+		if err := PostFormContext(ctx, hooks.accessTokenEndpoint, url.Values{
 			"client_id":   {cfg.ClientID},
 			"device_code": {dc.DeviceCode},
 			"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
 		}, &tr); err != nil {
-			fatal("login: polling GitHub for the token: %v", err)
+			return "", fmt.Errorf("polling GitHub for the token: %w", err)
 		}
 		if tr.AccessToken != "" {
 			ghToken = tr.AccessToken
@@ -291,36 +283,38 @@ func githubDeviceLoginContext(ctx context.Context, base string) string {
 			// server-controlled interval within the command's bounded policy.
 			pollInterval = min(pollInterval+5*time.Second, maximumDevicePollInterval)
 		case "access_denied":
-			fatal("login: authorization was denied on GitHub")
+			return "", errors.New("authorization was denied on GitHub")
 		case "expired_token":
-			fatal("login: the code expired before you authorized it — run `wago auth login --code` again")
+			return "", errors.New("the code expired before you authorized it — run `wago auth login --code` again")
 		default:
-			fatal("login: GitHub: %s", tr.Error)
+			return "", errors.New("GitHub returned an unknown device authorization error")
 		}
 	}
 	if ghToken == "" {
-		fatal("login: timed out waiting for GitHub authorization")
+		return "", errors.New("timed out waiting for GitHub authorization")
 	}
 
 	// 4. Exchange the GitHub token for a wago API token.
-	status, data, err = apiRequestContext(ctx, http.MethodPost, "/api/auth/github/exchange", "",
+	status, data, err = apiRequestAtBaseContext(ctx, base, http.MethodPost, "/api/auth/github/exchange", "",
 		map[string]string{"access_token": ghToken})
 	if err != nil {
-		fatal("login: exchanging GitHub token: %v", err)
+		return "", fmt.Errorf("exchanging GitHub token: %w", err)
 	}
 	if status != http.StatusOK {
-		fatal("login: exchanging GitHub token: %s", apiError(status, data))
+		// The exchange endpoint has received the GitHub access token. Do not include
+		// its response body in an error in case a faulty registry reflects secrets.
+		return "", fmt.Errorf("exchanging GitHub token: registry returned status %d", status)
 	}
 	var xr struct {
 		Token string `json:"token"`
 	}
 	if err := json.Unmarshal(data, &xr); err != nil {
-		fatal("login: parsing exchange response: %v", err)
+		return "", fmt.Errorf("parsing exchange response: %w", err)
 	}
 	if xr.Token == "" {
-		fatal("login: registry returned no token after the GitHub exchange")
+		return "", errors.New("registry returned no token after the GitHub exchange")
 	}
-	return xr.Token
+	return xr.Token, nil
 }
 
 // registryLogout deletes stored credentials for the current registry.

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -250,9 +249,13 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 	var cfg struct {
 		ClientID string `json:"client_id"`
 		Scope    string `json:"scope"`
+		Error    string `json:"error"`
 	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	if err := unmarshalUniqueJSON(data, &cfg); err != nil {
 		return "", fmt.Errorf("parsing GitHub client config: %w", err)
+	}
+	if cfg.Error != "" {
+		return "", errors.New("registry returned an error in the GitHub client configuration")
 	}
 	if cfg.ClientID == "" {
 		return "", errors.New("registry did not advertise a GitHub client id")
@@ -383,7 +386,7 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 		Token string `json:"token"`
 		Error string `json:"error"`
 	}
-	if err := json.Unmarshal(data, &xr); err != nil {
+	if err := unmarshalUniqueJSON(data, &xr); err != nil {
 		return "", fmt.Errorf("parsing exchange response: %w", err)
 	}
 	if xr.Error != "" {

--- a/cli/manager/internal/registry/auth_security_test.go
+++ b/cli/manager/internal/registry/auth_security_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -361,6 +362,47 @@ func TestRegistryTokenInputIsBounded(t *testing.T) {
 			t.Fatalf("accepted unsafe token input of length %d", len(input))
 		}
 	}
+}
+
+func TestRegistryTokenInputHonorsCancellation(t *testing.T) {
+	reader := &blockingTokenReader{started: make(chan struct{}), closed: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := readRegistryTokenContext(ctx, reader)
+		done <- err
+	}()
+	<-reader.started
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled token input = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled token input did not return")
+	}
+	select {
+	case <-reader.closed:
+	default:
+		t.Fatal("canceled token input left its reader open")
+	}
+}
+
+type blockingTokenReader struct {
+	started chan struct{}
+	closed  chan struct{}
+}
+
+func (reader *blockingTokenReader) Read([]byte) (int, error) {
+	close(reader.started)
+	<-reader.closed
+	return 0, os.ErrClosed
+}
+
+func (reader *blockingTokenReader) Close() error {
+	close(reader.closed)
+	return nil
 }
 
 func TestDeviceVerificationURLIsPinnedToProvider(t *testing.T) {

--- a/cli/manager/internal/registry/auth_security_test.go
+++ b/cli/manager/internal/registry/auth_security_test.go
@@ -170,6 +170,21 @@ func TestDeviceExchangeRejectsContradictoryErrorAndToken(t *testing.T) {
 	}
 }
 
+func TestDeviceExchangeRejectsDuplicateDecisionFields(t *testing.T) {
+	server, _ := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`","error":"failed","error":""}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+
+	_, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if err == nil || !strings.Contains(err.Error(), "duplicate object field") {
+		t.Fatalf("duplicate exchange response = %v", err)
+	}
+	if strings.Contains(err.Error(), testGitHubToken) || strings.Contains(err.Error(), testRegistryToken) {
+		t.Fatalf("duplicate exchange error leaked a credential: %v", err)
+	}
+}
+
 func TestDevicePollingErrorRedactsCredentials(t *testing.T) {
 	server, capture := newDeviceFlowServer(t,
 		`{"error":"`+testDeviceCode+` `+testGitHubToken+` `+testRegistryToken+`"}`,
@@ -230,6 +245,22 @@ func TestDevicePollingRejectsContradictoryErrorAndToken(t *testing.T) {
 	}
 	if capture.exchangedGitHubToken != "" {
 		t.Fatalf("contradictory token response exchanged %q", capture.exchangedGitHubToken)
+	}
+}
+
+func TestDevicePollingRejectsDuplicateDecisionFields(t *testing.T) {
+	server, capture := newDeviceFlowServer(t,
+		`{"access_token":"`+testGitHubToken+`","error":"access_denied","error":""}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+
+	_, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if err == nil || !strings.Contains(err.Error(), "duplicate object field") {
+		t.Fatalf("duplicate token response = %v", err)
+	}
+	if capture.exchangedGitHubToken != "" {
+		t.Fatalf("duplicate token response exchanged %q", capture.exchangedGitHubToken)
 	}
 }
 
@@ -321,6 +352,27 @@ func TestDeviceAuthorizationRejectsScopeEscalationBeforeGitHub(t *testing.T) {
 	}
 	if got := githubRequests.Load(); got != 0 {
 		t.Fatalf("scope escalation made %d GitHub requests", got)
+	}
+}
+
+func TestDeviceAuthorizationRejectsClientConfigErrorBeforeGitHub(t *testing.T) {
+	registry := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte(`{"client_id":"client-id","scope":"read:user","error":"failed"}`))
+	}))
+	defer registry.Close()
+	var githubRequests atomic.Int32
+	github := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		githubRequests.Add(1)
+	}))
+	defer github.Close()
+
+	hooks := deviceFlowTestHooks(t, github.URL, new(string))
+	_, err := githubDeviceTokenUsingContext(context.Background(), registry.URL, false, hooks)
+	if err == nil || !strings.Contains(err.Error(), "error in the GitHub client configuration") {
+		t.Fatalf("client config error response = %v", err)
+	}
+	if got := githubRequests.Load(); got != 0 {
+		t.Fatalf("client config error made %d GitHub requests", got)
 	}
 }
 

--- a/cli/manager/internal/registry/auth_security_test.go
+++ b/cli/manager/internal/registry/auth_security_test.go
@@ -1,0 +1,205 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testDeviceCode    = "device-secret"
+	testGitHubToken   = "github-access-secret"
+	testRegistryToken = "registry-bearer-secret"
+)
+
+type deviceFlowCapture struct {
+	requestURLs          []string
+	deviceForm           url.Values
+	pollForm             url.Values
+	exchangedGitHubToken string
+	verificationURL      string
+}
+
+func newDeviceFlowServer(t *testing.T, accessTokenBody string, exchangeStatus int, exchangeBody string) (*httptest.Server, *deviceFlowCapture) {
+	t.Helper()
+	capture := &deviceFlowCapture{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		capture.requestURLs = append(capture.requestURLs, request.URL.String())
+		switch request.URL.Path {
+		case "/api/auth/github/client":
+			_ = json.NewEncoder(w).Encode(map[string]string{"client_id": "client-id", "scope": "read:user"})
+		case "/login/device/code":
+			_ = request.ParseForm()
+			capture.deviceForm = cloneURLValues(request.Form)
+			capture.verificationURL = server.URL + "/login/device?user_code=short-lived-code"
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               testDeviceCode,
+				"user_code":                 "short-lived-code",
+				"verification_uri":          server.URL + "/login/device",
+				"verification_uri_complete": capture.verificationURL,
+				"expires_in":                600,
+				"interval":                  1,
+			})
+		case "/login/oauth/access_token":
+			_ = request.ParseForm()
+			capture.pollForm = cloneURLValues(request.Form)
+			_, _ = w.Write([]byte(accessTokenBody))
+		case "/api/auth/github/exchange":
+			var body map[string]string
+			_ = json.NewDecoder(request.Body).Decode(&body)
+			capture.exchangedGitHubToken = body["access_token"]
+			w.WriteHeader(exchangeStatus)
+			_, _ = w.Write([]byte(exchangeBody))
+		default:
+			http.NotFound(w, request)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, capture
+}
+
+func cloneURLValues(values url.Values) url.Values {
+	cloned := make(url.Values, len(values))
+	for key, items := range values {
+		cloned[key] = append([]string(nil), items...)
+	}
+	return cloned
+}
+
+func deviceFlowTestHooks(t *testing.T, serverURL string, openedURL *string) deviceFlowHooks {
+	t.Helper()
+	return deviceFlowHooks{
+		deviceCodeEndpoint:  serverURL + "/login/device/code",
+		accessTokenEndpoint: serverURL + "/login/oauth/access_token",
+		openBrowser: func(target string) error {
+			*openedURL = target
+			return nil
+		},
+		wait: func(ctx context.Context, _ time.Duration) error {
+			return ctx.Err()
+		},
+	}
+}
+
+func TestDeviceAuthorizationKeepsCredentialsOutOfURLs(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		openBrowser bool
+	}{
+		{name: "browser", openBrowser: true},
+		{name: "headless", openBrowser: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, capture := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+				http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+			var openedURL string
+			hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+
+			token, err := githubDeviceTokenUsingContext(context.Background(), server.URL, test.openBrowser, hooks)
+			if err != nil || token != testRegistryToken {
+				t.Fatalf("device token = %q, %v", token, err)
+			}
+			if capture.deviceForm.Get("client_id") != "client-id" || capture.pollForm.Get("device_code") != testDeviceCode {
+				t.Fatalf("device forms = %#v / %#v", capture.deviceForm, capture.pollForm)
+			}
+			if capture.exchangedGitHubToken != testGitHubToken {
+				t.Fatalf("exchanged token = %q", capture.exchangedGitHubToken)
+			}
+			if test.openBrowser {
+				if openedURL != capture.verificationURL {
+					t.Fatalf("opened URL = %q, want %q", openedURL, capture.verificationURL)
+				}
+			} else if openedURL != "" {
+				t.Fatalf("headless login opened %q", openedURL)
+			}
+			for _, visibleURL := range append(capture.requestURLs, openedURL) {
+				for _, secret := range []string{testDeviceCode, testGitHubToken, testRegistryToken} {
+					if strings.Contains(visibleURL, secret) {
+						t.Fatalf("URL %q leaked %q", visibleURL, secret)
+					}
+				}
+				if strings.Contains(visibleURL, "token=") || strings.Contains(visibleURL, "/callback") {
+					t.Fatalf("URL retained insecure callback shape: %q", visibleURL)
+				}
+			}
+		})
+	}
+}
+
+func TestDeviceExchangeErrorRedactsCredentials(t *testing.T) {
+	server, _ := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+		http.StatusInternalServerError,
+		`{"error":"`+testDeviceCode+` `+testGitHubToken+` `+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+
+	_, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if err == nil {
+		t.Fatal("failed exchange succeeded")
+	}
+	for _, secret := range []string{testDeviceCode, testGitHubToken, testRegistryToken} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("error leaked %q: %v", secret, err)
+		}
+	}
+}
+
+func TestDevicePollingErrorRedactsCredentials(t *testing.T) {
+	server, capture := newDeviceFlowServer(t,
+		`{"error":"`+testDeviceCode+` `+testGitHubToken+` `+testRegistryToken+`"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+
+	_, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if err == nil {
+		t.Fatal("failed token poll succeeded")
+	}
+	for _, secret := range []string{testDeviceCode, testGitHubToken, testRegistryToken} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("error leaked %q: %v", secret, err)
+		}
+	}
+	if capture.exchangedGitHubToken != "" {
+		t.Fatalf("failed poll exchanged %q", capture.exchangedGitHubToken)
+	}
+}
+
+func TestDeviceAuthorizationCancellationStopsBeforeTokenPolling(t *testing.T) {
+	server, capture := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+	hooks.wait = func(context.Context, time.Duration) error { return context.Canceled }
+
+	_, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled device flow = %v", err)
+	}
+	if capture.pollForm != nil || capture.exchangedGitHubToken != "" {
+		t.Fatalf("canceled flow polled or exchanged a credential: %#v / %q", capture.pollForm, capture.exchangedGitHubToken)
+	}
+}
+
+func TestDeviceAuthorizationPinsRegistryOrigin(t *testing.T) {
+	server, capture := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+	t.Setenv("WAGO_REGISTRY", "http://127.0.0.1:1")
+
+	token, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if err != nil || token != testRegistryToken {
+		t.Fatalf("pinned registry token = %q, %v", token, err)
+	}
+	if capture.exchangedGitHubToken != testGitHubToken {
+		t.Fatalf("pinned registry did not receive exchange token: %q", capture.exchangedGitHubToken)
+	}
+}

--- a/cli/manager/internal/registry/auth_security_test.go
+++ b/cli/manager/internal/registry/auth_security_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -204,6 +205,90 @@ func TestDeviceAuthorizationPinsRegistryOrigin(t *testing.T) {
 	}
 }
 
+func TestGitHubOAuthScopeAllowlist(t *testing.T) {
+	for _, test := range []struct {
+		name, scope, want string
+		wantError         bool
+	}{
+		{name: "none"},
+		{name: "identity", scope: "read:user", want: "read:user"},
+		{name: "email and identity", scope: "user:email read:user", want: "read:user user:email"},
+		{name: "duplicates", scope: "read:user  read:user", want: "read:user"},
+		{name: "repository", scope: "read:user repo", wantError: true},
+		{name: "workflow", scope: "workflow", wantError: true},
+		{name: "control", scope: "read:user\nuser:email", wantError: true},
+		{name: "oversized", scope: strings.Repeat("x", maximumOAuthScopeLength+1), wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := allowedGitHubScopes(test.scope)
+			if (err != nil) != test.wantError || got != test.want {
+				t.Fatalf("allowedGitHubScopes(%q) = %q, %v", test.scope, got, err)
+			}
+		})
+	}
+}
+
+func TestDeviceAuthorizationRejectsScopeEscalationBeforeGitHub(t *testing.T) {
+	registry := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte(`{"client_id":"client-id","scope":"read:user repo"}`))
+	}))
+	defer registry.Close()
+	var githubRequests atomic.Int32
+	github := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		githubRequests.Add(1)
+	}))
+	defer github.Close()
+
+	hooks := deviceFlowTestHooks(t, github.URL, new(string))
+	_, err := githubDeviceTokenUsingContext(context.Background(), registry.URL, false, hooks)
+	if err == nil || !strings.Contains(err.Error(), "unsupported GitHub OAuth scope") {
+		t.Fatalf("scope escalation = %v", err)
+	}
+	if got := githubRequests.Load(); got != 0 {
+		t.Fatalf("scope escalation made %d GitHub requests", got)
+	}
+}
+
+func TestAuthenticationFieldsAreBoundedAndPrintable(t *testing.T) {
+	for _, test := range []struct {
+		name, field string
+		maximum     int
+	}{
+		{name: "client id", field: "GitHub client id", maximum: maximumOAuthClientIDLength},
+		{name: "device code", field: "GitHub device code", maximum: maximumDeviceCodeLength},
+		{name: "user code", field: "GitHub user code", maximum: maximumUserCodeLength},
+		{name: "GitHub token", field: "GitHub access token", maximum: maximumGitHubTokenLength},
+		{name: "registry token", field: "registry token", maximum: maximumRegistryTokenLength},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validatePrintableASCIIField(test.field, strings.Repeat("x", test.maximum), test.maximum); err != nil {
+				t.Fatalf("exact limit: %v", err)
+			}
+			for _, value := range []string{"value\x1b[2J", "value\nforged", strings.Repeat("x", test.maximum+1)} {
+				if err := validatePrintableASCIIField(test.field, value, test.maximum); err == nil {
+					t.Fatalf("accepted unsafe value of length %d", len(value))
+				}
+			}
+		})
+	}
+}
+
+func TestRegistryTokenInputIsBounded(t *testing.T) {
+	valid := strings.Repeat("x", maximumRegistryTokenLength)
+	if got, err := readRegistryToken(strings.NewReader(valid + "\r\n")); err != nil || got != valid {
+		t.Fatalf("exact token input = %d bytes, %v", len(got), err)
+	}
+	for _, input := range []string{
+		"token\x1b[2J",
+		strings.Repeat("x", maximumRegistryInputLength+1),
+		" \r\n",
+	} {
+		if _, err := readRegistryToken(strings.NewReader(input)); err == nil {
+			t.Fatalf("accepted unsafe token input of length %d", len(input))
+		}
+	}
+}
+
 func TestDeviceVerificationURLIsPinnedToProvider(t *testing.T) {
 	const endpoint = "https://github.com/login/device/code"
 	const fallback = "https://github.com/login/device"
@@ -223,6 +308,7 @@ func TestDeviceVerificationURLIsPinnedToProvider(t *testing.T) {
 		{name: "port", candidate: "https://github.com:8443/login/device", want: fallback},
 		{name: "wrong path", candidate: "https://github.com/login/oauth/authorize", want: fallback},
 		{name: "fragment", candidate: "https://github.com/login/device#credential", want: fallback},
+		{name: "oversized", candidate: "https://github.com/login/device?" + strings.Repeat("x", maximumVerificationURLSize), want: fallback},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if got := trustedDeviceVerificationURL(test.candidate, endpoint); got != test.want {

--- a/cli/manager/internal/registry/auth_security_test.go
+++ b/cli/manager/internal/registry/auth_security_test.go
@@ -203,3 +203,83 @@ func TestDeviceAuthorizationPinsRegistryOrigin(t *testing.T) {
 		t.Fatalf("pinned registry did not receive exchange token: %q", capture.exchangedGitHubToken)
 	}
 }
+
+func TestDeviceVerificationURLIsPinnedToProvider(t *testing.T) {
+	const endpoint = "https://github.com/login/device/code"
+	const fallback = "https://github.com/login/device"
+	for _, test := range []struct {
+		name      string
+		candidate string
+		want      string
+	}{
+		{name: "empty", want: fallback},
+		{name: "plain", candidate: fallback, want: fallback},
+		{name: "complete", candidate: fallback + "?user_code=ABCD-EFGH", want: fallback + "?user_code=ABCD-EFGH"},
+		{name: "plaintext", candidate: "http://github.com/login/device", want: fallback},
+		{name: "custom scheme", candidate: "file:///etc/passwd", want: fallback},
+		{name: "userinfo", candidate: "https://github.com@evil.example/login/device", want: fallback},
+		{name: "lookalike", candidate: "https://github.com.evil.example/login/device", want: fallback},
+		{name: "subdomain", candidate: "https://device.github.com/login/device", want: fallback},
+		{name: "port", candidate: "https://github.com:8443/login/device", want: fallback},
+		{name: "wrong path", candidate: "https://github.com/login/oauth/authorize", want: fallback},
+		{name: "fragment", candidate: "https://github.com/login/device#credential", want: fallback},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := trustedDeviceVerificationURL(test.candidate, endpoint); got != test.want {
+				t.Fatalf("trustedDeviceVerificationURL(%q) = %q, want %q", test.candidate, got, test.want)
+			}
+		})
+	}
+}
+
+func TestBrowserDeviceFlowRejectsUntrustedVerificationURL(t *testing.T) {
+	registry := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/auth/github/client":
+			_, _ = writer.Write([]byte(`{"client_id":"client-id","scope":"read:user"}`))
+		case "/api/auth/github/exchange":
+			_, _ = writer.Write([]byte(`{"token":"` + testRegistryToken + `"}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer registry.Close()
+	oauth := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/login/device/code":
+			_ = json.NewEncoder(writer).Encode(map[string]any{
+				"device_code":               testDeviceCode,
+				"user_code":                 "short-lived-code",
+				"verification_uri":          "file:///etc/passwd",
+				"verification_uri_complete": "https://evil.example/collect?token=secret",
+				"expires_in":                600,
+				"interval":                  1,
+			})
+		case "/login/oauth/access_token":
+			_, _ = writer.Write([]byte(`{"access_token":"` + testGitHubToken + `"}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer oauth.Close()
+
+	var openedURL string
+	hooks := deviceFlowHooks{
+		deviceCodeEndpoint:  oauth.URL + "/login/device/code",
+		accessTokenEndpoint: oauth.URL + "/login/oauth/access_token",
+		openBrowser: func(target string) error {
+			openedURL = target
+			return nil
+		},
+		wait: func(ctx context.Context, _ time.Duration) error {
+			return ctx.Err()
+		},
+	}
+	_, err := githubDeviceTokenUsingContext(context.Background(), registry.URL, true, hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if openedURL != oauth.URL+"/login/device" {
+		t.Fatalf("opened URL = %q", openedURL)
+	}
+}

--- a/cli/manager/internal/registry/auth_security_test.go
+++ b/cli/manager/internal/registry/auth_security_test.go
@@ -152,6 +152,23 @@ func TestDeviceExchangeErrorRedactsCredentials(t *testing.T) {
 	}
 }
 
+func TestDeviceExchangeRejectsContradictoryErrorAndToken(t *testing.T) {
+	server, _ := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`","error":"failed"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+
+	_, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if err == nil || !strings.Contains(err.Error(), "error during the GitHub exchange") {
+		t.Fatalf("contradictory exchange response = %v", err)
+	}
+	for _, secret := range []string{testGitHubToken, testRegistryToken} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("error leaked %q: %v", secret, err)
+		}
+	}
+}
+
 func TestDevicePollingErrorRedactsCredentials(t *testing.T) {
 	server, capture := newDeviceFlowServer(t,
 		`{"error":"`+testDeviceCode+` `+testGitHubToken+` `+testRegistryToken+`"}`,
@@ -170,6 +187,63 @@ func TestDevicePollingErrorRedactsCredentials(t *testing.T) {
 	}
 	if capture.exchangedGitHubToken != "" {
 		t.Fatalf("failed poll exchanged %q", capture.exchangedGitHubToken)
+	}
+}
+
+func TestDeviceAuthorizationRejectsContradictoryErrorAndCodes(t *testing.T) {
+	registry := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte(`{"client_id":"client-id","scope":"read:user"}`))
+	}))
+	defer registry.Close()
+	var oauthRequests atomic.Int32
+	oauth := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		oauthRequests.Add(1)
+		_ = json.NewEncoder(writer).Encode(map[string]any{
+			"error":       "access_denied",
+			"device_code": testDeviceCode,
+			"user_code":   "short-lived-code",
+		})
+	}))
+	defer oauth.Close()
+
+	hooks := deviceFlowTestHooks(t, oauth.URL, new(string))
+	_, err := githubDeviceTokenUsingContext(context.Background(), registry.URL, false, hooks)
+	if err == nil || !strings.Contains(err.Error(), "rejected the device authorization") {
+		t.Fatalf("contradictory authorization response = %v", err)
+	}
+	if got := oauthRequests.Load(); got != 1 {
+		t.Fatalf("contradictory authorization made %d OAuth requests", got)
+	}
+}
+
+func TestDevicePollingRejectsContradictoryErrorAndToken(t *testing.T) {
+	server, capture := newDeviceFlowServer(t,
+		`{"access_token":"`+testGitHubToken+`","error":"access_denied"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+
+	_, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if err == nil || !strings.Contains(err.Error(), "authorization was denied") {
+		t.Fatalf("contradictory token response = %v", err)
+	}
+	if capture.exchangedGitHubToken != "" {
+		t.Fatalf("contradictory token response exchanged %q", capture.exchangedGitHubToken)
+	}
+}
+
+func TestDevicePollingRejectsMissingTokenAndError(t *testing.T) {
+	server, capture := newDeviceFlowServer(t, `{}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+
+	_, err := githubDeviceTokenUsingContext(context.Background(), server.URL, false, hooks)
+	if err == nil || !strings.Contains(err.Error(), "incomplete device token response") {
+		t.Fatalf("incomplete token response = %v", err)
+	}
+	if capture.exchangedGitHubToken != "" {
+		t.Fatalf("incomplete token response exchanged %q", capture.exchangedGitHubToken)
 	}
 }
 

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -88,6 +88,12 @@ func apiRequestAtBaseLimitContext(ctx context.Context, base, method, path, token
 		req.Header.Set("Content-Type", "application/json")
 	}
 	response, err := registryHTTP.Bytes(ctx, req, min(responseLimit, registryResponseMaximum))
+	if token != "" && (response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices) {
+		// A credential-bearing endpoint may accidentally reflect the bearer or
+		// request body in an error. Preserve only the status across this trust
+		// boundary so callers cannot render reflected credentials.
+		response.Body = nil
+	}
 	return response.StatusCode, response.Body, err
 }
 
@@ -189,7 +195,7 @@ func fetchMeAtBaseContext(ctx context.Context, base, token string) (meResponse, 
 		return meResponse{}, errUnauthorized
 	}
 	if status != http.StatusOK {
-		return meResponse{}, errors.New(apiError(status, data))
+		return meResponse{}, fmt.Errorf("registry returned status %d", status)
 	}
 	var me meResponse
 	if err := json.Unmarshal(data, &me); err != nil {

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -118,6 +118,10 @@ func validateRegistryBaseURL(base string) error {
 	}
 }
 
+// ValidateBaseURL applies the registry transport policy to consumers that use
+// the configured registry outside the JSON API helper, such as catalog lookup.
+func ValidateBaseURL(base string) error { return validateRegistryBaseURL(base) }
+
 func isLoopbackHost(host string) bool {
 	host = strings.TrimSuffix(strings.ToLower(host), ".")
 	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
@@ -138,19 +142,11 @@ func recordRegistryInstallContext(parent context.Context, module, version string
 	if automation.Offline() {
 		return
 	}
-	body, err := json.Marshal(map[string]string{"version": version})
-	if err != nil {
-		return
-	}
 	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 	path := "/api/packages/" + url.PathEscape(module) + "/installs"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registryBase()+path, bytes.NewReader(body))
-	if err != nil {
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	_, _ = registryHTTP.Bytes(ctx, req, 4<<10)
+	_, _, _ = apiRequestAtBaseLimitContext(ctx, registryBase(), http.MethodPost, path, "",
+		map[string]string{"version": version}, 4<<10)
 }
 
 // apiError extracts the {"error":...} message from a response body, falling back

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -43,6 +43,10 @@ func apiRequest(method, path, token string, body any) (int, []byte, error) {
 }
 
 func apiRequestContext(ctx context.Context, method, path, token string, body any) (int, []byte, error) {
+	return apiRequestAtBaseContext(ctx, registryBase(), method, path, token, body)
+}
+
+func apiRequestAtBaseContext(ctx context.Context, base, method, path, token string, body any) (int, []byte, error) {
 	if err := automation.RequireOnline("registry request"); err != nil {
 		return 0, nil, err
 	}
@@ -54,7 +58,7 @@ func apiRequestContext(ctx context.Context, method, path, token string, body any
 		}
 		reader = bytes.NewReader(b)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, registryBase()+path, reader)
+	req, err := http.NewRequestWithContext(ctx, method, base+path, reader)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -130,7 +134,7 @@ func fetchMeContext(ctx context.Context, token string) (meResponse, error) {
 }
 
 // registryLogin obtains an API token and stores it for the current registry.
-// Interactively it asks whether to log in with a browser link (loopback flow) or
-// a one-time code (device flow, for headless/remote machines); --link and --code
-// pick one without prompting. --token <t> uses a token directly and --with-token
-// reads one from stdin (for CI).
+// Interactively it asks whether to open the device-authorization link in a
+// browser or leave it for a headless/remote browser; --link and --code pick one
+// without prompting. --token <t> uses a token directly and --with-token reads
+// one from stdin (for CI).

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/wago-org/wago/cli/internal/automation"
@@ -50,6 +52,9 @@ func apiRequestAtBaseContext(ctx context.Context, base, method, path, token stri
 	if err := automation.RequireOnline("registry request"); err != nil {
 		return 0, nil, err
 	}
+	if err := validateRegistryBaseURL(base); err != nil {
+		return 0, nil, err
+	}
 	var reader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -70,6 +75,36 @@ func apiRequestAtBaseContext(ctx context.Context, base, method, path, token stri
 	}
 	response, err := registryHTTP.Bytes(ctx, req, registryResponseMaximum)
 	return response.StatusCode, response.Body, err
+}
+
+func validateRegistryBaseURL(base string) error {
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return fmt.Errorf("invalid registry URL: %w", err)
+	}
+	if parsed.Opaque != "" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("invalid registry URL: expected an HTTP(S) base URL without credentials, query, or fragment")
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(parsed.Hostname()) {
+			return nil
+		}
+		return errors.New("insecure registry URL: HTTPS is required except for loopback development servers")
+	default:
+		return errors.New("invalid registry URL: expected HTTPS or loopback HTTP")
+	}
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	address := net.ParseIP(host)
+	return address != nil && address.IsLoopback()
 }
 
 // recordRegistryInstall reports one successfully installed plugin to the public
@@ -116,7 +151,11 @@ func fetchMe(token string) (meResponse, error) {
 }
 
 func fetchMeContext(ctx context.Context, token string) (meResponse, error) {
-	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/me", token, nil)
+	return fetchMeAtBaseContext(ctx, registryBase(), token)
+}
+
+func fetchMeAtBaseContext(ctx context.Context, base, token string) (meResponse, error) {
+	status, data, err := apiRequestAtBaseContext(ctx, base, http.MethodGet, "/api/me", token, nil)
 	if err != nil {
 		return meResponse{}, err
 	}

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -20,8 +20,9 @@ import (
 const registryResponseLimit int64 = 4 << 20
 
 const (
-	registryAuthResponseLimit  int64 = 128 << 10
-	maximumRegistryLoginLength       = 256
+	registryAuthResponseLimit       int64 = 128 << 10
+	maximumRegistryLoginLength            = 256
+	maximumRegistryDisplayURLLength       = 4 << 10
 )
 
 var (
@@ -152,6 +153,12 @@ func recordRegistryInstallContext(parent context.Context, module, version string
 // apiError extracts the {"error":...} message from a response body, falling back
 // to the status code.
 func apiError(status int, data []byte) string {
+	return ResponseError(status, data)
+}
+
+// ResponseError returns a bounded, terminal-safe registry error or a numeric
+// status fallback. It is shared by registry consumers outside this package.
+func ResponseError(status int, data []byte) string {
 	var e struct {
 		Error string `json:"error"`
 	}
@@ -159,6 +166,14 @@ func apiError(status int, data []byte) string {
 		return e.Error
 	}
 	return fmt.Sprintf("server returned status %d", status)
+}
+
+func registryDisplayBase(base string) string {
+	if validateRegistryBaseURL(base) != nil ||
+		validateTerminalTextField("registry URL", base, maximumRegistryDisplayURLLength) != nil {
+		return "configured registry"
+	}
+	return base
 }
 
 func validateTerminalTextField(name, value string, maximum int) error {

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -209,8 +209,8 @@ func fetchMeAtBaseContext(ctx context.Context, base, token string) (meResponse, 
 		return meResponse{}, fmt.Errorf("registry returned status %d", status)
 	}
 	var me meResponse
-	if err := json.Unmarshal(data, &me); err != nil {
-		return meResponse{}, err
+	if err := unmarshalUniqueJSON(data, &me); err != nil {
+		return meResponse{}, fmt.Errorf("parsing registry identity: %w", err)
 	}
 	if me.Login == "" {
 		return meResponse{}, errors.New("registry returned no login")

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -162,7 +162,7 @@ func ResponseError(status int, data []byte) string {
 	var e struct {
 		Error string `json:"error"`
 	}
-	if json.Unmarshal(data, &e) == nil && e.Error != "" && validateTerminalTextField("registry error", e.Error, 1024) == nil {
+	if unmarshalUniqueJSON(data, &e) == nil && e.Error != "" && validateTerminalTextField("registry error", e.Error, 1024) == nil {
 		return e.Error
 	}
 	return fmt.Sprintf("server returned status %d", status)

--- a/cli/manager/internal/registry/client.go
+++ b/cli/manager/internal/registry/client.go
@@ -19,6 +19,11 @@ import (
 
 const registryResponseLimit int64 = 4 << 20
 
+const (
+	registryAuthResponseLimit  int64 = 128 << 10
+	maximumRegistryLoginLength       = 256
+)
+
 var (
 	registryResponseMaximum = registryResponseLimit
 	registryHTTP            = httpclient.NewAPI()
@@ -49,11 +54,20 @@ func apiRequestContext(ctx context.Context, method, path, token string, body any
 }
 
 func apiRequestAtBaseContext(ctx context.Context, base, method, path, token string, body any) (int, []byte, error) {
+	return apiRequestAtBaseLimitContext(ctx, base, method, path, token, body, registryResponseMaximum)
+}
+
+func apiRequestAtBaseLimitContext(ctx context.Context, base, method, path, token string, body any, responseLimit int64) (int, []byte, error) {
 	if err := automation.RequireOnline("registry request"); err != nil {
 		return 0, nil, err
 	}
 	if err := validateRegistryBaseURL(base); err != nil {
 		return 0, nil, err
+	}
+	if token != "" {
+		if err := validateRegistryToken(token); err != nil {
+			return 0, nil, err
+		}
 	}
 	var reader io.Reader
 	if body != nil {
@@ -73,7 +87,7 @@ func apiRequestAtBaseContext(ctx context.Context, base, method, path, token stri
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	response, err := registryHTTP.Bytes(ctx, req, registryResponseMaximum)
+	response, err := registryHTTP.Bytes(ctx, req, min(responseLimit, registryResponseMaximum))
 	return response.StatusCode, response.Body, err
 }
 
@@ -139,10 +153,22 @@ func apiError(status int, data []byte) string {
 	var e struct {
 		Error string `json:"error"`
 	}
-	if json.Unmarshal(data, &e) == nil && e.Error != "" {
+	if json.Unmarshal(data, &e) == nil && e.Error != "" && validateTerminalTextField("registry error", e.Error, 1024) == nil {
 		return e.Error
 	}
 	return fmt.Sprintf("server returned status %d", status)
+}
+
+func validateTerminalTextField(name, value string, maximum int) error {
+	if len(value) > maximum {
+		return fmt.Errorf("%s exceeds %d-byte limit", name, maximum)
+	}
+	for index := range len(value) {
+		if value[index] < 0x20 || value[index] > 0x7e {
+			return fmt.Errorf("%s contains non-printable characters", name)
+		}
+	}
+	return nil
 }
 
 // fetchMe calls GET /api/me and returns the user, or errUnauthorized on a 401.
@@ -155,7 +181,7 @@ func fetchMeContext(ctx context.Context, token string) (meResponse, error) {
 }
 
 func fetchMeAtBaseContext(ctx context.Context, base, token string) (meResponse, error) {
-	status, data, err := apiRequestAtBaseContext(ctx, base, http.MethodGet, "/api/me", token, nil)
+	status, data, err := apiRequestAtBaseLimitContext(ctx, base, http.MethodGet, "/api/me", token, nil, registryAuthResponseLimit)
 	if err != nil {
 		return meResponse{}, err
 	}
@@ -167,6 +193,12 @@ func fetchMeAtBaseContext(ctx context.Context, base, token string) (meResponse, 
 	}
 	var me meResponse
 	if err := json.Unmarshal(data, &me); err != nil {
+		return meResponse{}, err
+	}
+	if me.Login == "" {
+		return meResponse{}, errors.New("registry returned no login")
+	}
+	if err := validatePrintableASCIIField("registry login", me.Login, maximumRegistryLoginLength); err != nil {
 		return meResponse{}, err
 	}
 	return me, nil

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -106,6 +106,7 @@ func TestRegistryIdentityAndErrorsAreTerminalSafe(t *testing.T) {
 		`{"error":"broken\u001b[2J"}`,
 		`{"error":"broken\nforged"}`,
 		`{"error":"` + strings.Repeat("x", 1025) + `"}`,
+		`{"error":"one","Error":"two"}`,
 	} {
 		if got := apiError(http.StatusBadRequest, []byte(data)); got != "server returned status 400" {
 			t.Fatalf("unsafe registry error rendered as %q", got)
@@ -383,6 +384,14 @@ func TestRegistryModuleResolution(t *testing.T) {
 	status, body = http.StatusOK, `{}`
 	if _, err := resolveRegistryModule("empty"); err == nil || !strings.Contains(err.Error(), "no module path") {
 		t.Fatalf("empty module path = %v", err)
+	}
+	status, body = http.StatusOK, `{"name":"../../malicious"}`
+	if _, err := resolveRegistryModule("invalid-name"); err == nil || !strings.Contains(err.Error(), "invalid module path") {
+		t.Fatalf("invalid module path = %v", err)
+	}
+	status, body = http.StatusOK, `{"name":"github.com/acme/one","Name":"github.com/acme/two"}`
+	if _, err := resolveRegistryModule("ambiguous-name"); err == nil || !strings.Contains(err.Error(), "invalid package metadata") {
+		t.Fatalf("ambiguous module path = %v", err)
 	}
 }
 

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -116,6 +116,26 @@ func TestRegistryIdentityAndErrorsAreTerminalSafe(t *testing.T) {
 	}
 }
 
+func TestRegistryIdentityRejectsAmbiguousAndReflectedJSON(t *testing.T) {
+	remote := strings.Repeat("9", 32<<10)
+	for _, body := range []string{
+		`{"login":"alice","Login":"mallory"}`,
+		`{"login":` + remote + `}`,
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(body))
+		}))
+		_, err := fetchMeAtBaseContext(context.Background(), server.URL, testRegistryToken)
+		server.Close()
+		if err == nil {
+			t.Fatalf("ambiguous registry identity succeeded: %.80s", body)
+		}
+		if strings.Contains(err.Error(), remote[:1024]) || len(err.Error()) > 256 {
+			t.Fatalf("registry identity error was not bounded: %d bytes", len(err.Error()))
+		}
+	}
+}
+
 func TestRegistryDisplayBaseIsTerminalSafeAndBounded(t *testing.T) {
 	const valid = "https://registry.example/prefix"
 	if got := registryDisplayBase(valid); got != valid {

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -55,6 +56,101 @@ func TestRegistryHTTPHelpers(t *testing.T) {
 	}
 	if got := apiError(http.StatusBadRequest, []byte("not json")); got != "server returned status 400" {
 		t.Fatalf("apiError fallback = %q", got)
+	}
+}
+
+func TestRegistryBaseURLSecurityPolicy(t *testing.T) {
+	for _, base := range []string{
+		"https://registry.example",
+		"https://registry.example:8443/prefix",
+		"http://localhost:8080",
+		"http://api.localhost:8080",
+		"http://127.0.0.1:8080",
+		"http://127.255.255.254:8080",
+		"http://[::1]:8080",
+	} {
+		if err := validateRegistryBaseURL(base); err != nil {
+			t.Errorf("validateRegistryBaseURL(%q) = %v", base, err)
+		}
+	}
+	for _, base := range []string{
+		"http://registry.example",
+		"http://localhost.example",
+		"ftp://registry.example",
+		"registry.example",
+		"https://user:password@registry.example",
+		"https://registry.example?destination=evil",
+		"https://registry.example#fragment",
+	} {
+		if err := validateRegistryBaseURL(base); err == nil {
+			t.Errorf("validateRegistryBaseURL(%q) succeeded", base)
+		}
+	}
+}
+
+func TestRegistryRequestRejectsRemotePlaintextBeforeDial(t *testing.T) {
+	_, _, err := apiRequestAtBaseContext(context.Background(), "http://192.0.2.1", http.MethodPost,
+		"/api/auth/github/exchange", "", map[string]string{"access_token": testGitHubToken})
+	if err == nil || !strings.Contains(err.Error(), "HTTPS is required") {
+		t.Fatalf("remote plaintext registry = %v", err)
+	}
+}
+
+func TestFetchMeUsesPinnedRegistryOrigin(t *testing.T) {
+	var receivedBearer string
+	var unexpectedRequests atomic.Int32
+	pinned := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		receivedBearer = request.Header.Get("Authorization")
+		_, _ = writer.Write([]byte(`{"login":"alice"}`))
+	}))
+	defer pinned.Close()
+
+	unexpected := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		unexpectedRequests.Add(1)
+	}))
+	defer unexpected.Close()
+	t.Setenv("WAGO_REGISTRY", unexpected.URL)
+
+	me, err := fetchMeAtBaseContext(context.Background(), pinned.URL, testRegistryToken)
+	if err != nil || me.Login != "alice" {
+		t.Fatalf("fetchMeAtBaseContext = %+v, %v", me, err)
+	}
+	if receivedBearer != "Bearer "+testRegistryToken {
+		t.Fatalf("pinned registry received Authorization %q", receivedBearer)
+	}
+	if got := unexpectedRequests.Load(); got != 0 {
+		t.Fatalf("mutable registry received %d bearer validation requests", got)
+	}
+}
+
+func TestRegistryExchangeRedirectDoesNotForwardCredential(t *testing.T) {
+	for _, status := range []int{
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var sinkRequests atomic.Int32
+			sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				sinkRequests.Add(1)
+			}))
+			defer sink.Close()
+			registry := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Location", sink.URL)
+				writer.WriteHeader(status)
+			}))
+			defer registry.Close()
+
+			gotStatus, _, err := apiRequestAtBaseContext(context.Background(), registry.URL, http.MethodPost,
+				"/api/auth/github/exchange", testRegistryToken, map[string]string{"access_token": testGitHubToken})
+			if err != nil || gotStatus != status {
+				t.Fatalf("redirect response = %d, %v", gotStatus, err)
+			}
+			if got := sinkRequests.Load(); got != 0 {
+				t.Fatalf("redirect sink received %d credential-bearing requests", got)
+			}
+		})
 	}
 }
 

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -59,6 +60,37 @@ func TestRegistryHTTPHelpers(t *testing.T) {
 	}
 }
 
+func TestRegistryIdentityAndErrorsAreTerminalSafe(t *testing.T) {
+	for _, body := range []string{
+		`{"login":"alice\u001b[2J"}`,
+		`{"login":"alice\nforged"}`,
+		`{"login":"` + strings.Repeat("x", maximumRegistryLoginLength+1) + `"}`,
+		`{"login":""}`,
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(body))
+		}))
+		_, err := fetchMeAtBaseContext(context.Background(), server.URL, testRegistryToken)
+		server.Close()
+		if err == nil {
+			t.Fatalf("accepted unsafe identity %s", body)
+		}
+	}
+
+	for _, data := range []string{
+		`{"error":"broken\u001b[2J"}`,
+		`{"error":"broken\nforged"}`,
+		`{"error":"` + strings.Repeat("x", 1025) + `"}`,
+	} {
+		if got := apiError(http.StatusBadRequest, []byte(data)); got != "server returned status 400" {
+			t.Fatalf("unsafe registry error rendered as %q", got)
+		}
+	}
+	if got := apiError(http.StatusBadRequest, []byte(`{"error":"ordinary failure"}`)); got != "ordinary failure" {
+		t.Fatalf("safe registry error = %q", got)
+	}
+}
+
 func TestRegistryBaseURLSecurityPolicy(t *testing.T) {
 	for _, base := range []string{
 		"https://registry.example",
@@ -93,6 +125,31 @@ func TestRegistryRequestRejectsRemotePlaintextBeforeDial(t *testing.T) {
 		"/api/auth/github/exchange", "", map[string]string{"access_token": testGitHubToken})
 	if err == nil || !strings.Contains(err.Error(), "HTTPS is required") {
 		t.Fatalf("remote plaintext registry = %v", err)
+	}
+}
+
+func TestRegistryRequestRejectsUnsafeBearerBeforeDial(t *testing.T) {
+	for _, token := range []string{
+		"token\nforged",
+		"token\x1b[2J",
+		strings.Repeat("x", maximumRegistryTokenLength+1),
+	} {
+		_, _, err := apiRequestAtBaseContext(context.Background(), "https://192.0.2.1", http.MethodGet, "/api/me", token, nil)
+		if err == nil {
+			t.Fatalf("unsafe bearer of length %d reached request path", len(token))
+		}
+	}
+}
+
+func TestRegistryAuthenticationResponsesUseSmallerLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Length", strconv.FormatInt(registryAuthResponseLimit+1, 10))
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if _, err := fetchMeAtBaseContext(context.Background(), server.URL, testRegistryToken); !errors.Is(err, httpclient.ErrBodyTooLarge) {
+		t.Fatalf("oversized auth response = %v", err)
 	}
 }
 

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -48,7 +48,7 @@ func TestRegistryHTTPHelpers(t *testing.T) {
 		t.Fatalf("unauthorized fetchMe = %v", err)
 	}
 	status, body = http.StatusInternalServerError, `{"error":"broken"}`
-	if _, err := fetchMe("token"); err == nil || err.Error() != "broken" {
+	if _, err := fetchMe("token"); err == nil || err.Error() != "registry returned status 500" {
 		t.Fatalf("error fetchMe = %v", err)
 	}
 	status, body = http.StatusOK, "not json"
@@ -57,6 +57,31 @@ func TestRegistryHTTPHelpers(t *testing.T) {
 	}
 	if got := apiError(http.StatusBadRequest, []byte("not json")); got != "server returned status 400" {
 		t.Fatalf("apiError fallback = %q", got)
+	}
+}
+
+func TestAuthenticatedRegistryErrorsDiscardReflectedCredentials(t *testing.T) {
+	for _, status := range []int{
+		http.StatusBadRequest,
+		http.StatusInternalServerError,
+		http.StatusTemporaryRedirect,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(status)
+				_, _ = writer.Write([]byte(`{"error":"` + testRegistryToken + `"}`))
+			}))
+			defer server.Close()
+
+			gotStatus, data, err := apiRequestAtBaseContext(context.Background(), server.URL, http.MethodGet,
+				"/api/me", testRegistryToken, nil)
+			if err != nil || gotStatus != status {
+				t.Fatalf("authenticated failure = %d, %v", gotStatus, err)
+			}
+			if len(data) != 0 {
+				t.Fatalf("authenticated failure retained reflected body %q", data)
+			}
+		})
 	}
 }
 

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -116,6 +116,23 @@ func TestRegistryIdentityAndErrorsAreTerminalSafe(t *testing.T) {
 	}
 }
 
+func TestRegistryDisplayBaseIsTerminalSafeAndBounded(t *testing.T) {
+	const valid = "https://registry.example/prefix"
+	if got := registryDisplayBase(valid); got != valid {
+		t.Fatalf("valid registry display = %q", got)
+	}
+	for _, base := range []string{
+		"https://registry.example/failure\nforged",
+		"https://registry.example/failure\x1b[2J",
+		"https://secret@registry.example",
+		"https://registry.example/" + strings.Repeat("x", maximumRegistryDisplayURLLength),
+	} {
+		if got := registryDisplayBase(base); got != "configured registry" {
+			t.Fatalf("unsafe registry display of length %d = %q", len(base), got)
+		}
+	}
+}
+
 func TestRegistryBaseURLSecurityPolicy(t *testing.T) {
 	for _, base := range []string{
 		"https://registry.example",

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -298,6 +298,28 @@ func TestRecordRegistryInstall(t *testing.T) {
 	}
 }
 
+func TestRecordRegistryInstallRejectsRemotePlaintextBeforeDial(t *testing.T) {
+	oldClient := registryHTTP
+	var requests atomic.Int32
+	registryHTTP = httpclient.New(httpclient.Config{HTTPClient: &http.Client{Transport: registryRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return nil, errors.New("unexpected request")
+	})}})
+	t.Cleanup(func() { registryHTTP = oldClient })
+	t.Setenv("WAGO_REGISTRY", "http://192.0.2.1")
+
+	recordRegistryInstall("github.com/acme/plugin", "v1.2.3")
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("remote plaintext install metric made %d requests", got)
+	}
+}
+
+type registryRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function registryRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
 // ioReadAll makes the handler's read error irrelevant to the request assertions.
 func ioReadAll(r *http.Request) ([]byte, error) { return io.ReadAll(r.Body) }
 

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -192,7 +192,7 @@ func TestLoginMethodPickerDefaultsToLinkAndAcceptsRightArrow(t *testing.T) {
 	frame := p.Frame()
 	for _, want := range []string{
 		"Choose login method",
-		"Link", "Open a browser link on this machine",
+		"Link", "Open one-time authorization in a browser",
 		"Code", "Use a one-time code on another device",
 		"◉", "○", "enter/→ select", "esc cancel",
 	} {

--- a/cli/manager/internal/registry/config.go
+++ b/cli/manager/internal/registry/config.go
@@ -142,7 +142,7 @@ func loadCredentials() (_ map[string]credential, resultErr error) {
 	// Registry URLs are map keys and therefore case-sensitive, while fields in
 	// each credential object follow encoding/json's case-insensitive struct
 	// matching. Apply the matching rule appropriate to each layer.
-	if err := validateUniqueJSON(data, false); err != nil {
+	if err := ValidateUniqueJSON(data); err != nil {
 		return nil, errors.New("credential store contains invalid JSON")
 	}
 	var entries map[string]json.RawMessage

--- a/cli/manager/internal/registry/config.go
+++ b/cli/manager/internal/registry/config.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -22,6 +23,8 @@ import (
 	"github.com/wago-org/wago/internal/filelock"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
+
+const maximumCredentialStoreSize int64 = 1 << 20
 
 // defaultRegistry is the public registry API base used when WAGO_REGISTRY is unset.
 const defaultRegistry = "https://api.plugins.wago.sh"
@@ -108,13 +111,26 @@ func credentialsPath() string {
 
 // loadCredentials reads the registry->credential map. A missing file yields an
 // empty map (not an error); a malformed file yields an error.
-func loadCredentials() (map[string]credential, error) {
-	data, err := os.ReadFile(credentialsPath())
+func loadCredentials() (_ map[string]credential, resultErr error) {
+	file, err := os.Open(credentialsPath())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return map[string]credential{}, nil
 		}
 		return nil, err
+	}
+	defer func() { resultErr = errors.Join(resultErr, file.Close()) }()
+	if info, err := file.Stat(); err != nil {
+		return nil, err
+	} else if info.Size() > maximumCredentialStoreSize {
+		return nil, fmt.Errorf("credential store exceeds %d-byte limit", maximumCredentialStoreSize)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maximumCredentialStoreSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maximumCredentialStoreSize {
+		return nil, fmt.Errorf("credential store exceeds %d-byte limit", maximumCredentialStoreSize)
 	}
 	creds := map[string]credential{}
 	if len(strings.TrimSpace(string(data))) == 0 {
@@ -136,6 +152,15 @@ func saveCredentials(base, token, login string) error {
 }
 
 func saveCredentialsContext(ctx context.Context, base, token, login string) error {
+	if err := validateRegistryToken(token); err != nil {
+		return err
+	}
+	if login == "" {
+		return errors.New("registry login is empty")
+	}
+	if err := validatePrintableASCIIField("registry login", login, maximumRegistryLoginLength); err != nil {
+		return err
+	}
 	_, err := mutateCredentials(ctx, func(creds map[string]credential) bool {
 		creds[base] = credential{Token: token, Login: login}
 		return true
@@ -222,6 +247,9 @@ func writeCredentialsLocked(path string, creds map[string]credential) error {
 		return err
 	}
 	data = append(data, '\n')
+	if int64(len(data)) > maximumCredentialStoreSize {
+		return fmt.Errorf("credential store exceeds %d-byte limit", maximumCredentialStoreSize)
+	}
 	return replaceCredentialFile(path, atomicfile.Options{Mode: 0o600, Sync: true, Hooks: credentialAtomicHooks}, func(writer io.Writer) error {
 		_, err := writer.Write(data)
 		return err

--- a/cli/manager/internal/registry/config.go
+++ b/cli/manager/internal/registry/config.go
@@ -113,25 +113,18 @@ func credentialsPath() string {
 // empty map (not an error); a malformed file yields an error.
 func loadCredentials() (_ map[string]credential, resultErr error) {
 	path := credentialsPath()
-	pathInfo, err := os.Lstat(path)
+	file, err := openCredentialFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return map[string]credential{}, nil
 		}
 		return nil, err
 	}
-	if !pathInfo.Mode().IsRegular() {
-		return nil, errors.New("credential store must be a regular file")
-	}
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
 	defer func() { resultErr = errors.Join(resultErr, file.Close()) }()
 	if info, err := file.Stat(); err != nil {
 		return nil, err
-	} else if !info.Mode().IsRegular() || !os.SameFile(pathInfo, info) {
-		return nil, errors.New("credential store changed while opening it")
+	} else if !info.Mode().IsRegular() {
+		return nil, errors.New("credential store must be a regular file")
 	} else if info.Size() > maximumCredentialStoreSize {
 		return nil, fmt.Errorf("credential store exceeds %d-byte limit", maximumCredentialStoreSize)
 	}

--- a/cli/manager/internal/registry/config.go
+++ b/cli/manager/internal/registry/config.go
@@ -112,16 +112,26 @@ func credentialsPath() string {
 // loadCredentials reads the registry->credential map. A missing file yields an
 // empty map (not an error); a malformed file yields an error.
 func loadCredentials() (_ map[string]credential, resultErr error) {
-	file, err := os.Open(credentialsPath())
+	path := credentialsPath()
+	pathInfo, err := os.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return map[string]credential{}, nil
 		}
 		return nil, err
 	}
+	if !pathInfo.Mode().IsRegular() {
+		return nil, errors.New("credential store must be a regular file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
 	defer func() { resultErr = errors.Join(resultErr, file.Close()) }()
 	if info, err := file.Stat(); err != nil {
 		return nil, err
+	} else if !info.Mode().IsRegular() || !os.SameFile(pathInfo, info) {
+		return nil, errors.New("credential store changed while opening it")
 	} else if info.Size() > maximumCredentialStoreSize {
 		return nil, fmt.Errorf("credential store exceeds %d-byte limit", maximumCredentialStoreSize)
 	}

--- a/cli/manager/internal/registry/config.go
+++ b/cli/manager/internal/registry/config.go
@@ -139,11 +139,22 @@ func loadCredentials() (_ map[string]credential, resultErr error) {
 	if len(strings.TrimSpace(string(data))) == 0 {
 		return creds, nil
 	}
-	if err := json.Unmarshal(data, &creds); err != nil {
-		return nil, err
+	// Registry URLs are map keys and therefore case-sensitive, while fields in
+	// each credential object follow encoding/json's case-insensitive struct
+	// matching. Apply the matching rule appropriate to each layer.
+	if err := validateUniqueJSON(data, false); err != nil {
+		return nil, errors.New("credential store contains invalid JSON")
 	}
-	if creds == nil {
+	var entries map[string]json.RawMessage
+	if err := json.Unmarshal(data, &entries); err != nil || entries == nil {
 		return nil, errors.New("credential store must be a JSON object")
+	}
+	for base, raw := range entries {
+		var item credential
+		if err := unmarshalUniqueJSON(raw, &item); err != nil {
+			return nil, errors.New("credential store contains an invalid credential entry")
+		}
+		creds[base] = item
 	}
 	return creds, nil
 }

--- a/cli/manager/internal/registry/config_hardening_test.go
+++ b/cli/manager/internal/registry/config_hardening_test.go
@@ -77,6 +77,16 @@ func TestCredentialStoreReadAndWriteAreBounded(t *testing.T) {
 	}
 }
 
+func TestCredentialStoreRejectsNonRegularPath(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	if err := os.MkdirAll(credentialsPath(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadCredentials(); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("directory credential store = %v", err)
+	}
+}
+
 func TestCredentialMutationRejectsSymlinkDestination(t *testing.T) {
 	t.Setenv("WAGO_HOME", t.TempDir())
 	if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {

--- a/cli/manager/internal/registry/config_hardening_test.go
+++ b/cli/manager/internal/registry/config_hardening_test.go
@@ -49,6 +49,34 @@ func TestCredentialMutationRejectsNullStoreWithoutOverwritingIt(t *testing.T) {
 	assertNoCredentialTemps(t)
 }
 
+func TestCredentialStoreReadAndWriteAreBounded(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oversized := strings.Repeat("x", int(maximumCredentialStoreSize)+1)
+	if err := os.WriteFile(credentialsPath(), []byte(oversized), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadCredentials(); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("oversized credential read = %v", err)
+	}
+
+	if err := os.WriteFile(credentialsPath(), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	creds := map[string]credential{
+		"https://oversized.test": {Token: oversized, Login: "alice"},
+	}
+	if err := writeCredentials(creds); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("oversized credential write = %v", err)
+	}
+	data, err := os.ReadFile(credentialsPath())
+	if err != nil || string(data) != "{}\n" {
+		t.Fatalf("oversized write changed store to %q: %v", data, err)
+	}
+}
+
 func TestCredentialMutationRejectsSymlinkDestination(t *testing.T) {
 	t.Setenv("WAGO_HOME", t.TempDir())
 	if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {
@@ -297,7 +325,7 @@ func TestCredentialTemporaryFileIsPrivateAndReadersSeeCompleteJSON(t *testing.T)
 		}
 	}()
 	for index := range 50 {
-		if err := saveCredentials("https://one.test", strings.Repeat("x", 1024)+string(rune(index)), "one"); err != nil {
+		if err := saveCredentials("https://one.test", strings.Repeat("x", 1024)+string(rune('A'+index%26)), "one"); err != nil {
 			close(stop)
 			t.Fatal(err)
 		}

--- a/cli/manager/internal/registry/config_hardening_test.go
+++ b/cli/manager/internal/registry/config_hardening_test.go
@@ -49,6 +49,41 @@ func TestCredentialMutationRejectsNullStoreWithoutOverwritingIt(t *testing.T) {
 	assertNoCredentialTemps(t)
 }
 
+func TestCredentialStoreRejectsDuplicateMembers(t *testing.T) {
+	for _, data := range []string{
+		`{"https://one.test":{"token":"one","login":"alice"},"https://one.test":{"token":"two","login":"mallory"}}`,
+		`{"https://one.test":{"token":"one","Token":"two","login":"alice"}}`,
+	} {
+		t.Run(data[:min(len(data), 40)], func(t *testing.T) {
+			t.Setenv("WAGO_HOME", t.TempDir())
+			if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(credentialsPath(), []byte(data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadCredentials(); err == nil {
+				t.Fatal("credential store with duplicate members succeeded")
+			}
+		})
+	}
+}
+
+func TestCredentialStorePreservesCaseSensitiveRegistryPaths(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := `{"https://one.test/A":{"token":"one","login":"alice"},"https://one.test/a":{"token":"two","login":"bob"}}`
+	if err := os.WriteFile(credentialsPath(), []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	creds, err := loadCredentials()
+	if err != nil || len(creds) != 2 || creds["https://one.test/A"].Token != "one" || creds["https://one.test/a"].Token != "two" {
+		t.Fatalf("case-sensitive credential keys = %#v, %v", creds, err)
+	}
+}
+
 func TestCredentialStoreReadAndWriteAreBounded(t *testing.T) {
 	t.Setenv("WAGO_HOME", t.TempDir())
 	if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {

--- a/cli/manager/internal/registry/config_special_unix_test.go
+++ b/cli/manager/internal/registry/config_special_unix_test.go
@@ -1,0 +1,35 @@
+//go:build linux || darwin
+
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestCredentialStoreRejectsFIFOWithoutBlocking(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(credentialsPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(credentialsPath(), 0o600); err != nil {
+		t.Skipf("creating FIFO: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := loadCredentials()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("FIFO credential store = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("FIFO credential store blocked during open")
+	}
+}

--- a/cli/manager/internal/registry/credential_open_other.go
+++ b/cli/manager/internal/registry/credential_open_other.go
@@ -1,0 +1,32 @@
+//go:build !linux && !darwin && !windows
+
+package registry
+
+import (
+	"errors"
+	"os"
+)
+
+func openCredentialFile(path string) (*os.File, error) {
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !pathInfo.Mode().IsRegular() {
+		return nil, errors.New("credential store must be a regular file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || !os.SameFile(pathInfo, info) {
+		_ = file.Close()
+		return nil, errors.New("credential store changed while opening it")
+	}
+	return file, nil
+}

--- a/cli/manager/internal/registry/credential_open_unix.go
+++ b/cli/manager/internal/registry/credential_open_unix.go
@@ -1,0 +1,22 @@
+//go:build linux || darwin
+
+package registry
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openCredentialFile(path string) (*os.File, error) {
+	descriptor, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(descriptor), path)
+	if file == nil {
+		_ = unix.Close(descriptor)
+		return nil, os.ErrInvalid
+	}
+	return file, nil
+}

--- a/cli/manager/internal/registry/credential_open_windows.go
+++ b/cli/manager/internal/registry/credential_open_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package registry
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openCredentialFile(path string) (*os.File, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(name, windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil,
+		windows.OPEN_EXISTING, windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, os.ErrInvalid
+	}
+	return file, nil
+}

--- a/cli/manager/internal/registry/oauth.go
+++ b/cli/manager/internal/registry/oauth.go
@@ -2,8 +2,6 @@ package registry
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,12 +14,6 @@ import (
 )
 
 var oauthResponseMaximum int64 = 1 << 20
-
-const SuccessHTML = `<!doctype html><html><head><meta charset="utf-8">` +
-	`<title>wago — logged in</title></head>` +
-	`<body style="font-family:system-ui,sans-serif;text-align:center;padding:4rem">` +
-	`<h1>You're logged in ✓</h1><p>You can close this tab and return to your terminal.</p>` +
-	`</body></html>`
 
 // PostForm sends a GitHub OAuth form request and decodes its bounded JSON response.
 func PostForm(endpoint string, form url.Values, output any) error {
@@ -62,12 +54,4 @@ func OpenBrowser(target string) error {
 		command = exec.Command("xdg-open", target)
 	}
 	return command.Start()
-}
-
-func RandomState() (string, error) {
-	data := make([]byte, 16)
-	if _, err := rand.Read(data); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(data), nil
 }

--- a/cli/manager/internal/registry/oauth.go
+++ b/cli/manager/internal/registry/oauth.go
@@ -13,7 +13,7 @@ import (
 	"github.com/wago-org/wago/cli/internal/automation"
 )
 
-var oauthResponseMaximum int64 = 1 << 20
+var oauthResponseMaximum int64 = 128 << 10
 
 // PostForm sends a GitHub OAuth form request and decodes its bounded JSON response.
 func PostForm(endpoint string, form url.Values, output any) error {
@@ -35,7 +35,7 @@ func PostFormContext(ctx context.Context, endpoint string, form url.Values, outp
 		return err
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return fmt.Errorf("OAuth endpoint returned %s", response.Status)
+		return fmt.Errorf("OAuth endpoint returned status %d", response.StatusCode)
 	}
 	return json.Unmarshal(response.Body, output)
 }

--- a/cli/manager/internal/registry/oauth.go
+++ b/cli/manager/internal/registry/oauth.go
@@ -48,7 +48,7 @@ func PostFormContext(ctx context.Context, endpoint string, form url.Values, outp
 // responses contain security decisions whose meaning must not depend on whether
 // a decoder keeps the first or last spelling of a repeated field.
 func unmarshalUniqueJSON(data []byte, output any) error {
-	if err := ValidateUniqueJSON(data); err != nil {
+	if err := ValidateUniqueFoldedJSON(data); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(data, output); err != nil {
@@ -57,13 +57,27 @@ func unmarshalUniqueJSON(data []byte, output any) error {
 	return nil
 }
 
-// ValidateUniqueJSON validates one JSON value and rejects object members whose
-// names repeat under the case-insensitive matching used by encoding/json.
+// ValidateUniqueJSON validates one JSON value and rejects exactly repeated
+// object members. JSON map keys remain case-sensitive.
 func ValidateUniqueJSON(data []byte) error {
-	return validateUniqueJSON(data, true)
+	return validateUniqueJSON(data, false, nil)
 }
 
-func validateUniqueJSON(data []byte, foldNames bool) error {
+// ValidateUniqueFoldedJSON additionally treats case-folded object member names
+// as duplicates, matching encoding/json's struct-field lookup. Values of fields
+// in exactSubtrees use ordinary case-sensitive JSON object semantics.
+func ValidateUniqueFoldedJSON(data []byte, exactSubtrees ...string) error {
+	var exact map[string]struct{}
+	if len(exactSubtrees) > 0 {
+		exact = make(map[string]struct{}, len(exactSubtrees))
+	}
+	for _, field := range exactSubtrees {
+		exact[foldJSONName(field)] = struct{}{}
+	}
+	return validateUniqueJSON(data, true, exact)
+}
+
+func validateUniqueJSON(data []byte, foldNames bool, exactSubtrees map[string]struct{}) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 	var frames []uniqueJSONFrame
@@ -90,7 +104,14 @@ func validateUniqueJSON(data []byte, foldNames bool) error {
 				if err := beginUniqueJSONValue(frames, &rootStarted); err != nil {
 					return err
 				}
-				frames = append(frames, uniqueJSONFrame{object: delimiter == '{', wantKey: delimiter == '{'})
+				childFoldNames := foldNames
+				if len(frames) > 0 {
+					childFoldNames = frames[len(frames)-1].valueFoldNames
+				}
+				frames = append(frames, uniqueJSONFrame{
+					object: delimiter == '{', wantKey: delimiter == '{',
+					foldNames: childFoldNames, valueFoldNames: childFoldNames,
+				})
 			case '}', ']':
 				if len(frames) == 0 {
 					return errors.New("JSON response contains an unexpected closing delimiter")
@@ -117,13 +138,17 @@ func validateUniqueJSON(data []byte, foldNames bool) error {
 				frame.members = map[string]struct{}{}
 			}
 			canonicalKey := key
-			if foldNames {
+			if frame.foldNames {
 				canonicalKey = foldJSONName(key)
 			}
 			if _, exists := frame.members[canonicalKey]; exists {
 				return errors.New("JSON response contains a duplicate object field")
 			}
 			frame.members[canonicalKey] = struct{}{}
+			frame.valueFoldNames = frame.foldNames
+			if _, exact := exactSubtrees[foldJSONName(key)]; exact {
+				frame.valueFoldNames = false
+			}
 			frame.wantKey = false
 			continue
 		}
@@ -136,9 +161,11 @@ func validateUniqueJSON(data []byte, foldNames bool) error {
 }
 
 type uniqueJSONFrame struct {
-	object  bool
-	wantKey bool
-	members map[string]struct{}
+	object         bool
+	wantKey        bool
+	foldNames      bool
+	valueFoldNames bool
+	members        map[string]struct{}
 }
 
 func beginUniqueJSONValue(frames []uniqueJSONFrame, rootStarted *bool) error {

--- a/cli/manager/internal/registry/oauth.go
+++ b/cli/manager/internal/registry/oauth.go
@@ -1,14 +1,18 @@
 package registry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os/exec"
 	"runtime"
 	"strings"
+	"unicode"
 
 	"github.com/wago-org/wago/cli/internal/automation"
 )
@@ -37,7 +41,130 @@ func PostFormContext(ctx context.Context, endpoint string, form url.Values, outp
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return fmt.Errorf("OAuth endpoint returned status %d", response.StatusCode)
 	}
-	return json.Unmarshal(response.Body, output)
+	return unmarshalUniqueJSON(response.Body, output)
+}
+
+// unmarshalUniqueJSON rejects duplicate object members before decoding. OAuth
+// responses contain security decisions whose meaning must not depend on whether
+// a decoder keeps the first or last spelling of a repeated field.
+func unmarshalUniqueJSON(data []byte, output any) error {
+	if err := ValidateUniqueJSON(data); err != nil {
+		return err
+	}
+	return json.Unmarshal(data, output)
+}
+
+// ValidateUniqueJSON validates one JSON value and rejects object members whose
+// names repeat under the case-insensitive matching used by encoding/json.
+func ValidateUniqueJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	var frames []uniqueJSONFrame
+	rootStarted := false
+	rootComplete := false
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			if !rootComplete {
+				return io.EOF
+			}
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if rootComplete {
+			return errors.New("JSON response contains multiple values")
+		}
+
+		if delimiter, ok := token.(json.Delim); ok {
+			switch delimiter {
+			case '{', '[':
+				if err := beginUniqueJSONValue(frames, &rootStarted); err != nil {
+					return err
+				}
+				frames = append(frames, uniqueJSONFrame{object: delimiter == '{', wantKey: delimiter == '{'})
+			case '}', ']':
+				if len(frames) == 0 {
+					return errors.New("JSON response contains an unexpected closing delimiter")
+				}
+				frame := frames[len(frames)-1]
+				if frame.object != (delimiter == '}') || frame.object && !frame.wantKey {
+					return errors.New("JSON response contains an invalid closing delimiter")
+				}
+				frames = frames[:len(frames)-1]
+				completeUniqueJSONValue(frames, &rootComplete)
+			default:
+				return errors.New("JSON response contains an unexpected delimiter")
+			}
+			continue
+		}
+
+		if len(frames) > 0 && frames[len(frames)-1].object && frames[len(frames)-1].wantKey {
+			key, ok := token.(string)
+			if !ok {
+				return errors.New("JSON response contains a non-string object key")
+			}
+			frame := &frames[len(frames)-1]
+			if frame.members == nil {
+				frame.members = map[string]struct{}{}
+			}
+			canonicalKey := foldJSONName(key)
+			if _, exists := frame.members[canonicalKey]; exists {
+				return errors.New("JSON response contains a duplicate object field")
+			}
+			frame.members[canonicalKey] = struct{}{}
+			frame.wantKey = false
+			continue
+		}
+
+		if err := beginUniqueJSONValue(frames, &rootStarted); err != nil {
+			return err
+		}
+		completeUniqueJSONValue(frames, &rootComplete)
+	}
+}
+
+type uniqueJSONFrame struct {
+	object  bool
+	wantKey bool
+	members map[string]struct{}
+}
+
+func beginUniqueJSONValue(frames []uniqueJSONFrame, rootStarted *bool) error {
+	if len(frames) == 0 {
+		if *rootStarted {
+			return errors.New("JSON response contains multiple values")
+		}
+		*rootStarted = true
+		return nil
+	}
+	if frame := frames[len(frames)-1]; frame.object && frame.wantKey {
+		return errors.New("JSON response contains an object value without a key")
+	}
+	return nil
+}
+
+func completeUniqueJSONValue(frames []uniqueJSONFrame, rootComplete *bool) {
+	if len(frames) == 0 {
+		*rootComplete = true
+		return
+	}
+	frame := &frames[len(frames)-1]
+	if frame.object {
+		frame.wantKey = true
+	}
+}
+
+func foldJSONName(name string) string {
+	return strings.Map(func(character rune) rune {
+		for {
+			next := unicode.SimpleFold(character)
+			if next <= character {
+				return next
+			}
+			character = next
+		}
+	}, name)
 }
 
 func OpenBrowser(target string) error {

--- a/cli/manager/internal/registry/oauth.go
+++ b/cli/manager/internal/registry/oauth.go
@@ -51,13 +51,21 @@ func unmarshalUniqueJSON(data []byte, output any) error {
 	if err := ValidateUniqueJSON(data); err != nil {
 		return err
 	}
-	return json.Unmarshal(data, output)
+	if err := json.Unmarshal(data, output); err != nil {
+		return errors.New("JSON response does not match the expected schema")
+	}
+	return nil
 }
 
 // ValidateUniqueJSON validates one JSON value and rejects object members whose
 // names repeat under the case-insensitive matching used by encoding/json.
 func ValidateUniqueJSON(data []byte) error {
+	return validateUniqueJSON(data, true)
+}
+
+func validateUniqueJSON(data []byte, foldNames bool) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
 	var frames []uniqueJSONFrame
 	rootStarted := false
 	rootComplete := false
@@ -65,12 +73,12 @@ func ValidateUniqueJSON(data []byte) error {
 		token, err := decoder.Token()
 		if errors.Is(err, io.EOF) {
 			if !rootComplete {
-				return io.EOF
+				return errors.New("JSON response is incomplete")
 			}
 			return nil
 		}
 		if err != nil {
-			return err
+			return errors.New("JSON response is invalid")
 		}
 		if rootComplete {
 			return errors.New("JSON response contains multiple values")
@@ -108,7 +116,10 @@ func ValidateUniqueJSON(data []byte) error {
 			if frame.members == nil {
 				frame.members = map[string]struct{}{}
 			}
-			canonicalKey := foldJSONName(key)
+			canonicalKey := key
+			if foldNames {
+				canonicalKey = foldJSONName(key)
+			}
 			if _, exists := frame.members[canonicalKey]; exists {
 				return errors.New("JSON response contains a duplicate object field")
 			}

--- a/cli/manager/internal/registry/oauth_test.go
+++ b/cli/manager/internal/registry/oauth_test.go
@@ -74,3 +74,22 @@ func TestOAuthJSONRejectsDuplicateObjectMembers(t *testing.T) {
 		}
 	}
 }
+
+func TestOAuthJSONErrorsDoNotReflectRemoteValues(t *testing.T) {
+	remote := strings.Repeat("9", 32<<10)
+	for _, body := range []string{
+		`{"expires_in":` + remote + `}`,
+		`{"expires_in":1e` + remote + `}`,
+	} {
+		var reply struct {
+			ExpiresIn int `json:"expires_in"`
+		}
+		err := unmarshalUniqueJSON([]byte(body), &reply)
+		if err == nil {
+			t.Fatal("malformed remote number succeeded")
+		}
+		if strings.Contains(err.Error(), remote[:1024]) || len(err.Error()) > 256 {
+			t.Fatalf("remote JSON error was not bounded: %d bytes", len(err.Error()))
+		}
+	}
+}

--- a/cli/manager/internal/registry/oauth_test.go
+++ b/cli/manager/internal/registry/oauth_test.go
@@ -33,10 +33,6 @@ func TestDeviceFlowTimingIsBounded(t *testing.T) {
 }
 
 func TestOAuthHelpers(t *testing.T) {
-	state, err := RandomState()
-	if err != nil || len(state) != 32 {
-		t.Fatalf("RandomState = %q, %v", state, err)
-	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
@@ -57,8 +53,5 @@ func TestOAuthHelpers(t *testing.T) {
 	defer oversized.Close()
 	if err := PostForm(oversized.URL, url.Values{}, &reply); !errors.Is(err, httpclient.ErrBodyTooLarge) {
 		t.Fatalf("oversized OAuth response = %v", err)
-	}
-	if !strings.Contains(SuccessHTML, "logged in") {
-		t.Fatal("login success HTML missing confirmation")
 	}
 }

--- a/cli/manager/internal/registry/oauth_test.go
+++ b/cli/manager/internal/registry/oauth_test.go
@@ -55,3 +55,22 @@ func TestOAuthHelpers(t *testing.T) {
 		t.Fatalf("oversized OAuth response = %v", err)
 	}
 }
+
+func TestOAuthJSONRejectsDuplicateObjectMembers(t *testing.T) {
+	for _, body := range []string{
+		`{"access_token":"trusted","error":"access_denied","error":""}`,
+		`{"access_token":"trusted","error":"access_denied","Error":""}`,
+		`{"scope":"read:user","ſcope":"repo"}`,
+		`{"outer":{"error":"access_denied","error":""}}`,
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(body))
+		}))
+		var reply map[string]any
+		err := PostForm(server.URL, url.Values{}, &reply)
+		server.Close()
+		if err == nil || !strings.Contains(err.Error(), "duplicate object field") {
+			t.Fatalf("PostForm(%s) = %v", body, err)
+		}
+	}
+}

--- a/cli/manager/internal/registry/packages.go
+++ b/cli/manager/internal/registry/packages.go
@@ -1,13 +1,27 @@
 package registry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/wago-org/wago/cli/internal/project"
 )
+
+const (
+	maximumRegistrySuggestions = 1024
+	maximumSuggestionIDLength  = 300
+)
+
+type packageSuggestion struct {
+	ID string `json:"id"`
+}
 
 // closestModule returns the nearest package id in the registry when it is a
 // plausible typo. Suggestions are best-effort and never block installation.
@@ -21,23 +35,33 @@ func closestModuleContext(ctx context.Context, module string) string {
 		return ""
 	}
 	var response struct {
-		Packages []struct {
-			ID string `json:"id"`
-		} `json:"packages"`
+		Packages []packageSuggestion `json:"packages"`
 	}
-	if json.Unmarshal(data, &response) != nil {
+	if preflightPackageSuggestions(data, maximumRegistrySuggestions) != nil ||
+		unmarshalUniqueJSON(data, &response) != nil {
 		return ""
 	}
 	target := strings.TrimPrefix(module, "github.com/")
-	best, distance := "", len(target)+1
-	for _, candidate := range response.Packages {
-		if d := editDistance(target, candidate.ID); d < distance {
-			best, distance = candidate.ID, d
-		}
+	return closestModuleID(target, response.Packages)
+}
+
+func closestModuleID(target string, candidates []packageSuggestion) string {
+	if !validSuggestionID(target) {
+		return ""
 	}
 	limit := 2
 	if len(target) > 12 {
 		limit = 3
+	}
+	best, distance := "", limit+1
+	var previous, current [maximumSuggestionIDLength + 1]int
+	for _, candidate := range candidates {
+		if !validSuggestionID(candidate.ID) {
+			continue
+		}
+		if d, ok := editDistanceWithin(target, candidate.ID, limit, previous[:], current[:]); ok && d < distance {
+			best, distance = candidate.ID, d
+		}
 	}
 	if distance == 0 || distance > limit {
 		return ""
@@ -45,24 +69,125 @@ func closestModuleContext(ctx context.Context, module string) string {
 	return best
 }
 
-func editDistance(a, b string) int {
-	previous := make([]int, len(b)+1)
-	for i := range previous {
-		previous[i] = i
+func validSuggestionID(id string) bool {
+	if id == "" || len(id) > maximumSuggestionIDLength {
+		return false
+	}
+	if project.ValidatePluginID(id) == nil {
+		return true
+	}
+	return project.ValidatePluginID("registry.invalid/"+id) == nil
+}
+
+func editDistanceWithin(a, b string, limit int, previous, current []int) (int, bool) {
+	if difference := len(a) - len(b); difference > limit || difference < -limit {
+		return limit + 1, false
+	}
+	infinity := limit + 1
+	for index := 0; index <= len(b); index++ {
+		previous[index] = min(index, infinity)
 	}
 	for i := 1; i <= len(a); i++ {
-		current := make([]int, len(b)+1)
-		current[0] = i
-		for j := 1; j <= len(b); j++ {
+		start, end := max(1, i-limit), min(len(b), i+limit)
+		if start == 1 {
+			current[0] = min(i, infinity)
+		} else {
+			current[start-1] = infinity
+		}
+		for j := start; j <= end; j++ {
 			cost := 1
 			if a[i-1] == b[j-1] {
 				cost = 0
 			}
 			current[j] = min(current[j-1]+1, previous[j]+1, previous[j-1]+cost)
 		}
-		previous = current
+		if end < len(b) {
+			current[end+1] = infinity
+		}
+		previous, current = current, previous
 	}
-	return previous[len(b)]
+	distance := previous[len(b)]
+	return distance, distance <= limit
+}
+
+func preflightPackageSuggestions(data []byte, maximum int) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil || opening != json.Delim('{') {
+		return errors.New("package response must be a JSON object")
+	}
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return errors.New("package response contains a non-string key")
+		}
+		if !strings.EqualFold(key, "packages") {
+			if err := skipPackageJSONValue(decoder); err != nil {
+				return err
+			}
+			continue
+		}
+		array, err := decoder.Token()
+		if err != nil || array != json.Delim('[') {
+			return errors.New("package suggestions must be an array")
+		}
+		count := 0
+		for decoder.More() {
+			count++
+			if count > maximum {
+				return errors.New("package suggestions exceed the collection limit")
+			}
+			if err := skipPackageJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return errors.New("package suggestions array is incomplete")
+		}
+	}
+	closing, err := decoder.Token()
+	if err != nil || closing != json.Delim('}') {
+		return errors.New("package response object is incomplete")
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return errors.New("package response contains trailing data")
+	}
+	return nil
+}
+
+func skipPackageJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	if delimiter != '{' && delimiter != '[' {
+		return errors.New("package response contains an unexpected delimiter")
+	}
+	depth := 1
+	for depth > 0 {
+		token, err = decoder.Token()
+		if err != nil {
+			return err
+		}
+		if delimiter, ok = token.(json.Delim); ok {
+			switch delimiter {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+	return nil
 }
 
 func resolveRegistryModule(name string) (string, error) {
@@ -83,11 +208,14 @@ func resolveRegistryModuleContext(ctx context.Context, name string) (string, err
 	var p struct {
 		Name string `json:"name"`
 	}
-	if err := json.Unmarshal(data, &p); err != nil {
-		return "", err
+	if err := unmarshalUniqueJSON(data, &p); err != nil {
+		return "", errors.New("registry returned invalid package metadata")
 	}
 	if p.Name == "" {
 		return "", fmt.Errorf("plugin %q has no module path", name)
+	}
+	if err := project.ValidatePluginID(p.Name); err != nil {
+		return "", fmt.Errorf("plugin %q has an invalid module path", name)
 	}
 	return p.Name, nil
 }

--- a/cli/manager/internal/registry/packages_test.go
+++ b/cli/manager/internal/registry/packages_test.go
@@ -3,15 +3,97 @@ package registry
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 func TestEditDistance(t *testing.T) {
-	if got := editDistance("wago-org/asi", "wago-org/wasi"); got != 1 {
+	var previous, current [maximumSuggestionIDLength + 1]int
+	if got, ok := editDistanceWithin("wago-org/asi", "wago-org/wasi", 3, previous[:], current[:]); !ok || got != 1 {
 		t.Fatalf("edit distance = %d, want 1", got)
 	}
-	if got := editDistance("wasi", "wasi"); got != 0 {
+	if got, ok := editDistanceWithin("wasi", "wasi", 3, previous[:], current[:]); !ok || got != 0 {
 		t.Fatalf("identical edit distance = %d, want 0", got)
+	}
+	if _, ok := editDistanceWithin("short", strings.Repeat("x", 20), 3, previous[:], current[:]); ok {
+		t.Fatal("out-of-band edit distance succeeded")
+	}
+}
+
+func TestEditDistanceWithinMatchesExactDistance(t *testing.T) {
+	values := []string{""}
+	for length := 1; length <= 4; length++ {
+		for bits := 0; bits < 1<<length; bits++ {
+			var value strings.Builder
+			for index := range length {
+				if bits&(1<<index) == 0 {
+					value.WriteByte('a')
+				} else {
+					value.WriteByte('b')
+				}
+			}
+			values = append(values, value.String())
+		}
+	}
+	var previous, current [maximumSuggestionIDLength + 1]int
+	for _, left := range values {
+		for _, right := range values {
+			want := exactEditDistance(left, right)
+			for limit := 0; limit <= 3; limit++ {
+				got, ok := editDistanceWithin(left, right, limit, previous[:], current[:])
+				if ok != (want <= limit) || ok && got != want {
+					t.Fatalf("distance(%q, %q, %d) = %d, %t; want %d", left, right, limit, got, ok, want)
+				}
+			}
+		}
+	}
+}
+
+func exactEditDistance(left, right string) int {
+	previous := make([]int, len(right)+1)
+	for index := range previous {
+		previous[index] = index
+	}
+	for i := 1; i <= len(left); i++ {
+		current := make([]int, len(right)+1)
+		current[0] = i
+		for j := 1; j <= len(right); j++ {
+			cost := 1
+			if left[i-1] == right[j-1] {
+				cost = 0
+			}
+			current[j] = min(current[j-1]+1, previous[j]+1, previous[j-1]+cost)
+		}
+		previous = current
+	}
+	return previous[len(right)]
+}
+
+func BenchmarkClosestModuleAdversarialID(b *testing.B) {
+	target := strings.Repeat("a", 300)
+	candidates := []packageSuggestion{{ID: strings.Repeat("b", 10_000)}}
+	b.ReportAllocs()
+	for range b.N {
+		_ = closestModuleID(target, candidates)
+	}
+}
+
+func TestClosestModuleRejectsOversizedMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+		_, _ = output.Write([]byte(`{"packages":[` + strings.Repeat(`{"id":"x"},`, maximumRegistrySuggestions) + `{"id":"x"}]}`))
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_REGISTRY", server.URL)
+
+	if got := closestModule("github.com/wago-org/asi"); got != "" {
+		t.Fatalf("oversized package suggestions = %q", got)
+	}
+}
+
+func TestClosestModuleIgnoresInvalidCandidateID(t *testing.T) {
+	candidates := []packageSuggestion{{ID: "wago-org/asi\x1b[2J"}, {ID: strings.Repeat("x", maximumSuggestionIDLength+1)}}
+	if got := closestModuleID("wago-org/asj", candidates); got != "" {
+		t.Fatalf("invalid package suggestion = %q", got)
 	}
 }
 

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -49,7 +49,8 @@ redirects; HTTP remains available for loopback development servers.
 Bodies returned by failed authenticated requests are discarded so reflected
 credentials cannot reach errors or terminal output. Contradictory OAuth
 success/error responses fail closed, duplicate authentication JSON members are
-rejected before decoding, and credential stores must be regular files. Catalog
+rejected before decoding, and credential stores must be regular files containing
+unambiguous JSON entries. Catalog
 source checksums, versions, and digests are validated before use; invalid remote
 metadata is not copied into terminal errors.
 

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -52,9 +52,10 @@ success/error responses fail closed, duplicate authentication JSON members are
 rejected before decoding, and credential stores must be regular files containing
 unambiguous JSON entries. Catalog source checksums, versions, and digests are
 validated before use; invalid remote metadata is not copied into terminal errors.
-Catalog pages are preflighted before
-materializing release structs, so the 256-release page bound also bounds retained
-decode memory. Duplicate catalog struct fields fail closed while case-sensitive
+Catalog pages are preflighted before materializing release structs, and each
+requested plugin is limited to 1,024 candidates across at most four 256-release
+pages. These bounds limit both per-response decode memory and cumulative retained
+catalog metadata. Duplicate catalog struct fields fail closed while case-sensitive
 property names inside embedded configuration JSON Schema remain distinct.
 
 ## Release downloads

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -50,9 +50,12 @@ Bodies returned by failed authenticated requests are discarded so reflected
 credentials cannot reach errors or terminal output. Contradictory OAuth
 success/error responses fail closed, duplicate authentication JSON members are
 rejected before decoding, and credential stores must be regular files containing
-unambiguous JSON entries. Catalog
-source checksums, versions, and digests are validated before use; invalid remote
-metadata is not copied into terminal errors.
+unambiguous JSON entries. Catalog source checksums, versions, and digests are
+validated before use; invalid remote metadata is not copied into terminal errors.
+Catalog pages are preflighted before
+materializing release structs, so the 256-release page bound also bounds retained
+decode memory. Duplicate catalog struct fields fail closed while case-sensitive
+property names inside embedded configuration JSON Schema remain distinct.
 
 ## Release downloads
 

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -59,7 +59,12 @@ arrays, and nesting are structurally bounded to 128 members and 32 levels before
 decoding; case-sensitive property names and collections inside embedded
 configuration JSON Schema remain distinct and retain their schema semantics.
 Duplicate catalog struct fields fail closed, and dependency backtracking stops
-after 2,048 catalog queries independently of the solver's CPU-step ceiling.
+after 2,048 unique catalog queries and 64 MiB of aggregate response metadata,
+independently of the solver's CPU-step ceiling. Exact plugin/constraint queries
+are pinned and reused throughout one solve, preventing repeated downloads and
+mid-resolution result changes. Registry error and package-resolution JSON also
+rejects ambiguous fields; resolved module paths are canonical, and typo
+suggestions are limited to 1,024 bounded identifiers with banded edit distance.
 
 ## Release downloads
 

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -34,7 +34,10 @@ the short-lived user code; headless mode leaves that URL for the user to open
 elsewhere. The GitHub access token is sent to the registry in a bounded POST
 body, and the long-lived Wago bearer token is accepted only from that exchange's
 bounded response body. Both registry requests remain pinned to the origin chosen
-at login start. Wago does not run a loopback callback server or place either
+at login start, redirects are not followed, and bearer validation uses that same
+origin. Registry authentication requires HTTPS except for explicit loopback
+development servers. Browser targets must match GitHub's device-verification
+origin and path. Wago does not run a loopback callback server or place either
 credential in a browser-visible URL.
 
 ## Release downloads

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -54,9 +54,12 @@ unambiguous JSON entries. Catalog source checksums, versions, and digests are
 validated before use; invalid remote metadata is not copied into terminal errors.
 Catalog pages are preflighted before materializing release structs, and each
 requested plugin is limited to 1,024 candidates across at most four 256-release
-pages. These bounds limit both per-response decode memory and cumulative retained
-catalog metadata. Duplicate catalog struct fields fail closed while case-sensitive
-property names inside embedded configuration JSON Schema remain distinct.
+pages and 16 MiB of cumulative response metadata. Non-schema catalog objects,
+arrays, and nesting are structurally bounded to 128 members and 32 levels before
+decoding; case-sensitive property names and collections inside embedded
+configuration JSON Schema remain distinct and retain their schema semantics.
+Duplicate catalog struct fields fail closed, and dependency backtracking stops
+after 2,048 catalog queries independently of the solver's CPU-step ceiling.
 
 ## Release downloads
 

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -43,8 +43,9 @@ credential in a browser-visible URL.
 The registry's advertised GitHub scopes are restricted to `read:user` and
 `user:email`. Authentication identifiers, codes, tokens, displayed registry
 text, stdin token input, and the local credential store have explicit size and
-printable-text limits. All registry API operations—not only login—reject remote
-plaintext HTTP origins; HTTP remains available for loopback development servers.
+printable-text limits. All registry network operations—including dependency
+catalog lookup and install metrics—reject remote plaintext HTTP origins and
+redirects; HTTP remains available for loopback development servers.
 Bodies returned by failed authenticated requests are discarded so reflected
 credentials cannot reach errors or terminal output. Contradictory OAuth
 success/error responses fail closed, and credential stores must be regular files.

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -40,6 +40,12 @@ development servers. Browser targets must match GitHub's device-verification
 origin and path. Wago does not run a loopback callback server or place either
 credential in a browser-visible URL.
 
+The registry's advertised GitHub scopes are restricted to `read:user` and
+`user:email`. Authentication identifiers, codes, tokens, displayed registry
+text, stdin token input, and the local credential store have explicit size and
+printable-text limits. All registry API operations—not only login—reject remote
+plaintext HTTP origins; HTTP remains available for loopback development servers.
+
 ## Release downloads
 
 Canary and nightly binaries now stamp `canary@<full-sha>` or

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -28,6 +28,15 @@ releases, and requires the selected release to expose a canonical 40-hex commit
 target. OAuth device-flow lifetimes and server-provided polling intervals are
 also capped.
 
+Browser and headless registry login both use GitHub's one-time device
+authorization. Browser mode opens only GitHub's verification URL after printing
+the short-lived user code; headless mode leaves that URL for the user to open
+elsewhere. The GitHub access token is sent to the registry in a bounded POST
+body, and the long-lived Wago bearer token is accepted only from that exchange's
+bounded response body. Both registry requests remain pinned to the origin chosen
+at login start. Wago does not run a loopback callback server or place either
+credential in a browser-visible URL.
+
 ## Release downloads
 
 Canary and nightly binaries now stamp `canary@<full-sha>` or

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -18,7 +18,7 @@ A parent command cancellation is propagated to active manager requests,
 installer downloads, and Git/TinyGo/Go subprocesses used by source-build
 fallback. In-memory bodies are explicitly bounded: registry and GitHub release
 JSON use a 4 MiB limit, OAuth
-responses use 1 MiB, release checksums use 4 KiB, and non-success response
+responses use 128 KiB, release checksums use 4 KiB, and non-success response
 capture uses an independent 64 KiB limit. Declared oversized bodies are rejected
 before reading; chunked or dishonest responses are stopped after the configured
 limit. Release/commit browsing is capped at ten 100-item pages so repeated full
@@ -48,7 +48,10 @@ catalog lookup and install metrics—reject remote plaintext HTTP origins and
 redirects; HTTP remains available for loopback development servers.
 Bodies returned by failed authenticated requests are discarded so reflected
 credentials cannot reach errors or terminal output. Contradictory OAuth
-success/error responses fail closed, and credential stores must be regular files.
+success/error responses fail closed, duplicate authentication JSON members are
+rejected before decoding, and credential stores must be regular files. Catalog
+source checksums, versions, and digests are validated before use; invalid remote
+metadata is not copied into terminal errors.
 
 ## Release downloads
 

--- a/docs/cli-release-hardening.md
+++ b/docs/cli-release-hardening.md
@@ -45,6 +45,9 @@ The registry's advertised GitHub scopes are restricted to `read:user` and
 text, stdin token input, and the local credential store have explicit size and
 printable-text limits. All registry API operations—not only login—reject remote
 plaintext HTTP origins; HTTP remains available for loopback development servers.
+Bodies returned by failed authenticated requests are discarded so reflected
+credentials cannot reach errors or terminal output. Contradictory OAuth
+success/error responses fail closed, and credential stores must be regular files.
 
 ## Release downloads
 

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -99,7 +99,11 @@ func New(config Config) *Client {
 
 // NewAPI returns the policy for small registry/API/OAuth JSON operations.
 func NewAPI() *Client {
-	return New(Config{Timeout: 30 * time.Second, ResponseHeaderTimeout: 15 * time.Second})
+	client := New(Config{Timeout: 30 * time.Second, ResponseHeaderTimeout: 15 * time.Second})
+	httpClient := *client.httpClient
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	client.httpClient = &httpClient
+	return client
 }
 
 // NewMetadata returns the policy for release metadata and checksums.

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -78,6 +78,44 @@ func TestClientParentCancellation(t *testing.T) {
 	}
 }
 
+func TestAPIClientDoesNotFollowRedirects(t *testing.T) {
+	var sinkRequests atomic.Int32
+	sink := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		sinkRequests.Add(1)
+	}))
+	defer sink.Close()
+
+	for _, status := range []int{
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			redirector := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Location", sink.URL)
+				writer.WriteHeader(status)
+			}))
+			defer redirector.Close()
+
+			request, err := http.NewRequest(http.MethodPost, redirector.URL, strings.NewReader("credential=secret"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			response, err := NewAPI().Bytes(context.Background(), request, 1024)
+			if err != nil {
+				t.Fatalf("redirect response: %v", err)
+			}
+			if response.StatusCode != status {
+				t.Fatalf("status = %d, want %d", response.StatusCode, status)
+			}
+		})
+	}
+	if got := sinkRequests.Load(); got != 0 {
+		t.Fatalf("redirect sink received %d credential-bearing requests", got)
+	}
+}
+
 func TestReadBoundedLimits(t *testing.T) {
 	const limit = int64(8)
 	if got, err := ReadBounded(strings.NewReader("12345678"), -1, limit, "test"); err != nil || string(got) != "12345678" {


### PR DESCRIPTION
Closes #409.

## What changed

- replace the loopback bearer-token callback with GitHub device authorization for both browser and headless login
- keep GitHub and Wago bearer credentials in bounded request/response bodies
- pin registry requests and bearer validation to the origin selected at login start
- reject API/OAuth redirects and remote plaintext registry origins
- constrain browser targets to the OAuth provider device-verification path
- allow only the identity scopes required by the registry
- bound and validate authentication fields, stdin token input, terminal text, and the local credential document
- preserve cancellation and bounded polling behavior

## Root cause

The prior browser flow delivered the long-lived registry bearer in a loopback URL query. The shared API client also followed redirects, registry configuration could be re-read after token exchange, and authentication inputs lacked field-specific trust and resource boundaries.

## Validation

- `go test -count=1 -race ./internal/httpclient ./cli/manager/internal/registry`
- `go test -count=1 ./cli/manager/...`
- `go vet ./internal/httpclient ./cli/manager/...`
- `GOTOOLCHAIN=go1.22.12 go test -count=1 ./internal/httpclient ./cli/manager/internal/registry`
- `go test -count=1 -tags wago_runtime ./cli/...`
- `go vet -tags wago_runtime ./cli/...`
- TinyGo runtime CLI build
- CGO-disabled Linux, Darwin, and Windows manager/installer builds
- `go run ./tests/tools/docs-check`

The full local `go test -count=1 ./...` reaches the repository’s existing staged Core3/spec failures because the pinned Release 3 interpreter/current WABT is unavailable locally; all CLI and HTTP packages pass. The first PR CI run also hit an unrelated Linux/arm64 `TestReferenceTokensWaitForClosingInvocationQuiescence` failure; the updated head has a fresh CI run.