### PR TITLE
runtime: cover plugin start and close ordering

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -141,6 +141,17 @@ its reviewed limits. Public Runtime operations remain excluded until the whole
 Plugin Set has started, so unrelated callers cannot observe a partially started
 graph.
 
+Plugin loading and runtime shutdown also form one ordered transaction. Once
+loading begins, shutdown may publish the closing state immediately, but it
+defers its teardown snapshot until startup has stopped changing plugin teardown
+eligibility. A successful load publishes that boundary after every startup turn;
+a failed `Start` publishes it before rollback waits on the same shutdown result.
+Each plugin becomes eligible for `Stop` immediately before its startup turn,
+whether or not it defines a `Start` callback. Therefore a successful `Start`
+racing `Runtime.CloseContext` is stopped exactly once before closure completes,
+while a later plugin whose startup turn was never reached is not stopped.
+Neither callback runs while the runtime mutex is held.
+
 Configuration is opaque to Wago but not permissive: the registrar rejects
 unknown struct fields and trailing JSON, the provider validates its published
 JSON Schema, and `ValidateConfig` can enforce additional semantic rules.

--- a/src/wago/plugin_lifecycle_hardening_test.go
+++ b/src/wago/plugin_lifecycle_hardening_test.go
@@ -39,6 +39,70 @@ func TestLoadPluginsIsOneShotBeforeRuntimeUse(t *testing.T) {
 	}
 }
 
+func TestLoadPluginsCloseContextWaitsForStartAndStopsExactlyOnce(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	var starts, stops atomic.Int32
+	var active atomic.Bool
+	def := testDefinition("example.com/load/close-race")
+	provider := PluginProvider{Definition: def, New: func() Plugin {
+		return pluginFunc(func(r *Registrar) error {
+			return r.Lifecycle(PluginLifecycle{
+				Start: func(context.Context) error {
+					starts.Add(1)
+					active.Store(true)
+					close(entered)
+					<-release
+					return nil
+				},
+				Stop: func(context.Context) error {
+					stops.Add(1)
+					if !active.CompareAndSwap(true, false) {
+						return errors.New("plugin stopped while inactive")
+					}
+					return nil
+				},
+			})
+		})
+	}}
+	rt := NewRuntime()
+	set := testSet(t, provider)
+	loadDone := make(chan error, 1)
+	go func() { loadDone <- rt.LoadPlugins(context.Background(), set) }()
+	<-entered
+
+	closeCtx, cancelClose := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelClose()
+	if err := rt.CloseContext(closeCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("CloseContext while Start was blocked = %v, want deadline", err)
+	}
+	if got := stops.Load(); got != 0 {
+		t.Fatalf("Stop ran %d time(s) before Start completed", got)
+	}
+
+	close(release)
+	if err := <-loadDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.WaitClosed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("Start ran %d time(s), want 1", got)
+	}
+	if got := stops.Load(); got != 1 {
+		t.Fatalf("Stop ran %d time(s), want 1", got)
+	}
+	if active.Load() {
+		t.Fatal("plugin remained active after CloseContext returned")
+	}
+	if err := rt.CloseContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := stops.Load(); got != 1 {
+		t.Fatalf("idempotent CloseContext ran Stop %d time(s), want 1", got)
+	}
+}
+
 func TestLoadPluginsExclusiveAndCloseWaitsForStart(t *testing.T) {
 	entered, release := make(chan struct{}), make(chan struct{})
 	def := testDefinition("example.com/load/exclusive")


### PR DESCRIPTION
## Summary

- add a deterministic regression for `LoadPlugins` racing `Runtime.CloseContext`
- prove shutdown remains pending while `Start` is blocked, invokes `Stop` exactly once, and leaves no active plugin
- prove repeated closure does not invoke `Stop` again
- document the plugin-load/shutdown teardown-eligibility boundary

The runtime loading barrier and provisional `pluginRuns` teardown ownership already present on `main` prevent the race reported in #391. This PR records that behavior directly so it cannot regress.

## Validation

- `go test ./src/wago -count=1`
- focused lifecycle tests, 50 iterations
- focused lifecycle race tests, 20 iterations
- complete CI matrix green; one unrelated Linux/arm64 job-control flake passed on rerun
- `git diff --check`

Closes #391.