### PR TITLE
ARM64: admit memory-independent prepared leaves

### DIFF
--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -1883,9 +1883,11 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	touchesMemory := hints.touchesMemory
 	// A private prepared entry establishes X26 and preserves the full Go
 	// callee-saved set, so small integer functions need not be leaves. Keep host
-	// imports, memory caches, module-pinned globals, and EH state on the adapter.
+	// imports, memory-touching functions, module-pinned globals, and EH state on
+	// the adapter. A module-level memory alone is harmless when this function's
+	// bounded scan proves that its body never reads, writes, or grows memory.
 	directPrepared := policy.EnabledOption(optRegABI) && preparedDirectIntSig(ft) && !touchesMemory && len(modGlobals) == 0 && !hints.moduleEH &&
-		m.ImportedFuncCount() == 0 && m.MemCount() == 0 && len(c.BodyBytes) <= 96 && nLocals <= 8
+		m.ImportedFuncCount() == 0 && (m.MemCount() == 0 || !hasCall) && len(c.BodyBytes) <= 96 && nLocals <= 8
 	// Auto-inlining: collect the callees this caller will splice (before the pin
 	// setup below, which the plan can influence). A spliced memory-touching callee
 	// runs its linear-memory ops in THIS caller's frame, so fold it into

--- a/src/wago/prepared_direct_arm64_test.go
+++ b/src/wago/prepared_direct_arm64_test.go
@@ -2,7 +2,62 @@
 
 package wago
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func TestPreparedDirectARM64IgnoresUnusedModuleMemory(t *testing.T) {
+	module := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType([]wasm.ValType{wasm.I64, wasm.I64}, []wasm.ValType{wasm.I64}),
+			wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1), wasmtest.ULEB(1))),
+		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x00})), // one zero-page memory
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("add", 0, 0),
+			wasmtest.ExportEntry("size", 0, 1),
+			wasmtest.ExportEntry("call_size", 0, 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0x7c, 0x0b}),
+			wasmtest.Code([]byte{0x3f, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x10, 0x01, 0x0b}),
+		)),
+	)
+	compiled, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), module)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.directPreparedAt(0) {
+		t.Fatal("memory-independent function did not select the ARM64 direct prepared entry")
+	}
+	if compiled.directPreparedAt(1) {
+		t.Fatal("memory.size function selected the ARM64 direct prepared entry")
+	}
+	if compiled.directPreparedAt(2) {
+		t.Fatal("function calling memory.size selected the ARM64 direct prepared entry")
+	}
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareFunction("add")
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if !fn.directIntFast {
+		t.Fatal("memory-independent function did not prepare the ARM64 direct integer entry")
+	}
+	got, err := fn.Invoke2(20, 22)
+	if err != nil || len(got) != 1 || got[0] != 42 {
+		t.Fatalf("add(20,22) = %v, %v; want 42", got, err)
+	}
+}
 
 func TestPreparedDirectARM64CallIndirectAndTrapRecovery(t *testing.T) {
 	compiled, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), callIndirectModule(2, 1, 2))


### PR DESCRIPTION
## What changed

Allow a small ARM64 scalar leaf to use the existing direct prepared entry when its module declares memory but the bounded function scan proves that the function is both memory-independent and call-free.

The runtime ABI, generated native code, and ordinary memory-touching path are unchanged.

## Why

ARM64 previously rejected direct prepared entry for every function in a module with memory. Pure SWAR and multiply-high exports in such modules therefore used the wrapper path even though their bodies could not observe memory.

The call-free condition is required: an earlier candidate admitted a memory-free caller whose callee touched memory, and the full corpus caught that as an out-of-bounds trap. The final test matrix includes both direct memory use and call-through-memory near misses.

## Performance

Darwin ARM64, Apple M4 Max, Go 1.26.5, explicit bounds, Balanced objective. Each focused result is the median of 10 samples at 500 ms, candidate versus exact current `main`:

| row | main | candidate | delta |
| --- | ---: | ---: | ---: |
| `xjb-mulhi.mulhi` | 29.38 ns/op | 20.20 ns/op | -31.24% |
| `swar-pack-parse.pack` | 28.96 ns/op | 20.08 ns/op | -30.66% |
| `swar-pack-parse.parse4` | 29.16 ns/op | 20.20 ns/op | -30.70% |

All three remain 0 B/op and 0 allocs/op.

Across the complete 36-row execution corpus, the candidate improves geometric mean by 2.90% and workload-weighted time by 0.19% versus main. A long-run `globals.accumulate` control outlier was repeated back-to-back and moved about -0.9%, confirming no regression in the module-global path.

Generated native bytes for the affected corpus modules are byte-for-byte identical. Across all 36 one-shot `CompileFull` rows, summed B/op changes by 64 bytes (+0.0001%) and five allocations; weighted compile time changes by -0.15%. Peak RSS was 162,430,976 bytes on main and 161,611,776 bytes on the candidate.

## Validation

- `go test ./...`
- `go test ./...` in `bench/`
- Full 36-row execution corpus after the transitive-memory near miss was added
- Focused positive execution plus `memory.size` and call-through-`memory.size` rejection tests
- `git diff --check`

This is the first reviewable child extracted from the integration-only Railshot campaign. It is one commit, two files, and targets `main` because the generated-code-size PR is already merged.
