### PR TITLE
arm64: pair declared-local zero stores

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -72,6 +72,7 @@
               "compact-i32-frame",
               "deep-fp-pins",
               "entry-arg-pins",
+              "entry-zero-pairs",
               "ext-fp-pins",
               "frame-elide",
               "frame-elide-reghomed",

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -82,6 +82,10 @@ var inlineCallFreeHintsEnabled = os.Getenv("WAGO_ARM64_NO_INLINE_CALLFREE") != "
 // function. WAGO_ARM64_NO_IMMUTABLE_TABLE=1 restores the general home-tag fork.
 var immutableLocalTableEnabled = os.Getenv("WAGO_ARM64_NO_IMMUTABLE_TABLE") != "1"
 
+// entryZeroPairsEnabled packs adjacent declared-local zero stores into one
+// offset STP. The environment switch retains exact single-store lowering for A/B.
+var entryZeroPairsEnabled = os.Getenv("WAGO_ARM64_NO_ENTRY_ZERO_PAIRS") != "1"
+
 // immutableTableTypeEnabled removes call_indirect's dynamic type check only
 // when every possible non-null entry in the immutable local table has one
 // proven structural function type.
@@ -2642,30 +2646,75 @@ func (f *fn) zeroDeclaredLocals() {
 	}
 	if !f.lazyZero {
 		a := f.a
+		pairZeros := f.opt(optEntryZeroPairs)
+		pendingZero := int32(-1)
 		// AArch64 has a zero register (XZR): store it directly, no scratch to clear.
 		for i := f.nParams; i < f.nLocals; i++ {
 			if i < 64 && f.entryInitialized&(uint64(1)<<uint(i)) != 0 {
+				if pairZeros {
+					pendingZero = f.flushDeclaredZeroSlot(pendingZero)
+				}
 				f.stats.peep("entry-init-elide")
 				continue
 			}
 			if pr, _, ok := f.pinReg(i); ok && f.localType[i] == mtV128 {
+				if pairZeros {
+					pendingZero = f.flushDeclaredZeroSlot(pendingZero)
+				}
 				a.NeonEor16b(pr, pr, pr) // zero the whole 128-bit pin register
 			} else if pr, isFloat, ok := f.pinReg(i); ok && !isFloat {
+				if pairZeros {
+					pendingZero = f.flushDeclaredZeroSlot(pendingZero)
+				}
 				a.MovImm64(pr, 0)
 			} else if ok && isFloat {
+				if pairZeros {
+					pendingZero = f.flushDeclaredZeroSlot(pendingZero)
+				}
 				a.FmovFromGpr(pr, ZR, false) // fmov d,xzr → 0.0
 			} else if f.localType[i] == mtV128 {
-				f.st64(SP, f.localOff(i), ZR)
-				f.st64(SP, f.localOff(i)+8, ZR)
+				if pairZeros {
+					pendingZero = f.queueDeclaredZeroSlot(pendingZero, f.localOff(i))
+					pendingZero = f.queueDeclaredZeroSlot(pendingZero, f.localOff(i)+8)
+				} else {
+					f.st64(SP, f.localOff(i), ZR)
+					f.st64(SP, f.localOff(i)+8, ZR)
+				}
 			} else {
-				f.st64(SP, f.localOff(i), ZR)
+				if pairZeros {
+					pendingZero = f.queueDeclaredZeroSlot(pendingZero, f.localOff(i))
+				} else {
+					f.st64(SP, f.localOff(i), ZR)
+				}
 			}
+		}
+		if pairZeros {
+			f.flushDeclaredZeroSlot(pendingZero)
 		}
 		return
 	}
 	for i := f.nParams; i < f.nLocals; i++ {
 		f.markDeclaredLocalZero(i)
 	}
+}
+
+func (f *fn) queueDeclaredZeroSlot(pending, off int32) int32 {
+	if pending >= 0 && off == pending+8 && pending <= 504 {
+		f.a.StpOffset(ZR, ZR, SP, pending)
+		f.stats.peep("entry-zero-pair")
+		return -1
+	}
+	if pending >= 0 {
+		f.st64(SP, pending, ZR)
+	}
+	return off
+}
+
+func (f *fn) flushDeclaredZeroSlot(pending int32) int32 {
+	if pending >= 0 {
+		f.st64(SP, pending, ZR)
+	}
+	return -1
 }
 
 // emitStackFenceCheck traps (StackFence → "call stack exhausted") when SP has

