### PR TITLE
runtime: reject operations during guest storage borrows

### DIFF
--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4083,7 +4083,8 @@ func Load(b []byte) (*Compiled, error) {
 // only in the Runtime store (or standalone private store) that issued them.
 // Calls on one Instance are serialized, including while another call is parked
 // in a host callback. A host callback that must synchronously re-enter Wasm must
-// use InvokeFromHost with the HostModule value it received.
+// use InvokeFromHost with the HostModule value it received. Direct invocation
+// fails with ErrPermissionDenied while callback-scoped guest storage is borrowed.
 func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
 	return in.invoke(export, args, nil)
 }
@@ -4136,6 +4137,9 @@ func (in *Instance) invokeEntry(export string, args []uint64, cancel context.Con
 	// close the race with a concurrent Close.
 	if in.invocationState.Load()&instanceInvocationClosed != 0 {
 		return nil, fmt.Errorf("invoke %q: instance is closed", export)
+	}
+	if in.guestStorageBorrowed() {
+		return nil, fmt.Errorf("invoke %q: guest storage is borrowed: %w", export, ErrPermissionDenied)
 	}
 	state := in.ensurePluginState()
 	state.invokeMu.Lock()

--- a/src/wago/gc_collect.go
+++ b/src/wago/gc_collect.go
@@ -20,10 +20,14 @@ func gcCollectFrameRoots(in *Instance, public *gcPublicState, frameLayout uint8,
 // instances remain rooted for the duration of the collection.
 //
 // Instances without a live WasmGC collector return an error. Collection remains
-// serialized with native execution and collector-domain mutation.
+// serialized with native execution and collector-domain mutation, and fails with
+// ErrPermissionDenied while callback-scoped guest storage is borrowed.
 func (in *Instance) CollectGC() error {
 	if in == nil || in.gc == nil || in.c == nil {
 		return fmt.Errorf("wago: instance has no live WasmGC collector")
+	}
+	if in.guestStorageBorrowed() {
+		return fmt.Errorf("wago: collection is unavailable while guest storage is borrowed: %w", ErrPermissionDenied)
 	}
 	// Public collection is an independent operation, not a callback-scoped
 	// re-entry. Use a fresh identity instead of racing the instance's active

--- a/src/wago/gc_foreign_clone.go
+++ b/src/wago/gc_foreign_clone.go
@@ -59,13 +59,17 @@ func cloneGCDescriptor(c *Compiled, id gc.TypeID) (gc.TypeDesc, bool) {
 // references, i31 immediates, numeric/v128 payloads, and null opaque references
 // are transferable. Non-null funcref/externref payloads reject because they have
 // independent store ownership. The returned token belongs to target and must be
-// released with target.ReleaseGCRef.
+// released with target.ReleaseGCRef. Cloning fails with ErrPermissionDenied while
+// either instance has callback-scoped guest storage borrowed.
 func (target *Instance) CloneGCRefFrom(source *Instance, value GCRef) (GCRef, error) {
 	if target == nil || source == nil || target == source {
 		return GCRef{}, fmt.Errorf("GC graph clone requires distinct source and target instances")
 	}
 	if value.token == 0 {
 		return GCRef{}, nil
+	}
+	if source.guestStorageBorrowed() || target.guestStorageBorrowed() {
+		return GCRef{}, fmt.Errorf("GC graph clone is unavailable while guest storage is borrowed: %w", ErrPermissionDenied)
 	}
 	if target.refStore == nil || source.refStore == nil || target.gc == nil || source.gc == nil || target.c == nil || source.c == nil {
 		return GCRef{}, fmt.Errorf("GC graph clone requires live collector-backed instances")

--- a/src/wago/gc_telemetry_api.go
+++ b/src/wago/gc_telemetry_api.go
@@ -2,9 +2,10 @@ package wago
 
 // GCTelemetrySnapshot returns the current opt-in collector telemetry for this
 // instance's shared Runtime GC domain. The bool is false when the instance has no
-// collector, GCConfig.Telemetry was nil, or wago_gcstats was not compiled in.
+// collector, callback-scoped guest storage is borrowed, GCConfig.Telemetry was
+// nil, or wago_gcstats was not compiled in.
 func (in *Instance) GCTelemetrySnapshot() (GCTelemetrySnapshot, bool) {
-	if in == nil || in.gc == nil {
+	if in == nil || in.gc == nil || in.guestStorageBorrowed() {
 		return GCTelemetrySnapshot{}, false
 	}
 	unlockNative := lockNativeExecutionForHostAccess()
@@ -15,9 +16,10 @@ func (in *Instance) GCTelemetrySnapshot() (GCTelemetrySnapshot, bool) {
 }
 
 // ResetGCTelemetry clears the shared collector-domain recorder. It returns false
-// when telemetry is unavailable or a Tiny incremental cycle is active.
+// when telemetry is unavailable, callback-scoped guest storage is borrowed, or a
+// Tiny incremental cycle is active.
 func (in *Instance) ResetGCTelemetry() bool {
-	if in == nil || in.gc == nil {
+	if in == nil || in.gc == nil || in.guestStorageBorrowed() {
 		return false
 	}
 	unlockNative := lockNativeExecutionForHostAccess()

--- a/src/wago/guest_storage.go
+++ b/src/wago/guest_storage.go
@@ -98,9 +98,10 @@ type GuestStorage interface {
 // multi-memory, Memory64, or Wasm GC storage.
 //
 // Only the callback-scoped HostModule value handed to a live synchronous host
-// import implements this interface. Wago rejects guest re-entry while
-// WithGuestStorage is active. Re-entry could otherwise grow a linear memory or
-// run a moving collection while a host slice still refers to the prior storage.
+// import implements this interface. Wago rejects guest re-entry and public
+// instance operations that require overlapping native-state synchronization while
+// WithGuestStorage is active. They could otherwise grow a linear memory, move GC
+// objects, or self-deadlock while a host view still refers to the prior storage.
 type GuestStorageHostModule interface {
 	HostModule
 	WithGuestStorage(func(GuestStorage) error) error
@@ -118,6 +119,14 @@ func (v *guestStorageView) ensureActive() error {
 		return fmt.Errorf("wago: guest-storage view is no longer active: %w", ErrPermissionDenied)
 	}
 	return nil
+}
+
+func (in *Instance) guestStorageBorrowed() bool {
+	if in == nil {
+		return false
+	}
+	state := in.pluginState.Load()
+	return state != nil && state.guestStorageBorrow.Load() != 0
 }
 
 func beginGuestStorageBorrow(in *Instance) (func(), error) {

--- a/src/wago/guest_storage_gc_amd64_test.go
+++ b/src/wago/guest_storage_gc_amd64_test.go
@@ -4,10 +4,13 @@ package wago
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/runtime/gc"
+	"github.com/wago-org/wago/tests/wasmtest"
 )
 
 func findGuestStorageArrayType(t *testing.T, compiled *Compiled, storage gc.StorageKind, mutable bool) uint32 {
@@ -23,6 +26,53 @@ func findGuestStorageArrayType(t *testing.T, compiled *Compiled, storage gc.Stor
 	}
 	t.Fatalf("no array type with storage %d mutable=%v", storage, mutable)
 	return 0
+}
+
+func guestStorageGCCollectModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	funcType := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	body := []byte{0x00, 0x20, 0x00, 0xfb, 0x00, 0x00, 0xfb, 0x02, 0x00, 0x00, 0x0b}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, funcType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("roundtrip", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
+func TestCollectGCDuringGuestStorageFailsClosed(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), guestStorageGCCollectModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if got, err := in.Invoke("roundtrip", 7); err != nil || len(got) != 1 || uint32(got[0]) != 7 {
+		t.Fatalf("roundtrip = %v, %v; want [7], nil", got, err)
+	}
+
+	caller := in.beginHostCallScopeReservedWithID(newInvocationID(), nil)
+	defer caller.scope.end(caller.generation, caller.parentGeneration)
+	if err := caller.WithGuestStorage(func(GuestStorage) error {
+		collectErr := in.CollectGC()
+		if !errors.Is(collectErr, ErrPermissionDenied) {
+			if collectErr != nil {
+				return collectErr
+			}
+			return &guestStorageTestError{"collection during borrow was not rejected"}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := in.CollectGC(); err != nil {
+		t.Fatalf("collection after guest-storage borrow: %v", err)
+	}
 }
 
 func TestHostGuestStorageExactImmutableGCArrayResult(t *testing.T) {
@@ -53,6 +103,13 @@ func TestHostGuestStorageExactImmutableGCArrayResult(t *testing.T) {
 
 	want := []byte{1, 2, 3, 4, 5}
 	token, err := caller.NewGCArrayResult(0, uint32(len(want)), func(payload []byte, info GuestGCArrayInfo) error {
+		collectErr := in.CollectGC()
+		if !errors.Is(collectErr, ErrPermissionDenied) {
+			if collectErr != nil {
+				return collectErr
+			}
+			return &guestStorageTestError{"collection during GC result initialization was not rejected"}
+		}
 		if info.Storage != GuestGCArrayI8 || info.Length != uint32(len(want)) || info.Mutable || info.TypeIndex != typeIndex {
 			return &guestStorageTestError{"exact immutable GC result metadata"}
 		}
@@ -80,6 +137,12 @@ func TestHostGuestStorageExactImmutableGCArrayResult(t *testing.T) {
 		ref, err := storage.GCRef(token)
 		if err != nil {
 			return err
+		}
+		if releaseErr := in.ReleaseGCRef(GCRef{token: token}); !errors.Is(releaseErr, ErrPermissionDenied) {
+			if releaseErr != nil {
+				return releaseErr
+			}
+			return &guestStorageTestError{"GC token release during borrow was not rejected"}
 		}
 		retainedRef = ref
 		info, err := storage.GCArrayInfo(ref)

--- a/src/wago/guest_storage_test.go
+++ b/src/wago/guest_storage_test.go
@@ -4,6 +4,7 @@ package wago
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -96,6 +97,9 @@ func TestHostGuestStorageCallbackLifetimeAndReentry(t *testing.T) {
 			}
 			if _, err := in.InvokeFromHost(context.Background(), m, "peek"); err == nil || !strings.Contains(err.Error(), "guest storage is borrowed") {
 				return &guestStorageTestError{"re-entry during borrow was not rejected"}
+			}
+			if _, err := in.Invoke("peek"); !errors.Is(err, ErrPermissionDenied) {
+				return &guestStorageTestError{"direct instance access during borrow was not rejected"}
 			}
 			gcModule, ok := m.(GCHostModule)
 			if !ok {

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -43,7 +43,7 @@ func (in *Instance) InvokeFromHost(ctx context.Context, caller HostModule, expor
 	if active == nil || id == 0 {
 		return nil, fmt.Errorf("wago: re-entry requires the active host caller: %w", ErrPermissionDenied)
 	}
-	if state := active.pluginState.Load(); state != nil && state.guestStorageBorrow.Load() != 0 {
+	if active.guestStorageBorrowed() {
 		return nil, fmt.Errorf("wago: re-entry is unavailable while guest storage is borrowed: %w", ErrPermissionDenied)
 	}
 	if ctx != nil {
@@ -243,7 +243,7 @@ func (h staticHostModule) CollectGC() error {
 	if h.in == nil {
 		return fmt.Errorf("wago: GC host module has no instance")
 	}
-	if state := h.in.pluginState.Load(); state != nil && state.guestStorageBorrow.Load() != 0 {
+	if h.in.guestStorageBorrowed() {
 		return fmt.Errorf("wago: collection is unavailable while guest storage is borrowed: %w", ErrPermissionDenied)
 	}
 	return h.in.CollectGC()
@@ -632,7 +632,7 @@ func (h instanceHostModule) CollectGC() error {
 	if !h.valid() {
 		return fmt.Errorf("wago: GC host module is outside its active callback: %w", ErrPermissionDenied)
 	}
-	if state := h.in.pluginState.Load(); state != nil && state.guestStorageBorrow.Load() != 0 {
+	if h.in.guestStorageBorrowed() {
 		return fmt.Errorf("wago: collection is unavailable while guest storage is borrowed: %w", ErrPermissionDenied)
 	}
 	if h.in.ownsGCInvocation(h.invocationID) {

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -158,6 +158,9 @@ func (in *Instance) beginInvocation() error {
 	if in == nil {
 		return fmt.Errorf("instance is nil")
 	}
+	if in.guestStorageBorrowed() {
+		return fmt.Errorf("instance access is unavailable while guest storage is borrowed: %w", ErrPermissionDenied)
+	}
 	if in.rt != nil {
 		in.rt.mu.Lock()
 		if in.rt.state == runtimeClosed || in.rt.state == runtimeClosing && in.instantiateOrigin() != InstantiateManaged {

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -2264,14 +2264,18 @@ func (in *Instance) clearGCRefArgumentRoots() {
 
 // ReleaseGCRef releases one non-null GC result token issued by this producer.
 // It is valid after Instance.Close while the token retains the producer's
-// collector; null releases are no-ops. Stale, foreign-store, and cross-producer
-// tokens reject without changing either owner.
+// collector; null releases are no-ops. Non-null releases fail with
+// ErrPermissionDenied while callback-scoped guest storage is borrowed. Stale,
+// foreign-store, and cross-producer tokens reject without changing either owner.
 func (in *Instance) ReleaseGCRef(ref GCRef) error {
 	if ref.token == 0 {
 		return nil
 	}
 	if in == nil {
 		return fmt.Errorf("release GC reference token on nil instance")
+	}
+	if in.guestStorageBorrowed() {
+		return fmt.Errorf("release GC reference token is unavailable while guest storage is borrowed: %w", ErrPermissionDenied)
 	}
 	in.lifeMu.Lock()
 	store := in.refStore


### PR DESCRIPTION
## Summary

- reject `Instance.CollectGC` before it can reacquire native or collector synchronization held by `WithGuestStorage`
- centralize guest-storage borrow detection across direct invocation, host re-entry, retained GC token release, cross-store GC graph cloning, and telemetry access
- preserve the borrow's view-stability contract instead of releasing locks or making them reentrant

## Tests

- `go test ./src/wago`
- `go test -tags wago_guardpage ./src/wago`
- `go test -race ./src/wago -run 'TestCollectGCDuringGuestStorageFailsClosed|TestHostGuestStorageExactImmutableGCArrayResult|TestHostGuestStorageCallbackLifetimeAndReentry' -count=1`

The full `go test ./...` run reached unrelated `cli/manager/internal/registry` failures because this checkout's global Git configuration forces annotated/signed test tags while the test subprocess has no editor. All runtime and focused race tests pass.

Docs unchanged: public API comments were updated, with no developer workflow change.

Fixes #479
