### PR TITLE
plugin: choose package providers during add

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,12 @@ wago run program.wasm hello world
 ```
 
 For GitHub plugins, `owner/repository` is shorthand for the canonical
-`github.com/owner/repository` Plugin ID. `wago add` resolves the complete
-dependency and Contract graph, reviews exact scoped Authorities, pins sources
-and bindings in `wago-lock.json`, verifies the linked definitions, and
-atomically publishes the rebuilt runtime.
+`github.com/owner/repository` Plugin ID. When a package publishes multiple
+providers, adding its root offers to install everything or choose individual
+providers. Explicit paths such as `wago-org/wasi/p1` install that provider
+directly. `wago add` resolves the complete dependency and Contract graph,
+reviews exact scoped Authorities, pins sources and bindings in `wago-lock.json`,
+verifies the linked definitions, and atomically publishes the rebuilt runtime.
 
 Useful plugin commands:
 
@@ -142,9 +144,9 @@ wago plugin list
 wago plugin list --json
 wago plugin inspect github.com/wago-org/wasi
 wago plugin tree
-wago plugin grant github.com/wago-org/wasi
-wago plugin grant github.com/wago-org/wasi --scopes '{"github.com/wago-org/wasi":{"host.import.define":{"modules":["wasi_snapshot_preview1"]}}}'
-wago plugin config github.com/wago-org/wasi '{"stdout":"discard"}'
+wago plugin grant github.com/wago-org/wasi/p1
+wago plugin grant github.com/wago-org/wasi/p1 --scopes '{"github.com/wago-org/wasi/p1":{"host.import.define":{"modules":["wasi_snapshot_preview1"]}}}'
+wago plugin config github.com/wago-org/wasi/p1 '{"stdout":"discard"}'
 wago plugin update
 wago plugin rebuild --locked
 wago plugin remove github.com/wago-org/wasi

--- a/cli/manager/commands/plugin/add/command.go
+++ b/cli/manager/commands/plugin/add/command.go
@@ -28,7 +28,7 @@ type Environment interface {
 func Command(environment Environment) *command.Cmd {
 	return &command.Cmd{
 		Name: "add", Summary: "add and enable plugins, then rebuild Wago",
-		Long:       "GitHub plugins may use owner/repository[/subpackage] shorthand; Wago stores the canonical github.com/owner/repository[/subpackage] Plugin ID.",
+		Long:       "GitHub plugins may use owner/repository[/subpackage] shorthand. Package roots offer everything or selected providers interactively; --no-input installs everything.",
 		Automation: command.DryRun,
 		Args:       "<plugin-id>[@range]...",
 		Flags: []command.Flag{

--- a/cli/manager/internal/plugin/build.go
+++ b/cli/manager/internal/plugin/build.go
@@ -49,6 +49,22 @@ func pkgAddMany(specs []string, options pkgOpts) {
 		progress.Fail("Plugin fetch failed")
 		fatal("add: %v", err)
 	}
+	if !automation.NoInput() {
+		prompts, err := findPackageInstallPrompts(pluginContext(options.ctx), specs)
+		if err != nil {
+			progress.Fail("Plugin fetch failed")
+			fatal("add: %v", err)
+		}
+		if len(prompts) != 0 {
+			progress.Finish("Fetched package details")
+			specs, err = reviewPackageInstallChoices(specs, prompts)
+			if err != nil {
+				progress.Fail("Plugin install cancelled")
+				fatal("add: %v", err)
+			}
+			progress.Begin("Fetching selected plugins")
+		}
+	}
 	err = withPluginMutationLock(pluginContext(options.ctx), src, func(mutation *project.Mutation) error {
 		manifest, err := mutation.ReadManifest()
 		if err != nil {

--- a/cli/manager/internal/plugin/package_selection.go
+++ b/cli/manager/internal/plugin/package_selection.go
@@ -1,0 +1,150 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/wago-org/wago/cli/internal/automation"
+	"github.com/wago-org/wago/cli/internal/tui"
+	"github.com/wago-org/wago/cli/manager/internal/registry"
+)
+
+type packageInstallPrompt struct {
+	index      int
+	constraint string
+	pkg        registry.InstallPackage
+}
+
+func findPackageInstallPrompts(ctx context.Context, specs []string) ([]packageInstallPrompt, error) {
+	var prompts []packageInstallPrompt
+	for index, spec := range specs {
+		id, constraint, err := parsePluginSpec(spec)
+		if err != nil {
+			return nil, err
+		}
+		pkg, found, err := registry.ResolveInstallPackage(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if found && len(pkg.Subpackages) != 0 {
+			prompts = append(prompts, packageInstallPrompt{index: index, constraint: constraint, pkg: pkg})
+		}
+	}
+	return prompts, nil
+}
+
+func reviewPackageInstallChoices(specs []string, prompts []packageInstallPrompt) ([]string, error) {
+	if automation.NoInput() || len(prompts) == 0 {
+		return specs, nil
+	}
+	selected := append([]string(nil), specs...)
+	offset := 0
+	for _, prompt := range prompts {
+		modules, err := choosePackageInstall(prompt.pkg)
+		if err != nil {
+			return nil, err
+		}
+		position := prompt.index + offset
+		selected = replacePackageInstallSpec(selected, position, modules, prompt.constraint)
+		offset += len(modules) - 1
+	}
+	return selected, nil
+}
+
+func replacePackageInstallSpec(specs []string, position int, modules []string, constraint string) []string {
+	replacements := make([]string, len(modules))
+	for index, module := range modules {
+		replacements[index] = pluginSpec(module, constraint)
+	}
+	return append(specs[:position], append(replacements, specs[position+1:]...)...)
+}
+
+func choosePackageInstall(pkg registry.InstallPackage) ([]string, error) {
+	for {
+		mode, ok := tui.Choose("Install "+pkg.Name, packageInstallModeItems(len(pkg.Subpackages)))
+		if !ok {
+			return nil, fmt.Errorf("package selection cancelled; no changes were made")
+		}
+		if mode == "all" {
+			return []string{pkg.Module}, nil
+		}
+		selected, back, err := choosePackageProviders(pkg)
+		if err != nil {
+			return nil, err
+		}
+		if !back {
+			return selected, nil
+		}
+	}
+}
+
+func packageInstallModeItems(count int) []tui.Item {
+	return []tui.Item{
+		{Label: "Everything", Description: fmt.Sprintf("install all %d providers", count), Value: "all"},
+		{Label: "Choose providers", Description: "select only what you need", Value: "custom"},
+	}
+}
+
+func choosePackageProviders(pkg registry.InstallPackage) ([]string, bool, error) {
+	selector, modules := packageProviderSelector(pkg)
+	for {
+		submitted, cancelled := tui.Run(selector)
+		if cancelled || !submitted {
+			return nil, true, nil
+		}
+		selected := selectedPackageProviders(selector, modules)
+		if !selector.Rejected() && len(selected) != 0 {
+			return selected, false, nil
+		}
+		choice, ok := tui.Choose("Exit installation?", authorityExitItems())
+		if ok && choice == "cancel" {
+			return nil, false, fmt.Errorf("package selection cancelled; no changes were made")
+		}
+		for index := range selector.Items {
+			if selector.Items[index].Reject {
+				selector.Items[index].On = false
+			}
+		}
+	}
+}
+
+func packageProviderSelector(pkg registry.InstallPackage) (*tui.MultiSelect, []string) {
+	items := make([]tui.SelectItem, 0, len(pkg.Subpackages)+1)
+	modules := make([]string, 0, len(pkg.Subpackages))
+	for _, subpackage := range pkg.Subpackages {
+		label := subpackage.Name
+		if label == "" {
+			label = strings.TrimPrefix(subpackage.Module, pkg.Module+"/")
+		}
+		description := subpackage.Description
+		if subpackage.Stability != "" {
+			description = "(" + subpackage.Stability + ") " + description
+		}
+		items = append(items, tui.SelectItem{Label: label, Description: strings.TrimSpace(description), On: true})
+		modules = append(modules, subpackage.Module)
+	}
+	items = append(items, tui.SelectItem{Label: "Install none", Description: "cancel installation", Reject: true})
+	return &tui.MultiSelect{
+		Title:  "Providers · " + pkg.Name,
+		Prompt: "space toggle · enter confirm · r install none · esc back",
+		Items:  items,
+	}, modules
+}
+
+func selectedPackageProviders(selector *tui.MultiSelect, modules []string) []string {
+	var selected []string
+	for index, module := range modules {
+		if selector.Items[index].On {
+			selected = append(selected, module)
+		}
+	}
+	return selected
+}
+
+func pluginSpec(id, constraint string) string {
+	if constraint == "" || constraint == "*" {
+		return id
+	}
+	return id + "@" + constraint
+}

--- a/cli/manager/internal/plugin/package_selection_test.go
+++ b/cli/manager/internal/plugin/package_selection_test.go
@@ -1,0 +1,65 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/cli/manager/internal/registry"
+)
+
+func testInstallPackage() registry.InstallPackage {
+	return registry.InstallPackage{
+		Module: "github.com/wago-org/wasi",
+		Name:   "WASI",
+		Subpackages: []registry.InstallSubpackage{
+			{Module: "github.com/wago-org/wasi/p1", Name: "Preview 1", Description: "Core Wasm commands.", Stability: "stable"},
+			{Module: "github.com/wago-org/wasi/p2", Name: "Preview 2", Description: "Component commands.", Stability: "experimental"},
+			{Module: "github.com/wago-org/wasi/unstable", Name: "Unstable", Description: "Legacy snapshot 0.", Stability: "deprecated"},
+		},
+	}
+}
+
+func TestPackageInstallModeOffersEverythingOrProviderSelection(t *testing.T) {
+	items := packageInstallModeItems(3)
+	if len(items) != 2 || items[0].Label != "Everything" || items[0].Value != "all" || items[1].Label != "Choose providers" {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestPackageProviderSelectorStartsWithEveryProviderSelected(t *testing.T) {
+	selector, modules := packageProviderSelector(testInstallPackage())
+	frame := selector.Frame()
+	for _, want := range []string{"Providers · WASI", "Preview 1", "(stable) Core Wasm commands.", "Preview 2", "Install none"} {
+		if !strings.Contains(frame, want) {
+			t.Errorf("selector does not contain %q:\n%s", want, frame)
+		}
+	}
+	selected := selectedPackageProviders(selector, modules)
+	if len(selected) != 3 || selected[2] != "github.com/wago-org/wasi/unstable" {
+		t.Fatalf("selected = %q", selected)
+	}
+	selector.Items[1].On = false
+	selected = selectedPackageProviders(selector, modules)
+	if len(selected) != 2 || selected[0] != "github.com/wago-org/wasi/p1" || selected[1] != "github.com/wago-org/wasi/unstable" {
+		t.Fatalf("custom selected = %q", selected)
+	}
+}
+
+func TestReviewPackageInstallChoicesKeepsConstraintsForChosenProviders(t *testing.T) {
+	specs := []string{"github.com/acme/first", "github.com/wago-org/wasi@^0.2.0", "github.com/acme/last"}
+	pkg := testInstallPackage()
+	got := replacePackageInstallSpec(append([]string(nil), specs...), 1, []string{pkg.Subpackages[0].Module, pkg.Subpackages[1].Module}, "^0.2.0")
+	want := []string{"github.com/acme/first", "github.com/wago-org/wasi/p1@^0.2.0", "github.com/wago-org/wasi/p2@^0.2.0", "github.com/acme/last"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("specs = %q, want %q", got, want)
+	}
+}
+
+func TestNoInputKeepsPackageRootForInstallEverything(t *testing.T) {
+	t.Setenv("WAGO_NONINTERACTIVE", "1")
+	specs := []string{"github.com/wago-org/wasi@^0.2.0"}
+	got, err := reviewPackageInstallChoices(specs, []packageInstallPrompt{{index: 0, constraint: "^0.2.0", pkg: testInstallPackage()}})
+	if err != nil || len(got) != 1 || got[0] != specs[0] {
+		t.Fatalf("choices = %q, %v", got, err)
+	}
+}

--- a/cli/manager/internal/registry/packages.go
+++ b/cli/manager/internal/registry/packages.go
@@ -17,7 +17,21 @@ import (
 const (
 	maximumRegistrySuggestions = 1024
 	maximumSuggestionIDLength  = 300
+	maximumInstallSubpackages  = 128
 )
+
+type InstallPackage struct {
+	Module      string
+	Name        string
+	Subpackages []InstallSubpackage
+}
+
+type InstallSubpackage struct {
+	Module      string
+	Name        string
+	Description string
+	Stability   string
+}
 
 type packageSuggestion struct {
 	ID string `json:"id"`
@@ -218,6 +232,58 @@ func resolveRegistryModuleContext(ctx context.Context, name string) (string, err
 		return "", fmt.Errorf("plugin %q has an invalid module path", name)
 	}
 	return p.Name, nil
+}
+
+// ResolveInstallPackage returns the published package members when id names a
+// package root. A provider subpackage is not itself a package and returns false.
+func ResolveInstallPackage(ctx context.Context, id string) (InstallPackage, bool, error) {
+	status, data, err := apiRequestContext(ctx, http.MethodGet, "/api/packages/"+url.PathEscape(id), "", nil)
+	if err != nil {
+		return InstallPackage{}, false, err
+	}
+	if status == http.StatusNotFound {
+		return InstallPackage{}, false, nil
+	}
+	if status != http.StatusOK {
+		return InstallPackage{}, false, fmt.Errorf("resolve package %s: %s", id, apiError(status, data))
+	}
+	var response struct {
+		Module      string `json:"module"`
+		DisplayName string `json:"displayName"`
+		Subpackages []struct {
+			Module      string `json:"module"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Stability   string `json:"stability"`
+		} `json:"subpackages"`
+	}
+	if err := unmarshalUniqueJSON(data, &response); err != nil {
+		return InstallPackage{}, false, errors.New("registry returned invalid package metadata")
+	}
+	if response.Module != id || project.ValidatePluginID(response.Module) != nil || len(response.Subpackages) > maximumInstallSubpackages {
+		return InstallPackage{}, false, errors.New("registry returned invalid package metadata")
+	}
+	if response.DisplayName == "" {
+		response.DisplayName = response.Module
+	}
+	if validateTerminalTextField("package name", response.DisplayName, 256) != nil {
+		return InstallPackage{}, false, errors.New("registry returned invalid package metadata")
+	}
+	result := InstallPackage{Module: response.Module, Name: response.DisplayName}
+	seen := map[string]bool{}
+	for _, subpackage := range response.Subpackages {
+		if project.ValidatePluginID(subpackage.Module) != nil || !strings.HasPrefix(subpackage.Module, response.Module+"/") || seen[subpackage.Module] ||
+			validateTerminalTextField("subpackage name", subpackage.Name, 256) != nil ||
+			validateTerminalTextField("subpackage description", subpackage.Description, 2048) != nil ||
+			validateTerminalTextField("subpackage stability", subpackage.Stability, 64) != nil {
+			return InstallPackage{}, false, errors.New("registry returned invalid package metadata")
+		}
+		seen[subpackage.Module] = true
+		result.Subpackages = append(result.Subpackages, InstallSubpackage{
+			Module: subpackage.Module, Name: subpackage.Name, Description: subpackage.Description, Stability: subpackage.Stability,
+		})
+	}
+	return result, true, nil
 }
 
 // registryPublish reads a wago.json manifest and POSTs it to /api/publish

