### PR TITLE
arm64: skip dead forward-merge reloads

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -91,6 +91,7 @@
               "local-slot-order",
               "loop-precheck",
               "loop-region-pins",
+              "merge-next-use",
               "multi-bounds-cert",
               "olddest-rhs-sink",
               "reg-abi",

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -44,6 +44,11 @@ var uxtwAddEnabled = os.Getenv("WAGO_ARM64_NOUXTW") != "1"
 // nodes. WAGO_ARM64_NOPROVENANCE=1 retains the pre-facts path for A/B checks.
 var valueFactsEnabled = os.Getenv("WAGO_ARM64_NOPROVENANCE") != "1"
 
+// mergeNextUseEnabled avoids forward-edge local reloads when bounded lookahead
+// proves the local is overwritten or dead before its next read. Loop and EH
+// targets stay conservative. WAGO_ARM64_NO_MERGE_NEXT_USE=1 restores eager loads.
+var mergeNextUseEnabled = os.Getenv("WAGO_ARM64_NO_MERGE_NEXT_USE") != "1"
+
 // sharedTrapUnwindEnabled lets Size/Embedded functions replace repeated
 // terminal trap-unwind tails with one function-local cold tail. The hot trap
 // checks and the Speed/Balanced layouts are unchanged.

--- a/src/core/compiler/backend/railshot/arm64/control.go
+++ b/src/core/compiler/backend/railshot/arm64/control.go
@@ -1401,7 +1401,7 @@ func (f *fn) opElse() error {
 	return nil
 }
 
