### PR TITLE
arm64: pair adjacent scalar loads

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -85,6 +85,7 @@
               "leaf-scratch-pins",
               "legacy-fp-pins",
               "legacy-gp-pins",
+              "load-pair",
               "local-slot-order",
               "loop-precheck",
               "loop-region-pins",

--- a/src/core/compiler/backend/railshot/arm64/knobs.go
+++ b/src/core/compiler/backend/railshot/arm64/knobs.go
@@ -21,6 +21,7 @@ var optimizationBindings = optimization.NewBindings("arm64",
 	optimization.Bind("store-load-fwd", &storeLoadFwdEnabled),
 	optimization.Bind("uxtw-add", &uxtwAddEnabled),
 	optimization.Bind("value-facts", &valueFactsEnabled),
+	optimization.Bind("load-pair", &loadPairEnabled),
 	optimization.Bind("entry-arg-pins", &entryArgPinsEnabled),
 	optimization.Bind("x8-pin", &callFreeX8PinEnabled),
 	optimization.Bind("deep-fp-pins", &deepFPPinsEnabled),
@@ -59,6 +60,7 @@ var (
 	optStoreLoadFwd          = optimizationBindings.Option("store-load-fwd")
 	optUXTWAdd               = optimizationBindings.Option("uxtw-add")
 	optValueFacts            = optimizationBindings.Option("value-facts")
+	optLoadPair              = optimizationBindings.Option("load-pair")
 	optEntryArgPins          = optimizationBindings.Option("entry-arg-pins")
 	optX8Pin                 = optimizationBindings.Option("x8-pin")
 	optDeepFPPins            = optimizationBindings.Option("deep-fp-pins")

--- a/src/core/compiler/backend/railshot/arm64/load_pair_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/load_pair_arm64_test.go
@@ -1,0 +1,212 @@
+//go:build (linux || darwin) && arm64
+
+package arm64
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	coreruntime "github.com/wago-org/wago/src/core/runtime"
+)
+
+func loadPairModuleARM64(t testing.TB, secondOffset byte) *wasm.Module {
+	t.Helper()
+	return modMem(t, 1, []wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}, []byte{
+		0x00,
+		0x20, 0x00, 0x28, 0x02, 0x00,
+		0x20, 0x00, 0x28, 0x02, secondOffset,
+		0x6a,
+		0x0b,
+	})
+}
+
+func loadPairI64ModuleARM64(t testing.TB) *wasm.Module {
+	t.Helper()
+	return modMem(t, 1, []wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I64}, []byte{
+		0x00,
+		0x20, 0x00, 0x29, 0x03, 0x00,
+		0x20, 0x00, 0x29, 0x03, 0x08,
+		0x7c,
+		0x0b,
+	})
+}
+
+func loadPairBenchModuleARM64(b testing.TB) *wasm.Module {
+	body := []byte{0x01, 0x01, 0x7f} // one i32 accumulator local
+	for i := byte(0); i < 16; i++ {
+		off := i * 8
+		body = append(body,
+			0x20, 0x01,
+			0x20, 0x00, 0x28, 0x02, off,
+			0x20, 0x00, 0x28, 0x02, off+4,
+			0x6a, 0x6a, 0x21, 0x01,
+		)
+	}
+	body = append(body, 0x20, 0x01, 0x0b)
+	return modMem(b, 1, []wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}, body)
+}
+
+func TestLoadPairExecArm64(t *testing.T) {
+	m := loadPairModuleARM64(t, 4)
+	got, err := runArm64WrapperMem(t, m, 16, func(mem []byte) {
+		binary.LittleEndian.PutUint32(mem[16:], 123)
+		binary.LittleEndian.PutUint32(mem[20:], 456)
+	})
+	if err != nil || got != 579 {
+		t.Fatalf("paired load result = %d, %v; want 579", got, err)
+	}
+	got, err = runArm64WrapperMem(t, loadPairI64ModuleARM64(t), 16, func(mem []byte) {
+		binary.LittleEndian.PutUint64(mem[16:], 123)
+		binary.LittleEndian.PutUint64(mem[24:], 456)
+	})
+	if err != nil || got != 579 {
+		t.Fatalf("paired i64 load result = %d, %v; want 579", got, err)
+	}
+	if _, err := runArm64WrapperMem(t, m, 65532, nil); err == nil {
+		t.Fatal("paired load with an out-of-bounds second lane did not trap")
+	}
+}
+
+func BenchmarkLoadPairArm64(b *testing.B) {
+	for _, enabled := range []bool{true, false} {
+		name := "enabled"
+		if !enabled {
+			name = "disabled"
+		}
+		b.Run(name, func(b *testing.B) {
+			cm, err := CompileModuleWith(loadPairBenchModuleARM64(b), CompileOptions{Optimizations: map[string]bool{"load-pair": enabled}})
+			if err != nil {
+				b.Fatal(err)
+			}
+			eng, err := coreruntime.NewEngine()
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer eng.Close()
+			jm, err := coreruntime.NewJobMemory(65536)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer jm.Close()
+			for off := 0; off < 256; off += 4 {
+				binary.LittleEndian.PutUint32(jm.CurrentBytes()[off:], 1)
+			}
+			arena, err := coreruntime.NewArena(4096)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer arena.Close()
+			code, entry, err := coreruntime.MapCode(cm.Code)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer coreruntime.Unmap(code)
+			args, results, trap := arena.Alloc(8), arena.Alloc(8), arena.Alloc(8)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := eng.Call(entry+uintptr(cm.Entry[0]), args, jm.LinearMemory(), trap, results); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(len(cm.Code)), "code-B")
+			if got := binary.LittleEndian.Uint32(results); got != 32 {
+				b.Fatalf("result = %d, want 32", got)
+			}
+		})
+	}
+}
+
+func BenchmarkCompileLoadPairArm64(b *testing.B) {
+	m := loadPairBenchModuleARM64(b)
+	for _, enabled := range []bool{true, false} {
+		name := "enabled"
+		if !enabled {
+			name = "disabled"
+		}
+		b.Run(name, func(b *testing.B) {
+			opts := CompileOptions{Workers: 1, Optimizations: map[string]bool{"load-pair": enabled}}
+			b.ReportAllocs()
+			for range b.N {
+				cm, err := CompileModuleWith(m, opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if cm.CodeImage != nil {
+					_ = cm.CodeImage.Close()
+				}
+			}
+		})
+	}
+}
+
+func TestLoadPairFiresAndNearMissesArm64(t *testing.T) {
+	var stats ModuleStats
+	paired, err := CompileModuleWith(loadPairModuleARM64(t, 4), CompileOptions{Stats: &stats, Optimizations: map[string]bool{"load-pair": true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stats.Funcs[0].Peephole["load-pair"]; got != 1 {
+		t.Fatalf("load-pair = %d, want 1 (all: %v)", got, stats.Funcs[0].Peephole)
+	}
+	unpaired, err := CompileModuleWith(loadPairModuleARM64(t, 4), CompileOptions{Optimizations: map[string]bool{"load-pair": false}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paired.Code) >= len(unpaired.Code) {
+		t.Fatalf("paired code = %d bytes, want less than unpaired %d", len(paired.Code), len(unpaired.Code))
+	}
+	var i64Stats ModuleStats
+	if _, err := CompileModuleWith(loadPairI64ModuleARM64(t), CompileOptions{Stats: &i64Stats, Optimizations: map[string]bool{"load-pair": true}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := i64Stats.Funcs[0].Peephole["load-pair"]; got != 1 {
+		t.Fatalf("i64 load-pair = %d, want 1", got)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		off   byte
+		guard bool
+	}{
+		{name: "nonadjacent", off: 8},
+		{name: "guard", off: 4, guard: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stats ModuleStats
+			if _, err := CompileModuleWith(loadPairModuleARM64(t, tc.off), CompileOptions{Stats: &stats, ElideBoundsChecks: tc.guard, Optimizations: map[string]bool{"load-pair": true}}); err != nil {
+				t.Fatal(err)
+			}
+			if got := stats.Funcs[0].Peephole["load-pair"]; got != 0 {
+				t.Fatalf("load-pair near miss = %d, want 0", got)
+			}
+		})
+	}
+
+	shared := loadPairModuleARM64(t, 4)
+	shared.Memories[0].Shared = true
+	shared.Memories[0].Limits.HasMax = true
+	shared.Memories[0].Limits.Max = 1
+	var sharedStats ModuleStats
+	if _, err := CompileModuleWith(shared, CompileOptions{Stats: &sharedStats, Optimizations: map[string]bool{"load-pair": true}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := sharedStats.Funcs[0].Peephole["load-pair"]; got != 0 {
+		t.Fatalf("shared-memory load-pair = %d, want 0", got)
+	}
+
+	differentBase := modMem(t, 1, []wasm.ValType{wasm.I32, wasm.I32}, []wasm.ValType{wasm.I32}, []byte{
+		0x00,
+		0x20, 0x00, 0x28, 0x02, 0x00,
+		0x20, 0x01, 0x28, 0x02, 0x04,
+		0x6a, 0x0b,
+	})
+	var differentStats ModuleStats
+	if _, err := CompileModuleWith(differentBase, CompileOptions{Stats: &differentStats, Optimizations: map[string]bool{"load-pair": true}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := differentStats.Funcs[0].Peephole["load-pair"]; got != 0 {
+		t.Fatalf("different-base load-pair = %d, want 0", got)
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/memory.go
+++ b/src/core/compiler/backend/railshot/arm64/memory.go
@@ -719,6 +719,45 @@ func (f *fn) memLoad(r *wasm.Reader, size int, signed, wide bool) error {
 		aliasLocal = addrLocal
 	}
 	ea, eaOwned, borrow, disp := f.memAddr(off, size, true)
+	if f.opt(optLoadPair) && !f.memoryAddr64(0) && !f.guardMode && !f.threadedMemory0 && !signed &&
+		(size == 4 && !wide || size == 8 && wide) && addrOK {
+		if first := f.s.back(); first != nil && first.kind == ekValue && first.st.kind == stMemRef &&
+			first.st.memAliasLocal() == addrLocal && first.st.memSize() == size &&
+			!first.st.memSigned() && first.st.typ.is64() == wide &&
+			disp == first.st.memDisp()+int32(size) {
+			avoid := maskOf(first.st.reg, ea)
+			dst := first.st.reg
+			if first.st.memBorrow() >= 0 {
+				dst = f.allocReg(avoid)
+				avoid = avoid.add(dst)
+			}
+			dst2 := ea
+			if !eaOwned || dst2 == dst {
+				dst2 = f.allocReg(avoid)
+			}
+			if f.a.LoadPairIdx(dst, dst2, linMemReg, ea, first.st.memDisp(), size) {
+				if first.st.memBorrow() < 0 && first.st.reg != dst {
+					f.release(first.st.reg)
+				}
+				if eaOwned && ea != dst2 && ea != dst {
+					f.release(ea)
+				}
+				f.occupy(first, dst)
+				second := f.pushReg(dst2, first.st.typ)
+				if f.opt(optValueFacts) && !wide {
+					second.st.facts = factUpper32Zero
+				}
+				f.stats.peep("load-pair")
+				return nil
+			}
+			if first.st.memBorrow() >= 0 {
+				f.release(dst)
+			}
+			if !eaOwned || ea == dst {
+				f.release(dst2)
+			}
+		}
+	}
 	// Defer the load: push a bounds-checked memory reference (the LDR is emitted
 	// when the value is materialized — arm64 has no memory operand to fold into,
 	// so unlike x86 there is no r/m consumer, but deferring still lets the consumer

--- a/src/core/compiler/backend/railshot/arm64/memsmoke_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/memsmoke_arm64_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/wago-org/wago/tests/wasmtest"
 )
 
-func modMem(t *testing.T, pages uint32, params, results []wasm.ValType, funcBody []byte) *wasm.Module {
+func modMem(t testing.TB, pages uint32, params, results []wasm.ValType, funcBody []byte) *wasm.Module {
 	t.Helper()
 	entry := append(wasmtest.ULEB(uint32(len(funcBody))), funcBody...)
 	memType := append([]byte{0x00}, wasmtest.ULEB(pages)...) // flags=0 (min only)

--- a/src/core/compiler/backend/railshot/arm64/stats.go
+++ b/src/core/compiler/backend/railshot/arm64/stats.go
@@ -96,6 +96,9 @@ var (
 	// moduleSharedTrapBodyEnabled lets internal functions replace byte-identical
 	// complete trap bodies with one B thunk and one module cold-island copy.
 	moduleSharedTrapBodyEnabled = os.Getenv("WAGO_ARM64_NO_MODULE_SHARED_TRAP_BODY") != "1"
+	// loadPairEnabled combines exact adjacent full-width scalar loads into LDP.
+	// WAGO_ARM64_NO_LOAD_PAIR=1 is the A/B oracle and rollback switch.
+	loadPairEnabled = os.Getenv("WAGO_ARM64_NO_LOAD_PAIR") != "1"
 	// singleBitBranchEnabled lets the bounded finalizer replace an explicitly
 	// recorded one-bit TST+B.cond with TBZ/TBNZ when the final target fits imm14.
 	singleBitBranchEnabled = os.Getenv("WAGO_ARM64_NO_SINGLE_BIT_BRANCH") != "1"

--- a/src/core/compiler/optimization/catalog.go
+++ b/src/core/compiler/optimization/catalog.go
@@ -375,6 +375,7 @@ var catalog = []Definition{
 	arm64("store-load-fwd", "Store/load forwarding", "forward stores into loads after assembly"),
 	arm64("uxtw-add", "Extended adds", "fold zero-extension into ADD UXTW"),
 	both("value-facts", "Value facts", "propagate bounded upper-zero and boolean provenance"),
+	arm64("load-pair", "Adjacent load pairs", "combine adjacent full-width scalar loads from one local address into LDP"),
 	both("entry-arg-pins", "Entry argument pins", "keep entry arguments in incoming registers"),
 	arm64("x8-pin", "X8 scratch pin", "pin a scratch value in call-free functions"),
 	arm64("deep-fp-pins", "Deep float pins", "pin additional float locals in call-free functions"),

--- a/src/core/encoder/arm64/asm.go
+++ b/src/core/encoder/arm64/asm.go
@@ -379,6 +379,17 @@ func (a *Asm) StpPre(rt, rt2, rn Reg, imm int32) {
 	a.word(0xA9800000 | a.pairImm7(imm) | r(rt2)<<10 | r(rn)<<5 | r(rt))
 }
 
+// LdpOffset loads rt,rt2 from [rn, #imm] without modifying rn.
+func (a *Asm) LdpOffset(rt, rt2, rn Reg, imm int32) {
+	a.word(0xA9400000 | a.pairImm7(imm) | r(rt2)<<10 | r(rn)<<5 | r(rt))
+}
+
+// LdpOffset32 loads wt,wt2 from [rn, #imm] without modifying rn.
+// imm is a BYTE offset, a signed multiple of 4 in [-256, 252].
+func (a *Asm) LdpOffset32(rt, rt2, rn Reg, imm int32) {
+	a.word(0x29400000 | uint32((imm/4)&0x7F)<<15 | r(rt2)<<10 | r(rn)<<5 | r(rt))
+}
+
 // LdpPost loads rt,rt2 from [rn], #imm (post-index, writes rn back).
 func (a *Asm) LdpPost(rt, rt2, rn Reg, imm int32) {
 	a.word(0xA8C00000 | a.pairImm7(imm) | r(rt2)<<10 | r(rn)<<5 | r(rt))

--- a/src/core/encoder/arm64/asm2.go
+++ b/src/core/encoder/arm64/asm2.go
@@ -467,6 +467,21 @@ func (a *Asm) LoadIdx(dst, base, index Reg, disp int32, size int, signed, wideDe
 	a.addDispX16(disp)
 	a.LdrIdx(dst, X16, XZR, size, signed, wideDest)
 }
+
+// LoadPairIdx loads two adjacent full-width integer values from base+index+disp.
+// It returns false when disp cannot be represented by the scaled pair immediate.
+func (a *Asm) LoadPairIdx(dst, dst2, base, index Reg, disp int32, size int) bool {
+	if size != 4 && size != 8 || disp < 0 || disp%int32(size) != 0 || disp/int32(size) > 63 {
+		return false
+	}
+	a.AddShifted(X16, base, index, 0, false)
+	if size == 4 {
+		a.LdpOffset32(dst, dst2, X16, disp)
+	} else {
+		a.LdpOffset(dst, dst2, X16, disp)
+	}
+	return true
+}
 func (a *Asm) StoreIdx(base, index, src Reg, disp int32, size int) {
 	if disp == 0 {
 		a.StrIdx(src, base, index, size)

--- a/src/core/encoder/arm64/asm_test.go
+++ b/src/core/encoder/arm64/asm_test.go
@@ -60,6 +60,8 @@ func TestEncodings(t *testing.T) {
 		{"strb w17,[x18,#1]", func(a *Asm) { a.Strb(X17, X18, 1) }, 0x39000651},
 		// frame pair
 		{"stp x29,x30,[sp,#-16]!", func(a *Asm) { a.StpPre(X29, X30, SP, -16) }, 0xa9bf7bfd},
+		{"ldp x16,x17,[x0,#16]", func(a *Asm) { a.LdpOffset(X16, X17, X0, 16) }, 0xa9414410},
+		{"ldp w16,w17,[x0,#8]", func(a *Asm) { a.LdpOffset32(X16, X17, X0, 8) }, 0x29414410},
 		{"ldp x29,x30,[sp],#16", func(a *Asm) { a.LdpPost(X29, X30, SP, 16) }, 0xa8c17bfd},
 		// compare / select / set
 		{"cmp x0,x1", func(a *Asm) { a.CmpReg64(X0, X1) }, 0xeb01001f},


### PR DESCRIPTION
## Summary

- Lower exact adjacent unsigned full-width `i32.load`/`i64.load` memory32 pairs from the same local-derived address to one ARM64 `LDP`.
- Preserve both explicit bounds checks before the memory access.
- Exclude memory64, guard-page, and shared-memory modes; fall back when the scaled pair immediate does not fit.
- Add encoder coverage, positive/near-miss/trap execution tests, immutable option plumbing, and `WAGO_ARM64_NO_LOAD_PAIR=1` as the A/B and rollback switch.

This is one extracted Railshot optimization: one commit, ten files, with no runtime ABI or cross-architecture changes.

## Exact-head performance

Measured on Apple M4 Max with Go 1.26.5 at `c232cc68`, based on current main `374e150e`. The option-disabled side is current-main behavior for this rule.

| Measurement | Main / disabled | Candidate / enabled | Delta |
| --- | ---: | ---: | ---: |
| Focused execution median | 20.44 ns/op | 19.42 ns/op | **-4.99%** |
| Focused native code | 1,032 B | 908 B | **-124 B** |
| Focused execution allocations | 0 B/op, 0 allocs/op | 0 B/op, 0 allocs/op | unchanged |
| Focused compile median | 14,154 ns/op | 14,148 ns/op | -0.04% |
| Focused compile memory | 32,912 B/op, 36 allocs/op | 32,912 B/op, 36 allocs/op | unchanged |
| 36-row execution corpus geomean | rollback disabled | default enabled | **+0.27%** |
| esbuild compile | 377.15 ms | 377.65 ms | +0.13% |
| esbuild peak RSS | 139.53 MB | 139.86 MB | **+0.33 MB / +0.23%** |
| esbuild native code | 30,934,836 B | 30,931,764 B | **-3,072 B** |

The 36 executable corpus rows contain no load-pair matches, so their +0.27% geomean is the neutral/no-hit gate. All 36 rows remained at 0 B/op and 0 allocs/op.

The compile corpus contains **1,097 matches across seven modules** and emits **8,240 fewer native bytes** in aggregate. No affected module grows:

- regexmatch: 229 hits, -1,440 B
- wasm3: 14 hits, -128 B
- utf-as-simd: 1 hit, 0 B after final layout
- lua: 92 hits, -768 B
- sqlite3: 165 hits, -1,328 B
- ruby: 209 hits, -1,504 B
- esbuild: 387 hits, -3,072 B

## Safety boundary

The rule fires only when both deferred loads:

- use memory32 with explicit bounds checks;
- are non-shared and unsigned;
- have the same full-width type;
- derive from the same local address;
- use exactly adjacent displacements; and
- fit ARM64's scaled `LDP` immediate.

Both original bounds checks are emitted before `LDP`, retaining Wasm trap order. Every excluded or over-cap case uses the existing scalar lowering.

## Validation

- `go test -race ./src/core/compiler/backend/railshot/arm64 -run TestLoadPair -count=1`
- `go test ./src/core/encoder/arm64 ./src/core/compiler/backend/railshot/arm64 -count=1`
- `go test ./src/core/compiler/backend/railshot/arm64 -count=30`
- `go test ./...`
- `go test ./...` in `bench/`
- `make lint`
- generated schema is current

One earlier local full-suite run produced an isolated native ARM64 fault. It did not recur in 40 repeated backend-package runs or either subsequent full-suite run. This PR should remain draft until exact-head CI is green.