### PR TITLE
jit: reject frames beyond fence headroom

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -2626,7 +2626,9 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	f.emitNativeGCStubs()
 	f.emitTrapStubs()
 	f.finalizeBranchFolds()
-	f.patchFrameSize()
+	if err := f.patchFrameSize(); err != nil {
+		return nil, nil, 0, err
+	}
 	f.emitV128ConstPool() // trailing rip-relative pool for v128 constants (after all code)
 	if _, err := f.finalizeNativeCode(0); err != nil {
 		return nil, nil, 0, err
@@ -3324,7 +3326,9 @@ func (f *fn) emitRegABI(c *wasm.Func, hostAdapter, hasFloatConst, hasSIMD bool) 
 	f.finalizeBranchFolds()
 
 	f.elideRegisterOnlyFrame() // register-homed call-free leaf → frameSize 0
-	f.patchFrameSize()
+	if err := f.patchFrameSize(); err != nil {
+		return 0, err
+	}
 	if hostAdapter {
 		a.PatchRel32(adapterCall, internalOff)
 		if f.stats != nil {
@@ -3336,8 +3340,12 @@ func (f *fn) emitRegABI(c *wasm.Func, hostAdapter, hasFloatConst, hasSIMD bool) 
 	return internalOff, nil
 }
 
-func (f *fn) patchFrameSize() {
-	size := uint32(f.frameSize())
+func (f *fn) patchFrameSize() error {
+	frameBytes := f.frameSize()
+	if !shared.NativeFrameFitsStackFence(frameBytes) {
+		return fmt.Errorf("amd64: native frame %d bytes exceeds stack-fence headroom %d", frameBytes, shared.MaxNativeFrameBytes)
+	}
+	size := uint32(frameBytes)
 	if f.stats != nil {
 		sites := len(f.sc.tailFrameSites) + 2
 		f.stats.NativeSize.FrameAdjustmentBytes += 7 * sites
@@ -3354,6 +3362,7 @@ func (f *fn) patchFrameSize() {
 	for _, site := range f.sc.tailFrameSites {
 		f.a.PatchU32(site, size)
 	}
+	return nil
 }
 
 // epilogue: copy results from their canonical slots to the results buffer, clear

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -3342,8 +3342,8 @@ func (f *fn) emitRegABI(c *wasm.Func, hostAdapter, hasFloatConst, hasSIMD bool) 
 
 func (f *fn) patchFrameSize() error {
 	frameBytes := f.frameSize()
-	if !shared.NativeFrameFitsStackFence(frameBytes) {
-		return fmt.Errorf("amd64: native frame %d bytes exceeds stack-fence headroom %d", frameBytes, shared.MaxNativeFrameBytes)
+	if !shared.NativeFrameFitsStackFence(frameBytes, shared.MaxNativeInboundCallBytes) {
+		return fmt.Errorf("amd64: native frame %d bytes exceeds stack-fence headroom %d", frameBytes, shared.MaxNativeFrameBytes-shared.MaxNativeInboundCallBytes)
 	}
 	size := uint32(frameBytes)
 	if f.stats != nil {

--- a/src/core/compiler/backend/railshot/amd64/frame_limit_test.go
+++ b/src/core/compiler/backend/railshot/amd64/frame_limit_test.go
@@ -1,0 +1,19 @@
+//go:build linux && amd64
+
+package amd64
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func TestCompileRejectsFrameLargerThanStackFenceHeadroom(t *testing.T) {
+	body := append([]byte{0x01}, wasmtest.ULEB(40_000)...)
+	body = append(body, 0x7b, 0x0b) // v128 local run, end
+	m := mod1(t, nil, nil, body)
+	if _, err := CompileModule(m); err == nil || !strings.Contains(err.Error(), "exceeds stack-fence headroom") {
+		t.Fatalf("oversized native frame compile error = %v", err)
+	}
+}

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -767,8 +767,9 @@ func (f *fn) allLocalsRegisterHomed() bool {
 
 func (f *fn) patchFrameAdjusts() error {
 	size := f.frameSize()
-	if !shared.NativeFrameFitsStackFence(size) {
-		return fmt.Errorf("arm64: native frame %d bytes exceeds stack-fence headroom %d", size, shared.MaxNativeFrameBytes)
+	headroom := nativeFrameStackFenceHeadroom(f.usesCalls)
+	if size < 0 || size > headroom {
+		return fmt.Errorf("arm64: native frame %d bytes exceeds stack-fence headroom %d", size, headroom)
 	}
 	addSites := append(f.tailFrameSites, f.addRspAt)
 	if f.stats != nil {
@@ -807,6 +808,16 @@ func (f *fn) patchFrameAdjusts() error {
 		f.a.PatchMovImm(at, uint32(size))
 	}
 	return nil
+}
+
+func nativeFrameStackFenceHeadroom(usesCalls bool) int {
+	headroom := shared.MaxNativeFrameBytes
+	if usesCalls {
+		// A call-making frame first saves FP/LR below SP, before reserving the
+		// patched body frame and reaching its next stack-fence check.
+		headroom -= 16
+	}
+	return headroom
 }
 
 // ImportBinding is shared by both Railshot architectures.

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -765,8 +765,11 @@ func (f *fn) allLocalsRegisterHomed() bool {
 	return true
 }
 
-func (f *fn) patchFrameAdjusts() {
+func (f *fn) patchFrameAdjusts() error {
 	size := f.frameSize()
+	if !shared.NativeFrameFitsStackFence(size) {
+		return fmt.Errorf("arm64: native frame %d bytes exceeds stack-fence headroom %d", size, shared.MaxNativeFrameBytes)
+	}
 	addSites := append(f.tailFrameSites, f.addRspAt)
 	if f.stats != nil {
 		sites := len(addSites) + 1
@@ -797,12 +800,13 @@ func (f *fn) patchFrameAdjusts() {
 			f.a.PatchU32(at+4, nop)
 			f.a.PatchU32(at+8, nop)
 		}
-		return
+		return nil
 	}
 	f.a.PatchMovImm(f.subRspAt, uint32(size))
 	for _, at := range addSites {
 		f.a.PatchMovImm(at, uint32(size))
 	}
+	return nil
 }
 
 // ImportBinding is shared by both Railshot architectures.
@@ -2111,7 +2115,9 @@ func compileFuncAttempt(m *wasm.Module, gcTypeLayouts []codegen.GCTypeLayout, fu
 	}
 	f.epilogue()
 	f.emitTrapStubs()
-	f.patchFrameAdjusts()
+	if err := f.patchFrameAdjusts(); err != nil {
+		return nil, nil, 0, err
+	}
 	if f.gcFrameRoots != nil {
 		f.gcFrameRoots.FrameBytes = uint32(f.frameSize())
 		if f.gcCallsiteIndex != len(f.gcFrameRoots.LiveCallLocalMasks) {
@@ -2910,7 +2916,9 @@ func (f *fn) emitRegABI(c *wasm.Func, hostAdapter bool) (int, error) {
 	f.emitTrapStubs()
 
 	f.elideRegisterOnlyFrame()
-	f.patchFrameAdjusts()
+	if err := f.patchFrameAdjusts(); err != nil {
+		return 0, err
+	}
 	if hostAdapter {
 		f.a.PatchBranch26(adapterCall, internalOff)
 		if f.stats != nil {

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -811,7 +811,7 @@ func (f *fn) patchFrameAdjusts() error {
 }
 
 func nativeFrameStackFenceHeadroom(usesCalls bool) int {
-	headroom := shared.MaxNativeFrameBytes
+	headroom := shared.MaxNativeFrameBytes - shared.MaxNativeInboundCallBytes
 	if usesCalls {
 		// A call-making frame first saves FP/LR below SP, before reserving the
 		// patched body frame and reaching its next stack-fence check.

--- a/src/core/compiler/backend/railshot/arm64/frame_limit_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/frame_limit_arm64_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestCallFrameHeadroomIncludesFrameRecord(t *testing.T) {
-	if got, want := nativeFrameStackFenceHeadroom(true), shared.MaxNativeFrameBytes-16; got != want {
+	if got, want := nativeFrameStackFenceHeadroom(true), shared.MaxNativeFrameBytes-shared.MaxNativeInboundCallBytes-16; got != want {
 		t.Fatalf("call frame headroom = %d, want %d", got, want)
 	}
-	if got := nativeFrameStackFenceHeadroom(false); got != shared.MaxNativeFrameBytes {
-		t.Fatalf("leaf frame headroom = %d, want %d", got, shared.MaxNativeFrameBytes)
+	if got, want := nativeFrameStackFenceHeadroom(false), shared.MaxNativeFrameBytes-shared.MaxNativeInboundCallBytes; got != want {
+		t.Fatalf("leaf frame headroom = %d, want %d", got, want)
 	}
 }

--- a/src/core/compiler/backend/railshot/arm64/frame_limit_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/frame_limit_arm64_test.go
@@ -1,0 +1,18 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
+)
+
+func TestCallFrameHeadroomIncludesFrameRecord(t *testing.T) {
+	if got, want := nativeFrameStackFenceHeadroom(true), shared.MaxNativeFrameBytes-16; got != want {
+		t.Fatalf("call frame headroom = %d, want %d", got, want)
+	}
+	if got := nativeFrameStackFenceHeadroom(false); got != shared.MaxNativeFrameBytes {
+		t.Fatalf("leaf frame headroom = %d, want %d", got, shared.MaxNativeFrameBytes)
+	}
+}

--- a/src/core/compiler/backend/railshot/shared/capacity.go
+++ b/src/core/compiler/backend/railshot/shared/capacity.go
@@ -4,11 +4,12 @@
 package shared
 
 // MaxNativeFrameBytes matches the execution stack's fence margin. Inbound
-// cross-instance wrappers reserve 64 bytes before entering the target, so the
-// generated body frame must leave that space inside the checked headroom.
+// cross-instance wrappers reserve 64 bytes and the target's offset-0 adapter
+// reserves another 16 bytes before entering the target body, so the generated
+// frame must leave both inside the checked headroom.
 const (
 	MaxNativeFrameBytes       = 256 << 10
-	MaxNativeInboundCallBytes = 64
+	MaxNativeInboundCallBytes = 64 + 16
 )
 
 // NativeFrameFitsStackFence reports whether one frame fits inside the checked

--- a/src/core/compiler/backend/railshot/shared/capacity.go
+++ b/src/core/compiler/backend/railshot/shared/capacity.go
@@ -3,6 +3,17 @@
 // encoding remain in the architecture packages.
 package shared
 
+// MaxNativeFrameBytes matches the execution stack's fence margin. Every frame
+// must fit inside that already-checked headroom so subtracting the next frame
+// cannot leave the mapped foreign stack before its prologue checks the fence.
+const MaxNativeFrameBytes = 256 << 10
+
+// NativeFrameFitsStackFence reports whether one frame fits inside the checked
+// headroom maintained by the runtime stack fence.
+func NativeFrameFitsStackFence(frameBytes int) bool {
+	return frameBytes >= 0 && frameBytes <= MaxNativeFrameBytes
+}
+
 // StackArenaCapacity estimates operand nodes for one function. An opcode-based
 // hint avoids reserving nodes for immediate bytes while a body-size floor keeps
 // malformed or incomplete hints from causing allocation cliffs.

--- a/src/core/compiler/backend/railshot/shared/capacity.go
+++ b/src/core/compiler/backend/railshot/shared/capacity.go
@@ -3,15 +3,18 @@
 // encoding remain in the architecture packages.
 package shared
 
-// MaxNativeFrameBytes matches the execution stack's fence margin. Every frame
-// must fit inside that already-checked headroom so subtracting the next frame
-// cannot leave the mapped foreign stack before its prologue checks the fence.
-const MaxNativeFrameBytes = 256 << 10
+// MaxNativeFrameBytes matches the execution stack's fence margin. Inbound
+// cross-instance wrappers reserve 64 bytes before entering the target, so the
+// generated body frame must leave that space inside the checked headroom.
+const (
+	MaxNativeFrameBytes       = 256 << 10
+	MaxNativeInboundCallBytes = 64
+)
 
 // NativeFrameFitsStackFence reports whether one frame fits inside the checked
 // headroom maintained by the runtime stack fence.
-func NativeFrameFitsStackFence(frameBytes int) bool {
-	return frameBytes >= 0 && frameBytes <= MaxNativeFrameBytes
+func NativeFrameFitsStackFence(frameBytes, entryOverhead int) bool {
+	return frameBytes >= 0 && entryOverhead >= 0 && entryOverhead <= MaxNativeFrameBytes && frameBytes <= MaxNativeFrameBytes-entryOverhead
 }
 
 // StackArenaCapacity estimates operand nodes for one function. An opcode-based

--- a/src/core/compiler/backend/railshot/shared/frame_limit_test.go
+++ b/src/core/compiler/backend/railshot/shared/frame_limit_test.go
@@ -1,0 +1,16 @@
+package shared
+
+import "testing"
+
+func TestNativeFrameFitsStackFenceIncludesEntryOverhead(t *testing.T) {
+	maxBody := MaxNativeFrameBytes - MaxNativeInboundCallBytes
+	if !NativeFrameFitsStackFence(maxBody, MaxNativeInboundCallBytes) {
+		t.Fatalf("frame at body limit was rejected")
+	}
+	if NativeFrameFitsStackFence(maxBody+1, MaxNativeInboundCallBytes) {
+		t.Fatalf("frame exceeding body limit was accepted")
+	}
+	if NativeFrameFitsStackFence(0, MaxNativeFrameBytes+1) {
+		t.Fatalf("oversized entry overhead was accepted")
+	}
+}


### PR DESCRIPTION
Small correctness fix for native stack-frame admission.

Summary:
- enforce the 256 KiB runtime fence margin as the maximum single generated frame
- reject oversized amd64 and arm64 frames before patching executable prologues
- prevent a frame subtraction from leaving the 4 MiB mapped stack before the fence check

Testing:
- `go test ./src/core/compiler/backend/railshot/amd64 ./src/core/compiler/backend/railshot/arm64 ./src/core/compiler/backend/railshot/shared`

Hot path unchanged: accepted frames execute the same instructions; this adds only a compile-time size check.

Docs unchanged: this is an internal native-boundary correction.