### PR TITLE
wasm: bound function local counts

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -2626,7 +2626,9 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	f.emitNativeGCStubs()
 	f.emitTrapStubs()
 	f.finalizeBranchFolds()
-	f.patchFrameSize()
+	if err := f.patchFrameSize(); err != nil {
+		return nil, nil, 0, err
+	}
 	f.emitV128ConstPool() // trailing rip-relative pool for v128 constants (after all code)
 	if _, err := f.finalizeNativeCode(0); err != nil {
 		return nil, nil, 0, err
@@ -3324,7 +3326,9 @@ func (f *fn) emitRegABI(c *wasm.Func, hostAdapter, hasFloatConst, hasSIMD bool) 
 	f.finalizeBranchFolds()
 
 	f.elideRegisterOnlyFrame() // register-homed call-free leaf → frameSize 0
-	f.patchFrameSize()
+	if err := f.patchFrameSize(); err != nil {
+		return 0, err
+	}
 	if hostAdapter {
 		a.PatchRel32(adapterCall, internalOff)
 		if f.stats != nil {
@@ -3336,8 +3340,12 @@ func (f *fn) emitRegABI(c *wasm.Func, hostAdapter, hasFloatConst, hasSIMD bool) 
 	return internalOff, nil
 }
 
-func (f *fn) patchFrameSize() {
-	size := uint32(f.frameSize())
+func (f *fn) patchFrameSize() error {
+	frameBytes := f.frameSize()
+	if !shared.NativeFrameFitsStackFence(frameBytes, shared.MaxNativeInboundCallBytes) {
+		return fmt.Errorf("amd64: native frame %d bytes exceeds stack-fence headroom %d", frameBytes, shared.MaxNativeFrameBytes-shared.MaxNativeInboundCallBytes)
+	}
+	size := uint32(frameBytes)
 	if f.stats != nil {
 		sites := len(f.sc.tailFrameSites) + 2
 		f.stats.NativeSize.FrameAdjustmentBytes += 7 * sites
@@ -3354,6 +3362,7 @@ func (f *fn) patchFrameSize() {
 	for _, site := range f.sc.tailFrameSites {
 		f.a.PatchU32(site, size)
 	}
+	return nil
 }
 
 // epilogue: copy results from their canonical slots to the results buffer, clear

--- a/src/core/compiler/backend/railshot/amd64/frame_complete_limit_test.go
+++ b/src/core/compiler/backend/railshot/amd64/frame_complete_limit_test.go
@@ -6,18 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/wasmtest"
 )
 
 func TestCompileRejectsCompleteFrameAboveStackFenceHeadroom(t *testing.T) {
-	results := make([]wasm.ValType, 8192)
-	for i := range results {
-		results[i] = wasm.V128
-	}
-	body := append([]byte{0x01}, wasmtest.ULEB(8192)...)
-	body = append(body, 0x7b, 0x10, 0x00, 0x0b) // v128 locals; call self; end
-	m := mod1(t, nil, results, body)
+	body := append([]byte{0x01}, wasmtest.ULEB(32768)...)
+	body = append(body, 0x7e, 0x10, 0x00, 0x0b) // i64 locals; call self; end
+	m := mod1(t, nil, nil, body)
 	if _, err := CompileModule(m); err == nil || !strings.Contains(err.Error(), "exceeds stack-fence headroom") {
 		t.Fatalf("complete-frame compile error = %v", err)
 	}

--- a/src/core/compiler/backend/railshot/amd64/frame_complete_limit_test.go
+++ b/src/core/compiler/backend/railshot/amd64/frame_complete_limit_test.go
@@ -1,0 +1,24 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func TestCompileRejectsCompleteFrameAboveStackFenceHeadroom(t *testing.T) {
+	results := make([]wasm.ValType, 8192)
+	for i := range results {
+		results[i] = wasm.V128
+	}
+	body := append([]byte{0x01}, wasmtest.ULEB(8192)...)
+	body = append(body, 0x7b, 0x10, 0x00, 0x0b) // v128 locals; call self; end
+	m := mod1(t, nil, results, body)
+	if _, err := CompileModule(m); err == nil || !strings.Contains(err.Error(), "exceeds stack-fence headroom") {
+		t.Fatalf("complete-frame compile error = %v", err)
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -765,8 +765,12 @@ func (f *fn) allLocalsRegisterHomed() bool {
 	return true
 }
 
-func (f *fn) patchFrameAdjusts() {
+func (f *fn) patchFrameAdjusts() error {
 	size := f.frameSize()
+	headroom := nativeFrameStackFenceHeadroom(f.usesCalls)
+	if size < 0 || size > headroom {
+		return fmt.Errorf("arm64: native frame %d bytes exceeds stack-fence headroom %d", size, headroom)
+	}
 	addSites := append(f.tailFrameSites, f.addRspAt)
 	if f.stats != nil {
 		sites := len(addSites) + 1
@@ -797,12 +801,21 @@ func (f *fn) patchFrameAdjusts() {
 			f.a.PatchU32(at+4, nop)
 			f.a.PatchU32(at+8, nop)
 		}
-		return
+		return nil
 	}
 	f.a.PatchMovImm(f.subRspAt, uint32(size))
 	for _, at := range addSites {
 		f.a.PatchMovImm(at, uint32(size))
 	}
+	return nil
+}
+
+func nativeFrameStackFenceHeadroom(usesCalls bool) int {
+	overhead := shared.MaxNativeInboundCallBytes
+	if usesCalls {
+		overhead += 16 // FP/LR record is stored before the body-frame fence check.
+	}
+	return shared.MaxNativeFrameBytes - overhead
 }
 
 // ImportBinding is shared by both Railshot architectures.
@@ -2111,7 +2124,9 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	}
 	f.epilogue()
 	f.emitTrapStubs()
-	f.patchFrameAdjusts()
+	if err := f.patchFrameAdjusts(); err != nil {
+		return nil, nil, 0, err
+	}
 	if f.gcFrameRoots != nil {
 		f.gcFrameRoots.FrameBytes = uint32(f.frameSize())
 		if f.gcCallsiteIndex != len(f.gcFrameRoots.LiveCallLocalMasks) {
@@ -2910,7 +2925,9 @@ func (f *fn) emitRegABI(c *wasm.Func, hostAdapter bool) (int, error) {
 	f.emitTrapStubs()
 
 	f.elideRegisterOnlyFrame()
-	f.patchFrameAdjusts()
+	if err := f.patchFrameAdjusts(); err != nil {
+		return 0, err
+	}
 	if hostAdapter {
 		f.a.PatchBranch26(adapterCall, internalOff)
 		if f.stats != nil {

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -767,9 +767,8 @@ func (f *fn) allLocalsRegisterHomed() bool {
 
 func (f *fn) patchFrameAdjusts() error {
 	size := f.frameSize()
-	headroom := nativeFrameStackFenceHeadroom(f.usesCalls)
-	if size < 0 || size > headroom {
-		return fmt.Errorf("arm64: native frame %d bytes exceeds stack-fence headroom %d", size, headroom)
+	if err := f.validateFrameSize(size); err != nil {
+		return err
 	}
 	addSites := append(f.tailFrameSites, f.addRspAt)
 	if f.stats != nil {
@@ -806,6 +805,14 @@ func (f *fn) patchFrameAdjusts() error {
 	f.a.PatchMovImm(f.subRspAt, uint32(size))
 	for _, at := range addSites {
 		f.a.PatchMovImm(at, uint32(size))
+	}
+	return nil
+}
+
+func (f *fn) validateFrameSize(size int) error {
+	headroom := nativeFrameStackFenceHeadroom(f.usesCalls)
+	if size < 0 || size > headroom {
+		return fmt.Errorf("arm64: native frame %d bytes exceeds stack-fence headroom %d", size, headroom)
 	}
 	return nil
 }
@@ -2096,6 +2103,12 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	// caller's own locals only). Extends the frame's local arrays with unpinned
 	// scratch; the splice at each call site binds/zeroes them.
 	f.reserveInlineLocals(inlinedCallees, inlineTargets)
+	// Reject an already-oversized locals/header frame before emitting any
+	// SP-relative homes whose architecture encoding has a smaller displacement.
+	// Operand spills can only grow this frame and remain checked after lowering.
+	if err := f.validateFrameSize(f.frameSize()); err != nil {
+		return nil, nil, 0, err
+	}
 
 	if regABI {
 		internalOff, err := f.emitRegABI(c, hostAdapter)

--- a/src/core/compiler/backend/railshot/arm64/frame_complete_limit_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/frame_complete_limit_arm64_test.go
@@ -6,18 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/wasmtest"
 )
 
 func TestCompileRejectsCompleteFrameAboveStackFenceHeadroom(t *testing.T) {
-	results := make([]wasm.ValType, 8192)
-	for i := range results {
-		results[i] = wasm.V128
-	}
-	body := append([]byte{0x01}, wasmtest.ULEB(8192)...)
-	body = append(body, 0x7b, 0x10, 0x00, 0x0b) // v128 locals; call self; end
-	m := mod1(t, nil, results, body)
+	body := append([]byte{0x01}, wasmtest.ULEB(32768)...)
+	body = append(body, 0x7e, 0x10, 0x00, 0x0b) // i64 locals; call self; end
+	m := mod1(t, nil, nil, body)
 	if _, err := CompileModule(m); err == nil || !strings.Contains(err.Error(), "exceeds stack-fence headroom") {
 		t.Fatalf("complete-frame compile error = %v", err)
 	}

--- a/src/core/compiler/backend/railshot/arm64/frame_complete_limit_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/frame_complete_limit_arm64_test.go
@@ -1,0 +1,24 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func TestCompileRejectsCompleteFrameAboveStackFenceHeadroom(t *testing.T) {
+	results := make([]wasm.ValType, 8192)
+	for i := range results {
+		results[i] = wasm.V128
+	}
+	body := append([]byte{0x01}, wasmtest.ULEB(8192)...)
+	body = append(body, 0x7b, 0x10, 0x00, 0x0b) // v128 locals; call self; end
+	m := mod1(t, nil, results, body)
+	if _, err := CompileModule(m); err == nil || !strings.Contains(err.Error(), "exceeds stack-fence headroom") {
+		t.Fatalf("complete-frame compile error = %v", err)
+	}
+}

--- a/src/core/compiler/backend/railshot/shared/capacity.go
+++ b/src/core/compiler/backend/railshot/shared/capacity.go
@@ -4,11 +4,12 @@
 package shared
 
 // MaxNativeFrameBytes matches the execution stack's fence margin. Inbound
-// cross-instance wrappers reserve 64 bytes before entering the target, so the
-// generated body frame must leave that space inside the checked headroom.
+// cross-instance wrappers reserve 64 bytes and the target's offset-0 adapter
+// reserves another 16 bytes before entering the target body, so the generated
+// frame must leave both inside the checked headroom.
 const (
 	MaxNativeFrameBytes       = 256 << 10
-	MaxNativeInboundCallBytes = 64
+	MaxNativeInboundCallBytes = 64 + 16
 )
 
 // NativeFrameFitsStackFence reports whether a body frame plus fixed entry

--- a/src/core/compiler/backend/railshot/shared/capacity.go
+++ b/src/core/compiler/backend/railshot/shared/capacity.go
@@ -3,6 +3,20 @@
 // encoding remain in the architecture packages.
 package shared
 
+// MaxNativeFrameBytes matches the execution stack's fence margin. Inbound
+// cross-instance wrappers reserve 64 bytes before entering the target, so the
+// generated body frame must leave that space inside the checked headroom.
+const (
+	MaxNativeFrameBytes       = 256 << 10
+	MaxNativeInboundCallBytes = 64
+)
+
+// NativeFrameFitsStackFence reports whether a body frame plus fixed entry
+// overhead fits inside the already-checked stack-fence headroom.
+func NativeFrameFitsStackFence(frameBytes, entryOverhead int) bool {
+	return frameBytes >= 0 && entryOverhead >= 0 && entryOverhead <= MaxNativeFrameBytes && frameBytes <= MaxNativeFrameBytes-entryOverhead
+}
+
 // StackArenaCapacity estimates operand nodes for one function. An opcode-based
 // hint avoids reserving nodes for immediate bytes while a body-size floor keeps
 // malformed or incomplete hints from causing allocation cliffs.

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -201,10 +201,12 @@ const (
 	maxTable32Limit  = uint64(1<<32 - 1)
 	maxMemory32Pages = uint64(1 << 16)
 	maxMemory64Pages = uint64(1 << 48)
-	// The native stack reserves 4 MiB. Keeping the local index space at or below
-	// 2^17 leaves at least half of that reservation for v128 locals plus frame
-	// headers, operand spills, and the stack fence.
-	maxFunctionLocals = uint64(1 << 17)
+	// A generated prologue may reserve its frame before checking the next stack
+	// fence, whose guaranteed headroom is 256 KiB. At the worst-case 16 bytes per
+	// v128 local, 2^13 locals consume 128 KiB and leave the other half for frame
+	// headers and operand spills, instead of letting locals alone overrun the
+	// pre-check region.
+	maxFunctionLocals = uint64(1 << 13)
 )
 
 func (v *moduleValidator) err(c ValidationErrorCode, d string) error {

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -201,6 +201,10 @@ const (
 	maxTable32Limit  = uint64(1<<32 - 1)
 	maxMemory32Pages = uint64(1 << 16)
 	maxMemory64Pages = uint64(1 << 48)
+	// The native stack reserves 4 MiB. Keeping the local index space at or below
+	// 2^17 leaves at least half of that reservation for v128 locals plus frame
+	// headers, operand spills, and the stack fence.
+	maxFunctionLocals = uint64(1 << 17)
 )
 
 func (v *moduleValidator) err(c ValidationErrorCode, d string) error {
@@ -944,6 +948,9 @@ func (v *funcValidator) validateFunc(fn Func, ft *CompType) error {
 	v.localCount, overflow = LocalCount(ft.Params, fn.Locals.Runs)
 	if overflow {
 		return v.verr(ErrInvalidLimitRange, "local count overflow")
+	}
+	if v.localCount > maxFunctionLocals {
+		return v.verr(ErrInvalidLimitRange, "local count exceeds implementation limit")
 	}
 	for _, run := range fn.Locals.Runs {
 		if err := v.validateValType(run.Type); err != nil {

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -896,6 +896,9 @@ func (v *funcValidator) validateFuncDirect(body directCodeBody, ft *CompType, wi
 	if overflow {
 		return v.verr(ErrInvalidLimitRange, "local count overflow")
 	}
+	if v.localCount > maxFunctionLocals {
+		return v.verr(ErrInvalidLimitRange, "local count exceeds implementation limit")
+	}
 	for _, run := range body.locals.Runs {
 		if err := v.validateValType(run.Type); err != nil {
 			return err

--- a/src/core/compiler/wasm/validate_internal_test.go
+++ b/src/core/compiler/wasm/validate_internal_test.go
@@ -63,6 +63,24 @@ func TestValidatorCoverageCoreOpcodeFamilies(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsFunctionLocalCountAboveNativeFrameLimit(t *testing.T) {
+	m := modWithFunc(nil, nil)
+	m.Code[0].Locals = Locals{Runs: []LocalRun{{Count: uint32(maxFunctionLocals + 1), Type: I32}}}
+	expectValidateErr(t, m, ErrInvalidLimitRange)
+
+	localRun := append(u32(uint32(maxFunctionLocals+1)), byte(0x7f))
+	body := append([]byte{0x01}, localRun...)
+	body = append(body, 0x0b)
+	code := append(u32(uint32(len(body))), body...)
+	data := module(
+		section(secType, 0x01, 0x60, 0x00, 0x00),
+		section(secFunction, 0x01, 0x00),
+		section(secCode, append([]byte{0x01}, code...)...),
+	)
+	err := ValidateByteBackedModule(data)
+	expectValidationCode(t, err, ErrInvalidLimitRange)
+}
+
 func TestValidatorCoverageSIMDOpcodeFamilies(t *testing.T) {
 	for _, effect := range simdLoads {
 		k := effect.kind

--- a/src/core/compiler/wasm/validate_internal_test.go
+++ b/src/core/compiler/wasm/validate_internal_test.go
@@ -65,7 +65,7 @@ func TestValidatorCoverageCoreOpcodeFamilies(t *testing.T) {
 
 func TestValidateRejectsFunctionLocalCountAboveNativeFrameLimit(t *testing.T) {
 	m := modWithFunc(nil, nil)
-	m.Code[0].Locals = Locals{Runs: []LocalRun{{Count: uint32(maxFunctionLocals + 1), Type: I32}}}
+	m.Code[0].Locals = Locals{Runs: []LocalRun{{Count: uint32(maxFunctionLocals + 1), Type: V128}}}
 	expectValidateErr(t, m, ErrInvalidLimitRange)
 
 	localRun := append(u32(uint32(maxFunctionLocals+1)), byte(0x7f))


### PR DESCRIPTION
Small correctness fix for native function-frame admission.

Summary:
- reject functions above 2^13 total parameters and locals during both AST and byte-backed validation
- bound worst-case v128 local storage at 128 KiB, leaving fence headroom for headers, results, and operand spills
- reject complete amd64 and arm64 generated frames beyond the 256 KiB runtime fence margin
- include cross-instance wrapper, adapter-entry, and arm64 frame-record overhead
- reject oversized arm64 local/header frames before displacement-sensitive lowering

Proof:
- go test ./src/core/compiler/wasm
- go test ./src/core/compiler/backend/railshot/amd64 ./src/core/compiler/backend/railshot/arm64 ./src/core/compiler/backend/railshot/shared
- complete GitHub CI matrix passes at the current PR head

Hot path unchanged: all checks run during validation or compilation, and accepted frames execute the same instructions.

Docs unchanged: this is an internal implementation-limit correction with no developer or agent workflow impact.