### PR TITLE
cli: align compiled entry selection with run

### DIFF
--- a/cli/internal/wasmcall/export.go
+++ b/cli/internal/wasmcall/export.go
@@ -1,0 +1,33 @@
+package wasmcall
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wago-org/wago"
+)
+
+// ResolveExport applies the command entry-point convention shared by run and
+// standalone executables: an explicit request, _start, main, or the sole
+// exported function, in that order.
+func ResolveExport(compiled *wago.Compiled, requested string) (string, error) {
+	names := compiled.ExportedFunctions()
+	if requested != "" {
+		if _, ok := compiled.Exports[requested]; !ok {
+			return "", fmt.Errorf("no exported function %q (have: %s)", requested, strings.Join(names, ", "))
+		}
+		return requested, nil
+	}
+	for _, candidate := range []string{"_start", "main"} {
+		if _, ok := compiled.Exports[candidate]; ok {
+			return candidate, nil
+		}
+	}
+	if len(names) == 1 {
+		return names[0], nil
+	}
+	if len(names) == 0 {
+		return "", fmt.Errorf("module exports no functions")
+	}
+	return "", fmt.Errorf("multiple exports; select one (have: %s)", strings.Join(names, ", "))
+}

--- a/cli/internal/wasmcall/values.go
+++ b/cli/internal/wasmcall/values.go
@@ -86,9 +86,14 @@ func Format(export string, args, results []uint64, paramTypes, resultTypes []wag
 	if len(results) == 0 {
 		return call + " = ()"
 	}
+	return fmt.Sprintf("%s = %s", call, FormatResults(results, resultTypes))
+}
+
+// FormatResults renders raw function results without a call-expression prefix.
+func FormatResults(results []uint64, resultTypes []wago.ValType) string {
 	formatted := make([]string, len(results))
 	for index, value := range results {
 		formatted[index] = FormatValue(value, resultTypes[index])
 	}
-	return fmt.Sprintf("%s = %s", call, strings.Join(formatted, ", "))
+	return strings.Join(formatted, ", ")
 }

--- a/cli/manager/commands/compile/command.go
+++ b/cli/manager/commands/compile/command.go
@@ -51,7 +51,8 @@ func Command(environment Environment) *command.Cmd {
 			return internalparallel.NormalizeArgs(args, parserFlags, false)
 		},
 		Long: "The executable embeds the module and selected plugin configuration. By default it\n" +
-			"calls _start; use --invoke to bake in another exported function. Core features,\n" +
+			"calls _start, then main, then the sole exported function; use --invoke to select\n" +
+			"another export. Core features,\n" +
 			"parallelism, and optimization knobs are fixed at build time. Use --target\n" +
 			"linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64,\n" +
 			"or windows/arm64 to cross-compile with the matching Wago backend.",

--- a/cli/runtime/commands/run/module.go
+++ b/cli/runtime/commands/run/module.go
@@ -2,10 +2,10 @@ package run
 
 import (
 	"os"
-	"strings"
 
 	"github.com/wago-org/wago"
 	"github.com/wago-org/wago/cli/internal/ui"
+	"github.com/wago-org/wago/cli/internal/wasmcall"
 	"github.com/wago-org/wago/cli/runtime/internal/artifactcache"
 )
 
