### PR TITLE
runtime: guard native entry epoch reads

### DIFF
--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -169,11 +169,12 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 	}
 	resumeGCInvocation := leaseOwner.suspendGCInvocation(id)
 	var localMu *sync.Mutex
-	epoch := nativeExecutionEpoch
+	var epoch uint64
 	if active.usesIndependentExecution() {
 		localMu = active.independentNativeExecutionMu()
 		localMu.Unlock()
 	} else {
+		epoch = nativeExecutionEpoch
 		nativeExecutionMu.Unlock()
 	}
 	// Keep the parked activation and any GC host-result roots published until the

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"encoding/binary"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,6 +43,57 @@ func TestIndependentInstanceExecutionBypassesProcessLease(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("independent invocation waited for the process-wide native execution lease")
+	}
+}
+
+func TestIndependentHostDispatchDoesNotRaceProcessEpoch(t *testing.T) {
+	sig := wasmtest.FuncType(nil, nil)
+	body := []byte{0x00, 0x10, 0x00, 0x0b} // call 0; end
+	module := returningImportModule(sig, body)
+	instantiate := func(config *RuntimeConfig) *Instance {
+		compiled, err := config.Compile(module)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		t.Cleanup(func() { _ = compiled.Close() })
+		in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(HostModule, []uint64, []uint64) {})}})
+		if err != nil {
+			t.Fatalf("instantiate: %v", err)
+		}
+		t.Cleanup(func() { _ = in.Close() })
+		return in
+	}
+
+	independent := instantiate(NewRuntimeConfig().WithIndependentInstanceExecution(true))
+	serial := instantiate(NewRuntimeConfig().WithIndependentInstanceExecution(false))
+	if !independent.usesIndependentExecution() || serial.usesIndependentExecution() {
+		t.Fatal("test instances did not select distinct native execution leases")
+	}
+
+	const calls = 1000
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	run := func(in *Instance) {
+		ready.Done()
+		<-start
+		for range calls {
+			if _, err := in.Invoke("g"); err != nil {
+				errs <- err
+				return
+			}
+		}
+		errs <- nil
+	}
+	go run(independent)
+	go run(serial)
+	ready.Wait()
+	close(start)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Why

Concurrent WASI Preview 2 execution exposed a real data race: independent host dispatch read `nativeExecutionEpoch` without holding `nativeExecutionMu` while a process-serialized instance incremented it.

## What

- read the process epoch only on the process-lease path
- retain the existing local-lease rebind behavior
- add a concurrent mixed-lease regression test

## Proof

- regression fails current main under `go test -race`
- regression passes 5 consecutive times with the fix
- WASI Rust concurrent P2 test passes 5 times under `-race` with this checkout
- `go test ./...`
- `go vet ./...`

## Docs

No public API or behavior change.