### PR TITLE
wasm: reject overflowing byte ranges

### DIFF
--- a/src/core/compiler/wasm/decode_edges_test.go
+++ b/src/core/compiler/wasm/decode_edges_test.go
@@ -36,6 +36,17 @@ func TestDecodeRejectsHugeVectorLengthWithoutLargeAllocation(t *testing.T) {
 	}
 }
 
+func TestReaderBytesRejectsOverflowingRange(t *testing.T) {
+	r := newReader([]byte{0, 1})
+	if _, err := r.byte(); err != nil {
+		t.Fatalf("advance reader: %v", err)
+	}
+	maxInt := int(^uint(0) >> 1)
+	if _, err := r.bytes(maxInt); err == nil {
+		t.Fatal("overflowing byte range accepted")
+	}
+}
+
 func TestDecodeRejectsSectionOrderDuplicateAndTrailingPayload(t *testing.T) {
 	t.Run("section order", func(t *testing.T) {
 		_, err := DecodeModule(module(section(secFunction, 0x00), section(secType, 0x00)))

--- a/src/core/compiler/wasm/reader.go
+++ b/src/core/compiler/wasm/reader.go
@@ -36,7 +36,7 @@ func (r *reader) byte() (byte, error) {
 	return b, nil
 }
 func (r *reader) bytes(n int) ([]byte, error) {
-	if n < 0 || r.pos+n > len(r.data) {
+	if n < 0 || n > len(r.data)-r.pos {
 		return nil, &DecodeError{Code: ErrIndexOutOfBounds, Offset: r.pos}
 	}
 	b := r.data[r.pos : r.pos+n]


### PR DESCRIPTION
Small correctness fix for binary reader bounds checks.

Summary:
- validate requested byte counts against the remaining range without integer addition
- prevent an overflowing position-plus-length from reaching a slice-bounds panic
- add a maximum-int regression case after a nonzero cursor

Testing:
- `go test ./src/core/compiler/wasm -run '^(TestReaderBytesRejectsOverflowingRange|TestDecodeRejectsHugeVectorLengthWithoutLargeAllocation)$'`

Docs unchanged: this is an internal correctness fix with no workflow impact.