### PR TITLE
arm64: pair wrapper parameter homes

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -72,6 +72,7 @@
               "compact-i32-frame",
               "deep-fp-pins",
               "entry-arg-pins",
+              "entry-param-pairs",
               "entry-zero-pairs",
               "ext-fp-pins",
               "frame-elide",

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -82,6 +82,12 @@ var inlineCallFreeHintsEnabled = os.Getenv("WAGO_ARM64_NO_INLINE_CALLFREE") != "
 // function. WAGO_ARM64_NO_IMMUTABLE_TABLE=1 restores the general home-tag fork.
 var immutableLocalTableEnabled = os.Getenv("WAGO_ARM64_NO_IMMUTABLE_TABLE") != "1"
 
+// entryParamPairsEnabled packs adjacent wrapper-ABI scalar parameter homes into
+// pair loads/stores. Register-ABI entries retain scalar stores: their immediate
+// scalar-reload workloads measured slower with STP on current Apple cores.
+// The environment switch retains exact scalar lowering for A/B.
+var entryParamPairsEnabled = os.Getenv("WAGO_ARM64_NO_ENTRY_PARAM_PAIRS") != "1"
+
 // entryZeroPairsEnabled packs adjacent declared-local zero stores into one
 // offset STP. The environment switch retains exact single-store lowering for A/B.
 var entryZeroPairsEnabled = os.Getenv("WAGO_ARM64_NO_ENTRY_ZERO_PAIRS") != "1"
@@ -2607,6 +2613,8 @@ func (f *fn) prologue() {
 		paramOff += abiValSize(pt)
 	}
 	x0ParamOff := int32(-1) // a param pinned in X0 must load LAST: X0 is the args base