--- a/cli/manager/internal/registry/packages_test.go
+++ b/cli/manager/internal/registry/packages_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -112,5 +113,53 @@ func TestClosestModule(t *testing.T) {
 	}
 	if got := closestModule("github.com/unrelated/package"); got != "" {
 		t.Fatalf("unrelated suggestion = %q, want none", got)
+	}
+}
+
+func TestResolveInstallPackageReturnsPublishedSubpackages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/packages/github.com/acme/tools" {
+			t.Errorf("request path = %q", request.URL.Path)
+		}
+		_, _ = output.Write([]byte(`{
+			"module":"github.com/acme/tools",
+			"displayName":"Acme Tools",
+			"subpackages":[
+				{"module":"github.com/acme/tools/log","name":"Logging","description":"Write logs.","stability":"stable"},
+				{"module":"github.com/acme/tools/metrics","name":"Metrics","description":"Record metrics.","stability":"experimental"}
+			]
+		}`))
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_REGISTRY", server.URL)
+
+	pkg, found, err := ResolveInstallPackage(context.Background(), "github.com/acme/tools")
+	if err != nil || !found {
+		t.Fatalf("resolve = %#v, %t, %v", pkg, found, err)
+	}
+	if pkg.Name != "Acme Tools" || len(pkg.Subpackages) != 2 || pkg.Subpackages[1].Module != "github.com/acme/tools/metrics" {
+		t.Fatalf("package = %#v", pkg)
+	}
+}
+
+func TestResolveInstallPackageTreatsProviderIDAsNonPackage(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	t.Setenv("WAGO_REGISTRY", server.URL)
+
+	if pkg, found, err := ResolveInstallPackage(context.Background(), "github.com/acme/tools/log"); err != nil || found || pkg.Module != "" {
+		t.Fatalf("resolve = %#v, %t, %v", pkg, found, err)
+	}
+}
+
+func TestResolveInstallPackageRejectsForeignSubpackage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+		_, _ = output.Write([]byte(`{"module":"github.com/acme/tools","displayName":"Tools","subpackages":[{"module":"github.com/other/package","name":"Other","description":"Other.","stability":"stable"}]}`))
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_REGISTRY", server.URL)
+
+	if _, _, err := ResolveInstallPackage(context.Background(), "github.com/acme/tools"); err == nil {
+		t.Fatal("accepted foreign subpackage")
 	}
 }

