### PR TITLE
policy: reject unenforced invoke durations

### DIFF
--- a/src/wago/policy.go
+++ b/src/wago/policy.go
@@ -22,8 +22,8 @@ type Policy struct {
 	// MaxTags caps the number of declared/imported exception tags. 0 means unbounded.
 	MaxTags uint32
 
-	// MaxInvokeDuration bounds a single invocation. Accepted but not yet enforced
-	// by the low-level call path; reserved.
+	// MaxInvokeDuration bounds a single invocation. The low-level call path does
+	// not yet implement this bound, so nonzero values are rejected at admission.
 	MaxInvokeDuration time.Duration
 }
 
@@ -49,6 +49,9 @@ func (p Policy) allows(cap Capability) bool {
 // requires must be permitted, and its declared limits must fit. It returns an
 // error wrapping ErrPermissionDenied on violation. The zero Policy passes.
 func applyPolicy(mod *Module, p Policy) error {
+	if p.MaxInvokeDuration != 0 {
+		return fmt.Errorf("maximum invoke duration is not supported by the low-level call path: %w", ErrPermissionDenied)
+	}
 	for _, cap := range mod.RequiredCapabilities() {
 		if !p.allows(cap) {
 			return fmt.Errorf("module requires capability %q which the policy does not allow: %w", cap, ErrPermissionDenied)

--- a/src/wago/policy_test.go
+++ b/src/wago/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/tests/wasmtest"
 )
@@ -58,6 +59,18 @@ func TestPolicyCapabilityAllowDeny(t *testing.T) {
 		t.Fatalf("instantiate with zero policy: %v", err)
 	}
 	in.Close()
+}
+
+func TestPolicyRejectsUnenforcedInvokeDuration(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if _, err := rt.Instantiate(context.Background(), mod, WithPolicy(Policy{MaxInvokeDuration: time.Millisecond})); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("instantiate with unenforced invoke duration = %v, want ErrPermissionDenied", err)
+	}
 }
 
 func TestPolicyMemoryLimit(t *testing.T) {


### PR DESCRIPTION
Small correctness fix for policy admission.

Summary:
- reject nonzero `MaxInvokeDuration` values while the low-level call path cannot enforce them
- return `ErrPermissionDenied` instead of silently admitting a weaker policy
- document the strict current behavior on the public field

Testing:
- `go test ./src/wago -run '^(TestPolicyCapabilityAllowDeny|TestPolicyRejectsUnenforcedInvokeDuration)$'`

Docs unchanged: the public API comment records the behavior.