### PR TITLE
release: bind publication to qualified artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,3 +627,26 @@ jobs:
             fi
           done
           echo "all required jobs passed or were skipped"
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: Record exact main-branch qualification
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
+        env:
+          CI_NEEDS: ${{ toJSON(needs) }}
+          CI_REPOSITORY: ${{ github.repository }}
+          CI_SOURCE_SHA: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_ATTEMPT: ${{ github.run_attempt }}
+          CI_WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: scripts/release-qualification.sh record-ci stable-qualification/ci-qualification.json
+      - name: Upload exact main-branch qualification
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: stable-source-qualification-${{ github.sha }}-${{ github.run_attempt }}
+          path: stable-qualification/ci-qualification.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,10 @@ jobs:
             fi
           done
           echo "all required jobs passed or were skipped"
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
+        with:
+          ref: ${{ github.sha }}
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
           path: qualification/ci-qualification.json
           if-no-files-found: error
           retention-days: 90
+          overwrite: true
 
   build:
     name: Build and smoke stable release (${{ matrix.goos }}/${{ matrix.goarch }})
@@ -210,6 +211,7 @@ jobs:
             wago-runtime-*-${{ matrix.target }}.sha256
           if-no-files-found: error
           retention-days: 90
+          overwrite: true
 
   manifest:
     name: Record qualified release manifest
@@ -260,6 +262,7 @@ jobs:
             manifest/release-manifest.json.sha256
           if-no-files-found: error
           retention-days: 90
+          overwrite: true
 
   publish:
     name: Publish exactly qualified stable files
@@ -290,14 +293,26 @@ jobs:
             "${{ needs.prepare.outputs.ci_run_id }}" \
             "${{ needs.prepare.outputs.ci_run_attempt }}"
       - name: Create or verify immutable stable tag
+        id: stable
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.prepare.outputs.version }}
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
         run: |
-          if gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "::error::stable release $VERSION already exists; refusing to replace it"
-            exit 1
+          resume_draft=false
+          release_state=$(gh release view "$VERSION" --repo "${{ github.repository }}" \
+            --json isDraft,tagName --jq '[.isDraft, .tagName] | @tsv' 2>/dev/null || true)
+          if [ -n "$release_state" ]; then
+            read -r is_draft tag_name <<<"$release_state"
+            if [ "$is_draft" != "true" ]; then
+              echo "::error::published stable release $VERSION already exists; refusing to replace it"
+              exit 1
+            fi
+            if [ "$tag_name" != "$VERSION" ]; then
+              echo "::error::existing draft release does not identify stable tag $VERSION"
+              exit 1
+            fi
+            resume_draft=true
           fi
           if gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" >/dev/null 2>&1; then
             target=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" \
@@ -313,6 +328,7 @@ jobs:
           target=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" \
             --jq 'select(.object.type == "commit") | .object.sha')
           test "$target" = "$SOURCE_SHA"
+          echo "resume_draft=$resume_draft" >> "$GITHUB_OUTPUT"
       - name: Publish qualified GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -320,8 +336,12 @@ jobs:
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           CI_RUN_ID: ${{ needs.prepare.outputs.ci_run_id }}
           CI_RUN_ATTEMPT: ${{ needs.prepare.outputs.ci_run_attempt }}
+          RESUME_DRAFT: ${{ steps.stable.outputs.resume_draft }}
         run: |
           manifest_sha=$(awk '$2 == "release-manifest.json" {print $1}' release/release-manifest.json.sha256)
+          generated_notes=$(gh api --method POST \
+            "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$VERSION" -f target_commitish="$SOURCE_SHA" --jq .body)
           {
             printf 'Qualified stable release from commit `%s`.\n\n' "$SOURCE_SHA"
             printf -- '- Source commit: `%s`\n' "$SOURCE_SHA"
@@ -329,21 +349,48 @@ jobs:
               '${{ github.server_url }}/${{ github.repository }}' "$CI_RUN_ID" "$CI_RUN_ATTEMPT"
             printf -- '- Release manifest SHA-256: `%s`\n\n' "$manifest_sha"
             sed -n '1,$p' .github/release-asset-naming.md
+            printf '\n%s\n' "$generated_notes"
           } >release-notes.md
           mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
           assets+=(release/release-manifest.json release/release-manifest.json.sha256)
-          gh release create "$VERSION" \
-            --repo "${{ github.repository }}" \
-            --verify-tag \
-            --title "$VERSION" \
-            --generate-notes \
-            --notes-file release-notes.md \
-            --draft \
-            "${assets[@]}"
+          if [ "$RESUME_DRAFT" = "true" ]; then
+            release_state=$(gh release view "$VERSION" --repo "${{ github.repository }}" \
+              --json isDraft --jq .isDraft)
+            if [ "$release_state" != "true" ]; then
+              echo "::error::stable release $VERSION became published before draft recovery"
+              exit 1
+            fi
+            gh release upload "$VERSION" --repo "${{ github.repository }}" \
+              --clobber "${assets[@]}"
+            gh release edit "$VERSION" --repo "${{ github.repository }}" \
+              --title "$VERSION" --notes-file release-notes.md
+          else
+            gh release create "$VERSION" \
+              --repo "${{ github.repository }}" \
+              --verify-tag \
+              --title "$VERSION" \
+              --notes-file release-notes.md \
+              --draft \
+              "${assets[@]}"
+          fi
+          is_draft=$(gh release view "$VERSION" --repo "${{ github.repository }}" \
+            --json isDraft --jq .isDraft)
+          test "$is_draft" = "true"
           target=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" \
             --jq 'select(.object.type == "commit") | .object.sha')
           test "$target" = "$SOURCE_SHA"
+          expected_assets=$(for asset in "${assets[@]}"; do basename "$asset"; done | sort)
+          actual_assets=$(gh release view "$VERSION" --repo "${{ github.repository }}" \
+            --json assets --jq '.assets[].name' | sort)
+          if [ "$actual_assets" != "$expected_assets" ]; then
+            echo "::error::draft release assets do not exactly match the qualified manifest"
+            diff -u <(printf '%s\n' "$expected_assets") <(printf '%s\n' "$actual_assets") || true
+            exit 1
+          fi
           gh release edit "$VERSION" --repo "${{ github.repository }}" --draft=false
+          release_state=$(gh release view "$VERSION" --repo "${{ github.repository }}" \
+            --json isDraft --jq .isDraft)
+          test "$release_state" = "false"
           target=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" \
             --jq 'select(.object.type == "commit") | .object.sha')
           test "$target" = "$SOURCE_SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,144 @@
-name: Publish release
+name: Qualify and publish stable release
 
-# Version tags publish a standard-Go CLI plus Normal and Tiny builds of every
-# runtime profile for each successful target.
+# Stable publication is an explicit operation. A version tag does not trigger
+# publication. The workflow accepts one immutable main-branch commit, verifies
+# its complete CI qualification record, builds and smoke-tests the release files
+# once, records their hashes, and publishes those same files.
 on:
