### PR TITLE
tinygo: stabilize GC lifetimes and add fixed-arity entry

### DIFF
--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -36,10 +36,10 @@ and host-call resume thunks with the repository's AArch64 encoder. The standard
 tags select the right implementation automatically.
 
 Prepared integer exports have their own TinyGo direct-entry thunks on
-linux/amd64 and linux/darwin arm64. They accept the linear-memory base plus up
-to four integer slots in the platform ABI, preserve the callee-saved Go context,
-switch to the foreign stack, and enter the JIT function without the general
-WasmWrapper marshalling path.
+linux/amd64, linux/arm64, and darwin/arm64. They accept the linear-memory base
+plus up to four integer slots in the platform ABI, preserve the callee-saved Go
+context, switch to the foreign stack, and enter the JIT function without the
+general WasmWrapper marshalling path.
 
 ## Building
 

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -35,6 +35,12 @@ and host-call resume thunks with the repository's AArch64 encoder. The standard
 (`!tinygo`) build is unchanged and keeps using the assembly trampolines; build
 tags select the right implementation automatically.
 
+Prepared integer exports have their own TinyGo direct-entry thunks on
+linux/amd64 and linux/darwin arm64. They accept the linear-memory base plus up
+to four integer slots in the platform ABI, preserve the callee-saved Go context,
+switch to the foreign stack, and enter the JIT function without the general
+WasmWrapper marshalling path.
+
 ## Building
 
 TinyGo on Linux links with LLVM `lld`. Make sure `ld.lld` is on `PATH`
@@ -119,6 +125,19 @@ neither. The `-opt=2` build is about 0.8 MiB larger than `-opt=z`; use it only w
 measured compile-time speed matters more than footprint. UPX was not available on
 the measurement host, so no current UPX size is claimed.
 
+The fixed-arity prepared-call path is also footprint-bounded. The original
+implementation at `78d8273a`, measured against `10ff9733` with the release build
+and platform strip commands, had these effects. The rebased review fixes changed
+thunk ownership and error handling; use the current PR build-size check for the
+final artifact delta.
+
+| release runtime | baseline | fixed-arity path | delta |
+|---|---:|---:|---:|
+| Darwin/arm64 Standard/Tiny | 2,000,240 B | 2,000,328 B | +88 B |
+| Darwin/arm64 Minimal/Tiny | 1,900,480 B | 1,917,080 B | +16,600 B (0.87%) |
+| Linux/amd64 Standard/Tiny | 2,239,992 B | 2,245,736 B | +5,744 B (0.26%) |
+| Linux/amd64 Minimal/Tiny | 2,122,432 B | 2,127,952 B | +5,520 B (0.26%) |
+
 ## Call latency
 
 The runtime-generated trampoline **adds no latency to the standard build** — that
@@ -160,6 +179,50 @@ in.WriteUint32Le(off, v)
 
 None of this touches the wasm execution path, which runs wago's own JIT-emitted
 machine code, not TinyGo-compiled Go.