--- a/docs/plugin-api-plan.md
+++ b/docs/plugin-api-plan.md
@@ -203,18 +203,21 @@ configuration.
 
 `wago add` performs one transaction:
 
-1. Resolve the requested plugin and transitive definitions from the registry.
-2. Compute the proposed manifest, lock graph, authority review, and build inputs
+1. Resolve package metadata. An interactive package-root install chooses either
+   the root bundle or an explicit subset of its published providers;
+   non-interactive root installs keep the root and therefore select everything.
+2. Resolve the requested plugins and transitive definitions from the registry.
+3. Compute the proposed manifest, lock graph, authority review, and build inputs
    entirely in memory.
-3. Review all new or widened required and optional Authorities in one prompt.
+4. Review all new or widened required and optional Authorities in one prompt.
    Rejecting a required Authority cancels installation.
    Non-interactive callers may author exact narrower scopes with one strict
    `--scopes` JSON object keyed by full Plugin ID and exact Authority; optional
    selection remains explicit through `--allow`, `--allow-all`, or `--deny-all`.
-4. Download and verify modules into a staging build directory.
-5. Build an explicit provider catalog, verify every definition digest, validate
+5. Download and verify modules into a staging build directory.
+6. Build an explicit provider catalog, verify every definition digest, validate
    config, and dry-run the complete Plugin Plan.
