### PR TITLE
runtime: require exact dotted import identity

### DIFF
--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -25,7 +25,7 @@ func exactImportIdentityModule(includeTag bool) []byte {
 	}
 	imports := [][]byte{
 		entry("a.b", "c", 0x00, 0x00), // function, type 0
-		entry("a", "b.c", 0x00, 0x00), // same legacy key, distinct identity
+		entry("a", "bc", 0x00, 0x00),
 		entry("", "empty.module", 0x00, 0x00),
 		entry("empty.name", "", 0x00, 0x00),
 		entry("nul\x00.mod", "field\x00.name", 0x00, 0x00),
@@ -45,7 +45,7 @@ func exactImportIdentityModule(includeTag bool) []byte {
 func exactImportIdentities(includeTag bool) []importIdentity {
 	identities := []importIdentity{
 		{module: "a.b", name: "c", kind: ImportFunc},
-		{module: "a", name: "b.c", kind: ImportFunc},
+		{module: "a", name: "bc", kind: ImportFunc},
 		{module: "", name: "empty.module", kind: ImportFunc},
 		{module: "empty.name", name: "", kind: ImportFunc},
 		{module: "nul\x00.mod", name: "field\x00.name", kind: ImportFunc},
@@ -198,16 +198,49 @@ func TestRuntimePluginBindingRequiresExactImportIdentity(t *testing.T) {
 func TestRuntimeRejectsCollidingExactImportIdentities(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()
-	module, err := rt.Compile(exactImportIdentityModule(false))
+	moduleBytes := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(
+			importEntry("a.b", "c", 0, 0),
+			importEntry("a", "b.c", 0, 0),
+		)),
+	)
+	if module, err := rt.Compile(moduleBytes); err == nil || module != nil || !strings.Contains(err.Error(), "cannot be bound safely") {
+		t.Fatalf("colliding declared imports = %v, %v; want rejection", module, err)
+	}
+}
+
+func TestRuntimeRejectsExactOverrideCollidingWithDeclaration(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	module, err := rt.Compile(wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("a.b", "c", 0, 0))),
+	))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer module.Close()
 	if instance, err := rt.Instantiate(context.Background(), module,
-		WithImport("a.b", "c", HostFunc(func(HostModule, []uint64, []uint64) {})),
 		WithImport("a", "b.c", HostFunc(func(HostModule, []uint64, []uint64) {})),
 	); err == nil || instance != nil || !strings.Contains(err.Error(), "cannot be bound safely") {
-		t.Fatalf("colliding exact imports = %v, %v; want rejection", instance, err)
+		t.Fatalf("colliding exact override = %v, %v; want rejection", instance, err)
+	}
+}
+
+func TestRuntimeRejectsCollidingUndeclaredExactOverrides(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	module, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	if instance, err := rt.Instantiate(context.Background(), module,
+		WithImport("a.b", "c", new(int)),
+		WithImport("a", "b.c", new(int)),
+	); err == nil || instance != nil || !strings.Contains(err.Error(), "cannot be bound safely") {
+		t.Fatalf("colliding undeclared exact overrides = %v, %v; want rejection", instance, err)
 	}
 }
 

--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -182,14 +182,32 @@ func TestRuntimePluginBindingRequiresExactImportIdentity(t *testing.T) {
 		t.Fatalf("colliding plugin binding error = %v, want ErrMissingImport", err)
 	}
 
-	// Explicit flat Imports remain a deliberate compatibility boundary: callers
-	// supplying one directly chose the legacy namespace themselves.
-	instance, err := rt.Instantiate(context.Background(), module, WithImports(Imports{flatKey: HostFunc(func(HostModule, []uint64, []uint64) {})}))
+	if instance, err := rt.Instantiate(context.Background(), module, WithImports(Imports{flatKey: HostFunc(func(HostModule, []uint64, []uint64) {})})); err == nil || instance != nil || !strings.Contains(err.Error(), "use WithImport") {
+		t.Fatalf("ambiguous flat override = %v, %v; want exact-import error", instance, err)
+	}
+
+	instance, err := rt.Instantiate(context.Background(), module, WithImport("a.b", "c", HostFunc(func(HostModule, []uint64, []uint64) {})))
 	if err != nil {
-		t.Fatalf("explicit legacy override: %v", err)
+		t.Fatalf("exact override: %v", err)
 	}
 	if err := instance.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRuntimeRejectsCollidingExactImportIdentities(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	module, err := rt.Compile(exactImportIdentityModule(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	if instance, err := rt.Instantiate(context.Background(), module,
+		WithImport("a.b", "c", HostFunc(func(HostModule, []uint64, []uint64) {})),
+		WithImport("a", "b.c", HostFunc(func(HostModule, []uint64, []uint64) {})),
+	); err == nil || instance != nil || !strings.Contains(err.Error(), "cannot be bound safely") {
+		t.Fatalf("colliding exact imports = %v, %v; want rejection", instance, err)
 	}
 }
 

--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -251,6 +251,29 @@ func TestRuntimeReservedExactOverrideIgnoresCollidingIdentity(t *testing.T) {
 	instance.Close()
 }
 
+func TestRuntimeRejectsMixedExactAndFlatOverride(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	module, err := rt.Compile(wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "f", 0, 0))),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	first := HostFunc(func(HostModule, []uint64, []uint64) {})
+	second := HostFunc(func(HostModule, []uint64, []uint64) {})
+	for _, opts := range [][]InstantiateOption{
+		{WithImport("env", "f", first), WithImports(Imports{"env.f": second})},
+		{WithImports(Imports{"env.f": first}), WithImport("env", "f", second)},
+	} {
+		if instance, err := rt.Instantiate(context.Background(), module, opts...); err == nil || instance != nil || !strings.Contains(err.Error(), "both WithImport and WithImports") {
+			t.Fatalf("mixed override = %v, %v; want explicit rejection", instance, err)
+		}
+	}
+}
+
 func TestCompiledCodecBoundsDecodedImportDirectoryAllocation(t *testing.T) {
 	const count = 3
 	var prefix [binary.MaxVarintLen64]byte

--- a/src/wago/import_identity_test.go
+++ b/src/wago/import_identity_test.go
@@ -211,6 +211,46 @@ func TestRuntimeRejectsCollidingExactImportIdentities(t *testing.T) {
 	}
 }
 
