### PR TITLE
wasm: bound initial vector allocations

### DIFF
--- a/src/core/compiler/wasm/decode.go
+++ b/src/core/compiler/wasm/decode.go
@@ -512,10 +512,7 @@ func decodeImports(r *reader) ([]Import, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	imports := make([]Import, 0, capHint)
 	compact := false
 	for uint32(len(imports)) < n {

--- a/src/core/compiler/wasm/decode_edges_test.go
+++ b/src/core/compiler/wasm/decode_edges_test.go
@@ -47,6 +47,26 @@ func TestReaderBytesRejectsOverflowingRange(t *testing.T) {
 	}
 }
 
+func TestVectorCapacityHintIsBoundedBeforeElementsDecode(t *testing.T) {
+	const maxInitialVecElements = 1024
+	for _, tc := range []struct {
+		name      string
+		count     uint32
+		remaining int
+		want      int
+	}{
+		{name: "count", count: 7, remaining: 1 << 20, want: 7},
+		{name: "remaining bytes", count: 100, remaining: 9, want: 9},
+		{name: "malformed input bound", count: 1 << 20, remaining: 2 << 20, want: maxInitialVecElements},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := boundedVecCap(tc.count, tc.remaining); got != tc.want {
+				t.Fatalf("boundedVecCap(%d, %d) = %d, want %d", tc.count, tc.remaining, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDecodeRejectsSectionOrderDuplicateAndTrailingPayload(t *testing.T) {
 	t.Run("section order", func(t *testing.T) {
 		_, err := DecodeModule(module(section(secFunction, 0x00), section(secType, 0x00)))

--- a/src/core/compiler/wasm/reader.go
+++ b/src/core/compiler/wasm/reader.go
@@ -127,15 +127,7 @@ func readVec[T any](r *reader, fn func(*reader) (T, error)) ([]T, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The declared vector length is attacker-controlled. Do not use it as a
-	// capacity hint directly: a tiny malformed payload can otherwise request a
-	// multi-gigabyte allocation before the first element read discovers EOF. Keep
-	// the hint in int space until n has been proven smaller, so this is safe on
-	// 32-bit Go as well as amd64.
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	out := make([]T, 0, capHint)
 	for i := uint32(0); i < n; i++ {
 		v, err := fn(r)
@@ -145,5 +137,20 @@ func readVec[T any](r *reader, fn func(*reader) (T, error)) ([]T, error) {
 		out = append(out, v)
 	}
 	return out, nil
+}
+
+// boundedVecCap avoids multiplying an attacker-controlled byte count by the
+// in-memory size of a decoded element before any element has been validated.
+// Valid larger vectors grow normally after this modest initial allocation.
+func boundedVecCap(n uint32, remainingBytes int) int {
+	const maxInitialVecElements = 1024
+	capHint := remainingBytes
+	if capHint > maxInitialVecElements {
+		capHint = maxInitialVecElements
+	}
+	if uint64(n) < uint64(capHint) {
+		capHint = int(n)
+	}
+	return capHint
 }
 func ptr[T any](v T) *T { return &v }

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -319,10 +319,7 @@ func decodeDirectTableSection(dm *directModule, r *reader) error {
 	if err != nil {
 		return err
 	}
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	dm.m.Tables = make([]Table, 0, capHint)
 	dm.direct.tableHasInit = make([]bool, 0, capHint)
 	dm.direct.tableInits = make([]directConstExpr, 0, capHint)
@@ -362,10 +359,7 @@ func decodeDirectGlobalSection(dm *directModule, r *reader) error {
 	if err != nil {
 		return err
 	}
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	dm.m.Globals = make([]Global, 0, capHint)
 	dm.direct.globalInits = make([]directConstExpr, 0, capHint)
 	for i := uint32(0); i < n; i++ {
@@ -388,10 +382,7 @@ func decodeDirectDataSection(dm *directModule, r *reader) error {
 	if err != nil {
 		return err
 	}
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	dm.m.Data = make([]Data, 0, capHint)
 	dm.direct.dataOffsets = make([]directConstExpr, 0, capHint)
 	for i := uint32(0); i < n; i++ {
@@ -452,10 +443,7 @@ func decodeDirectElementSection(dm *directModule, r *reader) error {
 	if err != nil {
 		return err
 	}
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	dm.m.Elements = make([]Elem, 0, capHint)
 	dm.direct.elements = make([]directElem, 0, capHint)
 	for i := uint32(0); i < n; i++ {
@@ -616,10 +604,7 @@ func readDirectFuncIdxSummary(r *reader, de *directElem) error {
 		return err
 	}
 	de.elemLen = n
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	de.funcs = make([]FuncIdx, 0, capHint)
 	for i := uint32(0); i < n; i++ {
 		x, err := r.u32()
@@ -641,10 +626,7 @@ func readDirectConstExprVec(r *reader) ([]directConstExpr, error) {
 	if err != nil {
 		return nil, err
 	}
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	exprs := make([]directConstExpr, 0, capHint)
 	for i := uint32(0); i < n; i++ {
 		e, err := readDirectConstExprBytes(r)
@@ -695,10 +677,7 @@ func decodeDirectCodeSectionWithWidths(r *reader, widths memargWidths, multiMemo
 	if err != nil {
 		return nil, false, err
 	}
-	capHint := r.left()
-	if uint64(n) < uint64(capHint) {
-		capHint = int(n)
-	}
+	capHint := boundedVecCap(n, r.left())
 	out := make([]Func, 0, capHint)
 	var sub reader
 	var frames []exprSkipFrame


### PR DESCRIPTION
Small correctness fix for malformed module decoding.

Summary:
- cap initial decoder vector capacity hints at 1,024 elements
- apply the same bound to generic and byte-backed/manual decode paths
- preserve normal growth for valid larger vectors

Footprint:
- for 2 MiB remaining input and a 128-byte decoded element, the initial request drops from 256 MiB to 128 KiB

Testing:
- `go test ./src/core/compiler/wasm`
- `go test ./src/core/compiler/...`

Docs unchanged: this is an internal correctness fix with no workflow impact.