### PR TITLE
runtime: bound nested host re-entry

### DIFF
--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -65,6 +65,11 @@ call scratch, then restores the outer activation in LIFO order. Host code can
 use `Instance.InvokeFromHost` when it needs an explicit callback entry and
 `HostTrap` to return a host error through the native trap boundary.
 
+One invocation may have at most four active `InvokeFromHost` entries, including
+nested and concurrent entries. A fifth entry returns an error that wraps
+`ErrPermissionDenied`. This limit bounds the native stacks and call buffers
+retained under one synchronous host invocation.
+
 Use `wago.WithSynchronousHostCalls()` when instantiating a core adapter module
 whose host functions may be reached only indirectly through a table.
 

--- a/src/wago/bench_test.go
+++ b/src/wago/bench_test.go
@@ -1257,6 +1257,22 @@ func BenchmarkInvokeLegacyHostFuncVoid(b *testing.B) {
 	benchIntSink = calls
 }
 
+func BenchmarkHostReentryDepthAccounting(b *testing.B) {
+	id := newInvocationID()
+	if _, ok := acquireHostReentryDepth(id); !ok {
+		b.Fatal("warm host re-entry depth acquire failed")
+	}
+	releaseHostReentryDepth(id)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := acquireHostReentryDepth(id); !ok {
+			b.Fatal("host re-entry depth acquire failed")
+		}
+		releaseHostReentryDepth(id)
+	}
+}
+
 func BenchmarkInvokeHostFuncDirect(b *testing.B) {
 	c := benchMustCompile(b, benchReturningImportModule())
 	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] + 1 })}})

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -239,6 +239,13 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 	// call chain cannot masquerade as this parked activation.
 	markNativeActiveID(active, id)
 	defer unmarkNativeActiveID(active, id)
