### PR TITLE
runtime: support explicit externref release

### DIFF
--- a/src/wago/externref.go
+++ b/src/wago/externref.go
@@ -38,6 +38,24 @@ func (rt *Runtime) ExternRefValue(ref ExternRef) (any, bool) {
 	return rt.refStore.resolveExternref(ref.token)
 }
 
+// ReleaseExternRef releases the host value retained by ref. It returns false
+// for a stale, forged, or foreign token. The caller must first remove the token
+// from every Wasm table, global, and other location that may still use it.
+func (rt *Runtime) ReleaseExternRef(ref ExternRef) bool {
+	if ref.IsNull() {
+		return true
+	}
+	if rt == nil || rt.refStore == nil {
+		return false
+	}
+	operation, err := rt.beginOperation("ReleaseExternRef", false)
+	if err != nil {
+		return false
+	}
+	defer operation.end()
+	return rt.refStore.releaseExternref(ref.token)
+}
+
 // NewExternRef registers value in this instance's reference store. Runtime
 // instances use their shared runtime store; standalone instances create a lazy
 // private store whose tokens are incompatible with other standalone instances.
@@ -67,6 +85,18 @@ func (in *Instance) ExternRefValue(ref ExternRef) (any, bool) {
 		return nil, false
 	}
 	return in.refStore.resolveExternref(ref.token)
+}
+
+// ReleaseExternRef releases an externref from this instance's compatible store.
+// The token must no longer be reachable by Wasm. Stale and foreign tokens fail.
+func (in *Instance) ReleaseExternRef(ref ExternRef) bool {
+	if ref.IsNull() {
+		return true
+	}
+	if in == nil || in.refStore == nil || in.rt != nil && in.rt.isClosed() {
+		return false
+	}
+	return in.refStore.releaseExternref(ref.token)
 }
 
 func (in *Instance) validExternrefToken(token uint64) bool {

--- a/src/wago/externref_test.go
+++ b/src/wago/externref_test.go
@@ -313,6 +313,37 @@ func TestExternrefGenerationAndStoreTeardown(t *testing.T) {
 	}
 }
 