+func TestRuntimeRetainsUndeclaredExactImport(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	module, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	marker := new(int)
+	instance, err := rt.Instantiate(context.Background(), module, WithImport("unused.mod", "value.name", marker))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close()
+	if got := instance.Imports()["unused.mod.value.name"]; got != marker {
+		t.Fatalf("undeclared exact import = %v, want %p", got, marker)
+	}
+}
+
+func TestRuntimeReservedExactOverrideIgnoresCollidingIdentity(t *testing.T) {
+	const flatKey = "wago_timer.a.b"
+	rt := NewRuntime()
+	defer rt.Close()
+	rt.imports[flatKey] = HostFunc(func(HostModule, []uint64, []uint64) {})
+	rt.importMeta[flatKey] = &registeredImport{module: "wago_timer.a", name: "b"}
+	module, err := rt.Compile(wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(append(append(wasmtest.Name("wago_timer"), wasmtest.Name("a.b")...), 0x00, 0x00))),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	instance, err := rt.Instantiate(context.Background(), module, WithImport("wago_timer", "a.b", HostFunc(func(HostModule, []uint64, []uint64) {})))
+	if err != nil {
+		t.Fatalf("exact override of distinct reserved identity: %v", err)
+	}
+	instance.Close()
+}
+
 func TestCompiledCodecBoundsDecodedImportDirectoryAllocation(t *testing.T) {
 	const count = 3
 	var prefix [binary.MaxVarintLen64]byte

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -282,6 +283,42 @@ func buildModule(c *Compiled, bindings moduleBindings) *Module {
 		}
 	}
 	return m
+}
+
+// validateDeclaredImportIdentities rejects distinct structured import names
+// that the low-level flat Imports namespace cannot represent independently.
+// Run this once when the runtime wrapper is constructed, rather than rebuilding
+// collision state for every instance.
+func validateDeclaredImportIdentities(specs []ImportSpec) error {
+	var firstIdentity importBindingKey
+	haveIdentity, distinctIdentities, dottedModule := false, false, false
+	for _, spec := range specs {
+		identity := importBindingKey{module: spec.Module, name: spec.Name}
+		dottedModule = dottedModule || strings.Contains(identity.module, ".")
+		if !haveIdentity {
+			firstIdentity, haveIdentity = identity, true
+		} else if identity != firstIdentity {
+			distinctIdentities = true
+		}
+	}
+	if !distinctIdentities || !dottedModule {
+		return nil
+	}
+
+	flatIdentities := make(map[string]importBindingKey, len(specs))
+	for _, spec := range specs {
+		identity := importBindingKey{module: spec.Module, name: spec.Name}
+		key := spec.Key()
+		if previous, ok := flatIdentities[key]; ok && previous != identity {
+			return importIdentityCollisionError(previous, identity)
+		}
+		flatIdentities[key] = identity
+	}
+	return nil
+}
+
+func importIdentityCollisionError(previous, identity importBindingKey) error {
+	return fmt.Errorf("wago: imports %q.%q and %q.%q share flattened key %q and cannot be bound safely", previous.module, previous.name, identity.module, identity.name, identity.module+"."+identity.name)
 }
 
 // registeredImportMatches prevents the legacy flat binding namespace from

