### PR TITLE
runtime: preserve importer-local HostFuncRef types

### DIFF
--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -2338,7 +2338,7 @@ func (c *Compiled) validateImportBindings(imports Imports, store *referenceStore
 		if !ok {
 			if sigHasGCRefs {
 				owner, owned := imports[key].(*HostFuncRef)
-				if !owned || owner == nil || owner.gc == nil || store == nil || owner.store != store || c.genericGCFrameRoots() == nil {
+				if !owned || owner == nil || !owner.gcCapable || store == nil || owner.store != store || c.genericGCFrameRoots() == nil {
 					return fmt.Errorf("host import %q cannot transfer collector references; use Runtime.NewGCHostFuncRef or a same-Runtime InstanceExport", key)
 				}
 				continue

--- a/src/wago/gc_host_activation_arm64.go
+++ b/src/wago/gc_host_activation_arm64.go
@@ -23,8 +23,8 @@ func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32, _ uintpt
 	}
 	gcBridge := false
 	if dispatch&hostFuncRefDispatchBit != 0 {
-		owner := in.refStore.hostFuncRef(dispatch)
-		if owner == nil || !owner.isGCBridge() {
+		binding, ok := in.boundHostFuncRef(dispatch)
+		if !ok || !binding.owner.isGCBridge() {
 			return gcHostActivationToken{}
 		}
 		gcBridge = true

--- a/src/wago/gc_host_activation_linux_amd64.go
+++ b/src/wago/gc_host_activation_linux_amd64.go
@@ -23,8 +23,8 @@ func (in *Instance) pushGCHostActivation(ctrl uintptr, dispatch uint32, stackTop
 	}
 	gcBridge := false
 	if dispatch&hostFuncRefDispatchBit != 0 {
-		owner := in.refStore.hostFuncRef(dispatch)
-		if owner == nil || !owner.isGCBridge() {
+		binding, ok := in.boundHostFuncRef(dispatch)
+		if !ok || !binding.owner.isGCBridge() {
 			return gcHostActivationToken{}
 		}
 		gcBridge = true

--- a/src/wago/guest_storage.go
+++ b/src/wago/guest_storage.go
@@ -111,6 +111,7 @@ type guestStorageView struct {
 	in      *Instance
 	params  []ValueTypeDescriptor
 	results []ValueTypeDescriptor
+	types   []DefinedTypeDescriptor
 	active  atomic.Bool
 }
 
@@ -158,7 +159,13 @@ func (h instanceHostModule) WithGuestStorage(fn func(GuestStorage) error) error 
 		lockedDomain := h.in.lockGCCollector()
 		defer unlockGCCollector(lockedDomain)
 	}
-	view := &guestStorageView{in: h.in, params: h.exactParams, results: h.exactResults}
+	var types []DefinedTypeDescriptor
+	if h.ephemeralGCResults != nil && h.ephemeralGCResults.exactTypes != nil {
+		types = *h.ephemeralGCResults.exactTypes
+	} else if h.in.c != nil {
+		types = h.in.c.Types
+	}
+	view := &guestStorageView{in: h.in, params: h.exactParams, results: h.exactResults, types: types}
 	view.active.Store(true)
 	defer view.active.Store(false)
 	return fn(view)
@@ -385,8 +392,8 @@ func (v *guestStorageView) ImportResultType(index int) (ValueTypeDescriptor, boo
 }
 
 func (v *guestStorageView) DefinedType(index uint32) (DefinedTypeDescriptor, bool) {
-	if v == nil || !v.active.Load() || v.in == nil || v.in.c == nil || int(index) >= len(v.in.c.Types) {
+	if v == nil || !v.active.Load() || int(index) >= len(v.types) {
 		return DefinedTypeDescriptor{}, false
 	}
-	return v.in.c.Types[index], true
+	return v.types[index], true
 }

--- a/src/wago/host_funcref_exact_type_test.go
+++ b/src/wago/host_funcref_exact_type_test.go
@@ -114,6 +114,79 @@ func hostFuncRefDuplicateExactTypeModule() []byte {
 	)
 }
 
+func hostFuncRefScalarExactTypeModule() []byte {
+	ft := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I64})
+	importEntry := append(wasmtest.Name("host"), wasmtest.Name("scalar")...)
+	importEntry = append(importEntry, 0x00, 0x00)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(ft)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x00, 0x10, 0x00, 0x0b}))),
+	)
+}
+
+func TestHostFuncRefPreservesIndexedScalarSignature(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	owner, err := rt.NewHostFuncRef(HostFunc(func(m HostModule, args, results []uint64) {
+		storageModule, ok := m.(GuestStorageHostModule)
+		if !ok {
+			panic(HostTrap{Err: fmt.Errorf("host module does not expose guest storage")})
+		}
+		if err := storageModule.WithGuestStorage(func(storage GuestStorage) error {
+			param, paramOK := storage.ImportParamType(0)
+			result, resultOK := storage.ImportResultType(0)
+			defined, definedOK := storage.DefinedType(0)
+			if !paramOK || param.Kind != ValueTypeI32 || !resultOK || result.Kind != ValueTypeI64 || !definedOK || defined.Kind != CompositeTypeFunction || len(defined.Params) != 1 || len(defined.Results) != 1 {
+				return fmt.Errorf("scalar exact signature = param %#v/%v result %#v/%v type %#v/%v", param, paramOK, result, resultOK, defined, definedOK)
+			}
+			return nil
+		}); err != nil {
+			panic(HostTrap{Err: err})
+		}
+		results[0] = args[0]
+	}), FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI64}, TypeIndex: 0, HasTypeIndex: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owner.Close()
+	compiled, err := rt.Compile(hostFuncRefScalarExactTypeModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := rt.Instantiate(context.Background(), compiled, WithImports(Imports{"host.scalar": owner}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := in.Call(context.Background(), "run", ValueI32(9)); err != nil || len(got) != 1 || got[0].I64() != 9 {
+		t.Fatalf("scalar owned host call = %v, %v; want [9], nil", got, err)
+	}
+	owner.mu.Lock()
+	bindings := len(owner.gc.dispatchBindings)
+	if owner.gc.inlineDispatchBinding != nil {
+		bindings++
+	}
+	owner.mu.Unlock()
+	if bindings != 1 {
+		t.Fatalf("live scalar dispatch bindings = %d, want 1", bindings)
+	}
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	owner.mu.Lock()
+	bindings = len(owner.gc.dispatchBindings)
+	if owner.gc.inlineDispatchBinding != nil {
+		bindings++
+	}
+	owner.mu.Unlock()
+	if bindings != 0 {
+		t.Fatalf("scalar dispatch bindings after close = %d, want 0", bindings)
+	}
+}
+
 func TestHostFuncRefUsesImporterLocalExactSignature(t *testing.T) {
 	requireCompleteCore3Backend(t)
 	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)

--- a/src/wago/host_funcref_exact_type_test.go
+++ b/src/wago/host_funcref_exact_type_test.go
@@ -75,6 +75,45 @@ func hostFuncRefExactTypeModule(paddingTypes int, nodeResult wasm.ValType) []byt
 	)
 }
 
+func hostFuncRefDuplicateExactTypeModule() []byte {
+	padding := wasmtest.FuncType([]wasm.ValType{wasm.I64}, nil)
+	nodeAIndex, nodeBIndex := uint32(1), uint32(2)
+	nullNodeA := wasm.RefVal(wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: nodeAIndex}), false))
+	nodeA := wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: nodeAIndex}), false))
+	nullNodeB := wasm.RefVal(wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: nodeBIndex}), false))
+	nodeB := wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: nodeBIndex}), false))
+	types := [][]byte{
+		padding,
+		hostFuncRefTestFuncType([]wasm.ValType{nullNodeA}, []wasm.ValType{wasm.I32}),
+		hostFuncRefTestFuncType([]wasm.ValType{nullNodeB}, []wasm.ValType{wasm.I32}),
+		hostFuncRefTestFuncType([]wasm.ValType{nodeA}, []wasm.ValType{nodeA}),
+		hostFuncRefTestFuncType([]wasm.ValType{nodeB}, []wasm.ValType{nodeB}),
+		wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}),
+	}
+	importA := append(wasmtest.Name("host"), wasmtest.Name("echo-a")...)
+	importA = append(importA, 0x00)
+	importA = append(importA, wasmtest.ULEB(3)...)
+	importB := append(wasmtest.Name("host"), wasmtest.Name("echo-b")...)
+	importB = append(importB, 0x00)
+	importB = append(importB, wasmtest.ULEB(4)...)
+	runA := []byte{0xd2, 0x02, 0x41, 0x00, 0x11, 0x03, 0x00, 0xd1, 0x0b}
+	runB := []byte{0xd2, 0x03, 0x41, 0x01, 0x11, 0x04, 0x00, 0xd1, 0x0b}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(types...)),
+		wasmtest.Section(2, wasmtest.Vec(importA, importB)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(2), wasmtest.ULEB(5), wasmtest.ULEB(5))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x01, 0x02, 0x02})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run-a", 0, 4), wasmtest.ExportEntry("run-b", 0, 5))),
+		wasmtest.Section(9, wasmtest.Vec(tableTestActiveElem(0, 0, 1), tableTestDeclarativeElem(2, 3))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x07, 0x0b}),
+			wasmtest.Code([]byte{0x41, 0x08, 0x0b}),
+			wasmtest.Code(runA),
+			wasmtest.Code(runB),
+		)),
+	)
+}
+
 func TestHostFuncRefUsesImporterLocalExactSignature(t *testing.T) {
 	requireCompleteCore3Backend(t)
 	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
@@ -137,8 +176,23 @@ func TestHostFuncRefUsesImporterLocalExactSignature(t *testing.T) {
 			t.Fatalf("run importer with %d padding types = %v, %v; want [0], nil", padding, got, err)
 		}
 	}