-  push:
-    tags: ["v*"]
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to stamp into the binary (e.g. v0.1.0); defaults to the ref name"
-        required: false
+        description: "Stable version tag (for example v1.0.0)"
+        required: true
+        type: string
+      source_sha:
+        description: "Full 40-character main commit SHA that passed CI"
+        required: true
+        type: string
 
 permissions:
+  actions: read
   contents: write
+
+concurrency:
+  group: stable-release-${{ inputs.version }}
+  cancel-in-progress: false
 
 env:
   GO_VERSION: "1.22"
   TINYGO_VERSION: "0.41.1"
 
 jobs:
+  prepare:
+    name: Verify exact source qualification
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.inputs.outputs.version }}
+      source_sha: ${{ steps.inputs.outputs.source_sha }}
+      ci_run_id: ${{ steps.ci.outputs.run_id }}
+      ci_run_attempt: ${{ steps.ci.outputs.run_attempt }}
+      qualification_artifact: ${{ steps.names.outputs.qualification_artifact }}
+    steps:
+      - name: Validate immutable release inputs
+        id: inputs
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_SOURCE_SHA: ${{ inputs.source_sha }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          [[ "$WORKFLOW_REF" == "refs/heads/main" ]] || {
+            echo "::error::stable qualification must be dispatched from the main workflow"
+            exit 1
+          }
+          version=$REQUESTED_VERSION
+          source_sha=$(printf '%s' "$REQUESTED_SOURCE_SHA" | tr 'A-F' 'a-f')
+          [[ "$version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
+            echo "::error::stable version must have the form vMAJOR.MINOR.PATCH"
+            exit 1
+          }
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::source_sha must be one full commit SHA"
+            exit 1
+          }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ steps.inputs.outputs.source_sha }}
+          fetch-depth: 0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: Verify source is the requested main commit
+        env:
+          SOURCE_SHA: ${{ steps.inputs.outputs.source_sha }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$SOURCE_SHA" origin/main || {
+            echo "::error::$SOURCE_SHA is not reachable from main"
+            exit 1
+          }
+      - name: Resolve successful CI run for the exact SHA
+        id: ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.inputs.outputs.source_sha }}
+        run: |
+          run_id=$(gh api --method GET \
+            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs" \
+            -f head_sha="$SOURCE_SHA" -f branch=main -f event=push \
+            -f status=completed -f per_page=100 \
+            --jq "[.workflow_runs[] |
+              select(.head_sha == \"$SOURCE_SHA\" and .head_branch == \"main\" and
+                     .event == \"push\" and .conclusion == \"success\")] |
+              sort_by(.run_attempt, .id) | last | .id")
+          [[ "$run_id" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::no successful CI push run exists for $SOURCE_SHA"
+            exit 1
+          }
+          run_attempt=$(gh api "repos/${{ github.repository }}/actions/runs/$run_id" \
+            --jq "select(.head_sha == \"$SOURCE_SHA\" and .head_branch == \"main\" and
+                         .event == \"push\" and .status == \"completed\" and
+                         .conclusion == \"success\") | .run_attempt")
+          [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::CI run $run_id is not an exact successful source qualification"
+            exit 1
+          }
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "run_attempt=$run_attempt" >> "$GITHUB_OUTPUT"
+      - name: Download exact CI qualification record
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.ci.outputs.run_id }}
+          github-token: ${{ github.token }}
+          name: stable-source-qualification-${{ steps.inputs.outputs.source_sha }}-${{ steps.ci.outputs.run_attempt }}
+          path: qualification
+      - name: Verify complete CI qualification record
+        run: |
+          scripts/release-qualification.sh verify-ci \
+            qualification/ci-qualification.json \
+            "${{ github.repository }}" \
+            "${{ steps.inputs.outputs.source_sha }}" \
+            "${{ steps.ci.outputs.run_id }}" \
+            "${{ steps.ci.outputs.run_attempt }}"
+      - name: Name verified qualification artifact
+        id: names
+        run: |
+          echo "qualification_artifact=stable-ci-qualification-${{ steps.inputs.outputs.source_sha }}-${{ steps.ci.outputs.run_id }}-${{ steps.ci.outputs.run_attempt }}" >> "$GITHUB_OUTPUT"
+      - name: Preserve verified qualification record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.names.outputs.qualification_artifact }}
+          path: qualification/ci-qualification.json
+          if-no-files-found: error
+          retention-days: 90
+
   build:
-    name: Build release (${{ matrix.goos }}/${{ matrix.goarch }})
-    continue-on-error: ${{ matrix.best_effort }}
+    name: Build and smoke stable release (${{ matrix.goos }}/${{ matrix.goarch }})
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
@@ -30,36 +147,32 @@ jobs:
             goos: linux
             goarch: amd64
             target: linux-amd64
-            best_effort: false
           - runner: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
             target: linux-arm64
-            best_effort: false
           - runner: macos-15-intel
             goos: darwin
             goarch: amd64
             target: darwin-amd64
-            best_effort: false
           - runner: macos-15
             goos: darwin
             goarch: arm64
             target: darwin-arm64
-            best_effort: false
           - runner: windows-2025
             goos: windows
             goarch: amd64
             target: windows-amd64
-            best_effort: false
           - runner: windows-11-arm
             goos: windows
             goarch: arm64
             target: windows-arm64
-            best_effort: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -71,18 +184,23 @@ jobs:
       - name: Install lld
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y lld
-      - name: Build CLI and runtime profiles
+      - name: Build release files once
         shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          WAGO_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
-        run: |
-          scripts/build-release-assets.sh
-      - name: Upload release files
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+          WAGO_VERSION: ${{ needs.prepare.outputs.version }}
+        run: scripts/build-release-assets.sh
+      - name: Verify checksums and required files
+        shell: bash
+        run: scripts/verify-channel-assets.sh . "${{ matrix.target }}"
+      - name: Smoke-test the files that will be published
+        shell: bash
+        run: scripts/smoke-release-assets.sh . "${{ matrix.target }}" "${{ needs.prepare.outputs.version }}"
+      - name: Upload qualified release files
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: release-${{ matrix.target }}
+          name: stable-release-${{ matrix.target }}
           path: |
             wago-${{ matrix.target }}
             wago-${{ matrix.target }}.sha256
@@ -91,58 +209,154 @@ jobs:
             wago-runtime-*-${{ matrix.target }}
             wago-runtime-*-${{ matrix.target }}.sha256
           if-no-files-found: error
+          retention-days: 90
 
-  publish:
-    name: Publish release files
-    needs: build
+  manifest:
+    name: Record qualified release manifest
+    needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - name: Download release files
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          pattern: release-*
+          ref: ${{ needs.prepare.outputs.source_sha }}
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: Download qualified release files
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: stable-release-*
           merge-multiple: true
           path: release
-      - name: Verify available release files
+      - name: Download verified CI qualification
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ needs.prepare.outputs.qualification_artifact }}
+          path: qualification
+      - name: Create and verify release manifest
         run: |
           scripts/verify-channel-assets.sh release
