### PR TITLE
plugin: call package choices subpackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ wago run program.wasm hello world
 
 For GitHub plugins, `owner/repository` is shorthand for the canonical
 `github.com/owner/repository` Plugin ID. When a package publishes multiple
-providers, adding its root offers to install everything or choose individual
-providers. Explicit paths such as `wago-org/wasi/p1` install that provider
+subpackages, adding its root offers to install everything or choose individual
+subpackages. Explicit paths such as `wago-org/wasi/p1` install that subpackage
 directly. `wago add` resolves the complete dependency and Contract graph,
 reviews exact scoped Authorities, pins sources and bindings in `wago-lock.json`,
 verifies the linked definitions, and atomically publishes the rebuilt runtime.

--- a/cli/manager/commands/plugin/add/command.go
+++ b/cli/manager/commands/plugin/add/command.go
@@ -28,7 +28,7 @@ type Environment interface {
 func Command(environment Environment) *command.Cmd {
 	return &command.Cmd{
 		Name: "add", Summary: "add and enable plugins, then rebuild Wago",
-		Long:       "GitHub plugins may use owner/repository[/subpackage] shorthand. Package roots offer everything or selected providers interactively; --no-input installs everything.",
+		Long:       "GitHub plugins may use owner/repository[/subpackage] shorthand. Package roots offer everything or selected subpackages interactively; --no-input installs everything.",
 		Automation: command.DryRun,
 		Args:       "<plugin-id>[@range]...",
 		Flags: []command.Flag{

--- a/cli/manager/internal/plugin/package_selection.go
+++ b/cli/manager/internal/plugin/package_selection.go
@@ -69,7 +69,7 @@ func choosePackageInstall(pkg registry.InstallPackage) ([]string, error) {
 		if mode == "all" {
 			return []string{pkg.Module}, nil
 		}
-		selected, back, err := choosePackageProviders(pkg)
+		selected, back, err := choosePackageSubpackages(pkg)
 		if err != nil {
 			return nil, err
 		}
@@ -81,19 +81,19 @@ func choosePackageInstall(pkg registry.InstallPackage) ([]string, error) {
 
 func packageInstallModeItems(count int) []tui.Item {
 	return []tui.Item{
-		{Label: "Everything", Description: fmt.Sprintf("install all %d providers", count), Value: "all"},
-		{Label: "Choose providers", Description: "select only what you need", Value: "custom"},
+		{Label: "Everything", Description: fmt.Sprintf("install all %d subpackages", count), Value: "all"},
+		{Label: "Choose subpackages", Description: "select only what you need", Value: "custom"},
 	}
 }
 
-func choosePackageProviders(pkg registry.InstallPackage) ([]string, bool, error) {
-	selector, modules := packageProviderSelector(pkg)
+func choosePackageSubpackages(pkg registry.InstallPackage) ([]string, bool, error) {
+	selector, modules := packageSubpackageSelector(pkg)
 	for {
 		submitted, cancelled := tui.Run(selector)
 		if cancelled || !submitted {
 			return nil, true, nil
 		}
-		selected := selectedPackageProviders(selector, modules)
+		selected := selectedPackageSubpackages(selector, modules)
 		if !selector.Rejected() && len(selected) != 0 {
 			return selected, false, nil
 		}
@@ -109,7 +109,7 @@ func choosePackageProviders(pkg registry.InstallPackage) ([]string, bool, error)
 	}
 }
 
-func packageProviderSelector(pkg registry.InstallPackage) (*tui.MultiSelect, []string) {
+func packageSubpackageSelector(pkg registry.InstallPackage) (*tui.MultiSelect, []string) {
 	items := make([]tui.SelectItem, 0, len(pkg.Subpackages)+1)
 	modules := make([]string, 0, len(pkg.Subpackages))
 	for _, subpackage := range pkg.Subpackages {
@@ -126,13 +126,13 @@ func packageProviderSelector(pkg registry.InstallPackage) (*tui.MultiSelect, []s
 	}
 	items = append(items, tui.SelectItem{Label: "Install none", Description: "cancel installation", Reject: true})
 	return &tui.MultiSelect{
-		Title:  "Providers · " + pkg.Name,
+		Title:  "Subpackages · " + pkg.Name,
 		Prompt: "space toggle · enter confirm · r install none · esc back",
 		Items:  items,
 	}, modules
 }
 
-func selectedPackageProviders(selector *tui.MultiSelect, modules []string) []string {
+func selectedPackageSubpackages(selector *tui.MultiSelect, modules []string) []string {
 	var selected []string
 	for index, module := range modules {
 		if selector.Items[index].On {

--- a/cli/manager/internal/plugin/package_selection_test.go
+++ b/cli/manager/internal/plugin/package_selection_test.go
@@ -19,27 +19,27 @@ func testInstallPackage() registry.InstallPackage {
 	}
 }
 
-func TestPackageInstallModeOffersEverythingOrProviderSelection(t *testing.T) {
+func TestPackageInstallModeOffersEverythingOrSubpackageSelection(t *testing.T) {
 	items := packageInstallModeItems(3)
-	if len(items) != 2 || items[0].Label != "Everything" || items[0].Value != "all" || items[1].Label != "Choose providers" {
+	if len(items) != 2 || items[0].Label != "Everything" || items[0].Value != "all" || items[1].Label != "Choose subpackages" {
 		t.Fatalf("items = %#v", items)
 	}
 }
 
-func TestPackageProviderSelectorStartsWithEveryProviderSelected(t *testing.T) {
-	selector, modules := packageProviderSelector(testInstallPackage())
+func TestPackageSubpackageSelectorStartsWithEverySubpackageSelected(t *testing.T) {
+	selector, modules := packageSubpackageSelector(testInstallPackage())
 	frame := selector.Frame()
-	for _, want := range []string{"Providers · WASI", "Preview 1", "(stable) Core Wasm commands.", "Preview 2", "Install none"} {
+	for _, want := range []string{"Subpackages · WASI", "Preview 1", "(stable) Core Wasm commands.", "Preview 2", "Install none"} {
 		if !strings.Contains(frame, want) {
 			t.Errorf("selector does not contain %q:\n%s", want, frame)
 		}
 	}
-	selected := selectedPackageProviders(selector, modules)
+	selected := selectedPackageSubpackages(selector, modules)
 	if len(selected) != 3 || selected[2] != "github.com/wago-org/wasi/unstable" {
 		t.Fatalf("selected = %q", selected)
 	}
 	selector.Items[1].On = false
-	selected = selectedPackageProviders(selector, modules)
+	selected = selectedPackageSubpackages(selector, modules)
 	if len(selected) != 2 || selected[0] != "github.com/wago-org/wasi/p1" || selected[1] != "github.com/wago-org/wasi/unstable" {
 		t.Fatalf("custom selected = %q", selected)
 	}

--- a/docs/plugin-api-plan.md
+++ b/docs/plugin-api-plan.md
@@ -204,7 +204,7 @@ configuration.
 `wago add` performs one transaction:
 
 1. Resolve package metadata. An interactive package-root install chooses either
-   the root bundle or an explicit subset of its published providers;
+   the root bundle or an explicit subset of its published subpackages;
    non-interactive root installs keep the root and therefore select everything.
 2. Resolve the requested plugins and transitive definitions from the registry.
 3. Compute the proposed manifest, lock graph, authority review, and build inputs


### PR DESCRIPTION
## Summary
- rename package-install UI from providers to subpackages
- break internal package-selection helper names over without compatibility aliases
- retain `PluginProvider` only for the distinct runtime factory/catalog concept
- update CLI help and package-install documentation

## Proof
- `go test ./...`
- `go test -race ./cli/manager/internal/plugin ./cli/manager/commands/plugin/add`
- `go vet ./cli/manager/internal/plugin ./cli/manager/commands/plugin/add`
- live UI verified; cancellation left manifest and lock state unchanged