### PR TITLE
gc: terminate amd64 public root chains at Go boundary

### DIFF
--- a/src/wago/gc_frame_roots_runtime_linux_amd64.go
+++ b/src/wago/gc_frame_roots_runtime_linux_amd64.go
@@ -12,7 +12,9 @@ import (
 )
 
 func (in *Instance) gcCollectFrameRoots(public *gcPublicState) gcNativeFrameRoots {
-	return gcCollectFrameRoots(in, public, gcNativeFrameLayoutAMD64, false)
+	// Public entries return through enterNative into Go after the outermost
+	// generated frame. That external return is the valid end of the root chain.
+	return gcCollectFrameRoots(in, public, gcNativeFrameLayoutAMD64, true)
 }
 
 // gcHelperRoots publishes exact-typed collector-reference locals from the

--- a/src/wago/gc_frame_roots_runtime_test.go
+++ b/src/wago/gc_frame_roots_runtime_test.go
@@ -25,11 +25,11 @@ func TestGCCollectFrameRootsUsesCurrentArchitecture(t *testing.T) {
 	if !supportsCompleteCore3Backend(runtime.GOOS, runtime.GOARCH) {
 		t.Skipf("native GC frame roots are unavailable on %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
-	wantLayout, wantExternal := uint8(gcNativeFrameLayoutAMD64), false
+	wantLayout, wantExternal := uint8(gcNativeFrameLayoutAMD64), true
 	switch runtime.GOARCH {
 	case "amd64":
 	case "arm64":
-		wantLayout, wantExternal = gcNativeFrameLayoutARM64, true
+		wantLayout = gcNativeFrameLayoutARM64
 	default:
 		t.Skipf("native GC frame roots are unavailable on %s", runtime.GOARCH)
 	}


### PR DESCRIPTION
## Summary

Treat the return from the outermost Linux/amd64 generated frame into `enterNative` as the valid end of a public GC root chain. ARM64 already marks this boundary as externally terminating.

Without this flag, forced moving-nursery collection during a public call can walk past the outermost generated frame and reject the Go return PC as having no Runtime GC-domain owner. The new `wago-facet` moving-GC conformance gate exposed this in four GC-array cases.

## Validation

- `go test ./src/wago -count=1`
- `go test -race ./src/wago -run TestGCCollectFrameRoots -count=1`
- focused `wago-facet` GC-array regression with collection on every allocation

The architecture test now requires the public external-return boundary on both complete native backends.