-      - name: Publish tagged GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
+          scripts/release-qualification.sh create-release \
+            release "${{ needs.prepare.outputs.version }}" \
+            "${{ needs.prepare.outputs.source_sha }}" \
+            "${{ needs.prepare.outputs.ci_run_id }}" \
+            "${{ needs.prepare.outputs.ci_run_attempt }}" \
+            qualification/ci-qualification.json \
+            manifest/release-manifest.json
+          scripts/release-qualification.sh verify-release \
+            manifest/release-manifest.json release \
+            "${{ github.repository }}" \
+            "${{ needs.prepare.outputs.version }}" \
+            "${{ needs.prepare.outputs.source_sha }}" \
+            "${{ needs.prepare.outputs.ci_run_id }}" \
+            "${{ needs.prepare.outputs.ci_run_attempt }}"
+      - name: Upload immutable release manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: stable-release-manifest
+          path: |
+            manifest/release-manifest.json
+            manifest/release-manifest.json.sha256
+          if-no-files-found: error
+          retention-days: 90
+
+  publish:
+    name: Publish exactly qualified stable files
+    needs: [prepare, build, manifest]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: Download qualified release files
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: stable-release-*
+          merge-multiple: true
+          path: release
+      - name: Verify files and manifest again before publication
+        run: |
+          scripts/verify-channel-assets.sh release
+          scripts/release-qualification.sh verify-release \
+            release/release-manifest.json release \
+            "${{ github.repository }}" \
+            "${{ needs.prepare.outputs.version }}" \
+            "${{ needs.prepare.outputs.source_sha }}" \
+            "${{ needs.prepare.outputs.ci_run_id }}" \
+            "${{ needs.prepare.outputs.ci_run_attempt }}"
+      - name: Create or verify immutable stable tag
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
         run: |
-          mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
-          notes=$(sed -n '1,$p' .github/release-asset-naming.md)
-          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            gh release upload "${{ github.ref_name }}" --repo "${{ github.repository }}" --clobber "${assets[@]}"
-            existing=$(gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" --json body --jq .body)
-            case "$existing" in
-              *"Which file should I download?"*) notes="$existing" ;;
-              *) notes=$(printf '%s\n\n%s\n' "$existing" "$notes") ;;
-            esac
-            gh release edit "${{ github.ref_name }}" --repo "${{ github.repository }}" --notes "$notes"
-          else
-            gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --verify-tag --generate-notes --notes "$notes" "${assets[@]}"
+          if gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::stable release $VERSION already exists; refusing to replace it"
+            exit 1
           fi
+          if gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" >/dev/null 2>&1; then
+            target=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" \
+              --jq 'select(.object.type == "commit") | .object.sha')
+            if [ "$target" != "$SOURCE_SHA" ]; then
+              echo "::error::existing tag $VERSION does not point directly to qualified commit $SOURCE_SHA"
+              exit 1
+            fi
+          else
+            gh api --method POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/tags/$VERSION" -f sha="$SOURCE_SHA" >/dev/null
+          fi
+          target=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" \
+            --jq 'select(.object.type == "commit") | .object.sha')
+          test "$target" = "$SOURCE_SHA"
+      - name: Publish qualified GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          CI_RUN_ID: ${{ needs.prepare.outputs.ci_run_id }}
+          CI_RUN_ATTEMPT: ${{ needs.prepare.outputs.ci_run_attempt }}
+        run: |
+          manifest_sha=$(awk '$2 == "release-manifest.json" {print $1}' release/release-manifest.json.sha256)
+          {
+            printf 'Qualified stable release from commit `%s`.\n\n' "$SOURCE_SHA"
+            printf -- '- Source commit: `%s`\n' "$SOURCE_SHA"
+            printf -- '- Complete CI qualification: `%s/actions/runs/%s` (attempt `%s`)\n' \
+              '${{ github.server_url }}/${{ github.repository }}' "$CI_RUN_ID" "$CI_RUN_ATTEMPT"
+            printf -- '- Release manifest SHA-256: `%s`\n\n' "$manifest_sha"
+            sed -n '1,$p' .github/release-asset-naming.md
+          } >release-notes.md
+          mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
+          assets+=(release/release-manifest.json release/release-manifest.json.sha256)
+          gh release create "$VERSION" \
+            --repo "${{ github.repository }}" \
+            --verify-tag \
+            --title "$VERSION" \
+            --generate-notes \
+            --notes-file release-notes.md \
+            --draft \
+            "${assets[@]}"
+          target=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" \
+            --jq 'select(.object.type == "commit") | .object.sha')
+          test "$target" = "$SOURCE_SHA"
+          gh release edit "$VERSION" --repo "${{ github.repository }}" --draft=false
+          target=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" \
+            --jq 'select(.object.type == "commit") | .object.sha')
+          test "$target" = "$SOURCE_SHA"
       - name: Create documentation synchronization token
         id: docs-sync-token
-        if: startsWith(github.ref, 'refs/tags/') && vars.DOCS_SYNC_APP_ID != ''
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        if: vars.DOCS_SYNC_APP_ID != ''
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v1
         with:
           app-id: ${{ vars.DOCS_SYNC_APP_ID }}
           private-key: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
           owner: wago-org
           repositories: docs
       - name: Synchronize stable documentation
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           DOCS_SYNC_TOKEN: ${{ steps.docs-sync-token.outputs.token }}
-        run: scripts/dispatch-docs-release.sh release "${{ github.ref_name }}" "$(git rev-parse HEAD)"
-      - name: Upload manual build artifacts
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: wago-release-files
-          path: release
-          if-no-files-found: error
+        run: scripts/dispatch-docs-release.sh release "${{ needs.prepare.outputs.version }}" "${{ needs.prepare.outputs.source_sha }}"

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ test: ## Build and run the test suite (host)
 	go test -count=1 ./...
 	go test -count=1 -tags wago_runtime ./cli/...
 	tests/scripts/build-release-assets.sh
+	tests/scripts/release-qualification.sh
 
 .PHONY: test-concurrency
 test-concurrency: ## Run the deterministic runtime concurrency harness (WAGO_CONCURRENCY_SEED=...)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -117,10 +117,11 @@ release. The CI policy test also requires every top-level job to remain in the
 aggregate dependency set.
 
 Only after source qualification does the stable workflow build the release
-files. Each native matrix cell verifies checksums, checks the embedded version,
-executes a scalar Wasm module, creates a `.wago` artifact with the candidate
-runtime, and executes that artifact. The manifest job records the source SHA,
-CI run ID and attempt, exact CI job results, and the name, byte size, and SHA-256
+files. Each native matrix cell verifies checksums and the embedded version,
+then executes a scalar Wasm module and reloads one generated `.wago` artifact
+with every Normal or Tiny runtime file that cell will publish. The manifest job
+records the source SHA, CI run ID and attempt, exact CI job results, and the
+name, byte size, and SHA-256
 hash of every release file. Publication downloads those already tested files; it does not
 rebuild or replace them. It verifies the manifest again, creates or accepts only
 a lightweight version tag that points directly to the qualified SHA, refuses to

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -96,7 +96,7 @@ repository files: it rejects missing relative targets, exact-case path
 mismatches, and missing Markdown heading fragments without contacting external
 sites. Run the same check locally with `make docs-check`.
 