-6. Atomically publish the manifest, lockfile, and built runtime. Any error keeps
+7. Atomically publish the manifest, lockfile, and built runtime. Any error keeps
    the previous project and runtime usable.
 
 Updates use the same transaction and re-review only new or widened authority.

--- a/docs/plugin-ecosystem-vnext.md
+++ b/docs/plugin-ecosystem-vnext.md
@@ -16,7 +16,7 @@ self-register with `init`.
 
 | Source repository | Provider IDs | Required Plugin Authorities | Explicit requirements and Contracts |
 |---|---|---|---|
-| `github.com/wago-org/wasi` | `github.com/wago-org/wasi`, `github.com/wago-org/wasi/p1`, `github.com/wago-org/wasi/unstable` | `host.import.define` for the provider's exact WASI module, `host.arguments.read`, `host.caller.identify`, `instance.close.observe` | None. Preview 2 remains unpublished until it implements its world completely; a placeholder is not a provider. |
+| `github.com/wago-org/wasi` | root aggregate plus `/p1`, `/p2`, and `/unstable` | P1 and unstable request exact host-import, argument, caller-identity, and close-observation access; P2 requests guest arguments | The root selects every WASI provider. P2 consumes the Component Model service; package selection can install a smaller explicit subset. |
 | `github.com/wago-org/workers` | `github.com/wago-org/workers` | bounded `instance.manage`, `instance.close.observe` | Provides `github.com/wago-org/workers/service` major 1 as an interface Contract. |
 | `github.com/JairusSW/pool` | `github.com/JairusSW/pool` | None directly | Requires `github.com/wago-org/workers` with a semver range; requires Workers Contract major 1; provides `github.com/JairusSW/pool/service` major 1. |
 | `github.com/JairusSW/lease` | `github.com/JairusSW/lease` | None | Consumes every selected `github.com/JairusSW/lease/source` major 1 provider and provides `github.com/JairusSW/lease/service` major 1. Source factories and one-shot execution remain callback-scoped; discovery never requires a process-local snapshot or factory. |


### PR DESCRIPTION
## Summary
- offer a normal Everything / Choose providers radio choice for package-root installs
- validate registry package metadata and preserve explicit version constraints
- keep non-interactive installs on the root bundle without an extra metadata request
- document the package selection transaction and WASI provider paths

## Proof
- `go test ./...`
- `go test -race ./cli/internal/tui ./cli/manager/internal/registry ./cli/manager/internal/plugin ./cli/manager/commands/plugin/add`
- `go vet ./...`
- live-tested Everything, P2-only, and Install none with unchanged state on cancellation