### PR TITLE
wasm: enforce GC supertype ordering

### DIFF
--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -213,10 +213,16 @@ func (v *moduleValidator) validateModule() error {
 	}
 	v.collectDeclaredFuncs()
 	for gi, rt := range v.m.Types {
-		for _, st := range rt.SubTypes {
+		for si, st := range rt.SubTypes {
+			if len(st.Supers) > 1 {
+				return v.err(ErrTypeMismatch, "multiple supertypes")
+			}
 			for _, sup := range st.Supers {
 				if !v.validTypeIdxInRecGroup(sup, gi) {
 					return v.err(ErrUnknownType, "supertype")
+				}
+				if sup.Rec && sup.Index >= uint32(si) {
+					return v.err(ErrTypeMismatch, "supertype must precede subtype")
 				}
 			}
 			if describes, present := st.Metadata.Describes.Get(); present && !v.validTypeIdxInRecGroup(describes, gi) {

--- a/src/core/compiler/wasm/validate_gc_subtype_test.go
+++ b/src/core/compiler/wasm/validate_gc_subtype_test.go
@@ -55,6 +55,23 @@ func TestValidateGCSubtypeMetadata(t *testing.T) {
 		}}}}
 		expectValidateErr(t, m, ErrTypeMismatch)
 	})
+
+	t.Run("multiple direct supertypes are rejected", func(t *testing.T) {
+		m := &Module{Types: []RecType{
+			openStructType(nil),
+			openStructType(nil),
+			openStructType(nil, TypeIdx{Index: 0}, TypeIdx{Index: 1}),
+		}}
+		expectValidateErr(t, m, ErrTypeMismatch)
+	})
+
+	t.Run("forward recursive supertype is rejected", func(t *testing.T) {
+		m := &Module{Types: []RecType{{SubTypes: []SubType{
+			{Final: false, Supers: []TypeIdx{{Index: 1, Rec: true}}, Comp: CompType{Kind: CompStruct}},
+			{Final: false, Comp: CompType{Kind: CompStruct}},
+		}}}}
+		expectValidateErr(t, m, ErrTypeMismatch)
+	})
 }
 
 func TestRefTestAcceptsDefinedSiblingTypes(t *testing.T) {


### PR DESCRIPTION
Small correctness fix for Core GC type validation.

Summary:
- reject subtype declarations with more than one direct supertype
- reject forward and self supertype references inside a recursive group
- retain the existing finality, kind, and structural subtype checks

Testing:
- `go test ./src/core/compiler/wasm`

Docs unchanged: this is an internal correctness fix with no workflow impact.