### PR TITLE
compiler: guard proper-tail result rewrites

### DIFF
--- a/docs/tail-result-rewrite-contracts.md
+++ b/docs/tail-result-rewrite-contracts.md
@@ -43,8 +43,10 @@ recursive/GC type graphs, not only their local type indexes. Parameter projectio
 erase only the selected root result contract: result lists of function types
 reachable through parameters remain observable. The fence rejects changes to
 imported, exported, or start-function signatures; changes to local functions that
-may escape through imported callback parameters, mutable globals, tables, or tags,
-or through exported function-reference tables, globals, results, or tags;
+may escape through imported callback parameters, globals (including immutable
+references to interior-mutable host objects), tables, or tags, or through exported
+function-reference tables, globals, results, or tags; `externref` surfaces are
+conservative because externalized GC objects may carry nested function references;
 parameter rewrites; tail-site retargeting; mutable or exported tables; imported
 indirect targets; and dynamic `return_call_ref` producers. Byte-backed scans use
 the validated module's memory32 or memory64 memarg width.

--- a/docs/tail-result-rewrite-contracts.md
+++ b/docs/tail-result-rewrite-contracts.md
@@ -1,0 +1,85 @@
+# Proper-tail result rewrite contracts
+
+Status: implemented August 15, 2026 for issue #436.
+
+## Why this fence exists
+
+A proper tail transfers its result contract to another function without returning
+through the current Wasm frame. A later optimization that removes or rewrites
+function results must therefore update the complete contract, not only the body
+whose result appears unused.
+
+The target-knowledge boundary is:
+
+- `return_call` has one statically known function target;
+- `return_call_indirect` has a dynamic target unless a private immutable local
+  table proves its complete non-null target set;
+- `return_call_ref` has a dynamic target unless the producer is mechanically
+  known. The initial admitted proof is the exact adjacent `ref.func` shape;
+  typed globals, imported references, mutable tables, locals, parameters, and
+  computed references remain conservative.
+
+Changing only a caller to a covariant wider reference result is safe when the
+selected target/type contract is unchanged. Changing the selected indirect or
+reference type is not safe merely because the transformed module validates: an
+old dynamic target could begin trapping on its runtime signature check.
+
+## Required workflow for signature-changing transforms
+
+Any compiler pass that changes function result signatures while retaining
+proper-tail sites must:
+
+1. retain the validated pre-transform `*wasm.Module`;
+2. construct the transformed module without mutating the retained source;
+3. call `frontend.ValidateTailResultRewriteWithFeatures(before, after, features)`
+   with the exact validation feature set used by the compile (the compatibility
+   helper `ValidateTailResultRewrite` is sufficient only for default modules);
+4. abandon the transform on any error; and
+5. run ordinary module validation and backend differential execution tests.
+
+`ValidateTailResultRewrite` performs ordinary validation itself and additionally
+checks the target-knowledge rule above. Signature comparisons include complete
+recursive/GC type graphs, not only their local type indexes. It rejects changes
+to imported, exported, or start-function signatures; changes to local functions
+that may escape through exported function-reference tables, globals, results, or
+tags; parameter rewrites; tail-site retargeting; mutable or exported tables;
+imported indirect targets; and dynamic `return_call_ref` producers.
+
+The helper is intentionally off the ordinary compile hot path. The current
+Railshot optimizations do not rewrite Wasm function signatures, so paying for a
+second body scan on every compilation would provide no additional protection.
+The first pass that introduces signature rewriting must use this fence at its
+transform boundary.
+
+## Tests and benchmarks
+
+Focused checks:
+
+```sh
+go test ./src/core/compiler/frontend -run 'TailResult' -count=1
+go test ./src/wago -run '^TestProperTail' -count=1
+```
+
+The frontend tests cover coordinated scalar, multivalue, SIMD, direct,
+immutable-indirect, and immediate-reference elimination; partial transforms;
+mutable tables; imported targets; typed-global references; recursive signature
+graph changes; exported function-reference escape surfaces; caller-only reference
+covariance; AST/byte-backed parity; and fuzz seeds.
+
+The runtime matrix executes direct, indirect, and reference proper tails across
+Balanced, Size, and Embedded objectives. Scalar, multivalue, SIMD,
+typed-global `return_call_ref`, and million-transfer frame-discard coverage run
+on amd64 and arm64 build products. The generic funcref-result egress matrix runs
+on amd64, while the transform fence's reference and recursive-GC contract tests
+remain architecture-independent.
+
+Benchmarks:
+
+```sh
+go test ./src/core/compiler/frontend -run '^$' -bench 'TailResult' -benchmem
+go test ./src/wago -run '^$' -bench '^BenchmarkProperTailResultContracts$' -benchmem
+```
+
+The frontend analysis/validation benchmarks are transform-development costs,
+not ordinary compile-path costs. Runtime benchmarks must remain allocation-free
+once the instance and export are warm.

--- a/docs/tail-result-rewrite-contracts.md
+++ b/docs/tail-result-rewrite-contracts.md
@@ -43,10 +43,11 @@ recursive/GC type graphs, not only their local type indexes. Parameter projectio
 erase only the selected root result contract: result lists of function types
 reachable through parameters remain observable. The fence rejects changes to
 imported, exported, or start-function signatures; changes to local functions that
-may escape through imported callback parameters, globals (including immutable
-references to interior-mutable host objects), tables, or tags, or through exported
-function-reference tables, globals, results, or tags; `externref` surfaces are
-conservative because externalized GC objects may carry nested function references;
+may escape through imported function parameters or results, globals (including
+immutable references to interior-mutable host objects), tables, or tags, or through
+exported function parameters or results, tables, globals, or tags; `externref`
+surfaces are conservative because externalized GC objects may carry nested
+function references in either boundary direction;
 parameter rewrites; tail-site retargeting; mutable or exported tables; imported
 indirect targets; and dynamic `return_call_ref` producers. Byte-backed scans use
 the validated module's memory32 or memory64 memarg width.

--- a/docs/tail-result-rewrite-contracts.md
+++ b/docs/tail-result-rewrite-contracts.md
@@ -39,11 +39,15 @@ proper-tail sites must:
 
 `ValidateTailResultRewrite` performs ordinary validation itself and additionally
 checks the target-knowledge rule above. Signature comparisons include complete
-recursive/GC type graphs, not only their local type indexes. It rejects changes
-to imported, exported, or start-function signatures; changes to local functions
-that may escape through exported function-reference tables, globals, results, or
-tags; parameter rewrites; tail-site retargeting; mutable or exported tables;
-imported indirect targets; and dynamic `return_call_ref` producers.
+recursive/GC type graphs, not only their local type indexes. Parameter projections
+erase only the selected root result contract: result lists of function types
+reachable through parameters remain observable. The fence rejects changes to
+imported, exported, or start-function signatures; changes to local functions that
+may escape through imported callback parameters, mutable globals, tables, or tags,
+or through exported function-reference tables, globals, results, or tags;
+parameter rewrites; tail-site retargeting; mutable or exported tables; imported
+indirect targets; and dynamic `return_call_ref` producers. Byte-backed scans use
+the validated module's memory32 or memory64 memarg width.
 
 The helper is intentionally off the ordinary compile hot path. The current
 Railshot optimizations do not rewrite Wasm function signatures, so paying for a
@@ -62,9 +66,10 @@ go test ./src/wago -run '^TestProperTail' -count=1
 
 The frontend tests cover coordinated scalar, multivalue, SIMD, direct,
 immutable-indirect, and immediate-reference elimination; partial transforms;
-mutable tables; imported targets; typed-global references; recursive signature
-graph changes; exported function-reference escape surfaces; caller-only reference
-covariance; AST/byte-backed parity; and fuzz seeds.
+mutable tables; imported targets and reference sinks; typed-global references;
+recursive signature graphs, including nested function-result changes reached from
+parameters; exported function-reference escape surfaces; caller-only reference
+covariance; memory64 byte-backed memargs; AST/byte-backed parity; and fuzz seeds.
 
 The runtime matrix executes direct, indirect, and reference proper tails across
 Balanced, Size, and Embedded objectives. Scalar, multivalue, SIMD,

--- a/docs/tail-result-rewrite-contracts.md
+++ b/docs/tail-result-rewrite-contracts.md
@@ -50,7 +50,8 @@ surfaces are conservative because externalized GC objects may carry nested
 function references in either boundary direction;
 parameter rewrites; tail-site retargeting; mutable or exported tables; imported
 indirect targets; and dynamic `return_call_ref` producers. Byte-backed scans use
-the validated module's memory32 or memory64 memarg width.
+the validated module's memory32 or memory64 memarg width and staged multi-memory
+immediate encoding.
 
 The helper is intentionally off the ordinary compile hot path. The current
 Railshot optimizations do not rewrite Wasm function signatures, so paying for a
@@ -72,7 +73,8 @@ immutable-indirect, and immediate-reference elimination; partial transforms;
 mutable tables; imported targets and reference sinks; typed-global references;
 recursive signature graphs, including nested function-result changes reached from
 parameters; exported function-reference escape surfaces; caller-only reference
-covariance; memory64 byte-backed memargs; AST/byte-backed parity; and fuzz seeds.
+covariance; memory64 memargs and multi-memory indexes in byte-backed bodies;
+AST/byte-backed parity; and fuzz seeds.
 
 The runtime matrix executes direct, indirect, and reference proper tails across
 Balanced, Size, and Embedded objectives. Scalar, multivalue, SIMD,