+	pairParams := f.opt(optEntryParamPairs)
+	pendingParam := pendingWrapperParamHome{}
 	paramOff = 0
 	for i, pt := range f.ft.Params {
 		if f.localType[i] != mtV128 {
@@ -2619,14 +2627,21 @@ func (f *fn) prologue() {
 			} else if ok && isFloat {
 				a.FLoadDisp(pr, X0, paramOff, f.localType[i] == mtF64) // pinned float param → V reg
 			} else {
-				// X16 (backend scratch) is the copy temp: X0 is the serArgs base and
-				// must stay live for the remaining param loads (amd64 used RAX here,
-				// but on arm64 that role register aliases the args base).
-				f.ld64(X16, X0, paramOff)
-				f.st64(SP, f.localOff(i), X16)
+				if pairParams {
+					pendingParam = f.queueWrapperParamHome(pendingParam, paramOff, f.localOff(i))
+				} else {
+					// X16 (backend scratch) is the copy temp: X0 is the serArgs base and
+					// must stay live for the remaining param loads (amd64 used RAX here,
+					// but on arm64 that role register aliases the args base).
+					f.ld64(X16, X0, paramOff)
+					f.st64(SP, f.localOff(i), X16)
+				}
 			}
 		}
 		paramOff += abiValSize(pt)
+	}
+	if pairParams {
+		f.flushWrapperParamHome(pendingParam)
 	}
 	if x0ParamOff >= 0 {
 		f.ld64(X0, X0, x0ParamOff)
@@ -2634,6 +2649,33 @@ func (f *fn) prologue() {
 	f.zeroDeclaredLocals()
 	f.derivePinnedGlobals()
 	f.deriveModuleGlobals() // offset-0 entry: cells → module-pinned registers
+}
+
+type pendingWrapperParamHome struct {
+	argOff   int32
+	localOff int32
+	valid    bool
+}
+
+func (f *fn) queueWrapperParamHome(p pendingWrapperParamHome, argOff, localOff int32) pendingWrapperParamHome {
+	if p.valid && argOff == p.argOff+8 && localOff == p.localOff+8 && p.argOff <= 504 && p.localOff <= 504 {
+		f.a.LdpOffset(X16, X17, X0, p.argOff)
+		f.a.StpOffset(X16, X17, SP, p.localOff)
+		f.stats.peep("entry-param-pair-wrapper")
+		return pendingWrapperParamHome{}
+	}
+	if p.valid {
+		f.ld64(X16, X0, p.argOff)
+		f.st64(SP, p.localOff, X16)
+	}
+	return pendingWrapperParamHome{argOff: argOff, localOff: localOff, valid: true}
+}
+
+func (f *fn) flushWrapperParamHome(p pendingWrapperParamHome) {
+	if p.valid {
+		f.ld64(X16, X0, p.argOff)
+		f.st64(SP, p.localOff, X16)
+	}
 }
 
 // zeroDeclaredLocals initializes non-parameter locals. Most functions keep the

--- a/src/core/compiler/backend/railshot/arm64/entry_param_pairs_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/entry_param_pairs_arm64_test.go
@@ -1,0 +1,167 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	encoderarm64 "github.com/wago-org/wago/src/core/encoder/arm64"
+	coreruntime "github.com/wago-org/wago/src/core/runtime"
+)
+
+func parameterSumBody(n int) []byte {
+	body := []byte{0x00}
+	for i := range n {
+		body = append(body, 0x20, byte(i))
+		if i != 0 {
+			body = append(body, 0x7c) // i64.add
+		}
+	}
+	return append(body, 0x0b)
+}
+
+func parameterTypes(n int) []wasm.ValType {
+	params := make([]wasm.ValType, n)
+	for i := range params {
+		params[i] = wasm.I64
+	}
+	return params
+}
+
+func TestEntryParamPairsWrapperARM64(t *testing.T) {
+	const n = 32
+	m := mod1(t, parameterTypes(n), []wasm.ValType{wasm.I64}, parameterSumBody(n))
+	compile := func(on bool) (int, ModuleStats) {
+		var stats ModuleStats
+		cm, err := CompileModuleWith(m, CompileOptions{Stats: &stats, Optimizations: map[string]bool{
+			"entry-param-pairs": on,
+			"reg-abi":           false,
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		codeLen := len(cm.Code)
+		if cm.CodeImage != nil {
+			_ = cm.CodeImage.Close()
+		}
+		return codeLen, stats
+	}
+	off, _ := compile(false)
+	on, onStats := compile(true)
+	pairs := onStats.Funcs[0].Peephole["entry-param-pair-wrapper"]
+	if pairs != 8 {
+		t.Fatalf("wrapper parameter pairs = %d, want 8", pairs)
+	}
+	if got, want := off-on, pairs*8; got != want {
+		t.Fatalf("native reduction = %d, want %d", got, want)
+	}
+	args := make([]uint64, n)
+	for i := range args {
+		args[i] = uint64(i + 1)
+	}
+	got, err := runArm64WrapperWithOptions(t, m, CompileOptions{Optimizations: map[string]bool{
+		"entry-param-pairs": true,
+		"reg-abi":           false,
+	}}, args...)
+	if err != nil || got != 528 {
+		t.Fatalf("sum = %d, %v; want 528", got, err)
+	}
+}
+
+func TestEntryParamPairsOffsetCapARM64(t *testing.T) {
+	f := fn{a: &encoderarm64.Asm{}, stats: &CodegenStats{}}
+	p := f.queueWrapperParamHome(pendingWrapperParamHome{}, 504, 504)
+	p = f.queueWrapperParamHome(p, 512, 512)
+	if p.valid || f.stats.Peephole["entry-param-pair-wrapper"] != 1 {
+		t.Fatalf("in-range pair = %+v, stats=%v", p, f.stats.Peephole)
+	}
+	p = f.queueWrapperParamHome(pendingWrapperParamHome{}, 512, 512)
+	p = f.queueWrapperParamHome(p, 520, 520)
+	f.flushWrapperParamHome(p)
+	if got := f.stats.Peephole["entry-param-pair-wrapper"]; got != 1 {
+		t.Fatalf("out-of-range pair count = %d, want 1", got)
+	}
+}
+
+func BenchmarkEntryParamPairsARM64(b *testing.B) {
+	const n = 32
+	m := mod1(b, parameterTypes(n), []wasm.ValType{wasm.I64}, parameterSumBody(n))
+	for _, tc := range []struct {
+		name string
+		on   bool
+	}{{"single", false}, {"paired", true}} {
+		b.Run(tc.name, func(b *testing.B) {
+			var stats ModuleStats
+			cm, err := CompileModuleWith(m, CompileOptions{Stats: &stats, Optimizations: map[string]bool{
+				"entry-param-pairs": tc.on,
+				"reg-abi":           false,
+			}})
+			if err != nil {
+				b.Fatal(err)
+			}
+			eng, err := coreruntime.NewEngine()
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer eng.Close()
+			jm, err := coreruntime.NewJobMemory(65536)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer jm.Close()
+			arena, err := coreruntime.NewArena(4096)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer arena.Close()
+			code, entry, err := coreruntime.MapCode(cm.Code)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer coreruntime.Unmap(code)
+			args, results, trap := arena.Alloc(n*8), arena.Alloc(8), arena.Alloc(8)
+			for i := range n {
+				binary.LittleEndian.PutUint64(args[i*8:], uint64(i+1))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if err := eng.Call(entry+uintptr(cm.Entry[0]), args, jm.LinearMemory(), trap, results); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if got := binary.LittleEndian.Uint64(results); got != 528 {
+				b.Fatalf("sum = %d, want 528", got)
+			}
+			b.ReportMetric(float64(stats.Funcs[0].CodeBytes), "native-bytes")
+		})
+	}
+}
+
+func BenchmarkCompileEntryParamPairsARM64(b *testing.B) {
+	const n = 32
+	m := mod1(b, parameterTypes(n), []wasm.ValType{wasm.I64}, parameterSumBody(n))
+	for _, tc := range []struct {
+		name string
+		on   bool
+	}{{"single", false}, {"paired", true}} {
+		b.Run(tc.name, func(b *testing.B) {
+			opts := CompileOptions{Optimizations: map[string]bool{
+				"entry-param-pairs": tc.on,
+				"reg-abi":           false,
+			}}
+			b.ReportAllocs()
+			for range b.N {
+				cm, err := CompileModuleWith(m, opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if cm.CodeImage != nil {
+					_ = cm.CodeImage.Close()
+				}
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/knobs.go
+++ b/src/core/compiler/backend/railshot/arm64/knobs.go
@@ -22,6 +22,7 @@ var optimizationBindings = optimization.NewBindings("arm64",
 	optimization.Bind("uxtw-add", &uxtwAddEnabled),
 	optimization.Bind("value-facts", &valueFactsEnabled),
 	optimization.Bind("load-pair", &loadPairEnabled),
+	optimization.Bind("entry-param-pairs", &entryParamPairsEnabled),
 	optimization.Bind("entry-zero-pairs", &entryZeroPairsEnabled),
 	optimization.Bind("entry-arg-pins", &entryArgPinsEnabled),
 	optimization.Bind("x8-pin", &callFreeX8PinEnabled),
@@ -62,6 +63,7 @@ var (
 	optUXTWAdd               = optimizationBindings.Option("uxtw-add")
 	optValueFacts            = optimizationBindings.Option("value-facts")
 	optLoadPair              = optimizationBindings.Option("load-pair")
+	optEntryParamPairs       = optimizationBindings.Option("entry-param-pairs")
 	optEntryZeroPairs        = optimizationBindings.Option("entry-zero-pairs")
 	optEntryArgPins          = optimizationBindings.Option("entry-arg-pins")
 	optX8Pin                 = optimizationBindings.Option("x8-pin")

--- a/src/core/compiler/optimization/catalog.go
+++ b/src/core/compiler/optimization/catalog.go
@@ -376,6 +376,7 @@ var catalog = []Definition{
 	arm64("uxtw-add", "Extended adds", "fold zero-extension into ADD UXTW"),
 	both("value-facts", "Value facts", "propagate bounded upper-zero and boolean provenance"),
 	arm64("load-pair", "Adjacent load pairs", "combine adjacent full-width scalar loads from one local address into LDP"),
+	arm64("entry-param-pairs", "Entry parameter pairs", "pair adjacent serialized wrapper parameter homes in function prologues"),
 	arm64("entry-zero-pairs", "Entry zero pairs", "pair adjacent declared-local zero stores in function prologues"),
 	both("entry-arg-pins", "Entry argument pins", "keep entry arguments in incoming registers"),
 	arm64("x8-pin", "X8 scratch pin", "pin a scratch value in call-free functions"),


### PR DESCRIPTION
## What changed

Pair adjacent scalar wrapper-ABI parameter homes on ARM64:

```text
LDR X16, [X0, #arg]
STR X16, [SP, #local]
LDR X16, [X0, #arg+8]
STR X16, [SP, #local+8]
```

becomes:

```text
LDP X16, X17, [X0, #arg]
STP X16, X17, [SP, #local]
```

The matcher is bounded to exactly adjacent eight-byte argument and local offsets within the signed pair-immediate range. Pins, V128 parameters, holes, odd tails, and out-of-range offsets retain the existing scalar path. Register-ABI entry remains unchanged.

The optimization is part of the immutable ARM64 catalog and can be rolled back with `WAGO_ARM64_NO_ENTRY_PARAM_PAIRS=1`.

## Scope

- Base: exact `main` at `23e161476700bdfb37de93f9336b8a550ea7b675`.
- One commit, five files.
- No runtime, ABI, GC, AMD64, finalizer, or public API changes.
- No per-operation or execution allocation.

## Performance

Apple M4 Max, Go 1.26.5, balanced objective.

Focused 32-parameter wrapper, exact option-off versus option-on, five 500 ms samples:

| Metric | Scalar rollback | Paired | Delta |
| --- | ---: | ---: | ---: |
| Execution median | 17.94 ns/op | 16.00 ns/op | **-10.81%** |
| Native code | 456 B | 392 B | **-64 B / -14.04%** |
| Compile median | 8.374 us/op | 8.221 us/op | **-1.83%** |
| Execution allocations | 0 B / 0 allocs | 0 B / 0 allocs | unchanged |
| Compile allocations | 25,768 B / 33 allocs | 25,768 B / 33 allocs | unchanged |

Full 36-row executable corpus, exact option-on versus rollback, four paired 300 ms samples per mode:

- Execution geometric mean: **+0.247%**.
- Median row: **+0.054%**.
- Faster rows: 16/36.
- Every row: 0 B/op and 0 allocs/op.
- This remains inside the documented 0.5% whole-corpus gate.

Static exact-current corpus compilation:

- 612 paired homes across four affected modules.
- Native code: 81,633,736 B to 81,628,840 B (**-4,896 B**).
- No corpus module grows.

Worst-case affected Ruby compile, exact main versus this commit, balanced two-run order:

| Metric | Exact main | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Full compile median | 916.919 ms | 905.850 ms | **-1.21%** |
| Peak RSS median | 155,803,648 B | 155,885,568 B | **+81,920 B / +0.053%** |
| Native code | 41,032,560 B | 41,028,544 B | **-4,016 B** |
| Compile allocations | effectively unchanged | effectively unchanged | unchanged |

## Validation

- `go test -race ./src/core/compiler/backend/railshot/arm64 -run 'TestEntryParamPairs' -count=1`
- `go test ./src/core/encoder/arm64 ./src/core/compiler/backend/railshot/arm64 -count=1`
- `go test ./...`
- `go test ./...` in `bench/`
- `make lint` (local staticcheck unavailable; all other lint stages passed)
- `git diff --check`

Tests cover the exact code-size reduction, native execution, rollback behavior, the maximum encodable pair offset, and scalar fallback beyond that cap.