--- a/src/wago/module.go
+++ b/src/wago/module.go
@@ -17,6 +17,9 @@ type Module struct {
 	c       *Compiled
 	imports []ImportSpec
 	reqCaps []Capability
+	// importIdentities is populated only when a declared component contains a
+	// dot and the flat binding namespace can therefore be ambiguous.
+	importIdentities map[string]importBindingKey
 
 	identity             atomic.Pointer[moduleIdentityToken]
 	ownsCompiled         bool
@@ -285,24 +288,20 @@ func buildModule(c *Compiled, bindings moduleBindings) *Module {
 	return m
 }
 
-// validateDeclaredImportIdentities rejects distinct structured import names
-// that the low-level flat Imports namespace cannot represent independently.
-// Run this once when the runtime wrapper is constructed, rather than rebuilding
-// collision state for every instance.
-func validateDeclaredImportIdentities(specs []ImportSpec) error {
-	var firstIdentity importBindingKey
-	haveIdentity, distinctIdentities, dottedModule := false, false, false
+// indexDeclaredImportIdentities rejects distinct structured import names that
+// the low-level flat Imports namespace cannot represent independently. It keeps
+// the resulting index only when dotted components make alternate splits
+// possible, so per-instance exact overrides can be checked in linear time.
+func indexDeclaredImportIdentities(specs []ImportSpec) (map[string]importBindingKey, error) {
+	ambiguous := false
 	for _, spec := range specs {
-		identity := importBindingKey{module: spec.Module, name: spec.Name}
-		dottedModule = dottedModule || strings.Contains(identity.module, ".")
-		if !haveIdentity {
-			firstIdentity, haveIdentity = identity, true
-		} else if identity != firstIdentity {
-			distinctIdentities = true
+		if strings.Contains(spec.Module, ".") || strings.Contains(spec.Name, ".") {
+			ambiguous = true
+			break
 		}
 	}
-	if !distinctIdentities || !dottedModule {
-		return nil
+	if !ambiguous {
+		return nil, nil
 	}
 
 	flatIdentities := make(map[string]importBindingKey, len(specs))
@@ -310,11 +309,11 @@ func validateDeclaredImportIdentities(specs []ImportSpec) error {
 		identity := importBindingKey{module: spec.Module, name: spec.Name}
 		key := spec.Key()
 		if previous, ok := flatIdentities[key]; ok && previous != identity {
-			return importIdentityCollisionError(previous, identity)
+			return nil, importIdentityCollisionError(previous, identity)
 		}
 		flatIdentities[key] = identity
 	}
-	return nil
+	return flatIdentities, nil
 }
 
 func importIdentityCollisionError(previous, identity importBindingKey) error {

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -638,10 +638,16 @@ type InstantiateOption func(*instantiateConfig)
 
 type instantiateConfig struct {
 	imports       Imports
+	exactImports  map[importBindingKey]any
 	gc            GCConfig
 	hasGC         bool
 	policy        Policy
 	forceSyncHost bool
+}
+
+type importBindingKey struct {
+	module string
+	name   string
 }
 
 // WithPolicy applies a capability/resource policy to the instance. A module that
@@ -662,6 +668,18 @@ func WithImports(im Imports) InstantiateOption {
 		for k, v := range im {
 			c.imports[k] = v
 		}
+	}
+}
+
+// WithImport adds one per-call import using its exact Wasm module and name.
+// Prefer this form when either component contains a dot, because the legacy
+// Imports map represents bindings as a flattened "module.name" string.
+func WithImport(module, name string, value any) InstantiateOption {
+	return func(c *instantiateConfig) {
+		if c.exactImports == nil {
+			c.exactImports = make(map[importBindingKey]any)
+		}
+		c.exactImports[importBindingKey{module: module, name: name}] = value
 	}
 }
 
@@ -726,7 +744,7 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 		return nil, err
 	}
 
-	imports, pluginGCImports, err := rt.resolveInstanceImports(mod.imports, cfg.imports)
+	imports, pluginGCImports, err := rt.resolveInstanceImports(mod.imports, cfg.imports, cfg.exactImports)
 	if err != nil {
 		return nil, err
 	}
@@ -748,7 +766,7 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 // cloning runtime imports the module cannot use. Explicit per-call imports are
 // retained even when undeclared, preserving the low-level Imports inspection
 // behavior. Runtime imports are only retained for declared module keys.
-func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports) (Imports, map[uint32]struct{}, error) {
+func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports, exactOverrides map[importBindingKey]any) (Imports, map[uint32]struct{}, error) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
@@ -761,9 +779,26 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports)
 			return nil, nil, fmt.Errorf("wago: import %q may not override reserved module %q", key, module)
 		}
 	}
+	for identity := range exactOverrides {
+		if !isReserved(identity.module) || rt.overridePolicy == AllowTestOverrides {
+			continue
+		}
+		if _, provided := rt.imports[identity.module+"."+identity.name]; provided {
+			return nil, nil, fmt.Errorf("wago: import %q.%q may not override reserved module %q", identity.module, identity.name, identity.module)
+		}
+	}
+	flatIdentities := make(map[string]importBindingKey, len(specs))
+	for _, spec := range specs {
+		key := spec.Key()
+		identity := importBindingKey{module: spec.Module, name: spec.Name}
+		if previous, ok := flatIdentities[key]; ok && previous != identity {
+			return nil, nil, fmt.Errorf("wago: imports %q.%q and %q.%q share flattened key %q and cannot be bound safely", previous.module, previous.name, identity.module, identity.name, key)
+		}
+		flatIdentities[key] = identity
+	}
 
