### PR TITLE
Fix inline control boundaries and artifact objective identity

### DIFF
--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -117,6 +117,7 @@ func (cache Cache) path(source []byte, config *wago.RuntimeConfig) (string, bool
 		encoded[len(encoded)-1] = 1
 	}
 	encoded = binary.LittleEndian.AppendUint32(encoded, config.MemoryLimitPages())
+	encoded = binary.LittleEndian.AppendUint32(encoded, uint32(config.OptimizationObjective()))
 
 	knobs := config.OptimizationInfos()
 	encoded = binary.LittleEndian.AppendUint32(encoded, uint32(len(knobs)))

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -364,6 +364,8 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	bounds := base.WithBoundsChecks(wago.BoundsChecksSignalsBased)
 	deferredOff := base.WithDeferBoundsChecks(false)
 	memoryLimit := base.WithMemoryLimitPages(base.MemoryLimitPages() - 1)
+	size := base.WithOptimizationObjective(wago.OptimizeSize)
+	embedded := base.WithOptimizationObjective(wago.OptimizeEmbedded)
 
 	basePath, ok := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, base)
 	if !ok {
@@ -375,6 +377,8 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	boundsPath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, bounds)
 	deferredPath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, deferredOff)
 	memoryPath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, memoryLimit)
+	sizePath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, size)
+	embeddedPath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, embedded)
 	runtimePath, _ := (Cache{Dir: dir, Identity: []byte("runtime-b")}).path(source, base)
 	sourcePath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(append(source, 0), base)
 	if basePath == featurePath {
@@ -398,8 +402,62 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	if basePath == memoryPath {
 		t.Fatal("memory limit did not change artifact key")
 	}
+	if basePath == sizePath {
+		t.Fatal("optimization objective did not change artifact key")
+	}
+	if basePath == embeddedPath {
+		t.Fatal("embedded objective did not change artifact key")
+	}
 	if basePath == sourcePath {
 		t.Fatal("source bytes did not change artifact key")
+	}
+}
+
+func TestLoadOrCompileSeparatesOptimizationObjectives(t *testing.T) {
+	source := constantModule()
+	balanced := wago.NewRuntimeConfig().
+		WithBoundsChecks(wago.BoundsChecksExplicit).
+		WithOptimizationObjective(wago.OptimizeBalanced)
+	size := balanced.WithOptimizationObjective(wago.OptimizeSize)
+	for _, test := range []struct {
+		name  string
+		order []*wago.RuntimeConfig
+	}{
+		{name: "Balanced then Size", order: []*wago.RuntimeConfig{balanced, size}},
+		{name: "Size then Balanced", order: []*wago.RuntimeConfig{size, balanced}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a")}
+			for _, config := range test.order {
+				rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+				module, err := cache.LoadOrCompile(source, config, rt)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := module.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if err := rt.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			balancedPath, ok := cache.path(source, balanced)
+			if !ok {
+				t.Fatal("Balanced cache key unavailable")
+			}
+			sizePath, ok := cache.path(source, size)
+			if !ok {
+				t.Fatal("Size cache key unavailable")
+			}
+			if balancedPath == sizePath {
+				t.Fatal("Balanced and Size artifacts share a cache path")
+			}
+			for _, path := range []string{balancedPath, sizePath} {
+				if _, err := os.Stat(path); err != nil {
+					t.Fatalf("objective-specific artifact %q was not published: %v", path, err)
+				}
+			}
+		})
 	}
 }
 

--- a/docs/artifact-cache.md
+++ b/docs/artifact-cache.md
@@ -40,7 +40,8 @@ fixed-order configuration values:
 - target GOOS and GOARCH;
 - accepted Core feature bits;
 - bounds-check and deferred-bounds policy;
-- maximum memory pages; and
+- maximum memory pages;
+- the top-level optimization objective; and
 - the ordered compiler-optimization bit set.
 
 Function-worker policy is intentionally excluded: it controls only bounded

--- a/docs/generated-native-code-size-plan.md
+++ b/docs/generated-native-code-size-plan.md
@@ -465,7 +465,6 @@ type CodegenPolicy struct {
 	FunctionAlignLog2 uint8
 	InternalAlignLog2 uint8
 	LoopAlignLog2 uint8
-	InlineGrowthBudget int32
 	MaxMachineWindow uint8
 	MaxRelaxIterations uint8
 }

