### PR TITLE
cli: emit runtime-only precompiled standalone executables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,13 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y lld
 
+      # Drive the manager with standard Go while TinyGo links and executes the
+      # final runtime-only binary. This covers target-policy handoff, portable
+      # stripping, and cooperative interruption of a CPU-bound guest.
+      - name: Test precompiled standalone under TinyGo
+        if: runner.os == 'Linux'
+        run: go test -count=1 -run '^(TestBuildTinyGoEmbedsArtifactWithoutCompiler|TestBuildTinyGoStripsByDefault|TestTinyGoArtifactSupportsCooperativeInterruption)$' ./cli/manager/internal/standalone
+
       # Compile portability: the whole pipeline (wasm -> amd64 -> runtime ->
       # public API + CLI) must build under TinyGo. A NOTE: the output name must
       # not end in .bin, which TinyGo treats as a firmware image.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Build a command module as a standalone native executable:
 ```sh
 wago compile app.wasm -o app
 wago compile --tinygo app.wasm -o app-tiny
-wago compile app.wasm --target linux/arm64 -o app-linux-arm64
 wago compile fib.wasm --invoke fib -o fib
 wago compile component.wasm --core 3 -p -o component
 ./fib 20
@@ -93,20 +92,20 @@ wago compile component.wasm --core 3 -p -o component
 
 By default, the module must export `_start`. Pass `--invoke <name>` to bake in a
 different exported function; executable arguments are parsed from its typed Wasm
-signature just like `wago run --invoke`. The executable embeds Wago, the Wasm
-module, and the active local or global plugin configuration, so it runs without
-a Wago installation. Use `--bare`, `--local`, or `--global` to choose the plugin
-scope. Add plugins to `wago.json` before compiling so resolution, Authorities,
-and Contract bindings stay reviewable and reproducible. `--core 3`, `--parallel`,
-and compiler flags such as `--no-inline` and `--no-deferred-bounds-checking` are
-baked into the executable.
+signature just like `wago run --invoke`. The executable embeds a native `.wago`
+artifact, Wago's runtime-only loader, and the active local or global plugin
+configuration, so it runs without a Wago installation and performs no Wasm
+codegen at startup. It does not embed the source Wasm or Railshot compiler. Use
+`--bare`, `--local`, or `--global` to choose the plugin scope. Add plugins to
+`wago.json` before compiling so resolution, Authorities, and Contract bindings
+stay reviewable and reproducible. `--core 3`, `--parallel`, and compiler flags
+such as `--no-inline` and `--no-deferred-bounds-checking` are applied while
+producing the embedded machine code.
 There is no standalone watch mode because the module is immutable once embedded.
-Cross-builds support Darwin, Linux, and Windows on AMD64 and ARM64.
-`--tinygo` creates a native-target-only executable containing a precompiled
-`.wago` artifact and the runtime needed to load it; it performs no Wasm codegen
-at startup. TinyGo builds use the cooperative scheduler and the repository's
-size-oriented stripping policy. Build them on the destination OS and
-architecture so codegen, interruption, and feature admission match the target.
+Standalone builds are native-target-only because codegen, interruption, and
+feature admission must match the runtime that executes the artifact. `--tinygo`
+uses TinyGo instead of standard Go for the final runtime link; TinyGo builds use
+the cooperative scheduler and the repository's size-oriented stripping policy.
 
 Inspect its host requirements:
 
@@ -330,12 +329,11 @@ with `--core 3`.
 
 Wago has no interpreter tier: supported modules execute as native machine code.
 Source modules can be compiled in the running process or serialized as native
-`.wago` artifacts for later loading. Standard-Go standalone executables embed
-Wasm and compile it at startup. `wago compile --tinygo` instead embeds a
-precompiled `.wago` artifact and links a runtime-only loader, so it performs no
-Wasm codegen at startup. `.wago` code is specific to the target architecture and
-runtime configuration. Unsupported or disabled features fail during decode or
-validation.
+`.wago` artifacts for later loading. Every `wago compile` executable embeds that
+precompiled artifact and a runtime-only loader, so it contains no source compiler
+and performs no Wasm codegen at startup. `--tinygo` selects TinyGo for the final
+link. `.wago` code is specific to the target architecture and runtime
+configuration. Unsupported or disabled features fail during decode or validation.
 
 Read the [Wago documentation](https://docs.wago.sh) for guides and reference
 material. The repository also keeps the detailed [feature matrix](FEATURES.md),

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Build a command module as a standalone native executable:
 
 ```sh
 wago compile app.wasm -o app
+wago compile --tinygo app.wasm -o app-tiny
 wago compile app.wasm --target linux/arm64 -o app-linux-arm64
 wago compile fib.wasm --invoke fib -o fib
 wago compile component.wasm --core 3 -p -o component
@@ -101,6 +102,11 @@ and compiler flags such as `--no-inline` and `--no-deferred-bounds-checking` are
 baked into the executable.
 There is no standalone watch mode because the module is immutable once embedded.
 Cross-builds support Darwin, Linux, and Windows on AMD64 and ARM64.
+`--tinygo` creates a native-target-only executable containing a precompiled
+`.wago` artifact and the runtime needed to load it; it performs no Wasm codegen
+at startup. TinyGo builds use the cooperative scheduler and the repository's
+size-oriented stripping policy. Build them on the destination OS and
+architecture so codegen, interruption, and feature admission match the target.
 
 Inspect its host requirements:
 
@@ -323,12 +329,13 @@ linux/amd64, linux/arm64, and darwin/arm64; the complete set is available there
 with `--core 3`.
 
 Wago has no interpreter tier: supported modules execute as native machine code.