+	if root != nil && root != active {
+		// The producer parked on the root's native activation and invocation gate.
+		// A callback authorized by that invocation may therefore re-enter either
+		// the active producer or the public relay without waiting on its own gate.
+		markNativeActiveID(root, id)
+		defer unmarkNativeActiveID(root, id)
+	}
 	if active != root {
 		restoreInvocationContext := bindHostInvocationContext(ctrl, invocation)
 		defer restoreInvocationContext()

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -27,8 +27,10 @@ type HostModule interface {
 // InvokeFromHost invokes an export while caller is an active synchronous host
 // callback. The HostModule carries an unforgeable, callback-scoped invocation
 // identity. If that call chain re-enters a parked Instance, Wago supplies an
-// isolated native stack and call buffers for the nested activation. Retained or
-// unrelated HostModule values fail closed.
+// isolated native stack and call buffers for the nested activation. One
+// invocation may have at most four active InvokeFromHost calls; a fifth call
+// returns an error wrapping ErrPermissionDenied. Retained or unrelated
+// HostModule values fail closed.
 func (in *Instance) InvokeFromHost(ctx context.Context, caller HostModule, export string, args ...uint64) (results []uint64, err error) {
 	var active *Instance
 	var id invocationID
@@ -53,9 +55,66 @@ func (in *Instance) InvokeFromHost(ctx context.Context, caller HostModule, expor
 		}
 	}
 	contexts := invocationContextSetFor(ctx)
+	depth, ok := acquireHostReentryDepth(id)
+	if !ok {
+		return nil, fmt.Errorf("wago: host re-entry depth %d exceeds limit %d: %w", depth+1, maxHostReentryDepth, ErrPermissionDenied)
+	}
+	defer releaseHostReentryDepth(id)
 	results, err = in.invokeWithToken(export, args, contexts, id, false, false, reservation)
 	return results, contextInterruptError(ctx, err)
 }
+
+// hostReentryDepths retains its small map for allocation-free ordinary reuse.
+// A burst above the retained-chain cap discards the backing map after all
+// active chains unwind, so process-wide memory does not retain its high-water
+// capacity.
+var hostReentryDepths struct {
+	sync.Mutex
+	values        map[invocationID]uint8
+	resetWhenIdle bool
+}
+
+func acquireHostReentryDepth(id invocationID) (uint8, bool) {
+	hostReentryDepths.Lock()
+	defer hostReentryDepths.Unlock()
+	if hostReentryDepths.values == nil {
+		hostReentryDepths.values = make(map[invocationID]uint8)
+	}
+	depth := hostReentryDepths.values[id]
+	if depth >= maxHostReentryDepth {
+		return depth, false
+	}
+	depth++
+	hostReentryDepths.values[id] = depth
+	if len(hostReentryDepths.values) > maxRetainedHostReentryChains {
+		hostReentryDepths.resetWhenIdle = true
+	}
+	return depth, true
+}
+
+func releaseHostReentryDepth(id invocationID) {
+	hostReentryDepths.Lock()
+	defer hostReentryDepths.Unlock()
+	depth := hostReentryDepths.values[id]
+	if depth <= 1 {
+		delete(hostReentryDepths.values, id)
+		if hostReentryDepths.resetWhenIdle && len(hostReentryDepths.values) == 0 {
+			hostReentryDepths.values = nil
+			hostReentryDepths.resetWhenIdle = false
+		}
+	} else {
+		hostReentryDepths.values[id] = depth - 1
+	}
+}
+
+// Every re-entry level owns another native stack, control frame, and call
+// buffers. Four remains useful for component cycles while rejecting before
+// TinyGo's smaller host stack can corrupt its task-stack canary on supported
+// low-footprint targets.
+const (
+	maxHostReentryDepth          = 4
+	maxRetainedHostReentryChains = 64
+)
 
 // ExternRefHostModule is the optional reference-store surface implemented by the
 // HostModule value wago passes to callbacks. Keeping it separate preserves the

--- a/src/wago/runtime_regression_test.go
+++ b/src/wago/runtime_regression_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"math"
 	"os"
 	"path/filepath"
@@ -270,6 +271,221 @@ func TestRecursiveHostReentry(t *testing.T) {
 	if hostCalls != 3 {
 		t.Fatalf("host calls = %d, want 3", hostCalls)
 	}
+}
+
+func TestHostReentryDepthCounterBoundsAndReleases(t *testing.T) {
+	id := newInvocationID()
+	for want := uint8(1); want <= maxHostReentryDepth; want++ {
+		if got, ok := acquireHostReentryDepth(id); !ok || got != want {
+			t.Fatalf("acquire depth = %d, %t, want %d, true", got, ok, want)
+		}
+	}
+	if got, ok := acquireHostReentryDepth(id); ok || got != maxHostReentryDepth {
+		t.Fatalf("overflow acquire depth = %d, %t, want %d, false", got, ok, maxHostReentryDepth)
+	}
+	for range maxHostReentryDepth {
+		releaseHostReentryDepth(id)
+	}
+	hostReentryDepths.Lock()
+	_, retained := hostReentryDepths.values[id]
+	hostReentryDepths.Unlock()
+	if retained {
+		t.Fatal("released host re-entry depth retained its invocation")
+	}
+	if got, ok := acquireHostReentryDepth(id); !ok || got != 1 {
+		t.Fatalf("reacquire depth = %d, %t, want 1, true", got, ok)
+	}
+	releaseHostReentryDepth(id)
+}
+
+func TestHostReentryDepthCounterReleasesOversizedMap(t *testing.T) {
+	ids := make([]invocationID, maxRetainedHostReentryChains+1)
+	for i := range ids {
+		ids[i] = newInvocationID()
+		if _, ok := acquireHostReentryDepth(ids[i]); !ok {
+			t.Fatalf("acquire invocation %d failed", i)
+		}
+	}
+	hostReentryDepths.Lock()
+	resetWhenIdle := hostReentryDepths.resetWhenIdle
+	hostReentryDepths.Unlock()
+	if !resetWhenIdle {
+		t.Fatal("oversized host re-entry map was not marked for reset")
+	}
+	for _, id := range ids {
+		releaseHostReentryDepth(id)
+	}
+	hostReentryDepths.Lock()
+	values := hostReentryDepths.values
+	resetWhenIdle = hostReentryDepths.resetWhenIdle
+	hostReentryDepths.Unlock()
+	if values != nil || resetWhenIdle {
+		t.Fatalf("drained oversized host re-entry map = %p, reset %t; want nil, false", values, resetWhenIdle)
+	}
+}
+
+func assertHostReentryDepthsEmpty(t *testing.T) {
+	t.Helper()
+	hostReentryDepths.Lock()
+	entries := len(hostReentryDepths.values)
+	resetWhenIdle := hostReentryDepths.resetWhenIdle
+	hostReentryDepths.Unlock()
+	if entries != 0 || resetWhenIdle {
+		t.Fatalf("host re-entry accounting after unwind = %d entries, reset %t; want 0, false", entries, resetWhenIdle)
+	}
+}
+
+func TestRecursiveHostReentryDepthIsBounded(t *testing.T) {
+	funcImport := append(wasmtest.Name("env"), wasmtest.Name("reenter")...)
+	funcImport = append(funcImport, 0x00, 0x00)
+	mod := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(funcImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("recurse", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+	)
+	compiled, err := Compile(nil, mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	var in *Instance
+	host := HostFunc(func(caller HostModule, _, _ []uint64) {
+		if _, err := in.InvokeFromHost(context.Background(), caller, "recurse"); err != nil {
+			panic(HostTrap{Err: err})
+		}
+	})
+	in, err = Instantiate(compiled, InstantiateOptions{Imports: Imports{"env.reenter": host}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if _, err := in.Invoke("recurse"); err == nil || !errors.Is(err, ErrPermissionDenied) || !strings.Contains(err.Error(), "host re-entry depth") {
+		t.Fatalf("recursive re-entry error = %v, want bounded-depth rejection", err)
+	}
+	assertHostReentryDepthsEmpty(t)
+}
+
+func TestRecursiveHostReentryDepthCrossesInstanceExport(t *testing.T) {
+	typeSection := wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil)))
+	producerImport := append(wasmtest.Name("env"), wasmtest.Name("reenter")...)
+	producerImport = append(producerImport, 0x00, 0x00)
+	producerModule := wasmtest.Module(
+		typeSection,
+		wasmtest.Section(2, wasmtest.Vec(producerImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+	)
+	relayImport := append(wasmtest.Name("env"), wasmtest.Name("call")...)
+	relayImport = append(relayImport, 0x00, 0x00)
+	relayModule := wasmtest.Module(
+		typeSection,
+		wasmtest.Section(2, wasmtest.Vec(relayImport)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("recurse", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+	)
+	producerCompiled, err := Compile(nil, producerModule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producerCompiled.Close()
+	relayCompiled, err := Compile(nil, relayModule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relayCompiled.Close()
+
+	var relay *Instance
+	hostCalls := 0
+	host := HostFunc(func(caller HostModule, _, _ []uint64) {
+		hostCalls++
+		if _, err := relay.InvokeFromHost(context.Background(), caller, "recurse"); err != nil {
+			panic(HostTrap{Err: err})
+		}
+	})
+	producer, err := Instantiate(producerCompiled, InstantiateOptions{Imports: Imports{"env.reenter": host}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+	export, err := producer.ExportedFunc("call")
+	if err != nil {
+		t.Fatal(err)
+	}
+	relay, err = Instantiate(relayCompiled, InstantiateOptions{Imports: Imports{"env.call": export}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relay.Close()
+
+	if _, err := relay.Invoke("recurse"); err == nil || !errors.Is(err, ErrPermissionDenied) || !strings.Contains(err.Error(), "host re-entry depth") {
+		t.Fatalf("cross-instance recursive re-entry error = %v, want bounded-depth rejection", err)
+	}
+	if hostCalls != maxHostReentryDepth+1 {
+		t.Fatalf("host calls = %d, want %d", hostCalls, maxHostReentryDepth+1)
+	}
+	assertHostReentryDepthsEmpty(t)
+}
+
+func TestRecursiveHostReentryDepthTracksSavedOuterCaller(t *testing.T) {
+	callImportModule := func(importName, exportName string) []byte {
+		functionImport := append(wasmtest.Name("env"), wasmtest.Name(importName)...)
+		functionImport = append(functionImport, 0x00, 0x00)
+		return wasmtest.Module(
+			wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+			wasmtest.Section(2, wasmtest.Vec(functionImport)),
+			wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+			wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry(exportName, 0, 1))),
+			wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+		)
+	}
+	outerCompiled, err := Compile(nil, callImportModule("enter", "start"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outerCompiled.Close()
+	recursiveCompiled, err := Compile(nil, callImportModule("reenter", "recurse"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recursiveCompiled.Close()
+
+	var outerCaller HostModule
+	var recursive *Instance
+	hostCalls := 0
+	reenter := HostFunc(func(_ HostModule, _, _ []uint64) {
+		hostCalls++
+		if _, err := recursive.InvokeFromHost(context.Background(), outerCaller, "recurse"); err != nil {
+			panic(HostTrap{Err: err})
+		}
+	})
+	recursive, err = Instantiate(recursiveCompiled, InstantiateOptions{Imports: Imports{"env.reenter": reenter}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recursive.Close()
+	enter := HostFunc(func(caller HostModule, _, _ []uint64) {
+		outerCaller = caller
+		if _, err := recursive.InvokeFromHost(context.Background(), caller, "recurse"); err != nil {
+			panic(HostTrap{Err: err})
+		}
+	})
+	outer, err := Instantiate(outerCompiled, InstantiateOptions{Imports: Imports{"env.enter": enter}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outer.Close()
+
+	if _, err := outer.Invoke("start"); err == nil || !errors.Is(err, ErrPermissionDenied) || !strings.Contains(err.Error(), "host re-entry depth") {
+		t.Fatalf("saved-caller recursive re-entry error = %v, want bounded-depth rejection", err)
+	}
+	if hostCalls != maxHostReentryDepth {
+		t.Fatalf("saved-caller host calls = %d, want %d", hostCalls, maxHostReentryDepth)
+	}
+	assertHostReentryDepthsEmpty(t)
 }
 
 func TestConcurrentPublicInvokeWaitsForParkedHostCallback(t *testing.T) {


### PR DESCRIPTION
## Summary

Bounds synchronous host-to-Wasm re-entry by the active invocation identity.

Each nested activation owns an isolated engine, native stack, control frame, trap cell, and call buffers. Recursive callbacks could otherwise grow those resources without a process-enforced depth limit.

## Changes

- count active re-entry depth under the shared invocation identity;
- reject the fifth nested activation before another engine is acquired;
- apply the same bound across instance exports and producer/relay dispatch;
- resist retained outer caller tokens by not trusting token snapshots for current depth;
- delete invocation entries on every unwind path;
- retain a small reusable map for allocation-free steady-state accounting and discard oversized backing after more than 64 concurrent chains drain;
- preserve the current simplified imports and invocation API.

Sequential host calls and ordinary shallow component cycles are unchanged.

## Security and footprint

This is denial-of-service and resource-exhaustion hardening. A call chain now retains at most four nested re-entry engines, about 16 MiB of native stack reservation, instead of growing without a bound. Ordinary JIT and host calls do not take the new lock; only explicit `InvokeFromHost` entry uses it.

`BenchmarkHostReentryDepthAccounting`, Apple M4 Max, five samples:

- 21.5-21.9 ns/op;
- 0 B/op;
- 0 allocs/op.

## Verification

- `just test`
- focused re-entry and cleanup tests, 10 repetitions
- focused race tests, 10 repetitions
- `just test tinygo`
- `git diff --check`

Local Darwin/ARM64 `just lint` reaches the existing `interrupt_darwin_arm64.go` unsafe-pointer vet warning on both this branch and exact current main; the changed files pass formatting and repository tests.

## Documentation

`Instance.InvokeFromHost` documents the four-active-entry limit and `ErrPermissionDenied` result.