### PR TITLE
cli: make plugin and command workflows beginner-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ codegen at startup. It does not embed the source Wasm or Railshot compiler. Use
 `wago.json` before compiling so resolution, Authorities, and Contract bindings
 stay reviewable and reproducible. `--core 3`, `--parallel`, and compiler flags
 such as `--no-inline` and `--no-deferred-bounds-checking` are applied while
-producing the embedded machine code.
+producing the embedded machine code. Run `wago compile --help-optimizations` to
+see the advanced compiler controls without crowding the everyday command help.
 There is no standalone watch mode because the module is immutable once embedded.
 Standalone builds are native-target-only because codegen, interruption, and
 feature admission must match the runtime that executes the artifact. `--tinygo`

--- a/README.md
+++ b/README.md
@@ -124,13 +124,15 @@ Create a project and add the WASI plugin:
 
 ```sh
 wago init --run
-wago add github.com/wago-org/wasi
+wago add wago-org/wasi
 wago run program.wasm hello world
 ```
 
-`wago add` resolves the complete dependency and Contract graph, reviews exact
-scoped Authorities, pins sources and bindings in `wago-lock.json`, verifies the
-linked definitions, and atomically publishes the rebuilt runtime.
+For GitHub plugins, `owner/repository` is shorthand for the canonical
+`github.com/owner/repository` Plugin ID. `wago add` resolves the complete
+dependency and Contract graph, reviews exact scoped Authorities, pins sources
+and bindings in `wago-lock.json`, verifies the linked definitions, and
+atomically publishes the rebuilt runtime.
 
 Useful plugin commands:
 

--- a/cli/internal/command/command_test.go
+++ b/cli/internal/command/command_test.go
@@ -141,6 +141,46 @@ func TestHelpShowsShortFormForPairedBooleanFlags(t *testing.T) {
 	}
 }
 
+func TestHelpKeepsOptimizationFlagsOutOfEverydayHelp(t *testing.T) {
+	cmd := &Cmd{
+		Name:  "build",
+		Flags: []Flag{{Name: "output", Short: "o", Arg: "<file>", Help: "output path"}},
+		Knobs: []Flag{{Name: "fast", Bool: true, Help: "enable fast mode"}},
+	}
+	var output bytes.Buffer
+	cmd.PrintHelp(&output, "wago build")
+	if text := output.String(); strings.Contains(text, "--fast") || !strings.Contains(text, "--help-optimizations") {
+		t.Fatalf("everyday help did not collapse optimization flags:\n%s", text)
+	}
+	output.Reset()
+	cmd.PrintOptimizationHelp(&output, "wago build")
+	if text := output.String(); !strings.Contains(text, "Optimization flags for:") || !strings.Contains(text, "--fast") {
+		t.Fatalf("optimization help = %q", text)
+	}
+	if !InvocationWantsHelp(cmd, []string{"--help-optimizations"}) {
+		t.Fatal("optimization help was not recognized as local help")
+	}
+	if InvocationWantsHelp(&Cmd{Name: "validate"}, []string{"--help-optimizations"}) {
+		t.Fatal("command without optimization knobs accepted optimization help")
+	}
+}
+
+func TestSuggestChildFindsUnambiguousTypos(t *testing.T) {
+	root := &Cmd{Children: []*Cmd{
+		{Name: "build"},
+		{Name: "publish"},
+		{Name: "install", Aliases: []string{"add"}},
+	}}
+	for typo, want := range map[string]string{"bild": "build", "publsh": "publish", "instal": "install", "ad": "install"} {
+		if got := SuggestChild(root, typo); got != want {
+			t.Errorf("SuggestChild(%q) = %q, want %q", typo, got, want)
+		}
+	}
+	if got := SuggestChild(root, "completely-different"); got != "" {
+		t.Fatalf("unrelated suggestion = %q", got)
+	}
+}
+
 func TestAutomationFlagsAndCommandSchema(t *testing.T) {
 	automation.Reset()
 	t.Cleanup(automation.Reset)

--- a/cli/internal/command/dispatch.go
+++ b/cli/internal/command/dispatch.go
@@ -37,9 +37,16 @@ func (c *Cmd) Dispatch(path string, args []string) {
 			return
 		}
 		if automation.JSON() {
-			ui.UsageHint(path+" --help", "%s: unknown subcommand %q", c.Label(path), args[0])
+			hint := path + " --help"
+			if suggestion := SuggestChild(c, args[0]); suggestion != "" {
+				hint = path + " " + suggestion + " --help"
+			}
+			ui.UsageHint(hint, "%s: unknown subcommand %q", c.Label(path), args[0])
 		}
 		fmt.Fprintf(os.Stderr, "%s %s: unknown subcommand %q\n\n", ui.Red("wago:"), c.Label(path), args[0])
+		if suggestion := SuggestChild(c, args[0]); suggestion != "" {
+			fmt.Fprintf(os.Stderr, "Did you mean %q?\n\n", suggestion)
+		}
 		c.PrintHelp(os.Stderr, path)
 		os.Exit(2)
 	}
@@ -49,6 +56,10 @@ func (c *Cmd) Dispatch(path string, args []string) {
 		if err != nil {
 			ui.Fatal("%s: %v", c.Label(path), err)
 		}
+	}
+	if len(c.Knobs) != 0 && WantsOptimizationHelp(args, c.PassThrough, c.AllFlags()) {
+		c.PrintOptimizationHelp(os.Stdout, path)
+		return
 	}
 	if WantsHelp(args, c.PassThrough, c.AllFlags()) {
 		c.PrintHelp(os.Stdout, path)

--- a/cli/internal/command/help.go
+++ b/cli/internal/command/help.go
@@ -20,7 +20,8 @@ func InvocationWantsHelp(cmd *Cmd, args []string) bool {
 				return false
 			}
 		}