-	if fmt.Sprint(seenTypeIndexes) != "[1 2]" {
-		t.Fatalf("callback importer-local type indexes = %v, want [1 2]", seenTypeIndexes)
+	duplicate, err := rt.Compile(hostFuncRefDuplicateExactTypeModule())
+	if err != nil {
+		t.Fatalf("compile duplicate importer bindings: %v", err)
+	}
+	defer duplicate.Close()
+	duplicateInstance, err := rt.Instantiate(context.Background(), duplicate, WithImports(Imports{"host.echo-a": owner, "host.echo-b": owner}))
+	if err != nil {
+		t.Fatalf("instantiate duplicate importer bindings: %v", err)
+	}
+	instances = append(instances, duplicateInstance)
+	for _, export := range []string{"run-a", "run-b"} {
+		if got, err := duplicateInstance.Call(context.Background(), export); err != nil || len(got) != 1 || got[0].I32() != 0 {
+			t.Fatalf("%s duplicate importer binding = %v, %v; want [0], nil", export, got, err)
+		}
+	}
+	if fmt.Sprint(seenTypeIndexes) != "[1 2 1 2]" {
+		t.Fatalf("callback importer-local type indexes = %v, want [1 2 1 2]", seenTypeIndexes)
 	}
 
 	mismatch, err := rt.Compile(hostFuncRefExactTypeModule(2, wasm.I64))

--- a/src/wago/host_funcref_exact_type_test.go
+++ b/src/wago/host_funcref_exact_type_test.go
@@ -1,0 +1,152 @@
+//go:build !tinygo
+
+package wago
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func hostFuncRefTestFuncType(params, results []wasm.ValType) []byte {
+	out := []byte{0x60}
+	out = append(out, wasmtest.ULEB(uint32(len(params)))...)
+	appendType := func(t wasm.ValType) {
+		if b, ok := wasm.EncodeValType(t); ok {
+			out = append(out, b)
+			return
+		}
+		ref := t.Ref()
+		if ref.Nullable() {
+			out = append(out, 0x63)
+		} else {
+			out = append(out, 0x64)
+		}
+		out = append(out, wasmtest.SLEB32(int32(ref.Heap().Type().Index))...)
+	}
+	for _, param := range params {
+		appendType(param)
+	}
+	out = append(out, wasmtest.ULEB(uint32(len(results)))...)
+	for _, result := range results {
+		appendType(result)
+	}
+	return out
+}
+
+func hostFuncRefExactTypeModule(paddingTypes int, nodeResult wasm.ValType) []byte {
+	types := make([][]byte, 0, paddingTypes+3)
+	for i := 0; i < paddingTypes; i++ {
+		types = append(types, wasmtest.FuncType([]wasm.ValType{wasm.I64}, nil))
+	}
+	nodeIndex := uint32(len(types))
+	nullNodeRef := wasm.RefVal(wasm.Ref(true, wasm.IndexedHeap(wasm.TypeIdx{Index: nodeIndex}), false))
+	nodeRef := wasm.RefVal(wasm.Ref(false, wasm.IndexedHeap(wasm.TypeIdx{Index: nodeIndex}), false))
+	types = append(types, hostFuncRefTestFuncType([]wasm.ValType{nullNodeRef}, []wasm.ValType{nodeResult}))
+	hostTypeIndex := uint32(len(types))
+	types = append(types, hostFuncRefTestFuncType([]wasm.ValType{nodeRef}, []wasm.ValType{nodeRef}))
+	runTypeIndex := uint32(len(types))
+	types = append(types, wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}))
+
+	importEntry := append(wasmtest.Name("host"), wasmtest.Name("echo")...)
+	importEntry = append(importEntry, 0x00)
+	importEntry = append(importEntry, wasmtest.ULEB(hostTypeIndex)...)
+
+	targetBody := []byte{0x41, 0x07, 0x0b}
+	if nodeResult == wasm.I64 {
+		targetBody = []byte{0x42, 0x07, 0x0b}
+	}
+	runBody := []byte{0xd2, 0x01, 0x41, 0x00, 0x11}
+	runBody = append(runBody, wasmtest.ULEB(hostTypeIndex)...)
+	runBody = append(runBody, 0x00, 0xd1, 0x0b)
+
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(types...)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(nodeIndex), wasmtest.ULEB(runTypeIndex))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x01, 0x01, 0x01})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 2))),
+		wasmtest.Section(9, wasmtest.Vec(tableTestActiveElem(0, 0), tableTestDeclarativeElem(1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(targetBody), wasmtest.Code(runBody))),
+	)
+}
+
+func TestHostFuncRefUsesImporterLocalExactSignature(t *testing.T) {
+	requireCompleteCore3Backend(t)
+	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3)
+	rt := NewRuntime(WithRuntimeConfig(cfg))
+	defer rt.Close()
+
+	var seenTypeIndexes []uint32
+	owner, err := rt.NewHostFuncRef(HostFunc(func(m HostModule, args, results []uint64) {
+		storageModule, ok := m.(GuestStorageHostModule)
+		if !ok {
+			panic(HostTrap{Err: fmt.Errorf("host module does not expose guest storage")})
+		}
+		if err := storageModule.WithGuestStorage(func(storage GuestStorage) error {
+			param, ok := storage.ImportParamType(0)
+			if !ok || param.Kind != ValueTypeReference || param.Ref.Nullable || !param.Ref.Heap.Defined {
+				return fmt.Errorf("exact host parameter = %#v, %v", param, ok)
+			}
+			result, ok := storage.ImportResultType(0)
+			if !ok || result != param {
+				return fmt.Errorf("exact host result = %#v, %v; want %#v", result, ok, param)
+			}
+			node, ok := storage.DefinedType(param.Ref.Heap.TypeIndex)
+			if !ok || node.Kind != CompositeTypeFunction || len(node.Params) != 1 || len(node.Results) != 1 || node.Results[0].Kind != ValueTypeI32 {
+				return fmt.Errorf("defined recursive function type = %#v, %v", node, ok)
+			}
+			self := node.Params[0]
+			if self.Kind != ValueTypeReference || !self.Ref.Nullable || !self.Ref.Heap.Defined || self.Ref.Heap.TypeIndex != param.Ref.Heap.TypeIndex {
+				return fmt.Errorf("recursive parameter = %#v, want nullable self reference to %d", self, param.Ref.Heap.TypeIndex)
+			}
+			seenTypeIndexes = append(seenTypeIndexes, param.Ref.Heap.TypeIndex)
+			return nil
+		}); err != nil {
+			panic(HostTrap{Err: err})
+		}
+		results[0] = args[0]
+	}), FuncSig{Params: []ValType{ValFuncRef}, Results: []ValType{ValFuncRef}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owner.Close()
+
+	var instances []*Instance
+	defer func() {
+		for _, in := range instances {
+			_ = in.Close()
+		}
+	}()
+	for _, padding := range []int{1, 2} {
+		compiled, err := rt.Compile(hostFuncRefExactTypeModule(padding, wasm.I32))
+		if err != nil {
+			t.Fatalf("compile importer with %d padding types: %v", padding, err)
+		}
+		defer compiled.Close()
+		in, err := rt.Instantiate(context.Background(), compiled, WithImports(Imports{"host.echo": owner}))
+		if err != nil {
+			t.Fatalf("instantiate importer with %d padding types: %v", padding, err)
+		}
+		instances = append(instances, in)
+		if got, err := in.Call(context.Background(), "run"); err != nil || len(got) != 1 || got[0].I32() != 0 {
+			t.Fatalf("run importer with %d padding types = %v, %v; want [0], nil", padding, got, err)
+		}
+	}
+	if fmt.Sprint(seenTypeIndexes) != "[1 2]" {
+		t.Fatalf("callback importer-local type indexes = %v, want [1 2]", seenTypeIndexes)
+	}
+
+	mismatch, err := rt.Compile(hostFuncRefExactTypeModule(2, wasm.I64))
+	if err != nil {
+		t.Fatalf("compile structural mismatch: %v", err)
+	}
+	defer mismatch.Close()
+	if _, err := rt.Instantiate(context.Background(), mismatch, WithImports(Imports{"host.echo": owner})); err == nil || !strings.Contains(err.Error(), "structural signature mismatch") {
+		t.Fatalf("non-equivalent recursive host signature error = %v", err)
+	}
+}

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -275,11 +275,27 @@ type HostFuncRef struct {
 }
 
 type hostFuncRefGCState struct {
-	collector *gc.Collector
-	domainID  uint64
-	params    []ValueTypeDescriptor
-	results   []ValueTypeDescriptor
-	types     []DefinedTypeDescriptor
+	collector        *gc.Collector
+	domainID         uint64
+	params           []ValueTypeDescriptor
+	results          []ValueTypeDescriptor
+	types            []DefinedTypeDescriptor
+	dispatchBindings map[hostFuncRefBindingKey]*hostFuncRefDispatchBinding
+}
+
+type hostFuncRefBindingKey struct {
+	owner       *HostFuncRef
+	compiled    *Compiled
+	importIndex int
+}
+
+type hostFuncRefDispatchBinding struct {
+	owner           *HostFuncRef
+	sig             FuncSig
+	params, results []ValueTypeDescriptor
+	types           []DefinedTypeDescriptor
+	dispatchIndex   uint32
+	refs            uint32
 }
 
 // NewHostFuncRef creates an explicitly owned host function with one exact Wasm
@@ -538,6 +554,79 @@ func (h *HostFuncRef) attachImporter(store *referenceStore, sig FuncSig, collect
 	return nil
 }
 
+func (h *HostFuncRef) acquireDispatchBinding(store *referenceStore, c *Compiled, importIndex int, sig FuncSig) (uint32, bool, error) {
+	params, results, needed, err := hostFuncRefExactSignature(sig, c)
+	if err != nil {
+		return 0, false, fmt.Errorf("host funcref exact signature: %w", err)
+	}
+	if !needed {
+		return h.dispatchIndex, false, nil
+	}
+	key := hostFuncRefBindingKey{owner: h, compiled: c, importIndex: importIndex}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed || h.store != store || h.gc == nil || h.gc.types == nil || !exactSignatureEquivalent(h.gc.params, h.gc.results, h.gc.types, params, results, c.Types) {
+		return 0, false, fmt.Errorf("host funcref structural signature mismatch")
+	}
+	if binding := h.gc.dispatchBindings[key]; binding != nil {
+		if binding.refs == ^uint32(0) {
+			return 0, false, fmt.Errorf("host funcref dispatch binding has too many importers")
+		}
+		binding.refs++
+		return binding.dispatchIndex, true, nil
+	}
+	binding := &hostFuncRefDispatchBinding{
+		owner: h, sig: sig, params: params, results: results, types: c.Types, refs: 1,
+	}
+	dispatchIndex, err := store.registerHostFuncRefBindingLocked(binding)
+	if err != nil {
+		return 0, false, err
+	}
+	binding.dispatchIndex = dispatchIndex
+	if h.gc.dispatchBindings == nil {
+		h.gc.dispatchBindings = make(map[hostFuncRefBindingKey]*hostFuncRefDispatchBinding)
+	}
+	h.gc.dispatchBindings[key] = binding
+	return dispatchIndex, true, nil
+}
+
+func (h *HostFuncRef) dispatchBinding(c *Compiled, importIndex int) (*hostFuncRefDispatchBinding, bool) {
+	if h == nil {
+		return nil, false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.gc == nil {
+		return nil, false
+	}
+	binding := h.gc.dispatchBindings[hostFuncRefBindingKey{owner: h, compiled: c, importIndex: importIndex}]
+	return binding, binding != nil
+}
+
+func (h *HostFuncRef) releaseDispatchBinding(c *Compiled, importIndex int) {
+	if h == nil || h.store == nil {
+		return
+	}
+	store := h.store
+	key := hostFuncRefBindingKey{owner: h, compiled: c, importIndex: importIndex}
+	store.mu.Lock()
+	h.mu.Lock()
+	if h.gc != nil {
+		if binding := h.gc.dispatchBindings[key]; binding != nil {
+			if binding.refs > 1 {
+				binding.refs--
+			} else {
+				delete(h.gc.dispatchBindings, key)
+				store.unregisterHostFuncRefBindingLocked(binding)
+			}
+		}
+	}
+	h.mu.Unlock()
+	store.mu.Unlock()
+}
+
 func exactSignatureEquivalent(aParams, aResults []ValueTypeDescriptor, aTypes []DefinedTypeDescriptor, bParams, bResults []ValueTypeDescriptor, bTypes []DefinedTypeDescriptor) bool {
 	if len(aParams) != len(bParams) || len(aResults) != len(bResults) {
 		return false
@@ -569,6 +658,7 @@ func (h *HostFuncRef) detachImporter() {
 		h.gc.params = nil
 		h.gc.results = nil
 		h.gc.types = nil
+		h.gc.dispatchBindings = nil
 	}
 	h.mu.Unlock()
 }
@@ -805,40 +895,24 @@ type boundHostFuncRefCall struct {
 }
 
 func (in *Instance) boundHostFuncRef(dispatch uint32) (boundHostFuncRefCall, bool) {
-	if in == nil || in.c == nil || in.refStore == nil || dispatch&hostFuncRefDispatchBit == 0 {
+	if in == nil || in.refStore == nil || dispatch&hostFuncRefDispatchBit == 0 {
 		return boundHostFuncRefCall{}, false
 	}
-	owner := in.refStore.hostFuncRef(dispatch)
+	owner, exact := in.refStore.hostFuncRefDispatch(dispatch)
 	if owner == nil {
 		return boundHostFuncRefCall{}, false
 	}
 	owner.mu.Lock()
 	binding := boundHostFuncRefCall{owner: owner, fn: owner.fn, sig: owner.sig}
-	if owner.gc != nil && owner.gc.types != nil {
-		binding.params = owner.gc.params
-		binding.results = owner.gc.results
-		binding.types = &owner.gc.types
-	}
 	owner.mu.Unlock()
 	if binding.fn == nil {
 		return boundHostFuncRefCall{}, false
 	}
-	if binding.types == nil {
-		return binding, true
-	}
-	for i, key := range in.c.Imports {
-		if i >= len(in.c.importFuncSigs) || in.imports[key] != owner {
-			continue
-		}
-		params, results, err := exactFuncSignatureView(in.c.importFuncSigs[i], in.c.Types)
-		if err != nil {
-			return boundHostFuncRefCall{}, false
-		}
-		binding.sig = in.c.importFuncSigs[i]
-		binding.params = params
-		binding.results = results
-		binding.types = &in.c.Types
-		break
+	if exact != nil {
+		binding.sig = exact.sig
+		binding.params = exact.params
+		binding.results = exact.results
+		binding.types = &exact.types
 	}
 	return binding, true
 }
@@ -870,36 +944,22 @@ func (in *Instance) newHostDispatch() runtime.HostCall {
 		var exactTypes []DefinedTypeDescriptor
 		var exactTypesPtr *[]DefinedTypeDescriptor
 		if importIdx&hostFuncRefDispatchBit != 0 {
-			owner := in.refStore.hostFuncRef(importIdx)
+			owner, exact := in.refStore.hostFuncRefDispatch(importIdx)
 			if owner == nil {
 				panic(missingHostFunc{importIdx: importIdx})
 			}
 			owner.mu.Lock()
 			fn, sig = owner.fn, owner.sig
-			if owner.gc != nil && owner.gc.types != nil {
-				exactParams = owner.gc.params
-				exactResults = owner.gc.results
-				exactTypesPtr = &owner.gc.types
-			}
 			owner.mu.Unlock()
 			if fn == nil {
 				panic(missingHostFunc{importIdx: importIdx})
 			}
-			if exactTypesPtr != nil {
-				for i, key := range in.c.Imports {
-					if i >= len(in.c.importFuncSigs) || in.imports[key] != owner {
-						continue
-					}
-					var err error
-					exactParams, exactResults, err = exactFuncSignatureView(in.c.importFuncSigs[i], in.c.Types)
-					if err != nil {
-						panic(invalidHostReference{err: fmt.Errorf("host import %d exact signature: %w", importIdx, err)})
-					}
-					sig = in.c.importFuncSigs[i]
-					exactTypesPtr = &in.c.Types
-					break
-				}
-				exactTypes = *exactTypesPtr
+			if exact != nil {
+				sig = exact.sig
+				exactParams = exact.params
+				exactResults = exact.results
+				exactTypes = exact.types
+				exactTypesPtr = &exact.types
 			}
 		} else {
 			if int(importIdx) >= len(in.syncHosts) || in.syncHosts[importIdx] == nil {

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -275,12 +275,14 @@ type HostFuncRef struct {
 }
 
 type hostFuncRefGCState struct {
-	collector        *gc.Collector
-	domainID         uint64
-	params           []ValueTypeDescriptor
-	results          []ValueTypeDescriptor
-	types            []DefinedTypeDescriptor
-	dispatchBindings map[hostFuncRefBindingKey]*hostFuncRefDispatchBinding
+	collector             *gc.Collector
+	domainID              uint64
+	params                []ValueTypeDescriptor
+	results               []ValueTypeDescriptor
+	types                 []DefinedTypeDescriptor
+	inlineDispatchKey     hostFuncRefBindingKey
+	inlineDispatchBinding *hostFuncRefDispatchBinding
+	dispatchBindings      map[hostFuncRefBindingKey]*hostFuncRefDispatchBinding
 }
 
 type hostFuncRefBindingKey struct {
@@ -452,17 +454,6 @@ func (h *HostFuncRef) validateImportLocked(store *referenceStore, sig FuncSig) e
 	return nil
 }
 
-func exactSignatureHasReferences(params, results []ValueTypeDescriptor) bool {
-	for _, values := range [][]ValueTypeDescriptor{params, results} {
-		for _, value := range values {
-			if value.Kind == ValueTypeReference {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func hostFuncRefExactSignature(sig FuncSig, c *Compiled) (params, results []ValueTypeDescriptor, needed bool, err error) {
 	if c == nil {
 		return nil, nil, false, nil
@@ -471,7 +462,7 @@ func hostFuncRefExactSignature(sig FuncSig, c *Compiled) (params, results []Valu
 	if err != nil {
 		return nil, nil, false, err
 	}
-	return params, results, exactSignatureHasReferences(params, results), nil
+	return params, results, sig.HasTypeIndex, nil
 }
 
 func (h *HostFuncRef) validateExactBindingLocked(sig FuncSig, c *Compiled) error {
@@ -537,8 +528,8 @@ func (h *HostFuncRef) attachImporter(store *referenceStore, sig FuncSig, collect
 		if h.gc == nil {
 			h.gc = &hostFuncRefGCState{}
 		}
-		h.gc.params = append([]ValueTypeDescriptor(nil), params...)
-		h.gc.results = append([]ValueTypeDescriptor(nil), results...)
+		h.gc.params = params
+		h.gc.results = results
 		h.gc.types = c.Types
 	}
 	if gcRefs {
@@ -570,6 +561,13 @@ func (h *HostFuncRef) acquireDispatchBinding(store *referenceStore, c *Compiled,
 	if h.closed || h.store != store || h.gc == nil || h.gc.types == nil || !exactSignatureEquivalent(h.gc.params, h.gc.results, h.gc.types, params, results, c.Types) {
 		return 0, false, fmt.Errorf("host funcref structural signature mismatch")
 	}
+	if binding := h.gc.inlineDispatchBinding; binding != nil && h.gc.inlineDispatchKey == key {
+		if binding.refs == ^uint32(0) {
+			return 0, false, fmt.Errorf("host funcref dispatch binding has too many importers")
+		}
+		binding.refs++
+		return binding.dispatchIndex, true, nil
+	}
 	if binding := h.gc.dispatchBindings[key]; binding != nil {
 		if binding.refs == ^uint32(0) {
 			return 0, false, fmt.Errorf("host funcref dispatch binding has too many importers")
@@ -585,10 +583,15 @@ func (h *HostFuncRef) acquireDispatchBinding(store *referenceStore, c *Compiled,
 		return 0, false, err
 	}
 	binding.dispatchIndex = dispatchIndex
-	if h.gc.dispatchBindings == nil {
-		h.gc.dispatchBindings = make(map[hostFuncRefBindingKey]*hostFuncRefDispatchBinding)
+	if h.gc.inlineDispatchBinding == nil {
+		h.gc.inlineDispatchKey = key
+		h.gc.inlineDispatchBinding = binding
+	} else {
+		if h.gc.dispatchBindings == nil {
+			h.gc.dispatchBindings = make(map[hostFuncRefBindingKey]*hostFuncRefDispatchBinding)
+		}
+		h.gc.dispatchBindings[key] = binding
 	}
-	h.gc.dispatchBindings[key] = binding
 	return dispatchIndex, true, nil
 }
 
@@ -601,7 +604,11 @@ func (h *HostFuncRef) dispatchBinding(c *Compiled, importIndex int) (*hostFuncRe
 	if h.gc == nil {
 		return nil, false
 	}
-	binding := h.gc.dispatchBindings[hostFuncRefBindingKey{owner: h, compiled: c, importIndex: importIndex}]
+	key := hostFuncRefBindingKey{owner: h, compiled: c, importIndex: importIndex}
+	if h.gc.inlineDispatchBinding != nil && h.gc.inlineDispatchKey == key {
+		return h.gc.inlineDispatchBinding, true
+	}
+	binding := h.gc.dispatchBindings[key]
 	return binding, binding != nil
 }
 
@@ -614,7 +621,15 @@ func (h *HostFuncRef) releaseDispatchBinding(c *Compiled, importIndex int) {
 	store.mu.Lock()
 	h.mu.Lock()
 	if h.gc != nil {
-		if binding := h.gc.dispatchBindings[key]; binding != nil {
+		if binding := h.gc.inlineDispatchBinding; binding != nil && h.gc.inlineDispatchKey == key {
+			if binding.refs > 1 {
+				binding.refs--
+			} else {
+				h.gc.inlineDispatchKey = hostFuncRefBindingKey{}
+				h.gc.inlineDispatchBinding = nil
+				store.unregisterHostFuncRefBindingLocked(binding)
+			}
+		} else if binding := h.gc.dispatchBindings[key]; binding != nil {
 			if binding.refs > 1 {
 				binding.refs--
 			} else {
@@ -658,6 +673,8 @@ func (h *HostFuncRef) detachImporter() {
 		h.gc.params = nil
 		h.gc.results = nil
 		h.gc.types = nil
+		h.gc.inlineDispatchKey = hostFuncRefBindingKey{}
+		h.gc.inlineDispatchBinding = nil
 		h.gc.dispatchBindings = nil
 	}
 	h.mu.Unlock()

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -270,7 +270,8 @@ type HostFuncRef struct {
 	importers     int
 	tokenLive     bool
 	closed        bool
-	gc            *hostFuncRefGCState // nil for the common non-GC host owner
+	gcCapable     bool
+	gc            *hostFuncRefGCState // lazy exact binding state; collector fields are used only when gcCapable
 }
 
 type hostFuncRefGCState struct {
@@ -329,9 +330,7 @@ func (rt *Runtime) newHostFuncRef(fn HostFunc, sig FuncSig, gcCapable, allowLoad
 			HasTypeIndex: sig.HasTypeIndex,
 		},
 	}
-	if gcCapable {
-		owner.gc = &hostFuncRefGCState{}
-	}
+	owner.gcCapable = gcCapable
 	dispatchIndex, err := rt.refStore.registerHostFuncRef(owner)
 	if err != nil {
 		return nil, err
@@ -437,24 +436,56 @@ func (h *HostFuncRef) validateImportLocked(store *referenceStore, sig FuncSig) e
 	return nil
 }
 
+func exactSignatureHasReferences(params, results []ValueTypeDescriptor) bool {
+	for _, values := range [][]ValueTypeDescriptor{params, results} {
+		for _, value := range values {
+			if value.Kind == ValueTypeReference {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hostFuncRefExactSignature(sig FuncSig, c *Compiled) (params, results []ValueTypeDescriptor, needed bool, err error) {
+	if c == nil {
+		return nil, nil, false, nil
+	}
+	params, results, err = exactFuncSignatureView(sig, c.Types)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return params, results, exactSignatureHasReferences(params, results), nil
+}
+
+func (h *HostFuncRef) validateExactBindingLocked(sig FuncSig, c *Compiled) error {
+	params, results, needed, err := hostFuncRefExactSignature(sig, c)
+	if err != nil {
+		return fmt.Errorf("host funcref exact signature: %w", err)
+	}
+	if !needed {
+		return nil
+	}
+	if h.gc == nil || h.gc.types == nil || !exactSignatureEquivalent(h.gc.params, h.gc.results, h.gc.types, params, results, c.Types) {
+		return fmt.Errorf("host funcref structural signature mismatch")
+	}
+	return nil
+}
+
 func (h *HostFuncRef) validateAttachedImporter(store *referenceStore, sig FuncSig, collector *gc.Collector, domainID uint64, c *Compiled) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if err := h.validateImportLocked(store, sig); err != nil {
 		return err
 	}
+	if err := h.validateExactBindingLocked(sig, c); err != nil {
+		return err
+	}
 	if !funcSigHasGCRefs(sig) {
 		return nil
 	}
-	if h.gc == nil || collector == nil || h.gc.collector != collector || h.gc.domainID == 0 || h.gc.domainID != domainID || c == nil {
+	if !h.gcCapable || h.gc == nil || collector == nil || h.gc.collector != collector || h.gc.domainID == 0 || h.gc.domainID != domainID {
 		return fmt.Errorf("GC host funcref belongs to a different Runtime collector domain")
-	}
-	params, results, err := exactFuncSignatureView(sig, c.Types)
-	if err != nil {
-		return fmt.Errorf("GC host funcref exact signature: %w", err)
-	}
-	if !exactSignatureEquivalent(h.gc.params, h.gc.results, h.gc.types, params, results, c.Types) {
-		return fmt.Errorf("GC host funcref structural signature mismatch")
 	}
 	return nil
 }
@@ -465,33 +496,43 @@ func (h *HostFuncRef) attachImporter(store *referenceStore, sig FuncSig, collect
 	if err := h.validateImportLocked(store, sig); err != nil {
 		return err
 	}
-	if funcSigHasGCRefs(sig) {
-		if h.gc == nil {
+	params, results, exactNeeded, err := hostFuncRefExactSignature(sig, c)
+	if err != nil {
+		return fmt.Errorf("host funcref exact signature: %w", err)
+	}
+	if exactNeeded && h.gc != nil && h.gc.types != nil && !exactSignatureEquivalent(h.gc.params, h.gc.results, h.gc.types, params, results, c.Types) {
+		return fmt.Errorf("host funcref structural signature mismatch")
+	}
+	gcRefs := funcSigHasGCRefs(sig)
+	if gcRefs {
+		if !h.gcCapable {
 			return fmt.Errorf("host funcref collector-reference signature requires Runtime.NewGCHostFuncRef")
 		}
 		if collector == nil || domainID == 0 || c == nil || c.genericGCFrameRoots() == nil || !store.ownsGCCollector(collector) {
 			return fmt.Errorf("GC host funcref requires an exact live Runtime collector domain and native root maps")
 		}
-		params, results, err := exactFuncSignatureView(sig, c.Types)
-		if err != nil {
-			return fmt.Errorf("GC host funcref exact signature: %w", err)
+		if h.gc != nil && h.gc.collector != nil && (h.gc.collector != collector || h.gc.domainID != domainID) {
+			return fmt.Errorf("GC host funcref belongs to a different Runtime collector domain")
+		}
+	} else if h.gcCapable {
+		return fmt.Errorf("GC host funcref requires a collector-reference signature")
+	}
+	if exactNeeded && (h.gc == nil || h.gc.types == nil) {
+		if h.gc == nil {
+			h.gc = &hostFuncRefGCState{}
+		}
+		h.gc.params = append([]ValueTypeDescriptor(nil), params...)
+		h.gc.results = append([]ValueTypeDescriptor(nil), results...)
+		h.gc.types = c.Types
+	}
+	if gcRefs {
+		if h.gc == nil {
+			return fmt.Errorf("GC host funcref requires an exact structural signature")
 		}
 		if h.gc.collector == nil {
 			h.gc.collector = collector
 			h.gc.domainID = domainID
-			h.gc.params = append([]ValueTypeDescriptor(nil), params...)
-			h.gc.results = append([]ValueTypeDescriptor(nil), results...)
-			h.gc.types = c.Types
-		} else {
-			if h.gc.collector != collector || h.gc.domainID != domainID {
-				return fmt.Errorf("GC host funcref belongs to a different Runtime collector domain")
-			}
-			if !exactSignatureEquivalent(h.gc.params, h.gc.results, h.gc.types, params, results, c.Types) {
-				return fmt.Errorf("GC host funcref structural signature mismatch")
-			}
 		}
-	} else if h.gc != nil {
-		return fmt.Errorf("GC host funcref requires a collector-reference signature")
 	}
 	h.importers++
 	return nil
@@ -537,7 +578,7 @@ func (h *HostFuncRef) isGCBridge() bool {
 		return false
 	}
 	h.mu.Lock()
-	ok := h.gc != nil && !h.closed && h.gc.collector != nil && h.gc.domainID != 0
+	ok := h.gcCapable && h.gc != nil && !h.closed && h.gc.collector != nil && h.gc.domainID != 0
 	h.mu.Unlock()
 	return ok
 }
@@ -724,8 +765,9 @@ type missingHostFunc struct{ importIdx uint32 }
 type invalidHostReference struct{ err error }
 
 type gcHostTempTokens struct {
-	count  uint8
-	tokens [gcPublicSlotLimit]uint64
+	count      uint8
+	exactTypes *[]DefinedTypeDescriptor
+	tokens     [gcPublicSlotLimit]uint64
 }
 
 func (t *gcHostTempTokens) add(token uint64) error {
@@ -754,6 +796,53 @@ func (t *gcHostTempTokens) release(in *Instance) {
 	}
 }
 
+type boundHostFuncRefCall struct {
+	owner           *HostFuncRef
+	fn              HostFunc
+	sig             FuncSig
+	params, results []ValueTypeDescriptor
+	types           *[]DefinedTypeDescriptor
+}
+
+func (in *Instance) boundHostFuncRef(dispatch uint32) (boundHostFuncRefCall, bool) {
+	if in == nil || in.c == nil || in.refStore == nil || dispatch&hostFuncRefDispatchBit == 0 {
+		return boundHostFuncRefCall{}, false
+	}
+	owner := in.refStore.hostFuncRef(dispatch)
+	if owner == nil {
+		return boundHostFuncRefCall{}, false
+	}
+	owner.mu.Lock()
+	binding := boundHostFuncRefCall{owner: owner, fn: owner.fn, sig: owner.sig}
+	if owner.gc != nil && owner.gc.types != nil {
+		binding.params = owner.gc.params
+		binding.results = owner.gc.results
+		binding.types = &owner.gc.types
+	}
+	owner.mu.Unlock()
+	if binding.fn == nil {
+		return boundHostFuncRefCall{}, false
+	}
+	if binding.types == nil {
+		return binding, true
+	}
+	for i, key := range in.c.Imports {
+		if i >= len(in.c.importFuncSigs) || in.imports[key] != owner {
+			continue
+		}
+		params, results, err := exactFuncSignatureView(in.c.importFuncSigs[i], in.c.Types)
+		if err != nil {
+			return boundHostFuncRefCall{}, false
+		}
+		binding.sig = in.c.importFuncSigs[i]
+		binding.params = params
+		binding.results = results
+		binding.types = &in.c.Types
+		break
+	}
+	return binding, true
+}
+
 // newHostDispatch builds the runtime callback the CallWithHost loop invokes: it
 // maps the wasm import index to the bound HostFunc and runs it with a HostModule
 // bound to this instance. It is constructed once at instantiation so hot Invoke
@@ -777,6 +866,9 @@ func (in *Instance) newHostDispatch() runtime.HostCall {
 		}
 		var fn HostFunc
 		var sig FuncSig
+		var exactParams, exactResults []ValueTypeDescriptor
+		var exactTypes []DefinedTypeDescriptor
+		var exactTypesPtr *[]DefinedTypeDescriptor
 		if importIdx&hostFuncRefDispatchBit != 0 {
 			owner := in.refStore.hostFuncRef(importIdx)
 			if owner == nil {
@@ -784,9 +876,30 @@ func (in *Instance) newHostDispatch() runtime.HostCall {
 			}
 			owner.mu.Lock()
 			fn, sig = owner.fn, owner.sig
+			if owner.gc != nil && owner.gc.types != nil {
+				exactParams = owner.gc.params
+				exactResults = owner.gc.results
+				exactTypesPtr = &owner.gc.types
+			}
 			owner.mu.Unlock()
 			if fn == nil {
 				panic(missingHostFunc{importIdx: importIdx})
+			}
+			if exactTypesPtr != nil {
+				for i, key := range in.c.Imports {
+					if i >= len(in.c.importFuncSigs) || in.imports[key] != owner {
+						continue
+					}
+					var err error
+					exactParams, exactResults, err = exactFuncSignatureView(in.c.importFuncSigs[i], in.c.Types)
+					if err != nil {
+						panic(invalidHostReference{err: fmt.Errorf("host import %d exact signature: %w", importIdx, err)})
+					}
+					sig = in.c.importFuncSigs[i]
+					exactTypesPtr = &in.c.Types
+					break
+				}
+				exactTypes = *exactTypesPtr
 			}
 		} else {
 			if int(importIdx) >= len(in.syncHosts) || in.syncHosts[importIdx] == nil {
@@ -797,13 +910,16 @@ func (in *Instance) newHostDispatch() runtime.HostCall {
 			}
 			fn = in.syncHosts[importIdx]
 			sig = in.c.importFuncSigs[importIdx]
-		}
-		exactParams, exactResults, err := exactFuncSignatureView(sig, in.c.Types)
-		if err != nil {
-			panic(invalidHostReference{err: fmt.Errorf("host import %d exact signature: %w", importIdx, err)})
+			exactTypes = in.c.Types
+			exactTypesPtr = &in.c.Types
+			var err error
+			exactParams, exactResults, err = exactFuncSignatureView(sig, in.c.Types)
+			if err != nil {
+				panic(invalidHostReference{err: fmt.Errorf("host import %d exact signature: %w", importIdx, err)})
+			}
 		}
 		var gcTemps gcHostTempTokens
-		if err := in.translateHostReferenceArgs(args, sig.Params, exactParams, &gcTemps); err != nil {
+		if err := in.translateHostReferenceArgs(args, sig.Params, exactParams, exactTypes, &gcTemps); err != nil {
 			gcTemps.release(in)
 			panic(invalidHostReference{err: fmt.Errorf("host import %d: %w", importIdx, err)})
 		}
@@ -813,18 +929,19 @@ func (in *Instance) newHostDispatch() runtime.HostCall {
 		caller.exactParams = exactParams
 		caller.exactResults = exactResults
 		var gcResultTemps gcHostTempTokens
+		gcResultTemps.exactTypes = exactTypesPtr
 		caller.ephemeralGCResults = &gcResultTemps
 		defer gcResultTemps.release(in)
 		defer caller.scope.end(caller.generation, caller.parentGeneration)
 		var mod HostModule = caller
 		fn(mod, args, results)
-		if err := in.translateHostReferenceResults(ctrl, results, sig.Results, exactResults); err != nil {
+		if err := in.translateHostReferenceResults(ctrl, results, sig.Results, exactResults, exactTypes); err != nil {
 			panic(invalidHostReference{err: fmt.Errorf("host import %d: %w", importIdx, err)})
 		}
 	}
 }
 
-func (in *Instance) translateHostReferenceArgs(values []uint64, types []ValType, exact []ValueTypeDescriptor, gcTemps *gcHostTempTokens) error {
+func (in *Instance) translateHostReferenceArgs(values []uint64, types []ValType, exact []ValueTypeDescriptor, exactTypes []DefinedTypeDescriptor, gcTemps *gcHostTempTokens) error {
 	slot := 0
 	for i, typ := range types {
 		if typ == ValV128 {
@@ -853,7 +970,7 @@ func (in *Instance) translateHostReferenceArgs(values []uint64, types []ValType,
 				if !valid {
 					return fmt.Errorf("invalid funcref argument %d", i)
 				}
-				if !valueTypeSubtype(actual, actualTypes, required, in.c.Types) {
+				if !valueTypeSubtype(actual, actualTypes, required, exactTypes) {
 					return fmt.Errorf("funcref argument %d does not match its exact structural type", i)
 				}
 				token, err := store.issue(in, values[slot])
@@ -900,7 +1017,7 @@ func (in *Instance) translateHostReferenceArgs(values []uint64, types []ValType,
 	return nil
 }
 
-func (in *Instance) translateHostReferenceResults(ctrl uintptr, values []uint64, types []ValType, exact []ValueTypeDescriptor) error {
+func (in *Instance) translateHostReferenceResults(ctrl uintptr, values []uint64, types []ValType, exact []ValueTypeDescriptor, exactTypes []DefinedTypeDescriptor) error {
 	slot := 0
 	for i, typ := range types {
 		if typ == ValV128 {
@@ -932,7 +1049,7 @@ func (in *Instance) translateHostReferenceResults(ctrl uintptr, values []uint64,
 				if !valid {
 					return fmt.Errorf("invalid funcref token for result %d", i)
 				}
-				if !valueTypeSubtype(actual, actualTypes, required, in.c.Types) {
+				if !valueTypeSubtype(actual, actualTypes, required, exactTypes) {
 					return fmt.Errorf("funcref result %d does not match its exact structural type", i)
 				}
 				values[slot] = descriptor

--- a/src/wago/import_attachments.go
+++ b/src/wago/import_attachments.go
@@ -122,24 +122,41 @@ func detachImportedFunctions(in *Instance) {
 }
 
 type hostFuncRefAttachments struct {
-	set importDedup[*HostFuncRef]
+	set      importDedup[*HostFuncRef]
+	bindings importDedup[hostFuncRefBindingKey]
 }
 
-func (a *hostFuncRefAttachments) attach(owner *HostFuncRef, store *referenceStore, sig FuncSig, collector *gc.Collector, domainID uint64, c *Compiled) error {
+func (a *hostFuncRefAttachments) attach(owner *HostFuncRef, store *referenceStore, sig FuncSig, collector *gc.Collector, domainID uint64, c *Compiled, importIndex int) error {
 	if owner == nil {
 		return fmt.Errorf("host funcref owner is nil")
 	}
-	if a.set.contains(owner) {
-		return owner.validateAttachedImporter(store, sig, collector, domainID, c)
-	}
-	if err := owner.attachImporter(store, sig, collector, domainID, c); err != nil {
+	newOwner := !a.set.contains(owner)
+	if newOwner {
+		if err := owner.attachImporter(store, sig, collector, domainID, c); err != nil {
+			return err
+		}
+	} else if err := owner.validateAttachedImporter(store, sig, collector, domainID, c); err != nil {
 		return err
 	}
-	a.set.push(owner)
+	_, exact, err := owner.acquireDispatchBinding(store, c, importIndex, sig)
+	if err != nil {
+		if newOwner {
+			owner.detachImporter()
+		}
+		return err
+	}
+	if exact {
+		a.bindings.push(hostFuncRefBindingKey{owner: owner, compiled: c, importIndex: importIndex})
+	}
+	if newOwner {
+		a.set.push(owner)
+	}
 	return nil
 }
 
 func (a *hostFuncRefAttachments) detachAll() {
+	a.bindings.each(func(key hostFuncRefBindingKey) { key.owner.releaseDispatchBinding(key.compiled, key.importIndex) })
+	a.bindings.reset()
 	a.set.each((*HostFuncRef).detachImporter)
 	a.set.reset()
 }
@@ -149,11 +166,12 @@ func detachImportedHostFuncRefs(in *Instance) {
 		return
 	}
 	var seen importDedup[*HostFuncRef]
-	for _, key := range in.c.Imports {
+	for i, key := range in.c.Imports {
 		owner, ok := in.imports[key].(*HostFuncRef)
 		if !ok || owner == nil {
 			continue
 		}
+		owner.releaseDispatchBinding(in.c, i)
 		if seen.add(owner) {
 			owner.detachImporter()
 		}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -258,7 +258,7 @@ func (b *instanceBuilder) attachImports() ([]*resolvedGlobalImport, error) {
 			if i >= len(b.c.importFuncSigs) {
 				return nil, fmt.Errorf("imported host funcref %q has no signature", key)
 			}
-			if err := b.hostAttachments.attach(value, b.opts.store, b.c.importFuncSigs[i], b.collector, b.gcDomainID, b.c); err != nil {
+			if err := b.hostAttachments.attach(value, b.opts.store, b.c.importFuncSigs[i], b.collector, b.gcDomainID, b.c, i); err != nil {
 				return nil, fmt.Errorf("imported host funcref %q: %w", key, err)
 			}
 		}
@@ -1760,8 +1760,12 @@ func buildHostFuncThunks(c *Compiled, imports Imports, syncMode bool) (map[uint3
 			owned := false
 			if owner, ok := imports[key].(*HostFuncRef); ok && owner != nil {
 				owner.mu.Lock()
-				dispatch = hostFuncRefDispatchBit | owner.dispatchIndex
+				dispatchIndex := owner.dispatchIndex
 				owner.mu.Unlock()
+				if binding, ok := owner.dispatchBinding(c, fidx); ok {
+					dispatchIndex = binding.dispatchIndex
+				}
+				dispatch = hostFuncRefDispatchBit | dispatchIndex
 				owned = true
 			}
 			offs[uint32(fidx)] = len(blob)

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -2097,17 +2097,18 @@ func (in *Instance) rootGCHostArguments(token gcHostActivationToken, dispatch ui
 	if in == nil || state == nil || in.gc == nil || in.refStore == nil || dispatch&hostFuncRefDispatchBit == 0 {
 		return nil
 	}
-	owner := in.refStore.hostFuncRef(dispatch)
-	if owner == nil {
+	binding, ok := in.boundHostFuncRef(dispatch)
+	if !ok {
 		return fmt.Errorf("GC host argument owner is unavailable")
 	}
+	owner := binding.owner
 	owner.mu.Lock()
-	if owner.gc == nil || owner.closed || owner.gc.collector != in.gc || owner.gc.domainID == 0 {
+	if !owner.gcCapable || owner.gc == nil || owner.closed || owner.gc.collector != in.gc || owner.gc.domainID == 0 {
 		owner.mu.Unlock()
 		return fmt.Errorf("GC host argument owner is outside the active collector domain")
 	}
-	types := owner.sig.Params // immutable for the HostFuncRef lifetime
 	owner.mu.Unlock()
+	types := binding.sig.Params
 
 	lockedDomain := in.lockGCCollector()
 	defer unlockGCCollector(lockedDomain)

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -1677,17 +1677,68 @@ func (s *referenceStore) registerHostFuncRef(owner *HostFuncRef) (uint32, error)
 	return uint32(len(s.externrefs)), nil
 }
 
-func (s *referenceStore) hostFuncRef(dispatch uint32) *HostFuncRef {
+func nextExternrefGeneration(generation uint32) uint32 {
+	generation++
+	if generation == 0 {
+		generation = 1
+	}
+	return generation
+}
+
+var retiredHostFuncRefDispatchBinding = &hostFuncRefDispatchBinding{}
+
+func (s *referenceStore) registerHostFuncRefBindingLocked(binding *hostFuncRefDispatchBinding) (uint32, error) {
+	if s.runtimeClosed {
+		return 0, fmt.Errorf("wago: reference store is closed")
+	}
+	for i := range s.externrefs {
+		if s.externrefs[i].value == retiredHostFuncRefDispatchBinding {
+			s.externrefs[i].generation = nextExternrefGeneration(s.externrefs[i].generation)
+			s.externrefs[i].value = binding
+			return uint32(i + 1), nil
+		}
+	}
+	if len(s.externrefs) >= int(hostFuncRefDispatchBit-1) {
+		return 0, fmt.Errorf("wago: reference store has too many host dispatch bindings")
+	}
+	s.externrefs = append(s.externrefs, externrefSlot{value: binding, generation: 1})
+	return uint32(len(s.externrefs)), nil
+}
+
+func (s *referenceStore) unregisterHostFuncRefBindingLocked(binding *hostFuncRefDispatchBinding) {
+	if binding == nil || binding.dispatchIndex == 0 || uint64(binding.dispatchIndex) > uint64(len(s.externrefs)) {
+		return
+	}
+	slot := &s.externrefs[binding.dispatchIndex-1]
+	if slot.value != binding {
+		return
+	}
+	slot.value = retiredHostFuncRefDispatchBinding
+	slot.generation = nextExternrefGeneration(slot.generation)
+}
+
+func (s *referenceStore) hostFuncRefDispatch(dispatch uint32) (*HostFuncRef, *hostFuncRefDispatchBinding) {
 	index := dispatch &^ hostFuncRefDispatchBit
 	if dispatch&hostFuncRefDispatchBit == 0 || index == 0 {
-		return nil
+		return nil, nil
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if uint64(index) > uint64(len(s.externrefs)) {
-		return nil
+		return nil, nil
 	}
-	owner, _ := s.externrefs[index-1].value.(*HostFuncRef)
+	switch value := s.externrefs[index-1].value.(type) {
+	case *HostFuncRef:
+		return value, nil
+	case *hostFuncRefDispatchBinding:
+		return value.owner, value
+	default:
+		return nil, nil
+	}
+}
+
+func (s *referenceStore) hostFuncRef(dispatch uint32) *HostFuncRef {
+	owner, _ := s.hostFuncRefDispatch(dispatch)
 	return owner
 }
 

--- a/src/wago/reference_value_test.go
+++ b/src/wago/reference_value_test.go
@@ -281,10 +281,10 @@ func TestHostCallWaitRegistrationLifecycle(t *testing.T) {
 func TestHostReferenceTranslationSlotAndTokenValidation(t *testing.T) {
 	in := &Instance{}
 	var temps gcHostTempTokens
-	if err := in.translateHostReferenceArgs(nil, []ValType{ValV128}, nil, &temps); err != nil {
+	if err := in.translateHostReferenceArgs(nil, []ValType{ValV128}, nil, nil, &temps); err != nil {
 		t.Fatalf("v128 argument slots: %v", err)
 	}
-	if err := in.translateHostReferenceResults(0, nil, []ValType{ValV128}, nil); err != nil {
+	if err := in.translateHostReferenceResults(0, nil, []ValType{ValV128}, nil, nil); err != nil {
 		t.Fatalf("v128 result slots: %v", err)
 	}
 	funcrefType := []ValueTypeDescriptor{{
@@ -295,13 +295,17 @@ func TestHostReferenceTranslationSlotAndTokenValidation(t *testing.T) {
 		name string
 		fn   func() error
 	}{
-		{"missing argument", func() error { return in.translateHostReferenceArgs(nil, []ValType{ValI32}, nil, &temps) }},
-		{"invalid externref argument", func() error { return in.translateHostReferenceArgs([]uint64{1}, []ValType{ValExternRef}, nil, &temps) }},
-		{"missing result", func() error { return in.translateHostReferenceResults(0, nil, []ValType{ValI64}, nil) }},
-		{"invalid funcref result", func() error {
-			return in.translateHostReferenceResults(0, []uint64{1}, []ValType{ValFuncRef}, funcrefType)
+		{"missing argument", func() error { return in.translateHostReferenceArgs(nil, []ValType{ValI32}, nil, nil, &temps) }},
+		{"invalid externref argument", func() error {
+			return in.translateHostReferenceArgs([]uint64{1}, []ValType{ValExternRef}, nil, nil, &temps)
 		}},
-		{"invalid externref result", func() error { return in.translateHostReferenceResults(0, []uint64{1}, []ValType{ValExternRef}, nil) }},
+		{"missing result", func() error { return in.translateHostReferenceResults(0, nil, []ValType{ValI64}, nil, nil) }},
+		{"invalid funcref result", func() error {
+			return in.translateHostReferenceResults(0, []uint64{1}, []ValType{ValFuncRef}, funcrefType, nil)
+		}},
+		{"invalid externref result", func() error {
+			return in.translateHostReferenceResults(0, []uint64{1}, []ValType{ValExternRef}, nil, nil)
+		}},
 	} {
 		if err := tc.fn(); err == nil {
 			t.Errorf("%s accepted invalid host reference values", tc.name)

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -393,7 +393,7 @@ func TestInstantiationMarkersAndOwnedHostThunk(t *testing.T) {
 
 func TestHostFuncRefAttachmentDeduplication(t *testing.T) {
 	var attachments hostFuncRefAttachments
-	if err := attachments.attach(nil, nil, FuncSig{}, nil, 0, nil); err == nil {
+	if err := attachments.attach(nil, nil, FuncSig{}, nil, 0, nil, 0); err == nil {
 		t.Fatal("nil host funcref owner accepted")
 	}
 	rt := NewRuntime()
@@ -401,10 +401,10 @@ func TestHostFuncRefAttachmentDeduplication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := attachments.attach(owner, rt.refStore, FuncSig{}, nil, 0, nil); err != nil {
+	if err := attachments.attach(owner, rt.refStore, FuncSig{}, nil, 0, nil, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := attachments.attach(owner, rt.refStore, FuncSig{}, nil, 0, nil); err != nil {
+	if err := attachments.attach(owner, rt.refStore, FuncSig{}, nil, 0, nil, 0); err != nil {
 		t.Fatal(err)
 	}
 	if owner.importers != 1 {
@@ -417,7 +417,7 @@ func TestHostFuncRefAttachmentDeduplication(t *testing.T) {
 	if err := owner.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := (&hostFuncRefAttachments{}).attach(owner, rt.refStore, FuncSig{}, nil, 0, nil); err == nil {
+	if err := (&hostFuncRefAttachments{}).attach(owner, rt.refStore, FuncSig{}, nil, 0, nil, 0); err == nil {
 		t.Fatal("closed host funcref owner attached")
 	}
 }


### PR DESCRIPTION
## Summary

Fix the owned `HostFuncRef` binding path so typed-reference host imports retain and expose the exact structural signature from the importing module rather than interpreting the public flat `FuncSig` against whichever module happens to be active.

Closes #480.

## Problem

Owned host thunks dispatch through a store-global `HostFuncRef` index. The callback path therefore selected `owner.sig`, which only carries the public ABI categories, and then attempted to resolve its optional type index against the active instance's `Compiled.Types` graph. For ordinary `NewHostFuncRef` owners this left exact `(ref $type)` parameters/results unavailable. Reusing an owner across equivalent modules with shifted local indexes could also interpret an index in the wrong type universe.

## Changes

- Retain one exact reference-bearing signature and structural type graph while a `HostFuncRef` has attached importers.
- Compare later attachments structurally across independent module-local type numbering, including recursive groups, nullability, and indexed function references.
- Reject genuinely non-equivalent reference signatures before mutating importer state.
- Resolve direct calls against the active importer's own signature; transferred owned descriptors fall back to the structurally checked source binding.
- Pass the matching type graph through callback-scoped guest storage, so `ImportParamType`, `ImportResultType`, and `DefinedType` describe one coherent type universe.
- Keep GC capability explicit instead of inferring it from the now-general exact-binding sidecar.

## Regression coverage

The new test uses the same owner with two modules whose equivalent self-recursive function types have different flattened indexes. It verifies:

- non-null indexed funcref parameter/result descriptors;
- importer-local indexes observed as `1` and `2` respectively;
- recursive `DefinedType` self-reference and result shape;
- execution through an imported owner stored in a table and called indirectly;
- two imports of the same owner in one instance retaining distinct local type indexes;
- indexed scalar parameter/result descriptors and binding teardown; and
- deterministic rejection of a non-equivalent recursive graph.

The test was committed red first (`60bb3848`). The implementation landed in `7c5f2447`; Codex review corrections in `013c006d` and `06e79eb0` added exact per-import thunk identity and indexed scalar descriptor coverage.

## Validation

- `go test ./src/wago -count=1`
- `go test -tags wago_guardpage ./src/wago -count=1`
- `go test -race ./src/wago -run 'TestHostFuncRefUsesImporterLocalExactSignature|TestHostFuncRefProxyTransfersWriterLifetimeToTable|TestRuntimeGCHostFuncRefCallAndTailOwnership|TestHostFuncRefAttachmentDeduplication' -count=1`
- complete Release 3 `TestSpecSuiteExec`, explicit bounds
- complete Release 3 `TestSpecSuiteExec`, `wago_guardpage`
- `go test ./...` with local tag-signing disabled for registry fixtures
- `darwin/arm64` and `windows/amd64` `src/wago` cross-compilation

## Performance and footprint

- `HostFuncRef` remains 128 bytes.
- Existing scalar owned-host calls remain allocation-free.
- Five 300 ms samples remained in the same narrow host-noise band: egress approximately 250–272 ns/op at 0 B/op, and indirect approximately 858–912 ns/op at 784 B/op / 4 allocs/op.
- Exact per-import metadata changes owned-host instantiation from 3,088 B / 29 allocs to 3,232 B / 30 allocs. The common binding is inline and additional records are reused after teardown. This is a correctness change; no speed claim is made.

## Docs

Unchanged: this fixes internal binding correctness without changing the public API or developer workflow.