-	capacity := len(overrides) + len(specs)
-	if available := len(overrides) + len(rt.imports); available < capacity {
+	capacity := len(overrides) + len(exactOverrides) + len(specs)
+	if available := len(overrides) + len(exactOverrides) + len(rt.imports); available < capacity {
 		capacity = available
 	}
 	var resolved Imports
@@ -776,7 +811,17 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports)
 	}
 	for _, spec := range specs {
 		key := spec.Key()
+		if value, provided := exactOverrides[importBindingKey{module: spec.Module, name: spec.Name}]; provided {
+			if resolved == nil {
+				resolved = make(Imports, capacity)
+			}
+			resolved[key] = value
+			continue
+		}
 		if _, provided := overrides[key]; provided {
+			if module, name := splitImportKey(key); module != spec.Module || name != spec.Name {
+				return nil, nil, fmt.Errorf("wago: flattened import %q is ambiguous for Wasm import %q.%q; use WithImport with separate module and name", key, spec.Module, spec.Name)
+			}
 			continue
 		}
 		value, provided := rt.imports[key]

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -536,9 +536,11 @@ func (p *PreparedCompile) Adopt(c *Compiled) (*Module, error) {
 
 func (p *PreparedCompile) finishCompile(c *Compiled) (*Module, error) {
 	mod := buildModule(c, p.bindings)
-	if err := validateDeclaredImportIdentities(mod.imports); err != nil {
+	identities, err := indexDeclaredImportIdentities(mod.imports)
+	if err != nil {
 		return nil, emitCompileError(p.hooks, p.compilation, joinPrimary(err, c.Close()))
 	}
+	mod.importIdentities = identities
 	if len(p.hooks.afterCompile) != 0 {
 		event := ModuleCompiledEvent{Compilation: p.compilation, Module: moduleView(mod), SourceDigest: DigestModuleSource(p.source)}
 		for _, fn := range p.hooks.afterCompile {
@@ -623,9 +625,11 @@ func (rt *Runtime) bindModule(c *Compiled, ownsCompiled bool) (*Module, error) {
 		compilation = CompilationIdentity{value: &compilationIdentityToken{}}
 	}
 	mod := buildModule(c, bindings)
-	if err := validateDeclaredImportIdentities(mod.imports); err != nil {
+	identities, err := indexDeclaredImportIdentities(mod.imports)
+	if err != nil {
 		return nil, emitCompileError(hooks, compilation, err)
 	}
+	mod.importIdentities = identities
 	if len(hooks.afterCompile) != 0 {
 		event := ModuleCompiledEvent{Compilation: compilation, Module: moduleView(mod)}
 		for _, fn := range hooks.afterCompile {
@@ -644,7 +648,8 @@ type InstantiateOption func(*instantiateConfig)
 
 type instantiateConfig struct {
 	imports       Imports
-	exactImports  map[importBindingKey]any
+	exactImports  map[string]exactImportOverride
+	importErr     error
 	gc            GCConfig
 	hasGC         bool
 	policy        Policy
@@ -654,6 +659,11 @@ type instantiateConfig struct {
 type importBindingKey struct {
 	module string
 	name   string
+}
+
+type exactImportOverride struct {
+	identity importBindingKey
+	value    any
 }
 
 // WithPolicy applies a capability/resource policy to the instance. A module that
@@ -683,9 +693,15 @@ func WithImports(im Imports) InstantiateOption {
 func WithImport(module, name string, value any) InstantiateOption {
 	return func(c *instantiateConfig) {
 		if c.exactImports == nil {
-			c.exactImports = make(map[importBindingKey]any)
+			c.exactImports = make(map[string]exactImportOverride)
 		}
-		c.exactImports[importBindingKey{module: module, name: name}] = value
+		identity := importBindingKey{module: module, name: name}
+		key := module + "." + name
+		if previous, ok := c.exactImports[key]; ok && previous.identity != identity {
+			c.importErr = importIdentityCollisionError(previous.identity, identity)
+			return
+		}
+		c.exactImports[key] = exactImportOverride{identity: identity, value: value}
 	}
 }
 
@@ -746,11 +762,14 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	if len(opts) != 0 {
 		cfg = applyInstantiateOptions(opts)
 	}
+	if cfg.importErr != nil {
+		return nil, cfg.importErr
+	}
 	if err := applyPolicy(mod, cfg.policy); err != nil {
 		return nil, err
 	}
 
-	imports, pluginGCImports, err := rt.resolveInstanceImports(mod.imports, cfg.imports, cfg.exactImports)
+	imports, pluginGCImports, err := rt.resolveInstanceImports(mod.imports, mod.importIdentities, cfg.imports, cfg.exactImports)
 	if err != nil {
 		return nil, err
 	}
@@ -772,12 +791,12 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 // cloning runtime imports the module cannot use. Explicit per-call imports are
 // retained even when undeclared, preserving the low-level Imports inspection
 // behavior. Runtime imports are only retained for declared module keys.
-func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports, exactOverrides map[importBindingKey]any) (Imports, map[uint32]struct{}, error) {
+func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, declaredIdentities map[string]importBindingKey, overrides Imports, exactOverrides map[string]exactImportOverride) (Imports, map[uint32]struct{}, error) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
-	for identity := range exactOverrides {
-		key := identity.module + "." + identity.name
+	for key, exact := range exactOverrides {
+		identity := exact.identity
 		if _, duplicated := overrides[key]; duplicated {
 			return nil, nil, fmt.Errorf("wago: import %q.%q is configured by both WithImport and WithImports", identity.module, identity.name)
 		}
@@ -791,26 +810,18 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 			return nil, nil, fmt.Errorf("wago: import %q may not override reserved module %q", key, module)
 		}
 	}
-	for identity := range exactOverrides {
+	for key, exact := range exactOverrides {
+		identity := exact.identity
 		if !isReserved(identity.module) || rt.overridePolicy == AllowTestOverrides {
 			continue
 		}
-		key := identity.module + "." + identity.name
 		if _, provided := rt.imports[key]; provided && registeredImportMatches(rt.importMeta[key], identity.module, identity.name) {
 			return nil, nil, fmt.Errorf("wago: import %q.%q may not override reserved module %q", identity.module, identity.name, identity.module)
 		}
 	}
-	for identity := range exactOverrides {
-		for _, spec := range specs {
-			declared := importBindingKey{module: spec.Module, name: spec.Name}
-			if identity != declared && flattenedImportIdentitiesEqual(identity, declared) {
-				return nil, nil, importIdentityCollisionError(declared, identity)
-			}
-		}
-		for other := range exactOverrides {
-			if identity != other && flattenedImportIdentitiesEqual(identity, other) {
-				return nil, nil, importIdentityCollisionError(other, identity)
-			}
+	for key, exact := range exactOverrides {
+		if declared, ok := declaredIdentities[key]; ok && declared != exact.identity {
+			return nil, nil, importIdentityCollisionError(declared, exact.identity)
 		}
 	}
 
@@ -828,11 +839,12 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 	}
 	for _, spec := range specs {
 		key := spec.Key()
-		if value, provided := exactOverrides[importBindingKey{module: spec.Module, name: spec.Name}]; provided {
+		identity := importBindingKey{module: spec.Module, name: spec.Name}
+		if exact, provided := exactOverrides[key]; provided && exact.identity == identity {
 			if resolved == nil {
 				resolved = make(Imports, capacity)
 			}
-			resolved[key] = value
+			resolved[key] = exact.value
 			continue
 		}
 		if _, provided := overrides[key]; provided {
@@ -872,35 +884,13 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 			}
 		}
 	}
-	for identity, value := range exactOverrides {
+	for key, exact := range exactOverrides {
 		if resolved == nil {
 			resolved = make(Imports, capacity)
 		}
-		resolved[identity.module+"."+identity.name] = value
+		resolved[key] = exact.value
 	}
 	return resolved, pluginGCImports, nil
-}
-
-func flattenedImportIdentitiesEqual(a, b importBindingKey) bool {
-	aLen := len(a.module) + 1 + len(a.name)
-	if aLen != len(b.module)+1+len(b.name) {
-		return false
-	}
-	byteAt := func(identity importBindingKey, index int) byte {
-		if index < len(identity.module) {
-			return identity.module[index]
-		}
-		if index == len(identity.module) {
-			return '.'
-		}
-		return identity.name[index-len(identity.module)-1]
-	}
-	for i := 0; i < aLen; i++ {
-		if byteAt(a, i) != byteAt(b, i) {
-			return false
-		}
-	}
-	return true
 }
 
 func applyInstantiateOptions(opts []InstantiateOption) instantiateConfig {

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -771,6 +771,12 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
+	for identity := range exactOverrides {
+		key := identity.module + "." + identity.name
+		if _, duplicated := overrides[key]; duplicated {
+			return nil, nil, fmt.Errorf("wago: import %q.%q is configured by both WithImport and WithImports", identity.module, identity.name)
+		}
+	}
 	for key := range overrides {
 		module := importModule(key)
 		if !isReserved(module) || rt.overridePolicy == AllowTestOverrides {

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	goruntime "runtime"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -537,6 +536,9 @@ func (p *PreparedCompile) Adopt(c *Compiled) (*Module, error) {
 
 func (p *PreparedCompile) finishCompile(c *Compiled) (*Module, error) {
 	mod := buildModule(c, p.bindings)
+	if err := validateDeclaredImportIdentities(mod.imports); err != nil {
+		return nil, emitCompileError(p.hooks, p.compilation, joinPrimary(err, c.Close()))
+	}
 	if len(p.hooks.afterCompile) != 0 {
 		event := ModuleCompiledEvent{Compilation: p.compilation, Module: moduleView(mod), SourceDigest: DigestModuleSource(p.source)}
 		for _, fn := range p.hooks.afterCompile {
@@ -621,6 +623,9 @@ func (rt *Runtime) bindModule(c *Compiled, ownsCompiled bool) (*Module, error) {
 		compilation = CompilationIdentity{value: &compilationIdentityToken{}}
 	}
 	mod := buildModule(c, bindings)
+	if err := validateDeclaredImportIdentities(mod.imports); err != nil {
+		return nil, emitCompileError(hooks, compilation, err)
+	}
 	if len(hooks.afterCompile) != 0 {
 		event := ModuleCompiledEvent{Compilation: compilation, Module: moduleView(mod)}
 		for _, fn := range hooks.afterCompile {
@@ -795,40 +800,16 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 			return nil, nil, fmt.Errorf("wago: import %q.%q may not override reserved module %q", identity.module, identity.name, identity.module)
 		}
 	}
-	var firstIdentity importBindingKey
-	haveIdentity, distinctIdentities, dottedModule := false, false, false
-	considerIdentity := func(identity importBindingKey) {
-		dottedModule = dottedModule || strings.Contains(identity.module, ".")
-		if !haveIdentity {
-			firstIdentity, haveIdentity = identity, true
-		} else if identity != firstIdentity {
-			distinctIdentities = true
-		}
-	}
-	for _, spec := range specs {
-		considerIdentity(importBindingKey{module: spec.Module, name: spec.Name})
-	}
 	for identity := range exactOverrides {
-		considerIdentity(identity)
-	}
-	needsCollisionCheck := distinctIdentities && dottedModule
-	if needsCollisionCheck {
-		flatIdentities := make(map[string]importBindingKey, len(specs)+len(exactOverrides))
-		checkIdentity := func(key string, identity importBindingKey) error {
-			if previous, ok := flatIdentities[key]; ok && previous != identity {
-				return fmt.Errorf("wago: imports %q.%q and %q.%q share flattened key %q and cannot be bound safely", previous.module, previous.name, identity.module, identity.name, key)
-			}
-			flatIdentities[key] = identity
-			return nil
-		}
 		for _, spec := range specs {
-			if err := checkIdentity(spec.Key(), importBindingKey{module: spec.Module, name: spec.Name}); err != nil {
-				return nil, nil, err
+			declared := importBindingKey{module: spec.Module, name: spec.Name}
+			if identity != declared && flattenedImportIdentitiesEqual(identity, declared) {
+				return nil, nil, importIdentityCollisionError(declared, identity)
 			}
 		}
-		for identity := range exactOverrides {
-			if err := checkIdentity(identity.module+"."+identity.name, identity); err != nil {
-				return nil, nil, err
+		for other := range exactOverrides {
+			if identity != other && flattenedImportIdentitiesEqual(identity, other) {
+				return nil, nil, importIdentityCollisionError(other, identity)
 			}
 		}
 	}
@@ -898,6 +879,28 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 		resolved[identity.module+"."+identity.name] = value
 	}
 	return resolved, pluginGCImports, nil
+}
+
+func flattenedImportIdentitiesEqual(a, b importBindingKey) bool {
+	aLen := len(a.module) + 1 + len(a.name)
+	if aLen != len(b.module)+1+len(b.name) {
+		return false
+	}
+	byteAt := func(identity importBindingKey, index int) byte {
+		if index < len(identity.module) {
+			return identity.module[index]
+		}
+		if index == len(identity.module) {
+			return '.'
+		}
+		return identity.name[index-len(identity.module)-1]
+	}
+	for i := 0; i < aLen; i++ {
+		if byteAt(a, i) != byteAt(b, i) {
+			return false
+		}
+	}
+	return true
 }
 
 func applyInstantiateOptions(opts []InstantiateOption) instantiateConfig {

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	goruntime "runtime"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -783,18 +784,39 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 		if !isReserved(identity.module) || rt.overridePolicy == AllowTestOverrides {
 			continue
 		}
-		if _, provided := rt.imports[identity.module+"."+identity.name]; provided {
+		key := identity.module + "." + identity.name
+		if _, provided := rt.imports[key]; provided && registeredImportMatches(rt.importMeta[key], identity.module, identity.name) {
 			return nil, nil, fmt.Errorf("wago: import %q.%q may not override reserved module %q", identity.module, identity.name, identity.module)
 		}
 	}
-	flatIdentities := make(map[string]importBindingKey, len(specs))
-	for _, spec := range specs {
-		key := spec.Key()
-		identity := importBindingKey{module: spec.Module, name: spec.Name}
-		if previous, ok := flatIdentities[key]; ok && previous != identity {
-			return nil, nil, fmt.Errorf("wago: imports %q.%q and %q.%q share flattened key %q and cannot be bound safely", previous.module, previous.name, identity.module, identity.name, key)
+	needsCollisionCheck := len(exactOverrides) != 0
+	if !needsCollisionCheck && len(specs) > 1 {
+		for _, spec := range specs {
+			if strings.Contains(spec.Module, ".") || strings.Contains(spec.Name, ".") {
+				needsCollisionCheck = true
+				break
+			}
 		}
-		flatIdentities[key] = identity
+	}
+	if needsCollisionCheck {
+		flatIdentities := make(map[string]importBindingKey, len(specs)+len(exactOverrides))
+		checkIdentity := func(key string, identity importBindingKey) error {
+			if previous, ok := flatIdentities[key]; ok && previous != identity {
+				return fmt.Errorf("wago: imports %q.%q and %q.%q share flattened key %q and cannot be bound safely", previous.module, previous.name, identity.module, identity.name, key)
+			}
+			flatIdentities[key] = identity
+			return nil
+		}
+		for _, spec := range specs {
+			if err := checkIdentity(spec.Key(), importBindingKey{module: spec.Module, name: spec.Name}); err != nil {
+				return nil, nil, err
+			}
+		}
+		for identity := range exactOverrides {
+			if err := checkIdentity(identity.module+"."+identity.name, identity); err != nil {
+				return nil, nil, err
+			}
+		}
 	}
 
 	capacity := len(overrides) + len(exactOverrides) + len(specs)
@@ -854,6 +876,12 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 				}
 			}
 		}
+	}
+	for identity, value := range exactOverrides {
+		if resolved == nil {
+			resolved = make(Imports, capacity)
+		}
+		resolved[identity.module+"."+identity.name] = value
 	}
 	return resolved, pluginGCImports, nil
 }

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -795,12 +795,20 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 			return nil, nil, fmt.Errorf("wago: import %q.%q may not override reserved module %q", identity.module, identity.name, identity.module)
 		}
 	}
-	needsCollisionCheck := len(exactOverrides) != 0
-	if !needsCollisionCheck && len(specs) > 1 {
+	needsCollisionCheck := false
+	if len(specs)+len(exactOverrides) > 1 {
 		for _, spec := range specs {
-			if strings.Contains(spec.Module, ".") || strings.Contains(spec.Name, ".") {
+			if strings.Contains(spec.Module, ".") {
 				needsCollisionCheck = true
 				break
+			}
+		}
+		if !needsCollisionCheck {
+			for identity := range exactOverrides {
+				if strings.Contains(identity.module, ".") {
+					needsCollisionCheck = true
+					break
+				}
 			}
 		}
 	}

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -795,23 +795,23 @@ func (rt *Runtime) resolveInstanceImports(specs []ImportSpec, overrides Imports,
 			return nil, nil, fmt.Errorf("wago: import %q.%q may not override reserved module %q", identity.module, identity.name, identity.module)
 		}
 	}
-	needsCollisionCheck := false
-	if len(specs)+len(exactOverrides) > 1 {
-		for _, spec := range specs {
-			if strings.Contains(spec.Module, ".") {
-				needsCollisionCheck = true
-				break
-			}
-		}
-		if !needsCollisionCheck {
-			for identity := range exactOverrides {
-				if strings.Contains(identity.module, ".") {
-					needsCollisionCheck = true
-					break
-				}
-			}
+	var firstIdentity importBindingKey
+	haveIdentity, distinctIdentities, dottedModule := false, false, false
+	considerIdentity := func(identity importBindingKey) {
+		dottedModule = dottedModule || strings.Contains(identity.module, ".")
+		if !haveIdentity {
+			firstIdentity, haveIdentity = identity, true
+		} else if identity != firstIdentity {
+			distinctIdentities = true
 		}
 	}
+	for _, spec := range specs {
+		considerIdentity(importBindingKey{module: spec.Module, name: spec.Name})
+	}
+	for identity := range exactOverrides {
+		considerIdentity(identity)
+	}
+	needsCollisionCheck := distinctIdentities && dottedModule
 	if needsCollisionCheck {
 		flatIdentities := make(map[string]importBindingKey, len(specs)+len(exactOverrides))
 		checkIdentity := func(key string, identity importBindingKey) error {

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -160,6 +160,23 @@ func TestResolveInstanceImportsDoesNotAllocateForUnrelatedNamespace(t *testing.T
 	}
 }
 
+func TestResolveInstanceImportsOrdinaryImportDoesNotAllocateCollisionMap(t *testing.T) {
+	rt := NewRuntime()
+	fn := HostFunc(func(HostModule, []uint64, []uint64) {})
+	rt.imports["env.f"] = fn
+	rt.importMeta["env.f"] = &registeredImport{module: "env", name: "f", fn: fn}
+	specs := []ImportSpec{{Module: "env", Name: "f", Kind: ImportFunc}}
+	allocs := testing.AllocsPerRun(100, func() {
+		imports, pluginGCImports, err := rt.resolveInstanceImports(specs, nil, nil)
+		if err != nil || len(imports) != 1 || imports["env.f"] == nil || pluginGCImports != nil {
+			t.Fatalf("resolveInstanceImports = %#v, %#v, %v", imports, pluginGCImports, err)
+		}
+	})
+	if allocs != 3 {
+		t.Fatalf("resolveInstanceImports allocations = %v, want 3 without a collision map", allocs)
+	}
+}
+
 func TestRuntimeReservedUnusedOverrideRejected(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -201,6 +201,26 @@ func TestResolveInstanceImportsDottedFieldsDoNotAllocateCollisionMap(t *testing.
 	}
 }
 
+func TestResolveInstanceImportsMatchingExactIdentityDoesNotAllocateCollisionMap(t *testing.T) {
+	rt := NewRuntime()
+	fn := HostFunc(func(HostModule, []uint64, []uint64) {})
+	allocations := func(module string) float64 {
+		specs := []ImportSpec{{Module: module, Name: "f", Kind: ImportFunc}}
+		exact := map[importBindingKey]any{{module: module, name: "f"}: fn}
+		return testing.AllocsPerRun(100, func() {
+			imports, pluginGCImports, err := rt.resolveInstanceImports(specs, nil, exact)
+			if err != nil || len(imports) != 1 || pluginGCImports != nil {
+				panic(fmt.Sprintf("resolveInstanceImports = %#v, %#v, %v", imports, pluginGCImports, err))
+			}
+		})
+	}
+	plain := allocations("env")
+	dotted := allocations("env.prod")
+	if dotted > plain {
+		t.Fatalf("matching dotted identity allocations = %.0f, plain identity = %.0f", dotted, plain)
+	}
+}
+
 func TestRuntimeReservedUnusedOverrideRejected(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -150,7 +150,7 @@ func TestResolveInstanceImportsDoesNotAllocateForUnrelatedNamespace(t *testing.T
 	}
 
 	allocs := testing.AllocsPerRun(100, func() {
-		imports, pluginGCImports, err := rt.resolveInstanceImports(nil, nil)
+		imports, pluginGCImports, err := rt.resolveInstanceImports(nil, nil, nil)
 		if err != nil || imports != nil || pluginGCImports != nil {
 			t.Fatalf("resolveInstanceImports = %#v, %#v, %v, want nil, nil, nil", imports, pluginGCImports, err)
 		}

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -151,7 +151,7 @@ func TestResolveInstanceImportsDoesNotAllocateForUnrelatedNamespace(t *testing.T
 	}
 
 	allocs := testing.AllocsPerRun(100, func() {
-		imports, pluginGCImports, err := rt.resolveInstanceImports(nil, nil, nil)
+		imports, pluginGCImports, err := rt.resolveInstanceImports(nil, nil, nil, nil)
 		if err != nil || imports != nil || pluginGCImports != nil {
 			t.Fatalf("resolveInstanceImports = %#v, %#v, %v, want nil, nil, nil", imports, pluginGCImports, err)
 		}
@@ -168,7 +168,7 @@ func TestResolveInstanceImportsOrdinaryImportDoesNotAllocateCollisionMap(t *test
 	rt.importMeta["env.f"] = &registeredImport{module: "env", name: "f", fn: fn}
 	specs := []ImportSpec{{Module: "env", Name: "f", Kind: ImportFunc}}
 	allocs := testing.AllocsPerRun(100, func() {
-		imports, pluginGCImports, err := rt.resolveInstanceImports(specs, nil, nil)
+		imports, pluginGCImports, err := rt.resolveInstanceImports(specs, nil, nil, nil)
 		if err != nil || len(imports) != 1 || imports["env.f"] == nil || pluginGCImports != nil {
 			t.Fatalf("resolveInstanceImports = %#v, %#v, %v", imports, pluginGCImports, err)
 		}
@@ -188,7 +188,7 @@ func TestResolveInstanceImportsDottedFieldsDoNotAllocateCollisionMap(t *testing.
 	}
 	allocations := func(specs []ImportSpec) float64 {
 		return testing.AllocsPerRun(100, func() {
-			imports, pluginGCImports, err := rt.resolveInstanceImports(specs, nil, nil)
+			imports, pluginGCImports, err := rt.resolveInstanceImports(specs, nil, nil, nil)
 			if err != nil || len(imports) != 2 || pluginGCImports != nil {
 				panic(fmt.Sprintf("resolveInstanceImports = %#v, %#v, %v", imports, pluginGCImports, err))
 			}
@@ -206,9 +206,14 @@ func TestResolveInstanceImportsMatchingExactIdentityDoesNotAllocateCollisionMap(
 	fn := HostFunc(func(HostModule, []uint64, []uint64) {})
 	allocations := func(module string) float64 {
 		specs := []ImportSpec{{Module: module, Name: "f", Kind: ImportFunc}}
-		exact := map[importBindingKey]any{{module: module, name: "f"}: fn}
+		declared, err := indexDeclaredImportIdentities(specs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		identity := importBindingKey{module: module, name: "f"}
+		exact := map[string]exactImportOverride{module + ".f": {identity: identity, value: fn}}
 		return testing.AllocsPerRun(100, func() {
-			imports, pluginGCImports, err := rt.resolveInstanceImports(specs, nil, exact)
+			imports, pluginGCImports, err := rt.resolveInstanceImports(specs, declared, nil, exact)
 			if err != nil || len(imports) != 1 || pluginGCImports != nil {
 				panic(fmt.Sprintf("resolveInstanceImports = %#v, %#v, %v", imports, pluginGCImports, err))
 			}

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -172,8 +172,8 @@ func TestResolveInstanceImportsOrdinaryImportDoesNotAllocateCollisionMap(t *test
 			t.Fatalf("resolveInstanceImports = %#v, %#v, %v", imports, pluginGCImports, err)
 		}
 	})
-	if allocs != 3 {
-		t.Fatalf("resolveInstanceImports allocations = %v, want 3 without a collision map", allocs)
+	if allocs > 3 {
+		t.Fatalf("resolveInstanceImports allocations = %v, want at most 3 without a collision map", allocs)
 	}
 }
 

--- a/src/wago/runtime_test.go
+++ b/src/wago/runtime_test.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -174,6 +175,29 @@ func TestResolveInstanceImportsOrdinaryImportDoesNotAllocateCollisionMap(t *test
 	})
 	if allocs > 3 {
 		t.Fatalf("resolveInstanceImports allocations = %v, want at most 3 without a collision map", allocs)
+	}
+}
+
+func TestResolveInstanceImportsDottedFieldsDoNotAllocateCollisionMap(t *testing.T) {
+	rt := NewRuntime()
+	fn := HostFunc(func(HostModule, []uint64, []uint64) {})
+	for _, name := range []string{"a", "b", "a.b", "c.d"} {
+		key := "env." + name
+		rt.imports[key] = fn
+		rt.importMeta[key] = &registeredImport{module: "env", name: name, fn: fn}
+	}
+	allocations := func(specs []ImportSpec) float64 {
+		return testing.AllocsPerRun(100, func() {
+			imports, pluginGCImports, err := rt.resolveInstanceImports(specs, nil, nil)
+			if err != nil || len(imports) != 2 || pluginGCImports != nil {
+				panic(fmt.Sprintf("resolveInstanceImports = %#v, %#v, %v", imports, pluginGCImports, err))
+			}
+		})
+	}
+	plain := allocations([]ImportSpec{{Module: "env", Name: "a", Kind: ImportFunc}, {Module: "env", Name: "b", Kind: ImportFunc}})
+	dotted := allocations([]ImportSpec{{Module: "env", Name: "a.b", Kind: ImportFunc}, {Module: "env", Name: "c.d", Kind: ImportFunc}})
+	if dotted > plain {
+		t.Fatalf("dotted-field allocations = %.0f, plain fields = %.0f", dotted, plain)
 	}
 }
 

--- a/wago.go
+++ b/wago.go
@@ -527,6 +527,10 @@ func WithGC(gc GCConfig) InstantiateOption { return impl.WithGC(gc) }
 
 func WithGuestArguments(args []string) RuntimeOption { return impl.WithGuestArguments(args) }
 
+func WithImport(module string, name string, value any) InstantiateOption {
+	return impl.WithImport(module, name, value)
+}
+
 func WithImportOverridePolicy(p ImportOverridePolicy) RuntimeOption {
 	return impl.WithImportOverridePolicy(p)
 }


### PR DESCRIPTION
Small correctness fix: legacy `Imports` keys flatten a Wasm module and field into `module.name`. When a module component itself contains a dot, a binding for a different structural identity can have the same flat key.

This rejects ambiguous flat overrides, adds `WithImport(module, name, value)` for exact binding, and rejects modules containing two distinct imports that the remaining internal flat namespace cannot distinguish. Unambiguous legacy keys continue to work.

Proof:
- `go test ./src/wago -run '^(TestRuntimePluginBindingRequiresExactImportIdentity|TestRuntimeRejectsCollidingExactImportIdentities|TestRuntime.*Import.*)$'`\n- `go test ./src/wago -run '^(TestRuntime|TestCompiledCodec|TestModule)'`