### PR TITLE
wasm: index GC type groups once

### DIFF
--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -186,6 +186,12 @@ type moduleValidator struct {
 	compCache       map[uint32]compCacheEntry
 	compCacheFrozen bool
 
+	// Type-section indexes are built once and reused by GC subtype validation.
+	// Without them, every flat or recursive-group lookup rescans preceding groups.
+	typeIndexReady bool
+	flatSubTypes   []moduleSubTypeRef
+	typeGroupBases []int
+
 	// constFV is serial module-validation scratch for global/table/data offsets
 	// and element initializer expressions. Function-body validation never reaches
 	// it: table.init reads the element type metadata validated in this phase.

--- a/src/core/compiler/wasm/validate_gc_helpers.go
+++ b/src/core/compiler/wasm/validate_gc_helpers.go
@@ -13,18 +13,12 @@ func (v *moduleValidator) subtypeByTypeIdxWithRecGroup(idx TypeIdx) (*SubType, i
 }
 
 func (v *moduleValidator) subtypeByFlatTypeIdx(idx int) (*SubType, int, bool) {
-	if idx < 0 {
+	v.ensureTypeIndex()
+	if idx < 0 || idx >= len(v.flatSubTypes) {
 		return nil, 0, false
 	}
-	want := idx
-	for gi := range v.m.Types {
-		rt := &v.m.Types[gi]
-		if want < len(rt.SubTypes) {
-			return &rt.SubTypes[want], gi, true
-		}
-		want -= len(rt.SubTypes)
-	}
-	return nil, 0, false
+	ref := v.flatSubTypes[idx]
+	return ref.st, ref.recGroup, true
 }
 
 func (v *moduleValidator) validTypeIdx(idx TypeIdx) bool {
@@ -35,14 +29,15 @@ func (v *moduleValidator) validTypeIdx(idx TypeIdx) bool {
 func (v *moduleValidator) subtypeByTypeIdxInRecGroup(idx TypeIdx, recGroup int) (*SubType, bool) {
 	if !idx.Rec {
 		if recGroup >= 0 {
+			if recGroup >= len(v.m.Types) {
+				return nil, false
+			}
 			// An absolute index inside a type definition may only name a type
 			// declared before the current recursive group. References to members
 			// of the current group are decoded as Rec indexes; later groups are
 			// out of scope even though they exist in the flattened type section.
-			base := 0
-			for gi := 0; gi < recGroup && gi < len(v.m.Types); gi++ {
-				base += len(v.m.Types[gi].SubTypes)
-			}
+			v.ensureTypeIndex()
+			base := v.typeGroupBases[recGroup]
 			if int(idx.Index) >= base {
 				return nil, false
 			}
@@ -66,13 +61,28 @@ type moduleSubTypeRef struct {
 }
 
 func (v *moduleValidator) flattenedSubTypeRefs() []moduleSubTypeRef {
-	var flat []moduleSubTypeRef
+	v.ensureTypeIndex()
+	return v.flatSubTypes
+}
+
+func (v *moduleValidator) ensureTypeIndex() {
+	if v.typeIndexReady {
+		return
+	}
+	v.typeIndexReady = true
+	v.typeGroupBases = make([]int, len(v.m.Types)+1)
+	total := 0
+	for gi := range v.m.Types {
+		v.typeGroupBases[gi] = total
+		total += len(v.m.Types[gi].SubTypes)
+	}
+	v.typeGroupBases[len(v.m.Types)] = total
+	v.flatSubTypes = make([]moduleSubTypeRef, 0, total)
 	for gi := range v.m.Types {
 		for si := range v.m.Types[gi].SubTypes {
-			flat = append(flat, moduleSubTypeRef{st: &v.m.Types[gi].SubTypes[si], recGroup: gi})
+			v.flatSubTypes = append(v.flatSubTypes, moduleSubTypeRef{st: &v.m.Types[gi].SubTypes[si], recGroup: gi})
 		}
 	}
-	return flat
 }
 
 func (v *moduleValidator) flatTypeIdxInRecGroup(idx TypeIdx, recGroup int) (int, bool) {
@@ -85,11 +95,8 @@ func (v *moduleValidator) flatTypeIdxInRecGroup(idx TypeIdx, recGroup int) (int,
 	if recGroup < 0 || recGroup >= len(v.m.Types) || idx.Index >= uint32(len(v.m.Types[recGroup].SubTypes)) {
 		return 0, false
 	}
-	abs := 0
-	for gi := 0; gi < recGroup; gi++ {
-		abs += len(v.m.Types[gi].SubTypes)
-	}
-	return abs + int(idx.Index), true
+	v.ensureTypeIndex()
+	return v.typeGroupBases[recGroup] + int(idx.Index), true
 }
 
 func (v *moduleValidator) validateSubtypeMetadata() error {

--- a/src/core/compiler/wasm/validate_gc_subtype_test.go
+++ b/src/core/compiler/wasm/validate_gc_subtype_test.go
@@ -57,6 +57,41 @@ func TestValidateGCSubtypeMetadata(t *testing.T) {
 	})
 }
 
+func TestGCTypeIndexFlattensGroupsOnce(t *testing.T) {
+	m := &Module{Types: make([]RecType, 4096)}
+	for i := range m.Types {
+		m.Types[i] = openStructType(nil)
+	}
+	v := &moduleValidator{m: m}
+	st, group, ok := v.subtypeByFlatTypeIdx(len(m.Types) - 1)
+	if !ok || st == nil || group != len(m.Types)-1 {
+		t.Fatalf("last flat type = %p, %d, %v", st, group, ok)
+	}
+	flat := v.flattenedSubTypeRefs()
+	if len(flat) != len(m.Types) || len(v.typeGroupBases) != len(m.Types)+1 {
+		t.Fatalf("type index sizes = flat %d bases %d", len(flat), len(v.typeGroupBases))
+	}
+	if &flat[0] != &v.flattenedSubTypeRefs()[0] {
+		t.Fatal("flattened type index was rebuilt")
+	}
+}
+
+func BenchmarkGCFlatTypeLookupManyGroups(b *testing.B) {
+	m := &Module{Types: make([]RecType, 4096)}
+	for i := range m.Types {
+		m.Types[i] = openStructType(nil)
+	}
+	v := &moduleValidator{m: m}
+	v.ensureTypeIndex()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, ok := v.subtypeByFlatTypeIdx(i & 4095); !ok {
+			b.Fatal("flat type missing")
+		}
+	}
+}
+
 func TestRefTestAcceptsDefinedSiblingTypes(t *testing.T) {
 	m := modWithFunc(
 		[]ValType{refToType(2, true)}, nil,


### PR DESCRIPTION
Small correctness and validation-cost fix for GC subtype metadata.

Summary:
- build one flat subtype index and one recursive-group base table per module validator
- replace repeated scans of all preceding type groups with constant-time lookups
- reuse the same immutable index throughout validation

Benchmark:
- 4,096-group flat lookup: 2.65–3.65 ns/op, 0 B/op, 0 allocs/op on the local Ryzen 7 8845HS run

Testing:
- `go test ./src/core/compiler/wasm`
- `go test ./src/core/compiler/wasm -run '^TestGCTypeIndexFlattensGroupsOnce$' -bench '^BenchmarkGCFlatTypeLookupManyGroups$' -benchtime=200ms -count=3`

Docs unchanged: this is an internal validation-performance fix.