-Nightly, canary, and tagged release workflows require Linux, Darwin, and Windows
+Nightly, canary, and stable release workflows require Linux, Darwin, and Windows
 CLI builds for both amd64 and arm64, then publish every successful binary with
 its SHA-256 checksum. A push to `main` becomes a canary only after that commit's
 `CI` workflow succeeds; failed or cancelled CI runs do not publish a canary.
@@ -104,8 +104,32 @@ Manual canary runs build the current `main` tip. Nightly and canary use unique
 never-retargeted prerelease tags; canary tags contain the full 40-hex commit ID,
 and both channels stamp binaries with their canonical full commit identity. The
 CLI resolves the newest `nightly-*` or `canary-*` tag when a channel is
-installed. Every target publishes a
-standard-Go CLI plus Normal builds of the Standard and Minimal runtimes.
+installed.
+
+Stable releases are not tag-triggered. Dispatch `Qualify and publish stable
+release` with an exact `vMAJOR.MINOR.PATCH` version and the full 40-character SHA
+of a commit reachable from `main`. The workflow locates a successful `CI` push
+run for that exact SHA and downloads its immutable qualification record. The
+record names every aggregate dependency and stable publication rejects missing,
+failed, cancelled, or skipped required jobs. This means a documentation-only CI
+run with skipped executable qualification cannot authorize a stable binary
+release. The CI policy test also requires every top-level job to remain in the
+aggregate dependency set.
+
+Only after source qualification does the stable workflow build the release
+files. Each native matrix cell verifies checksums, checks the embedded version,
+executes a scalar Wasm module, creates a `.wago` artifact with the candidate
+runtime, and executes that artifact. The manifest job records the source SHA,
+CI run ID and attempt, exact CI job results, and the name, byte size, and SHA-256
+hash of every release file. Publication downloads those already tested files; it does not
+rebuild or replace them. It verifies the manifest again, creates or accepts only
+a lightweight version tag that points directly to the qualified SHA, refuses to
+replace an existing GitHub Release, and publishes the manifest with the files.
+A manually created or moved `v*` tag does not start publication and cannot reuse
+a qualification record for another commit.
+
+Every target publishes a standard-Go CLI plus Normal builds of the Standard and
+Minimal runtimes.
 Linux also requires Tiny builds of both profiles; other platforms publish
 each feature-complete Tiny profile supported by their TinyGo port. Normal favors
 runtime speed; Tiny favors executable size. Windows uses a native Windows 11