+func TestRuntimeExternrefExplicitReleaseReusesSlot(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	first, err := rt.NewExternRef("first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rt.ReleaseExternRef(first) {
+		t.Fatal("release live externref failed")
+	}
+	if rt.ReleaseExternRef(first) {
+		t.Fatal("released externref accepted twice")
+	}
+	if _, ok := rt.ExternRefValue(first); ok {
+		t.Fatal("released externref still resolved")
+	}
+	second, err := rt.NewExternRef("second")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.refStore.externrefs) != 1 {
+		t.Fatalf("externref slots = %d, want reuse at high-water mark 1", len(rt.refStore.externrefs))
+	}
+	if value, ok := rt.ExternRefValue(second); !ok || value != "second" {
+		t.Fatalf("reused externref = %v, %v", value, ok)
+	}
+	if _, ok := rt.ExternRefValue(first); ok {
+		t.Fatal("stale token resolved after slot reuse")
+	}
+}
+
 func TestExternrefCodecCarriesStructureButNoStoreIdentity(t *testing.T) {
 	c := compileExplicitArtifact(t, externrefControlModule())
 	blob, err := c.MarshalBinary()

--- a/src/wago/externref_test.go
+++ b/src/wago/externref_test.go
@@ -133,6 +133,17 @@ func TestExternrefHostImportRoundTripsObjects(t *testing.T) {
 	in, err := rt.Instantiate(context.Background(), mod, WithImports(Imports{
 		"env.echo": HostFunc(func(m HostModule, params, results []uint64) {
 			calls++
+			hostRefs, ok := m.(ExternRefHostModule)
+			if !ok {
+				t.Fatalf("host module %T does not expose externref lifecycle", m)
+			}
+			temporary := issueExternref(t, hostRefs, "temporary")
+			if !hostRefs.ReleaseExternRef(temporary) {
+				t.Fatal("host callback could not release temporary externref")
+			}
+			if _, ok := hostRefs.ExternRefValue(temporary); ok {
+				t.Fatal("released host-callback externref still resolved")
+			}
 			ref := ValueOf(ValExternRef, params[0]).ExternRef()
 			if got := resolveExternref(t, m, ref); got != inputObject {
 				t.Fatalf("host resolved %#v, want original input object", got)

--- a/src/wago/externref_test.go
+++ b/src/wago/externref_test.go
@@ -344,6 +344,22 @@ func TestRuntimeExternrefExplicitReleaseReusesSlot(t *testing.T) {
 	}
 }
 
+func TestRuntimeExternrefReleaseUsesSlotOwnershipNotPayloadType(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	payload := &HostFuncRef{}
+	ref, err := rt.NewExternRef(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rt.ReleaseExternRef(ref) {
+		t.Fatal("release of user-owned HostFuncRef payload failed")
+	}
+	if _, ok := rt.ExternRefValue(ref); ok {
+		t.Fatal("released HostFuncRef payload still resolved")
+	}
+}
+
 func TestExternrefCodecCarriesStructureButNoStoreIdentity(t *testing.T) {
 	c := compileExplicitArtifact(t, externrefControlModule())
 	blob, err := c.MarshalBinary()

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -70,6 +70,8 @@ type ExternRefHostModule interface {
 	// ExternRefValue resolves a token from the calling instance's compatible
 	// store. Forged, stale, and incompatible-store tokens return false.
 	ExternRefValue(ExternRef) (any, bool)
+	// ReleaseExternRef releases a token after it is no longer reachable by Wasm.
+	ReleaseExternRef(ExternRef) bool
 }
 
 // GCHostModule is the optional exact-collection surface implemented by HostModule
@@ -253,6 +255,9 @@ func (h staticHostModule) NewExternRef(value any) (ExternRef, error) {
 }
 func (h staticHostModule) ExternRefValue(ref ExternRef) (any, bool) {
 	return h.in.ExternRefValue(ref)
+}
+func (h staticHostModule) ReleaseExternRef(ref ExternRef) bool {
+	return h.in.ReleaseExternRef(ref)
 }
 
 // HostFuncRef is an explicit Runtime/store ownership handle for a host function
@@ -801,6 +806,12 @@ func (h instanceHostModule) ExternRefValue(ref ExternRef) (any, bool) {
 		return nil, false
 	}
 	return h.in.ExternRefValue(ref)
+}
+func (h instanceHostModule) ReleaseExternRef(ref ExternRef) bool {
+	if !h.valid() {
+		return false
+	}
+	return h.in.ReleaseExternRef(ref)
 }
 
 // bindHostImport normalizes an Imports value into a HostFunc for the synchronous

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -732,6 +732,8 @@ type externrefSlot struct {
 	nextFree   uint32
 }
 
+const externrefInternalSlot = ^uint32(0)
+
 func newReferenceStore(private bool) *referenceStore {
 	return &referenceStore{private: private, runtimeClosed: private}
 }
@@ -1675,7 +1677,7 @@ func (s *referenceStore) registerHostFuncRef(owner *HostFuncRef) (uint32, error)
 		return 0, fmt.Errorf("wago: reference store has too many live objects")
 	}
 	s.liveObjects++
-	s.externrefs = append(s.externrefs, externrefSlot{value: owner})
+	s.externrefs = append(s.externrefs, externrefSlot{value: owner, nextFree: externrefInternalSlot})
 	return uint32(len(s.externrefs)), nil
 }
 
@@ -1703,7 +1705,7 @@ func (s *referenceStore) registerHostFuncRefBindingLocked(binding *hostFuncRefDi
 	if len(s.externrefs) >= int(hostFuncRefDispatchBit-1) {
 		return 0, fmt.Errorf("wago: reference store has too many host dispatch bindings")
 	}
-	s.externrefs = append(s.externrefs, externrefSlot{value: binding, generation: 1})
+	s.externrefs = append(s.externrefs, externrefSlot{value: binding, generation: 1, nextFree: externrefInternalSlot})
 	return uint32(len(s.externrefs)), nil
 }
 
@@ -2531,11 +2533,7 @@ func (s *referenceStore) releaseExternref(token uint64) bool {
 		return false
 	}
 	slot := &s.externrefs[index-1]
-	if slot.generation != generation || slot.value == releasedExternrefValue {
-		return false
-	}
-	switch slot.value.(type) {
-	case *HostFuncRef, *hostFuncRefDispatchBinding:
+	if slot.generation != generation || slot.value == releasedExternrefValue || slot.nextFree == externrefInternalSlot {
 		return false
 	}
 	slot.value = releasedExternrefValue

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -36,6 +36,7 @@ type referenceStore struct {
 	gcByToken     map[uint64]gcRefTokenEntry
 	externKey     uint64
 	externSeed    uint32
+	externFree    uint32
 	externrefs    []externrefSlot
 	gcDomains     *gcDomainTopology
 }
@@ -728,6 +729,7 @@ type gcPublicState struct {
 type externrefSlot struct {
 	value      any
 	generation uint32
+	nextFree   uint32
 }
 
 func newReferenceStore(private bool) *referenceStore {
@@ -2473,7 +2475,7 @@ func (s *referenceStore) issueExternref(value any) (uint64, error) {
 	if s.runtimeClosed && !s.private {
 		return 0, fmt.Errorf("wago: reference store is closed")
 	}
-	if uint64(len(s.externrefs)) >= uint64(^uint32(0)) {
+	if s.externFree == 0 && uint64(len(s.externrefs)) >= uint64(^uint32(0)) {
 		return 0, fmt.Errorf("wago: externref store is full")
 	}
 	if s.externKey == 0 {
@@ -2484,23 +2486,63 @@ func (s *referenceStore) issueExternref(value any) (uint64, error) {
 		s.externKey = key
 		s.externSeed = uint32(key>>32) | 1
 	}
-	index := uint32(len(s.externrefs)) + 1
-	generation := s.externSeed + index - 1
-	if generation == 0 {
-		generation = 1
-	}
-	for {
-		raw := uint64(generation)<<32 | uint64(index)
-		token := bits.RotateLeft64(raw^s.externKey, 17)
-		if token != 0 {
-			s.externrefs = append(s.externrefs, externrefSlot{value: value, generation: generation})
-			return token, nil
-		}
-		generation++
+	var index uint32
+	if s.externFree != 0 {
+		index = s.externFree
+		slot := &s.externrefs[index-1]
+		s.externFree = slot.nextFree
+		slot.nextFree = 0
+		slot.value = value
+	} else {
+		index = uint32(len(s.externrefs)) + 1
+		generation := s.externSeed + index - 1
 		if generation == 0 {
 			generation = 1
 		}
+		s.externrefs = append(s.externrefs, externrefSlot{value: value, generation: generation})
 	}
+	slot := &s.externrefs[index-1]
+	for {
+		raw := uint64(slot.generation)<<32 | uint64(index)
+		token := bits.RotateLeft64(raw^s.externKey, 17)
+		if token != 0 {
+			return token, nil
+		}
+		slot.generation = nextExternrefGeneration(slot.generation)
+	}
+}
+
+type releasedExternrefMarker struct{ reserved byte }
+
+var releasedExternrefValue = &releasedExternrefMarker{}
+
+func (s *referenceStore) releaseExternref(token uint64) bool {
+	if token == 0 {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.externKey == 0 {
+		return false
+	}
+	raw := bits.RotateLeft64(token, -17) ^ s.externKey
+	index, generation := uint32(raw), uint32(raw>>32)
+	if index == 0 || uint64(index) > uint64(len(s.externrefs)) {
+		return false
+	}
+	slot := &s.externrefs[index-1]
+	if slot.generation != generation || slot.value == releasedExternrefValue {
+		return false
+	}
+	switch slot.value.(type) {
+	case *HostFuncRef, *hostFuncRefDispatchBinding:
+		return false
+	}
+	slot.value = releasedExternrefValue
+	slot.generation = nextExternrefGeneration(slot.generation)
+	slot.nextFree = s.externFree
+	s.externFree = index
+	return true
 }
 
 func (s *referenceStore) resolveExternref(token uint64) (any, bool) {
@@ -2577,6 +2619,7 @@ func (s *referenceStore) releaseEntriesLocked() referenceTokenEntries {
 	s.externrefs = nil
 	s.externKey = 0
 	s.externSeed = 0
+	s.externFree = 0
 	if topology := s.gcDomains; topology != nil {
 		for domain := topology.first; domain != nil; domain = domain.next {
 			entries.collectors = append(entries.collectors, domain.collector)

--- a/src/wago/reference_value_test.go
+++ b/src/wago/reference_value_test.go
@@ -246,6 +246,9 @@ func TestHostFuncRefValidationAndLifecycleHelpers(t *testing.T) {
 	if _, ok := expired.ExternRefValue(ExternRef{}); ok {
 		t.Fatal("expired host module resolved externref")
 	}
+	if expired.ReleaseExternRef(ExternRef{}) {
+		t.Fatal("expired host module released externref")
+	}
 	if err := rt.Close(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Small correctness fix: runtime-scoped externrefs retained host values until the whole runtime closed, so transient references accumulated in long-lived embeddings.

`Runtime.ReleaseExternRef` and `Instance.ReleaseExternRef` now invalidate tokens and release their host values. Freed slots are reused with a bumped generation, keeping stale tokens invalid. The free-list link fits existing 64-bit slot padding, so `externrefSlot` remains 24 bytes.

Callers must remove a token from Wasm storage before releasing it, as documented on the new methods.

Proof:
- `go test ./src/wago -run '^(TestRuntimeExternrefExplicitReleaseReusesSlot|TestExternrefGenerationAndStoreTeardown|TestExternref.*|TestRuntime.*ExternRef.*)$'`