### PR TITLE
api: expose module-local defined types through ModuleView

### DIFF
--- a/src/wago/module_view_types.go
+++ b/src/wago/module_view_types.go
@@ -1,0 +1,18 @@
+package wago
+
+// DefinedType resolves one flattened module-local type index from this view.
+// The returned descriptor is detached from runtime-owned metadata: callers may
+// mutate its slices without affecting the compiled module. Type indexes inside
+// the descriptor remain local to this ModuleView and may be resolved by calling
+// DefinedType again.
+//
+// This is intentionally narrower than exposing the underlying Compiled module.
+// Instantiation interceptors and observers can use it to validate exact imported
+// reference signatures while retaining the read-only authority of ModuleView.
+func (v ModuleView) DefinedType(index uint32) (DefinedTypeDescriptor, bool) {
+	if v.compiled == nil || uint64(index) >= uint64(len(v.compiled.Types)) {
+		return DefinedTypeDescriptor{}, false
+	}
+	cloned := cloneDefinedTypeDescriptors(v.compiled.Types[index : index+1])
+	return cloned[0], true
+}

--- a/src/wago/module_view_types_test.go
+++ b/src/wago/module_view_types_test.go
@@ -1,0 +1,47 @@
+package wago
+
+import "testing"
+
+func TestModuleViewDefinedTypeReturnsDetachedDescriptor(t *testing.T) {
+	compiled := &Compiled{Types: []DefinedTypeDescriptor{
+		{
+			Kind:   CompositeTypeFunction,
+			Supers: []uint32{1},
+			Params: []ValueTypeDescriptor{{Kind: ValueTypeI32}},
+		},
+		{
+			Kind: CompositeTypeArray,
+			Array: FieldTypeDescriptor{
+				Storage: StorageTypeDescriptor{Packed: true, PackedType: PackedTypeI8},
+				Mutable: true,
+			},
+		},
+	}}
+	view := ModuleView{compiled: compiled}
+
+	got, ok := view.DefinedType(0)
+	if !ok {
+		t.Fatal("DefinedType(0) was not found")
+	}
+	if got.Kind != CompositeTypeFunction || len(got.Supers) != 1 || got.Supers[0] != 1 || len(got.Params) != 1 || got.Params[0].Kind != ValueTypeI32 {
+		t.Fatalf("DefinedType(0) = %#v", got)
+	}
+
+	got.Supers[0] = 99
+	got.Params[0].Kind = ValueTypeI64
+	if compiled.Types[0].Supers[0] != 1 || compiled.Types[0].Params[0].Kind != ValueTypeI32 {
+		t.Fatal("DefinedType returned slices aliasing compiled metadata")
+	}
+
+	array, ok := view.DefinedType(1)
+	if !ok || array.Kind != CompositeTypeArray || !array.Array.Storage.Packed || array.Array.Storage.PackedType != PackedTypeI8 || !array.Array.Mutable {
+		t.Fatalf("DefinedType(1) = %#v, %v", array, ok)
+	}
+
+	if _, ok := view.DefinedType(2); ok {
+		t.Fatal("DefinedType accepted an out-of-range type index")
+	}
+	if _, ok := (ModuleView{}).DefinedType(0); ok {
+		t.Fatal("nil ModuleView unexpectedly resolved a type")
+	}
+}


### PR DESCRIPTION
## Summary

Add a narrow read-only `ModuleView.DefinedType(index)` accessor for resolving flattened module-local type indexes during compile/instantiation lifecycle hooks.

The accessor:

- returns `DefinedTypeDescriptor` without exposing the underlying `Compiled` module;
- returns detached slice fields so plugins cannot mutate runtime-owned type metadata;
- fails closed for nil views and out-of-range indexes;
- preserves the existing rule that embedded type indexes are local to the containing module's flattened type graph.

## Motivation

Plugins that validate exact structural import signatures before instantiation can already inspect `ImportSpec.ResultTypes`, including a defined heap type index, but cannot currently resolve that index through `ModuleView`. Facet is one consumer: caller-typed GC-array result imports must reject an incompatible concrete element storage type at instantiation rather than deferring the error to a host call.

This API is general and does not add Facet-specific behavior to Wago.

## Validation

Includes focused tests for lookup, array descriptors, bounds, nil views, and detached returned slices. Normal repository CI is the source of truth for the full test matrix.