### PR TITLE
runtime: require native stack fencing

### DIFF
--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -677,6 +677,9 @@ func (c *RuntimeConfig) Validate() error {
 	if c.functionWorkers < 0 {
 		return fmt.Errorf("wago: function workers must be non-negative, got %d", c.functionWorkers)
 	}
+	if enabled, present := c.optimizations["stack-fence"]; present && !enabled {
+		return fmt.Errorf("wago: stack-fence is required for bounded native execution")
+	}
 	if !c.trustedOptimizations {
 		for name := range c.optimizations {
 			if !optimization.Exists(runtime.GOARCH, name) {

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -504,6 +504,16 @@ func TestConfigOptimizationSelectionIsImmutableAndValidated(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigRejectsDisabledStackFence(t *testing.T) {
+	cfg := NewRuntimeConfig().WithOptimization("stack-fence", false)
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "stack-fence is required") {
+		t.Fatalf("disabled stack-fence validation = %v", err)
+	}
+	if _, err := cfg.Compile(benchAddOneModule()); err == nil || !strings.Contains(err.Error(), "stack-fence is required") {
+		t.Fatalf("disabled stack-fence compile = %v", err)
+	}
+}
+
 func TestMeasuredLowValueOptimizationsAreDisabledByDefault(t *testing.T) {
 	wantOff := map[string]bool{
 		"loop-precheck": true,


### PR DESCRIPTION
Small correctness fix for runtime configuration.

Summary:
- reject public optimization selections that disable `stack-fence`
- fail during config validation and compilation with a clear bounded-execution error
- keep the backend measurement knob internal without allowing unsafe runtime admission

Testing:
- `go test ./src/wago -run '^(TestRuntimeConfigRejectsDisabledStackFence|TestConfigOptimizationSelectionIsImmutableAndValidated)$'`

Hot path unchanged: accepted configurations emit the same fence.

Docs unchanged: the existing option now rejects the unsupported unsafe selection clearly.