### PR TITLE
railshot: preserve borrowed compare memrefs

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/emit.go
+++ b/src/core/compiler/backend/railshot/amd64/emit.go
@@ -822,10 +822,13 @@ func (f *fn) condenseCompare(node *elem, dest Reg) Reg {
 			if memRefFoldable(right.st, w) {
 				f.a.AluIdx(cmpRMcode, L, RBX, right.st.reg, right.st.memDisp(), w)
 			} else {
-				f.loadMemRef(right.st.reg, right.st)
-				f.cmpRR(L, right.st.reg, w)
+				// A narrow/wide mismatch needs a register value. Preserve a pinned
+				// local whose register is only borrowed as the load address.
+				r := f.memRefValue(right.st)
+				f.cmpRR(L, r, w)
+				f.release(r)
 			}
-			f.release(right.st.reg)
+			f.releaseMemRef(right.st)
 		}
 	}
 	f.pinned = f.pinned.remove(L)

--- a/src/core/compiler/backend/railshot/amd64/memref_borrow_test.go
+++ b/src/core/compiler/backend/railshot/amd64/memref_borrow_test.go
@@ -1,0 +1,67 @@
+//go:build amd64
+
+package amd64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+// TestBorrowedLocalSurvivesDeferredCompareLoad is the minimized LZ4 regression.
+// The outer add keeps local 0 live while the equality comparison consumes a
+// deferred load whose effective address borrows local 0's pinned register. The
+// compare must neither load into nor release that borrowed address register.
+func TestBorrowedLocalSurvivesDeferredCompareLoad(t *testing.T) {
+	body := []byte{0x01, 0x01, 0x7f} // one declared i32 local
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(100)...)
+	body = append(body,
+		0x21, 0x00, // local.set 0
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(100)...)
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(5)...)
+	body = append(body,
+		0x3a, 0x00, 0x00, // i32.store8 mem[100] = 5
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(200)...)
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(5)...)
+	body = append(body,
+		0x3a, 0x00, 0x00, // i32.store8 mem[200] = 5
+		0x20, 0x00, // local.get 0: preserved outer add operand
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(200)...)
+	body = append(body,
+		0x2d, 0x00, 0x00, // i32.load8_u mem[200]
+		0x20, 0x00,
+		0x2d, 0x00, 0x00, // i32.load8_u mem[local 0], borrowing local 0's register
+		0x46, // i32.eq
+		0x6a, // i32.add: 100 + 1
+		0x0b,
+	)
+	m := modMem(t, 1, nil, []wasm.ValType{wasm.I32}, body)
+
+	for _, tc := range []struct {
+		name string
+		opts CompileOptions
+	}{
+		{name: "explicit"},
+		{name: "guard", opts: CompileOptions{ElideBoundsChecks: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, err := runMemAmd64WithOptions(t, m, tc.opts, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != 101 {
+				t.Fatalf("borrowed local after deferred comparison = %d, want 101", got)
+			}
+		})
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/emit.go
+++ b/src/core/compiler/backend/railshot/arm64/emit.go
@@ -899,10 +899,13 @@ func (f *fn) condenseCompare(node *elem, dest Reg) Reg {
 			f.release(t)
 		case stMemRef:
 			// arm64: a deferred load is never foldable into a CMP (memRefFoldable is
-			// always false), so materialize it and compare register-register.
-			f.loadMemRef(right.st.reg, right.st)
-			f.cmpRR(L, right.st.reg, w)
-			f.release(right.st.reg)
+			// always false), so materialize it and compare register-register. A load
+			// whose address borrows a pinned local must use a fresh destination and
+			// must not release the local's register.
+			r := f.memRefValue(right.st)
+			f.cmpRR(L, r, w)
+			f.release(r)
+			f.releaseMemRef(right.st)
 		}
 	}
 	f.pinned = f.pinned.remove(L)

--- a/src/core/compiler/backend/railshot/arm64/memref_borrow_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/memref_borrow_arm64_test.go
@@ -1,0 +1,52 @@
+//go:build (linux || darwin) && arm64
+
+package arm64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+// TestBorrowedLocalSurvivesDeferredCompareLoadArm64 is the minimized LZ4
+// regression. A deferred comparison load addresses memory through local 0's
+// pinned register while an older local.get 0 remains the outer add operand.
+// Materializing the load must use a fresh register and retain the borrowed one.
+func TestBorrowedLocalSurvivesDeferredCompareLoadArm64(t *testing.T) {
+	body := []byte{0x01, 0x01, 0x7f} // one declared i32 local
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(100)...)
+	body = append(body,
+		0x21, 0x00, // local.set 0
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(100)...)
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(5)...)
+	body = append(body,
+		0x3a, 0x00, 0x00, // i32.store8 mem[100] = 5
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(200)...)
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(5)...)
+	body = append(body,
+		0x3a, 0x00, 0x00, // i32.store8 mem[200] = 5
+		0x20, 0x00, // local.get 0: preserved outer add operand
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(200)...)
+	body = append(body,
+		0x2d, 0x00, 0x00, // i32.load8_u mem[200]
+		0x20, 0x00,
+		0x2d, 0x00, 0x00, // i32.load8_u mem[local 0], borrowing local 0's register
+		0x46, // i32.eq
+		0x6a, // i32.add: 100 + 1
+		0x0b,
+	)
+	m := modMem(t, 1, nil, []wasm.ValType{wasm.I32}, body)
+	if got := runArm64(t, m); got != 101 {
+		t.Fatalf("borrowed local after deferred comparison = %d, want 101", got)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve pinned-local address registers borrowed by deferred comparison loads
- materialize non-foldable compare loads into owned registers on amd64 and arm64
- add minimized backend regressions for both architectures

This fixes the LZ4 compression failure found while validating the semantic corpus in #474. The bad lowering corrupted local 0 and eventually produced a false linear-memory out-of-bounds trap instead of returning `3421`.

The test and fix are combined because the reproducer directly exercises this small cross-backend ownership correction.

## Validation

- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null go test ./...`
- `go test -tags wago_guardpage ./src/core/compiler/backend/railshot/amd64 ./src/core/runtime/... ./src/wago/...`
- `cd bench && go test ./...`
- `make lint` (`staticcheck` unavailable locally; remaining checks passed)
- Linux/arm64 backend test binary cross-compiles
- exact LZ4 fixture returns `3421`, matching wazero, under explicit and signal bounds modes

## Performance / footprint

Correctness-only ownership fix. It adds no runtime data structures or Go allocations; no benchmark was run.

## Docs

Unchanged: internal backend correctness fix with no developer workflow impact.
