### PR TITLE
runtime: add seeded concurrency harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,38 @@ jobs:
             -wast2json "$PWD/.tmp/wabt/build/wast2json" \
             -fetch
 
+  runtime-concurrency:
+    name: Runtime concurrency / ${{ matrix.name }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux amd64
+            runner: ubuntu-24.04
+          - name: Linux arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: Run bounded seeded runtime concurrency harness
+        env:
+          WAGO_CONCURRENCY_SEED: 439000001,439000019,439000043,439000081
+          WAGO_CONCURRENCY_ROUNDS: 24
+        run: make test-concurrency
+
   race:
     name: Race detector / Linux amd64
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
@@ -158,7 +185,7 @@ jobs:
       - name: Initialize Release 3 suite
         run: git submodule update --init --depth=1 tests/spec-v3
       - name: Run focused runtime race suites
-        run: go test -race -count=1 ./src/wago ./src/core/runtime
+        run: go test -race -count=1 ./src/wago ./src/core/runtime ./tests/runtimeconcurrency
 
   platform-test:
     name: ${{ matrix.name }}
@@ -579,7 +606,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [changes, docs, lint, regression-corpus, race, platform-test, core-v2, tinygo, coverage, size]
+    needs: [changes, docs, lint, regression-corpus, runtime-concurrency, race, platform-test, core-v2, tinygo, coverage, size]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 #   make lint        gofmt + generate sync + vet + staticcheck (host, no act)
 #   make docs-check  local Markdown paths and anchors           (host, no act)
 #   make test        go build + go test                         (host, no act)
+#   make test-concurrency  seeded runtime concurrency harness   (host, no act)
 #   make ci          replay the whole workflow in Docker via act
 #   make bench       benchmark suite (BENCH=<regex> to filter)  (host)
 #
@@ -102,6 +103,10 @@ test: ## Build and run the test suite (host)
 	go test -count=1 ./...
 	go test -count=1 -tags wago_runtime ./cli/...
 	tests/scripts/build-release-assets.sh
+
+.PHONY: test-concurrency
+test-concurrency: ## Run the deterministic runtime concurrency harness (WAGO_CONCURRENCY_SEED=...)
+	go test -count=1 -run '^TestRuntimeConcurrency' ./tests/runtimeconcurrency
 
 .PHONY: install-local
 install-local: ## Run the installer from this checkout

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -46,7 +46,10 @@ directly from PowerShell rather than through Make.
 Linux/amd64 continues to host architecture-independent lint, TinyGo, and
 binary-size jobs on pull requests and pushes to `main`; coverage runs only for
 code changes pushed to `main`, keeping the expensive merged report off pull
-requests while retaining it as a post-merge gate.
+requests while retaining it as a post-merge gate. A separate bounded runtime
+concurrency matrix runs the deterministic public-API harness on native Linux
+amd64 and arm64. The Linux/amd64 race lane runs the same harness under `-race`
+alongside the focused runtime packages.
 The size job runs `scripts/size-card.sh` for four explicit Linux/AMD64 release
 profiles: manager, Standard runtime, Minimal runtime, and the TinyGo Minimal
 runtime. It fails above the byte ceilings in
@@ -137,6 +140,7 @@ do not contaminate `make lint`.
 make docs-check
 make lint
 make test
+make test-concurrency  # replay with WAGO_CONCURRENCY_SEED=<seed>[,<seed>...]
 make test-guard   # only on a supported guard-page target
 WAGO_CORPUS_TIMEOUT=20s make test-corpus
 make simd

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -2219,6 +2219,11 @@ func (c *Compiled) importsRequireSync(imports Imports, force bool) bool {
 // concrete targets into the per-instance dispatch table.
 func (c *Compiled) validateImportBindings(imports Imports, store *referenceStore) error {
 	ehNativeCalls := c.stagedFeatures().IsEnabled(CoreFeatureExceptionHandling) && len(c.Imports) != 0
+	privateWaitGC := store != nil && !store.private && c.usesGenericGCExecution() && c.usesAtomicWaitHelpers()
+	dynamicFuncrefReachability := compiledHasDynamicFuncrefReachability(c)
+	if privateWaitGC && dynamicFuncrefReachability {
+		return fmt.Errorf("dynamic funcref reachability is unsupported for modules with atomic wait helpers")
+	}
 	moduleTransfersGC := false
 	for i := range c.Imports {
 		if i < len(c.importFuncSigs) && (hasValType(c.importFuncSigs[i].Params, ValAnyRef) || hasValType(c.importFuncSigs[i].Params, ValI31Ref) || hasValType(c.importFuncSigs[i].Results, ValAnyRef) || hasValType(c.importFuncSigs[i].Results, ValI31Ref)) {
@@ -2231,6 +2236,9 @@ func (c *Compiled) validateImportBindings(imports Imports, store *referenceStore
 	gcSubtypeLinkProvider := gcSubtypeLinkProduct.linkProviderProduct()
 	for i, key := range c.Imports {
 		sigHasGCRefs := i < len(c.importFuncSigs) && (hasValType(c.importFuncSigs[i].Params, ValAnyRef) || hasValType(c.importFuncSigs[i].Params, ValI31Ref) || hasValType(c.importFuncSigs[i].Results, ValAnyRef) || hasValType(c.importFuncSigs[i].Results, ValI31Ref))
+		if privateWaitGC && sigHasGCRefs {
+			return fmt.Errorf("collector-reference import %q is unsupported for modules with atomic wait helpers", key)
+		}
 		ex, ok := imports[key].(*InstanceExport)
 		if !ok {
 			if sigHasGCRefs {
@@ -2253,6 +2261,18 @@ func (c *Compiled) validateImportBindings(imports Imports, store *referenceStore
 		}
 		if ex == nil || ex.inst == nil {
 			return fmt.Errorf("cross-instance import %q is nil", key)
+		}
+		if ex.inst.executionFlags.Load()&executionFlagDynamicGCDomain != 0 && ex.inst.refStore != store {
+			return fmt.Errorf("cross-instance import %q from a dynamic funcref producer requires the same Runtime", key)
+		}
+		if dynamicFuncrefReachability && ex.inst.refStore != store && (ex.inst.gc != nil || ex.inst.executionFlags.Load()&executionFlagImportedGCDomain != 0) {
+			return fmt.Errorf("dynamic funcref import %q from a GC-domain producer requires the same Runtime", key)
+		}
+		if dynamicFuncrefReachability && ex.inst.reachesPrivateGCInvocationDomain() {
+			return fmt.Errorf("dynamic funcref import %q cannot reach a private GC invocation domain", key)
+		}
+		if privateWaitGC && (ex.inst.gc != nil || ex.inst.executionFlags.Load()&executionFlagImportedGCDomain != 0) {
+			return fmt.Errorf("Runtime GC-domain import %q is unsupported for modules with atomic wait helpers", key)
 		}
 		if ex.localIdx < 0 || ex.localIdx >= len(ex.inst.c.Entry) {
 			return fmt.Errorf("cross-instance import %q references an unavailable function", key)
@@ -4024,6 +4044,9 @@ func (in *Instance) invokeEntry(export string, args []uint64, cancel context.Con
 func (in *Instance) invokeWithToken(export string, args []uint64, cancel context.Context, id invocationID, gateHeld, alreadyAdmitted bool, reservation *pluginOperationReservation) ([]uint64, error) {
 	reentry := !gateHeld && isNativeActive(in, id)
 	if !reentry && !gateHeld {
+		// Acquire the target instance gate before the shared collector lease. A
+		// parked same-domain callback must be able to reacquire the collector and
+		// finish releasing this gate while a second callback waits to enter.
 		state := in.ensurePluginState()
 		state.invokeMu.Lock()
 		state.invocationID = id
@@ -4032,18 +4055,29 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 			state.invokeMu.Unlock()
 		}()
 	}
+	if !alreadyAdmitted {
+		if err := in.beginInvocation(); err != nil {
+			return nil, fmt.Errorf("invoke %q: %w", export, err)
+		}
+		defer in.endInvocation()
+	}
+	gcLease := in.lockGCInvocation(id)
+	var reconcileAttached *Instance
+	defer func() {
+		gcLease.unlock()
+		if in.importsFuncrefStorage() || in.table != nil {
+			in.reconcileFuncrefRoots()
+		}
+		if reconcileAttached != nil && (reconcileAttached.importsFuncrefStorage() || reconcileAttached.table != nil) {
+			reconcileAttached.reconcileFuncrefRoots()
+		}
+	}()
 	if reentry {
 		restore, err := in.prepareHostReentryState()
 		if err != nil {
 			return nil, err
 		}
 		defer restore()
-	}
-	if !alreadyAdmitted {
-		if err := in.beginInvocation(); err != nil {
-			return nil, fmt.Errorf("invoke %q: %w", export, err)
-		}
-		defer in.endInvocation()
 	}
 	previousReservation := in.swapInvocationReservation(reservation)
 	defer in.swapInvocationReservation(previousReservation)
@@ -4065,13 +4099,14 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 			return nil, fmt.Errorf("export %q imported function index %d has no binding", export, importIdx)
 		}
 		if ex, ok := in.imports[in.c.Imports[importIdx]].(*InstanceExport); ok && ex != nil && ex.inst != nil {
+			reconcileAttached = ex.inst
 			// Native cross-instance calls carry only the caller's invocation lease and
 			// trap cell; the import attachment retains the producer's physical resources.
 			// Keep this Go-level re-export path identical so producer Close neither owns
 			// nor strands an invocation initiated through the relay.
 			return ex.inst.invokeAttachedLocalContext(ex.localIdx, args, cancel, in.trap, true)
 		}
-		return in.invokeReexportedHost(export, importIdx, args)
+		return in.invokeReexportedHost(export, importIdx, args, id)
 	}
 	if len(args) != ic.paramSlots {
 		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
@@ -4101,9 +4136,6 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 		binary.LittleEndian.PutUint32(in.hostLog, 0) // reset host-call log
 	}
 	entry := in.base + uintptr(in.c.Entry[li])
-	if in.importsFuncrefStorage() || in.table != nil {
-		defer in.reconcileFuncrefRoots()
-	}
 	if cancel != nil {
 		stopCancel := in.startCancellationWatch(cancel, in.trap)
 		defer stopCancel()
@@ -4178,6 +4210,13 @@ func (in *Instance) invokeLocalContext(li int, args []uint64, cancel context.Con
 		return nil, fmt.Errorf("invoke function %d: %w", li, err)
 	}
 	defer in.endInvocation()
+	gcLease := in.lockGCInvocation(in.currentInvocationID())
+	defer func() {
+		gcLease.unlock()
+		if in.importsFuncrefStorage() || in.table != nil {
+			in.reconcileFuncrefRoots()
+		}
+	}()
 	return in.invokeAttachedLocalContext(li, args, cancel, activeTrap, false)
 }
 
@@ -4228,9 +4267,6 @@ func (in *Instance) invokeAttachedLocalContext(li int, args []uint64, cancel con
 	entry := in.base + uintptr(in.c.Entry[li])
 	if len(activeTrap) < 4 {
 		activeTrap = in.trap
-	}
-	if in.importsFuncrefStorage() || in.table != nil {
-		defer in.reconcileFuncrefRoots()
 	}
 	stopCancel := noOpCancellationWatch
 	if cancel != nil {
@@ -4401,7 +4437,7 @@ func (in *Instance) replayHostLog() (err error) {
 	return nil
 }
 
-func (in *Instance) invokeReexportedHost(export string, importIdx int, args []uint64) (results []uint64, err error) {
+func (in *Instance) invokeReexportedHost(export string, importIdx int, args []uint64, id invocationID) (results []uint64, err error) {
 	if importIdx < 0 || importIdx >= len(in.syncHosts) || in.syncHosts[importIdx] == nil || importIdx >= len(in.c.importFuncSigs) {
 		return nil, fmt.Errorf("export %q is an imported function without a callable host owner", export)
 	}
@@ -4460,6 +4496,13 @@ func (in *Instance) invokeReexportedHost(export string, importIdx int, args []ui
 			}
 		}
 	}()
+	// This direct Go-level path does not pass through dispatchSynchronousHostCall,
+	// but the imported function is still arbitrary host code. Release the shared
+	// collector lease after scalar-only validation so same-domain InvokeFromHost
+	// and CollectGC calls can proceed, then restore it before returning results to
+	// the public invocation boundary.
+	resumeGCInvocation := in.suspendGCInvocation(id)
+	defer resumeGCInvocation()
 	fn := in.syncHosts[importIdx]
 	caller := in.beginHostCallScope()
 	defer caller.scope.end(caller.generation, caller.parentGeneration)

--- a/src/wago/container_close_race_test.go
+++ b/src/wago/container_close_race_test.go
@@ -46,7 +46,7 @@ func TestTableCloseVersusAttachValidation(t *testing.T) {
 		close(start)
 		wg.Wait()
 		if <-attached {
-			table.detachImporter()
+			table.detachImporter(nil)
 		}
 		if err := table.Close(); err != nil {
 			t.Fatal(err)

--- a/src/wago/cross_instance.go
+++ b/src/wago/cross_instance.go
@@ -106,6 +106,11 @@ type tableOwner struct {
 	// with no declared maximum cannot satisfy an import that requires one.
 	declaredHasMax bool
 	addr64         bool // exact table index/address form; host tables are table32
+	// Host funcref tables may be shared by scalar-only stores. Once any
+	// participating store owns a Runtime GC domain, the table is pinned to that
+	// store; creating a domain or adding an importer rejects a mixed-store graph.
+	funcrefStores  map[*referenceStore]uint32
+	funcrefGCStore *referenceStore
 	importers      int
 	closed         bool
 }
@@ -244,6 +249,55 @@ func (t *Table) validateImport(elementType ValType, exact ValueTypeDescriptor, t
 	return t.validateImportWithCollector(elementType, exact, types, store, nil, addr64)
 }
 
+func (o *tableOwner) hasForeignFuncrefStoreLocked(store *referenceStore) bool {
+	for candidate, refs := range o.funcrefStores {
+		if refs != 0 && candidate != store {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *Table) hasIncompatibleGCProducer(store *referenceStore) bool {
+	for _, producer := range t.funcrefProducerRoots() {
+		if producer == nil {
+			continue
+		}
+		domains, topology := producer.gcInvocationDomainsForInspection()
+		incompatible := false
+		for i := 0; i < domains.len(); i++ {
+			domain := domains.at(i)
+			if domain.private || store == nil || producer.refStore != store {
+				incompatible = true
+				break
+			}
+		}
+		if topology != nil {
+			topology.RUnlock()
+		}
+		if incompatible {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *tableOwner) validateFuncrefStoreLocked(store *referenceStore) error {
+	if o.elementType != ValFuncRef {
+		return nil
+	}
+	if o.instance != nil {
+		if o.store != store {
+			return fmt.Errorf("instance-owned funcref table requires its producer and importer in the same reference store")
+		}
+		return nil
+	}
+	if o.funcrefGCStore != nil && o.funcrefGCStore != store {
+		return fmt.Errorf("host funcref table is bound to a different Runtime GC reference store")
+	}
+	return nil
+}
+
 func (t *Table) validateImportWithCollector(elementType ValType, exact ValueTypeDescriptor, types []DefinedTypeDescriptor, store *referenceStore, collector *gc.Collector, addr64 bool) error {
 	if t == nil || t.owner == nil {
 		return fmt.Errorf("table descriptor is invalid")
@@ -280,6 +334,9 @@ func (t *Table) validateImportWithCollector(elementType ValType, exact ValueType
 	}
 	if o.elementType != elementType {
 		return fmt.Errorf("table element type %s is incompatible with required %s", o.elementType, elementType)
+	}
+	if err := o.validateFuncrefStoreLocked(store); err != nil {
+		return err
 	}
 	actual := o.valueType
 	actualTypes := o.types
@@ -338,10 +395,63 @@ func (t *Table) attachImporterWithCollector(elementType ValType, exact ValueType
 		return err
 	}
 	o := t.owner
+	if o.elementType == ValFuncRef && o.instance == nil {
+		if t.hasIncompatibleGCProducer(store) {
+			return fmt.Errorf("funcref table contains a producer from an incompatible GC invocation domain")
+		}
+		var topology *gcDomainTopology
+		if store != nil {
+			topology = store.ensureGCTopology()
+			topology.funcrefMu.Lock()
+			defer topology.funcrefMu.Unlock()
+		}
+		o.mu.Lock()
+		defer o.mu.Unlock()
+		if o.closed {
+			return fmt.Errorf("table owner is closed")
+		}
+		if err := o.validateFuncrefStoreLocked(store); err != nil {
+			return err
+		}
+		if store == nil {
+			if o.hasForeignFuncrefStoreLocked(nil) {
+				return fmt.Errorf("standalone and Runtime instances cannot concurrently share a mutable funcref table")
+			}
+		} else if o.funcrefStores[nil] != 0 {
+			return fmt.Errorf("standalone and Runtime instances cannot concurrently share a mutable funcref table")
+		}
+		if topology != nil && topology.funcrefGCActive {
+			if o.hasForeignFuncrefStoreLocked(store) {
+				return fmt.Errorf("Runtime GC domains cannot share a mutable funcref table across reference stores")
+			}
+			o.funcrefGCStore = store
+		}
+		if o.funcrefStores[store] == ^uint32(0) {
+			return fmt.Errorf("funcref table has too many importers in one reference store")
+		}
+		if topology != nil && topology.funcrefTables[t] == ^uint32(0) {
+			return fmt.Errorf("funcref table has too many importers in one Runtime")
+		}
+		if o.funcrefStores == nil {
+			o.funcrefStores = make(map[*referenceStore]uint32)
+		}
+		o.funcrefStores[store]++
+		if topology != nil {
+			if topology.funcrefTables == nil {
+				topology.funcrefTables = make(map[*Table]uint32)
+			}
+			topology.funcrefTables[t]++
+		}
+		o.importers++
+		return nil
+	}
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.closed {
 		return fmt.Errorf("table owner is closed")
+	}
+	if err := o.validateFuncrefStoreLocked(store); err != nil {
+		return err
 	}
 	if o.instance != nil && !o.instance.retainResourceRoot() {
 		return fmt.Errorf("table owner instance is closed")
@@ -350,11 +460,41 @@ func (t *Table) attachImporterWithCollector(elementType ValType, exact ValueType
 	return nil
 }
 
-func (t *Table) detachImporter() {
+func (t *Table) detachImporter(store *referenceStore) {
 	if t == nil || t.owner == nil {
 		return
 	}
 	o := t.owner
+	if o.elementType == ValFuncRef && o.instance == nil {
+		var topology *gcDomainTopology
+		if store != nil {
+			store.mu.Lock()
+			topology = store.gcDomains
+			store.mu.Unlock()
+			if topology != nil {
+				topology.funcrefMu.Lock()
+				defer topology.funcrefMu.Unlock()
+			}
+		}
+		o.mu.Lock()
+		if o.importers > 0 {
+			o.importers--
+			if refs := o.funcrefStores[store]; refs <= 1 {
+				delete(o.funcrefStores, store)
+			} else {
+				o.funcrefStores[store] = refs - 1
+			}
+			if topology != nil {
+				if refs := topology.funcrefTables[t]; refs <= 1 {
+					delete(topology.funcrefTables, t)
+				} else {
+					topology.funcrefTables[t] = refs - 1
+				}
+			}
+		}
+		o.mu.Unlock()
+		return
+	}
 	var instance *Instance
 	o.mu.Lock()
 	if o.importers > 0 {

--- a/src/wago/funcref_boundary_test.go
+++ b/src/wago/funcref_boundary_test.go
@@ -312,14 +312,8 @@ func TestRuntimeImportedFuncrefRejectsForeignOrCorruptCanonicalDescriptor(t *tes
 			t.Fatalf("Compile importer: %v", err)
 		}
 		importer, err := importerRT.Instantiate(context.Background(), importerMod, WithImports(Imports{"env.target": target}))
-		if err != nil {
-			t.Fatalf("Instantiate importer: %v", err)
-		}
-		defer importer.Close()
-
-		got, err := importer.Invoke("get")
-		if err == nil || !strings.Contains(err.Error(), "invalid funcref result") || got != nil {
-			t.Fatalf("cross-runtime imported get = %v, %v; want fail-closed result", got, err)
+		if err == nil || importer != nil || !strings.Contains(err.Error(), "dynamic funcref producer requires the same Runtime") {
+			t.Fatalf("cross-runtime dynamic producer instantiate = %v, %v; want same-Runtime rejection", importer, err)
 		}
 		if len(importerRT.refStore.byToken) != 0 || len(importerRT.refStore.byIdentity) != 0 {
 			t.Fatal("cross-runtime rejection issued a public token")

--- a/src/wago/gc_array_globals.go
+++ b/src/wago/gc_array_globals.go
@@ -318,7 +318,7 @@ func (in *Instance) collectGenericGCAtBoundary() error {
 	if in == nil || in.gc == nil || in.c == nil || !in.c.genericGCBoundaryCollectionSafe() {
 		return nil
 	}
-	return in.CollectGC()
+	return in.collectGC()
 }
 
 // reconcileGCGlobalRoots synchronizes exact staged mutable GC global cells with

--- a/src/wago/gc_atomic_wait_policy_test.go
+++ b/src/wago/gc_atomic_wait_policy_test.go
@@ -1,0 +1,113 @@
+package wago
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/runtime/gc"
+)
+
+func TestGCAtomicWaitDynamicFuncrefReachabilityRejected(t *testing.T) {
+	consumer := &Compiled{
+		HasTable:  true,
+		TableType: ValFuncRef,
+		codeCache: &compiledCodeCache{
+			gcStructProduct: stagedGCStructGeneric,
+			flags:           compiledCacheAtomicWaitHelpers,
+		},
+	}
+
+	err := consumer.validateImportBindings(nil, newReferenceStore(false))
+	if err == nil || !strings.Contains(err.Error(), "dynamic funcref reachability") || !strings.Contains(err.Error(), "atomic wait helpers") {
+		t.Fatalf("GC+Threads dynamic funcref error = %v, want atomic-wait rejection", err)
+	}
+}
+
+func TestGCAtomicWaitReferenceImportRejected(t *testing.T) {
+	collector := new(gc.Collector)
+	store := &referenceStore{gcDomains: &gcDomainTopology{first: &gcStoreDomain{collector: collector}, n: 1}}
+	store.gcDomains.last = store.gcDomains.first
+	producer := &Instance{
+		c: &Compiled{
+			Entry:        []int{0},
+			Funcs:        []FuncSig{{Params: []ValType{ValAnyRef}, Results: []ValType{ValI32}}},
+			validateMemo: &validateMemo{gcFrameRoots: &compiledGCFrameRoots{}},
+		},
+		gc:       collector,
+		refStore: store,
+	}
+	export := &InstanceExport{inst: producer, localIdx: 0, params: producer.c.Funcs[0].Params, results: producer.c.Funcs[0].Results}
+	consumer := &Compiled{
+		Imports:        []string{"env.read"},
+		importFuncSigs: []FuncSig{{Params: []ValType{ValAnyRef}, Results: []ValType{ValI32}}},
+		codeCache: &compiledCodeCache{
+			gcStructProduct: stagedGCStructGeneric,
+			flags:           compiledCacheAtomicWaitHelpers,
+		},
+		validateMemo: &validateMemo{gcFrameRoots: &compiledGCFrameRoots{}},
+	}
+
+	err := consumer.validateImportBindings(Imports{"env.read": export}, store)
+	if err == nil || !strings.Contains(err.Error(), "atomic wait helpers") {
+		t.Fatalf("GC+Threads reference import error = %v, want atomic-wait rejection", err)
+	}
+}
+
+func TestGCAtomicWaitScalarRuntimeGCDomainImportRejected(t *testing.T) {
+	collector := new(gc.Collector)
+	domain := &gcStoreDomain{collector: collector}
+	store := &referenceStore{gcDomains: &gcDomainTopology{first: domain, last: domain, n: 1}}
+	producer := &Instance{
+		c: &Compiled{
+			Entry: []int{0},
+			Funcs: []FuncSig{{Results: []ValType{ValI32}}},
+		},
+		gc:       collector,
+		refStore: store,
+	}
+	export := &InstanceExport{inst: producer, localIdx: 0, results: producer.c.Funcs[0].Results}
+	consumer := &Compiled{
+		Imports:        []string{"env.notify"},
+		importFuncSigs: []FuncSig{{Results: []ValType{ValI32}}},
+		codeCache: &compiledCodeCache{
+			gcStructProduct: stagedGCStructGeneric,
+			flags:           compiledCacheAtomicWaitHelpers,
+		},
+		validateMemo: &validateMemo{gcFrameRoots: &compiledGCFrameRoots{}},
+	}
+
+	err := consumer.validateImportBindings(Imports{"env.notify": export}, store)
+	if err == nil || !strings.Contains(err.Error(), "Runtime GC-domain import") || !strings.Contains(err.Error(), "atomic wait helpers") {
+		t.Fatalf("GC+Threads scalar Runtime GC import error = %v, want atomic-wait GC-domain rejection", err)
+	}
+}
+
+func TestGCAtomicWaitForeignRuntimeGCDomainImportRejected(t *testing.T) {
+	collector := new(gc.Collector)
+	domain := &gcStoreDomain{collector: collector}
+	producerStore := &referenceStore{gcDomains: &gcDomainTopology{first: domain, last: domain, n: 1}}
+	producer := &Instance{
+		c: &Compiled{
+			Entry: []int{0},
+			Funcs: []FuncSig{{Results: []ValType{ValI32}}},
+		},
+		gc:       collector,
+		refStore: producerStore,
+	}
+	export := &InstanceExport{inst: producer, localIdx: 0, results: producer.c.Funcs[0].Results}
+	consumer := &Compiled{
+		Imports:        []string{"env.notify"},
+		importFuncSigs: []FuncSig{{Results: []ValType{ValI32}}},
+		codeCache: &compiledCodeCache{
+			gcStructProduct: stagedGCStructGeneric,
+			flags:           compiledCacheAtomicWaitHelpers,
+		},
+		validateMemo: &validateMemo{gcFrameRoots: &compiledGCFrameRoots{}},
+	}
+	consumerStore := newReferenceStore(false)
+
+	err := consumer.validateImportBindings(Imports{"env.notify": export}, consumerStore)
+	if err == nil || !strings.Contains(err.Error(), "Runtime GC-domain import") || !strings.Contains(err.Error(), "atomic wait helpers") {
+		t.Fatalf("GC+Threads foreign Runtime GC import error = %v, want atomic-wait GC-domain rejection", err)
+	}
+}

--- a/src/wago/gc_collect.go
+++ b/src/wago/gc_collect.go
@@ -1,6 +1,9 @@
 package wago
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 func gcCollectFrameRoots(in *Instance, public *gcPublicState, frameLayout uint8, allowExternalReturn bool) gcNativeFrameRoots {
 	return gcNativeFrameRoots{
@@ -22,12 +25,29 @@ func (in *Instance) CollectGC() error {
 	if in == nil || in.gc == nil || in.c == nil {
 		return fmt.Errorf("wago: instance has no live WasmGC collector")
 	}
+	// Public collection is an independent operation, not a callback-scoped
+	// re-entry. Use a fresh identity instead of racing the instance's active
+	// invocation ID; GCHostModule.CollectGC handles lease ownership explicitly.
+	invocation := in.lockGCInvocation(newInvocationID())
+	defer invocation.unlock()
+	return in.collectGC()
+}
+
+func (in *Instance) collectGC() error {
 	public := in.existingPublicGCState()
 	if public == nil {
 		return errGenericGCRootState
 	}
-	unlockNative := lockNativeExecutionForHostAccess()
-	defer unlockNative()
+	var nativeMu *sync.Mutex
+	if in.usesIndependentExecution() {
+		nativeMu = in.independentNativeExecutionMu()
+	} else if in.c.threadedMemory0() {
+		nativeMu = &in.memoryDir.nativeMu
+	} else {
+		nativeMu = &nativeExecutionMu
+	}
+	nativeMu.Lock()
+	defer nativeMu.Unlock()
 	lockedDomain := in.lockGCCollector()
 	defer unlockGCCollector(lockedDomain)
 	public.mu.Lock()

--- a/src/wago/gc_cross_instance_amd64_test.go
+++ b/src/wago/gc_cross_instance_amd64_test.go
@@ -115,11 +115,10 @@ func gcUnresolvedImportDistinctDomainModule() []byte {
 func gcStoreDomainCount(store *referenceStore) int {
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	count := 0
-	for domain := store.gcDomains; domain != nil; domain = domain.next {
-		count++
+	if store.gcDomains == nil {
+		return 0
 	}
-	return count
+	return store.gcDomains.n
 }
 
 func TestGCCrossInstanceSharedCollectorOwnership(t *testing.T) {

--- a/src/wago/gc_cross_instance_invocation_test.go
+++ b/src/wago/gc_cross_instance_invocation_test.go
@@ -1,0 +1,1091 @@
+//go:build linux && (amd64 || arm64) && !tinygo
+
+package wago
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func gcAllocatingScalarProducerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	i32Type := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, i32Type)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("allocate", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x41, 0x07, 0x0b}),
+		)),
+	)
+}
+
+func gcAtomicWaitReferenceResultModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	resultType := []byte{0x60, 0x00, 0x01, 0x63, 0x00}
+	waitType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	memoryImport := append(wasmtest.Name("env"), wasmtest.Name("memory")...)
+	memoryImport = append(memoryImport, byte(wasm.ExternMem), 0x03, 0x01, 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, resultType, waitType)),
+		wasmtest.Section(2, wasmtest.Vec(memoryImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("new", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("wait", byte(wasm.ExternFunc), 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x41, 0x00, 0x41, 0x00, 0x42, 0x00, 0xfe, 0x01, 0x02, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func gcDynamicPrivateReferenceResultModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	resultType := []byte{0x60, 0x00, 0x01, 0x63, 0x00}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, resultType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x6f, 0x00, 0x01})),
+		wasmtest.Section(6, wasmtest.Vec([]byte{0x70, 0x01, 0xd0, 0x70, 0x0b})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("new", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{
+			0x41, 0x01,
+			0xfb, 0x00, 0x00,
+			0x0b,
+		}))),
+	)
+}
+
+func gcReferenceTokenProducerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	resultType := []byte{0x60, 0x00, 0x01, 0x63, 0x00}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, resultType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("new", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{
+			0x41, 0x01,
+			0xfb, 0x00, 0x00,
+			0x0b,
+		}))),
+	)
+}
+
+func gcAllocatingHostScalarProducerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7e, 0x01}
+	i32Type := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("host")...)
+	importEntry = append(importEntry, byte(wasm.ExternFunc), 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, i32Type)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", byte(wasm.ExternFunc), 1))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x42, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x10, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func gcPrivateAllocatingFuncrefProducerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	targetType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	getType := wasmtest.FuncType(nil, []wasm.ValType{wasm.FuncRef})
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, targetType, getType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(1), wasmtest.ULEB(2))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x6f, 0x00, 0x01})),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("target", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("get", byte(wasm.ExternFunc), 2),
+		)),
+		wasmtest.Section(9, wasmtest.Vec(append([]byte{0x03, 0x00}, wasmtest.Vec(wasmtest.ULEB(0))...))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x07, 0x0b}),
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x41, 0x07, 0x0b}),
+			wasmtest.Code([]byte{0xd2, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func gcAllocatingFuncrefProducerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	targetType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	getType := wasmtest.FuncType(nil, []wasm.ValType{wasm.FuncRef})
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, targetType, getType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(1), wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("target", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("get", byte(wasm.ExternFunc), 2),
+		)),
+		wasmtest.Section(9, wasmtest.Vec(append([]byte{0x03, 0x00}, wasmtest.Vec(wasmtest.ULEB(0))...))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x07, 0x0b}),
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x41, 0x07, 0x0b}),
+			wasmtest.Code([]byte{0xd2, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func localFuncrefRelayModule() []byte {
+	targetType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	callType := wasmtest.FuncType([]wasm.ValType{wasm.FuncRef}, []wasm.ValType{wasm.I32})
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(targetType, callType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x01, 0x01, 0x01})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{
+			0x41, 0x00, 0x20, 0x00, 0x26, 0x00,
+			0x41, 0x00, 0x11, 0x00, 0x00,
+			0x0b,
+		}))),
+	)
+}
+
+func parameterFuncrefRelayModule() []byte {
+	targetType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	callType := []byte{0x60, 0x01, 0x64, 0x00, 0x01, 0x7f}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(targetType, callType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{
+			0x20, 0x00,
+			0x14, 0x00,
+			0x0b,
+		}))),
+	)
+}
+
+func dynamicScalarRelayModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x01, 0x00, 0x00})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x01, 0x0b}))),
+	)
+}
+
+func importedFuncrefGlobalRelayModule() []byte {
+	targetType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	globalImport := append(wasmtest.Name("env"), wasmtest.Name("target")...)
+	globalImport = append(globalImport, byte(wasm.ExternGlobal), byte(wasm.HeapFunc), 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(targetType)),
+		wasmtest.Section(2, wasmtest.Vec(globalImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x01, 0x01, 0x01})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{
+			0x41, 0x00, 0x23, 0x00, 0x26, 0x00,
+			0x41, 0x00, 0x11, 0x00, 0x00,
+			0x0b,
+		}))),
+	)
+}
+
+func dynamicFuncrefGlobalHostRelayModule() []byte {
+	targetType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	hostType := wasmtest.FuncType(nil, nil)
+	hostImport := append(wasmtest.Name("env"), wasmtest.Name("install")...)
+	hostImport = append(hostImport, byte(wasm.ExternFunc), 0x01)
+	globalImport := append(wasmtest.Name("env"), wasmtest.Name("target")...)
+	globalImport = append(globalImport, byte(wasm.ExternGlobal), byte(wasm.HeapFunc), 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(targetType, hostType)),
+		wasmtest.Section(2, wasmtest.Vec(hostImport, globalImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x01, 0x01, 0x01})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", byte(wasm.ExternFunc), 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{
+			0x10, 0x00,
+			0x41, 0x00, 0x23, 0x00, 0x26, 0x00,
+			0x41, 0x00, 0x11, 0x00, 0x00,
+			0x0b,
+		}))),
+	)
+}
+
+func gcInvocationFuncrefTableWriterModule() []byte {
+	setType := wasmtest.FuncType([]wasm.ValType{wasm.FuncRef}, nil)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(setType)),
+		wasmtest.Section(2, wasmtest.Vec(tableTestImportTable("env", "target", 1, 1))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("set", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x00, 0x20, 0x00, 0x26, 0x00, 0x0b}))),
+	)
+}
+
+func importedFuncrefTableRelayModule() []byte {
+	targetType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(targetType)),
+		wasmtest.Section(2, wasmtest.Vec(tableTestImportTable("env", "target", 1, 1))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x41, 0x00, 0x11, 0x00, 0x00, 0x0b}))),
+	)
+}
+
+func scalarCrossInstanceRelayModule() []byte {
+	i32Type := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("allocate")...)
+	importEntry = append(importEntry, byte(wasm.ExternFunc), 0x00)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(i32Type)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("direct", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("wrapped", byte(wasm.ExternFunc), 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+	)
+}
+
+func scalarTwoProducerRelayModule() []byte {
+	i32Type := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	firstImport := append(wasmtest.Name("env"), wasmtest.Name("first")...)
+	firstImport = append(firstImport, byte(wasm.ExternFunc), 0x00)
+	secondImport := append(wasmtest.Name("env"), wasmtest.Name("second")...)
+	secondImport = append(secondImport, byte(wasm.ExternFunc), 0x00)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(i32Type)),
+		wasmtest.Section(2, wasmtest.Vec(firstImport, secondImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", byte(wasm.ExternFunc), 2))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+	)
+}
+
+func TestMutableFuncrefCalleesWaitForProducerGCInvocationLease(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	producerCode, err := Compile(cfg, gcAllocatingFuncrefProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCode.Close()
+	rt := NewRuntime(WithRuntimeConfig(cfg))
+	defer rt.Close()
+	store := rt.refStore
+	producer, err := instantiateCore(producerCode, InstantiateOptions{
+		GC:    GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true},
+		store: store,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+	ref, err := producer.Invoke("get")
+	if err != nil || len(ref) != 1 || ref[0] == 0 {
+		t.Fatalf("producer get = %v, %v; want one non-null funcref", ref, err)
+	}
+
+	type result struct {
+		values []uint64
+		err    error
+	}
+	assertWaits := func(t *testing.T, call func() ([]uint64, error)) {
+		t.Helper()
+		lease := producer.lockGCInvocation(newInvocationID())
+		done := make(chan result, 1)
+		go func() {
+			out, callErr := call()
+			done <- result{values: out, err: callErr}
+		}()
+		select {
+		case got := <-done:
+			lease.unlock()
+			t.Fatalf("mutable funcref call completed before producer GC lease release: %v, %v", got.values, got.err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		lease.unlock()
+		select {
+		case got := <-done:
+			if got.err != nil || len(got.values) != 1 || AsI32(got.values[0]) != 7 {
+				t.Fatalf("mutable funcref call after lease release = %v, %v; want [7], nil", got.values, got.err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("mutable funcref call did not resume after producer GC lease release")
+		}
+	}
+
+	t.Run("parameter-call-ref", func(t *testing.T) {
+		code, compileErr := Compile(cfg, parameterFuncrefRelayModule())
+		if compileErr != nil {
+			t.Fatal(compileErr)
+		}
+		defer code.Close()
+		relay, instantiateErr := instantiateCore(code, InstantiateOptions{store: store})
+		if instantiateErr != nil {
+			t.Fatal(instantiateErr)
+		}
+		defer relay.Close()
+		assertWaits(t, func() ([]uint64, error) { return relay.Invoke("call", ref[0]) })
+	})
+
+	t.Run("local-table-argument", func(t *testing.T) {
+		code, compileErr := Compile(cfg, localFuncrefRelayModule())
+		if compileErr != nil {
+			t.Fatal(compileErr)
+		}
+		defer code.Close()
+		relay, instantiateErr := instantiateCore(code, InstantiateOptions{store: store})
+		if instantiateErr != nil {
+			t.Fatal(instantiateErr)
+		}
+		defer relay.Close()
+		assertWaits(t, func() ([]uint64, error) { return relay.Invoke("call", ref[0]) })
+	})
+
+	t.Run("imported-global-later-mutation", func(t *testing.T) {
+		global, globalErr := rt.NewFuncRefGlobal(NullFuncRef(), true)
+		if globalErr != nil {
+			t.Fatal(globalErr)
+		}
+		defer global.Close()
+		code, compileErr := Compile(cfg, importedFuncrefGlobalRelayModule())
+		if compileErr != nil {
+			t.Fatal(compileErr)
+		}
+		defer code.Close()
+		relay, instantiateErr := instantiateCore(code, InstantiateOptions{store: store, Imports: Imports{"env.target": global}})
+		if instantiateErr != nil {
+			t.Fatal(instantiateErr)
+		}
+		defer relay.Close()
+		if setErr := global.SetValue(ValueFuncRef(FuncRef{token: ref[0]})); setErr != nil {
+			t.Fatal(setErr)
+		}
+		assertWaits(t, func() ([]uint64, error) { return relay.Invoke("call") })
+	})
+
+	t.Run("imported-table-later-mutation", func(t *testing.T) {
+		table, tableErr := NewTable(1, 1)
+		if tableErr != nil {
+			t.Fatal(tableErr)
+		}
+		defer table.Close()
+		writerCode, compileErr := Compile(cfg, gcInvocationFuncrefTableWriterModule())
+		if compileErr != nil {
+			t.Fatal(compileErr)
+		}
+		defer writerCode.Close()
+		relayCode, compileErr := Compile(cfg, importedFuncrefTableRelayModule())
+		if compileErr != nil {
+			t.Fatal(compileErr)
+		}
+		defer relayCode.Close()
+		writer, instantiateErr := instantiateCore(writerCode, InstantiateOptions{store: store, Imports: Imports{"env.target": table}})
+		if instantiateErr != nil {
+			t.Fatal(instantiateErr)
+		}
+		defer writer.Close()
+		relay, instantiateErr := instantiateCore(relayCode, InstantiateOptions{store: store, Imports: Imports{"env.target": table}})
+		if instantiateErr != nil {
+			t.Fatal(instantiateErr)
+		}
+		defer relay.Close()
+		if _, setErr := writer.Invoke("set", ref[0]); setErr != nil {
+			t.Fatal(setErr)
+		}
+		assertWaits(t, func() ([]uint64, error) { return relay.Invoke("call") })
+	})
+}
+
+func TestForeignRuntimeHostFuncrefTableImportRejected(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	producerCode, err := Compile(cfg, gcAllocatingFuncrefProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCode.Close()
+	writerCode, err := Compile(cfg, gcInvocationFuncrefTableWriterModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writerCode.Close()
+	relayCode, err := Compile(cfg, importedFuncrefTableRelayModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relayCode.Close()
+	table, err := NewTable(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer table.Close()
+	rtA := NewRuntime(WithRuntimeConfig(cfg))
+	defer rtA.Close()
+	rtB := NewRuntime(WithRuntimeConfig(cfg))
+	defer rtB.Close()
+	producer, err := instantiateCore(producerCode, InstantiateOptions{store: rtA.refStore})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+	writer, err := instantiateCore(writerCode, InstantiateOptions{store: rtA.refStore, Imports: Imports{"env.target": table}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := producer.Invoke("get")
+	if err != nil || len(ref) != 1 || ref[0] == 0 {
+		t.Fatalf("producer get = %v, %v; want one funcref", ref, err)
+	}
+	if _, err := writer.Invoke("set", ref[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := instantiateCore(relayCode, InstantiateOptions{store: rtB.refStore, Imports: Imports{"env.target": table}}); err == nil || !strings.Contains(err.Error(), "different Runtime GC reference store") {
+		t.Fatalf("foreign Runtime funcref-table import error = %v, want reference-store rejection", err)
+	}
+}
+
+func TestPrivateGCProducerInHostFuncrefTableRejectedAcrossRuntime(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	producerCode, err := Compile(cfg, gcPrivateAllocatingFuncrefProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCode.Close()
+	writerCode, err := Compile(cfg, gcInvocationFuncrefTableWriterModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writerCode.Close()
+	relayCode, err := Compile(cfg, importedFuncrefTableRelayModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relayCode.Close()
+	table, err := NewTable(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer table.Close()
+	rtA := NewRuntime(WithRuntimeConfig(cfg))
+	defer rtA.Close()
+	rtB := NewRuntime(WithRuntimeConfig(cfg))
+	defer rtB.Close()
+	producer, err := instantiateCore(producerCode, InstantiateOptions{store: rtA.refStore})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+	if rtA.refStore.ownsGCCollector(producer.gc) {
+		t.Fatal("private funcref producer unexpectedly joined the Runtime topology")
+	}
+	writer, err := instantiateCore(writerCode, InstantiateOptions{store: rtA.refStore, Imports: Imports{"env.target": table}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := producer.Invoke("get")
+	if err != nil || len(ref) != 1 || ref[0] == 0 {
+		t.Fatalf("private producer get = %v, %v; want one funcref", ref, err)
+	}
+	if _, err := writer.Invoke("set", ref[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := instantiateCore(relayCode, InstantiateOptions{store: rtB.refStore, Imports: Imports{"env.target": table}}); err == nil || (!strings.Contains(err.Error(), "incompatible GC invocation domain") && !strings.Contains(err.Error(), "different Runtime GC reference store")) {
+		t.Fatalf("private GC funcref-table import error = %v, want explicit domain rejection", err)
+	}
+}
+
+func TestRuntimeGCDomainCreationRejectsSharedForeignFuncrefTable(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	relayCode, err := Compile(cfg, importedFuncrefTableRelayModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relayCode.Close()
+	producerCode, err := Compile(cfg, gcReferenceTokenProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCode.Close()
+	table, err := NewTable(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer table.Close()
+	rtA := NewRuntime(WithRuntimeConfig(cfg))
+	defer rtA.Close()
+	rtB := NewRuntime(WithRuntimeConfig(cfg))
+	defer rtB.Close()
+	first, err := instantiateCore(relayCode, InstantiateOptions{store: rtA.refStore, Imports: Imports{"env.target": table}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := instantiateCore(relayCode, InstantiateOptions{store: rtB.refStore, Imports: Imports{"env.target": table}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	if _, err := instantiateCore(producerCode, InstantiateOptions{store: rtA.refStore}); err == nil || !strings.Contains(err.Error(), "cannot share a mutable funcref table") {
+		t.Fatalf("GC domain creation with foreign funcref-table importer error = %v, want explicit rejection", err)
+	}
+}
+
+func TestPrivateGCCollectorCreationRejectsSharedForeignFuncrefTable(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	relayCode, err := Compile(cfg, importedFuncrefTableRelayModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relayCode.Close()
+	producerCode, err := Compile(cfg, gcDynamicPrivateReferenceResultModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCode.Close()
+	table, err := NewTable(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer table.Close()
+	rtA := NewRuntime(WithRuntimeConfig(cfg))
+	defer rtA.Close()
+	rtB := NewRuntime(WithRuntimeConfig(cfg))
+	defer rtB.Close()
+	first, err := instantiateCore(relayCode, InstantiateOptions{store: rtA.refStore, Imports: Imports{"env.target": table}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := instantiateCore(relayCode, InstantiateOptions{store: rtB.refStore, Imports: Imports{"env.target": table}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	if _, err := instantiateCore(producerCode, InstantiateOptions{store: rtA.refStore}); err == nil || !strings.Contains(err.Error(), "cannot share a mutable funcref table") {
+		t.Fatalf("private GC creation with foreign funcref-table importer error = %v, want explicit rejection", err)
+	}
+}
+
+func TestDynamicPrivateCollectorUsesCompleteInvocationLease(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	code, err := Compile(cfg, gcDynamicPrivateReferenceResultModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer code.Close()
+	if !compiledHasDynamicFuncrefReachability(code) || code.sharedGCPersistentDomainSafe() {
+		t.Fatalf("dynamic private module admission = dynamic %v persistent-safe %v, want true/false", compiledHasDynamicFuncrefReachability(code), code.sharedGCPersistentDomainSafe())
+	}
+	rt := NewRuntime(WithRuntimeConfig(cfg))
+	defer rt.Close()
+	in, err := instantiateCore(code, InstantiateOptions{store: rt.refStore})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if rt.refStore.ownsGCCollector(in.gc) {
+		t.Fatal("dynamic collector requiring private persistent roots unexpectedly joined the Runtime topology")
+	}
+	domain := in.gcInvocationDomain()
+	if domain == nil || !domain.private || domain.collector != in.gc {
+		t.Fatalf("dynamic private invocation domain = %#v, want instance collector", domain)
+	}
+	lease := in.lockGCInvocation(newInvocationID())
+	collectDone := make(chan error, 1)
+	go func() { collectDone <- in.CollectGC() }()
+	select {
+	case collectErr := <-collectDone:
+		lease.unlock()
+		t.Fatalf("CollectGC bypassed dynamic private complete-call lease: %v", collectErr)
+	case <-time.After(50 * time.Millisecond):
+	}
+	lease.unlock()
+	select {
+	case collectErr := <-collectDone:
+		if collectErr != nil {
+			t.Fatal(collectErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("CollectGC did not resume after dynamic private complete-call lease release")
+	}
+}
+
+func TestGCAtomicWaitPrivateCollectorUsesCompleteInvocationLease(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3 | CoreFeatureThreads).WithBoundsChecks(BoundsChecksExplicit)
+	code, err := Compile(cfg, gcAtomicWaitReferenceResultModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer code.Close()
+	rt := NewRuntime(WithRuntimeConfig(cfg))
+	defer rt.Close()
+	memory, err := NewSharedMemory(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer memory.Close()
+	in, err := instantiateCore(code, InstantiateOptions{
+		GC: GCConfig{}, store: rt.refStore, Imports: Imports{"env.memory": memory},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if rt.refStore.ownsGCCollector(in.gc) {
+		t.Fatal("GC+Threads atomic-wait collector unexpectedly joined the Runtime topology")
+	}
+	domain := in.gcInvocationDomain()
+	if domain == nil || domain.collector != in.gc {
+		t.Fatalf("private collector invocation domain = %#v, want instance collector", domain)
+	}
+	lease := in.lockGCInvocation(newInvocationID())
+	collectDone := make(chan error, 1)
+	go func() { collectDone <- in.CollectGC() }()
+	select {
+	case collectErr := <-collectDone:
+		lease.unlock()
+		t.Fatalf("CollectGC bypassed private complete-call lease: %v", collectErr)
+	case <-time.After(50 * time.Millisecond):
+	}
+	lease.unlock()
+	select {
+	case collectErr := <-collectDone:
+		if collectErr != nil {
+			t.Fatal(collectErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("CollectGC did not resume after private complete-call lease release")
+	}
+	values, err := in.Invoke("new")
+	if err != nil || len(values) != 1 || values[0] == 0 {
+		t.Fatalf("private atomic-wait new = %v, %v; want one GC token", values, err)
+	}
+	if err := in.ReleaseGCRef(GCRef{token: values[0]}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGCRefReleaseDoesNotInvertDynamicTopologyLock(t *testing.T) {
+	if guardPageBuilt {
+		t.Skip("signals-based execution uses instance-local native guards")
+	}
+	const childEnv = "WAGO_GC_REF_RELEASE_TOPOLOGY_CHILD"
+	if os.Getenv(childEnv) == "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGCRefReleaseDoesNotInvertDynamicTopologyLock$", "-test.count=1")
+		cmd.Env = append(os.Environ(), childEnv+"=1")
+		out, err := cmd.CombinedOutput()
+		if ctx.Err() != nil {
+			t.Fatalf("GC reference release/topology lock-order child timed out: %v\n%s", ctx.Err(), out)
+		}
+		if err != nil {
+			t.Fatalf("GC reference release/topology lock-order child failed: %v\n%s", err, out)
+		}
+		return
+	}
+
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	producerCode, err := Compile(cfg, gcReferenceTokenProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCode.Close()
+	relayCode, err := Compile(cfg, dynamicScalarRelayModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relayCode.Close()
+	rt := NewRuntime(WithRuntimeConfig(cfg))
+	defer rt.Close()
+	producer, err := instantiateCore(producerCode, InstantiateOptions{GC: GCConfig{}, store: rt.refStore})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+	relay, err := instantiateCore(relayCode, InstantiateOptions{store: rt.refStore})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relay.Close()
+	values, err := producer.Invoke("new")
+	if err != nil || len(values) != 1 || values[0] == 0 {
+		t.Fatalf("producer new = %v, %v; want one non-null GC token", values, err)
+	}
+	ref := GCRef{token: values[0]}
+	domain := producer.gcInvocationDomain()
+	if domain == nil {
+		t.Fatal("producer has no Runtime GC domain")
+	}
+	domain.mu.Lock()
+	releaseDone := make(chan error, 1)
+	go func() { releaseDone <- producer.ReleaseGCRef(ref) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for nativeExecutionMu.TryLock() {
+		nativeExecutionMu.Unlock()
+		if time.Now().After(deadline) {
+			domain.mu.Unlock()
+			t.Fatal("GC reference release did not acquire the native guard")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	invokeDone := make(chan error, 1)
+	go func() {
+		_, callErr := relay.Invoke("run")
+		invokeDone <- callErr
+	}()
+	topology := rt.refStore.gcDomains
+	if topology == nil {
+		domain.mu.Unlock()
+		t.Fatal("Runtime GC domain topology is unavailable")
+	}
+	for topology.TryLock() {
+		topology.Unlock()
+		if time.Now().After(deadline) {
+			domain.mu.Unlock()
+			t.Fatal("dynamic invocation did not acquire the topology read lease")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	domain.mu.Unlock()
+	select {
+	case releaseErr := <-releaseDone:
+		if releaseErr != nil {
+			t.Fatal(releaseErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GC reference release deadlocked with dynamic invocation")
+	}
+	select {
+	case callErr := <-invokeDone:
+		if callErr != nil {
+			t.Fatalf("dynamic invocation failed: %v", callErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("dynamic invocation did not resume after GC reference release")
+	}
+}
+
+func TestDynamicFuncrefHostResumeLeasesNewGCDomain(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	producerCode, err := Compile(cfg, gcAllocatingFuncrefProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCode.Close()
+	relayCode, err := Compile(cfg, dynamicFuncrefGlobalHostRelayModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relayCode.Close()
+
+	rt := NewRuntime(WithRuntimeConfig(cfg))
+	defer rt.Close()
+	global, err := rt.NewFuncRefGlobal(NullFuncRef(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer global.Close()
+
+	type installedTarget struct {
+		producer *Instance
+		domain   *gcStoreDomain
+	}
+	installed := make(chan installedTarget, 1)
+	var producer *Instance
+	relay, err := instantiateCore(relayCode, InstantiateOptions{
+		store: rt.refStore,
+		Imports: Imports{
+			"env.target": global,
+			"env.install": HostFunc(func(HostModule, []uint64, []uint64) {
+				var instantiateErr error
+				producer, instantiateErr = instantiateCore(producerCode, InstantiateOptions{
+					GC:    GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true},
+					store: rt.refStore,
+				})
+				if instantiateErr != nil {
+					panic(HostTrap{Err: instantiateErr})
+				}
+				ref, getErr := producer.Invoke("get")
+				if getErr != nil || len(ref) != 1 {
+					panic(HostTrap{Err: getErr})
+				}
+				if setErr := global.SetValue(ValueFuncRef(FuncRef{token: ref[0]})); setErr != nil {
+					panic(HostTrap{Err: setErr})
+				}
+				domain := producer.gcInvocationDomain()
+				if domain == nil {
+					panic(HostTrap{Err: fmt.Errorf("new funcref producer has no Runtime GC domain")})
+				}
+				domain.invocationMu.Lock()
+				installed <- installedTarget{producer: producer, domain: domain}
+			})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relay.Close()
+
+	type result struct {
+		values []uint64
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		out, callErr := relay.Invoke("call")
+		done <- result{values: out, err: callErr}
+	}()
+	var target installedTarget
+	select {
+	case target = <-installed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("host callback did not install a new GC-domain funcref target")
+	}
+	select {
+	case got := <-done:
+		target.domain.invocationMu.Unlock()
+		t.Fatalf("dynamic funcref call resumed without leasing the newly installed GC domain: %v, %v", got.values, got.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	target.domain.invocationMu.Unlock()
+	select {
+	case got := <-done:
+		if got.err != nil || len(got.values) != 1 || AsI32(got.values[0]) != 7 {
+			t.Fatalf("dynamic funcref call after new-domain lease release = %v, %v; want [7], nil", got.values, got.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dynamic funcref call did not resume after new-domain lease release")
+	}
+	if target.producer != nil {
+		if err := target.producer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDynamicFuncrefCrossGCDomain(b *testing.B) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	producerCode, err := Compile(cfg, gcAllocatingFuncrefProducerModule())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer producerCode.Close()
+	relayCode, err := Compile(cfg, localFuncrefRelayModule())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer relayCode.Close()
+	rt := NewRuntime(WithRuntimeConfig(cfg))
+	defer rt.Close()
+	producer, err := instantiateCore(producerCode, InstantiateOptions{GC: GCConfig{}, store: rt.refStore})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer producer.Close()
+	relay, err := instantiateCore(relayCode, InstantiateOptions{store: rt.refStore})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer relay.Close()
+	ref, err := producer.Invoke("get")
+	if err != nil || len(ref) != 1 {
+		b.Fatalf("producer get = %v, %v", ref, err)
+	}
+	if got, callErr := relay.Invoke("call", ref[0]); callErr != nil || len(got) != 1 || AsI32(got[0]) != 7 {
+		b.Fatalf("warm dynamic call = %v, %v", got, callErr)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got, callErr := relay.Invoke("call", ref[0]); callErr != nil || len(got) != 1 || AsI32(got[0]) != 7 {
+			b.Fatalf("dynamic call = %v, %v", got, callErr)
+		}
+	}
+}
+
+func TestScalarCrossInstanceRelayWaitsForProducerGCInvocationLease(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	producerCode, err := Compile(cfg, gcAllocatingScalarProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCode.Close()
+	relayCode, err := Compile(cfg, scalarCrossInstanceRelayModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relayCode.Close()
+
+	store := newReferenceStore(false)
+	defer store.closeRuntime()
+	gcCfg := GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	producer, err := instantiateCore(producerCode, InstantiateOptions{GC: gcCfg, store: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+	export, err := producer.ExportedFunc("allocate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	relay, err := instantiateCore(relayCode, InstantiateOptions{store: store, Imports: Imports{"env.allocate": export}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relay.Close()
+
+	type result struct {
+		values []uint64
+		err    error
+	}
+	for _, name := range []string{"direct", "wrapped"} {
+		lease := producer.lockGCInvocation(newInvocationID())
+		done := make(chan result, 1)
+		go func(export string) {
+			out, callErr := relay.Invoke(export)
+			done <- result{values: out, err: callErr}
+		}(name)
+		select {
+		case result := <-done:
+			lease.unlock()
+			t.Fatalf("relay %q completed while producer GC domain was leased: %v, %v", name, result.values, result.err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		lease.unlock()
+		select {
+		case result := <-done:
+			if result.err != nil || len(result.values) != 1 || AsI32(result.values[0]) != 7 {
+				t.Fatalf("relay %q after lease release = %v, %v; want [7], nil", name, result.values, result.err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("relay %q did not resume after producer GC lease release", name)
+		}
+	}
+}
+
+func TestScalarCrossInstanceRelaySuspendsAllProducerGCDomainsForHostCollection(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	firstCode, err := Compile(cfg, gcAllocatingHostScalarProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondCode, err := Compile(cfg, gcAllocatingScalarProducerModule())
+	if err != nil {
+		firstCode.Close()
+		t.Fatal(err)
+	}
+	relayCode, err := Compile(cfg, scalarTwoProducerRelayModule())
+	if err != nil {
+		firstCode.Close()
+		secondCode.Close()
+		t.Fatal(err)
+	}
+	store := newReferenceStore(false)
+	var second *Instance
+	first, err := instantiateCore(firstCode, InstantiateOptions{
+		GC:    GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true},
+		store: store,
+		Imports: Imports{"env.host": HostFunc(func(module HostModule, _ []uint64, results []uint64) {
+			if collectErr := second.CollectGC(); collectErr != nil {
+				panic(HostTrap{Err: collectErr})
+			}
+			out, callErr := second.InvokeFromHost(context.Background(), module, "allocate")
+			if callErr != nil || len(out) != 1 {
+				panic(HostTrap{Err: callErr})
+			}
+			results[0] = out[0]
+		})},
+	})
+	if err != nil {
+		store.closeRuntime()
+		firstCode.Close()
+		secondCode.Close()
+		relayCode.Close()
+		t.Fatal(err)
+	}
+	second, err = instantiateCore(secondCode, InstantiateOptions{
+		GC:    GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true, StressBarriers: true},
+		store: store,
+	})
+	if err != nil {
+		first.Close()
+		store.closeRuntime()
+		firstCode.Close()
+		secondCode.Close()
+		relayCode.Close()
+		t.Fatal(err)
+	}
+	if first.gcInvocationDomain() == nil || second.gcInvocationDomain() == nil || first.gcInvocationDomain() == second.gcInvocationDomain() {
+		t.Fatal("test producers did not receive distinct Runtime GC domains")
+	}
+	firstExport, err := first.ExportedFunc("call")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondExport, err := second.ExportedFunc("allocate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	relay, err := instantiateCore(relayCode, InstantiateOptions{store: store, Imports: Imports{"env.first": firstExport, "env.second": secondExport}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := relay.gcInvocationDomains().len(); got != 2 {
+		t.Fatalf("relay invocation domains = %d, want 2", got)
+	}
+
+	type result struct {
+		values []uint64
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		out, callErr := relay.Invoke("run")
+		done <- result{values: out, err: callErr}
+	}()
+	select {
+	case result := <-done:
+		if result.err != nil || len(result.values) != 1 || AsI32(result.values[0]) != 7 {
+			t.Fatalf("two-domain relay host collection/re-entry = %v, %v; want [7], nil", result.values, result.err)
+		}
+	case <-time.After(5 * time.Second):
+		// Cleanup would wait behind the deadlocked invocation and obscure the
+		// bounded diagnostic on an implementation that suspends only the callee.
+		t.Fatal("two-domain relay host collection/re-entry deadlocked")
+	}
+	if err := relay.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store.closeRuntime()
+	if err := firstCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := secondCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := relayCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/src/wago/gc_host_activation_arm64.go
+++ b/src/wago/gc_host_activation_arm64.go
@@ -17,7 +17,7 @@ type gcHostActivationToken struct {
 	index uint8
 }
 
-func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32) gcHostActivationToken {
+func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32, _ uintptr) gcHostActivationToken {
 	if in == nil || ctrl == 0 || dispatch&gcStructDispatchBit != 0 {
 		return gcHostActivationToken{}
 	}

--- a/src/wago/gc_host_activation_linux_amd64.go
+++ b/src/wago/gc_host_activation_linux_amd64.go
@@ -17,7 +17,7 @@ type gcHostActivationToken struct {
 	index uint8
 }
 
-func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32) gcHostActivationToken {
+func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32, stackTop uintptr) gcHostActivationToken {
 	if in == nil || ctrl == 0 || dispatch&gcStructDispatchBit != 0 {
 		return gcHostActivationToken{}
 	}
@@ -58,7 +58,6 @@ func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32) gcHostAc
 		// above the host stub. Scan only the fixed wrapper envelope and accept a
 		// candidate solely when it equals a validated logical callsite return PC.
 		const wrapperScanBytes = uintptr(512)
-		stackTop := in.eng.StackTop()
 		if stackTop <= savedRSP+8 {
 			panic(gcStructHelperError{err: fmt.Errorf("generic GC host activation saved RSP %#x is outside the foreign stack", savedRSP)})
 		}

--- a/src/wago/gc_host_activation_other.go
+++ b/src/wago/gc_host_activation_other.go
@@ -11,7 +11,7 @@ type gcHostActivationToken struct {
 	index uint8
 }
 
-func (*Instance) pushGCHostActivation(uintptr, uint32) gcHostActivationToken {
+func (*Instance) pushGCHostActivation(uintptr, uint32, uintptr) gcHostActivationToken {
 	return gcHostActivationToken{}
 }
 

--- a/src/wago/gc_shared_global_test.go
+++ b/src/wago/gc_shared_global_test.go
@@ -97,11 +97,10 @@ func gcSharedImmutableGlobalConsumerModule(mutable bool) []byte {
 func sharedGlobalDomainCount(store *referenceStore) int {
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	count := 0
-	for domain := store.gcDomains; domain != nil; domain = domain.next {
-		count++
+	if store.gcDomains == nil {
+		return 0
 	}
-	return count
+	return store.gcDomains.n
 }
 
 func TestGCSharedImmutableGlobalSameDomainCollectionAndCloseOrder(t *testing.T) {

--- a/src/wago/gc_start_invocation_amd64_test.go
+++ b/src/wago/gc_start_invocation_amd64_test.go
@@ -1,0 +1,90 @@
+//go:build linux && amd64
+
+package wago
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func gcAllocatingHostStartModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	startType := wasmtest.FuncType(nil, nil)
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("started")...)
+	importEntry = append(importEntry, byte(wasm.ExternFunc), 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, startType)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(8, wasmtest.ULEB(1)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x10, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func TestGCAllocatingLocalStartWaitsForInvocationLease(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), gcAllocatingHostStartModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	if compiled.genericGCFrameRoots() == nil {
+		t.Fatal("allocating local start has no exact native root map")
+	}
+	store := newReferenceStore(false)
+	defer store.closeRuntime()
+	gcCfg := GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	first, err := instantiateCore(compiled, InstantiateOptions{
+		GC:      gcCfg,
+		store:   store,
+		Imports: Imports{"env.started": HostFunc(func(HostModule, []uint64, []uint64) {})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+
+	lease := first.lockGCInvocation(newInvocationID())
+	started := make(chan struct{}, 1)
+	done := make(chan error, 1)
+	go func() {
+		second, instantiateErr := instantiateCore(compiled, InstantiateOptions{
+			GC:    gcCfg,
+			store: store,
+			Imports: Imports{"env.started": HostFunc(func(HostModule, []uint64, []uint64) {
+				started <- struct{}{}
+			})},
+		})
+		if second != nil {
+			_ = second.Close()
+		}
+		done <- instantiateErr
+	}()
+	select {
+	case <-started:
+		lease.unlock()
+		t.Fatal("allocating local start ran while another invocation owned the GC domain")
+	case err := <-done:
+		lease.unlock()
+		t.Fatalf("instantiation completed before the GC lease was released: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	lease.unlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("allocating local start did not resume after the GC lease was released")
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("allocating local start did not reach its host callback")
+	}
+}

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -16,6 +16,51 @@ import (
 // import namespace and HostModule rather than the public root's.
 var hostControlInstances sync.Map // map[uintptr]*Instance
 
+// hostInvocationContexts carries the public root's callback identity across a
+// native cross-instance transfer. The control-frame address is unique to the
+// parked activation and lets the producer's bound host dispatcher construct a
+// HostModule authorized by the invocation that actually owns the GC lease.
+type hostInvocationContext struct {
+	id          invocationID
+	reservation *pluginOperationReservation
+}
+
+var hostInvocationContexts sync.Map // map[uintptr]hostInvocationContext
+
+func currentHostInvocationContext(ctrl uintptr, in *Instance) hostInvocationContext {
+	if value, ok := hostInvocationContexts.Load(ctrl); ok {
+		return value.(hostInvocationContext)
+	}
+	if in != nil {
+		if id := in.currentInvocationID(); id != 0 {
+			return hostInvocationContext{id: id, reservation: currentInvocationReservation(in)}
+		}
+	}
+	return hostInvocationContext{}
+}
+
+func activeHostInvocationContext(in *Instance) hostInvocationContext {
+	if in == nil {
+		return hostInvocationContext{}
+	}
+	return currentHostInvocationContext(offHeapSlicePtr(in.ctrl), in)
+}
+
+func bindHostInvocationContext(ctrl uintptr, next hostInvocationContext) func() {
+	if ctrl == 0 || next.id == 0 {
+		return func() {}
+	}
+	previous, loaded := hostInvocationContexts.Load(ctrl)
+	hostInvocationContexts.Store(ctrl, next)
+	return func() {
+		if loaded {
+			hostInvocationContexts.Store(ctrl, previous)
+		} else {
+			hostInvocationContexts.Delete(ctrl)
+		}
+	}
+}
+
 func registerHostControl(in *Instance) error {
 	if in == nil || len(in.ctrl) < coreruntime.HostCtrlFrameBytes {
 		return fmt.Errorf("invalid synchronous host control frame")
@@ -94,12 +139,35 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 	// lease. The deferred reacquire covers normal return, HostExit, validation
 	// panics, and arbitrary host panics. Rebind the exact parked callee because a
 	// nested wasm entry may have replaced its shared basedata context.
-	activation := active.pushGCHostActivation(ctrl, importIdx)
+	stackTop := active.eng.StackTop()
+	if root != nil && root.eng != nil {
+		// Cross-instance native calls remain on the public root's foreign stack
+		// even though the parked control frame and callsite map belong to active.
+		stackTop = root.eng.StackTop()
+	}
+	activation := active.pushGCHostActivation(ctrl, importIdx, stackTop)
 	if err := active.rootGCHostArguments(activation, importIdx, args); err != nil {
 		active.clearGCHostResultRoots(activation)
 		active.popGCHostActivation(activation)
 		panic(invalidHostReference{err: err})
 	}
+	// Cross-instance native dispatch parks the producer while the public root still
+	// owns the invocation identity and collector lease. Carry that identity into
+	// the producer's HostModule instead of reading its zero local invocation ID.
+	invocation := activeHostInvocationContext(root)
+	if invocation.id == 0 {
+		invocation = activeHostInvocationContext(active)
+	}
+	id := invocation.id
+	// Exact parked native roots and translated GC host arguments are now
+	// published. Release every collector lease owned by the public native root
+	// while arbitrary host code runs. A non-GC relay may have pre-acquired more
+	// imported GC domains than the active producer whose frame parked here.
+	leaseOwner := active
+	if root != nil && root.executionFlags.Load()&executionFlagImportedGCDomain != 0 {
+		leaseOwner = root
+	}
+	resumeGCInvocation := leaseOwner.suspendGCInvocation(id)
 	var localMu *sync.Mutex
 	epoch := nativeExecutionEpoch
 	if active.usesIndependentExecution() {
@@ -114,6 +182,7 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 	// between host result validation and the caller's resumed native frame.
 	defer active.popGCHostActivation(activation)
 	defer func() {
+		resumeGCInvocation()
 		if localMu != nil {
 			localMu.Lock()
 		} else {
@@ -142,8 +211,12 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 	// Only arbitrary host code can synchronously re-enter this instance. The
 	// active marker includes the callback-scoped invocation identity, so another
 	// call chain cannot masquerade as this parked activation.
-	markNativeActive(active)
-	defer unmarkNativeActive(active)
+	markNativeActiveID(active, id)
+	defer unmarkNativeActiveID(active, id)
+	if active != root {
+		restoreInvocationContext := bindHostInvocationContext(ctrl, invocation)
+		defer restoreInvocationContext()
+	}
 	active.hostCall(ctrl, importIdx, args, results)
 }
 
@@ -153,13 +226,17 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 // is parked. Reusing any of those buffers corrupts the parked frame and can turn
 // an ordinary guest trap into a process fault.
 func (in *Instance) prepareHostReentryState() (func(), error) {
+	in.lifeMu.Lock()
+	invocation := activeHostInvocationContext(in)
 	eng, err := coreruntime.AcquireEngine()
 	if err != nil {
+		in.lifeMu.Unlock()
 		return nil, fmt.Errorf("acquire host re-entry engine: %w", err)
 	}
 	ctrl := make([]byte, coreruntime.HostCtrlFrameBytes)
 	if err := coreruntime.InitHostCtrlFrame(ctrl); err != nil {
 		_ = coreruntime.ReleaseEngine(eng)
+		in.lifeMu.Unlock()
 		return nil, err
 	}
 
@@ -184,8 +261,10 @@ func (in *Instance) prepareHostReentryState() (func(), error) {
 		in.ic, in.icNext = outerInvokeCache, outerInvokeCacheNext
 		in.instructionState = outerInstructionState
 		_ = coreruntime.ReleaseEngine(eng)
+		in.lifeMu.Unlock()
 		return nil, err
 	}
+	restoreInvocationContext := bindHostInvocationContext(offHeapSlicePtr(ctrl), invocation)
 	// Cross-instance and imported-host dispatch descriptors restore their target
 	// from this stable context image. Publish the activation's private control
 	// frame there as well as in basedata, otherwise a nested import switches back
@@ -193,9 +272,12 @@ func (in *Instance) prepareHostReentryState() (func(), error) {
 	nativeCtx := unsafe.Slice((*byte)(offHeapPtr(in.nativeContext)), coreruntime.InstanceContextBytes)
 	outerCustomCtx := binary.LittleEndian.Uint64(nativeCtx)
 	binary.LittleEndian.PutUint64(nativeCtx, uint64(offHeapSlicePtr(ctrl)))
+	in.lifeMu.Unlock()
 
 	return func() {
+		in.lifeMu.Lock()
 		binary.LittleEndian.PutUint64(nativeCtx, outerCustomCtx)
+		restoreInvocationContext()
 		unregisterHostControl(in)
 		in.eng, in.ctrl = outerEngine, outerCtrl
 		in.serArgs, in.results, in.trap = outerArgs, outerResults, outerTrap
@@ -203,7 +285,9 @@ func (in *Instance) prepareHostReentryState() (func(), error) {
 		in.ic, in.icNext = outerInvokeCache, outerInvokeCacheNext
 		in.instructionState = outerInstructionState
 		if err := coreruntime.ReleaseEngine(eng); err != nil {
+			in.lifeMu.Unlock()
 			panic(invalidHostReference{err: fmt.Errorf("release host re-entry engine: %w", err)})
 		}
+		in.lifeMu.Unlock()
 	}, nil
 }

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -178,10 +178,14 @@ func (s *hostCallScope) begin(in *Instance) instanceHostModule {
 }
 
 func (s *hostCallScope) beginReserved(in *Instance, reservation *pluginOperationReservation) instanceHostModule {
+	return s.beginReservedWithID(in, in.currentInvocationID(), reservation)
+}
+
+func (s *hostCallScope) beginReservedWithID(in *Instance, id invocationID, reservation *pluginOperationReservation) instanceHostModule {
 	parent := s.active.Load()
 	generation := uint64(newInvocationID())
 	s.active.Store(generation)
-	return instanceHostModule{in: in, scope: s, generation: generation, parentGeneration: parent, invocationID: in.currentInvocationID(), reservation: reservation}
+	return instanceHostModule{in: in, scope: s, generation: generation, parentGeneration: parent, invocationID: id, reservation: reservation}
 }
 
 func (s *hostCallScope) end(generation, parent uint64) {
@@ -214,7 +218,11 @@ func (in *Instance) beginHostCallScope() instanceHostModule {
 }
 
 func (in *Instance) beginHostCallScopeReserved(reservation *pluginOperationReservation) instanceHostModule {
-	return in.ensurePluginState().hostScope.beginReserved(in, reservation)
+	return in.beginHostCallScopeReservedWithID(in.currentInvocationID(), reservation)
+}
+
+func (in *Instance) beginHostCallScopeReservedWithID(id invocationID, reservation *pluginOperationReservation) instanceHostModule {
+	return in.ensurePluginState().hostScope.beginReservedWithID(in, id, reservation)
 }
 
 func (in *Instance) currentInvocationID() invocationID {
@@ -609,7 +617,12 @@ func (h instanceHostModule) CollectGC() error {
 	if !h.valid() {
 		return fmt.Errorf("wago: GC host module is outside its active callback: %w", ErrPermissionDenied)
 	}
-	return h.in.CollectGC()
+	if h.in.ownsGCInvocation(h.invocationID) {
+		return h.in.collectGC()
+	}
+	lease := h.in.lockGCInvocation(h.invocationID)
+	defer lease.unlock()
+	return h.in.collectGC()
 }
 func (h instanceHostModule) NewExternRef(value any) (ExternRef, error) {
 	if !h.valid() {
@@ -777,7 +790,8 @@ func (in *Instance) newHostDispatch() runtime.HostCall {
 			panic(invalidHostReference{err: fmt.Errorf("host import %d: %w", importIdx, err)})
 		}
 		defer gcTemps.release(in)
-		caller := in.beginHostCallScope()
+		invocation := currentHostInvocationContext(ctrl, in)
+		caller := in.beginHostCallScopeReservedWithID(invocation.id, invocation.reservation)
 		defer caller.scope.end(caller.generation, caller.parentGeneration)
 		var mod HostModule = caller
 		fn(mod, args, results)

--- a/src/wago/import_attachments.go
+++ b/src/wago/import_attachments.go
@@ -260,7 +260,8 @@ func retainProducerRootsInImportedGlobalsMode(in *Instance, finalization bool) b
 }
 
 type tableImportAttachments struct {
-	set importDedup[*Table]
+	set   importDedup[*Table]
+	store *referenceStore
 }
 
 func (a *tableImportAttachments) attach(table *Table, elementType ValType, exact ValueTypeDescriptor, types []DefinedTypeDescriptor, store *referenceStore, collector *gc.Collector, addr64 bool) error {
@@ -273,13 +274,19 @@ func (a *tableImportAttachments) attach(table *Table, elementType ValType, exact
 	if err := table.attachImporterWithCollector(elementType, exact, types, store, collector, addr64); err != nil {
 		return err
 	}
+	if a.set.n == 0 {
+		a.store = store
+	} else if a.store != store {
+		return fmt.Errorf("table import attachments use inconsistent reference stores")
+	}
 	a.set.push(table)
 	return nil
 }
 
 func (a *tableImportAttachments) detachAll() {
-	a.set.each((*Table).detachImporter)
+	a.set.each(func(table *Table) { table.detachImporter(a.store) })
 	a.set.reset()
+	a.store = nil
 }
 
 func (c *Compiled) preflightImportBindings(imports Imports) error {
@@ -320,7 +327,7 @@ func detachImportedTables(in *Instance) {
 			continue
 		}
 		if seen.add(table) && !in.ownsTransferredTableAttachment(table) {
-			table.detachImporter()
+			table.detachImporter(in.refStore)
 		}
 	}
 }

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -79,6 +79,8 @@ func (in *Instance) closeOnce() error {
 	activeInvocations := previousInvocations & instanceInvocationCount
 	in.lifeMu.Lock()
 	if activeInvocations != 0 && len(in.trap) >= 4 {
+		// Host re-entry swaps the trap slice under lifeMu, so Close observes one
+		// complete active slice header before requesting interruption.
 		in.ensurePluginState().close.Load().interruptStop = runtime.RequestInterruptAsync(in.trap)
 	}
 	in.lifeMu.Unlock()
@@ -318,7 +320,7 @@ func (in *Instance) releaseResources() {
 			if table := in.existingGCRefTestTableState(); table != nil {
 				table.drop(in.gc)
 			}
-			if in.refStore == nil || !in.refStore.ownsGCCollector(in.gc) {
+			if in.executionFlags.Load()&executionFlagStoreOwnedGCCollector == 0 {
 				in.gc.Close()
 			}
 		}

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -28,6 +28,9 @@ var (
 const (
 	executionFlagIndependent uint32 = 1 << iota
 	executionFlagNativeControlShared
+	executionFlagImportedGCDomain
+	executionFlagDynamicGCDomain
+	executionFlagStoreOwnedGCCollector
 )
 
 type invocationID uint64
@@ -47,15 +50,15 @@ type nativeActivation struct {
 	id invocationID
 }
 
-func markNativeActive(in *Instance) {
-	activation := nativeActivation{in: in, id: in.currentInvocationID()}
+func markNativeActiveID(in *Instance, id invocationID) {
+	activation := nativeActivation{in: in, id: id}
 	nativeActiveMu.Lock()
 	nativeActive[activation]++
 	nativeActiveMu.Unlock()
 }
 
-func unmarkNativeActive(in *Instance) {
-	activation := nativeActivation{in: in, id: in.currentInvocationID()}
+func unmarkNativeActiveID(in *Instance, id invocationID) {
+	activation := nativeActivation{in: in, id: id}
 	nativeActiveMu.Lock()
 	if nativeActive[activation] <= 1 {
 		delete(nativeActive, activation)

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -197,7 +197,11 @@ func (b *instanceBuilder) prepareCollector() error {
 		gcConfig.Profile = gc.ProfileThroughput
 		gcConfig.DisableCollection = true
 	}
-	if b.opts.store != nil && !b.opts.store.private && b.c.usesGenericGCExecution() && b.c.sharedGCPersistentDomainSafe() {
+	// Atomic waits park while holding an instance-local native execution lease.
+	// Until their compiler callsites publish exact GC frame roots, keep GC+Threads
+	// modules in private collector domains so a same-memory notifier never waits
+	// behind the parked invocation's Runtime-wide collector lease.
+	if b.opts.store != nil && !b.opts.store.private && b.c.usesGenericGCExecution() && b.c.sharedGCPersistentDomainSafe() && !b.c.usesAtomicWaitHelpers() {
 		preferred, err := preferredGCCollectorFromImports(b.imports, b.opts.store)
 		if err != nil {
 			return err
@@ -224,6 +228,11 @@ func (b *instanceBuilder) prepareCollector() error {
 		var err error
 		mapping, descs, _, err = gcCanonicalTypePlan(b.c, nil, nil, true)
 		if err != nil {
+			return err
+		}
+	}
+	if b.opts.store != nil && !b.opts.store.private {
+		if err := b.opts.store.bindFuncrefGCStore(); err != nil {
 			return err
 		}
 	}
@@ -1313,7 +1322,12 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 	if opts.hasExecutionPolicy {
 		independentInstances = opts.independentInstances
 	}
-	if c.allowsIndependentInstanceExecution(imports, independentInstances) {
+	// Instances in one Runtime GC domain share a mutable collector. Keep their
+	// complete native activations under the process-wide execution lease: helper
+	// calls take the domain lock, but native allocation fast paths also mutate the
+	// collector and cannot safely overlap another tenant. Private collectors may
+	// retain instance-local execution.
+	if !b.collectorShared && c.allowsIndependentInstanceExecution(imports, independentInstances) {
 		in.executionFlags.Store(executionFlagIndependent)
 	}
 	b.registeredInstance = in
@@ -1480,12 +1494,29 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 				return nil, fmt.Errorf("start function index %d out of range", c.StartLocalFunc)
 			}
 			startEntry := base + uintptr(c.Entry[c.StartLocalFunc])
-			var startErr error
-			if in.syncMode {
-				startErr = in.callNativeSync(startEntry)
-			} else {
-				startErr = in.callNativeAsync(startEntry, false)
-			}
+			// A Runtime-owned local start executes after the instance joins its shared
+			// collector domain. Publish a normal invocation identity and hold the
+			// complete-call lease so start-time allocation cannot collect another
+			// tenant's native result before public tokenization. The instance gate is
+			// acquired first, matching Invoke and prepared-call lock ordering.
+			startErr := func() error {
+				state := in.ensurePluginState()
+				state.invokeMu.Lock()
+				id := newInvocationID()
+				state.invocationID = id
+				defer func() {
+					state.invocationID = 0
+					state.invokeMu.Unlock()
+				}()
+				gcLease := in.lockGCInvocation(id)
+				defer gcLease.unlock()
+				previousReservation := in.swapInvocationReservation(in.constructionReservationSnapshot())
+				defer in.swapInvocationReservation(previousReservation)
+				if in.syncMode {
+					return in.callNativeSync(startEntry)
+				}
+				return in.callNativeAsync(startEntry, false)
+			}()
 			if startErr != nil {
 				// Instantiation writes to imported tables are store side effects. If a
 				// local funcref remains installed when start traps, the shared table

--- a/src/wago/prepared_function.go
+++ b/src/wago/prepared_function.go
@@ -145,6 +145,25 @@ func (fn *PreparedFunction) Invoke(args ...uint64) ([]uint64, error) {
 	return fn.invokeGeneral(args)
 }
 
+type preparedInvocationLease struct {
+	state *instancePluginState
+	gc    gcInvocationLease
+}
+
+func (in *Instance) lockPreparedInvocation() preparedInvocationLease {
+	state := in.ensurePluginState()
+	state.invokeMu.Lock()
+	id := newInvocationID()
+	state.invocationID = id
+	return preparedInvocationLease{state: state, gc: in.lockGCInvocation(id)}
+}
+
+func (l preparedInvocationLease) unlock() {
+	l.gc.unlock()
+	l.state.invocationID = 0
+	l.state.invokeMu.Unlock()
+}
+
 func (fn *PreparedFunction) invokeGeneral(args []uint64) ([]uint64, error) {
 	if fn == nil || fn.in == nil {
 		return nil, fmt.Errorf("wago: invoke closed prepared function")
@@ -154,6 +173,12 @@ func (fn *PreparedFunction) invokeGeneral(args []uint64) ([]uint64, error) {
 		return nil, fmt.Errorf("wago: invoke prepared function: %w", err)
 	}
 	defer in.endInvocation()
+	// Prepared calls share the same instance buffers and Runtime GC domain as
+	// Invoke. Publish an invocation identity under the instance gate so host
+	// callbacks can suspend the domain lease, and retain that lease through public
+	// reference-result tokenization.
+	preparedLease := in.lockPreparedInvocation()
+	defer preparedLease.unlock()
 	if len(args) != fn.paramSlots {
 		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", fn.export, fn.paramSlots, len(args))
 	}
@@ -227,6 +252,8 @@ func (fn *PreparedFunction) invokeScalar(args []uint64) ([]uint64, error) {
 			return nil, fmt.Errorf("wago: invoke prepared function: %w", err)
 		}
 		defer in.endInvocation()
+		preparedLease := in.lockPreparedInvocation()
+		defer preparedLease.unlock()
 	}
 	put := func(slot int) {
 		bits := args[slot]

--- a/src/wago/reference_lifetime.go
+++ b/src/wago/reference_lifetime.go
@@ -170,7 +170,7 @@ func (in *Instance) transferImportedTableAttachment(table *Table) {
 	}
 	state.mu.Unlock()
 	if !exists {
-		table.detachImporter()
+		table.detachImporter(in.refStore)
 	}
 }
 

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -37,22 +37,48 @@ type referenceStore struct {
 	externKey     uint64
 	externSeed    uint32
 	externrefs    []externrefSlot
-	gcDomains     *gcStoreDomain
+	gcDomains     *gcDomainTopology
+}
+
+// gcDomainTopology keeps the globally ordered Runtime GC-domain list stable
+// across dynamic funcref invocations. It is a sidecar so scalar-only stores keep
+// the established referenceStore footprint. Host callbacks suspend the read
+// lease together with collector leases, allowing instantiation and teardown to
+// update the list before native resume.
+type gcDomainTopology struct {
+	sync.RWMutex
+	first *gcStoreDomain
+	last  *gcStoreDomain
+	n     int
+
+	funcrefMu       sync.Mutex
+	funcrefGCActive bool
+	funcrefTables   map[*Table]uint32
 }
 
 // gcStoreDomain gives Runtime-owned WasmGC instances one compact-reference
 // address space. Module-local type indexes are translated through canonical
 // recursive structural identities before they enter this collector.
 type gcStoreDomain struct {
-	mu        sync.Mutex
-	id        uint64
-	collector *gc.Collector
-	config    gc.Config
-	types     []gc.TypeDesc
-	typeReps  []gcDomainTypeRepresentative
-	refs      uint32
-	claims    uint32 // prepared instantiations not yet registered
-	next      *gcStoreDomain
+	mu sync.Mutex
+	// invocationMu covers the complete guest-call boundary, including compact
+	// reference result tokenization after native code returns. Native execution
+	// and helper locks alone leave a window where another tenant can collect an
+	// as-yet-unrooted result from this shared collector. Arbitrary host callbacks
+	// suspend this lease while exact parked roots remain published.
+	invocationMu    sync.Mutex
+	invocationState sync.Mutex
+	invocationOwner invocationID
+	id              uint64
+	collector       *gc.Collector
+	private         bool
+	config          gc.Config
+	types           []gc.TypeDesc
+	typeReps        []gcDomainTypeRepresentative
+	refs            uint32
+	claims          uint32 // prepared instantiations not yet registered
+	prev            *gcStoreDomain
+	next            *gcStoreDomain
 }
 
 var nextGCDomainIdentity atomic.Uint64
@@ -70,6 +96,259 @@ type referenceStoreInstance struct {
 	quiesced          bool
 	resourcesReleased bool
 	gcDomain          *gcStoreDomain
+	// invocationDomains is allocated only when direct/transitive function imports
+	// reach a GC domain other than this instance's own domain. The common local-GC
+	// case uses gcDomain directly and pays no sidecar allocation.
+	invocationDomains        *gcInvocationDomainSet
+	dynamicInvocationDomains bool
+}
+
+const inlineGCInvocationDomains = 4
+
+type gcInvocationDomainSet struct {
+	inline [inlineGCInvocationDomains]*gcStoreDomain
+	extra  []*gcStoreDomain
+	n      int
+}
+
+func (s *gcInvocationDomainSet) len() int {
+	if s == nil {
+		return 0
+	}
+	return s.n
+}
+
+func (s *gcInvocationDomainSet) at(i int) *gcStoreDomain {
+	if s == nil || i < 0 || i >= s.n {
+		return nil
+	}
+	if i < len(s.inline) {
+		return s.inline[i]
+	}
+	return s.extra[i-len(s.inline)]
+}
+
+func (s *gcInvocationDomainSet) set(i int, domain *gcStoreDomain) {
+	if i < len(s.inline) {
+		s.inline[i] = domain
+		return
+	}
+	s.extra[i-len(s.inline)] = domain
+}
+
+func (s *gcInvocationDomainSet) add(domain *gcStoreDomain) {
+	if domain == nil {
+		return
+	}
+	for i := 0; i < s.n; i++ {
+		if s.at(i) == domain {
+			return
+		}
+	}
+	if s.n < len(s.inline) {
+		s.inline[s.n] = domain
+	} else {
+		s.extra = append(s.extra, domain)
+	}
+	s.n++
+}
+
+func (s *gcInvocationDomainSet) sort() {
+	for i := 1; i < s.n; i++ {
+		domain := s.at(i)
+		j := i
+		for j > 0 && s.at(j-1).id > domain.id {
+			s.set(j, s.at(j-1))
+			j--
+		}
+		s.set(j, domain)
+	}
+}
+
+type gcInvocationDomainView struct {
+	local   *gcStoreDomain
+	set     *gcInvocationDomainSet
+	first   *gcStoreDomain
+	last    *gcStoreDomain
+	n       int
+	dynamic bool
+}
+
+type gcInvocationDomainIterator struct {
+	topology *gcStoreDomain
+	local    *gcStoreDomain
+	reverse  bool
+}
+
+func (v gcInvocationDomainView) iterator(reverse bool) gcInvocationDomainIterator {
+	it := gcInvocationDomainIterator{local: v.local, reverse: reverse}
+	if reverse {
+		it.topology = v.last
+	} else {
+		it.topology = v.first
+	}
+	return it
+}
+
+func (it *gcInvocationDomainIterator) next() *gcStoreDomain {
+	if it.local != nil && (it.topology == nil || (!it.reverse && it.local.id < it.topology.id) || (it.reverse && it.local.id > it.topology.id)) {
+		domain := it.local
+		it.local = nil
+		return domain
+	}
+	domain := it.topology
+	if domain == nil {
+		return nil
+	}
+	if it.reverse {
+		it.topology = domain.prev
+	} else {
+		it.topology = domain.next
+	}
+	return domain
+}
+
+func (v gcInvocationDomainView) len() int {
+	if v.dynamic {
+		if v.local != nil {
+			return v.n + 1
+		}
+		return v.n
+	}
+	if v.set != nil {
+		return v.set.len()
+	}
+	if v.local != nil {
+		return 1
+	}
+	return 0
+}
+
+func (v gcInvocationDomainView) at(i int) *gcStoreDomain {
+	if v.dynamic {
+		if i < 0 || i >= v.len() {
+			return nil
+		}
+		it := v.iterator(false)
+		var domain *gcStoreDomain
+		for ; i >= 0; i-- {
+			domain = it.next()
+		}
+		return domain
+	}
+	if v.set != nil {
+		return v.set.at(i)
+	}
+	if i == 0 {
+		return v.local
+	}
+	return nil
+}
+
+func (v gcInvocationDomainView) lock() {
+	if v.dynamic {
+		it := v.iterator(false)
+		for domain := it.next(); domain != nil; domain = it.next() {
+			domain.invocationMu.Lock()
+		}
+		return
+	}
+	for i := 0; i < v.len(); i++ {
+		v.at(i).invocationMu.Lock()
+	}
+}
+
+func (v gcInvocationDomainView) unlock() {
+	if v.dynamic {
+		it := v.iterator(true)
+		for domain := it.next(); domain != nil; domain = it.next() {
+			domain.invocationMu.Unlock()
+		}
+		return
+	}
+	for i := v.len() - 1; i >= 0; i-- {
+		v.at(i).invocationMu.Unlock()
+	}
+}
+
+func (v gcInvocationDomainView) ownedBy(owner invocationID) bool {
+	if owner == 0 {
+		return false
+	}
+	if v.dynamic {
+		it := v.iterator(false)
+		for domain := it.next(); domain != nil; domain = it.next() {
+			domain.invocationState.Lock()
+			owned := domain.invocationOwner == owner
+			domain.invocationState.Unlock()
+			if !owned {
+				return false
+			}
+		}
+		return true
+	}
+	for i := 0; i < v.len(); i++ {
+		domain := v.at(i)
+		domain.invocationState.Lock()
+		owned := domain.invocationOwner == owner
+		domain.invocationState.Unlock()
+		if !owned {
+			return false
+		}
+	}
+	return true
+}
+
+func (v gcInvocationDomainView) claim(owner invocationID) {
+	if v.dynamic {
+		it := v.iterator(false)
+		for domain := it.next(); domain != nil; domain = it.next() {
+			domain.invocationState.Lock()
+			if domain.invocationOwner != 0 {
+				domain.invocationState.Unlock()
+				panic("wago: occupied Runtime GC invocation lease")
+			}
+			domain.invocationOwner = owner
+			domain.invocationState.Unlock()
+		}
+		return
+	}
+	for i := 0; i < v.len(); i++ {
+		domain := v.at(i)
+		domain.invocationState.Lock()
+		if domain.invocationOwner != 0 {
+			domain.invocationState.Unlock()
+			panic("wago: occupied Runtime GC invocation lease")
+		}
+		domain.invocationOwner = owner
+		domain.invocationState.Unlock()
+	}
+}
+
+func (v gcInvocationDomainView) release(owner invocationID) {
+	if v.dynamic {
+		it := v.iterator(false)
+		for domain := it.next(); domain != nil; domain = it.next() {
+			domain.invocationState.Lock()
+			if domain.invocationOwner != owner {
+				domain.invocationState.Unlock()
+				panic("wago: invalid Runtime GC invocation lease")
+			}
+			domain.invocationOwner = 0
+			domain.invocationState.Unlock()
+		}
+		return
+	}
+	for i := 0; i < v.len(); i++ {
+		domain := v.at(i)
+		domain.invocationState.Lock()
+		if domain.invocationOwner != owner {
+			domain.invocationState.Unlock()
+			panic("wago: invalid Runtime GC invocation lease")
+		}
+		domain.invocationOwner = 0
+		domain.invocationState.Unlock()
+	}
 }
 
 type structuralTypeRegistration struct {
@@ -455,15 +734,61 @@ func newReferenceStore(private bool) *referenceStore {
 	return &referenceStore{private: private, runtimeClosed: private}
 }
 
+func (s *referenceStore) ensureGCTopology() *gcDomainTopology {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	if s.gcDomains == nil {
+		s.gcDomains = new(gcDomainTopology)
+	}
+	topology := s.gcDomains
+	s.mu.Unlock()
+	return topology
+}
+
+func (topology *gcDomainTopology) bindFuncrefTables(store *referenceStore) error {
+	for table := range topology.funcrefTables {
+		if table == nil || table.owner == nil {
+			continue
+		}
+		o := table.owner
+		o.mu.Lock()
+		foreign := o.hasForeignFuncrefStoreLocked(store)
+		bound := o.funcrefGCStore
+		if !foreign && (bound == nil || bound == store) {
+			o.funcrefGCStore = store
+		}
+		o.mu.Unlock()
+		if foreign || bound != nil && bound != store {
+			return fmt.Errorf("wago: Runtime GC domains cannot share a mutable funcref table across reference stores")
+		}
+	}
+	return nil
+}
+
+func (s *referenceStore) bindFuncrefGCStore() error {
+	topology := s.ensureGCTopology()
+	topology.funcrefMu.Lock()
+	defer topology.funcrefMu.Unlock()
+	if err := topology.bindFuncrefTables(s); err != nil {
+		return err
+	}
+	topology.funcrefGCActive = true
+	return nil
+}
+
 func (s *referenceStore) ownsGCCollector(collector *gc.Collector) bool {
 	if s == nil || collector == nil {
 		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for domain := s.gcDomains; domain != nil; domain = domain.next {
-		if domain.collector == collector {
-			return true
+	if topology := s.gcDomains; topology != nil {
+		for domain := topology.first; domain != nil; domain = domain.next {
+			if domain.collector == collector {
+				return true
+			}
 		}
 	}
 	return false
@@ -475,9 +800,11 @@ func (s *referenceStore) gcDomainIdentity(collector *gc.Collector) uint64 {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for domain := s.gcDomains; domain != nil; domain = domain.next {
-		if domain.collector == collector {
-			return domain.id
+	if topology := s.gcDomains; topology != nil {
+		for domain := topology.first; domain != nil; domain = domain.next {
+			if domain.collector == collector {
+				return domain.id
+			}
 		}
 	}
 	return 0
@@ -489,10 +816,12 @@ func (s *referenceStore) lockGCCollector(collector *gc.Collector) *gcStoreDomain
 	}
 	s.mu.Lock()
 	var found *gcStoreDomain
-	for domain := s.gcDomains; domain != nil; domain = domain.next {
-		if domain.collector == collector {
-			found = domain
-			break
+	if topology := s.gcDomains; topology != nil {
+		for domain := topology.first; domain != nil; domain = domain.next {
+			if domain.collector == collector {
+				found = domain
+				break
+			}
 		}
 	}
 	s.mu.Unlock()
@@ -512,6 +841,189 @@ func (in *Instance) lockGCCollector() *gcStoreDomain {
 func unlockGCCollector(domain *gcStoreDomain) {
 	if domain != nil {
 		domain.mu.Unlock()
+	}
+}
+
+type gcInvocationLease struct {
+	in       *Instance
+	topology *gcDomainTopology
+	domains  gcInvocationDomainView
+	owner    invocationID
+	acquired bool
+	dynamic  bool
+}
+
+func (in *Instance) gcInvocationDomainsForInspection() (gcInvocationDomainView, *gcDomainTopology) {
+	if in == nil || in.refStore == nil || in.executionFlags.Load()&executionFlagDynamicGCDomain == 0 {
+		return in.gcInvocationDomains(), nil
+	}
+	in.refStore.mu.Lock()
+	topology := in.refStore.gcDomains
+	in.refStore.mu.Unlock()
+	if topology != nil {
+		topology.RLock()
+	}
+	return in.gcInvocationDomains(), topology
+}
+
+func (in *Instance) reachesPrivateGCInvocationDomain() bool {
+	domains, topology := in.gcInvocationDomainsForInspection()
+	if topology != nil {
+		defer topology.RUnlock()
+	}
+	for i := 0; i < domains.len(); i++ {
+		if domains.at(i).private {
+			return true
+		}
+	}
+	return false
+}
+
+func (in *Instance) gcInvocationDomain() *gcStoreDomain {
+	if in == nil || in.refStore == nil || in.gc == nil {
+		return nil
+	}
+	in.refStore.mu.Lock()
+	entry := in.refStore.instances[in]
+	var domain *gcStoreDomain
+	if entry != nil {
+		domain = entry.gcDomain
+	}
+	in.refStore.mu.Unlock()
+	return domain
+}
+
+func (in *Instance) gcInvocationDomains() gcInvocationDomainView {
+	if in == nil || in.refStore == nil || in.gc == nil && in.executionFlags.Load()&executionFlagImportedGCDomain == 0 {
+		return gcInvocationDomainView{}
+	}
+	store := in.refStore
+	store.mu.Lock()
+	entry := store.instances[in]
+	var domains gcInvocationDomainView
+	if entry != nil {
+		if entry.dynamicInvocationDomains {
+			if entry.gcDomain != nil && entry.gcDomain.private {
+				domains.local = entry.gcDomain
+			}
+			if topology := store.gcDomains; topology != nil {
+				domains.first, domains.last, domains.n = topology.first, topology.last, topology.n
+			}
+			domains.dynamic = true
+		} else {
+			domains = gcInvocationDomainView{local: entry.gcDomain, set: entry.invocationDomains}
+		}
+	}
+	store.mu.Unlock()
+	return domains
+}
+
+func (in *Instance) lockGCInvocation(owner invocationID) gcInvocationLease {
+	if owner == 0 {
+		owner = newInvocationID()
+	}
+	dynamic := in != nil && in.refStore != nil && in.executionFlags.Load()&executionFlagDynamicGCDomain != 0
+	var topology *gcDomainTopology
+	if dynamic {
+		in.refStore.mu.Lock()
+		topology = in.refStore.gcDomains
+		in.refStore.mu.Unlock()
+		if topology == nil {
+			panic("wago: dynamic Runtime GC invocation has no topology")
+		}
+		topology.RLock()
+	}
+	domains := in.gcInvocationDomains()
+	if domains.len() == 0 {
+		if dynamic {
+			return gcInvocationLease{in: in, topology: topology, owner: owner, acquired: true, dynamic: true}
+		}
+		return gcInvocationLease{}
+	}
+	// A native cross-instance call reuses the public root's invocation identity.
+	// The root pre-acquires the transitive, globally ordered domain set, so a
+	// target reached through its retained imports borrows the already-held lease
+	// instead of recursively locking the same non-reentrant mutexes.
+	first := domains.at(0)
+	first.invocationState.Lock()
+	borrowed := first.invocationOwner == owner
+	first.invocationState.Unlock()
+	if borrowed {
+		if !domains.ownedBy(owner) {
+			panic("wago: partial Runtime GC invocation lease ownership")
+		}
+		if dynamic {
+			topology.RUnlock()
+		}
+		return gcInvocationLease{in: in, topology: topology, domains: domains, owner: owner}
+	}
+	domains.lock()
+	domains.claim(owner)
+	return gcInvocationLease{in: in, topology: topology, domains: domains, owner: owner, acquired: true, dynamic: dynamic}
+}
+
+func (l gcInvocationLease) unlock() {
+	if !l.acquired {
+		return
+	}
+	domains := l.domains
+	if l.dynamic {
+		domains = l.in.gcInvocationDomains()
+	}
+	domains.release(l.owner)
+	domains.unlock()
+	if l.dynamic {
+		l.topology.RUnlock()
+	}
+}
+
+func (in *Instance) ownsGCInvocation(owner invocationID) bool {
+	domain := in.gcInvocationDomain()
+	if domain == nil || owner == 0 {
+		return false
+	}
+	domain.invocationState.Lock()
+	owned := domain.invocationOwner == owner
+	domain.invocationState.Unlock()
+	return owned
+}
+
+func (in *Instance) suspendGCInvocation(owner invocationID) func() {
+	dynamic := in != nil && in.refStore != nil && in.executionFlags.Load()&executionFlagDynamicGCDomain != 0
+	var topology *gcDomainTopology
+	if dynamic {
+		in.refStore.mu.Lock()
+		topology = in.refStore.gcDomains
+		in.refStore.mu.Unlock()
+		if topology == nil {
+			panic("wago: dynamic Runtime GC invocation has no topology")
+		}
+	}
+	domains := in.gcInvocationDomains()
+	if owner == 0 || domains.len() == 0 && !dynamic {
+		return func() {}
+	}
+	if !domains.ownedBy(owner) {
+		if !domains.dynamic && domains.set == nil {
+			// Start-function and construction callbacks can run before a public
+			// invocation lease exists. Their native entry is already serialized, so
+			// there is no complete-call lease to suspend or restore.
+			return func() {}
+		}
+		panic("wago: partial Runtime GC invocation lease ownership")
+	}
+	domains.release(owner)
+	domains.unlock()
+	if dynamic {
+		topology.RUnlock()
+	}
+	return func() {
+		if dynamic {
+			topology.RLock()
+			domains = in.gcInvocationDomains()
+		}
+		domains.lock()
+		domains.claim(owner)
 	}
 }
 
@@ -602,8 +1114,15 @@ func (s *referenceStore) releaseUnclaimedGCCollector(collector *gc.Collector) {
 		return
 	}
 	s.mu.Lock()
-	var prev *gcStoreDomain
-	for domain := s.gcDomains; domain != nil; domain = domain.next {
+	topology := s.gcDomains
+	s.mu.Unlock()
+	if topology == nil {
+		return
+	}
+	topology.Lock()
+	defer topology.Unlock()
+	s.mu.Lock()
+	for domain := topology.first; domain != nil; domain = domain.next {
 		if domain.collector == collector {
 			if domain.claims > 0 {
 				domain.claims--
@@ -612,16 +1131,24 @@ func (s *referenceStore) releaseUnclaimedGCCollector(collector *gc.Collector) {
 				s.mu.Unlock()
 				return
 			}
-			if prev == nil {
-				s.gcDomains = domain.next
+			if domain.prev == nil {
+				topology.first = domain.next
 			} else {
-				prev.next = domain.next
+				domain.prev.next = domain.next
+			}
+			if domain.next == nil {
+				topology.last = domain.prev
+			} else {
+				domain.next.prev = domain.prev
+			}
+			domain.prev, domain.next = nil, nil
+			if topology.n > 0 {
+				topology.n--
 			}
 			s.mu.Unlock()
 			collector.Close()
 			return
 		}
-		prev = domain
 	}
 	s.mu.Unlock()
 }
@@ -640,6 +1167,17 @@ func (s *referenceStore) acquireGCCollector(config gc.Config, c *Compiled, prefe
 	if s == nil || s.private {
 		return nil, nil, fmt.Errorf("wago: shared WasmGC ownership requires an explicit Runtime")
 	}
+	topology := s.ensureGCTopology()
+	topology.Lock()
+	topologyLocked := true
+	defer func() {
+		if topologyLocked {
+			topology.Unlock()
+		}
+	}()
+	if err := s.bindFuncrefGCStore(); err != nil {
+		return nil, nil, err
+	}
 	s.mu.Lock()
 	if s.runtimeClosed {
 		s.mu.Unlock()
@@ -647,7 +1185,7 @@ func (s *referenceStore) acquireGCCollector(config gc.Config, c *Compiled, prefe
 	}
 	var selected *gcStoreDomain
 	if preferred != nil {
-		for domain := s.gcDomains; domain != nil; domain = domain.next {
+		for domain := topology.first; domain != nil; domain = domain.next {
 			if domain.collector == preferred {
 				selected = domain
 				break
@@ -666,7 +1204,7 @@ func (s *referenceStore) acquireGCCollector(config gc.Config, c *Compiled, prefe
 			return nil, nil, fmt.Errorf("wago: WasmGC telemetry recorder does not own the imported Runtime GC domain")
 		}
 	} else {
-		for domain := s.gcDomains; domain != nil; domain = domain.next {
+		for domain := topology.first; domain != nil; domain = domain.next {
 			if !gcModuleFitsDomain(c, domain) {
 				continue
 			}
@@ -693,8 +1231,14 @@ func (s *referenceStore) acquireGCCollector(config gc.Config, c *Compiled, prefe
 			s.mu.Unlock()
 			return nil, nil, err
 		}
-		selected = &gcStoreDomain{id: newGCDomainIdentity(), collector: collector, config: config, types: types, typeReps: reps, claims: 1, next: s.gcDomains}
-		s.gcDomains = selected
+		selected = &gcStoreDomain{id: newGCDomainIdentity(), collector: collector, config: config, types: types, typeReps: reps, claims: 1, prev: topology.last}
+		if topology.last == nil {
+			topology.first = selected
+		} else {
+			topology.last.next = selected
+		}
+		topology.last = selected
+		topology.n++
 		s.mu.Unlock()
 		return collector, mapping, nil
 	}
@@ -704,6 +1248,8 @@ func (s *referenceStore) acquireGCCollector(config gc.Config, c *Compiled, prefe
 	}
 	selected.claims++
 	s.mu.Unlock()
+	topology.Unlock()
+	topologyLocked = false
 
 	selected.mu.Lock()
 	mapping, types, reps, err := gcCanonicalTypePlan(c, selected.typeReps, selected.types, preferred != nil)
@@ -722,6 +1268,35 @@ func (s *referenceStore) acquireGCCollector(config gc.Config, c *Compiled, prefe
 }
 
 func (s *referenceStore) registerInstance(in *Instance) error {
+	var importedInvocationDomains gcInvocationDomainSet
+	dynamicInvocationDomains := !s.private && in != nil && compiledHasDynamicFuncrefReachability(in.c)
+	importsPrivateInvocationDomain := false
+	if in != nil && in.c != nil {
+		for _, key := range in.c.Imports {
+			export, ok := in.imports[key].(*InstanceExport)
+			if !ok || export == nil || export.inst == nil {
+				continue
+			}
+			if export.inst.executionFlags.Load()&executionFlagDynamicGCDomain != 0 {
+				if export.inst.refStore != s {
+					return fmt.Errorf("wago: dynamic funcref import %q requires the same Runtime", key)
+				}
+				dynamicInvocationDomains = true
+				continue
+			}
+			domains := export.inst.gcInvocationDomains()
+			for i := 0; i < domains.len(); i++ {
+				domain := domains.at(i)
+				if domain.private {
+					importsPrivateInvocationDomain = true
+				}
+				importedInvocationDomains.add(domain)
+			}
+		}
+	}
+	if dynamicInvocationDomains && importsPrivateInvocationDomain {
+		return fmt.Errorf("wago: dynamic funcref imports cannot reach a private GC invocation domain")
+	}
 	if in != nil && in.c != nil {
 		if err := in.c.prepareStructuralCallIdentities(); err != nil {
 			return fmt.Errorf("wago: prepare structural call identities: %w", err)
@@ -737,6 +1312,9 @@ func (s *referenceStore) registerInstance(in *Instance) error {
 	}
 	if s.instances == nil {
 		s.instances = make(map[*Instance]*referenceStoreInstance)
+	}
+	if dynamicInvocationDomains && s.gcDomains == nil {
+		s.gcDomains = new(gcDomainTopology)
 	}
 	if _, exists := s.instances[in]; exists {
 		return nil
@@ -791,8 +1369,11 @@ func (s *referenceStore) registerInstance(in *Instance) error {
 		s.typeKeys[key] = registered
 	}
 	var domain *gcStoreDomain
-	for candidate := s.gcDomains; candidate != nil; candidate = candidate.next {
-		if candidate.collector == in.gc {
+	if topology := s.gcDomains; topology != nil {
+		for candidate := topology.first; candidate != nil; candidate = candidate.next {
+			if candidate.collector != in.gc {
+				continue
+			}
 			domain = candidate
 			if domain.refs == ^uint32(0) {
 				return fmt.Errorf("wago: Runtime GC domain has too many instances")
@@ -805,10 +1386,88 @@ func (s *referenceStore) registerInstance(in *Instance) error {
 			break
 		}
 	}
+	if domain == nil && in.gc != nil {
+		// Private collectors still need complete-call ownership through public
+		// result tokenization. Keep their invocation domain out of the Runtime
+		// topology so ownership, root scanning, and collector lifetime remain local.
+		domain = &gcStoreDomain{id: newGCDomainIdentity(), collector: in.gc, private: true}
+	}
+	invocationDomains := importedInvocationDomains
+	invocationDomains.add(domain)
+	invocationDomains.sort()
+	var storedInvocationDomains *gcInvocationDomainSet
+	if !dynamicInvocationDomains && invocationDomains.len() != 0 && (invocationDomains.len() != 1 || invocationDomains.at(0) != domain) {
+		storedInvocationDomains = new(gcInvocationDomainSet)
+		*storedInvocationDomains = invocationDomains
+	}
+	flagsToAdd := uint32(0)
+	if domain != nil && !domain.private {
+		flagsToAdd |= executionFlagStoreOwnedGCCollector
+	}
+	if dynamicInvocationDomains || storedInvocationDomains != nil {
+		flagsToAdd |= executionFlagImportedGCDomain
+		if dynamicInvocationDomains {
+			flagsToAdd |= executionFlagDynamicGCDomain
+		}
+	}
+	for flagsToAdd != 0 {
+		flags := in.executionFlags.Load()
+		if flags&flagsToAdd == flagsToAdd || in.executionFlags.CompareAndSwap(flags, flags|flagsToAdd) {
+			break
+		}
+	}
 	s.instanceTypes[in] = keys
-	s.instances[in] = &referenceStoreInstance{gcDomain: domain}
+	s.instances[in] = &referenceStoreInstance{
+		gcDomain: domain, invocationDomains: storedInvocationDomains,
+		dynamicInvocationDomains: dynamicInvocationDomains,
+	}
 	s.liveInstances++
 	return nil
+}
+
+func compiledHasDynamicFuncrefReachability(c *Compiled) bool {
+	if c == nil {
+		return false
+	}
+	// A funcref table or global can acquire a cross-instance descriptor after
+	// instantiation. Conservatively lease every live Runtime GC domain for these
+	// container-bearing modules; ordinary ref.func and direct-import modules keep
+	// their compact statically discovered domain sets.
+	if c.hasFuncrefTable() {
+		return true
+	}
+	for i := range c.Globals {
+		if c.Globals[i].Type == ValFuncRef {
+			return true
+		}
+	}
+	if c.requiredFeatures.IsEnabled(CoreFeatureTypedFunctionReferences) {
+		for i := range c.importFuncSigs {
+			if funcSigHasFuncref(c.importFuncSigs[i]) {
+				return true
+			}
+		}
+		for i := range c.Funcs {
+			if funcSigHasFuncref(c.Funcs[i]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func funcSigHasFuncref(sig FuncSig) bool {
+	for _, typ := range sig.Params {
+		if typ == ValFuncRef {
+			return true
+		}
+	}
+	for _, typ := range sig.Results {
+		if typ == ValFuncRef {
+			return true
+		}
+	}
+	return false
 }
 
 func compiledFunctionSignature(c *Compiled, index int) (FuncSig, bool) {
@@ -834,25 +1493,59 @@ func (s *referenceStore) releaseGCDomainLocked(entry *referenceStoreInstance) *g
 	}
 	domain := entry.gcDomain
 	entry.gcDomain = nil
+	if domain.private {
+		return nil
+	}
 	if domain.refs > 0 {
 		domain.refs--
 	}
 	if domain.refs != 0 || domain.claims != 0 {
 		return nil
 	}
-	var prev *gcStoreDomain
-	for candidate := s.gcDomains; candidate != nil; candidate = candidate.next {
+	topology := s.gcDomains
+	if topology == nil {
+		return nil
+	}
+	for candidate := topology.first; candidate != nil; candidate = candidate.next {
 		if candidate == domain {
-			if prev == nil {
-				s.gcDomains = candidate.next
+			if candidate.prev == nil {
+				topology.first = candidate.next
 			} else {
-				prev.next = candidate.next
+				candidate.prev.next = candidate.next
+			}
+			if candidate.next == nil {
+				topology.last = candidate.prev
+			} else {
+				candidate.next.prev = candidate.prev
+			}
+			candidate.prev, candidate.next = nil, nil
+			if topology.n > 0 {
+				topology.n--
 			}
 			return domain.collector
 		}
-		prev = candidate
 	}
 	return nil
+}
+
+func (s *referenceStore) lockGCDomainTopology() *gcDomainTopology {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	topology := s.gcDomains
+	s.mu.Unlock()
+	if topology != nil {
+		topology.Lock()
+	}
+	return topology
+}
+
+func (s *referenceStore) lockGCDomainTopologyForInstance(in *Instance) *gcDomainTopology {
+	if in == nil || in.gc == nil {
+		return nil
+	}
+	return s.lockGCDomainTopology()
 }
 
 // abortRegisteredInstance terminates store membership for an instance whose
@@ -860,6 +1553,7 @@ func (s *referenceStore) releaseGCDomainLocked(entry *referenceStoreInstance) *g
 func (s *referenceStore) abortRegisteredInstance(in *Instance) {
 	var release referenceTokenEntries
 	var collector *gc.Collector
+	topology := s.lockGCDomainTopologyForInstance(in)
 	s.mu.Lock()
 	if entry := s.instances[in]; entry != nil {
 		if !entry.closeAccounted && s.liveInstances > 0 {
@@ -871,6 +1565,9 @@ func (s *referenceStore) abortRegisteredInstance(in *Instance) {
 	}
 	release = s.maybeReleaseEntriesLocked()
 	s.mu.Unlock()
+	if topology != nil {
+		topology.Unlock()
+	}
 	if collector != nil {
 		collector.Close()
 	}
@@ -880,6 +1577,7 @@ func (s *referenceStore) abortRegisteredInstance(in *Instance) {
 func (s *referenceStore) advanceInstanceLifetime(in *Instance, event referenceLifetimeEvent) {
 	var release referenceTokenEntries
 	var collector *gc.Collector
+	topology := s.lockGCDomainTopologyForInstance(in)
 	s.mu.Lock()
 	if entry := s.instances[in]; entry != nil {
 		switch event {
@@ -905,6 +1603,9 @@ func (s *referenceStore) advanceInstanceLifetime(in *Instance, event referenceLi
 	}
 	release = s.maybeReleaseEntriesLocked()
 	s.mu.Unlock()
+	if topology != nil {
+		topology.Unlock()
+	}
 	if collector != nil {
 		collector.Close()
 	}
@@ -992,21 +1693,29 @@ func (s *referenceStore) hostFuncRef(dispatch uint32) *HostFuncRef {
 
 func (s *referenceStore) storeObjectClosed() {
 	var release referenceTokenEntries
+	topology := s.lockGCDomainTopology()
 	s.mu.Lock()
 	if s.liveObjects > 0 {
 		s.liveObjects--
 	}
 	release = s.maybeReleaseEntriesLocked()
 	s.mu.Unlock()
+	if topology != nil {
+		topology.Unlock()
+	}
 	releaseReferenceEntries(release)
 }
 
 func (s *referenceStore) closeRuntime() {
 	var release referenceTokenEntries
+	topology := s.lockGCDomainTopology()
 	s.mu.Lock()
 	s.runtimeClosed = true
 	release = s.maybeReleaseEntriesLocked()
 	s.mu.Unlock()
+	if topology != nil {
+		topology.Unlock()
+	}
 	releaseReferenceEntries(release)
 }
 
@@ -1238,9 +1947,7 @@ func (s *referenceStore) releaseGCRef(source *Instance, token uint64) error {
 		return fmt.Errorf("GC reference token owner state is unavailable")
 	}
 	unlockNative := lockNativeExecutionForHostAccess()
-	defer unlockNative()
 	lockedDomain := source.lockGCCollector()
-	defer unlockGCCollector(lockedDomain)
 	state.mu.Lock()
 	s.mu.Lock()
 	entry, ok = s.gcByToken[token]
@@ -1248,16 +1955,22 @@ func (s *referenceStore) releaseGCRef(source *Instance, token uint64) error {
 	if !ok || entry.owner != source || state.resultTokenCount == 0 || ownerIndex >= state.resultRootsMade || state.resultTokens[ownerIndex] != token || state.resultRootSlots[ownerIndex] != entry.slot {
 		s.mu.Unlock()
 		state.mu.Unlock()
+		unlockGCCollector(lockedDomain)
+		unlockNative()
 		return fmt.Errorf("invalid or stale GC reference token")
 	}
 	if source.gc == nil {
 		s.mu.Unlock()
 		state.mu.Unlock()
+		unlockGCCollector(lockedDomain)
+		unlockNative()
 		return fmt.Errorf("GC reference token collector is unavailable")
 	}
 	if err := source.gc.SetGlobalSlot(entry.slot, gc.Null()); err != nil {
 		s.mu.Unlock()
 		state.mu.Unlock()
+		unlockGCCollector(lockedDomain)
+		unlockNative()
 		return fmt.Errorf("release GC reference token: %w", err)
 	}
 	delete(s.gcByToken, token)
@@ -1265,13 +1978,19 @@ func (s *referenceStore) releaseGCRef(source *Instance, token uint64) error {
 	state.resultTokenCount--
 	s.mu.Unlock()
 	state.mu.Unlock()
+	unlockGCCollector(lockedDomain)
+	unlockNative()
 	source.releaseResourceRoot()
 	var release referenceTokenEntries
+	topology := s.lockGCDomainTopology()
 	s.mu.Lock()
 	if s.runtimeClosed && s.liveInstances == 0 && s.liveObjects == 0 && len(s.gcByToken) == 0 {
 		release = s.releaseEntriesLocked()
 	}
 	s.mu.Unlock()
+	if topology != nil {
+		topology.Unlock()
+	}
 	releaseReferenceEntries(release)
 	return nil
 }
@@ -1780,10 +2499,17 @@ func (s *referenceStore) releaseEntriesLocked() referenceTokenEntries {
 	s.externrefs = nil
 	s.externKey = 0
 	s.externSeed = 0
-	for domain := s.gcDomains; domain != nil; domain = domain.next {
-		entries.collectors = append(entries.collectors, domain.collector)
+	if topology := s.gcDomains; topology != nil {
+		for domain := topology.first; domain != nil; domain = domain.next {
+			entries.collectors = append(entries.collectors, domain.collector)
+		}
+		topology.first = nil
+		topology.last = nil
+		topology.n = 0
+		topology.funcrefMu.Lock()
+		topology.funcrefTables = nil
+		topology.funcrefMu.Unlock()
 	}
-	s.gcDomains = nil
 	return entries
 }
 

--- a/src/wago/reference_store_invocation_test.go
+++ b/src/wago/reference_store_invocation_test.go
@@ -1,0 +1,264 @@
+package wago
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/src/core/runtime/gc"
+)
+
+func TestGCInvocationDomainUsesRegisteredAssociation(t *testing.T) {
+	collector := new(gc.Collector)
+	domain := &gcStoreDomain{collector: collector}
+	in := &Instance{gc: collector}
+	store := &referenceStore{
+		instances: map[*Instance]*referenceStoreInstance{
+			in: {gcDomain: domain},
+		},
+	}
+	in.refStore = store
+
+	if got := in.gcInvocationDomain(); got != domain {
+		t.Fatalf("invocation domain = %p, want registered domain %p", got, domain)
+	}
+	store.instances[in].gcDomain = nil
+	if got := in.gcInvocationDomain(); got != nil {
+		t.Fatalf("released invocation domain = %p, want nil", got)
+	}
+}
+
+func TestReferenceStoreInvocationDomainsIgnoreUnusedImportBindings(t *testing.T) {
+	collector := new(gc.Collector)
+	domain := &gcStoreDomain{id: 1, collector: collector}
+	producer := &Instance{c: &Compiled{}, gc: collector}
+	store := &referenceStore{
+		instances: map[*Instance]*referenceStoreInstance{
+			producer: {gcDomain: domain},
+		},
+		gcDomains: &gcDomainTopology{first: domain, last: domain, n: 1},
+	}
+	producer.refStore = store
+
+	consumer := &Instance{
+		c:       &Compiled{},
+		imports: Imports{"env.unused": &InstanceExport{inst: producer}},
+	}
+	if err := store.registerInstance(consumer); err != nil {
+		t.Fatal(err)
+	}
+	consumer.refStore = store
+	if got := consumer.gcInvocationDomains().len(); got != 0 {
+		t.Fatalf("unused import binding added %d GC invocation domain(s), want 0", got)
+	}
+}
+
+func TestDynamicFuncrefImportOfPrivateGCInvocationDomainRejected(t *testing.T) {
+	collector := new(gc.Collector)
+	domain := &gcStoreDomain{id: 1, collector: collector, private: true}
+	producer := &Instance{
+		c:  &Compiled{Entry: []int{0}, Funcs: []FuncSig{{Results: []ValType{ValI32}}}},
+		gc: collector,
+	}
+	store := &referenceStore{
+		instances: map[*Instance]*referenceStoreInstance{
+			producer: {gcDomain: domain},
+		},
+	}
+	producer.refStore = store
+	export := &InstanceExport{inst: producer, localIdx: 0, results: producer.c.Funcs[0].Results}
+	consumer := &Compiled{
+		Imports:        []string{"env.run"},
+		importFuncSigs: []FuncSig{{Results: []ValType{ValI32}}},
+		HasTable:       true,
+		TableType:      ValFuncRef,
+	}
+
+	err := consumer.validateImportBindings(Imports{"env.run": export}, store)
+	if err == nil || !strings.Contains(err.Error(), "dynamic funcref import") || !strings.Contains(err.Error(), "private GC invocation domain") {
+		t.Fatalf("dynamic private-domain import error = %v, want explicit rejection", err)
+	}
+}
+
+func TestDynamicFuncrefImportOfTransitivePrivateGCInvocationDomainRejected(t *testing.T) {
+	privateDomain := &gcStoreDomain{id: 1, collector: new(gc.Collector), private: true}
+	var domains gcInvocationDomainSet
+	domains.add(privateDomain)
+	relay := &Instance{c: &Compiled{Entry: []int{0}, Funcs: []FuncSig{{Results: []ValType{ValI32}}}}}
+	relay.executionFlags.Store(executionFlagImportedGCDomain)
+	store := &referenceStore{
+		instances: map[*Instance]*referenceStoreInstance{
+			relay: {invocationDomains: &domains},
+		},
+	}
+	relay.refStore = store
+	export := &InstanceExport{inst: relay, localIdx: 0, results: relay.c.Funcs[0].Results}
+	consumer := &Compiled{
+		Imports:        []string{"env.run"},
+		importFuncSigs: []FuncSig{{Results: []ValType{ValI32}}},
+		HasTable:       true,
+		TableType:      ValFuncRef,
+	}
+
+	err := consumer.validateImportBindings(Imports{"env.run": export}, store)
+	if err == nil || !strings.Contains(err.Error(), "dynamic funcref import") || !strings.Contains(err.Error(), "private GC invocation domain") {
+		t.Fatalf("dynamic transitive private-domain import error = %v, want explicit rejection", err)
+	}
+}
+
+func TestDynamicInvocationDomainsIncludePrivateLocalDomain(t *testing.T) {
+	first := &gcStoreDomain{id: 1, collector: new(gc.Collector)}
+	private := &gcStoreDomain{id: 2, collector: new(gc.Collector), private: true}
+	last := &gcStoreDomain{id: 3, collector: new(gc.Collector), prev: first}
+	first.next = last
+	in := &Instance{c: &Compiled{}, gc: private.collector}
+	in.executionFlags.Store(executionFlagDynamicGCDomain | executionFlagImportedGCDomain)
+	store := &referenceStore{
+		gcDomains: &gcDomainTopology{first: first, last: last, n: 2},
+		instances: map[*Instance]*referenceStoreInstance{
+			in: {gcDomain: private, dynamicInvocationDomains: true},
+		},
+	}
+	in.refStore = store
+
+	domains := in.gcInvocationDomains()
+	if got := domains.len(); got != 3 {
+		t.Fatalf("dynamic private invocation domains = %d, want 3", got)
+	}
+	for i, want := range []*gcStoreDomain{first, private, last} {
+		if got := domains.at(i); got != want {
+			t.Fatalf("dynamic private invocation domain %d = %p, want %p", i, got, want)
+		}
+	}
+	owner := newInvocationID()
+	lease := in.lockGCInvocation(owner)
+	for _, domain := range []*gcStoreDomain{first, private, last} {
+		domain.invocationState.Lock()
+		got := domain.invocationOwner
+		domain.invocationState.Unlock()
+		if got != owner {
+			lease.unlock()
+			t.Fatalf("dynamic private invocation owner = %d, want %d", got, owner)
+		}
+	}
+	lease.unlock()
+}
+
+func TestDynamicInvocationDomainInspectionHoldsTopologyReadLease(t *testing.T) {
+	domain := &gcStoreDomain{id: 1, collector: new(gc.Collector)}
+	in := &Instance{c: &Compiled{}, gc: domain.collector}
+	in.executionFlags.Store(executionFlagDynamicGCDomain | executionFlagImportedGCDomain)
+	topology := &gcDomainTopology{first: domain, last: domain, n: 1}
+	store := &referenceStore{
+		gcDomains: topology,
+		instances: map[*Instance]*referenceStoreInstance{
+			in: {gcDomain: domain, dynamicInvocationDomains: true},
+		},
+	}
+	in.refStore = store
+
+	domains, locked := in.gcInvocationDomainsForInspection()
+	if locked != topology || domains.len() != 1 || domains.at(0) != domain {
+		if locked != nil {
+			locked.RUnlock()
+		}
+		t.Fatalf("inspection view = %#v topology %p, want one domain and topology %p", domains, locked, topology)
+	}
+	writeStarted := make(chan struct{})
+	writeAcquired := make(chan struct{})
+	go func() {
+		close(writeStarted)
+		topology.Lock()
+		close(writeAcquired)
+		topology.Unlock()
+	}()
+	<-writeStarted
+	select {
+	case <-writeAcquired:
+		locked.RUnlock()
+		t.Fatal("topology writer bypassed dynamic inspection read lease")
+	default:
+	}
+	locked.RUnlock()
+	select {
+	case <-writeAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("topology writer did not resume after inspection read lease release")
+	}
+}
+
+func TestForeignRuntimeStaticGCProducerImportRejectedForDynamicConsumer(t *testing.T) {
+	producerStore := newReferenceStore(false)
+	collector := new(gc.Collector)
+	producer := &Instance{
+		c:        &Compiled{Entry: []int{0}, Funcs: []FuncSig{{Results: []ValType{ValI32}}}},
+		gc:       collector,
+		refStore: producerStore,
+	}
+	producerStore.instances = map[*Instance]*referenceStoreInstance{
+		producer: {gcDomain: &gcStoreDomain{id: 1, collector: collector}},
+	}
+	export := &InstanceExport{inst: producer, localIdx: 0, results: producer.c.Funcs[0].Results}
+	consumer := &Compiled{
+		Imports:        []string{"env.run"},
+		importFuncSigs: []FuncSig{{Results: []ValType{ValI32}}},
+		HasTable:       true,
+		TableType:      ValFuncRef,
+	}
+
+	err := consumer.validateImportBindings(Imports{"env.run": export}, newReferenceStore(false))
+	if err == nil || !strings.Contains(err.Error(), "GC-domain producer") || !strings.Contains(err.Error(), "same Runtime") {
+		t.Fatalf("foreign static GC producer import error = %v, want same-Runtime rejection", err)
+	}
+}
+
+func TestForeignRuntimeDynamicFuncrefProducerImportRejected(t *testing.T) {
+	producerStore := newReferenceStore(false)
+	producer := &Instance{
+		c:        &Compiled{Entry: []int{0}, Funcs: []FuncSig{{Results: []ValType{ValI32}}}},
+		refStore: producerStore,
+	}
+	producer.executionFlags.Store(executionFlagDynamicGCDomain)
+	export := &InstanceExport{inst: producer, localIdx: 0, results: producer.c.Funcs[0].Results}
+	consumer := &Compiled{
+		Imports:        []string{"env.run"},
+		importFuncSigs: []FuncSig{{Results: []ValType{ValI32}}},
+	}
+
+	err := consumer.validateImportBindings(Imports{"env.run": export}, newReferenceStore(false))
+	if err == nil || !strings.Contains(err.Error(), "dynamic funcref producer") || !strings.Contains(err.Error(), "same Runtime") {
+		t.Fatalf("foreign dynamic producer import error = %v, want same-Runtime rejection", err)
+	}
+}
+
+func BenchmarkGCInvocationDomainManyDomains(b *testing.B) {
+	const domainCount = 4096
+	collectors := make([]gc.Collector, domainCount)
+	domains := make([]gcStoreDomain, domainCount)
+	for i := range domains {
+		domains[i].collector = &collectors[i]
+		if i > 0 {
+			domains[i].prev = &domains[i-1]
+		}
+		if i+1 < len(domains) {
+			domains[i].next = &domains[i+1]
+		}
+	}
+	target := &domains[len(domains)-1]
+	in := &Instance{gc: target.collector}
+	store := &referenceStore{
+		gcDomains: &gcDomainTopology{first: &domains[0], last: target, n: len(domains)},
+		instances: map[*Instance]*referenceStoreInstance{
+			in: {gcDomain: target},
+		},
+	}
+	in.refStore = store
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if in.gcInvocationDomain() != target {
+			b.Fatal("invocation domain changed")
+		}
+	}
+}

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -114,6 +114,30 @@ func TestWindowsWABTInstallIsPinnedAndVerified(t *testing.T) {
 	}
 }
 
+func TestRuntimeConcurrencyHarnessRunsOnLinuxAMD64AndARM64(t *testing.T) {
+	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(workflow)
+	for _, required := range []string{
+		`runtime-concurrency:`,
+		`name: Runtime concurrency / ${{ matrix.name }}`,
+		`runner: ubuntu-24.04`,
+		`runner: ubuntu-24.04-arm`,
+		`WAGO_CONCURRENCY_SEED: 439000001,439000019,439000043,439000081`,
+		`run: make test-concurrency`,
+		`name: Race detector / Linux amd64`,
+		`timeout-minutes: 15`,
+		`go test -race -count=1 ./src/wago ./src/core/runtime ./tests/runtimeconcurrency`,
+		`needs: [changes, docs, lint, regression-corpus, runtime-concurrency, race`,
+	} {
+		if !strings.Contains(contents, required) {
+			t.Errorf("CI workflow is missing runtime-concurrency policy %q", required)
+		}
+	}
+}
+
 func TestDocsChangesRunDocumentationValidation(t *testing.T) {
 	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
 	if err != nil {

--- a/tests/runtimeconcurrency/harness_test.go
+++ b/tests/runtimeconcurrency/harness_test.go
@@ -1,0 +1,1388 @@
+//go:build !tinygo
+
+package runtimeconcurrency_test
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	goruntime "runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+
+	wago "github.com/wago-org/wago"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+const (
+	defaultHarnessRounds = 12
+	harnessTimeout       = 15 * time.Second
+)
+
+// TestRuntimeConcurrencyHarness is a black-box, seed-replayable concurrency
+// workload. It intentionally uses only public Wago APIs and guest-visible
+// memory/results as its oracles; scheduler controls and state probes stay in
+// this test package and never enter production builds.
+func TestRuntimeConcurrencyHarness(t *testing.T) {
+	if (goruntime.GOOS != "linux" && goruntime.GOOS != "darwin") || (goruntime.GOARCH != "amd64" && goruntime.GOARCH != "arm64") {
+		t.Skipf("runtime concurrency product is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	seeds := harnessSeeds(t)
+	rounds := harnessRounds(t)
+	for _, seed := range seeds {
+		seed := seed
+		t.Run(fmt.Sprintf("seed-%d", seed), func(t *testing.T) {
+			h := newHarness(t, seed, rounds)
+			t.Cleanup(h.reportFailure)
+			t.Run("threads-shared-memory-wait-close", h.testThreads)
+			t.Run("host-reentry-close", h.testHostReentry)
+			t.Run("gc-shared-domain-close", h.testGC)
+		})
+	}
+}
+
+func TestRuntimeConcurrencyGCAtomicWaitNotify(t *testing.T) {
+	if !completeCore3Host() {
+		t.Skipf("complete Core 3 GC execution is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV3 | wago.CoreFeatureThreads).WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	compiled, err := rt.Compile(harnessGCThreadsModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	memory, err := wago.NewSharedMemory(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcCfg := wago.GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	waiter, err := rt.Instantiate(context.Background(), compiled, wago.WithGC(gcCfg), wago.WithImports(wago.Imports{"env.memory": memory}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	notifier, err := rt.Instantiate(context.Background(), compiled, wago.WithGC(gcCfg), wago.WithImports(wago.Imports{"env.memory": memory}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	marker := (*uint32)(unsafe.Pointer(&memory.Bytes()[4]))
+	atomic.StoreUint32(marker, 0)
+	waitDone := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := waiter.Invoke("wait-marked")
+		waitDone <- invokeResult{values: out, err: callErr}
+	}()
+	waitForMarker(t, marker)
+	collectDone := make(chan error, 1)
+	go func() { collectDone <- waiter.CollectGC() }()
+	select {
+	case err := <-collectDone:
+		t.Fatalf("CollectGC completed while atomic.wait held the instance native lease: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	notifyDone := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := notifier.Invoke("notify", wago.I32(8), wago.I32(1))
+		notifyDone <- invokeResult{values: out, err: callErr}
+	}()
+	select {
+	case result := <-notifyDone:
+		if result.err != nil || len(result.values) != 1 || wago.AsI32(result.values[0]) != 1 {
+			t.Fatalf("GC-domain atomic.notify = %v, %v; want [1], nil", result.values, result.err)
+		}
+	case <-time.After(harnessTimeout):
+		// A waiter holding a shared collector lease prevents cleanup too, so keep
+		// this failure bounded instead of obscuring it behind Close.
+		t.Fatal("GC-domain atomic.notify deadlocked behind atomic.wait")
+	}
+	select {
+	case result := <-waitDone:
+		if result.err != nil || len(result.values) != 1 || wago.AsI32(result.values[0]) != 0 {
+			t.Fatalf("GC-domain atomic.wait = %v, %v; want [0], nil", result.values, result.err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("GC-domain atomic.wait did not resume")
+	}
+	select {
+	case err := <-collectDone:
+		if err != nil {
+			t.Fatalf("CollectGC after atomic.wait resume: %v", err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("CollectGC remained blocked after atomic.wait resumed")
+	}
+	for _, in := range []*wago.Instance{waiter, notifier} {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := memory.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := compiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeConcurrencyCrossInstanceHostCollectGC(t *testing.T) {
+	if !completeCore3Host() {
+		t.Skipf("complete Core 3 GC execution is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV3).WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	producerCode, err := rt.Compile(harnessGCHostProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumerCode, err := rt.Compile(harnessGCCrossInstanceConsumerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcCfg := wago.GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	var producer *wago.Instance
+	host := wago.HostFunc(func(module wago.HostModule, _ []uint64, _ []uint64) {
+		collector, ok := module.(wago.GCHostModule)
+		if !ok {
+			panic(wago.HostTrap{Err: fmt.Errorf("cross-instance host module has no collector")})
+		}
+		if err := collector.CollectGC(); err != nil {
+			panic(wago.HostTrap{Err: fmt.Errorf("cross-instance host collect: %w", err)})
+		}
+		nested, err := producer.InvokeFromHost(context.Background(), module, "nested")
+		if err != nil || len(nested) != 1 || wago.AsI32(nested[0]) != 7 {
+			panic(wago.HostTrap{Err: fmt.Errorf("cross-instance nested re-entry = %v, %v; want [7], nil", nested, err)})
+		}
+	})
+	producer, err = rt.Instantiate(context.Background(), producerCode, wago.WithGC(gcCfg), wago.WithImports(wago.Imports{"env.collect": host}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, err := producer.ExportedFunc("call")
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := rt.Instantiate(context.Background(), consumerCode, wago.WithGC(gcCfg), wago.WithImports(wago.Imports{"env.call": call}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := consumer.Invoke("run")
+		done <- invokeResult{values: out, err: callErr}
+	}()
+	select {
+	case result := <-done:
+		if result.err != nil || len(result.values) != 1 || wago.AsI32(result.values[0]) != 1 {
+			t.Fatalf("cross-instance host CollectGC = %v, %v; want [1], nil", result.values, result.err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("cross-instance host CollectGC deadlocked")
+	}
+	for _, in := range []*wago.Instance{consumer, producer} {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := consumerCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := producerCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeConcurrencySameDomainHostReentry(t *testing.T) {
+	if !completeCore3Host() {
+		t.Skipf("complete Core 3 GC execution is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV3).WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	gcCode, err := rt.Compile(harnessGCModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostCode, err := rt.Compile(harnessGCCallerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcCfg := wago.GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	first, err := rt.Instantiate(context.Background(), gcCode, wago.WithGC(gcCfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := rt.Instantiate(context.Background(), gcCode, wago.WithGC(gcCfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := first.Call(context.Background(), "new")
+	if err != nil || len(created) != 1 || created[0].GCRef().IsNull() {
+		t.Fatalf("new = %v, %v", created, err)
+	}
+	ref := created[0].GCRef()
+	read, err := target.Call(context.Background(), "read", wago.ValueGCRef(ref))
+	if err != nil || len(read) != 1 || read[0].I32() != 42 {
+		t.Fatalf("cross-instance read = %v, %v; instances did not share one collector domain", read, err)
+	}
+
+	var caller *wago.Instance
+	host := wago.HostFunc(func(callback wago.HostModule, _ []uint64, results []uint64) {
+		out, callErr := target.InvokeFromHost(context.Background(), callback, "read", wago.ValueGCRef(ref).Bits())
+		if callErr != nil || len(out) != 1 {
+			panic(wago.HostTrap{Err: fmt.Errorf("same-domain re-entry: %v, %w", out, callErr)})
+		}
+		results[0] = out[0]
+	})
+	caller, err = rt.Instantiate(context.Background(), hostCode, wago.WithGC(gcCfg), wago.WithImports(wago.Imports{"env.reenter": host}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := caller.Invoke("outer", wago.I32(77))
+		done <- invokeResult{values: out, err: callErr}
+	}()
+	select {
+	case result := <-done:
+		if result.err != nil || len(result.values) != 1 || wago.AsI32(result.values[0]) != 42 {
+			t.Fatalf("same-domain host re-entry = %v, %v", result.values, result.err)
+		}
+	case <-time.After(harnessTimeout):
+		// Deliberately skip cleanup on this failure path: closing a Runtime whose
+		// invocation is deadlocked would hide the bounded replay diagnostic.
+		t.Fatal("same-domain cross-instance host re-entry deadlocked")
+	}
+	prepared, err := caller.PrepareFunction("outer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		out, callErr := prepared.Invoke(wago.I32(78))
+		done <- invokeResult{values: out, err: callErr}
+	}()
+	select {
+	case result := <-done:
+		if result.err != nil || len(result.values) != 1 || wago.AsI32(result.values[0]) != 42 {
+			t.Fatalf("prepared same-domain host re-entry = %v, %v", result.values, result.err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("prepared same-domain cross-instance host re-entry deadlocked")
+	}
+	if err := first.ReleaseGCRef(ref); err != nil {
+		t.Fatal(err)
+	}
+	for _, in := range []*wago.Instance{caller, first, target} {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := hostCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gcCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeConcurrencySameDomainReexportedHostReentry(t *testing.T) {
+	if !completeCore3Host() {
+		t.Skipf("complete Core 3 GC execution is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV3).WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	gcCode, err := rt.Compile(harnessGCModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	reexportCode, err := rt.Compile(harnessGCReexportedHostModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcCfg := wago.GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	target, err := rt.Instantiate(context.Background(), gcCode, wago.WithGC(gcCfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var refBits uint64
+	host := wago.HostFunc(func(callback wago.HostModule, _ []uint64, results []uint64) {
+		out, callErr := target.InvokeFromHost(context.Background(), callback, "read", refBits)
+		if callErr != nil || len(out) != 1 {
+			panic(wago.HostTrap{Err: fmt.Errorf("same-domain re-exported host re-entry: %v, %w", out, callErr)})
+		}
+		results[0] = out[0]
+	})
+	reexport, err := rt.Instantiate(context.Background(), reexportCode, wago.WithGC(gcCfg), wago.WithImports(wago.Imports{"env.reenter": host}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := reexport.Call(context.Background(), "new")
+	if err != nil || len(created) != 1 || created[0].GCRef().IsNull() {
+		t.Fatalf("re-exporter new = %v, %v", created, err)
+	}
+	ref := created[0].GCRef()
+	refBits = wago.ValueGCRef(ref).Bits()
+	read, err := target.Call(context.Background(), "read", wago.ValueGCRef(ref))
+	if err != nil || len(read) != 1 || read[0].I32() != 42 {
+		t.Fatalf("cross-instance read = %v, %v; re-exporter did not join target collector domain", read, err)
+	}
+
+	done := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := reexport.Invoke("reenter", wago.I32(77))
+		done <- invokeResult{values: out, err: callErr}
+	}()
+	select {
+	case result := <-done:
+		if result.err != nil || len(result.values) != 1 || wago.AsI32(result.values[0]) != 42 {
+			t.Fatalf("same-domain re-exported host re-entry = %v, %v", result.values, result.err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("same-domain re-exported host re-entry deadlocked")
+	}
+	if err := reexport.ReleaseGCRef(ref); err != nil {
+		t.Fatal(err)
+	}
+	for _, in := range []*wago.Instance{reexport, target} {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := reexportCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gcCode.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeConcurrencyCollectGCWithInvoke(t *testing.T) {
+	if !completeCore3Host() {
+		t.Skipf("complete Core 3 GC execution is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV3).WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	compiled, err := rt.Compile(harnessGCPreparedModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcCfg := wago.GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	in, err := rt.Instantiate(context.Background(), compiled, wago.WithGC(gcCfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const iterations = 512
+	start := make(chan struct{})
+	invokeDone := make(chan error, 1)
+	collectDone := make(chan error, 1)
+	go func() {
+		<-start
+		for i := 0; i < iterations; i++ {
+			if _, callErr := in.Invoke("churn", wago.I32(int32(i))); callErr != nil {
+				invokeDone <- fmt.Errorf("invoke %d: %w", i, callErr)
+				return
+			}
+		}
+		invokeDone <- nil
+	}()
+	go func() {
+		<-start
+		for i := 0; i < iterations; i++ {
+			if collectErr := in.CollectGC(); collectErr != nil {
+				collectDone <- fmt.Errorf("collect %d: %w", i, collectErr)
+				return
+			}
+		}
+		collectDone <- nil
+	}()
+	close(start)
+	for name, done := range map[string]<-chan error{"invoke": invokeDone, "collect": collectDone} {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+		case <-time.After(harnessTimeout):
+			t.Fatalf("concurrent %s deadlocked", name)
+		}
+	}
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := compiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeConcurrencyPreparedGCResultOwnership(t *testing.T) {
+	if !completeCore3Host() {
+		t.Skipf("complete Core 3 GC execution is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV3).WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	compiled, err := rt.Compile(harnessGCPreparedModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcCfg := wago.GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	producer, err := rt.Instantiate(context.Background(), compiled, wago.WithGC(gcCfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	competitor, err := rt.Instantiate(context.Background(), compiled, wago.WithGC(gcCfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := producer.PrepareFunction("new")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const iterations = 512
+	start := make(chan struct{})
+	churnDone := make(chan error, 1)
+	go func() {
+		<-start
+		for i := 0; i < iterations*2; i++ {
+			if _, callErr := competitor.Invoke("churn", wago.I32(int32(i))); callErr != nil {
+				churnDone <- fmt.Errorf("churn %d: %w", i, callErr)
+				return
+			}
+		}
+		churnDone <- nil
+	}()
+	close(start)
+	for i := 0; i < iterations; i++ {
+		out, callErr := prepared.Invoke()
+		if callErr != nil || len(out) != 1 || out[0] == 0 {
+			t.Fatalf("prepared new %d = %v, %v", i, out, callErr)
+		}
+		ref := wago.ValueOf(wago.ValAnyRef, out[0]).GCRef()
+		read, readErr := producer.Call(context.Background(), "read", wago.ValueGCRef(ref))
+		if readErr != nil || len(read) != 1 || read[0].I32() != 42 {
+			t.Fatalf("prepared result %d read = %v, %v", i, read, readErr)
+		}
+		if err := producer.ReleaseGCRef(ref); err != nil {
+			t.Fatalf("release prepared result %d: %v", i, err)
+		}
+	}
+	select {
+	case err := <-churnDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("prepared GC result competitor deadlocked")
+	}
+	for _, in := range []*wago.Instance{producer, competitor} {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := compiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeConcurrencyParkedSameDomainTargetDoesNotDeadlock(t *testing.T) {
+	if !completeCore3Host() {
+		t.Skipf("complete Core 3 GC execution is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV3).WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	compiled, err := rt.Compile(harnessGCCallerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcCfg := wago.GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	parked := make(chan struct{})
+	release := make(chan struct{})
+	secondEntered := make(chan struct{})
+	var first *wago.Instance
+	host := wago.HostFunc(func(callback wago.HostModule, params, results []uint64) {
+		switch id := wago.AsI32(params[0]); id {
+		case 1:
+			close(parked)
+			<-release
+			results[0] = params[0]
+		case 2:
+			close(secondEntered)
+			out, callErr := first.InvokeFromHost(context.Background(), callback, "inner", wago.I32(42))
+			if callErr != nil || len(out) != 1 {
+				panic(wago.HostTrap{Err: fmt.Errorf("parked same-domain target re-entry: %v, %w", out, callErr)})
+			}
+			results[0] = out[0]
+		default:
+			panic(wago.HostTrap{Err: fmt.Errorf("unexpected host callback id %d", id)})
+		}
+	})
+	first, err = rt.Instantiate(context.Background(), compiled, wago.WithGC(gcCfg), wago.WithImports(wago.Imports{"env.reenter": host}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := rt.Instantiate(context.Background(), compiled, wago.WithGC(gcCfg), wago.WithImports(wago.Imports{"env.reenter": host}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, callErr := first.Invoke("outer", wago.I32(1))
+		// Invoke results are instance-backed and may be overwritten by the queued
+		// re-entry as soon as this call releases the instance gate. Only the error
+		// is an observable invariant for the parked call.
+		firstDone <- callErr
+	}()
+	select {
+	case <-parked:
+	case <-time.After(harnessTimeout):
+		t.Fatal("first same-domain callback did not park")
+	}
+	secondDone := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := second.Invoke("outer", wago.I32(2))
+		secondDone <- invokeResult{values: append([]uint64(nil), out...), err: callErr}
+	}()
+	select {
+	case <-secondEntered:
+	case <-time.After(harnessTimeout):
+		t.Fatal("second same-domain callback did not attempt target re-entry")
+	}
+	close(release)
+	select {
+	case callErr := <-firstDone:
+		if callErr != nil {
+			t.Fatalf("first same-domain invocation: %v", callErr)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("first same-domain invocation deadlocked")
+	}
+	select {
+	case result := <-secondDone:
+		if result.err != nil || len(result.values) != 1 || wago.AsI32(result.values[0]) != 42 {
+			t.Fatalf("second same-domain invocation = %v, %v; want 42", result.values, result.err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("second same-domain invocation deadlocked")
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := compiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type concurrencyHarness struct {
+	t      *testing.T
+	seed   int64
+	rounds int
+	rng    *rand.Rand
+
+	traceMu sync.Mutex
+	trace   []string
+}
+
+func newHarness(t *testing.T, seed int64, rounds int) *concurrencyHarness {
+	t.Helper()
+	h := &concurrencyHarness{t: t, seed: seed, rounds: rounds, rng: rand.New(rand.NewSource(seed))}
+	h.record("start goos=%s goarch=%s rounds=%d", goruntime.GOOS, goruntime.GOARCH, rounds)
+	return h
+}
+
+func (h *concurrencyHarness) reportFailure() {
+	if !h.t.Failed() {
+		return
+	}
+	h.t.Logf("reproduce with: WAGO_CONCURRENCY_SEED=%d WAGO_CONCURRENCY_ROUNDS=%d go test -count=1 -run '^TestRuntimeConcurrencyHarness/seed-%d$' ./tests/runtimeconcurrency", h.seed, h.rounds, h.seed)
+	h.traceMu.Lock()
+	defer h.traceMu.Unlock()
+	start := 0
+	if len(h.trace) > 128 {
+		start = len(h.trace) - 128
+	}
+	h.t.Log("bounded concurrency trace:")
+	for _, event := range h.trace[start:] {
+		h.t.Log(event)
+	}
+}
+
+func (h *concurrencyHarness) record(format string, args ...any) {
+	h.traceMu.Lock()
+	if len(h.trace) < 1024 {
+		h.trace = append(h.trace, fmt.Sprintf(format, args...))
+	}
+	h.traceMu.Unlock()
+}
+
+func (h *concurrencyHarness) deadlineContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), harnessTimeout)
+}
+
+func (h *concurrencyHarness) testThreads(t *testing.T) {
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV2 | wago.CoreFeatureThreads).WithBoundsChecks(wago.BoundsChecksExplicit)
+	compiled, err := wago.Compile(cfg, harnessThreadsModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	memory, err := wago.NewSharedMemory(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer memory.Close()
+
+	workers := 3 + h.rng.Intn(3)
+	instances := make([]*wago.Instance, workers)
+	for i := range instances {
+		instances[i], err = wago.Instantiate(compiled, wago.Imports{"env.memory": memory})
+		if err != nil {
+			t.Fatalf("instantiate worker %d: %v", i, err)
+		}
+	}
+	defer func() {
+		for _, in := range instances {
+			if in != nil {
+				_ = in.Close()
+			}
+		}
+	}()
+
+	if err := memory.Close(); err == nil {
+		t.Fatal("shared memory closed with live importers")
+	}
+
+	plans := make([][]int32, workers)
+	var want uint32
+	for worker := range workers {
+		plans[worker] = make([]int32, h.rounds)
+		for round := range h.rounds {
+			delta := int32(1 + h.rng.Intn(5))
+			plans[worker][round] = delta
+			want += uint32(delta)
+		}
+	}
+	h.record("threads workers=%d atomic-total=%d", workers, want)
+
+	start := make(chan struct{})
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker, in := range instances {
+		worker, in := worker, in
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for round, delta := range plans[worker] {
+				out, callErr := in.Invoke("add", wago.I32(delta))
+				if callErr != nil || len(out) != 1 {
+					errCh <- fmt.Errorf("worker %d round %d add(%d) = %v, %v", worker, round, delta, out, callErr)
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	waitForWorkers(t, &wg, "thread atomic-add")
+	close(errCh)
+	for callErr := range errCh {
+		t.Error(callErr)
+	}
+	if t.Failed() {
+		return
+	}
+	if got := binary.LittleEndian.Uint32(memory.Bytes()[:4]); got != want {
+		t.Fatalf("shared atomic total = %d, want %d", got, want)
+	}
+
+	marker := (*uint32)(unsafe.Pointer(&memory.Bytes()[4]))
+	atomic.StoreUint32(marker, 0)
+	ctx, cancel := h.deadlineContext()
+	defer cancel()
+	waitDone := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := instances[0].InvokeContext(ctx, "wait-marked")
+		waitDone <- invokeResult{values: out, err: callErr}
+	}()
+	waitForMarker(t, marker)
+	for {
+		out, callErr := instances[1].Invoke("notify", wago.I32(8), wago.I32(1))
+		if callErr != nil || len(out) != 1 {
+			t.Fatalf("notify = %v, %v", out, callErr)
+		}
+		if wago.AsI32(out[0]) == 1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("waiter never became observable to atomic.notify")
+		default:
+			goruntime.Gosched()
+		}
+	}
+	select {
+	case result := <-waitDone:
+		if result.err != nil || len(result.values) != 1 || wago.AsI32(result.values[0]) != 0 {
+			t.Fatalf("notified wait = %v, %v; want [0], nil", result.values, result.err)
+		}
+	case <-ctx.Done():
+		t.Fatal("notified waiter did not resume")
+	}
+
+	atomic.StoreUint32(marker, 0)
+	closeWaitDone := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := instances[0].Invoke("wait-marked")
+		closeWaitDone <- invokeResult{values: out, err: callErr}
+	}()
+	waitForMarker(t, marker)
+	if err := instances[0].Close(); err != nil {
+		t.Fatalf("close waiting instance: %v", err)
+	}
+	select {
+	case result := <-closeWaitDone:
+		var trap *wago.TrapError
+		if !errors.As(result.err, &trap) || trap.Code != wago.TrapInterrupted {
+			t.Fatalf("close-interrupted wait = %v, %v", result.values, result.err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("close did not release waiting invocation")
+	}
+	if _, err := instances[0].Invoke("add", wago.I32(1)); err == nil {
+		t.Fatal("closed threaded instance accepted another invocation")
+	}
+	instances[0] = nil
+
+	if err := memory.Close(); err == nil {
+		t.Fatal("shared memory closed while other importers remained live")
+	}
+	order := h.rng.Perm(workers - 1)
+	for _, index := range order {
+		actual := index + 1
+		if err := instances[actual].Close(); err != nil {
+			t.Fatalf("close worker %d: %v", actual, err)
+		}
+		instances[actual] = nil
+	}
+	if err := memory.Close(); err != nil {
+		t.Fatalf("close shared memory after consumers: %v", err)
+	}
+	if memory.Bytes() != nil {
+		t.Fatal("closed shared memory retained a host-visible byte view")
+	}
+	h.record("threads complete close-order=%v", order)
+}
+
+func (h *concurrencyHarness) testHostReentry(t *testing.T) {
+	compiled, err := wago.Compile(nil, harnessHostReentryModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+
+	workers := 2 + h.rng.Intn(3)
+	instances := make([]*wago.Instance, workers)
+	var hostCalls atomic.Uint64
+	for worker := range workers {
+		var in *wago.Instance
+		host := wago.HostFunc(func(caller wago.HostModule, params, results []uint64) {
+			hostCalls.Add(1)
+			goruntime.GC()
+			out, callErr := in.InvokeFromHost(context.Background(), caller, "inner", params[0])
+			if callErr != nil || len(out) != 1 {
+				panic(wago.HostTrap{Err: fmt.Errorf("nested inner: %v, %w", out, callErr)})
+			}
+			results[0] = out[0]
+		})
+		in, err = wago.Instantiate(compiled, wago.InstantiateOptions{Imports: wago.Imports{"env.reenter": host}})
+		if err != nil {
+			t.Fatalf("instantiate reentry worker %d: %v", worker, err)
+		}
+		instances[worker] = in
+	}
+	defer func() {
+		for _, in := range instances {
+			if in != nil {
+				_ = in.Close()
+			}
+		}
+	}()
+
+	plans := make([][]int32, workers)
+	for worker := range workers {
+		plans[worker] = make([]int32, h.rounds)
+		for round := range h.rounds {
+			plans[worker][round] = int32(h.rng.Intn(10_000))
+		}
+	}
+	start := make(chan struct{})
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker, in := range instances {
+		worker, in := worker, in
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for round, input := range plans[worker] {
+				out, callErr := in.Invoke("outer", wago.I32(input))
+				if callErr != nil || len(out) != 1 || wago.AsI32(out[0]) != input+3 {
+					errCh <- fmt.Errorf("worker %d round %d outer(%d) = %v, %v", worker, round, input, out, callErr)
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	waitForWorkers(t, &wg, "host re-entry")
+	close(errCh)
+	for callErr := range errCh {
+		t.Error(callErr)
+	}
+	if t.Failed() {
+		return
+	}
+	if want := uint64(workers * h.rounds); hostCalls.Load() != want {
+		t.Fatalf("host callback count = %d, want %d", hostCalls.Load(), want)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	nested := make(chan error, 1)
+	var parked *wago.Instance
+	parkedHost := wago.HostFunc(func(caller wago.HostModule, params, results []uint64) {
+		close(entered)
+		<-release
+		out, callErr := parked.InvokeFromHost(context.Background(), caller, "inner", params[0])
+		if callErr == nil {
+			if len(out) != 1 {
+				callErr = fmt.Errorf("inner returned %v", out)
+			} else {
+				results[0] = out[0]
+			}
+		}
+		nested <- callErr
+	})
+	parked, err = wago.Instantiate(compiled, wago.InstantiateOptions{Imports: wago.Imports{"env.reenter": parkedHost}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	invokeDone := make(chan invokeResult, 1)
+	go func() {
+		out, callErr := parked.Invoke("outer", wago.I32(9))
+		invokeDone <- invokeResult{values: out, err: callErr}
+	}()
+	select {
+	case <-entered:
+	case <-time.After(harnessTimeout):
+		t.Fatal("host callback did not park")
+	}
+	closeStarted := make(chan struct{})
+	closeDone := make(chan error, 1)
+	go func() {
+		close(closeStarted)
+		closeDone <- parked.Close()
+	}()
+	<-closeStarted
+	goruntime.Gosched()
+	close(release)
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("concurrent parked close: %v", err)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("concurrent parked close timed out")
+	}
+	select {
+	case result := <-invokeDone:
+		if result.err == nil && (len(result.values) != 1 || wago.AsI32(result.values[0]) != 12) {
+			t.Fatalf("parked invocation completed with corrupt result %v", result.values)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("parked invocation did not unwind")
+	}
+	select {
+	case nestedErr := <-nested:
+		if nestedErr == nil {
+			h.record("host close allowed already-authorized nested reentry to finish")
+		} else {
+			h.record("host close rejected nested reentry: %v", nestedErr)
+		}
+	case <-time.After(harnessTimeout):
+		t.Fatal("parked host callback did not finish")
+	}
+	if _, err := parked.Invoke("outer", wago.I32(1)); err == nil {
+		t.Fatal("closed host-reentry instance accepted another invocation")
+	}
+	h.record("host reentry workers=%d callbacks=%d", workers, hostCalls.Load())
+}
+
+func (h *concurrencyHarness) testGC(t *testing.T) {
+	if !completeCore3Host() {
+		t.Skipf("complete Core 3 GC execution is unavailable on %s/%s", goruntime.GOOS, goruntime.GOARCH)
+	}
+	cfg := wago.NewRuntimeConfig().WithCoreFeatures(wago.CoreFeaturesV3).WithBoundsChecks(wago.BoundsChecksExplicit)
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(cfg))
+	defer rt.Close()
+	compiled, err := rt.Compile(harnessGCModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+
+	workers := 2 + h.rng.Intn(3)
+	instances := make([]*wago.Instance, workers)
+	gcCfg := wago.GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}
+	for worker := range workers {
+		instances[worker], err = rt.Instantiate(context.Background(), compiled, wago.WithGC(gcCfg))
+		if err != nil {
+			t.Fatalf("instantiate GC worker %d: %v", worker, err)
+		}
+	}
+	defer func() {
+		for _, in := range instances {
+			if in != nil {
+				_ = in.Close()
+			}
+		}
+	}()
+
+	held := make([]wago.GCRef, workers)
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker, in := range instances {
+		worker, in := worker, in
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			values, callErr := in.Call(context.Background(), "new")
+			if callErr != nil || len(values) != 1 || values[0].GCRef().IsNull() {
+				errCh <- fmt.Errorf("worker %d create held GC object = %v, %v", worker, values, callErr)
+				return
+			}
+			held[worker] = values[0].GCRef()
+		}()
+	}
+	waitForWorkers(t, &wg, "GC retained-object creation")
+	close(errCh)
+	for callErr := range errCh {
+		t.Error(callErr)
+	}
+	if t.Failed() {
+		return
+	}
+
+	churn := make([]int, workers)
+	for worker := range workers {
+		churn[worker] = h.rounds * (1 + h.rng.Intn(3))
+	}
+	errCh = make(chan error, workers)
+	for worker, in := range instances {
+		worker, in := worker, in
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for iteration := 0; iteration < churn[worker]; iteration++ {
+				values, callErr := in.Call(context.Background(), "new")
+				if callErr != nil || len(values) != 1 || values[0].GCRef().IsNull() {
+					errCh <- fmt.Errorf("worker %d churn %d create = %v, %v", worker, iteration, values, callErr)
+					return
+				}
+				if releaseErr := in.ReleaseGCRef(values[0].GCRef()); releaseErr != nil {
+					errCh <- fmt.Errorf("worker %d churn %d release: %w", worker, iteration, releaseErr)
+					return
+				}
+			}
+		}()
+	}
+	waitForWorkers(t, &wg, "GC allocation churn")
+	close(errCh)
+	for callErr := range errCh {
+		t.Error(callErr)
+	}
+	if t.Failed() {
+		return
+	}
+
+	errCh = make(chan error, workers)
+	for worker, in := range instances {
+		worker, in := worker, in
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			values, callErr := in.Call(context.Background(), "read", wago.ValueGCRef(held[worker]))
+			if callErr != nil || len(values) != 1 || values[0].I32() != 42 {
+				errCh <- fmt.Errorf("worker %d read held GC object = %v, %v", worker, values, callErr)
+			}
+		}()
+	}
+	waitForWorkers(t, &wg, "GC retained-object reads")
+	close(errCh)
+	for callErr := range errCh {
+		t.Error(callErr)
+	}
+	if t.Failed() {
+		return
+	}
+
+	order := h.rng.Perm(workers)
+	errCh = make(chan error, workers)
+	for _, worker := range order {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if closeErr := instances[worker].Close(); closeErr != nil {
+				errCh <- fmt.Errorf("close GC worker %d: %w", worker, closeErr)
+			}
+		}()
+	}
+	waitForWorkers(t, &wg, "GC instance close")
+	close(errCh)
+	for closeErr := range errCh {
+		t.Error(closeErr)
+	}
+	if t.Failed() {
+		return
+	}
+
+	errCh = make(chan error, workers)
+	for worker, in := range instances {
+		worker, in := worker, in
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if releaseErr := in.ReleaseGCRef(held[worker]); releaseErr != nil {
+				errCh <- fmt.Errorf("release worker %d token after close: %w", worker, releaseErr)
+			}
+		}()
+	}
+	waitForWorkers(t, &wg, "GC token release")
+	close(errCh)
+	for releaseErr := range errCh {
+		t.Error(releaseErr)
+	}
+	if t.Failed() {
+		return
+	}
+	for i := range instances {
+		instances[i] = nil
+	}
+	h.record("gc workers=%d churn=%v close-order=%v", workers, churn, order)
+}
+
+type invokeResult struct {
+	values []uint64
+	err    error
+}
+
+func waitForWorkers(t *testing.T, wg *sync.WaitGroup, phase string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(harnessTimeout):
+		t.Fatalf("%s workers did not complete within %s", phase, harnessTimeout)
+	}
+}
+
+func waitForMarker(t *testing.T, marker *uint32) {
+	t.Helper()
+	deadline := time.Now().Add(harnessTimeout)
+	for atomic.LoadUint32(marker) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("guest did not publish its wait marker")
+		}
+		goruntime.Gosched()
+	}
+}
+
+func harnessSeeds(t *testing.T) []int64 {
+	t.Helper()
+	if path := os.Getenv("WAGO_CONCURRENCY_SEED_FILE"); path != "" {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read WAGO_CONCURRENCY_SEED_FILE: %v", err)
+		}
+		return parseSeeds(t, string(contents))
+	}
+	if raw := os.Getenv("WAGO_CONCURRENCY_SEED"); raw != "" {
+		return parseSeeds(t, raw)
+	}
+	return []int64{439_000_001, 439_000_019}
+}
+
+func parseSeeds(t *testing.T, raw string) []int64 {
+	t.Helper()
+	fields := strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == '\n' || r == '\r' || r == ' ' || r == '\t' })
+	seeds := make([]int64, 0, len(fields))
+	for _, field := range fields {
+		if strings.HasPrefix(field, "#") {
+			continue
+		}
+		seed, err := strconv.ParseInt(field, 0, 64)
+		if err != nil {
+			t.Fatalf("parse concurrency seed %q: %v", field, err)
+		}
+		seeds = append(seeds, seed)
+	}
+	if len(seeds) == 0 {
+		t.Fatal("concurrency seed input is empty")
+	}
+	return seeds
+}
+
+func harnessRounds(t *testing.T) int {
+	t.Helper()
+	rounds := defaultHarnessRounds
+	if testing.Short() {
+		rounds = 4
+	}
+	if raw := os.Getenv("WAGO_CONCURRENCY_ROUNDS"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 || parsed > 1_000 {
+			t.Fatalf("WAGO_CONCURRENCY_ROUNDS=%q must be an integer in [1,1000]", raw)
+		}
+		rounds = parsed
+	}
+	return rounds
+}
+
+func completeCore3Host() bool {
+	return (goruntime.GOOS == "linux" && (goruntime.GOARCH == "amd64" || goruntime.GOARCH == "arm64")) || (goruntime.GOOS == "darwin" && goruntime.GOARCH == "arm64")
+}
+
+func harnessGCHostProducerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	voidSig := wasmtest.FuncType(nil, nil)
+	i32Sig := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("collect")...)
+	importEntry = append(importEntry, byte(wasm.ExternFunc), 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, voidSig, i32Sig)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2), wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("call", byte(wasm.ExternFunc), 1),
+			wasmtest.ExportEntry("nested", byte(wasm.ExternFunc), 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x10, 0x00, 0xfb, 0x02, 0x00, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x41, 0x07, 0x0b}),
+		)),
+	)
+}
+
+func harnessGCCrossInstanceConsumerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	i32Sig := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("call")...)
+	importEntry = append(importEntry, byte(wasm.ExternFunc), 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, i32Sig)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", byte(wasm.ExternFunc), 1))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x10, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func harnessGCThreadsModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	memoryImport := append(wasmtest.Name("env"), wasmtest.Name("memory")...)
+	memoryImport = append(memoryImport, 0x02, 0x03, 0x01, 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			structType,
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32}, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(memoryImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(2), wasmtest.ULEB(3), wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("add", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("notify", byte(wasm.ExternFunc), 1),
+			wasmtest.ExportEntry("wait-marked", byte(wasm.ExternFunc), 2),
+			wasmtest.ExportEntry("allocate", byte(wasm.ExternFunc), 3),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x00, 0x20, 0x00, 0xfe, 0x1e, 0x02, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b}),
+			wasmtest.Code([]byte{
+				0x41, 0x04, 0x41, 0x01, 0xfe, 0x17, 0x02, 0x00,
+				0x41, 0x08, 0x41, 0x00, 0x42, 0x7f, 0xfe, 0x01, 0x02, 0x00,
+				0x0b,
+			}),
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x20, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func harnessThreadsModule() []byte {
+	memoryImport := append(wasmtest.Name("env"), wasmtest.Name("memory")...)
+	memoryImport = append(memoryImport, 0x02, 0x03, 0x01, 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32}, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(memoryImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1), wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("add", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("notify", byte(wasm.ExternFunc), 1),
+			wasmtest.ExportEntry("wait-marked", byte(wasm.ExternFunc), 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x00, 0x20, 0x00, 0xfe, 0x1e, 0x02, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b}),
+			wasmtest.Code([]byte{
+				0x41, 0x04, 0x41, 0x01, 0xfe, 0x17, 0x02, 0x00,
+				0x41, 0x08, 0x41, 0x00, 0x42, 0x7f, 0xfe, 0x01, 0x02, 0x00,
+				0x0b,
+			}),
+		)),
+	)
+}
+
+func harnessHostReentryModule() []byte {
+	i32 := []wasm.ValType{wasm.I32}
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("reenter")...)
+	importEntry = append(importEntry, byte(wasm.ExternFunc), 0x00)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(i32, i32))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("inner", byte(wasm.ExternFunc), 1),
+			wasmtest.ExportEntry("outer", byte(wasm.ExternFunc), 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x20, 0x00, 0x41, 0x01, 0x6a, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0x10, 0x00, 0x41, 0x02, 0x6a, 0x0b}),
+		)),
+	)
+}
+
+func harnessGCReexportedHostModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	newSig := []byte{0x60, 0x00, 0x01, 0x64, 0x00}
+	readSig := []byte{0x60, 0x01, 0x64, 0x00, 0x01, 0x7f}
+	i32Sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("reenter")...)
+	importEntry = append(importEntry, byte(wasm.ExternFunc), 0x03)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, newSig, readSig, i32Sig)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("reenter", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("new", byte(wasm.ExternFunc), 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x2a, 0xfb, 0x00, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func harnessGCCallerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	i32Sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("reenter")...)
+	importEntry = append(importEntry, byte(wasm.ExternFunc), 0x01)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, i32Sig)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("inner", byte(wasm.ExternFunc), 1),
+			wasmtest.ExportEntry("outer", byte(wasm.ExternFunc), 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x20, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0x10, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func harnessGCPreparedModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	newSig := []byte{0x60, 0x00, 0x01, 0x64, 0x00}
+	readSig := []byte{0x60, 0x01, 0x64, 0x00, 0x01, 0x7f}
+	i32Sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, newSig, readSig, i32Sig)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(2), wasmtest.ULEB(3))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("new", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("read", byte(wasm.ExternFunc), 1),
+			wasmtest.ExportEntry("churn", byte(wasm.ExternFunc), 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x2a, 0xfb, 0x00, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0xfb, 0x02, 0x00, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x41, 0x01, 0xfb, 0x00, 0x00, 0x1a, 0x20, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func harnessGCModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	newSig := []byte{0x60, 0x00, 0x01, 0x64, 0x00}
+	readSig := []byte{0x60, 0x01, 0x64, 0x00, 0x01, 0x7f}
+	i32Sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, newSig, readSig, i32Sig)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("new", byte(wasm.ExternFunc), 0),
+			wasmtest.ExportEntry("read", byte(wasm.ExternFunc), 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x2a, 0xfb, 0x00, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0xfb, 0x02, 0x00, 0x00, 0x0b}),
+		)),
+	)
+}


### PR DESCRIPTION
## Summary

- add a deterministic, seed-replayable public-API runtime concurrency harness
- cover Threads atomics, shared-memory lifecycle, wait/notify, host re-entry, concurrent close, and shared WasmGC domains
- fix two failures exposed by the harness:
  - serialize the complete shared collector invocation/result-ownership boundary so a second tenant cannot collect an unrooted result
  - synchronize concurrent `Instance.Close` with temporary host re-entry call-state swaps
- add bounded native Linux amd64/arm64 CI coverage and include the harness in the Linux amd64 race lane

## Reproduction

```sh
WAGO_CONCURRENCY_SEED=439000001 WAGO_CONCURRENCY_ROUNDS=24 make test-concurrency
```

Multiple comma-separated seeds and `WAGO_CONCURRENCY_SEED_FILE` are also supported. Failures print the exact replay command and a bounded event trace.

## Validation

- `make lint`
- `make test`
- `make docs-check`
- `go test -race -count=1 ./src/wago ./src/core/runtime ./tests/runtimeconcurrency`
- `go test -count=100 -run '^TestRuntimeConcurrencyHarness$' ./tests/runtimeconcurrency`
- focused cross-instance GC, GC host bridge, public GC token, and nested host re-entry tests

## Performance / footprint

- no ordinary non-GC hot-path lock is added; the new complete-call lease is limited to Runtime-shared collector domains
- private collectors and non-GC independent instances retain their existing execution policy
- `instancePluginState` remains 128 bytes; the existing footprint assertion passes

Closes #439
