### PR TITLE
threads: bound host-global serialization test

### DIFF
--- a/docs/threads-atomics-plan.md
+++ b/docs/threads-atomics-plan.md
@@ -405,8 +405,13 @@ passes the full operation/width matrix, end-of-memory and effective-address
 overflow checks for every write/RMW form, contention invariants, true-overlap
 rendezvous, waiter lifecycle tests, and 250 instantiate/invoke/close cycles.
 
-Race-focused waiter and lifecycle tests pass under `go test -race`. Test
-binaries cross-compile for linux, darwin, and windows on amd64 and arm64; Windows
+Race-focused waiter and lifecycle tests pass under `go test -race`. Tests that
+hold generated native code in a deliberate spin while a Go controller publishes a
+shared-memory release must reserve at least two `GOMAXPROCS`: generated code does
+not yield its P to Go's scheduler, so a one-P test process cannot run the controller.
+Every such rendezvous must also use bounded phase waits with state diagnostics rather
+than relying on the package timeout. Test binaries cross-compile for linux, darwin,
+and windows on amd64 and arm64; Windows
 does not advertise Threads, and this local run did not provide native Linux or
 Windows execution.
 

--- a/src/wago/threads_atomic_test.go
+++ b/src/wago/threads_atomic_test.go
@@ -324,6 +324,15 @@ func TestThreadsSameInstanceConcurrentInvokeSerializesScratch(t *testing.T) {
 }
 
 func TestThreadsHostGlobalAccessSerializesWithInvoke(t *testing.T) {
+	// Generated native code does not participate in Go's asynchronous scheduler.
+	// Keep one P available for the controller while the guest deliberately spins;
+	// a one-P test process would otherwise deadlock before it can publish release.
+	previousProcs := goruntime.GOMAXPROCS(0)
+	if previousProcs < 2 {
+		goruntime.GOMAXPROCS(2)
+		t.Cleanup(func() { goruntime.GOMAXPROCS(previousProcs) })
+	}
+
 	config := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV2 | CoreFeatureThreads).WithBoundsChecks(BoundsChecksExplicit)
 	compiled, err := Compile(config, sharedThreadedGlobalHoldModule())
 	if err != nil {
@@ -355,12 +364,13 @@ func TestThreadsHostGlobalAccessSerializesWithInvoke(t *testing.T) {
 	}()
 	signal := (*uint32)(unsafe.Pointer(&memory.Bytes()[0]))
 	release := (*uint32)(unsafe.Pointer(&memory.Bytes()[4]))
-	deadline := time.Now().Add(time.Second)
+	defer atomic.StoreUint32(release, 1)
+	deadline := time.Now().Add(5 * time.Second)
 	for atomic.LoadUint32(signal) == 0 && time.Now().Before(deadline) {
 		goruntime.Gosched()
 	}
 	if atomic.LoadUint32(signal) == 0 {
-		t.Fatal("guest did not enter hold function")
+		t.Fatalf("guest did not enter hold function within 5s: signal=%d release=%d GOMAXPROCS=%d", atomic.LoadUint32(signal), atomic.LoadUint32(release), goruntime.GOMAXPROCS(0))
 	}
 	setDone := make(chan error, 1)
 	go func() { setDone <- instance.SetGlobal("global", I32(99)) }()
@@ -370,12 +380,25 @@ func TestThreadsHostGlobalAccessSerializesWithInvoke(t *testing.T) {
 	case <-time.After(20 * time.Millisecond):
 	}
 	atomic.StoreUint32(release, 1)
-	got := <-result
+	var got struct {
+		value uint64
+		err   error
+	}
+	select {
+	case got = <-result:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("guest did not observe release within 5s: signal=%d release=%d GOMAXPROCS=%d", atomic.LoadUint32(signal), atomic.LoadUint32(release), goruntime.GOMAXPROCS(0))
+	}
 	if got.err != nil || got.value != 7 {
 		t.Fatalf("hold = %d, %v; want original global 7", got.value, got.err)
 	}
-	if err := <-setDone; err != nil {
-		t.Fatal(err)
+	select {
+	case err := <-setDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("SetGlobal remained blocked after guest exit: signal=%d release=%d GOMAXPROCS=%d", atomic.LoadUint32(signal), atomic.LoadUint32(release), goruntime.GOMAXPROCS(0))
 	}
 	if value, err := instance.Global("global"); err != nil || value != I32(99) {
 		t.Fatalf("global after serialized set = %d, %v", value, err)


### PR DESCRIPTION
## Summary

- reserve two Go scheduler Ps for the test's deliberate generated-code spin rendezvous;
- bound guest entry, guest release, and host-global completion phases with focused state diagnostics;
- document the concurrency-test requirement.

## Root cause

Generated native Wasm does not yield its P to Go's asynchronous scheduler. When this test ran in a one-P process, the guest's deliberate atomic spin occupied the only P, so the Go controller could not publish the release word. The test then consumed the package-level timeout. This explains the intermittent Darwin behavior under constrained runner scheduling.

## Validation

- `GOMAXPROCS=1 go test ./src/wago -run '^TestThreadsHostGlobalAccessSerializesWithInvoke$' -count=100`
- `go test -race ./src/wago -run '^TestThreadsHostGlobalAccessSerializesWithInvoke$' -count=20`
- `go test ./...`
- `make lint`
- `make docs-check`
- Darwin amd64 and arm64 `src/wago` test binaries cross-compiled

Closes #462