@@ -149,7 +173,7 @@ do not contaminate `make lint`.
 ```sh
 make docs-check
 make lint
-make test
+make test  # includes release-manifest, tamper-rejection, and artifact-smoke policy tests
 make test-concurrency  # replay with WAGO_CONCURRENCY_SEED=<seed>[,<seed>...]
 make test-guard   # only on a supported guard-page target
 WAGO_CORPUS_TIMEOUT=20s make test-corpus

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -121,12 +121,15 @@ files. Each native matrix cell verifies checksums and the embedded version,
 then executes a scalar Wasm module and reloads one generated `.wago` artifact
 with every Normal or Tiny runtime file that cell will publish. The manifest job
 records the source SHA, CI run ID and attempt, exact CI job results, and the
-name, byte size, and SHA-256
-hash of every release file. Publication downloads those already tested files; it does not
-rebuild or replace them. It verifies the manifest again, creates or accepts only
-a lightweight version tag that points directly to the qualified SHA, refuses to
-replace an existing GitHub Release, and publishes the manifest with the files.
-A manually created or moved `v*` tag does not start publication and cannot reuse
+name, byte size, and SHA-256 hash of every release file. Publication downloads
+those already tested files; it does not rebuild or replace them. It verifies the
+manifest again and creates or accepts
+only a lightweight version tag that points directly to the qualified SHA. A
+retry may overwrite this workflow run's internal per-target artifacts or resume
+a matching draft release, but it re-verifies the complete manifest and exact
+draft asset-name set before publication. An already published GitHub Release is
+never replaced. A manually created or moved `v*` tag does not start publication
+and cannot reuse
 a qualification record for another commit.
 
 Every target publishes a standard-Go CLI plus Normal builds of the Standard and

--- a/scripts/release-qualification.sh
+++ b/scripts/release-qualification.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root=$(git rev-parse --show-toplevel)
+exec go run "$repository_root/tests/tools/release-qualification" "$@"

--- a/scripts/smoke-release-assets.sh
+++ b/scripts/smoke-release-assets.sh
@@ -42,8 +42,18 @@ grep -Eq '"managerVersion"[[:space:]]*:[[:space:]]*"'"$version_pattern"'"' <<<"$
   exit 1
 }
 
+runtimes=("$standard" "$minimal")
+for runtime in "$release_dir"/wago-runtime-*-tiny-"$target"; do
+  [[ -e "$runtime" ]] || continue
+  [[ -s "$runtime" && ! -L "$runtime" ]] || {
+    echo "invalid smoke-test runtime: $runtime" >&2
+    exit 1
+  }
+  runtimes+=("$runtime")
+done
+
 fixture="$repository_root/tests/fixtures/wasm/fib.wasm"
-for runtime in "$standard" "$minimal"; do
+for runtime in "${runtimes[@]}"; do
   runtime_version=$("$runtime" --json --version)
   grep -Eq '"release"[[:space:]]*:[[:space:]]*"'"$version_pattern"'"' <<<"$runtime_version" || {
     echo "$(basename "$runtime") does not report release version $version" >&2
@@ -62,17 +72,10 @@ artifact="$scratch/fib.wago"
   echo "release runtime did not produce a .wago artifact" >&2
   exit 1
 }
-output=$("$standard" run --invoke fib "$artifact" 20)
-[[ "$output" == "fib(20) = 6765" ]] || {
-  echo "release runtime .wago smoke output: $output" >&2
-  exit 1
-}
-
-for runtime in "$release_dir"/wago-runtime-*-tiny-"$target"; do
-  [[ -e "$runtime" ]] || continue
-  runtime_version=$("$runtime" --json --version)
-  grep -Eq '"release"[[:space:]]*:[[:space:]]*"'"$version_pattern"'"' <<<"$runtime_version" || {
-    echo "$(basename "$runtime") does not report release version $version" >&2
+for runtime in "${runtimes[@]}"; do
+  output=$("$runtime" run --invoke fib "$artifact" 20)
+  [[ "$output" == "fib(20) = 6765" ]] || {
+    echo "$(basename "$runtime") .wago smoke output: $output" >&2
     exit 1
   }
 done

--- a/scripts/smoke-release-assets.sh
+++ b/scripts/smoke-release-assets.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_dir="${1:?release directory is required}"
+target="${2:?release target is required}"
+version="${3:?release version is required}"
+repository_root=$(git rev-parse --show-toplevel)
+
+[[ "$version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
+  echo "invalid stable version: $version" >&2
+  exit 1
+}
+
+manager="$release_dir/wago-$target"
+installer="$release_dir/wago-installer-$target"
+standard="$release_dir/wago-runtime-standard-normal-$target"
+minimal="$release_dir/wago-runtime-minimal-normal-$target"
+for asset in "$manager" "$installer" "$standard" "$minimal"; do
+  [[ -s "$asset" && ! -L "$asset" ]] || {
+    echo "missing smoke-test asset: $asset" >&2
+    exit 1
+  }
+done
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+export HOME="$scratch/home"
+export WAGO_HOME="$scratch/wago"
+export XDG_CONFIG_HOME="$scratch/config"
+export XDG_CACHE_HOME="$scratch/cache"
+export XDG_DATA_HOME="$scratch/data"
+export NO_COLOR=1
+version_pattern=${version//./\\.}
+
+manager_version=$("$manager" --json --version)
+grep -Eq '"managerVersion"[[:space:]]*:[[:space:]]*"'"$version_pattern"'"' <<<"$manager_version" || {
+  echo "manager does not report release version $version" >&2
+  exit 1
+}
+[[ "$("$installer" --version)" == "$version" ]] || {
+  echo "installer does not report release version $version" >&2
+  exit 1
+}
+
+fixture="$repository_root/tests/fixtures/wasm/fib.wasm"
+for runtime in "$standard" "$minimal"; do
+  runtime_version=$("$runtime" --json --version)
+  grep -Eq '"release"[[:space:]]*:[[:space:]]*"'"$version_pattern"'"' <<<"$runtime_version" || {
+    echo "$(basename "$runtime") does not report release version $version" >&2
+    exit 1
+  }
+  output=$("$runtime" run --invoke fib "$fixture" 20)
+  [[ "$output" == "fib(20) = 6765" ]] || {
+    echo "$(basename "$runtime") raw wasm smoke output: $output" >&2
+    exit 1
+  }
+done
+
+artifact="$scratch/fib.wago"
+"$standard" build --output "$artifact" "$fixture" >/dev/null
+[[ -s "$artifact" ]] || {
+  echo "release runtime did not produce a .wago artifact" >&2
+  exit 1
+}
+output=$("$standard" run --invoke fib "$artifact" 20)
+[[ "$output" == "fib(20) = 6765" ]] || {
+  echo "release runtime .wago smoke output: $output" >&2
+  exit 1
+}
+
+for runtime in "$release_dir"/wago-runtime-*-tiny-"$target"; do
+  [[ -e "$runtime" ]] || continue
+  runtime_version=$("$runtime" --json --version)
+  grep -Eq '"release"[[:space:]]*:[[:space:]]*"'"$version_pattern"'"' <<<"$runtime_version" || {
+    echo "$(basename "$runtime") does not report release version $version" >&2
+    exit 1
+  }
+done
+
+printf 'smoke-tested qualified release assets for %s at %s\n' "$target" "$version"

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -214,6 +214,13 @@ func TestStableReleasePublishesOnlyExactQualifiedArtifacts(t *testing.T) {
 		`needs: [prepare, build, manifest]`,
 		`ref: ${{ needs.prepare.outputs.source_sha }}`,
 		`existing tag $VERSION does not point directly to qualified commit $SOURCE_SHA`,
+		`published stable release $VERSION already exists; refusing to replace it`,
+		`--json isDraft,tagName`,
+		`RESUME_DRAFT: ${{ steps.stable.outputs.resume_draft }}`,
+		`gh release upload "$VERSION" --repo "${{ github.repository }}"`,
+		`stable release $VERSION became published before draft recovery`,
+		`draft release assets do not exactly match the qualified manifest`,
+		`releases/generate-notes`,
 		`--verify-tag`,
 		`--draft`,
 		`--draft=false`,
@@ -222,9 +229,6 @@ func TestStableReleasePublishesOnlyExactQualifiedArtifacts(t *testing.T) {
 		if !strings.Contains(release, required) {
 			t.Errorf("stable release workflow is missing exact qualification policy %q", required)
 		}
-	}
-	if strings.Contains(release, "--clobber") {
-		t.Fatal("stable publication must not replace previously published assets")
 	}
 	jobs := workflowJobBlocks(release)
 	if !strings.Contains(jobs["build"], "scripts/build-release-assets.sh") {
@@ -235,6 +239,15 @@ func TestStableReleasePublishesOnlyExactQualifiedArtifacts(t *testing.T) {
 	}
 	if strings.Contains(jobs["publish"], "scripts/build-release-assets.sh") {
 		t.Fatal("stable publish job rebuilds release assets after qualification")
+	}
+	if !strings.Contains(jobs["publish"], `if [ "$RESUME_DRAFT" = "true" ]; then`) ||
+		!strings.Contains(jobs["publish"], `--clobber "${assets[@]}"`) {
+		t.Fatal("stable publication does not restrict asset replacement to a resumable draft")
+	}
+	for _, job := range []string{"prepare", "build", "manifest"} {
+		if !strings.Contains(jobs[job], "overwrite: true") {
+			t.Errorf("stable %s artifacts cannot be replaced safely by a workflow retry", job)
+		}
 	}
 
 	ciWorkflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -242,14 +242,17 @@ func TestStableReleasePublishesOnlyExactQualifiedArtifacts(t *testing.T) {
 		t.Fatal(err)
 	}
 	ci := string(ciWorkflow)
+	ciAggregate := workflowJobBlocks(ci)["ci-ok"]
 	for _, required := range []string{
+		`actions/checkout@11d5960a326750d5838078e36cf38b85af677262`,
+		`ref: ${{ github.sha }}`,
 		`Record exact main-branch qualification`,
 		`CI_NEEDS: ${{ toJSON(needs) }}`,
 		`stable-source-qualification-${{ github.sha }}-${{ github.run_attempt }}`,
 		`scripts/release-qualification.sh record-ci stable-qualification/ci-qualification.json`,
 	} {
-		if !strings.Contains(ci, required) {
-			t.Errorf("CI workflow is missing stable qualification record %q", required)
+		if !strings.Contains(ciAggregate, required) {
+			t.Errorf("CI aggregate job is missing stable qualification record %q", required)
 		}
 	}
 }

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -191,6 +191,69 @@ func splitWorkflowNeeds(value string) map[string]struct{} {
 	return needs
 }
 
+func TestStableReleasePublishesOnlyExactQualifiedArtifacts(t *testing.T) {
+	releaseWorkflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := string(releaseWorkflow)
+	if strings.Contains(release, "\n  push:") || strings.Contains(release, `tags: ["v*"]`) {
+		t.Fatal("stable publication must not start automatically from a version tag")
+	}
+	for _, required := range []string{
+		`workflow_dispatch:`,
+		`source_sha:`,
+		`stable qualification must be dispatched from the main workflow`,
+		`actions: read`,
+		`contents: write`,
+		`Resolve successful CI run for the exact SHA`,
+		`stable-source-qualification-${{ steps.inputs.outputs.source_sha }}-${{ steps.ci.outputs.run_attempt }}`,
+		`scripts/release-qualification.sh verify-ci`,
+		`Smoke-test the files that will be published`,
+		`scripts/release-qualification.sh create-release`,
+		`needs: [prepare, build, manifest]`,
+		`ref: ${{ needs.prepare.outputs.source_sha }}`,
+		`existing tag $VERSION does not point directly to qualified commit $SOURCE_SHA`,
+		`--verify-tag`,
+		`--draft`,
+		`--draft=false`,
+		`release/release-manifest.json`,
+	} {
+		if !strings.Contains(release, required) {
+			t.Errorf("stable release workflow is missing exact qualification policy %q", required)
+		}
+	}
+	if strings.Contains(release, "--clobber") {
+		t.Fatal("stable publication must not replace previously published assets")
+	}
+	jobs := workflowJobBlocks(release)
+	if !strings.Contains(jobs["build"], "scripts/build-release-assets.sh") {
+		t.Fatal("stable build job does not create release assets")
+	}
+	if !strings.Contains(jobs["build"], "scripts/smoke-release-assets.sh") {
+		t.Fatal("stable build job does not smoke-test release assets")
+	}
+	if strings.Contains(jobs["publish"], "scripts/build-release-assets.sh") {
+		t.Fatal("stable publish job rebuilds release assets after qualification")
+	}
+
+	ciWorkflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ci := string(ciWorkflow)
+	for _, required := range []string{
+		`Record exact main-branch qualification`,
+		`CI_NEEDS: ${{ toJSON(needs) }}`,
+		`stable-source-qualification-${{ github.sha }}-${{ github.run_attempt }}`,
+		`scripts/release-qualification.sh record-ci stable-qualification/ci-qualification.json`,
+	} {
+		if !strings.Contains(ci, required) {
+			t.Errorf("CI workflow is missing stable qualification record %q", required)
+		}
+	}
+}
+
 func TestWindowsWABTInstallIsPinnedAndVerified(t *testing.T) {
 	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
 	if err != nil {

--- a/tests/scripts/release-qualification.sh
+++ b/tests/scripts/release-qualification.sh
@@ -104,7 +104,23 @@ fi
 exit 1
 EOF
 done
+broken_tiny="$smoke/wago-runtime-standard-tiny-linux-amd64"
+cat >"$broken_tiny" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "--json" && "\${2:-}" == "--version" ]]; then
+  printf '{"release":"$version"}\n'
+  exit 0
+fi
+exit 1
+EOF
 chmod +x "$smoke"/*
+if "$repository_root/scripts/smoke-release-assets.sh" \
+  "$smoke" linux-amd64 "$version" >/dev/null 2>&1; then
+  echo "nonfunctional published Tiny runtime unexpectedly passed smoke testing" >&2
+  exit 1
+fi
+cp "$smoke/wago-runtime-standard-normal-linux-amd64" "$broken_tiny"
 "$repository_root/scripts/smoke-release-assets.sh" \
   "$smoke" linux-amd64 "$version"
 

--- a/tests/scripts/release-qualification.sh
+++ b/tests/scripts/release-qualification.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root=$(git rev-parse --show-toplevel)
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+source_sha=0123456789abcdef0123456789abcdef01234567
+run_id=123456
+version=v1.2.3
+repository=wago-org/wago
+success_needs='{"changes":{"result":"success"},"docs":{"result":"success"},"lint":{"result":"success"},"regression-corpus":{"result":"success"},"runtime-concurrency":{"result":"success"},"race":{"result":"success"},"platform-test":{"result":"success"},"core-v2":{"result":"success"},"core-v3":{"result":"success"},"tinygo":{"result":"success"},"coverage":{"result":"success"},"size":{"result":"success"}}'
+
+CI_NEEDS="$success_needs" \
+CI_REPOSITORY="$repository" \
+CI_SOURCE_SHA="$source_sha" \
+CI_RUN_ID="$run_id" \
+CI_RUN_ATTEMPT=1 \
+CI_WORKFLOW_REF="$repository/.github/workflows/ci.yml@refs/heads/main" \
+  "$repository_root/scripts/release-qualification.sh" record-ci "$test_root/ci.json"
+
+"$repository_root/scripts/release-qualification.sh" verify-ci \
+  "$test_root/ci.json" "$repository" "$source_sha" "$run_id" 1
+if "$repository_root/scripts/release-qualification.sh" verify-ci \
+  "$test_root/ci.json" "$repository" "$source_sha" "$run_id" 2 >/dev/null 2>&1; then
+  echo "qualification record unexpectedly matched a different run attempt" >&2
+  exit 1
+fi
+
+skipped_needs=${success_needs/\"core-v3\":{\"result\":\"success\"}/\"core-v3\":{\"result\":\"skipped\"}}
+CI_NEEDS="$skipped_needs" \
+CI_REPOSITORY="$repository" \
+CI_SOURCE_SHA="$source_sha" \
+CI_RUN_ID="$run_id" \
+CI_RUN_ATTEMPT=1 \
+CI_WORKFLOW_REF="$repository/.github/workflows/ci.yml@refs/heads/main" \
+  go run "$repository_root/tests/tools/release-qualification" record-ci "$test_root/ci-skipped.json" 2>/dev/null && {
+    echo "skipped required CI job unexpectedly produced a qualification record" >&2
+    exit 1
+  }
+
+mkdir -p "$test_root/release" "$test_root/manifest"
+for name in \
+  wago-linux-amd64 \
+  wago-linux-amd64.sha256 \
+  wago-installer-linux-amd64 \
+  wago-installer-linux-amd64.sha256 \
+  wago-runtime-standard-normal-linux-amd64 \
+  wago-runtime-standard-normal-linux-amd64.sha256 \
+  wago-runtime-minimal-normal-linux-amd64 \
+  wago-runtime-minimal-normal-linux-amd64.sha256; do
+  printf '%s\n' "$name" >"$test_root/release/$name"
+done
+
+GITHUB_REPOSITORY="$repository" \
+  "$repository_root/scripts/release-qualification.sh" create-release \
+  "$test_root/release" "$version" "$source_sha" "$run_id" 1 \
+  "$test_root/ci.json" "$test_root/manifest/release-manifest.json"
+"$repository_root/scripts/release-qualification.sh" verify-release \
+  "$test_root/manifest/release-manifest.json" "$test_root/release" \
+  "$repository" "$version" "$source_sha" "$run_id" 1
+
+printf 'tampered\n' >>"$test_root/release/wago-linux-amd64"
+if "$repository_root/scripts/release-qualification.sh" verify-release \
+  "$test_root/manifest/release-manifest.json" "$test_root/release" \
+  "$repository" "$version" "$source_sha" "$run_id" 1 >/dev/null 2>&1; then
+  echo "tampered release asset unexpectedly verified" >&2
+  exit 1
+fi
+
+smoke="$test_root/smoke"
+mkdir -p "$smoke"
+cat >"$smoke/wago-linux-amd64" <<EOF
+#!/usr/bin/env bash
+printf '{"managerVersion":"$version"}\n'
+EOF
+cat >"$smoke/wago-installer-linux-amd64" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' '$version'
+EOF
+for profile in standard minimal; do
+  runtime="$smoke/wago-runtime-${profile}-normal-linux-amd64"
+  cat >"$runtime" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "--json" ]]; then
+  printf '{"release":"$version"}\n'
+  exit 0
+fi
+if [[ "\${1:-}" == "build" ]]; then
+  while ((\$# > 0)); do
+    if [[ "\$1" == "--output" ]]; then
+      printf 'artifact\n' >"\$2"
+      exit 0
+    fi
+    shift
+  done
+  exit 1
+fi
+if [[ "\${1:-}" == "run" ]]; then
+  printf 'fib(20) = 6765\n'
+  exit 0
+fi
+exit 1
+EOF
+done
+chmod +x "$smoke"/*
+"$repository_root/scripts/smoke-release-assets.sh" \
+  "$smoke" linux-amd64 "$version"
+
+echo "release qualification tests passed"

--- a/tests/tools/release-qualification/main.go
+++ b/tests/tools/release-qualification/main.go
@@ -1,0 +1,393 @@
+// Command release-qualification creates and verifies the immutable records used
+// to authorize stable Wago publication.
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var (
+	shaPattern     = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	versionPattern = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+	assetPattern   = regexp.MustCompile(`^wago-[A-Za-z0-9._-]+$`)
+	digestPattern  = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+var requiredJobs = []string{
+	"changes", "docs", "lint", "regression-corpus", "runtime-concurrency",
+	"race", "platform-test", "core-v2", "core-v3", "tinygo", "coverage", "size",
+}
+
+type qualificationJob struct {
+	ID     string `json:"id"`
+	Result string `json:"result"`
+}
+
+type qualification struct {
+	Schema      int                `json:"schema"`
+	Repository  string             `json:"repository"`
+	SourceSHA   string             `json:"source_sha"`
+	WorkflowSHA string             `json:"workflow_sha"`
+	RunID       int64              `json:"run_id"`
+	RunAttempt  int64              `json:"run_attempt"`
+	Event       string             `json:"event"`
+	Ref         string             `json:"ref"`
+	WorkflowRef string             `json:"workflow_ref"`
+	Jobs        []qualificationJob `json:"jobs"`
+}
+
+type releaseAsset struct {
+	Name   string `json:"name"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+type releaseManifest struct {
+	Schema        int            `json:"schema"`
+	Version       string         `json:"version"`
+	SourceSHA     string         `json:"source_sha"`
+	CIRunID       int64          `json:"ci_run_id"`
+	CIRunAttempt  int64          `json:"ci_run_attempt"`
+	Qualification qualification  `json:"qualification"`
+	Assets        []releaseAsset `json:"assets"`
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "release qualification:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		return usageError()
+	}
+	switch args[0] {
+	case "record-ci":
+		if len(args) != 2 {
+			return usageError()
+		}
+		return recordCI(args[1])
+	case "verify-ci":
+		if len(args) != 6 {
+			return usageError()
+		}
+		runID, err := positiveInt(args[4], "CI run ID")
+		if err != nil {
+			return err
+		}
+		runAttempt, err := positiveInt(args[5], "CI run attempt")
+		if err != nil {
+			return err
+		}
+		q, err := readQualification(args[1])
+		if err != nil {
+			return err
+		}
+		return verifyQualification(q, args[2], args[3], runID, runAttempt)
+	case "create-release":
+		if len(args) != 8 {
+			return usageError()
+		}
+		runID, err := positiveInt(args[4], "CI run ID")
+		if err != nil {
+			return err
+		}
+		runAttempt, err := positiveInt(args[5], "CI run attempt")
+		if err != nil {
+			return err
+		}
+		return createRelease(args[1], args[2], args[3], runID, runAttempt, args[6], args[7])
+	case "verify-release":
+		if len(args) != 8 {
+			return usageError()
+		}
+		runID, err := positiveInt(args[6], "CI run ID")
+		if err != nil {
+			return err
+		}
+		runAttempt, err := positiveInt(args[7], "CI run attempt")
+		if err != nil {
+			return err
+		}
+		return verifyRelease(args[1], args[2], args[3], args[4], args[5], runID, runAttempt)
+	default:
+		return usageError()
+	}
+}
+
+func usageError() error {
+	return errors.New("usage: record-ci <output> | verify-ci <manifest> <repository> <source-sha> <run-id> <run-attempt> | create-release <release-dir> <version> <source-sha> <run-id> <run-attempt> <ci-manifest> <output> | verify-release <manifest> <release-dir> <repository> <version> <source-sha> <run-id> <run-attempt>")
+}
+
+func positiveInt(value, name string) (int64, error) {
+	result, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || result < 1 {
+		return 0, fmt.Errorf("invalid %s %q", name, value)
+	}
+	return result, nil
+}
+
+func recordCI(output string) error {
+	runID, err := positiveInt(os.Getenv("CI_RUN_ID"), "CI run ID")
+	if err != nil {
+		return err
+	}
+	runAttempt, err := positiveInt(os.Getenv("CI_RUN_ATTEMPT"), "CI run attempt")
+	if err != nil {
+		return err
+	}
+	var needs map[string]struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(os.Getenv("CI_NEEDS")), &needs); err != nil {
+		return fmt.Errorf("decode CI needs: %w", err)
+	}
+	jobs := make([]qualificationJob, 0, len(needs))
+	for id, need := range needs {
+		jobs = append(jobs, qualificationJob{ID: id, Result: need.Result})
+	}
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].ID < jobs[j].ID })
+	q := qualification{
+		Schema: 1, Repository: os.Getenv("CI_REPOSITORY"),
+		SourceSHA: os.Getenv("CI_SOURCE_SHA"), WorkflowSHA: os.Getenv("CI_SOURCE_SHA"),
+		RunID: runID, RunAttempt: runAttempt, Event: "push", Ref: "refs/heads/main",
+		WorkflowRef: os.Getenv("CI_WORKFLOW_REF"), Jobs: jobs,
+	}
+	if err := verifyQualification(q, q.Repository, q.SourceSHA, q.RunID, q.RunAttempt); err != nil {
+		return err
+	}
+	return writeJSON(output, q)
+}
+
+func readQualification(path string) (qualification, error) {
+	var q qualification
+	if err := readJSON(path, &q); err != nil {
+		return q, fmt.Errorf("read CI qualification: %w", err)
+	}
+	return q, nil
+}
+
+func verifyQualification(q qualification, repository, sourceSHA string, runID, runAttempt int64) error {
+	if !shaPattern.MatchString(sourceSHA) {
+		return fmt.Errorf("invalid full commit SHA %q", sourceSHA)
+	}
+	if q.Schema != 1 || q.Repository != repository || q.SourceSHA != sourceSHA ||
+		q.WorkflowSHA != sourceSHA || q.RunID != runID || q.RunAttempt != runAttempt ||
+		q.Event != "push" || q.Ref != "refs/heads/main" ||
+		q.WorkflowRef != repository+"/.github/workflows/ci.yml@refs/heads/main" {
+		return errors.New("CI qualification does not identify the exact successful main source run")
+	}
+	seen := make(map[string]bool, len(q.Jobs))
+	for _, job := range q.Jobs {
+		if job.ID == "" || seen[job.ID] {
+			return fmt.Errorf("duplicate or empty qualified job %q", job.ID)
+		}
+		seen[job.ID] = true
+		if job.Result != "success" {
+			return fmt.Errorf("required CI job %s did not succeed: %s", job.ID, job.Result)
+		}
+	}
+	for _, id := range requiredJobs {
+		if !seen[id] {
+			return fmt.Errorf("CI qualification is missing required job %s", id)
+		}
+	}
+	return nil
+}
+
+func createRelease(releaseDir, version, sourceSHA string, runID, runAttempt int64, ciPath, output string) error {
+	if !versionPattern.MatchString(version) {
+		return fmt.Errorf("invalid stable version %q", version)
+	}
+	q, err := readQualification(ciPath)
+	if err != nil {
+		return err
+	}
+	repository := os.Getenv("GITHUB_REPOSITORY")
+	if repository == "" {
+		repository = "wago-org/wago"
+	}
+	if err := verifyQualification(q, repository, sourceSHA, runID, runAttempt); err != nil {
+		return err
+	}
+	assets, err := inventoryAssets(releaseDir)
+	if err != nil {
+		return err
+	}
+	manifest := releaseManifest{Schema: 1, Version: version, SourceSHA: sourceSHA, CIRunID: runID, CIRunAttempt: runAttempt, Qualification: q, Assets: assets}
+	if err := writeJSON(output, manifest); err != nil {
+		return err
+	}
+	digest, err := fileDigest(output)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(output+".sha256", []byte(digest+"  "+filepath.Base(output)+"\n"), 0o644)
+}
+
+func verifyRelease(manifestPath, releaseDir, repository, version, sourceSHA string, runID, runAttempt int64) error {
+	if !versionPattern.MatchString(version) {
+		return fmt.Errorf("invalid stable version %q", version)
+	}
+	var manifest releaseManifest
+	if err := readJSON(manifestPath, &manifest); err != nil {
+		return fmt.Errorf("read release manifest: %w", err)
+	}
+	if manifest.Schema != 1 || manifest.Version != version || manifest.SourceSHA != sourceSHA || manifest.CIRunID != runID || manifest.CIRunAttempt != runAttempt {
+		return errors.New("release manifest does not identify the requested version, source, and CI run")
+	}
+	if err := verifyQualification(manifest.Qualification, repository, sourceSHA, runID, runAttempt); err != nil {
+		return err
+	}
+	actual, err := inventoryAssets(releaseDir)
+	if err != nil {
+		return err
+	}
+	if !equalAssets(manifest.Assets, actual) {
+		return errors.New("release directory names, sizes, or SHA-256 hashes do not exactly match the manifest")
+	}
+	checksum, err := os.ReadFile(manifestPath + ".sha256")
+	if err != nil {
+		return fmt.Errorf("read release manifest checksum: %w", err)
+	}
+	fields := strings.Fields(string(checksum))
+	if len(fields) != 2 || fields[1] != filepath.Base(manifestPath) || !digestPattern.MatchString(fields[0]) {
+		return errors.New("invalid release manifest checksum file")
+	}
+	digest, err := fileDigest(manifestPath)
+	if err != nil {
+		return err
+	}
+	if digest != fields[0] {
+		return errors.New("release manifest checksum mismatch")
+	}
+	return nil
+}
+
+func inventoryAssets(dir string) ([]releaseAsset, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read release directory: %w", err)
+	}
+	var assets []releaseAsset
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, "wago-") {
+			continue
+		}
+		if !assetPattern.MatchString(name) {
+			return nil, fmt.Errorf("unsafe release asset name %q", name)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		if !info.Mode().IsRegular() || info.Size() < 1 {
+			return nil, fmt.Errorf("release asset is not a non-empty regular file: %s", name)
+		}
+		digest, err := fileDigest(filepath.Join(dir, name))
+		if err != nil {
+			return nil, err
+		}
+		assets = append(assets, releaseAsset{Name: name, Size: info.Size(), SHA256: digest})
+	}
+	if len(assets) == 0 {
+		return nil, errors.New("release directory has no wago-* assets")
+	}
+	sort.Slice(assets, func(i, j int) bool { return assets[i].Name < assets[j].Name })
+	return assets, nil
+}
+
+func equalAssets(a, b []releaseAsset) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] || !assetPattern.MatchString(a[i].Name) || a[i].Size < 1 || !digestPattern.MatchString(a[i].SHA256) {
+			return false
+		}
+		if i > 0 && a[i-1].Name >= a[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+func fileDigest(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func readJSON(path string, target any) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return errors.New("trailing JSON value")
+		}
+		return fmt.Errorf("trailing JSON content: %w", err)
+	}
+	return nil
+}
+
+func writeJSON(path string, value any) error {
+	var data bytes.Buffer
+	encoder := json.NewEncoder(&data)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".release-qualification-*")
+	if err != nil {
+		return err
+	}
+	name := temp.Name()
+	defer os.Remove(name)
+	if _, err := temp.Write(data.Bytes()); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Chmod(0o644); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(name, path)
+}