@@ -33,21 +33,9 @@ func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runti
 }
 
 func mustResolveExport(compiled *wago.Compiled, requested string) string {
-	names := compiled.ExportedFunctions()
-	if requested != "" {
-		if _, ok := compiled.Exports[requested]; !ok {
-			ui.Fatal("no exported function %q (have: %s)", requested, strings.Join(names, ", "))
-		}
-		return requested
+	export, err := wasmcall.ResolveExport(compiled, requested)
+	if err != nil {
+		ui.Fatal("%v", err)
 	}
-	for _, candidate := range []string{"_start", "main"} {
-		if _, ok := compiled.Exports[candidate]; ok {
-			return candidate
-		}
-	}
-	if len(names) == 1 {
-		return names[0]
-	}
-	ui.Fatal("multiple exports; pass -e <name> (have: %s)", strings.Join(names, ", "))
-	return ""
+	return export
 }

--- a/cli/standalone/standalone.go
+++ b/cli/standalone/standalone.go
@@ -53,24 +53,16 @@ func execute(source []byte, plugins wago.PluginSet, options Options, args []stri
 	if err != nil {
 		return err
 	}
-	invoke := options.Invoke
-	explicitInvoke := invoke != ""
-	if !explicitInvoke {
-		invoke = "_start"
-	}
-	if invoke == "_start" {
-		if _, ok := module.Compiled().Exports[invoke]; !ok {
-			return errors.New("module does not export _start")
-		}
-	} else if _, ok := module.Compiled().Exports[invoke]; !ok {
-		return fmt.Errorf("no exported function %q", invoke)
+	invoke, err := wasmcall.ResolveExport(module.Compiled(), options.Invoke)
+	if err != nil {
+		return err
 	}
 	params, results, err := module.Compiled().Signature(invoke)
 	if err != nil {
 		return err
 	}
 	values := []uint64(nil)
-	if explicitInvoke {
+	if invoke != "_start" {
 		callArgs := args
 		if len(callArgs) != 0 {
 			callArgs = callArgs[1:]
@@ -89,7 +81,7 @@ func execute(source []byte, plugins wago.PluginSet, options Options, args []stri
 	if err != nil {
 		return err
 	}
-	if explicitInvoke {
+	if invoke != "_start" {
 		fmt.Println(wasmcall.Format(invoke, values, result, params, results))
 	}
 	return nil

--- a/cli/standalone/standalone.go
+++ b/cli/standalone/standalone.go
@@ -81,8 +81,8 @@ func execute(source []byte, plugins wago.PluginSet, options Options, args []stri
 	if err != nil {
 		return err
 	}
-	if invoke != "_start" {
-		fmt.Println(wasmcall.Format(invoke, values, result, params, results))
+	if invoke != "_start" && len(result) != 0 {
+		fmt.Println(wasmcall.FormatResults(result, results))
 	}
 	return nil
 }

--- a/cli/standalone/standalone_test.go
+++ b/cli/standalone/standalone_test.go
@@ -41,7 +41,7 @@ func TestExecuteInvokesExportWithTypedArgs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := string(output[:n]); got != "add(20, 22) = 42\n" {
+	if got := string(output[:n]); got != "42\n" {
 		t.Fatalf("output = %q", got)
 	}
 }
@@ -52,7 +52,7 @@ func TestExecuteSelectsSoleExportWithTypedArgs(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	if output != "add(20, 22) = 42\n" {
+	if output != "42\n" {
 		t.Fatalf("output = %q", output)
 	}
 }
@@ -63,7 +63,7 @@ func TestExecuteSelectsMainBeforeOtherExports(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	if output != "main() = 7\n" {
+	if output != "7\n" {
 		t.Fatalf("output = %q", output)
 	}
 }

--- a/cli/standalone/standalone_test.go
+++ b/cli/standalone/standalone_test.go
@@ -14,9 +14,9 @@ func TestRunEmptyStartModule(t *testing.T) {
 	}
 }
 
-func TestExecuteRequiresStartExport(t *testing.T) {
+func TestExecuteRejectsModuleWithoutFunctionExports(t *testing.T) {
 	empty := []byte{'\x00', 'a', 's', 'm', 1, 0, 0, 0}
-	if err := execute(empty, wago.PluginSet{}, Options{DeferBoundsChecks: true}, nil); err == nil || err.Error() != "module does not export _start" {
+	if err := execute(empty, wago.PluginSet{}, Options{DeferBoundsChecks: true}, nil); err == nil || err.Error() != "module exports no functions" {
 		t.Fatalf("execute error = %v", err)
 	}
 }
@@ -43,6 +43,28 @@ func TestExecuteInvokesExportWithTypedArgs(t *testing.T) {
 	}
 	if got := string(output[:n]); got != "add(20, 22) = 42\n" {
 		t.Fatalf("output = %q", got)
+	}
+}
+
+func TestExecuteSelectsSoleExportWithTypedArgs(t *testing.T) {
+	output := captureStdout(t, func() {
+		if err := execute(addModule(), wago.PluginSet{}, Options{DeferBoundsChecks: true}, []string{"add", "20", "22"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if output != "add(20, 22) = 42\n" {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestExecuteSelectsMainBeforeOtherExports(t *testing.T) {
+	output := captureStdout(t, func() {
+		if err := execute(mainAndOtherModule(), wago.PluginSet{}, Options{DeferBoundsChecks: true}, []string{"program"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if output != "main() = 7\n" {
+		t.Fatalf("output = %q", output)
 	}
 }
 
@@ -115,6 +137,37 @@ func addModule() []byte {
 		7, 7, 1, 3, 'a', 'd', 'd', 0, 0,
 		10, 9, 1, 7, 0, 0x20, 0, 0x20, 1, 0x6a, 0x0b,
 	}
+}
+
+func mainAndOtherModule() []byte {
+	return []byte{
+		'\x00', 'a', 's', 'm', 1, 0, 0, 0,
+		1, 5, 1, 0x60, 0, 1, 0x7f,
+		3, 2, 1, 0,
+		7, 16, 2, 4, 'm', 'a', 'i', 'n', 0, 0, 5, 'o', 't', 'h', 'e', 'r', 0, 0,
+		10, 6, 1, 4, 0, 0x41, 7, 0x0b,
+	}
+}
+
+func captureStdout(t *testing.T, run func()) string {
+	t.Helper()
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := os.Stdout
+	os.Stdout = write
+	t.Cleanup(func() { os.Stdout = original })
+	run()
+	if err := write.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output := make([]byte, 256)
+	n, err := read.Read(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(output[:n])
 }
 
 func tailCallStartModule() []byte {


### PR DESCRIPTION
## What changed

- share entry-point resolution between `wago run` and compiled standalone executables
- select an explicit `--invoke`, then `_start`, then `main`, then the sole exported function
- parse typed arguments for automatically selected non-`_start` functions
- print only raw return values from standalone value functions; keep `wago run`'s descriptive formatting unchanged
- update `wago compile` help and add regression coverage for sole-export and `main` selection

## Why

Standalone executables built without `--invoke` always attempted `_start`. A module with one exported function therefore compiled successfully but failed at runtime with `module does not export _start`, even though `wago run` selected and invoked that function correctly.

Generated executables are command-line programs, so their successful value output should also be directly consumable rather than prefixed with the function call expression.

## User impact

A compiled single-export module now selects the same entry point as `wago run` and emits its result directly. For example:

```text
$ ./fib 30
832040
```

Void functions emit no result line.

## Validation

- `go test ./... -count=1`
- end-to-end manager build, `wago compile --bare tests/fixtures/wasm/fib.wasm`, and exact generated output assertion for argument `30`
- `git diff --check`

Supersedes #445, which GitHub closed automatically when its head branch was renamed to follow the `jairus/` branch convention.
