### PR TITLE
wasm: validate catch payloads without copies

### DIFF
--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -1201,36 +1201,8 @@ func (v *funcValidator) directStartTryTable(bt BlockType, catches []Catch) error
 		return err
 	}
 	for _, c := range catches {
-		lt, err := v.label(uint32(c.Label))
-		if err != nil {
+		if err := v.validateCatchPayload(c); err != nil {
 			return err
-		}
-		var payload []ValType
-		if c.Kind == CatchTag || c.Kind == CatchRef {
-			if int(c.Tag) >= v.m.TagCount() {
-				return v.verr(ErrUnknownTag, "catch")
-			}
-			ft, ok := v.tagFuncType(uint32(c.Tag))
-			if !ok {
-				return v.verr(ErrUnknownTag, "catch")
-			}
-			payload = append(payload, ft.Params...)
-		}
-		if c.Kind == CatchRef || c.Kind == CatchAllRef {
-			// Reference catches materialize a non-null exception reference. The
-			// target label may widen it to nullable exnref, but not vice versa.
-			payload = append(payload, RefVal(Ref(false, AbsHeap(HeapExn), false)))
-		}
-		if c.Kind == CatchAll && len(lt) != 0 {
-			return v.verr(ErrTypeMismatch, "catch_all label must expect no values")
-		}
-		if len(payload) != len(lt) {
-			return v.verr(ErrTypeMismatch, "catch payload label mismatch")
-		}
-		for i := range payload {
-			if !v.subtype(payload[i], lt[i]) {
-				return v.verr(ErrTypeMismatch, "catch payload label mismatch")
-			}
 		}
 	}
 	return v.directPushCtrl(ctrlTry, ins, outs)

--- a/src/core/compiler/wasm/validate_internal_test.go
+++ b/src/core/compiler/wasm/validate_internal_test.go
@@ -806,6 +806,30 @@ func TestDirectStartTryTableCatchPayloads(t *testing.T) {
 	}
 }
 
+func TestTryTableCatchValidationDoesNotCopyTagParameters(t *testing.T) {
+	params := make([]ValType, 256)
+	for i := range params {
+		params[i] = I32
+	}
+	m := &Module{Types: []RecType{ft(params, nil)}, Tags: []TagType{{Type: TypeIdx{Index: 0}}}}
+	fv := coverageFuncValidator(m, params)
+	catch := Catch{Kind: CatchTag, Tag: 0, Label: 0}
+	if err := fv.validateCatchPayload(catch); err != nil {
+		t.Fatalf("warm catch validation: %v", err)
+	}
+	var validationErr error
+	if allocs := testing.AllocsPerRun(100, func() {
+		for i := 0; i < 100; i++ {
+			validationErr = fv.validateCatchPayload(catch)
+		}
+	}); allocs != 0 {
+		t.Fatalf("catch validation allocations = %.2f, want 0", allocs)
+	}
+	if validationErr != nil {
+		t.Fatalf("catch validation: %v", validationErr)
+	}
+}
+
 func TestValidatorCoverageModuleLevelNegativeBranches(t *testing.T) {
 	t.Run("table init expression type mismatch", func(t *testing.T) {
 		m := &Module{Tables: []Table{{Type: TableType{Ref: AbsRef(HeapFunc), Limits: Limits{Min: 1}}, Init: &Expr{Instrs: []Instruction{{Kind: InstrRefNull, ext: &instrExt{RefType: AbsRef(HeapExtern)}}}}}}}

--- a/src/core/compiler/wasm/validate_proposal.go
+++ b/src/core/compiler/wasm/validate_proposal.go
@@ -103,36 +103,8 @@ func (v *funcValidator) stepTryTable(in Instruction) error {
 		return err
 	}
 	for _, c := range in.Catches() {
-		lt, err := v.label(uint32(c.Label))
-		if err != nil {
+		if err := v.validateCatchPayload(c); err != nil {
 			return err
-		}
-		var payload []ValType
-		if c.Kind == CatchTag || c.Kind == CatchRef {
-			if int(c.Tag) >= v.m.TagCount() {
-				return v.verr(ErrUnknownTag, "catch")
-			}
-			ft, ok := v.tagFuncType(uint32(c.Tag))
-			if !ok {
-				return v.verr(ErrUnknownTag, "catch")
-			}
-			payload = append(payload, ft.Params...)
-		}
-		if c.Kind == CatchRef || c.Kind == CatchAllRef {
-			// Reference catches materialize a non-null exception reference. The
-			// target label may widen it to nullable exnref, but not vice versa.
-			payload = append(payload, RefVal(Ref(false, AbsHeap(HeapExn), false)))
-		}
-		if c.Kind == CatchAll && len(lt) != 0 {
-			return v.verr(ErrTypeMismatch, "catch_all label must expect no values")
-		}
-		if len(payload) != len(lt) {
-			return v.verr(ErrTypeMismatch, "catch payload label mismatch")
-		}
-		for i := range payload {
-			if !v.subtype(payload[i], lt[i]) {
-				return v.verr(ErrTypeMismatch, "catch payload label mismatch")
-			}
 		}
 	}
 	if err := v.pushCtrl(ctrlTry, ins, outs); err != nil {
@@ -150,6 +122,49 @@ func (v *funcValidator) stepTryTable(in Instruction) error {
 		v.unreachable()
 	}
 	return err
+}
+
+func (v *funcValidator) validateCatchPayload(c Catch) error {
+	lt, err := v.label(uint32(c.Label))
+	if err != nil {
+		return err
+	}
+	var params []ValType
+	if c.Kind == CatchTag || c.Kind == CatchRef {
+		if int(c.Tag) >= v.m.TagCount() {
+			return v.verr(ErrUnknownTag, "catch")
+		}
+		ft, ok := v.tagFuncType(uint32(c.Tag))
+		if !ok {
+			return v.verr(ErrUnknownTag, "catch")
+		}
+		params = ft.Params
+	}
+	hasRef := c.Kind == CatchRef || c.Kind == CatchAllRef
+	if c.Kind == CatchAll && len(lt) != 0 {
+		return v.verr(ErrTypeMismatch, "catch_all label must expect no values")
+	}
+	payloadLen := len(params)
+	if hasRef {
+		payloadLen++
+	}
+	if payloadLen != len(lt) {
+		return v.verr(ErrTypeMismatch, "catch payload label mismatch")
+	}
+	for i := range params {
+		if !v.subtype(params[i], lt[i]) {
+			return v.verr(ErrTypeMismatch, "catch payload label mismatch")
+		}
+	}
+	if hasRef {
+		// Reference catches materialize a non-null exception reference. The target
+		// label may widen it to nullable exnref, but not vice versa.
+		exn := RefVal(Ref(false, AbsHeap(HeapExn), false))
+		if !v.subtype(exn, lt[len(params)]) {
+			return v.verr(ErrTypeMismatch, "catch payload label mismatch")
+		}
+	}
+	return nil
 }
 
 func (v *moduleValidator) tagFuncType(idx uint32) (*CompType, bool) {


### PR DESCRIPTION
Small correctness and footprint fix for `try_table` validation.

Summary:
- compare tag parameters directly against catch-label types
- validate the optional exception reference without building a concatenated slice
- share the same allocation-free check across AST and byte-backed paths

Footprint:
- 100 validations of a 256-parameter catch now report 0 allocations in the regression test

Testing:
- `go test ./src/core/compiler/wasm`

Docs unchanged: this is an internal validation-footprint fix.