-		return WantsHelp(normalized, cmd.PassThrough, cmd.Flags)
+		return WantsHelp(normalized, cmd.PassThrough, cmd.Flags) ||
+			(len(cmd.Knobs) != 0 && WantsOptimizationHelp(normalized, cmd.PassThrough, cmd.AllFlags()))
 	}
 	if WantsHelp(args, true, cmd.AllFlags()) {
 		return true
@@ -30,6 +31,29 @@ func InvocationWantsHelp(cmd *Cmd, args []string) bool {
 	}
 	child := cmd.Child(args[0])
 	return child != nil && InvocationWantsHelp(child, args[1:])
+}
+
+// WantsOptimizationHelp reports whether advanced compiler help appears before
+// positional pass-through begins.
+func WantsOptimizationHelp(args []string, passThrough bool, flags []Flag) bool {
+	lookup := flagLookup(flags)
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if arg == "--" {
+			return false
+		}
+		if arg == "--help-optimizations" {
+			return true
+		}
+		if passThrough && (arg == "" || arg[0] != '-') {
+			return false
+		}
+		name, inline := splitFlag(arg)
+		if flag := lookup[name]; flag != nil && !flag.Bool && !inline && index+1 < len(args) {
+			index++
+		}
+	}
+	return false
 }
 
 func (c *Cmd) PrintHelp(output io.Writer, path string) {
@@ -59,6 +83,16 @@ func (c *Cmd) PrintHelp(output io.Writer, path string) {
 	if c.Long != "" {
 		fmt.Fprintf(&text, "\n%s\n", strings.TrimRight(c.Long, "\n"))
 	}
+	fmt.Fprint(output, text.String())
+}
+
+// PrintOptimizationHelp prints the advanced compiler controls separately from
+// the everyday command help.
+func (c *Cmd) PrintOptimizationHelp(output io.Writer, path string) {
+	var text strings.Builder
+	fmt.Fprintf(&text, "%s %s\n\n", ui.Bold("Optimization flags for:"), path)
+	text.WriteString("These advanced controls override Wago's tuned defaults for this build.\n")
+	writeFlags(&text, c.Knobs)
 	fmt.Fprint(output, text.String())
 }
 
@@ -108,7 +142,10 @@ func (c *Cmd) displayFlags() []Flag {
 	flags := append([]Flag(nil), c.Flags...)
 	flags = append(flags, c.automationFlags()...)
 	flags = append(flags, Flag{Name: "help", Short: "h", Bool: true, Help: "show this help"})
-	return append(flags, c.Knobs...)
+	if len(c.Knobs) != 0 {
+		flags = append(flags, Flag{Name: "help-optimizations", Bool: true, Help: "show advanced compiler optimization flags"})
+	}
+	return flags
 }
 
 func DimHelpSyntax(value string, style func(string) string) string {

--- a/cli/internal/command/schema.go
+++ b/cli/internal/command/schema.go
@@ -73,6 +73,9 @@ func describeCommandFlags(cmd *Cmd) []FlagSpec {
 	flags := append([]Flag(nil), cmd.Flags...)
 	flags = append(flags, cmd.automationFlags()...)
 	flags = append(flags, Flag{Name: "help", Short: "h", Bool: true, Help: "show this help"})
+	if len(cmd.Knobs) != 0 {
+		flags = append(flags, Flag{Name: "help-optimizations", Bool: true, Help: "show advanced compiler optimization flags"})
+	}
 	result := describeFlags(flags)
 	for _, flag := range describeFlags(cmd.Knobs) {
 		flag.Category = "optimization"

--- a/cli/internal/command/suggest.go
+++ b/cli/internal/command/suggest.go
@@ -1,0 +1,45 @@
+package command
+
+// SuggestChild returns one unambiguous nearby command name for a typo.
+func SuggestChild(cmd *Cmd, value string) string {
+	best, bestDistance, tied := "", len(value)+1, false
+	for _, child := range cmd.Children {
+		for _, candidate := range append([]string{child.Name}, child.Aliases...) {
+			distance := editDistance(value, candidate)
+			switch {
+			case distance < bestDistance:
+				best, bestDistance, tied = child.Name, distance, false
+			case distance == bestDistance && best != child.Name:
+				tied = true
+			}
+		}
+	}
+	limit := 1
+	if len(value) >= 4 {
+		limit = 2
+	}
+	if tied || bestDistance > limit {
+		return ""
+	}
+	return best
+}
+
+func editDistance(left, right string) int {
+	previous := make([]int, len(right)+1)
+	for index := range previous {
+		previous[index] = index
+	}
+	for leftIndex := 1; leftIndex <= len(left); leftIndex++ {
+		current := make([]int, len(right)+1)
+		current[0] = leftIndex
+		for rightIndex := 1; rightIndex <= len(right); rightIndex++ {
+			replace := previous[rightIndex-1]
+			if left[leftIndex-1] != right[rightIndex-1] {
+				replace++
+			}
+			current[rightIndex] = min(previous[rightIndex]+1, current[rightIndex-1]+1, replace)
+		}
+		previous = current
+	}
+	return previous[len(right)]
+}

--- a/cli/internal/tui/select.go
+++ b/cli/internal/tui/select.go
@@ -15,6 +15,7 @@ import (
 type SelectItem struct {
 	Label       string // machine value, e.g. a capability id "wasi:stdio"
 	Description string // one-line human description (may be empty)
+	Group       string // optional section heading shared by adjacent rows
 	On          bool   // currently selected
 	Disabled    bool   // visible preview row that cannot be toggled or selected
 	Reject      bool   // exclusive visible action that clears every normal row
@@ -231,11 +232,22 @@ func (m *MultiSelect) frame() string {
 	if start > 0 {
 		fmt.Fprintf(&b, "%s\n", ui.Dim(fmt.Sprintf("  ↑ %d more", start)))
 	}
+	previousGroup := ""
 	for i := start; i < end; i++ {
 		it := m.Items[i]
+		if it.Group != "" && it.Group != previousGroup {
+			fmt.Fprintf(&b, "%s\n", ui.Bold(it.Group))
+		}
+		previousGroup = it.Group
 		cursor := "  "
+		if it.Group != "" {
+			cursor = "    "
+		}
 		if i == m.Cursor {
 			cursor = ui.Cyan("› ")
+			if it.Group != "" {
+				cursor = ui.Cyan("  › ")
+			}
 		}
 		mark := "○"
 		if it.Disabled {

--- a/cli/internal/tui/select.go
+++ b/cli/internal/tui/select.go
@@ -18,6 +18,7 @@ type SelectItem struct {
 	On          bool   // currently selected
 	Disabled    bool   // visible preview row that cannot be toggled or selected
 	Reject      bool   // exclusive visible action that clears every normal row
+	ConfirmOff  bool   // submit immediately when this selected row is toggled off
 }
 
 // selectKey is a normalized keypress the model understands.
@@ -87,10 +88,13 @@ func (m *MultiSelect) apply(k selectKey) (done, cancelled bool) {
 				for i := range m.Items {
 					m.Items[i].On = i == m.Cursor
 				}
+				return true, false
 			} else {
 				m.Items[m.Cursor].On = !m.Items[m.Cursor].On
 				if m.Items[m.Cursor].On {
 					m.clearRejection()
+				} else if m.Items[m.Cursor].ConfirmOff {
+					return true, false
 				}
 			}
 		}

--- a/cli/internal/tui/select.go
+++ b/cli/internal/tui/select.go
@@ -110,9 +110,8 @@ type selectorModel interface {
 	frame() string
 }
 
-// multiSelect is the pure capability picker state: a list plus a cursor.
-// prompt overrides the default footer hint. Rejection is a footer key (r), not
-// a selectable row.
+// MultiSelect is the pure picker state: a list plus a cursor. Prompt overrides
+// the default footer hint. A Reject item and the r key both submit rejection.
 type MultiSelect struct {
 	Title  string
 	Prompt string
@@ -122,8 +121,8 @@ type MultiSelect struct {
 
 // apply advances the model by one key. It reports whether the interaction is
 // finished, and if so whether it was cancelled (esc) rather than submitted.
-// Enter always submits the checked items; r clears then submits (reject-all);
-// movement clamps at the ends; → is an alternate submit key.
+// Enter submits the focused action, r clears then submits rejection, movement
+// clamps at the ends, and → is an alternate submit key.
 func (m *MultiSelect) apply(k selectKey) (done, cancelled bool) {
 	switch k {
 	case keyUp:

--- a/cli/internal/tui/select.go
+++ b/cli/internal/tui/select.go
@@ -137,9 +137,7 @@ func (m *MultiSelect) apply(k selectKey) (done, cancelled bool) {
 	case keyToggle:
 		if len(m.Items) > 0 && !m.Items[m.Cursor].Disabled {
 			if m.Items[m.Cursor].Reject {
-				for i := range m.Items {
-					m.Items[i].On = i == m.Cursor
-				}
+				m.rejectAll()
 				return true, false
 			} else {
 				m.Items[m.Cursor].On = !m.Items[m.Cursor].On
@@ -177,16 +175,23 @@ func (m *MultiSelect) apply(k selectKey) (done, cancelled bool) {
 			}
 		}
 	case keyReject: // clear all, then submit — a deliberate "grant nothing"
-		for i := range m.Items {
-			m.Items[i].On = m.Items[i].Reject
-		}
+		m.rejectAll()
 		return true, false
 	case keyAccept, keyRight:
+		if len(m.Items) > 0 && m.Items[m.Cursor].Reject && !m.Items[m.Cursor].Disabled {
+			m.rejectAll()
+		}
 		return true, false
 	case keyLeft, keyCancel, keyQuit:
 		return true, true
 	}
 	return false, false
+}
+
+func (m *MultiSelect) rejectAll() {
+	for i := range m.Items {
+		m.Items[i].On = m.Items[i].Reject
+	}
 }
 
 // chosen returns the labels of the selected rows, in list order.

--- a/cli/internal/tui/select.go
+++ b/cli/internal/tui/select.go
@@ -17,6 +17,7 @@ type SelectItem struct {
 	Description string // one-line human description (may be empty)
 	On          bool   // currently selected
 	Disabled    bool   // visible preview row that cannot be toggled or selected
+	Reject      bool   // exclusive visible action that clears every normal row
 }
 
 // selectKey is a normalized keypress the model understands.
@@ -82,12 +83,21 @@ func (m *MultiSelect) apply(k selectKey) (done, cancelled bool) {
 		}
 	case keyToggle:
 		if len(m.Items) > 0 && !m.Items[m.Cursor].Disabled {
-			m.Items[m.Cursor].On = !m.Items[m.Cursor].On
+			if m.Items[m.Cursor].Reject {
+				for i := range m.Items {
+					m.Items[i].On = i == m.Cursor
+				}
+			} else {
+				m.Items[m.Cursor].On = !m.Items[m.Cursor].On
+				if m.Items[m.Cursor].On {
+					m.clearRejection()
+				}
+			}
 		}
 	case keyAll:
 		allSelected, selectable := true, false
 		for _, item := range m.Items {
-			if item.Disabled {
+			if item.Disabled || item.Reject {
 				continue
 			}
 			selectable = true
@@ -98,8 +108,10 @@ func (m *MultiSelect) apply(k selectKey) (done, cancelled bool) {
 		}
 		allSelected = allSelected && selectable
 		for i := range m.Items {
-			if !m.Items[i].Disabled {
+			if !m.Items[i].Disabled && !m.Items[i].Reject {
 				m.Items[i].On = !allSelected
+			} else if m.Items[i].Reject {
+				m.Items[i].On = false
 			}
 		}
 	case keyClear:
@@ -110,7 +122,7 @@ func (m *MultiSelect) apply(k selectKey) (done, cancelled bool) {
 		}
 	case keyReject: // clear all, then submit — a deliberate "grant nothing"
 		for i := range m.Items {
-			m.Items[i].On = false
+			m.Items[i].On = m.Items[i].Reject
 		}
 		return true, false
 	case keyAccept, keyRight:
@@ -125,11 +137,29 @@ func (m *MultiSelect) apply(k selectKey) (done, cancelled bool) {
 func (m *MultiSelect) Chosen() []string {
 	var out []string
 	for _, it := range m.Items {
-		if it.On && !it.Disabled {
+		if it.On && !it.Disabled && !it.Reject {
 			out = append(out, it.Label)
 		}
 	}
 	return out
+}
+
+// Rejected reports whether the explicit reject-all action is selected.
+func (m *MultiSelect) Rejected() bool {
+	for _, item := range m.Items {
+		if item.Reject && item.On {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MultiSelect) clearRejection() {
+	for i := range m.Items {
+		if m.Items[i].Reject {
+			m.Items[i].On = false
+		}
+	}
 }
 
 // decodeKey maps a raw input chunk (one keypress, possibly a multi-byte escape

--- a/cli/internal/tui/select.go
+++ b/cli/internal/tui/select.go
@@ -40,6 +40,8 @@ const (
 	keyQuit   // q / ctrl-c — abort from any page
 	keyLeft
 	keyRight
+	keyCopy // c
+	keyOpen // o
 )
 
 const (
@@ -51,6 +53,55 @@ const (
 	KeyLeft   = keyLeft
 	KeyRight  = keyRight
 )
+
+// Action is the result of a one-key action prompt.
+type Action int
+
+const (
+	ActionNone Action = iota
+	ActionContinue
+	ActionCopy
+	ActionOpen
+)
+
+// ActionPrompt presents compact keyboard actions without a selectable list.
+// The model remains pure; callers perform the selected side effect after Run.
+type ActionPrompt struct {
+	Text   string
+	Prompt string
+	action Action
+}
+
+func (p *ActionPrompt) apply(key selectKey) (done, cancelled bool) {
+	switch key {
+	case keyCopy:
+		p.action = ActionCopy
+		return true, false
+	case keyOpen:
+		p.action = ActionOpen
+		return true, false
+	case keyAccept, keyRight:
+		p.action = ActionContinue
+		return true, false
+	case keyLeft, keyCancel, keyQuit:
+		return true, true
+	}
+	return false, false
+}
+
+func (p *ActionPrompt) frame() string {
+	prompt := p.Prompt
+	if prompt == "" {
+		prompt = "c copy code · o open browser · enter continue · esc cancel"
+	}
+	return p.Text + "\n" + ui.Dim(prompt) + "\n"
+}
+
+// Action reports the submitted action after Run returns.
+func (p *ActionPrompt) Action() Action { return p.action }
+
+// Frame returns the prompt's rendered text for tests and previews.
+func (p *ActionPrompt) Frame() string { return p.frame() }
 
 // selectorModel is implemented by both the capability multi-select and the
 // hierarchical single-choice picker.
@@ -186,6 +237,10 @@ func decodeKey(b []byte) selectKey {
 			return keyClear
 		case 'r', 'R':
 			return keyReject
+		case 'c', 'C':
+			return keyCopy
+		case 'o', 'O':
+			return keyOpen
 		case 27:
 			return keyCancel
 		case 'q', 'Q', 3:

--- a/cli/internal/tui/select_test.go
+++ b/cli/internal/tui/select_test.go
@@ -93,6 +93,14 @@ func TestMultiSelectDisabledPreviewCannotBeSelected(t *testing.T) {
 	}
 }
 
+func TestMultiSelectConfirmOffSubmitsImmediately(t *testing.T) {
+	m := &MultiSelect{Items: []SelectItem{{Label: "required", On: true, ConfirmOff: true}}}
+	done, cancelled := m.apply(keyToggle)
+	if !done || cancelled || m.Items[0].On {
+		t.Fatalf("required toggle = done %v, cancelled %v, row %#v", done, cancelled, m.Items[0])
+	}
+}
+
 func TestMultiSelectAcceptCancel(t *testing.T) {
 	m := newTestSelect()
 	if done, cancelled := m.apply(keyAccept); !done || cancelled {
@@ -130,7 +138,9 @@ func TestMultiSelectRejectRowIsExclusive(t *testing.T) {
 		{Label: "optional", On: true},
 		{Label: "Reject all", Reject: true},
 	}, Cursor: 2}
-	m.apply(keyToggle)
+	if done, cancelled := m.apply(keyToggle); !done || cancelled {
+		t.Fatalf("reject row should submit immediately: done=%v cancelled=%v", done, cancelled)
+	}
 	if got := m.Chosen(); got != nil || !m.Rejected() {
 		t.Fatalf("reject row left grants selected: chosen=%v rejected=%v", got, m.Rejected())
 	}

--- a/cli/internal/tui/select_test.go
+++ b/cli/internal/tui/select_test.go
@@ -174,9 +174,20 @@ func TestMultiSelectRejectRowIsExclusive(t *testing.T) {
 	}
 }
 
+func TestMultiSelectEnterOnRejectRowRejects(t *testing.T) {
+	m := &MultiSelect{Items: []SelectItem{
+		{Label: "required", On: true},
+		{Label: "Reject all", Reject: true},
+	}, Cursor: 1}
+	done, cancelled := m.apply(keyAccept)
+	if !done || cancelled || !m.Rejected() || m.Items[0].On {
+		t.Fatalf("enter on Reject all = done %v, cancelled %v, items %#v", done, cancelled, m.Items)
+	}
+}
+
 func TestMultiSelectEnterAccepts(t *testing.T) {
 	m := &MultiSelect{Items: []SelectItem{{Label: "a", On: true}, {Label: "b", On: false}}}
-	// Enter always submits the checked items (never rejects), wherever the cursor is.
+	// Enter on an ordinary row submits the checked items.
 	m.apply(keyDown) // cursor on the unchecked "b"
 	done, cancelled := m.apply(keyAccept)
 	if !done || cancelled {

--- a/cli/internal/tui/select_test.go
+++ b/cli/internal/tui/select_test.go
@@ -110,7 +110,7 @@ func TestMultiSelectAcceptCancel(t *testing.T) {
 }
 
 func TestMultiSelectRejectKey(t *testing.T) {
-	m := &MultiSelect{Items: []SelectItem{{Label: "a", On: true}, {Label: "b", On: true}}}
+	m := &MultiSelect{Items: []SelectItem{{Label: "a", On: true}, {Label: "b", On: true}, {Label: "Reject all", Reject: true}}}
 	// r clears everything and submits (grant nothing), and is NOT a cancel.
 	done, cancelled := m.apply(keyReject)
 	if !done || cancelled {
@@ -118,6 +118,26 @@ func TestMultiSelectRejectKey(t *testing.T) {
 	}
 	if got := m.Chosen(); len(got) != 0 {
 		t.Fatalf("r must clear all selections, got %v", got)
+	}
+	if !m.Rejected() {
+		t.Fatal("r did not select the explicit reject row")
+	}
+}
+
+func TestMultiSelectRejectRowIsExclusive(t *testing.T) {
+	m := &MultiSelect{Items: []SelectItem{
+		{Label: "required", On: true},
+		{Label: "optional", On: true},
+		{Label: "Reject all", Reject: true},
+	}, Cursor: 2}
+	m.apply(keyToggle)
+	if got := m.Chosen(); got != nil || !m.Rejected() {
+		t.Fatalf("reject row left grants selected: chosen=%v rejected=%v", got, m.Rejected())
+	}
+	m.Cursor = 0
+	m.apply(keyToggle)
+	if got := m.Chosen(); !reflect.DeepEqual(got, []string{"required"}) || m.Rejected() {
+		t.Fatalf("grant row did not clear rejection: chosen=%v rejected=%v", got, m.Rejected())
 	}
 }
 

--- a/cli/internal/tui/select_test.go
+++ b/cli/internal/tui/select_test.go
@@ -37,6 +37,29 @@ func TestMultiSelectFrame(t *testing.T) {
 	}
 }
 
+func TestMultiSelectFrameGroupsAndIndentsRows(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	m := &MultiSelect{Items: []SelectItem{
+		{Label: "host.arguments.read", Group: "github.com/wago-org/wasi", On: true},
+		{Label: "host.import.define", Group: "github.com/wago-org/wasi", On: true},
+		{Label: "instance.manage", Group: "github.com/wago-org/workers", On: true},
+		{Label: "Reject all", Reject: true},
+	}}
+	frame := m.Frame()
+	for _, want := range []string{
+		"github.com/wago-org/wasi\n  › ◉ host.arguments.read",
+		"github.com/wago-org/workers\n    ◉ instance.manage",
+		"\n  ○ Reject all",
+	} {
+		if !strings.Contains(frame, want) {
+			t.Fatalf("grouped frame missing %q:\n%s", want, frame)
+		}
+	}
+	if strings.Count(frame, "github.com/wago-org/wasi\n") != 1 {
+		t.Fatalf("plugin heading repeated:\n%s", frame)
+	}
+}
+
 func TestMultiSelectMovementClamps(t *testing.T) {
 	m := newTestSelect()
 	m.apply(keyUp) // already at top

--- a/cli/internal/tui/select_test.go
+++ b/cli/internal/tui/select_test.go
@@ -205,6 +205,8 @@ func TestDecodeKey(t *testing.T) {
 		{[]byte{'a'}, keyAll},
 		{[]byte{'n'}, keyClear},
 		{[]byte{'r'}, keyReject},
+		{[]byte{'c'}, keyCopy},
+		{[]byte{'o'}, keyOpen},
 		{[]byte{'q'}, keyQuit},
 		{[]byte{3}, keyQuit},    // Ctrl-C
 		{[]byte{27}, keyCancel}, // bare ESC
@@ -224,6 +226,31 @@ func TestDecodeKey(t *testing.T) {
 	for _, tc := range cases {
 		if got := decodeKey(tc.in); got != tc.want {
 			t.Errorf("decodeKey(%v) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestActionPrompt(t *testing.T) {
+	for _, test := range []struct {
+		key       selectKey
+		action    Action
+		cancelled bool
+	}{
+		{keyCopy, ActionCopy, false},
+		{keyOpen, ActionOpen, false},
+		{keyAccept, ActionContinue, false},
+		{keyCancel, ActionNone, true},
+	} {
+		prompt := &ActionPrompt{Text: "Authorize on GitHub"}
+		done, cancelled := prompt.apply(test.key)
+		if !done || cancelled != test.cancelled || prompt.Action() != test.action {
+			t.Fatalf("action %d = done %v, cancelled %v, action %d", test.key, done, cancelled, prompt.Action())
+		}
+	}
+	frame := (&ActionPrompt{Text: "Authorize on GitHub"}).Frame()
+	for _, want := range []string{"Authorize on GitHub", "c copy code", "o open browser", "enter continue", "esc cancel"} {
+		if !strings.Contains(frame, want) {
+			t.Fatalf("action frame missing %q:\n%s", want, frame)
 		}
 	}
 }

--- a/cli/manager/command_environment.go
+++ b/cli/manager/command_environment.go
@@ -444,7 +444,7 @@ func (commandEnvironment) RebuildPlugins(options pluginrebuild.Options) {
 
 func (e commandEnvironment) Publish(options publish.Options) {
 	if automation.DryRun() {
-		manifest, err := registry.ValidatePublishManifest(options.Manifest)
+		manifest, err := registry.ValidatePublishPlan(e.context(), options.Manifest)
 		if err != nil {
 			fatal("publish: %v", err)
 		}
@@ -458,7 +458,7 @@ func (e commandEnvironment) Publish(options publish.Options) {
 
 func (e commandEnvironment) Catalog(options plugincatalog.Options) {
 	if automation.DryRun() {
-		manifest, err := registry.ValidatePublishManifest(options.Manifest)
+		manifest, err := registry.ValidateCatalogPlan(e.context(), registry.CatalogRequest{Manifest: options.Manifest, Check: options.Check})
 		if err != nil {
 			fatal("catalog: %v", err)
 		}

--- a/cli/manager/command_environment.go
+++ b/cli/manager/command_environment.go
@@ -189,7 +189,7 @@ func (commandEnvironment) Configure(request configoptions.Request) {
 	case configoptions.Get:
 		value, err := target.Get(request.Key)
 		if err != nil {
-			fatal("config get: %v", err)
+			ui.FatalHint("wago config list", "config get: %v", err)
 		}
 		if automation.JSON() {
 			ui.PrintJSON(map[string]any{"scope": scope, "key": settings.CanonicalKey(request.Key), "value": value})
@@ -199,7 +199,7 @@ func (commandEnvironment) Configure(request configoptions.Request) {
 	case configoptions.Set:
 		key := settings.CanonicalKey(request.Key)
 		if err := target.Set(key, request.Value, request.Experimental); err != nil {
-			fatal("config set: %v", err)
+			ui.FatalHint("wago config list", "config set: %v", err)
 		}
 		if automation.DryRun() {
 			automation.PrintPlan("change Wago default", map[string]any{"scope": scope, "path": target.Path(), "key": key, "value": request.Value})
@@ -215,14 +215,17 @@ func (commandEnvironment) Configure(request configoptions.Request) {
 		}
 		fmt.Printf("%s Set %s = %s (%s)\n", ui.Cyan("✓"), key, value, scope)
 	case configoptions.Reset:
+		if !request.All {
+			if err := target.Reset(request.Key, request.Experimental); err != nil {
+				ui.FatalHint("wago config list", "config reset: %v", err)
+			}
+		}
 		if automation.DryRun() {
 			automation.PrintPlan("reset Wago defaults", map[string]any{"scope": scope, "path": target.Path(), "key": request.Key, "all": request.All})
 			return
 		}
 		if request.All {
 			target.ResetAll()
-		} else if err := target.Reset(request.Key, request.Experimental); err != nil {
-			fatal("config reset: %v", err)
 		}
 		if err := target.Save(); err != nil {
 			fatal("config reset: %v", err)
@@ -441,7 +444,11 @@ func (commandEnvironment) RebuildPlugins(options pluginrebuild.Options) {
 
 func (e commandEnvironment) Publish(options publish.Options) {
 	if automation.DryRun() {
-		automation.PrintPlan("publish plugin", map[string]any{"manifest": options.Manifest})
+		manifest, err := registry.ValidatePublishManifest(options.Manifest)
+		if err != nil {
+			fatal("publish: %v", err)
+		}
+		automation.PrintPlan("publish plugin", map[string]any{"manifest": manifest})
 		return
 	}
 	registry.PublishContext(e.context(), registry.PublishRequest{
@@ -451,7 +458,11 @@ func (e commandEnvironment) Publish(options publish.Options) {
 
 func (e commandEnvironment) Catalog(options plugincatalog.Options) {
 	if automation.DryRun() {
-		automation.PrintPlan("generate plugin provider catalog", map[string]any{"manifest": options.Manifest, "check": options.Check})
+		manifest, err := registry.ValidatePublishManifest(options.Manifest)
+		if err != nil {
+			fatal("catalog: %v", err)
+		}
+		automation.PrintPlan("generate plugin provider catalog", map[string]any{"manifest": manifest, "check": options.Check})
 		return
 	}
 	registry.CatalogContext(e.context(), registry.CatalogRequest{Manifest: options.Manifest, Check: options.Check})

--- a/cli/manager/commands/auth/login/command.go
+++ b/cli/manager/commands/auth/login/command.go
@@ -22,7 +22,7 @@ func Command(environment Environment) *command.Cmd {
 		Summary:    "log in to the registry",
 		Automation: command.DryRun,
 		Flags: []command.Flag{
-			{Name: "link", Short: "l", Bool: true, Help: "open one-time authorization in a browser on this machine"},
+			{Name: "link", Short: "l", Bool: true, Help: "show one-time authorization with copy and browser shortcuts"},
 			{Name: "code", Short: "c", Bool: true, Help: "log in with a one-time code (headless/remote)"},
 			{Name: "token", Short: "t", Arg: "<t>", Help: "use this API token directly"},
 			{Name: "with-token", Bool: true, Help: "read an API token from stdin (for CI)"},

--- a/cli/manager/commands/plugin/add/command.go
+++ b/cli/manager/commands/plugin/add/command.go
@@ -2,6 +2,8 @@
 package add
 
 import (
+	"strings"
+
 	"github.com/wago-org/wago/cli/internal/command"
 	"github.com/wago-org/wago/cli/internal/project"
 	"github.com/wago-org/wago/cli/internal/ui"
@@ -26,6 +28,7 @@ type Environment interface {
 func Command(environment Environment) *command.Cmd {
 	return &command.Cmd{
 		Name: "add", Summary: "add and enable plugins, then rebuild Wago",
+		Long:       "GitHub plugins may use owner/repository shorthand; Wago stores the canonical github.com/owner/repository Plugin ID.",
 		Automation: command.DryRun,
 		Args:       "<plugin-id>[@range]...",
 		Flags: []command.Flag{
@@ -52,8 +55,12 @@ func Command(environment Environment) *command.Cmd {
 			if err != nil {
 				ui.Usage("add: %v", err)
 			}
+			modules := make([]string, len(c.Args))
+			for i, module := range c.Args {
+				modules[i] = expandGitHubPluginSpec(module)
+			}
 			options := Options{
-				Modules: c.Args, Global: c.Bool("global"), Local: c.Bool("local"),
+				Modules: modules, Global: c.Bool("global"), Local: c.Bool("local"),
 				Force: c.Bool("force"), Verbose: c.Bool("verbose"),
 				Authorities:     plugin.SplitCommaList(c.Str("allow")),
 				GrantAll:        c.Bool("allow-all"),
@@ -67,4 +74,19 @@ func Command(environment Environment) *command.Cmd {
 			environment.Add(options)
 		},
 	}
+}
+
+func expandGitHubPluginSpec(spec string) string {
+	id := spec
+	if index := strings.LastIndexByte(spec, '@'); index > 0 {
+		id = spec[:index]
+	}
+	if project.ValidatePluginID(id) == nil || strings.Count(id, "/") != 1 {
+		return spec
+	}
+	candidate := "github.com/" + id
+	if project.ValidatePluginID(candidate) != nil {
+		return spec
+	}
+	return "github.com/" + spec
 }

--- a/cli/manager/commands/plugin/add/command_test.go
+++ b/cli/manager/commands/plugin/add/command_test.go
@@ -28,6 +28,39 @@ func TestCommandForwardsNonInteractiveAuthorityChoice(t *testing.T) {
 	}
 }
 
+func TestCommandExpandsGitHubPluginShorthand(t *testing.T) {
+	environment := &testEnvironment{}
+	cmd := Command(environment)
+	context, err := cmd.Parse("wago add", []string{"wago-org/wasi", "wago-org/workers@^1.2.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Run(context)
+
+	want := []string{"github.com/wago-org/wasi", "github.com/wago-org/workers@^1.2.3"}
+	if !reflect.DeepEqual(environment.options.Modules, want) {
+		t.Fatalf("modules = %q, want %q", environment.options.Modules, want)
+	}
+}
+
+func TestCommandPreservesQualifiedPluginIDs(t *testing.T) {
+	environment := &testEnvironment{}
+	Command(environment).Run(command.NewContext([]string{
+		"github.com/wago-org/wasi",
+		"gitlab.com/wago-org/wasi",
+		"gopkg.in/yaml.v3",
+	}, nil, nil))
+
+	want := []string{
+		"github.com/wago-org/wasi",
+		"gitlab.com/wago-org/wasi",
+		"gopkg.in/yaml.v3",
+	}
+	if !reflect.DeepEqual(environment.options.Modules, want) {
+		t.Fatalf("modules = %q, want %q", environment.options.Modules, want)
+	}
+}
+
 func TestCommandForwardsScopeOverridesForTheResolvedGraph(t *testing.T) {
 	environment := &testEnvironment{}
 	cmd := Command(environment)

--- a/cli/manager/commands/plugin/publish/command.go
+++ b/cli/manager/commands/plugin/publish/command.go
@@ -14,6 +14,7 @@ type Environment interface {
 func Command(environment Environment) *command.Cmd {
 	return &command.Cmd{
 		Name: "publish", Summary: "publish a plugin from wago.json",
+		Long:       "Interactive publishing confirms an existing version tag or guides you through creating and pushing it from the default or another local branch.",
 		Automation: command.DryRun,
 		Flags: []command.Flag{
 			{Name: "manifest", Short: "m", Arg: "<p>", Help: "manifest path (default wago.json)"},

--- a/cli/manager/internal/plugin/build.go
+++ b/cli/manager/internal/plugin/build.go
@@ -38,15 +38,15 @@ func pkgAddMany(specs []string, options pkgOpts) {
 		progress.DisableAnimation()
 	}
 	progress.Title("Installing plugins")
-	progress.Begin("Resolving the complete plugin graph")
+	progress.Begin("Fetching plugins")
 	src, err := depsSource(options.global)
 	if err != nil {
-		progress.Fail("Plugin resolution failed")
+		progress.Fail("Plugin fetch failed")
 		fatal("add: %v", err)
 	}
 	buildDir, err := buildDirFor(options.global)
 	if err != nil {
-		progress.Fail("Plugin resolution failed")
+		progress.Fail("Plugin fetch failed")
 		fatal("add: %v", err)
 	}
 	err = withPluginMutationLock(pluginContext(options.ctx), src, func(mutation *project.Mutation) error {
@@ -75,10 +75,14 @@ func pkgAddMany(specs []string, options pkgOpts) {
 		if err != nil {
 			return err
 		}
+		progress.Finish("Fetched plugins")
+		progress.Title("Checking permissions")
 		lock, err := reviewResolution(plan, options)
 		if err != nil {
 			return err
 		}
+		progress.Finish("Permissions checked")
+		progress.Begin("Building plugin runtime")
 		return stageAndPublishLockedState(mutation, src, buildDir, manifest, lock, options.verbose)
 	})
 	if err != nil {

--- a/cli/manager/internal/plugin/build/module.go
+++ b/cli/manager/internal/plugin/build/module.go
@@ -490,7 +490,7 @@ func ensureBinary(dir string, input Input, force, verbose bool, config Config) (
 	if err := tidyBuildModule(dir, verbose); err != nil {
 		_, haveSrc := SourceDir()
 		if !haveSrc {
-			return "", false, fmt.Errorf("go mod tidy: %w\n  (wago may not be published yet — set WAGO_SRC to a wago checkout to build from source)", err)
+			return "", false, fmt.Errorf("go mod tidy: %w\n  (wago may not be published yet; set WAGO_SRC to a wago checkout to build from source)", err)
 		}
 		return "", false, fmt.Errorf("go mod tidy: %w", err)
 	}

--- a/cli/manager/internal/plugin/maintenance.go
+++ b/cli/manager/internal/plugin/maintenance.go
@@ -35,6 +35,10 @@ func Outdated(request MaintenanceRequest) {
 		ui.PrintJSON(reports)
 		return
 	}
+	if len(reports) == 0 {
+		fmt.Println("no plugins enabled")
+		return
+	}
 	for _, report := range reports {
 		fmt.Printf("%s  %s  %s\n", report.Plugin, report.Current, dim(report.Constraint))
 	}
@@ -64,6 +68,10 @@ func Tree(request MaintenanceRequest) {
 		return
 	}
 	fmt.Printf("Plugins (%s)\n", scope)
+	if len(entries) == 0 {
+		fmt.Println("  no plugins enabled")
+		return
+	}
 	for _, entry := range entries {
 		kind := "transitive"
 		if entry.Direct {

--- a/cli/manager/internal/plugin/maintenance_test.go
+++ b/cli/manager/internal/plugin/maintenance_test.go
@@ -1,0 +1,52 @@
+package plugin
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/cli/internal/automation"
+)
+
+func TestEmptyMaintenanceReportsSayNoPluginsEnabled(t *testing.T) {
+	automation.Reset()
+	t.Cleanup(automation.Reset)
+	t.Setenv("WAGO_HOME", t.TempDir())
+	dir := t.TempDir()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+	if err := os.WriteFile("wago.json", []byte("{\n  \"$schema\": \"https://wago.sh/v1/schema.json\",\n  \"plugins\": {}\n}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, run := range map[string]func(){
+		"outdated": func() { Outdated(MaintenanceRequest{}) },
+		"tree":     func() { Tree(MaintenanceRequest{}) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			old := os.Stdout
+			reader, writer, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stdout = writer
+			run()
+			_ = writer.Close()
+			os.Stdout = old
+			output, err := io.ReadAll(reader)
+			_ = reader.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(output), "no plugins enabled") {
+				t.Fatalf("empty %s output = %q", name, output)
+			}
+		})
+	}
+}

--- a/cli/manager/internal/plugin/output.go
+++ b/cli/manager/internal/plugin/output.go
@@ -3,5 +3,6 @@ package plugin
 import "github.com/wago-org/wago/cli/internal/ui"
 
 func fatal(format string, args ...any) { ui.Fatal(format, args...) }
+func bold(value string) string         { return ui.Bold(value) }
 func dim(value string) string          { return ui.Dim(value) }
 func cyan(value string) string         { return ui.Cyan(value) }

--- a/cli/manager/internal/plugin/review.go
+++ b/cli/manager/internal/plugin/review.go
@@ -124,7 +124,10 @@ func authorityReviewSelector(reviews []AuthorityReview, choices map[string]bool)
 		if scope := projectScopeSuffix(review.Request.Scope); scope != "" {
 			description += scope
 		}
-		items = append(items, tui.SelectItem{Label: label, Description: description, On: choices[key]})
+		items = append(items, tui.SelectItem{
+			Label: label, Description: description, On: choices[key],
+			ConfirmOff: review.Request.Mode == project.AuthorityRequired,
+		})
 		itemKeys = append(itemKeys, key)
 	}
 	items = append(items, tui.SelectItem{

--- a/cli/manager/internal/plugin/review.go
+++ b/cli/manager/internal/plugin/review.go
@@ -110,12 +110,9 @@ func authorityReviewSelector(reviews []AuthorityReview, choices map[string]bool)
 	for _, review := range reviews {
 		key := authorityKey(review.PluginID, review.Request.Name)
 		label := review.Request.Name
-		if showPluginID {
-			label = review.PluginID + ": " + label
-		}
-		description := string(review.Request.Mode)
+		description := "(" + string(review.Request.Mode) + ")"
 		if review.Request.Reason != "" {
-			description += " — " + review.Request.Reason
+			description += " " + review.Request.Reason
 		}
 		if review.Request.Mode == project.AuthorityRequired {
 			description += "; deselecting cancels installation"
@@ -124,8 +121,12 @@ func authorityReviewSelector(reviews []AuthorityReview, choices map[string]bool)
 		if scope := projectScopeSuffix(review.Request.Scope); scope != "" {
 			description += scope
 		}
+		group := ""
+		if showPluginID {
+			group = review.PluginID
+		}
 		items = append(items, tui.SelectItem{
-			Label: label, Description: description, On: choices[key],
+			Label: label, Description: description, On: choices[key], Group: group,
 			ConfirmOff: review.Request.Mode == project.AuthorityRequired,
 		})
 		itemKeys = append(itemKeys, key)

--- a/cli/manager/internal/plugin/review.go
+++ b/cli/manager/internal/plugin/review.go
@@ -148,16 +148,14 @@ func reviewAuthorityChoices(reviews []AuthorityReview, choices map[string]bool) 
 		}
 		missingRequired := requiredAuthorityDeselected(selector, itemKeys, requiredKeys)
 		if selector.Rejected() || missingRequired {
-			title := "Reject all authority grants?"
+			title := "Exit installation?"
+			backDescription := "return to authority review"
 			cancelDescription := "reject all grants and make no changes"
 			if missingRequired && !selector.Rejected() {
-				title = "Required authority deselected"
+				backDescription = "restore required authorities and return to the list"
 				cancelDescription = "required authorities cannot be denied"
 			}
-			selection, ok := tui.Choose(title, []tui.Item{
-				{Label: "Continue review", Description: "restore required authorities and return to the list", Value: "continue"},
-				{Label: "Cancel installation", Description: cancelDescription, Value: "cancel"},
-			})
+			selection, ok := tui.Choose(title, authorityRejectionItems(backDescription, cancelDescription))
 			if ok && selection == "cancel" {
 				return fmt.Errorf("authority review rejected; no changes were made")
 			}
@@ -177,6 +175,13 @@ func reviewAuthorityChoices(reviews []AuthorityReview, choices map[string]bool) 
 			choices[key] = selector.Items[index].On
 		}
 		return nil
+	}
+}
+
+func authorityRejectionItems(backDescription, cancelDescription string) []tui.Item {
+	return []tui.Item{
+		{Label: "No", Description: backDescription, Value: "continue"},
+		{Label: "Yes", Description: cancelDescription, Value: "cancel"},
 	}
 }
 

--- a/cli/manager/internal/plugin/review.go
+++ b/cli/manager/internal/plugin/review.go
@@ -11,8 +11,6 @@ import (
 	"github.com/wago-org/wago/cli/internal/tui"
 )
 
-const inProcessWarning = "Plugins run native code inside this Wago process. Authority grants constrain Wago interfaces; they are not an OS sandbox."
-
 func reviewResolution(plan ResolutionPlan, options pkgOpts) (project.LockDocument, error) {
 	if len(plan.Reviews) == 0 && len(plan.ContractReviews) == 0 && len(options.scopes) == 0 {
 		return plan.Lock, nil
@@ -64,26 +62,7 @@ func reviewResolution(plan ResolutionPlan, options pkgOpts) (project.LockDocumen
 	interactiveAuthorities := len(plan.Reviews) != 0 && !explicit && !automation.NoInput()
 	interactiveContracts := len(plan.ContractReviews) != 0 && !options.acceptContracts && !automation.NoInput()
 	if interactiveAuthorities || interactiveContracts {
-		fmt.Printf("\n%s\n\n", inProcessWarning)
-		for _, review := range plan.Reviews {
-			mode := review.Request.Mode
-			fmt.Printf("  %s\n    %s (%s, %s)\n    %s%s\n", review.PluginID, review.Request.Name, mode, review.Change, review.Request.Reason, projectScopeSuffix(review.Request.Scope))
-		}
-		for _, review := range plan.ContractReviews {
-			previous := strings.Join(review.Previous, ", ")
-			if previous == "" {
-				previous = "none"
-			}
-			proposed := strings.Join(review.Proposed, ", ")
-			if proposed == "" {
-				proposed = "none"
-			}
-			available := strings.Join(review.Available, ", ")
-			if available == "" {
-				available = "none"
-			}
-			fmt.Printf("  %s\n    contract %s@%d (%s, %s)\n    available: %s\n    binding: %s -> %s\n", review.PluginID, review.Request.ID, review.Request.Major, review.Request.Mode, review.Change, available, previous, proposed)
-		}
+		fmt.Printf("\n%s\n", formatReviewPlan(plan))
 		if interactiveContracts {
 			if err := reviewContractChoices(&plan); err != nil {
 				return project.LockDocument{}, err
@@ -132,6 +111,68 @@ func reviewResolution(plan ResolutionPlan, options pkgOpts) (project.LockDocumen
 		return project.LockDocument{}, err
 	}
 	return plan.Lock, nil
+}
+
+type pluginReviewGroup struct {
+	id          string
+	authorities []AuthorityReview
+	contracts   []ContractReview
+}
+
+func formatReviewPlan(plan ResolutionPlan) string {
+	groups := make([]pluginReviewGroup, 0)
+	indexes := make(map[string]int)
+	group := func(id string) *pluginReviewGroup {
+		if index, ok := indexes[id]; ok {
+			return &groups[index]
+		}
+		indexes[id] = len(groups)
+		groups = append(groups, pluginReviewGroup{id: id})
+		return &groups[len(groups)-1]
+	}
+	for _, review := range plan.Reviews {
+		current := group(review.PluginID)
+		current.authorities = append(current.authorities, review)
+	}
+	for _, review := range plan.ContractReviews {
+		current := group(review.PluginID)
+		current.contracts = append(current.contracts, review)
+	}
+
+	var output strings.Builder
+	fmt.Fprintf(&output, "%s\n", bold("Plugin security"))
+	fmt.Fprintln(&output, "  Plugins run native code inside this Wago process.")
+	fmt.Fprintln(&output, "  Authority grants constrain Wago interfaces; they are not an OS sandbox.")
+	for _, group := range groups {
+		fmt.Fprintf(&output, "\n%s\n", cyan(group.id))
+		if len(group.authorities) != 0 {
+			fmt.Fprintf(&output, "  %s\n", bold("Authorities"))
+			for _, review := range group.authorities {
+				fmt.Fprintf(&output, "    %s  %s\n", review.Request.Name, dim(string(review.Request.Mode)+" · "+review.Change))
+				reason := review.Request.Reason
+				if scope := projectScopeText(review.Request.Scope); scope != "" {
+					reason += "  " + dim(scope)
+				}
+				fmt.Fprintf(&output, "      %s\n", reason)
+			}
+		}
+		if len(group.contracts) != 0 {
+			fmt.Fprintf(&output, "  %s\n", bold("Contracts"))
+			for _, review := range group.contracts {
+				fmt.Fprintf(&output, "    %s@%d  %s\n", review.Request.ID, review.Request.Major, dim(review.Request.Mode+" · "+review.Change))
+				fmt.Fprintf(&output, "      %s %s\n", dim("available:"), joinedOrNone(review.Available))
+				fmt.Fprintf(&output, "      %s %s -> %s\n", dim("binding:"), joinedOrNone(review.Previous), joinedOrNone(review.Proposed))
+			}
+		}
+	}
+	return output.String()
+}
+
+func joinedOrNone(values []string) string {
+	if value := strings.Join(values, ", "); value != "" {
+		return value
+	}
+	return "none"
 }
 
 func reviewContractChoices(plan *ResolutionPlan) error {
@@ -215,6 +256,14 @@ func applyReviewedAuthorities(lock *project.LockDocument, choices map[string]boo
 func authorityKey(pluginID, authority string) string { return pluginID + "\x00" + authority }
 
 func projectScopeSuffix(scope project.AuthorityScope) string {
+	fields := projectScopeText(scope)
+	if fields == "" {
+		return ""
+	}
+	return " [" + fields + "]"
+}
+
+func projectScopeText(scope project.AuthorityScope) string {
 	var fields []string
 	if len(scope.Modules) != 0 {
 		fields = append(fields, "modules="+strings.Join(scope.Modules, ","))
@@ -228,7 +277,7 @@ func projectScopeSuffix(scope project.AuthorityScope) string {
 	if len(fields) == 0 {
 		return ""
 	}
-	return " [" + strings.Join(fields, "; ") + "]"
+	return strings.Join(fields, "; ")
 }
 
 func containsString(values []string, value string) bool {

--- a/cli/manager/internal/plugin/review.go
+++ b/cli/manager/internal/plugin/review.go
@@ -68,32 +68,11 @@ func reviewResolution(plan ResolutionPlan, options pkgOpts) (project.LockDocumen
 				return project.LockDocument{}, err
 			}
 		}
-		var items []tui.SelectItem
-		var itemKeys []string
 		if interactiveAuthorities {
-			for _, review := range plan.Reviews {
-				if review.Request.Mode != project.AuthorityOptional {
-					continue
-				}
-				key := authorityKey(review.PluginID, review.Request.Name)
-				items = append(items, tui.SelectItem{
-					Label:       review.PluginID + ": " + review.Request.Name,
-					Description: review.Request.Reason + projectScopeSuffix(review.Request.Scope),
-					On:          keys[key],
-				})
-				itemKeys = append(itemKeys, key)
+			if err := reviewAuthorityChoices(plan.Reviews, keys); err != nil {
+				return project.LockDocument{}, err
 			}
-		}
-		if len(items) != 0 {
-			selector := &tui.MultiSelect{Title: "Optional authority grants", Prompt: "space toggle · enter accept · esc cancel", Items: items}
-			_, cancelled := tui.Run(selector)
-			if cancelled {
-				return project.LockDocument{}, fmt.Errorf("authority review cancelled; no changes were made")
-			}
-			for index := range itemKeys {
-				keys[itemKeys[index]] = selector.Items[index].On
-			}
-		} else if interactiveAuthorities || interactiveContracts {
+		} else if interactiveContracts {
 			selector := &tui.MultiSelect{Title: "Approve this reviewed plugin plan", Prompt: "enter accept · space decline · esc cancel", Items: []tui.SelectItem{{Label: "Apply this plan", Description: "publish the staged manifest, lock graph, and runtime together", On: true}}}
 			_, cancelled := tui.Run(selector)
 			if cancelled || !selector.Items[0].On {
@@ -113,10 +92,102 @@ func reviewResolution(plan ResolutionPlan, options pkgOpts) (project.LockDocumen
 	return plan.Lock, nil
 }
 
+func authorityReviewSelector(reviews []AuthorityReview, choices map[string]bool) (*tui.MultiSelect, []string, map[string]bool) {
+	pluginIDs := map[string]bool{}
+	for _, review := range reviews {
+		pluginIDs[review.PluginID] = true
+	}
+	showPluginID := len(pluginIDs) > 1
+	title := "Authority grants"
+	if len(pluginIDs) == 1 {
+		for pluginID := range pluginIDs {
+			title += " · " + pluginID
+		}
+	}
+	items := make([]tui.SelectItem, 0, len(reviews)+1)
+	itemKeys := make([]string, 0, len(reviews))
+	requiredKeys := map[string]bool{}
+	for _, review := range reviews {
+		key := authorityKey(review.PluginID, review.Request.Name)
+		label := review.Request.Name
+		if showPluginID {
+			label = review.PluginID + ": " + label
+		}
+		description := string(review.Request.Mode)
+		if review.Request.Reason != "" {
+			description += " — " + review.Request.Reason
+		}
+		if review.Request.Mode == project.AuthorityRequired {
+			description += "; deselecting cancels installation"
+			requiredKeys[key] = true
+		}
+		if scope := projectScopeSuffix(review.Request.Scope); scope != "" {
+			description += scope
+		}
+		items = append(items, tui.SelectItem{Label: label, Description: description, On: choices[key]})
+		itemKeys = append(itemKeys, key)
+	}
+	items = append(items, tui.SelectItem{
+		Label: "Reject all", Description: "cancel installation and make no changes", Reject: true,
+	})
+	return &tui.MultiSelect{
+		Title: title, Prompt: "space toggle · enter confirm · r reject all · esc cancel", Items: items,
+	}, itemKeys, requiredKeys
+}
+
+func reviewAuthorityChoices(reviews []AuthorityReview, choices map[string]bool) error {
+	selector, itemKeys, requiredKeys := authorityReviewSelector(reviews, choices)
+	for {
+		submitted, cancelled := tui.Run(selector)
+		if !submitted || cancelled {
+			return fmt.Errorf("authority review cancelled; no changes were made")
+		}
+		missingRequired := requiredAuthorityDeselected(selector, itemKeys, requiredKeys)
+		if selector.Rejected() || missingRequired {
+			title := "Reject all authority grants?"
+			cancelDescription := "reject all grants and make no changes"
+			if missingRequired && !selector.Rejected() {
+				title = "Required authority deselected"
+				cancelDescription = "required authorities cannot be denied"
+			}
+			selection, ok := tui.Choose(title, []tui.Item{
+				{Label: "Continue review", Description: "restore required authorities and return to the list", Value: "continue"},
+				{Label: "Cancel installation", Description: cancelDescription, Value: "cancel"},
+			})
+			if ok && selection == "cancel" {
+				return fmt.Errorf("authority review rejected; no changes were made")
+			}
+			for index, key := range itemKeys {
+				if requiredKeys[key] {
+					selector.Items[index].On = true
+				}
+			}
+			for index := range selector.Items {
+				if selector.Items[index].Reject {
+					selector.Items[index].On = false
+				}
+			}
+			continue
+		}
+		for index, key := range itemKeys {
+			choices[key] = selector.Items[index].On
+		}
+		return nil
+	}
+}
+
+func requiredAuthorityDeselected(selector *tui.MultiSelect, itemKeys []string, requiredKeys map[string]bool) bool {
+	for index, key := range itemKeys {
+		if requiredKeys[key] && !selector.Items[index].On {
+			return true
+		}
+	}
+	return false
+}
+
 type pluginReviewGroup struct {
-	id          string
-	authorities []AuthorityReview
-	contracts   []ContractReview
+	id        string
+	contracts []ContractReview
 }
 
 func formatReviewPlan(plan ResolutionPlan) string {
@@ -130,10 +201,6 @@ func formatReviewPlan(plan ResolutionPlan) string {
 		groups = append(groups, pluginReviewGroup{id: id})
 		return &groups[len(groups)-1]
 	}
-	for _, review := range plan.Reviews {
-		current := group(review.PluginID)
-		current.authorities = append(current.authorities, review)
-	}
 	for _, review := range plan.ContractReviews {
 		current := group(review.PluginID)
 		current.contracts = append(current.contracts, review)
@@ -145,17 +212,6 @@ func formatReviewPlan(plan ResolutionPlan) string {
 	fmt.Fprintln(&output, "  Authority grants constrain Wago interfaces; they are not an OS sandbox.")
 	for _, group := range groups {
 		fmt.Fprintf(&output, "\n%s\n", cyan(group.id))
-		if len(group.authorities) != 0 {
-			fmt.Fprintf(&output, "  %s\n", bold("Authorities"))
-			for _, review := range group.authorities {
-				fmt.Fprintf(&output, "    %s  %s\n", review.Request.Name, dim(string(review.Request.Mode)+" · "+review.Change))
-				reason := review.Request.Reason
-				if scope := projectScopeText(review.Request.Scope); scope != "" {
-					reason += "  " + dim(scope)
-				}
-				fmt.Fprintf(&output, "      %s\n", reason)
-			}
-		}
 		if len(group.contracts) != 0 {
 			fmt.Fprintf(&output, "  %s\n", bold("Contracts"))
 			for _, review := range group.contracts {

--- a/cli/manager/internal/plugin/review.go
+++ b/cli/manager/internal/plugin/review.go
@@ -115,7 +115,6 @@ func authorityReviewSelector(reviews []AuthorityReview, choices map[string]bool)
 			description += " " + review.Request.Reason
 		}
 		if review.Request.Mode == project.AuthorityRequired {
-			description += "; deselecting cancels installation"
 			requiredKeys[key] = true
 		}
 		if scope := projectScopeSuffix(review.Request.Scope); scope != "" {
@@ -132,7 +131,7 @@ func authorityReviewSelector(reviews []AuthorityReview, choices map[string]bool)
 		itemKeys = append(itemKeys, key)
 	}
 	items = append(items, tui.SelectItem{
-		Label: "Reject all", Description: "cancel installation and make no changes", Reject: true,
+		Label: "Reject all", Description: "cancel installation", Reject: true,
 	})
 	return &tui.MultiSelect{
 		Title: title, Prompt: "space toggle · enter confirm · r reject all · esc cancel", Items: items,
@@ -148,14 +147,7 @@ func reviewAuthorityChoices(reviews []AuthorityReview, choices map[string]bool) 
 		}
 		missingRequired := requiredAuthorityDeselected(selector, itemKeys, requiredKeys)
 		if selector.Rejected() || missingRequired {
-			title := "Exit installation?"
-			backDescription := "return to authority review"
-			cancelDescription := "reject all grants and make no changes"
-			if missingRequired && !selector.Rejected() {
-				backDescription = "restore required authorities and return to the list"
-				cancelDescription = "required authorities cannot be denied"
-			}
-			selection, ok := tui.Choose(title, authorityRejectionItems(backDescription, cancelDescription))
+			selection, ok := tui.Choose("Exit installation?", authorityExitItems())
 			if ok && selection == "cancel" {
 				return fmt.Errorf("authority review rejected; no changes were made")
 			}
@@ -178,10 +170,10 @@ func reviewAuthorityChoices(reviews []AuthorityReview, choices map[string]bool) 
 	}
 }
 
-func authorityRejectionItems(backDescription, cancelDescription string) []tui.Item {
+func authorityExitItems() []tui.Item {
 	return []tui.Item{
-		{Label: "No", Description: backDescription, Value: "continue"},
-		{Label: "Yes", Description: cancelDescription, Value: "cancel"},
+		{Label: "No", Value: "continue"},
+		{Label: "Yes", Value: "cancel"},
 	}
 }
 

--- a/cli/manager/internal/plugin/review_output_test.go
+++ b/cli/manager/internal/plugin/review_output_test.go
@@ -1,0 +1,70 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/cli/internal/project"
+)
+
+func TestFormatReviewPlanGroupsChangesByPlugin(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	plan := ResolutionPlan{
+		Reviews: []AuthorityReview{
+			{
+				PluginID: "github.com/wago-org/wasi",
+				Request: project.AuthorityRequest{
+					Name: "host.arguments.read", Mode: project.AuthorityRequired,
+					Reason: "expose the guest argv",
+				},
+				Change: "new",
+			},
+			{
+				PluginID: "github.com/wago-org/wasi",
+				Request: project.AuthorityRequest{
+					Name: "host.import.define", Mode: project.AuthorityRequired,
+					Reason: "define WASI host functions", Scope: project.AuthorityScope{Modules: []string{"wasi_snapshot_preview1"}},
+				},
+				Change: "new",
+			},
+		},
+		ContractReviews: []ContractReview{
+			{
+				PluginID:  "github.com/wago-org/wasi",
+				Request:   project.ContractRequirement{ID: "github.com/wago-org/stdio", Major: 1, Mode: "optional"},
+				Available: []string{"github.com/wago-org/stdio-native"},
+				Change:    "changed",
+			},
+			{
+				PluginID: "github.com/acme/clock",
+				Request:  project.ContractRequirement{ID: "github.com/acme/time", Major: 1, Mode: "required"},
+				Previous: []string{"github.com/acme/old-clock"}, Proposed: []string{"github.com/acme/new-clock"},
+				Available: []string{"github.com/acme/new-clock"}, Change: "changed",
+			},
+		},
+	}
+
+	want := `Plugin security
+  Plugins run native code inside this Wago process.
+  Authority grants constrain Wago interfaces; they are not an OS sandbox.
+
+github.com/wago-org/wasi
+  Authorities
+    host.arguments.read  required · new
+      expose the guest argv
+    host.import.define  required · new
+      define WASI host functions  modules=wasi_snapshot_preview1
+  Contracts
+    github.com/wago-org/stdio@1  optional · changed
+      available: github.com/wago-org/stdio-native
+      binding: none -> none
+
+github.com/acme/clock
+  Contracts
+    github.com/acme/time@1  required · changed
+      available: github.com/acme/new-clock
+      binding: github.com/acme/old-clock -> github.com/acme/new-clock
+`
+	if got := formatReviewPlan(plan); got != want {
+		t.Fatalf("review plan:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/cli/manager/internal/plugin/review_output_test.go
+++ b/cli/manager/internal/plugin/review_output_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/wago-org/wago/cli/internal/project"
 )
 
-func TestFormatReviewPlanGroupsChangesByPlugin(t *testing.T) {
+func TestFormatReviewPlanGroupsContractChangesByPlugin(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	plan := ResolutionPlan{
 		Reviews: []AuthorityReview{
@@ -48,11 +48,6 @@ func TestFormatReviewPlanGroupsChangesByPlugin(t *testing.T) {
   Authority grants constrain Wago interfaces; they are not an OS sandbox.
 
 github.com/wago-org/wasi
-  Authorities
-    host.arguments.read  required · new
-      expose the guest argv
-    host.import.define  required · new
-      define WASI host functions  modules=wasi_snapshot_preview1
   Contracts
     github.com/wago-org/stdio@1  optional · changed
       available: github.com/wago-org/stdio-native

--- a/cli/manager/internal/plugin/review_selector_test.go
+++ b/cli/manager/internal/plugin/review_selector_test.go
@@ -34,11 +34,31 @@ func TestAuthorityReviewSelectorShowsRequiredAndRejectAll(t *testing.T) {
 	if selector.Items[1].On || !strings.Contains(selector.Items[1].Description, "optional") {
 		t.Fatalf("optional row = %#v", selector.Items[1])
 	}
+	if strings.Contains(selector.Items[0].Description, "—") || !strings.HasPrefix(selector.Items[0].Description, "(required)") {
+		t.Fatalf("required metadata = %q", selector.Items[0].Description)
+	}
 	if !selector.Items[2].Reject || selector.Items[2].Label != "Reject all" {
 		t.Fatalf("reject row = %#v", selector.Items[2])
 	}
 	selector.Items[0].On = false
 	if !requiredAuthorityDeselected(selector, itemKeys, requiredKeys) {
 		t.Fatal("deselecting a required authority did not require cancellation confirmation")
+	}
+}
+
+func TestAuthorityReviewSelectorSectionsMultiplePlugins(t *testing.T) {
+	reviews := []AuthorityReview{
+		{PluginID: "github.com/acme/one", Request: project.AuthorityRequest{Name: "host.arguments.read", Mode: project.AuthorityRequired}},
+		{PluginID: "github.com/acme/one", Request: project.AuthorityRequest{Name: "host.import.define", Mode: project.AuthorityRequired}},
+		{PluginID: "github.com/acme/two", Request: project.AuthorityRequest{Name: "instance.manage", Mode: project.AuthorityOptional}},
+	}
+	selector, _, _ := authorityReviewSelector(reviews, map[string]bool{})
+	if selector.Title != "Authority grants" {
+		t.Fatalf("selector title = %q", selector.Title)
+	}
+	for index, want := range []string{"github.com/acme/one", "github.com/acme/one", "github.com/acme/two"} {
+		if selector.Items[index].Group != want {
+			t.Fatalf("row %d group = %q, want %q", index, selector.Items[index].Group, want)
+		}
 	}
 }

--- a/cli/manager/internal/plugin/review_selector_test.go
+++ b/cli/manager/internal/plugin/review_selector_test.go
@@ -28,7 +28,7 @@ func TestAuthorityReviewSelectorShowsRequiredAndRejectAll(t *testing.T) {
 	if !strings.Contains(selector.Title, required.PluginID) {
 		t.Fatalf("selector title = %q", selector.Title)
 	}
-	if !selector.Items[0].On || !strings.Contains(selector.Items[0].Description, "required") || !strings.Contains(selector.Items[0].Description, required.Request.Reason) || !strings.Contains(selector.Items[0].Description, "cancels installation") {
+	if !selector.Items[0].On || !selector.Items[0].ConfirmOff || !strings.Contains(selector.Items[0].Description, "required") || !strings.Contains(selector.Items[0].Description, required.Request.Reason) || !strings.Contains(selector.Items[0].Description, "cancels installation") {
 		t.Fatalf("required row = %#v", selector.Items[0])
 	}
 	if selector.Items[1].On || !strings.Contains(selector.Items[1].Description, "optional") {

--- a/cli/manager/internal/plugin/review_selector_test.go
+++ b/cli/manager/internal/plugin/review_selector_test.go
@@ -1,0 +1,44 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/cli/internal/project"
+)
+
+func TestAuthorityReviewSelectorShowsRequiredAndRejectAll(t *testing.T) {
+	required := AuthorityReview{
+		PluginID: "github.com/wago-org/wasi",
+		Request:  project.AuthorityRequest{Name: "host.arguments.read", Mode: project.AuthorityRequired, Reason: "read argv"},
+		Change:   "new",
+	}
+	optional := AuthorityReview{
+		PluginID: "github.com/wago-org/wasi",
+		Request:  project.AuthorityRequest{Name: "host.environment.read", Mode: project.AuthorityOptional, Reason: "read environment"},
+		Change:   "new",
+	}
+	selector, itemKeys, requiredKeys := authorityReviewSelector([]AuthorityReview{required, optional}, map[string]bool{
+		authorityKey(required.PluginID, required.Request.Name): true,
+	})
+
+	if len(selector.Items) != 3 || len(itemKeys) != 2 || len(requiredKeys) != 1 {
+		t.Fatalf("selector rows=%d item keys=%d required keys=%d", len(selector.Items), len(itemKeys), len(requiredKeys))
+	}
+	if !strings.Contains(selector.Title, required.PluginID) {
+		t.Fatalf("selector title = %q", selector.Title)
+	}
+	if !selector.Items[0].On || !strings.Contains(selector.Items[0].Description, "required") || !strings.Contains(selector.Items[0].Description, required.Request.Reason) || !strings.Contains(selector.Items[0].Description, "cancels installation") {
+		t.Fatalf("required row = %#v", selector.Items[0])
+	}
+	if selector.Items[1].On || !strings.Contains(selector.Items[1].Description, "optional") {
+		t.Fatalf("optional row = %#v", selector.Items[1])
+	}
+	if !selector.Items[2].Reject || selector.Items[2].Label != "Reject all" {
+		t.Fatalf("reject row = %#v", selector.Items[2])
+	}
+	selector.Items[0].On = false
+	if !requiredAuthorityDeselected(selector, itemKeys, requiredKeys) {
+		t.Fatal("deselecting a required authority did not require cancellation confirmation")
+	}
+}

--- a/cli/manager/internal/plugin/review_selector_test.go
+++ b/cli/manager/internal/plugin/review_selector_test.go
@@ -62,3 +62,13 @@ func TestAuthorityReviewSelectorSectionsMultiplePlugins(t *testing.T) {
 		}
 	}
 }
+
+func TestAuthorityRejectionChoicesUseYesAndNo(t *testing.T) {
+	items := authorityRejectionItems("restore required authorities", "required authorities cannot be denied")
+	if len(items) != 2 || items[0].Label != "No" || items[0].Value != "continue" {
+		t.Fatalf("back choice = %#v", items)
+	}
+	if items[1].Label != "Yes" || items[1].Value != "cancel" {
+		t.Fatalf("exit choice = %#v", items)
+	}
+}

--- a/cli/manager/internal/plugin/review_selector_test.go
+++ b/cli/manager/internal/plugin/review_selector_test.go
@@ -28,8 +28,11 @@ func TestAuthorityReviewSelectorShowsRequiredAndRejectAll(t *testing.T) {
 	if !strings.Contains(selector.Title, required.PluginID) {
 		t.Fatalf("selector title = %q", selector.Title)
 	}
-	if !selector.Items[0].On || !selector.Items[0].ConfirmOff || !strings.Contains(selector.Items[0].Description, "required") || !strings.Contains(selector.Items[0].Description, required.Request.Reason) || !strings.Contains(selector.Items[0].Description, "cancels installation") {
+	if !selector.Items[0].On || !selector.Items[0].ConfirmOff || !strings.Contains(selector.Items[0].Description, "required") || !strings.Contains(selector.Items[0].Description, required.Request.Reason) {
 		t.Fatalf("required row = %#v", selector.Items[0])
+	}
+	if strings.Contains(selector.Items[0].Description, "cancel") || strings.Contains(selector.Items[0].Description, "deselect") {
+		t.Fatalf("required row repeats cancellation behavior: %q", selector.Items[0].Description)
 	}
 	if selector.Items[1].On || !strings.Contains(selector.Items[1].Description, "optional") {
 		t.Fatalf("optional row = %#v", selector.Items[1])
@@ -37,7 +40,7 @@ func TestAuthorityReviewSelectorShowsRequiredAndRejectAll(t *testing.T) {
 	if strings.Contains(selector.Items[0].Description, "—") || !strings.HasPrefix(selector.Items[0].Description, "(required)") {
 		t.Fatalf("required metadata = %q", selector.Items[0].Description)
 	}
-	if !selector.Items[2].Reject || selector.Items[2].Label != "Reject all" {
+	if !selector.Items[2].Reject || selector.Items[2].Label != "Reject all" || selector.Items[2].Description != "cancel installation" {
 		t.Fatalf("reject row = %#v", selector.Items[2])
 	}
 	selector.Items[0].On = false
@@ -64,11 +67,11 @@ func TestAuthorityReviewSelectorSectionsMultiplePlugins(t *testing.T) {
 }
 
 func TestAuthorityRejectionChoicesUseYesAndNo(t *testing.T) {
-	items := authorityRejectionItems("restore required authorities", "required authorities cannot be denied")
-	if len(items) != 2 || items[0].Label != "No" || items[0].Value != "continue" {
+	items := authorityExitItems()
+	if len(items) != 2 || items[0].Label != "No" || items[0].Value != "continue" || items[0].Description != "" {
 		t.Fatalf("back choice = %#v", items)
 	}
-	if items[1].Label != "Yes" || items[1].Value != "cancel" {
+	if items[1].Label != "Yes" || items[1].Value != "cancel" || items[1].Description != "" {
 		t.Fatalf("exit choice = %#v", items)
 	}
 }

--- a/cli/manager/internal/progress/progress_test.go
+++ b/cli/manager/internal/progress/progress_test.go
@@ -35,3 +35,20 @@ func TestInstallProgressLineAndTerminalRendering(t *testing.T) {
 		t.Fatalf("terminal progress = %q", text)
 	}
 }
+
+func TestFinishStopsSpinnerBeforeInteractiveOutput(t *testing.T) {
+	var log bytes.Buffer
+	p := &Progress{out: &log, tty: true, lastPercent: -1}
+	p.Begin("Fetching plugins")
+	p.Finish("Fetched plugins")
+	log.WriteString("Checking permissions\nAuthority grants\n")
+	want := log.String()
+	time.Sleep(100 * time.Millisecond)
+
+	if got := log.String(); got != want {
+		t.Fatalf("spinner repainted over interactive output:\n%q\nwant stable:\n%q", got, want)
+	}
+	if !strings.Contains(want, "✓ Fetched plugins\nChecking permissions\nAuthority grants\n") {
+		t.Fatalf("completed fetch did not advance before interactive output:\n%q", want)
+	}
+}

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -115,7 +115,7 @@ func loginMethodPicker() *tui.Picker {
 	return tui.NewPicker("Choose login method", []tui.Item{
 		{
 			Label:       "Link",
-			Description: "Open one-time authorization in a browser",
+			Description: "Copy the code or open GitHub from this terminal",
 			Value:       "link",
 		},
 		{
@@ -127,7 +127,8 @@ func loginMethodPicker() *tui.Picker {
 }
 
 // chooseLoginMethodContext asks how to log in using the shared radio selector.
-// Link is selected by default and remains the fallback for non-interactive callers.
+// Link is selected by default. Non-interactive callers fall back to code mode,
+// which never launches a browser without an explicit --link.
 func chooseLoginMethodContext(ctx context.Context, base string) (string, bool) {
 	p := loginMethodPicker()
 	submitted, cancelled := tui.Run(p)
@@ -136,7 +137,7 @@ func chooseLoginMethodContext(ctx context.Context, base string) (string, bool) {
 	}
 	method := p.Selected()
 	if !submitted {
-		method = "link"
+		method = "code"
 	}
 	switch method {
 	case "code":
@@ -214,6 +215,8 @@ type deviceFlowHooks struct {
 	deviceCodeEndpoint  string
 	accessTokenEndpoint string
 	openBrowser         func(string) error
+	copyCode            func(string) error
+	promptAction        func() (tui.Action, bool, bool)
 	wait                func(context.Context, time.Duration) error
 }
 
@@ -233,8 +236,19 @@ func githubDeviceTokenContext(ctx context.Context, base string, openBrowser bool
 		deviceCodeEndpoint:  "https://github.com/login/device/code",
 		accessTokenEndpoint: "https://github.com/login/oauth/access_token",
 		openBrowser:         OpenBrowser,
+		copyCode:            CopyClipboard,
+		promptAction:        promptDeviceAuthorizationAction,
 		wait:                waitDevicePollContext,
 	})
+}
+
+func promptDeviceAuthorizationAction() (action tui.Action, submitted, cancelled bool) {
+	if !tui.StdinIsTTY() {
+		return tui.ActionNone, false, false
+	}
+	prompt := &tui.ActionPrompt{Text: "Authorize this login"}
+	submitted, cancelled = tui.Run(prompt)
+	return prompt.Action(), submitted, cancelled
 }
 
 func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser bool, hooks deviceFlowHooks) (string, error) {
@@ -301,18 +315,51 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 	lifetime, pollInterval := deviceFlowTiming(dc.ExpiresIn, dc.Interval)
 	verifyURI := trustedDeviceVerificationURL(dc.VerificationURI, hooks.deviceCodeEndpoint)
 
-	// Print the one-time code before launching a browser so it remains available
-	// when GitHub does not provide a verification_uri_complete value.
+	// Print the one-time code before offering any browser action so the user can
+	// copy it first when GitHub does not provide a complete verification URL.
 	fmt.Printf("\n  First, copy your one-time code:\n\n      %s\n\n", bold(dc.UserCode))
 	if openBrowser {
 		browserURL := trustedDeviceVerificationURL(dc.VerificationURIComplete, hooks.deviceCodeEndpoint)
 		if dc.VerificationURIComplete == "" || browserURL == "" {
 			browserURL = verifyURI
 		}
-		if err := hooks.openBrowser(browserURL); err != nil {
-			fmt.Printf("  Then open %s and enter it.\n", cyan(verifyURI))
-		} else {
-			fmt.Printf("%s Opened %s in your browser.\n", dim("→"), cyan(browserURL))
+		handled := hooks.promptAction != nil
+		if hooks.promptAction != nil {
+			for {
+				action, submitted, cancelled := hooks.promptAction()
+				if cancelled {
+					return "", context.Canceled
+				}
+				if !submitted {
+					fmt.Printf("  Open %s and enter the code.\n", cyan(verifyURI))
+					break
+				}
+				switch action {
+				case tui.ActionCopy:
+					if hooks.copyCode == nil || hooks.copyCode(dc.UserCode) != nil {
+						fmt.Printf("%s Could not copy automatically; copy %s manually.\n", dim("→"), bold(dc.UserCode))
+					} else {
+						fmt.Printf("%s Copied the one-time code.\n", cyan("✓"))
+					}
+					continue
+				case tui.ActionOpen:
+					if err := hooks.openBrowser(browserURL); err != nil {
+						fmt.Printf("  Open %s and enter the code.\n", cyan(verifyURI))
+					} else {
+						fmt.Printf("%s Opened %s in your browser.\n", dim("→"), cyan(browserURL))
+					}
+				default:
+					fmt.Printf("  Open %s and enter the code.\n", cyan(verifyURI))
+				}
+				break
+			}
+		}
+		if !handled {
+			if err := hooks.openBrowser(browserURL); err != nil {
+				fmt.Printf("  Then open %s and enter it.\n", cyan(verifyURI))
+			} else {
+				fmt.Printf("%s Opened %s in your browser.\n", dim("→"), cyan(browserURL))
+			}
 		}
 	} else {
 		fmt.Printf("  Then open %s and enter it.\n", cyan(verifyURI))

--- a/cli/manager/internal/registry/auth.go
+++ b/cli/manager/internal/registry/auth.go
@@ -298,7 +298,7 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 	}
 	if dc.Error != "" {
 		if dc.Error == "device_flow_disabled" {
-			return "", errors.New("GitHub device flow is disabled for this OAuth app — enable \"Device Flow\" in its settings")
+			return "", errors.New("GitHub device flow is disabled for this OAuth app; enable \"Device Flow\" in its settings")
 		}
 		return "", errors.New("GitHub rejected the device authorization request")
 	}
@@ -399,7 +399,7 @@ func githubDeviceTokenUsingContext(ctx context.Context, base string, openBrowser
 			case "access_denied":
 				return "", errors.New("authorization was denied on GitHub")
 			case "expired_token":
-				return "", errors.New("the code expired before you authorized it — run `wago auth login --code` again")
+				return "", errors.New("the code expired before you authorized it; run `wago auth login --code` again")
 			default:
 				return "", errors.New("GitHub returned an unknown device authorization error")
 			}

--- a/cli/manager/internal/registry/auth_security_test.go
+++ b/cli/manager/internal/registry/auth_security_test.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/wago-org/wago/cli/internal/tui"
 )
 
 const (
@@ -132,6 +134,70 @@ func TestDeviceAuthorizationKeepsCredentialsOutOfURLs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestInteractiveDeviceAuthorizationWaitsForBrowserAction(t *testing.T) {
+	server, _ := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL, copiedCode string
+	actions := []tui.Action{tui.ActionCopy, tui.ActionOpen}
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+	hooks.copyCode = func(code string) error {
+		copiedCode = code
+		return nil
+	}
+	hooks.promptAction = func() (tui.Action, bool, bool) {
+		action := actions[0]
+		actions = actions[1:]
+		return action, true, false
+	}
+
+	token, err := githubDeviceTokenUsingContext(context.Background(), server.URL, true, hooks)
+	if err != nil || token != testRegistryToken {
+		t.Fatalf("device token = %q, %v", token, err)
+	}
+	if copiedCode != "short-lived-code" {
+		t.Fatalf("copied code = %q", copiedCode)
+	}
+	if openedURL == "" {
+		t.Fatal("browser was not opened after the explicit action")
+	}
+}
+
+func TestInteractiveDeviceAuthorizationContinuesWithoutOpeningBrowser(t *testing.T) {
+	server, _ := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+	hooks.promptAction = func() (tui.Action, bool, bool) {
+		return tui.ActionContinue, true, false
+	}
+
+	token, err := githubDeviceTokenUsingContext(context.Background(), server.URL, true, hooks)
+	if err != nil || token != testRegistryToken {
+		t.Fatalf("device token = %q, %v", token, err)
+	}
+	if openedURL != "" {
+		t.Fatalf("browser opened without the explicit action: %q", openedURL)
+	}
+}
+
+func TestUnavailableDevicePromptDoesNotOpenBrowser(t *testing.T) {
+	server, _ := newDeviceFlowServer(t, `{"access_token":"`+testGitHubToken+`"}`,
+		http.StatusOK, `{"token":"`+testRegistryToken+`"}`)
+	var openedURL string
+	hooks := deviceFlowTestHooks(t, server.URL, &openedURL)
+	hooks.promptAction = func() (tui.Action, bool, bool) {
+		return tui.ActionNone, false, false
+	}
+
+	token, err := githubDeviceTokenUsingContext(context.Background(), server.URL, true, hooks)
+	if err != nil || token != testRegistryToken {
+		t.Fatalf("device token = %q, %v", token, err)
+	}
+	if openedURL != "" {
+		t.Fatalf("browser opened when the action prompt was unavailable: %q", openedURL)
 	}
 }
 

--- a/cli/manager/internal/registry/client_test.go
+++ b/cli/manager/internal/registry/client_test.go
@@ -438,7 +438,7 @@ func TestLoginMethodPickerDefaultsToLinkAndAcceptsRightArrow(t *testing.T) {
 	frame := p.Frame()
 	for _, want := range []string{
 		"Choose login method",
-		"Link", "Open one-time authorization in a browser",
+		"Link", "Copy the code or open GitHub from this terminal",
 		"Code", "Use a one-time code on another device",
 		"◉", "○", "enter/→ select", "esc cancel",
 	} {

--- a/cli/manager/internal/registry/oauth.go
+++ b/cli/manager/internal/registry/oauth.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -219,4 +220,36 @@ func OpenBrowser(target string) error {
 		command = exec.Command("xdg-open", target)
 	}
 	return command.Start()
+}
+
+// CopyClipboard writes short user-facing text to the platform clipboard.
+func CopyClipboard(text string) error {
+	var command *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		command = exec.Command("pbcopy")
+	case "windows":
+		command = exec.Command("clip.exe")
+	default:
+		for _, candidate := range []struct {
+			name string
+			args []string
+		}{
+			{name: "wl-copy"},
+			{name: "xclip", args: []string{"-selection", "clipboard"}},
+			{name: "xsel", args: []string{"--clipboard", "--input"}},
+		} {
+			if _, err := exec.LookPath(candidate.name); err == nil {
+				command = exec.Command(candidate.name, candidate.args...)
+				break
+			}
+		}
+		if command == nil {
+			return errors.New("no clipboard command found")
+		}
+	}
+	command.Stdin = strings.NewReader(text)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
 }

--- a/cli/manager/internal/registry/provider_catalog.go
+++ b/cli/manager/internal/registry/provider_catalog.go
@@ -20,6 +20,13 @@ import (
 
 const providerCatalogFileLimit = 2 << 20
 
+type providerCatalogBuild struct {
+	generated []byte
+	providers []publishProvider
+	version   string
+	path      string
+}
+
 func registryCatalogContext(ctx context.Context, request CatalogRequest) {
 	if err := generateProviderCatalog(ctx, request); err != nil {
 		fatal("catalog: %v", err)
@@ -35,36 +42,55 @@ func generateProviderCatalog(ctx context.Context, request CatalogRequest) error 
 	if err != nil {
 		return err
 	}
-	generated, providers, err := generateLocalProviderCatalog(ctx, filepath.Dir(manifestPath), metadata)
+	catalog, err := buildProviderCatalog(ctx, manifestPath, metadata)
 	if err != nil {
 		return err
+	}
+	if request.Check {
+		if err := checkProviderCatalogCurrent(catalog); err != nil {
+			return err
+		}
+		fmt.Printf("%s %s is current (%d provider%s)\n", cyan("✓"), catalog.path, len(catalog.providers), pluralRegistry(len(catalog.providers)))
+		return nil
+	}
+	if err := atomicfile.ReplaceFile(catalog.path, atomicfile.Options{Mode: 0o644}, func(writer io.Writer) error {
+		_, err := writer.Write(catalog.generated)
+		return err
+	}); err != nil {
+		return fmt.Errorf("write %s: %w", catalog.path, err)
+	}
+	fmt.Printf("%s Wrote %s with %d provider%s\n", cyan("✓"), catalog.path, len(catalog.providers), pluralRegistry(len(catalog.providers)))
+	return nil
+}
+
+func buildProviderCatalog(ctx context.Context, manifestPath string, metadata publishMetadata) (providerCatalogBuild, error) {
+	generated, providers, err := generateLocalProviderCatalog(ctx, filepath.Dir(manifestPath), metadata)
+	if err != nil {
+		return providerCatalogBuild{}, err
 	}
 	version, err := catalogVersion(metadata.Version, providers)
 	if err != nil {
-		return err
+		return providerCatalogBuild{}, err
 	}
 	if err := validatePublishProviders(providers, metadata, version); err != nil {
-		return err
+		return providerCatalogBuild{}, err
 	}
-	path := filepath.Join(filepath.Dir(manifestPath), wago.ProviderCatalogFile)
-	if request.Check {
-		committed, err := readRegularFile(path, providerCatalogFileLimit)
-		if err != nil {
-			return fmt.Errorf("%s is missing or unreadable: %v (run: wago plugin catalog)", path, err)
-		}
-		if !bytes.Equal(committed, generated) {
-			return fmt.Errorf("%s is stale (run: wago plugin catalog)", path)
-		}
-		fmt.Printf("%s %s is current (%d provider%s)\n", cyan("✓"), path, len(providers), pluralRegistry(len(providers)))
-		return nil
+	return providerCatalogBuild{
+		generated: generated,
+		providers: providers,
+		version:   version,
+		path:      filepath.Join(filepath.Dir(manifestPath), wago.ProviderCatalogFile),
+	}, nil
+}
+
+func checkProviderCatalogCurrent(catalog providerCatalogBuild) error {
+	committed, err := readRegularFile(catalog.path, providerCatalogFileLimit)
+	if err != nil {
+		return fmt.Errorf("%s is missing or unreadable: %v (run: wago plugin catalog)", catalog.path, err)
 	}
-	if err := atomicfile.ReplaceFile(path, atomicfile.Options{Mode: 0o644}, func(writer io.Writer) error {
-		_, err := writer.Write(generated)
-		return err
-	}); err != nil {
-		return fmt.Errorf("write %s: %w", path, err)
+	if !bytes.Equal(committed, catalog.generated) {
+		return fmt.Errorf("%s is stale (run: wago plugin catalog)", catalog.path)
 	}
-	fmt.Printf("%s Wrote %s with %d provider%s\n", cyan("✓"), path, len(providers), pluralRegistry(len(providers)))
 	return nil
 }
 

--- a/cli/manager/internal/registry/publish.go
+++ b/cli/manager/internal/registry/publish.go
@@ -50,7 +50,7 @@ func registryPublishContext(ctx context.Context, options PublishRequest) {
 		version = strings.TrimSpace(gitOutputAt(moduleRoot, "describe", "--tags", "--abbrev=0"))
 	}
 	if version == "" {
-		fatal("publish: no version — set package.version or tag the repository")
+		fatal("publish: no version; set package.version or tag the repository")
 	}
 	version = canonicalGoVersion(version)
 	generated, localProviders, err := generateLocalProviderCatalog(ctx, moduleRoot, metadata)
@@ -191,7 +191,7 @@ func parsePublishManifest(raw []byte) (map[string]any, publishMetadata, []string
 	}
 	pkg, ok := manifest["package"].(map[string]any)
 	if !ok {
-		return nil, publishMetadata{}, nil, fmt.Errorf("package must be an object")
+		return nil, publishMetadata{}, nil, fmt.Errorf("this manifest configures an application, not a publishable plugin; add the required package object to wago.json (see https://docs.wago.sh/reference/configuration)")
 	}
 	module, _ := pkg["module"].(string)
 	if err := project.ValidatePluginID(module); err != nil {

--- a/cli/manager/internal/registry/publish.go
+++ b/cli/manager/internal/registry/publish.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -52,13 +53,6 @@ func registryPublishContext(ctx context.Context, options PublishRequest) {
 		fatal("publish: no version — set package.version or tag the repository")
 	}
 	version = canonicalGoVersion(version)
-	commit := strings.TrimSpace(gitOutputAt(moduleRoot, "rev-list", "-n", "1", version))
-	if commit == "" {
-		fatal("publish: %s", unresolvedReleaseTagInstructions(version))
-	}
-	if !fullGitCommit(commit) {
-		fatal("publish: commit must be the full 40-character commit for tag %s", version)
-	}
 	generated, localProviders, err := generateLocalProviderCatalog(ctx, moduleRoot, metadata)
 	if err != nil {
 		fatal("publish: local provider catalog: %v", err)
@@ -80,6 +74,16 @@ func registryPublishContext(ctx context.Context, options PublishRequest) {
 	}
 	if !bytes.Equal(committed, generated) {
 		fatal("publish: %s is stale (run: wago plugin catalog)", committedPath)
+	}
+	commit, err := resolvePublishTag(ctx, moduleRoot, manifestPath, version, defaultPublishTagUI())
+	if errors.Is(err, errPublishCancelled) {
+		return
+	}
+	if err != nil {
+		fatal("publish: %v", err)
+	}
+	if !fullGitCommit(commit) {
+		fatal("publish: commit must be the full 40-character commit for tag %s", version)
 	}
 	download, err := downloadModuleSource(ctx, metadata.Module, version)
 	if err != nil {

--- a/cli/manager/internal/registry/publish.go
+++ b/cli/manager/internal/registry/publish.go
@@ -54,7 +54,7 @@ func registryPublishContext(ctx context.Context, options PublishRequest) {
 	version = canonicalGoVersion(version)
 	commit := strings.TrimSpace(gitOutputAt(moduleRoot, "rev-list", "-n", "1", version))
 	if commit == "" {
-		fatal("publish: cannot resolve the commit for tag %s; fetch the exact release tag", version)
+		fatal("publish: %s", unresolvedReleaseTagInstructions(version))
 	}
 	if !fullGitCommit(commit) {
 		fatal("publish: commit must be the full 40-character commit for tag %s", version)
@@ -135,6 +135,21 @@ func registryPublishContext(ctx context.Context, options PublishRequest) {
 	default:
 		fatal("publish: %s", apiError(status, data))
 	}
+}
+
+func unresolvedReleaseTagInstructions(version string) string {
+	return fmt.Sprintf(`cannot resolve release tag %[1]s.
+The tag must match package.version in wago.json and point to the commit containing the release manifest and wago.providers.json.
+
+If %[1]s already exists remotely:
+  git fetch origin tag %[1]s
+
+If this is a new release, first commit the exact release files, then run:
+  git tag %[1]s
+  git push origin HEAD %[1]s
+
+Then retry:
+  wago plugin publish`, version)
 }
 
 type publishMetadata struct {

--- a/cli/manager/internal/registry/publish.go
+++ b/cli/manager/internal/registry/publish.go
@@ -53,27 +53,15 @@ func registryPublishContext(ctx context.Context, options PublishRequest) {
 		fatal("publish: no version; set package.version or tag the repository")
 	}
 	version = canonicalGoVersion(version)
-	generated, localProviders, err := generateLocalProviderCatalog(ctx, moduleRoot, metadata)
+	catalog, err := buildProviderCatalog(ctx, manifestPath, metadata)
 	if err != nil {
 		fatal("publish: local provider catalog: %v", err)
 	}
-	localVersion, err := catalogVersion(metadata.Version, localProviders)
-	if err != nil {
-		fatal("publish: local provider catalog: %v", err)
+	if strings.TrimPrefix(catalog.version, "v") != strings.TrimPrefix(version, "v") {
+		fatal("publish: local provider version %s does not match release %s", catalog.version, version)
 	}
-	if strings.TrimPrefix(localVersion, "v") != strings.TrimPrefix(version, "v") {
-		fatal("publish: local provider version %s does not match release %s", localVersion, version)
-	}
-	if err := validatePublishProviders(localProviders, metadata, version); err != nil {
-		fatal("publish: local provider catalog: %v", err)
-	}
-	committedPath := filepath.Join(moduleRoot, wago.ProviderCatalogFile)
-	committed, err := readRegularFile(committedPath, providerCatalogFileLimit)
-	if err != nil {
-		fatal("publish: read %s: %v (run: wago plugin catalog)", committedPath, err)
-	}
-	if !bytes.Equal(committed, generated) {
-		fatal("publish: %s is stale (run: wago plugin catalog)", committedPath)
+	if err := checkProviderCatalogCurrent(catalog); err != nil {
+		fatal("publish: %v", err)
 	}
 	commit, err := resolvePublishTag(ctx, moduleRoot, manifestPath, version, defaultPublishTagUI())
 	if errors.Is(err, errPublishCancelled) {
@@ -107,7 +95,7 @@ func registryPublishContext(ctx context.Context, options PublishRequest) {
 	if err != nil {
 		fatal("publish: exact source artifact %s: %v", wago.ProviderCatalogFile, err)
 	}
-	if !bytes.Equal(artifactCatalog, generated) {
+	if !bytes.Equal(artifactCatalog, catalog.generated) {
 		fatal("publish: exact source artifact %s does not match the local generated catalog", wago.ProviderCatalogFile)
 	}
 	document, err := wago.DecodeProviderCatalog(artifactCatalog)

--- a/cli/manager/internal/registry/publish_tag.go
+++ b/cli/manager/internal/registry/publish_tag.go
@@ -145,8 +145,23 @@ func publishBranchItems(ctx context.Context, root string, now time.Time) ([]tui.
 		return nil, fmt.Errorf("list release branches: %w", err)
 	}
 	branches := strings.Fields(output)
+	defaultRef := defaultBranch
+	defaultIsLocal := false
+	for _, branch := range branches {
+		if branch == defaultBranch {
+			defaultIsLocal = true
+			break
+		}
+	}
+	if !defaultIsLocal && defaultBranch != "" {
+		remoteRef := "origin/" + defaultBranch
+		if commit := strings.TrimSpace(gitOutputAt(root, "show-ref", "--verify", "--hash", "refs/remotes/"+remoteRef)); commit != "" {
+			branches = append(branches, remoteRef)
+			defaultRef = remoteRef
+		}
+	}
 	if len(branches) == 0 {
-		return nil, errors.New("no local branches are available for the release tag")
+		return nil, errors.New("no local or fetched origin branches are available for the release tag")
 	}
 	sort.Strings(branches)
 	ordered := make([]string, 0, len(branches))
@@ -166,7 +181,7 @@ func publishBranchItems(ctx context.Context, root string, now time.Time) ([]tui.
 			}
 		}
 	}
-	appendBranch(defaultBranch)
+	appendBranch(defaultRef)
 	appendBranch(current)
 	for _, branch := range branches {
 		appendBranch(branch)
@@ -178,8 +193,11 @@ func publishBranchItems(ctx context.Context, root string, now time.Time) ([]tui.
 			return nil, err
 		}
 		label := branch
-		if branch == defaultBranch {
-			label += " (default)"
+		if branch == defaultRef {
+			label = defaultBranch + " (default)"
+			if !defaultIsLocal {
+				label = defaultBranch + " (default, origin)"
+			}
 		} else if branch == current {
 			label += " (current)"
 		}

--- a/cli/manager/internal/registry/publish_tag.go
+++ b/cli/manager/internal/registry/publish_tag.go
@@ -1,0 +1,362 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wago-org/wago"
+	"github.com/wago-org/wago/cli/internal/automation"
+	"github.com/wago-org/wago/cli/internal/tui"
+)
+
+var errPublishCancelled = errors.New("publication cancelled")
+
+type publishTagUI struct {
+	interactive bool
+	choose      func(string, []tui.Item) (string, bool)
+	out         io.Writer
+	now         func() time.Time
+}
+
+func defaultPublishTagUI() publishTagUI {
+	return publishTagUI{
+		interactive: tui.StdinIsTTY() && !automation.NoInput(),
+		choose:      tui.Choose,
+		out:         os.Stdout,
+		now:         time.Now,
+	}
+}
+
+func resolvePublishTag(ctx context.Context, root, manifestPath, version string, ui publishTagUI) (string, error) {
+	localCommit, err := localTagCommit(ctx, root, version)
+	if err != nil {
+		return "", err
+	}
+	remoteCommit, remoteFound, err := remoteTagCommit(ctx, root, version)
+	if err != nil {
+		return "", err
+	}
+	if localCommit == "" && remoteFound {
+		if _, err := runGit(ctx, root, "fetch", "--no-tags", "origin", "refs/tags/"+version+":refs/tags/"+version); err != nil {
+			return "", fmt.Errorf("fetch release tag %s: %w", version, err)
+		}
+		localCommit, err = localTagCommit(ctx, root, version)
+		if err != nil {
+			return "", err
+		}
+	}
+	if localCommit != "" && remoteFound && localCommit != remoteCommit {
+		return "", fmt.Errorf("local tag %s points to %s but origin points to %s; refusing to move a release tag", version, shortCommit(localCommit), shortCommit(remoteCommit))
+	}
+	if localCommit != "" {
+		return useExistingPublishTag(ctx, root, version, localCommit, remoteFound, ui)
+	}
+	if !ui.interactive {
+		return "", errors.New(unresolvedReleaseTagInstructions(version))
+	}
+	return createPublishTag(ctx, root, manifestPath, version, ui)
+}
+
+func useExistingPublishTag(ctx context.Context, root, version, commit string, remoteFound bool, ui publishTagUI) (string, error) {
+	age := commitAge(ctx, root, commit, ui.now())
+	fmt.Fprintf(ui.out, "Found tag %s tied to commit %s (updated %s).\n", version, shortCommit(commit), age)
+	if ui.interactive && !chooseYes(ui, "Use this release tag?", "Use "+version, "Cancel publication") {
+		return "", errPublishCancelled
+	}
+	if remoteFound {
+		return commit, nil
+	}
+	if !ui.interactive {
+		return "", fmt.Errorf("tag %s exists locally but not on origin; run `git push origin refs/tags/%s`", version, version)
+	}
+	if !chooseYes(ui, "Tag "+version+" is not on origin. Push it now?", "Push tag", "Cancel publication") {
+		return "", errPublishCancelled
+	}
+	if _, err := runGit(ctx, root, "push", "origin", "refs/tags/"+version); err != nil {
+		return "", fmt.Errorf("push release tag %s: %w", version, err)
+	}
+	fmt.Fprintf(ui.out, "Pushed tag %s to origin.\n", version)
+	return commit, nil
+}
+
+func createPublishTag(ctx context.Context, root, manifestPath, version string, ui publishTagUI) (string, error) {
+	if !chooseYes(ui, "No release tag "+version+" was found. Create it?", "Create tag", "Cancel publication") {
+		return "", errPublishCancelled
+	}
+	items, err := publishBranchItems(ctx, root, ui.now())
+	if err != nil {
+		return "", err
+	}
+	selected, ok := ui.choose("Create "+version+" from which branch?", items)
+	if !ok {
+		return "", errPublishCancelled
+	}
+	commit, err := resolveCommit(ctx, root, selected)
+	if err != nil {
+		return "", err
+	}
+	if err := verifyReleaseFilesAtCommit(ctx, root, manifestPath, commit); err != nil {
+		return "", err
+	}
+	label := selected
+	for _, item := range items {
+		if item.Value == selected {
+			label = item.Label
+			break
+		}
+	}
+	title := fmt.Sprintf("Create and push %s from %s at %s?", version, label, shortCommit(commit))
+	if !chooseYes(ui, title, "Create and push tag", "Cancel publication") {
+		return "", errPublishCancelled
+	}
+	if _, err := runGit(ctx, root, "tag", version, commit); err != nil {
+		return "", fmt.Errorf("create release tag %s: %w", version, err)
+	}
+	if _, err := runGit(ctx, root, "push", "origin", "refs/tags/"+version); err != nil {
+		return "", fmt.Errorf("created local tag %s, but push failed: %w; retry with `git push origin refs/tags/%s`", version, err, version)
+	}
+	fmt.Fprintf(ui.out, "Created and pushed tag %s at %s.\n", version, shortCommit(commit))
+	return commit, nil
+}
+
+func chooseYes(ui publishTagUI, title, yesDescription, noDescription string) bool {
+	selected, ok := ui.choose(title, []tui.Item{
+		{Label: "Yes", Description: yesDescription, Value: "yes"},
+		{Label: "No", Description: noDescription, Value: "no"},
+	})
+	return ok && selected == "yes"
+}
+
+func publishBranchItems(ctx context.Context, root string, now time.Time) ([]tui.Item, error) {
+	current := strings.TrimSpace(gitOutputAt(root, "branch", "--show-current"))
+	defaultBranch := publishDefaultBranch(ctx, root)
+	output, err := runGit(ctx, root, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+	if err != nil {
+		return nil, fmt.Errorf("list release branches: %w", err)
+	}
+	branches := strings.Fields(output)
+	if len(branches) == 0 {
+		return nil, errors.New("no local branches are available for the release tag")
+	}
+	sort.Strings(branches)
+	ordered := make([]string, 0, len(branches))
+	appendBranch := func(branch string) {
+		if branch == "" {
+			return
+		}
+		for _, existing := range ordered {
+			if existing == branch {
+				return
+			}
+		}
+		for _, available := range branches {
+			if available == branch {
+				ordered = append(ordered, branch)
+				return
+			}
+		}
+	}
+	appendBranch(defaultBranch)
+	appendBranch(current)
+	for _, branch := range branches {
+		appendBranch(branch)
+	}
+	items := make([]tui.Item, 0, len(ordered))
+	for _, branch := range ordered {
+		commit, err := resolveCommit(ctx, root, branch)
+		if err != nil {
+			return nil, err
+		}
+		label := branch
+		if branch == defaultBranch {
+			label += " (default)"
+		} else if branch == current {
+			label += " (current)"
+		}
+		items = append(items, tui.Item{
+			Label:       label,
+			Description: shortCommit(commit) + " · updated " + commitAge(ctx, root, commit, now),
+			Value:       branch,
+		})
+	}
+	return items, nil
+}
+
+func publishDefaultBranch(ctx context.Context, root string) string {
+	if ref := strings.TrimSpace(gitOutputAt(root, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")); strings.HasPrefix(ref, "origin/") {
+		return strings.TrimPrefix(ref, "origin/")
+	}
+	output, err := runGit(ctx, root, "ls-remote", "--symref", "origin", "HEAD")
+	if err == nil {
+		for _, line := range strings.Split(output, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 3 && fields[0] == "ref:" && fields[2] == "HEAD" && strings.HasPrefix(fields[1], "refs/heads/") {
+				return strings.TrimPrefix(fields[1], "refs/heads/")
+			}
+		}
+	}
+	if main := strings.TrimSpace(gitOutputAt(root, "show-ref", "--verify", "--hash", "refs/heads/main")); main != "" {
+		return "main"
+	}
+	return strings.TrimSpace(gitOutputAt(root, "branch", "--show-current"))
+}
+
+func localTagCommit(ctx context.Context, root, version string) (string, error) {
+	output, err := runGit(ctx, root, "rev-parse", "--verify", "--quiet", "refs/tags/"+version+"^{commit}")
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+			return "", nil
+		}
+		return "", fmt.Errorf("resolve local release tag %s: %w", version, err)
+	}
+	commit := strings.TrimSpace(output)
+	if !fullGitCommit(commit) {
+		return "", fmt.Errorf("tag %s did not resolve to a full commit", version)
+	}
+	return commit, nil
+}
+
+func remoteTagCommit(ctx context.Context, root, version string) (string, bool, error) {
+	output, err := runGit(ctx, root, "ls-remote", "--exit-code", "--tags", "origin", "refs/tags/"+version, "refs/tags/"+version+"^{}")
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && exitError.ExitCode() == 2 {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("check origin for release tag %s: %w", version, err)
+	}
+	var commit string
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 {
+			commit = fields[0]
+			if strings.HasSuffix(fields[1], "^{}") {
+				break
+			}
+		}
+	}
+	if !fullGitCommit(commit) {
+		return "", false, fmt.Errorf("origin tag %s did not resolve to a full commit", version)
+	}
+	return commit, true, nil
+}
+
+func resolveCommit(ctx context.Context, root, ref string) (string, error) {
+	output, err := runGit(ctx, root, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolve release branch %s: %w", ref, err)
+	}
+	commit := strings.TrimSpace(output)
+	if !fullGitCommit(commit) {
+		return "", fmt.Errorf("release branch %s did not resolve to a full commit", ref)
+	}
+	return commit, nil
+}
+
+func verifyReleaseFilesAtCommit(ctx context.Context, root, manifestPath, commit string) error {
+	status, err := runGit(ctx, root, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return fmt.Errorf("inspect release checkout: %w", err)
+	}
+	if strings.TrimSpace(status) != "" {
+		return errors.New("release checkout has uncommitted or untracked files; commit or remove them before creating an immutable release tag")
+	}
+	if _, err := runGit(ctx, root, "diff", "--quiet", commit, "--", "."); err != nil {
+		return fmt.Errorf("commit %s does not match the current release checkout; switch to the selected branch, prepare and commit the release, then run publish again", shortCommit(commit))
+	}
+	prefix := strings.TrimSpace(gitOutputAt(root, "rev-parse", "--show-prefix"))
+	localManifestPath := manifestPath
+	if !filepath.IsAbs(localManifestPath) {
+		localManifestPath = filepath.Join(root, filepath.Base(manifestPath))
+	}
+	files := []struct {
+		path string
+		name string
+	}{
+		{path: localManifestPath, name: filepath.ToSlash(filepath.Join(prefix, filepath.Base(manifestPath)))},
+		{path: filepath.Join(root, wago.ProviderCatalogFile), name: filepath.ToSlash(filepath.Join(prefix, wago.ProviderCatalogFile))},
+	}
+	for _, file := range files {
+		local, err := os.ReadFile(file.path)
+		if err != nil {
+			return fmt.Errorf("read release file %s: %w", file.path, err)
+		}
+		committed, err := runGit(ctx, root, "show", commit+":"+file.name)
+		if err != nil || !bytes.Equal(local, []byte(committed)) {
+			return fmt.Errorf("commit %s does not contain the current %s; commit the exact release files to the selected branch first", shortCommit(commit), filepath.Base(file.path))
+		}
+	}
+	return nil
+}
+
+func commitAge(ctx context.Context, root, commit string, now time.Time) string {
+	output, err := runGit(ctx, root, "show", "-s", "--format=%ct", commit)
+	if err != nil {
+		return "at an unknown time"
+	}
+	seconds, err := strconv.ParseInt(strings.TrimSpace(output), 10, 64)
+	if err != nil {
+		return "at an unknown time"
+	}
+	return relativeAge(now.Sub(time.Unix(seconds, 0)))
+}
+
+func relativeAge(age time.Duration) string {
+	if age < 0 {
+		return "in the future"
+	}
+	unit := func(value int64, name string) string {
+		if value == 1 {
+			return "1 " + name + " ago"
+		}
+		return fmt.Sprintf("%d %ss ago", value, name)
+	}
+	switch {
+	case age < time.Minute:
+		return "just now"
+	case age < time.Hour:
+		return unit(int64(age/time.Minute), "minute")
+	case age < 24*time.Hour:
+		return unit(int64(age/time.Hour), "hour")
+	case age < 14*24*time.Hour:
+		return unit(int64(age/(24*time.Hour)), "day")
+	case age < 60*24*time.Hour:
+		return unit(int64(age/(7*24*time.Hour)), "week")
+	case age < 2*365*24*time.Hour:
+		return unit(int64(age/(30*24*time.Hour)), "month")
+	default:
+		return unit(int64(age/(365*24*time.Hour)), "year")
+	}
+}
+
+func shortCommit(commit string) string {
+	if len(commit) > 8 {
+		return commit[:8]
+	}
+	return commit
+}
+
+func runGit(ctx context.Context, root string, args ...string) (string, error) {
+	command := exec.CommandContext(ctx, "git", args...)
+	command.Dir = root
+	output, err := command.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message != "" {
+			return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, message)
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return string(output), nil
+}

--- a/cli/manager/internal/registry/publish_tag_test.go
+++ b/cli/manager/internal/registry/publish_tag_test.go
@@ -1,0 +1,313 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/cli/internal/tui"
+)
+
+func TestResolvePublishTagConfirmsExistingTagWithCommitAndAge(t *testing.T) {
+	repository, _, commit := newPublishTagRepository(t)
+	testGit(t, repository, "tag", "v1.2.3", commit)
+	testGit(t, repository, "push", "origin", "refs/tags/v1.2.3")
+	var output bytes.Buffer
+	var titles []string
+	ui := publishTagUI{
+		interactive: true,
+		choose: func(title string, items []tui.Item) (string, bool) {
+			titles = append(titles, title)
+			if len(items) != 2 || items[0].Value != "yes" || items[1].Value != "no" {
+				t.Fatalf("confirmation items = %#v", items)
+			}
+			return "yes", true
+		},
+		out: &output,
+		now: time.Now,
+	}
+
+	got, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err != nil || got != commit {
+		t.Fatalf("resolve tag = %q, %v; want %q", got, err, commit)
+	}
+	if len(titles) != 1 || titles[0] != "Use this release tag?" {
+		t.Fatalf("confirmation titles = %q", titles)
+	}
+	for _, want := range []string{"Found tag v1.2.3", shortCommit(commit), "updated"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("tag summary missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestResolvePublishTagCreatesAndPushesFromDefaultBranch(t *testing.T) {
+	repository, remote, commit := newPublishTagRepository(t)
+	var output bytes.Buffer
+	ui := publishTagUI{
+		interactive: true,
+		choose: func(title string, items []tui.Item) (string, bool) {
+			switch {
+			case strings.HasPrefix(title, "No release tag"):
+				return "yes", true
+			case strings.HasPrefix(title, "Create v1.2.3 from"):
+				if len(items) == 0 || items[0].Label != "main (default)" || items[0].Value != "main" {
+					t.Fatalf("branch items = %#v", items)
+				}
+				return items[0].Value, true
+			case strings.HasPrefix(title, "Create and push"):
+				return "yes", true
+			default:
+				t.Fatalf("unexpected prompt %q", title)
+				return "", false
+			}
+		},
+		out: &output,
+		now: time.Now,
+	}
+
+	got, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err != nil || got != commit {
+		t.Fatalf("resolve tag = %q, %v; want %q", got, err, commit)
+	}
+	remoteCommit := strings.TrimSpace(testGit(t, remote, "rev-parse", "refs/tags/v1.2.3^{commit}"))
+	if remoteCommit != commit {
+		t.Fatalf("remote tag = %q, want %q", remoteCommit, commit)
+	}
+	if !strings.Contains(output.String(), "Created and pushed tag v1.2.3 at "+shortCommit(commit)) {
+		t.Fatalf("creation output = %q", output.String())
+	}
+}
+
+func TestResolvePublishTagFetchesAnExistingRemoteTag(t *testing.T) {
+	repository, _, commit := newPublishTagRepository(t)
+	testGit(t, repository, "tag", "v1.2.3", commit)
+	testGit(t, repository, "push", "origin", "refs/tags/v1.2.3")
+	testGit(t, repository, "tag", "-d", "v1.2.3")
+	ui := publishTagUI{
+		interactive: true,
+		choose:      func(string, []tui.Item) (string, bool) { return "yes", true },
+		out:         &bytes.Buffer{},
+		now:         time.Now,
+	}
+
+	got, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err != nil || got != commit {
+		t.Fatalf("resolve remote tag = %q, %v; want %q", got, err, commit)
+	}
+	if local := strings.TrimSpace(testGit(t, repository, "rev-parse", "refs/tags/v1.2.3^{commit}")); local != commit {
+		t.Fatalf("fetched local tag = %q, want %q", local, commit)
+	}
+}
+
+func TestResolvePublishTagOffersToPushAnExistingLocalTag(t *testing.T) {
+	repository, remote, commit := newPublishTagRepository(t)
+	testGit(t, repository, "tag", "v1.2.3", commit)
+	var titles []string
+	ui := publishTagUI{
+		interactive: true,
+		choose: func(title string, _ []tui.Item) (string, bool) {
+			titles = append(titles, title)
+			return "yes", true
+		},
+		out: &bytes.Buffer{},
+		now: time.Now,
+	}
+
+	got, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err != nil || got != commit {
+		t.Fatalf("resolve local tag = %q, %v; want %q", got, err, commit)
+	}
+	if len(titles) != 2 || titles[0] != "Use this release tag?" || !strings.Contains(titles[1], "Push it now?") {
+		t.Fatalf("confirmation titles = %q", titles)
+	}
+	if pushed := strings.TrimSpace(testGit(t, remote, "rev-parse", "refs/tags/v1.2.3^{commit}")); pushed != commit {
+		t.Fatalf("pushed tag = %q, want %q", pushed, commit)
+	}
+}
+
+func TestResolvePublishTagCanChooseCurrentBranchInsteadOfDefault(t *testing.T) {
+	repository, remote, mainCommit := newPublishTagRepository(t)
+	testGit(t, repository, "switch", "-c", "release-candidate")
+	writePublishReleaseFiles(t, repository, "1.2.3-release")
+	testGit(t, repository, "add", "wago.json", "wago.providers.json")
+	testGit(t, repository, "commit", "-m", "prepare release")
+	releaseCommit := strings.TrimSpace(testGit(t, repository, "rev-parse", "HEAD"))
+	if releaseCommit == mainCommit {
+		t.Fatal("release branch did not advance")
+	}
+	ui := publishTagUI{
+		interactive: true,
+		choose: func(title string, items []tui.Item) (string, bool) {
+			switch {
+			case strings.HasPrefix(title, "No release tag"), strings.HasPrefix(title, "Create and push"):
+				return "yes", true
+			case strings.HasPrefix(title, "Create v1.2.3 from"):
+				if len(items) < 2 || items[0].Label != "main (default)" || items[1].Label != "release-candidate (current)" {
+					t.Fatalf("branch ordering = %#v", items)
+				}
+				return "release-candidate", true
+			default:
+				return "", false
+			}
+		},
+		out: &bytes.Buffer{},
+		now: time.Now,
+	}
+
+	got, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err != nil || got != releaseCommit {
+		t.Fatalf("resolve tag = %q, %v; want %q", got, err, releaseCommit)
+	}
+	remoteCommit := strings.TrimSpace(testGit(t, remote, "rev-parse", "refs/tags/v1.2.3^{commit}"))
+	if remoteCommit != releaseCommit {
+		t.Fatalf("remote tag = %q, want release branch %q", remoteCommit, releaseCommit)
+	}
+}
+
+func TestResolvePublishTagRejectsBranchWithoutCurrentReleaseFiles(t *testing.T) {
+	repository, _, _ := newPublishTagRepository(t)
+	testGit(t, repository, "switch", "-c", "release-candidate")
+	writePublishReleaseFiles(t, repository, "1.2.3-release")
+	testGit(t, repository, "add", "wago.json", "wago.providers.json")
+	testGit(t, repository, "commit", "-m", "prepare release")
+	ui := publishTagUI{
+		interactive: true,
+		choose: func(title string, _ []tui.Item) (string, bool) {
+			switch {
+			case strings.HasPrefix(title, "No release tag"), strings.HasPrefix(title, "Create and push"):
+				return "yes", true
+			case strings.HasPrefix(title, "Create v1.2.3 from"):
+				return "main", true
+			default:
+				return "", false
+			}
+		},
+		out: &bytes.Buffer{},
+		now: time.Now,
+	}
+
+	_, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err == nil || !strings.Contains(err.Error(), "does not match the current release checkout") {
+		t.Fatalf("mismatched branch error = %v", err)
+	}
+	if tag := strings.TrimSpace(gitOutputAt(repository, "tag", "--list", "v1.2.3")); tag != "" {
+		t.Fatalf("mismatched branch created tag %q", tag)
+	}
+}
+
+func TestResolvePublishTagRejectsDirtyReleaseCheckout(t *testing.T) {
+	repository, _, _ := newPublishTagRepository(t)
+	if err := os.WriteFile(filepath.Join(repository, "untracked.go"), []byte("package plugin\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ui := publishTagUI{
+		interactive: true,
+		choose: func(title string, items []tui.Item) (string, bool) {
+			switch {
+			case strings.HasPrefix(title, "No release tag"), strings.HasPrefix(title, "Create and push"):
+				return "yes", true
+			case strings.HasPrefix(title, "Create v1.2.3 from"):
+				return items[0].Value, true
+			default:
+				return "", false
+			}
+		},
+		out: &bytes.Buffer{},
+		now: time.Now,
+	}
+
+	_, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err == nil || !strings.Contains(err.Error(), "uncommitted or untracked files") {
+		t.Fatalf("dirty checkout error = %v", err)
+	}
+	if tag := strings.TrimSpace(gitOutputAt(repository, "tag", "--list", "v1.2.3")); tag != "" {
+		t.Fatalf("dirty checkout created tag %q", tag)
+	}
+}
+
+func TestResolvePublishTagCancellationAndNonInteractiveInstructions(t *testing.T) {
+	repository, _, _ := newPublishTagRepository(t)
+	ui := publishTagUI{
+		interactive: true,
+		choose:      func(string, []tui.Item) (string, bool) { return "no", true },
+		out:         &bytes.Buffer{},
+		now:         time.Now,
+	}
+	if _, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui); !errors.Is(err, errPublishCancelled) {
+		t.Fatalf("cancel error = %v", err)
+	}
+	if tag := strings.TrimSpace(gitOutputAt(repository, "tag", "--list", "v1.2.3")); tag != "" {
+		t.Fatalf("cancellation created tag %q", tag)
+	}
+
+	ui.interactive = false
+	_, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err == nil || !strings.Contains(err.Error(), "git fetch origin tag v1.2.3") || !strings.Contains(err.Error(), "git tag v1.2.3") {
+		t.Fatalf("non-interactive error = %v", err)
+	}
+}
+
+func TestRelativeAge(t *testing.T) {
+	for _, test := range []struct {
+		age  time.Duration
+		want string
+	}{
+		{30 * time.Second, "just now"},
+		{time.Minute, "1 minute ago"},
+		{2 * time.Hour, "2 hours ago"},
+		{3 * 24 * time.Hour, "3 days ago"},
+		{21 * 24 * time.Hour, "3 weeks ago"},
+		{-time.Second, "in the future"},
+	} {
+		if got := relativeAge(test.age); got != test.want {
+			t.Errorf("relativeAge(%v) = %q, want %q", test.age, got, test.want)
+		}
+	}
+}
+
+func newPublishTagRepository(t *testing.T) (repository, remote, commit string) {
+	t.Helper()
+	repository = filepath.Join(t.TempDir(), "work")
+	remote = filepath.Join(t.TempDir(), "remote.git")
+	testGit(t, "", "init", "--bare", "--initial-branch=main", remote)
+	testGit(t, "", "init", "--initial-branch=main", repository)
+	testGit(t, repository, "config", "user.name", "Wago test")
+	testGit(t, repository, "config", "user.email", "wago@example.test")
+	writePublishReleaseFiles(t, repository, "1.2.3")
+	testGit(t, repository, "add", "wago.json", "wago.providers.json")
+	testGit(t, repository, "commit", "-m", "release files")
+	testGit(t, repository, "remote", "add", "origin", remote)
+	testGit(t, repository, "push", "-u", "origin", "main")
+	commit = strings.TrimSpace(testGit(t, repository, "rev-parse", "HEAD"))
+	return
+}
+
+func writePublishReleaseFiles(t *testing.T, repository, value string) {
+	t.Helper()
+	for name, contents := range map[string]string{
+		"wago.json":           `{"package":{"version":"` + value + `"}}` + "\n",
+		"wago.providers.json": `{"providers":[]}` + "\n",
+	} {
+		if err := os.WriteFile(filepath.Join(repository, name), []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func testGit(t *testing.T, directory string, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}

--- a/cli/manager/internal/registry/publish_tag_test.go
+++ b/cli/manager/internal/registry/publish_tag_test.go
@@ -171,6 +171,40 @@ func TestResolvePublishTagCanChooseCurrentBranchInsteadOfDefault(t *testing.T) {
 	}
 }
 
+func TestPublishBranchItemsIncludeRemoteOnlyDefaultBranch(t *testing.T) {
+	repository, remote, commit := newPublishTagRepository(t)
+	testGit(t, repository, "switch", "-c", "feature")
+	testGit(t, repository, "branch", "-D", "main")
+
+	ui := publishTagUI{
+		interactive: true,
+		choose: func(title string, items []tui.Item) (string, bool) {
+			switch {
+			case strings.HasPrefix(title, "No release tag"), strings.HasPrefix(title, "Create and push"):
+				return "yes", true
+			case strings.HasPrefix(title, "Create v1.2.3 from"):
+				if len(items) < 2 || items[0].Label != "main (default, origin)" || items[0].Value != "origin/main" || items[1].Label != "feature (current)" {
+					t.Fatalf("remote-only default branch ordering = %#v", items)
+				}
+				return items[0].Value, true
+			default:
+				return "", false
+			}
+		},
+		out: &bytes.Buffer{},
+		now: time.Now,
+	}
+
+	got, err := resolvePublishTag(context.Background(), repository, filepath.Join(repository, "wago.json"), "v1.2.3", ui)
+	if err != nil || got != commit {
+		t.Fatalf("resolve remote-only default branch = %q, %v; want %q", got, err, commit)
+	}
+	remoteCommit := strings.TrimSpace(testGit(t, remote, "rev-parse", "refs/tags/v1.2.3^{commit}"))
+	if remoteCommit != commit {
+		t.Fatalf("remote tag = %q, want remote-only default commit %q", remoteCommit, commit)
+	}
+}
+
 func TestResolvePublishTagRejectsBranchWithoutCurrentReleaseFiles(t *testing.T) {
 	repository, _, _ := newPublishTagRepository(t)
 	testGit(t, repository, "switch", "-c", "release-candidate")

--- a/cli/manager/internal/registry/publish_test.go
+++ b/cli/manager/internal/registry/publish_test.go
@@ -95,6 +95,13 @@ func TestParsePublishManifestUsesNestedV1PackageAndExplicitCatalogs(t *testing.T
 	}
 }
 
+func TestParsePublishManifestExplainsApplicationManifest(t *testing.T) {
+	_, _, _, err := parsePublishManifest([]byte(`{"$schema":"https://wago.sh/v1/schema.json","plugins":{}}`))
+	if err == nil || !strings.Contains(err.Error(), "configures an application") || !strings.Contains(err.Error(), "required package object") {
+		t.Fatalf("application manifest error = %v", err)
+	}
+}
+
 func TestCanonicalGoVersionAndIsolatedWorkspace(t *testing.T) {
 	for input, want := range map[string]string{
 		"0.1.0":   "v0.1.0",

--- a/cli/manager/internal/registry/publish_test.go
+++ b/cli/manager/internal/registry/publish_test.go
@@ -223,8 +223,33 @@ func Providers() []wago.PluginProvider { return []wago.PluginProvider{{Definitio
 	if err := generateProviderCatalog(context.Background(), CatalogRequest{Manifest: manifest, Check: true}); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := ValidateCatalogPlan(context.Background(), CatalogRequest{Manifest: manifest, Check: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ValidatePublishPlan(context.Background(), manifest); err != nil {
+		t.Fatal(err)
+	}
 	write("wago.providers.json", "{}\n")
 	if err := generateProviderCatalog(context.Background(), CatalogRequest{Manifest: manifest, Check: true}); err == nil || !strings.Contains(err.Error(), "stale") {
 		t.Fatalf("stale check error = %v", err)
+	}
+	if _, err := ValidateCatalogPlan(context.Background(), CatalogRequest{Manifest: manifest, Check: true}); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("catalog dry-run stale check error = %v", err)
+	}
+	if _, err := ValidatePublishPlan(context.Background(), manifest); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("publish dry-run stale check error = %v", err)
+	}
+	catalogPath := filepath.Join(root, wago.ProviderCatalogFile)
+	if err := os.Remove(catalogPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ValidateCatalogPlan(context.Background(), CatalogRequest{Manifest: manifest}); err != nil {
+		t.Fatalf("catalog generation dry run = %v", err)
+	}
+	if _, err := os.Stat(catalogPath); !os.IsNotExist(err) {
+		t.Fatalf("catalog dry run wrote %s: %v", catalogPath, err)
+	}
+	if _, err := ValidatePublishPlan(context.Background(), manifest); err == nil || !strings.Contains(err.Error(), "missing or unreadable") {
+		t.Fatalf("publish dry-run missing catalog error = %v", err)
 	}
 }

--- a/cli/manager/internal/registry/publish_test.go
+++ b/cli/manager/internal/registry/publish_test.go
@@ -136,6 +136,22 @@ func TestCatalogVersionInfersOneProviderVersion(t *testing.T) {
 	}
 }
 
+func TestUnresolvedReleaseTagInstructions(t *testing.T) {
+	message := unresolvedReleaseTagInstructions("v1.2.3")
+	for _, want := range []string{
+		"cannot resolve release tag v1.2.3",
+		"must match package.version in wago.json",
+		"git fetch origin tag v1.2.3",
+		"git tag v1.2.3",
+		"git push origin HEAD v1.2.3",
+		"wago plugin publish",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("release tag instructions missing %q:\n%s", want, message)
+		}
+	}
+}
+
 func TestComparePublishedPackageManifestIgnoresProjectStateOnly(t *testing.T) {
 	local := map[string]any{"package": map[string]any{"module": "github.com/acme/root", "tags": []any{"one"}}, "plugins": map[string]any{"local": "^1"}}
 	artifact := map[string]any{"package": map[string]any{"module": "github.com/acme/root", "tags": []any{"one"}}, "plugins": map[string]any{}}

--- a/cli/manager/internal/registry/registry.go
+++ b/cli/manager/internal/registry/registry.go
@@ -4,6 +4,10 @@ package registry
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/wago-org/wago/cli/internal/project"
 )
@@ -48,14 +52,55 @@ func RecordInstallContext(ctx context.Context, module, version string) {
 }
 func Closest(module string) string { return closestModule(module) }
 
-// ValidatePublishManifest checks the package metadata used by catalog and
-// publish dry runs, and returns the resolved manifest path.
-func ValidatePublishManifest(path string) (string, error) {
+// ValidateCatalogPlan performs the non-writing work required by a catalog dry
+// run, including loading the provider package and checking a committed catalog
+// when requested.
+func ValidateCatalogPlan(ctx context.Context, request CatalogRequest) (string, error) {
+	path := request.Manifest
 	if path == "" {
 		path = project.File
 	}
-	_, _, err := readPublishManifest(path)
+	_, metadata, err := readPublishManifest(path)
+	if err != nil {
+		return path, err
+	}
+	catalog, err := buildProviderCatalog(ctx, path, metadata)
+	if err != nil {
+		return path, err
+	}
+	if request.Check {
+		err = checkProviderCatalogCurrent(catalog)
+	}
 	return path, err
+}
+
+// ValidatePublishPlan performs the local, non-publishing checks required by a
+// publish dry run. Authentication, tag creation, source download, and upload
+// remain execution-time work because they require remote state or mutations.
+func ValidatePublishPlan(ctx context.Context, path string) (string, error) {
+	if path == "" {
+		path = project.File
+	}
+	_, metadata, err := readPublishManifest(path)
+	if err != nil {
+		return path, err
+	}
+	version := strings.TrimSpace(metadata.Version)
+	if version == "" {
+		version = strings.TrimSpace(gitOutputAt(filepath.Dir(path), "describe", "--tags", "--abbrev=0"))
+	}
+	if version == "" {
+		return path, errors.New("no version; set package.version or tag the repository")
+	}
+	version = canonicalGoVersion(version)
+	catalog, err := buildProviderCatalog(ctx, path, metadata)
+	if err != nil {
+		return path, fmt.Errorf("local provider catalog: %w", err)
+	}
+	if strings.TrimPrefix(catalog.version, "v") != strings.TrimPrefix(version, "v") {
+		return path, fmt.Errorf("local provider version %s does not match release %s", catalog.version, version)
+	}
+	return path, checkProviderCatalogCurrent(catalog)
 }
 
 func LoginContext(ctx context.Context, request LoginRequest) { registryLoginContext(ctx, request) }

--- a/cli/manager/internal/registry/registry.go
+++ b/cli/manager/internal/registry/registry.go
@@ -2,7 +2,11 @@
 // registry credentials for the Wago manager.
 package registry
 
-import "context"
+import (
+	"context"
+
+	"github.com/wago-org/wago/cli/internal/project"
+)
 
 type LoginRequest struct {
 	Link, Code, WithToken bool
@@ -43,6 +47,16 @@ func RecordInstallContext(ctx context.Context, module, version string) {
 	recordRegistryInstallContext(ctx, module, version)
 }
 func Closest(module string) string { return closestModule(module) }
+
+// ValidatePublishManifest checks the package metadata used by catalog and
+// publish dry runs, and returns the resolved manifest path.
+func ValidatePublishManifest(path string) (string, error) {
+	if path == "" {
+		path = project.File
+	}
+	_, _, err := readPublishManifest(path)
+	return path, err
+}
 
 func LoginContext(ctx context.Context, request LoginRequest) { registryLoginContext(ctx, request) }
 func LogoutContext(ctx context.Context)                      { registryLogoutContext(ctx) }

--- a/cli/manager/internal/version/state.go
+++ b/cli/manager/internal/version/state.go
@@ -170,7 +170,7 @@ func vmList(d wagopaths.Dirs) {
 		return
 	}
 	if len(vers) == 0 {
-		fmt.Println(dim("no versions installed; try: wago version install <ver>"))
+		fmt.Println(dim("no versions installed; run: wago version install --latest --use"))
 		return
 	}
 	active, profile, build := activeVersion(d), activeProfile(d), activeBuild(d)
@@ -216,7 +216,7 @@ func vmCurrent(d wagopaths.Dirs) {
 		fmt.Printf("%s %s %s\n", a, activeProfile(d), activeBuild(d))
 		return
 	}
-	fmt.Println(dim("no active version set"))
+	fmt.Println(dim("no active version set; run: wago version install --latest --use"))
 }
 
 func vmWhich(d wagopaths.Dirs) {

--- a/cli/manager/main.go
+++ b/cli/manager/main.go
@@ -66,6 +66,9 @@ func Main(v string) {
 		os.Exit(2)
 	}
 	configureInvocationAutomation(args)
+	if dispatchRuntimeHelp(args) {
+		return
+	}
 	switch args[0] {
 	case "__complete":
 		for _, candidate := range command.Complete(managerCommandRoot(), args[1:]) {
@@ -110,7 +113,46 @@ func Main(v string) {
 		cmd.Dispatch("wago "+cmd.Name, childArgs)
 		return
 	}
-	runActiveRunner(args)
+	if shouldForwardToRuntime(args[0]) {
+		runActiveRunner(args)
+		return
+	}
+	managerUnknownCommand(args[0])
+}
+
+func shouldForwardToRuntime(name string) bool {
+	return managerCommandRoot().Child(name) != nil || handoff.LooksLikeRuntimeTarget(name) || strings.HasPrefix(name, "-")
+}
+
+func managerUnknownCommand(name string) {
+	root := managerCommandRoot()
+	if automation.JSON() {
+		hint := "wago help --json"
+		if suggestion := command.SuggestChild(root, name); suggestion != "" {
+			hint = "wago " + suggestion + " --help"
+		}
+		ui.UsageHint(hint, "unknown command %q", name)
+	}
+	fmt.Fprintf(os.Stderr, "%s unknown command %q\n\n", ui.Red("wago:"), name)
+	if suggestion := command.SuggestChild(root, name); suggestion != "" {
+		fmt.Fprintf(os.Stderr, "Did you mean %q?\n\n", suggestion)
+	}
+	managerUsage(os.Stderr)
+	os.Exit(2)
+}
+
+// dispatchRuntimeHelp keeps command discovery available before a runtime has
+// been installed. The manager carries the runtime command schema specifically
+// so newcomers can learn how to install and use Wago without first completing
+// an installation or reaching the network.
+func dispatchRuntimeHelp(args []string) bool {
+	root := &command.Cmd{Name: "wago", Children: runtimeSchemaCommands()}
+	cmd := root.Child(args[0])
+	if cmd == nil || !command.InvocationWantsHelp(cmd, args[1:]) {
+		return false
+	}
+	cmd.Dispatch("wago "+cmd.Name, args[1:])
+	return true
 }
 
 // configureInvocationAutomation observes flags on runtime-owned commands before
@@ -208,7 +250,7 @@ func commandFromSpec(spec command.CommandSpec) *command.Cmd {
 		Args: spec.Arguments, PassThrough: spec.PassThrough,
 	}
 	for _, flag := range spec.Flags {
-		if flag.Name == "help" || flag.Name == "json" || flag.Name == "dry-run" || flag.Name == "no-input" || flag.Name == "locked" || flag.Name == "offline" {
+		if flag.Name == "help" || flag.Name == "help-optimizations" || flag.Name == "json" || flag.Name == "dry-run" || flag.Name == "no-input" || flag.Name == "locked" || flag.Name == "offline" {
 			continue
 		}
 		value := command.Flag{Name: flag.Name, Short: flag.Short, Bool: flag.Type == "boolean", Arg: flag.Value, Help: flag.Summary}
@@ -236,7 +278,7 @@ func commandFromSpec(spec command.CommandSpec) *command.Cmd {
 
 func runWithFirstRunInstall(args []string) {
 	if !hasActiveRunner() && automation.NoInput() {
-		ui.FailHint(1, "runtime_not_installed", "wago version install --canary --profile standard --build normal --use", "no active runtime is selected")
+		ui.FailHint(1, "runtime_not_installed", "wago version install --latest --use", "no active runtime is selected")
 	}
 	if !versioninstall.EnsureRuntime(hasActiveRunner, installRuntimeForFirstRun) {
 		return
@@ -346,7 +388,7 @@ func runActiveRunner(args []string) {
 	d := wagopaths.DirsFor(versionString())
 	path, active, profile, build, ok := managerversion.ActiveRunner(d)
 	if !ok {
-		ui.FatalHint("wago version install", "no active runtime is selected")
+		ui.FatalHint("wago version install --latest --use", "no active runtime is selected")
 	}
 	path, err := managerplugin.Resolve(path, profile, args, commandEnvironment{})
 	if err != nil {

--- a/cli/manager/main.go
+++ b/cli/manager/main.go
@@ -66,7 +66,7 @@ func Main(v string) {
 		os.Exit(2)
 	}
 	configureInvocationAutomation(args)
-	if dispatchRuntimeHelp(args) {
+	if dispatchRuntimeDiscovery(args) {
 		return
 	}
 	switch args[0] {
@@ -141,17 +141,29 @@ func managerUnknownCommand(name string) {
 	os.Exit(2)
 }
 
-// dispatchRuntimeHelp keeps command discovery available before a runtime has
-// been installed. The manager carries the runtime command schema specifically
-// so newcomers can learn how to install and use Wago without first completing
-// an installation or reaching the network.
-func dispatchRuntimeHelp(args []string) bool {
+// dispatchRuntimeDiscovery keeps command help and nested typo diagnostics
+// available before a runtime has been installed. The manager carries the
+// runtime command schema specifically so newcomers can learn how to install and
+// use Wago without first completing an installation or reaching the network.
+func dispatchRuntimeDiscovery(args []string) bool {
 	root := &command.Cmd{Name: "wago", Children: runtimeSchemaCommands()}
 	cmd := root.Child(args[0])
-	if cmd == nil || !command.InvocationWantsHelp(cmd, args[1:]) {
+	if cmd == nil {
 		return false
 	}
-	cmd.Dispatch("wago "+cmd.Name, args[1:])
+	childArgs := args[1:]
+	if command.InvocationWantsHelp(cmd, childArgs) {
+		cmd.Dispatch("wago "+cmd.Name, childArgs)
+		return true
+	}
+	if len(cmd.Children) == 0 {
+		return false
+	}
+	remaining, err := automation.ParseLeading(childArgs)
+	if err != nil || len(remaining) == 0 || strings.HasPrefix(remaining[0], "-") || cmd.Child(remaining[0]) != nil {
+		return false
+	}
+	cmd.Dispatch("wago "+cmd.Name, childArgs)
 	return true
 }
 

--- a/cli/manager/manager_commands_test.go
+++ b/cli/manager/manager_commands_test.go
@@ -102,6 +102,20 @@ func TestManagerCapturesForwardedAutomation(t *testing.T) {
 	t.Cleanup(automation.Reset)
 }
 
+func TestManagerRoutesRuntimeCommandsAndImplicitTargets(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+	for _, name := range []string{"run", "module", "build", "validate", "module.wasm", "--invoke"} {
+		if !shouldForwardToRuntime(name) {
+			t.Errorf("shouldForwardToRuntime(%q) = false", name)
+		}
+	}
+	for _, name := range []string{"bild", "publsh", "unknown"} {
+		if shouldForwardToRuntime(name) {
+			t.Errorf("shouldForwardToRuntime(%q) = true", name)
+		}
+	}
+}
+
 func TestManagerOwnsPluginLifecycleAndDelegatesIntrospection(t *testing.T) {
 	plugins := managerRoot.Child("plugin")
 	for _, name := range []string{"add", "remove", "grant", "update", "outdated", "tree", "rebuild", "catalog", "publish", "unpublish", "deprecate"} {

--- a/cli/runtime/commands/plugin/inspect/command.go
+++ b/cli/runtime/commands/plugin/inspect/command.go
@@ -80,7 +80,7 @@ func printDefinition(definition wago.PluginDefinition, entry *wago.PluginPlanEnt
 	if len(definition.Authorities) != 0 {
 		fmt.Printf("  %s\n", ui.Dim("authorities:"))
 		for _, request := range definition.Authorities {
-			fmt.Printf("    %s %s — %s%s\n", ui.Cyan(string(request.Name)), ui.Dim(string(request.Mode)), request.Reason, scopeLabel(request.Scope))
+			fmt.Printf("    %s %s: %s%s\n", ui.Cyan(string(request.Name)), ui.Dim(string(request.Mode)), request.Reason, scopeLabel(request.Scope))
 		}
 	}
 	if entry != nil && len(entry.Contracts) != 0 {

--- a/cli/runtime/commands/run/command.go
+++ b/cli/runtime/commands/run/command.go
@@ -47,7 +47,7 @@ func Command(environment Environment) *command.Cmd {
 			"Selected Core 3 features default on where supported; use --core 2 for strict Release 2\n" +
 			"or --core 3 for the complete release. Use -p for\n" +
 			"adaptive validation/compile parallelism, or -p8 / -p 8 / --parallel=8 to force a\n" +
-			"worker maximum. Optimization knobs are listed in `wago run --help`.",
+			"worker maximum. Advanced compiler controls are listed in `wago run --help-optimizations`.",
 		Run: implementation.Run,
 	}
 }

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -69,24 +69,28 @@ func TestSettingsCatalogMatchesActiveBackendKnobs(t *testing.T) {
 }
 
 func TestHelpCollapsesBooleanPairs(t *testing.T) {
+	cmd := Command(testEnvironment{})
 	var output strings.Builder
-	Command(testEnvironment{}).PrintHelp(&output, "wago run")
+	cmd.PrintHelp(&output, "wago run")
 	text := output.String()
-	if !strings.Contains(text, "--<no->st-flags") ||
-		strings.Contains(text, "enable: keep comparison results") {
-		t.Fatalf("run help did not collapse optimization pair:\n%s", text)
+	if strings.Contains(text, "--<no->st-flags") || !strings.Contains(text, "--help-optimizations") {
+		t.Fatalf("run help did not collapse advanced optimization help:\n%s", text)
 	}
 	if !strings.Contains(text, "--parallel, -p [workers]") ||
 		!strings.Contains(text, "-p8 / -p 8 / --parallel=8") {
 		t.Fatalf("run help did not document function parallelism:\n%s", text)
 	}
-	profileIndex := strings.Index(text, "--local")
-	helpIndex := strings.Index(text, "--help, -h")
+	output.Reset()
+	cmd.PrintOptimizationHelp(&output, "wago run")
+	text = output.String()
+	if !strings.Contains(text, "--<no->st-flags") || strings.Contains(text, "enable: keep comparison results") {
+		t.Fatalf("optimization help did not collapse boolean pair:\n%s", text)
+	}
 	deferredIndex := strings.Index(text, "--<no->deferred-bounds-checking")
 	optimizationFlags := OptimizationFlags()
 	lastKnobIndex := strings.Index(text, "--<no->"+optimizationFlags[len(optimizationFlags)-2].Name)
-	if profileIndex < 0 || helpIndex < profileIndex || deferredIndex < helpIndex || lastKnobIndex < deferredIndex {
-		t.Fatalf("optimization knobs are not the trailing flag group:\n%s", text)
+	if deferredIndex < 0 || lastKnobIndex < deferredIndex {
+		t.Fatalf("optimization knobs are not ordered in advanced help:\n%s", text)
 	}
 }
 

--- a/cli/runtime/commands/validate/command.go
+++ b/cli/runtime/commands/validate/command.go
@@ -49,7 +49,9 @@ func run(c *command.Ctx) {
 	}
 	if automation.JSON() {
 		ui.PrintJSON(map[string]any{"valid": true, "file": c.Args[0], "bytes": len(src), "workers": selection.FunctionWorkers})
+		return
 	}
+	fmt.Printf("%s %s is valid\n", ui.Cyan("✓"), c.Args[0])
 }
 
 func ModuleBytes(src []byte) error {

--- a/cli/runtime/commands/validate/command_test.go
+++ b/cli/runtime/commands/validate/command_test.go
@@ -1,8 +1,13 @@
 package validate
 
 import (
+	"io"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/wago-org/wago/cli/internal/automation"
+	"github.com/wago-org/wago/cli/internal/command"
 )
 
 func TestModuleBytes(t *testing.T) {
@@ -12,6 +17,32 @@ func TestModuleBytes(t *testing.T) {
 	}
 	if err := ModuleBytes([]byte("not wasm")); err == nil || !strings.Contains(err.Error(), "decode:") {
 		t.Fatalf("malformed module error = %v", err)
+	}
+}
+
+func TestCommandConfirmsValidModule(t *testing.T) {
+	automation.Reset()
+	t.Cleanup(automation.Reset)
+	file := t.TempDir() + "/empty.wasm"
+	if err := os.WriteFile(file, []byte{'\x00', 'a', 's', 'm', 1, 0, 0, 0}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = old })
+	Command().Run(command.NewContext([]string{file}, nil, nil))
+	_ = writer.Close()
+	output, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := string(output); !strings.Contains(text, "is valid") || !strings.Contains(text, file) {
+		t.Fatalf("validation confirmation = %q", text)
 	}
 }
 

--- a/cli/runtime/main.go
+++ b/cli/runtime/main.go
@@ -83,9 +83,16 @@ func Main(v string) {
 		return
 	}
 	if automation.JSON() {
-		ui.UsageHint("wago help --json", "unknown command %q", args[0])
+		hint := "wago help --json"
+		if suggestion := command.SuggestChild(root, args[0]); suggestion != "" {
+			hint = "wago " + suggestion + " --help"
+		}
+		ui.UsageHint(hint, "unknown command %q", args[0])
 	}
 	fmt.Fprintf(os.Stderr, "%s unknown command %q\n\n", red("wago:"), args[0])
+	if suggestion := command.SuggestChild(root, args[0]); suggestion != "" {
+		fmt.Fprintf(os.Stderr, "Did you mean %q?\n\n", suggestion)
+	}
 	usage(os.Stderr)
 	os.Exit(2)
 }

--- a/cli/runtime/main.go
+++ b/cli/runtime/main.go
@@ -30,12 +30,22 @@ func versionString() string {
 	return version
 }
 
-// root is the profile-specific runtime command registry.
-var root = buildCommandRegistry()
+// root is the profile-specific runtime command registry. Keep its construction
+// lazy so generated plugin binaries can validate their plugin set without
+// loading project settings while the manager holds the project mutation lock.
+var root *command.Cmd
+
+func runtimeCommandRegistry() *command.Cmd {
+	if root == nil {
+		root = buildCommandRegistry()
+	}
+	return root
+}
 
 // Main runs the runtime command matching os.Args.
 func Main(v string) {
 	version = v
+	registry := runtimeCommandRegistry()
 	args, err := automation.ParseLeading(os.Args[1:])
 	if err != nil {
 		ui.Usage("%v", err)
@@ -68,29 +78,29 @@ func Main(v string) {
 	// Help describes the invoked CLI, not a generated plugin artifact that may
 	// have been compiled by an older Wago. Resolve it before plugin handoff so
 	// every command advertises the current interface.
-	if cmd := root.Child(args[0]); cmd != nil && command.InvocationWantsHelp(cmd, args[1:]) {
+	if cmd := registry.Child(args[0]); cmd != nil && command.InvocationWantsHelp(cmd, args[1:]) {
 		cmd.Dispatch("wago "+cmd.Name, args[1:])
 		return
 	}
-	if cmd := root.Child(args[0]); cmd != nil {
+	if cmd := registry.Child(args[0]); cmd != nil {
 		cmd.Dispatch("wago "+cmd.Name, args[1:])
 		return
 	}
 	// Not a known command. A file path (or a leading flag) is an implicit `run`;
 	// anything else is an unknown command rather than a mystery file-open.
 	if handoff.LooksLikeRuntimeTarget(args[0]) || strings.HasPrefix(args[0], "-") {
-		root.Child("run").Dispatch("wago run", args)
+		registry.Child("run").Dispatch("wago run", args)
 		return
 	}
 	if automation.JSON() {
 		hint := "wago help --json"
-		if suggestion := command.SuggestChild(root, args[0]); suggestion != "" {
+		if suggestion := command.SuggestChild(registry, args[0]); suggestion != "" {
 			hint = "wago " + suggestion + " --help"
 		}
 		ui.UsageHint(hint, "unknown command %q", args[0])
 	}
 	fmt.Fprintf(os.Stderr, "%s unknown command %q\n\n", red("wago:"), args[0])
-	if suggestion := command.SuggestChild(root, args[0]); suggestion != "" {
+	if suggestion := command.SuggestChild(registry, args[0]); suggestion != "" {
 		fmt.Fprintf(os.Stderr, "Did you mean %q?\n\n", suggestion)
 	}
 	usage(os.Stderr)
@@ -130,7 +140,7 @@ func parseTopAutomation(args []string) {
 }
 
 func writeRuntimeSchema() {
-	if err := command.WriteSchema(os.Stdout, root); err != nil {
+	if err := command.WriteSchema(os.Stdout, runtimeCommandRegistry()); err != nil {
 		ui.Fatal("commands: %v", err)
 	}
 }
@@ -181,5 +191,5 @@ func writeCommandList(w *os.File) {
 // The manager owns the cohesive user-facing help and never asks a runtime to
 // advertise manager commands.
 func topLevelHelpCommands() []*command.Cmd {
-	return append([]*command.Cmd(nil), root.Children...)
+	return append([]*command.Cmd(nil), runtimeCommandRegistry().Children...)
 }

--- a/cli/runtime/main_test.go
+++ b/cli/runtime/main_test.go
@@ -4,14 +4,59 @@ package runtime
 
 import (
 	"bytes"
+	"context"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/cli/internal/command"
 	"github.com/wago-org/wago/cli/internal/handoff"
+	"github.com/wago-org/wago/cli/internal/project"
 )
+
+const validationProcessEnvironment = "WAGO_TEST_VALIDATION_PROCESS"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(validationProcessEnvironment) != "1" {
+		root = buildCommandRegistry()
+	}
+	os.Exit(m.Run())
+}
+
+func TestValidationModeDoesNotWaitForProjectLock(t *testing.T) {
+	if os.Getenv(validationProcessEnvironment) == "1" {
+		return
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "wago.json"), []byte(`{"$schema":"https://wago.sh/v1/schema.json"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var output []byte
+	var childErr error
+	err := project.WithMutation(context.Background(), dir, func(*project.Mutation) error {
+		command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestValidationModeDoesNotWaitForProjectLock$")
+		command.Dir = dir
+		command.Env = append(os.Environ(), validationProcessEnvironment+"=1", "WAGO_INTERNAL_VALIDATE_PLUGIN_SET=1")
+		output, childErr = command.CombinedOutput()
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("validation process waited for the project lock: %v\n%s", ctx.Err(), output)
+	}
+	if childErr != nil {
+		t.Fatalf("validation process failed: %v\n%s", childErr, output)
+	}
+}
 
 func TestUsageDocumentsCommandSurface(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "usage-*.txt")

--- a/cli/wago/manager_test.go
+++ b/cli/wago/manager_test.go
@@ -7,10 +7,33 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestManagerSuggestsRuntimeNestedTypoWithoutSelectedRuntime(t *testing.T) {
+	const helperEnvironment = "WAGO_TEST_RUNTIME_NESTED_TYPO"
+	if os.Getenv(helperEnvironment) == "1" {
+		os.Args = []string{"wago", "module", "improts", "--help"}
+		main()
+		return
+	}
+
+	t.Setenv("WAGO_HOME", t.TempDir())
+	command := exec.Command(os.Args[0], "-test.run=^TestManagerSuggestsRuntimeNestedTypoWithoutSelectedRuntime$")
+	command.Env = append(os.Environ(), helperEnvironment+"=1")
+	output, err := command.CombinedOutput()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() != 2 {
+		t.Fatalf("nested typo exit = %v, want status 2\n%s", err, output)
+	}
+	text := string(output)
+	if !strings.Contains(text, `Did you mean "imports"?`) || strings.Contains(text, "no active runtime is selected") {
+		t.Fatalf("nested typo was not diagnosed by the manager:\n%s", text)
+	}
+}
 
 func TestManagerLaunchesSelectedRunner(t *testing.T) {
 	root := t.TempDir()

--- a/cli/wago/manager_test.go
+++ b/cli/wago/manager_test.go
@@ -145,6 +145,44 @@ func TestManagerOwnsPluginIntrospectionHelpWithoutSelectedRuntime(t *testing.T) 
 	}
 }
 
+func TestManagerOwnsRuntimeHelpWithoutSelectedRuntime(t *testing.T) {
+	t.Setenv("WAGO_HOME", t.TempDir())
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "run", args: []string{"run", "--help"}, want: "Usage: wago run"},
+		{name: "module group", args: []string{"module"}, want: "Usage: wago module <command>"},
+		{name: "module child", args: []string{"module", "imports", "--help"}, want: "Usage: wago module imports"},
+		{name: "build", args: []string{"build", "--help"}, want: "Usage: wago build"},
+		{name: "validate", args: []string{"validate", "--help"}, want: "Usage: wago validate"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oldArgs, oldStdout := os.Args, os.Stdout
+			t.Cleanup(func() { os.Args, os.Stdout = oldArgs, oldStdout })
+			read, write, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stdout = write
+			os.Args = append([]string{"wago"}, test.args...)
+			main()
+			_ = write.Close()
+			output, err := io.ReadAll(read)
+			_ = read.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if text := string(output); !strings.Contains(text, test.want) {
+				t.Fatalf("runtime help missing %q:\n%s", test.want, text)
+			}
+		})
+	}
+}
+
 func TestManagerRunRedirectsToVersionInstallWithoutSelectedRunner(t *testing.T) {
 	t.Setenv("WAGO_HOME", t.TempDir())
 	requests := make([]string, 0, 2)

--- a/docs/plugin-scopes.md
+++ b/docs/plugin-scopes.md
@@ -9,15 +9,17 @@ Wago separates project intent, reviewed resolution, and generated artifacts:
 - `.wago/` contains replaceable generated build artifacts for one exact Wago
   release, profile, target, and lock fingerprint.
 
-Plugin IDs are canonical Go module or package paths everywhere. For example,
-use `github.com/wago-org/wasi`; `wago-org/wasi` is not an alias.
+Plugin IDs are canonical Go module or package paths everywhere. `wago add`
+accepts `owner/repository` as GitHub shorthand, so `wago add wago-org/wasi`
+resolves and stores the canonical `github.com/wago-org/wasi` Plugin ID. Other
+hosts must be written as fully qualified paths; Wago does not infer them.
 
 ## Local projects
 
 `wago add` changes the current project by default:
 
 ```sh
-wago add github.com/wago-org/wasi
+wago add wago-org/wasi
 wago add github.com/JairusSW/pool
 ```
 

--- a/docs/plugin-scopes.md
+++ b/docs/plugin-scopes.md
@@ -64,10 +64,12 @@ Add, update, and remove use the same all-or-nothing transaction:
 6. Atomically replace the manifest, lockfile, and artifact only after every
    prior step succeeds.
 
-Rejecting a required Authority cancels the transaction. Optional Authorities
-may be denied or narrowed. An error, interruption, failed build, mismatched
-definition, or invalid plugin leaves the previous project and runnable artifact
-unchanged.
+Interactive review shows required and optional Authorities as selectable rows.
+Required rows start selected and are marked as required; deselecting one asks
+for confirmation before cancelling the transaction. `Reject all` explicitly
+cancels installation without publishing changes. Optional Authorities may be
+denied or narrowed. An error, interruption, failed build, mismatched definition,
+or invalid plugin leaves the previous project and runnable artifact unchanged.
 
 ## Author narrower grants
 


### PR DESCRIPTION
## Summary

- accept `owner/repository` as GitHub shorthand in `wago add`, while keeping stored IDs canonical
- separate plugin fetching, permission review, and runtime building into clean terminal phases
- show required and optional Authorities as grouped radio-style rows with explicit cancellation and Reject all behavior
- keep the GitHub device code visible; use `c` to copy, `o` to open the browser, or Enter to continue
- make plugin publishing confirm existing tags or guide safe tag creation from a selected branch
- reject dirty release checkouts and local/remote tag mismatches
- show runtime-owned command help before any runtime is installed
- suggest nearby commands for top-level and nested typos, with complete manager help
- keep everyday compile, run, and build help short; expose advanced controls through `--help-optimizations`
- provide pasteable runtime-install and configuration recovery commands
- confirm successful validation and explain empty plugin states
- validate config, catalog, and publish dry runs instead of printing impossible plans
- make application-versus-publishable-plugin manifest errors actionable
- keep non-interactive and JSON behavior deterministic
- do not add shorthand resolution for non-GitHub hosts

## Proof

- `go test ./...`
- `go vet ./...`
- all 48 leaf command help paths pass with and without an installed runtime
- generated command schema contains no duplicate flags
- exercised valid, malformed, missing, precompiled, and native module paths in a disposable project
- exercised empty, configured, offline, no-input, dry-run, and invalid plugin/config/version states
- built and ran standard-Go and TinyGo standalone executables on Darwin ARM64
- cross-built the CLI for Linux and Windows on AMD64 and ARM64
- release-tag tests use real local and bare Git repositories for existing, remote-only, local-only, missing, alternate-branch, cancellation, dirty-checkout, and mismatch paths
- pseudo-terminal replay verifies `Fetched plugins` completes before permission review starts on a clean line
- Darwin-native tests plus Windows and Linux auth-package cross-compiles

## TDD and diagnosis

- shorthand failed because `wago-org/wasi` reached the manager unchanged
- the plugin selector collided with an active fetch spinner and did not distinguish mandatory grants clearly
- device login opened a browser before the user could copy the one-time code
- publish collapsed existing-tag and new-release recovery into one vague fetch instruction
- manager/runtime handoff delegated help and typo errors to a runtime that may not exist or only knows part of the CLI
- compiler optimization flags were mixed into normal help, producing 50 to 80 line first-contact screens
- several empty and successful paths printed nothing or a misleading next step
- dry-run returned plans before checking configuration keys or publishable package metadata
