### PR TITLE
cli: make WASI P2 installation reliable

### DIFF
--- a/cli/manager/commands/plugin/add/command.go
+++ b/cli/manager/commands/plugin/add/command.go
@@ -28,7 +28,7 @@ type Environment interface {
 func Command(environment Environment) *command.Cmd {
 	return &command.Cmd{
 		Name: "add", Summary: "add and enable plugins, then rebuild Wago",
-		Long:       "GitHub plugins may use owner/repository shorthand; Wago stores the canonical github.com/owner/repository Plugin ID.",
+		Long:       "GitHub plugins may use owner/repository[/subpackage] shorthand; Wago stores the canonical github.com/owner/repository[/subpackage] Plugin ID.",
 		Automation: command.DryRun,
 		Args:       "<plugin-id>[@range]...",
 		Flags: []command.Flag{
@@ -81,7 +81,7 @@ func expandGitHubPluginSpec(spec string) string {
 	if index := strings.LastIndexByte(spec, '@'); index > 0 {
 		id = spec[:index]
 	}
-	if project.ValidatePluginID(id) == nil || strings.Count(id, "/") != 1 {
+	if project.ValidatePluginID(id) == nil || !strings.Contains(id, "/") {
 		return spec
 	}
 	candidate := "github.com/" + id

--- a/cli/manager/commands/plugin/add/command_test.go
+++ b/cli/manager/commands/plugin/add/command_test.go
@@ -31,13 +31,23 @@ func TestCommandForwardsNonInteractiveAuthorityChoice(t *testing.T) {
 func TestCommandExpandsGitHubPluginShorthand(t *testing.T) {
 	environment := &testEnvironment{}
 	cmd := Command(environment)
-	context, err := cmd.Parse("wago add", []string{"wago-org/wasi", "wago-org/workers@^1.2.3"})
+	context, err := cmd.Parse("wago add", []string{
+		"wago-org/wasi",
+		"wago-org/wasi/p2",
+		"wago-org/workers@^1.2.3",
+		"wago-org/workers/runner@^1.2.3",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	cmd.Run(context)
 
-	want := []string{"github.com/wago-org/wasi", "github.com/wago-org/workers@^1.2.3"}
+	want := []string{
+		"github.com/wago-org/wasi",
+		"github.com/wago-org/wasi/p2",
+		"github.com/wago-org/workers@^1.2.3",
+		"github.com/wago-org/workers/runner@^1.2.3",
+	}
 	if !reflect.DeepEqual(environment.options.Modules, want) {
 		t.Fatalf("modules = %q, want %q", environment.options.Modules, want)
 	}

--- a/cli/manager/internal/self/self.go
+++ b/cli/manager/internal/self/self.go
@@ -89,10 +89,11 @@ func selfExecutablePath() string {
 var (
 	resolveManagerUpdate  = managerversion.ResolveManagerUpdate
 	installManagerPayload = managerversion.InstallManagerPayload
+	syncManagerSource     = managerversion.SyncInstalledSource
 )
 
 func selfUpdate(current, executable string, force bool) {
-	selfUpdateUsing(current, executable, force, resolveManagerUpdate, installManagerPayload)
+	selfUpdateUsing(current, executable, force, resolveManagerUpdate, installManagerPayload, syncManagerSource)
 }
 
 func selfUpdateContext(ctx context.Context, current, executable string, force bool) {
@@ -103,6 +104,9 @@ func selfUpdateContext(ctx context.Context, current, executable string, force bo
 		func(resolved, destination string, sourceOnly bool, progress *managerprogress.Progress) error {
 			return managerversion.InstallManagerPayloadContext(ctx, resolved, destination, sourceOnly, progress)
 		},
+		func(resolved, destination string, progress *managerprogress.Progress) error {
+			return managerversion.SyncInstalledSourceContext(ctx, resolved, destination, progress)
+		},
 	)
 }
 
@@ -111,6 +115,7 @@ func selfUpdateUsing(
 	force bool,
 	resolve func(string, *managerprogress.Progress) (string, bool, error),
 	install func(string, string, bool, *managerprogress.Progress) error,
+	syncSource func(string, string, *managerprogress.Progress) error,
 ) {
 	progress := managerprogress.NewProgress(os.Stderr)
 	progress.Title("Updating Wago")
@@ -132,6 +137,12 @@ func selfUpdateUsing(
 		_ = os.Remove(staged)
 		fatal("self update: %v", err)
 	}
+	if source := managedSourceForUpdate(executable); source != "" {
+		if err := syncSource(resolved, source, progress); err != nil {
+			_ = os.Remove(staged)
+			fatal("self update: sync plugin build source: %v", err)
+		}
+	}
 	deferred, err := selfreplace.Executable(executable, staged)
 	if err != nil {
 		_ = os.Remove(staged)
@@ -143,6 +154,17 @@ func selfUpdateUsing(
 	}
 	progress.Finish("Updated Wago to " + managerversion.DisplayRelease(resolved))
 	printDetail(progress.Writer(), "location", displayPath(executable))
+}
+
+func managedSourceForUpdate(executable string) string {
+	source := InstalledSourcePath()
+	if source == "" {
+		return ""
+	}
+	if os.Getenv("WAGO_SRC_DIR") != "" || pathContains(filepath.Dir(source), executable) {
+		return source
+	}
+	return ""
 }
 
 func createSelfUpdateStage(executable string) (string, error) {

--- a/cli/manager/internal/self/self_test.go
+++ b/cli/manager/internal/self/self_test.go
@@ -79,6 +79,44 @@ func TestSelfUpdateSkipsMatchingManagerCommit(t *testing.T) {
 	}
 }
 
+func TestSelfUpdateSynchronizesManagedPluginBuildSource(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	managed := filepath.Join(home, ".wago")
+	executable := filepath.Join(managed, "bin", "wago")
+	source := filepath.Join(managed, "src")
+	for _, dir := range []string{filepath.Dir(executable), source} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(executable, []byte("manager"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldResolve, oldInstall, oldSync := resolveManagerUpdate, installManagerPayload, syncManagerSource
+	t.Cleanup(func() {
+		resolveManagerUpdate, installManagerPayload, syncManagerSource = oldResolve, oldInstall, oldSync
+	})
+	const resolved = "canary@2ff00ddd12345678901234567890123456789012"
+	resolveManagerUpdate = func(string, *managerprogress.Progress) (string, bool, error) {
+		return resolved, true, nil
+	}
+	installManagerPayload = func(_ string, dest string, _ bool, _ *managerprogress.Progress) error {
+		return os.WriteFile(dest, []byte("updated manager"), 0o755)
+	}
+	var syncedRef, syncedDest string
+	syncManagerSource = func(ref, dest string, _ *managerprogress.Progress) error {
+		syncedRef, syncedDest = ref, dest
+		return nil
+	}
+
+	selfUpdate("canary@old", executable, true)
+	if syncedRef != resolved || syncedDest != source {
+		t.Fatalf("source sync = (%q, %q), want (%q, %q)", syncedRef, syncedDest, resolved, source)
+	}
+}
+
 func TestSelfUninstallModePickerUsesRadioButtonsAndDefaultsFull(t *testing.T) {
 	p := selfUninstallModePicker()
 	if got := p.Selected(); got != string(Full) {


### PR DESCRIPTION
## Why

Published WASI Preview 2 is a subpackage provider, so the documented GitHub shorthand needs to accept subpackage paths. Separately, plugin runtime builds use the installer-managed Wago source checkout; self-update previously replaced only the manager binary and could leave that checkout stale enough to deadlock during installation.

## What

- expand owner/repository/subpackage plugin IDs to canonical github.com IDs
- preserve version constraints while expanding shorthand
- synchronize installer-managed plugin build source to the exact resolved manager ref during self-update
- cover both behaviors with regression tests

## Proof

- `go test ./cli/...`
- `go vet ./cli/...`
- clean install: `wago add wago-org/wasi/p2 --allow-all --accept-contracts --no-input`
- resolved `github.com/wago-org/wasi/p2 v0.1.1` and `github.com/wago-org/component-model v0.1.1`

## Docs

No separate documentation update: command help now describes subpackage shorthand.