+
+### Public API hot path
+
+For a repeatedly called local integer export, resolve it once and use the
+matching fixed-arity method:
+
+```go
+fn, err := instance.PrepareFunction("step")
+if err != nil {
+    return err
+}
+result, err := fn.Invoke2(state, input)
+```
+
+`PreparedFunction.Invoke0` through `Invoke4` avoid the argument-slice allocation
+that TinyGo emits at a variadic call site. Eligible signatures (up to four
+`i32`/`i64` argument slots and one `i32`/`i64` result) take the direct-entry
+thunk above. The ordinary variadic `Invoke` remains the compatibility path for
+dynamic arity, references, vectors, and larger signatures.
+
+This distinction matters when comparing complete public calls rather than only
+the low-level trampoline. Fixed prepared integer calls are allocation-free under
+both toolchains and are the closest TinyGo public-API latency path. General
+`Instance.Invoke`, host imports, and instantiation still carry more TinyGo
+allocator/runtime overhead; do not infer their performance from the
+boundary-only table above.
+
+The table below measures complete public operations with the release TinyGo
+flags (`-scheduler=tasks -no-debug -opt=z -gc=conservative`). Values are medians
+of ten 300 ms samples. ARM64 is an Apple M4 Max; AMD64 is a Ryzen 7 7800X3D with
+both binaries pinned to otherwise-idle core 7.
+
+| public benchmark | ARM64 Go | ARM64 TinyGo | ratio | AMD64 Go | AMD64 TinyGo | ratio |
+|---|---:|---:|---:|---:|---:|---:|
+| compile small scalar | 6.47 us | 10.97 us | 1.69x | 15.24 us | 13.63 us | **0.89x** |
+| instantiate small scalar | 0.976 us | 3.44 us | 3.52x | 1.89 us | 4.03 us | 2.13x |
+| `Instance.Invoke` | 74.2 ns | 212.6 ns | 2.87x | 71.3 ns | 214.0 ns | 3.00x |
+| indirect invoke | 75.6 ns | 226.7 ns | 3.00x | 72.4 ns | 231.2 ns | 3.19x |
+| direct host import | 252.7 ns | 927.8 ns | 3.67x | 418.6 ns | 921.7 ns | 2.20x |
+| prepared `Invoke1` | 16.43 ns | **14.24 ns** | **0.87x** | 6.66 ns | 11.45 ns | 1.72x |
+
+Prepared `Invoke1` is zero-allocation under both toolchains. The TinyGo
+variadic invoke paths still allocate five objects per call, host import calls
+allocate 19, and instantiation allocates 66; those are the next parity targets.
 
 `make build-runtime-minimal-tinygo` uses `-opt=z` (size); it is already at parity above. `-opt=2`
 trades ~size for a further ~15-20% on these wrappers and on compile-time Go (decode
@@ -206,6 +269,14 @@ checks. Go keeps its ~2× edge only on pure host-side *memory loops* (0.57 vs 1.
   and the external `WAGO_SPECTEST_DIR` spec harness are standard-Go-only. The
   runtime stress test is build-tagged `!tinygo`, with a TinyGo-appropriate
   counterpart in `stress_tinygo_test.go`.
+
+- **Conservative-GC liveness.** Compiler metadata owners and asynchronous
+  Runtime shutdown tasks are held through explicit value leases and final-use
+  barriers. `tinygo_lifecycle_test.go` repeatedly collects across decode,
+  compile, instantiate, close, and queued teardown boundaries. Keep these
+  ownership points explicit when adding callbacks or replacing value state with
+  closures; TinyGo boxes captured variables differently from the standard
+  compiler.
 
 - **Platform.** Native execution is covered on `linux/amd64`, `linux/arm64`, and
   `darwin/arm64`. Darwin/amd64 is a compiler/encoder portability target until

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -1119,6 +1119,13 @@ func CompileModule(m *wasm.Module) (*amd64.CompiledModule, error) {
 // inline linear-memory bounds check, relying on a guard-page mapping + SIGSEGV
 // handler (the caller must back memory with runtime guard pages).
 func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModule, error) {
+	compiled, err := compileModuleWith(m, opts)
+	runtime.KeepAlive(m)
+	runtime.KeepAlive(opts)
+	return compiled, err
+}
+
+func compileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModule, error) {
 	selection, err := optimizationBindings.ResolveSnapshot(opts.Optimizations, opts.OptimizationSnapshot, opts.OptimizationDeltas)
 	if err != nil {
 		return nil, fmt.Errorf("amd64: %w", err)

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -931,6 +931,13 @@ func CompileModule(m *wasm.Module) (*a64.CompiledModule, error) {
 // inline linear-memory bounds check, relying on a guard-page mapping + SIGSEGV
 // handler (the caller must back memory with runtime guard pages).
 func CompileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule, error) {
+	compiled, err := compileModuleWith(m, opts)
+	runtime.KeepAlive(m)
+	runtime.KeepAlive(opts)
+	return compiled, err
+}
+
+func compileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule, error) {
 	selection, err := optimizationBindings.ResolveSnapshot(opts.Optimizations, opts.OptimizationSnapshot, opts.OptimizationDeltas)
 	if err != nil {
 		return nil, fmt.Errorf("arm64: %w", err)

--- a/src/core/compiler/optimization/catalog.go
+++ b/src/core/compiler/optimization/catalog.go
@@ -253,9 +253,37 @@ func (b *Bindings) Set(name string, on bool) bool {
 	return true
 }
 
-// Apply installs overrides for one compile and returns a function that restores
-// the process defaults and releases the compile lock.
-func (b *Bindings) Apply(overrides map[string]bool) (func(), error) {
+// Lease holds one installed optimization selection and its compile lock. It is
+// deliberately a value rather than a restore closure: that keeps compiler
+// inputs out of closure boxes under TinyGo's conservative collector.
+type Lease struct {
+	bindings *Bindings
+	changed  int // -1 restores the complete selection
+	active   bool
+}
+
+// Restore restores the process defaults and releases the compile lock.
+func (l *Lease) Restore() {
+	if l == nil || !l.active {
+		return
+	}
+	l.active = false
+	b := l.bindings
+	if l.changed < 0 {
+		for index, entry := range b.entries {
+			*entry.value = b.before[index]
+		}
+	} else {
+		for _, index := range b.changed[:l.changed] {
+			*b.entries[index].value = b.before[index]
+		}
+	}
+	b.mu.Unlock()
+}
+
+// Apply installs overrides for one compile and returns an explicit lease that
+// restores the process defaults and releases the compile lock.
+func (b *Bindings) Apply(overrides map[string]bool) (Lease, error) {
 	return b.ApplySnapshot(overrides, Snapshot{}, nil)
 }
 
@@ -265,10 +293,10 @@ func (b *Bindings) Apply(overrides map[string]bool) (func(), error) {
 // validated and applied in full. The revision comparison, installation,
 // compilation lease, and restoration all share the same lock, so a concurrent
 // Set cannot invalidate the fast path.
-func (b *Bindings) ApplySnapshot(overrides map[string]bool, snapshot Snapshot, deltas map[string]bool) (func(), error) {
+func (b *Bindings) ApplySnapshot(overrides map[string]bool, snapshot Snapshot, deltas map[string]bool) (Lease, error) {
 	b.mu.Lock()
 	if overrides == nil {
-		return b.mu.Unlock, nil
+		return Lease{bindings: b, active: true}, nil
 	}
 	if snapshot.bindings == b && snapshot.revision == b.revision && b.deltasMatchLocked(overrides, deltas) {
 		changed := 0
@@ -286,12 +314,7 @@ func (b *Bindings) ApplySnapshot(overrides map[string]bool, snapshot Snapshot, d
 			b.before[index] = *entry.value
 			*entry.value = on
 		}
-		return func() {
-			for _, index := range b.changed[:changed] {
-				*b.entries[index].value = b.before[index]
-			}
-			b.mu.Unlock()
-		}, nil
+		return Lease{bindings: b, changed: changed, active: true}, nil
 	}
 	for index, entry := range b.entries {
 		b.before[index] = *entry.value
@@ -303,7 +326,7 @@ func (b *Bindings) ApplySnapshot(overrides map[string]bool, snapshot Snapshot, d
 				*entry.value = b.before[index]
 			}
 			b.mu.Unlock()
-			return nil, fmt.Errorf("unknown %s optimization %q", b.arch, name)
+			return Lease{}, fmt.Errorf("unknown %s optimization %q", b.arch, name)
 		}
 		entry := b.entries[index]
 		if entry.inverted {
@@ -311,12 +334,7 @@ func (b *Bindings) ApplySnapshot(overrides map[string]bool, snapshot Snapshot, d
 		}
 		*entry.value = on
 	}
-	return func() {
-		for index, entry := range b.entries {
-			*entry.value = b.before[index]
-		}
-		b.mu.Unlock()
-	}, nil
+	return Lease{bindings: b, changed: -1, active: true}, nil
 }
 
 // deltasMatchLocked reports whether deltas are a complete, coherent summary of

--- a/src/core/compiler/optimization/catalog_test.go
+++ b/src/core/compiler/optimization/catalog_test.go
@@ -59,7 +59,7 @@ func TestBindingsApplyAndRestoreSelection(t *testing.T) {
 	if values[0] {
 		t.Fatal("selection was not applied")
 	}
-	restore()
+	restore.Restore()
 	if !values[0] {
 		t.Fatal("selection was not restored")
 	}
@@ -79,7 +79,7 @@ func TestBindingsApplySnapshotUsesDeltasAtMatchingRevision(t *testing.T) {
 	if values[0] {
 		t.Fatal("matching snapshot delta was not applied")
 	}
-	restore()
+	restore.Restore()
 	if !values[0] {
 		t.Fatal("matching snapshot delta was not restored")
 	}
@@ -98,7 +98,7 @@ func TestBindingsApplySnapshotUsesChangedOverrideMissingFromDeltas(t *testing.T)
 	if values[0] {
 		t.Fatal("changed override omitted from deltas was not applied")
 	}
-	restore()
+	restore.Restore()
 }
 
 func TestBindingsApplySnapshotUsesSelectionWhenDeltaConflicts(t *testing.T) {
@@ -115,7 +115,7 @@ func TestBindingsApplySnapshotUsesSelectionWhenDeltaConflicts(t *testing.T) {
 	if values[0] {
 		t.Fatal("conflicting delta took precedence over complete selection")
 	}
-	restore()
+	restore.Restore()
 }
 
 func TestBindingsApplySnapshotRejectsUnknownOverrideAtMatchingRevision(t *testing.T) {
@@ -145,7 +145,7 @@ func TestBindingsApplySnapshotRevisionMismatchUsesCapturedSelection(t *testing.T
 	if !values[0] {
 		t.Fatal("stale snapshot did not install its captured selection")
 	}
-	restore()
+	restore.Restore()
 	if values[0] {
 		t.Fatal("stale snapshot did not restore the newer process default")
 	}
@@ -174,7 +174,7 @@ func TestBindingsApplySnapshotSerializesConcurrentSet(t *testing.T) {
 		t.Fatal("Set completed while a compile snapshot held the binding lease")
 	default:
 	}
-	restore()
+	restore.Restore()
 	if !<-done {
 		t.Fatalf("Set(%q) failed", name)
 	}
@@ -192,7 +192,7 @@ func TestBindingsDefaultApplyAllocationBudget(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		restore()
+		restore.Restore()
 	})
 	if allocs > 1 {
 		t.Fatalf("matching default ApplySnapshot allocations = %.0f, want <= 1", allocs)

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -1,6 +1,7 @@
 package wasm
 
 import (
+	"runtime"
 	"sync"
 	"sync/atomic"
 )
@@ -47,11 +48,22 @@ func ValidateModuleWithFeaturesAndWorkers(m *Module, features ValidationFeatures
 }
 
 func validateModuleWithWorkersAndFeatures(m *Module, direct *directValidationEnv, workers int, features ValidationFeatures) error {
-	v := &moduleValidator{m: m, funcIndex: -1, direct: direct, features: features}
+	// Keep the serial validation owner in this frame. TinyGo's conservative
+	// collector can otherwise lose a short-lived heap validator while nested
+	// decoding allocates, leaving its inline operand/control stacks reclaimed
+	// during validation.
+	v := moduleValidator{m: m, funcIndex: -1, direct: direct, features: features}
 	if err := v.validateModule(); err != nil {
+		runtime.KeepAlive(m)
+		runtime.KeepAlive(direct)
 		return err
 	}
-	return v.validateFunctions(workers)
+	err := v.validateFunctions(workers)
+	// TinyGo's conservative collector needs the metadata owners to remain live
+	// while validators consume their nested byte slices and type views.
+	runtime.KeepAlive(m)
+	runtime.KeepAlive(direct)
+	return err
 }
 
 func (v *moduleValidator) validateFunctions(workers int) error {
@@ -68,9 +80,12 @@ func (v *moduleValidator) validateFunctions(workers int) error {
 func (v *moduleValidator) validateFunctionsSerial() error {
 	importedFuncs := v.m.ImportedFuncCount()
 	memarg64 := moduleMemargOffset64(v.m)
-	fv := &funcValidator{moduleValidator: v}
+	// Keep the reusable operand/control-stack owner in the validating frame.
+	// Besides avoiding one allocation, this makes its lifetime explicit for
+	// TinyGo's conservative collector across allocation-heavy decode steps.
+	fv := funcValidator{moduleValidator: v}
 	for i := range v.m.Code {
-		if err := v.validateFunction(fv, i, importedFuncs, memarg64); err != nil {
+		if err := v.validateFunction(&fv, i, importedFuncs, memarg64); err != nil {
 			return err
 		}
 	}

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -1,5 +1,7 @@
 package wasm
 
+import "runtime"
+
 // directCodeBody is the part of a code-section function body the byte-backed
 // validator keeps: compact local runs plus raw expression bytes. This matches
 // DecodeModule's no-body instruction representation for decoded function bodies.
@@ -168,7 +170,17 @@ func directExpr(e directConstExpr) Expr {
 }
 
 func decodeDirectModule(data []byte) (*directModule, error) {
-	r := newReader(data)
+	dm, err := decodeDirectModuleInner(data)
+	runtime.KeepAlive(data)
+	return dm, err
+}
+
+func decodeDirectModuleInner(data []byte) (*directModule, error) {
+	// Keep the top-level cursor in this frame. TinyGo's conservative collector
+	// can otherwise lose the heap-allocated reader while its backing slice is
+	// still being consumed across allocation-heavy section decoding.
+	var r reader
+	r.reset(data)
 	magic, err := r.bytes(4)
 	if err != nil {
 		return nil, err

--- a/src/core/runtime/engine.go
+++ b/src/core/runtime/engine.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -19,8 +20,9 @@ import (
 
 // Engine owns a dedicated, off-heap execution stack for native wasm code.
 type Engine struct {
-	stack    []byte
-	stackTop uintptr
+	stack       []byte
+	stackTop    uintptr
+	preparedInt tinygoPreparedIntState
 
 	// Scratch for the common non-reentrant synchronous host-call path. Passing
 	// slices to HostCall makes stack-local arrays escape; keeping one bounded pair
@@ -287,7 +289,9 @@ func (e *Engine) callWithHostLoop(code uintptr, serArgs []byte, linMemBase uintp
 	}
 }
 
-func (e *Engine) Close() error { return munmap(e.stack) }
+func (e *Engine) Close() error {
+	return errors.Join(e.preparedInt.close(), munmap(e.stack))
+}
 
 // MapCode copies machine code into a fresh W^X executable mapping and returns
 // the mapping (keep it alive / Unmap to free) plus the entry-point pointer to

--- a/src/core/runtime/engine_int_amd64.go
+++ b/src/core/runtime/engine_int_amd64.go
@@ -9,8 +9,8 @@ func enterNativeInt(code, linMem, a0, a1, a2, a3, foreignStackTop uintptr) uintp
 
 // EnterPreparedInt performs only the native transition. Callers must inspect
 // PreparedIntTrapCode immediately afterward and consume any non-zero trap.
-func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) uint64 {
-	return uint64(enterNativeInt(code, linMemBase, uintptr(a0), uintptr(a1), uintptr(a2), uintptr(a3), e.stackTop))
+func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) (uint64, error) {
+	return uint64(enterNativeInt(code, linMemBase, uintptr(a0), uintptr(a1), uintptr(a2), uintptr(a3), e.stackTop)), nil
 }
 
 func PreparedIntTrapCode(trap []byte) TrapCode {

--- a/src/core/runtime/engine_int_arm64.go
+++ b/src/core/runtime/engine_int_arm64.go
@@ -4,8 +4,8 @@ package runtime
 
 func enterNativeInt(code, linMem, a0, a1, a2, a3, foreignStackTop uintptr) uintptr
 
-func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) uint64 {
-	return uint64(enterNativeInt(code, linMemBase, uintptr(a0), uintptr(a1), uintptr(a2), uintptr(a3), e.stackTop))
+func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) (uint64, error) {
+	return uint64(enterNativeInt(code, linMemBase, uintptr(a0), uintptr(a1), uintptr(a2), uintptr(a3), e.stackTop)), nil
 }
 
 func PreparedIntTrapCode(trap []byte) TrapCode {

--- a/src/core/runtime/engine_int_tinygo_amd64.go
+++ b/src/core/runtime/engine_int_tinygo_amd64.go
@@ -1,0 +1,87 @@
+//go:build linux && amd64 && tinygo
+
+package runtime
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+// TinyGo cannot assemble engine_int_amd64.s. Its indirect-call ABI passes the
+// five explicit uintptr arguments in RDI, RSI, RDX, RCX, and R8, followed by the
+// func-value context in R9. The generated thunk rearranges those registers into
+// Wago's direct integer ABI and performs the same foreign-stack transition as
+// the standard Go assembly entry.
+var tinygoIntThunkTemplate = []byte{
+	0x49, 0xba, 0, 0, 0, 0, 0, 0, 0, 0, // movabs stackTop, r10
+	0x49, 0x83, 0xea, 0x40, // sub $64, r10
+	0x49, 0x89, 0x22, // mov rsp, 0(r10)
+	0x49, 0x89, 0x6a, 0x08, // mov rbp, 8(r10)
+	0x49, 0x89, 0x5a, 0x10, // mov rbx, 16(r10)
+	0x4d, 0x89, 0x62, 0x18, // mov r12, 24(r10)
+	0x4d, 0x89, 0x6a, 0x20, // mov r13, 32(r10)
+	0x4d, 0x89, 0x72, 0x28, // mov r14, 40(r10)
+	0x4d, 0x89, 0x7a, 0x30, // mov r15, 48(r10)
+	0x48, 0x89, 0xfb, // mov rdi, rbx (linMem)
+	0x49, 0x8d, 0x7a, 0xf8, // lea -8(r10), rdi
+	0x48, 0x89, 0x7b, 0xe8, // mov rdi, -24(rbx)
+	0x49, 0x89, 0xcb, // mov rcx, r11 (preserve a2)
+	0x48, 0x89, 0xf0, // mov rsi, rax (a0)
+	0x48, 0x89, 0xd1, // mov rdx, rcx (a1)
+	0x4c, 0x89, 0xda, // mov r11, rdx (a2)
+	0x4c, 0x89, 0xd4, // mov r10, rsp
+	0x31, 0xed, // xor ebp, ebp
+	0x41, 0xff, 0xd1, // call r9 (func-value context = code)
+	0x48, 0x8b, 0x6c, 0x24, 0x08, // mov 8(rsp), rbp
+	0x48, 0x8b, 0x5c, 0x24, 0x10, // mov 16(rsp), rbx
+	0x4c, 0x8b, 0x64, 0x24, 0x18, // mov 24(rsp), r12
+	0x4c, 0x8b, 0x6c, 0x24, 0x20, // mov 32(rsp), r13
+	0x4c, 0x8b, 0x74, 0x24, 0x28, // mov 40(rsp), r14
+	0x4c, 0x8b, 0x7c, 0x24, 0x30, // mov 48(rsp), r15
+	0x48, 0x8b, 0x24, 0x24, // mov 0(rsp), rsp
+	0xc3, // ret
+}
+
+const tinygoIntThunkStackTopOff = 2
+
+func preparedIntThunkFor(e *Engine) (uintptr, error) {
+	if e.preparedInt.entry != 0 {
+		return e.preparedInt.entry, nil
+	}
+	code := make([]byte, len(tinygoIntThunkTemplate))
+	copy(code, tinygoIntThunkTemplate)
+	binary.LittleEndian.PutUint64(code[tinygoIntThunkStackTopOff:], uint64(e.stackTop))
+	mem, err := mmapExec(code)
+	if err != nil {
+		return 0, err
+	}
+	e.preparedInt.mem = mem
+	e.preparedInt.entry = uintptr(unsafe.Pointer(&mem[0]))
+	return e.preparedInt.entry, nil
+}
+
+func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) (uint64, error) {
+	entry, err := preparedIntThunkFor(e)
+	if err != nil {
+		return 0, err
+	}
+	fv := funcValue{context: code, fnptr: entry}
+	call := *(*func(uintptr, uintptr, uintptr, uintptr, uintptr) uintptr)(unsafe.Pointer(&fv))
+	return uint64(call(linMemBase, uintptr(a0), uintptr(a1), uintptr(a2), uintptr(a3))), nil
+}
+
+func PreparedIntTrapCode(trap []byte) TrapCode {
+	if len(trap) < 4 {
+		return TrapNone
+	}
+	return TrapCode(loadTrap(trap))
+}
+
+func ConsumePreparedIntTrap(trap []byte) error {
+	tc := PreparedIntTrapCode(trap)
+	if tc == TrapNone {
+		return nil
+	}
+	storeTrap(trap, 0)
+	return trapErrorFromBuffer(tc, trap)
+}

--- a/src/core/runtime/engine_int_tinygo_arm64.go
+++ b/src/core/runtime/engine_int_tinygo_arm64.go
@@ -1,0 +1,76 @@
+//go:build (linux || darwin) && arm64 && tinygo
+
+package runtime
+
+import (
+	"unsafe"
+
+	a64 "github.com/wago-org/wago/src/core/encoder/arm64"
+)
+
+// TinyGo passes the five explicit uintptr arguments in X0-X4 and the func-value
+// context in X5. This thunk shifts them into Wago's direct integer ABI, saves the
+// complete AAPCS64 Go context, and enters native code on the foreign stack.
+func tinygoARM64IntEntryCode(foreignStackTop uintptr) []byte {
+	var a a64.Asm
+	a.MovReg64(a64.X9, a64.X0) // preserve linMem while shifting arguments
+	a.MovReg64(a64.X0, a64.X1)
+	a.MovReg64(a64.X1, a64.X2)
+	a.MovReg64(a64.X2, a64.X3)
+	a.MovReg64(a64.X3, a64.X4)
+	a.MovImm64(a64.X10, uint64(foreignStackTop))
+	tinygoARM64SaveGoContext(&a, a64.X10)
+	a.MovReg64(a64.X26, a64.X9)
+	a.AddImm64(a64.SP, a64.X10, 0)
+	a.MovReg64(a64.X22, a64.ZR)
+	a.MovReg64(a64.FP, a64.ZR)
+	a.Stur64(a64.X10, a64.X26, -offTrapStackReentry)
+	continuation := a.Adr(a64.X11)
+	a.Stur64(a64.X11, a64.X26, -arm64TrapHandlerPtrOffset)
+	a.Blr(a64.X5)
+	epilogue := a.Len()
+	if !a.PatchAdr(continuation, epilogue) {
+		panic("wago: arm64 TinyGo integer trampoline continuation is out of range")
+	}
+	tinygoARM64RestoreGoContext(&a)
+	return a.B
+}
+
+func preparedIntThunkFor(e *Engine) (uintptr, error) {
+	if e.preparedInt.entry != 0 {
+		return e.preparedInt.entry, nil
+	}
+	mem, err := mmapExec(tinygoARM64IntEntryCode(e.stackTop))
+	if err != nil {
+		return 0, err
+	}
+	e.preparedInt.mem = mem
+	e.preparedInt.entry = uintptr(unsafe.Pointer(&mem[0]))
+	return e.preparedInt.entry, nil
+}
+
+func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) (uint64, error) {
+	entry, err := preparedIntThunkFor(e)
+	if err != nil {
+		return 0, err
+	}
+	fv := tinygoARM64FuncValue{context: code, fnptr: entry}
+	call := *(*func(uintptr, uintptr, uintptr, uintptr, uintptr) uintptr)(unsafe.Pointer(&fv))
+	return uint64(call(linMemBase, uintptr(a0), uintptr(a1), uintptr(a2), uintptr(a3))), nil
+}
+
+func PreparedIntTrapCode(trap []byte) TrapCode {
+	if len(trap) < 4 {
+		return TrapNone
+	}
+	return TrapCode(loadTrap(trap))
+}
+
+func ConsumePreparedIntTrap(trap []byte) error {
+	tc := PreparedIntTrapCode(trap)
+	if tc == TrapNone {
+		return nil
+	}
+	storeTrap(trap, 0)
+	return trapErrorFromBuffer(tc, trap)
+}

--- a/src/core/runtime/engine_int_tinygo_test.go
+++ b/src/core/runtime/engine_int_tinygo_test.go
@@ -1,0 +1,29 @@
+//go:build tinygo && ((linux && amd64) || ((linux || darwin) && arm64))
+
+package runtime
+
+import "testing"
+
+func TestPreparedIntThunkOwnedByEngine(t *testing.T) {
+	e := &Engine{}
+	first, err := preparedIntThunkFor(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := preparedIntThunkFor(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == 0 || second != first {
+		t.Fatalf("prepared integer entry: first=%#x second=%#x", first, second)
+	}
+	if len(e.preparedInt.mem) == 0 {
+		t.Fatal("prepared integer entry has no owned mapping")
+	}
+	if err := e.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if e.preparedInt.entry != 0 || e.preparedInt.mem != nil {
+		t.Fatal("prepared integer entry mapping retained after engine close")
+	}
+}

--- a/src/core/runtime/engine_prepared_state_other.go
+++ b/src/core/runtime/engine_prepared_state_other.go
@@ -1,0 +1,7 @@
+//go:build !tinygo || windows || (darwin && amd64)
+
+package runtime
+
+type tinygoPreparedIntState struct{}
+
+func (*tinygoPreparedIntState) close() error { return nil }

--- a/src/core/runtime/engine_prepared_state_tinygo.go
+++ b/src/core/runtime/engine_prepared_state_tinygo.go
@@ -1,0 +1,17 @@
+//go:build tinygo && ((linux && amd64) || ((linux || darwin) && arm64))
+
+package runtime
+
+type tinygoPreparedIntState struct {
+	mem   []byte
+	entry uintptr
+}
+
+func (state *tinygoPreparedIntState) close() error {
+	if err := munmap(state.mem); err != nil {
+		return err
+	}
+	state.mem = nil
+	state.entry = 0
+	return nil
+}

--- a/src/core/runtime/trampoline_tinygo_arm64.go
+++ b/src/core/runtime/trampoline_tinygo_arm64.go
@@ -51,11 +51,17 @@ func tinygoARM64SaveGoContext(a *a64.Asm, top a64.Reg) {
 	for reg, off := a64.X19, uint32(8); reg <= a64.LR; reg, off = reg+1, off+8 {
 		tinygoARM64Store(a, reg, top, off)
 	}
+	for reg, off := a64.Reg(8), int32(104); reg <= a64.Reg(15); reg, off = reg+1, off+8 {
+		a.FStoreDisp(top, off, reg, true)
+	}
 }
 
 func tinygoARM64RestoreGoContext(a *a64.Asm) {
 	for reg, off := a64.X19, uint32(8); reg <= a64.LR; reg, off = reg+1, off+8 {
 		tinygoARM64Load(a, reg, a64.SP, off)
+	}
+	for reg, off := a64.Reg(8), int32(104); reg <= a64.Reg(15); reg, off = reg+1, off+8 {
+		a.FLoadDisp(reg, a64.SP, off, true)
 	}
 	tinygoARM64Load(a, a64.X11, a64.SP, 0)
 	a.AddImm64(a64.SP, a64.X11, 0)

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -173,7 +173,14 @@ func compileWithConfigAndInstructions(cfg *RuntimeConfig, wasmBytes []byte, inst
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	return compileWithFrontendFeaturesAndInstructions(cfg, wasmBytes, cfg.frontendFeatures(), instructions)
+	compiled, err := compileWithFrontendFeaturesAndInstructions(cfg, wasmBytes, cfg.frontendFeatures(), instructions)
+	// TinyGo's conservative collector must not reclaim compiler inputs whose
+	// derived slices and pointers remain in use below this public boundary.
+	// Keep the complete owners live until decoding and code generation finish.
+	goruntime.KeepAlive(wasmBytes)
+	goruntime.KeepAlive(cfg)
+	goruntime.KeepAlive(instructions)
+	return compiled, err
 }
 
 func stagedTwoLocalTableOperation(k wasm.InstrKind) (allowed bool, tableOperation bool) {

--- a/src/wago/cross_instance.go
+++ b/src/wago/cross_instance.go
@@ -143,11 +143,11 @@ func (rt *Runtime) NewExternRefTable(minSize, maxSize uint32) (*Table, error) {
 	if rt == nil || rt.refStore == nil {
 		return nil, fmt.Errorf("wago: nil runtime")
 	}
-	end, err := rt.beginOperation("NewExternRefTable", false)
+	operation, err := rt.beginOperation("NewExternRefTable", false)
 	if err != nil {
 		return nil, err
 	}
-	defer end()
+	defer operation.end()
 	return newHostTable(minSize, maxSize, ValExternRef, rt.refStore)
 }
 

--- a/src/wago/externref.go
+++ b/src/wago/externref.go
@@ -9,11 +9,11 @@ func (rt *Runtime) NewExternRef(value any) (ExternRef, error) {
 	if rt == nil || rt.refStore == nil {
 		return ExternRef{}, fmt.Errorf("wago: nil runtime")
 	}
-	end, err := rt.beginOperation("NewExternRef", false)
+	operation, err := rt.beginOperation("NewExternRef", false)
 	if err != nil {
 		return ExternRef{}, err
 	}
-	defer end()
+	defer operation.end()
 	token, err := rt.refStore.issueExternref(value)
 	if err != nil {
 		return ExternRef{}, err
@@ -30,11 +30,11 @@ func (rt *Runtime) ExternRefValue(ref ExternRef) (any, bool) {
 	if rt == nil || rt.refStore == nil {
 		return nil, false
 	}
-	end, err := rt.beginOperation("ExternRefValue", false)
+	operation, err := rt.beginOperation("ExternRefValue", false)
 	if err != nil {
 		return nil, false
 	}
-	defer end()
+	defer operation.end()
 	return rt.refStore.resolveExternref(ref.token)
 }
 

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -406,11 +406,11 @@ func (rt *Runtime) NewFuncRefGlobal(initial FuncRef, mutable bool) (*Global, err
 	if rt == nil || rt.refStore == nil {
 		return nil, fmt.Errorf("wago: nil runtime")
 	}
-	end, err := rt.beginOperation("NewFuncRefGlobal", false)
+	operation, err := rt.beginOperation("NewFuncRefGlobal", false)
 	if err != nil {
 		return nil, err
 	}
-	defer end()
+	defer operation.end()
 	descriptor := uint64(0)
 	if initial.token != 0 {
 		var ok bool
@@ -439,11 +439,11 @@ func (rt *Runtime) NewExternRefGlobal(initial ExternRef, mutable bool) (*Global,
 	if rt == nil || rt.refStore == nil {
 		return nil, fmt.Errorf("wago: nil runtime")
 	}
-	end, err := rt.beginOperation("NewExternRefGlobal", false)
+	operation, err := rt.beginOperation("NewExternRefGlobal", false)
 	if err != nil {
 		return nil, err
 	}
-	defer end()
+	defer operation.end()
 	if initial.token != 0 {
 		if _, ok := rt.refStore.resolveExternref(initial.token); !ok {
 			return nil, fmt.Errorf("wago: invalid externref token for global initializer")

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -293,11 +293,11 @@ func (rt *Runtime) newHostFuncRef(fn HostFunc, sig FuncSig, gcCapable, allowLoad
 	if rt == nil || rt.refStore == nil {
 		return nil, fmt.Errorf("wago: nil runtime")
 	}
-	end, err := rt.beginOperation("NewHostFuncRef", allowLoading)
+	operation, err := rt.beginOperation("NewHostFuncRef", allowLoading)
 	if err != nil {
 		return nil, err
 	}
-	defer end()
+	defer operation.end()
 	if fn == nil {
 		return nil, fmt.Errorf("wago: host function is nil")
 	}

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -206,6 +206,16 @@ func (in *Instance) endInvocation() {
 		if !in.invocationState.CompareAndSwap(state, next) {
 			continue
 		}
+		if next == instanceInvocationClosed {
+			if closeState := in.ensurePluginState().close.Load(); closeState != nil {
+				closeState.quiescedOnce.Do(func() { close(closeState.quiesced) })
+			}
+			in.tryFinalize()
+		}
+		// Keep the Runtime operation admitted through terminal instance
+		// finalization. Runtime shutdown uses this count as its barrier, so
+		// publishing it earlier could let WaitClosed return before reference
+		// tokens and store membership were released.
 		if in.rt != nil {
 			in.rt.mu.Lock()
 			if in.rt.activeOperations == 0 {
@@ -215,12 +225,6 @@ func (in *Instance) endInvocation() {
 			in.rt.activeOperations--
 			in.rt.stateCond.Broadcast()
 			in.rt.mu.Unlock()
-		}
-		if next == instanceInvocationClosed {
-			if closeState := in.ensurePluginState().close.Load(); closeState != nil {
-				closeState.quiescedOnce.Do(func() { close(closeState.quiesced) })
-			}
-			in.tryFinalize()
 		}
 		return
 	}

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -128,15 +128,14 @@ func (in *Instance) closeAndWait() error {
 	if in == nil {
 		return nil
 	}
-	if err := in.Close(); err != nil {
-		return err
-	}
+	closeErr := in.Close()
 	state := in.ensurePluginState().close.Load()
 	if state != nil {
+		<-state.done
 		<-state.quiesced
 		return joinPrimary(state.result, state.terminalResult)
 	}
-	return nil
+	return closeErr
 }
 
 func (in *Instance) isLogicallyClosed() bool {

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -175,11 +175,11 @@ func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*Managed
 	if err != nil {
 		return nil, err
 	}
-	hooks, reservation, end, err := m.rt.beginOperationGeneration("managed Fork", true)
+	hooks, operation, err := m.rt.beginOperationGeneration("managed Fork", true)
 	if err != nil {
 		return nil, err
 	}
-	defer end()
+	defer operation.end()
 	imports, err := managedForkImports(parent)
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*Managed
 	if hasGC {
 		gc = *state.gcConfig
 	}
-	child, err := rt.instantiateWithHooksOrigin(buildModule(parent.c, bindings), imports, gc, hasGC, false, InstantiateManaged, hooks, reservation)
+	child, err := rt.instantiateWithHooksOrigin(buildModule(parent.c, bindings), imports, gc, hasGC, false, InstantiateManaged, hooks, operation.reservation)
 	if err != nil {
 		m.mu.Lock()
 		m.live--

--- a/src/wago/prepared_direct_amd64.go
+++ b/src/wago/prepared_direct_amd64.go
@@ -1,4 +1,4 @@
-//go:build amd64 && !tinygo
+//go:build amd64 && (!tinygo || linux)
 
 package wago
 
@@ -13,37 +13,44 @@ const preparedDirectIntSupported = true
 const preparedDirectIntPrivateSupported = false
 
 func (fn *PreparedFunction) invokeDirectInt(args []uint64) ([]uint64, error) {
-	in := fn.in
-	if in.isLogicallyClosed() {
-		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
-	}
 	var a0, a1, a2, a3 uint64
 	switch len(args) {
 	case 4:
 		a3 = args[3]
-		if fn.scalarWideMask&8 == 0 {
-			a3 = uint64(uint32(a3))
-		}
 		fallthrough
 	case 3:
 		a2 = args[2]
-		if fn.scalarWideMask&4 == 0 {
-			a2 = uint64(uint32(a2))
-		}
 		fallthrough
 	case 2:
 		a1 = args[1]
-		if fn.scalarWideMask&2 == 0 {
-			a1 = uint64(uint32(a1))
-		}
 		fallthrough
 	case 1:
 		a0 = args[0]
-		if fn.scalarWideMask&1 == 0 {
-			a0 = uint64(uint32(a0))
-		}
 	}
-	result := in.eng.EnterPreparedInt(fn.directEntry, in.jm.LinMemBase(), a0, a1, a2, a3)
+	return fn.invokeDirectIntFixed(a0, a1, a2, a3)
+}
+
+func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint64, error) {
+	in := fn.in
+	if in.isLogicallyClosed() {
+		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
+	}
+	if fn.scalarWideMask&1 == 0 {
+		a0 = uint64(uint32(a0))
+	}
+	if fn.scalarWideMask&2 == 0 {
+		a1 = uint64(uint32(a1))
+	}
+	if fn.scalarWideMask&4 == 0 {
+		a2 = uint64(uint32(a2))
+	}
+	if fn.scalarWideMask&8 == 0 {
+		a3 = uint64(uint32(a3))
+	}
+	result, err := in.eng.EnterPreparedInt(fn.directEntry, in.jm.LinMemBase(), a0, a1, a2, a3)
+	if err != nil {
+		return nil, fmt.Errorf("wago: map prepared integer entry: %w", err)
+	}
 	if wruntime.PreparedIntTrapCode(in.trap) != wruntime.TrapNone {
 		return nil, in.decorateTrap(wruntime.ConsumePreparedIntTrap(in.trap))
 	}

--- a/src/wago/prepared_direct_arm64.go
+++ b/src/wago/prepared_direct_arm64.go
@@ -1,4 +1,4 @@
-//go:build arm64 && !tinygo && (linux || darwin || windows)
+//go:build arm64 && (linux || darwin || (windows && !tinygo))
 
 package wago
 
@@ -13,42 +13,49 @@ const preparedDirectIntSupported = true
 const preparedDirectIntPrivateSupported = true
 
 func (fn *PreparedFunction) invokeDirectInt(args []uint64) ([]uint64, error) {
-	in := fn.in
-	if in.isLogicallyClosed() {
-		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
-	}
 	var a0, a1, a2, a3 uint64
 	switch len(args) {
 	case 4:
 		a3 = args[3]
-		if fn.scalarWideMask&8 == 0 {
-			a3 = uint64(uint32(a3))
-		}
 		fallthrough
 	case 3:
 		a2 = args[2]
-		if fn.scalarWideMask&4 == 0 {
-			a2 = uint64(uint32(a2))
-		}
 		fallthrough
 	case 2:
 		a1 = args[1]
-		if fn.scalarWideMask&2 == 0 {
-			a1 = uint64(uint32(a1))
-		}
 		fallthrough
 	case 1:
 		a0 = args[0]
-		if fn.scalarWideMask&1 == 0 {
-			a0 = uint64(uint32(a0))
-		}
+	}
+	return fn.invokeDirectIntFixed(a0, a1, a2, a3)
+}
+
+func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint64, error) {
+	in := fn.in
+	if in.isLogicallyClosed() {
+		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
+	}
+	if fn.scalarWideMask&1 == 0 {
+		a0 = uint64(uint32(a0))
+	}
+	if fn.scalarWideMask&2 == 0 {
+		a1 = uint64(uint32(a1))
+	}
+	if fn.scalarWideMask&4 == 0 {
+		a2 = uint64(uint32(a2))
+	}
+	if fn.scalarWideMask&8 == 0 {
+		a3 = uint64(uint32(a3))
 	}
 	if !fn.isolatedFast {
 		nativeExecutionMu.Lock()
 		nativeExecutionEpoch++
 		defer nativeExecutionMu.Unlock()
 	}
-	result := in.eng.EnterPreparedInt(fn.directEntry, in.jm.LinMemBase(), a0, a1, a2, a3)
+	result, err := in.eng.EnterPreparedInt(fn.directEntry, in.jm.LinMemBase(), a0, a1, a2, a3)
+	if err != nil {
+		return nil, fmt.Errorf("wago: map prepared integer entry: %w", err)
+	}
 	if wruntime.PreparedIntTrapCode(in.trap) != wruntime.TrapNone {
 		return nil, in.decorateTrap(wruntime.ConsumePreparedIntTrap(in.trap))
 	}

--- a/src/wago/prepared_direct_other.go
+++ b/src/wago/prepared_direct_other.go
@@ -1,4 +1,4 @@
-//go:build (!amd64 && !arm64) || tinygo || (arm64 && !(linux || darwin || windows))
+//go:build (!amd64 && !arm64) || (tinygo && amd64 && !linux) || (arm64 && !(linux || darwin || windows)) || (tinygo && arm64 && windows)
 
 package wago
 
@@ -8,5 +8,9 @@ const preparedDirectIntSupported = false
 const preparedDirectIntPrivateSupported = false
 
 func (fn *PreparedFunction) invokeDirectInt([]uint64) ([]uint64, error) {
+	return nil, fmt.Errorf("wago: direct prepared integer entry is unavailable on this architecture")
+}
+
+func (fn *PreparedFunction) invokeDirectIntFixed(uint64, uint64, uint64, uint64) ([]uint64, error) {
 	return nil, fmt.Errorf("wago: direct prepared integer entry is unavailable on this architecture")
 }

--- a/src/wago/prepared_function.go
+++ b/src/wago/prepared_function.go
@@ -164,6 +164,49 @@ func (l preparedInvocationLease) unlock() {
 	l.state.invokeMu.Unlock()
 }
 
+// Invoke0 calls a prepared export with no argument slots. Unlike the variadic
+// Invoke, fixed-arity calls do not require TinyGo to allocate an argument slice.
+func (fn *PreparedFunction) Invoke0() ([]uint64, error) {
+	return fn.invokeFixed(0, 0, 0, 0, 0)
+}
+
+// Invoke1 calls a prepared export with one argument slot.
+func (fn *PreparedFunction) Invoke1(a0 uint64) ([]uint64, error) {
+	return fn.invokeFixed(1, a0, 0, 0, 0)
+}
+
+// Invoke2 calls a prepared export with two argument slots.
+func (fn *PreparedFunction) Invoke2(a0, a1 uint64) ([]uint64, error) {
+	return fn.invokeFixed(2, a0, a1, 0, 0)
+}
+
+// Invoke3 calls a prepared export with three argument slots.
+func (fn *PreparedFunction) Invoke3(a0, a1, a2 uint64) ([]uint64, error) {
+	return fn.invokeFixed(3, a0, a1, a2, 0)
+}
+
+// Invoke4 calls a prepared export with four argument slots.
+func (fn *PreparedFunction) Invoke4(a0, a1, a2, a3 uint64) ([]uint64, error) {
+	return fn.invokeFixed(4, a0, a1, a2, a3)
+}
+
+func (fn *PreparedFunction) invokeFixed(count int, a0, a1, a2, a3 uint64) ([]uint64, error) {
+	if fn == nil || fn.in == nil {
+		return nil, fmt.Errorf("wago: invoke closed prepared function")
+	}
+	if count != fn.paramSlots {
+		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", fn.export, fn.paramSlots, count)
+	}
+	if fn.directIntFast {
+		return fn.invokeDirectIntFixed(a0, a1, a2, a3)
+	}
+	args := [4]uint64{a0, a1, a2, a3}
+	if fn.scalarFast {
+		return fn.invokeScalar(args[:count])
+	}
+	return fn.invokeGeneral(args[:count])
+}
+
 func (fn *PreparedFunction) invokeGeneral(args []uint64) ([]uint64, error) {
 	if fn == nil || fn.in == nil {
 		return nil, fmt.Errorf("wago: invoke closed prepared function")

--- a/src/wago/prepared_function_test.go
+++ b/src/wago/prepared_function_test.go
@@ -131,7 +131,7 @@ func TestPreparedFunctionDirectIntArgumentsAndTrap(t *testing.T) {
 	if !fn.directIntFast {
 		t.Fatal("i64 add did not select direct integer entry")
 	}
-	got, err := fn.Invoke(0x1_0000_0000, 7)
+	got, err := fn.Invoke2(0x1_0000_0000, 7)
 	if err != nil || len(got) != 1 || got[0] != 0x1_0000_0007 {
 		t.Fatalf("direct i64 add = %v, %v", got, err)
 	}
@@ -161,12 +161,45 @@ func TestPreparedFunctionDirectIntArgumentsAndTrap(t *testing.T) {
 	if !fn.directIntFast {
 		t.Fatal("i32 div did not select direct integer entry")
 	}
-	if _, err := fn.Invoke(I32(7), I32(0)); err == nil {
+	if _, err := fn.Invoke2(I32(7), I32(0)); err == nil {
 		t.Fatal("direct division by zero did not trap")
 	}
-	got, err = fn.Invoke(I32(8), I32(2))
+	got, err = fn.Invoke2(I32(8), I32(2))
 	if err != nil || len(got) != 1 || AsI32(got[0]) != 4 {
 		t.Fatalf("direct i32 div after trap = %v, %v", got, err)
+	}
+}
+
+func TestPreparedFunctionFixedArityFourArguments(t *testing.T) {
+	module := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(
+			[]wasm.ValType{wasm.I64, wasm.I64, wasm.I64, wasm.I64},
+			[]wasm.ValType{wasm.I64},
+		))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("sum", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{
+			0x20, 0x00, 0x20, 0x01, 0x7c,
+			0x20, 0x02, 0x7c,
+			0x20, 0x03, 0x7c,
+			0x0b,
+		}))),
+	)
+	in, err := Instantiate(MustCompile(module), InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareFunction("sum")
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	got, err := fn.Invoke4(1, 2, 4, 8)
+	if err != nil || len(got) != 1 || got[0] != 15 {
+		t.Fatalf("fixed four-argument sum = %v, %v; want 15", got, err)
+	}
+	if _, err := fn.Invoke3(1, 2, 4); err == nil || !strings.Contains(err.Error(), "expects 4") {
+		t.Fatalf("fixed arity mismatch error = %v", err)
 	}
 }
 
@@ -341,7 +374,7 @@ func BenchmarkPreparedInvokeAddOne(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		res, err := fn.Invoke(I32(int32(i)))
+		res, err := fn.Invoke1(I32(int32(i)))
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/src/wago/reference_quiescence_test.go
+++ b/src/wago/reference_quiescence_test.go
@@ -43,6 +43,15 @@ func TestReferenceTokensWaitForClosingInvocationQuiescence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	finalizing := make(chan struct{})
+	finishFinalizing := make(chan struct{})
+	rt.hooks.afterClose = append(rt.hooks.afterClose, func(event InstanceCloseEvent) {
+		if !sameInstance(event.Instance, writer) {
+			return
+		}
+		close(finalizing)
+		<-finishFinalizing
+	})
 	callDone := make(chan error, 1)
 	go func() {
 		result, err := writer.Invoke("use", token)
@@ -90,6 +99,14 @@ func TestReferenceTokensWaitForClosingInvocationQuiescence(t *testing.T) {
 	}
 
 	close(resume)
+	<-finalizing
+	rt.mu.Lock()
+	activeOperations := rt.activeOperations
+	rt.mu.Unlock()
+	if activeOperations != 1 {
+		t.Fatalf("runtime operations during terminal finalization = %d, want 1", activeOperations)
+	}
+	close(finishFinalizing)
 	if err := <-callDone; err != nil && !strings.Contains(err.Error(), "interrupt") {
 		t.Fatalf("resumed descriptor use = %v; want result 42 or caller-close interruption", err)
 	}

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -1719,6 +1719,16 @@ func (s *referenceStore) closeRuntime() {
 	releaseReferenceEntries(release)
 }
 
+// emptyForInlineClose reports whether closing the store has constant work. The
+// caller has already published Runtime shutdown, so no new entries can arrive.
+func (s *referenceStore) emptyForInlineClose() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.liveInstances == 0 && s.liveObjects == 0 && len(s.instances) == 0 &&
+		len(s.instanceTypes) == 0 && len(s.byIdentity) == 0 && len(s.byToken) == 0 &&
+		len(s.gcByToken) == 0 && len(s.externrefs) == 0 && s.gcDomains == nil
+}
+
 func (s *referenceStore) issue(source *Instance, descriptor uint64) (uint64, error) {
 	return s.issueMode(source, descriptor, false)
 }

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -1131,9 +1131,9 @@ func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, ho
 
 	instances := rt.directInstancesSnapshot()
 	for i := len(instances) - 1; i >= 0; i-- {
-		if err := instances[i].Close(); err != nil {
-			errs = append(errs, err)
-		}
+		// The close state below owns both the logical-close result and the
+		// terminal result published after admitted invocations quiesce.
+		_ = instances[i].Close()
 	}
 	for i := len(pluginRuns) - 1; i >= 0; i-- {
 		errs = append(errs, closePluginRun(ctx, pluginRuns[i])...)
@@ -1156,8 +1156,9 @@ func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, ho
 		closeState := instances[i].ensurePluginState().close.Load()
 		if closeState != nil {
 			<-closeState.done
-			if closeState.result != nil {
-				errs = append(errs, closeState.result)
+			<-closeState.quiesced
+			if err := joinPrimary(closeState.result, closeState.terminalResult); err != nil {
+				errs = append(errs, err)
 			}
 		}
 	}

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	goruntime "runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -72,6 +73,41 @@ const (
 type runtimeCloseState struct {
 	done   chan struct{}
 	result error
+}
+
+// runtimeCloseTask owns every value consumed by one asynchronous shutdown.
+// TinyGo additionally roots active tasks explicitly; see
+// runtime_close_task_tinygo.go.
+type runtimeCloseTask struct {
+	rt            *Runtime
+	ctx           context.Context
+	state         *runtimeCloseState
+	loadingDone   <-chan struct{}
+	hooks         []func(RuntimeCloseEvent)
+	internalClose []func() error
+	pluginRuns    []registeredPluginRun
+	store         *referenceStore
+}
+
+func (task *runtimeCloseTask) run() {
+	defer releaseRuntimeCloseTask(task)
+	if task.loadingDone != nil {
+		task.rt.finishCloseAfterLoading(task.ctx, task.state, task.loadingDone)
+		return
+	}
+	task.rt.finishClose(task.ctx, task.state, task.hooks, task.internalClose, task.pluginRuns, task.store)
+}
+
+func (rt *Runtime) finishCloseAsync(ctx context.Context, state *runtimeCloseState, hooks []func(RuntimeCloseEvent), internalClose []func() error, pluginRuns []registeredPluginRun, store *referenceStore) {
+	task := &runtimeCloseTask{rt: rt, ctx: ctx, state: state, hooks: hooks, internalClose: internalClose, pluginRuns: pluginRuns, store: store}
+	retainRuntimeCloseTask(task)
+	go task.run()
+}
+
+func (rt *Runtime) finishCloseAfterLoadingAsync(ctx context.Context, state *runtimeCloseState, loadingDone <-chan struct{}) {
+	task := &runtimeCloseTask{rt: rt, ctx: ctx, state: state, loadingDone: loadingDone}
+	retainRuntimeCloseTask(task)
+	go task.run()
 }
 
 type registeredPluginRun struct {
@@ -170,69 +206,82 @@ func (rt *Runtime) storeHooks(hooks *hookRegistry) {
 // and leases the immutable plugin callback set through the operation. Loading
 // excludes public callers; committed authority handles may opt into the Start
 // phase after the complete plan has activated.
-func (rt *Runtime) beginOperation(label string, allowLoading bool) (func(), error) {
+type runtimeOperation struct {
+	rt          *Runtime
+	reservation *pluginOperationReservation
+	compile     bool
+	active      bool
+}
+
+func (operation *runtimeOperation) end() {
+	if operation == nil || !operation.active {
+		return
+	}
+	operation.active = false
+	operation.reservation.release()
+	rt := operation.rt
+	rt.mu.Lock()
+	if rt.activeOperations == 0 || operation.compile && rt.compileOperations == 0 {
+		rt.mu.Unlock()
+		panic("wago: runtime operation lease underflow")
+	}
+	rt.activeOperations--
+	if operation.compile {
+		rt.compileOperations--
+	}
+	rt.stateCond.Broadcast()
+	rt.mu.Unlock()
+}
+
+func (rt *Runtime) beginOperation(label string, allowLoading bool) (runtimeOperation, error) {
 	return rt.beginOperationKind(label, allowLoading, false)
 }
 
-func (rt *Runtime) beginOperationGeneration(label string, allowLoading bool) (*hookRegistry, *pluginOperationReservation, func(), error) {
+func (rt *Runtime) beginOperationGeneration(label string, allowLoading bool) (*hookRegistry, runtimeOperation, error) {
 	if rt == nil {
-		return nil, nil, nil, fmt.Errorf("wago: %s on a nil runtime", label)
+		return nil, runtimeOperation{}, fmt.Errorf("wago: %s on a nil runtime", label)
 	}
 	rt.mu.Lock()
 	switch rt.state {
 	case runtimeLoading:
 		if !allowLoading {
 			rt.mu.Unlock()
-			return nil, nil, nil, fmt.Errorf("wago: %s while plugins are loading", label)
+			return nil, runtimeOperation{}, fmt.Errorf("wago: %s while plugins are loading", label)
 		}
 	case runtimeClosing, runtimeClosed:
 		rt.mu.Unlock()
-		return nil, nil, nil, fmt.Errorf("wago: %s on a closed runtime", label)
+		return nil, runtimeOperation{}, fmt.Errorf("wago: %s on a closed runtime", label)
 	}
 	hooks := rt.loadHooks()
 	reservation, err := reservePluginOperation(hooks.operationGates)
 	if err != nil {
 		rt.mu.Unlock()
-		return nil, nil, nil, err
+		return nil, runtimeOperation{}, err
 	}
 	rt.operational = true
 	rt.activeOperations++
 	rt.mu.Unlock()
-	var once sync.Once
-	end := func() {
-		once.Do(func() {
-			reservation.release()
-			rt.mu.Lock()
-			if rt.activeOperations == 0 {
-				rt.mu.Unlock()
-				panic("wago: runtime operation lease underflow")
-			}
-			rt.activeOperations--
-			rt.stateCond.Broadcast()
-			rt.mu.Unlock()
-		})
-	}
-	return hooks, reservation, end, nil
+	return hooks, runtimeOperation{rt: rt, reservation: reservation, active: true}, nil
 }
 
-func (rt *Runtime) beginCompileOperation(label string, allowLoading bool) (func(), error) {
+func (rt *Runtime) beginCompileOperation(label string, allowLoading bool) (runtimeOperation, error) {
 	return rt.beginOperationKind(label, allowLoading, true)
 }
 
-func (rt *Runtime) beginOperationKind(label string, allowLoading, compile bool) (func(), error) {
+func (rt *Runtime) beginOperationKind(label string, allowLoading, compile bool) (runtimeOperation, error) {
 	if rt == nil {
-		return nil, fmt.Errorf("wago: %s on a nil runtime", label)
+		return runtimeOperation{}, fmt.Errorf("wago: %s on a nil runtime", label)
 	}
 	rt.mu.Lock()
 	switch rt.state {
 	case runtimeLoading:
 		if !allowLoading {
 			rt.mu.Unlock()
-			return nil, fmt.Errorf("wago: %s while plugins are loading", label)
+			return runtimeOperation{}, fmt.Errorf("wago: %s while plugins are loading", label)
 		}
 	case runtimeClosing, runtimeClosed:
 		rt.mu.Unlock()
-		return nil, fmt.Errorf("wago: %s on a closed runtime", label)
+		return runtimeOperation{}, fmt.Errorf("wago: %s on a closed runtime", label)
 	}
 	rt.operational = true
 	rt.activeOperations++
@@ -240,22 +289,7 @@ func (rt *Runtime) beginOperationKind(label string, allowLoading, compile bool) 
 		rt.compileOperations++
 	}
 	rt.mu.Unlock()
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			rt.mu.Lock()
-			if rt.activeOperations == 0 || compile && rt.compileOperations == 0 {
-				rt.mu.Unlock()
-				panic("wago: runtime operation lease underflow")
-			}
-			rt.activeOperations--
-			if compile {
-				rt.compileOperations--
-			}
-			rt.stateCond.Broadcast()
-			rt.mu.Unlock()
-		})
-	}, nil
+	return runtimeOperation{rt: rt, compile: compile, active: true}, nil
 }
 
 func (rt *Runtime) registerInstance(in *Instance) error {
@@ -360,7 +394,7 @@ func (rt *Runtime) compilePlugin(wasmBytes []byte) (*Module, error) {
 type PreparedCompile struct {
 	mu           sync.Mutex
 	rt           *Runtime
-	end          func()
+	operation    runtimeOperation
 	compilation  CompilationIdentity
 	source       []byte
 	cfg          *RuntimeConfig
@@ -378,12 +412,8 @@ func (rt *Runtime) PrepareCompile(wasmBytes []byte) (*PreparedCompile, error) {
 }
 
 func (rt *Runtime) prepareCompile(wasmBytes []byte, allowLoading bool) (*PreparedCompile, error) {
-	end, err := rt.beginCompileOperation("Compile", allowLoading)
+	operation, err := rt.beginCompileOperation("Compile", allowLoading)
 	if err != nil {
-		return nil, err
-	}
-	fail := func(err error) (*PreparedCompile, error) {
-		end()
 		return nil, err
 	}
 
@@ -397,7 +427,8 @@ func (rt *Runtime) prepareCompile(wasmBytes []byte, allowLoading bool) (*Prepare
 	}
 	rt.mu.Unlock()
 	if err := cfg.Validate(); err != nil {
-		return fail(err)
+		operation.end()
+		return nil, err
 	}
 
 	var compilation CompilationIdentity
@@ -415,7 +446,8 @@ func (rt *Runtime) prepareCompile(wasmBytes []byte, allowLoading bool) (*Prepare
 		var transformErr error
 		panicErr := callHookSafely("ModuleSourceTransformer", func() { next, transformErr = transform(ctx, source) })
 		if err := joinPrimary(transformErr, panicErr); err != nil {
-			return fail(emitCompileError(hooks, compilation, err))
+			operation.end()
+			return nil, emitCompileError(hooks, compilation, err)
 		}
 		if next == nil {
 			next = source
@@ -426,7 +458,7 @@ func (rt *Runtime) prepareCompile(wasmBytes []byte, allowLoading bool) (*Prepare
 		source = append([]byte(nil), next...)
 	}
 	return &PreparedCompile{
-		rt: rt, end: end, compilation: compilation, source: source, cfg: cfg,
+		rt: rt, operation: operation, compilation: compilation, source: source, cfg: cfg,
 		bindings: bindings, hooks: hooks, instructions: instructions,
 		cacheable: len(hooks.beforeCompile) == 0 && len(instructions) == 0,
 	}, nil
@@ -471,12 +503,8 @@ func (p *PreparedCompile) finish() {
 		return
 	}
 	p.finished = true
-	end := p.end
-	p.end = nil
 	p.mu.Unlock()
-	if end != nil {
-		end()
-	}
+	p.operation.end()
 }
 
 // Compile compiles the prepared source and adopts ownership into the returned
@@ -578,11 +606,11 @@ func (rt *Runtime) bindModule(c *Compiled, ownsCompiled bool) (*Module, error) {
 	if rt == nil || c == nil {
 		return nil, fmt.Errorf("wago: nil runtime or compiled module")
 	}
-	end, err := rt.beginCompileOperation("Module", false)
+	operation, err := rt.beginCompileOperation("Module", false)
 	if err != nil {
 		return nil, err
 	}
-	defer end()
+	defer operation.end()
 	rt.mu.Lock()
 	hooks := rt.loadHooks()
 	bindings := rt.snapshotModuleBindingsLocked(hooks)
@@ -670,11 +698,11 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	if mod.rt != rt {
 		return nil, fmt.Errorf("wago: Instantiate: %w", ErrForeignModule)
 	}
-	hooks, reservation, end, err := rt.beginOperationGeneration("Instantiate", allowLoading)
+	hooks, operation, err := rt.beginOperationGeneration("Instantiate", allowLoading)
 	if err != nil {
 		return nil, err
 	}
-	defer end()
+	defer operation.end()
 	if !mod.beginUse() {
 		return nil, fmt.Errorf("wago: Instantiate: module is closed")
 	}
@@ -708,7 +736,7 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	// retained code ownership before start-time host callbacks.
 	mod.endUse()
 	usingModule = false
-	in, err := rt.instantiateWithHooksOrigin(mod, imports, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks, reservation)
+	in, err := rt.instantiateWithHooksOrigin(mod, imports, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks, operation.reservation)
 	if err == nil && rt.isClosed() {
 		err = joinPrimary(fmt.Errorf("wago: runtime closed during instantiation"), in.Close())
 		in = nil
@@ -796,7 +824,15 @@ func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, gc G
 	if len(hooks.beforeInstantiate) == 0 && len(hooks.afterCreate) == 0 && len(hooks.afterInstantiate) == 0 && len(hooks.onInstantiateError) == 0 {
 		return instantiateCoreWithModuleUse(mod, iopts)
 	}
+	return instantiateWithLifecycleHooks(mod, iopts, origin, hooks, reservation)
+}
 
+// instantiateWithLifecycleHooks is kept separate from the ordinary no-hook
+// path. TinyGo boxes every value captured by a closure for the complete
+// containing function, even when execution returns before reaching that closure.
+// Keeping callbacks here prevents the default instantiation path's Runtime,
+// Module, hooks, and options from being routed through those heap boxes.
+func instantiateWithLifecycleHooks(mod *Module, iopts InstantiateOptions, origin InstantiateOrigin, hooks *hookRegistry, reservation *pluginOperationReservation) (*Instance, error) {
 	request := InstantiationRequest{Module: moduleView(mod), Origin: origin, reservation: reservation}
 	emitError := func(original error) error {
 		var hookErrs []error
@@ -850,7 +886,12 @@ func instantiateCoreWithModuleUse(mod *Module, opts InstantiateOptions) (*Instan
 	if !mod.beginUse() {
 		return nil, fmt.Errorf("wago: Instantiate: module is closed")
 	}
-	return instantiateCoreWithModuleLease(mod.c, opts, mod)
+	inst, err := instantiateCoreWithModuleLease(mod.c, opts, mod)
+	// The compiled module owns metadata and backing slices consumed throughout
+	// instantiation. TinyGo needs an explicit final use to keep that owner rooted.
+	goruntime.KeepAlive(mod)
+	goruntime.KeepAlive(opts)
+	return inst, err
 }
 
 // Plugins returns immutable definitions in dependency-resolved activation order.
@@ -899,11 +940,11 @@ func (rt *Runtime) ProvidedImports() []ImportSpec {
 	return specs
 }
 
-// Close publishes shutdown and returns promptly. It never waits for teardown,
-// so plugin callbacks, host imports, contract calls, invoke hooks, and close
-// observers may initiate Runtime closure without self-deadlock. Use
-// CloseContext or WaitClosed when completion and the joined teardown error are
-// required.
+// Close publishes shutdown and returns promptly. An empty callback-free Runtime
+// completes inline; all other teardown continues asynchronously so plugin
+// callbacks, host imports, contract calls, invoke hooks, and close observers may
+// initiate Runtime closure without self-deadlock. Use CloseContext or WaitClosed
+// when completion and the joined teardown error are required.
 func (rt *Runtime) Close() error {
 	if rt == nil {
 		return nil
@@ -917,12 +958,24 @@ func (rt *Runtime) Close() error {
 	if rt.stateWasLoadingLocked() {
 		loadingDone := rt.loadingDone
 		rt.mu.Unlock()
-		go rt.finishCloseAfterLoading(context.Background(), state, loadingDone)
+		rt.finishCloseAfterLoadingAsync(context.Background(), state, loadingDone)
 		return nil
 	}
 	hooks, internalClose, pluginRuns, store := rt.snapshotCloseLocked()
+	// A callback-free Runtime with no admitted work or live instances has
+	// nothing that can block or re-enter shutdown. Finish that bounded path in
+	// place. Besides avoiding a needless goroutine, this prevents cooperative
+	// TinyGo builds from accumulating teardown tasks between short-lived runtime
+	// iterations.
+	finishInline := rt.activeOperations == 0 && len(rt.instances) == 0 &&
+		len(hooks) == 0 && len(internalClose) == 0 && len(pluginRuns) == 0 &&
+		store.emptyForInlineClose()
 	rt.mu.Unlock()
-	go rt.finishClose(context.Background(), state, hooks, internalClose, pluginRuns, store)
+	if finishInline {
+		rt.finishClose(context.Background(), state, hooks, internalClose, pluginRuns, store)
+		return nil
+	}
+	rt.finishCloseAsync(context.Background(), state, hooks, internalClose, pluginRuns, store)
 	return nil
 }
 
@@ -985,11 +1038,11 @@ func (rt *Runtime) CloseContext(ctx context.Context) error {
 		if rt.stateWasLoadingLocked() {
 			loadingDone := rt.loadingDone
 			rt.mu.Unlock()
-			go rt.finishCloseAfterLoading(ctx, state, loadingDone)
+			rt.finishCloseAfterLoadingAsync(ctx, state, loadingDone)
 		} else {
 			hooks, internalClose, pluginRuns, store := rt.snapshotCloseLocked()
 			rt.mu.Unlock()
-			go rt.finishClose(ctx, state, hooks, internalClose, pluginRuns, store)
+			rt.finishCloseAsync(ctx, state, hooks, internalClose, pluginRuns, store)
 		}
 	} else {
 		rt.mu.Unlock()
@@ -1143,7 +1196,7 @@ func (rt *Runtime) rollbackCommittedPluginPlan(ctx context.Context) error {
 		var store *referenceStore
 		state, hooks, internalClose, pluginRuns, store = rt.startCloseLocked()
 		rt.mu.Unlock()
-		go rt.finishClose(ctx, state, hooks, internalClose, pluginRuns, store)
+		rt.finishCloseAsync(ctx, state, hooks, internalClose, pluginRuns, store)
 	} else {
 		rt.mu.Unlock()
 	}

--- a/src/wago/runtime_adversarial_test.go
+++ b/src/wago/runtime_adversarial_test.go
@@ -740,7 +740,10 @@ func TestRepeatedRuntimeCompileInstantiateDoesNotRetainHeap(t *testing.T) {
 			if err := table.Close(); err != nil {
 				t.Fatal(err)
 			}
-			if err := rt.Close(); err != nil {
+			// The heap assertion below must observe completed teardown. Close only
+			// publishes asynchronous shutdown, which can leave all n runtimes live
+			// until the cooperative TinyGo scheduler gets another yield.
+			if err := rt.CloseContext(context.Background()); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/src/wago/runtime_close_panic_test.go
+++ b/src/wago/runtime_close_panic_test.go
@@ -5,7 +5,91 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/wago-org/wago/tests/wasmtest"
 )
+
+func TestRuntimeWaitClosedReportsDeferredAfterClosePanic(t *testing.T) {
+	beforeClose := make(chan struct{})
+	rt := NewRuntime()
+	rt.storeHooks(&hookRegistry{
+		beforeClose: []func(InstanceCloseEvent){func(InstanceCloseEvent) { close(beforeClose) }},
+		afterClose:  []func(InstanceCloseEvent){func(InstanceCloseEvent) { panic("after close") }},
+	})
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if err := in.beginInvocation(); err != nil {
+		t.Fatalf("begin invocation: %v", err)
+	}
+
+	if err := rt.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	<-beforeClose
+	in.endInvocation()
+	if err := rt.WaitClosed(context.Background()); !errors.Is(err, ErrCallbackPanic) {
+		t.Fatalf("WaitClosed error = %v, want ErrCallbackPanic", err)
+	}
+}
+
+func TestRuntimeWaitClosedJoinsInstanceCloseErrorsOnce(t *testing.T) {
+	rt := NewRuntime()
+	rt.storeHooks(&hookRegistry{
+		beforeClose: []func(InstanceCloseEvent){func(InstanceCloseEvent) { panic("before close") }},
+		afterClose:  []func(InstanceCloseEvent){func(InstanceCloseEvent) { panic("after close") }},
+	})
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if _, err := rt.Instantiate(context.Background(), mod); err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	err = rt.CloseContext(context.Background())
+	if !errors.Is(err, ErrCallbackPanic) {
+		t.Fatalf("CloseContext error = %v, want ErrCallbackPanic", err)
+	}
+	if got := strings.Count(err.Error(), "BeforeClose"); got != 1 {
+		t.Fatalf("BeforeClose error count = %d, want 1: %v", got, err)
+	}
+	if got := strings.Count(err.Error(), "AfterClose"); got != 1 {
+		t.Fatalf("AfterClose error count = %d, want 1: %v", got, err)
+	}
+}
+
+func TestInstanceCloseAndWaitJoinsOrdinaryAndTerminalErrors(t *testing.T) {
+	rt := NewRuntime()
+	rt.storeHooks(&hookRegistry{
+		beforeClose: []func(InstanceCloseEvent){func(InstanceCloseEvent) { panic("before close") }},
+		afterClose:  []func(InstanceCloseEvent){func(InstanceCloseEvent) { panic("after close") }},
+	})
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	err = in.closeAndWait()
+	if !errors.Is(err, ErrCallbackPanic) {
+		t.Fatalf("closeAndWait error = %v, want ErrCallbackPanic", err)
+	}
+	if got := strings.Count(err.Error(), "BeforeClose"); got != 1 {
+		t.Fatalf("BeforeClose error count = %d, want 1: %v", got, err)
+	}
+	if got := strings.Count(err.Error(), "AfterClose"); got != 1 {
+		t.Fatalf("AfterClose error count = %d, want 1: %v", got, err)
+	}
+}
 
 func TestRuntimeCloseSanitizesShutdownPanicsAndContinues(t *testing.T) {
 	secret := strings.Repeat("secret-token-", 1024)

--- a/src/wago/runtime_close_task_notinygo.go
+++ b/src/wago/runtime_close_task_notinygo.go
@@ -1,0 +1,6 @@
+//go:build !tinygo
+
+package wago
+
+func retainRuntimeCloseTask(*runtimeCloseTask)  {}
+func releaseRuntimeCloseTask(*runtimeCloseTask) {}

--- a/src/wago/runtime_close_task_tinygo.go
+++ b/src/wago/runtime_close_task_tinygo.go
@@ -1,0 +1,28 @@
+//go:build tinygo
+
+package wago
+
+import "sync"
+
+// TinyGo's conservative collector needs an explicit process root for the heap
+// graph owned only by a queued shutdown goroutine. Entries exist only while the
+// corresponding close task is active and are removed by runtimeCloseTask.run.
+var runtimeCloseTaskRoots struct {
+	sync.Mutex
+	active map[*runtimeCloseTask]struct{}
+}
+
+func retainRuntimeCloseTask(task *runtimeCloseTask) {
+	runtimeCloseTaskRoots.Lock()
+	if runtimeCloseTaskRoots.active == nil {
+		runtimeCloseTaskRoots.active = make(map[*runtimeCloseTask]struct{})
+	}
+	runtimeCloseTaskRoots.active[task] = struct{}{}
+	runtimeCloseTaskRoots.Unlock()
+}
+
+func releaseRuntimeCloseTask(task *runtimeCloseTask) {
+	runtimeCloseTaskRoots.Lock()
+	delete(runtimeCloseTaskRoots.active, task)
+	runtimeCloseTaskRoots.Unlock()
+}

--- a/src/wago/runtime_hardening_test.go
+++ b/src/wago/runtime_hardening_test.go
@@ -272,6 +272,37 @@ func TestRuntimeCloseFromImportedStartIsReentrant(t *testing.T) {
 	}
 }
 
+func TestRuntimeCloseCallbackFreeFastPathCompletesInline(t *testing.T) {
+	rt := NewRuntime()
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-rt.Closed():
+	default:
+		t.Fatal("callback-free runtime shutdown did not complete inline")
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeCloseReferenceStoreWorkIsNotInline(t *testing.T) {
+	rt := NewRuntime()
+	if _, err := rt.NewExternRef("retained"); err != nil {
+		t.Fatal(err)
+	}
+	if rt.refStore.emptyForInlineClose() {
+		t.Fatal("reference store with an externref reported constant close work")
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRuntimeCloseContextPreCanceledHasNoSideEffects(t *testing.T) {
 	rt := NewRuntime()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/src/wago/tinygo_lifecycle_test.go
+++ b/src/wago/tinygo_lifecycle_test.go
@@ -15,8 +15,7 @@ import (
 // operations use this value shape for deferred lease release.
 func TestTinyGoOperationLeaseSurvivesCollection(t *testing.T) {
 	for i := 0; i < 100; i++ {
-		rt := NewRuntime()
-		_, operation, err := rt.beginOperationGeneration("test", false)
+		operation, err := rootlessRuntimeOperation()
 		if err != nil {
 			t.Errorf("begin operation %d: %v", i, err)
 			return
@@ -24,6 +23,38 @@ func TestTinyGoOperationLeaseSurvivesCollection(t *testing.T) {
 		gruntime.GC()
 		operation.end()
 	}
+}
+
+//go:noinline
+func rootlessRuntimeOperation() (runtimeOperation, error) {
+	rt := NewRuntime()
+	_, operation, err := rt.beginOperationGeneration("test", false)
+	return operation, err
+}
+
+// TestTinyGoRuntimeCloseTaskSurvivesCollection isolates the queued task as the
+// only owner of the Runtime shutdown graph before the TinyGo scheduler runs it.
+func TestTinyGoRuntimeCloseTaskSurvivesCollection(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		closed, err := rootlessRuntimeClose()
+		if err != nil {
+			t.Errorf("Close %d: %v", i, err)
+			return
+		}
+		gruntime.GC()
+		gruntime.Gosched()
+		<-closed
+	}
+}
+
+//go:noinline
+func rootlessRuntimeClose() (<-chan struct{}, error) {
+	rt := NewRuntime()
+	rt.storeHooks(&hookRegistry{onRuntimeClose: []func(RuntimeCloseEvent){func(RuntimeCloseEvent) {}}})
+	if err := rt.Close(); err != nil {
+		return nil, err
+	}
+	return rt.Closed(), nil
 }
 
 // TestTinyGoRuntimeInstantiateCloseStability is the smallest public lifecycle

--- a/src/wago/tinygo_lifecycle_test.go
+++ b/src/wago/tinygo_lifecycle_test.go
@@ -1,0 +1,134 @@
+//go:build tinygo
+
+package wago
+
+import (
+	"context"
+	gruntime "runtime"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TestTinyGoOperationLeaseSurvivesCollection keeps the explicit operation lease
+// as the only live owner of its Runtime across a collection. Runtime public
+// operations use this value shape for deferred lease release.
+func TestTinyGoOperationLeaseSurvivesCollection(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		rt := NewRuntime()
+		_, operation, err := rt.beginOperationGeneration("test", false)
+		if err != nil {
+			t.Errorf("begin operation %d: %v", i, err)
+			return
+		}
+		gruntime.GC()
+		operation.end()
+	}
+}
+
+// TestTinyGoRuntimeInstantiateCloseStability is the smallest public lifecycle
+// that reproduced the linux/amd64 TinyGo release-profile crash: compile once,
+// then repeatedly instantiate and close the same module. Collections between
+// iterations make stale heap references fail at their owning transition.
+func TestTinyGoRuntimeInstantiateCloseStability(t *testing.T) {
+	rt := NewRuntime()
+	mod, err := rt.Compile(benchAddOneModule())
+	if err != nil {
+		t.Errorf("Compile: %v", err)
+		return
+	}
+	for i := 0; i < 100; i++ {
+		in, err := rt.Instantiate(context.Background(), mod)
+		if err != nil {
+			t.Errorf("Instantiate %d: %v", i, err)
+			return
+		}
+		if err := in.Close(); err != nil {
+			t.Errorf("Close %d: %v", i, err)
+			return
+		}
+		gruntime.GC()
+	}
+}
+
+func TestTinyGoDecodeStability(t *testing.T) {
+	for i := 0; i < 10_000; i++ {
+		source := benchAddOneModule()
+		if _, err := wasm.DecodeModule(source); err != nil {
+			t.Errorf("DecodeModule %d: %v", i, err)
+			return
+		}
+	}
+}
+
+func TestTinyGoPackageCompileCloseStability(t *testing.T) {
+	for i := 0; i < 1_000; i++ {
+		compiled, err := Compile(benchAddOneModule())
+		if err != nil {
+			t.Errorf("Compile %d: %v", i, err)
+			return
+		}
+		if err := compiled.Close(); err != nil {
+			t.Errorf("Close %d: %v", i, err)
+			return
+		}
+	}
+}
+
+// TestTinyGoRuntimeCloseOverlapStability mirrors benchmark calibration: each
+// round publishes asynchronous Runtime shutdown, then the next round immediately
+// starts constructing and recycling runtime resources.
+func TestTinyGoRuntimeCloseOverlapStability(t *testing.T) {
+	tinyGoRuntimeCloseOverlap(t, 100, 100, false, true)
+}
+
+func TestTinyGoRuntimeCloseOverlapCompileOnly(t *testing.T) {
+	tinyGoRuntimeCloseOverlap(t, 100, 0, false, true)
+}
+
+func TestTinyGoRuntimeCloseOverlapSingleInstance(t *testing.T) {
+	tinyGoRuntimeCloseOverlap(t, 100, 1, false, true)
+}
+
+func TestTinyGoRuntimeCloseOwnsInstanceStability(t *testing.T) {
+	tinyGoRuntimeCloseOverlap(t, 100, 1, false, false)
+}
+
+func TestTinyGoRuntimeSynchronousCloseStability(t *testing.T) {
+	tinyGoRuntimeCloseOverlap(t, 100, 100, true, true)
+}
+
+func tinyGoRuntimeCloseOverlap(t *testing.T, rounds, instances int, synchronous, closeInstances bool) {
+	t.Helper()
+	for round := 0; round < rounds; round++ {
+		rt := NewRuntime()
+		mod, err := rt.Compile(benchAddOneModule())
+		if err != nil {
+			t.Errorf("round %d Compile: %v", round, err)
+			return
+		}
+		for i := 0; i < instances; i++ {
+			in, err := rt.Instantiate(context.Background(), mod)
+			if err != nil {
+				t.Errorf("round %d Instantiate %d: %v", round, i, err)
+				return
+			}
+			if closeInstances {
+				if err := in.Close(); err != nil {
+					t.Errorf("round %d Close %d: %v", round, i, err)
+					return
+				}
+			}
+		}
+		if synchronous {
+			if err := rt.CloseContext(context.Background()); err != nil {
+				t.Errorf("round %d Runtime.CloseContext: %v", round, err)
+				return
+			}
+		} else if err := rt.Close(); err != nil {
+			t.Errorf("round %d Runtime.Close: %v", round, err)
+			return
+		}
+		gruntime.Gosched()
+	}
+}


### PR DESCRIPTION
## What changed

- replace closure-backed compiler/runtime leases with explicit value leases so TinyGo's conservative collector retains their owners correctly
- keep decoder, validator, compiler input, module, and instantiation owners live across allocation-heavy boundaries
- root asynchronous runtime-close tasks until teardown completes, while completing the bounded callback-free close path inline
- preserve the complete ARM64 callee-saved TinyGo context, including V8-V15
- add TinyGo direct prepared integer-entry thunks for Linux/AMD64, Linux/ARM64, and Darwin/ARM64
- add allocation-free `PreparedFunction.Invoke0` through `Invoke4` entry points
- document paired performance and stripped release-size results

## Why

TinyGo's conservative GC could reclaim short-lived heap owners while decoding, validating, or running queued runtime teardown. Under repeated compile/instantiate/close cycles this appeared as corrupted validator types such as `val? is not i32`, and as failures in asynchronous runtime close.

The general variadic invocation API also forces TinyGo to allocate an argument slice. The fixed-arity API gives common zero-to-four-argument integer exports an allocation-free route into the JIT.

## Measured impact

Release TinyGo flags: `-scheduler=tasks -no-debug -opt=z -gc=conservative`. Values are medians of ten 300 ms samples. ARM64 used an Apple M4 Max; AMD64 used a Ryzen 7 7800X3D pinned to otherwise-idle core 7.

| Benchmark | ARM64 Go | ARM64 TinyGo | AMD64 Go | AMD64 TinyGo |
|---|---:|---:|---:|---:|
| compile small scalar | 6.47 us | 10.97 us | 15.24 us | 13.63 us |
| instantiate small scalar | 0.976 us | 3.44 us | 1.89 us | 4.03 us |
| `Instance.Invoke` | 74.2 ns | 212.6 ns | 71.3 ns | 214.0 ns |
| direct host import | 252.7 ns | 927.8 ns | 418.6 ns | 921.7 ns |
| prepared `Invoke1` | 16.43 ns | **14.24 ns** | 6.66 ns | 11.45 ns |

Prepared `Invoke1` improved from 50.9 to 14.24 ns on ARM64 and from 44.8 to 11.45 ns on AMD64, with allocations reduced from one to zero. General invoke, host import, and instantiation remain TinyGo allocator/runtime targets and are not claimed to be at parity.

Stripped release-size deltas:

| Runtime | Delta |
|---|---:|
| Darwin/ARM64 Standard/Tiny | +88 B |
| Darwin/ARM64 Minimal/Tiny | +16,600 B (0.87%) |
| Linux/AMD64 Standard/Tiny | +5,744 B (0.26%) |
| Linux/AMD64 Minimal/Tiny | +5,520 B (0.26%) |

## Validation

- `go test ./...`
- full `make tinygo-test` on Darwin/ARM64
- full `make tinygo-test` on Linux/AMD64
- 500,000 asynchronous live-instance runtime-close cycles on Linux/AMD64
- 100 repeated compile benchmark rounds on Linux/AMD64 after the validator lifetime fix
- paired Big Go/TinyGo benchmarks run one process at a time on both architectures
- release-equivalent TinyGo builds and platform stripping on both architectures
- `git diff --check`


## Review update

Rebased onto `dfec05bf`. The review pass also:

- made prepared TinyGo integer thunks engine-owned and released them with the bounded engine lifecycle
- returns executable-mapping failures through the prepared invocation API instead of panicking
- limits inline `Runtime.Close` teardown to a truly empty reference store
- keeps runtime operations live through terminal reference finalization before shutdown publishes quiescence
- joins logical and terminal instance-close failures exactly once after quiescence
- isolates TinyGo operation and queued-close ownership roots in non-inlined GC regressions
- corrects the documented direct-entry target list

The performance tables above were captured at the original implementation head (`78d8273a`). The review fixes preserve the fixed-arity hot path but change ownership and error handling; the current PR build-size check is authoritative for final artifact size.

Current-head validation:

- `make test`
- `make tinygo-test` on Darwin/ARM64
- focused runtime shutdown regressions under `go test -race` for 20 iterations
- `(cd bench && go test ./... -count=1)`
- independent standards and PR-intent reviews
- `git diff --check`

## AI assistance

AI assistance was used to resolve the rebase conflicts, add regression coverage for review findings, and run independent standards/spec reviews. Every resulting change was validated with the repository test gates above.
