### PR TITLE
runtime: avoid second import decode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,10 @@ Unknown, duplicate, reordered, truncated, over-limit, and non-canonical section
 encodings fail closed. `Compiled.WriteTo` streams code without constructing a
 second full image; `Compiled.ReadFromWithLimits` reads code directly into an RW
 mapping, bounds code and metadata independently, validates all metadata, and
-seals that same mapping RX on first use. Wago is unreleased, so incompatible
+seals that same mapping RX on first use. Non-global imports retain their legacy
+flat lookup key plus a validated module-name boundary, so source compilation and
+artifact loading expose the same exact module/name pair without decoding source
+again. Wago is unreleased, so incompatible
 development layouts were consolidated into version 1 instead of consuming public
 version numbers. Any artifact version other than 1 is rejected; there is no
 compatibility decoder or dual-format ambiguity.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,11 @@ mapping, bounds code and metadata independently, validates all metadata, and
 seals that same mapping RX on first use. Non-global imports retain their legacy
 flat lookup key plus a validated module-name boundary, so source compilation and
 artifact loading expose the same exact module/name pair without decoding source
-again. Wago is unreleased, so incompatible
+again. Plugin bindings must match that exact pair before they can satisfy an
+import, preventing dotted flat-key collisions from crossing module authority
+boundaries. Artifact decoding separately caps the expanded function-import
+directory at 64 MiB so compact empty names cannot amplify into an unbounded
+slice allocation. Wago is unreleased, so incompatible
 development layouts were consolidated into version 1 instead of consuming public
 version numbers. Any artifact version other than 1 is rejected; there is no
 compatibility decoder or dual-format ambiguity.

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1443,16 +1443,26 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 		}
 	}
 	importedTables := m.ImportedTableCount()
+	importedMemories := m.ImportedMemCount()
+	importedTags := m.ImportedTagCount()
+	if importNameCount := importedFuncs + importedTables + importedMemories + importedTags; importNameCount != 0 {
+		c.validateMemo.importModuleEnds = make([]uint64, importNameCount)
+	}
 	var additionalTableImports []tableImportDef
 	if importedTables > 1 {
 		additionalTableImports = make([]tableImportDef, 0, importedTables-1)
 	}
 	tableImportIndex := 0