-Source modules can be compiled in the running process, serialized as native
-`.wago` artifacts for later loading, or embedded in standalone native
-executables. Standalone executables compile their embedded Wasm at startup;
-`.wago` artifacts instead load previously generated code for the target
-architecture and runtime configuration. Unsupported or disabled features fail
-during decode or validation.
+Source modules can be compiled in the running process or serialized as native
+`.wago` artifacts for later loading. Standard-Go standalone executables embed
+Wasm and compile it at startup. `wago compile --tinygo` instead embeds a
+precompiled `.wago` artifact and links a runtime-only loader, so it performs no
+Wasm codegen at startup. `.wago` code is specific to the target architecture and
+runtime configuration. Unsupported or disabled features fail during decode or
+validation.
 
 Read the [Wago documentation](https://docs.wago.sh) for guides and reference
 material. The repository also keeps the detailed [feature matrix](FEATURES.md),

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -300,12 +300,11 @@ current optimization priorities. The Core 3.0 implementation ledger is
   `wago run` reuses an automatic cache keyed by the module, exact runtime
   executable, GOOS/GOARCH, effective feature/bounds/memory configuration, and
   optimization knobs. `wago cache` owns inspection, pruning, and cleanup.
-- [x] Runtime-only TinyGo standalone commands: `wago compile --tinygo`
-  precompiles the reviewed module/plugin graph into a native `.wago` artifact,
-  embeds it in a `wago_precompiled` loader, strips the resulting native binary,
-  and retains no Railshot source compiler. Platform-sensitive codegen keeps this
-  path native-target-only; ordinary Go standalone builds retain cross-target
-  support.
+- [x] Runtime-only standalone commands: `wago compile` precompiles the reviewed
+  module/plugin graph into a native `.wago` artifact and embeds it in a
+  `wago_precompiled` loader, retaining no Railshot source compiler. `--tinygo`
+  selects TinyGo for the final link and strips the resulting native binary.
+  Platform-sensitive codegen keeps both link paths native-target-only.
 
 ## Verification & quality
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -300,6 +300,12 @@ current optimization priorities. The Core 3.0 implementation ledger is
   `wago run` reuses an automatic cache keyed by the module, exact runtime
   executable, GOOS/GOARCH, effective feature/bounds/memory configuration, and
   optimization knobs. `wago cache` owns inspection, pruning, and cleanup.
+- [x] Runtime-only TinyGo standalone commands: `wago compile --tinygo`
+  precompiles the reviewed module/plugin graph into a native `.wago` artifact,
+  embeds it in a `wago_precompiled` loader, strips the resulting native binary,
+  and retains no Railshot source compiler. Platform-sensitive codegen keeps this
+  path native-target-only; ordinary Go standalone builds retain cross-target
+  support.
 
 ## Verification & quality
 

--- a/cli/manager/command_environment.go
+++ b/cli/manager/command_environment.go
@@ -83,6 +83,10 @@ func (commandEnvironment) Compile(options compilecmd.Options) {
 			"input": options.Input, "output": output, "target": target.String(), "core": core,
 			"functionWorkers": selection.FunctionWorkers, "deferredBoundsChecking": selection.DeferredBoundsChecking,
 		}
+		if options.TinyGo {
+			plan["toolchain"] = "tinygo"
+			plan["precompiled"] = true
+		}
 		if options.Invoke != "" {
 			plan["invoke"] = options.Invoke
 		}
@@ -101,6 +105,7 @@ func (commandEnvironment) Compile(options compilecmd.Options) {
 	result, err := managerstandalone.Build(managerstandalone.Request{
 		Input: options.Input, Output: output, Target: target, Invoke: options.Invoke, Core: selection.Core, Verbose: options.Verbose,
 		DeferredBoundsChecking: selection.DeferredBoundsChecking, FunctionWorkers: selection.FunctionWorkers, Optimizations: selection.Optimizations,
+		TinyGo: options.TinyGo,
 	})
 	if err != nil {
 		progress.Fail("Standalone build failed")

--- a/cli/manager/commands/compile/command.go
+++ b/cli/manager/commands/compile/command.go
@@ -19,7 +19,7 @@ type Options struct {
 	DeferredBoundsChecking        *bool
 	Optimizations                 map[string]bool
 	Global, Local, Bare           bool
-	Verbose                       bool
+	Verbose, TinyGo               bool
 }
 
 type Environment interface {
@@ -37,6 +37,7 @@ func Command(environment Environment) *command.Cmd {
 		{Name: "global", Short: "g", Bool: true, Help: "include shared user-wide plugins"},
 		{Name: "local", Bool: true, Help: "include this project's plugins"},
 		{Name: "bare", Bool: true, Help: "build without plugins"},
+		{Name: "tinygo", Bool: true, Help: "build a small TinyGo executable with precompiled Wasm code"},
 		{Name: "verbose", Short: "v", Bool: true, Help: "show Go build output"},
 	}
 	parserFlags := append(append([]command.Flag(nil), flags...), knobs...)
@@ -52,7 +53,7 @@ func Command(environment Environment) *command.Cmd {
 		},
 		Long: "The executable embeds the module and selected plugin configuration. By default it\n" +
 			"calls _start, then main, then the sole exported function; use --invoke to select\n" +
-			"another export. Core features,\n" +
+			"another export. --tinygo embeds precompiled native code and requires a native target. Core features,\n" +
 			"parallelism, and optimization knobs are fixed at build time. Use --target\n" +
 			"linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64,\n" +
 			"or windows/arm64 to cross-compile with the matching Wago backend.",
@@ -65,7 +66,7 @@ func Command(environment Environment) *command.Cmd {
 				Input: context.Args[0], Output: context.Str("output"), Target: context.Str("target"), Invoke: context.Str("invoke"),
 				Core: context.Str("core"), Parallel: context.Str("parallel"), DeferredBoundsChecking: deferred, Optimizations: optimizations,
 				Global: context.Bool("global"), Local: context.Bool("local"), Bare: context.Bool("bare"),
-				Verbose: context.Bool("verbose"),
+				Verbose: context.Bool("verbose"), TinyGo: context.Bool("tinygo"),
 			})
 		},
 	}

--- a/cli/manager/commands/compile/command.go
+++ b/cli/manager/commands/compile/command.go
@@ -30,7 +30,7 @@ func Command(environment Environment) *command.Cmd {
 	knobs := compileKnobFlags()
 	flags := []command.Flag{
 		{Name: "output", Short: "o", Arg: "<file>", Help: "output executable path"},
-		{Name: "target", Arg: "<os/arch>", Help: "target platform (default: current platform)"},
+		{Name: "target", Arg: "<os/arch>", Help: "native target platform (default: current platform)"},
 		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
 		{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 | 3 (default: best supported)"},
 		internalparallel.Flag(),
@@ -51,12 +51,11 @@ func Command(environment Environment) *command.Cmd {
 		Normalize: func(args []string) ([]string, error) {
 			return internalparallel.NormalizeArgs(args, parserFlags, false)
 		},
-		Long: "The executable embeds the module and selected plugin configuration. By default it\n" +
+		Long: "The executable embeds precompiled machine code, the runtime, and selected plugin configuration. By default it\n" +
 			"calls _start, then main, then the sole exported function; use --invoke to select\n" +
-			"another export. --tinygo embeds precompiled native code and requires a native target. Core features,\n" +
-			"parallelism, and optimization knobs are fixed at build time. Use --target\n" +
-			"linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64,\n" +
-			"or windows/arm64 to cross-compile with the matching Wago backend.",
+			"another export. --tinygo uses TinyGo for the final runtime link. Core features,\n" +
+			"parallelism, and optimization knobs are fixed at build time. Because the machine code\n" +
+			"is generated before linking, --target must match the current platform.",
 		Run: func(context *command.Ctx) {
 			if len(context.Args) != 1 {
 				ui.Usage("compile: need exactly one <file>")

--- a/cli/manager/commands/compile/command_test.go
+++ b/cli/manager/commands/compile/command_test.go
@@ -18,9 +18,9 @@ func TestCommandPassesStandaloneOptions(t *testing.T) {
 	Command(environment).Run(command.NewContext(
 		[]string{"app.wasm"},
 		map[string]string{"output": "app", "target": "linux/arm64", "invoke": "main"},
-		map[string]bool{"local": true, "verbose": true},
+		map[string]bool{"local": true, "verbose": true, "tinygo": true},
 	))
-	want := Options{Input: "app.wasm", Output: "app", Target: "linux/arm64", Invoke: "main", Optimizations: map[string]bool{}, Local: true, Verbose: true}
+	want := Options{Input: "app.wasm", Output: "app", Target: "linux/arm64", Invoke: "main", Optimizations: map[string]bool{}, Local: true, Verbose: true, TinyGo: true}
 	if !reflect.DeepEqual(environment.options, want) {
 		t.Fatalf("compile options = %#v, want %#v", environment.options, want)
 	}

--- a/cli/manager/internal/standalone/build.go
+++ b/cli/manager/internal/standalone/build.go
@@ -148,11 +148,13 @@ func Build(request Request) (Result, error) {
 		return Result{}, err
 	}
 	if request.TinyGo {
-		hostEnvironment := append(os.Environ(), "CGO_ENABLED=0")
 		if err := os.WriteFile(mainPath, artifactCompilerSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations), 0o644); err != nil {
 			return Result{}, err
 		}
-		if err := runGo(buildDir, hostEnvironment, request.Verbose, "run", "."); err != nil {
+		// The helper itself uses standard Go, but its output executes under TinyGo.
+		// Select final-runtime capabilities such as cooperative interruption while
+		// retaining the standard compiler needed to generate the artifact.
+		if err := runGo(buildDir, environment, request.Verbose, "run", "-tags=wago_target_tinygo", "."); err != nil {
 			return Result{}, fmt.Errorf("precompile standalone artifact: %w", err)
 		}
 		if err := os.WriteFile(mainPath, mainSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations, true), 0o644); err != nil {
@@ -260,9 +262,7 @@ func stripTinyGo(dir string, environment []string, verbose bool, output string, 
 	case "darwin":
 		return runTool("strip", dir, environment, verbose, "-x", output)
 	case "linux":
-		return runTool("strip", dir, environment, verbose,
-			"-s", "--strip-section-headers", "--remove-section=.eh_frame",
-			"--remove-section=.eh_frame_hdr", "--remove-section=.comment", output)
+		return runTool("strip", dir, environment, verbose, "-s", output)
 	default:
 		return fmt.Errorf("TinyGo stripping is not supported for target %s", target)
 	}

--- a/cli/manager/internal/standalone/build.go
+++ b/cli/manager/internal/standalone/build.go
@@ -94,13 +94,13 @@ func Build(request Request) (Result, error) {
 		if !request.Target.supportsTinyGo() {
 			return Result{}, fmt.Errorf("TinyGo standalone executables are not supported for target %s", request.Target)
 		}
-		host := Target{OS: runtime.GOOS, Arch: runtime.GOARCH}
-		if request.Target != host {
-			return Result{}, fmt.Errorf("TinyGo precompiled standalone builds require the native target %s; got %s", host, request.Target)
-		}
 	}
 	if request.Core == 3 && !request.Target.supportsCore3() {
 		return Result{}, fmt.Errorf("WebAssembly Core 3 is not supported for target %s", request.Target)
+	}
+	host := Target{OS: runtime.GOOS, Arch: runtime.GOARCH}
+	if request.Target != host {
+		return Result{}, fmt.Errorf("precompiled standalone builds require the native target %s; got %s", host, request.Target)
 	}
 	if request.Output == "" {
 		request.Output = DefaultOutput(request.Input, request.Target)
@@ -147,19 +147,24 @@ func Build(request Request) (Result, error) {
 	if err := runGo(buildDir, environment, request.Verbose, "mod", "tidy"); err != nil {
 		return Result{}, err
 	}
+	if err := os.WriteFile(mainPath, artifactCompilerSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations), 0o644); err != nil {
+		return Result{}, err
+	}
+	helperArgs := []string{"run"}
 	if request.TinyGo {
-		if err := os.WriteFile(mainPath, artifactCompilerSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations), 0o644); err != nil {
-			return Result{}, err
-		}
 		// The helper itself uses standard Go, but its output executes under TinyGo.
 		// Select final-runtime capabilities such as cooperative interruption while
 		// retaining the standard compiler needed to generate the artifact.
-		if err := runGo(buildDir, environment, request.Verbose, "run", "-tags=wago_target_tinygo", "."); err != nil {
-			return Result{}, fmt.Errorf("precompile standalone artifact: %w", err)
-		}
-		if err := os.WriteFile(mainPath, mainSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations, true), 0o644); err != nil {
-			return Result{}, err
-		}
+		helperArgs = append(helperArgs, "-tags=wago_target_tinygo")
+	}
+	helperArgs = append(helperArgs, ".")
+	if err := runGo(buildDir, environment, request.Verbose, helperArgs...); err != nil {
+		return Result{}, fmt.Errorf("precompile standalone artifact: %w", err)
+	}
+	if err := os.WriteFile(mainPath, mainSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations, true), 0o644); err != nil {
+		return Result{}, err
+	}
+	if request.TinyGo {
 		args := []string{"build", "-scheduler=tasks", "-opt=z", "-gc=conservative", "-tags=wago_precompiled"}
 		if !request.KeepSymbols {
 			args = append(args, "-no-debug")
@@ -175,7 +180,7 @@ func Build(request Request) (Result, error) {
 		}
 		return Result{Output: output, Target: request.Target, Plugins: len(inputs.Build.Selections)}, nil
 	}
-	args := []string{"build", "-buildvcs=false", "-trimpath"}
+	args := []string{"build", "-buildvcs=false", "-trimpath", "-tags=wago_precompiled"}
 	if !request.KeepSymbols {
 		args = append(args, "-ldflags=-s -w")
 	}

--- a/cli/manager/internal/standalone/build.go
+++ b/cli/manager/internal/standalone/build.go
@@ -54,6 +54,7 @@ type Request struct {
 	Target                 Target
 	Verbose                bool
 	KeepSymbols            bool
+	TinyGo                 bool
 }
 
 type Result struct {
@@ -87,6 +88,15 @@ func Build(request Request) (Result, error) {
 		request.Target, err = ParseTarget("")
 		if err != nil {
 			return Result{}, err
+		}
+	}
+	if request.TinyGo {
+		if !request.Target.supportsTinyGo() {
+			return Result{}, fmt.Errorf("TinyGo standalone executables are not supported for target %s", request.Target)
+		}
+		host := Target{OS: runtime.GOOS, Arch: runtime.GOARCH}
+		if request.Target != host {
+			return Result{}, fmt.Errorf("TinyGo precompiled standalone builds require the native target %s; got %s", host, request.Target)
 		}
 	}
 	if request.Core == 3 && !request.Target.supportsCore3() {
@@ -125,7 +135,8 @@ func Build(request Request) (Result, error) {
 	if err := os.WriteFile(filepath.Join(buildDir, "module.wasm"), source, 0o644); err != nil {
 		return Result{}, err
 	}
-	if err := os.WriteFile(filepath.Join(buildDir, "main.go"), mainSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations), 0o644); err != nil {
+	mainPath := filepath.Join(buildDir, "main.go")
+	if err := os.WriteFile(mainPath, mainSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations, false), 0o644); err != nil {
 		return Result{}, err
 	}
 	environment := append(os.Environ(),
@@ -135,6 +146,32 @@ func Build(request Request) (Result, error) {
 	)
 	if err := runGo(buildDir, environment, request.Verbose, "mod", "tidy"); err != nil {
 		return Result{}, err
+	}
+	if request.TinyGo {
+		hostEnvironment := append(os.Environ(), "CGO_ENABLED=0")
+		if err := os.WriteFile(mainPath, artifactCompilerSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations), 0o644); err != nil {
+			return Result{}, err
+		}
+		if err := runGo(buildDir, hostEnvironment, request.Verbose, "run", "."); err != nil {
+			return Result{}, fmt.Errorf("precompile standalone artifact: %w", err)
+		}
+		if err := os.WriteFile(mainPath, mainSource(inputs.Build.ProviderImports, selections, request.Invoke, request.Core, request.DeferredBoundsChecking, request.FunctionWorkers, request.Optimizations, true), 0o644); err != nil {
+			return Result{}, err
+		}
+		args := []string{"build", "-scheduler=tasks", "-opt=z", "-gc=conservative", "-tags=wago_precompiled"}
+		if !request.KeepSymbols {
+			args = append(args, "-no-debug")
+		}
+		args = append(args, "-o", output, ".")
+		if err := runTool("tinygo", buildDir, environment, request.Verbose, args...); err != nil {
+			return Result{}, err
+		}
+		if !request.KeepSymbols {
+			if err := stripTinyGo(buildDir, environment, request.Verbose, output, request.Target); err != nil {
+				return Result{}, err
+			}
+		}
+		return Result{Output: output, Target: request.Target, Plugins: len(inputs.Build.Selections)}, nil
 	}
 	args := []string{"build", "-buildvcs=false", "-trimpath"}
 	if !request.KeepSymbols {
@@ -147,7 +184,7 @@ func Build(request Request) (Result, error) {
 	return Result{Output: output, Target: request.Target, Plugins: len(inputs.Build.Selections)}, nil
 }
 
-func mainSource(providerImports []string, selections []byte, invoke string, core int, deferredBoundsChecking bool, functionWorkers int, optimizations map[string]bool) []byte {
+func mainSource(providerImports []string, selections []byte, invoke string, core int, deferredBoundsChecking bool, functionWorkers int, optimizations map[string]bool, precompiled bool) []byte {
 	providerImports = append([]string(nil), providerImports...)
 	sort.Strings(providerImports)
 	var source bytes.Buffer
@@ -157,7 +194,13 @@ func mainSource(providerImports []string, selections []byte, invoke string, core
 	for index, providerImport := range providerImports {
 		fmt.Fprintf(&source, "\tprovider%d %q\n", index, providerImport)
 	}
-	source.WriteString(")\n\n//go:embed module.wasm\nvar module []byte\n\n")
+	artifact := "module.wasm"
+	run := "Run"
+	if precompiled {
+		artifact = "module.wago"
+		run = "RunArtifact"
+	}
+	fmt.Fprintf(&source, ")\n\n//go:embed %s\nvar module []byte\n\n", artifact)
 	fmt.Fprintf(&source, "var selectionJSON = []byte(%q)\n\n", selections)
 	source.WriteString("func pluginSet() wago.PluginSet {\n\tvar selections []wago.PluginSelection\n\tif err := json.Unmarshal(selectionJSON, &selections); err != nil { panic(err) }\n\tvar providers []wago.PluginProvider\n")
 	for index := range providerImports {
@@ -174,12 +217,25 @@ func mainSource(providerImports []string, selections []byte, invoke string, core
 		fmt.Fprintf(&source, "%q: %t, ", name, optimizations[name])
 	}
 	source.WriteString("}}\n\n")
-	source.WriteString("func main() { os.Exit(standalone.Run(module, pluginSet(), options, os.Args)) }\n")
+	fmt.Fprintf(&source, "func main() { os.Exit(standalone.%s(module, pluginSet(), options, os.Args)) }\n", run)
 	return source.Bytes()
 }
 
+func artifactCompilerSource(providerImports []string, selections []byte, invoke string, core int, deferredBoundsChecking bool, functionWorkers int, optimizations map[string]bool) []byte {
+	source := mainSource(providerImports, selections, invoke, core, deferredBoundsChecking, functionWorkers, optimizations, false)
+	source = bytes.Replace(source, []byte("\t\"os\"\n"), []byte("\t\"os\"\n\t\"fmt\"\n"), 1)
+	source = bytes.Replace(source,
+		[]byte("func main() { os.Exit(standalone.Run(module, pluginSet(), options, os.Args)) }"),
+		[]byte("func main() { artifact, err := standalone.CompileArtifact(module, pluginSet(), options); if err == nil { err = os.WriteFile(\"module.wago\", artifact, 0o644) }; if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) } }"), 1)
+	return source
+}
+
 func runGo(dir string, environment []string, verbose bool, args ...string) error {
-	command := exec.Command("go", args...)
+	return runTool("go", dir, environment, verbose, args...)
+}
+
+func runTool(tool, dir string, environment []string, verbose bool, args ...string) error {
+	command := exec.Command(tool, args...)
 	command.Dir = dir
 	command.Env = environment
 	automation.ConfigureCommand(command)
@@ -189,7 +245,25 @@ func runGo(dir string, environment []string, verbose bool, args ...string) error
 	}
 	output, err := command.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("go %s: %w\n%s", args[0], err, strings.TrimSpace(string(output)))
+		return fmt.Errorf("%s %s: %w\n%s", tool, args[0], err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+func (t Target) supportsTinyGo() bool {
+	return (t.OS == "linux" && (t.Arch == "amd64" || t.Arch == "arm64")) ||
+		(t.OS == "darwin" && t.Arch == "arm64")
+}
+
+func stripTinyGo(dir string, environment []string, verbose bool, output string, target Target) error {
+	switch target.OS {
+	case "darwin":
+		return runTool("strip", dir, environment, verbose, "-x", output)
+	case "linux":
+		return runTool("strip", dir, environment, verbose,
+			"-s", "--strip-section-headers", "--remove-section=.eh_frame",
+			"--remove-section=.eh_frame_hdr", "--remove-section=.comment", output)
+	default:
+		return fmt.Errorf("TinyGo stripping is not supported for target %s", target)
+	}
 }

--- a/cli/manager/internal/standalone/build_linux_test.go
+++ b/cli/manager/internal/standalone/build_linux_test.go
@@ -1,0 +1,133 @@
+//go:build linux
+
+package standalone
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestTinyGoArtifactSupportsCooperativeInterruption(t *testing.T) {
+	if _, err := exec.LookPath("tinygo"); err != nil {
+		t.Skip("tinygo is not installed")
+	}
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goMod := fmt.Sprintf("module tinygo-interruption-test\n\ngo 1.22\n\nrequire github.com/wago-org/wago v0.0.0\n\nreplace github.com/wago-org/wago => %s\n", root)
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(interruptionArtifactCompilerSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	environment := append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux", "GOARCH="+runtime.GOARCH)
+	if err := runGo(dir, environment, false, "mod", "tidy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGo(dir, environment, false, "run", "-tags=wago_target_tinygo", "."); err != nil {
+		t.Fatalf("compile artifact for TinyGo target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(interruptionTinyGoRunnerSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	executable := filepath.Join(dir, "runner")
+	// A distinct host thread publishes cancellation while the CPU-bound guest
+	// owns its execution thread. This isolates whether the artifact contains the
+	// cooperative poll that the TinyGo runtime needs to consume that request.
+	if err := runTool("tinygo", dir, environment, false, "build", "-scheduler=threads", "-gc=conservative", "-tags=wago_precompiled", "-o", executable, "."); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, executable).CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("TinyGo standalone did not interrupt its infinite guest within 5s: %v", ctx.Err())
+	}
+	if err != nil {
+		t.Fatalf("TinyGo standalone interruption: %v\n%s", err, output)
+	}
+}
+
+const interruptionArtifactCompilerSource = `package main
+
+import (
+	"os"
+
+	"github.com/wago-org/wago"
+	"github.com/wago-org/wago/cli/standalone"
+)
+
+var infiniteLoop = []byte{
+	0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+	0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+	0x03, 0x02, 0x01, 0x00,
+	0x07, 0x08, 0x01, 0x04, 0x73, 0x70, 0x69, 0x6e, 0x00, 0x00,
+	0x0a, 0x09, 0x01, 0x07, 0x00, 0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b,
+}
+
+func main() {
+	artifact, err := standalone.CompileArtifact(infiniteLoop, wago.PluginSet{}, standalone.Options{})
+	if err == nil {
+		err = os.WriteFile("module.wago", artifact, 0o644)
+	}
+	if err != nil {
+		panic(err)
+	}
+}
+`
+
+const interruptionTinyGoRunnerSource = `package main
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"time"
+
+	"github.com/wago-org/wago"
+)
+
+//go:embed module.wago
+var artifact []byte
+
+func main() {
+	compiled, err := wago.Load(artifact)
+	if err != nil {
+		panic(err)
+	}
+	rt := wago.NewRuntime()
+	module, err := rt.AdoptModule(compiled)
+	if err != nil {
+		panic(err)
+	}
+	instance, err := rt.Instantiate(context.Background(), module)
+	if err != nil {
+		panic(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, invokeErr := instance.InvokeContext(ctx, "spin")
+		done <- invokeErr
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err = <-done:
+		if !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	case <-time.After(2 * time.Second):
+		panic("infinite guest did not consume cancellation")
+	}
+}
+`

--- a/cli/manager/internal/standalone/build_test.go
+++ b/cli/manager/internal/standalone/build_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -23,11 +24,83 @@ func TestParseTargetAndDefaultOutput(t *testing.T) {
 }
 
 func TestMainSourceBakesInvokeExport(t *testing.T) {
-	source := string(mainSource(nil, nil, "fib", 3, false, 4, map[string]bool{"inline": false}))
+	source := string(mainSource(nil, nil, "fib", 3, false, 4, map[string]bool{"inline": false}, false))
 	if !strings.Contains(source, `Invoke: "fib", Core: 3, DeferBoundsChecks: false, FunctionWorkers: 4`) ||
 		!strings.Contains(source, `"inline": false`) ||
 		!strings.Contains(source, `standalone.Run(module, pluginSet(), options, os.Args)`) {
 		t.Fatalf("generated main does not invoke fib:\n%s", source)
+	}
+}
+
+func TestMainSourceEmbedsPrecompiledArtifactForTinyGo(t *testing.T) {
+	source := string(mainSource(nil, nil, "", 2, true, 0, nil, true))
+	if !strings.Contains(source, "//go:embed module.wago") ||
+		!strings.Contains(source, `standalone.RunArtifact(module, pluginSet(), options, os.Args)`) ||
+		strings.Contains(source, "module.wasm") {
+		t.Fatalf("generated TinyGo main does not load the precompiled artifact:\n%s", source)
+	}
+	compiler := string(artifactCompilerSource(nil, nil, "", 2, true, 0, nil))
+	if !strings.Contains(compiler, `standalone.CompileArtifact(module, pluginSet(), options)`) ||
+		!strings.Contains(compiler, `os.WriteFile("module.wago", artifact, 0o644)`) {
+		t.Fatalf("generated artifact compiler does not precompile the module:\n%s", compiler)
+	}
+}
+
+func TestBuildRejectsNonNativeTinyGoTarget(t *testing.T) {
+	project := t.TempDir()
+	input := filepath.Join(project, "hello.wasm")
+	if err := os.WriteFile(input, emptyStartModule(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := Target{OS: "linux", Arch: "amd64"}
+	if target == (Target{OS: runtime.GOOS, Arch: runtime.GOARCH}) {
+		target = Target{OS: "linux", Arch: "arm64"}
+	}
+	_, err := Build(Request{Input: input, Target: target, TinyGo: true})
+	if err == nil || !strings.Contains(err.Error(), "TinyGo precompiled standalone builds require the native target") {
+		t.Fatalf("build error = %v", err)
+	}
+}
+
+func TestBuildTinyGoEmbedsArtifactWithoutCompiler(t *testing.T) {
+	host := Target{OS: runtime.GOOS, Arch: runtime.GOARCH}
+	if !host.supportsTinyGo() {
+		t.Skipf("TinyGo standalone is unsupported on %s", host)
+	}
+	if _, err := exec.LookPath("tinygo"); err != nil {
+		t.Skip("tinygo is not installed")
+	}
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	input := filepath.Join(project, "hello.wasm")
+	output := filepath.Join(project, "hello")
+	if err := os.WriteFile(input, emptyStartModule(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WAGO_SRC", root)
+	t.Setenv("WAGO_HOME", t.TempDir())
+	t.Setenv("WAGO_BARE", "1")
+	result, err := Build(Request{Input: input, Output: output, Target: host, TinyGo: true, KeepSymbols: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output, err := exec.Command(result.Output).CombinedOutput(); err != nil {
+		t.Fatalf("run TinyGo standalone: %v\n%s", err, output)
+	}
+	names, err := exec.Command("go", "tool", "nm", result.Output).Output()
+	if err != nil {
+		t.Fatalf("inspect TinyGo standalone: %v", err)
+	}
+	for _, forbidden := range []string{
+		"compiler/backend/railshot/amd64.", "compiler/backend/railshot/arm64.",
+		"compileWithConfig", "CompileModuleWith", "CompileArtifact",
+	} {
+		if strings.Contains(string(names), forbidden) {
+			t.Errorf("TinyGo precompiled executable retains compiler symbol containing %q", forbidden)
+		}
 	}
 }
 

--- a/cli/manager/internal/standalone/build_test.go
+++ b/cli/manager/internal/standalone/build_test.go
@@ -69,7 +69,7 @@ func TestBuildEmbedsArtifactWithoutCompiler(t *testing.T) {
 	}
 	project := t.TempDir()
 	input := filepath.Join(root, "tests", "fixtures", "wasm", "fib.wasm")
-	output := filepath.Join(project, "hello")
+	output := filepath.Join(project, DefaultOutput("hello.wasm", host))
 	t.Setenv("WAGO_SRC", root)
 	t.Setenv("WAGO_HOME", t.TempDir())
 	t.Setenv("WAGO_BARE", "1")

--- a/cli/manager/internal/standalone/build_test.go
+++ b/cli/manager/internal/standalone/build_test.go
@@ -83,6 +83,12 @@ func TestBuildTinyGoEmbedsArtifactWithoutCompiler(t *testing.T) {
 	t.Setenv("WAGO_SRC", root)
 	t.Setenv("WAGO_HOME", t.TempDir())
 	t.Setenv("WAGO_BARE", "1")
+	t.Setenv("GOOS", "windows")
+	if host.Arch == "amd64" {
+		t.Setenv("GOARCH", "arm64")
+	} else {
+		t.Setenv("GOARCH", "amd64")
+	}
 	result, err := Build(Request{Input: input, Output: output, Target: host, TinyGo: true, KeepSymbols: true})
 	if err != nil {
 		t.Fatal(err)
@@ -101,6 +107,39 @@ func TestBuildTinyGoEmbedsArtifactWithoutCompiler(t *testing.T) {
 		if strings.Contains(string(names), forbidden) {
 			t.Errorf("TinyGo precompiled executable retains compiler symbol containing %q", forbidden)
 		}
+	}
+}
+
+func TestBuildTinyGoStripsByDefault(t *testing.T) {
+	host := Target{OS: runtime.GOOS, Arch: runtime.GOARCH}
+	if !host.supportsTinyGo() {
+		t.Skipf("TinyGo standalone is unsupported on %s", host)
+	}
+	if _, err := exec.LookPath("tinygo"); err != nil {
+		t.Skip("tinygo is not installed")
+	}
+	if _, err := exec.LookPath("strip"); err != nil {
+		t.Skip("strip is not installed")
+	}
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	input := filepath.Join(project, "hello.wasm")
+	output := filepath.Join(project, "hello")
+	if err := os.WriteFile(input, emptyStartModule(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WAGO_SRC", root)
+	t.Setenv("WAGO_HOME", t.TempDir())
+	t.Setenv("WAGO_BARE", "1")
+	result, err := Build(Request{Input: input, Output: output, Target: host, TinyGo: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output, err := exec.Command(result.Output).CombinedOutput(); err != nil {
+		t.Fatalf("run stripped TinyGo standalone: %v\n%s", err, output)
 	}
 }
 

--- a/cli/manager/internal/standalone/build_test.go
+++ b/cli/manager/internal/standalone/build_test.go
@@ -1,7 +1,6 @@
 package standalone
 
 import (
-	"debug/elf"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,12 +31,12 @@ func TestMainSourceBakesInvokeExport(t *testing.T) {
 	}
 }
 
-func TestMainSourceEmbedsPrecompiledArtifactForTinyGo(t *testing.T) {
+func TestMainSourceEmbedsPrecompiledArtifact(t *testing.T) {
 	source := string(mainSource(nil, nil, "", 2, true, 0, nil, true))
 	if !strings.Contains(source, "//go:embed module.wago") ||
 		!strings.Contains(source, `standalone.RunArtifact(module, pluginSet(), options, os.Args)`) ||
 		strings.Contains(source, "module.wasm") {
-		t.Fatalf("generated TinyGo main does not load the precompiled artifact:\n%s", source)
+		t.Fatalf("generated main does not load the precompiled artifact:\n%s", source)
 	}
 	compiler := string(artifactCompilerSource(nil, nil, "", 2, true, 0, nil))
 	if !strings.Contains(compiler, `standalone.CompileArtifact(module, pluginSet(), options)`) ||
@@ -46,7 +45,7 @@ func TestMainSourceEmbedsPrecompiledArtifactForTinyGo(t *testing.T) {
 	}
 }
 
-func TestBuildRejectsNonNativeTinyGoTarget(t *testing.T) {
+func TestBuildRejectsNonNativeTarget(t *testing.T) {
 	project := t.TempDir()
 	input := filepath.Join(project, "hello.wasm")
 	if err := os.WriteFile(input, emptyStartModule(), 0o644); err != nil {
@@ -56,10 +55,41 @@ func TestBuildRejectsNonNativeTinyGoTarget(t *testing.T) {
 	if target == (Target{OS: runtime.GOOS, Arch: runtime.GOARCH}) {
 		target = Target{OS: "linux", Arch: "arm64"}
 	}
-	_, err := Build(Request{Input: input, Target: target, TinyGo: true})
-	if err == nil || !strings.Contains(err.Error(), "TinyGo precompiled standalone builds require the native target") {
+	_, err := Build(Request{Input: input, Target: target})
+	if err == nil || !strings.Contains(err.Error(), "precompiled standalone builds require the native target") {
 		t.Fatalf("build error = %v", err)
 	}
+}
+
+func TestBuildEmbedsArtifactWithoutCompiler(t *testing.T) {
+	host := Target{OS: runtime.GOOS, Arch: runtime.GOARCH}
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	input := filepath.Join(root, "tests", "fixtures", "wasm", "fib.wasm")
+	output := filepath.Join(project, "hello")
+	t.Setenv("WAGO_SRC", root)
+	t.Setenv("WAGO_HOME", t.TempDir())
+	t.Setenv("WAGO_BARE", "1")
+	t.Setenv("GOOS", "windows")
+	if host.Arch == "amd64" {
+		t.Setenv("GOARCH", "arm64")
+	} else {
+		t.Setenv("GOARCH", "amd64")
+	}
+	result, err := Build(Request{Input: input, Output: output, Target: host, Invoke: "fib", KeepSymbols: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(result.Output, "20")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("run standalone: %v\n%s", err, output)
+	} else if got := strings.TrimSpace(string(output)); got != "6765" {
+		t.Fatalf("standalone output = %q, want 6765", got)
+	}
+	assertNoCompilerSymbols(t, result.Output, "standalone")
 }
 
 func TestBuildTinyGoEmbedsArtifactWithoutCompiler(t *testing.T) {
@@ -96,16 +126,29 @@ func TestBuildTinyGoEmbedsArtifactWithoutCompiler(t *testing.T) {
 	if output, err := exec.Command(result.Output).CombinedOutput(); err != nil {
 		t.Fatalf("run TinyGo standalone: %v\n%s", err, output)
 	}
-	names, err := exec.Command("go", "tool", "nm", result.Output).Output()
+	assertNoCompilerSymbols(t, result.Output, "TinyGo standalone")
+}
+
+func assertNoCompilerSymbols(t *testing.T, executable, description string) {
+	t.Helper()
+	names, err := exec.Command("go", "tool", "nm", executable).Output()
 	if err != nil {
-		t.Fatalf("inspect TinyGo standalone: %v", err)
+		t.Fatalf("inspect %s: %v", description, err)
 	}
 	for _, forbidden := range []string{
-		"compiler/backend/railshot/amd64.", "compiler/backend/railshot/arm64.",
-		"compileWithConfig", "CompileModuleWith", "CompileArtifact",
+		"compiler/backend/railshot/amd64.", "compiler/backend/railshot/arm64.", "CompileArtifact",
 	} {
 		if strings.Contains(string(names), forbidden) {
-			t.Errorf("TinyGo precompiled executable retains compiler symbol containing %q", forbidden)
+			var matches []string
+			for _, line := range strings.Split(string(names), "\n") {
+				if strings.Contains(line, forbidden) {
+					matches = append(matches, line)
+					if len(matches) == 5 {
+						break
+					}
+				}
+			}
+			t.Errorf("%s retains compiler symbol containing %q:\n%s", description, forbidden, strings.Join(matches, "\n"))
 		}
 	}
 }
@@ -140,57 +183,6 @@ func TestBuildTinyGoStripsByDefault(t *testing.T) {
 	}
 	if output, err := exec.Command(result.Output).CombinedOutput(); err != nil {
 		t.Fatalf("run stripped TinyGo standalone: %v\n%s", err, output)
-	}
-}
-
-func TestBuildSelectsOnlyTargetBackend(t *testing.T) {
-	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
-	if err != nil {
-		t.Fatal(err)
-	}
-	project := t.TempDir()
-	input := filepath.Join(project, "hello.wasm")
-	if err := os.WriteFile(input, emptyStartModule(), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("WAGO_SRC", root)
-	t.Setenv("WAGO_HOME", t.TempDir())
-	t.Setenv("WAGO_BARE", "1")
-
-	for _, test := range []struct {
-		arch    string
-		machine elf.Machine
-		backend string
-		other   string
-	}{
-		{arch: "amd64", machine: elf.EM_X86_64, backend: "railshot/amd64", other: "railshot/arm64"},
-		{arch: "arm64", machine: elf.EM_AARCH64, backend: "railshot/arm64", other: "railshot/amd64"},
-	} {
-		output := filepath.Join(project, "hello-"+test.arch)
-		result, err := Build(Request{
-			Input: input, Output: output, Target: Target{OS: "linux", Arch: test.arch}, KeepSymbols: true,
-		})
-		if err != nil {
-			t.Fatalf("build linux/%s: %v", test.arch, err)
-		}
-		binary, err := elf.Open(result.Output)
-		if err != nil {
-			t.Fatalf("open linux/%s: %v", test.arch, err)
-		}
-		if binary.Machine != test.machine {
-			t.Errorf("linux/%s machine = %v, want %v", test.arch, binary.Machine, test.machine)
-		}
-		_ = binary.Close()
-		names, err := exec.Command("go", "tool", "nm", result.Output).Output()
-		if err != nil {
-			t.Fatalf("nm linux/%s: %v", test.arch, err)
-		}
-		if !strings.Contains(string(names), test.backend) {
-			t.Errorf("linux/%s executable does not contain target backend %q", test.arch, test.backend)
-		}
-		if strings.Contains(string(names), test.other) {
-			t.Errorf("linux/%s executable contains opposite backend %q", test.arch, test.other)
-		}
 	}
 }
 

--- a/cli/manager/internal/standalone/strip_unix_test.go
+++ b/cli/manager/internal/standalone/strip_unix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package standalone
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStripTinyGoLinuxUsesPortableOptions(t *testing.T) {
+	dir := t.TempDir()
+	strip := filepath.Join(dir, "strip")
+	if err := os.WriteFile(strip, []byte("#!/bin/sh\n[ \"$#\" -eq 2 ] && [ \"$1\" = -s ]\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	if err := stripTinyGo(dir, os.Environ(), false, "program", Target{OS: "linux", Arch: "amd64"}); err != nil {
+		t.Fatalf("strip with portable implementation: %v", err)
+	}
+}

--- a/cli/standalone/source.go
+++ b/cli/standalone/source.go
@@ -1,0 +1,43 @@
+//go:build !wago_precompiled
+
+package standalone
+
+import "github.com/wago-org/wago"
+
+// Run executes source as a command and returns its process exit code. Plugins
+// are handed in as one explicit, reviewed PluginSet.
+func Run(source []byte, plugins wago.PluginSet, options Options, args []string) int {
+	if err := execute(source, plugins, options, args); err != nil {
+		return reportError(err, args)
+	}
+	return 0
+}
+
+func execute(source []byte, plugins wago.PluginSet, options Options, args []string) error {
+	runtime, err := loadRuntime(plugins, options, args)
+	if err != nil {
+		return err
+	}
+	defer runtime.Close()
+	module, err := runtime.Compile(source)
+	if err != nil {
+		return err
+	}
+	return executeModule(runtime, module, options, args)
+}
+
+// CompileArtifact applies the selected plugins and compilation options once and
+// returns the target-specific artifact embedded by TinyGo standalone builds.
+func CompileArtifact(source []byte, plugins wago.PluginSet, options Options) ([]byte, error) {
+	runtime, err := loadRuntime(plugins, options, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer runtime.Close()
+	module, err := runtime.Compile(source)
+	if err != nil {
+		return nil, err
+	}
+	defer module.Close()
+	return module.Compiled().MarshalBinary()
+}

--- a/cli/standalone/source.go
+++ b/cli/standalone/source.go
@@ -27,7 +27,7 @@ func execute(source []byte, plugins wago.PluginSet, options Options, args []stri
 }
 
 // CompileArtifact applies the selected plugins and compilation options once and
-// returns the target-specific artifact embedded by TinyGo standalone builds.
+// returns the target-specific artifact embedded by standalone builds.
 func CompileArtifact(source []byte, plugins wago.PluginSet, options Options) ([]byte, error) {
 	runtime, err := loadRuntime(plugins, options, nil)
 	if err != nil {

--- a/cli/standalone/standalone.go
+++ b/cli/standalone/standalone.go
@@ -21,38 +21,60 @@ type Options struct {
 	OptimizationKnobs map[string]bool
 }
 
-// Run executes source as a command and returns its process exit code. Plugins
-// are handed in as one explicit, reviewed PluginSet.
-func Run(source []byte, plugins wago.PluginSet, options Options, args []string) int {
-	if err := execute(source, plugins, options, args); err != nil {
-		var exit *wago.ExitError
-		if errors.As(err, &exit) {
-			return int(exit.Code)
-		}
-		name := "program"
-		if len(args) != 0 {
-			name = filepath.Base(args[0])
-		}
-		fmt.Fprintf(os.Stderr, "%s: %v\n", name, err)
-		return 1
+// RunArtifact executes a precompiled module embedded in a native executable.
+// Unlike Run, it never invokes Wago's compiler.
+func RunArtifact(artifact []byte, plugins wago.PluginSet, options Options, args []string) int {
+	if err := executeArtifact(artifact, plugins, options, args); err != nil {
+		return reportError(err, args)
 	}
 	return 0
 }
 
-func execute(source []byte, plugins wago.PluginSet, options Options, args []string) error {
+func reportError(err error, args []string) int {
+	var exit *wago.ExitError
+	if errors.As(err, &exit) {
+		return int(exit.Code)
+	}
+	name := "program"
+	if len(args) != 0 {
+		name = filepath.Base(args[0])
+	}
+	fmt.Fprintf(os.Stderr, "%s: %v\n", name, err)
+	return 1
+}
+
+func executeArtifact(artifact []byte, plugins wago.PluginSet, options Options, args []string) error {
+	runtime, err := loadRuntime(plugins, options, args)
+	if err != nil {
+		return err
+	}
+	defer runtime.Close()
+	compiled, err := wago.Load(artifact)
+	if err != nil {
+		return err
+	}
+	module, err := runtime.AdoptModule(compiled)
+	if err != nil {
+		return err
+	}
+	return executeModule(runtime, module, options, args)
+}
+
+func loadRuntime(plugins wago.PluginSet, options Options, args []string) (*wago.Runtime, error) {
 	config, err := runtimeConfig(options)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	runtime := wago.NewRuntime(wago.WithRuntimeConfig(config), wago.WithGuestArguments(args))
-	defer runtime.Close()
 	if err := runtime.LoadPlugins(context.Background(), plugins); err != nil {
-		return err
+		_ = runtime.Close()
+		return nil, err
 	}
-	module, err := runtime.Compile(source)
-	if err != nil {
-		return err
-	}
+	return runtime, nil
+}
+
+func executeModule(runtime *wago.Runtime, module *wago.Module, options Options, args []string) error {
+	defer module.Close()
 	invoke, err := wasmcall.ResolveExport(module.Compiled(), options.Invoke)
 	if err != nil {
 		return err

--- a/cli/standalone/standalone_test.go
+++ b/cli/standalone/standalone_test.go
@@ -14,6 +14,20 @@ func TestRunEmptyStartModule(t *testing.T) {
 	}
 }
 
+func TestCompileAndRunArtifact(t *testing.T) {
+	options := Options{DeferBoundsChecks: true}
+	artifact, err := CompileArtifact(emptyStartModule(), wago.PluginSet{}, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wago.IsCompiled(artifact) {
+		t.Fatal("CompileArtifact did not return a .wago artifact")
+	}
+	if code := RunArtifact(artifact, wago.PluginSet{}, options, []string{"hello"}); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+}
+
 func TestExecuteRejectsModuleWithoutFunctionExports(t *testing.T) {
 	empty := []byte{'\x00', 'a', 's', 'm', 1, 0, 0, 0}
 	if err := execute(empty, wago.PluginSet{}, Options{DeferBoundsChecks: true}, nil); err == nil || err.Error() != "module exports no functions" {

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -77,6 +77,13 @@ generated target applies the settings through the selected runtime backend.
 GOOS/GOARCH select exactly one build-tagged Railshot backend, so an AMD64
 executable does not link ARM64 codegen and vice versa. `--watch` intentionally
 has no standalone equivalent because the embedded module cannot change.
+With `--tinygo`, the manager first runs a native standard-Go helper containing
+the reviewed plugin set to produce `module.wago`, then replaces that helper with
+a `wago_precompiled` entry point and invokes TinyGo. The final binary contains
+the artifact loader, runtime, selected plugins, and runtime-owned host-call
+thunk emitter, but no Railshot source compiler. Because compilation policy is
+platform-sensitive, this path rejects non-native `--target` values instead of
+producing an artifact under the wrong OS or architecture assumptions.
 
 `cli/internal/handoff.Metadata` is the sole definition of launch metadata. It
 encodes and decodes the `WAGO_MANAGER_*` and `WAGO_RUNTIME_*` environment

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -83,7 +83,11 @@ a `wago_precompiled` entry point and invokes TinyGo. The final binary contains
 the artifact loader, runtime, selected plugins, and runtime-owned host-call
 thunk emitter, but no Railshot source compiler. Because compilation policy is
 platform-sensitive, this path rejects non-native `--target` values instead of
-producing an artifact under the wrong OS or architecture assumptions.
+producing an artifact under the wrong OS or architecture assumptions. The
+helper environment pins that native target rather than inheriting ambient
+cross-compilation variables. Its `wago_target_tinygo` build tag also selects the
+final runtime's cooperative interruption policy, which is distinct from the
+standard-Go Linux helper's signal-based policy.
 
 `cli/internal/handoff.Metadata` is the sole definition of launch metadata. It
 encodes and decodes the `WAGO_MANAGER_*` and `WAGO_RUNTIME_*` environment

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -60,8 +60,8 @@ runtime adapts strict locked selections into engine configuration. Manager and
 runtime code must not define separate `wago.json` or `wago-lock.json` models,
 and the shared project package must not import the runtime facade.
 
-`wago compile` is manager-owned because it orchestrates the Go toolchain and
-cross-target builds. Its generated module embeds the Wasm command, imports the
+`wago compile` is manager-owned because it orchestrates artifact generation and
+the Go toolchain. Its temporary helper embeds the Wasm command, imports the
 active plugins' explicit `/register` provider catalogs, and embeds their exact
 definition digests, Authority Grants, configuration, and Contract bindings. Each
 package exports an explicit provider catalog; none self-registers through
@@ -73,21 +73,22 @@ Go module and imported through their conventional `/register` package. Linked
 definitions must match the lockfile before activation. The resulting executable
 imports `cli/standalone`, not the runtime CLI. The manager
 reads the architecture-neutral settings and parallel-policy packages, while the
-generated target applies the settings through the selected runtime backend.
-GOOS/GOARCH select exactly one build-tagged Railshot backend, so an AMD64
-executable does not link ARM64 codegen and vice versa. `--watch` intentionally
-has no standalone equivalent because the embedded module cannot change.
-With `--tinygo`, the manager first runs a native standard-Go helper containing
-the reviewed plugin set to produce `module.wago`, then replaces that helper with
-a `wago_precompiled` entry point and invokes TinyGo. The final binary contains
-the artifact loader, runtime, selected plugins, and runtime-owned host-call
-thunk emitter, but no Railshot source compiler. Because compilation policy is
-platform-sensitive, this path rejects non-native `--target` values instead of
-producing an artifact under the wrong OS or architecture assumptions. The
-helper environment pins that native target rather than inheriting ambient
-cross-compilation variables. Its `wago_target_tinygo` build tag also selects the
-final runtime's cooperative interruption policy, which is distinct from the
-standard-Go Linux helper's signal-based policy.
+generated helper applies the settings through the selected runtime backend. It
+runs once under standard Go to produce `module.wago`; the manager then replaces
+it with a `wago_precompiled` entry point and performs the final link with standard
+Go or, when `--tinygo` is set, TinyGo. The final binary embeds the artifact rather
+than the source Wasm and contains the artifact loader, runtime, selected plugins,
+and runtime-owned host-call thunk emitter, but no Railshot source compiler.
+`--watch` intentionally has no standalone equivalent because the embedded module
+cannot change.
+
+Because compilation policy is platform-sensitive, standalone compilation rejects
+non-native `--target` values instead of producing an artifact under the wrong OS
+or architecture assumptions. The helper environment pins that native target
+rather than inheriting ambient cross-compilation variables. For TinyGo links its
+`wago_target_tinygo` build tag also selects the final runtime's cooperative
+interruption policy, which is distinct from the standard-Go Linux helper's
+signal-based policy.
 
 `cli/internal/handoff.Metadata` is the sole definition of launch metadata. It
 encodes and decodes the `WAGO_MANAGER_*` and `WAGO_RUNTIME_*` environment

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -66,15 +66,24 @@ wago compile --tinygo --invoke fib fib.wasm -o fib
 
 This mode compiles the Wasm once with the native standard-Go compiler, embeds
 the resulting `.wago` artifact, then links the loader with TinyGo under the
-`wago_precompiled` build tag. The emitted executable does not retain Railshot's
-source compiler and does not generate Wasm machine code at startup. It retains
-the small runtime-owned host-call thunk emitter required to bind imported
-functions during instantiation.
+`wago_precompiled` build tag. The helper is pinned to the validated native
+`GOOS/GOARCH` even when the caller has cross-compilation variables exported. It
+also compiles under `wago_target_tinygo`, so Linux artifacts contain cooperative
+interruption safepoints for the final TinyGo runtime instead of assuming the
+standard-Go helper's signal unwinder will be present. The emitted executable
+does not retain Railshot's source compiler and does not generate Wasm machine
+code at startup. It retains the small runtime-owned host-call thunk emitter
+required to bind imported functions during instantiation.
 
 Precompiled TinyGo standalone builds intentionally require the destination to
 equal the build host's `GOOS/GOARCH`. Native artifacts incorporate platform
 admission and interruption decisions as well as the instruction set; ordinary
 standard-Go standalone builds remain cross-compilable.
+Linux standalone outputs use the portable `strip -s` interface by default;
+release packaging may apply additional pinned-toolchain ELF section removal.
+The Linux TinyGo CI matrix builds this path with default stripping and verifies
+that a context cancellation interrupts an artifact containing an infinite loop
+on both AMD64 and ARM64.
 
 ## Scheduler: use `-scheduler=tasks`
 

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -57,6 +57,25 @@ tinygo build -scheduler=tasks -tags wago_runtime,wago_lean,wago_minimal \
 ./wago-runtime-minimal-tiny run tests/fixtures/wasm/fib.wasm --invoke fib 20
 ```
 
+The standard-Go manager can also produce a runtime-only TinyGo command binary:
+
+```bash
+wago compile --tinygo --invoke fib fib.wasm -o fib
+./fib 20
+```
+
+This mode compiles the Wasm once with the native standard-Go compiler, embeds
+the resulting `.wago` artifact, then links the loader with TinyGo under the
+`wago_precompiled` build tag. The emitted executable does not retain Railshot's
+source compiler and does not generate Wasm machine code at startup. It retains
+the small runtime-owned host-call thunk emitter required to bind imported
+functions during instantiation.
+
+Precompiled TinyGo standalone builds intentionally require the destination to
+equal the build host's `GOOS/GOARCH`. Native artifacts incorporate platform
+admission and interruption decisions as well as the instruction set; ordinary
+standard-Go standalone builds remain cross-compilable.
+
 ## Scheduler: use `-scheduler=tasks`
 
 Build wago programs with **`-scheduler=tasks`** (cooperative, single-threaded).

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -57,16 +57,18 @@ tinygo build -scheduler=tasks -tags wago_runtime,wago_lean,wago_minimal \
 ./wago-runtime-minimal-tiny run tests/fixtures/wasm/fib.wasm --invoke fib 20
 ```
 
-The standard-Go manager can also produce a runtime-only TinyGo command binary:
+The standard-Go manager can use TinyGo for the final link of a runtime-only
+command binary:
 
 ```bash
 wago compile --tinygo --invoke fib fib.wasm -o fib
 ./fib 20
 ```
 
-This mode compiles the Wasm once with the native standard-Go compiler, embeds
-the resulting `.wago` artifact, then links the loader with TinyGo under the
-`wago_precompiled` build tag. The helper is pinned to the validated native
+Like every `wago compile` build, this compiles the Wasm once with the native
+standard-Go compiler, embeds the resulting `.wago` artifact, then links the
+loader under the `wago_precompiled` build tag. `--tinygo` selects TinyGo for that
+final link. The helper is pinned to the validated native
 `GOOS/GOARCH` even when the caller has cross-compilation variables exported. It
 also compiles under `wago_target_tinygo`, so Linux artifacts contain cooperative
 interruption safepoints for the final TinyGo runtime instead of assuming the
@@ -75,10 +77,9 @@ does not retain Railshot's source compiler and does not generate Wasm machine
 code at startup. It retains the small runtime-owned host-call thunk emitter
 required to bind imported functions during instantiation.
 
-Precompiled TinyGo standalone builds intentionally require the destination to
-equal the build host's `GOOS/GOARCH`. Native artifacts incorporate platform
-admission and interruption decisions as well as the instruction set; ordinary
-standard-Go standalone builds remain cross-compilable.
+Precompiled standalone builds intentionally require the destination to equal the
+build host's `GOOS/GOARCH`. Native artifacts incorporate platform admission and
+interruption decisions as well as the instruction set.
 Linux standalone outputs use the portable `strip -s` interface by default;
 release packaging may apply additional pinned-toolchain ELF section removal.
 The Linux TinyGo CI matrix builds this path with default stripping and verifies

--- a/src/core/runtime/hostthunk/amd64.go
+++ b/src/core/runtime/hostthunk/amd64.go
@@ -1,0 +1,71 @@
+//go:build amd64
+
+// Package hostthunk emits the small per-instance native adapters needed when a
+// host function is reached through a Wasm table. It is runtime-owned so loading
+// precompiled artifacts does not retain the Railshot compiler.
+package hostthunk
+
+import "github.com/wago-org/wago/src/core/encoder/amd64"
+
+const (
+	offCustomCtx = 40
+	hcTrampoline = 56
+	hcImportIdx  = 64
+	hcNArgs      = 68
+	hcArgs       = 72
+	hcResults    = 584
+)
+
+func Indirect(importIdx uint32) []byte {
+	a := &amd64.Asm{}
+	a.Load32(amd64.RAX, amd64.RDI, 0)
+	a.Load64(amd64.R8, amd64.RSI, -offCustomCtx)
+	a.Load32(amd64.RCX, amd64.R8, 0)
+	a.LeaScaled(amd64.RDX, amd64.R8, amd64.RCX, 3, 8)
+	a.StoreImm32Mem(amd64.RDX, 0, int32(importIdx))
+	a.Store32(amd64.RDX, 4, amd64.RAX)
+	a.AluRI(0, amd64.RCX, 1, false)
+	a.Store32(amd64.R8, 0, amd64.RCX)
+	a.Ret()
+	return a.B
+}
+
+func IndirectSync(importIdx uint32, paramSlots, resultSlots int) []byte {
+	return indirectSync(importIdx, paramSlots, resultSlots, true)
+}
+
+func IndirectOwnedSync(importIdx uint32, paramSlots, resultSlots int) []byte {
+	return indirectSync(importIdx, paramSlots, resultSlots, false)
+}
+
+func indirectSync(importIdx uint32, paramSlots, resultSlots int, useHome bool) []byte {
+	a := &amd64.Asm{}
+	a.Push(amd64.RBX)
+	a.Push(amd64.RCX)
+	if useHome {
+		a.MovReg64(amd64.RBX, amd64.RSI)
+	}
+	a.Load64(amd64.R8, amd64.RBX, -offCustomCtx)
+	for i := 0; i < paramSlots; i++ {
+		a.Load64(amd64.RAX, amd64.RDI, int32(i*8))
+		a.Store64(amd64.R8, hcArgs+int32(i*8), amd64.RAX)
+	}
+	a.StoreImm32Mem(amd64.R8, hcImportIdx, int32(importIdx))
+	a.StoreImm32Mem(amd64.R8, hcNArgs, int32(paramSlots|resultSlots<<16))
+	a.CallMem(amd64.R8, hcTrampoline)
+	a.Load64(amd64.R8, amd64.RBX, -offCustomCtx)
+	a.Pop(amd64.RCX)
+	for i := 0; i < resultSlots; i++ {
+		a.Load64(amd64.RAX, amd64.R8, hcResults+int32(i*8))
+		a.Store64(amd64.RCX, int32(i*8), amd64.RAX)
+	}
+	if resultSlots > 0 {
+		a.Load64(amd64.RAX, amd64.R8, hcResults)
+	}
+	if resultSlots > 1 {
+		a.Load64(amd64.RDX, amd64.R8, hcResults+8)
+	}
+	a.Pop(amd64.RBX)
+	a.Ret()
+	return a.B
+}

--- a/src/core/runtime/hostthunk/amd64_test.go
+++ b/src/core/runtime/hostthunk/amd64_test.go
@@ -1,0 +1,27 @@
+//go:build amd64
+
+package hostthunk_test
+
+import (
+	"bytes"
+	"testing"
+
+	railshot "github.com/wago-org/wago/src/core/compiler/backend/railshot/amd64"
+	"github.com/wago-org/wago/src/core/runtime/hostthunk"
+)
+
+func TestAMD64MatchesCompilerThunks(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		got  []byte
+		want []byte
+	}{
+		{name: "indirect", got: hostthunk.Indirect(7), want: railshot.HostIndirectThunk(7)},
+		{name: "sync", got: hostthunk.IndirectSync(7, 3, 2), want: railshot.HostIndirectSyncThunk(7, 3, 2)},
+		{name: "owned sync", got: hostthunk.IndirectOwnedSync(7, 3, 2), want: railshot.HostIndirectOwnedSyncThunk(7, 3, 2)},
+	} {
+		if !bytes.Equal(test.got, test.want) {
+			t.Errorf("%s runtime thunk differs from compiler thunk", test.name)
+		}
+	}
+}

--- a/src/core/runtime/hostthunk/arm64.go
+++ b/src/core/runtime/hostthunk/arm64.go
@@ -1,0 +1,72 @@
+//go:build arm64
+
+package hostthunk
+
+import a64 "github.com/wago-org/wago/src/core/encoder/arm64"
+
+const (
+	offCustomCtx = 40
+	hcTrampoline = 176
+	hcImportIdx  = 184
+	hcNArgs      = 188
+	hcArgs       = 192
+	hcResults    = 704
+)
+
+func Indirect(importIdx uint32) []byte {
+	a := &a64.Asm{DisableLogicalMoveImmediate: true}
+	a.Load32(a64.X9, a64.X0, 0)
+	a.SubImm64(a64.X10, a64.X1, offCustomCtx)
+	a.Load64(a64.X10, a64.X10, 0)
+	a.Load32(a64.X11, a64.X10, 0)
+	a.AddShifted(a64.X12, a64.X10, a64.X11, 3, false)
+	a.AddImm64(a64.X12, a64.X12, 8)
+	a.MovImm64(a64.X16, uint64(importIdx))
+	a.Store32(a64.X16, a64.X12, 0)
+	a.Store32(a64.X9, a64.X12, 4)
+	a.AddImm32(a64.X11, a64.X11, 1)
+	a.Store32(a64.X11, a64.X10, 0)
+	a.Ret()
+	return a.B
+}
+
+func IndirectSync(importIdx uint32, paramSlots, resultSlots int) []byte {
+	return indirectSync(importIdx, paramSlots, resultSlots, true)
+}
+
+func IndirectOwnedSync(importIdx uint32, paramSlots, resultSlots int) []byte {
+	return indirectSync(importIdx, paramSlots, resultSlots, false)
+}
+
+func indirectSync(importIdx uint32, paramSlots, resultSlots int, useHome bool) []byte {
+	a := &a64.Asm{DisableLogicalMoveImmediate: true}
+	const linMem = a64.X26
+	a.StpPre(linMem, a64.X3, a64.SP, -32)
+	a.Store64(a64.LR, a64.SP, 16)
+	if useHome {
+		a.MovReg64(linMem, a64.X1)
+	}
+	a.SubImm64(a64.X10, linMem, offCustomCtx)
+	a.Load64(a64.X10, a64.X10, 0)
+	for i := 0; i < paramSlots; i++ {
+		a.Load64(a64.X9, a64.X0, uint32(i*8))
+		a.Store64(a64.X9, a64.X10, uint32(hcArgs+i*8))
+	}
+	a.MovImm64(a64.X16, uint64(importIdx))
+	a.Store32(a64.X16, a64.X10, hcImportIdx)
+	a.MovImm64(a64.X16, uint64(uint32(paramSlots)|uint32(resultSlots)<<16))
+	a.Store32(a64.X16, a64.X10, hcNArgs)
+	a.Load64(a64.X16, a64.X10, hcTrampoline)
+	a.Blr(a64.X16)
+	a.SubImm64(a64.X10, linMem, offCustomCtx)
+	a.Load64(a64.X10, a64.X10, 0)
+	a.Load64(a64.X3, a64.SP, 8)
+	for i := 0; i < resultSlots; i++ {
+		a.Load64(a64.X9, a64.X10, uint32(hcResults+i*8))
+		a.Store64(a64.X9, a64.X3, uint32(i*8))
+	}
+	a.Load64(a64.LR, a64.SP, 16)
+	a.LdpPost(linMem, a64.X3, a64.SP, 32)
+	a.Ret()
+	return a.B
+}

--- a/src/core/runtime/hostthunk/arm64_test.go
+++ b/src/core/runtime/hostthunk/arm64_test.go
@@ -1,0 +1,27 @@
+//go:build arm64
+
+package hostthunk_test
+
+import (
+	"bytes"
+	"testing"
+
+	railshot "github.com/wago-org/wago/src/core/compiler/backend/railshot/arm64"
+	"github.com/wago-org/wago/src/core/runtime/hostthunk"
+)
+
+func TestArm64MatchesCompilerThunks(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		got  []byte
+		want []byte
+	}{
+		{name: "indirect", got: hostthunk.Indirect(7), want: railshot.HostIndirectThunk(7)},
+		{name: "sync", got: hostthunk.IndirectSync(7, 3, 2), want: railshot.HostIndirectSyncThunk(7, 3, 2)},
+		{name: "owned sync", got: hostthunk.IndirectOwnedSync(7, 3, 2), want: railshot.HostIndirectOwnedSyncThunk(7, 3, 2)},
+	} {
+		if !bytes.Equal(test.got, test.want) {
+			t.Errorf("%s runtime thunk differs from compiler thunk", test.name)
+		}
+	}
+}

--- a/src/core/runtime/interrupt_config_linux_amd64.go
+++ b/src/core/runtime/interrupt_config_linux_amd64.go
@@ -1,4 +1,4 @@
-//go:build linux && amd64 && !tinygo
+//go:build linux && amd64 && !tinygo && !wago_target_tinygo
 
 package runtime
 

--- a/src/core/runtime/interrupt_config_linux_arm64.go
+++ b/src/core/runtime/interrupt_config_linux_arm64.go
@@ -1,4 +1,4 @@
-//go:build linux && arm64 && !tinygo
+//go:build linux && arm64 && !tinygo && !wago_target_tinygo
 
 package runtime
 

--- a/src/core/runtime/interrupt_linux.go
+++ b/src/core/runtime/interrupt_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && (amd64 || arm64) && !tinygo
+//go:build linux && (amd64 || arm64) && !tinygo && !wago_target_tinygo
 
 package runtime
 

--- a/src/core/runtime/interrupt_linux_amd64.s
+++ b/src/core/runtime/interrupt_linux_amd64.s
@@ -1,4 +1,4 @@
-//go:build linux && amd64 && !tinygo
+//go:build linux && amd64 && !tinygo && !wago_target_tinygo
 
 #include "textflag.h"
 

--- a/src/core/runtime/interrupt_linux_arm64.s
+++ b/src/core/runtime/interrupt_linux_arm64.s
@@ -1,4 +1,4 @@
-//go:build linux && arm64 && !tinygo
+//go:build linux && arm64 && !tinygo && !wago_target_tinygo
 
 #include "textflag.h"
 

--- a/src/core/runtime/interrupt_stub.go
+++ b/src/core/runtime/interrupt_stub.go
@@ -1,4 +1,4 @@
-//go:build !linux || (!amd64 && !arm64) || tinygo
+//go:build !linux || (!amd64 && !arm64) || tinygo || wago_target_tinygo
 
 package runtime
 

--- a/src/wago/gc_frame_roots_arm64.go
+++ b/src/wago/gc_frame_roots_arm64.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && arm64
+//go:build (linux || darwin) && arm64 && !wago_precompiled
 
 package wago
 

--- a/src/wago/gc_frame_roots_linux_amd64.go
+++ b/src/wago/gc_frame_roots_linux_amd64.go
@@ -1,4 +1,4 @@
-//go:build linux && amd64
+//go:build linux && amd64 && !wago_precompiled
 
 package wago
 

--- a/src/wago/gc_frame_roots_precompiled.go
+++ b/src/wago/gc_frame_roots_precompiled.go
@@ -1,0 +1,15 @@
+//go:build wago_precompiled && ((linux && amd64) || ((linux || darwin) && arm64))
+
+package wago
+
+import (
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func newGCFrameRootPlan(_ *wasm.Module, genericGC bool) *shared.GCModuleFrameRootPlan {
+	if !genericGC {
+		return nil
+	}
+	return &shared.GCModuleFrameRootPlan{Diagnostic: "source compilation is unavailable in a precompiled runtime"}
+}

--- a/src/wago/railshot_amd64.go
+++ b/src/wago/railshot_amd64.go
@@ -1,4 +1,4 @@
-//go:build amd64
+//go:build amd64 && !wago_precompiled
 
 package wago
 

--- a/src/wago/railshot_arm64.go
+++ b/src/wago/railshot_arm64.go
@@ -1,4 +1,4 @@
-//go:build arm64
+//go:build arm64 && !wago_precompiled
 
 package wago
 

--- a/src/wago/railshot_precompiled.go
+++ b/src/wago/railshot_precompiled.go
@@ -1,0 +1,61 @@
+//go:build wago_precompiled
+
+package wago
+
+import (
+	"runtime"
+
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot"
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+	"github.com/wago-org/wago/src/core/compiler/codegen"
+	"github.com/wago-org/wago/src/core/compiler/optimization"
+)
+
+// These lightweight compile-contract definitions keep the public package
+// type-correct while allowing whole-program builds to discard source codegen.
+// railshotCompileModuleWith is unreachable in a wago_precompiled executable.
+type railshotImportBinding = shared.ImportBinding
+type railshotKnobInfo = optimization.Info
+type railshotOptimizationSnapshot = optimization.Snapshot
+type railshotOptimizationObjective = shared.OptimizationObjective
+type railshotModuleStats struct{}
+
+type railshotCompileOptions struct {
+	Optimizations          map[string]bool
+	OptimizationSnapshot   railshotOptimizationSnapshot
+	OptimizationDeltas     map[string]bool
+	Objective              *railshotOptimizationObjective
+	Workers                int
+	ElideBoundsChecks      bool
+	NoBoundsFacts          bool
+	ImportBindings         []railshotImportBinding
+	SyncHostCalls          bool
+	Interruptible          bool
+	MemoryPressureAt       int
+	MemoryPressure         func()
+	GCTypeSubtypingRefTest bool
+	GCStructHelpers        bool
+	GCArrayHelpers         bool
+	GCFrameRoots           *shared.GCModuleFrameRootPlan
+	Codegen                codegen.Options
+	Stats                  *railshotModuleStats
+	CustomInstructions     map[uint32]railshot.CustomInstruction
+}
+
+func railshotOptKnobs() []railshotKnobInfo {
+	return optimization.InfosForArch(runtime.GOARCH)
+}
+
+func railshotOptKnobSnapshot() ([]railshotKnobInfo, railshotOptimizationSnapshot) {
+	return railshotOptKnobs(), railshotOptimizationSnapshot{}
+}
+
+func railshotCurrentOptKnobSnapshot() railshotOptimizationSnapshot {
+	return railshotOptimizationSnapshot{}
+}
+
+func railshotSetOptKnob(string, bool) bool { return false }
+
+func railshotGCNativeCodeTelemetry(*railshotModuleStats) GCNativeCodeTelemetry {
+	return GCNativeCodeTelemetry{}
+}

--- a/src/wago/railshot_precompiled_amd64.go
+++ b/src/wago/railshot_precompiled_amd64.go
@@ -1,0 +1,29 @@
+//go:build amd64 && wago_precompiled
+
+package wago
+
+import (
+	"fmt"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	encoder "github.com/wago-org/wago/src/core/encoder/amd64"
+	"github.com/wago-org/wago/src/core/runtime/hostthunk"
+)
+
+type railshotCompiledModule = encoder.CompiledModule
+
+func railshotCompileModuleWith(*wasm.Module, railshotCompileOptions) (*railshotCompiledModule, error) {
+	return nil, fmt.Errorf("source compilation is unavailable in a precompiled runtime")
+}
+
+func railshotHostIndirectThunk(importIdx uint32) []byte {
+	return hostthunk.Indirect(importIdx)
+}
+
+func railshotHostIndirectSyncThunk(importIdx uint32, paramSlots, resultSlots int) []byte {
+	return hostthunk.IndirectSync(importIdx, paramSlots, resultSlots)
+}
+
+func railshotHostIndirectOwnedSyncThunk(importIdx uint32, paramSlots, resultSlots int) []byte {
+	return hostthunk.IndirectOwnedSync(importIdx, paramSlots, resultSlots)
+}

--- a/src/wago/railshot_precompiled_arm64.go
+++ b/src/wago/railshot_precompiled_arm64.go
@@ -1,0 +1,29 @@
+//go:build arm64 && wago_precompiled
+
+package wago
+
+import (
+	"fmt"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	encoder "github.com/wago-org/wago/src/core/encoder/arm64"
+	"github.com/wago-org/wago/src/core/runtime/hostthunk"
+)
+
+type railshotCompiledModule = encoder.CompiledModule
+
+func railshotCompileModuleWith(*wasm.Module, railshotCompileOptions) (*railshotCompiledModule, error) {
+	return nil, fmt.Errorf("source compilation is unavailable in a precompiled runtime")
+}
+
+func railshotHostIndirectThunk(importIdx uint32) []byte {
+	return hostthunk.Indirect(importIdx)
+}
+
+func railshotHostIndirectSyncThunk(importIdx uint32, paramSlots, resultSlots int) []byte {
+	return hostthunk.IndirectSync(importIdx, paramSlots, resultSlots)
+}
+
+func railshotHostIndirectOwnedSyncThunk(importIdx uint32, paramSlots, resultSlots int) []byte {
+	return hostthunk.IndirectOwnedSync(importIdx, paramSlots, resultSlots)
+}


### PR DESCRIPTION
## Summary

- make every `wago compile` precompile Wasm into an embedded native `.wago` artifact
- link only the `wago_precompiled` loader/runtime, selected plugins, and required host thunks; do not embed raw Wasm or the Railshot source compiler
- keep `--tinygo` as the switch selecting TinyGo for the final runtime link
- require native targets so artifact codegen, feature admission, and interruption policy match the final runtime

## Architecture

The manager creates an isolated helper containing the reviewed module/plugin graph and runs it once under standard Go to produce `module.wago`. It then replaces the helper entry point with `RunArtifact` and links with `-tags=wago_precompiled` using standard Go or TinyGo. The emitted command loads pregenerated machine code at startup; it does not compile Wasm at runtime.

TinyGo artifact generation additionally uses `wago_target_tinygo`, selecting cooperative interruption safepoints instead of the standard-Go Linux signal-unwinding policy. The helper pins `GOOS/GOARCH` to the native target despite ambient cross-compilation variables.

## Validation

- `go test ./...`
- `go vet ./...`
- default standard-Go standalone executes precompiled `fib(20)` and prints `6765`
- standard-Go and TinyGo symbol audits reject either Railshot backend and `CompileArtifact`
- default stripped TinyGo build coverage
- Linux AMD64/ARM64 TinyGo infinite-loop cancellation coverage
