### PR TITLE
ci: require Core v3 in aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,7 +613,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [changes, docs, lint, regression-corpus, runtime-concurrency, race, platform-test, core-v2, tinygo, coverage, size]
+    needs: [changes, docs, lint, regression-corpus, runtime-concurrency, race, platform-test, core-v2, core-v3, tinygo, coverage, size]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -36,9 +36,13 @@ per-case timeout and the official SIMD proposal corpus. Their guard-page cells
 additionally run `make test-guard`. A separate mandatory Linux amd64/arm64
 **Core v2 conformance** matrix initializes the pinned `tests/spec-v2` submodule
 and runs `make spec2`; it is included in the final `CI` aggregate, so it cannot
-be replaced by a skipped ordinary wrapper or an informational report. This is a
-tooling distinction, not a second test suite: `make spec2` selects package tests
-that ordinary `go test ./...` also discovers. All six targets run the shared
+be replaced by a skipped ordinary wrapper or an informational report. A separate
+mandatory **Core v3 conformance** matrix runs `make spec3` and
+`make spec3-signals` on Linux amd64, Linux arm64, and Darwin arm64. The final
+`CI` aggregate depends on the complete Core v3 matrix as well, so any failed or
+cancelled explicit- or signal-bounds cell makes the branch-protection check fail.
+This is a tooling distinction, not a second test suite: `make spec2` selects
+package tests that ordinary `go test ./...` also discovers. All six targets run the shared
 single-P, parallel-fault, unrelated-fault chaining, public API, and
 corpus-differential guard-page gates. Windows runs the equivalent Go commands
 directly from PowerShell rather than through Make.
@@ -75,7 +79,13 @@ reject incomplete Core 3 families before decoding or native lowering.
 The main-push coverage job runs the WebAssembly 1.0, 2.0, and 3.0 suites and
 uploads their report fragments with the merged coverage profile. The final `CI`
 aggregation job is the stable branch-protection check and fails if any required
-matrix cell or supporting job fails.
+matrix cell or supporting job fails or is cancelled. Every top-level job in
+`.github/workflows/ci.yml` other than the aggregate itself must appear in its
+`needs` set; `tests/cipolicy` enforces that policy so a newly added qualification
+job cannot silently bypass branch protection. Path-gated jobs remain aggregate
+dependencies and may report `skipped` when their documented condition does not
+apply—for example, coverage on pull requests—but no independent top-level CI job
+is merely informational.
 
 The change detector reports documentation and code changes independently. Every
 change runs `make docs-check`, because a code-only refactor can remove a source

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -83,6 +83,114 @@ func TestRollingReleaseWorkflowsUseImmutableTagsAndTargets(t *testing.T) {
 	}
 }
 
+func TestAggregateCIRequiresEveryWorkflowJob(t *testing.T) {
+	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobs := workflowJobBlocks(string(workflow))
+	aggregate, ok := jobs["ci-ok"]
+	if !ok {
+		t.Fatal("CI workflow has no ci-ok aggregate job")
+	}
+	needs := workflowJobNeeds(t, aggregate)
+	for job := range jobs {
+		if job == "ci-ok" {
+			continue
+		}
+		if _, ok := needs[job]; !ok {
+			t.Errorf("ci-ok aggregate does not depend on workflow job %q", job)
+		}
+	}
+	for need := range needs {
+		if _, ok := jobs[need]; !ok {
+			t.Errorf("ci-ok aggregate depends on unknown workflow job %q", need)
+		}
+	}
+	for _, required := range []string{
+		"if: always()",
+		"join(needs.*.result",
+		`[ "$r" = "failure" ]`,
+		`[ "$r" = "cancelled" ]`,
+	} {
+		if !strings.Contains(aggregate, required) {
+			t.Errorf("ci-ok aggregate is missing fail-closed result handling %q", required)
+		}
+	}
+}
+
+func workflowJobBlocks(workflow string) map[string]string {
+	lines := strings.Split(workflow, "\n")
+	jobLine := regexp.MustCompile(`^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$`)
+	blocks := make(map[string]string)
+	inJobs := false
+	current := ""
+	start := 0
+	for i, line := range lines {
+		if !inJobs {
+			if line == "jobs:" {
+				inJobs = true
+			}
+			continue
+		}
+		match := jobLine.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		if current != "" {
+			blocks[current] = strings.Join(lines[start:i], "\n")
+		}
+		current = match[1]
+		start = i
+	}
+	if current != "" {
+		blocks[current] = strings.Join(lines[start:], "\n")
+	}
+	return blocks
+}
+
+func workflowJobNeeds(t *testing.T, job string) map[string]struct{} {
+	t.Helper()
+	lines := strings.Split(job, "\n")
+	for i, line := range lines {
+		const prefix = "    needs:"
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+			return splitWorkflowNeeds(strings.TrimSuffix(strings.TrimPrefix(value, "["), "]"))
+		}
+		if value != "" {
+			return splitWorkflowNeeds(value)
+		}
+		needs := make(map[string]struct{})
+		for _, item := range lines[i+1:] {
+			if !strings.HasPrefix(item, "      - ") {
+				break
+			}
+			name := strings.TrimSpace(strings.TrimPrefix(item, "      - "))
+			if name != "" {
+				needs[name] = struct{}{}
+			}
+		}
+		return needs
+	}
+	t.Fatal("ci-ok aggregate job has no needs declaration")
+	return nil
+}
+
+func splitWorkflowNeeds(value string) map[string]struct{} {
+	needs := make(map[string]struct{})
+	for _, item := range strings.Split(value, ",") {
+		name := strings.TrimSpace(item)
+		if name != "" {
+			needs[name] = struct{}{}
+		}
+	}
+	return needs
+}
+
 func TestWindowsWABTInstallIsPinnedAndVerified(t *testing.T) {
 	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
 	if err != nil {


### PR DESCRIPTION
## Summary

- add the `core-v3` matrix to the required aggregate `CI` job
- add a CI policy test requiring every top-level workflow job to appear in the aggregate dependency set
- document mandatory, path-gated, and skipped job behavior

This makes the branch-protection check fail when any Core v3 explicit- or signal-bounds cell fails or is cancelled, and prevents future qualification jobs from silently bypassing the aggregate.

## Testing

- `go test -count=1 ./tests/cipolicy`
- `make docs-check`
- `git diff --check`

Closes #481