--- a/src/core/compiler/backend/railshot/amd64/hints.go
+++ b/src/core/compiler/backend/railshot/amd64/hints.go
@@ -326,17 +326,13 @@ func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcH
 			if wasm.IsSIMDValidationInstructionKind(in.Kind) {
 				h.hasSIMD = true
 			}
-			switch in.Kind {
-			case wasm.InstrTryTable, wasm.InstrThrow, wasm.InstrThrowRef:
+			if shared.InstructionNeedsEHFrame(0, in.Kind) {
 				h.moduleEH = true
 			}
 			if gcOrAtomicInstructionMayCall(in.Kind, gcStructHelpers) {
 				h.hasCall, sub = true, true
 			}
-			// Inline-candidacy control-flow signals (matches scanInlineFactsAST).
-			switch in.Kind {
-			case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf, wasm.InstrTryTable,
-				wasm.InstrBr, wasm.InstrBrIf, wasm.InstrBrTable, wasm.InstrReturn:
+			if shared.InstructionNeedsInlineBoundary(0, in.Kind) {
 				h.hasControlFlow = true
 				if in.Kind == wasm.InstrLoop {
 					h.hasLoop = true
@@ -637,15 +633,10 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 		} else if op == 0xfd {
 			s.h.hasSIMD = true
 		}
-		switch op {
-		case 0x08, 0x0a, 0x1f: // throw, throw_ref, try_table
+		if shared.InstructionNeedsEHFrame(op, wasm.InstrInvalid) {
 			s.h.moduleEH = true
 		}
-		// Inline-candidacy signals (folded in so buildInlineTargets needs no second
-		// walk). Exactly scanInlineFactsBytes's control-flow set — try_table (0x1f)
-		// is deliberately excluded to match it.
-		switch op {
-		case 0x00, 0x02, 0x03, 0x04, 0x05, 0x0c, 0x0d, 0x0e, 0x0f:
+		if shared.InstructionNeedsInlineBoundary(op, wasm.InstrInvalid) {
 			s.h.hasControlFlow = true
 			s.entryPrefix = false
 			if op == 0x03 {
@@ -804,6 +795,12 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				return true, 0, err
 			}
 			s.noteStackArenaOp(op, &imm)
+			if shared.InstructionNeedsInlineBoundary(op, imm.Kind) {
+				s.h.hasControlFlow = true
+			}
+			if shared.InstructionNeedsEHFrame(op, imm.Kind) {
+				s.h.moduleEH = true
+			}
 			if gcOrAtomicInstructionMayCall(imm.Kind, s.gcStructHelpers) {
 				s.h.hasCall, subHasCall = true, true
 			}
@@ -843,6 +840,12 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				return true, 0, err
 			}
 			s.noteStackArenaOp(op, &imm)
+			if shared.InstructionNeedsInlineBoundary(op, imm.Kind) {
+				s.h.hasControlFlow = true
+			}
+			if shared.InstructionNeedsEHFrame(op, imm.Kind) {
+				s.h.moduleEH = true
+			}
 			if imm.TouchesMemory {
 				s.h.touchesMemory = true
 			}

--- a/src/core/compiler/backend/railshot/amd64/inline.go
+++ b/src/core/compiler/backend/railshot/amd64/inline.go
@@ -78,6 +78,7 @@ type inlineFacts struct {
 	hasControlCall bool     // call_indirect / return_call* / call_ref (inline blocker)
 	hasLoop        bool
 	hasControlFlow bool // any block/loop/if/else/br*/return/unreachable
+	moduleEH       bool // requires caller EH frame planning, so cannot yet inline
 	touchesMem     bool // any linear-memory op (load/store/size/grow/bulk)
 	touchesGlobal  bool // any global.get/global.set
 	params         int
@@ -183,6 +184,8 @@ func analyzeInlineCandidates(m *wasm.Module, policy CodegenPolicy) (*InlineRepor
 // only for the opt-in stats report.
 func inlineOK(f inlineFacts, policy CodegenPolicy) bool {
 	switch {
+	case f.moduleEH:
+		return false
 	case policy.Objective == OptimizeSize || policy.Objective == OptimizeEmbedded:
 		return sizeInlineOK(f, policy)
 	case f.hasControlCall:
@@ -202,6 +205,8 @@ func inlineOK(f inlineFacts, policy CodegenPolicy) bool {
 
 func inlineClass(f inlineFacts, policy CodegenPolicy) (bool, string) {
 	switch {
+	case f.moduleEH:
+		return false, "requires exception-handling frame"
 	case (policy.Objective == OptimizeSize || policy.Objective == OptimizeEmbedded) && !sizeInlineOK(f, policy):
 		return false, "size objective requires proved native-byte win"
 	case f.hasControlCall:
@@ -233,7 +238,7 @@ func inlineClass(f inlineFacts, policy CodegenPolicy) (bool, string) {
 }
 
 func sizeInlineOK(f inlineFacts, policy CodegenPolicy) bool {
-	return !f.hasControlCall && f.calleeCount == 0 &&
+	return !f.moduleEH && !f.hasControlCall && f.calleeCount == 0 &&
 		f.callSites == 1 && f.straightLine() && f.bodyBytes <= sizeInlineBodyLimit(policy) &&
 		f.params <= 1 && f.results <= 1 && f.declaredLocals == 0 &&
 		!f.touchesMem && !f.touchesGlobal
@@ -290,18 +295,24 @@ func scanInlineFactsBytes(body []byte, f *inlineFacts) error {
 		if err != nil {
 			return err
 		}
-		// Control-flow opcodes: unreachable/block/loop/if/else/br/br_if/br_table/
-		// return. The single terminating `end` (0x0b) is the body end, not a nested
-		// block close, so it is not treated as control flow. (ClassifyInstruction-
-		// Immediate handles these structurally, so key off the raw opcode.)
-		switch op {
-		case 0x00, 0x02, 0x03, 0x04, 0x05, 0x0c, 0x0d, 0x0e, 0x0f:
+		if shared.InstructionNeedsInlineBoundary(op, wasm.InstrInvalid) {
 			f.hasControlFlow = true
+		}
+		if shared.InstructionNeedsEHFrame(op, wasm.InstrInvalid) {
+			f.moduleEH = true
+		}
+		switch op {
 		case 0x23, 0x24: // global.get / global.set
 			f.touchesGlobal = true
 		}
 		if err := wasm.ClassifyInstructionImmediateInto(r, op, &imm); err != nil {
 			return err
+		}
+		if shared.InstructionNeedsInlineBoundary(op, imm.Kind) {
+			f.hasControlFlow = true
+		}
+		if shared.InstructionNeedsEHFrame(op, imm.Kind) {
+			f.moduleEH = true
 		}
 		if imm.TouchesMemory || imm.UsesBulkMemory {
 			f.touchesMem = true
@@ -323,6 +334,12 @@ func scanInlineFactsBytes(body []byte, f *inlineFacts) error {
 func scanInlineFactsAST(instrs []wasm.Instruction, f *inlineFacts) {
 	for i := range instrs {
 		in := &instrs[i]
+		if shared.InstructionNeedsInlineBoundary(0, in.Kind) {
+			f.hasControlFlow = true
+		}
+		if shared.InstructionNeedsEHFrame(0, in.Kind) {
+			f.moduleEH = true
+		}
 		switch in.Kind {
 		case wasm.InstrCall:
 			f.calleeCount++
@@ -511,6 +528,9 @@ func buildInlineTargets(m *wasm.Module, allHints []funcHints, policy CodegenPoli
 			continue
 		}
 		h := allHints[i]
+		if h.moduleEH {
+			continue
+		}
 		facts := inlineFacts{
 			bodyBytes:      len(body),
 			hasLoop:        h.hasLoop,

--- a/src/core/compiler/backend/railshot/amd64/inline_test.go
+++ b/src/core/compiler/backend/railshot/amd64/inline_test.go
@@ -184,6 +184,66 @@ func TestInlineExecAdd(t *testing.T) {
 	})
 }
 
+func TestInlineBrOnNullRespectsCalleeBoundaryAMD64(t *testing.T) {
+	withInlineEnabled(t, func() {
+		m := modFuncs(t,
+			funcDef{results: []wasm.ValType{wasm.I32}, body: []byte{0x00, 0x41, 0x00, 0x10, 0x01, 0x1a, 0x41, 0x01, 0x0b}},
+			funcDef{body: []byte{0x00, 0xd0, 0x70, 0xd5, 0x00, 0x1a, 0x0b}},
+		)
+		hints, _, err := computeModuleHints(m, 0, 0, nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		target := buildInlineTargets(m, hints, currentCodegenPolicy()).target(1)
+		if target == nil || !target.hasCtrl {
+			t.Fatalf("inline target = %#v, want synthetic control boundary", target)
+		}
+		if got := uint32(runAmd64u(t, m)); got != 1 {
+			t.Fatalf("caller result = %d, want 1", got)
+		}
+	})
+}
+
+func TestInlineTargetsRejectEHAMD64(t *testing.T) {
+	m := modFuncs(t,
+		funcDef{results: []wasm.ValType{wasm.I32}, body: []byte{0x00, 0x10, 0x01, 0x41, 0x01, 0x0b}},
+		funcDef{body: []byte{0x00, 0x0b}},
+	)
+	for _, objective := range []OptimizationObjective{OptimizeBalanced, OptimizeSize, OptimizeEmbedded} {
+		policy := shared.CodegenPolicyForObjective(currentCodegenPolicy().Selection, objective)
+		hints := []funcHints{{hasCall: true}, {moduleEH: true, inlineCallSites: 1}}
+		if target := buildInlineTargets(m, hints, policy).target(1); target != nil {
+			t.Fatalf("objective %v admitted EH inline target", objective)
+		}
+	}
+}
+
+func TestInlineBoundaryParityAMD64(t *testing.T) {
+	var astFacts inlineFacts
+	scanInlineFactsAST([]wasm.Instruction{
+		{Kind: wasm.InstrBrOnNull},
+		{Kind: wasm.InstrBrOnCast},
+		{Kind: wasm.InstrTryTable},
+	}, &astFacts)
+	if !astFacts.hasControlFlow || !astFacts.moduleEH {
+		t.Fatalf("AST inline facts = %#v", astFacts)
+	}
+	for _, op := range []byte{0xd5, 0xd6} {
+		body := []byte{op, 0x00, 0x0b}
+		h, err := scanBodyBytes(body, 0, 0, 0)
+		if err != nil {
+			t.Fatalf("production scan opcode %#x: %v", op, err)
+		}
+		var facts inlineFacts
+		if err := scanInlineFactsBytes(body, &facts); err != nil {
+			t.Fatalf("inline scan opcode %#x: %v", op, err)
+		}
+		if !h.hasControlFlow || !facts.hasControlFlow {
+			t.Fatalf("opcode %#x control classification: production=%v inline=%v", op, h.hasControlFlow, facts.hasControlFlow)
+		}
+	}
+}
+
 func TestInlineSizeObjectiveRequiresNativeByteProofAMD64(t *testing.T) {
 	caller := []byte{0x00, 0x41, 0x05, 0x41, 0x07, 0x10, 0x01, 0x0b}
 	leaf := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b}

--- a/src/core/compiler/backend/railshot/arm64/hints.go
+++ b/src/core/compiler/backend/railshot/arm64/hints.go
@@ -253,16 +253,13 @@ func scanBodyInto(body wasm.Expr, nLocals, nGlobals int, selfIdx uint32, h funcH
 			if gcOrAtomicInstructionMayCall(in.Kind) {
 				sub, h.hasCall = true, true
 			}
-			switch in.Kind {
-			case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf, wasm.InstrTryTable,
-				wasm.InstrBr, wasm.InstrBrIf, wasm.InstrBrTable, wasm.InstrReturn:
+			if shared.InstructionNeedsInlineBoundary(0, in.Kind) {
 				h.hasControlFlow = true
 				if in.Kind == wasm.InstrLoop {
 					h.hasLoop = true
 				}
 			}
-			switch in.Kind {
-			case wasm.InstrTryTable, wasm.InstrThrow, wasm.InstrThrowRef:
+			if shared.InstructionNeedsEHFrame(0, in.Kind) {
 				h.moduleEH = true
 			}
 			switch in.Kind {
@@ -535,8 +532,7 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 		if err != nil {
 			return true, 0, err
 		}
-		switch op {
-		case 0x00, 0x02, 0x03, 0x04, 0x05, 0x0c, 0x0d, 0x0e, 0x0f, 0x1f:
+		if shared.InstructionNeedsInlineBoundary(op, wasm.InstrInvalid) {
 			s.h.hasControlFlow = true
 			s.entryPrefix = false
 			if op == 0x03 {
@@ -682,6 +678,12 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				return true, 0, err
 			}
 			s.noteStackArenaOp(op, &imm)
+			if shared.InstructionNeedsInlineBoundary(op, imm.Kind) {
+				s.h.hasControlFlow = true
+			}
+			if shared.InstructionNeedsEHFrame(op, imm.Kind) {
+				s.h.moduleEH = true
+			}
 			if op == 0xfb {
 				// Collector-backed GC instructions may enter the synchronous Go
 				// helper bridge. Preserve LR and use call-safe local state for the
@@ -728,6 +730,12 @@ func (s *byteBodyScanner) scanExpr(depth int, loopDepth int, curLoop int, stopAt
 				return true, 0, err
 			}
 			s.noteStackArenaOp(op, &imm)
+			if shared.InstructionNeedsInlineBoundary(op, imm.Kind) {
+				s.h.hasControlFlow = true
+			}
+			if shared.InstructionNeedsEHFrame(op, imm.Kind) {
+				s.h.moduleEH = true
+			}
 			if imm.TouchesMemory {
 				s.h.touchesMemory = true
 				s.h.memOps++

--- a/src/core/compiler/backend/railshot/arm64/hints_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/hints_arm64_test.go
@@ -137,12 +137,32 @@ func TestScanInlineFactsAST(t *testing.T) {
 		{Kind: wasm.InstrCall, Index: 3},
 		{Kind: wasm.InstrCallIndirect},
 		{Kind: wasm.InstrBrIf},
+		{Kind: wasm.InstrBrOnNull},
+		{Kind: wasm.InstrBrOnCast},
+		{Kind: wasm.InstrTryTable},
 		{Kind: wasm.InstrGlobalGet},
 		{Kind: wasm.InstrI32Load},
 	}, &facts)
 	if facts.calleeCount != 1 || len(facts.callees) != 1 || facts.callees[0] != 3 ||
-		!facts.hasControlCall || !facts.hasControlFlow || !facts.touchesGlobal || !facts.touchesMem {
+		!facts.hasControlCall || !facts.hasControlFlow || !facts.moduleEH || !facts.touchesGlobal || !facts.touchesMem {
 		t.Fatalf("inline facts = %#v", facts)
+	}
+}
+
+func TestInlineBoundaryParityBytesArm64(t *testing.T) {
+	for _, op := range []byte{0xd5, 0xd6} {
+		body := []byte{op, 0x00, 0x0b}
+		h, err := scanBodyBytes(body, 0, 0, 0)
+		if err != nil {
+			t.Fatalf("production scan opcode %#x: %v", op, err)
+		}
+		var facts inlineFacts
+		if err := scanInlineFactsBytes(body, &facts); err != nil {
+			t.Fatalf("inline scan opcode %#x: %v", op, err)
+		}
+		if !h.hasControlFlow || !facts.hasControlFlow {
+			t.Fatalf("opcode %#x control classification: production=%v inline=%v", op, h.hasControlFlow, facts.hasControlFlow)
+		}
 	}
 }
 

--- a/src/core/compiler/backend/railshot/arm64/inline.go
+++ b/src/core/compiler/backend/railshot/arm64/inline.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
@@ -79,6 +80,7 @@ type inlineFacts struct {
 	hasControlCall bool     // call_indirect / return_call* / call_ref (inline blocker)
 	hasLoop        bool
 	hasControlFlow bool // any block/loop/if/else/br*/return/unreachable
+	moduleEH       bool // requires caller EH frame planning, so cannot yet inline
 	touchesMem     bool // any linear-memory op (load/store/size/grow/bulk)
 	touchesGlobal  bool // any global.get/global.set
 	params         int
@@ -180,6 +182,8 @@ func analyzeInlineCandidates(m *wasm.Module, policy CodegenPolicy) (*InlineRepor
 // can be spliced wherever it appears.
 func inlineClass(f inlineFacts, policy CodegenPolicy) (bool, string) {
 	switch {
+	case f.moduleEH:
+		return false, "requires exception-handling frame"
 	case (policy.Objective == OptimizeSize || policy.Objective == OptimizeEmbedded) && !sizeInlineOK(f, policy):
 		return false, "size objective requires proved native-byte win"
 	case f.hasControlCall:
@@ -212,6 +216,8 @@ func inlineClass(f inlineFacts, policy CodegenPolicy) (bool, string) {
 
 func inlineOK(f inlineFacts, policy CodegenPolicy) bool {
 	switch {
+	case f.moduleEH:
+		return false
 	case policy.Objective == OptimizeSize || policy.Objective == OptimizeEmbedded:
 		return sizeInlineOK(f, policy)
 	case f.hasControlCall, f.calleeCount > 0, !f.regABIIntOnly:
@@ -226,7 +232,7 @@ func inlineOK(f inlineFacts, policy CodegenPolicy) bool {
 }
 
 func sizeInlineOK(f inlineFacts, policy CodegenPolicy) bool {
-	return !f.hasControlCall && f.calleeCount == 0 &&
+	return !f.moduleEH && !f.hasControlCall && f.calleeCount == 0 &&
 		f.callSites == 1 && f.straightLine() && f.bodyBytes <= sizeInlineBodyLimit(policy) &&
 		f.params <= 1 && f.results <= 1 && f.declaredLocals == 0 &&
 		!f.touchesMem && !f.touchesGlobal
@@ -283,18 +289,24 @@ func scanInlineFactsBytes(body []byte, f *inlineFacts) error {
 		if err != nil {
 			return err
 		}
-		// Control-flow opcodes: unreachable/block/loop/if/else/br/br_if/br_table/
-		// return. The single terminating `end` (0x0b) is the body end, not a nested
-		// block close, so it is not treated as control flow. (ClassifyInstruction-
-		// Immediate handles these structurally, so key off the raw opcode.)
-		switch op {
-		case 0x00, 0x02, 0x03, 0x04, 0x05, 0x0c, 0x0d, 0x0e, 0x0f:
+		if shared.InstructionNeedsInlineBoundary(op, wasm.InstrInvalid) {
 			f.hasControlFlow = true
+		}
+		if shared.InstructionNeedsEHFrame(op, wasm.InstrInvalid) {
+			f.moduleEH = true
+		}
+		switch op {
 		case 0x23, 0x24: // global.get / global.set
 			f.touchesGlobal = true
 		}
 		if err := wasm.ClassifyInstructionImmediateInto(r, op, &imm); err != nil {
 			return err
+		}
+		if shared.InstructionNeedsInlineBoundary(op, imm.Kind) {
+			f.hasControlFlow = true
+		}
+		if shared.InstructionNeedsEHFrame(op, imm.Kind) {
+			f.moduleEH = true
 		}
 		if imm.TouchesMemory || imm.UsesBulkMemory {
 			f.touchesMem = true
@@ -316,6 +328,12 @@ func scanInlineFactsBytes(body []byte, f *inlineFacts) error {
 func scanInlineFactsAST(instrs []wasm.Instruction, f *inlineFacts) {
 	for i := range instrs {
 		in := &instrs[i]
+		if shared.InstructionNeedsInlineBoundary(0, in.Kind) {
+			f.hasControlFlow = true
+		}
+		if shared.InstructionNeedsEHFrame(0, in.Kind) {
+			f.moduleEH = true
+		}
 		switch in.Kind {
 		case wasm.InstrCall:
 			f.calleeCount++
@@ -499,6 +517,9 @@ func buildInlineTargets(m *wasm.Module, allHints []funcHints, policy CodegenPoli
 			continue
 		}
 		h := allHints[i]
+		if h.moduleEH {
+			continue
+		}
 		touchesGlobal := false
 		for _, score := range h.globalScore {
 			if score != 0 {

--- a/src/core/compiler/backend/railshot/arm64/inline_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/inline_arm64_test.go
@@ -52,6 +52,42 @@ func TestInlineLeafExecAndStatsArm64(t *testing.T) {
 	}
 }
 
+func TestInlineBrOnNullRespectsCalleeBoundaryArm64(t *testing.T) {
+	saved := inlineEnabled
+	inlineEnabled = true
+	defer func() { inlineEnabled = saved }()
+
+	m := modFuncs(t,
+		funcDef{results: []wasm.ValType{wasm.I32}, body: []byte{0x00, 0x41, 0x00, 0x10, 0x01, 0x1a, 0x41, 0x01, 0x0b}},
+		funcDef{body: []byte{0x00, 0xd0, 0x70, 0xd5, 0x00, 0x1a, 0x0b}},
+	)
+	hints, _, err := computeModuleHints(m, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := buildInlineTargets(m, hints, currentCodegenPolicy()).target(1)
+	if target == nil || !target.hasCtrl {
+		t.Fatalf("inline target = %#v, want synthetic control boundary", target)
+	}
+	if got := uint32(runArm64Internal2(t, m, 0, 0)); got != 1 {
+		t.Fatalf("caller result = %d, want 1", got)
+	}
+}
+
+func TestInlineTargetsRejectEHArm64(t *testing.T) {
+	m := modFuncs(t,
+		funcDef{results: []wasm.ValType{wasm.I32}, body: []byte{0x00, 0x10, 0x01, 0x41, 0x01, 0x0b}},
+		funcDef{body: []byte{0x00, 0x0b}},
+	)
+	for _, objective := range []OptimizationObjective{OptimizeBalanced, OptimizeSize, OptimizeEmbedded} {
+		policy := shared.CodegenPolicyForObjective(currentCodegenPolicy().Selection, objective)
+		hints := []funcHints{{hasCall: true}, {moduleEH: true, inlineCallSites: 1}}
+		if target := buildInlineTargets(m, hints, policy).target(1); target != nil {
+			t.Fatalf("objective %v admitted EH inline target", objective)
+		}
+	}
+}
+
 func TestInlineRejectsRecursiveArm64(t *testing.T) {
 	caller := []byte{0x00, 0x41, 0x01, 0x10, 0x01, 0x0b}
 	recursive := []byte{0x00, 0x20, 0x00, 0x10, 0x01, 0x0b}

--- a/src/core/compiler/backend/railshot/shared/inline.go
+++ b/src/core/compiler/backend/railshot/shared/inline.go
@@ -1,0 +1,53 @@
+package shared
+
+import "github.com/wago-org/wago/src/core/compiler/wasm"
+
+// InstructionNeedsInlineBoundary reports whether an instruction consumes or
+// creates a control label that must remain inside a synthetic callee frame when
+// its body is spliced into a caller. The opcode covers byte-backed scanners;
+// kind covers decoded AST instructions and prefixed instructions.
+func InstructionNeedsInlineBoundary(op byte, kind wasm.InstrKind) bool {
+	if kind == wasm.InstrInvalid {
+		switch op {
+		case 0x00, // unreachable
+			0x02, // block
+			0x03, // loop
+			0x04, // if
+			0x05, // else
+			0x0c, // br
+			0x0d, // br_if
+			0x0e, // br_table
+			0x0f, // return
+			0x1f, // try_table
+			0xd5, // br_on_null
+			0xd6: // br_on_non_null
+			return true
+		}
+	}
+	switch kind {
+	case wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf,
+		wasm.InstrBr, wasm.InstrBrIf, wasm.InstrBrTable, wasm.InstrReturn,
+		wasm.InstrTryTable, wasm.InstrBrOnNull, wasm.InstrBrOnNonNull,
+		wasm.InstrBrOnCast, wasm.InstrBrOnCastFail:
+		return true
+	default:
+		return false
+	}
+}
+
+// InstructionNeedsEHFrame reports whether an instruction requires the
+// exception-handling frame plan that inline targets do not yet transfer.
+func InstructionNeedsEHFrame(op byte, kind wasm.InstrKind) bool {
+	if kind == wasm.InstrInvalid {
+		switch op {
+		case 0x08, 0x0a, 0x1f: // throw, throw_ref, try_table
+			return true
+		}
+	}
+	switch kind {
+	case wasm.InstrThrow, wasm.InstrThrowRef, wasm.InstrTryTable:
+		return true
+	default:
+		return false
+	}
+}

--- a/src/core/compiler/backend/railshot/shared/inline_test.go
+++ b/src/core/compiler/backend/railshot/shared/inline_test.go
@@ -1,0 +1,41 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func TestInstructionNeedsInlineBoundary(t *testing.T) {
+	for _, op := range []byte{0x00, 0x02, 0x03, 0x04, 0x05, 0x0c, 0x0d, 0x0e, 0x0f, 0x1f, 0xd5, 0xd6} {
+		if !InstructionNeedsInlineBoundary(op, wasm.InstrInvalid) {
+			t.Fatalf("opcode %#x does not require an inline boundary", op)
+		}
+	}
+	for _, kind := range []wasm.InstrKind{
+		wasm.InstrUnreachable, wasm.InstrBlock, wasm.InstrLoop, wasm.InstrIf,
+		wasm.InstrBr, wasm.InstrBrIf, wasm.InstrBrTable, wasm.InstrReturn,
+		wasm.InstrTryTable, wasm.InstrBrOnNull, wasm.InstrBrOnNonNull,
+		wasm.InstrBrOnCast, wasm.InstrBrOnCastFail,
+	} {
+		if !InstructionNeedsInlineBoundary(0, kind) {
+			t.Fatalf("instruction %v does not require an inline boundary", kind)
+		}
+	}
+	if InstructionNeedsInlineBoundary(0x6a, wasm.InstrI32Add) {
+		t.Fatal("i32.add unexpectedly requires an inline boundary")
+	}
+}
+
+func TestInstructionNeedsEHFrame(t *testing.T) {
+	for _, op := range []byte{0x08, 0x0a, 0x1f} {
+		if !InstructionNeedsEHFrame(op, wasm.InstrInvalid) {
+			t.Fatalf("opcode %#x does not require an EH frame", op)
+		}
+	}
+	for _, kind := range []wasm.InstrKind{wasm.InstrThrow, wasm.InstrThrowRef, wasm.InstrTryTable} {
+		if !InstructionNeedsEHFrame(0, kind) {
+			t.Fatalf("instruction %v does not require an EH frame", kind)
+		}
+	}
+}

--- a/src/core/compiler/backend/railshot/shared/policy.go
+++ b/src/core/compiler/backend/railshot/shared/policy.go
@@ -26,7 +26,6 @@ type CodegenPolicy struct {
 	InternalAlignLog2 uint8
 	LoopAlignLog2     uint8
 
-	InlineGrowthBudget     int32
 	MaxMachineWindow       uint8
 	MaxRelaxIterations     uint8
 	MaxFinalizerDeletions  uint8

--- a/src/wago/inline_boundary_test.go
+++ b/src/wago/inline_boundary_test.go
@@ -1,0 +1,49 @@
+//go:build ((linux && (amd64 || arm64)) || (darwin && arm64)) && !tinygo
+
+package wago
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func TestInlineBrOnNullPreservesCallerContinuation(t *testing.T) {
+	module := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType(nil, nil),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(6, wasmtest.Vec(
+			wasmtest.GlobalEntry(wasm.FuncRef, true, []byte{0xd0, 0x70, 0x0b}),
+		)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x00, 0x10, 0x01, 0x1a, 0x41, 0x01, 0x0b}),
+			wasmtest.Code([]byte{0x23, 0x00, 0xd5, 0x00, 0x1a, 0x0b}),
+		)),
+	)
+	for _, objective := range []OptimizationObjective{OptimizeBalanced, OptimizeSize, OptimizeEmbedded} {
+		t.Run(objective.String(), func(t *testing.T) {
+			config := NewRuntimeConfig().
+				WithCoreFeatures(CoreFeaturesV3).
+				WithOptimizationObjective(objective)
+			compiled, err := Compile(config, module)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer compiled.Close()
+			instance, err := Instantiate(compiled, InstantiateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer instance.Close()
+			got, err := instance.Invoke("run")
+			if err != nil || len(got) != 1 || uint32(got[0]) != 1 {
+				t.Fatalf("run = %v, %v; want [1]", got, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- centralize inline-boundary classification so reference branches retain the callee control frame on AMD64 and ARM64
- reject EH callees until caller EH frame planning can safely import their requirements
- include the optimization objective in artifact-cache identity
- remove the unused `InlineGrowthBudget` policy field

## Root cause

The production hint scanners and the independent inline-analysis scanners carried separate opcode inventories. Both omitted `br_on_null` and `br_on_non_null`, and prefixed GC branch kinds were not consistently classified. That allowed a callee label to resolve against the caller control stack in the frameless inline path. EH presence was also discarded when inline targets were built.

The artifact cache encoded individual optimization selections but not the top-level objective, so Balanced, Size, and Embedded configurations could collide.

## Validation

- reproduced the ARM64 `br_on_null` failure before the fix as a split-stack overflow; the same test passes after the fix
- reproduced the cache-key collision before the fix; objective-specific cache paths and warm-cache ordering now pass
- `go test ./... -count=1`
- focused shared, ARM64, artifact-cache, public runtime, and docs-check suites on Go 1.22.12
- full AMD64 backend suite under Rosetta
- Linux AMD64 and ARM64 cross-builds
- runtime regression covers Balanced, Size, and Embedded with a runtime-loaded nullable reference

The red and green regression changes are combined so the branch remains buildable at every commit.

AI assistance: used to implement focused regression tests and review the fix; changes were validated against the repository test surfaces.