### PR TITLE
runtime: bind only effective instance imports

### DIFF
--- a/src/wago/bench_test.go
+++ b/src/wago/bench_test.go
@@ -1431,6 +1431,42 @@ func BenchmarkRuntimeInstantiateSmallScalar(b *testing.B) {
 	}
 }
 
+func BenchmarkRuntimeInstantiateUnrelatedImports(b *testing.B) {
+	for _, namespaceSize := range []int{0, 10, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("Namespace=%d", namespaceSize), func(b *testing.B) {
+			rt := NewRuntime()
+			fn := HostFunc(func(HostModule, []uint64, []uint64) {})
+			for i := 0; i < namespaceSize; i++ {
+				rt.imports[fmt.Sprintf("unused.%d", i)] = fn
+			}
+			mod, err := rt.Compile(benchAddOneModule())
+			if err != nil {
+				b.Fatalf("Compile: %v", err)
+			}
+			warm, err := rt.Instantiate(context.Background(), mod)
+			if err != nil {
+				b.Fatalf("warm Instantiate: %v", err)
+			}
+			_ = warm.Close()
+			b.Cleanup(func() {
+				_ = mod.Close()
+				_ = rt.Close()
+			})
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				in, err := rt.Instantiate(context.Background(), mod)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := in.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkRuntimeInstantiateFuncrefIngressCaller(b *testing.B) {
 	rt := NewRuntime()
 	mod, err := rt.Compile(funcrefCallableConsumerModule())

--- a/src/wago/import_attachments.go
+++ b/src/wago/import_attachments.go
@@ -515,7 +515,16 @@ func (in *Instance) tableDescriptor(index int) []byte {
 	return unsafe.Slice((*byte)(offHeapPtr(descPtr)), 8+capacity*in.c.tableEntryBytes(index))
 }
 
-// Imports returns the imports map this instance was created with, for retrieving
-// imported objects (e.g. a *Memory or *Global) by "module.name" key. The map is
-// the one passed to Instantiate; do not mutate it.
-func (in *Instance) Imports() Imports { return in.imports }
+// Imports returns a caller-owned snapshot of the imports this instance was
+// created with, for retrieving imported objects (e.g. a *Memory or *Global) by
+// "module.name" key. Mutating the map does not affect the instance.
+func (in *Instance) Imports() Imports {
+	if in.imports == nil {
+		return nil
+	}
+	imports := make(Imports, len(in.imports))
+	for key, value := range in.imports {
+		imports[key] = value
+	}
+	return imports
+}

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -717,37 +717,9 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 		return nil, err
 	}
 
-	rt.mu.Lock()
-	// Merge plugin imports first, then per-call imports on top. Hooks, imports,
-	// and execution policy come from one admitted immutable generation.
-	var merged Imports
-	if n := len(rt.imports) + len(cfg.imports); n != 0 {
-		merged = make(Imports, n)
-		for k, v := range rt.imports {
-			merged[k] = v
-		}
-	}
-	policy := rt.overridePolicy
-	rt.mu.Unlock()
-
-	for k, v := range cfg.imports {
-		if module := importModule(k); isReserved(module) && policy != AllowTestOverrides {
-			if _, provided := merged[k]; provided {
-				return nil, fmt.Errorf("wago: import %q may not override reserved module %q", k, module)
-			}
-		}
-		merged[k] = v
-	}
-
-	// Surface an unsatisfied function import as a clear, actionable error before
-	// the low-level binder fails on it.
-	for _, spec := range mod.imports {
-		if spec.Kind != ImportFunc {
-			continue
-		}
-		if _, ok := merged[spec.Key()]; !ok {
-			return nil, missingImportError(spec)
-		}
+	imports, err := rt.resolveInstanceImports(mod.imports, cfg.imports)
+	if err != nil {
+		return nil, err
 	}
 
 	// Lifecycle callbacks may close their Module. End the inspection lease before
@@ -755,12 +727,61 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	// retained code ownership before start-time host callbacks.
 	mod.endUse()
 	usingModule = false
-	in, err := rt.instantiateWithHooksOrigin(mod, merged, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks, reservation)
+	in, err := rt.instantiateWithHooksOrigin(mod, imports, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks, reservation)
 	if err == nil && rt.isClosed() {
 		err = joinPrimary(fmt.Errorf("wago: runtime closed during instantiation"), in.Close())
 		in = nil
 	}
 	return in, err
+}
+
+// resolveInstanceImports captures one instance-owned binding set without
+// cloning runtime imports the module cannot use. Explicit per-call imports are
+// retained even when undeclared, preserving the low-level Imports inspection
+// behavior. Runtime imports are only retained for declared module keys.
+func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports) (Imports, error) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	for key := range overrides {
+		module := importModule(key)
+		if !isReserved(module) || rt.overridePolicy == AllowTestOverrides {
+			continue
+		}
+		if _, provided := rt.imports[key]; provided {
+			return nil, fmt.Errorf("wago: import %q may not override reserved module %q", key, module)
+		}
+	}
+
+	capacity := len(overrides) + len(specs)
+	if available := len(overrides) + len(rt.imports); available < capacity {
+		capacity = available
+	}
+	var resolved Imports
+	if len(overrides) != 0 {
+		resolved = make(Imports, capacity)
+		for key, value := range overrides {
+			resolved[key] = value
+		}
+	}
+	for _, spec := range specs {
+		key := spec.Key()
+		if _, provided := overrides[key]; provided {
+			continue
+		}
+		value, provided := rt.imports[key]
+		if !provided {
+			if spec.Kind == ImportFunc {
+				return nil, missingImportError(spec)
+			}
+			continue
+		}
+		if resolved == nil {
+			resolved = make(Imports, capacity)
+		}
+		resolved[key] = value
+	}
+	return resolved, nil
 }
 
 func applyInstantiateOptions(opts []InstantiateOption) instantiateConfig {

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -72,6 +73,107 @@ func TestRuntimeUseAndInvoke(t *testing.T) {
 	}
 	if AsI32(res[0]) != 21 {
 		t.Fatalf("g(7) = %d, want 21", AsI32(res[0]))
+	}
+}
+
+func TestRuntimeInstantiateRetainsOnlyEffectiveImports(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	rt.imports["env.f"] = HostFunc(func(_ HostModule, p, r []uint64) { r[0] = I32(AsI32(p[0]) * 3) })
+	for i := 0; i < 256; i++ {
+		rt.imports["unused."+strconv.Itoa(i)] = HostFunc(func(HostModule, []uint64, []uint64) {})
+	}
+
+	mod := callsEnvF(t, rt)
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+
+	imports := in.Imports()
+	if len(imports) != 1 || imports["env.f"] == nil {
+		t.Fatalf("Imports = %#v, want only env.f", imports)
+	}
+	imports["env.f"] = "caller mutation"
+	if got := in.Imports()["env.f"]; got == "caller mutation" {
+		t.Fatal("Imports exposed the instance's internal binding map")
+	}
+
+	result, err := in.Invoke("g", I32(7))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got := AsI32(result[0]); got != 21 {
+		t.Fatalf("g(7) = %d, want 21", got)
+	}
+}
+
+func TestRuntimeInstantiateRetainsExplicitUnusedOverrides(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	rt.imports["env.f"] = HostFunc(func(_ HostModule, p, r []uint64) { r[0] = I32(AsI32(p[0]) * 3) })
+	rt.imports["unused.runtime"] = HostFunc(func(HostModule, []uint64, []uint64) {})
+	mod := callsEnvF(t, rt)
+
+	marker := new(int)
+	in, err := rt.Instantiate(context.Background(), mod, WithImports(Imports{
+		"env.f":           HostFunc(func(_ HostModule, p, r []uint64) { r[0] = I32(AsI32(p[0]) + 1) }),
+		"unused.explicit": marker,
+	}))
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	defer in.Close()
+
+	imports := in.Imports()
+	if len(imports) != 2 || imports["unused.explicit"] != marker {
+		t.Fatalf("Imports = %#v, want effective env.f and explicit unused override", imports)
+	}
+	if _, ok := imports["unused.runtime"]; ok {
+		t.Fatal("Imports retained an unrelated runtime binding")
+	}
+	result, err := in.Invoke("g", I32(7))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got := AsI32(result[0]); got != 8 {
+		t.Fatalf("g(7) = %d, want override result 8", got)
+	}
+}
+
+func TestResolveInstanceImportsDoesNotAllocateForUnrelatedNamespace(t *testing.T) {
+	rt := NewRuntime()
+	fn := HostFunc(func(HostModule, []uint64, []uint64) {})
+	for i := 0; i < 10_000; i++ {
+		rt.imports["unused."+strconv.Itoa(i)] = fn
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		imports, err := rt.resolveInstanceImports(nil, nil)
+		if err != nil || imports != nil {
+			t.Fatalf("resolveInstanceImports = %#v, %v, want nil, nil", imports, err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("resolveInstanceImports allocations = %v, want 0", allocs)
+	}
+}
+
+func TestRuntimeReservedUnusedOverrideRejected(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	rt.imports["wago_timer.now"] = HostFunc(func(HostModule, []uint64, []uint64) {})
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer mod.Close()
+
+	if _, err := rt.Instantiate(context.Background(), mod, WithImports(Imports{
+		"wago_timer.now": HostFunc(func(HostModule, []uint64, []uint64) {}),
+	})); err == nil {
+		t.Fatal("unused reserved-module override was accepted")
 	}
 }
 


### PR DESCRIPTION
Closes #398.

## What changed

- Resolve runtime-provided imports only for keys declared by the module instead of cloning the complete plugin namespace for every instance.
- Preserve explicit `WithImports` entries, override precedence, reserved-module policy, and actionable missing-function errors.
- Return caller-owned snapshots from `Instance.Imports()` so callers cannot mutate live instance bindings.
- Add adversarial regression tests and a namespace-scaling allocation benchmark.

## Impact

Instantiation work now scales with the module import set and explicit overrides, not unrelated registered plugins. The 10,000-unrelated-import benchmark dropped from approximately 766 us/op, 1,094,512 B/op, and 81 allocs/op to approximately 2.2 us/op, 1,537 B/op, and 12 allocs/op.

## Validation

- `make lint`
- focused and broad race-enabled runtime/import/lifecycle suites
- `go test -count=1 -race ./src/core/runtime`
- `go test -count=1 ./cli/...`
- `go test -count=1 -tags wago_runtime ./cli/...`
- Go 1.22.12 focused tests
- TinyGo 0.41.1 focused tests and minimal runtime CLI build
- CGO-disabled Linux, Darwin, and Windows builds on amd64 and arm64
- explicit allocation benchmark through 10,000 unrelated imports

The complete local runtime race suite also exposed an unrelated existing test-only synchronization race and requires CI-provisioned Release 3 tooling for staged fixtures; the affected race subsets are clean.