### PR TITLE
perf(version): load browse history incrementally

### DIFF
--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -56,10 +56,13 @@ func vmBrowseContext(ctx context.Context, d wagopaths.Dirs, profileValue, buildV
 			return
 		}
 		var err error
+		history := ""
 		switch choice {
 		case pickerLoadMoreReleases:
+			history = "release"
 			err = discovery.loadReleases(ctx)
 		case pickerLoadMoreCommits:
+			history = "commit"
 			err = discovery.loadCommits(ctx)
 		default:
 			if choice == "latest" {
@@ -77,7 +80,12 @@ func vmBrowseContext(ctx context.Context, d wagopaths.Dirs, profileValue, buildV
 			return
 		}
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "wago: version browse: unable to load older history: %v\n", err)
+			fmt.Fprintf(os.Stderr, "wago: version browse: unable to load older %s history: %v\n", history, err)
+			continue
+		}
+		if (choice == pickerLoadMoreReleases && discovery.releasesPager.limitReached()) ||
+			(choice == pickerLoadMoreCommits && discovery.commitsPager.limitReached()) {
+			fmt.Fprintf(os.Stderr, "wago: version browse: %s history page limit reached; install an exact version with `wago version install <version>`\n", history)
 		}
 	}
 }
@@ -108,6 +116,10 @@ func newReleaseDiscoveryPager() releaseDiscoveryPager {
 
 func (p *releaseDiscoveryPager) hasMore() bool {
 	return p.address != "" && p.pages < releaseDiscoveryPageLimit
+}
+
+func (p *releaseDiscoveryPager) limitReached() bool {
+	return p.address != "" && p.pages >= releaseDiscoveryPageLimit
 }
 
 func (p *releaseDiscoveryPager) next(ctx context.Context, operation string) ([]remoteRelease, error) {
@@ -167,6 +179,10 @@ type commitDiscoveryPager struct {
 
 func (p *commitDiscoveryPager) hasMore() bool {
 	return !p.done && p.page < discoveryPageLimit
+}
+
+func (p *commitDiscoveryPager) limitReached() bool {
+	return !p.done && p.page >= discoveryPageLimit
 }
 
 func (p *commitDiscoveryPager) next(ctx context.Context) ([]remoteCommit, error) {

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -35,27 +35,51 @@ func latestStableReleaseContext(ctx context.Context) (string, error) {
 }
 
 func vmBrowseContext(ctx context.Context, d wagopaths.Dirs, profileValue, buildValue, use string) {
-	releases, err := fetchReleasesContext(ctx)
-	if err != nil {
+	discovery := newVersionBrowseDiscovery()
+	if err := discovery.loadReleases(ctx); err != nil {
 		fatal("version browse: unable to fetch releases: %v", err)
 	}
-	commits, err := fetchMainCommitsContext(ctx)
-	if err != nil {
+	if err := discovery.loadCommits(ctx); err != nil {
 		fatal("version browse: unable to fetch main commits: %v", err)
 	}
-	choice, profile, build, ok := chooseInstallPicker(releases, commits, time.Now(), profileValue, buildValue)
-	if !ok {
-		return
-	}
-	if choice == "latest" {
-		release, err := latestStableReleaseContext(ctx)
-		if err != nil {
-			fatal("version latest: %v", err)
+	for {
+		choice, profile, build, ok := chooseInstallPicker(
+			discovery.releases,
+			discovery.commits,
+			time.Now(),
+			profileValue,
+			buildValue,
+			discovery.releasesPager.hasMore(),
+			discovery.commitsPager.hasMore(),
+		)
+		if !ok {
+			return
 		}
-		vmInstallContext(ctx, d, release, profile, build, use)
-		return
+		var err error
+		switch choice {
+		case pickerLoadMoreReleases:
+			err = discovery.loadReleases(ctx)
+		case pickerLoadMoreCommits:
+			err = discovery.loadCommits(ctx)
+		default:
+			if choice == "latest" {
+				release, resolveErr := latestStableReleaseContext(ctx)
+				if resolveErr != nil {
+					fatal("version latest: %v", resolveErr)
+				}
+				vmInstallContext(ctx, d, release, profile, build, use)
+				return
+			}
+			vmInstallContext(ctx, d, choice, profile, build, use)
+			return
+		}
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wago: version browse: unable to load older history: %v\n", err)
+		}
 	}
-	vmInstallContext(ctx, d, choice, profile, build, use)
 }
 
 func fetchReleases() ([]remoteRelease, error) {
@@ -64,9 +88,143 @@ func fetchReleases() ([]remoteRelease, error) {
 
 const (
 	discoveryPageLimit        = 10
+	commitDiscoveryPageSize   = 100
 	releaseDiscoveryPageSize  = 20
 	releaseDiscoveryPageLimit = 50
 )
+
+type releaseDiscoveryPager struct {
+	address string
+	seen    map[string]struct{}
+	pages   int
+}
+
+func newReleaseDiscoveryPager() releaseDiscoveryPager {
+	return releaseDiscoveryPager{
+		address: fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=%d&page=1", releaseAPI(), releaseDiscoveryPageSize),
+		seen:    make(map[string]struct{}, releaseDiscoveryPageLimit),
+	}
+}
+
+func (p *releaseDiscoveryPager) hasMore() bool {
+	return p.address != "" && p.pages < releaseDiscoveryPageLimit
+}
+
+func (p *releaseDiscoveryPager) next(ctx context.Context, operation string) ([]remoteRelease, error) {
+	if p.address == "" {
+		return nil, nil
+	}
+	if p.pages >= releaseDiscoveryPageLimit {
+		return nil, fmt.Errorf("GitHub release discovery exceeded %d pages", releaseDiscoveryPageLimit)
+	}
+	address := p.address
+	page := p.pages + 1
+	if _, duplicate := p.seen[address]; duplicate {
+		return nil, fmt.Errorf("GitHub release pagination loop at page %d", page)
+	}
+	response, err := getReleaseBytes(ctx, operation, address, releaseMetadataMaximum)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub returned %s", response.Status)
+	}
+	var batch []remoteRelease
+	if err := json.Unmarshal(response.Body, &batch); err != nil {
+		return nil, err
+	}
+	if len(batch) > releaseDiscoveryPageSize {
+		return nil, fmt.Errorf("GitHub returned too many releases on page %d", page)
+	}
+	next, found, err := releaseNextLink(response.Header, address)
+	if err != nil {
+		return nil, err
+	}
+	if !found && len(batch) == releaseDiscoveryPageSize {
+		next = fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=%d&page=%d", releaseAPI(), releaseDiscoveryPageSize, page+1)
+		found = true
+	}
+	if found {
+		if next == address {
+			return nil, fmt.Errorf("GitHub release pagination loop at page %d", page)
+		}
+		if _, duplicate := p.seen[next]; duplicate {
+			return nil, fmt.Errorf("GitHub release pagination loop at page %d", page)
+		}
+	} else {
+		next = ""
+	}
+	p.seen[address] = struct{}{}
+	p.address = next
+	p.pages = page
+	return batch, nil
+}
+
+type commitDiscoveryPager struct {
+	page int
+	done bool
+}
+
+func (p *commitDiscoveryPager) hasMore() bool {
+	return !p.done && p.page < discoveryPageLimit
+}
+
+func (p *commitDiscoveryPager) next(ctx context.Context) ([]remoteCommit, error) {
+	if p.done {
+		return nil, nil
+	}
+	if p.page >= discoveryPageLimit {
+		return nil, fmt.Errorf("GitHub commit discovery exceeded %d pages", discoveryPageLimit)
+	}
+	page := p.page + 1
+	address := fmt.Sprintf("%s/repos/wago-org/wago/commits?sha=main&per_page=%d&page=%d", releaseAPI(), commitDiscoveryPageSize, page)
+	response, err := getReleaseBytes(ctx, "main commit discovery", address, releaseMetadataMaximum)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub returned %s", response.Status)
+	}
+	var batch []remoteCommit
+	if err := json.Unmarshal(response.Body, &batch); err != nil {
+		return nil, err
+	}
+	if len(batch) > commitDiscoveryPageSize {
+		return nil, fmt.Errorf("GitHub returned too many commits on page %d", page)
+	}
+	p.page = page
+	p.done = len(batch) < commitDiscoveryPageSize
+	return batch, nil
+}
+
+type versionBrowseDiscovery struct {
+	releases      []remoteRelease
+	commits       []remoteCommit
+	releasesPager releaseDiscoveryPager
+	commitsPager  commitDiscoveryPager
+}
+
+func newVersionBrowseDiscovery() versionBrowseDiscovery {
+	return versionBrowseDiscovery{releasesPager: newReleaseDiscoveryPager()}
+}
+
+func (d *versionBrowseDiscovery) loadReleases(ctx context.Context) error {
+	batch, err := d.releasesPager.next(ctx, "release discovery")
+	if err != nil {
+		return err
+	}
+	d.releases = append(d.releases, batch...)
+	return nil
+}
+
+func (d *versionBrowseDiscovery) loadCommits(ctx context.Context) error {
+	batch, err := d.commitsPager.next(ctx)
+	if err != nil {
+		return err
+	}
+	d.commits = append(d.commits, batch...)
+	return nil
+}
 
 func fetchReleasesContext(ctx context.Context) ([]remoteRelease, error) {
 	var releases []remoteRelease
@@ -78,44 +236,20 @@ func fetchReleasesContext(ctx context.Context) ([]remoteRelease, error) {
 }
 
 func forEachReleasePage(ctx context.Context, operation string, visit func([]remoteRelease) bool) error {
-	address := fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=%d&page=1", releaseAPI(), releaseDiscoveryPageSize)
-	seen := make(map[string]struct{}, releaseDiscoveryPageLimit)
-	for page := 1; page <= releaseDiscoveryPageLimit; page++ {
-		if _, duplicate := seen[address]; duplicate {
-			return fmt.Errorf("GitHub release pagination loop at page %d", page)
-		}
-		seen[address] = struct{}{}
-		response, err := getReleaseBytes(ctx, operation, address, releaseMetadataMaximum)
+	pager := newReleaseDiscoveryPager()
+	for pager.hasMore() {
+		batch, err := pager.next(ctx, operation)
 		if err != nil {
 			return err
-		}
-		if response.StatusCode != http.StatusOK {
-			return fmt.Errorf("GitHub returned %s", response.Status)
-		}
-		var batch []remoteRelease
-		if err := json.Unmarshal(response.Body, &batch); err != nil {
-			return err
-		}
-		if len(batch) > releaseDiscoveryPageSize {
-			return fmt.Errorf("GitHub returned too many releases on page %d", page)
 		}
 		if !visit(batch) {
 			return nil
 		}
-		next, found, err := releaseNextLink(response.Header, address)
-		if err != nil {
-			return err
-		}
-		if found {
-			address = next
-			continue
-		}
-		if len(batch) < releaseDiscoveryPageSize {
-			return nil
-		}
-		address = fmt.Sprintf("%s/repos/wago-org/wago/releases?per_page=%d&page=%d", releaseAPI(), releaseDiscoveryPageSize, page+1)
 	}
-	return fmt.Errorf("GitHub release discovery exceeded %d pages", releaseDiscoveryPageLimit)
+	if pager.address != "" {
+		return fmt.Errorf("GitHub release discovery exceeded %d pages", releaseDiscoveryPageLimit)
+	}
+	return nil
 }
 
 func releaseNextLink(header http.Header, current string) (string, bool, error) {
@@ -392,28 +526,18 @@ func fetchMainCommits() ([]remoteCommit, error) {
 
 func fetchMainCommitsContext(ctx context.Context) ([]remoteCommit, error) {
 	var commits []remoteCommit
-	for page := 1; page <= discoveryPageLimit; page++ {
-		address := fmt.Sprintf("%s/repos/wago-org/wago/commits?sha=main&per_page=100&page=%d", releaseAPI(), page)
-		response, err := getReleaseBytes(ctx, "main commit discovery", address, releaseMetadataMaximum)
+	var pager commitDiscoveryPager
+	for pager.hasMore() {
+		batch, err := pager.next(ctx)
 		if err != nil {
 			return nil, err
 		}
-		if response.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("GitHub returned %s", response.Status)
-		}
-		var batch []remoteCommit
-		if err := json.Unmarshal(response.Body, &batch); err != nil {
-			return nil, err
-		}
-		if len(batch) > 100 {
-			return nil, fmt.Errorf("GitHub returned too many commits on page %d", page)
-		}
 		commits = append(commits, batch...)
-		if len(batch) < 100 {
-			return commits, nil
-		}
 	}
-	return nil, fmt.Errorf("GitHub commit discovery exceeded %d pages", discoveryPageLimit)
+	if !pager.done {
+		return nil, fmt.Errorf("GitHub commit discovery exceeded %d pages", discoveryPageLimit)
+	}
+	return commits, nil
 }
 
 func latestChannelRelease(channel string) (string, error) {

--- a/cli/manager/internal/version/lifecycle_test.go
+++ b/cli/manager/internal/version/lifecycle_test.go
@@ -505,6 +505,41 @@ func TestInstallPickerProfilePageReturnsToReleasePage(t *testing.T) {
 	}
 }
 
+func TestPaginatedInstallPickerKeepsChannelsSelectableAndLoadActionsTerminal(t *testing.T) {
+	items := paginatedInstallPickerItems(nil, nil, time.Now(), true, true)
+	if len(items) != 4 {
+		t.Fatalf("root picker items = %d, want 4", len(items))
+	}
+	tests := []struct {
+		name       string
+		item       tui.Item
+		channel    string
+		loadAction string
+	}{
+		{name: "canary", item: items[0], channel: "canary", loadAction: pickerLoadMoreCommits},
+		{name: "nightly", item: items[1], channel: "nightly", loadAction: pickerLoadMoreReleases},
+		{name: "latest", item: items[2], channel: "latest", loadAction: pickerLoadMoreReleases},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if len(test.item.Children) != 2 {
+				t.Fatalf("children = %d, want channel and load action", len(test.item.Children))
+			}
+			if test.item.Children[0].Value != test.channel || len(test.item.Children[0].AcceptItems) == 0 {
+				t.Fatalf("channel child = %#v", test.item.Children[0])
+			}
+			load := test.item.Children[1]
+			if load.Value != test.loadAction || len(load.AcceptItems) != 0 || len(load.Children) != 0 {
+				t.Fatalf("load action = %#v", load)
+			}
+		})
+	}
+	load := items[len(items)-1]
+	if load.Value != pickerLoadMoreReleases || len(load.AcceptItems) != 0 || len(load.Children) != 0 {
+		t.Fatalf("root load action = %#v", load)
+	}
+}
+
 func TestRelativeReleaseAgeUsesCompactElapsedUnits(t *testing.T) {
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	tests := []struct {

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -483,6 +483,29 @@ func TestReleaseDiscoveryBoundsTotalPagination(t *testing.T) {
 	}
 }
 
+func TestDiscoveryPagersDistinguishExhaustionFromHardLimit(t *testing.T) {
+	releases := newReleaseDiscoveryPager()
+	releases.address = ""
+	releases.pages = 1
+	if releases.hasMore() || releases.limitReached() {
+		t.Fatal("exhausted release pager reported more history or a hard limit")
+	}
+	releases.address = "https://api.github.test/releases?page=51"
+	releases.pages = releaseDiscoveryPageLimit
+	if releases.hasMore() || !releases.limitReached() {
+		t.Fatal("capped release pager did not report its hard limit")
+	}
+
+	commits := commitDiscoveryPager{page: 1, done: true}
+	if commits.hasMore() || commits.limitReached() {
+		t.Fatal("exhausted commit pager reported more history or a hard limit")
+	}
+	commits = commitDiscoveryPager{page: discoveryPageLimit}
+	if commits.hasMore() || !commits.limitReached() {
+		t.Fatal("capped commit pager did not report its hard limit")
+	}
+}
+
 func TestReleaseMetadataIsBoundedAndCancelable(t *testing.T) {
 	oldMaximum := releaseMetadataMaximum
 	releaseMetadataMaximum = 32

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -308,6 +308,144 @@ func TestMainCommitBrowsingPaginatesAndResolvesTip(t *testing.T) {
 	}
 }
 
+func TestVersionBrowseDiscoveryFetchesOnePageAtATime(t *testing.T) {
+	releaseRequests, commitRequests := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/repos/wago-org/wago/releases":
+			releaseRequests++
+			count := releaseDiscoveryPageSize
+			if request.URL.Query().Get("page") == "2" {
+				count = 1
+			}
+			releases := make([]remoteRelease, count)
+			for index := range releases {
+				releases[index].TagName = fmt.Sprintf("v1.%d.%d", releaseRequests, index)
+			}
+			_ = json.NewEncoder(writer).Encode(releases)
+		case "/repos/wago-org/wago/commits":
+			commitRequests++
+			count := commitDiscoveryPageSize
+			if request.URL.Query().Get("page") == "2" {
+				count = 1
+			}
+			commits := make([]remoteCommit, count)
+			for index := range commits {
+				commits[index].SHA = fmt.Sprintf("%040x", commitRequests*commitDiscoveryPageSize+index)
+			}
+			_ = json.NewEncoder(writer).Encode(commits)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_RELEASE_API", server.URL)
+
+	discovery := newVersionBrowseDiscovery()
+	if err := discovery.loadReleases(context.Background()); err != nil {
+		t.Fatalf("initial release page: %v", err)
+	}
+	if err := discovery.loadCommits(context.Background()); err != nil {
+		t.Fatalf("initial commit page: %v", err)
+	}
+	if releaseRequests != 1 || commitRequests != 1 {
+		t.Fatalf("initial requests = releases %d, commits %d; want one each", releaseRequests, commitRequests)
+	}
+	if len(discovery.releases) != releaseDiscoveryPageSize || len(discovery.commits) != commitDiscoveryPageSize {
+		t.Fatalf("initial history = releases %d, commits %d", len(discovery.releases), len(discovery.commits))
+	}
+	if !discovery.releasesPager.hasMore() || !discovery.commitsPager.hasMore() {
+		t.Fatal("full initial pages did not advertise older history")
+	}
+
+	if err := discovery.loadReleases(context.Background()); err != nil {
+		t.Fatalf("older release page: %v", err)
+	}
+	if releaseRequests != 2 || commitRequests != 1 {
+		t.Fatalf("release load requests = releases %d, commits %d; want 2, 1", releaseRequests, commitRequests)
+	}
+	if discovery.releasesPager.hasMore() || len(discovery.releases) != releaseDiscoveryPageSize+1 {
+		t.Fatalf("release history after short page = %d, more %v", len(discovery.releases), discovery.releasesPager.hasMore())
+	}
+
+	if err := discovery.loadCommits(context.Background()); err != nil {
+		t.Fatalf("older commit page: %v", err)
+	}
+	if releaseRequests != 2 || commitRequests != 2 {
+		t.Fatalf("commit load requests = releases %d, commits %d; want 2, 2", releaseRequests, commitRequests)
+	}
+	if discovery.commitsPager.hasMore() || len(discovery.commits) != commitDiscoveryPageSize+1 {
+		t.Fatalf("commit history after short page = %d, more %v", len(discovery.commits), discovery.commitsPager.hasMore())
+	}
+}
+
+func TestVersionBrowseDiscoveryLaterFailurePreservesHistoryAndCursor(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/repos/wago-org/wago/releases" {
+			http.NotFound(writer, request)
+			return
+		}
+		requests++
+		if requests == 2 {
+			http.Error(writer, "temporary failure", http.StatusBadGateway)
+			return
+		}
+		count := releaseDiscoveryPageSize
+		if requests == 3 {
+			count = 1
+		}
+		_ = json.NewEncoder(writer).Encode(make([]remoteRelease, count))
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_RELEASE_API", server.URL)
+
+	discovery := newVersionBrowseDiscovery()
+	if err := discovery.loadReleases(context.Background()); err != nil {
+		t.Fatalf("initial release page: %v", err)
+	}
+	address, pages := discovery.releasesPager.address, discovery.releasesPager.pages
+	if err := discovery.loadReleases(context.Background()); err == nil || !strings.Contains(err.Error(), "502") {
+		t.Fatalf("later release failure = %v, want 502", err)
+	}
+	if len(discovery.releases) != releaseDiscoveryPageSize || discovery.releasesPager.address != address || discovery.releasesPager.pages != pages {
+		t.Fatalf("failed page mutated history or cursor: releases %d, address %q, pages %d", len(discovery.releases), discovery.releasesPager.address, discovery.releasesPager.pages)
+	}
+	if err := discovery.loadReleases(context.Background()); err != nil {
+		t.Fatalf("retry older release page: %v", err)
+	}
+	if requests != 3 || len(discovery.releases) != releaseDiscoveryPageSize+1 || discovery.releasesPager.hasMore() {
+		t.Fatalf("retried page = requests %d, releases %d, more %v", requests, len(discovery.releases), discovery.releasesPager.hasMore())
+	}
+}
+
+func TestVersionBrowseDiscoveryCancellationPreservesHistoryAndCursor(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		if requests == 1 {
+			_ = json.NewEncoder(writer).Encode(make([]remoteCommit, commitDiscoveryPageSize))
+			return
+		}
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_RELEASE_API", server.URL)
+
+	discovery := newVersionBrowseDiscovery()
+	if err := discovery.loadCommits(context.Background()); err != nil {
+		t.Fatalf("initial commit page: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := discovery.loadCommits(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled older commit page = %v", err)
+	}
+	if len(discovery.commits) != commitDiscoveryPageSize || discovery.commitsPager.page != 1 || !discovery.commitsPager.hasMore() {
+		t.Fatalf("canceled page mutated history or cursor: commits %d, page %d, more %v", len(discovery.commits), discovery.commitsPager.page, discovery.commitsPager.hasMore())
+	}
+}
+
 func TestReleaseDiscoveryBoundsTotalPagination(t *testing.T) {
 	releases := make([]remoteRelease, releaseDiscoveryPageSize)
 	commits := make([]remoteCommit, 100)

--- a/cli/manager/internal/version/releases.go
+++ b/cli/manager/internal/version/releases.go
@@ -265,26 +265,65 @@ func releasePickerChildren(channel string, versions []tui.Item) []tui.Item {
 	return append(items, versions...)
 }
 
+const (
+	pickerLoadMoreReleases = "\x00wago:load-more-releases"
+	pickerLoadMoreCommits  = "\x00wago:load-more-commits"
+)
+
+func loadMorePickerItem(label, value string) tui.Item {
+	return tui.Item{Label: label, Description: "fetch one more page", Value: value}
+}
+
+func appendLoadMorePickerItem(channel string, items []tui.Item, item tui.Item) []tui.Item {
+	if len(items) == 0 {
+		items = []tui.Item{{Label: "latest", Value: channel}}
+	}
+	return append(items, item)
+}
+
 func versionPickerItemsWithCommits(releases []remoteRelease, commits []remoteCommit, now time.Time) []tui.Item {
+	return paginatedVersionPickerItems(releases, commits, now, false, false)
+}
+
+func paginatedVersionPickerItems(releases []remoteRelease, commits []remoteCommit, now time.Time, moreReleases, moreCommits bool) []tui.Item {
 	canary := canaryCommitItems(commits, now)
 	nightly := releasePickerItems(releases, "nightly", now)
 	stable := releasePickerItems(releases, "", now)
-	items := []tui.Item{
-		{Label: "canary", Value: "canary", Children: releasePickerChildren("canary", canary)},
-		{Label: "nightly", Value: "nightly", Children: releasePickerChildren("nightly", nightly)},
-		{Label: "latest", Value: "latest", Children: releasePickerChildren("latest", stable)},
+	canaryChildren := releasePickerChildren("canary", canary)
+	if moreCommits {
+		canaryChildren = appendLoadMorePickerItem("canary", canaryChildren, loadMorePickerItem("Load older commits…", pickerLoadMoreCommits))
 	}
-	return append(items, stable...)
+	nightlyChildren := releasePickerChildren("nightly", nightly)
+	latestChildren := releasePickerChildren("latest", stable)
+	if moreReleases {
+		loadMore := loadMorePickerItem("Load older releases…", pickerLoadMoreReleases)
+		nightlyChildren = appendLoadMorePickerItem("nightly", nightlyChildren, loadMore)
+		latestChildren = appendLoadMorePickerItem("latest", latestChildren, loadMore)
+	}
+	items := []tui.Item{
+		{Label: "canary", Value: "canary", Children: canaryChildren},
+		{Label: "nightly", Value: "nightly", Children: nightlyChildren},
+		{Label: "latest", Value: "latest", Children: latestChildren},
+	}
+	items = append(items, stable...)
+	if moreReleases {
+		items = append(items, loadMorePickerItem("Load older releases…", pickerLoadMoreReleases))
+	}
+	return items
 }
 
 func installPickerItemsWithCommits(releases []remoteRelease, commits []remoteCommit, now time.Time) []tui.Item {
 	return addProfileChoices(versionPickerItemsWithCommits(releases, commits, now))
 }
 
+func paginatedInstallPickerItems(releases []remoteRelease, commits []remoteCommit, now time.Time, moreReleases, moreCommits bool) []tui.Item {
+	return addProfileChoices(paginatedVersionPickerItems(releases, commits, now, moreReleases, moreCommits))
+}
+
 func addProfileChoices(items []tui.Item) []tui.Item {
 	for i := range items {
 		items[i].Children = addProfileChoices(items[i].Children)
-		if items[i].Value == "" {
+		if items[i].Value == "" || isPickerLoadMore(items[i].Value) {
 			continue
 		}
 		items[i].AcceptTitle = "Choose Wago profile"
@@ -309,19 +348,29 @@ func addProfileChoices(items []tui.Item) []tui.Item {
 	return items
 }
 
-func chooseInstallPicker(releases []remoteRelease, commits []remoteCommit, now time.Time, profileValue, buildValue string) (string, wagopaths.Profile, wagopaths.Build, bool) {
+func isPickerLoadMore(value string) bool {
+	return value == pickerLoadMoreReleases || value == pickerLoadMoreCommits
+}
+
+func chooseInstallPicker(releases []remoteRelease, commits []remoteCommit, now time.Time, profileValue, buildValue string, moreReleases, moreCommits bool) (string, wagopaths.Profile, wagopaths.Build, bool) {
 	if profileValue != "" || buildValue != "" {
-		choice, ok := tui.Choose("Install Wago version", versionPickerItemsWithCommits(releases, commits, now))
+		choice, ok := tui.Choose("Install Wago version", paginatedVersionPickerItems(releases, commits, now, moreReleases, moreCommits))
 		if !ok {
 			return "", "", "", false
+		}
+		if isPickerLoadMore(choice) {
+			return choice, "", "", true
 		}
 		profile, build, ok := chooseInstallVariant(profileValue, buildValue)
 		return choice, profile, build, ok
 	}
-	p := tui.NewPicker("Install Wago version", installPickerItemsWithCommits(releases, commits, now))
+	p := tui.NewPicker("Install Wago version", paginatedInstallPickerItems(releases, commits, now, moreReleases, moreCommits))
 	submitted, cancelled := tui.Run(p)
 	if !submitted || cancelled {
 		return "", "", "", false
+	}
+	if choice := p.Selected(); isPickerLoadMore(choice) {
+		return choice, "", "", true
 	}
 	return parseInstalledSelection(p.Selected())
 }


### PR DESCRIPTION
Closes #412.

## What changed

- fetch one recent release page and one recent main-commit page before opening the picker
- add explicit one-page “Load older releases…” and “Load older commits…” actions
- retain existing release and commit page ceilings
- preserve accumulated results and pagination cursors after a later request fails or is cancelled
- keep moving-channel resolution exhaustive and separate from interactive browsing
- disclose hard history caps and point users to exact-version installation

## Why

The interactive browser previously fetched every permitted history page before first paint. Startup therefore used up to 60 API requests and retained up to 2,000 records even when the user only needed a recent version; an old-page failure could also prevent selection of already-fetched results.

The initial view is now bounded to two API requests and at most 120 records, independent of total repository history.

## Validation

- `go test -count=1 -race ./cli/manager/...`
- `go test -count=1 ./cli/manager/...`
- `GOTOOLCHAIN=go1.22.12 go test -count=1 ./cli/manager/internal/version`
- `go test -shuffle=on -count=20 ./cli/manager/internal/version`
- repeated adversarial pagination tests with `-count=100`
- `go vet ./...`
- `go test -count=1 -tags wago_runtime ./cli/...`
- CGO-disabled release-manager builds for linux/amd64, windows/amd64, and darwin/arm64

A local `go test ./...` run reached the staged Wasm 3 accounting tests but could not complete them because the pinned spec interpreter was unavailable and the installed WABT could not parse that corpus. All applicable manager and changed-package gates pass.