### PR TITLE
wasm: share owned name-section payload

### DIFF
--- a/src/core/compiler/wasm/decode.go
+++ b/src/core/compiler/wasm/decode.go
@@ -66,9 +66,12 @@ func decodeSection(m *Module, r *reader, id byte) error {
 				return err
 			}
 			m.NameSec = ns
-			m.RawNameSecPayload = append([]byte(nil), payload...)
 		}
-		m.Customs = append(m.Customs, CustomSec{Name: name, Data: append([]byte(nil), payload...)})
+		ownedPayload := append([]byte(nil), payload...)
+		if name == "name" {
+			m.RawNameSecPayload = ownedPayload
+		}
+		m.Customs = append(m.Customs, CustomSec{Name: name, Data: ownedPayload})
 	case secType:
 		v, err := readVec(r, decodeRecType)
 		if err != nil {

--- a/src/core/compiler/wasm/decode_validate_test.go
+++ b/src/core/compiler/wasm/decode_validate_test.go
@@ -166,4 +166,7 @@ func TestCustomNameSectionPreserved(t *testing.T) {
 	if string(m.RawNameSecPayload) != string(namePayload) {
 		t.Fatalf("raw name payload mismatch")
 	}
+	if &m.RawNameSecPayload[0] != &m.Customs[0].Data[0] {
+		t.Fatal("raw name payload does not share the owned custom-section bytes")
+	}
 }

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -293,7 +293,6 @@ func (dm *directModule) decodeDirectCustomSection(r *reader) error {
 			return err
 		}
 		dm.m.NameSec = ns
-		dm.m.RawNameSecPayload = append([]byte(nil), payload...)
 		dm.seenName = true
 	}
 	if name == branchHintSectionName {
@@ -307,7 +306,11 @@ func (dm *directModule) decodeDirectCustomSection(r *reader) error {
 		dm.m.BranchHints = hints
 		dm.seenBranchHints = true
 	}
-	dm.m.Customs = append(dm.m.Customs, CustomSec{Name: name, Data: append([]byte(nil), payload...)})
+	ownedPayload := append([]byte(nil), payload...)
+	if name == "name" {
+		dm.m.RawNameSecPayload = ownedPayload
+	}
+	dm.m.Customs = append(dm.m.Customs, CustomSec{Name: name, Data: ownedPayload})
 	return nil
 }
 


### PR DESCRIPTION
Small correctness and footprint fix for preserved name sections.

Summary:
- keep strict structured `name` decoding unchanged
- allocate one owned raw payload after validation succeeds
- share those bytes between `RawNameSecPayload` and the matching custom-section record

Footprint:
- removes one full-payload allocation; a 16 MiB name payload retains 16 MiB less duplicate storage

Testing:
- `go test ./src/core/compiler/wasm -run '^(TestCustomNameSectionPreserved|TestValidateByteBackedModuleStrictNameSection|TestDecodeNameSectionStrictness)$'`

Docs unchanged: this is an internal footprint fix with no workflow impact.