### PR TITLE
policy: charge full no-max memory32 reserve

### DIFF
--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -3611,8 +3611,12 @@ func (c *Compiled) declaredMemoryMaxBytes() (uint64, error) {
 		if !def.HasMax {
 			// The exact Wasm type remains unbounded in metadata. Policy and managed-
 			// instance accounting charge the finite implementation reservation used
-			// by instantiation, matching the existing memory32 resource model.
-			pages = 65535
+			// by instantiation. Memory32 can reach the Core limit of 65,536 pages;
+			// staged memory64 retains its smaller finite implementation ceiling.
+			pages = 1 << 16
+			if def.Addr64 {
+				pages = 65535
+			}
 		}
 		if pages > ^uint64(0)/pageBytes {
 			return 0, fmt.Errorf("memory %d maximum %d pages overflows bytes", i, pages)

--- a/src/wago/policy_test.go
+++ b/src/wago/policy_test.go
@@ -79,6 +79,17 @@ func TestPolicyMemoryLimit(t *testing.T) {
 	in.Close()
 }
 
+func TestDeclaredMemoryMaxBytesChargesFullNoMaxMemory32Reservation(t *testing.T) {
+	c := &Compiled{HasMemory: true, MemMinPages: 1}
+	got, err := c.declaredMemoryMaxBytes()
+	if err != nil {
+		t.Fatalf("declaredMemoryMaxBytes: %v", err)
+	}
+	if want := uint64(1) << 32; got != want {
+		t.Fatalf("no-max memory32 reservation = %d bytes, want %d", got, want)
+	}
+}
+
 func TestPolicyChecksEveryLocalTable(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()


### PR DESCRIPTION
Small correctness fix for memory policy accounting.

Summary:
- account for the full 65,536-page Core memory32 limit when no maximum is declared
- preserve the separate staged 65,535-page memory64 implementation ceiling
- add an exact 4 GiB reservation regression test

Testing:
- `go test ./src/wago -run TestDeclaredMemoryMaxBytesChargesFullNoMaxMemory32Reservation`

The broader `go test ./src/wago` run reached unrelated pinned-corpus tests that are unavailable in the isolated worktree.

Docs unchanged: this is an internal correctness fix with no workflow impact.