--- a/src/core/compiler/backend/railshot/arm64/entry_zero_pairs_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/entry_zero_pairs_arm64_test.go
@@ -1,0 +1,159 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	coreruntime "github.com/wago-org/wago/src/core/runtime"
+)
+
+func entryZeroPairsModuleARM64(t testing.TB, locals, localType byte) *wasm.Module {
+	t.Helper()
+	body := []byte{0x01, locals, localType, 0x02, 0x40} // locals; block
+	for i := byte(0); i < locals; i++ {
+		body = append(body, 0x20, i, 0x1a) // local.get i; drop
+	}
+	body = append(body, 0x0b, 0x41, 0x07, 0x0b) // end block; i32.const 7; end
+	return mod1(t, nil, []wasm.ValType{wasm.I32}, body)
+}
+
+func TestEntryZeroPairsARM64(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		locals    byte
+		localType byte
+		wantPairs int
+	}{
+		{name: "offset-cap-fallback", locals: 80, localType: 0x7e, wantPairs: 32},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := entryZeroPairsModuleARM64(t, tc.locals, tc.localType)
+			var offStats, onStats ModuleStats
+			off, err := CompileModuleWith(m, CompileOptions{Stats: &offStats, Optimizations: map[string]bool{
+				"entry-zero-pairs": false,
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			on, err := CompileModuleWith(m, CompileOptions{Stats: &onStats, Optimizations: map[string]bool{
+				"entry-zero-pairs": true,
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := onStats.Funcs[0].Peephole["entry-zero-pair"]; got != tc.wantPairs {
+				t.Fatalf("entry-zero-pair = %d, want %d", got, tc.wantPairs)
+			}
+			if got, want := len(off.Code)-len(on.Code), tc.wantPairs*4; got != want {
+				t.Fatalf("native reduction = %d, want %d", got, want)
+			}
+			got, err := runArm64WrapperWithOptions(t, m, CompileOptions{Optimizations: map[string]bool{
+				"entry-zero-pairs": true,
+			}})
+			if err != nil || got != 7 {
+				t.Fatalf("result = %d, %v; want 7", got, err)
+			}
+		})
+	}
+}
+
+func TestEntryZeroPairsV128ARM64(t *testing.T) {
+	body := []byte{0x01, 0x02, 0x7b, 0x20, 0x01, 0x1a, 0x20, 0x00}
+	body = append(body, simdOp(29)...)
+	body = append(body, 0x01, 0x0b) // i64x2.extract_lane 1; end
+	m := mod1(t, nil, []wasm.ValType{wasm.I64}, body)
+	opts := CompileOptions{Stats: &ModuleStats{}, Optimizations: map[string]bool{
+		"entry-zero-pairs": true,
+		"v128-pins":        false,
+	}}
+	cm, err := CompileModuleWith(m, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := opts.Stats.Funcs[0].Peephole["entry-zero-pair"]; got != 2 {
+		t.Fatalf("entry-zero-pair = %d, want 2", got)
+	}
+	if len(cm.Code) == 0 {
+		t.Fatal("empty native code")
+	}
+	if got, err := runArm64WrapperWithOptions(t, m, CompileOptions{Optimizations: opts.Optimizations}); err != nil || got != 0 {
+		t.Fatalf("zero v128 lane = %d, %v; want 0", got, err)
+	}
+}
+
+func BenchmarkEntryZeroPairsARM64(b *testing.B) {
+	m := entryZeroPairsModuleARM64(b, 64, 0x70)
+	for _, tc := range []struct {
+		name string
+		on   bool
+	}{{"single", false}, {"paired", true}} {
+		b.Run(tc.name, func(b *testing.B) {
+			var stats ModuleStats
+			cm, err := CompileModuleWith(m, CompileOptions{Stats: &stats, Optimizations: map[string]bool{
+				"entry-zero-pairs": tc.on,
+			}})
+			if err != nil {
+				b.Fatal(err)
+			}
+			eng, err := coreruntime.NewEngine()
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer eng.Close()
+			jm, err := coreruntime.NewJobMemory(65536)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer jm.Close()
+			arena, err := coreruntime.NewArena(4096)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer arena.Close()
+			code, entry, err := coreruntime.MapCode(cm.Code)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer coreruntime.Unmap(code)
+			args, results, trap := arena.Alloc(8), arena.Alloc(8), arena.Alloc(8)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if err := eng.Call(entry+uintptr(cm.Entry[0]), args, jm.LinearMemory(), trap, results); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if got := binary.LittleEndian.Uint32(results); got != 7 {
+				b.Fatalf("result = %d, want 7", got)
+			}
+			b.ReportMetric(float64(stats.Funcs[0].CodeBytes), "native-bytes")
+		})
+	}
+}
+
+func BenchmarkCompileEntryZeroPairsARM64(b *testing.B) {
+	m := entryZeroPairsModuleARM64(b, 64, 0x70)
+	for _, tc := range []struct {
+		name string
+		on   bool
+	}{{"single", false}, {"paired", true}} {
+		b.Run(tc.name, func(b *testing.B) {
+			opts := CompileOptions{Optimizations: map[string]bool{
+				"entry-zero-pairs": tc.on,
+			}}
+			b.ReportAllocs()
+			for range b.N {
+				cm, err := CompileModuleWith(m, opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if cm.CodeImage != nil {
+					_ = cm.CodeImage.Close()
+				}
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/knobs.go
+++ b/src/core/compiler/backend/railshot/arm64/knobs.go
@@ -22,6 +22,7 @@ var optimizationBindings = optimization.NewBindings("arm64",
 	optimization.Bind("uxtw-add", &uxtwAddEnabled),
 	optimization.Bind("value-facts", &valueFactsEnabled),
 	optimization.Bind("load-pair", &loadPairEnabled),
+	optimization.Bind("entry-zero-pairs", &entryZeroPairsEnabled),
 	optimization.Bind("entry-arg-pins", &entryArgPinsEnabled),
 	optimization.Bind("x8-pin", &callFreeX8PinEnabled),
 	optimization.Bind("deep-fp-pins", &deepFPPinsEnabled),
@@ -61,6 +62,7 @@ var (
 	optUXTWAdd               = optimizationBindings.Option("uxtw-add")
 	optValueFacts            = optimizationBindings.Option("value-facts")
 	optLoadPair              = optimizationBindings.Option("load-pair")
+	optEntryZeroPairs        = optimizationBindings.Option("entry-zero-pairs")
 	optEntryArgPins          = optimizationBindings.Option("entry-arg-pins")
 	optX8Pin                 = optimizationBindings.Option("x8-pin")
 	optDeepFPPins            = optimizationBindings.Option("deep-fp-pins")

--- a/src/core/compiler/optimization/catalog.go
+++ b/src/core/compiler/optimization/catalog.go
@@ -376,6 +376,7 @@ var catalog = []Definition{
 	arm64("uxtw-add", "Extended adds", "fold zero-extension into ADD UXTW"),
 	both("value-facts", "Value facts", "propagate bounded upper-zero and boolean provenance"),
 	arm64("load-pair", "Adjacent load pairs", "combine adjacent full-width scalar loads from one local address into LDP"),
+	arm64("entry-zero-pairs", "Entry zero pairs", "pair adjacent declared-local zero stores in function prologues"),
 	both("entry-arg-pins", "Entry argument pins", "keep entry arguments in incoming registers"),
 	arm64("x8-pin", "X8 scratch pin", "pin a scratch value in call-free functions"),
 	arm64("deep-fp-pins", "Deep float pins", "pin additional float locals in call-free functions"),

--- a/src/core/encoder/arm64/asm.go
+++ b/src/core/encoder/arm64/asm.go
@@ -379,6 +379,11 @@ func (a *Asm) StpPre(rt, rt2, rn Reg, imm int32) {
 	a.word(0xA9800000 | a.pairImm7(imm) | r(rt2)<<10 | r(rn)<<5 | r(rt))
 }
 
+// StpOffset stores rt,rt2 at [rn, #imm] without modifying rn.
+func (a *Asm) StpOffset(rt, rt2, rn Reg, imm int32) {
+	a.word(0xA9000000 | a.pairImm7(imm) | r(rt2)<<10 | r(rn)<<5 | r(rt))
+}
+
 // LdpOffset loads rt,rt2 from [rn, #imm] without modifying rn.
 func (a *Asm) LdpOffset(rt, rt2, rn Reg, imm int32) {
 	a.word(0xA9400000 | a.pairImm7(imm) | r(rt2)<<10 | r(rn)<<5 | r(rt))

--- a/src/core/encoder/arm64/asm_test.go
+++ b/src/core/encoder/arm64/asm_test.go
@@ -60,6 +60,7 @@ func TestEncodings(t *testing.T) {
 		{"strb w17,[x18,#1]", func(a *Asm) { a.Strb(X17, X18, 1) }, 0x39000651},
 		// frame pair
 		{"stp x29,x30,[sp,#-16]!", func(a *Asm) { a.StpPre(X29, X30, SP, -16) }, 0xa9bf7bfd},
+		{"stp xzr,xzr,[sp,#16]", func(a *Asm) { a.StpOffset(XZR, XZR, SP, 16) }, 0xa9017fff},
 		{"ldp x16,x17,[x0,#16]", func(a *Asm) { a.LdpOffset(X16, X17, X0, 16) }, 0xa9414410},
 		{"ldp w16,w17,[x0,#8]", func(a *Asm) { a.LdpOffset32(X16, X17, X0, 8) }, 0x29414410},
 		{"ldp x29,x30,[sp],#16", func(a *Asm) { a.LdpPost(X29, X30, SP, 16) }, 0xa8c17bfd},


### PR DESCRIPTION
## Summary

- Pair adjacent declared-local zero stores in ARM64 function prologues as `STP XZR, XZR`.
- Flush gaps, pinned locals, initialized locals, and offsets beyond the signed scaled-pair range through the existing scalar `STR` path.
- Add offset-`STP` encoding, policy/schema plumbing, execution and near-boundary coverage, focused benchmarks, and `WAGO_ARM64_NO_ENTRY_ZERO_PAIRS=1` as the A/B and rollback switch.

This is one extracted Railshot optimization: one commit, seven files, with no runtime ABI or cross-architecture changes.

## Exact-main performance

Measured on Apple M4 Max with Go 1.26.5 at `6fcf428d`, based on current main `084c9c41`. The disabled side is current-main lowering for this rule.

| Measurement | Main / single | Candidate / paired | Delta |
| --- | ---: | ---: | ---: |
| Focused entry execution median | 15.59 ns/op | 14.12 ns/op | **-9.43%** |
| Focused native code | 320 B | 236 B | **-84 B / -26.25%** |
| Focused execution allocations | 0 B/op, 0 allocs/op | 0 B/op, 0 allocs/op | unchanged |
| Focused compile median | 10,057 ns/op | 9,743 ns/op | **-3.12%** |
| Focused compile memory | 30,891 B/op, 32 allocs/op | 30,891 B/op, 32 allocs/op | unchanged |
| 36-row execution corpus geomean | rollback disabled | default enabled | **+0.24%** |
| esbuild compile | 377.53 ms | 376.36 ms | **-0.31%** |
| esbuild peak RSS | 139.57 MB | 139.82 MB | **+0.25 MB / +0.18%** |
| esbuild native code | 30,931,764 B | 30,902,116 B | **-29,648 B** |

All 36 execution rows remain at 0 B/op and 0 allocs/op. The +0.24% corpus geomean stays within the 0.5% gate.

The compile corpus contains **39,382 matches across 16 modules** and emits **158,816 fewer native bytes** in aggregate. No affected module grows:

- Ruby: 26,645 hits, -109,008 B
- esbuild: 7,596 hits, -29,648 B
- sqlite3: 2,464 hits, -9,648 B
- regexmatch: 1,781 hits, -6,976 B
- lua: 433 hits, -1,600 B
- wasm3: 342 hits, -1,408 B
- remaining ten modules: 121 hits, -528 B after final layout

## Safety boundary

The rule runs only while eagerly zeroing declared-local frame slots. It keeps one pending aligned slot and emits a pair only when:

- the next slot is exactly eight bytes later; and
- the first slot fits ARM64's signed scaled `STP` offset (at most +504).

Any local hole, register-pinned local, definitely initialized local, or out-of-range offset flushes through the existing single-store path. There is no safepoint between these prologue stores, so pairing preserves root initialization and observable Wasm behavior.

## Validation

- `go test -race ./src/core/compiler/backend/railshot/arm64 -run TestEntryZeroPairs -count=1`
- `go test ./src/core/encoder/arm64 ./src/core/compiler/backend/railshot/arm64 -count=1`
- `go test ./...`
- `go test ./...` in `bench/`
- `make lint`
- generated schema is current
