### PR TITLE
runtime: cancel managed table invocations

### DIFF
--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -340,10 +340,20 @@ func (m *ManagedInstance) InvokeVoidTable(ctx context.Context, index uint32) err
 	if len(in.hostLog) > 0 {
 		binary.LittleEndian.PutUint32(in.hostLog, 0)
 	}
-	if ctx.Done() != nil {
-		stopCancel := in.startCancellationWatch(ctx, in.trap)
-		defer stopCancel()
+	if ctx.Done() == nil {
+		// Keep the common non-cancelable path identical to the original dispatch:
+		// Go 1.22 otherwise retains the context through the trap translation call
+		// and adds a heap allocation even though no watcher can ever fire.
+		if in.syncMode {
+			return in.callNativeSync(base)
+		}
+		if err := in.callNativeAsync(base, false); err != nil {
+			return err
+		}
+		return in.replayHostLog()
 	}
+	stopCancel := in.startCancellationWatch(ctx, in.trap)
+	defer stopCancel()
 	if in.syncMode {
 		return contextInterruptError(ctx, in.callNativeSyncWithTrapContext(base, in.trap, ctx))
 	}

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -46,9 +46,12 @@ type ManagedInstance struct {
 	memoryBytes uint64
 }
 
-var voidFuncType = wasm.CompType{Kind: wasm.CompFunc}
+var (
+	voidFuncType         = wasm.CompType{Kind: wasm.CompFunc}
+	voidFuncTypeKeyValue = wasm.StructuralFuncTypeKey(&voidFuncType)
+)
 
-func voidFuncTypeKey() uint64 { return wasm.StructuralFuncTypeKey(&voidFuncType) }
+func voidFuncTypeKey() uint64 { return voidFuncTypeKeyValue }
 
 func newPendingInstanceManager(owner string, budget AuthorityScope) *InstanceManager {
 	return &InstanceManager{owner: owner, budget: budget, instances: map[*ManagedInstance]struct{}{}, byInstance: map[*Instance]*ManagedInstance{}}

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -340,13 +340,15 @@ func (m *ManagedInstance) InvokeVoidTable(ctx context.Context, index uint32) err
 	if len(in.hostLog) > 0 {
 		binary.LittleEndian.PutUint32(in.hostLog, 0)
 	}
+	stopCancel := in.startCancellationWatch(ctx, in.trap)
+	defer stopCancel()
 	if in.syncMode {
-		return in.callNativeSync(base)
+		return contextInterruptError(ctx, in.callNativeSyncWithTrapContext(base, in.trap, ctx))
 	}
 	if err := in.callNativeAsync(base, false); err != nil {
-		return err
+		return contextInterruptError(ctx, err)
 	}
-	return in.replayHostLog()
+	return contextInterruptError(ctx, in.replayHostLog())
 }
 
 func (m *InstanceManager) ensureVoidDispatcher() (uintptr, error) {

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -340,8 +340,10 @@ func (m *ManagedInstance) InvokeVoidTable(ctx context.Context, index uint32) err
 	if len(in.hostLog) > 0 {
 		binary.LittleEndian.PutUint32(in.hostLog, 0)
 	}
-	stopCancel := in.startCancellationWatch(ctx, in.trap)
-	defer stopCancel()
+	if ctx.Done() != nil {
+		stopCancel := in.startCancellationWatch(ctx, in.trap)
+		defer stopCancel()
+	}
 	if in.syncMode {
 		return contextInterruptError(ctx, in.callNativeSyncWithTrapContext(base, in.trap, ctx))
 	}

--- a/src/wago/managed_instances_test.go
+++ b/src/wago/managed_instances_test.go
@@ -264,6 +264,11 @@ func TestManagedVoidTableValidationRejectsNullAndWrongSignature(t *testing.T) {
 }
 
 func TestManagedInvokeVoidTableContextInterruptsNativeLoop(t *testing.T) {
+	if !requireStandardGoTestRuntime(t) {
+		// TinyGo's cooperative scheduler cannot run a context timer while native
+		// Wasm owns the thread; its interruption coverage uses external signals.
+		return
+	}
 	ext := &managedTestExtension{}
 	rt := NewRuntime()
 	defer rt.Close()

--- a/src/wago/managed_instances_test.go
+++ b/src/wago/managed_instances_test.go
@@ -2,9 +2,11 @@ package wago
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/wasmtest"
@@ -252,6 +254,40 @@ func TestManagedVoidTableValidationRejectsNullAndWrongSignature(t *testing.T) {
 			t.Fatal("non-void table entry accepted")
 		}
 	})
+}
+
+func TestManagedInvokeVoidTableContextInterruptsNativeLoop(t *testing.T) {
+	ext := &managedTestExtension{}
+	rt := NewRuntime()
+	defer rt.Close()
+	if err := rt.Use(ext); err != nil {
+		t.Fatal(err)
+	}
+	mod, err := rt.Compile(wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x00, 0x01})),
+		wasmtest.Section(9, wasmtest.Vec(tableTestActiveElem(0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b}))),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Close()
+	owned, err := ext.manager.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owned.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if err := owned.InvokeVoidTable(ctx, 0); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("infinite table invocation = %v, want context deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("table cancellation took %v, want bounded interruption", elapsed)
+	}
 }
 
 func TestManagedCapabilityGuardHelpers(t *testing.T) {

--- a/src/wago/managed_instances_test.go
+++ b/src/wago/managed_instances_test.go
@@ -206,6 +206,13 @@ func TestManagedVoidTableDispatch(t *testing.T) {
 	if err := owned.InvokeVoidTable(context.Background(), 0); err != nil {
 		t.Fatalf("InvokeVoidTable: %v", err)
 	}
+	if allocs := testing.AllocsPerRun(100, func() {
+		if err := owned.InvokeVoidTable(context.Background(), 0); err != nil {
+			panic(err)
+		}
+	}); allocs != 0 {
+		t.Fatalf("background InvokeVoidTable allocations = %.0f, want 0", allocs)
+	}
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
 	if err := owned.InvokeVoidTable(canceled, 0); err != context.Canceled {


### PR DESCRIPTION
Small correctness fix: `ManagedInstance.InvokeVoidTable` checked cancellation before native entry but did not interrupt a table target that kept running.

The invocation now uses the established native cancellation watcher and translates an interruption trap back to the caller context. The regression invokes an infinite-loop table entry and observes its deadline.

Proof:
- `go test ./src/wago -run '^(TestManagedInvokeVoidTableContextInterruptsNativeLoop|TestManagedInstanceLifecycle|TestManagedVoidTableValidationRejectsNullAndWrongSignature)$' -count=3`