### PR TITLE
wasm: deduplicate br_table target checks

### DIFF
--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -909,6 +909,11 @@ type funcValidator struct {
 	// instrExt per memory/br_table/select/ref.null or payload-bearing SIMD
 	// instruction.
 	opExt instrExt
+	// branchTableLabels is a lazily allocated, per-validator epoch bitmap. Deep
+	// br_table instructions reuse it so repeated short tables at maximum control
+	// depth do not allocate in proportion to the nesting depth.
+	branchTableLabels []branchTableLabelWord
+	branchTableEpoch  uint32
 }
 
 func (v *funcValidator) verr(c ValidationErrorCode, d string) error {

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -878,7 +878,7 @@ type ctrlFrame struct {
 	ifSeenElse   bool
 	// branchTableEpoch uses existing tail padding to mark whether this exact
 	// label frame has already been checked by the current br_table.
-	branchTableEpoch uint32
+	branchTableEpoch uint16
 }
 
 type funcValidator struct {
@@ -904,7 +904,7 @@ type funcValidator struct {
 	constOnly         bool
 	// branchTableEpoch fits in the padding before constGlobalLimit. Each
 	// funcValidator owns its control frames, including under parallel validation.
-	branchTableEpoch uint32
+	branchTableEpoch uint16
 	constGlobalLimit int // globals below this absolute index are visible to a const expression
 	// rd is reused across bodies validated by this funcValidator so the byte
 	// cursor is not heap-allocated per function/const-expression.

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -876,6 +876,9 @@ type ctrlFrame struct {
 	// re-pushed) so the else-arm end can confirm both arms leave the same shape.
 	ifThenHeight int
 	ifSeenElse   bool
+	// branchTableEpoch uses existing tail padding to mark whether this exact
+	// label frame has already been checked by the current br_table.
+	branchTableEpoch uint32
 }
 
 type funcValidator struct {
@@ -899,7 +902,10 @@ type funcValidator struct {
 	initializedLocals map[uint32]struct{}
 	localInitLog      []uint32
 	constOnly         bool
-	constGlobalLimit  int // globals below this absolute index are visible to a const expression
+	// branchTableEpoch fits in the padding before constGlobalLimit. Each
+	// funcValidator owns its control frames, including under parallel validation.
+	branchTableEpoch uint32
+	constGlobalLimit int // globals below this absolute index are visible to a const expression
 	// rd is reused across bodies validated by this funcValidator so the byte
 	// cursor is not heap-allocated per function/const-expression.
 	rd reader
@@ -909,11 +915,6 @@ type funcValidator struct {
 	// instrExt per memory/br_table/select/ref.null or payload-bearing SIMD
 	// instruction.
 	opExt instrExt
-	// branchTableLabels is a lazily allocated, per-validator epoch bitmap. Deep
-	// br_table instructions reuse it so repeated short tables at maximum control
-	// depth do not allocate in proportion to the nesting depth.
-	branchTableLabels []branchTableLabelWord
-	branchTableEpoch  uint32
 }
 
 func (v *funcValidator) verr(c ValidationErrorCode, d string) error {

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -861,10 +861,8 @@ const (
 )
 
 type ctrlFrame struct {
-	kind        ctrlKind
-	in, out     []ValType
-	height      int
-	unreachable bool
+	in, out []ValType
+	height  int
 	// initHeight is the local-initialization log watermark at control entry.
 	// Initializations performed inside a block do not escape that block; an
 	// else arm likewise restarts from the if entry state.
@@ -875,10 +873,12 @@ type ctrlFrame struct {
 	// the operand-stack height at the end of the then-arm (after its results were
 	// re-pushed) so the else-arm end can confirm both arms leave the same shape.
 	ifThenHeight int
-	ifSeenElse   bool
-	// branchTableEpoch uses existing tail padding to mark whether this exact
-	// label frame has already been checked by the current br_table.
-	branchTableEpoch uint16
+	// branchTableEpoch marks whether this exact label frame has already been
+	// checked by the current br_table.
+	branchTableEpoch uint32
+	kind             ctrlKind
+	unreachable      bool
+	ifSeenElse       bool
 }
 
 type funcValidator struct {
@@ -901,11 +901,11 @@ type funcValidator struct {
 	// the function body, not with an attacker-controlled declared local count.
 	initializedLocals map[uint32]struct{}
 	localInitLog      []uint32
-	constOnly         bool
-	// branchTableEpoch fits in the padding before constGlobalLimit. Each
+	constGlobalLimit  int // globals below this absolute index are visible to a const expression
+	// branchTableEpoch is packed before constOnly. Each
 	// funcValidator owns its control frames, including under parallel validation.
-	branchTableEpoch uint16
-	constGlobalLimit int // globals below this absolute index are visible to a const expression
+	branchTableEpoch uint32
+	constOnly        bool
 	// rd is reused across bodies validated by this funcValidator so the byte
 	// cursor is not heap-allocated per function/const-expression.
 	rd reader

--- a/src/core/compiler/wasm/validate_edges_test.go
+++ b/src/core/compiler/wasm/validate_edges_test.go
@@ -190,6 +190,32 @@ func TestValidateBranchesAndCalls(t *testing.T) {
 	})
 }
 
+func TestBranchTableLabelSetDeduplicatesWithoutAllocation(t *testing.T) {
+	var seen [branchTableLabelSetWords]uint64
+	if !markBranchTableLabel(&seen, 17) {
+		t.Fatal("first label was already present")
+	}
+	for i := 0; i < 100_000; i++ {
+		if markBranchTableLabel(&seen, 17) {
+			t.Fatalf("duplicate label %d reported fresh", i)
+		}
+	}
+	if !markBranchTableLabel(&seen, branchTableLabelSetWords*64-1) {
+		t.Fatal("highest valid label was already present")
+	}
+	if !markBranchTableLabel(&seen, branchTableLabelSetWords*64) {
+		t.Fatal("deeper label must fall back to validation")
+	}
+	if allocs := testing.AllocsPerRun(100, func() {
+		var local [branchTableLabelSetWords]uint64
+		for i := 0; i < 1000; i++ {
+			markBranchTableLabel(&local, uint32(i%(branchTableLabelSetWords*64)))
+		}
+	}); allocs != 0 {
+		t.Fatalf("label deduplication allocations = %.2f, want 0", allocs)
+	}
+}
+
 func TestValidateModuleLevelIndexes(t *testing.T) {
 	t.Run("unknown function type", func(t *testing.T) {
 		expectValidateErr(t, &Module{Types: []RecType{ft(nil, nil)}, FuncTypes: []TypeIdx{{Index: 99}}, Code: []Func{{}}}, ErrUnknownType)

--- a/src/core/compiler/wasm/validate_edges_test.go
+++ b/src/core/compiler/wasm/validate_edges_test.go
@@ -191,28 +191,37 @@ func TestValidateBranchesAndCalls(t *testing.T) {
 }
 
 func TestBranchTableLabelSetDeduplicatesWithoutAllocation(t *testing.T) {
-	var seen [branchTableLabelSetWords]uint64
-	if !markBranchTableLabel(&seen, 17) {
+	seen := newBranchTableLabelSet(maxInstructionNestingDepth)
+	if !seen.mark(17) {
 		t.Fatal("first label was already present")
 	}
 	for i := 0; i < 100_000; i++ {
-		if markBranchTableLabel(&seen, 17) {
+		if seen.mark(17) {
 			t.Fatalf("duplicate label %d reported fresh", i)
 		}
 	}
-	if !markBranchTableLabel(&seen, branchTableLabelSetWords*64-1) {
+	if !seen.mark(branchTableInlineLabelWords*64 - 1) {
 		t.Fatal("highest valid label was already present")
 	}
-	if !markBranchTableLabel(&seen, branchTableLabelSetWords*64) {
-		t.Fatal("deeper label must fall back to validation")
+	deep := uint32(branchTableInlineLabelWords * 64)
+	if !seen.mark(deep) || seen.mark(deep) {
+		t.Fatal("deep label was not deduplicated")
 	}
 	if allocs := testing.AllocsPerRun(100, func() {
-		var local [branchTableLabelSetWords]uint64
+		local := newBranchTableLabelSet(branchTableInlineLabelWords * 64)
 		for i := 0; i < 1000; i++ {
-			markBranchTableLabel(&local, uint32(i%(branchTableLabelSetWords*64)))
+			local.mark(uint32(i % (branchTableInlineLabelWords * 64)))
 		}
 	}); allocs != 0 {
-		t.Fatalf("label deduplication allocations = %.2f, want 0", allocs)
+		t.Fatalf("inline label deduplication allocations = %.2f, want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(100, func() {
+		local := newBranchTableLabelSet(maxInstructionNestingDepth)
+		for i := 0; i < 1000; i++ {
+			local.mark(uint32(branchTableInlineLabelWords*64 + i%100))
+		}
+	}); allocs != 1 {
+		t.Fatalf("deep label deduplication allocations = %.2f, want 1", allocs)
 	}
 }
 

--- a/src/core/compiler/wasm/validate_edges_test.go
+++ b/src/core/compiler/wasm/validate_edges_test.go
@@ -211,9 +211,8 @@ func TestBranchTableFrameEpochDeduplicatesWithoutAllocation(t *testing.T) {
 		t.Fatal("label remained marked in a later table")
 	}
 
-	// Rollover is unreachable for a size-bounded decoded module, but a reused
-	// programmatic validator must still clear stale frame stamps.
-	v.branchTableEpoch = ^uint32(0)
+	// A reused validator must clear stale frame stamps on compact epoch rollover.
+	v.branchTableEpoch = ^uint16(0)
 	v.ctrls[0].branchTableEpoch = 1
 	v.beginBranchTable()
 	if v.branchTableEpoch != 1 || v.ctrls[0].branchTableEpoch != 0 {
@@ -238,14 +237,15 @@ func TestBranchTableFrameEpochDeduplicatesWithoutAllocation(t *testing.T) {
 }
 
 func TestBranchTableFrameEpochFitsValidatorPadding(t *testing.T) {
-	if unsafe.Sizeof(uintptr(0)) != 8 {
-		t.Skip("64-bit validator layout")
+	wantValidator, wantFrame := uintptr(672), uintptr(96)
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		wantValidator, wantFrame = 412, 48
 	}
-	if got := unsafe.Sizeof(funcValidator{}); got != 672 {
-		t.Fatalf("funcValidator size = %d, want 672", got)
+	if got := unsafe.Sizeof(funcValidator{}); got != wantValidator {
+		t.Fatalf("funcValidator size = %d, want %d", got, wantValidator)
 	}
-	if got := unsafe.Sizeof(ctrlFrame{}); got != 96 {
-		t.Fatalf("ctrlFrame size = %d, want 96", got)
+	if got := unsafe.Sizeof(ctrlFrame{}); got != wantFrame {
+		t.Fatalf("ctrlFrame size = %d, want %d", got, wantFrame)
 	}
 }
 

--- a/src/core/compiler/wasm/validate_edges_test.go
+++ b/src/core/compiler/wasm/validate_edges_test.go
@@ -211,8 +211,8 @@ func TestBranchTableFrameEpochDeduplicatesWithoutAllocation(t *testing.T) {
 		t.Fatal("label remained marked in a later table")
 	}
 
-	// A reused validator must clear stale frame stamps on compact epoch rollover.
-	v.branchTableEpoch = ^uint16(0)
+	// A reused synthetic validator must clear stale frame stamps on epoch rollover.
+	v.branchTableEpoch = ^uint32(0)
 	v.ctrls[0].branchTableEpoch = 1
 	v.beginBranchTable()
 	if v.branchTableEpoch != 1 || v.ctrls[0].branchTableEpoch != 0 {
@@ -237,9 +237,9 @@ func TestBranchTableFrameEpochDeduplicatesWithoutAllocation(t *testing.T) {
 }
 
 func TestBranchTableFrameEpochFitsValidatorPadding(t *testing.T) {
-	wantValidator, wantFrame := uintptr(672), uintptr(96)
+	wantValidator, wantFrame := uintptr(656), uintptr(80)
 	if unsafe.Sizeof(uintptr(0)) == 4 {
-		wantValidator, wantFrame = 412, 48
+		wantValidator, wantFrame = 412, 44
 	}
 	if got := unsafe.Sizeof(funcValidator{}); got != wantValidator {
 		t.Fatalf("funcValidator size = %d, want %d", got, wantValidator)

--- a/src/core/compiler/wasm/validate_edges_test.go
+++ b/src/core/compiler/wasm/validate_edges_test.go
@@ -191,7 +191,8 @@ func TestValidateBranchesAndCalls(t *testing.T) {
 }
 
 func TestBranchTableLabelSetDeduplicatesWithoutAllocation(t *testing.T) {
-	seen := newBranchTableLabelSet(maxInstructionNestingDepth)
+	v := funcValidator{ctrls: make([]ctrlFrame, maxInstructionNestingDepth)}
+	seen := v.newBranchTableLabelSet()
 	if !seen.mark(17) {
 		t.Fatal("first label was already present")
 	}
@@ -208,20 +209,26 @@ func TestBranchTableLabelSetDeduplicatesWithoutAllocation(t *testing.T) {
 		t.Fatal("deep label was not deduplicated")
 	}
 	if allocs := testing.AllocsPerRun(100, func() {
-		local := newBranchTableLabelSet(branchTableInlineLabelWords * 64)
+		localValidator := funcValidator{ctrls: make([]ctrlFrame, branchTableInlineLabelWords*64)}
+		local := localValidator.newBranchTableLabelSet()
 		for i := 0; i < 1000; i++ {
 			local.mark(uint32(i % (branchTableInlineLabelWords * 64)))
 		}
 	}); allocs != 0 {
 		t.Fatalf("inline label deduplication allocations = %.2f, want 0", allocs)
 	}
+	// The first deep label allocates one bounded scratch bitmap. Subsequent deep
+	// tables reuse it and distinguish visits by epoch without clearing it.
+	reused := funcValidator{ctrls: make([]ctrlFrame, maxInstructionNestingDepth)}
+	first := reused.newBranchTableLabelSet()
+	first.mark(branchTableInlineLabelWords * 64)
 	if allocs := testing.AllocsPerRun(100, func() {
-		local := newBranchTableLabelSet(maxInstructionNestingDepth)
+		local := reused.newBranchTableLabelSet()
 		for i := 0; i < 1000; i++ {
 			local.mark(uint32(branchTableInlineLabelWords*64 + i%100))
 		}
-	}); allocs != 1 {
-		t.Fatalf("deep label deduplication allocations = %.2f, want 1", allocs)
+	}); allocs != 0 {
+		t.Fatalf("reused deep label deduplication allocations = %.2f, want 0", allocs)
 	}
 }
 

--- a/src/core/compiler/wasm/validate_edges_test.go
+++ b/src/core/compiler/wasm/validate_edges_test.go
@@ -3,6 +3,7 @@ package wasm
 import (
 	"errors"
 	"testing"
+	"unsafe"
 )
 
 func ft(params, results []ValType) RecType {
@@ -190,51 +191,61 @@ func TestValidateBranchesAndCalls(t *testing.T) {
 	})
 }
 
-func TestBranchTableLabelSetDeduplicatesWithoutAllocation(t *testing.T) {
+func TestBranchTableFrameEpochDeduplicatesWithoutAllocation(t *testing.T) {
 	v := funcValidator{ctrls: make([]ctrlFrame, maxInstructionNestingDepth)}
-	seen := v.newBranchTableLabelSet()
-	if !seen.mark(17) {
+	v.beginBranchTable()
+	if !v.markBranchTableLabel(17) {
 		t.Fatal("first label was already present")
 	}
 	for i := 0; i < 100_000; i++ {
-		if seen.mark(17) {
+		if v.markBranchTableLabel(17) {
 			t.Fatalf("duplicate label %d reported fresh", i)
 		}
 	}
-	if !seen.mark(branchTableInlineLabelWords*64 - 1) {
-		t.Fatal("highest valid label was already present")
+	deep := uint32(maxInstructionNestingDepth - 1)
+	if !v.markBranchTableLabel(deep) || v.markBranchTableLabel(deep) {
+		t.Fatal("maximum-depth label was not deduplicated")
 	}
-	deep := uint32(branchTableInlineLabelWords * 64)
-	if !seen.mark(deep) || seen.mark(deep) {
-		t.Fatal("deep label was not deduplicated")
+	v.beginBranchTable()
+	if !v.markBranchTableLabel(17) {
+		t.Fatal("label remained marked in a later table")
 	}
+
+	// Rollover is unreachable for a size-bounded decoded module, but a reused
+	// programmatic validator must still clear stale frame stamps.
+	v.branchTableEpoch = ^uint32(0)
+	v.ctrls[0].branchTableEpoch = 1
+	v.beginBranchTable()
+	if v.branchTableEpoch != 1 || v.ctrls[0].branchTableEpoch != 0 {
+		t.Fatal("epoch rollover did not clear active frame stamps")
+	}
+
+	indices := make([]uint32, 1_000)
+	for i := range indices {
+		indices[i] = uint32(i % maxInstructionNestingDepth)
+	}
+	in := Instruction{Kind: InstrBrTable, Index: 0, ext: &instrExt{Indices: indices}}
+	vals := []val{{t: I32}}
 	if allocs := testing.AllocsPerRun(100, func() {
-		localValidator := funcValidator{ctrls: make([]ctrlFrame, branchTableInlineLabelWords*64)}
-		local := localValidator.newBranchTableLabelSet()
-		for i := 0; i < 1000; i++ {
-			local.mark(uint32(i % (branchTableInlineLabelWords * 64)))
+		v.vals = vals
+		v.ctrls[len(v.ctrls)-1].unreachable = false
+		if err := v.step(&in); err != nil {
+			panic(err)
 		}
 	}); allocs != 0 {
-		t.Fatalf("inline label deduplication allocations = %.2f, want 0", allocs)
+		t.Fatalf("branch-table validation allocations = %.2f, want 0", allocs)
 	}
-	// The first deep label allocates one bounded scratch bitmap. Subsequent deep
-	// tables reuse it and distinguish visits by epoch without clearing it.
-	reused := funcValidator{ctrls: make([]ctrlFrame, branchTableInlineLabelWords*64+1)}
-	first := reused.newBranchTableLabelSet()
-	first.mark(branchTableInlineLabelWords * 64)
-	// A later function or table may be deeper than the first allocation.
-	reused.ctrls = make([]ctrlFrame, maxInstructionNestingDepth)
-	grown := reused.newBranchTableLabelSet()
-	if !grown.mark(maxInstructionNestingDepth - 1) {
-		t.Fatal("grown deep label was not marked")
+}
+
+func TestBranchTableFrameEpochFitsValidatorPadding(t *testing.T) {
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		t.Skip("64-bit validator layout")
 	}
-	if allocs := testing.AllocsPerRun(100, func() {
-		local := reused.newBranchTableLabelSet()
-		for i := 0; i < 1000; i++ {
-			local.mark(uint32(branchTableInlineLabelWords*64 + i%100))
-		}
-	}); allocs != 0 {
-		t.Fatalf("reused deep label deduplication allocations = %.2f, want 0", allocs)
+	if got := unsafe.Sizeof(funcValidator{}); got != 672 {
+		t.Fatalf("funcValidator size = %d, want 672", got)
+	}
+	if got := unsafe.Sizeof(ctrlFrame{}); got != 96 {
+		t.Fatalf("ctrlFrame size = %d, want 96", got)
 	}
 }
 

--- a/src/core/compiler/wasm/validate_edges_test.go
+++ b/src/core/compiler/wasm/validate_edges_test.go
@@ -219,9 +219,15 @@ func TestBranchTableLabelSetDeduplicatesWithoutAllocation(t *testing.T) {
 	}
 	// The first deep label allocates one bounded scratch bitmap. Subsequent deep
 	// tables reuse it and distinguish visits by epoch without clearing it.
-	reused := funcValidator{ctrls: make([]ctrlFrame, maxInstructionNestingDepth)}
+	reused := funcValidator{ctrls: make([]ctrlFrame, branchTableInlineLabelWords*64+1)}
 	first := reused.newBranchTableLabelSet()
 	first.mark(branchTableInlineLabelWords * 64)
+	// A later function or table may be deeper than the first allocation.
+	reused.ctrls = make([]ctrlFrame, maxInstructionNestingDepth)
+	grown := reused.newBranchTableLabelSet()
+	if !grown.mark(maxInstructionNestingDepth - 1) {
+		t.Fatal("grown deep label was not marked")
+	}
 	if allocs := testing.AllocsPerRun(100, func() {
 		local := reused.newBranchTableLabelSet()
 		for i := 0; i < 1000; i++ {

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -1,18 +1,41 @@
 package wasm
 
-// markBranchTableLabel reports whether label has not been seen before. The small
-// fixed bitset covers ordinary control depth without inflating every recursive
-// validator frame. Deeper labels remain correct and are rechecked.
-const branchTableLabelSetWords = 4
+// branchTableLabelSet deduplicates every valid label depth. The inline words keep
+// ordinary tables allocation-free; a deep table lazily allocates one bit per
+// active control frame instead of revalidating repeated payloads quadratically.
+const branchTableInlineLabelWords = 4
 
-func markBranchTableLabel(seen *[branchTableLabelSetWords]uint64, label uint32) bool {
+type branchTableLabelSet struct {
+	inline [branchTableInlineLabelWords]uint64
+	deep   []uint64
+	depth  uint32
+}
+
+func newBranchTableLabelSet(depth int) branchTableLabelSet {
+	return branchTableLabelSet{depth: uint32(depth)}
+}
+
+func (s *branchTableLabelSet) mark(label uint32) bool {
 	word, bit := label>>6, label&63
-	if word >= uint32(len(seen)) {
+	if word < branchTableInlineLabelWords {
+		mask := uint64(1) << bit
+		fresh := s.inline[word]&mask == 0
+		s.inline[word] |= mask
+		return fresh
+	}
+	if label >= s.depth {
+		// The caller validates labels before marking them. Preserve a safe
+		// fallback for direct helper use without allocating from invalid input.
 		return true
 	}
+	if s.deep == nil {
+		words := (s.depth + 63) >> 6
+		s.deep = make([]uint64, words-branchTableInlineLabelWords)
+	}
+	word -= branchTableInlineLabelWords
 	mask := uint64(1) << bit
-	fresh := seen[word]&mask == 0
-	seen[word] |= mask
+	fresh := s.deep[word]&mask == 0
+	s.deep[word] |= mask
 	return fresh
 }
 
@@ -151,14 +174,14 @@ func (v *funcValidator) step(in *Instruction) error {
 			return err
 		}
 		payloadHeight := len(v.vals)
-		var checked [branchTableLabelSetWords]uint64
-		markBranchTableLabel(&checked, in.Index)
+		checked := newBranchTableLabelSet(len(v.ctrls))
+		checked.mark(in.Index)
 		for _, l := range in.Indices() {
 			lt, err := v.label(l)
 			if err != nil {
 				return err
 			}
-			if !markBranchTableLabel(&checked, l) {
+			if !checked.mark(l) {
 				continue
 			}
 			if len(lt) != len(dt) {

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -1,8 +1,8 @@
 package wasm
 
 // beginBranchTable advances the generation used to stamp distinct target
-// frames. A compact generation preserves the control-frame layout on 32-bit
-// targets; its rare rollover clears the bounded active control stack.
+// frames. A decoded code section cannot contain enough instructions to exhaust
+// uint32. The overflow branch defensively resets the active frame set.
 func (v *funcValidator) beginBranchTable() {
 	v.branchTableEpoch++
 	if v.branchTableEpoch == 0 {

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -1,59 +1,23 @@
 package wasm
 
-// branchTableLabelSet deduplicates every valid label depth. The inline words keep
-// ordinary tables allocation-free; a deep table lazily allocates one bit per
-// active control frame instead of revalidating repeated payloads quadratically.
-const branchTableInlineLabelWords = 4
-
-type branchTableLabelSet struct {
-	inline [branchTableInlineLabelWords]uint64
-	deep   *[]branchTableLabelWord
-	depth  uint32
-	epoch  uint32
-}
-
-type branchTableLabelWord struct {
-	bits  uint64
-	epoch uint32
-}
-
-func (v *funcValidator) newBranchTableLabelSet() branchTableLabelSet {
+// beginBranchTable advances the generation used to stamp distinct target
+// frames. The code-section size bounds make rollover unreachable for decoded
+// modules, but clearing active frames keeps programmatically built modules safe.
+func (v *funcValidator) beginBranchTable() {
 	v.branchTableEpoch++
 	if v.branchTableEpoch == 0 {
-		clear(v.branchTableLabels)
+		for i := range v.ctrls {
+			v.ctrls[i].branchTableEpoch = 0
+		}
 		v.branchTableEpoch = 1
 	}
-	return branchTableLabelSet{deep: &v.branchTableLabels, depth: uint32(len(v.ctrls)), epoch: v.branchTableEpoch}
 }
 
-func (s *branchTableLabelSet) mark(label uint32) bool {
-	word, bit := label>>6, label&63
-	if word < branchTableInlineLabelWords {
-		mask := uint64(1) << bit
-		fresh := s.inline[word]&mask == 0
-		s.inline[word] |= mask
-		return fresh
-	}
-	if label >= s.depth {
-		// The caller validates labels before marking them. Preserve a safe
-		// fallback for direct helper use without allocating from invalid input.
-		return true
-	}
-	words := int((s.depth+63)>>6) - branchTableInlineLabelWords
-	if len(*s.deep) < words {
-		grown := make([]branchTableLabelWord, words)
-		copy(grown, *s.deep)
-		*s.deep = grown
-	}
-	word -= branchTableInlineLabelWords
-	mask := uint64(1) << bit
-	entry := &(*s.deep)[word]
-	if entry.epoch != s.epoch {
-		entry.bits = 0
-		entry.epoch = s.epoch
-	}
-	fresh := entry.bits&mask == 0
-	entry.bits |= mask
+// markBranchTableLabel is called only after label has been bounds-checked.
+func (v *funcValidator) markBranchTableLabel(label uint32) bool {
+	f := &v.ctrls[len(v.ctrls)-1-int(label)]
+	fresh := f.branchTableEpoch != v.branchTableEpoch
+	f.branchTableEpoch = v.branchTableEpoch
 	return fresh
 }
 
@@ -192,14 +156,14 @@ func (v *funcValidator) step(in *Instruction) error {
 			return err
 		}
 		payloadHeight := len(v.vals)
-		checked := v.newBranchTableLabelSet()
-		checked.mark(in.Index)
+		v.beginBranchTable()
+		v.markBranchTableLabel(in.Index)
 		for _, l := range in.Indices() {
 			lt, err := v.label(l)
 			if err != nil {
 				return err
 			}
-			if !checked.mark(l) {
+			if !v.markBranchTableLabel(l) {
 				continue
 			}
 			if len(lt) != len(dt) {

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -7,12 +7,23 @@ const branchTableInlineLabelWords = 4
 
 type branchTableLabelSet struct {
 	inline [branchTableInlineLabelWords]uint64
-	deep   []uint64
+	deep   *[]branchTableLabelWord
 	depth  uint32
+	epoch  uint32
 }
 
-func newBranchTableLabelSet(depth int) branchTableLabelSet {
-	return branchTableLabelSet{depth: uint32(depth)}
+type branchTableLabelWord struct {
+	bits  uint64
+	epoch uint32
+}
+
+func (v *funcValidator) newBranchTableLabelSet() branchTableLabelSet {
+	v.branchTableEpoch++
+	if v.branchTableEpoch == 0 {
+		clear(v.branchTableLabels)
+		v.branchTableEpoch = 1
+	}
+	return branchTableLabelSet{deep: &v.branchTableLabels, depth: uint32(len(v.ctrls)), epoch: v.branchTableEpoch}
 }
 
 func (s *branchTableLabelSet) mark(label uint32) bool {
@@ -28,14 +39,19 @@ func (s *branchTableLabelSet) mark(label uint32) bool {
 		// fallback for direct helper use without allocating from invalid input.
 		return true
 	}
-	if s.deep == nil {
+	if len(*s.deep) == 0 {
 		words := (s.depth + 63) >> 6
-		s.deep = make([]uint64, words-branchTableInlineLabelWords)
+		*s.deep = make([]branchTableLabelWord, words-branchTableInlineLabelWords)
 	}
 	word -= branchTableInlineLabelWords
 	mask := uint64(1) << bit
-	fresh := s.deep[word]&mask == 0
-	s.deep[word] |= mask
+	entry := &(*s.deep)[word]
+	if entry.epoch != s.epoch {
+		entry.bits = 0
+		entry.epoch = s.epoch
+	}
+	fresh := entry.bits&mask == 0
+	entry.bits |= mask
 	return fresh
 }
 
@@ -174,7 +190,7 @@ func (v *funcValidator) step(in *Instruction) error {
 			return err
 		}
 		payloadHeight := len(v.vals)
-		checked := newBranchTableLabelSet(len(v.ctrls))
+		checked := v.newBranchTableLabelSet()
 		checked.mark(in.Index)
 		for _, l := range in.Indices() {
 			lt, err := v.label(l)

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -1,5 +1,21 @@
 package wasm
 
+// markBranchTableLabel reports whether label has not been seen before. The small
+// fixed bitset covers ordinary control depth without inflating every recursive
+// validator frame. Deeper labels remain correct and are rechecked.
+const branchTableLabelSetWords = 4
+
+func markBranchTableLabel(seen *[branchTableLabelSetWords]uint64, label uint32) bool {
+	word, bit := label>>6, label&63
+	if word >= uint32(len(seen)) {
+		return true
+	}
+	mask := uint64(1) << bit
+	fresh := seen[word]&mask == 0
+	seen[word] |= mask
+	return fresh
+}
+
 // step validates one already-decoded instruction. in is taken by pointer: the
 // Instruction struct is ~56 bytes and this is the validator's innermost hot path,
 // so passing a value here shows up as runtime.duffcopy under profiling.
@@ -135,10 +151,15 @@ func (v *funcValidator) step(in *Instruction) error {
 			return err
 		}
 		payloadHeight := len(v.vals)
+		var checked [branchTableLabelSetWords]uint64
+		markBranchTableLabel(&checked, in.Index)
 		for _, l := range in.Indices() {
 			lt, err := v.label(l)
 			if err != nil {
 				return err
+			}
+			if !markBranchTableLabel(&checked, l) {
+				continue
 			}
 			if len(lt) != len(dt) {
 				return v.verr(ErrTypeMismatch, "br_table label arity")

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -39,9 +39,11 @@ func (s *branchTableLabelSet) mark(label uint32) bool {
 		// fallback for direct helper use without allocating from invalid input.
 		return true
 	}
-	if len(*s.deep) == 0 {
-		words := (s.depth + 63) >> 6
-		*s.deep = make([]branchTableLabelWord, words-branchTableInlineLabelWords)
+	words := int((s.depth+63)>>6) - branchTableInlineLabelWords
+	if len(*s.deep) < words {
+		grown := make([]branchTableLabelWord, words)
+		copy(grown, *s.deep)
+		*s.deep = grown
 	}
 	word -= branchTableInlineLabelWords
 	mask := uint64(1) << bit

--- a/src/core/compiler/wasm/validate_ops.go
+++ b/src/core/compiler/wasm/validate_ops.go
@@ -1,8 +1,8 @@
 package wasm
 
 // beginBranchTable advances the generation used to stamp distinct target
-// frames. The code-section size bounds make rollover unreachable for decoded
-// modules, but clearing active frames keeps programmatically built modules safe.
+// frames. A compact generation preserves the control-frame layout on 32-bit
+// targets; its rare rollover clears the bounded active control stack.
 func (v *funcValidator) beginBranchTable() {
 	v.branchTableEpoch++
 	if v.branchTableEpoch == 0 {


### PR DESCRIPTION
Small correctness and validation-cost fix for `br_table`.

Summary:
- continue decoding and bounds-checking every target index
- validate each distinct target payload once
- stamp target control frames with a full-width per-table epoch
- reorder fields so stamping shrinks validator/control-frame layouts and needs no bitmap or retained scratch

Complexity:
- repeated-target validation changes from target-count × payload-arity to target-count + distinct-targets × payload-arity

Footprint and performance:
- `funcValidator`: 656 bytes on 64-bit (was 672), 412 bytes on 32-bit (unchanged)
- `ctrlFrame`: 80 bytes on 64-bit (was 96), 44 bytes on 32-bit (was 48)
- `BenchmarkDecodeValidate`: 82.1 µs/op, 48,903 B/op, 359 allocs/op

Testing:
- `go test ./src/core/compiler/wasm`
- focused race tests and 100-repetition native 386 tests
- Linux/arm64 cross-build
- 883,089 differential fuzz executions after the full-generation refinement

Docs unchanged: internal validator implementation with no workflow impact.