### PR TITLE
amd64: preserve applyMul borrowed memrefs

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/emit.go
+++ b/src/core/compiler/backend/railshot/amd64/emit.go
@@ -1191,7 +1191,6 @@ func (f *fn) applyMul(dest Reg, right *elem, w bool) {
 			f.release(r)
 			f.releaseMemRef(right.st)
 		}
-		f.release(right.st.reg)
 	}
 }
 

--- a/src/core/compiler/backend/railshot/amd64/memref_borrow_test.go
+++ b/src/core/compiler/backend/railshot/amd64/memref_borrow_test.go
@@ -67,17 +67,35 @@ func TestBorrowedLocalSurvivesDeferredCompareLoad(t *testing.T) {
 	}
 }
 
-func TestApplyMulPreservesBorrowedMemRefOwnership(t *testing.T) {
-	owner := &elem{}
-	f := fn{a: &x86.Asm{}}
-	f.regUser[R12] = owner
-	f.pinnedLocalMask = maskOf(R12)
-	right := &elem{kind: ekValue, st: memRefStorage(R12, 0, 4, false, false, 0)}
+func TestApplyMulMemRefOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		size   int
+		borrow int
+		want   bool
+	}{
+		{name: "borrowed/foldable", size: 4, borrow: 0, want: true},
+		{name: "borrowed/materialized", size: 1, borrow: 0, want: true},
+		{name: "owned/foldable", size: 4, borrow: -1},
+		{name: "owned/materialized", size: 1, borrow: -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// regUser is a canary for release: borrowed address ownership must be
+			// untouched, while an allocator-owned address must become available.
+			owner := &elem{}
+			f := fn{a: &x86.Asm{}}
+			f.regUser[R12] = owner
+			if tc.borrow >= 0 {
+				f.pinnedLocalMask = maskOf(R12)
+			}
+			right := &elem{kind: ekValue, st: memRefStorage(R12, 0, tc.size, false, false, tc.borrow)}
 
-	f.applyMul(RAX, right, false)
+			f.applyMul(RAX, right, false)
 
-	if f.regUser[R12] != owner {
-		t.Fatal("applyMul released a borrowed memory-reference address register")
+			if got := f.regUser[R12] == owner; got != tc.want {
+				t.Fatalf("address-register ownership retained = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/src/core/compiler/backend/railshot/amd64/memref_borrow_test.go
+++ b/src/core/compiler/backend/railshot/amd64/memref_borrow_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
+	x86 "github.com/wago-org/wago/src/core/encoder/amd64"
 	"github.com/wago-org/wago/tests/wasmtest"
 )
 
@@ -61,6 +62,77 @@ func TestBorrowedLocalSurvivesDeferredCompareLoad(t *testing.T) {
 			}
 			if got != 101 {
 				t.Fatalf("borrowed local after deferred comparison = %d, want 101", got)
+			}
+		})
+	}
+}
+
+func TestApplyMulPreservesBorrowedMemRefOwnership(t *testing.T) {
+	owner := &elem{}
+	f := fn{a: &x86.Asm{}}
+	f.regUser[R12] = owner
+	f.pinnedLocalMask = maskOf(R12)
+	right := &elem{kind: ekValue, st: memRefStorage(R12, 0, 4, false, false, 0)}
+
+	f.applyMul(RAX, right, false)
+
+	if f.regUser[R12] != owner {
+		t.Fatal("applyMul released a borrowed memory-reference address register")
+	}
+}
+
+// TestBorrowedLocalSurvivesDeferredMultiplyLoad keeps local 0 live as an outer
+// add operand while i32.mul consumes a deferred load addressed through that
+// local's pinned register. Multiplication must not release the borrowed address
+// register before the outer add reads the local again.
+func TestBorrowedLocalSurvivesDeferredMultiplyLoad(t *testing.T) {
+	body := []byte{0x01, 0x01, 0x7f} // one declared i32 local
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(100)...)
+	body = append(body,
+		0x21, 0x00, // local.set 0
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(100)...)
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(7)...)
+	body = append(body,
+		0x3a, 0x00, 0x00, // i32.store8 mem[100] = 7
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(200)...)
+	body = append(body, 0x41)
+	body = append(body, wasmtest.SLEB32(3)...)
+	body = append(body,
+		0x3a, 0x00, 0x00, // i32.store8 mem[200] = 3
+		0x20, 0x00, // local.get 0: preserved outer add operand
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(200)...)
+	body = append(body,
+		0x2d, 0x00, 0x00, // i32.load8_u mem[200]
+		0x20, 0x00,
+		0x2d, 0x00, 0x00, // i32.load8_u mem[local 0], borrowing local 0's register
+		0x6c, // i32.mul: 3 * 7
+		0x6a, // i32.add: 100 + 21
+		0x0b,
+	)
+	m := modMem(t, 1, nil, []wasm.ValType{wasm.I32}, body)
+
+	for _, tc := range []struct {
+		name string
+		opts CompileOptions
+	}{
+		{name: "explicit"},
+		{name: "guard", opts: CompileOptions{ElideBoundsChecks: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, err := runMemAmd64WithOptions(t, m, tc.opts, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != 121 {
+				t.Fatalf("borrowed local after deferred multiplication = %d, want 121", got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- remove the duplicate AMD64 `applyMul` address-register release
- preserve pinned-local ownership for borrowed deferred memory operands
- cover folded/materialized and borrowed/owned cleanup paths
- add an executing explicit/guard-bounds multiplication regression

Fixes #478.

## Correctness

`releaseMemRef` is the sole owner-aware cleanup for an `stMemRef` address. It releases allocator-owned addresses and deliberately preserves registers borrowed from pinned locals. The removed trailing `f.release(right.st.reg)` bypassed that distinction.

## Adversarial review

1. Audited every AMD64 `releaseMemRef` consumer for a second unconditional address release; `applyMul` was the sole remaining duplicate.
2. Compared AMD64 multiplication cleanup against ARM64 and the corrected AMD64 ALU/compare paths.
3. Mutation-tested the regression by restoring the bad release: both borrowed folded and borrowed materialized cases fail.
4. Verified owned folded/materialized operands still release their address registers.
5. Exercised the guest multiplication shape in explicit and guard-page bounds modes and under the race detector.

## Tests

- `go test ./src/core/compiler/backend/railshot/amd64 -count=1`
- `go test -tags=wago_guardpage ./src/core/compiler/backend/railshot/amd64 -count=1`
- `go test -race ./src/core/compiler/backend/railshot/amd64 -run 'TestApplyMulMemRefOwnership|TestBorrowedLocalSurvivesDeferredMultiplyLoad' -count=1`
- `go test ./src/core/compiler/backend/railshot/amd64 -run 'TestApplyMulMemRefOwnership|TestBorrowedLocalSurvivesDeferredMultiplyLoad' -count=20`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false go test ./... -count=1`
- `make lint` (staticcheck unavailable locally; CI installs it)

The first unqualified `go test ./...` attempt inherited the host's signed-tag Git configuration and failed only registry tests that create lightweight test tags. Re-running with `tag.gpgSign=false` passed the full repository. No product code was implicated.

## Performance and footprint

The implementation removes one compile-time bookkeeping write and emits no additional native instructions or runtime data. No hot-path or footprint regression is expected.

## Docs

Unchanged: this is an internal compiler ownership correction with no developer workflow or public API impact.
