### PR TITLE
cli: fix release browsing and checksum fallback

### DIFF
--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,7 +62,11 @@ func fetchReleases() ([]remoteRelease, error) {
 	return fetchReleasesContext(context.Background())
 }
 
-const discoveryPageLimit = 10
+const (
+	discoveryPageLimit        = 10
+	releaseDiscoveryPageSize  = 20
+	releaseDiscoveryPageLimit = 50
+)
 
 func fetchReleasesContext(ctx context.Context) ([]remoteRelease, error) {
 	var releases []remoteRelease
@@ -73,9 +78,9 @@ func fetchReleasesContext(ctx context.Context) ([]remoteRelease, error) {
 }
 
 func forEachReleasePage(ctx context.Context, operation string, visit func([]remoteRelease) bool) error {
-	address := fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=100&page=1", releaseAPI())
-	seen := make(map[string]struct{}, discoveryPageLimit)
-	for page := 1; page <= discoveryPageLimit; page++ {
+	address := fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=%d&page=1", releaseAPI(), releaseDiscoveryPageSize)
+	seen := make(map[string]struct{}, releaseDiscoveryPageLimit)
+	for page := 1; page <= releaseDiscoveryPageLimit; page++ {
 		if _, duplicate := seen[address]; duplicate {
 			return fmt.Errorf("GitHub release pagination loop at page %d", page)
 		}
@@ -91,7 +96,7 @@ func forEachReleasePage(ctx context.Context, operation string, visit func([]remo
 		if err := json.Unmarshal(response.Body, &batch); err != nil {
 			return err
 		}
-		if len(batch) > 100 {
+		if len(batch) > releaseDiscoveryPageSize {
 			return fmt.Errorf("GitHub returned too many releases on page %d", page)
 		}
 		if !visit(batch) {
@@ -105,12 +110,12 @@ func forEachReleasePage(ctx context.Context, operation string, visit func([]remo
 			address = next
 			continue
 		}
-		if len(batch) < 100 {
+		if len(batch) < releaseDiscoveryPageSize {
 			return nil
 		}
-		address = fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=100&page=%d", releaseAPI(), page+1)
+		address = fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=%d&page=%d", releaseAPI(), releaseDiscoveryPageSize, page+1)
 	}
-	return fmt.Errorf("GitHub release discovery exceeded %d pages", discoveryPageLimit)
+	return fmt.Errorf("GitHub release discovery exceeded %d pages", releaseDiscoveryPageLimit)
 }
 
 func releaseNextLink(header http.Header, current string) (string, bool, error) {
@@ -133,13 +138,26 @@ func releaseNextLink(header http.Header, current string) (string, bool, error) {
 				return "", false, fmt.Errorf("GitHub returned a malformed release pagination link: %w", err)
 			}
 			next := base.ResolveReference(reference)
-			if next.Scheme != base.Scheme || next.Host != base.Host || next.Path != base.Path {
+			if next.Scheme != base.Scheme || next.Host != base.Host || !validReleasePaginationPath(base.Path, next.Path) {
 				return "", false, fmt.Errorf("GitHub returned an invalid release pagination target")
 			}
 			return next.String(), true, nil
 		}
 	}
 	return "", false, nil
+}
+
+func validReleasePaginationPath(current, next string) bool {
+	if next == current {
+		return true
+	}
+	const prefix, suffix = "/repositories/", "/releases"
+	if !strings.HasPrefix(next, prefix) || !strings.HasSuffix(next, suffix) {
+		return false
+	}
+	repositoryID := strings.TrimSuffix(strings.TrimPrefix(next, prefix), suffix)
+	id, err := strconv.ParseUint(repositoryID, 10, 64)
+	return err == nil && id != 0
 }
 
 // vmUpdate resolves the moving channel before touching the installed runtime.

--- a/cli/manager/internal/version/download.go
+++ b/cli/manager/internal/version/download.go
@@ -66,15 +66,17 @@ func downloadReleaseAssetWithProgressContext(ctx context.Context, baseURL, ver, 
 	if progress != nil {
 		progress.Begin("fetching checksum")
 	}
-	checksumResponse, err := getReleaseBytes(ctx, "release checksum download", address+".sha256", checksumBodyMaximum)
+	checksumAddress := address + ".sha256"
+	checksumResponse, err := openReleaseMetadata(ctx, "release checksum download", checksumAddress)
 	if err != nil {
 		if progress != nil {
 			progress.Fail("checksum download failed")
 		}
 		return fmt.Errorf("fetch checksum: %w", err)
 	}
+	defer checksumResponse.Body.Close()
 	if checksumResponse.StatusCode != http.StatusOK {
-		err := &httpStatusError{url: address + ".sha256", code: checksumResponse.StatusCode, status: checksumResponse.Status}
+		err := &httpStatusError{url: checksumAddress, code: checksumResponse.StatusCode, status: checksumResponse.Status}
 		if progress != nil {
 			if releaseAssetUnavailable(err) {
 				progress.Done("checksum unavailable; using source")
@@ -84,7 +86,14 @@ func downloadReleaseAssetWithProgressContext(ctx context.Context, baseURL, ver, 
 		}
 		return fmt.Errorf("fetch checksum: %w", err)
 	}
-	want, err := parseReleaseChecksum(checksumResponse.Body, asset)
+	checksum, err := httpclient.ReadBounded(checksumResponse.Body, checksumResponse.ContentLength, checksumBodyMaximum, checksumAddress)
+	if err != nil {
+		if progress != nil {
+			progress.Fail("checksum download failed")
+		}
+		return fmt.Errorf("fetch checksum: %w", err)
+	}
+	want, err := parseReleaseChecksum(checksum, asset)
 	if err != nil {
 		if progress != nil {
 			progress.Fail("invalid checksum")

--- a/cli/manager/internal/version/http.go
+++ b/cli/manager/internal/version/http.go
@@ -31,6 +31,17 @@ func getReleaseBytes(ctx context.Context, operation, address string, limit int64
 	return releaseMetadataHTTP.Bytes(ctx, request, limit)
 }
 
+func openReleaseMetadata(ctx context.Context, operation, address string) (*http.Response, error) {
+	if err := automation.RequireOnline(operation); err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		return nil, err
+	}
+	return releaseMetadataHTTP.Open(ctx, request)
+}
+
 func openReleaseStream(ctx context.Context, operation, address string) (*http.Response, error) {
 	if err := automation.RequireOnline(operation); err != nil {
 		return nil, err

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -46,7 +47,7 @@ func TestLatestChannelReleasePaginates(t *testing.T) {
 		}
 		requests++
 		if r.URL.Query().Get("page") == "1" {
-			releases := make([]remoteRelease, 100)
+			releases := make([]remoteRelease, releaseDiscoveryPageSize)
 			for i := range releases {
 				releases[i].TagName = fmt.Sprintf("v1.0.%d", i)
 			}
@@ -67,13 +68,60 @@ func TestLatestChannelReleasePaginates(t *testing.T) {
 	}
 }
 
+func TestReleaseDiscoveryKeepsLargePagesWithinMetadataLimit(t *testing.T) {
+	const releaseCount = 100
+	requests := 0
+	maximumPageSize := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		pageSize, err := strconv.Atoi(r.URL.Query().Get("per_page"))
+		if err != nil || pageSize <= 0 {
+			t.Errorf("release page size = %q, want a positive integer", r.URL.Query().Get("per_page"))
+			http.Error(w, "invalid page size", http.StatusBadRequest)
+			return
+		}
+		if pageSize > maximumPageSize {
+			maximumPageSize = pageSize
+		}
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil || page <= 0 {
+			t.Errorf("release page = %q, want a positive integer", r.URL.Query().Get("page"))
+			http.Error(w, "invalid page", http.StatusBadRequest)
+			return
+		}
+		first := (page - 1) * pageSize
+		last := min(first+pageSize, releaseCount)
+		releases := make([]map[string]any, 0, max(last-first, 0))
+		for index := first; index < last; index++ {
+			releases = append(releases, map[string]any{
+				"tag_name": fmt.Sprintf("v1.0.%d", index),
+				"body":     strings.Repeat("x", 48<<10),
+			})
+		}
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	releases, err := fetchReleasesContext(context.Background())
+	if err != nil || len(releases) != releaseCount {
+		t.Fatalf("fetchReleasesContext = %d releases, %v", len(releases), err)
+	}
+	if maximumPageSize > 20 {
+		t.Fatalf("release page size = %d, want at most 20", maximumPageSize)
+	}
+	if requests < 2 {
+		t.Fatalf("release page requests = %d, want pagination", requests)
+	}
+}
+
 func TestLatestChannelReleaseUsesLinkPaginationAndSkipsDrafts(t *testing.T) {
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		switch r.URL.Query().Get("cursor") {
 		case "":
-			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/wago-org/wago/releases?cursor=next>; rel="next"`, "http://"+r.Host))
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repositories/1277210043/releases?cursor=next>; rel="next"`, "http://"+r.Host))
 			_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "nightly-draft", Draft: true, TargetCommitish: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}})
 		case "next":
 			_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "nightly-20260812-deadbee", TargetCommitish: "deadbee123456789012345678901234567890123"}})
@@ -193,7 +241,7 @@ func TestRollingChannelWithoutPublishedReleaseUsesCanonicalMainSource(t *testing
 }
 
 func TestLatestChannelReleaseBoundsPagination(t *testing.T) {
-	releases := make([]remoteRelease, 100)
+	releases := make([]remoteRelease, releaseDiscoveryPageSize)
 	for i := range releases {
 		releases[i].TagName = fmt.Sprintf("v1.0.%d", i)
 	}
@@ -208,8 +256,8 @@ func TestLatestChannelReleaseBoundsPagination(t *testing.T) {
 	if _, err := latestChannelReleaseContext(context.Background(), "nightly"); err == nil || !strings.Contains(err.Error(), "exceeded") {
 		t.Fatalf("channel pagination error = %v", err)
 	}
-	if requests != discoveryPageLimit {
-		t.Fatalf("release page requests = %d, want %d", requests, discoveryPageLimit)
+	if requests != releaseDiscoveryPageLimit {
+		t.Fatalf("release page requests = %d, want %d", requests, releaseDiscoveryPageLimit)
 	}
 }
 
@@ -233,7 +281,7 @@ func TestMainCommitBrowsingPaginatesAndResolvesTip(t *testing.T) {
 		case "/repos/wago-org/wago/releases":
 			count := 1
 			if r.URL.Query().Get("page") == "1" {
-				count = 100
+				count = releaseDiscoveryPageSize
 			}
 			releases := make([]remoteRelease, count)
 			for i := range releases {
@@ -255,13 +303,13 @@ func TestMainCommitBrowsingPaginatesAndResolvesTip(t *testing.T) {
 		t.Fatalf("fetchMainCommits = %d commits, %v", len(commits), err)
 	}
 	releases, err := fetchReleases()
-	if err != nil || len(releases) != 101 {
+	if err != nil || len(releases) != releaseDiscoveryPageSize+1 {
 		t.Fatalf("fetchReleases = %d releases, %v", len(releases), err)
 	}
 }
 
 func TestReleaseDiscoveryBoundsTotalPagination(t *testing.T) {
-	releases := make([]remoteRelease, 100)
+	releases := make([]remoteRelease, releaseDiscoveryPageSize)
 	commits := make([]remoteCommit, 100)
 	for index := range releases {
 		releases[index].TagName = fmt.Sprintf("v%d.0.0", index)
@@ -286,8 +334,8 @@ func TestReleaseDiscoveryBoundsTotalPagination(t *testing.T) {
 	if _, err := fetchReleasesContext(context.Background()); err == nil || !strings.Contains(err.Error(), "exceeded") {
 		t.Fatalf("unbounded release pagination error = %v", err)
 	}
-	if releaseRequests != discoveryPageLimit {
-		t.Fatalf("release page requests = %d, want %d", releaseRequests, discoveryPageLimit)
+	if releaseRequests != releaseDiscoveryPageLimit {
+		t.Fatalf("release page requests = %d, want %d", releaseRequests, releaseDiscoveryPageLimit)
 	}
 	if _, err := fetchMainCommitsContext(context.Background()); err == nil || !strings.Contains(err.Error(), "exceeded") {
 		t.Fatalf("unbounded commit pagination error = %v", err)

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -182,7 +182,11 @@ func TestMissingManagerAssetFallsBackToSource(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 	defer api.Close()
-	releases := httptest.NewServer(http.NotFoundHandler())
+	releases := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.(http.Flusher).Flush()
+		_, _ = w.Write([]byte(strings.Repeat("missing release asset", 1<<12)))
+	}))
 	defer releases.Close()
 	t.Setenv("WAGO_RELEASE_API", api.URL)
 	t.Setenv("WAGO_RELEASE_BASE", releases.URL)


### PR DESCRIPTION
## What changed

- request GitHub releases in 20-item pages while retaining the existing 1,000-release discovery bound
- accept GitHub's same-origin canonical `/repositories/<id>/releases` pagination links
- inspect checksum response status before reading the body, allowing missing manager assets to fall back to a source build
- retain the 4 MiB release-metadata limit and 4 KiB successful-checksum limit

## Why

`wago version install` requested 100 full release objects at once. The current GitHub response is larger than the manager's intentional 4 MiB metadata limit. Once smaller pages were used, GitHub's canonical numeric-repository `Link` target exposed an overly strict path check.

`wago self update` had a related failure when a canary manager checksum asset was absent. GitHub's oversized 404 body hit the error-body limit before the downloader could observe the 404 and use its existing source-build fallback.

## User impact

- interactive version browsing can load the complete release list without weakening memory limits
- self-update can recover from unpublished manager assets by building the resolved release from source
- successful checksum downloads remain bounded and verified before installation

## Validation

- regression test reproduced the exact 4 MiB release-discovery failure before the fix
- regression test reproduced the exact 65,536-byte missing-checksum failure before the fix
- live `wago version install` reached the interactive picker
- `make test`
- `go test ./cli/... -count=1`
- `go test -tags wago_lean ./cli/manager/internal/version -count=1`