### PR DESCRIPTION
## Summary

- record an immutable per-attempt qualification manifest after every complete successful `main` CI push
- replace tag-triggered stable publication with an explicit version plus full source-SHA workflow
- verify the exact successful CI run and every required aggregate dependency before building
- build, checksum, smoke-test, and manifest release files once, then publish those same files
- require the stable tag to point directly to the qualified commit, refuse published-release replacement, and safely resume only matching drafts

## Qualification chain

1. `CI` records the source SHA, workflow run ID and attempt, and every required job result.
2. Stable release preparation verifies the requested commit is reachable from `main` and downloads that exact record.
3. Every required CI job must be present and successful. Missing, skipped, failed, cancelled, stale, or mismatched records reject.
4. Native release cells build and smoke-test the files that will be published.
5. The release manifest records the source SHA, CI identity, job results, and every asset name, size, and SHA-256 hash.
6. Publication downloads and verifies those artifacts again without rebuilding them.
7. The workflow creates or safely resumes a matching draft, replaces only draft assets on retry, verifies the exact remote asset-name set and direct tag identity, and only then publishes it.

A manually created or moved `v*` tag no longer starts stable publication.

## Artifact smoke coverage

Each native target checks every Normal or Tiny runtime selected for publication:

- manager, installer, and runtime embedded versions
- raw scalar Wasm compile/instantiate/invoke
- `.wago` serialization
- reload and execution of the generated `.wago` artifact with every published runtime
- checksums and required profile files

## Testing

Passed locally:

- `tests/scripts/build-release-assets.sh`
- `tests/scripts/release-qualification.sh`
- real Linux/AMD64 release-binary smoke test
- `go test -count=1 ./tests/cipolicy ./tests/tools/release-qualification`
- `go vet ./tests/cipolicy ./tests/tools/release-qualification`
- `make docs-check`
- `git diff --check`
- `actionlint` on `ci.yml` and `release.yml`, ignoring only the repository's existing custom runner-label warnings

`make test` was also attempted. Unrelated local failures came from the host's `tag.gpgSign=true` configuration, a TinyGo standalone timeout, and one terminal job-control failure that passed on focused rerun. The PR CI matrix remains the authoritative clean-environment gate.

No runtime hot path or shipped library behavior changes; no benchmark impact expected.

Closes #482