--- a/src/core/compiler/frontend/tail_result_contract.go
+++ b/src/core/compiler/frontend/tail_result_contract.go
@@ -1,0 +1,527 @@
+package frontend
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+// TailResultSite identifies one proper-tail result contract. Caller is a global
+// function index. Target is a global function index for return_call and a type
+// index for return_call_indirect/return_call_ref. Table is meaningful only for
+// return_call_indirect. Ordinal is the site's stable order within Caller.
+type TailResultSite struct {
+	Caller        uint32
+	Ordinal       uint32
+	Kind          wasm.InstrKind
+	Target        uint32
+	Table         uint32
+	KnownFunction uint32
+	Known         bool
+}
+
+// AnalyzeTailResultSites returns every proper-tail site in deterministic module
+// and instruction order. A return_call_ref site is marked Known only for the
+// deliberately narrow, mechanically evident ref.func-immediately-before-call
+// shape. Other reference producers remain dynamic and conservative.
+func AnalyzeTailResultSites(m *wasm.Module) ([]TailResultSite, error) {
+	if m == nil {
+		return nil, fmt.Errorf("nil module")
+	}
+	imports := m.ImportedFuncCount()
+	var sites []TailResultSite
+	for local := range m.Code {
+		caller := uint32(imports + local)
+		ordinal := uint32(0)
+		fn := &m.Code[local]
+		if len(fn.BodyBytes) != 0 {
+			if err := scanTailResultByteBody(fn.BodyBytes, caller, &ordinal, &sites, nil); err != nil {
+				return nil, fmt.Errorf("function %d tail-result scan: %w", caller, err)
+			}
+			continue
+		}
+		scanTailResultInstrs(fn.Body.Instrs, caller, &ordinal, &sites, nil)
+	}
+	return sites, nil
+}
+
+// ValidateTailResultRewrite is the post-transform fence for optimizations that
+// alter function result signatures while retaining the same proper-tail sites.
+// It validates the transformed module and then enforces the target-knowledge
+// boundary that ordinary Wasm validation cannot express:
+//   - return_call has one statically known target;
+//   - return_call_ref may change its selected result contract only when the
+//     callee is the immediately preceding ref.func in both modules;
+//   - return_call_indirect may change its selected result contract only for a
+//     private immutable local table whose complete non-null target set is known,
+//     local, unchanged, and rewritten to the selected type.
+//
+// Dynamic/imported/exported/mutable target sets fail closed. Callers may widen a
+// result contract without a target proof when the selected target/type contract
+// itself is unchanged; ValidateModule proves the resulting covariance.
+func ValidateTailResultRewrite(before, after *wasm.Module) error {
+	return ValidateTailResultRewriteWithFeatures(before, after, wasm.ValidationFeatures{})
+}
+
+// ValidateTailResultRewriteWithFeatures is ValidateTailResultRewrite under the
+// caller's exact staged validation feature set. Signature-changing transforms in
+// the production pipeline must pass through the same feature set used before the
+// transform so unrelated multi-memory or constant-expression syntax is not
+// rejected by the compatibility default.
+func ValidateTailResultRewriteWithFeatures(before, after *wasm.Module, features wasm.ValidationFeatures) error {
+	if before == nil || after == nil {
+		return fmt.Errorf("tail-result rewrite requires non-nil modules")
+	}
+	if before == after {
+		return fmt.Errorf("tail-result rewrite requires a distinct retained source module")
+	}
+	if err := wasm.ValidateModuleWithFeatures(before, features); err != nil {
+		return fmt.Errorf("tail-result rewrite source is invalid: %w", err)
+	}
+	if err := wasm.ValidateModuleWithFeatures(after, features); err != nil {
+		return fmt.Errorf("tail-result rewrite result is invalid: %w", err)
+	}
+	if before.FuncCount() != after.FuncCount() || len(before.Code) != len(after.Code) || before.ImportedFuncCount() != after.ImportedFuncCount() {
+		return fmt.Errorf("tail-result rewrite changed the function index space")
+	}
+	if err := validateObservableTailRewriteSignatures(before, after); err != nil {
+		return err
+	}
+
+	beforeSites, err := AnalyzeTailResultSites(before)
+	if err != nil {
+		return err
+	}
+	afterSites, err := AnalyzeTailResultSites(after)
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(beforeSites, afterSites) {
+		return fmt.Errorf("tail-result rewrite changed proper-tail site identity or target")
+	}
+
+	for _, site := range beforeSites {
+		if !functionParameterContractEqual(before, site.Caller, after, site.Caller) || !tailTargetParameterContractEqual(before, after, site) {
+			return fmt.Errorf("tail-result rewrite changed parameters at caller %d site %d", site.Caller, site.Ordinal)
+		}
+		// A caller-only result change is fully checked by ValidateModule when the
+		// complete selected target contract, including referenced recursive/GC
+		// type graphs, remains structurally identical.
+		if tailTargetContractEqual(before, after, site) {
+			continue
+		}
+
+		switch site.Kind {
+		case wasm.InstrReturnCall:
+			// The target is exact and after-validation checks the coordinated edge.
+			continue
+		case wasm.InstrReturnCallRef:
+			if !site.Known || site.KnownFunction < uint32(before.ImportedFuncCount()) {
+				return fmt.Errorf("return_call_ref at caller %d site %d has a dynamic or imported target", site.Caller, site.Ordinal)
+			}
+			if !functionFlowsToType(before, site.KnownFunction, site.Target) || !functionFlowsToType(after, site.KnownFunction, site.Target) {
+				return fmt.Errorf("return_call_ref at caller %d site %d did not rewrite its known target with type %d", site.Caller, site.Ordinal, site.Target)
+			}
+		case wasm.InstrReturnCallIndirect:
+			beforeTargets, ok := immutableLocalTableTargets(before, site.Table)
+			if !ok {
+				return fmt.Errorf("return_call_indirect at caller %d site %d has an unknown target set", site.Caller, site.Ordinal)
+			}
+			afterTargets, ok := immutableLocalTableTargets(after, site.Table)
+			if !ok || !slices.Equal(beforeTargets, afterTargets) {
+				return fmt.Errorf("return_call_indirect at caller %d site %d changed or lost its proven target set", site.Caller, site.Ordinal)
+			}
+			if len(beforeTargets) == 0 {
+				return fmt.Errorf("return_call_indirect at caller %d site %d has no proven non-null target", site.Caller, site.Ordinal)
+			}
+			for _, target := range beforeTargets {
+				if target < uint32(before.ImportedFuncCount()) || !functionExactlyMatchesType(before, target, site.Target) || !functionExactlyMatchesType(after, target, site.Target) {
+					return fmt.Errorf("return_call_indirect at caller %d site %d did not rewrite local target %d with type %d", site.Caller, site.Ordinal, target, site.Target)
+				}
+			}
+		default:
+			return fmt.Errorf("caller %d site %d is not a proper tail", site.Caller, site.Ordinal)
+		}
+	}
+	return nil
+}
+
+func validateObservableTailRewriteSignatures(before, after *wasm.Module) error {
+	for i := 0; i < before.ImportedFuncCount(); i++ {
+		if !functionSignatureEqual(before, uint32(i), after, uint32(i)) {
+			return fmt.Errorf("tail-result rewrite changed imported function %d", i)
+		}
+	}
+	if len(before.Exports) != len(after.Exports) {
+		return fmt.Errorf("tail-result rewrite changed exports")
+	}
+	for i := range before.Exports {
+		beforeExport, afterExport := before.Exports[i], after.Exports[i]
+		if beforeExport != afterExport {
+			return fmt.Errorf("tail-result rewrite changed export %d", i)
+		}
+		if beforeExport.Index.Kind != wasm.ExternFunc {
+			continue
+		}
+		if !functionSignatureEqual(before, beforeExport.Index.Index, after, afterExport.Index.Index) {
+			return fmt.Errorf("tail-result rewrite changed exported function %q", beforeExport.Name)
+		}
+	}
+	if (before.Start == nil) != (after.Start == nil) {
+		return fmt.Errorf("tail-result rewrite changed start function")
+	}
+	if before.Start != nil {
+		if *before.Start != *after.Start {
+			return fmt.Errorf("tail-result rewrite changed start function")
+		}
+		if !functionSignatureEqual(before, uint32(*before.Start), after, uint32(*after.Start)) {
+			return fmt.Errorf("tail-result rewrite changed start function signature")
+		}
+	}
+	if moduleExportsFunctionReferences(before) || moduleExportsFunctionReferences(after) {
+		imports := before.ImportedFuncCount()
+		for local := range before.Code {
+			function := uint32(imports + local)
+			if !functionSignatureEqual(before, function, after, function) {
+				return fmt.Errorf("tail-result rewrite changed function %d observable through exported function references", function)
+			}
+		}
+	}
+	return nil
+}
+
+func moduleExportsFunctionReferences(m *wasm.Module) bool {
+	for _, ex := range m.Exports {
+		switch ex.Index.Kind {
+		case wasm.ExternTable:
+			table, ok := m.TableType(ex.Index.Index)
+			if !ok || refTypeMayContainFunction(m, table.Ref) {
+				return true
+			}
+		case wasm.ExternGlobal:
+			global, ok := m.GlobalTypeByIndex(ex.Index.Index)
+			if !ok || valTypeMayContainFunction(m, global.Type) {
+				return true
+			}
+		case wasm.ExternFunc:
+			typeIndex, ok := m.FuncTypeIndex(ex.Index.Index)
+			if !ok || typeIndex.Rec {
+				return true
+			}
+			sig, ok := m.ResolvedTypeFunc(typeIndex.Index)
+			if !ok {
+				return true
+			}
+			for _, result := range sig.Results {
+				if valTypeMayContainFunction(m, result) {
+					return true
+				}
+			}
+		case wasm.ExternTag:
+			// An exported exception payload may carry a function reference. Tag
+			// lookup is intentionally avoided here: treating every exported tag as
+			// an escape keeps this transform-only fence conservative.
+			return true
+		}
+	}
+	return false
+}
+
+func valTypeMayContainFunction(m *wasm.Module, t wasm.ValType) bool {
+	return t.Kind() == wasm.ValRef && refTypeMayContainFunction(m, t.Ref())
+}
+
+func refTypeMayContainFunction(m *wasm.Module, ref wasm.RefType) bool {
+	heap := ref.Heap()
+	switch heap.Kind() {
+	case wasm.HeapAbs:
+		return heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc
+	case wasm.HeapTypeIndex:
+		_, ok := m.TypeFunc(heap.Type().Index)
+		return ok
+	case wasm.HeapDefType:
+		kind, ok := heap.DefCompKind()
+		return !ok || kind == wasm.CompFunc
+	default:
+		return true
+	}
+}
+
+func functionSignatureEqual(a *wasm.Module, aFunction uint32, b *wasm.Module, bFunction uint32) bool {
+	aType, ok := a.FuncTypeIndex(aFunction)
+	if !ok || aType.Rec {
+		return false
+	}
+	bType, ok := b.FuncTypeIndex(bFunction)
+	if !ok || bType.Rec {
+		return false
+	}
+	aKey, ok := a.StructuralTypeKeyChecked(aType.Index)
+	if !ok {
+		return false
+	}
+	bKey, ok := b.StructuralTypeKeyChecked(bType.Index)
+	return ok && aKey == bKey
+}
+
+func tailTargetContractEqual(before, after *wasm.Module, site TailResultSite) bool {
+	if site.Kind == wasm.InstrReturnCall {
+		return functionSignatureEqual(before, site.Target, after, site.Target)
+	}
+	beforeKey, beforeOK := before.StructuralTypeKeyChecked(site.Target)
+	afterKey, afterOK := after.StructuralTypeKeyChecked(site.Target)
+	return beforeOK && afterOK && beforeKey == afterKey
+}
+
+func functionParameterContractEqual(a *wasm.Module, aFunction uint32, b *wasm.Module, bFunction uint32) bool {
+	aType, ok := a.FuncTypeIndex(aFunction)
+	if !ok || aType.Rec {
+		return false
+	}
+	bType, ok := b.FuncTypeIndex(bFunction)
+	return ok && !bType.Rec && typeParameterContractEqual(a, aType.Index, b, bType.Index)
+}
+
+func tailTargetParameterContractEqual(before, after *wasm.Module, site TailResultSite) bool {
+	if site.Kind == wasm.InstrReturnCall {
+		return functionParameterContractEqual(before, site.Target, after, site.Target)
+	}
+	return typeParameterContractEqual(before, site.Target, after, site.Target)
+}
+
+func typeParameterContractEqual(a *wasm.Module, aType uint32, b *wasm.Module, bType uint32) bool {
+	aKey, ok := parameterOnlyTypeKey(a, aType)
+	if !ok {
+		return false
+	}
+	bKey, ok := parameterOnlyTypeKey(b, bType)
+	return ok && aKey == bKey
+}
+
+func parameterOnlyTypeKey(m *wasm.Module, typeIndex uint32) (uint64, bool) {
+	// StructuralTypeKey includes the complete recursive/GC graph. Clone only the
+	// type section and erase every function result list so the resulting key is a
+	// conservative identity for parameter contracts without touching module cache
+	// state or retaining transformed mutable storage.
+	types := make([]wasm.RecType, len(m.Types))
+	for group := range m.Types {
+		types[group] = m.Types[group]
+		types[group].SubTypes = append([]wasm.SubType(nil), m.Types[group].SubTypes...)
+		for member := range types[group].SubTypes {
+			if types[group].SubTypes[member].Comp.Kind == wasm.CompFunc {
+				types[group].SubTypes[member].Comp.Results = nil
+			}
+		}
+	}
+	projection := wasm.Module{Types: types}
+	return projection.StructuralTypeKeyChecked(typeIndex)
+}
+
+func functionExactlyMatchesType(m *wasm.Module, function, typeIndex uint32) bool {
+	declared, ok := m.FuncTypeIndex(function)
+	if !ok || declared.Rec {
+		return false
+	}
+	functionKey, ok := m.StructuralTypeKeyChecked(declared.Index)
+	if !ok {
+		return false
+	}
+	typeKey, ok := m.StructuralTypeKeyChecked(typeIndex)
+	return ok && functionKey == typeKey
+}
+
+func functionFlowsToType(m *wasm.Module, function, typeIndex uint32) bool {
+	declared, ok := m.FuncTypeIndex(function)
+	if !ok || declared.Rec {
+		return false
+	}
+	actual := wasm.Ref(false, wasm.IndexedHeap(declared), false)
+	required := wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: typeIndex}), false)
+	return m.ReferenceTypeSubtype(actual, required)
+}
+
+func scanTailResultByteBody(body []byte, caller uint32, ordinal *uint32, sites *[]TailResultSite, mutatedTables map[uint32]bool) error {
+	r := wasm.NewReader(body)
+	var previous wasm.InstructionImmediate
+	for r.HasNext() {
+		op, err := r.Byte()
+		if err != nil {
+			return err
+		}
+		var imm wasm.InstructionImmediate
+		if err := wasm.ClassifyInstructionImmediateInto(r, op, &imm); err != nil {
+			return err
+		}
+		markMutatedTable(imm.Kind, uint32(imm.Index), uint32(imm.Index2), mutatedTables)
+		if sites != nil {
+			switch imm.Kind {
+			case wasm.InstrReturnCall:
+				*sites = append(*sites, TailResultSite{Caller: caller, Ordinal: *ordinal, Kind: imm.Kind, Target: uint32(imm.Index), Known: true, KnownFunction: uint32(imm.Index)})
+				(*ordinal)++
+			case wasm.InstrReturnCallIndirect:
+				*sites = append(*sites, TailResultSite{Caller: caller, Ordinal: *ordinal, Kind: imm.Kind, Target: uint32(imm.Index), Table: uint32(imm.Index2)})
+				(*ordinal)++
+			case wasm.InstrReturnCallRef:
+				site := TailResultSite{Caller: caller, Ordinal: *ordinal, Kind: imm.Kind, Target: uint32(imm.Index)}
+				if previous.Kind == wasm.InstrRefFunc {
+					site.Known = true
+					site.KnownFunction = uint32(previous.Index)
+				}
+				*sites = append(*sites, site)
+				(*ordinal)++
+			}
+		}
+		previous = imm
+	}
+	return nil
+}
+
+func scanTailResultInstrs(instrs []wasm.Instruction, caller uint32, ordinal *uint32, sites *[]TailResultSite, mutatedTables map[uint32]bool) {
+	var previous wasm.Instruction
+	for i := range instrs {
+		in := instrs[i]
+		markMutatedTable(in.Kind, in.Index, in.Index2, mutatedTables)
+		if sites != nil {
+			switch in.Kind {
+			case wasm.InstrReturnCall:
+				*sites = append(*sites, TailResultSite{Caller: caller, Ordinal: *ordinal, Kind: in.Kind, Target: in.Index, Known: true, KnownFunction: in.Index})
+				(*ordinal)++
+			case wasm.InstrReturnCallIndirect:
+				*sites = append(*sites, TailResultSite{Caller: caller, Ordinal: *ordinal, Kind: in.Kind, Target: in.Index, Table: in.Index2})
+				(*ordinal)++
+			case wasm.InstrReturnCallRef:
+				site := TailResultSite{Caller: caller, Ordinal: *ordinal, Kind: in.Kind, Target: in.Index}
+				if previous.Kind == wasm.InstrRefFunc {
+					site.Known = true
+					site.KnownFunction = previous.Index
+				}
+				*sites = append(*sites, site)
+				(*ordinal)++
+			}
+		}
+		scanTailResultInstrs(in.Body().Instrs, caller, ordinal, sites, mutatedTables)
+		scanTailResultInstrs(in.Then(), caller, ordinal, sites, mutatedTables)
+		scanTailResultInstrs(in.Else(), caller, ordinal, sites, mutatedTables)
+		previous = in
+	}
+}
+
+func markMutatedTable(kind wasm.InstrKind, index, index2 uint32, mutated map[uint32]bool) {
+	if mutated == nil {
+		return
+	}
+	switch kind {
+	case wasm.InstrTableSet, wasm.InstrTableGrow, wasm.InstrTableFill:
+		mutated[index] = true
+	case wasm.InstrTableInit:
+		mutated[index2] = true
+	case wasm.InstrTableCopy:
+		// Conservatively treat both tables as mutable; one is the destination and
+		// rejecting the source as well keeps the proof independent of immediate
+		// field naming conventions.
+		mutated[index] = true
+		mutated[index2] = true
+	}
+}
+
+func immutableLocalTableTargets(m *wasm.Module, table uint32) ([]uint32, bool) {
+	imports := uint32(m.ImportedTableCount())
+	if table < imports || int(table) >= m.TableCount() {
+		return nil, false
+	}
+	for _, ex := range m.Exports {
+		if ex.Index.Kind == wasm.ExternTable && ex.Index.Index == table {
+			return nil, false
+		}
+	}
+	mutated := make(map[uint32]bool)
+	for i := range m.Code {
+		fn := &m.Code[i]
+		ordinal := uint32(0)
+		if len(fn.BodyBytes) != 0 {
+			if err := scanTailResultByteBody(fn.BodyBytes, uint32(m.ImportedFuncCount()+i), &ordinal, nil, mutated); err != nil {
+				return nil, false
+			}
+		} else {
+			scanTailResultInstrs(fn.Body.Instrs, uint32(m.ImportedFuncCount()+i), &ordinal, nil, mutated)
+		}
+	}
+	if mutated[table] {
+		return nil, false
+	}
+
+	seen := make(map[uint32]struct{})
+	add := func(index uint32) { seen[index] = struct{}{} }
+	localTable := int(table - imports)
+	if localTable < 0 || localTable >= len(m.Tables) {
+		return nil, false
+	}
+	if init := m.Tables[localTable].Init; init != nil {
+		if !collectConstRefFuncs(*init, add) {
+			return nil, false
+		}
+	}
+	for i := range m.Elements {
+		elem := &m.Elements[i]
+		if elem.Mode.Kind != wasm.ElemActive || uint32(elem.Mode.Table) != table {
+			continue
+		}
+		if elem.Kind.Kind == wasm.ElemFuncs {
+			for _, index := range elem.Kind.Funcs {
+				add(uint32(index))
+			}
+			continue
+		}
+		for _, expr := range elem.Kind.Exprs {
+			if !collectConstRefFuncs(expr, add) {
+				return nil, false
+			}
+		}
+	}
+	targets := make([]uint32, 0, len(seen))
+	for target := range seen {
+		targets = append(targets, target)
+	}
+	slices.Sort(targets)
+	return targets, true
+}
+
+func collectConstRefFuncs(expr wasm.Expr, add func(uint32)) bool {
+	if len(expr.BodyBytes) == 0 {
+		for i := range expr.Instrs {
+			switch expr.Instrs[i].Kind {
+			case wasm.InstrRefFunc:
+				add(expr.Instrs[i].Index)
+			case wasm.InstrRefNull:
+			default:
+				// Imported global.get and future reference-producing constant
+				// instructions make the target identity dynamic.
+				return false
+			}
+		}
+		return true
+	}
+	r := wasm.NewReader(expr.BodyBytes)
+	for r.HasNext() {
+		op, err := r.Byte()
+		if err != nil {
+			return false
+		}
+		if op == 0x0b {
+			return r.BytesLeft() == 0
+		}
+		var imm wasm.InstructionImmediate
+		if wasm.ClassifyInstructionImmediateInto(r, op, &imm) != nil {
+			return false
+		}
+		switch imm.Kind {
+		case wasm.InstrRefFunc:
+			add(uint32(imm.Index))
+		case wasm.InstrRefNull:
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/src/core/compiler/frontend/tail_result_contract.go
+++ b/src/core/compiler/frontend/tail_result_contract.go
@@ -224,13 +224,8 @@ func moduleImportsFunctionReferences(m *wasm.Module) bool {
 				return true
 			}
 			sig, ok := m.ResolvedTypeFunc(typeIndex.Index)
-			if !ok {
+			if !ok || functionBoundaryMayContainReferences(m, sig) {
 				return true
-			}
-			for _, param := range sig.Params {
-				if valTypeMayContainFunction(m, param) {
-					return true
-				}
 			}
 		case wasm.ExternTag:
 			// Imported exception tags are host-owned payload sinks. Treat every
@@ -261,19 +256,25 @@ func moduleExportsFunctionReferences(m *wasm.Module) bool {
 				return true
 			}
 			sig, ok := m.ResolvedTypeFunc(typeIndex.Index)
-			if !ok {
+			if !ok || functionBoundaryMayContainReferences(m, sig) {
 				return true
-			}
-			for _, result := range sig.Results {
-				if valTypeMayContainFunction(m, result) {
-					return true
-				}
 			}
 		case wasm.ExternTag:
 			// An exported exception payload may carry a function reference. Tag
 			// lookup is intentionally avoided here: treating every exported tag as
 			// an escape keeps this transform-only fence conservative.
 			return true
+		}
+	}
+	return false
+}
+
+func functionBoundaryMayContainReferences(m *wasm.Module, sig *wasm.CompType) bool {
+	for _, values := range [][]wasm.ValType{sig.Params, sig.Results} {
+		for _, value := range values {
+			if valTypeMayContainFunction(m, value) {
+				return true
+			}
 		}
 	}
 	return false

--- a/src/core/compiler/frontend/tail_result_contract.go
+++ b/src/core/compiler/frontend/tail_result_contract.go
@@ -30,13 +30,14 @@ func AnalyzeTailResultSites(m *wasm.Module) ([]TailResultSite, error) {
 		return nil, fmt.Errorf("nil module")
 	}
 	imports := m.ImportedFuncCount()
+	memarg64 := moduleMemargOffset64(m)
 	var sites []TailResultSite
 	for local := range m.Code {
 		caller := uint32(imports + local)
 		ordinal := uint32(0)
 		fn := &m.Code[local]
 		if len(fn.BodyBytes) != 0 {
-			if err := scanTailResultByteBody(fn.BodyBytes, caller, &ordinal, &sites, nil); err != nil {
+			if err := scanTailResultByteBody(fn.BodyBytes, caller, &ordinal, &sites, nil, memarg64); err != nil {
 				return nil, fmt.Errorf("function %d tail-result scan: %w", caller, err)
 			}
 			continue
@@ -179,6 +180,15 @@ func validateObservableTailRewriteSignatures(before, after *wasm.Module) error {
 			return fmt.Errorf("tail-result rewrite changed start function signature")
 		}
 	}
+	if moduleImportsFunctionReferences(before) || moduleImportsFunctionReferences(after) {
+		imports := before.ImportedFuncCount()
+		for local := range before.Code {
+			function := uint32(imports + local)
+			if !functionSignatureEqual(before, function, after, function) {
+				return fmt.Errorf("tail-result rewrite changed function %d observable through imported function references", function)
+			}
+		}
+	}
 	if moduleExportsFunctionReferences(before) || moduleExportsFunctionReferences(after) {
 		imports := before.ImportedFuncCount()
 		for local := range before.Code {
@@ -189,6 +199,43 @@ func validateObservableTailRewriteSignatures(before, after *wasm.Module) error {
 		}
 	}
 	return nil
+}
+
+func moduleImportsFunctionReferences(m *wasm.Module) bool {
+	for i := range m.Imports {
+		im := m.Imports[i].Type
+		switch im.Kind {
+		case wasm.ExternTable:
+			if refTypeMayContainFunction(m, im.TableType().Ref) {
+				return true
+			}
+		case wasm.ExternGlobal:
+			global := im.GlobalType()
+			if global.Mutable && valTypeMayContainFunction(m, global.Type) {
+				return true
+			}
+		case wasm.ExternFunc:
+			typeIndex := im.FuncType()
+			if typeIndex.Rec {
+				return true
+			}
+			sig, ok := m.ResolvedTypeFunc(typeIndex.Index)
+			if !ok {
+				return true
+			}
+			for _, param := range sig.Params {
+				if valTypeMayContainFunction(m, param) {
+					return true
+				}
+			}
+		case wasm.ExternTag:
+			// Imported exception tags are host-owned payload sinks. Treat every
+			// imported tag as observable rather than depending on payload flow
+			// analysis in this transform-only fence.
+			return true
+		}
+	}
+	return false
 }
 
 func moduleExportsFunctionReferences(m *wasm.Module) bool {
@@ -232,17 +279,23 @@ func valTypeMayContainFunction(m *wasm.Module, t wasm.ValType) bool {
 	return t.Kind() == wasm.ValRef && refTypeMayContainFunction(m, t.Ref())
 }
 
-func refTypeMayContainFunction(m *wasm.Module, ref wasm.RefType) bool {
+func refTypeMayContainFunction(_ *wasm.Module, ref wasm.RefType) bool {
 	heap := ref.Heap()
 	switch heap.Kind() {
 	case wasm.HeapAbs:
-		return heap.Abs() == wasm.HeapFunc || heap.Abs() == wasm.HeapNoFunc
-	case wasm.HeapTypeIndex:
-		_, ok := m.TypeFunc(heap.Type().Index)
-		return ok
-	case wasm.HeapDefType:
-		kind, ok := heap.DefCompKind()
-		return !ok || kind == wasm.CompFunc
+		switch heap.Abs() {
+		case wasm.HeapFunc, wasm.HeapNoFunc, wasm.HeapAny, wasm.HeapEq, wasm.HeapStruct, wasm.HeapArray, wasm.HeapExn:
+			return true
+		default:
+			return false
+		}
+	case wasm.HeapTypeIndex, wasm.HeapDefType:
+		// A defined function is directly callable, while a defined struct or
+		// array may carry a function reference in a nested field. Proving the
+		// absence of such fields would require whole-value flow analysis, so the
+		// transform fence deliberately treats every defined reference as capable
+		// of carrying an observable function.
+		return true
 	default:
 		return true
 	}
@@ -299,23 +352,51 @@ func typeParameterContractEqual(a *wasm.Module, aType uint32, b *wasm.Module, bT
 	return ok && aKey == bKey
 }
 
-func parameterOnlyTypeKey(m *wasm.Module, typeIndex uint32) (uint64, bool) {
-	// StructuralTypeKey includes the complete recursive/GC graph. Clone only the
-	// type section and erase every function result list so the resulting key is a
-	// conservative identity for parameter contracts without touching module cache
-	// state or retaining transformed mutable storage.
+type parameterContractKey struct {
+	root   uint64
+	nested uint64
+}
+
+func parameterOnlyTypeKey(m *wasm.Module, typeIndex uint32) (parameterContractKey, bool) {
+	// The root projection preserves subtype metadata and the complete parameter
+	// graph while erasing function results. It intentionally erases every result
+	// list so a coordinated root result rewrite does not perturb recursive-group
+	// digests through an unrelated sibling.
 	types := make([]wasm.RecType, len(m.Types))
+	flatCount := uint32(0)
 	for group := range m.Types {
 		types[group] = m.Types[group]
 		types[group].SubTypes = append([]wasm.SubType(nil), m.Types[group].SubTypes...)
+		flatCount += uint32(len(types[group].SubTypes))
 		for member := range types[group].SubTypes {
 			if types[group].SubTypes[member].Comp.Kind == wasm.CompFunc {
 				types[group].SubTypes[member].Comp.Results = nil
 			}
 		}
 	}
-	projection := wasm.Module{Types: types}
-	return projection.StructuralTypeKeyChecked(typeIndex)
+	rootProjection := wasm.Module{Types: types}
+	rootKey, ok := rootProjection.StructuralTypeKeyChecked(typeIndex)
+	if !ok {
+		return parameterContractKey{}, false
+	}
+
+	// A synthetic result-less wrapper points at the original, unmodified type
+	// graph. This keeps result lists of function types reachable from parameters
+	// observable, including a recursive reference back to the selected root.
+	// Moving the wrapper to a fresh group requires flattened parameter indexes.
+	sig, ok := m.ResolvedTypeFunc(typeIndex)
+	if !ok {
+		return parameterContractKey{}, false
+	}
+	wrapper := wasm.SubType{Final: true, Comp: wasm.CompType{
+		Kind:   wasm.CompFunc,
+		Params: append([]wasm.ValType(nil), sig.Params...),
+	}}
+	fullTypes := append([]wasm.RecType(nil), m.Types...)
+	fullTypes = append(fullTypes, wasm.RecType{SubTypes: []wasm.SubType{wrapper}})
+	nestedProjection := wasm.Module{Types: fullTypes}
+	nestedKey, ok := nestedProjection.StructuralTypeKeyChecked(flatCount)
+	return parameterContractKey{root: rootKey, nested: nestedKey}, ok
 }
 
 func functionExactlyMatchesType(m *wasm.Module, function, typeIndex uint32) bool {
@@ -341,7 +422,7 @@ func functionFlowsToType(m *wasm.Module, function, typeIndex uint32) bool {
 	return m.ReferenceTypeSubtype(actual, required)
 }
 
-func scanTailResultByteBody(body []byte, caller uint32, ordinal *uint32, sites *[]TailResultSite, mutatedTables map[uint32]bool) error {
+func scanTailResultByteBody(body []byte, caller uint32, ordinal *uint32, sites *[]TailResultSite, mutatedTables map[uint32]bool, memarg64 bool) error {
 	r := wasm.NewReader(body)
 	var previous wasm.InstructionImmediate
 	for r.HasNext() {
@@ -350,7 +431,7 @@ func scanTailResultByteBody(body []byte, caller uint32, ordinal *uint32, sites *
 			return err
 		}
 		var imm wasm.InstructionImmediate
-		if err := wasm.ClassifyInstructionImmediateInto(r, op, &imm); err != nil {
+		if err := wasm.ClassifyInstructionImmediateIntoWithMemarg64(r, op, &imm, memarg64); err != nil {
 			return err
 		}
 		markMutatedTable(imm.Kind, uint32(imm.Index), uint32(imm.Index2), mutatedTables)
@@ -436,11 +517,12 @@ func immutableLocalTableTargets(m *wasm.Module, table uint32) ([]uint32, bool) {
 		}
 	}
 	mutated := make(map[uint32]bool)
+	memarg64 := moduleMemargOffset64(m)
 	for i := range m.Code {
 		fn := &m.Code[i]
 		ordinal := uint32(0)
 		if len(fn.BodyBytes) != 0 {
-			if err := scanTailResultByteBody(fn.BodyBytes, uint32(m.ImportedFuncCount()+i), &ordinal, nil, mutated); err != nil {
+			if err := scanTailResultByteBody(fn.BodyBytes, uint32(m.ImportedFuncCount()+i), &ordinal, nil, mutated, memarg64); err != nil {
 				return nil, false
 			}
 		} else {
@@ -485,6 +567,14 @@ func immutableLocalTableTargets(m *wasm.Module, table uint32) ([]uint32, bool) {
 	}
 	slices.Sort(targets)
 	return targets, true
+}
+
+func moduleMemargOffset64(m *wasm.Module) bool {
+	if m == nil || m.MemCount() != 1 {
+		return false
+	}
+	memory, ok := m.MemoryType(0)
+	return ok && memory.Limits.Addr64
 }
 
 func collectConstRefFuncs(expr wasm.Expr, add func(uint32)) bool {

--- a/src/core/compiler/frontend/tail_result_contract.go
+++ b/src/core/compiler/frontend/tail_result_contract.go
@@ -210,8 +210,12 @@ func moduleImportsFunctionReferences(m *wasm.Module) bool {
 				return true
 			}
 		case wasm.ExternGlobal:
-			global := im.GlobalType()
-			if global.Mutable && valTypeMayContainFunction(m, global.Type) {
+			// Even an immutable imported reference may name a host-owned GC object
+			// with mutable fields into which this module can store a local function.
+			// Scalar immutable funcrefs are harmless by themselves, but separating
+			// them from interior-mutable and externalized values requires flow and
+			// heap-shape analysis; fail closed for every function-capable reference.
+			if valTypeMayContainFunction(m, im.GlobalType().Type) {
 				return true
 			}
 		case wasm.ExternFunc:
@@ -284,7 +288,7 @@ func refTypeMayContainFunction(_ *wasm.Module, ref wasm.RefType) bool {
 	switch heap.Kind() {
 	case wasm.HeapAbs:
 		switch heap.Abs() {
-		case wasm.HeapFunc, wasm.HeapNoFunc, wasm.HeapAny, wasm.HeapEq, wasm.HeapStruct, wasm.HeapArray, wasm.HeapExn:
+		case wasm.HeapFunc, wasm.HeapNoFunc, wasm.HeapExtern, wasm.HeapNoExtern, wasm.HeapAny, wasm.HeapEq, wasm.HeapStruct, wasm.HeapArray, wasm.HeapExn:
 			return true
 		default:
 			return false

--- a/src/core/compiler/frontend/tail_result_contract.go
+++ b/src/core/compiler/frontend/tail_result_contract.go
@@ -26,6 +26,10 @@ type TailResultSite struct {
 // deliberately narrow, mechanically evident ref.func-immediately-before-call
 // shape. Other reference producers remain dynamic and conservative.
 func AnalyzeTailResultSites(m *wasm.Module) ([]TailResultSite, error) {
+	return analyzeTailResultSitesWithFeatures(m, wasm.ValidationFeatures{})
+}
+
+func analyzeTailResultSitesWithFeatures(m *wasm.Module, features wasm.ValidationFeatures) ([]TailResultSite, error) {
 	if m == nil {
 		return nil, fmt.Errorf("nil module")
 	}
@@ -37,7 +41,7 @@ func AnalyzeTailResultSites(m *wasm.Module) ([]TailResultSite, error) {
 		ordinal := uint32(0)
 		fn := &m.Code[local]
 		if len(fn.BodyBytes) != 0 {
-			if err := scanTailResultByteBody(fn.BodyBytes, caller, &ordinal, &sites, nil, memarg64); err != nil {
+			if err := scanTailResultByteBody(fn.BodyBytes, caller, &ordinal, &sites, nil, memarg64, features.MultiMemory); err != nil {
 				return nil, fmt.Errorf("function %d tail-result scan: %w", caller, err)
 			}
 			continue
@@ -90,11 +94,11 @@ func ValidateTailResultRewriteWithFeatures(before, after *wasm.Module, features 
 		return err
 	}
 
-	beforeSites, err := AnalyzeTailResultSites(before)
+	beforeSites, err := analyzeTailResultSitesWithFeatures(before, features)
 	if err != nil {
 		return err
 	}
-	afterSites, err := AnalyzeTailResultSites(after)
+	afterSites, err := analyzeTailResultSitesWithFeatures(after, features)
 	if err != nil {
 		return err
 	}
@@ -125,11 +129,11 @@ func ValidateTailResultRewriteWithFeatures(before, after *wasm.Module, features 
 				return fmt.Errorf("return_call_ref at caller %d site %d did not rewrite its known target with type %d", site.Caller, site.Ordinal, site.Target)
 			}
 		case wasm.InstrReturnCallIndirect:
-			beforeTargets, ok := immutableLocalTableTargets(before, site.Table)
+			beforeTargets, ok := immutableLocalTableTargets(before, site.Table, features.MultiMemory)
 			if !ok {
 				return fmt.Errorf("return_call_indirect at caller %d site %d has an unknown target set", site.Caller, site.Ordinal)
 			}
-			afterTargets, ok := immutableLocalTableTargets(after, site.Table)
+			afterTargets, ok := immutableLocalTableTargets(after, site.Table, features.MultiMemory)
 			if !ok || !slices.Equal(beforeTargets, afterTargets) {
 				return fmt.Errorf("return_call_indirect at caller %d site %d changed or lost its proven target set", site.Caller, site.Ordinal)
 			}
@@ -427,7 +431,7 @@ func functionFlowsToType(m *wasm.Module, function, typeIndex uint32) bool {
 	return m.ReferenceTypeSubtype(actual, required)
 }
 
-func scanTailResultByteBody(body []byte, caller uint32, ordinal *uint32, sites *[]TailResultSite, mutatedTables map[uint32]bool, memarg64 bool) error {
+func scanTailResultByteBody(body []byte, caller uint32, ordinal *uint32, sites *[]TailResultSite, mutatedTables map[uint32]bool, memarg64, multiMemory bool) error {
 	r := wasm.NewReader(body)
 	var previous wasm.InstructionImmediate
 	for r.HasNext() {
@@ -436,7 +440,7 @@ func scanTailResultByteBody(body []byte, caller uint32, ordinal *uint32, sites *
 			return err
 		}
 		var imm wasm.InstructionImmediate
-		if err := wasm.ClassifyInstructionImmediateIntoWithMemarg64(r, op, &imm, memarg64); err != nil {
+		if err := wasm.ClassifyInstructionImmediateIntoWithFeatures(r, op, &imm, memarg64, multiMemory); err != nil {
 			return err
 		}
 		markMutatedTable(imm.Kind, uint32(imm.Index), uint32(imm.Index2), mutatedTables)
@@ -511,7 +515,7 @@ func markMutatedTable(kind wasm.InstrKind, index, index2 uint32, mutated map[uin
 	}
 }
 
-func immutableLocalTableTargets(m *wasm.Module, table uint32) ([]uint32, bool) {
+func immutableLocalTableTargets(m *wasm.Module, table uint32, multiMemory bool) ([]uint32, bool) {
 	imports := uint32(m.ImportedTableCount())
 	if table < imports || int(table) >= m.TableCount() {
 		return nil, false
@@ -527,7 +531,7 @@ func immutableLocalTableTargets(m *wasm.Module, table uint32) ([]uint32, bool) {
 		fn := &m.Code[i]
 		ordinal := uint32(0)
 		if len(fn.BodyBytes) != 0 {
-			if err := scanTailResultByteBody(fn.BodyBytes, uint32(m.ImportedFuncCount()+i), &ordinal, nil, mutated, memarg64); err != nil {
+			if err := scanTailResultByteBody(fn.BodyBytes, uint32(m.ImportedFuncCount()+i), &ordinal, nil, mutated, memarg64, multiMemory); err != nil {
 				return nil, false
 			}
 		} else {

--- a/src/core/compiler/frontend/tail_result_contract_test.go
+++ b/src/core/compiler/frontend/tail_result_contract_test.go
@@ -223,6 +223,26 @@ func importedCallbackSinkTailModule(results []wasm.ValType) *wasm.Module {
 	}
 }
 
+func importedReferenceCallbackTailModule(param wasm.ValType, results []wasm.ValType) *wasm.Module {
+	targetBody := []wasm.Instruction{}
+	if len(results) != 0 {
+		targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrI32Const})
+	}
+	return &wasm.Module{
+		Types: []wasm.RecType{
+			tailResultFuncType([]wasm.ValType{param}, nil),
+			tailResultFuncType(nil, results),
+			tailResultFuncType(nil, results),
+		},
+		Imports:   []wasm.Import{{Module: "env", Name: "callback", Type: wasm.NewFuncExternType(wasm.TypeIdx{Index: 0})}},
+		FuncTypes: []wasm.TypeIdx{{Index: 1}, {Index: 2}},
+		Code: []wasm.Func{
+			{Body: wasm.Expr{Instrs: targetBody}},
+			{Body: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrReturnCall, Index: 1}}}},
+		},
+	}
+}
+
 func TestValidateTailResultRewriteAllowsCoordinatedKnownTargets(t *testing.T) {
 	shapes := []struct {
 		name    string
@@ -410,6 +430,32 @@ func TestValidateTailResultRewriteRejectsImportedReferenceSinks(t *testing.T) {
 		after := importedCallbackSinkTailModule(nil)
 		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through imported function references") {
 			t.Fatalf("imported callback rewrite error = %v", err)
+		}
+	})
+
+	t.Run("immutable defined-reference global", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule(nil)
+		for _, m := range []*wasm.Module{before, after} {
+			m.Types = append(m.Types, wasm.RecType{SubTypes: []wasm.SubType{{Final: true, Comp: wasm.CompType{
+				Kind: wasm.CompStruct,
+				Fields: []wasm.FieldType{
+					wasm.NewFieldType(wasm.StorageVal(wasm.FuncRef), wasm.Var),
+				},
+			}}}})
+			object := wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: 2}), false))
+			m.Imports = []wasm.Import{{Module: "env", Name: "object", Type: wasm.NewGlobalExternType(wasm.GlobalType{Type: object})}}
+		}
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through imported function references") {
+			t.Fatalf("immutable imported object rewrite error = %v", err)
+		}
+	})
+
+	t.Run("externref callback", func(t *testing.T) {
+		before := importedReferenceCallbackTailModule(wasm.ExternRef, []wasm.ValType{wasm.I32})
+		after := importedReferenceCallbackTailModule(wasm.ExternRef, nil)
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through imported function references") {
+			t.Fatalf("externref callback rewrite error = %v", err)
 		}
 	})
 }

--- a/src/core/compiler/frontend/tail_result_contract_test.go
+++ b/src/core/compiler/frontend/tail_result_contract_test.go
@@ -182,6 +182,47 @@ func recursiveParameterTailModule(field wasm.ValType, results []wasm.ValType) *w
 	}
 }
 
+func nestedFunctionParameterTailModule(callbackResults, tailResults []wasm.ValType) *wasm.Module {
+	callback := wasm.RefVal(wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: 0}), false))
+	targetBody := []wasm.Instruction{}
+	if len(tailResults) != 0 {
+		targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrI32Const})
+	}
+	return &wasm.Module{
+		Types: []wasm.RecType{
+			tailResultFuncType(nil, callbackResults),
+			tailResultFuncType([]wasm.ValType{callback}, tailResults),
+			tailResultFuncType([]wasm.ValType{callback}, tailResults),
+		},
+		FuncTypes: []wasm.TypeIdx{{Index: 1}, {Index: 2}},
+		Code: []wasm.Func{
+			{Body: wasm.Expr{Instrs: targetBody}},
+			{Body: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrLocalGet, Index: 0}, {Kind: wasm.InstrReturnCall, Index: 0}}}},
+		},
+	}
+}
+
+func importedCallbackSinkTailModule(results []wasm.ValType) *wasm.Module {
+	targetBody := []wasm.Instruction{{Kind: wasm.InstrRefFunc, Index: 1}, {Kind: wasm.InstrCall, Index: 0}}
+	if len(results) != 0 {
+		targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrI32Const})
+	}
+	return &wasm.Module{
+		Types: []wasm.RecType{
+			tailResultFuncType([]wasm.ValType{wasm.FuncRef}, nil),
+			tailResultFuncType(nil, results),
+			tailResultFuncType(nil, results),
+		},
+		Imports:   []wasm.Import{{Module: "env", Name: "callback", Type: wasm.NewFuncExternType(wasm.TypeIdx{Index: 0})}},
+		FuncTypes: []wasm.TypeIdx{{Index: 1}, {Index: 2}},
+		Elements:  []wasm.Elem{{Mode: wasm.ElemMode{Kind: wasm.ElemDeclarative}, Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{1}}}},
+		Code: []wasm.Func{
+			{Body: wasm.Expr{Instrs: targetBody}},
+			{Body: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrReturnCall, Index: 1}}}},
+		},
+	}
+}
+
 func TestValidateTailResultRewriteAllowsCoordinatedKnownTargets(t *testing.T) {
 	shapes := []struct {
 		name    string
@@ -325,6 +366,52 @@ func TestValidateTailResultRewriteRejectsPartialAndAdversarialTransforms(t *test
 			t.Fatalf("parameter rewrite error = %v", err)
 		}
 	})
+
+	t.Run("nested function parameter results changed", func(t *testing.T) {
+		before := nestedFunctionParameterTailModule([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+		after := nestedFunctionParameterTailModule(nil, nil)
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "changed parameters") {
+			t.Fatalf("nested function parameter rewrite error = %v", err)
+		}
+	})
+}
+
+func TestValidateTailResultRewriteRejectsImportedReferenceSinks(t *testing.T) {
+	t.Run("table", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule(nil)
+		for _, m := range []*wasm.Module{before, after} {
+			m.Imports = []wasm.Import{{Module: "env", Name: "functions", Type: wasm.NewTableExternType(wasm.TableType{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1}})}}
+			m.Elements = []wasm.Elem{{
+				Mode: wasm.ElemMode{Kind: wasm.ElemActive, Table: 0, Offset: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrI32Const}}}},
+				Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0}},
+			}}
+		}
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through imported function references") {
+			t.Fatalf("imported table rewrite error = %v", err)
+		}
+	})
+
+	t.Run("mutable global", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule(nil)
+		for _, m := range []*wasm.Module{before, after} {
+			m.Imports = []wasm.Import{{Module: "env", Name: "callback", Type: wasm.NewGlobalExternType(wasm.GlobalType{Type: wasm.FuncRef, Mutable: true})}}
+			m.Elements = []wasm.Elem{{Mode: wasm.ElemMode{Kind: wasm.ElemDeclarative}, Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0}}}}
+			m.Code[0].Body.Instrs = append([]wasm.Instruction{{Kind: wasm.InstrRefFunc, Index: 0}, {Kind: wasm.InstrGlobalSet, Index: 0}}, m.Code[0].Body.Instrs...)
+		}
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through imported function references") {
+			t.Fatalf("imported mutable global rewrite error = %v", err)
+		}
+	})
+
+	t.Run("callback parameter", func(t *testing.T) {
+		before := importedCallbackSinkTailModule([]wasm.ValType{wasm.I32})
+		after := importedCallbackSinkTailModule(nil)
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through imported function references") {
+			t.Fatalf("imported callback rewrite error = %v", err)
+		}
+	})
 }
 
 func TestAnalyzeTailResultSitesMatchesASTAndByteBackedBodies(t *testing.T) {
@@ -351,16 +438,40 @@ func TestAnalyzeTailResultSitesMatchesASTAndByteBackedBodies(t *testing.T) {
 }
 
 func TestValidateTailResultRewriteUsesExactValidationFeatures(t *testing.T) {
-	before := directTailRewriteModule([]wasm.ValType{wasm.I32})
-	after := directTailRewriteModule(nil)
-	before.Memories = []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1}}}
-	after.Memories = []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1}}}
-	if err := ValidateTailResultRewrite(before, after); err == nil {
-		t.Fatal("compatibility validation unexpectedly accepted multi-memory rewrite")
-	}
-	if err := ValidateTailResultRewriteWithFeatures(before, after, wasm.ValidationFeatures{MultiMemory: true}); err != nil {
-		t.Fatalf("multi-memory result rewrite: %v", err)
-	}
+	t.Run("multi-memory", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule(nil)
+		before.Memories = []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1}}}
+		after.Memories = []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1}}}
+		if err := ValidateTailResultRewrite(before, after); err == nil {
+			t.Fatal("compatibility validation unexpectedly accepted multi-memory rewrite")
+		}
+		if err := ValidateTailResultRewriteWithFeatures(before, after, wasm.ValidationFeatures{MultiMemory: true}); err != nil {
+			t.Fatalf("multi-memory result rewrite: %v", err)
+		}
+	})
+
+	t.Run("memory64 byte-backed memarg", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule(nil)
+		for _, m := range []*wasm.Module{before, after} {
+			m.Memories = []wasm.MemType{{Limits: wasm.Limits{Min: 1, Addr64: true}}}
+			m.Code[0].Body.Instrs = nil
+			m.Code[1].Body.Instrs = nil
+			m.Code[1].BodyBytes = []byte{
+				0x42, 0x00, // i64.const 0
+				0x28, 0x02, 0x80, 0x80, 0x80, 0x80, 0x10, // i32.load align=2 offset=2^32
+				0x1a,       // drop
+				0x12, 0x00, // return_call 0
+				0x0b,
+			}
+		}
+		before.Code[0].BodyBytes = []byte{0x41, 0x00, 0x0b}
+		after.Code[0].BodyBytes = []byte{0x0b}
+		if err := ValidateTailResultRewrite(before, after); err != nil {
+			t.Fatalf("memory64 result rewrite: %v", err)
+		}
+	})
 }
 
 func TestValidateTailResultRewriteCallerOnlyCovarianceNeedsNoDynamicProof(t *testing.T) {

--- a/src/core/compiler/frontend/tail_result_contract_test.go
+++ b/src/core/compiler/frontend/tail_result_contract_test.go
@@ -517,6 +517,26 @@ func TestValidateTailResultRewriteUsesExactValidationFeatures(t *testing.T) {
 		if err := ValidateTailResultRewriteWithFeatures(before, after, wasm.ValidationFeatures{MultiMemory: true}); err != nil {
 			t.Fatalf("multi-memory result rewrite: %v", err)
 		}
+
+		before = indirectTailRewriteModule([]wasm.ValType{wasm.I32}, false)
+		after = indirectTailRewriteModule(nil, false)
+		for _, m := range []*wasm.Module{before, after} {
+			m.Memories = []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1}}}
+			m.Code[0].Body.Instrs = nil
+			m.Code[1].Body.Instrs = nil
+			m.Code[1].BodyBytes = []byte{
+				0x3f, 0x01, // memory.size 1
+				0x1a,       // drop
+				0x41, 0x00, // i32.const 0
+				0x13, 0x00, 0x00, // return_call_indirect type 0 table 0
+				0x0b,
+			}
+		}
+		before.Code[0].BodyBytes = []byte{0x41, 0x00, 0x0b}
+		after.Code[0].BodyBytes = []byte{0x0b}
+		if err := ValidateTailResultRewriteWithFeatures(before, after, wasm.ValidationFeatures{MultiMemory: true}); err != nil {
+			t.Fatalf("byte-backed multi-memory result rewrite: %v", err)
+		}
 	})
 
 	t.Run("memory64 byte-backed memarg", func(t *testing.T) {

--- a/src/core/compiler/frontend/tail_result_contract_test.go
+++ b/src/core/compiler/frontend/tail_result_contract_test.go
@@ -1,0 +1,472 @@
+package frontend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func tailResultFuncType(params, results []wasm.ValType) wasm.RecType {
+	return wasm.RecType{SubTypes: []wasm.SubType{{Final: true, Comp: wasm.CompType{Kind: wasm.CompFunc, Params: params, Results: results}}}}
+}
+
+func directTailRewriteModule(results []wasm.ValType) *wasm.Module {
+	targetBody := []wasm.Instruction{}
+	hasReferenceResult := false
+	for _, result := range results {
+		switch {
+		case wasm.EqualValType(result, wasm.I32):
+			targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrI32Const})
+		case wasm.EqualValType(result, wasm.I64):
+			targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrI64Const})
+		case wasm.EqualValType(result, wasm.F32):
+			targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrF32Const})
+		case wasm.EqualValType(result, wasm.F64):
+			targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrF64Const})
+		case wasm.EqualValType(result, wasm.V128):
+			targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrV128Const})
+		default:
+			hasReferenceResult = true
+			targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrRefFunc, Index: 0})
+		}
+	}
+	m := &wasm.Module{
+		Types: []wasm.RecType{
+			tailResultFuncType(nil, results),
+			tailResultFuncType(nil, results),
+		},
+		FuncTypes: []wasm.TypeIdx{{Index: 0}, {Index: 1}},
+		Code: []wasm.Func{
+			{Body: wasm.Expr{Instrs: targetBody}},
+			{Body: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrReturnCall, Index: 0}}}},
+		},
+	}
+	if hasReferenceResult {
+		m.Elements = []wasm.Elem{{Mode: wasm.ElemMode{Kind: wasm.ElemDeclarative}, Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0}}}}
+	}
+	return m
+}
+
+func indirectTailRewriteModule(results []wasm.ValType, mutateTable bool) *wasm.Module {
+	m := directTailRewriteModule(results)
+	m.Tables = []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1}}}}
+	m.Elements = []wasm.Elem{{
+		Mode: wasm.ElemMode{Kind: wasm.ElemActive, Table: 0, Offset: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrI32Const}}}},
+		Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0}},
+	}}
+	m.Code[1].Body.Instrs = []wasm.Instruction{{Kind: wasm.InstrI32Const}, {Kind: wasm.InstrReturnCallIndirect, Index: 0, Index2: 0}}
+	if mutateTable {
+		prefix := []wasm.Instruction{
+			{Kind: wasm.InstrI32Const},
+			{Kind: wasm.InstrRefFunc, Index: 0},
+			{Kind: wasm.InstrTableSet, Index: 0},
+		}
+		m.Code[0].Body.Instrs = append(prefix, m.Code[0].Body.Instrs...)
+	}
+	return m
+}
+
+func twoTargetIndirectTailRewriteModule(first, second, caller []wasm.ValType) *wasm.Module {
+	body := func(results []wasm.ValType) []wasm.Instruction {
+		out := make([]wasm.Instruction, 0, len(results))
+		for _, result := range results {
+			if wasm.EqualValType(result, wasm.I64) {
+				out = append(out, wasm.Instruction{Kind: wasm.InstrI64Const})
+			} else {
+				out = append(out, wasm.Instruction{Kind: wasm.InstrI32Const})
+			}
+		}
+		return out
+	}
+	return &wasm.Module{
+		Types: []wasm.RecType{
+			tailResultFuncType(nil, first),
+			tailResultFuncType(nil, second),
+			tailResultFuncType(nil, caller),
+		},
+		FuncTypes: []wasm.TypeIdx{{Index: 0}, {Index: 1}, {Index: 2}},
+		Tables:    []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 2}}}},
+		Elements: []wasm.Elem{{
+			Mode: wasm.ElemMode{Kind: wasm.ElemActive, Table: 0, Offset: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrI32Const}}}},
+			Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0, 1}},
+		}},
+		Code: []wasm.Func{
+			{Body: wasm.Expr{Instrs: body(first)}},
+			{Body: wasm.Expr{Instrs: body(second)}},
+			{Body: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrI32Const}, {Kind: wasm.InstrReturnCallIndirect, Index: 0, Index2: 0}}}},
+		},
+	}
+}
+
+func importedIndirectTailRewriteModule(results []wasm.ValType) *wasm.Module {
+	return &wasm.Module{
+		Types: []wasm.RecType{
+			tailResultFuncType(nil, results),
+			tailResultFuncType(nil, results),
+		},
+		Imports:   []wasm.Import{{Module: "env", Name: "target", Type: wasm.NewFuncExternType(wasm.TypeIdx{Index: 0})}},
+		FuncTypes: []wasm.TypeIdx{{Index: 1}},
+		Tables:    []wasm.Table{{Type: wasm.TableType{Ref: wasm.FuncRef.Ref(), Limits: wasm.Limits{Min: 1}}}},
+		Elements: []wasm.Elem{{
+			Mode: wasm.ElemMode{Kind: wasm.ElemActive, Table: 0, Offset: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrI32Const}}}},
+			Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0}},
+		}},
+		Code: []wasm.Func{{Body: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrI32Const}, {Kind: wasm.InstrReturnCallIndirect, Index: 0, Index2: 0}}}}},
+	}
+}
+
+func refTailRewriteModule(results []wasm.ValType, dynamicGlobal bool) *wasm.Module {
+	m := directTailRewriteModule(results)
+	m.Elements = []wasm.Elem{{Mode: wasm.ElemMode{Kind: wasm.ElemDeclarative}, Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0}}}}
+	if dynamicGlobal {
+		ref := wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: 0}), false))
+		m.Globals = []wasm.Global{{Type: wasm.GlobalType{Type: ref}, Init: wasm.Expr{Instrs: []wasm.Instruction{{Kind: wasm.InstrRefFunc, Index: 0}}}}}
+		m.Code[1].Body.Instrs = []wasm.Instruction{{Kind: wasm.InstrGlobalGet, Index: 0}, {Kind: wasm.InstrReturnCallRef, Index: 0}}
+	} else {
+		m.Code[1].Body.Instrs = []wasm.Instruction{{Kind: wasm.InstrRefFunc, Index: 0}, {Kind: wasm.InstrReturnCallRef, Index: 0}}
+	}
+	return m
+}
+
+func recursiveReferenceTailModule(field wasm.ValType) *wasm.Module {
+	result := wasm.RefVal(wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: 0}), false))
+	functionRef := wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: 1}), false))
+	return &wasm.Module{
+		Types: []wasm.RecType{
+			{SubTypes: []wasm.SubType{{Final: true, Comp: wasm.CompType{Kind: wasm.CompStruct, Fields: []wasm.FieldType{wasm.NewFieldType(wasm.StorageVal(field), wasm.Const)}}}}},
+			tailResultFuncType(nil, []wasm.ValType{result}),
+			tailResultFuncType(nil, []wasm.ValType{result}),
+		},
+		FuncTypes: []wasm.TypeIdx{{Index: 1}, {Index: 2}},
+		Globals: []wasm.Global{{
+			Type: wasm.GlobalType{Type: functionRef},
+			Init: wasm.Expr{BodyBytes: []byte{0xd2, 0x00, 0x0b}},
+		}},
+		Elements: []wasm.Elem{{Mode: wasm.ElemMode{Kind: wasm.ElemDeclarative}, Kind: wasm.ElemKind{Kind: wasm.ElemFuncs, Funcs: []wasm.FuncIdx{0}}}},
+		Code: []wasm.Func{
+			{BodyBytes: []byte{0xd0, 0x00, 0x0b}},
+			{BodyBytes: []byte{0x23, 0x00, 0x15, 0x01, 0x0b}},
+		},
+	}
+}
+
+func importedRecursiveReferenceSignatureModule(field wasm.ValType) *wasm.Module {
+	result := wasm.RefVal(wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: 0}), false))
+	return &wasm.Module{
+		Types: []wasm.RecType{
+			{SubTypes: []wasm.SubType{{Final: true, Comp: wasm.CompType{Kind: wasm.CompStruct, Fields: []wasm.FieldType{wasm.NewFieldType(wasm.StorageVal(field), wasm.Const)}}}}},
+			tailResultFuncType(nil, []wasm.ValType{result}),
+		},
+		Imports: []wasm.Import{{Module: "env", Name: "f", Type: wasm.NewFuncExternType(wasm.TypeIdx{Index: 1})}},
+	}
+}
+
+func recursiveParameterTailModule(field wasm.ValType, results []wasm.ValType) *wasm.Module {
+	param := wasm.RefVal(wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: 0}), false))
+	targetBody := []byte{0x0b}
+	if len(results) != 0 {
+		targetBody = []byte{0x41, 0x00, 0x0b}
+	}
+	return &wasm.Module{
+		Types: []wasm.RecType{
+			{SubTypes: []wasm.SubType{{Final: true, Comp: wasm.CompType{Kind: wasm.CompStruct, Fields: []wasm.FieldType{wasm.NewFieldType(wasm.StorageVal(field), wasm.Const)}}}}},
+			tailResultFuncType([]wasm.ValType{param}, results),
+			tailResultFuncType([]wasm.ValType{param}, results),
+		},
+		FuncTypes: []wasm.TypeIdx{{Index: 1}, {Index: 2}},
+		Code: []wasm.Func{
+			{BodyBytes: targetBody},
+			{BodyBytes: []byte{0x20, 0x00, 0x12, 0x00, 0x0b}},
+		},
+	}
+}
+
+func TestValidateTailResultRewriteAllowsCoordinatedKnownTargets(t *testing.T) {
+	shapes := []struct {
+		name    string
+		results []wasm.ValType
+	}{
+		{name: "unused scalar", results: []wasm.ValType{wasm.I32}},
+		{name: "multivalue", results: []wasm.ValType{wasm.I32, wasm.I64, wasm.F32, wasm.F64}},
+		{name: "SIMD", results: []wasm.ValType{wasm.V128}},
+	}
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name   string
+				before func([]wasm.ValType) *wasm.Module
+			}{
+				{name: "direct", before: directTailRewriteModule},
+				{name: "immutable indirect", before: func(results []wasm.ValType) *wasm.Module { return indirectTailRewriteModule(results, false) }},
+				{name: "immediate ref", before: func(results []wasm.ValType) *wasm.Module { return refTailRewriteModule(results, false) }},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					before := tc.before(shape.results)
+					after := tc.before(nil)
+					if err := ValidateTailResultRewrite(before, after); err != nil {
+						t.Fatalf("coordinated result elimination: %v", err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestValidateTailResultRewriteFailsClosedForUnknownTargets(t *testing.T) {
+	before := indirectTailRewriteModule([]wasm.ValType{wasm.I32}, true)
+	after := indirectTailRewriteModule(nil, true)
+	if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "unknown target set") {
+		t.Fatalf("mutable table rewrite error = %v", err)
+	}
+
+	before = refTailRewriteModule([]wasm.ValType{wasm.I32}, true)
+	after = refTailRewriteModule(nil, true)
+	if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "dynamic or imported target") {
+		t.Fatalf("typed-global return_call_ref rewrite error = %v", err)
+	}
+
+	before = importedIndirectTailRewriteModule([]wasm.ValType{wasm.I32})
+	after = importedIndirectTailRewriteModule(nil)
+	if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "changed imported function") {
+		t.Fatalf("imported indirect target rewrite error = %v", err)
+	}
+}
+
+func TestValidateTailResultRewriteRequiresEveryProvenIndirectTarget(t *testing.T) {
+	before := twoTargetIndirectTailRewriteModule([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	after := twoTargetIndirectTailRewriteModule(nil, []wasm.ValType{wasm.I32}, nil)
+	if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "did not rewrite local target 1") {
+		t.Fatalf("partial immutable-table target rewrite error = %v", err)
+	}
+
+	after = twoTargetIndirectTailRewriteModule(nil, nil, nil)
+	if err := ValidateTailResultRewrite(before, after); err != nil {
+		t.Fatalf("complete immutable-table target rewrite: %v", err)
+	}
+}
+
+func TestValidateTailResultRewriteRejectsExportedAndEmptyIndirectSets(t *testing.T) {
+	before := indirectTailRewriteModule([]wasm.ValType{wasm.I32}, false)
+	after := indirectTailRewriteModule(nil, false)
+	before.Exports = []wasm.Export{{Name: "table", Index: wasm.ExternIdx{Kind: wasm.ExternTable, Index: 0}}}
+	after.Exports = []wasm.Export{{Name: "table", Index: wasm.ExternIdx{Kind: wasm.ExternTable, Index: 0}}}
+	if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through exported function references") {
+		t.Fatalf("exported table rewrite error = %v", err)
+	}
+
+	before = indirectTailRewriteModule([]wasm.ValType{wasm.I32}, false)
+	after = indirectTailRewriteModule(nil, false)
+	before.Elements = nil
+	after.Elements = nil
+	if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "no proven non-null target") {
+		t.Fatalf("empty table rewrite error = %v", err)
+	}
+}
+
+func TestValidateTailResultRewriteRejectsPartialAndAdversarialTransforms(t *testing.T) {
+	t.Run("missing retained source", func(t *testing.T) {
+		module := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		if err := ValidateTailResultRewrite(nil, module); err == nil || !strings.Contains(err.Error(), "non-nil") {
+			t.Fatalf("nil source error = %v", err)
+		}
+		if err := ValidateTailResultRewrite(module, module); err == nil || !strings.Contains(err.Error(), "distinct retained source") {
+			t.Fatalf("aliased source error = %v", err)
+		}
+	})
+
+	t.Run("callee only", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after.Types[0].SubTypes[0].Comp.Results = nil
+		after.Code[0].Body.Instrs = nil
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "result is invalid") {
+			t.Fatalf("partial direct rewrite error = %v", err)
+		}
+	})
+
+	t.Run("site target changed", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule(nil)
+		after.Code[1].Body.Instrs[0].Index = 1
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "site identity or target") {
+			t.Fatalf("retargeted rewrite error = %v", err)
+		}
+	})
+
+	t.Run("exported caller changed", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule(nil)
+		before.Exports = []wasm.Export{{Name: "run", Index: wasm.ExternIdx{Kind: wasm.ExternFunc, Index: 1}}}
+		after.Exports = []wasm.Export{{Name: "run", Index: wasm.ExternIdx{Kind: wasm.ExternFunc, Index: 1}}}
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "changed exported function") {
+			t.Fatalf("exported caller rewrite error = %v", err)
+		}
+	})
+
+	t.Run("target escapes through exported table", func(t *testing.T) {
+		before := indirectTailRewriteModule([]wasm.ValType{wasm.I32}, false)
+		after := indirectTailRewriteModule(nil, false)
+		before.Code[1].Body.Instrs = []wasm.Instruction{{Kind: wasm.InstrReturnCall, Index: 0}}
+		after.Code[1].Body.Instrs = []wasm.Instruction{{Kind: wasm.InstrReturnCall, Index: 0}}
+		before.Exports = []wasm.Export{{Name: "functions", Index: wasm.ExternIdx{Kind: wasm.ExternTable, Index: 0}}}
+		after.Exports = []wasm.Export{{Name: "functions", Index: wasm.ExternIdx{Kind: wasm.ExternTable, Index: 0}}}
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through exported function references") {
+			t.Fatalf("escaped direct target rewrite error = %v", err)
+		}
+	})
+
+	t.Run("parameters changed", func(t *testing.T) {
+		before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+		after := directTailRewriteModule(nil)
+		after.Types[0].SubTypes[0].Comp.Params = []wasm.ValType{wasm.I32}
+		after.Code[1].Body.Instrs = []wasm.Instruction{{Kind: wasm.InstrI32Const}, {Kind: wasm.InstrReturnCall, Index: 0}}
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "changed parameters") {
+			t.Fatalf("parameter rewrite error = %v", err)
+		}
+	})
+}
+
+func TestAnalyzeTailResultSitesMatchesASTAndByteBackedBodies(t *testing.T) {
+	ast := refTailRewriteModule([]wasm.ValType{wasm.I32}, false)
+	byteBacked := refTailRewriteModule([]wasm.ValType{wasm.I32}, false)
+	byteBacked.Code[1].Body.Instrs = nil
+	byteBacked.Code[1].BodyBytes = []byte{0xd2, 0x00, 0x15, 0x00, 0x0b}
+	for _, m := range []*wasm.Module{ast, byteBacked} {
+		if err := wasm.ValidateModule(m); err != nil {
+			t.Fatalf("validate test module: %v", err)
+		}
+	}
+	gotAST, err := AnalyzeTailResultSites(ast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotBytes, err := AnalyzeTailResultSites(byteBacked)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotAST) != 1 || len(gotBytes) != 1 || gotAST[0] != gotBytes[0] || !gotAST[0].Known || gotAST[0].KnownFunction != 0 {
+		t.Fatalf("AST sites = %#v, byte-backed sites = %#v", gotAST, gotBytes)
+	}
+}
+
+func TestValidateTailResultRewriteUsesExactValidationFeatures(t *testing.T) {
+	before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+	after := directTailRewriteModule(nil)
+	before.Memories = []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1}}}
+	after.Memories = []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1}}}
+	if err := ValidateTailResultRewrite(before, after); err == nil {
+		t.Fatal("compatibility validation unexpectedly accepted multi-memory rewrite")
+	}
+	if err := ValidateTailResultRewriteWithFeatures(before, after, wasm.ValidationFeatures{MultiMemory: true}); err != nil {
+		t.Fatalf("multi-memory result rewrite: %v", err)
+	}
+}
+
+func TestValidateTailResultRewriteCallerOnlyCovarianceNeedsNoDynamicProof(t *testing.T) {
+	nonNull := wasm.RefVal(wasm.Ref(false, wasm.AbsHeap(wasm.HeapFunc), false))
+	nullable := wasm.FuncRef
+	before := refTailRewriteModule([]wasm.ValType{nonNull}, true)
+	after := refTailRewriteModule([]wasm.ValType{nonNull}, true)
+	after.Types[1].SubTypes[0].Comp.Results = []wasm.ValType{nullable}
+	if err := ValidateTailResultRewrite(before, after); err != nil {
+		t.Fatalf("caller-only covariant widening: %v", err)
+	}
+}
+
+func TestValidateTailResultRewriteComparesCompleteRecursiveSignatureGraphs(t *testing.T) {
+	t.Run("imported signature", func(t *testing.T) {
+		before := importedRecursiveReferenceSignatureModule(wasm.I32)
+		after := importedRecursiveReferenceSignatureModule(wasm.I64)
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "changed imported function") {
+			t.Fatalf("recursive imported signature rewrite error = %v", err)
+		}
+	})
+
+	t.Run("dynamic return-call-ref target contract", func(t *testing.T) {
+		before := recursiveReferenceTailModule(wasm.I32)
+		after := recursiveReferenceTailModule(wasm.I64)
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "dynamic or imported target") {
+			t.Fatalf("recursive dynamic target rewrite error = %v", err)
+		}
+	})
+
+	t.Run("parameter graph", func(t *testing.T) {
+		before := recursiveParameterTailModule(wasm.I32, []wasm.ValType{wasm.I32})
+		after := recursiveParameterTailModule(wasm.I64, nil)
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "changed parameters") {
+			t.Fatalf("recursive parameter rewrite error = %v", err)
+		}
+	})
+}
+
+func BenchmarkAnalyzeTailResultSites(b *testing.B) {
+	m := indirectTailRewriteModule([]wasm.ValType{wasm.I32, wasm.I64}, false)
+	const funcs = 256
+	m.FuncTypes = make([]wasm.TypeIdx, funcs)
+	m.Code = make([]wasm.Func, funcs)
+	for i := range m.Code {
+		m.FuncTypes[i] = wasm.TypeIdx{Index: 0}
+		m.Code[i].BodyBytes = []byte{0x41, 0x00, 0x13, 0x00, 0x00, 0x0b}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := AnalyzeTailResultSites(m); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValidateTailResultRewrite(b *testing.B) {
+	for _, tc := range []struct {
+		name   string
+		before *wasm.Module
+		after  *wasm.Module
+	}{
+		{name: "direct", before: directTailRewriteModule([]wasm.ValType{wasm.I32, wasm.I64}), after: directTailRewriteModule(nil)},
+		{name: "immutable-indirect", before: indirectTailRewriteModule([]wasm.ValType{wasm.I32, wasm.I64}, false), after: indirectTailRewriteModule(nil, false)},
+		{name: "immediate-ref", before: refTailRewriteModule([]wasm.ValType{wasm.I32}, false), after: refTailRewriteModule(nil, false)},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := ValidateTailResultRewrite(tc.before, tc.after); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func FuzzValidateTailResultRewrite(f *testing.F) {
+	f.Add(byte(0), true, false)
+	f.Add(byte(1), false, false)
+	f.Add(byte(2), true, true)
+	f.Fuzz(func(t *testing.T, kind byte, eliminate, dynamic bool) {
+		results := []wasm.ValType{wasm.I32}
+		var build func([]wasm.ValType) *wasm.Module
+		switch kind % 3 {
+		case 0:
+			build = directTailRewriteModule
+		case 1:
+			build = func(r []wasm.ValType) *wasm.Module { return indirectTailRewriteModule(r, dynamic) }
+		default:
+			build = func(r []wasm.ValType) *wasm.Module { return refTailRewriteModule(r, dynamic) }
+		}
+		before := build(results)
+		afterResults := results
+		if eliminate {
+			afterResults = nil
+		}
+		after := build(afterResults)
+		err := ValidateTailResultRewrite(before, after)
+		wantReject := eliminate && dynamic && kind%3 != 0
+		if wantReject && err == nil {
+			t.Fatal("dynamic result rewrite unexpectedly accepted")
+		}
+		if !wantReject && err != nil {
+			t.Fatalf("known/no-op result rewrite rejected: %v", err)
+		}
+	})
+}

--- a/src/core/compiler/frontend/tail_result_contract_test.go
+++ b/src/core/compiler/frontend/tail_result_contract_test.go
@@ -223,18 +223,18 @@ func importedCallbackSinkTailModule(results []wasm.ValType) *wasm.Module {
 	}
 }
 
-func importedReferenceCallbackTailModule(param wasm.ValType, results []wasm.ValType) *wasm.Module {
+func importedReferenceFunctionTailModule(params, results, tailResults []wasm.ValType) *wasm.Module {
 	targetBody := []wasm.Instruction{}
-	if len(results) != 0 {
+	if len(tailResults) != 0 {
 		targetBody = append(targetBody, wasm.Instruction{Kind: wasm.InstrI32Const})
 	}
 	return &wasm.Module{
 		Types: []wasm.RecType{
-			tailResultFuncType([]wasm.ValType{param}, nil),
-			tailResultFuncType(nil, results),
-			tailResultFuncType(nil, results),
+			tailResultFuncType(params, results),
+			tailResultFuncType(nil, tailResults),
+			tailResultFuncType(nil, tailResults),
 		},
-		Imports:   []wasm.Import{{Module: "env", Name: "callback", Type: wasm.NewFuncExternType(wasm.TypeIdx{Index: 0})}},
+		Imports:   []wasm.Import{{Module: "env", Name: "boundary", Type: wasm.NewFuncExternType(wasm.TypeIdx{Index: 0})}},
 		FuncTypes: []wasm.TypeIdx{{Index: 1}, {Index: 2}},
 		Code: []wasm.Func{
 			{Body: wasm.Expr{Instrs: targetBody}},
@@ -451,13 +451,35 @@ func TestValidateTailResultRewriteRejectsImportedReferenceSinks(t *testing.T) {
 		}
 	})
 
-	t.Run("externref callback", func(t *testing.T) {
-		before := importedReferenceCallbackTailModule(wasm.ExternRef, []wasm.ValType{wasm.I32})
-		after := importedReferenceCallbackTailModule(wasm.ExternRef, nil)
+	t.Run("externref callback parameter", func(t *testing.T) {
+		before := importedReferenceFunctionTailModule([]wasm.ValType{wasm.ExternRef}, nil, []wasm.ValType{wasm.I32})
+		after := importedReferenceFunctionTailModule([]wasm.ValType{wasm.ExternRef}, nil, nil)
 		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through imported function references") {
-			t.Fatalf("externref callback rewrite error = %v", err)
+			t.Fatalf("externref callback parameter rewrite error = %v", err)
 		}
 	})
+
+	t.Run("externref callback result", func(t *testing.T) {
+		before := importedReferenceFunctionTailModule(nil, []wasm.ValType{wasm.ExternRef}, []wasm.ValType{wasm.I32})
+		after := importedReferenceFunctionTailModule(nil, []wasm.ValType{wasm.ExternRef}, nil)
+		if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through imported function references") {
+			t.Fatalf("externref callback result rewrite error = %v", err)
+		}
+	})
+}
+
+func TestValidateTailResultRewriteRejectsExportedReferenceParameters(t *testing.T) {
+	before := directTailRewriteModule([]wasm.ValType{wasm.I32})
+	after := directTailRewriteModule(nil)
+	for _, m := range []*wasm.Module{before, after} {
+		m.Types = append(m.Types, tailResultFuncType([]wasm.ValType{wasm.ExternRef}, nil))
+		m.FuncTypes = append(m.FuncTypes, wasm.TypeIdx{Index: 2})
+		m.Code = append(m.Code, wasm.Func{Body: wasm.Expr{}})
+		m.Exports = []wasm.Export{{Name: "accept", Index: wasm.ExternIdx{Kind: wasm.ExternFunc, Index: 2}}}
+	}
+	if err := ValidateTailResultRewrite(before, after); err == nil || !strings.Contains(err.Error(), "observable through exported function references") {
+		t.Fatalf("exported reference parameter rewrite error = %v", err)
+	}
 }
 
 func TestAnalyzeTailResultSitesMatchesASTAndByteBackedBodies(t *testing.T) {

--- a/src/core/compiler/wasm/bytecode_walk.go
+++ b/src/core/compiler/wasm/bytecode_walk.go
@@ -47,6 +47,13 @@ func ClassifyInstructionImmediateInto(r *Reader, op byte, imm *InstructionImmedi
 // The width flag affects only memory offsets; instruction classification and all
 // malformed-immediate checks remain identical to ClassifyInstructionImmediateInto.
 func ClassifyInstructionImmediateIntoWithMemarg64(r *Reader, op byte, imm *InstructionImmediate, memarg64 bool) error {
+	return ClassifyInstructionImmediateIntoWithFeatures(r, op, imm, memarg64, false)
+}
+
+// ClassifyInstructionImmediateIntoWithFeatures is the staged-feature form used
+// by validated module walkers. multiMemory changes memory.size/memory.grow from
+// the legacy reserved-zero byte to a memory index; memarg64 selects u64 offsets.
+func ClassifyInstructionImmediateIntoWithFeatures(r *Reader, op byte, imm *InstructionImmediate, memarg64, multiMemory bool) error {
 	*imm = InstructionImmediate{}
 	if kind := simpleOpcode[op]; kind != InstrInvalid {
 		imm.Kind = kind
@@ -80,7 +87,7 @@ func ClassifyInstructionImmediateIntoWithMemarg64(r *Reader, op byte, imm *Instr
 		return err
 	}
 	ir := &reader{data: r.data, pos: r.pos}
-	_, err := classifyExprOpAfterOpcodeWithMemarg64(ir, op, imm, memarg64)
+	_, err := classifyExprOpAfterOpcodeWithFeatures(ir, op, imm, memarg64, multiMemory)
 	r.pos = ir.pos
 	return err
 }

--- a/src/core/compiler/wasm/bytecode_walk_test.go
+++ b/src/core/compiler/wasm/bytecode_walk_test.go
@@ -113,6 +113,14 @@ func TestClassifyInstructionImmediateReportsMemargMetadata(t *testing.T) {
 	if imm.Kind != InstrI64Load || imm.MemAlign != 3 || imm.MemOffset != 1<<32 {
 		t.Fatalf("memory64 memarg metadata = %+v", imm)
 	}
+
+	r = NewReader([]byte{0x01}) // memory index 1
+	if err := ClassifyInstructionImmediateIntoWithFeatures(r, 0x3f, &imm, false, true); err != nil {
+		t.Fatal(err)
+	}
+	if imm.Kind != InstrMemorySize || imm.Index != 1 || !imm.TouchesMemory {
+		t.Fatalf("multi-memory immediate metadata = %+v", imm)
+	}
 }
 
 func TestSkipInstructionImmediateRejectsMalformedVectors(t *testing.T) {

--- a/src/wago/proper_tail_reference_result_amd64_test.go
+++ b/src/wago/proper_tail_reference_result_amd64_test.go
@@ -1,0 +1,31 @@
+//go:build linux && amd64 && !tinygo && !wago_guardpage
+
+package wago
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func TestProperTailReferenceResultContractsExecuteAcrossKinds(t *testing.T) {
+	for _, kind := range []properTailBehaviorKind{properTailDirect, properTailIndirect, properTailRef} {
+		t.Run([]string{"direct", "indirect", "ref"}[kind], func(t *testing.T) {
+			for _, objective := range []OptimizationObjective{OptimizeBalanced, OptimizeSize, OptimizeEmbedded} {
+				t.Run(objective.String(), func(t *testing.T) {
+					compiled := compileProperTailBehavior(t, properTailResultModule(kind, []wasm.ValType{wasm.FuncRef}, []byte{0xd2, 0x00, 0x0b}), objective, 2)
+					in, err := instantiateCore(compiled, InstantiateOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer in.Close()
+					got, err := in.Call(context.Background(), "run")
+					if err != nil || len(got) != 1 || got[0].Type() != ValFuncRef || got[0].FuncRef().IsNull() || !in.FuncRefMatchesFunction(got[0].FuncRef(), 0) {
+						t.Fatalf("proper-tail funcref result = %v, %v", got, err)
+					}
+				})
+			}
+		})
+	}
+}

--- a/src/wago/proper_tail_result_contract_test.go
+++ b/src/wago/proper_tail_result_contract_test.go
@@ -1,0 +1,209 @@
+//go:build (linux && amd64 && !tinygo && !wago_guardpage) || ((linux || darwin) && arm64 && !tinygo && !wago_guardpage)
+
+package wago
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+type properTailBehaviorKind uint8
+
+const (
+	properTailDirect properTailBehaviorKind = iota
+	properTailIndirect
+	properTailRef
+)
+
+func properTailResultModule(kind properTailBehaviorKind, results []wasm.ValType, targetBody []byte) []byte {
+	sections := [][]byte{
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, results))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
+	}
+	if kind == properTailIndirect {
+		sections = append(sections, wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x00, 0x01})))
+	}
+	sections = append(sections, wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))))
+	switch kind {
+	case properTailIndirect:
+		sections = append(sections, wasmtest.Section(9, wasmtest.Vec([]byte{0x00, 0x41, 0x00, 0x0b, 0x01, 0x00})))
+	case properTailDirect, properTailRef:
+		sections = append(sections, wasmtest.Section(9, wasmtest.Vec(append([]byte{0x03, 0x00}, wasmtest.Vec(wasmtest.ULEB(0))...))))
+	}
+	caller := []byte{0x12, 0x00, 0x0b}
+	if kind == properTailIndirect {
+		caller = []byte{0x41, 0x00, 0x13, 0x00, 0x00, 0x0b}
+	} else if kind == properTailRef {
+		caller = []byte{0xd2, 0x00, 0x15, 0x00, 0x0b}
+	}
+	sections = append(sections, wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(targetBody), wasmtest.Code(caller))))
+	return wasmtest.Module(sections...)
+}
+
+func compileProperTailBehavior(t testing.TB, module []byte, objective OptimizationObjective, workers int) *Compiled {
+	t.Helper()
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3).WithBoundsChecks(BoundsChecksExplicit).WithOptimizationObjective(objective).WithFunctionWorkers(workers)
+	compiled, err := cfg.Compile(module)
+	if err != nil {
+		t.Fatalf("compile proper-tail behavior module: %v", err)
+	}
+	t.Cleanup(func() { _ = compiled.Close() })
+	return compiled
+}
+
+func TestProperTailResultContractsExecuteAcrossKindsAndObjectives(t *testing.T) {
+	vector := [16]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	shapes := []struct {
+		name     string
+		results  []wasm.ValType
+		body     []byte
+		wantSlot []uint64
+	}{
+		{name: "scalar", results: []wasm.ValType{wasm.I32}, body: []byte{0x41, 0x2a, 0x0b}, wantSlot: []uint64{42}},
+		{name: "multivalue", results: []wasm.ValType{wasm.I32, wasm.I64, wasm.F32, wasm.F64}, body: []byte{
+			0x41, 0x2a,
+			0x42, 0x09,
+			0x43, 0x00, 0x00, 0xc0, 0x3f,
+			0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x40,
+			0x0b,
+		}, wantSlot: []uint64{42, 9, uint64(math.Float32bits(1.5)), math.Float64bits(2.25)}},
+		{name: "SIMD", results: []wasm.ValType{wasm.V128}, body: append(append([]byte{0xfd, 0x0c}, vector[:]...), 0x0b), wantSlot: []uint64{binary.LittleEndian.Uint64(vector[:8]), binary.LittleEndian.Uint64(vector[8:])}},
+	}
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			kinds := []properTailBehaviorKind{properTailDirect, properTailIndirect}
+			if shape.name == "scalar" {
+				kinds = append(kinds, properTailRef)
+			}
+			for _, kind := range kinds {
+				t.Run([]string{"direct", "indirect", "ref"}[kind], func(t *testing.T) {
+					for _, objective := range []OptimizationObjective{OptimizeBalanced, OptimizeSize, OptimizeEmbedded} {
+						t.Run(objective.String(), func(t *testing.T) {
+							compiled := compileProperTailBehavior(t, properTailResultModule(kind, shape.results, shape.body), objective, 2)
+							in, err := instantiateCore(compiled, InstantiateOptions{})
+							if err != nil {
+								t.Fatal(err)
+							}
+							defer in.Close()
+							got, err := in.Invoke("run")
+							if err != nil || !reflect.DeepEqual(got, shape.wantSlot) {
+								t.Fatalf("proper-tail result slots = %#x, %v; want %#x", got, err, shape.wantSlot)
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func recursiveProperTailResultModule(kind properTailBehaviorKind) []byte {
+	body := []byte{
+		0x20, 0x00, 0x45, // local.get 0; i32.eqz
+		0x04, 0x7f, // if (result i32)
+		0x41, 0x07, // i32.const 7
+		0x05,                         // else
+		0x20, 0x00, 0x41, 0x01, 0x6b, // n - 1
+	}
+	switch kind {
+	case properTailDirect:
+		body = append(body, 0x12, 0x00)
+	case properTailIndirect:
+		body = append(body, 0x41, 0x00, 0x13, 0x00, 0x00)
+	case properTailRef:
+		body = append(body, 0xd2, 0x00, 0x15, 0x00)
+	}
+	body = append(body, 0x0b, 0x0b)
+	sections := [][]byte{
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+	}
+	if kind == properTailIndirect {
+		sections = append(sections, wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x00, 0x01})))
+	}
+	sections = append(sections, wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 0))))
+	if kind == properTailIndirect {
+		sections = append(sections, wasmtest.Section(9, wasmtest.Vec([]byte{0x00, 0x41, 0x00, 0x0b, 0x01, 0x00})))
+	} else {
+		sections = append(sections, wasmtest.Section(9, wasmtest.Vec(append([]byte{0x03, 0x00}, wasmtest.Vec(wasmtest.ULEB(0))...))))
+	}
+	sections = append(sections, wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))))
+	return wasmtest.Module(sections...)
+}
+
+func TestProperTailResultContractsDiscardFrames(t *testing.T) {
+	for _, kind := range []properTailBehaviorKind{properTailDirect, properTailIndirect, properTailRef} {
+		t.Run([]string{"direct", "indirect", "ref"}[kind], func(t *testing.T) {
+			compiled := compileProperTailBehavior(t, recursiveProperTailResultModule(kind), OptimizeSize, 2)
+			in, err := instantiateCore(compiled, InstantiateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			got, err := in.Invoke("run", 1_000_000)
+			if err != nil || !reflect.DeepEqual(got, []uint64{7}) {
+				t.Fatalf("million-deep proper tail = %v, %v; want [7]", got, err)
+			}
+		})
+	}
+}
+
+func typedGlobalReturnCallRefModule() []byte {
+	type0 := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	global := []byte{0x64, 0x00, 0x00, 0xd2, 0x00, 0x0b} // (ref 0), immutable, ref.func 0
+	declared := append([]byte{0x03, 0x00}, wasmtest.Vec(wasmtest.ULEB(0))...)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(type0)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
+		wasmtest.Section(6, wasmtest.Vec(global)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(9, wasmtest.Vec(declared)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0xcd, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x23, 0x00, 0x15, 0x00, 0x0b}),
+		)),
+	)
+}
+
+func TestProperTailTypedGlobalReturnCallRefPreservesAdapterResult(t *testing.T) {
+	for _, objective := range []OptimizationObjective{OptimizeBalanced, OptimizeSize, OptimizeEmbedded} {
+		t.Run(objective.String(), func(t *testing.T) {
+			compiled := compileProperTailBehavior(t, typedGlobalReturnCallRefModule(), objective, 2)
+			in, err := instantiateCore(compiled, InstantiateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			got, err := in.Call(context.Background(), "run")
+			if err != nil || len(got) != 1 || got[0].Type() != ValI32 || got[0].I32() != 77 {
+				t.Fatalf("typed-global return_call_ref = %v, %v", got, err)
+			}
+		})
+	}
+}
+
+func BenchmarkProperTailResultContracts(b *testing.B) {
+	for _, kind := range []properTailBehaviorKind{properTailDirect, properTailIndirect, properTailRef} {
+		b.Run([]string{"direct", "indirect", "ref"}[kind], func(b *testing.B) {
+			compiled := compileProperTailBehavior(b, properTailResultModule(kind, []wasm.ValType{wasm.I32, wasm.I64}, []byte{0x41, 0x2a, 0x42, 0x09, 0x0b}), OptimizeBalanced, 1)
+			in, err := instantiateCore(compiled, InstantiateOptions{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer in.Close()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := in.Invoke("run"); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #436

## Summary

- add a post-transform `ValidateTailResultRewriteWithFeatures` fence for future Wasm function-result/signature rewrites
- audit and encode the target-knowledge boundary for `return_call`, `return_call_indirect`, and `return_call_ref`
- fail closed for dynamic/imported targets, mutable or exported tables, incomplete target sets, recursive signature-graph changes, and function references that can escape through exports
- preserve legal caller-only covariance and coordinated scalar, multivalue, SIMD, direct, immutable-indirect, and adjacent-`ref.func` result elimination
- add amd64/arm64 execution matrices, million-transfer frame-discard coverage, fuzzing, benchmarks, and developer documentation

The current Railshot optimization catalog does not rewrite Wasm function signatures, so this fence is intentionally not placed on the ordinary compile hot path. The first signature-changing pass must retain the source module and invoke the fence with the same validation features used by compilation.

## Correctness boundary

- `return_call`: exact static function target
- `return_call_ref`: exact target only for the mechanically evident adjacent `ref.func` shape
- `return_call_indirect`: complete target set only for a private immutable local table initialized from known local `ref.func` values
- caller-only result widening remains legal when the selected target contract is structurally unchanged
- recursive/GC type graphs are compared structurally, and parameter contracts are checked independently of rewritten result lists

## Validation

- `go test ./...`
- `go test ./src/core/compiler/...`
- focused frontend and runtime proper-tail tests
- focused race tests for frontend and runtime proper-tail coverage
- 10s and 15s fuzz runs; latest run completed 980,239 executions without failure
- `make lint` (`go vet` clean; repository staticcheck binary was unavailable)
- `make docs-check`
- TinyGo frontend tests
- full guard-page Wago tests
- Linux and Darwin arm64 Wago test binaries cross-compiled successfully
- `make spec3`: 2,226 modules / 58,238 assertions, zero failures, skips, or gaps
- `make spec3-signals`: 2,226 modules / 58,238 assertions, zero failures, skips, or gaps

## Benchmarks (linux/amd64, Ryzen 7 8845HS)

Transform-development fence, off the normal compile path:

- 256-site analysis: 10.2–11.2 µs/op, 15,856 B/op, 9 allocs/op
- direct rewrite validation: 2.6–2.7 µs/op, 4,308 B/op, 40 allocs/op
- immutable-indirect validation: 3.8–3.9 µs/op, 5,852 B/op, 50 allocs/op
- adjacent-reference validation: 2.6–2.7 µs/op, 4,268 B/op, 40 allocs/op

Warm runtime invocation:

- direct: 112–121 ns/op, 0 B/op, 0 allocs/op
- indirect: 117–122 ns/op, 0 B/op, 0 allocs/op
- reference: 114–119 ns/op, 0 B/op, 0 allocs/op


## Adversarial review follow-up

Native ARM64 CI exposed a pre-existing generic funcref-result tail egress defect: direct tails lose canonical function identity, while indirect/reference tails trap. It is isolated and tracked in #461. This PR keeps that specific egress matrix amd64-only while retaining ARM64 scalar, multivalue, SIMD, typed-global, million-transfer, and full Core 3 conformance coverage.