### PR TITLE
project: make metadata updates transactional

### DIFF
--- a/cli/internal/project/lock.go
+++ b/cli/internal/project/lock.go
@@ -129,7 +129,7 @@ func LockPath(dir string) string { return filepath.Join(dir, LockFile) }
 
 func ReadLock(dir string) (LockDocument, error) {
 	var document LockDocument
-	err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+	err := withMetadataRead(dir, func(mutation *Mutation) error {
 		var err error
 		document, err = mutation.ReadLock()
 		return err

--- a/cli/internal/project/lock.go
+++ b/cli/internal/project/lock.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -127,6 +128,16 @@ func NewLockDocument() LockDocument {
 func LockPath(dir string) string { return filepath.Join(dir, LockFile) }
 
 func ReadLock(dir string) (LockDocument, error) {
+	var document LockDocument
+	err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		var err error
+		document, err = mutation.ReadLock()
+		return err
+	})
+	return document, err
+}
+
+func readLock(dir string) (LockDocument, error) {
 	data, err := os.ReadFile(LockPath(dir))
 	if os.IsNotExist(err) {
 		return NewLockDocument(), nil
@@ -178,11 +189,9 @@ func WriteLock(dir string, document LockDocument) error {
 	if automation.Locked() {
 		return fmt.Errorf("locked mode prevents changing %s", displayFilePath(LockPath(dir)))
 	}
-	data, err := EncodeLock(document)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(LockPath(dir), data, 0o644)
+	return WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		return mutation.PublishLock(document)
+	})
 }
 
 func ValidateLock(document LockDocument) error {

--- a/cli/internal/project/manifest.go
+++ b/cli/internal/project/manifest.go
@@ -46,7 +46,7 @@ func DisplayPath(dir string) string {
 // publishers and future schema versions.
 func Read(dir string) (map[string]any, error) {
 	var manifest map[string]any
-	err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+	err := withMetadataRead(dir, func(mutation *Mutation) error {
 		var err error
 		manifest, err = mutation.ReadManifest()
 		return err

--- a/cli/internal/project/manifest.go
+++ b/cli/internal/project/manifest.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -44,6 +45,16 @@ func DisplayPath(dir string) string {
 // Read loads wago.json as a generic map so updates preserve fields owned by
 // publishers and future schema versions.
 func Read(dir string) (map[string]any, error) {
+	var manifest map[string]any
+	err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		var err error
+		manifest, err = mutation.ReadManifest()
+		return err
+	})
+	return manifest, err
+}
+
+func readManifest(dir string) (map[string]any, error) {
 	data, err := os.ReadFile(Path(dir))
 	if os.IsNotExist(err) {
 		return map[string]any{}, nil
@@ -51,6 +62,10 @@ func Read(dir string) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	return decodeManifest(data, dir)
+}
+
+func decodeManifest(data []byte, dir string) (map[string]any, error) {
 	manifest := map[string]any{}
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	if err := decoder.Decode(&manifest); err != nil {
@@ -69,11 +84,9 @@ func Write(dir string, manifest map[string]any) error {
 	if automation.Locked() {
 		return fmt.Errorf("locked mode prevents changing %s", DisplayPath(dir))
 	}
-	data, err := EncodeManifest(manifest)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(Path(dir), data, 0o644)
+	return WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		return mutation.PublishManifest(manifest)
+	})
 }
 
 func EncodeManifest(manifest map[string]any) ([]byte, error) {
@@ -557,20 +570,27 @@ func Initialize(dir string) (bool, error) {
 // InitializeWith creates or updates a manifest while preserving fields that
 // are not owned by the caller. Values replace fields with the same key.
 func InitializeWith(dir string, values map[string]any) (bool, error) {
-	_, statErr := os.Stat(Path(dir))
-	created := os.IsNotExist(statErr)
-	manifest, err := Read(dir)
-	if err != nil {
-		return false, err
-	}
-	EnsureMetadata(manifest)
-	if _, ok := manifest["plugins"]; !ok {
-		manifest["plugins"] = map[string]any{}
-	}
-	for key, value := range values {
-		manifest[key] = value
-	}
-	return created, Write(dir, manifest)
+	var created bool
+	err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		_, statErr := os.Stat(Path(dir))
+		created = os.IsNotExist(statErr)
+		if statErr != nil && !created {
+			return statErr
+		}
+		manifest, err := mutation.ReadManifest()
+		if err != nil {
+			return err
+		}
+		EnsureMetadata(manifest)
+		if _, ok := manifest["plugins"]; !ok {
+			manifest["plugins"] = map[string]any{}
+		}
+		for key, value := range values {
+			manifest[key] = value
+		}
+		return mutation.PublishManifest(manifest)
+	})
+	return created, err
 }
 
 func EnsureMetadata(manifest map[string]any) {

--- a/cli/internal/project/plugins.go
+++ b/cli/internal/project/plugins.go
@@ -1,7 +1,9 @@
 package project
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -101,50 +103,106 @@ func AddDependency(dir, id, constraint string) (bool, error) {
 	if err := ValidateConstraint(constraint); err != nil {
 		return false, fmt.Errorf("plugin %q has invalid version constraint %q", id, constraint)
 	}
-	manifest, err := Read(dir)
-	if err != nil {
-		return false, err
-	}
-	changed, err := SetRequirement(manifest, id, constraint)
-	if err != nil || !changed {
-		return changed, err
-	}
-	return true, Write(dir, manifest)
+	var changed bool
+	err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		manifest, err := mutation.ReadManifest()
+		if err != nil {
+			return err
+		}
+		changed, err = SetRequirement(manifest, id, constraint)
+		if err != nil || !changed {
+			return err
+		}
+		return mutation.PublishManifest(manifest)
+	})
+	return changed, err
 }
 
 func RemoveDependency(dir, name string) (removed bool, module string, err error) {
-	manifest, err := Read(dir)
-	if err != nil {
-		return false, "", err
-	}
-	requirements, err := requirementsFromMap(manifest, dir)
-	if err != nil {
-		return false, "", err
-	}
 	id := strings.TrimSpace(name)
-	var matchedID string
-	for _, requirement := range requirements {
-		if requirement.ID == id {
-			matchedID = requirement.ID
-			break
+	err = WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		manifest, readErr := mutation.ReadManifest()
+		if readErr != nil {
+			return readErr
+		}
+		requirements, readErr := requirementsFromMap(manifest, dir)
+		if readErr != nil {
+			return readErr
+		}
+		for _, requirement := range requirements {
+			if requirement.ID == id {
+				module = requirement.ID
+				break
+			}
+		}
+		if module == "" {
+			return nil
+		}
+		_, lockStatErr := os.Stat(LockPath(dir))
+		if lockStatErr != nil && !os.IsNotExist(lockStatErr) {
+			return lockStatErr
+		}
+		if os.IsNotExist(lockStatErr) {
+			delete(manifest["plugins"].(map[string]any), id)
+			if publishErr := mutation.PublishManifest(manifest); publishErr != nil {
+				return publishErr
+			}
+			removed = true
+			return nil
+		}
+		lock, readErr := mutation.ReadLock()
+		if readErr != nil {
+			return readErr
+		}
+		delete(manifest["plugins"].(map[string]any), id)
+		if entry, ok := lock.Plugins[id]; ok {
+			entry.Direct = false
+			lock.Plugins[id] = entry
+		}
+		pruneLock(&lock)
+		if publishErr := mutation.PublishMetadata(manifest, lock); publishErr != nil {
+			return publishErr
+		}
+		removed = true
+		return nil
+	})
+	if err != nil {
+		return false, "", err
+	}
+	return removed, module, nil
+}
+
+func pruneLock(document *LockDocument) {
+	reachable := make(map[string]bool, len(document.Plugins))
+	var visit func(string)
+	visit = func(id string) {
+		if reachable[id] {
+			return
+		}
+		entry, ok := document.Plugins[id]
+		if !ok {
+			return
+		}
+		reachable[id] = true
+		for dependency := range entry.Dependencies {
+			visit(dependency)
+		}
+		for _, binding := range entry.Bindings {
+			for _, provider := range binding.Providers {
+				visit(provider)
+			}
 		}
 	}
-	if matchedID == "" {
-		return false, "", nil
+	for id, entry := range document.Plugins {
+		if entry.Direct {
+			visit(id)
+		}
 	}
-	delete(manifest["plugins"].(map[string]any), id)
-	if err := Write(dir, manifest); err != nil {
-		return false, "", err
+	for id := range document.Plugins {
+		if !reachable[id] {
+			delete(document.Plugins, id)
+		}
 	}
-	lock, err := ReadLock(dir)
-	if err != nil {
-		return false, "", err
-	}
-	delete(lock.Plugins, id)
-	if err := WriteLock(dir, lock); err != nil {
-		return false, "", err
-	}
-	return true, matchedID, nil
 }
 
 func requirementsFromMap(manifest map[string]any, dir string) ([]PluginRequirement, error) {

--- a/cli/internal/project/plugins_test.go
+++ b/cli/internal/project/plugins_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -49,6 +50,55 @@ func TestDependencyUpdatePreservesPackageField(t *testing.T) {
 	plugins := manifest["plugins"].(map[string]any)
 	if plugins["github.com/acme/wago-timer"] != "^1.0.0" {
 		t.Fatalf("full plugin requirement not recorded: %v", plugins)
+	}
+}
+
+func TestRemoveDependencyPublishesPrunedCoherentMetadata(t *testing.T) {
+	dir := t.TempDir()
+	removedID := "github.com/acme/pool"
+	retainedID := "github.com/acme/logger"
+	transitiveID := "github.com/acme/workers"
+	manifest := map[string]any{
+		"$schema": SchemaURI,
+		"plugins": map[string]any{removedID: "^1.0.0", retainedID: "^1.0.0"},
+	}
+	lock := NewLockDocument()
+	lock.Plugins[removedID] = testLockEntry(true, removedID, map[string]string{transitiveID: "^1.0.0"})
+	lock.Plugins[retainedID] = testLockEntry(true, retainedID, map[string]string{})
+	lock.Plugins[transitiveID] = testLockEntry(false, transitiveID, map[string]string{})
+	if err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		return mutation.PublishMetadata(manifest, lock)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, id, err := RemoveDependency(dir, removedID)
+	if err != nil || !removed || id != removedID {
+		t.Fatalf("RemoveDependency = %v, %q, %v", removed, id, err)
+	}
+	gotManifest, err := Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotLock, err := ReadLock(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requirements, err := RequirementsFromManifest(gotManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateLockedResolution(requirements, gotLock); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := gotLock.Plugins[removedID]; ok {
+		t.Fatalf("removed direct plugin remains in lock: %#v", gotLock.Plugins)
+	}
+	if _, ok := gotLock.Plugins[transitiveID]; ok {
+		t.Fatalf("unreachable transitive plugin remains in lock: %#v", gotLock.Plugins)
+	}
+	if _, ok := gotLock.Plugins[retainedID]; !ok {
+		t.Fatalf("unrelated direct plugin was pruned: %#v", gotLock.Plugins)
 	}
 }
 

--- a/cli/internal/project/sync_unix.go
+++ b/cli/internal/project/sync_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package project
+
+import (
+	"errors"
+	"os"
+)
+
+func syncProjectDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	return joinClose(directory.Sync(), directory)
+}
+
+func joinClose(primary error, file *os.File) error {
+	return errors.Join(primary, file.Close())
+}

--- a/cli/internal/project/sync_windows.go
+++ b/cli/internal/project/sync_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package project
+
+// atomicfile uses MoveFileEx with MOVEFILE_WRITE_THROUGH on Windows. Opening
+// directories for FlushFileBuffers is not portable through os.File.
+func syncProjectDirectory(string) error { return nil }

--- a/cli/internal/project/transaction.go
+++ b/cli/internal/project/transaction.go
@@ -55,6 +55,7 @@ type projectJournal struct {
 type journalFile struct {
 	Data   []byte `json:"data"`
 	SHA256 string `json:"sha256"`
+	Mode   uint32 `json:"mode"`
 }
 
 func projectLockPath(dir string) string {
@@ -63,6 +64,22 @@ func projectLockPath(dir string) string {
 
 func projectJournalPath(dir string) string {
 	return filepath.Join(dir, projectDirectory, projectJournalFile)
+}
+
+// withMetadataRead avoids creating project state for ordinary read-only
+// access. Once a writer has created the shared lock, readers join that lock and
+// recover any committed journal before inspecting metadata.
+func withMetadataRead(dir string, fn func(*Mutation) error) error {
+	for _, path := range []string{projectJournalPath(dir), projectLockPath(dir)} {
+		if _, err := os.Lstat(path); err == nil {
+			return WithMutation(context.Background(), dir, fn)
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	mutation := &Mutation{dir: dir, active: true}
+	defer func() { mutation.active = false }()
+	return fn(mutation)
 }
 
 // WithMutation serializes project metadata access across processes, recovers
@@ -175,12 +192,19 @@ func (mutation *Mutation) publish(manifestData, lockData *[]byte) error {
 	if automation.Locked() {
 		return fmt.Errorf("locked mode prevents changing project metadata")
 	}
+	var err error
 	journal := projectJournal{FormatVersion: projectTransactionFormat}
 	if manifestData != nil {
-		journal.Manifest = newJournalFile(*manifestData)
+		journal.Manifest, err = newJournalFile(Path(mutation.dir), *manifestData)
+		if err != nil {
+			return err
+		}
 	}
 	if lockData != nil {
-		journal.Lock = newJournalFile(*lockData)
+		journal.Lock, err = newJournalFile(LockPath(mutation.dir), *lockData)
+		if err != nil {
+			return err
+		}
 	}
 	if journal.Manifest == nil && journal.Lock == nil {
 		return errors.New("project transaction has no files")
@@ -246,12 +270,12 @@ func (mutation *Mutation) recover() error {
 
 func (mutation *Mutation) applyJournal(journal projectJournal) error {
 	if journal.Manifest != nil {
-		if err := writeJournalFile(Path(mutation.dir), 0o644, journal.Manifest); err != nil {
+		if err := writeJournalFile(Path(mutation.dir), journal.Manifest); err != nil {
 			return fmt.Errorf("recover %s: %w", File, err)
 		}
 	}
 	if journal.Lock != nil {
-		if err := writeJournalFile(LockPath(mutation.dir), 0o644, journal.Lock); err != nil {
+		if err := writeJournalFile(LockPath(mutation.dir), journal.Lock); err != nil {
 			return fmt.Errorf("recover %s: %w", LockFile, err)
 		}
 	}
@@ -268,16 +292,29 @@ func (mutation *Mutation) applyJournal(journal projectJournal) error {
 	return nil
 }
 
-func writeJournalFile(path string, mode os.FileMode, file *journalFile) error {
-	return replaceProjectFile(path, atomicfile.Options{Mode: mode, Sync: true}, func(writer io.Writer) error {
+func writeJournalFile(path string, file *journalFile) error {
+	return replaceProjectFile(path, atomicfile.Options{Mode: os.FileMode(file.Mode), Sync: true}, func(writer io.Writer) error {
 		_, err := writer.Write(file.Data)
 		return err
 	})
 }
 
-func newJournalFile(data []byte) *journalFile {
+func newJournalFile(path string, data []byte) (*journalFile, error) {
+	mode := os.FileMode(0o644)
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("project metadata target %s is not a regular file", path)
+		}
+		mode = info.Mode().Perm()
+		if mode == 0 {
+			return nil, fmt.Errorf("project metadata target %s has unsupported mode 0000", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
 	sum := sha256.Sum256(data)
-	return &journalFile{Data: append([]byte(nil), data...), SHA256: hex.EncodeToString(sum[:])}
+	return &journalFile{Data: append([]byte(nil), data...), SHA256: hex.EncodeToString(sum[:]), Mode: uint32(mode)}, nil
 }
 
 func validateJournal(journal projectJournal) error {
@@ -294,6 +331,9 @@ func validateJournal(journal projectJournal) error {
 		sum := sha256.Sum256(file.Data)
 		if file.SHA256 != hex.EncodeToString(sum[:]) {
 			return fmt.Errorf("project transaction journal has invalid %s checksum", name)
+		}
+		if file.Mode == 0 || file.Mode > 0o777 {
+			return fmt.Errorf("project transaction journal has invalid %s mode %04o", name, file.Mode)
 		}
 	}
 	var manifest map[string]any

--- a/cli/internal/project/transaction.go
+++ b/cli/internal/project/transaction.go
@@ -1,0 +1,330 @@
+package project
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/wago-org/wago/cli/internal/automation"
+	"github.com/wago-org/wago/internal/atomicfile"
+	"github.com/wago-org/wago/internal/filelock"
+)
+
+const (
+	projectTransactionFormat = 1
+	projectDirectory         = ".wago"
+	projectLockFile          = "project.lock"
+	projectJournalFile       = "project-transaction.json"
+)
+
+var replaceProjectFile = atomicfile.ReplaceFile
+
+// Mutation owns the project-wide metadata lock. It is valid only during the
+// callback passed to WithMutation.
+type Mutation struct {
+	dir    string
+	active bool
+}
+
+type committedTransactionError struct{ err error }
+
+func (err *committedTransactionError) Error() string { return err.err.Error() }
+func (err *committedTransactionError) Unwrap() error { return err.err }
+
+// TransactionCommitted reports whether the requested metadata is durably
+// recorded in the recovery journal and must be completed rather than rolled
+// back by a wider caller transaction.
+func TransactionCommitted(err error) bool {
+	var committed *committedTransactionError
+	return errors.As(err, &committed)
+}
+
+type projectJournal struct {
+	FormatVersion int          `json:"formatVersion"`
+	Manifest      *journalFile `json:"manifest,omitempty"`
+	Lock          *journalFile `json:"lock,omitempty"`
+}
+
+type journalFile struct {
+	Data   []byte `json:"data"`
+	SHA256 string `json:"sha256"`
+}
+
+func projectLockPath(dir string) string {
+	return filepath.Join(dir, projectDirectory, projectLockFile)
+}
+
+func projectJournalPath(dir string) string {
+	return filepath.Join(dir, projectDirectory, projectJournalFile)
+}
+
+// WithMutation serializes project metadata access across processes, recovers
+// any committed interrupted update, and then calls fn while holding the lock.
+func WithMutation(ctx context.Context, dir string, fn func(*Mutation) error) (err error) {
+	if fn == nil {
+		return errors.New("project mutation callback is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	lock, err := filelock.Acquire(ctx, projectLockPath(dir))
+	if err != nil {
+		return fmt.Errorf("lock project metadata: %w", err)
+	}
+	mutation := &Mutation{dir: dir, active: true}
+	defer func() {
+		mutation.active = false
+		err = errors.Join(err, lock.Close())
+	}()
+	if err := mutation.recover(); err != nil {
+		return err
+	}
+	return fn(mutation)
+}
+
+// ReadManifest reads the current manifest while the project lock is held.
+func (mutation *Mutation) ReadManifest() (map[string]any, error) {
+	if err := mutation.ensureActive(); err != nil {
+		return nil, err
+	}
+	return readManifest(mutation.dir)
+}
+
+// ReadLock reads the current lock document while the project lock is held.
+func (mutation *Mutation) ReadLock() (LockDocument, error) {
+	if err := mutation.ensureActive(); err != nil {
+		return LockDocument{}, err
+	}
+	return readLock(mutation.dir)
+}
+
+// PublishManifest validates and atomically publishes one manifest through the
+// same crash-recoverable transaction used for paired metadata updates.
+func (mutation *Mutation) PublishManifest(manifest map[string]any) error {
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		return err
+	}
+	return mutation.publish(&data, nil)
+}
+
+// PublishLock validates and atomically publishes one lock document through the
+// same crash-recoverable transaction used for paired metadata updates.
+func (mutation *Mutation) PublishLock(document LockDocument) error {
+	data, err := EncodeLock(document)
+	if err != nil {
+		return err
+	}
+	return mutation.publish(nil, &data)
+}
+
+// PublishMetadata atomically publishes a coherent manifest and lock document.
+func (mutation *Mutation) PublishMetadata(manifest map[string]any, document LockDocument) error {
+	manifestData, err := EncodeManifest(manifest)
+	if err != nil {
+		return err
+	}
+	lockData, err := EncodeLock(document)
+	if err != nil {
+		return err
+	}
+	requirements, err := requirementsFromMap(manifest, mutation.dir)
+	if err != nil {
+		return err
+	}
+	if err := ValidateLockedResolution(requirements, document); err != nil {
+		return fmt.Errorf("manifest and lock are inconsistent: %w", err)
+	}
+	return mutation.publish(&manifestData, &lockData)
+}
+
+// PublishEncodedMetadata is for callers that already staged and validated the
+// exact bytes used to build another project artifact. It decodes and validates
+// both documents again before publication.
+func (mutation *Mutation) PublishEncodedMetadata(manifestData, lockData []byte) error {
+	manifest, err := decodeManifest(manifestData, mutation.dir)
+	if err != nil {
+		return err
+	}
+	document, err := DecodeLock(lockData)
+	if err != nil {
+		return err
+	}
+	requirements, err := requirementsFromMap(manifest, mutation.dir)
+	if err != nil {
+		return err
+	}
+	if err := ValidateLockedResolution(requirements, document); err != nil {
+		return fmt.Errorf("manifest and lock are inconsistent: %w", err)
+	}
+	manifestCopy, lockCopy := append([]byte(nil), manifestData...), append([]byte(nil), lockData...)
+	return mutation.publish(&manifestCopy, &lockCopy)
+}
+
+func (mutation *Mutation) publish(manifestData, lockData *[]byte) error {
+	if err := mutation.ensureActive(); err != nil {
+		return err
+	}
+	if automation.Locked() {
+		return fmt.Errorf("locked mode prevents changing project metadata")
+	}
+	journal := projectJournal{FormatVersion: projectTransactionFormat}
+	if manifestData != nil {
+		journal.Manifest = newJournalFile(*manifestData)
+	}
+	if lockData != nil {
+		journal.Lock = newJournalFile(*lockData)
+	}
+	if journal.Manifest == nil && journal.Lock == nil {
+		return errors.New("project transaction has no files")
+	}
+	encoded, err := json.MarshalIndent(journal, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	journalPath := projectJournalPath(mutation.dir)
+	if err := replaceProjectFile(journalPath, atomicfile.Options{Mode: 0o600, Sync: true}, func(writer io.Writer) error {
+		_, err := writer.Write(encoded)
+		return err
+	}); err != nil {
+		return fmt.Errorf("commit project transaction journal: %w", err)
+	}
+	if err := syncProjectDirectory(filepath.Dir(journalPath)); err != nil {
+		return &committedTransactionError{err: fmt.Errorf("sync project transaction journal: %w", err)}
+	}
+	if err := mutation.applyJournal(journal); err != nil {
+		return &committedTransactionError{err: err}
+	}
+	return nil
+}
+
+func (mutation *Mutation) recover() error {
+	path := projectJournalPath(mutation.dir)
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open project transaction journal: %w", err)
+	}
+	opened, openErr := file.Stat()
+	linked, linkErr := os.Lstat(path)
+	if openErr != nil || linkErr != nil || !opened.Mode().IsRegular() || linked.Mode()&os.ModeSymlink != 0 || !linked.Mode().IsRegular() || !os.SameFile(opened, linked) {
+		_ = file.Close()
+		if cause := errors.Join(openErr, linkErr); cause != nil {
+			return fmt.Errorf("project transaction journal %s is not a stable regular file: %w", path, cause)
+		}
+		return fmt.Errorf("project transaction journal %s is not a stable regular file", path)
+	}
+	data, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if err := errors.Join(readErr, closeErr); err != nil {
+		return fmt.Errorf("read project transaction journal: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var journal projectJournal
+	if err := decoder.Decode(&journal); err != nil {
+		return fmt.Errorf("decode project transaction journal: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return fmt.Errorf("decode project transaction journal: %w", err)
+	}
+	if err := validateJournal(journal); err != nil {
+		return err
+	}
+	return mutation.applyJournal(journal)
+}
+
+func (mutation *Mutation) applyJournal(journal projectJournal) error {
+	if journal.Manifest != nil {
+		if err := writeJournalFile(Path(mutation.dir), 0o644, journal.Manifest); err != nil {
+			return fmt.Errorf("recover %s: %w", File, err)
+		}
+	}
+	if journal.Lock != nil {
+		if err := writeJournalFile(LockPath(mutation.dir), 0o644, journal.Lock); err != nil {
+			return fmt.Errorf("recover %s: %w", LockFile, err)
+		}
+	}
+	if err := syncProjectDirectory(mutation.dir); err != nil {
+		return fmt.Errorf("sync project metadata: %w", err)
+	}
+	journalPath := projectJournalPath(mutation.dir)
+	if err := os.Remove(journalPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove project transaction journal: %w", err)
+	}
+	if err := syncProjectDirectory(filepath.Dir(journalPath)); err != nil {
+		return fmt.Errorf("sync project transaction completion: %w", err)
+	}
+	return nil
+}
+
+func writeJournalFile(path string, mode os.FileMode, file *journalFile) error {
+	return replaceProjectFile(path, atomicfile.Options{Mode: mode, Sync: true}, func(writer io.Writer) error {
+		_, err := writer.Write(file.Data)
+		return err
+	})
+}
+
+func newJournalFile(data []byte) *journalFile {
+	sum := sha256.Sum256(data)
+	return &journalFile{Data: append([]byte(nil), data...), SHA256: hex.EncodeToString(sum[:])}
+}
+
+func validateJournal(journal projectJournal) error {
+	if journal.FormatVersion != projectTransactionFormat {
+		return fmt.Errorf("unsupported project transaction format %d", journal.FormatVersion)
+	}
+	if journal.Manifest == nil && journal.Lock == nil {
+		return errors.New("project transaction journal has no files")
+	}
+	for name, file := range map[string]*journalFile{File: journal.Manifest, LockFile: journal.Lock} {
+		if file == nil {
+			continue
+		}
+		sum := sha256.Sum256(file.Data)
+		if file.SHA256 != hex.EncodeToString(sum[:]) {
+			return fmt.Errorf("project transaction journal has invalid %s checksum", name)
+		}
+	}
+	var manifest map[string]any
+	var document LockDocument
+	if journal.Manifest != nil {
+		var err error
+		if manifest, err = decodeManifest(journal.Manifest.Data, "."); err != nil {
+			return fmt.Errorf("project transaction journal has invalid %s: %w", File, err)
+		}
+	}
+	if journal.Lock != nil {
+		var err error
+		if document, err = DecodeLock(journal.Lock.Data); err != nil {
+			return fmt.Errorf("project transaction journal has invalid %s: %w", LockFile, err)
+		}
+	}
+	if journal.Manifest != nil && journal.Lock != nil {
+		requirements, err := requirementsFromMap(manifest, ".")
+		if err != nil {
+			return fmt.Errorf("project transaction journal has invalid %s: %w", File, err)
+		}
+		if err := ValidateLockedResolution(requirements, document); err != nil {
+			return fmt.Errorf("project transaction journal metadata is inconsistent: %w", err)
+		}
+	}
+	return nil
+}
+
+func (mutation *Mutation) ensureActive() error {
+	if mutation == nil || !mutation.active {
+		return errors.New("project mutation is not active")
+	}
+	return nil
+}

--- a/cli/internal/project/transaction_test.go
+++ b/cli/internal/project/transaction_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -80,6 +82,67 @@ func TestMetadataTransactionRejectsInconsistentPairBeforeCommit(t *testing.T) {
 	}
 	if _, statErr := os.Stat(Path(dir)); !os.IsNotExist(statErr) {
 		t.Fatalf("inconsistent transaction wrote manifest: %v", statErr)
+	}
+}
+
+func TestMetadataReadDoesNotRequireOrCreateProjectState(t *testing.T) {
+	dir := t.TempDir()
+	manifest := map[string]any{"$schema": SchemaURI, "plugins": map[string]any{}}
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(Path(dir), data, 0o444); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, manifest) {
+		t.Fatalf("read-only manifest = %#v, want %#v", got, manifest)
+	}
+	if _, err := os.Stat(filepath.Join(dir, projectDirectory)); !os.IsNotExist(err) {
+		t.Fatalf("metadata read created project state: %v", err)
+	}
+}
+
+func TestMetadataTransactionPreservesExistingFileModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits")
+	}
+	dir := t.TempDir()
+	id := "github.com/acme/pool"
+	manifest := map[string]any{"$schema": SchemaURI, "plugins": map[string]any{id: "^1.0.0"}}
+	lock := NewLockDocument()
+	lock.Plugins[id] = testLockEntry(true, id, map[string]string{})
+	initialManifest, err := EncodeManifest(map[string]any{"$schema": SchemaURI, "plugins": map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialLock, err := EncodeLock(NewLockDocument())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(Path(dir), initialManifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(LockPath(dir), initialLock, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		return mutation.PublishMetadata(manifest, lock)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for path, want := range map[string]os.FileMode{Path(dir): 0o600, LockPath(dir): 0o640} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Fatalf("%s mode = %04o, want %04o", path, got, want)
+		}
 	}
 }
 

--- a/cli/internal/project/transaction_test.go
+++ b/cli/internal/project/transaction_test.go
@@ -1,0 +1,184 @@
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/wago-org/wago/internal/atomicfile"
+)
+
+func TestMetadataTransactionRecoversCommittedSplitWrite(t *testing.T) {
+	dir := t.TempDir()
+	initialManifest := map[string]any{"$schema": SchemaURI, "plugins": map[string]any{}}
+	if err := Write(dir, initialManifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteLock(dir, NewLockDocument()); err != nil {
+		t.Fatal(err)
+	}
+
+	id := "github.com/acme/pool"
+	manifest := map[string]any{"$schema": SchemaURI, "plugins": map[string]any{id: "^1.0.0"}}
+	lock := NewLockDocument()
+	lock.Plugins[id] = testLockEntry(true, id, map[string]string{})
+
+	previous := replaceProjectFile
+	t.Cleanup(func() { replaceProjectFile = previous })
+	failed := false
+	replaceProjectFile = func(destination string, options atomicfile.Options, write func(io.Writer) error) error {
+		if destination == LockPath(dir) && !failed {
+			failed = true
+			return errors.New("injected lock replacement failure")
+		}
+		return atomicfile.ReplaceFile(destination, options, write)
+	}
+	err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		return mutation.PublishMetadata(manifest, lock)
+	})
+	replaceProjectFile = previous
+	if err == nil || !TransactionCommitted(err) {
+		t.Fatalf("split publication error = %v, committed = %v", err, TransactionCommitted(err))
+	}
+	if _, statErr := os.Stat(projectJournalPath(dir)); statErr != nil {
+		t.Fatalf("committed journal is absent: %v", statErr)
+	}
+
+	gotManifest, err := Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotLock, err := ReadLock(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotManifest, manifest) || !reflect.DeepEqual(gotLock, lock) {
+		t.Fatalf("recovered metadata = %#v, %#v; want %#v, %#v", gotManifest, gotLock, manifest, lock)
+	}
+	if _, statErr := os.Stat(projectJournalPath(dir)); !os.IsNotExist(statErr) {
+		t.Fatalf("completed journal remains: %v", statErr)
+	}
+}
+
+func TestMetadataTransactionRejectsInconsistentPairBeforeCommit(t *testing.T) {
+	dir := t.TempDir()
+	manifest := map[string]any{"$schema": SchemaURI, "plugins": map[string]any{"github.com/acme/pool": "^1.0.0"}}
+	err := WithMutation(context.Background(), dir, func(mutation *Mutation) error {
+		return mutation.PublishMetadata(manifest, NewLockDocument())
+	})
+	if err == nil || TransactionCommitted(err) {
+		t.Fatalf("inconsistent publication error = %v, committed = %v", err, TransactionCommitted(err))
+	}
+	if _, statErr := os.Stat(projectJournalPath(dir)); !os.IsNotExist(statErr) {
+		t.Fatalf("inconsistent transaction wrote journal: %v", statErr)
+	}
+	if _, statErr := os.Stat(Path(dir)); !os.IsNotExist(statErr) {
+		t.Fatalf("inconsistent transaction wrote manifest: %v", statErr)
+	}
+}
+
+func TestMetadataTransactionPreservesPriorFileWhenJournalCommitFails(t *testing.T) {
+	dir := t.TempDir()
+	want := map[string]any{"$schema": SchemaURI, "plugins": map[string]any{}}
+	if err := Write(dir, want); err != nil {
+		t.Fatal(err)
+	}
+	previous := replaceProjectFile
+	t.Cleanup(func() { replaceProjectFile = previous })
+	replaceProjectFile = func(destination string, options atomicfile.Options, write func(io.Writer) error) error {
+		if destination == projectJournalPath(dir) {
+			return errors.New("injected journal failure")
+		}
+		return atomicfile.ReplaceFile(destination, options, write)
+	}
+	err := Write(dir, map[string]any{"$schema": SchemaURI, "plugins": map[string]any{}, "settings": map[string]any{"runtime": map[string]any{"parallel": "2"}}})
+	replaceProjectFile = previous
+	if err == nil || TransactionCommitted(err) {
+		t.Fatalf("journal failure = %v, committed = %v", err, TransactionCommitted(err))
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("manifest after failed journal = %#v, want %#v", got, want)
+	}
+}
+
+func TestMetadataTransactionRejectsCorruptRecoveryJournal(t *testing.T) {
+	dir := t.TempDir()
+	want := map[string]any{"$schema": SchemaURI, "plugins": map[string]any{}}
+	if err := Write(dir, want); err != nil {
+		t.Fatal(err)
+	}
+	journal := projectJournal{
+		FormatVersion: projectTransactionFormat,
+		Manifest: &journalFile{
+			Data:   []byte(`{"$schema":"https://wago.sh/v1/schema.json","plugins":{}}`),
+			SHA256: "not-the-data-checksum",
+		},
+	}
+	data, err := json.Marshal(journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectJournalPath(dir), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(dir); err == nil {
+		t.Fatal("Read accepted a corrupt project transaction journal")
+	}
+	data, err = os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeManifest(data, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("corrupt journal changed manifest: %#v", decoded)
+	}
+}
+
+func TestConcurrentDependencyUpdatesAreSerialized(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Initialize(dir); err != nil {
+		t.Fatal(err)
+	}
+	const count = 24
+	var wait sync.WaitGroup
+	errs := make(chan error, count)
+	for index := 0; index < count; index++ {
+		wait.Add(1)
+		go func(index int) {
+			defer wait.Done()
+			id := fmt.Sprintf("example.com/plugins/plugin-%02d", index)
+			added, err := AddDependency(dir, id, "^1.0.0")
+			if err == nil && !added {
+				err = fmt.Errorf("%s was not added", id)
+			}
+			errs <- err
+		}(index)
+	}
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	requirements, err := Requirements(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requirements) != count {
+		t.Fatalf("serialized dependencies = %d, want %d", len(requirements), count)
+	}
+}

--- a/cli/internal/settings/scope.go
+++ b/cli/internal/settings/scope.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -137,13 +138,23 @@ func (target *Target) Save() error {
 		return Save(target.config)
 	}
 	layer := diffLayer(target.config, target.base)
-	if layerEmpty(layer) {
-		delete(target.manifest, localField)
-	} else {
-		target.manifest[localField] = layer
-	}
-	project.EnsureMetadata(target.manifest)
-	return project.Write(".", target.manifest)
+	return project.WithMutation(context.Background(), ".", func(mutation *project.Mutation) error {
+		manifest, err := mutation.ReadManifest()
+		if err != nil {
+			return err
+		}
+		if layerEmpty(layer) {
+			delete(manifest, localField)
+		} else {
+			manifest[localField] = layer
+		}
+		project.EnsureMetadata(manifest)
+		if err := mutation.PublishManifest(manifest); err != nil {
+			return err
+		}
+		target.manifest = manifest
+		return nil
+	})
 }
 
 func decodeLocalLayer(value any) (localLayer, bool, error) {

--- a/cli/internal/settings/scope_test.go
+++ b/cli/internal/settings/scope_test.go
@@ -119,6 +119,33 @@ func TestLocalRuntimeOverrideIsSparse(t *testing.T) {
 	}
 }
 
+func TestLocalSettingsSavePreservesConcurrentManifestUpdate(t *testing.T) {
+	dir := enterSettingsTestDir(t)
+	t.Setenv("WAGO_CONFIG", filepath.Join(t.TempDir(), "settings.json"))
+	writeTestManifest(t, dir)
+	target, err := Open(false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := target.Set("simd", "off", false); err != nil {
+		t.Fatal(err)
+	}
+	id := "github.com/acme/logger"
+	if added, err := project.AddDependency(dir, id, "^1.0.0"); err != nil || !added {
+		t.Fatalf("AddDependency = %v, %v", added, err)
+	}
+	if err := target.Save(); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := project.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest["plugins"].(map[string]any)[id] != "^1.0.0" {
+		t.Fatalf("settings save lost concurrent plugin update: %#v", manifest)
+	}
+}
+
 func TestGlobalTargetIgnoresLocalManifest(t *testing.T) {
 	dir := enterSettingsTestDir(t)
 	t.Setenv("WAGO_CONFIG", filepath.Join(t.TempDir(), "settings.json"))

--- a/cli/manager/internal/plugin/build.go
+++ b/cli/manager/internal/plugin/build.go
@@ -49,8 +49,8 @@ func pkgAddMany(specs []string, options pkgOpts) {
 		progress.Fail("Plugin resolution failed")
 		fatal("add: %v", err)
 	}
-	err = withPluginMutationLock(pluginContext(options.ctx), src, func() error {
-		manifest, err := project.Read(src)
+	err = withPluginMutationLock(pluginContext(options.ctx), src, func(mutation *project.Mutation) error {
+		manifest, err := mutation.ReadManifest()
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ func pkgAddMany(specs []string, options pkgOpts) {
 		if err != nil {
 			return err
 		}
-		previous, err := project.ReadLock(src)
+		previous, err := mutation.ReadLock()
 		if err != nil {
 			return err
 		}
@@ -79,7 +79,7 @@ func pkgAddMany(specs []string, options pkgOpts) {
 		if err != nil {
 			return err
 		}
-		return stageAndPublishLockedState(src, buildDir, manifest, lock, options.verbose)
+		return stageAndPublishLockedState(mutation, src, buildDir, manifest, lock, options.verbose)
 	})
 	if err != nil {
 		progress.Fail("Plugin install failed")
@@ -104,8 +104,8 @@ func pkgRemove(name string, options pkgOpts) {
 	if err := project.ValidatePluginID(id); err != nil {
 		fatal("plugin remove: %v", err)
 	}
-	err = withPluginMutationLock(pluginContext(options.ctx), src, func() error {
-		manifest, err := project.Read(src)
+	err = withPluginMutationLock(pluginContext(options.ctx), src, func(mutation *project.Mutation) error {
+		manifest, err := mutation.ReadManifest()
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func pkgRemove(name string, options pkgOpts) {
 		if err != nil {
 			return err
 		}
-		previous, err := project.ReadLock(src)
+		previous, err := mutation.ReadLock()
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func pkgRemove(name string, options pkgOpts) {
 				return err
 			}
 		}
-		return stageAndPublishLockedState(src, buildDir, manifest, lock, false)
+		return stageAndPublishLockedState(mutation, src, buildDir, manifest, lock, false)
 	})
 	if err != nil {
 		fatal("plugin remove: %v", err)
@@ -159,8 +159,8 @@ func pkgUpdate(target string, options pkgOpts) {
 	if err != nil {
 		fatal("plugin update: %v", err)
 	}
-	err = withPluginMutationLock(pluginContext(options.ctx), src, func() error {
-		manifest, err := project.Read(src)
+	err = withPluginMutationLock(pluginContext(options.ctx), src, func(mutation *project.Mutation) error {
+		manifest, err := mutation.ReadManifest()
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func pkgUpdate(target string, options pkgOpts) {
 				return fmt.Errorf("%q is not a direct plugin", target)
 			}
 		}
-		previous, err := project.ReadLock(src)
+		previous, err := mutation.ReadLock()
 		if err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ func pkgUpdate(target string, options pkgOpts) {
 		if err != nil {
 			return err
 		}
-		return stageAndPublishLockedState(src, buildDir, manifest, lock, options.verbose)
+		return stageAndPublishLockedState(mutation, src, buildDir, manifest, lock, options.verbose)
 	})
 	if err != nil {
 		fatal("plugin update: %v", err)
@@ -201,7 +201,7 @@ func pkgUpdate(target string, options pkgOpts) {
 	fmt.Printf("%s updated the complete plugin graph\n", cyan("✓"))
 }
 
-func stageAndPublishLockedState(manifestDir, buildDir string, manifest map[string]any, lock project.LockDocument, verbose bool) error {
+func stageAndPublishLockedState(mutation *project.Mutation, manifestDir, buildDir string, manifest map[string]any, lock project.LockDocument, verbose bool) error {
 	manifestData, err := project.EncodeManifest(manifest)
 	if err != nil {
 		return err
@@ -246,7 +246,7 @@ func stageAndPublishLockedState(manifestDir, buildDir string, manifest map[strin
 	if err := verifyStagedRuntime(bin); err != nil {
 		return err
 	}
-	return publishPluginTransaction(manifestDir, buildDir, staged, manifestData, lockData)
+	return publishPluginTransaction(mutation, buildDir, staged, manifestData, lockData)
 }
 
 func verifyStagedRuntime(binary string) error {

--- a/cli/manager/internal/plugin/config.go
+++ b/cli/manager/internal/plugin/config.go
@@ -36,12 +36,12 @@ func Configure(request ConfigRequest) error {
 	if err != nil {
 		return err
 	}
-	return withPluginMutationLock(pluginContext(request.Context), src, func() error {
-		manifest, err := project.Read(src)
+	return withPluginMutationLock(pluginContext(request.Context), src, func(mutation *project.Mutation) error {
+		manifest, err := mutation.ReadManifest()
 		if err != nil {
 			return err
 		}
-		lock, err := project.ReadLock(src)
+		lock, err := mutation.ReadLock()
 		if err != nil {
 			return err
 		}
@@ -54,6 +54,6 @@ func Configure(request ConfigRequest) error {
 		if err := project.ValidateLock(lock); err != nil {
 			return err
 		}
-		return stageAndPublishLockedState(src, buildDir, manifest, lock, false)
+		return stageAndPublishLockedState(mutation, src, buildDir, manifest, lock, false)
 	})
 }

--- a/cli/manager/internal/plugin/review.go
+++ b/cli/manager/internal/plugin/review.go
@@ -246,12 +246,12 @@ func pkgGrant(name string, useGlobal bool, requested []string, grantAll, denyAll
 		fatal("plugin grant: %v", err)
 	}
 	ctx := context.Background()
-	err = withPluginMutationLock(ctx, src, func() error {
-		manifest, readErr := project.Read(src)
+	err = withPluginMutationLock(ctx, src, func(mutation *project.Mutation) error {
+		manifest, readErr := mutation.ReadManifest()
 		if readErr != nil {
 			return readErr
 		}
-		lock, readErr := project.ReadLock(src)
+		lock, readErr := mutation.ReadLock()
 		if readErr != nil {
 			return readErr
 		}
@@ -267,7 +267,7 @@ func pkgGrant(name string, useGlobal bool, requested []string, grantAll, denyAll
 		if err != nil {
 			return err
 		}
-		return stageAndPublishLockedState(src, buildDir, manifest, lock, false)
+		return stageAndPublishLockedState(mutation, src, buildDir, manifest, lock, false)
 	})
 	if err != nil {
 		fatal("plugin grant: %v", err)

--- a/cli/manager/internal/plugin/transaction.go
+++ b/cli/manager/internal/plugin/transaction.go
@@ -4,89 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/wago-org/wago/cli/internal/project"
-	"github.com/wago-org/wago/internal/atomicfile"
-	"github.com/wago-org/wago/internal/filelock"
 )
 
-var replacePluginFile = atomicfile.ReplaceFile
-
-func withPluginMutationLock(ctx context.Context, manifestDir string, fn func() error) error {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
-		return err
-	}
-	lockPath := filepath.Join(manifestDir, ".wago", "plugin-transaction.lock")
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
-		return err
-	}
-	lock, err := filelock.Acquire(ctx, lockPath)
-	if err != nil {
-		return fmt.Errorf("lock plugin transaction: %w", err)
-	}
-	return errors.Join(fn(), lock.Close())
+var publishProjectMetadata = func(mutation *project.Mutation, manifestData, lockData []byte) error {
+	return mutation.PublishEncodedMetadata(manifestData, lockData)
 }
 
-type fileSnapshot struct {
-	path    string
-	data    []byte
-	existed bool
-	mode    os.FileMode
-}
-
-func snapshotFile(path string) (fileSnapshot, error) {
-	snapshot := fileSnapshot{path: path, mode: 0o644}
-	info, err := os.Lstat(path)
-	if os.IsNotExist(err) {
-		return snapshot, nil
-	}
-	if err != nil {
-		return snapshot, err
-	}
-	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-		return snapshot, fmt.Errorf("transaction target %s is not a regular file", path)
-	}
-	snapshot.data, err = os.ReadFile(path)
-	if err != nil {
-		return snapshot, err
-	}
-	snapshot.existed, snapshot.mode = true, info.Mode().Perm()
-	return snapshot, nil
-}
-
-func restoreSnapshot(snapshot fileSnapshot) error {
-	if !snapshot.existed {
-		if err := os.Remove(snapshot.path); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		return nil
-	}
-	return atomicfile.ReplaceFile(snapshot.path, atomicfile.Options{Mode: snapshot.mode, Sync: true}, func(writer io.Writer) error {
-		_, err := writer.Write(snapshot.data)
-		return err
-	})
+func withPluginMutationLock(ctx context.Context, manifestDir string, fn func(*project.Mutation) error) error {
+	return project.WithMutation(ctx, manifestDir, fn)
 }
 
 // publishPluginTransaction makes a fully staged build, manifest, and lockfile
-// visible as one recoverable transaction. Each file replacement is atomic; if
-// any publication step fails, all previously visible state is restored before
-// returning the error.
-func publishPluginTransaction(manifestDir, buildDir, stagedBuildDir string, manifestData, lockData []byte) error {
-	manifestPath, lockPath := project.Path(manifestDir), project.LockPath(manifestDir)
-	manifestBefore, err := snapshotFile(manifestPath)
-	if err != nil {
-		return err
-	}
-	lockBefore, err := snapshotFile(lockPath)
-	if err != nil {
-		return err
-	}
+// visible under the project-wide mutation lock. Metadata is crash-recoverable;
+// failures before its journal commit restore the prior generated build.
+func publishPluginTransaction(mutation *project.Mutation, buildDir, stagedBuildDir string, manifestData, lockData []byte) error {
 	if info, err := os.Lstat(stagedBuildDir); err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("staged plugin build is not a directory: %s", stagedBuildDir)
 	}
@@ -113,7 +48,7 @@ func publishPluginTransaction(manifestDir, buildDir, stagedBuildDir string, mani
 		return statErr
 	}
 	buildPublished := false
-	rollback := func(cause error) error {
+	rollbackBuild := func(cause error) error {
 		var rollbackErrs []error
 		if buildPublished {
 			if err := os.RemoveAll(buildDir); err != nil {
@@ -125,12 +60,6 @@ func publishPluginTransaction(manifestDir, buildDir, stagedBuildDir string, mani
 				rollbackErrs = append(rollbackErrs, err)
 			}
 		}
-		if err := restoreSnapshot(manifestBefore); err != nil {
-			rollbackErrs = append(rollbackErrs, err)
-		}
-		if err := restoreSnapshot(lockBefore); err != nil {
-			rollbackErrs = append(rollbackErrs, err)
-		}
 		return errors.Join(append([]error{cause}, rollbackErrs...)...)
 	}
 	if err := os.Rename(stagedBuildDir, buildDir); err != nil {
@@ -140,17 +69,14 @@ func publishPluginTransaction(manifestDir, buildDir, stagedBuildDir string, mani
 		return fmt.Errorf("publish staged plugin build: %w", err)
 	}
 	buildPublished = true
-	write := func(path string, data []byte) error {
-		return replacePluginFile(path, atomicfile.Options{Mode: 0o644, Sync: true}, func(writer io.Writer) error {
-			_, err := writer.Write(data)
-			return err
-		})
-	}
-	if err := write(manifestPath, manifestData); err != nil {
-		return rollback(fmt.Errorf("publish %s: %w", project.File, err))
-	}
-	if err := write(lockPath, lockData); err != nil {
-		return rollback(fmt.Errorf("publish %s: %w", project.LockFile, err))
+	if err := publishProjectMetadata(mutation, manifestData, lockData); err != nil {
+		if !project.TransactionCommitted(err) {
+			return rollbackBuild(err)
+		}
+		if hadBuild {
+			err = errors.Join(err, os.RemoveAll(backup))
+		}
+		return err
 	}
 	if hadBuild {
 		if err := os.RemoveAll(backup); err != nil {

--- a/cli/manager/internal/plugin/transaction_test.go
+++ b/cli/manager/internal/plugin/transaction_test.go
@@ -1,17 +1,16 @@
 package plugin
 
 import (
+	"context"
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/wago-org/wago/cli/internal/project"
-	"github.com/wago-org/wago/internal/atomicfile"
 )
 
-func TestPublishPluginTransactionRollsBackManifestLockAndArtifact(t *testing.T) {
+func TestPublishPluginTransactionRollsBackBuildBeforeMetadataCommit(t *testing.T) {
 	root := t.TempDir()
 	manifestDir := filepath.Join(root, "project")
 	buildDir := filepath.Join(root, "build")
@@ -34,16 +33,15 @@ func TestPublishPluginTransactionRollsBackManifestLockAndArtifact(t *testing.T) 
 	if err := os.WriteFile(filepath.Join(stagedDir, "artifact"), []byte("new artifact"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	previous := replacePluginFile
-	replacePluginFile = func(destination string, options atomicfile.Options, write func(io.Writer) error) error {
-		if destination == project.LockPath(manifestDir) {
-			return errors.New("injected lock publication failure")
-		}
-		return atomicfile.ReplaceFile(destination, options, write)
+	previous := publishProjectMetadata
+	publishProjectMetadata = func(*project.Mutation, []byte, []byte) error {
+		return errors.New("injected metadata publication failure")
 	}
-	t.Cleanup(func() { replacePluginFile = previous })
+	t.Cleanup(func() { publishProjectMetadata = previous })
 
-	err := publishPluginTransaction(manifestDir, buildDir, stagedDir, []byte("new manifest\n"), []byte("new lock\n"))
+	err := project.WithMutation(context.Background(), manifestDir, func(mutation *project.Mutation) error {
+		return publishPluginTransaction(mutation, buildDir, stagedDir, []byte("new manifest\n"), []byte("new lock\n"))
+	})
 	if err == nil {
 		t.Fatal("publication failure was ignored")
 	}
@@ -65,11 +63,21 @@ func TestPublishPluginTransactionPublishesCompleteStagedState(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(stagedDir, "artifact"), []byte("new artifact"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := publishPluginTransaction(manifestDir, buildDir, stagedDir, []byte("new manifest\n"), []byte("new lock\n")); err != nil {
+	manifestData, err := project.EncodeManifest(map[string]any{"$schema": project.SchemaURI, "plugins": map[string]any{}})
+	if err != nil {
 		t.Fatal(err)
 	}
-	assertFileBytes(t, project.Path(manifestDir), []byte("new manifest\n"))
-	assertFileBytes(t, project.LockPath(manifestDir), []byte("new lock\n"))
+	lockData, err := project.EncodeLock(project.NewLockDocument())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := project.WithMutation(context.Background(), manifestDir, func(mutation *project.Mutation) error {
+		return publishPluginTransaction(mutation, buildDir, stagedDir, manifestData, lockData)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertFileBytes(t, project.Path(manifestDir), manifestData)
+	assertFileBytes(t, project.LockPath(manifestDir), lockData)
 	assertFileBytes(t, filepath.Join(buildDir, "artifact"), []byte("new artifact"))
 }
 

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -33,6 +33,10 @@ func Acquire(ctx context.Context, path string) (*Lock, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateLockFile(file, path); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
 	if err := file.Chmod(0o600); err != nil {
 		_ = file.Close()
 		return nil, err
@@ -61,6 +65,21 @@ func Acquire(ctx context.Context, path string) (*Lock, error) {
 		case <-timer.C:
 		}
 	}
+}
+
+func validateLockFile(file *os.File, path string) error {
+	opened, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	linked, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !opened.Mode().IsRegular() || linked.Mode()&os.ModeSymlink != 0 || !linked.Mode().IsRegular() || !os.SameFile(opened, linked) {
+		return fmt.Errorf("lock file %s is not a stable regular file", path)
+	}
+	return nil
 }
 
 // Close releases the lock and closes its file descriptor.

--- a/internal/filelock/filelock_symlink_unix_test.go
+++ b/internal/filelock/filelock_symlink_unix_test.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package filelock
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLockRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	path := filepath.Join(dir, "lock")
+	if err := os.WriteFile(target, []byte("unchanged"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Acquire(context.Background(), path); err == nil {
+		t.Fatal("Acquire accepted a symlink")
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("symlink target mode = %o, want 644", info.Mode().Perm())
+	}
+}

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -45,3 +45,13 @@ func TestLockSerializesAndHonorsCancellation(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestLockRejectsNonRegularPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lock")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Acquire(context.Background(), path); err == nil {
+		t.Fatal("Acquire accepted a directory as a lock file")
+	}
+}


### PR DESCRIPTION
## Summary

- serialize every project metadata read and write through one cross-process lock
- publish wago.json and wago-lock.json with atomic replacement and a durable recovery journal
- make plugin add, remove, update, grant, config, init, and local settings use the same transaction
- reject unsafe lock and journal paths

## Root cause

Project commands used separate unlocked read-modify-write sequences. Multi-file changes had no durable commit record, so crashes and concurrent processes could lose changes or leave the manifest and lock graph split.

## Validation

- go test -race ./cli/... ./internal/filelock
- go vet ./cli/internal/project ./cli/internal/settings ./cli/manager/internal/plugin ./internal/filelock
- Windows amd64 cross-compilation for all affected packages
- go test ./... passed for affected packages; unrelated staged spec tests need the pinned Release 3 interpreter that is not installed locally

Docs are unchanged because this is an internal correctness fix with no developer or agent workflow change.

Closes #410