-func (f *fn) opEnd() error {
+func (f *fn) opEnd(r *wasm.Reader) error {
 	last := len(f.ctrl) - 1
 	fr := f.ctrl[last]
 	// ctrl backing is reused across functions. Clear the popped slot so its
@@ -1447,7 +1447,8 @@ func (f *fn) opEnd() error {
 			// Merge edge: converge to the end's recorded state (or fix it).
 			// A loop end is NOT a merge — br edges target the loop TOP — so the
 			// fall-through's state simply flows out.
-			f.convergeEdgeTo(&fr.branchState)
+			deadGP, deadFP := f.planForwardMergeDeadLocals(r, fr.branchState, nil)
+			f.convergeEdgeToWithDead(&fr.branchState, deadGP, deadFP)
 		}
 		if fr.regMerge1 {
 			f.reconcileMerge1(&fr) // result → mergeReg, operands below → slots
@@ -1467,10 +1468,19 @@ func (f *fn) opEnd() error {
 		// edges fixed a stronger end state (or a regMerge1 passthrough needs its
 		// value in mergeReg), a stub on this edge converges it. The then
 		// fall-through jumps over the stub.
+		deadGP, deadFP := f.planForwardMergeDeadLocals(r, fr.branchState, fr.entryState)
 		needLoads := false
 		if f.usesCalls && fr.branchState != nil && fr.entryState != nil {
 			for x := 0; x < f.nLocals; x++ {
-				if _, _, ok := f.pinReg(x); ok && fr.branchState[x] == lsStackReg && fr.entryState[x] == lsMem {
+				reg, isFloat, ok := f.pinReg(x)
+				if !ok || fr.branchState[x] != lsStackReg || fr.entryState[x] != lsMem {
+					continue
+				}
+				dead := deadGP.has(reg)
+				if isFloat {
+					dead = deadFP.has(reg)
+				}
+				if !dead {
 					needLoads = true
 					break
 				}
@@ -1492,7 +1502,7 @@ func (f *fn) opEnd() error {
 		// Converge the cond-false edge from the header snapshot into the end state
 		// (records it when this is the only end edge).
 		f.setLocalsState(fr.entryState)
-		f.convergeEdgeTo(&fr.branchState)
+		f.convergeEdgeToWithDead(&fr.branchState, deadGP, deadFP)
 		if skip != -1 {
 			f.a.PatchBranch26(skip, f.a.Len()) // the skip is an unconditional B (imm26)
 		}

--- a/src/core/compiler/backend/railshot/arm64/driver.go
+++ b/src/core/compiler/backend/railshot/arm64/driver.go
@@ -61,7 +61,7 @@ func (f *fn) bodyLoop(r *wasm.Reader, minCtrl int) error {
 		case 0x05: // else
 			err = f.opElse()
 		case 0x0b: // end
-			err = f.opEnd()
+			err = f.opEnd(r)
 		case 0x0c, 0x0d: // br / br_if
 			err = f.opBr(r, op == 0x0d)
 		case 0x0e: // br_table

--- a/src/core/compiler/backend/railshot/arm64/knobs.go
+++ b/src/core/compiler/backend/railshot/arm64/knobs.go
@@ -22,6 +22,7 @@ var optimizationBindings = optimization.NewBindings("arm64",
 	optimization.Bind("uxtw-add", &uxtwAddEnabled),
 	optimization.Bind("value-facts", &valueFactsEnabled),
 	optimization.Bind("load-pair", &loadPairEnabled),
+	optimization.Bind("merge-next-use", &mergeNextUseEnabled),
 	optimization.Bind("entry-param-pairs", &entryParamPairsEnabled),
 	optimization.Bind("entry-zero-pairs", &entryZeroPairsEnabled),
 	optimization.Bind("entry-arg-pins", &entryArgPinsEnabled),
@@ -63,6 +64,7 @@ var (
 	optUXTWAdd               = optimizationBindings.Option("uxtw-add")
 	optValueFacts            = optimizationBindings.Option("value-facts")
 	optLoadPair              = optimizationBindings.Option("load-pair")
+	optMergeNextUse          = optimizationBindings.Option("merge-next-use")
 	optEntryParamPairs       = optimizationBindings.Option("entry-param-pairs")
 	optEntryZeroPairs        = optimizationBindings.Option("entry-zero-pairs")
 	optEntryArgPins          = optimizationBindings.Option("entry-arg-pins")

--- a/src/core/compiler/backend/railshot/arm64/localstate.go
+++ b/src/core/compiler/backend/railshot/arm64/localstate.go
@@ -2,7 +2,11 @@
 
 package arm64
 
-import a64 "github.com/wago-org/wago/src/core/encoder/arm64"
+import (
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	a64 "github.com/wago-org/wago/src/core/encoder/arm64"
+)
 
 // WARP's STACK_REG lazy local-spill model (Common.cpp saveLocalsAndParamsFor
 // FuncCall / recoverLocalToReg / recoverAllLocalsToRegBranch), for CALL-MAKING
@@ -308,6 +312,10 @@ func (f *fn) freeEndsBuf(b []int) {
 }
 
 func (f *fn) convergeEdgeTo(target *[]locState) {
+	f.convergeEdgeToWithDead(target, 0, 0)
+}
+
+func (f *fn) convergeEdgeToWithDead(target *[]locState, deadGP, deadFP regMask) {
 	// Dirty registers and lazy zeros always materialize to the slot: every
 	// target guarantees at least "slot is current". Non-lazy functions can never
 	// contain lsConstZero and skip that complete local-array scan.
@@ -346,10 +354,60 @@ func (f *fn) convergeEdgeTo(target *[]locState) {
 			continue
 		}
 		if t[x] == lsStackReg && f.locals[x].state == lsMem {
+			dead := deadGP.has(reg)
+			if isFloat {
+				dead = deadFP.has(reg)
+			}
+			if dead {
+				t[x] = lsMem
+				f.stats.peep("merge-dead-reload")
+				continue
+			}
 			f.loadLocalReg(x, reg, isFloat)
 			f.locals[x].state = lsStackReg
 		}
 	}
+}
+
+const maxMergeNextUseOps = shared.MergeNextUseFuel
+
+// planForwardMergeDeadLocals returns fixed register masks for target locals
+// that arrive memory-only on the current forward edge and are overwritten or
+// dead before their next read after the merge. It copies the active reader and
+// uses constant storage; uncertainty, nested control, and fuel exhaustion keep
+// the existing eager edge reload.
+func (f *fn) planForwardMergeDeadLocals(r *wasm.Reader, target, source []locState) (deadGP, deadFP regMask) {
+	if !f.opt(optMergeNextUse) || !f.usesCalls || f.moduleEH || target == nil {
+		return 0, 0
+	}
+	var candidates [64]shared.MergeLocalCandidate
+	n := 0
+	for x := 0; x < f.nLocals; x++ {
+		state := f.locals[x].state
+		if source != nil {
+			state = source[x]
+		}
+		if target[x] != lsStackReg || state != lsMem {
+			continue
+		}
+		reg, isFloat, ok := f.pinReg(x)
+		if !ok {
+			continue
+		}
+		if n == len(candidates) {
+			return 0, 0
+		}
+		candidates[n] = shared.MergeLocalCandidate{Local: uint32(x), Reg: uint8(reg), FP: isFloat}
+		n++
+	}
+	if n == 0 {
+		return 0, 0
+	}
+	gp, fp, ok := shared.ScanForwardMergeDeadLocals(r, f.localBase, candidates[:n])
+	if !ok {
+		return 0, 0
+	}
+	return regMask(gp), regMask(fp)
 }
 
 // setLocalsState installs a merge point's recorded target as the tracked state

--- a/src/core/compiler/backend/railshot/arm64/merge_next_use_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/merge_next_use_arm64_test.go
@@ -1,0 +1,158 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func forwardMergeModuleARM64(t testing.TB, after []byte) *wasm.Module {
+	t.Helper()
+	i32x2 := []wasm.ValType{wasm.I32, wasm.I32}
+	body := []byte{
+		0x00,
+		0x20, 0x00, 0x41, 0x01, 0x6a, 0x21, 0x00, // dirty local0
+		0x10, 0x01, // call: local0 becomes memory-only
+		0x20, 0x01, 0x04, 0x40, // if param1
+		0x20, 0x00, 0x1a, // then edge reloads local0
+		0x0b,
+	}
+	body = append(body, after...)
+	body = append(body, 0x41, 0x07, 0x0b)
+	return modFuncs(t,
+		funcDef{params: i32x2, results: []wasm.ValType{wasm.I32}, body: body},
+		funcDef{body: []byte{0x01, 0x01, 0x7f, 0x0b}},
+	)
+}
+
+func compileForwardMergeStatsARM64(t testing.TB, m *wasm.Module, on bool) CodegenStats {
+	t.Helper()
+	var stats ModuleStats
+	cm, err := CompileModuleWith(m, CompileOptions{Stats: &stats, Optimizations: map[string]bool{
+		"inline":         false,
+		"merge-next-use": on,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cm.CodeImage != nil {
+		_ = cm.CodeImage.Close()
+	}
+	return *stats.Funcs[0]
+}
+
+func TestForwardMergeNextUseSkipsDeadReloadARM64(t *testing.T) {
+	m := forwardMergeModuleARM64(t, nil)
+	without := compileForwardMergeStatsARM64(t, m, false)
+	with := compileForwardMergeStatsARM64(t, m, true)
+	if without.Peephole["merge-dead-reload"] != 0 || with.Peephole["merge-dead-reload"] != 1 {
+		t.Fatalf("merge dead reloads disabled=%v enabled=%v", without.Peephole, with.Peephole)
+	}
+	if with.CodeBytes >= without.CodeBytes {
+		t.Fatalf("enabled code bytes = %d, want less than %d", with.CodeBytes, without.CodeBytes)
+	}
+	got, err := runArm64WrapperWithOptions(t, m, CompileOptions{Optimizations: map[string]bool{
+		"inline":         false,
+		"merge-next-use": true,
+	}}, 3, 0)
+	if err != nil || got != 7 {
+		t.Fatalf("result = %d, %v; want 7", got, err)
+	}
+}
+
+func TestForwardMergeNextUseSkipsDeadFloatReloadARM64(t *testing.T) {
+	body := []byte{
+		0x00,
+		0x20, 0x00,
+		0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, // f64.const 1
+		0xa0, 0x21, 0x00, // f64.add; local.set 0
+		0x10, 0x01, // call: local0 becomes memory-only
+		0x20, 0x01, 0x04, 0x40, // if param1
+		0x20, 0x00, 0x1a, // then edge reloads local0
+		0x0b,
+		0x41, 0x07, 0x0b,
+	}
+	m := modFuncs(t,
+		funcDef{params: []wasm.ValType{wasm.F64, wasm.I32}, results: []wasm.ValType{wasm.I32}, body: body},
+		funcDef{body: []byte{0x01, 0x01, 0x7f, 0x0b}},
+	)
+	without := compileForwardMergeStatsARM64(t, m, false)
+	with := compileForwardMergeStatsARM64(t, m, true)
+	if without.Peephole["merge-dead-reload"] != 0 || with.Peephole["merge-dead-reload"] != 1 || with.CodeBytes >= without.CodeBytes {
+		t.Fatalf("float merge code disabled=%d enabled=%d peep=%v", without.CodeBytes, with.CodeBytes, with.Peephole)
+	}
+	got, err := runArm64WrapperWithOptions(t, m, CompileOptions{Optimizations: map[string]bool{
+		"inline":         false,
+		"merge-next-use": true,
+	}}, math.Float64bits(3), 0)
+	if err != nil || got != 7 {
+		t.Fatalf("result = %d, %v; want 7", got, err)
+	}
+}
+
+func TestForwardMergeNextUseKeepsReadAndFuelFallbackARM64(t *testing.T) {
+	read := forwardMergeModuleARM64(t, []byte{0x20, 0x00, 0x1a})
+	readStats := compileForwardMergeStatsARM64(t, read, true)
+	readFallback := compileForwardMergeStatsARM64(t, read, false)
+	if readStats.CodeBytes != readFallback.CodeBytes || readStats.Peephole["merge-dead-reload"] != 0 {
+		t.Fatalf("read near miss code enabled=%d fallback=%d peep=%v", readStats.CodeBytes, readFallback.CodeBytes, readStats.Peephole)
+	}
+
+	after := make([]byte, maxMergeNextUseOps)
+	for i := range after {
+		after[i] = 0x01 // nop
+	}
+	after = append(after, 0x41, 0x09, 0x21, 0x00) // overwrite beyond the fuel cap
+	fuel := forwardMergeModuleARM64(t, after)
+	fuelStats := compileForwardMergeStatsARM64(t, fuel, true)
+	fuelFallback := compileForwardMergeStatsARM64(t, fuel, false)
+	if fuelStats.CodeBytes != fuelFallback.CodeBytes || fuelStats.Peephole["merge-dead-reload"] != 0 {
+		t.Fatalf("fuel fallback code enabled=%d fallback=%d peep=%v", fuelStats.CodeBytes, fuelFallback.CodeBytes, fuelStats.Peephole)
+	}
+	compile := func() []byte {
+		cm, err := CompileModuleWith(fuel, CompileOptions{Optimizations: map[string]bool{
+			"inline":         false,
+			"merge-next-use": true,
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		code := bytes.Clone(cm.Code)
+		if cm.CodeImage != nil {
+			_ = cm.CodeImage.Close()
+		}
+		return code
+	}
+	if a, b := compile(), compile(); !bytes.Equal(a, b) {
+		t.Fatal("fuel fallback emitted nondeterministic code")
+	}
+}
+
+func BenchmarkCompileForwardMergeNextUseARM64(b *testing.B) {
+	m := forwardMergeModuleARM64(b, nil)
+	for _, tc := range []struct {
+		name string
+		on   bool
+	}{{"eager", false}, {"dead", true}} {
+		b.Run(tc.name, func(b *testing.B) {
+			opts := CompileOptions{Optimizations: map[string]bool{
+				"inline":         false,
+				"merge-next-use": tc.on,
+			}}
+			b.ReportAllocs()
+			for range b.N {
+				cm, err := CompileModuleWith(m, opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if cm.CodeImage != nil {
+					_ = cm.CodeImage.Close()
+				}
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/shared/merge_next_use.go
+++ b/src/core/compiler/backend/railshot/shared/merge_next_use.go
@@ -1,0 +1,101 @@
+package shared
+
+import "github.com/wago-org/wago/src/core/compiler/wasm"
+
+// MergeNextUseFuel bounds the post-merge semantic scan shared by targets.
+const MergeNextUseFuel = 64
+
+// MergeLocalCandidate maps one Wasm local to its target register bank and bit.
+// Backends build candidates in fixed stack storage from target-owned state.
+type MergeLocalCandidate struct {
+	Local uint32
+	Reg   uint8
+	FP    bool
+}
+
+// ScanForwardMergeDeadLocals proves which candidate registers do not need an
+// eager merge reload. It owns the architecture-neutral opcode, barrier, fuel,
+// and physical-function-end policy. Malformed input or an uncertain boundary
+// returns ok=false and no dead registers.
+func ScanForwardMergeDeadLocals(r *wasm.Reader, localBase int, candidates []MergeLocalCandidate) (deadGP, deadFP uint64, ok bool) {
+	if r == nil || localBase < 0 || uint64(localBase) > uint64(^uint32(0)) || len(candidates) == 0 || len(candidates) > 64 {
+		return 0, 0, false
+	}
+	for _, candidate := range candidates {
+		if candidate.Reg >= 64 {
+			return 0, 0, false
+		}
+	}
+	active := ^uint64(0)
+	if len(candidates) < 64 {
+		active = uint64(1)<<uint(len(candidates)) - 1
+	}
+	base := uint32(localBase)
+	peek := *r
+	for fuel := 0; fuel < MergeNextUseFuel; fuel++ {
+		op, err := peek.Byte()
+		if err != nil {
+			return 0, 0, false
+		}
+		switch op {
+		case 0x00, 0x0f: // unreachable / return
+			deadGP, deadFP = addActiveMergeCandidates(deadGP, deadFP, active, candidates)
+			return deadGP, deadFP, true
+		case 0x0b: // only the physical function end proves every candidate dead
+			if localBase == 0 && peek.BytesLeft() == 0 {
+				deadGP, deadFP = addActiveMergeCandidates(deadGP, deadFP, active, candidates)
+				return deadGP, deadFP, true
+			}
+			return 0, 0, false
+		case 0x02, 0x03, 0x04, 0x05, 0x08, 0x0a, 0x0c, 0x0d, 0x0e, 0x1f:
+			return 0, 0, false // structured or exceptional control
+		case 0x10, 0x11, 0x12, 0x13, 0x14, 0x15:
+			return 0, 0, false // calls may inline or transfer
+		case 0x40, 0xfb, 0xfc, 0xfe:
+			return 0, 0, false // helper, safepoint, bulk, or atomic barrier
+		case 0x20, 0x21, 0x22: // local.get / local.set / local.tee
+			x, err := peek.U32()
+			if err != nil || x > ^uint32(0)-base {
+				return 0, 0, false
+			}
+			x += base
+			for i, candidate := range candidates {
+				bit := uint64(1) << uint(i)
+				if active&bit == 0 || candidate.Local != x {
+					continue
+				}
+				if op != 0x20 {
+					if candidate.FP {
+						deadFP |= uint64(1) << candidate.Reg
+					} else {
+						deadGP |= uint64(1) << candidate.Reg
+					}
+				}
+				active &^= bit
+				break
+			}
+			if active == 0 {
+				return deadGP, deadFP, true
+			}
+		default:
+			if err := wasm.SkipInstructionImmediate(&peek, op); err != nil {
+				return 0, 0, false
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+func addActiveMergeCandidates(deadGP, deadFP, active uint64, candidates []MergeLocalCandidate) (uint64, uint64) {
+	for i, candidate := range candidates {
+		if active&(uint64(1)<<uint(i)) == 0 {
+			continue
+		}
+		if candidate.FP {
+			deadFP |= uint64(1) << candidate.Reg
+		} else {
+			deadGP |= uint64(1) << candidate.Reg
+		}
+	}
+	return deadGP, deadFP
+}

--- a/src/core/compiler/backend/railshot/shared/merge_next_use.go
+++ b/src/core/compiler/backend/railshot/shared/merge_next_use.go
@@ -47,8 +47,11 @@ func ScanForwardMergeDeadLocals(r *wasm.Reader, localBase int, candidates []Merg
 				return deadGP, deadFP, true
 			}
 			return 0, 0, false
-		case 0x02, 0x03, 0x04, 0x05, 0x08, 0x0a, 0x0c, 0x0d, 0x0e, 0x1f:
-			return 0, 0, false // structured or exceptional control
+		}
+		if InstructionNeedsInlineBoundary(op, wasm.InstrInvalid) || InstructionNeedsEHFrame(op, wasm.InstrInvalid) {
+			return 0, 0, false
+		}
+		switch op {
 		case 0x10, 0x11, 0x12, 0x13, 0x14, 0x15:
 			return 0, 0, false // calls may inline or transfer
 		case 0x40, 0xfb, 0xfc, 0xfe:

--- a/src/core/compiler/backend/railshot/shared/merge_next_use_test.go
+++ b/src/core/compiler/backend/railshot/shared/merge_next_use_test.go
@@ -1,0 +1,50 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+)
+
+func TestScanForwardMergeDeadLocals(t *testing.T) {
+	candidates := []MergeLocalCandidate{{Local: 2, Reg: 3}, {Local: 4, Reg: 5, FP: true}}
+	for _, tc := range []struct {
+		name         string
+		body         []byte
+		localBase    int
+		wantGP       uint64
+		wantFP       uint64
+		wantComplete bool
+	}{
+		{name: "overwrites after immediate", body: []byte{0x41, 0x7f, 0x1a, 0x21, 0x02, 0x22, 0x04}, wantGP: 1 << 3, wantFP: 1 << 5, wantComplete: true},
+		{name: "read", body: []byte{0x20, 0x02, 0x21, 0x04}, wantFP: 1 << 5, wantComplete: true},
+		{name: "barrier", body: []byte{0x40, 0x00}},
+		{name: "exception barrier", body: []byte{0x08, 0x00}},
+		{name: "physical end", body: []byte{0x0b}, wantGP: 1 << 3, wantFP: 1 << 5, wantComplete: true},
+		{name: "nested end", body: []byte{0x0b}, localBase: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gp, fp, complete := ScanForwardMergeDeadLocals(wasm.NewReader(tc.body), tc.localBase, candidates)
+			if gp != tc.wantGP || fp != tc.wantFP || complete != tc.wantComplete {
+				t.Fatalf("got gp=%#x fp=%#x complete=%v, want gp=%#x fp=%#x complete=%v", gp, fp, complete, tc.wantGP, tc.wantFP, tc.wantComplete)
+			}
+		})
+	}
+}
+
+func TestScanForwardMergeDeadLocalsBounds(t *testing.T) {
+	body := make([]byte, MergeNextUseFuel)
+	for i := range body {
+		body[i] = 0x6a // i32.add: no immediate and no local effect
+	}
+	if gp, fp, ok := ScanForwardMergeDeadLocals(wasm.NewReader(body), 0, []MergeLocalCandidate{{Local: 0, Reg: 1}}); gp != 0 || fp != 0 || ok {
+		t.Fatalf("fuel fallback = %#x, %#x, %v", gp, fp, ok)
+	}
+	tooMany := make([]MergeLocalCandidate, 65)
+	if gp, fp, ok := ScanForwardMergeDeadLocals(wasm.NewReader([]byte{0x0b}), 0, tooMany); gp != 0 || fp != 0 || ok {
+		t.Fatalf("capacity fallback = %#x, %#x, %v", gp, fp, ok)
+	}
+	if gp, fp, ok := ScanForwardMergeDeadLocals(wasm.NewReader([]byte{0x21}), 0, []MergeLocalCandidate{{Local: 0, Reg: 1}}); gp != 0 || fp != 0 || ok {
+		t.Fatalf("malformed fallback = %#x, %#x, %v", gp, fp, ok)
+	}
+}

--- a/src/core/compiler/backend/railshot/shared/merge_next_use_test.go
+++ b/src/core/compiler/backend/railshot/shared/merge_next_use_test.go
@@ -20,6 +20,8 @@ func TestScanForwardMergeDeadLocals(t *testing.T) {
 		{name: "read", body: []byte{0x20, 0x02, 0x21, 0x04}, wantFP: 1 << 5, wantComplete: true},
 		{name: "barrier", body: []byte{0x40, 0x00}},
 		{name: "exception barrier", body: []byte{0x08, 0x00}},
+		{name: "br_on_null barrier", body: []byte{0xd5, 0x00, 0x21, 0x02, 0x20, 0x04}},
+		{name: "br_on_non_null barrier", body: []byte{0xd6, 0x00, 0x21, 0x02, 0x20, 0x04}},
 		{name: "physical end", body: []byte{0x0b}, wantGP: 1 << 3, wantFP: 1 << 5, wantComplete: true},
 		{name: "nested end", body: []byte{0x0b}, localBase: 1},
 	} {

--- a/src/core/compiler/optimization/catalog.go
+++ b/src/core/compiler/optimization/catalog.go
@@ -383,6 +383,7 @@ var catalog = []Definition{
 	arm64("deep-fp-pins", "Deep float pins", "pin additional float locals in call-free functions"),
 	both("ext-fp-pins", "Extended float pins", "use the larger floating-point register pool"),
 	amd64("call-next-use", "Call next-use", "skip dead pinned-local stores before calls"),
+	arm64("merge-next-use", "Merge next-use", "keep dead forward-merge locals lazy with bounded post-merge lookahead"),
 	amd64("affine-lea", "Affine LEA", "fold bounded affine index trees into scaled addressing"),
 	amd64("tree-order", "Valent tree ordering", "schedule bounded commutative trees by register need"),
 	amd64("assoc-tree", "Associative tree cover", "cover high-pressure bounded associative trees with one accumulator"),


### PR DESCRIPTION
## What changes

ARM64 currently reloads pinned locals while converging a forward control-flow edge, even when the local is overwritten or never read after the merge.

This PR adds a shared, fixed-capacity next-use scan and lets ARM64 keep those locals memory-only when a bounded proof shows the reload is dead.

- Scans at most 64 Wasm operations.
- Uses fixed stack storage for at most 64 candidates.
- Allocates no per-operation state and retains no CFG or IR.
- Falls back to the existing eager reload on calls, nested control, EH, atomics, bulk operations, malformed input, capacity exhaustion, or fuel exhaustion.
- Adds the immutable `merge-next-use` option.
- `WAGO_ARM64_NO_MERGE_NEXT_USE=1` restores the previous behavior.

The architecture-neutral scan lives in `railshot/shared`; ARM64 retains ownership of register selection and merge-state changes.

## Measured effect

Base: `2f1f54faa62a6bf2a4ffe0b404f1102e19b2c7a6`  
Candidate: `9528f3bdd2829b048a5ec8b74a75a570b93169d5`  
Machine: Apple M4 Max, Go 1.26.5

### Candidate with optimization enabled vs same candidate with rollback enabled

| Measurement | Delta |
| --- | ---: |
| 36-row execution geometric mean | +0.12% |
| Rows faster | 17/36 |
| `memory_tree` execution | -0.92% |
| `fib_rec` execution | +0.37% |
| `raytrace` execution | +0.15% |
| Focused merge compile time | -1.53% |
| Focused merge compile B/op | 0.00% |
| Focused merge compile allocs/op | 0 |
| Native code across the corpus | -3,524 bytes |
| Modules with native-code growth | 0 |

The corpus recorded 844 eliminated merge reloads. All 288 execution samples remained at 0 B/op and 0 allocs/op.

The execution geometric mean is neutral and remains inside the 0.5% whole-corpus regression gate. The material result is reduced merge traffic and generated code without a measurable broad execution regression.

### Candidate vs exact main

Measured with one serialized `esbuild` full-compile run per sample in main/child/child/main order:

| Measurement | Delta vs main |
| --- | ---: |
| Full compile time | +1.19% |
| Compile B/op | +0.012% |
| Compile allocs/op | +5 |
| Peak RSS | +0.15% |

These remain inside the compiler time and memory gates.

## Validation

- `go test ./...`
- `go test ./...` in `bench/`
- focused ARM64 tests under `-race`
- shared scanner tests for overwrite, read, barrier, function end, fuel, capacity, malformed input, and deterministic fallback
- `make lint` — Go vet and Node checks passed; staticcheck was unavailable and the target reported it skipped
- `git diff --check`
- final-head GitHub CI: 27 passed, 1 intentionally skipped