+	funcImportIndex := 0
+	memoryImportIndex := 0
+	tagImportIndex := 0
 	for i := range m.Imports {
 		im := &m.Imports[i]
 		switch im.Type.Kind {
 		case wasm.ExternFunc:
 			c.Imports = append(c.Imports, im.Module+"."+im.Name)
+			c.validateMemo.importModuleEnds[funcImportIndex] = exactImportModuleEnd(im.Module)
+			funcImportIndex++
 		case wasm.ExternGlobal:
 			exact, err := typeConverter.valueType(im.Type.GlobalType().Type, -1)
 			if err != nil {
@@ -1469,6 +1479,8 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 		case wasm.ExternMem:
 			def := memoryDefFromWasm(im.Type.MemType())
 			def.ImportKey = im.Module + "." + im.Name
+			c.validateMemo.importModuleEnds[importedFuncs+importedTables+memoryImportIndex] = exactImportModuleEnd(im.Module)
+			memoryImportIndex++
 			c.memoryDir.defs = append(c.memoryDir.defs, def)
 			if c.memoryImport == "" {
 				c.memoryImport = def.ImportKey
@@ -1483,6 +1495,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 				return nil, fmt.Errorf("table import %q.%q ABI type: %w", im.Module, im.Name, err)
 			}
 			def := tableImportDef{Key: im.Module + "." + im.Name, Type: abiType, ValueTypeIndex: internValueType(&c.ValueTypes, exact), HasValueType: true, Addr64: im.Type.TableType().Limits.Addr64}
+			c.validateMemo.importModuleEnds[importedFuncs+tableImportIndex] = exactImportModuleEnd(im.Module)
 			min := im.Type.TableType().Limits.Min
 			if min > uint64(maxInt()) {
 				return nil, fmt.Errorf("table import %q.%q minimum %d overflows int", im.Module, im.Name, min)
@@ -1508,6 +1521,8 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 			tableImportIndex++
 		case wasm.ExternTag:
 			c.memoryDir.ehTags = append(c.memoryDir.ehTags, compiledTagDef{ImportKey: im.Module + "." + im.Name, TypeIndex: im.Type.TagType().Type.Index})
+			c.validateMemo.importModuleEnds[importedFuncs+importedTables+importedMemories+tagImportIndex] = exactImportModuleEnd(im.Module)
+			tagImportIndex++
 		}
 	}
 	if features.ExceptionHandling {
@@ -2640,6 +2655,9 @@ func (c *Compiled) validate() error {
 	if len(c.importFuncSigs) != c.NumImports {
 		return fmt.Errorf("compiled metadata invalid: importFuncSigs length %d != NumImports %d", len(c.importFuncSigs), c.NumImports)
 	}
+	if err := c.validateImportModuleEnds(); err != nil {
+		return err
+	}
 	if c.dynamicImports != (c.NumImports > 0) {
 		return fmt.Errorf("compiled metadata invalid: dynamic import dispatch=%v with %d function import(s)", c.dynamicImports, c.NumImports)
 	}
@@ -3178,6 +3196,9 @@ func (c *Compiled) validateExactValueMetadata() error {
 }
 
 func (c *Compiled) validateCodecMetadata() error {
+	if err := c.validateImportModuleEnds(); err != nil {
+		return err
+	}
 	if err := validateDefinedTypeDescriptors(c.Types); err != nil {
 		return err
 	}

--- a/src/wago/bench_test.go
+++ b/src/wago/bench_test.go
@@ -98,6 +98,18 @@ func benchImportedModule(funcs, adds int) []byte {
 	)
 }
 
+func benchImportMetadataModule(imports int) []byte {
+	entries := make([][]byte, imports)
+	for i := range entries {
+		entry := append(wasmtest.Name("mod.with.dot"), wasmtest.Name(fmt.Sprintf("field.%d", i))...)
+		entries[i] = append(entry, 0x00, 0x00) // function import, type 0
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(entries...)),
+	)
+}
+
 func benchTableReturningImportModule() []byte {
 	return tableHostImportModule(returningI32Sig(), []byte{0x20, 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x0b}) // local.get 0; i32.const 0; call_indirect type 0 table 0; end
 }
@@ -338,6 +350,41 @@ func BenchmarkCompileImportedWorkers(b *testing.B) {
 				}
 			}
 			b.ReportMetric(float64(codeBytes), "code-B")
+		})
+	}
+}
+
+func BenchmarkCompileImportMetadata(b *testing.B) {
+	for _, imports := range []int{0, 10, 1000, 10000} {
+		mod := benchImportMetadataModule(imports)
+		b.Run(fmt.Sprintf("imports=%d/low-level", imports), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(mod)))
+			for i := 0; i < b.N; i++ {
+				compiled, err := Compile(nil, mod)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchCompiledSink = compiled
+				if err := compiled.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("imports=%d/runtime", imports), func(b *testing.B) {
+			rt := NewRuntime()
+			defer rt.Close()
+			b.ReportAllocs()
+			b.SetBytes(int64(len(mod)))
+			for i := 0; i < b.N; i++ {
+				module, err := rt.Compile(mod)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := module.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
 		})
 	}
 }

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -90,12 +90,15 @@ func installCompiledFinalizer(c *Compiled) *Compiled {
 	c.ensureCodeCache()
 	// Give this compiler/deserialize-produced module its own validation memo so
 	// Instantiate validates immutable compiler-produced metadata once. Preserve
-	// a codec-decoded immutable native root map while resetting validation state.
+	// codec-decoded immutable root and import-name sidecars while resetting the
+	// validation result.
 	var gcFrameRoots *compiledGCFrameRoots
+	var importModuleEnds []uint64
 	if c.validateMemo != nil {
 		gcFrameRoots = c.validateMemo.gcFrameRoots
+		importModuleEnds = c.validateMemo.importModuleEnds
 	}
-	c.validateMemo = &validateMemo{gcFrameRoots: gcFrameRoots}
+	c.validateMemo = &validateMemo{gcFrameRoots: gcFrameRoots, importModuleEnds: importModuleEnds}
 	goruntime.SetFinalizer(c, func(c *Compiled) {
 		_ = c.Close()
 	})

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -268,6 +268,14 @@ func marshalCompiledMetadataMeasured(c *Compiled) ([]byte, ArtifactSectionSizes,
 	mark(&sizes.Entries)
 	w.uvar(uint64(c.NumImports))
 	w.stringSlice(c.Imports)
+	funcModuleEnds, _, _, _, exactImportNames := c.importModuleEndSections()
+	for i := range c.Imports {
+		moduleEnd := uint64(0)
+		if exactImportNames {
+			moduleEnd = funcModuleEnds[i]
+		}
+		w.uvar(moduleEnd)
+	}
 	mark(&sizes.Imports)
 	if err := w.typeDescriptors(c.Types); err != nil {
 		return nil, sizes, err
@@ -423,19 +431,31 @@ func (w *compiledWriter) tags(c *Compiled) {
 		w.stringIntMap(nil)
 		return
 	}
+	_, _, _, tagModuleEnds, exactImportNames := c.importModuleEndSections()
 	w.uvar(uint64(len(c.memoryDir.ehTags)))
-	for _, tag := range c.memoryDir.ehTags {
+	for i, tag := range c.memoryDir.ehTags {
 		w.str(tag.ImportKey)
+		moduleEnd := uint64(0)
+		if exactImportNames && tag.ImportKey != "" {
+			moduleEnd = tagModuleEnds[i]
+		}
+		w.uvar(moduleEnd)
 		w.u32(tag.TypeIndex)
 	}
 	w.stringIntMap(c.memoryDir.ehTagExports)
 }
 
 func (w *compiledWriter) memories(c *Compiled) {
+	_, _, memoryModuleEnds, _, exactImportNames := c.importModuleEndSections()
 	w.uvar(uint64(c.memoryCount()))
 	for i := 0; i < c.memoryCount(); i++ {
 		def := c.memoryDef(i)
 		w.str(def.ImportKey)
+		moduleEnd := uint64(0)
+		if exactImportNames && def.ImportKey != "" {
+			moduleEnd = memoryModuleEnds[i]
+		}
+		w.uvar(moduleEnd)
 		w.uvar(def.Min)
 		w.uvar(def.Max)
 		w.bool(def.HasMax)
@@ -681,6 +701,7 @@ func (w *compiledWriter) globals(v []GlobalDef, c *Compiled) error {
 
 func (w *compiledWriter) tables(c *Compiled) error {
 	count := c.tableCount()
+	_, tableModuleEnds, _, _, exactImportNames := c.importModuleEndSections()
 	w.uvar(uint64(count))
 	for i := 0; i < count; i++ {
 		def := c.tableDef(i)
@@ -691,6 +712,11 @@ func (w *compiledWriter) tables(c *Compiled) error {
 		if imp, ok := c.tableImportAt(i); ok {
 			w.u8(1)
 			w.str(imp.Key)
+			moduleEnd := uint64(0)
+			if exactImportNames {
+				moduleEnd = tableModuleEnds[i]
+			}
+			w.uvar(moduleEnd)
 			w.uvar(uint64(imp.Min))
 			w.uvar(uint64(imp.Max))
 			w.bool(imp.HasMax)
@@ -813,6 +839,13 @@ func unmarshalCompiledMetadata(c *Compiled, data []byte) error {
 	c.Imports, err = r.stringSlice()
 	if err != nil {
 		return err
+	}
+	for i, key := range c.Imports {
+		moduleEnd, readErr := r.importModuleEnd(key)
+		if readErr != nil {
+			return fmt.Errorf("function import %d name: %w", i, readErr)
+		}
+		c.appendImportModuleEnd(moduleEnd)
 	}
 	c.Types, err = r.typeDescriptors()
 	if err != nil {
@@ -971,7 +1004,10 @@ func unmarshalCompiledMetadata(c *Compiled, data []byte) error {
 		}
 	}
 	if gcFrameRoots != nil {
-		c.validateMemo = &validateMemo{gcFrameRoots: gcFrameRoots}
+		if c.validateMemo == nil {
+			c.validateMemo = &validateMemo{}
+		}
+		c.validateMemo.gcFrameRoots = gcFrameRoots
 		if err := validateCompiledGCFrameRoots(c, gcFrameRoots); err != nil {
 			return err
 		}
@@ -1026,7 +1062,7 @@ const (
 	minGlobalBytes       = 1 + 1 + 1
 	minTableBytes        = 1 + 1 + minVarintBytes + minVarintBytes + 1
 	minGlobalImportBytes = minStringBytes + minStringBytes + 1 + 1
-	minTagBytes          = minStringBytes + minU32Bytes
+	minTagBytes          = minStringBytes + minVarintBytes + minU32Bytes
 	minGCDescTailBytes   = 20
 	minGCDescBytes       = minU32Bytes + 1 + 1 + minVarintBytes + minGCDescTailBytes
 	minGCFieldBytes      = 1 + minU32Bytes
@@ -1072,6 +1108,17 @@ func (r *compiledReader) uvar() (uint64, error) {
 	}
 	r.data = r.data[n:]
 	return v, nil
+}
+
+func (r *compiledReader) importModuleEnd(key string) (uint64, error) {
+	moduleEnd, err := r.uvar()
+	if err != nil {
+		return 0, err
+	}
+	if err := validateImportModuleEnd(key, moduleEnd); err != nil {
+		return 0, err
+	}
+	return moduleEnd, nil
 }
 func (r *compiledReader) ivar() (int, error) {
 	v, n := binary.Varint(r.data)
@@ -1204,6 +1251,13 @@ func (r *compiledReader) tags(c *Compiled) error {
 		if err != nil {
 			return fmt.Errorf("exception tag %d import: %w", i, err)
 		}
+		moduleEnd, readErr := r.importModuleEnd(tag.ImportKey)
+		if readErr != nil {
+			return fmt.Errorf("exception tag %d import name: %w", i, readErr)
+		}
+		if tag.ImportKey != "" {
+			c.appendImportModuleEnd(moduleEnd)
+		}
 		tag.TypeIndex, err = r.u32()
 		if err != nil {
 			return fmt.Errorf("exception tag %d type: %w", i, err)
@@ -1222,7 +1276,7 @@ func (r *compiledReader) tags(c *Compiled) error {
 }
 
 func (r *compiledReader) memories(c *Compiled) error {
-	n, err := r.countElements("memories", 6)
+	n, err := r.countElements("memories", 7)
 	if err != nil {
 		return err
 	}
@@ -1237,6 +1291,13 @@ func (r *compiledReader) memories(c *Compiled) error {
 		def.ImportKey, err = r.str()
 		if err != nil {
 			return fmt.Errorf("memory %d import: %w", i, err)
+		}
+		moduleEnd, readErr := r.importModuleEnd(def.ImportKey)
+		if readErr != nil {
+			return fmt.Errorf("memory %d import name: %w", i, readErr)
+		}
+		if def.ImportKey != "" {
+			c.appendImportModuleEnd(moduleEnd)
 		}
 		def.Min, err = r.uvar()
 		if err != nil {
@@ -1865,6 +1926,11 @@ func (r *compiledReader) tables(c *Compiled, pool []ValueTypeDescriptor, types [
 			if err != nil {
 				return err
 			}
+			moduleEnd, readErr := r.importModuleEnd(def.ImportKey)
+			if readErr != nil {
+				return fmt.Errorf("table import %d name: %w", i, readErr)
+			}
+			c.appendImportModuleEnd(moduleEnd)
 			min, err := r.uvar()
 			if err != nil {
 				return err

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -843,7 +843,7 @@ func unmarshalCompiledMetadata(c *Compiled, data []byte) error {
 	}
 	c.NumImports = int(n)
 	var functionModuleEnds []uint64
-	c.Imports, functionModuleEnds, err = r.importDirectory()
+	c.Imports, functionModuleEnds, err = r.importDirectory(c.NumImports)
 	if err != nil {
 		return err
 	}
@@ -1209,17 +1209,20 @@ func (r *compiledReader) stringSlice() ([]string, error) {
 	return out, nil
 }
 
-func (r *compiledReader) importDirectory() ([]string, []uint64, error) {
-	return r.importDirectoryWithAllocationLimit(maxImportDirectoryAllocationBytes)
+func (r *compiledReader) importDirectory(want int) ([]string, []uint64, error) {
+	return r.importDirectoryWithAllocationLimit(want, maxImportDirectoryAllocationBytes)
 }
 
-func (r *compiledReader) importDirectoryWithAllocationLimit(allocationLimit int) ([]string, []uint64, error) {
+func (r *compiledReader) importDirectoryWithAllocationLimit(want, allocationLimit int) ([]string, []uint64, error) {
 	// Each entry needs at least an empty string length and one module-boundary
 	// varint in the remainder. This also rejects an impossible count before any
 	// decoded directory allocation.
 	n, err := r.countElements("function imports", minStringBytes+minVarintBytes)
 	if err != nil {
 		return nil, nil, err
+	}
+	if n != want {
+		return nil, nil, fmt.Errorf("function import directory count %d != NumImports %d", n, want)
 	}
 	const moduleEndBytes = 8
 	decodedBytesPerImport := bits.UintSize/4 + moduleEndBytes // string header + uint64

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math/bits"
 	"sort"
 
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
@@ -26,6 +27,11 @@ const (
 	compiledGCExecutionGenericStruct      uint64 = 1 << 62
 	compiledGCExecutionGenericArray       uint64 = 1 << 63
 	compiledGCExecutionMask                      = compiledGCExecutionDynamicFuncRefTest | compiledGCExecutionGenericStruct | compiledGCExecutionGenericArray
+
+	// Import names are attacker-controlled artifact metadata. Bound the decoded
+	// string headers plus exact-name sidecar independently of the encoded section
+	// size so compact empty strings cannot amplify into multi-gigabyte allocations.
+	maxImportDirectoryAllocationBytes = 64 << 20
 )
 
 func compiledUvarintLen(v uint64) int {
@@ -836,16 +842,13 @@ func unmarshalCompiledMetadata(c *Compiled, data []byte) error {
 		return fmt.Errorf("NumImports overflows int")
 	}
 	c.NumImports = int(n)
-	c.Imports, err = r.stringSlice()
+	var functionModuleEnds []uint64
+	c.Imports, functionModuleEnds, err = r.importDirectory()
 	if err != nil {
 		return err
 	}
-	for i, key := range c.Imports {
-		moduleEnd, readErr := r.importModuleEnd(key)
-		if readErr != nil {
-			return fmt.Errorf("function import %d name: %w", i, readErr)
-		}
-		c.appendImportModuleEnd(moduleEnd)
+	if len(functionModuleEnds) != 0 {
+		c.validateMemo = &validateMemo{importModuleEnds: functionModuleEnds}
 	}
 	c.Types, err = r.typeDescriptors()
 	if err != nil {
@@ -1204,6 +1207,40 @@ func (r *compiledReader) stringSlice() ([]string, error) {
 		}
 	}
 	return out, nil
+}
+
+func (r *compiledReader) importDirectory() ([]string, []uint64, error) {
+	return r.importDirectoryWithAllocationLimit(maxImportDirectoryAllocationBytes)
+}
+
+func (r *compiledReader) importDirectoryWithAllocationLimit(allocationLimit int) ([]string, []uint64, error) {
+	// Each entry needs at least an empty string length and one module-boundary
+	// varint in the remainder. This also rejects an impossible count before any
+	// decoded directory allocation.
+	n, err := r.countElements("function imports", minStringBytes+minVarintBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	const moduleEndBytes = 8
+	decodedBytesPerImport := bits.UintSize/4 + moduleEndBytes // string header + uint64
+	if allocationLimit < 0 || n > allocationLimit/decodedBytesPerImport {
+		return nil, nil, fmt.Errorf("function import count %d exceeds decoded directory allocation limit %d bytes", n, allocationLimit)
+	}
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i], err = r.str()
+		if err != nil {
+			return nil, nil, fmt.Errorf("function import %d key: %w", i, err)
+		}
+	}
+	ends := make([]uint64, n)
+	for i, key := range keys {
+		ends[i], err = r.importModuleEnd(key)
+		if err != nil {
+			return nil, nil, fmt.Errorf("function import %d name: %w", i, err)
+		}
+	}
+	return keys, ends, nil
 }
 func (r *compiledReader) intSlice() ([]int, error) {
 	n, err := r.countElements("int slice", minVarintBytes)

--- a/src/wago/gc_type_subtyping_product_amd64_test.go
+++ b/src/wago/gc_type_subtyping_product_amd64_test.go
@@ -470,8 +470,8 @@ func TestStagedGCTypeSubtypingFirstLinkingClusterLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{103, 179, 439, 86, 0, 306} {
-		t.Fatalf("link product wasm/code/codec sizes = %v, want [103 179 439 86 0 306]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{103, 179, 439, 86, 0, 312} {
+		t.Fatalf("link product wasm/code/codec sizes = %v, want [103 179 439 86 0 312]", got)
 	}
 
 	instantiateProvider := func() (*Instance, map[string]*InstanceExport) {
@@ -659,8 +659,8 @@ func TestStagedGCTypeSubtypingStructLinkingClusterLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{70, 31, 273, 51, 0, 242} {
-		t.Fatalf("struct link wasm/code/codec sizes = %v, want [70 31 273 51 0 242]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{70, 31, 273, 51, 0, 243} {
+		t.Fatalf("struct link wasm/code/codec sizes = %v, want [70 31 273 51 0 243]", got)
 	}
 
 	resourceState := func(in *Instance) (refs int, closed bool) {
@@ -849,8 +849,8 @@ func TestStagedGCTypeSubtypingStructProjectionLinkingClusterLifecycle(t *testing
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{104, 31, 442, 85, 0, 411} {
-		t.Fatalf("struct projection link wasm/code/codec sizes = %v, want [104 31 442 85 0 411]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{104, 31, 442, 85, 0, 412} {
+		t.Fatalf("struct projection link wasm/code/codec sizes = %v, want [104 31 442 85 0 412]", got)
 	}
 
 	resourceState := func(in *Instance) (refs int, closed bool) {
@@ -1035,7 +1035,7 @@ func TestStagedGCTypeSubtypingRemainingProductsLifecycle(t *testing.T) {
 		codec      int
 	}{
 		{m9ProviderCompiled, 136, 156, 634},
-		{m9ConsumerCompiled, 164, 0, 595},
+		{m9ConsumerCompiled, 164, 0, 603},
 	} {
 		blob, err := marshalCompiled(item.c)
 		if err != nil {
@@ -1129,8 +1129,8 @@ func TestStagedGCTypeSubtypingRemainingProductsLifecycle(t *testing.T) {
 		providerSizes      [3]int
 		consumerSizes      [3]int
 	}{
-		{stagedGCTypeSubtypingCrossGroupMismatchLinkProviderPin, stagedGCTypeSubtypingCrossGroupMismatchLinkConsumerPin, "M10.f", [3]int{74, 31, 264}, [3]int{43, 0, 154}},
-		{stagedGCTypeSubtypingTransitiveMismatchLinkProviderPin, stagedGCTypeSubtypingTransitiveMismatchLinkConsumerPin, "M11.f", [3]int{87, 31, 344}, [3]int{56, 0, 234}},
+		{stagedGCTypeSubtypingCrossGroupMismatchLinkProviderPin, stagedGCTypeSubtypingCrossGroupMismatchLinkConsumerPin, "M10.f", [3]int{74, 31, 264}, [3]int{43, 0, 155}},
+		{stagedGCTypeSubtypingTransitiveMismatchLinkProviderPin, stagedGCTypeSubtypingTransitiveMismatchLinkConsumerPin, "M11.f", [3]int{87, 31, 344}, [3]int{56, 0, 235}},
 	} {
 		pc, cc := compile(tc.provider), compile(tc.consumer)
 		for _, item := range []struct {
@@ -1204,7 +1204,7 @@ func TestStagedGCTypeSubtypingDuplicateRecursiveLinkingClusterLifecycle(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{100, 156, 440, 92, 0, 321} {
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{100, 156, 440, 92, 0, 325} {
 		t.Fatalf("wasm/code/codec sizes = %v", got)
 	}
 	state := func(in *Instance) (int, bool) {
@@ -1334,8 +1334,8 @@ func TestStagedGCTypeSubtypingExtendedProjectionLinkingClusterLifecycle(t *testi
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{114, 31, 521, 102, 0, 508} {
-		t.Fatalf("extended projection link wasm/code/codec sizes = %v, want [114 31 521 102 0 508]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{114, 31, 521, 102, 0, 510} {
+		t.Fatalf("extended projection link wasm/code/codec sizes = %v, want [114 31 521 102 0 510]", got)
 	}
 
 	resourceState := func(in *Instance) (refs int, closed bool) {
@@ -1523,8 +1523,8 @@ func TestStagedGCTypeSubtypingIndependentStructLinkingClusterLifecycle(t *testin
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 363, 63, 0, 332} {
-		t.Fatalf("independent struct link wasm/code/codec sizes = %v, want [82 31 363 63 0 332]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 363, 63, 0, 333} {
+		t.Fatalf("independent struct link wasm/code/codec sizes = %v, want [82 31 363 63 0 333]", got)
 	}
 
 	resourceState := func(in *Instance) (refs int, closed bool) {
@@ -1713,8 +1713,8 @@ func TestStagedGCTypeSubtypingStructMismatchLinkingClusterLifecycle(t *testing.T
 	if err != nil {
 		t.Fatalf("marshal unlinked consumer: %v", err)
 	}
-	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 363, 51, 0, 242} {
-		t.Fatalf("struct mismatch wasm/code/codec sizes = %v, want [82 31 363 51 0 242]", got)
+	if got := [6]int{len(providerData), len(providerCompiled.code), len(providerBlob), len(consumerData), len(consumerCompiled.code), len(consumerBlob)}; got != [6]int{82, 31, 363, 51, 0, 243} {
+		t.Fatalf("struct mismatch wasm/code/codec sizes = %v, want [82 31 363 51 0 243]", got)
 	}
 	if got, want := (len(providerCompiled.FuncTypeID)+1)*coreruntime.FuncRefDescBytes, 2*coreruntime.FuncRefDescBytes; got != want {
 		t.Fatalf("provider descriptor requirement = %d bytes, want %d", got, want)
@@ -1871,8 +1871,8 @@ func TestStagedGCTypeSubtypingFinalityLinkingClusterLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal unlinked %s: %v", pin.Filename, err)
 		}
-		if got := [3]int{pin.Size, len(consumerCompiled[i].code), len(consumerBlobs[i])}; got != [3]int{38, 0, 150} {
-			t.Fatalf("%s wasm/code/codec sizes = %v, want [38 0 150]", pin.Filename, got)
+		if got := [3]int{pin.Size, len(consumerCompiled[i].code), len(consumerBlobs[i])}; got != [3]int{38, 0, 151} {
+			t.Fatalf("%s wasm/code/codec sizes = %v, want [38 0 151]", pin.Filename, got)
 		}
 	}
 	if providerCompiled.stagedGCTypeSubtypingProduct() != stagedGCTypeSubtypingFinalityLinkProvider || !providerCompiled.NeedsFuncRefDescs {

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -1090,12 +1090,13 @@ type Compiled struct {
 	maxResultSlots       int
 	instantiateArenaNeed int
 
-	// validateMemo memoizes the instantiate-boundary metadata validation for
-	// modules produced by Compile/UnmarshalBinary, which are immutable: the full
-	// check (which loops all funcs/globals/exports/GC descs) then only runs once
-	// instead of on every Instantiate. A nil memo means "validate every time" —
-	// which is what a hand-constructed Compiled (exported fields,
-	// no memo) gets, preserving its first-use validation.
+	// validateMemo owns immutable validation sidecars and memoizes the
+	// instantiate-boundary metadata validation for modules produced by
+	// Compile/UnmarshalBinary: the full check (which loops all
+	// funcs/globals/exports/GC descs) then only runs once instead of on every
+	// Instantiate. A nil memo means "validate every time" — which is what a
+	// hand-constructed Compiled (exported fields, no memo) gets, preserving its
+	// first-use validation.
 	validateMemo *validateMemo
 
 	codeCache          *compiledCodeCache
@@ -1133,6 +1134,11 @@ type validateMemo struct {
 	err                      error
 	gcFrameRoots             *compiledGCFrameRoots // immutable compiled/codec native safepoint and callsite map
 	structuralCallIdentities *structuralCallIdentityCache
+	// importModuleEnds stores one plus the module-name byte length for each
+	// non-global import, grouped as functions, tables, memories, then tags. A
+	// zero entry retains the legacy first-dot interpretation for hand-built
+	// Compiled values; source compilation always records an exact nonzero end.
+	importModuleEnds []uint64
 }
 
 // validateCached returns the metadata-validation result, running the full check

--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -1,6 +1,9 @@
 package wago
 
 import (
+	"context"
+	"encoding/binary"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -135,5 +138,55 @@ func TestCompiledCodecRejectsMalformedImportModuleEnd(t *testing.T) {
 	var decoded Compiled
 	if err := unmarshalCompiledMetadata(&decoded, metadata); err == nil || !strings.Contains(err.Error(), "does not identify the import-key separator") {
 		t.Fatalf("malformed import module-name end error = %v", err)
+	}
+}
+
+func TestRuntimePluginBindingRequiresExactImportIdentity(t *testing.T) {
+	const flatKey = "a.b.c"
+	rt := NewRuntime()
+	defer rt.Close()
+	rt.imports[flatKey] = HostFunc(func(HostModule, []uint64, []uint64) {})
+	rt.importMeta[flatKey] = &registeredImport{
+		module: "a", name: "b.c",
+		cap: Capability("host.exact"), hasCap: true,
+	}
+
+	moduleBytes := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(append(append(wasmtest.Name("a.b"), wasmtest.Name("c")...), 0x00, 0x00))),
+	)
+	module, err := rt.Compile(moduleBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	imports := module.Imports()
+	if len(imports) != 1 || imports[0].Module != "a.b" || imports[0].Name != "c" || imports[0].Provided || imports[0].HasCapability {
+		t.Fatalf("colliding plugin import metadata = %#v", imports)
+	}
+	if _, err := rt.Instantiate(context.Background(), module); !errors.Is(err, ErrMissingImport) {
+		t.Fatalf("colliding plugin binding error = %v, want ErrMissingImport", err)
+	}
+
+	// Explicit flat Imports remain a deliberate compatibility boundary: callers
+	// supplying one directly chose the legacy namespace themselves.
+	instance, err := rt.Instantiate(context.Background(), module, WithImports(Imports{flatKey: HostFunc(func(HostModule, []uint64, []uint64) {})}))
+	if err != nil {
+		t.Fatalf("explicit legacy override: %v", err)
+	}
+	if err := instance.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCompiledCodecBoundsDecodedImportDirectoryAllocation(t *testing.T) {
+	const count = 3
+	var prefix [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(prefix[:], uint64(count))
+	encoded := make([]byte, n+2*count)
+	copy(encoded, prefix[:n])
+	r := compiledReader{data: encoded}
+	if _, _, err := r.importDirectoryWithAllocationLimit(1); err == nil || !strings.Contains(err.Error(), "decoded directory allocation limit") {
+		t.Fatalf("oversized import directory error = %v", err)
 	}
 }

--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -1,0 +1,139 @@
+package wago
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+type importIdentity struct {
+	module string
+	name   string
+	kind   ImportKind
+}
+
+func exactImportIdentityModule() []byte {
+	entry := func(module, name string, tail ...byte) []byte {
+		out := append(wasmtest.Name(module), wasmtest.Name(name)...)
+		return append(out, tail...)
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(
+			entry("a.b", "c", 0x00, 0x00), // function, type 0
+			entry("a", "b.c", 0x00, 0x00), // same legacy key, distinct identity
+			entry("", "empty.module", 0x00, 0x00),
+			entry("empty.name", "", 0x00, 0x00),
+			entry("nul\x00.mod", "field\x00.name", 0x00, 0x00),
+			entry("table.mod", "table.名", 0x01, 0x70, 0x00, 0x00),
+			entry("memory.mod", "memory.名", 0x02, 0x00, 0x00),
+			wasmtest.GlobalImportEntry("global.mod", "global.名", wasm.I32, false),
+			entry("tag.mod", "tag.名", 0x04, 0x00, 0x00), // tag attribute 0, type 0
+		)),
+	)
+}
+
+func moduleImportIdentities(module *Module) []importIdentity {
+	imports := module.Imports()
+	out := make([]importIdentity, len(imports))
+	for i, spec := range imports {
+		out[i] = importIdentity{module: spec.Module, name: spec.Name, kind: spec.Kind}
+	}
+	return out
+}
+
+func TestRuntimeCompilePreservesExactImportIdentitiesAcrossArtifact(t *testing.T) {
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	rt := NewRuntime(WithRuntimeConfig(cfg))
+	defer rt.Close()
+
+	module, err := rt.Compile(exactImportIdentityModule())
+	if err != nil {
+		t.Fatalf("Runtime.Compile: %v", err)
+	}
+	want := []importIdentity{
+		{module: "a.b", name: "c", kind: ImportFunc},
+		{module: "a", name: "b.c", kind: ImportFunc},
+		{module: "", name: "empty.module", kind: ImportFunc},
+		{module: "empty.name", name: "", kind: ImportFunc},
+		{module: "nul\x00.mod", name: "field\x00.name", kind: ImportFunc},
+		{module: "global.mod", name: "global.名", kind: ImportGlobal},
+		{module: "memory.mod", name: "memory.名", kind: ImportMemory},
+		{module: "table.mod", name: "table.名", kind: ImportTable},
+		{module: "tag.mod", name: "tag.名", kind: ImportTag},
+	}
+	if got := moduleImportIdentities(module); !reflect.DeepEqual(got, want) {
+		t.Fatalf("source import identities = %#v, want %#v", got, want)
+	}
+
+	metadata := module.Metadata()
+	gotMetadata := make([]importIdentity, 0, len(want))
+	for i := 0; i < metadata.FuncImportCount; i++ {
+		gotMetadata = append(gotMetadata, importIdentity{module: metadata.Functions[i].ImportModule, name: metadata.Functions[i].ImportName, kind: ImportFunc})
+	}
+	gotMetadata = append(gotMetadata,
+		importIdentity{module: metadata.Globals[0].ImportModule, name: metadata.Globals[0].ImportName, kind: ImportGlobal},
+		importIdentity{module: metadata.Memories[0].ImportModule, name: metadata.Memories[0].ImportName, kind: ImportMemory},
+		importIdentity{module: metadata.Tables[0].ImportModule, name: metadata.Tables[0].ImportName, kind: ImportTable},
+		importIdentity{module: metadata.Tags[0].ImportModule, name: metadata.Tags[0].ImportName, kind: ImportTag},
+	)
+	if !reflect.DeepEqual(gotMetadata, want) {
+		t.Fatalf("source metadata identities = %#v, want %#v", gotMetadata, want)
+	}
+
+	artifact, err := module.c.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	if err := module.Close(); err != nil {
+		t.Fatalf("close source module: %v", err)
+	}
+	var compiled Compiled
+	if err := compiled.UnmarshalBinary(artifact); err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+	loaded, err := rt.Module(&compiled)
+	if err != nil {
+		t.Fatalf("Runtime.Module: %v", err)
+	}
+	defer loaded.Close()
+	if got := moduleImportIdentities(loaded); !reflect.DeepEqual(got, want) {
+		t.Fatalf("artifact import identities = %#v, want %#v", got, want)
+	}
+}
+
+func TestCompiledCodecRejectsMalformedImportModuleEnd(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), exactImportIdentityModule())
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	defer compiled.Close()
+	metadata, err := marshalCompiledMetadata(compiled)
+	if err != nil {
+		t.Fatalf("marshalCompiledMetadata: %v", err)
+	}
+
+	r := compiledReader{data: metadata}
+	if _, err := r.intSlice(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.intSlice(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.uvar(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.stringSlice(); err != nil {
+		t.Fatal(err)
+	}
+	moduleEndOffset := len(metadata) - len(r.data)
+	metadata[moduleEndOffset]++ // Move the one-byte boundary from '.' onto 'c'.
+
+	var decoded Compiled
+	if err := unmarshalCompiledMetadata(&decoded, metadata); err == nil || !strings.Contains(err.Error(), "does not identify the import-key separator") {
+		t.Fatalf("malformed import module-name end error = %v", err)
+	}
+}

--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -186,7 +186,19 @@ func TestCompiledCodecBoundsDecodedImportDirectoryAllocation(t *testing.T) {
 	encoded := make([]byte, n+2*count)
 	copy(encoded, prefix[:n])
 	r := compiledReader{data: encoded}
-	if _, _, err := r.importDirectoryWithAllocationLimit(1); err == nil || !strings.Contains(err.Error(), "decoded directory allocation limit") {
+	if _, _, err := r.importDirectoryWithAllocationLimit(count, 1); err == nil || !strings.Contains(err.Error(), "decoded directory allocation limit") {
 		t.Fatalf("oversized import directory error = %v", err)
+	}
+}
+
+func TestCompiledCodecRejectsImportCountMismatchBeforeAllocation(t *testing.T) {
+	const encodedCount = 3
+	var prefix [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(prefix[:], encodedCount)
+	encoded := make([]byte, n+2*encodedCount)
+	copy(encoded, prefix[:n])
+	r := compiledReader{data: encoded}
+	if _, _, err := r.importDirectoryWithAllocationLimit(0, maxImportDirectoryAllocationBytes); err == nil || !strings.Contains(err.Error(), "directory count 3 != NumImports 0") {
+		t.Fatalf("mismatched import count error = %v", err)
 	}
 }

--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -49,7 +49,7 @@ func moduleImportIdentities(module *Module) []importIdentity {
 }
 
 func TestRuntimeCompilePreservesExactImportIdentitiesAcrossArtifact(t *testing.T) {
-	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3).WithBoundsChecks(BoundsChecksExplicit)
 	rt := NewRuntime(WithRuntimeConfig(cfg))
 	defer rt.Close()
 

--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -18,25 +18,45 @@ type importIdentity struct {
 	kind   ImportKind
 }
 
-func exactImportIdentityModule() []byte {
+func exactImportIdentityModule(includeTag bool) []byte {
 	entry := func(module, name string, tail ...byte) []byte {
 		out := append(wasmtest.Name(module), wasmtest.Name(name)...)
 		return append(out, tail...)
 	}
+	imports := [][]byte{
+		entry("a.b", "c", 0x00, 0x00), // function, type 0
+		entry("a", "b.c", 0x00, 0x00), // same legacy key, distinct identity
+		entry("", "empty.module", 0x00, 0x00),
+		entry("empty.name", "", 0x00, 0x00),
+		entry("nul\x00.mod", "field\x00.name", 0x00, 0x00),
+		entry("table.mod", "table.名", 0x01, 0x70, 0x00, 0x00),
+		entry("memory.mod", "memory.名", 0x02, 0x00, 0x00),
+		wasmtest.GlobalImportEntry("global.mod", "global.名", wasm.I32, false),
+	}
+	if includeTag {
+		imports = append(imports, entry("tag.mod", "tag.名", 0x04, 0x00, 0x00)) // tag attribute 0, type 0
+	}
 	return wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
-		wasmtest.Section(2, wasmtest.Vec(
-			entry("a.b", "c", 0x00, 0x00), // function, type 0
-			entry("a", "b.c", 0x00, 0x00), // same legacy key, distinct identity
-			entry("", "empty.module", 0x00, 0x00),
-			entry("empty.name", "", 0x00, 0x00),
-			entry("nul\x00.mod", "field\x00.name", 0x00, 0x00),
-			entry("table.mod", "table.名", 0x01, 0x70, 0x00, 0x00),
-			entry("memory.mod", "memory.名", 0x02, 0x00, 0x00),
-			wasmtest.GlobalImportEntry("global.mod", "global.名", wasm.I32, false),
-			entry("tag.mod", "tag.名", 0x04, 0x00, 0x00), // tag attribute 0, type 0
-		)),
+		wasmtest.Section(2, wasmtest.Vec(imports...)),
 	)
+}
+
+func exactImportIdentities(includeTag bool) []importIdentity {
+	identities := []importIdentity{
+		{module: "a.b", name: "c", kind: ImportFunc},
+		{module: "a", name: "b.c", kind: ImportFunc},
+		{module: "", name: "empty.module", kind: ImportFunc},
+		{module: "empty.name", name: "", kind: ImportFunc},
+		{module: "nul\x00.mod", name: "field\x00.name", kind: ImportFunc},
+		{module: "global.mod", name: "global.名", kind: ImportGlobal},
+		{module: "memory.mod", name: "memory.名", kind: ImportMemory},
+		{module: "table.mod", name: "table.名", kind: ImportTable},
+	}
+	if includeTag {
+		identities = append(identities, importIdentity{module: "tag.mod", name: "tag.名", kind: ImportTag})
+	}
+	return identities
 }
 
 func moduleImportIdentities(module *Module) []importIdentity {
@@ -49,25 +69,17 @@ func moduleImportIdentities(module *Module) []importIdentity {
 }
 
 func TestRuntimeCompilePreservesExactImportIdentitiesAcrossArtifact(t *testing.T) {
-	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3).WithBoundsChecks(BoundsChecksExplicit)
+	features := CoreFeaturesV3 & SupportedFeatures()
+	includeTag := features.IsEnabled(CoreFeatureExceptionHandling)
+	cfg := NewRuntimeConfig().WithCoreFeatures(features).WithBoundsChecks(BoundsChecksExplicit)
 	rt := NewRuntime(WithRuntimeConfig(cfg))
 	defer rt.Close()
 
-	module, err := rt.Compile(exactImportIdentityModule())
+	module, err := rt.Compile(exactImportIdentityModule(includeTag))
 	if err != nil {
 		t.Fatalf("Runtime.Compile: %v", err)
 	}
-	want := []importIdentity{
-		{module: "a.b", name: "c", kind: ImportFunc},
-		{module: "a", name: "b.c", kind: ImportFunc},
-		{module: "", name: "empty.module", kind: ImportFunc},
-		{module: "empty.name", name: "", kind: ImportFunc},
-		{module: "nul\x00.mod", name: "field\x00.name", kind: ImportFunc},
-		{module: "global.mod", name: "global.名", kind: ImportGlobal},
-		{module: "memory.mod", name: "memory.名", kind: ImportMemory},
-		{module: "table.mod", name: "table.名", kind: ImportTable},
-		{module: "tag.mod", name: "tag.名", kind: ImportTag},
-	}
+	want := exactImportIdentities(includeTag)
 	if got := moduleImportIdentities(module); !reflect.DeepEqual(got, want) {
 		t.Fatalf("source import identities = %#v, want %#v", got, want)
 	}
@@ -81,8 +93,10 @@ func TestRuntimeCompilePreservesExactImportIdentitiesAcrossArtifact(t *testing.T
 		importIdentity{module: metadata.Globals[0].ImportModule, name: metadata.Globals[0].ImportName, kind: ImportGlobal},
 		importIdentity{module: metadata.Memories[0].ImportModule, name: metadata.Memories[0].ImportName, kind: ImportMemory},
 		importIdentity{module: metadata.Tables[0].ImportModule, name: metadata.Tables[0].ImportName, kind: ImportTable},
-		importIdentity{module: metadata.Tags[0].ImportModule, name: metadata.Tags[0].ImportName, kind: ImportTag},
 	)
+	if includeTag {
+		gotMetadata = append(gotMetadata, importIdentity{module: metadata.Tags[0].ImportModule, name: metadata.Tags[0].ImportName, kind: ImportTag})
+	}
 	if !reflect.DeepEqual(gotMetadata, want) {
 		t.Fatalf("source metadata identities = %#v, want %#v", gotMetadata, want)
 	}
@@ -109,7 +123,7 @@ func TestRuntimeCompilePreservesExactImportIdentitiesAcrossArtifact(t *testing.T
 }
 
 func TestCompiledCodecRejectsMalformedImportModuleEnd(t *testing.T) {
-	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), exactImportIdentityModule())
+	compiled, err := Compile(NewRuntimeConfig(), exactImportIdentityModule(false))
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -221,9 +221,10 @@ func buildModule(c *Compiled, bindings moduleBindings) *Module {
 		m.identity.Store(&moduleIdentityToken{})
 	}
 
+	funcModuleEnds, tableModuleEnds, memoryModuleEnds, tagModuleEnds, _ := c.importModuleEndSections()
 	capSeen := map[Capability]bool{}
 	for i, key := range c.Imports { // function imports, in "module.name" form
-		mod, name := splitImportKey(key)
+		mod, name := splitImportKeyAt(key, importModuleEndAt(funcModuleEnds, i))
 		spec := ImportSpec{Module: mod, Name: name, Kind: ImportFunc, Index: i}
 		if i < len(c.importFuncSigs) {
 			spec.Params = append([]ValType(nil), c.importFuncSigs[i].Params...)
@@ -253,7 +254,7 @@ func buildModule(c *Compiled, bindings moduleBindings) *Module {
 	}
 	for i := 0; i < c.memoryImportCount(); i++ {
 		def, _ := c.memoryImportAt(i)
-		mod, name := splitImportKey(def.ImportKey)
+		mod, name := splitImportKeyAt(def.ImportKey, importModuleEndAt(memoryModuleEnds, i))
 		m.imports = append(m.imports, ImportSpec{
 			Module: mod, Name: name, Kind: ImportMemory, Index: i,
 			MemoryMin: def.Min, MemoryMax: def.Max, HasMax: def.HasMax, Addr64: def.Addr64, Shared: def.Shared,
@@ -262,7 +263,7 @@ func buildModule(c *Compiled, bindings moduleBindings) *Module {
 	}
 	for i := 0; i < c.tableImportCount(); i++ {
 		def, _ := c.tableImportAt(i)
-		mod, name := splitImportKey(def.Key)
+		mod, name := splitImportKeyAt(def.Key, importModuleEndAt(tableModuleEnds, i))
 		exact, exactErr := exactValueType(def.Type, def.HasValueType, def.ValueTypeIndex, c.ValueTypes, c.Types)
 		m.imports = append(m.imports, ImportSpec{
 			Module: mod, Name: name, Kind: ImportTable, Index: i,
@@ -273,7 +274,7 @@ func buildModule(c *Compiled, bindings moduleBindings) *Module {
 	if c.memoryDir != nil {
 		for i := 0; i < c.tagImportCount(); i++ {
 			def := c.memoryDir.ehTags[i]
-			mod, name := splitImportKey(def.ImportKey)
+			mod, name := splitImportKeyAt(def.ImportKey, importModuleEndAt(tagModuleEnds, i))
 			sig := c.Types[def.TypeIndex]
 			params, _ := valTypesFromDescriptors(sig.Params, c.Types)
 			m.imports = append(m.imports, ImportSpec{Module: mod, Name: name, Kind: ImportTag, Index: i, Params: params, ParamTypes: append([]ValueTypeDescriptor(nil), sig.Params...), Provided: bindings.imports[def.ImportKey] != nil})
@@ -321,6 +322,7 @@ func (m *Module) Metadata() ModuleMetadata {
 		return ModuleMetadata{}
 	}
 	c := m.c
+	funcModuleEnds, tableModuleEnds, memoryModuleEnds, tagModuleEnds, _ := c.importModuleEndSections()
 	functionExports := exportsByIndex(c.Exports, c.NumImports+len(c.Funcs))
 	functions := make([]FunctionMetadata, c.NumImports+len(c.Funcs))
 	for i := range functions {
@@ -333,7 +335,7 @@ func (m *Module) Metadata() ModuleMetadata {
 				functions[i].ParamTypes, functions[i].ResultTypes, _ = exactFuncSignature(c.importFuncSigs[i], c.Types)
 			}
 			if i < len(c.Imports) {
-				functions[i].ImportModule, functions[i].ImportName = splitImportKey(c.Imports[i])
+				functions[i].ImportModule, functions[i].ImportName = splitImportKeyAt(c.Imports[i], importModuleEndAt(funcModuleEnds, i))
 			}
 			continue
 		}
@@ -361,7 +363,7 @@ func (m *Module) Metadata() ModuleMetadata {
 		exact, exactErr := exactValueType(c.tableElementType(i), def.HasValueType, def.ValueTypeIndex, c.ValueTypes, c.Types)
 		tables[i] = TableMetadata{Index: i, Type: c.tableElementType(i), ValueType: exact, HasValueType: exactErr == nil, Addr64: def.Addr64, Exports: tableExports[i]}
 		if imp, ok := c.tableImportAt(i); ok {
-			tables[i].ImportModule, tables[i].ImportName = splitImportKey(imp.Key)
+			tables[i].ImportModule, tables[i].ImportName = splitImportKeyAt(imp.Key, importModuleEndAt(tableModuleEnds, i))
 			tables[i].Min, tables[i].Max, tables[i].HasMax = imp.Min, imp.Max, imp.HasMax
 			continue
 		}
@@ -378,7 +380,7 @@ func (m *Module) Metadata() ModuleMetadata {
 		def := c.memoryDef(i)
 		memories[i] = MemoryMetadata{Index: i, Min: def.Min, Max: def.Max, HasMax: def.HasMax, Addr64: def.Addr64, Shared: def.Shared, Exports: memoryExports[i]}
 		if def.ImportKey != "" {
-			memories[i].ImportModule, memories[i].ImportName = splitImportKey(def.ImportKey)
+			memories[i].ImportModule, memories[i].ImportName = splitImportKeyAt(def.ImportKey, importModuleEndAt(memoryModuleEnds, i))
 		}
 	}
 
@@ -389,7 +391,7 @@ func (m *Module) Metadata() ModuleMetadata {
 		for i, tag := range c.memoryDir.ehTags {
 			tags[i] = TagMetadata{Index: i, TypeIndex: tag.TypeIndex, Exports: tagExports[i]}
 			if tag.ImportKey != "" {
-				tags[i].ImportModule, tags[i].ImportName = splitImportKey(tag.ImportKey)
+				tags[i].ImportModule, tags[i].ImportName = splitImportKeyAt(tag.ImportKey, importModuleEndAt(tagModuleEnds, i))
 			}
 			if int(tag.TypeIndex) < len(c.Types) && c.Types[tag.TypeIndex].Kind == CompositeTypeFunction {
 				tags[i].Params, _ = valTypesFromDescriptors(c.Types[tag.TypeIndex].Params, c.Types)
@@ -543,4 +545,106 @@ func splitImportKey(key string) (module, name string) {
 		}
 	}
 	return key, ""
+}
+
+// exactImportModuleEnd encodes one plus the module-name byte length so zero can
+// retain the legacy first-dot interpretation for hand-built Compiled values.
+func exactImportModuleEnd(module string) uint64 { return uint64(len(module)) + 1 }
+
+func importModuleEndAt(ends []uint64, index int) uint64 {
+	if index < 0 || index >= len(ends) {
+		return 0
+	}
+	return ends[index]
+}
+
+func splitImportKeyAt(key string, moduleEnd uint64) (module, name string) {
+	if validateImportModuleEnd(key, moduleEnd) == nil && moduleEnd != 0 {
+		i := int(moduleEnd - 1)
+		return key[:i], key[i+1:]
+	}
+	return splitImportKey(key)
+}
+
+func validateImportModuleEnd(key string, moduleEnd uint64) error {
+	if moduleEnd == 0 { // Legacy hand-built Compiled metadata.
+		return nil
+	}
+	separator := moduleEnd - 1
+	if separator >= uint64(len(key)) || key[separator] != '.' {
+		return fmt.Errorf("module-name end %d does not identify the import-key separator", moduleEnd)
+	}
+	return nil
+}
+
+// importModuleEndSections returns exact-name sidecars in their persisted order.
+// A false result identifies a legacy hand-built Compiled value or malformed
+// private metadata; callers retain the historical first-dot fallback in either
+// case, while validation rejects malformed non-empty sidecars.
+func (c *Compiled) importModuleEndSections() (functions, tables, memories, tags []uint64, exact bool) {
+	if c == nil {
+		return nil, nil, nil, nil, false
+	}
+	var ends []uint64
+	if c.validateMemo != nil {
+		ends = c.validateMemo.importModuleEnds
+	}
+	functionCount := len(c.Imports)
+	tableCount := c.tableImportCount()
+	memoryCount := c.memoryImportCount()
+	tagCount := c.tagImportCount()
+	total := functionCount + tableCount + memoryCount + tagCount
+	if total == 0 {
+		return nil, nil, nil, nil, len(ends) == 0
+	}
+	if len(ends) != total {
+		return nil, nil, nil, nil, false
+	}
+	tableStart := functionCount
+	memoryStart := tableStart + tableCount
+	tagStart := memoryStart + memoryCount
+	return ends[:tableStart], ends[tableStart:memoryStart], ends[memoryStart:tagStart], ends[tagStart:], true
+}
+
+func (c *Compiled) appendImportModuleEnd(moduleEnd uint64) {
+	if c.validateMemo == nil {
+		c.validateMemo = &validateMemo{}
+	}
+	c.validateMemo.importModuleEnds = append(c.validateMemo.importModuleEnds, moduleEnd)
+}
+
+func (c *Compiled) validateImportModuleEnds() error {
+	if c == nil || c.validateMemo == nil || len(c.validateMemo.importModuleEnds) == 0 {
+		return nil
+	}
+	functionEnds, tableEnds, memoryEnds, tagEnds, exact := c.importModuleEndSections()
+	if !exact {
+		want := len(c.Imports) + c.tableImportCount() + c.memoryImportCount() + c.tagImportCount()
+		return fmt.Errorf("compiled metadata invalid: import module-name ends length %d != non-global import count %d", len(c.validateMemo.importModuleEnds), want)
+	}
+	for i, key := range c.Imports {
+		if err := validateImportModuleEnd(key, functionEnds[i]); err != nil {
+			return fmt.Errorf("compiled metadata invalid: function import %d: %w", i, err)
+		}
+	}
+	for i := range tableEnds {
+		def, _ := c.tableImportAt(i)
+		if err := validateImportModuleEnd(def.Key, tableEnds[i]); err != nil {
+			return fmt.Errorf("compiled metadata invalid: table import %d: %w", i, err)
+		}
+	}
+	for i := range memoryEnds {
+		def, _ := c.memoryImportAt(i)
+		if err := validateImportModuleEnd(def.ImportKey, memoryEnds[i]); err != nil {
+			return fmt.Errorf("compiled metadata invalid: memory import %d: %w", i, err)
+		}
+	}
+	if c.memoryDir != nil {
+		for i := range tagEnds {
+			if err := validateImportModuleEnd(c.memoryDir.ehTags[i].ImportKey, tagEnds[i]); err != nil {
+				return fmt.Errorf("compiled metadata invalid: tag import %d: %w", i, err)
+			}
+		}
+	}
+	return nil
 }

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -231,10 +231,11 @@ func buildModule(c *Compiled, bindings moduleBindings) *Module {
 			spec.Results = append([]ValType(nil), c.importFuncSigs[i].Results...)
 			spec.ParamTypes, spec.ResultTypes, _ = exactFuncSignature(c.importFuncSigs[i], c.Types)
 		}
-		if _, ok := bindings.imports[key]; ok {
+		meta := bindings.importMeta[key]
+		if _, ok := bindings.imports[key]; ok && registeredImportMatches(meta, mod, name) {
 			spec.Provided = true
 		}
-		if meta := bindings.importMeta[key]; meta != nil {
+		if meta != nil && registeredImportMatches(meta, mod, name) {
 			spec.Capability, spec.HasCapability = meta.cap, meta.hasCap
 			spec.Docs = meta.docs
 			if meta.hasCap && !capSeen[meta.cap] {
@@ -281,6 +282,14 @@ func buildModule(c *Compiled, bindings moduleBindings) *Module {
 		}
 	}
 	return m
+}
+
+// registeredImportMatches prevents the legacy flat binding namespace from
+// crossing an exact Wasm module/name boundary. A nil record identifies an
+// explicitly supplied legacy binding, which has no structured identity to
+// verify and retains the public Imports API's historical behavior.
+func registeredImportMatches(meta *registeredImport, module, name string) bool {
+	return meta == nil || meta.module == module && meta.name == name
 }
 
 func (h *hookRegistry) needsModuleIdentity() bool {

--- a/src/wago/reference_quiescence_test.go
+++ b/src/wago/reference_quiescence_test.go
@@ -56,7 +56,7 @@ func TestReferenceTokensWaitForClosingInvocationQuiescence(t *testing.T) {
 		t.Fatal(err)
 	}
 	closeDone := make(chan error, 1)
-	go func() { closeDone <- rt.Close() }()
+	go func() { closeDone <- rt.CloseContext(context.Background()) }()
 
 	var closeAccounted, quiesced, resourcesReleased bool
 	var tokens int

--- a/src/wago/reference_quiescence_test.go
+++ b/src/wago/reference_quiescence_test.go
@@ -58,15 +58,20 @@ func TestReferenceTokensWaitForClosingInvocationQuiescence(t *testing.T) {
 	closeDone := make(chan error, 1)
 	go func() { closeDone <- rt.Close() }()
 
-	var writerState *referenceStoreInstance
+	var closeAccounted, quiesced, resourcesReleased bool
 	var tokens int
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		rt.refStore.mu.Lock()
-		writerState = rt.refStore.instances[writer]
+		writerState := rt.refStore.instances[writer]
+		if writerState != nil {
+			closeAccounted = writerState.closeAccounted
+			quiesced = writerState.quiesced
+			resourcesReleased = writerState.resourcesReleased
+		}
 		tokens = len(rt.refStore.byToken)
 		rt.refStore.mu.Unlock()
-		if writerState != nil && writerState.closeAccounted {
+		if closeAccounted {
 			break
 		}
 		if time.Now().After(deadline) {
@@ -74,8 +79,8 @@ func TestReferenceTokensWaitForClosingInvocationQuiescence(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 	}
-	if writerState == nil || !writerState.closeAccounted || writerState.quiesced || writerState.resourcesReleased {
-		t.Fatalf("writer store state before resume = %+v", writerState)
+	if !closeAccounted || quiesced || resourcesReleased {
+		t.Fatalf("writer store state before resume: closed=%v quiesced=%v released=%v", closeAccounted, quiesced, resourcesReleased)
 	}
 	if tokens != 1 {
 		t.Fatalf("token entries before quiescence = %d, want 1", tokens)

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -751,6 +751,9 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports)
 			continue
 		}
 		value, provided := rt.imports[key]
+		if provided && spec.Kind == ImportFunc && !registeredImportMatches(rt.importMeta[key], spec.Module, spec.Name) {
+			provided = false
+		}
 		if !provided {
 			if spec.Kind == ImportFunc {
 				return nil, missingImportError(spec)

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/semver"
 )
 
@@ -509,7 +508,6 @@ func (p *PreparedCompile) Adopt(c *Compiled) (*Module, error) {
 
 func (p *PreparedCompile) finishCompile(c *Compiled) (*Module, error) {
 	mod := buildModule(c, p.bindings)
-	p.rt.restoreStructuredImportNames(mod, p.source)
 	if len(p.hooks.afterCompile) != 0 {
 		event := ModuleCompiledEvent{Compilation: p.compilation, Module: moduleView(mod), SourceDigest: DigestModuleSource(p.source)}
 		for _, fn := range p.hooks.afterCompile {
@@ -550,23 +548,6 @@ func emitCompileError(hooks *hookRegistry, compilation CompilationIdentity, orig
 		}
 	}
 	return joinPrimary(original, hookErrs...)
-}
-
-func (rt *Runtime) restoreStructuredImportNames(mod *Module, source []byte) {
-	// The historical Imports key joins module and field with a dot. Both Wasm
-	// names may contain dots, so recover the exact pair from validated source.
-	if decoded, err := wasm.DecodeModule(source); err == nil {
-		funcIndex := 0
-		for i := range decoded.Imports {
-			im := &decoded.Imports[i]
-			if im.Type.Kind != wasm.ExternFunc || funcIndex >= len(mod.imports) {
-				continue
-			}
-			mod.imports[funcIndex].Module = im.Module
-			mod.imports[funcIndex].Name = im.Name
-			funcIndex++
-		}
-	}
 }
 
 func (rt *Runtime) compile(wasmBytes []byte, allowLoading bool) (*Module, error) {


### PR DESCRIPTION
Closes #397.

## What changed

- preserve each non-global import's exact module-name boundary during the original validated decode/compile pipeline;
- serialize and strictly validate those boundaries in codec version 1, so source compilation and artifact loading expose identical function, table, memory, and tag identities;
- remove the post-compilation `wasm.DecodeModule` pass from `Runtime.Compile`;
- require plugin bindings and capability metadata to match the exact `(module, name)` pair before satisfying a flattened legacy key;
- cap expanded function-import directory headers and boundaries at 64 MiB, and reject contradictory import counts before allocation;
- fix an independently discovered race in the reference-quiescence regression test by snapshotting state under the store lock;
- add adversarial exact-identity, malformed-artifact, allocation-bound, race, and 0/10/1,000/10,000-import benchmark coverage.

## Security and correctness invariants

- dotted, empty, NUL-containing, and valid UTF-8 import names are never reconstructed by splitting an ambiguous flat key;
- plugin authority cannot cross a dotted flat-key collision;
- malformed module-name boundaries and count disagreements fail before artifact publication or unbounded directory allocation;
- compiler-produced, decoded, and finalizer-owned metadata retain the same immutable sidecar;
- the public legacy `Imports` map remains source-compatible for explicit caller overrides.

## Measurement

Go 1.23.2, linux/amd64, 10,000 function imports, five iterations:

| path | before | after |
| --- | --- | --- |
| Runtime time | 34.89–35.71 ms/op | 34.44–35.43 ms/op |
| Runtime bytes | 18,271,203–18,271,692 B/op | 17,312,036–17,312,246 B/op |
| Runtime allocations | 89,852–89,853 allocs/op | 69,847 allocs/op |

The retained exact-name sidecar costs 8 bytes per non-global import and one allocation; it replaces the second full source decode.

## Validation

- focused and codec-wide `go test -race` coverage passed;
- codec mutation fuzzing passed (up to 445,132 executions in a 10-second run);
- generated-valid codec fuzzing passed (241,924 executions in a 10-second run);
- `go vet ./src/wago` passed;
- `tinygo test -scheduler=tasks ./src/wago` passed;
- linux/darwin/windows amd64/arm64 test compilation passed;
- the 10,000-import benchmark reports allocations with `-benchmem`.

The complete local Core 3 accounting suite still requires the repository's pinned Release 3 interpreter/newer WABT; those environment-dependent failures are unchanged by this PR.
