### PR TITLE
cli: bound module inputs and artifact cache

### DIFF
--- a/cli/runtime/commands/build/command.go
+++ b/cli/runtime/commands/build/command.go
@@ -14,6 +14,7 @@ import (
 	"github.com/wago-org/wago/cli/internal/settings"
 	"github.com/wago-org/wago/cli/internal/ui"
 	runcmd "github.com/wago-org/wago/cli/runtime/commands/run"
+	"github.com/wago-org/wago/cli/runtime/internal/modulefile"
 )
 
 type Environment interface {
@@ -81,7 +82,7 @@ func (cmd implementation) Run(c *command.Ctx) {
 		automation.PrintPlan("build artifact", plan)
 		return
 	}
-	source, err := os.ReadFile(input)
+	source, err := modulefile.Read(input)
 	if err != nil {
 		ui.Fatal("build: %v", err)
 	}

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -186,6 +187,9 @@ func TestLoadModuleAndResolveExport(t *testing.T) {
 	withTrailing := append(append([]byte(nil), encoded...), 0)
 	if compiled, err := loadCompiledArtifact(withTrailing); err == nil || compiled != nil || !strings.Contains(err.Error(), "trailing 1 byte") {
 		t.Fatalf("artifact with trailing byte = %v, %v; want rejection", compiled, err)
+	}
+	if compiled, err := loadCompiledArtifactReader(bytes.NewReader(withTrailing), -1); err == nil || compiled != nil || !strings.Contains(err.Error(), "trailing data") {
+		t.Fatalf("streamed artifact with trailing byte = %v, %v; want rejection", compiled, err)
 	}
 }
 

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -181,6 +182,32 @@ func TestLoadModuleAndResolveExport(t *testing.T) {
 	}
 	if got := mustResolveExport(mustLoadModule(compiledPath, config, rt, artifactcache.Cache{}).Compiled(), "f"); got != "f" {
 		t.Fatalf("loaded export = %q", got)
+	}
+}
+
+func TestLoadCompiledArtifactEnforcesSectionLimits(t *testing.T) {
+	limits := wago.DefaultArtifactLimits()
+	for _, tc := range []struct {
+		name        string
+		codeBytes   uint64
+		metadataLen uint64
+		want        string
+	}{
+		{name: "code", codeBytes: uint64(limits.MaxCodeBytes) + 1, want: "code section length"},
+		{name: "metadata", metadataLen: uint64(limits.MaxMetadataBytes) + 1, want: "metadata section length"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact := []byte{'W', 'A', 'G', 'O', 1, 2, 1}
+			artifact = binary.AppendUvarint(artifact, tc.codeBytes)
+			if tc.codeBytes == 0 {
+				artifact = append(artifact, 2)
+				artifact = binary.AppendUvarint(artifact, tc.metadataLen)
+			}
+			compiled, err := loadCompiledArtifact(artifact)
+			if err == nil || compiled != nil || !strings.Contains(err.Error(), tc.want) || !strings.Contains(err.Error(), "exceeds limit") {
+				t.Fatalf("loadCompiledArtifact = %v, %v; want bounded %s error", compiled, err, tc.want)
+			}
+		})
 	}
 }
 

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -183,6 +183,10 @@ func TestLoadModuleAndResolveExport(t *testing.T) {
 	if got := mustResolveExport(mustLoadModule(compiledPath, config, rt, artifactcache.Cache{}).Compiled(), "f"); got != "f" {
 		t.Fatalf("loaded export = %q", got)
 	}
+	withTrailing := append(append([]byte(nil), encoded...), 0)
+	if compiled, err := loadCompiledArtifact(withTrailing); err == nil || compiled != nil || !strings.Contains(err.Error(), "trailing 1 byte") {
+		t.Fatalf("artifact with trailing byte = %v, %v; want rejection", compiled, err)
+	}
 }
 
 func TestLoadCompiledArtifactEnforcesSectionLimits(t *testing.T) {

--- a/cli/runtime/commands/run/module.go
+++ b/cli/runtime/commands/run/module.go
@@ -9,7 +9,7 @@ import (
 )
 
 func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runtime, cache artifactcache.Cache) *wago.Module {
-	source, err := modulefile.Read(file)
+	source, err := modulefile.ReadSourceOrArtifact(file)
 	if err != nil {
 		ui.Fatal("%v", err)
 	}

--- a/cli/runtime/commands/run/module.go
+++ b/cli/runtime/commands/run/module.go
@@ -1,16 +1,15 @@
 package run
 
 import (
-	"os"
-
 	"github.com/wago-org/wago"
 	"github.com/wago-org/wago/cli/internal/ui"
 	"github.com/wago-org/wago/cli/internal/wasmcall"
 	"github.com/wago-org/wago/cli/runtime/internal/artifactcache"
+	"github.com/wago-org/wago/cli/runtime/internal/modulefile"
 )
 
 func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runtime, cache artifactcache.Cache) *wago.Module {
-	source, err := os.ReadFile(file)
+	source, err := modulefile.Read(file)
 	if err != nil {
 		ui.Fatal("%v", err)
 	}

--- a/cli/runtime/commands/run/module.go
+++ b/cli/runtime/commands/run/module.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"bytes"
+
 	"github.com/wago-org/wago"
 	"github.com/wago-org/wago/cli/internal/ui"
 	"github.com/wago-org/wago/cli/internal/wasmcall"
@@ -14,11 +16,11 @@ func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runti
 		ui.Fatal("%v", err)
 	}
 	if wago.IsCompiled(source) {
-		compiled, err := wago.Load(source)
+		compiled, err := loadCompiledArtifact(source)
 		if err != nil {
 			ui.Fatal("%v", err)
 		}
-		module, err := runtime.Module(compiled)
+		module, err := runtime.AdoptModule(compiled)
 		if err != nil {
 			ui.Fatal("%v", err)
 		}
@@ -29,6 +31,14 @@ func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runti
 		ui.Fatal("%v", err)
 	}
 	return module
+}
+
+func loadCompiledArtifact(source []byte) (*wago.Compiled, error) {
+	compiled := new(wago.Compiled)
+	if _, err := compiled.ReadFromWithLimits(bytes.NewReader(source), wago.DefaultArtifactLimits()); err != nil {
+		return nil, err
+	}
+	return compiled, nil
 }
 
 func mustResolveExport(compiled *wago.Compiled, requested string) string {

--- a/cli/runtime/commands/run/module.go
+++ b/cli/runtime/commands/run/module.go
@@ -2,7 +2,9 @@ package run
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/wago-org/wago"
 	"github.com/wago-org/wago/cli/internal/ui"
@@ -12,12 +14,17 @@ import (
 )
 
 func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runtime, cache artifactcache.Cache) *wago.Module {
-	source, err := modulefile.ReadSourceOrArtifact(file)
+	input, err := modulefile.OpenSourceOrArtifact(file)
 	if err != nil {
 		ui.Fatal("%v", err)
 	}
-	if wago.IsCompiled(source) {
-		compiled, err := loadCompiledArtifact(source)
+	defer input.Close()
+	if input.IsArtifact() {
+		size, regular := input.Size()
+		if !regular {
+			size = -1
+		}
+		compiled, err := loadCompiledArtifactReader(input, size)
 		if err != nil {
 			ui.Fatal("%v", err)
 		}
@@ -27,6 +34,10 @@ func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runti
 		}
 		return module
 	}
+	source, err := input.ReadSource()
+	if err != nil {
+		ui.Fatal("%v", err)
+	}
 	module, err := cache.LoadOrCompile(source, config, runtime)
 	if err != nil {
 		ui.Fatal("%v", err)
@@ -35,14 +46,32 @@ func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runti
 }
 
 func loadCompiledArtifact(source []byte) (*wago.Compiled, error) {
+	return loadCompiledArtifactReader(bytes.NewReader(source), int64(len(source)))
+}
+
+func loadCompiledArtifactReader(source io.Reader, size int64) (*wago.Compiled, error) {
 	compiled := new(wago.Compiled)
-	read, err := compiled.ReadFromWithLimits(bytes.NewReader(source), wago.DefaultArtifactLimits())
+	read, err := compiled.ReadFromWithLimits(source, wago.DefaultArtifactLimits())
 	if err != nil {
+		_ = compiled.Close()
 		return nil, err
 	}
-	if read != int64(len(source)) {
+	if size >= 0 && read != size {
 		_ = compiled.Close()
-		return nil, fmt.Errorf("trailing %d byte(s) after compiled sections", int64(len(source))-read)
+		if read < size {
+			return nil, fmt.Errorf("trailing %d byte(s) after compiled sections", size-read)
+		}
+		return nil, fmt.Errorf("compiled artifact changed size while being read")
+	}
+	var trailing [1]byte
+	n, trailingErr := source.Read(trailing[:])
+	if n != 0 {
+		_ = compiled.Close()
+		return nil, fmt.Errorf("trailing data after compiled sections")
+	}
+	if trailingErr != nil && !errors.Is(trailingErr, io.EOF) {
+		_ = compiled.Close()
+		return nil, trailingErr
 	}
 	return compiled, nil
 }

--- a/cli/runtime/commands/run/module.go
+++ b/cli/runtime/commands/run/module.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/wago-org/wago"
 	"github.com/wago-org/wago/cli/internal/ui"
@@ -35,8 +36,13 @@ func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runti
 
 func loadCompiledArtifact(source []byte) (*wago.Compiled, error) {
 	compiled := new(wago.Compiled)
-	if _, err := compiled.ReadFromWithLimits(bytes.NewReader(source), wago.DefaultArtifactLimits()); err != nil {
+	read, err := compiled.ReadFromWithLimits(bytes.NewReader(source), wago.DefaultArtifactLimits())
+	if err != nil {
 		return nil, err
+	}
+	if read != int64(len(source)) {
+		_ = compiled.Close()
+		return nil, fmt.Errorf("trailing %d byte(s) after compiled sections", int64(len(source))-read)
 	}
 	return compiled, nil
 }

--- a/cli/runtime/commands/run/module.go
+++ b/cli/runtime/commands/run/module.go
@@ -14,17 +14,13 @@ import (
 )
 
 func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runtime, cache artifactcache.Cache) *wago.Module {
-	input, err := modulefile.OpenSourceOrArtifact(file)
+	source, artifact, artifactFile, size, err := modulefile.ReadSourceOrOpenArtifact(file)
 	if err != nil {
 		ui.Fatal("%v", err)
 	}
-	defer input.Close()
-	if input.IsArtifact() {
-		size, regular := input.Size()
-		if !regular {
-			size = -1
-		}
-		compiled, err := loadCompiledArtifactReader(input, size)
+	if artifact != nil {
+		defer artifactFile.Close()
+		compiled, err := loadCompiledArtifactReader(artifact, size)
 		if err != nil {
 			ui.Fatal("%v", err)
 		}
@@ -33,10 +29,6 @@ func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runti
 			ui.Fatal("%v", err)
 		}
 		return module
-	}
-	source, err := input.ReadSource()
-	if err != nil {
-		ui.Fatal("%v", err)
 	}
 	module, err := cache.LoadOrCompile(source, config, runtime)
 	if err != nil {

--- a/cli/runtime/commands/validate/command.go
+++ b/cli/runtime/commands/validate/command.go
@@ -3,7 +3,6 @@ package validate
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 
 	"github.com/wago-org/wago/cli/internal/automation"
@@ -11,6 +10,7 @@ import (
 	"github.com/wago-org/wago/cli/internal/settings"
 	"github.com/wago-org/wago/cli/internal/ui"
 	runcmd "github.com/wago-org/wago/cli/runtime/commands/run"
+	"github.com/wago-org/wago/cli/runtime/internal/modulefile"
 	"github.com/wago-org/wago/internal/functionworkers"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
@@ -33,7 +33,7 @@ func run(c *command.Ctx) {
 	if len(c.Args) != 1 {
 		ui.Usage("validate: need exactly one <file>")
 	}
-	src, err := os.ReadFile(c.Args[0])
+	src, err := modulefile.Read(c.Args[0])
 	if err != nil {
 		ui.Fatal("%v", err)
 	}

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -113,6 +113,9 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 			return module, nil
 		}
 		if sizes.Total > limit {
+			if err := cache.pruneIfDue(time.Now()); err != nil {
+				cache.report(err)
+			}
 			return module, nil
 		}
 	}
@@ -227,7 +230,7 @@ func (cache Cache) prune() error {
 		total += entry.size
 		return nil
 	}
-	err := scanCacheFiles(cache.Dir, true, visit)
+	err := scanCacheFiles(cache.Dir, visit)
 	if err != nil || total <= limit {
 		return err
 	}
@@ -250,8 +253,7 @@ func cacheEntryNewer(left, right cacheEntry) bool {
 
 // scanCacheFiles uses File.ReadDir batches instead of os.ReadDir or WalkDir,
 // both of which read and sort a complete directory before yielding entries.
-// Automatic cache paths have one shard directory, so deeper trees are ignored.
-func scanCacheFiles(dir string, descend bool, visit func(string, os.FileInfo) error) error {
+func scanCacheFiles(dir string, visit func(string, os.FileInfo) error) error {
 	directory, err := os.Open(dir)
 	if err != nil {
 		return err
@@ -269,10 +271,8 @@ func scanCacheFiles(dir string, descend bool, visit func(string, os.FileInfo) er
 				return err
 			}
 			if info.IsDir() {
-				if descend {
-					if err := scanCacheFiles(path, false, visit); err != nil {
-						return err
-					}
+				if err := scanCacheFiles(path, visit); err != nil {
+					return err
 				}
 				continue
 			}

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -2,10 +2,10 @@
 package artifactcache
 
 import (
-	"container/heap"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -191,24 +191,44 @@ type cacheEntry struct {
 
 type cacheEntryHeap []cacheEntry
 
-func (h cacheEntryHeap) Len() int { return len(h) }
-func (h cacheEntryHeap) Less(i, j int) bool {
-	if h[i].modTime.Equal(h[j].modTime) {
-		return h[i].path < h[j].path
+func pushCacheEntry(entries *cacheEntryHeap, entry cacheEntry) {
+	h := append(*entries, entry)
+	for child := len(h) - 1; child > 0; {
+		parent := (child - 1) / 2
+		if !cacheEntryOlder(h[child], h[parent]) {
+			break
+		}
+		h[parent], h[child] = h[child], h[parent]
+		child = parent
 	}
-	return h[i].modTime.Before(h[j].modTime)
+	*entries = h
 }
-func (h cacheEntryHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
-func (h *cacheEntryHeap) Push(value interface{}) {
-	*h = append(*h, value.(cacheEntry))
-}
-func (h *cacheEntryHeap) Pop() interface{} {
-	old := *h
-	last := len(old) - 1
-	value := old[last]
-	old[last] = cacheEntry{}
-	*h = old[:last]
-	return value
+
+func popOldestCacheEntry(entries *cacheEntryHeap) cacheEntry {
+	h := *entries
+	oldest := h[0]
+	last := len(h) - 1
+	h[0] = h[last]
+	h[last] = cacheEntry{}
+	h = h[:last]
+	for parent := 0; ; {
+		left := parent*2 + 1
+		if left >= len(h) {
+			break
+		}
+		child := left
+		right := left + 1
+		if right < len(h) && cacheEntryOlder(h[right], h[left]) {
+			child = right
+		}
+		if !cacheEntryOlder(h[child], h[parent]) {
+			break
+		}
+		h[parent], h[child] = h[child], h[parent]
+		parent = child
+	}
+	*entries = h
+	return oldest
 }
 
 func (cache Cache) prune() error {
@@ -230,7 +250,7 @@ func (cache Cache) prune() error {
 	visit := func(path string, info os.FileInfo) error {
 		entry := cacheEntry{path: path, size: info.Size(), modTime: info.ModTime()}
 		if len(entries) < maxPruneEntries {
-			heap.Push(&entries, entry)
+			pushCacheEntry(&entries, entry)
 			total += entry.size
 			return nil
 		}
@@ -241,9 +261,9 @@ func (cache Cache) prune() error {
 		if err := remove(oldest); err != nil {
 			return err
 		}
-		heap.Pop(&entries)
+		popOldestCacheEntry(&entries)
 		total -= oldest.size
-		heap.Push(&entries, entry)
+		pushCacheEntry(&entries, entry)
 		total += entry.size
 		return nil
 	}
@@ -252,7 +272,7 @@ func (cache Cache) prune() error {
 		return err
 	}
 	for total > limit && len(entries) != 0 {
-		entry := heap.Pop(&entries).(cacheEntry)
+		entry := popOldestCacheEntry(&entries)
 		if err := remove(entry); err != nil {
 			return err
 		}
@@ -268,11 +288,15 @@ func cacheEntryNewer(left, right cacheEntry) bool {
 	return left.modTime.After(right.modTime)
 }
 
-// scanCacheFiles uses File.ReadDir batches instead of os.ReadDir or WalkDir,
+func cacheEntryOlder(left, right cacheEntry) bool {
+	return cacheEntryNewer(right, left)
+}
+
+// scanCacheFiles uses File.Readdir batches instead of os.ReadDir or WalkDir,
 // both of which read and sort a complete directory before yielding entries.
 func scanCacheFiles(dir string, depth int, visit func(string, os.FileInfo) error) error {
 	if depth > maxCacheDirectoryDepth {
-		return fmt.Errorf("cache directory nesting exceeds limit %d at %s", maxCacheDirectoryDepth, dir)
+		return errors.New("cache directory nesting exceeds limit")
 	}
 	directory, err := os.Open(dir)
 	if err != nil {
@@ -280,23 +304,20 @@ func scanCacheFiles(dir string, depth int, visit func(string, os.FileInfo) error
 	}
 	defer directory.Close()
 	for {
-		entries, readErr := directory.ReadDir(128)
-		for _, entry := range entries {
-			if entry.Type()&os.ModeSymlink != 0 {
+		entries, readErr := directory.Readdir(128)
+		for _, info := range entries {
+			if info.Mode()&os.ModeSymlink != 0 {
 				continue
 			}
-			path := filepath.Join(dir, entry.Name())
-			info, err := entry.Info()
-			if err != nil {
-				return err
-			}
+			name := info.Name()
+			path := filepath.Join(dir, name)
 			if info.IsDir() {
 				if err := scanCacheFiles(path, depth+1, visit); err != nil {
 					return err
 				}
 				continue
 			}
-			if info.Mode().IsRegular() && info.Size() >= 0 && filepath.Ext(path) == ".wago" {
+			if info.Mode().IsRegular() && info.Size() >= 0 && len(name) >= 5 && name[len(name)-5:] == ".wago" {
 				if err := visit(path, info); err != nil {
 					return err
 				}

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -83,6 +83,9 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 	cacheable = cacheable && cacheableGeneration
 	if cacheable {
 		if compiled, hit := loadArtifact(path); hit {
+			if err := cache.prune(); err != nil {
+				cache.report(err)
+			}
 			return prepared.Adopt(compiled)
 		}
 	}

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -144,12 +144,11 @@ func (cache Cache) pruneIfDue(now time.Time) error {
 	marker := filepath.Join(cache.Dir, cachePruneMarker)
 	info, err := os.Lstat(marker)
 	if err == nil {
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("cache prune marker %s is not a regular file", marker)
-		}
-		age := now.Sub(info.ModTime())
-		if age >= 0 && age < cachePruneInterval {
-			return nil
+		if info.Mode().IsRegular() {
+			age := now.Sub(info.ModTime())
+			if age >= 0 && age < cachePruneInterval {
+				return nil
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		return err
@@ -175,6 +174,11 @@ func (cache Cache) pruneAndMark() error {
 		return nil
 	}
 	marker := filepath.Join(cache.Dir, cachePruneMarker)
+	if info, err := os.Lstat(marker); err == nil && !info.Mode().IsRegular() {
+		return nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
 	return atomicfile.ReplaceFile(marker, atomicfile.Options{Mode: 0o600}, func(io.Writer) error { return nil })
 }
 

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -109,20 +110,11 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 	if limit == 0 {
 		limit = DefaultMaxBytes
 	}
-	if limit >= 0 {
-		sizes, err := module.Compiled().ArtifactSectionSizes()
-		if err != nil {
+	if err := publishArtifact(path, module.Compiled(), limit); errors.Is(err, errArtifactExceedsCacheLimit) {
+		if err := cache.pruneIfDue(time.Now()); err != nil {
 			cache.report(err)
-			return module, nil
 		}
-		if sizes.Total > limit {
-			if err := cache.pruneIfDue(time.Now()); err != nil {
-				cache.report(err)
-			}
-			return module, nil
-		}
-	}
-	if err := publishArtifact(path, module.Compiled()); err != nil {
+	} else if err != nil {
 		cache.report(err)
 	} else if err := cache.pruneAndMark(); err != nil {
 		cache.report(err)
@@ -440,6 +432,8 @@ func writeUint64(h interface{ Write([]byte) (int, error) }, value uint64) {
 	h.Write(encoded[:])
 }
 
+var errArtifactExceedsCacheLimit = errors.New("compiled artifact exceeds cache limit")
+
 var publishArtifact = writeAtomic
 
 func loadArtifact(path string) (*wago.Compiled, bool) {
@@ -485,9 +479,25 @@ func loadOpenedArtifact(path string, file *os.File, opened os.FileInfo) (*wago.C
 	return compiled, true
 }
 
-func writeAtomic(path string, compiled *wago.Compiled) error {
+type artifactLimitWriter struct {
+	target    io.Writer
+	remaining int64
+}
+
+func (writer *artifactLimitWriter) Write(p []byte) (int, error) {
+	if writer.remaining >= 0 && int64(len(p)) > writer.remaining {
+		return 0, errArtifactExceedsCacheLimit
+	}
+	n, err := writer.target.Write(p)
+	if writer.remaining >= 0 {
+		writer.remaining -= int64(n)
+	}
+	return n, err
+}
+
+func writeAtomic(path string, compiled *wago.Compiled, limit int64) error {
 	return atomicfile.ReplaceFile(path, atomicfile.Options{Mode: 0o644}, func(writer io.Writer) error {
-		_, err := compiled.WriteTo(writer)
+		_, err := compiled.WriteTo(&artifactLimitWriter{target: writer, remaining: limit})
 		return err
 	})
 }

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/wago-org/wago"
@@ -40,6 +41,10 @@ const DefaultMaxBytes int64 = 512 << 20
 
 // maxPruneEntries bounds both cache file count and prune's in-memory index.
 const maxPruneEntries = 4096
+
+const cacheHitPruneInterval = 64
+
+var cacheHitPruneCount atomic.Uint64
 
 var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	info, ok := debug.ReadBuildInfo()
@@ -83,8 +88,13 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 	cacheable = cacheable && cacheableGeneration
 	if cacheable {
 		if compiled, hit := loadArtifact(path); hit {
-			if err := cache.prune(); err != nil {
-				cache.report(err)
+			// Retry missed maintenance on the first process hit and periodically
+			// thereafter without turning every warm load into a full cache scan.
+			hits := cacheHitPruneCount.Add(1)
+			if hits == 1 || hits%cacheHitPruneInterval == 0 {
+				if err := cache.prune(); err != nil {
+					cache.report(err)
+				}
 			}
 			return prepared.Adopt(compiled)
 		}

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -2,6 +2,7 @@
 package artifactcache
 
 import (
+	"container/heap"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -11,7 +12,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"sort"
 	"sync"
 	"time"
 
@@ -116,6 +116,28 @@ type cacheEntry struct {
 	modTime time.Time
 }
 
+type cacheEntryHeap []cacheEntry
+
+func (h cacheEntryHeap) Len() int { return len(h) }
+func (h cacheEntryHeap) Less(i, j int) bool {
+	if h[i].modTime.Equal(h[j].modTime) {
+		return h[i].path < h[j].path
+	}
+	return h[i].modTime.Before(h[j].modTime)
+}
+func (h cacheEntryHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *cacheEntryHeap) Push(value interface{}) {
+	*h = append(*h, value.(cacheEntry))
+}
+func (h *cacheEntryHeap) Pop() interface{} {
+	old := *h
+	last := len(old) - 1
+	value := old[last]
+	old[last] = cacheEntry{}
+	*h = old[:last]
+	return value
+}
+
 func (cache Cache) prune() error {
 	limit := cache.MaxBytes
 	if limit == 0 {
@@ -125,52 +147,95 @@ func (cache Cache) prune() error {
 		return nil
 	}
 	var total int64
-	var entries []cacheEntry
-	err := filepath.WalkDir(cache.Dir, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.Type()&os.ModeSymlink != 0 || entry.IsDir() || filepath.Ext(path) != ".wago" {
-			return nil
-		}
-		info, err := entry.Info()
-		if err != nil {
+	entries := make(cacheEntryHeap, 0, maxPruneEntries)
+	remove := func(entry cacheEntry) error {
+		if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
-		if !info.Mode().IsRegular() || info.Size() < 0 {
-			return nil
-		}
-		if len(entries) == maxPruneEntries {
-			// Cache entries are regenerable. Removing overflow during the walk
-			// keeps even a directory full of zero-length files memory-bounded.
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				return err
-			}
-			return nil
-		}
-		total += info.Size()
-		entries = append(entries, cacheEntry{path: path, size: info.Size(), modTime: info.ModTime()})
 		return nil
-	})
+	}
+	visit := func(path string, info os.FileInfo) error {
+		entry := cacheEntry{path: path, size: info.Size(), modTime: info.ModTime()}
+		if len(entries) < maxPruneEntries {
+			heap.Push(&entries, entry)
+			total += entry.size
+			return nil
+		}
+		oldest := entries[0]
+		if !cacheEntryNewer(entry, oldest) {
+			return remove(entry)
+		}
+		if err := remove(oldest); err != nil {
+			return err
+		}
+		heap.Pop(&entries)
+		total -= oldest.size
+		heap.Push(&entries, entry)
+		total += entry.size
+		return nil
+	}
+	err := scanCacheFiles(cache.Dir, true, visit)
 	if err != nil || total <= limit {
 		return err
 	}
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].modTime.Equal(entries[j].modTime) {
-			return entries[i].path < entries[j].path
-		}
-		return entries[i].modTime.Before(entries[j].modTime)
-	})
-	for _, entry := range entries {
-		if total <= limit {
-			break
-		}
-		if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
+	for total > limit && len(entries) != 0 {
+		entry := heap.Pop(&entries).(cacheEntry)
+		if err := remove(entry); err != nil {
 			return err
 		}
 		total -= entry.size
 	}
 	return nil
+}
+
+func cacheEntryNewer(left, right cacheEntry) bool {
+	if left.modTime.Equal(right.modTime) {
+		return left.path > right.path
+	}
+	return left.modTime.After(right.modTime)
+}
+
+// scanCacheFiles uses File.ReadDir batches instead of os.ReadDir or WalkDir,
+// both of which read and sort a complete directory before yielding entries.
+// Automatic cache paths have one shard directory, so deeper trees are ignored.
+func scanCacheFiles(dir string, descend bool, visit func(string, os.FileInfo) error) error {
+	directory, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	for {
+		entries, readErr := directory.ReadDir(128)
+		for _, entry := range entries {
+			if entry.Type()&os.ModeSymlink != 0 {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if descend {
+					if err := scanCacheFiles(path, false, visit); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+			if info.Mode().IsRegular() && info.Size() >= 0 && filepath.Ext(path) == ".wago" {
+				if err := visit(path, info); err != nil {
+					return err
+				}
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
 }
 
 func (cache Cache) path(source []byte, config *wago.RuntimeConfig) (string, bool) {

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -110,11 +109,20 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 	if limit == 0 {
 		limit = DefaultMaxBytes
 	}
-	if err := publishArtifact(path, module.Compiled(), limit); errors.Is(err, errArtifactExceedsCacheLimit) {
-		if err := cache.pruneIfDue(time.Now()); err != nil {
+	if limit >= 0 {
+		sizes, err := module.Compiled().ArtifactSectionSizes()
+		if err != nil {
 			cache.report(err)
+			return module, nil
 		}
-	} else if err != nil {
+		if sizes.Total > limit {
+			if err := cache.pruneIfDue(time.Now()); err != nil {
+				cache.report(err)
+			}
+			return module, nil
+		}
+	}
+	if err := publishArtifact(path, module.Compiled()); err != nil {
 		cache.report(err)
 	} else if err := cache.pruneAndMark(); err != nil {
 		cache.report(err)
@@ -432,8 +440,6 @@ func writeUint64(h interface{ Write([]byte) (int, error) }, value uint64) {
 	h.Write(encoded[:])
 }
 
-var errArtifactExceedsCacheLimit = errors.New("compiled artifact exceeds cache limit")
-
 var publishArtifact = writeAtomic
 
 func loadArtifact(path string) (*wago.Compiled, bool) {
@@ -479,25 +485,9 @@ func loadOpenedArtifact(path string, file *os.File, opened os.FileInfo) (*wago.C
 	return compiled, true
 }
 
-type artifactLimitWriter struct {
-	target    io.Writer
-	remaining int64
-}
-
-func (writer *artifactLimitWriter) Write(p []byte) (int, error) {
-	if writer.remaining >= 0 && int64(len(p)) > writer.remaining {
-		return 0, errArtifactExceedsCacheLimit
-	}
-	n, err := writer.target.Write(p)
-	if writer.remaining >= 0 {
-		writer.remaining -= int64(n)
-	}
-	return n, err
-}
-
-func writeAtomic(path string, compiled *wago.Compiled, limit int64) error {
+func writeAtomic(path string, compiled *wago.Compiled) error {
 	return atomicfile.ReplaceFile(path, atomicfile.Options{Mode: 0o644}, func(writer io.Writer) error {
-		_, err := compiled.WriteTo(&artifactLimitWriter{target: writer, remaining: limit})
+		_, err := compiled.WriteTo(writer)
 		return err
 	})
 }

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -184,9 +183,10 @@ func (cache Cache) report(err error) {
 }
 
 type cacheEntry struct {
-	path    string
-	size    int64
-	modTime time.Time
+	path         string
+	relativePath string
+	size         int64
+	modTime      time.Time
 }
 
 type cacheEntryHeap []cacheEntry
@@ -239,16 +239,21 @@ func (cache Cache) prune() error {
 	if limit < 0 || cache.Dir == "" {
 		return nil
 	}
+	root, err := openCacheRoot(cache.Dir)
+	if err != nil {
+		return err
+	}
+	defer root.close()
 	var total int64
 	entries := make(cacheEntryHeap, 0, maxPruneEntries)
 	remove := func(entry cacheEntry) error {
-		if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
+		if err := root.remove(entry.relativePath); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 		return nil
 	}
-	visit := func(path string, info os.FileInfo) error {
-		entry := cacheEntry{path: path, size: info.Size(), modTime: info.ModTime()}
+	visit := func(relativePath, path string, info os.FileInfo) error {
+		entry := cacheEntry{path: path, relativePath: relativePath, size: info.Size(), modTime: info.ModTime()}
 		if len(entries) < maxPruneEntries {
 			pushCacheEntry(&entries, entry)
 			total += entry.size
@@ -267,7 +272,7 @@ func (cache Cache) prune() error {
 		total += entry.size
 		return nil
 	}
-	err := scanCacheFiles(cache.Dir, 0, visit)
+	err = root.scan(visit)
 	if err != nil || total <= limit {
 		return err
 	}
@@ -290,46 +295,6 @@ func cacheEntryNewer(left, right cacheEntry) bool {
 
 func cacheEntryOlder(left, right cacheEntry) bool {
 	return cacheEntryNewer(right, left)
-}
-
-// scanCacheFiles uses File.Readdir batches instead of os.ReadDir or WalkDir,
-// both of which read and sort a complete directory before yielding entries.
-func scanCacheFiles(dir string, depth int, visit func(string, os.FileInfo) error) error {
-	if depth > maxCacheDirectoryDepth {
-		return errors.New("cache directory nesting exceeds limit")
-	}
-	directory, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer directory.Close()
-	for {
-		entries, readErr := directory.Readdir(128)
-		for _, info := range entries {
-			if info.Mode()&os.ModeSymlink != 0 {
-				continue
-			}
-			name := info.Name()
-			path := filepath.Join(dir, name)
-			if info.IsDir() {
-				if err := scanCacheFiles(path, depth+1, visit); err != nil {
-					return err
-				}
-				continue
-			}
-			if info.Mode().IsRegular() && info.Size() >= 0 && len(name) >= 5 && name[len(name)-5:] == ".wago" {
-				if err := visit(path, info); err != nil {
-					return err
-				}
-			}
-		}
-		if readErr == io.EOF {
-			return nil
-		}
-		if readErr != nil {
-			return readErr
-		}
-	}
 }
 
 func (cache Cache) path(source []byte, config *wago.RuntimeConfig) (string, bool) {

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -11,7 +11,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"sort"
 	"sync"
+	"time"
 
 	"github.com/wago-org/wago"
 	"github.com/wago-org/wago/internal/atomicfile"
@@ -24,12 +26,17 @@ import (
 type Cache struct {
 	Dir      string
 	Identity []byte
+	// MaxBytes caps regular .wago files below Dir. Zero uses DefaultMaxBytes.
+	MaxBytes int64
 	// ReportError observes best-effort publication failures. When nil, failures
 	// are reported on stderr so persistent cache misses are diagnosable.
 	ReportError func(error)
 }
 
 const cacheKeyFormat = 2
+
+// DefaultMaxBytes bounds the automatic CLI artifact cache at 512 MiB.
+const DefaultMaxBytes int64 = 512 << 20
 
 var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	info, ok := debug.ReadBuildInfo()
@@ -85,13 +92,74 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 		return module, nil
 	}
 	if err := publishArtifact(path, module.Compiled()); err != nil {
-		if cache.ReportError != nil {
-			cache.ReportError(err)
-		} else {
-			fmt.Fprintf(os.Stderr, "wago: artifact cache publication failed: %v\n", err)
-		}
+		cache.report(err)
+	} else if err := cache.prune(); err != nil {
+		cache.report(err)
 	}
 	return module, nil
+}
+
+func (cache Cache) report(err error) {
+	if cache.ReportError != nil {
+		cache.ReportError(err)
+	} else {
+		fmt.Fprintf(os.Stderr, "wago: artifact cache maintenance failed: %v\n", err)
+	}
+}
+
+type cacheEntry struct {
+	path    string
+	size    int64
+	modTime time.Time
+}
+
+func (cache Cache) prune() error {
+	limit := cache.MaxBytes
+	if limit == 0 {
+		limit = DefaultMaxBytes
+	}
+	if limit < 0 || cache.Dir == "" {
+		return nil
+	}
+	var total int64
+	var entries []cacheEntry
+	err := filepath.WalkDir(cache.Dir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 || entry.IsDir() || filepath.Ext(path) != ".wago" {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() || info.Size() < 0 {
+			return nil
+		}
+		total += info.Size()
+		entries = append(entries, cacheEntry{path: path, size: info.Size(), modTime: info.ModTime()})
+		return nil
+	})
+	if err != nil || total <= limit {
+		return err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].modTime.Equal(entries[j].modTime) {
+			return entries[i].path < entries[j].path
+		}
+		return entries[i].modTime.Before(entries[j].modTime)
+	})
+	for _, entry := range entries {
+		if total <= limit {
+			break
+		}
+		if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		total -= entry.size
+	}
+	return nil
 }
 
 func (cache Cache) path(source []byte, config *wago.RuntimeConfig) (string, bool) {

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -100,6 +100,9 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 		return nil, err
 	}
 	if !cacheable {
+		if err := cache.pruneIfDue(time.Now()); err != nil {
+			cache.report(err)
+		}
 		return module, nil
 	}
 	limit := cache.MaxBytes
@@ -143,6 +146,16 @@ func (cache Cache) pruneIfDue(now time.Time) error {
 		}
 	} else if !os.IsNotExist(err) {
 		return err
+	}
+	info, err = os.Stat(cache.Dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("cache root %s is not a directory", cache.Dir)
 	}
 	return cache.pruneAndMark()
 }

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/wago-org/wago"
@@ -42,9 +41,10 @@ const DefaultMaxBytes int64 = 512 << 20
 // maxPruneEntries bounds both cache file count and prune's in-memory index.
 const maxPruneEntries = 4096
 
-const cacheHitPruneInterval = 64
-
-var cacheHitPruneCount atomic.Uint64
+const (
+	cachePruneInterval = 5 * time.Minute
+	cachePruneMarker   = ".wago-prune"
+)
 
 var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	info, ok := debug.ReadBuildInfo()
@@ -88,13 +88,8 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 	cacheable = cacheable && cacheableGeneration
 	if cacheable {
 		if compiled, hit := loadArtifact(path); hit {
-			// Retry missed maintenance on the first process hit and periodically
-			// thereafter without turning every warm load into a full cache scan.
-			hits := cacheHitPruneCount.Add(1)
-			if hits == 1 || hits%cacheHitPruneInterval == 0 {
-				if err := cache.prune(); err != nil {
-					cache.report(err)
-				}
+			if err := cache.pruneIfDue(time.Now()); err != nil {
+				cache.report(err)
 			}
 			return prepared.Adopt(compiled)
 		}
@@ -109,10 +104,41 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 	}
 	if err := publishArtifact(path, module.Compiled()); err != nil {
 		cache.report(err)
-	} else if err := cache.prune(); err != nil {
+	} else if err := cache.pruneAndMark(); err != nil {
 		cache.report(err)
 	}
 	return module, nil
+}
+
+func (cache Cache) pruneIfDue(now time.Time) error {
+	if cache.MaxBytes < 0 || cache.Dir == "" {
+		return nil
+	}
+	marker := filepath.Join(cache.Dir, cachePruneMarker)
+	info, err := os.Lstat(marker)
+	if err == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("cache prune marker %s is not a regular file", marker)
+		}
+		age := now.Sub(info.ModTime())
+		if age >= 0 && age < cachePruneInterval {
+			return nil
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return cache.pruneAndMark()
+}
+
+func (cache Cache) pruneAndMark() error {
+	if err := cache.prune(); err != nil {
+		return err
+	}
+	if cache.MaxBytes < 0 || cache.Dir == "" {
+		return nil
+	}
+	marker := filepath.Join(cache.Dir, cachePruneMarker)
+	return atomicfile.ReplaceFile(marker, atomicfile.Options{Mode: 0o600}, func(io.Writer) error { return nil })
 }
 
 func (cache Cache) report(err error) {

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -112,18 +112,16 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 	if limit == 0 {
 		limit = DefaultMaxBytes
 	}
-	if limit >= 0 {
-		sizes, err := module.Compiled().ArtifactSectionSizes()
-		if err != nil {
+	sizes, err := module.Compiled().ArtifactSectionSizes()
+	if err != nil {
+		cache.report(err)
+		return module, nil
+	}
+	if !artifactFitsCache(sizes, limit) {
+		if err := cache.pruneIfDue(time.Now()); err != nil {
 			cache.report(err)
-			return module, nil
 		}
-		if sizes.Total > limit {
-			if err := cache.pruneIfDue(time.Now()); err != nil {
-				cache.report(err)
-			}
-			return module, nil
-		}
+		return module, nil
 	}
 	if err := publishArtifact(path, module.Compiled()); err != nil {
 		cache.report(err)
@@ -131,6 +129,12 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 		cache.report(err)
 	}
 	return module, nil
+}
+
+func artifactFitsCache(sizes wago.ArtifactSectionSizes, maxBytes int64) bool {
+	limits := wago.DefaultArtifactLimits()
+	return sizes.Code <= limits.MaxCodeBytes && sizes.Metadata <= limits.MaxMetadataBytes &&
+		(maxBytes < 0 || sizes.Total <= maxBytes)
 }
 
 func (cache Cache) pruneIfDue(now time.Time) error {

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -41,6 +41,10 @@ const DefaultMaxBytes int64 = 512 << 20
 // maxPruneEntries bounds both cache file count and prune's in-memory index.
 const maxPruneEntries = 4096
 
+// maxCacheDirectoryDepth bounds descriptors retained by recursive batched scans.
+// Generated cache entries use one shard level; deeper trees are corruption.
+const maxCacheDirectoryDepth = 8
+
 const (
 	cachePruneInterval = 5 * time.Minute
 	cachePruneMarker   = ".wago-prune"
@@ -243,7 +247,7 @@ func (cache Cache) prune() error {
 		total += entry.size
 		return nil
 	}
-	err := scanCacheFiles(cache.Dir, visit)
+	err := scanCacheFiles(cache.Dir, 0, visit)
 	if err != nil || total <= limit {
 		return err
 	}
@@ -266,7 +270,10 @@ func cacheEntryNewer(left, right cacheEntry) bool {
 
 // scanCacheFiles uses File.ReadDir batches instead of os.ReadDir or WalkDir,
 // both of which read and sort a complete directory before yielding entries.
-func scanCacheFiles(dir string, visit func(string, os.FileInfo) error) error {
+func scanCacheFiles(dir string, depth int, visit func(string, os.FileInfo) error) error {
+	if depth > maxCacheDirectoryDepth {
+		return fmt.Errorf("cache directory nesting exceeds limit %d at %s", maxCacheDirectoryDepth, dir)
+	}
 	directory, err := os.Open(dir)
 	if err != nil {
 		return err
@@ -284,7 +291,7 @@ func scanCacheFiles(dir string, visit func(string, os.FileInfo) error) error {
 				return err
 			}
 			if info.IsDir() {
-				if err := scanCacheFiles(path, visit); err != nil {
+				if err := scanCacheFiles(path, depth+1, visit); err != nil {
 					return err
 				}
 				continue

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -102,6 +102,20 @@ func (cache Cache) LoadOrCompile(source []byte, _ *wago.RuntimeConfig, rt *wago.
 	if !cacheable {
 		return module, nil
 	}
+	limit := cache.MaxBytes
+	if limit == 0 {
+		limit = DefaultMaxBytes
+	}
+	if limit >= 0 {
+		sizes, err := module.Compiled().ArtifactSectionSizes()
+		if err != nil {
+			cache.report(err)
+			return module, nil
+		}
+		if sizes.Total > limit {
+			return module, nil
+		}
+	}
 	if err := publishArtifact(path, module.Compiled()); err != nil {
 		cache.report(err)
 	} else if err := cache.pruneAndMark(); err != nil {

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -38,6 +38,9 @@ const cacheKeyFormat = 2
 // DefaultMaxBytes bounds the automatic CLI artifact cache at 512 MiB.
 const DefaultMaxBytes int64 = 512 << 20
 
+// maxPruneEntries bounds both cache file count and prune's in-memory index.
+const maxPruneEntries = 4096
+
 var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
@@ -135,6 +138,14 @@ func (cache Cache) prune() error {
 			return err
 		}
 		if !info.Mode().IsRegular() || info.Size() < 0 {
+			return nil
+		}
+		if len(entries) == maxPruneEntries {
+			// Cache entries are regenerable. Removing overflow during the walk
+			// keeps even a directory full of zero-length files memory-bounded.
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return err
+			}
 			return nil
 		}
 		total += info.Size()

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -91,8 +91,21 @@ func TestCacheHitRetriesPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 	cache.MaxBytes = info.Size()
-	previousHits := cacheHitPruneCount.Swap(0)
-	t.Cleanup(func() { cacheHitPruneCount.Store(previousHits) })
+	module, err = cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(old); err != nil {
+		t.Fatalf("recent maintenance did not skip warm-hit scan: %v", err)
+	}
+	marker := filepath.Join(dir, cachePruneMarker)
+	stale := time.Now().Add(-cachePruneInterval - time.Second)
+	if err := os.Chtimes(marker, stale, stale); err != nil {
+		t.Fatal(err)
+	}
 	module, err = cache.LoadOrCompile(constantModule(), config, rt)
 	if err != nil {
 		t.Fatal(err)

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -156,6 +156,23 @@ func TestCachePruneBoundsTotalArtifacts(t *testing.T) {
 	}
 }
 
+func TestCachePruneRemovesArtifactLargerThanLimit(t *testing.T) {
+	dir := t.TempDir()
+	artifact := filepath.Join(dir, "nested", "large.wago")
+	if err := os.Mkdir(filepath.Dir(artifact), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artifact, []byte("large"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Cache{Dir: dir, MaxBytes: 1}).prune(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(artifact); !os.IsNotExist(err) {
+		t.Fatalf("oversize artifact remains: %v", err)
+	}
+}
+
 func TestCachePruneBoundsEntryIndex(t *testing.T) {
 	dir := t.TempDir()
 	old := time.Unix(1, 0)

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -289,7 +289,7 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 
 	injected := errors.New("injected cache publication failure")
 	oldPublish := publishArtifact
-	publishArtifact = func(string, *wago.Compiled) error { return injected }
+	publishArtifact = func(string, *wago.Compiled, int64) error { return injected }
 	t.Cleanup(func() { publishArtifact = oldPublish })
 
 	module, err := cache.LoadOrCompile(source, config, rt)
@@ -304,6 +304,8 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 func TestLoadOrCompileSkipsArtifactLargerThanCache(t *testing.T) {
 	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
 	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a"), MaxBytes: 1}
+	var reported error
+	cache.ReportError = func(err error) { reported = err }
 	stale := filepath.Join(cache.Dir, "stale.wago")
 	if err := os.WriteFile(stale, []byte("old"), 0o600); err != nil {
 		t.Fatal(err)
@@ -311,31 +313,33 @@ func TestLoadOrCompileSkipsArtifactLargerThanCache(t *testing.T) {
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
 	defer rt.Close()
 
-	calls := 0
-	oldPublish := publishArtifact
-	publishArtifact = func(string, *wago.Compiled) error {
-		calls++
-		return nil
-	}
-	t.Cleanup(func() { publishArtifact = oldPublish })
-
 	module, err := cache.LoadOrCompile(constantModule(), config, rt)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer module.Close()
-	if calls != 0 {
-		t.Fatalf("oversized artifact publication calls = %d, want 0", calls)
+	if reported != nil {
+		t.Fatalf("oversized artifact reported cache error: %v", reported)
 	}
-	entries, err := filepath.Glob(filepath.Join(cache.Dir, "*.wago"))
-	if err != nil || len(entries) != 0 {
-		t.Fatalf("oversized artifact cache entries = %v, %v; want none", entries, err)
+	path, ok := cache.path(constantModule(), config)
+	if !ok {
+		t.Fatal("cache key unavailable")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("oversized artifact was published: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale oversized cache entry remains: %v", err)
 	}
 }
 
-func TestLoadOrCompileOversizedArtifactTreatsMissingCacheAsEmpty(t *testing.T) {
+func TestLoadOrCompileOversizedArtifactMaintainsMissingCache(t *testing.T) {
 	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
 	cache := Cache{Dir: filepath.Join(t.TempDir(), "missing"), Identity: []byte("runtime-a"), MaxBytes: 1}
+	path, ok := cache.path(constantModule(), config)
+	if !ok {
+		t.Fatal("cache key unavailable")
+	}
 	var reported error
 	cache.ReportError = func(err error) { reported = err }
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
@@ -349,8 +353,11 @@ func TestLoadOrCompileOversizedArtifactTreatsMissingCacheAsEmpty(t *testing.T) {
 	if reported != nil {
 		t.Fatalf("missing empty cache reported maintenance error: %v", reported)
 	}
-	if _, err := os.Stat(cache.Dir); !os.IsNotExist(err) {
-		t.Fatalf("oversized artifact created cache root: %v", err)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("oversized artifact was published: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(cache.Dir, cachePruneMarker)); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("missing cache maintenance marker = %v, %v", info, err)
 	}
 }
 

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -121,6 +121,16 @@ func TestCacheHitRetriesPrune(t *testing.T) {
 func TestCachePruneBoundsTotalArtifacts(t *testing.T) {
 	dir := t.TempDir()
 	cache := Cache{Dir: dir, MaxBytes: 5}
+	nestedOld := filepath.Join(dir, "legacy", "nested", "old.wago")
+	if err := os.MkdirAll(filepath.Dir(nestedOld), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nestedOld, []byte("123"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(nestedOld, time.Unix(1, 0), time.Unix(1, 0)); err != nil {
+		t.Fatal(err)
+	}
 	for i, name := range []string{"old.wago", "middle.wago", "new.wago"} {
 		path := filepath.Join(dir, name)
 		if err := os.WriteFile(path, []byte("123"), 0o600); err != nil {
@@ -140,6 +150,9 @@ func TestCachePruneBoundsTotalArtifacts(t *testing.T) {
 	}
 	if len(entries) != 1 || filepath.Base(entries[0]) != "new.wago" {
 		t.Fatalf("remaining cache entries = %v, want newest only", entries)
+	}
+	if _, err := os.Stat(nestedOld); !os.IsNotExist(err) {
+		t.Fatalf("nested overflow entry remains: %v", err)
 	}
 }
 
@@ -291,6 +304,10 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 func TestLoadOrCompileSkipsArtifactLargerThanCache(t *testing.T) {
 	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
 	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a"), MaxBytes: 1}
+	stale := filepath.Join(cache.Dir, "stale.wago")
+	if err := os.WriteFile(stale, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
 	defer rt.Close()
 

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -173,6 +173,31 @@ func TestCachePruneRemovesArtifactLargerThanLimit(t *testing.T) {
 	}
 }
 
+func TestArtifactFitsCacheRespectsDecoderSectionLimits(t *testing.T) {
+	limits := wago.DefaultArtifactLimits()
+	within := wago.ArtifactSectionSizes{
+		Code:     limits.MaxCodeBytes,
+		Metadata: limits.MaxMetadataBytes,
+		Total:    limits.MaxCodeBytes + limits.MaxMetadataBytes + 16,
+	}
+	if !artifactFitsCache(within, within.Total) {
+		t.Fatal("artifact at decoder and cache limits was rejected")
+	}
+	tooMuchCode := within
+	tooMuchCode.Code++
+	if artifactFitsCache(tooMuchCode, -1) {
+		t.Fatal("artifact beyond decoder code limit was accepted")
+	}
+	tooMuchMetadata := within
+	tooMuchMetadata.Metadata++
+	if artifactFitsCache(tooMuchMetadata, -1) {
+		t.Fatal("artifact beyond decoder metadata limit was accepted")
+	}
+	if artifactFitsCache(within, within.Total-1) {
+		t.Fatal("artifact beyond cache total limit was accepted")
+	}
+}
+
 func TestCachePruneBoundsEntryIndex(t *testing.T) {
 	dir := t.TempDir()
 	old := time.Unix(1, 0)

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -91,6 +91,8 @@ func TestCacheHitRetriesPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 	cache.MaxBytes = info.Size()
+	previousHits := cacheHitPruneCount.Swap(0)
+	t.Cleanup(func() { cacheHitPruneCount.Store(previousHits) })
 	module, err = cache.LoadOrCompile(constantModule(), config, rt)
 	if err != nil {
 		t.Fatal(err)

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -333,6 +333,27 @@ func TestLoadOrCompileSkipsArtifactLargerThanCache(t *testing.T) {
 	}
 }
 
+func TestLoadOrCompileOversizedArtifactTreatsMissingCacheAsEmpty(t *testing.T) {
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: filepath.Join(t.TempDir(), "missing"), Identity: []byte("runtime-a"), MaxBytes: 1}
+	var reported error
+	cache.ReportError = func(err error) { reported = err }
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	defer rt.Close()
+
+	module, err := cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	if reported != nil {
+		t.Fatalf("missing empty cache reported maintenance error: %v", reported)
+	}
+	if _, err := os.Stat(cache.Dir); !os.IsNotExist(err) {
+		t.Fatalf("oversized artifact created cache root: %v", err)
+	}
+}
+
 type cachePlugin func(*wago.Registrar) error
 
 func (f cachePlugin) Register(reg *wago.Registrar) error { return f(reg) }
@@ -477,6 +498,14 @@ func TestLoadOrCompileBypassesArtifactsForCompileOnlyTelemetry(t *testing.T) {
 	if err := seedRuntime.Close(); err != nil {
 		t.Fatal(err)
 	}
+	seedPath, ok := cache.path(source, base)
+	if !ok {
+		t.Fatal("seed cache key unavailable")
+	}
+	cache.MaxBytes = 1
+	if err := os.Remove(filepath.Join(cache.Dir, cachePruneMarker)); err != nil {
+		t.Fatal(err)
+	}
 
 	telemetry := base.WithGCCodeTelemetry(true)
 	var compileCalls int
@@ -502,6 +531,9 @@ func TestLoadOrCompileBypassesArtifactsForCompileOnlyTelemetry(t *testing.T) {
 	}
 	if _, ok := module.Compiled().GCNativeCodeTelemetry(); !ok {
 		t.Fatal("fresh telemetry compile did not retain requested attribution")
+	}
+	if _, err := os.Stat(seedPath); !os.IsNotExist(err) {
+		t.Fatalf("non-cacheable compile left oversized cache entry: %v", err)
 	}
 	if err := module.Close(); err != nil {
 		t.Fatal(err)

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -60,6 +60,49 @@ func TestLoadOrCompileCachesAndRepairsArtifact(t *testing.T) {
 	}
 }
 
+func TestCacheHitRetriesPrune(t *testing.T) {
+	dir := t.TempDir()
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: dir, Identity: []byte("runtime-a")}
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	defer rt.Close()
+
+	module, err := cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path, ok := cache.path(constantModule(), config)
+	if !ok {
+		t.Fatal("cache key unavailable")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := filepath.Join(dir, "old.wago")
+	if err := os.WriteFile(old, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	when := time.Unix(1, 0)
+	if err := os.Chtimes(old, when, when); err != nil {
+		t.Fatal(err)
+	}
+	cache.MaxBytes = info.Size()
+	module, err = cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := module.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Fatalf("stale overflow entry remains after cache hit: %v", err)
+	}
+}
+
 func TestCachePruneBoundsTotalArtifacts(t *testing.T) {
 	dir := t.TempDir()
 	cache := Cache{Dir: dir, MaxBytes: 5}

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -187,6 +187,24 @@ func TestCachePruneBoundsEntryIndex(t *testing.T) {
 	}
 }
 
+func TestCachePruneRejectsExcessiveDirectoryDepth(t *testing.T) {
+	dir := t.TempDir()
+	deep := dir
+	for i := 0; i <= maxCacheDirectoryDepth; i++ {
+		deep = filepath.Join(deep, "nested")
+	}
+	if err := os.MkdirAll(deep, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deep, "entry.wago"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := (Cache{Dir: dir, MaxBytes: 1}).prune()
+	if err == nil || !strings.Contains(err.Error(), "directory nesting exceeds limit") {
+		t.Fatalf("deep cache prune error = %v, want nesting limit", err)
+	}
+}
+
 func TestLoadArtifactRejectsSymlinkAndOversizeEntry(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.wago")

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -288,6 +288,34 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 	}
 }
 
+func TestLoadOrCompileSkipsArtifactLargerThanCache(t *testing.T) {
+	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
+	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a"), MaxBytes: 1}
+	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
+	defer rt.Close()
+
+	calls := 0
+	oldPublish := publishArtifact
+	publishArtifact = func(string, *wago.Compiled) error {
+		calls++
+		return nil
+	}
+	t.Cleanup(func() { publishArtifact = oldPublish })
+
+	module, err := cache.LoadOrCompile(constantModule(), config, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	if calls != 0 {
+		t.Fatalf("oversized artifact publication calls = %d, want 0", calls)
+	}
+	entries, err := filepath.Glob(filepath.Join(cache.Dir, "*.wago"))
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("oversized artifact cache entries = %v, %v; want none", entries, err)
+	}
+}
+
 type cachePlugin func(*wago.Registrar) error
 
 func (f cachePlugin) Register(reg *wago.Registrar) error { return f(reg) }

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -87,11 +87,19 @@ func TestCachePruneBoundsTotalArtifacts(t *testing.T) {
 
 func TestCachePruneBoundsEntryIndex(t *testing.T) {
 	dir := t.TempDir()
+	old := time.Unix(1, 0)
 	for i := 0; i < maxPruneEntries+1; i++ {
 		path := filepath.Join(dir, fmt.Sprintf("%04d.wago", i))
 		if err := os.WriteFile(path, nil, 0o600); err != nil {
 			t.Fatal(err)
 		}
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+	newest := filepath.Join(dir, fmt.Sprintf("%04d.wago", maxPruneEntries))
+	if err := os.Chtimes(newest, old.Add(time.Second), old.Add(time.Second)); err != nil {
+		t.Fatal(err)
 	}
 	if err := (Cache{Dir: dir}).prune(); err != nil {
 		t.Fatal(err)
@@ -102,6 +110,9 @@ func TestCachePruneBoundsEntryIndex(t *testing.T) {
 	}
 	if len(entries) != maxPruneEntries {
 		t.Fatalf("remaining cache entries = %d, want %d", len(entries), maxPruneEntries)
+	}
+	if _, err := os.Stat(newest); err != nil {
+		t.Fatalf("newest overflow entry was not retained: %v", err)
 	}
 }
 

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -81,6 +82,26 @@ func TestCachePruneBoundsTotalArtifacts(t *testing.T) {
 	}
 	if len(entries) != 1 || filepath.Base(entries[0]) != "new.wago" {
 		t.Fatalf("remaining cache entries = %v, want newest only", entries)
+	}
+}
+
+func TestCachePruneBoundsEntryIndex(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < maxPruneEntries+1; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("%04d.wago", i))
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := (Cache{Dir: dir}).prune(); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := filepath.Glob(filepath.Join(dir, "*.wago"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != maxPruneEntries {
+		t.Fatalf("remaining cache entries = %d, want %d", len(entries), maxPruneEntries)
 	}
 }
 

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -118,6 +118,24 @@ func TestCacheHitRetriesPrune(t *testing.T) {
 	}
 }
 
+func TestMalformedPruneMarkerDoesNotDisableMaintenance(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, cachePruneMarker), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	artifact := filepath.Join(dir, "oversize.wago")
+	if err := os.WriteFile(artifact, []byte("oversize"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cache := Cache{Dir: dir, MaxBytes: 1}
+	if err := cache.pruneIfDue(time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(artifact); !os.IsNotExist(err) {
+		t.Fatalf("oversize artifact remains with malformed marker: %v", err)
+	}
+}
+
 func TestCachePruneBoundsTotalArtifacts(t *testing.T) {
 	dir := t.TempDir()
 	cache := Cache{Dir: dir, MaxBytes: 5}

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago"
 )
@@ -55,6 +56,31 @@ func TestLoadOrCompileCachesAndRepairsArtifact(t *testing.T) {
 	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), ".wago-*"))
 	if err != nil || len(matches) != 0 {
 		t.Fatalf("temporary artifacts remain: %v (err %v)", matches, err)
+	}
+}
+
+func TestCachePruneBoundsTotalArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	cache := Cache{Dir: dir, MaxBytes: 5}
+	for i, name := range []string{"old.wago", "middle.wago", "new.wago"} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("123"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		when := time.Unix(int64(i+1), 0)
+		if err := os.Chtimes(path, when, when); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := cache.prune(); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := filepath.Glob(filepath.Join(dir, "*.wago"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || filepath.Base(entries[0]) != "new.wago" {
+		t.Fatalf("remaining cache entries = %v, want newest only", entries)
 	}
 }
 

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -289,7 +289,7 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 
 	injected := errors.New("injected cache publication failure")
 	oldPublish := publishArtifact
-	publishArtifact = func(string, *wago.Compiled, int64) error { return injected }
+	publishArtifact = func(string, *wago.Compiled) error { return injected }
 	t.Cleanup(func() { publishArtifact = oldPublish })
 
 	module, err := cache.LoadOrCompile(source, config, rt)
@@ -304,8 +304,6 @@ func TestLoadOrCompileReportsPublicationFailure(t *testing.T) {
 func TestLoadOrCompileSkipsArtifactLargerThanCache(t *testing.T) {
 	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
 	cache := Cache{Dir: t.TempDir(), Identity: []byte("runtime-a"), MaxBytes: 1}
-	var reported error
-	cache.ReportError = func(err error) { reported = err }
 	stale := filepath.Join(cache.Dir, "stale.wago")
 	if err := os.WriteFile(stale, []byte("old"), 0o600); err != nil {
 		t.Fatal(err)
@@ -313,33 +311,31 @@ func TestLoadOrCompileSkipsArtifactLargerThanCache(t *testing.T) {
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
 	defer rt.Close()
 
+	calls := 0
+	oldPublish := publishArtifact
+	publishArtifact = func(string, *wago.Compiled) error {
+		calls++
+		return nil
+	}
+	t.Cleanup(func() { publishArtifact = oldPublish })
+
 	module, err := cache.LoadOrCompile(constantModule(), config, rt)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer module.Close()
-	if reported != nil {
-		t.Fatalf("oversized artifact reported cache error: %v", reported)
+	if calls != 0 {
+		t.Fatalf("oversized artifact publication calls = %d, want 0", calls)
 	}
-	path, ok := cache.path(constantModule(), config)
-	if !ok {
-		t.Fatal("cache key unavailable")
-	}
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("oversized artifact was published: %v", err)
-	}
-	if _, err := os.Stat(stale); !os.IsNotExist(err) {
-		t.Fatalf("stale oversized cache entry remains: %v", err)
+	entries, err := filepath.Glob(filepath.Join(cache.Dir, "*.wago"))
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("oversized artifact cache entries = %v, %v; want none", entries, err)
 	}
 }
 
-func TestLoadOrCompileOversizedArtifactMaintainsMissingCache(t *testing.T) {
+func TestLoadOrCompileOversizedArtifactTreatsMissingCacheAsEmpty(t *testing.T) {
 	config := wago.NewRuntimeConfig().WithBoundsChecks(wago.BoundsChecksExplicit)
 	cache := Cache{Dir: filepath.Join(t.TempDir(), "missing"), Identity: []byte("runtime-a"), MaxBytes: 1}
-	path, ok := cache.path(constantModule(), config)
-	if !ok {
-		t.Fatal("cache key unavailable")
-	}
 	var reported error
 	cache.ReportError = func(err error) { reported = err }
 	rt := wago.NewRuntime(wago.WithRuntimeConfig(config))
@@ -353,11 +349,8 @@ func TestLoadOrCompileOversizedArtifactMaintainsMissingCache(t *testing.T) {
 	if reported != nil {
 		t.Fatalf("missing empty cache reported maintenance error: %v", reported)
 	}
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("oversized artifact was published: %v", err)
-	}
-	if info, err := os.Stat(filepath.Join(cache.Dir, cachePruneMarker)); err != nil || !info.Mode().IsRegular() {
-		t.Fatalf("missing cache maintenance marker = %v, %v", info, err)
+	if _, err := os.Stat(cache.Dir); !os.IsNotExist(err) {
+		t.Fatalf("oversized artifact created cache root: %v", err)
 	}
 }
 

--- a/cli/runtime/internal/artifactcache/root_darwin.go
+++ b/cli/runtime/internal/artifactcache/root_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package artifactcache
+
+import "golang.org/x/sys/unix"
+
+const cacheDirectoryOpenFlags = unix.O_RDONLY | unix.O_CLOEXEC | unix.O_DIRECTORY | unix.O_NOFOLLOW
+
+func openCacheDirectory(path string) (int, error) {
+	return unix.Open(path, cacheDirectoryOpenFlags, 0)
+}
+
+func openCacheDirectoryAt(directory int, name string) (int, error) {
+	return unix.Openat(directory, name, cacheDirectoryOpenFlags, 0)
+}
+
+func duplicateCacheDescriptor(fd int) (int, error) { return unix.Dup(fd) }
+
+func closeCacheDescriptor(fd int) error { return unix.Close(fd) }
+
+func unlinkCacheEntryAt(directory int, name string) error { return unix.Unlinkat(directory, name, 0) }

--- a/cli/runtime/internal/artifactcache/root_linux.go
+++ b/cli/runtime/internal/artifactcache/root_linux.go
@@ -1,0 +1,21 @@
+//go:build linux && !tinygo
+
+package artifactcache
+
+import "syscall"
+
+const cacheDirectoryOpenFlags = syscall.O_RDONLY | syscall.O_CLOEXEC | syscall.O_DIRECTORY | syscall.O_NOFOLLOW
+
+func openCacheDirectory(path string) (int, error) {
+	return syscall.Open(path, cacheDirectoryOpenFlags, 0)
+}
+
+func openCacheDirectoryAt(directory int, name string) (int, error) {
+	return syscall.Openat(directory, name, cacheDirectoryOpenFlags, 0)
+}
+
+func duplicateCacheDescriptor(fd int) (int, error) { return syscall.Dup(fd) }
+
+func closeCacheDescriptor(fd int) error { return syscall.Close(fd) }
+
+func unlinkCacheEntryAt(directory int, name string) error { return syscall.Unlinkat(directory, name) }

--- a/cli/runtime/internal/artifactcache/root_linux_tinygo.go
+++ b/cli/runtime/internal/artifactcache/root_linux_tinygo.go
@@ -1,0 +1,31 @@
+//go:build linux && tinygo
+
+package artifactcache
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+const cacheDirectoryOpenFlags = syscall.O_RDONLY | syscall.O_CLOEXEC | syscall.O_DIRECTORY | syscall.O_NOFOLLOW
+
+func openCacheDirectory(path string) (int, error) {
+	return syscall.Open(path, cacheDirectoryOpenFlags, 0)
+}
+
+func openCacheDirectoryAt(directory int, name string) (int, error) {
+	return syscall.Open(cacheDescriptorPath(directory)+"/"+name, cacheDirectoryOpenFlags, 0)
+}
+
+func duplicateCacheDescriptor(fd int) (int, error) {
+	return syscall.Open(cacheDescriptorPath(fd), cacheDirectoryOpenFlags&^syscall.O_NOFOLLOW, 0)
+}
+
+func closeCacheDescriptor(fd int) error { return syscall.Close(fd) }
+
+func unlinkCacheEntryAt(directory int, name string) error {
+	return os.Remove(cacheDescriptorPath(directory) + "/" + name)
+}
+
+func cacheDescriptorPath(fd int) string { return "/proc/self/fd/" + strconv.Itoa(fd) }

--- a/cli/runtime/internal/artifactcache/root_unix.go
+++ b/cli/runtime/internal/artifactcache/root_unix.go
@@ -1,0 +1,115 @@
+//go:build linux || darwin
+
+package artifactcache
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type cacheRoot struct {
+	file *os.File
+	path string
+}
+
+func openCacheRoot(path string) (*cacheRoot, error) {
+	fd, err := openCacheDirectory(path)
+	if err != nil {
+		return nil, err
+	}
+	return &cacheRoot{file: os.NewFile(uintptr(fd), path), path: path}, nil
+}
+
+func (root *cacheRoot) close() error {
+	return root.file.Close()
+}
+
+// scan uses directory handles so a concurrent symlink replacement cannot move
+// traversal outside the cache root. Batches avoid sorting or retaining a whole
+// directory, and the depth cap bounds simultaneously open descriptors.
+func (root *cacheRoot) scan(visit func(string, string, os.FileInfo) error) error {
+	return root.scanDirectory(root.file, "", 0, visit)
+}
+
+func (root *cacheRoot) scanDirectory(directory *os.File, relative string, depth int, visit func(string, string, os.FileInfo) error) error {
+	if depth > maxCacheDirectoryDepth {
+		return errors.New("cache directory nesting exceeds limit")
+	}
+	for {
+		entries, readErr := directory.Readdir(128)
+		for _, info := range entries {
+			if info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+			name := info.Name()
+			relativePath := filepath.Join(relative, name)
+			if info.IsDir() {
+				fd, err := openCacheDirectoryAt(int(directory.Fd()), name)
+				if err != nil {
+					return err
+				}
+				child := os.NewFile(uintptr(fd), filepath.Join(root.path, relativePath))
+				err = root.scanDirectory(child, relativePath, depth+1, visit)
+				closeErr := child.Close()
+				if err != nil {
+					return err
+				}
+				if closeErr != nil {
+					return closeErr
+				}
+				continue
+			}
+			if info.Mode().IsRegular() && info.Size() >= 0 && strings.HasSuffix(name, ".wago") {
+				if err := visit(relativePath, filepath.Join(root.path, relativePath), info); err != nil {
+					return err
+				}
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}
+
+func (root *cacheRoot) remove(relativePath string) error {
+	parts, ok := cachePathParts(relativePath)
+	if !ok {
+		return errors.New("invalid cache entry path")
+	}
+	fd, err := duplicateCacheDescriptor(int(root.file.Fd()))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeCacheDescriptor(fd) }()
+	for _, name := range parts[:len(parts)-1] {
+		next, err := openCacheDirectoryAt(fd, name)
+		if err != nil {
+			return err
+		}
+		if err := closeCacheDescriptor(fd); err != nil {
+			closeCacheDescriptor(next)
+			return err
+		}
+		fd = next
+	}
+	return unlinkCacheEntryAt(fd, parts[len(parts)-1])
+}
+
+func cachePathParts(path string) ([]string, bool) {
+	if filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return nil, false
+	}
+	parts := strings.Split(path, string(filepath.Separator))
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return nil, false
+		}
+	}
+	return parts, len(parts) != 0
+}

--- a/cli/runtime/internal/artifactcache/root_unix_test.go
+++ b/cli/runtime/internal/artifactcache/root_unix_test.go
@@ -1,0 +1,45 @@
+//go:build linux || darwin
+
+package artifactcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCacheRootRemoveDoesNotFollowReplacedParent(t *testing.T) {
+	rootPath := t.TempDir()
+	parent := filepath.Join(rootPath, "aa")
+	if err := os.Mkdir(parent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root, err := openCacheRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.close()
+
+	outside := t.TempDir()
+	outsideArtifact := filepath.Join(outside, "outside.wago")
+	if err := os.WriteFile(outsideArtifact, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(parent, parent+"-moved"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, parent); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := root.remove(filepath.Join("aa", "outside.wago")); err == nil {
+		t.Fatal("cache removal followed replaced parent")
+	}
+	contents, err := os.ReadFile(outsideArtifact)
+	if err != nil {
+		t.Fatalf("outside artifact removed: %v", err)
+	}
+	if string(contents) != "keep" {
+		t.Fatalf("outside artifact contents = %q", contents)
+	}
+}

--- a/cli/runtime/internal/artifactcache/root_unsupported.go
+++ b/cli/runtime/internal/artifactcache/root_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !linux && !darwin && !windows
+
+package artifactcache
+
+import (
+	"errors"
+	"os"
+)
+
+type cacheRoot struct{}
+
+func openCacheRoot(string) (*cacheRoot, error) {
+	return nil, errors.New("secure cache pruning is unsupported on this platform")
+}
+
+func (*cacheRoot) close() error { return nil }
+
+func (*cacheRoot) scan(func(string, string, os.FileInfo) error) error { return nil }
+
+func (*cacheRoot) remove(string) error { return nil }

--- a/cli/runtime/internal/artifactcache/root_windows.go
+++ b/cli/runtime/internal/artifactcache/root_windows.go
@@ -19,11 +19,27 @@ type cacheRoot struct {
 }
 
 func openCacheRoot(path string) (*cacheRoot, error) {
-	file, err := os.Open(path)
+	name, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		return nil, err
 	}
-	finalPath, err := finalHandlePath(windows.Handle(file.Fd()))
+	handle, err := windows.CreateFile(name, windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil,
+		windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	if err != nil {
+		return nil, err
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		windows.CloseHandle(handle)
+		return nil, err
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		windows.CloseHandle(handle)
+		return nil, errors.New("cache root is a reparse point")
+	}
+	file := os.NewFile(uintptr(handle), path)
+	finalPath, err := finalHandlePath(handle)
 	if err != nil {
 		file.Close()
 		return nil, err

--- a/cli/runtime/internal/artifactcache/root_windows.go
+++ b/cli/runtime/internal/artifactcache/root_windows.go
@@ -1,0 +1,121 @@
+//go:build windows
+
+package artifactcache
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+type cacheRoot struct {
+	file      *os.File
+	path      string
+	finalPath string
+}
+
+func openCacheRoot(path string) (*cacheRoot, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	finalPath, err := finalHandlePath(windows.Handle(file.Fd()))
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	return &cacheRoot{file: file, path: path, finalPath: finalPath}, nil
+}
+
+func (root *cacheRoot) close() error {
+	return root.file.Close()
+}
+
+func (root *cacheRoot) scan(visit func(string, string, os.FileInfo) error) error {
+	return root.scanDirectory(root.path, "", 0, visit)
+}
+
+func (root *cacheRoot) scanDirectory(directory, relative string, depth int, visit func(string, string, os.FileInfo) error) error {
+	if depth > maxCacheDirectoryDepth {
+		return errors.New("cache directory nesting exceeds limit")
+	}
+	opened, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer opened.Close()
+	for {
+		entries, readErr := opened.Readdir(128)
+		for _, info := range entries {
+			if info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+			name := info.Name()
+			relativePath := filepath.Join(relative, name)
+			path := filepath.Join(root.path, relativePath)
+			if info.IsDir() {
+				if err := root.scanDirectory(path, relativePath, depth+1, visit); err != nil {
+					return err
+				}
+				continue
+			}
+			if info.Mode().IsRegular() && info.Size() >= 0 && strings.HasSuffix(name, ".wago") {
+				if err := visit(relativePath, path, info); err != nil {
+					return err
+				}
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}
+
+func (root *cacheRoot) remove(relativePath string) error {
+	if filepath.IsAbs(relativePath) || filepath.Clean(relativePath) != relativePath {
+		return errors.New("invalid cache entry path")
+	}
+	path, err := windows.UTF16PtrFromString(filepath.Join(root.path, relativePath))
+	if err != nil {
+		return err
+	}
+	const deleteAccess = 0x00010000
+	handle, err := windows.CreateFile(path, deleteAccess|windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil,
+		windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle)
+	finalPath, err := finalHandlePath(handle)
+	if err != nil {
+		return err
+	}
+	rootPrefix := strings.TrimRight(root.finalPath, `\`) + `\`
+	if !strings.HasPrefix(strings.ToLower(finalPath), strings.ToLower(rootPrefix)) {
+		return errors.New("cache entry resolves outside cache root")
+	}
+	disposition := [4]byte{1}
+	return windows.SetFileInformationByHandle(handle, windows.FileDispositionInfo, &disposition[0], uint32(len(disposition)))
+}
+
+func finalHandlePath(handle windows.Handle) (string, error) {
+	buffer := make([]uint16, windows.MAX_PATH)
+	for {
+		n, err := windows.GetFinalPathNameByHandle(handle, &buffer[0], uint32(len(buffer)), 0)
+		if err != nil {
+			return "", err
+		}
+		if n < uint32(len(buffer)) {
+			return windows.UTF16ToString(buffer[:n]), nil
+		}
+		buffer = make([]uint16, n+1)
+	}
+}

--- a/cli/runtime/internal/artifactcache/root_windows_test.go
+++ b/cli/runtime/internal/artifactcache/root_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package artifactcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenCacheRootRejectsReparsePoint(t *testing.T) {
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "cache-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	root, err := openCacheRoot(link)
+	if err == nil {
+		root.close()
+		t.Fatal("opened reparse-point cache root")
+	}
+}

--- a/cli/runtime/internal/module/inspect.go
+++ b/cli/runtime/internal/module/inspect.go
@@ -3,10 +3,10 @@ package module
 
 import (
 	"context"
-	"os"
 
 	"github.com/wago-org/wago"
 	"github.com/wago-org/wago/cli/internal/ui"
+	"github.com/wago-org/wago/cli/runtime/internal/modulefile"
 	runtimeplugin "github.com/wago-org/wago/cli/runtime/internal/plugin"
 )
 
@@ -18,7 +18,7 @@ func Compile(file string) (*wago.Runtime, *wago.Module) {
 			ui.Fatal("plugins: %v", err)
 		}
 	}
-	src, err := os.ReadFile(file)
+	src, err := modulefile.Read(file)
 	if err != nil {
 		rt.Close()
 		ui.Fatal("%v", err)

--- a/cli/runtime/internal/modulefile/read.go
+++ b/cli/runtime/internal/modulefile/read.go
@@ -17,65 +17,121 @@ const MaxBytes int64 = 256 << 20
 // MaxArtifactBytes matches the public artifact decoder plus framing overhead.
 const MaxArtifactBytes int64 = (1 << 30) + (256 << 20) + 64
 
+// Input is one bounded module input. Compiled artifacts remain streaming;
+// source modules can be materialized exactly once for compilation.
+type Input struct {
+	path     string
+	file     *os.File
+	reader   *io.LimitedReader
+	size     int64
+	regular  bool
+	artifact bool
+	limit    int64
+}
+
 // Read reads path without accepting more than MaxBytes.
 func Read(path string) ([]byte, error) {
-	return read(path, false)
+	input, err := open(path, false)
+	if err != nil {
+		return nil, err
+	}
+	defer input.Close()
+	return input.ReadSource()
 }
 
-// ReadSourceOrArtifact reads a run-command input, selecting the larger decoder
-// ceiling only when the input carries Wago's compiled-artifact magic.
-func ReadSourceOrArtifact(path string) ([]byte, error) {
-	return read(path, true)
+// OpenSourceOrArtifact inspects a run-command input without materializing a
+// compiled artifact. The caller must close the returned input.
+func OpenSourceOrArtifact(path string) (*Input, error) {
+	return open(path, true)
 }
 
-func read(path string, allowArtifact bool) ([]byte, error) {
+func open(path string, allowArtifact bool) (*Input, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
 	info, err := file.Stat()
 	if err != nil {
+		file.Close()
 		return nil, err
 	}
-	if info.Mode().IsRegular() {
-		limit := MaxBytes
-		if allowArtifact {
-			var prefix [5]byte
-			n, readErr := io.ReadFull(file, prefix[:])
-			if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
-				return nil, readErr
-			}
-			limit = inputLimit(prefix[:n])
-			if _, err := file.Seek(0, io.SeekStart); err != nil {
-				return nil, err
-			}
-		}
-		if info.Size() > limit {
-			return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), limit)
-		}
-		// Reserve one sentinel byte so growth after Stat is detected without
-		// io.ReadAll's geometric over-allocation.
-		readLimit := info.Size() + 1
-		data := make([]byte, int(readLimit))
-		n, err := io.ReadFull(file, data)
-		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
-			return nil, err
-		}
-		if int64(n) > limit {
-			return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, limit)
-		}
-		if int64(n) > info.Size() {
-			return nil, fmt.Errorf("module %q changed size while being read", path)
-		}
-		return data[:n:n], nil
-	}
-	if !allowArtifact {
-		return readStream(path, file, MaxBytes)
-	}
 	buffered := bufio.NewReaderSize(file, 5)
-	prefix, _ := buffered.Peek(5)
-	return readStream(path, buffered, inputLimit(prefix))
+	limit := MaxBytes
+	artifact := false
+	if allowArtifact {
+		prefix, peekErr := buffered.Peek(5)
+		if peekErr != nil && !errors.Is(peekErr, io.EOF) {
+			file.Close()
+			return nil, peekErr
+		}
+		artifact = wago.IsCompiled(prefix)
+		limit = inputLimit(prefix)
+	}
+	regular := info.Mode().IsRegular()
+	if regular && info.Size() > limit {
+		file.Close()
+		return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), limit)
+	}
+	return &Input{
+		path: path, file: file, reader: &io.LimitedReader{R: buffered, N: limit + 1},
+		size: info.Size(), regular: regular, artifact: artifact, limit: limit,
+	}, nil
+}
+
+// Read implements io.Reader for streaming artifact decoding.
+func (input *Input) Read(p []byte) (int, error) {
+	if input == nil || input.reader == nil {
+		return 0, io.EOF
+	}
+	return input.reader.Read(p)
+}
+
+// Close closes the underlying module input.
+func (input *Input) Close() error {
+	if input == nil || input.file == nil {
+		return nil
+	}
+	err := input.file.Close()
+	input.file = nil
+	return err
+}
+
+// IsArtifact reports whether the input carries Wago compiled-artifact magic.
+func (input *Input) IsArtifact() bool { return input != nil && input.artifact }
+
+// Size reports the stable pre-read size of a regular input.
+func (input *Input) Size() (int64, bool) {
+	if input == nil || !input.regular {
+		return 0, false
+	}
+	return input.size, true
+}
+
+// ReadSource materializes a bounded source module with exact slice capacity.
+func (input *Input) ReadSource() ([]byte, error) {
+	if input == nil {
+		return nil, fmt.Errorf("module input is nil")
+	}
+	if input.artifact {
+		return nil, fmt.Errorf("compiled artifact must be decoded as a stream")
+	}
+	if !input.regular {
+		return readStream(input.path, input, input.limit)
+	}
+	// Reserve one sentinel byte so growth after Stat is detected without
+	// io.ReadAll's geometric over-allocation.
+	data := make([]byte, int(input.size+1))
+	n, err := io.ReadFull(input, data)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, err
+	}
+	if int64(n) > input.limit {
+		return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", input.path, input.limit)
+	}
+	if int64(n) > input.size {
+		return nil, fmt.Errorf("module %q changed size while being read", input.path)
+	}
+	return data[:n:n], nil
 }
 
 func inputLimit(prefix []byte) int64 {

--- a/cli/runtime/internal/modulefile/read.go
+++ b/cli/runtime/internal/modulefile/read.go
@@ -2,7 +2,6 @@
 package modulefile
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -17,119 +16,96 @@ const MaxBytes int64 = 256 << 20
 // MaxArtifactBytes matches the public artifact decoder plus framing overhead.
 const MaxArtifactBytes int64 = (1 << 30) + (256 << 20) + 64
 
-// Input is one bounded module input. Compiled artifacts remain streaming;
-// source modules can be materialized exactly once for compilation.
-type Input struct {
-	path     string
-	file     *os.File
-	reader   *io.LimitedReader
-	size     int64
-	regular  bool
-	artifact bool
-	limit    int64
-}
-
 // Read reads path without accepting more than MaxBytes.
 func Read(path string) ([]byte, error) {
-	input, err := open(path, false)
-	if err != nil {
-		return nil, err
-	}
-	defer input.Close()
-	return input.ReadSource()
-}
-
-// OpenSourceOrArtifact inspects a run-command input without materializing a
-// compiled artifact. The caller must close the returned input.
-func OpenSourceOrArtifact(path string) (*Input, error) {
-	return open(path, true)
-}
-
-func open(path string, allowArtifact bool) (*Input, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return readSource(path, file, info)
+}
+
+// ReadSourceOrOpenArtifact inspects a run-command input once. Source bytes are
+// materialized exactly; compiled artifacts remain bounded streams. The caller
+// must close a non-nil artifactFile. Size is -1 for non-regular artifacts.
+func ReadSourceOrOpenArtifact(path string) (source []byte, artifact io.Reader, artifactFile *os.File, size int64, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
 	info, err := file.Stat()
 	if err != nil {
 		file.Close()
-		return nil, err
+		return nil, nil, nil, 0, err
 	}
-	buffered := bufio.NewReaderSize(file, 5)
-	limit := MaxBytes
-	artifact := false
-	if allowArtifact {
-		prefix, peekErr := buffered.Peek(5)
-		if peekErr != nil && !errors.Is(peekErr, io.EOF) {
-			file.Close()
-			return nil, peekErr
-		}
-		artifact = wago.IsCompiled(prefix)
-		limit = inputLimit(prefix)
-	}
-	regular := info.Mode().IsRegular()
-	if regular && info.Size() > limit {
+	var prefix [5]byte
+	n, readErr := io.ReadFull(file, prefix[:])
+	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
 		file.Close()
-		return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), limit)
+		return nil, nil, nil, 0, readErr
 	}
-	return &Input{
-		path: path, file: file, reader: &io.LimitedReader{R: buffered, N: limit + 1},
-		size: info.Size(), regular: regular, artifact: artifact, limit: limit,
-	}, nil
+	var reader io.Reader = &prefixReader{prefix: prefix[:n], file: file}
+	if info.Mode().IsRegular() {
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			file.Close()
+			return nil, nil, nil, 0, err
+		}
+		reader = file
+	}
+	if !wago.IsCompiled(prefix[:n]) {
+		source, err := readSource(path, reader, info)
+		file.Close()
+		return source, nil, nil, 0, err
+	}
+	if info.Mode().IsRegular() && info.Size() > MaxArtifactBytes {
+		file.Close()
+		return nil, nil, nil, 0, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), MaxArtifactBytes)
+	}
+	size = -1
+	if info.Mode().IsRegular() {
+		size = info.Size()
+	}
+	return nil, io.LimitReader(reader, MaxArtifactBytes+1), file, size, nil
 }
 
-// Read implements io.Reader for streaming artifact decoding.
-func (input *Input) Read(p []byte) (int, error) {
-	if input == nil || input.reader == nil {
-		return 0, io.EOF
-	}
-	return input.reader.Read(p)
+type prefixReader struct {
+	prefix []byte
+	file   *os.File
 }
 
-// Close closes the underlying module input.
-func (input *Input) Close() error {
-	if input == nil || input.file == nil {
-		return nil
+func (reader *prefixReader) Read(p []byte) (int, error) {
+	if len(reader.prefix) != 0 {
+		n := copy(p, reader.prefix)
+		reader.prefix = reader.prefix[n:]
+		return n, nil
 	}
-	err := input.file.Close()
-	input.file = nil
-	return err
+	return reader.file.Read(p)
 }
 
-// IsArtifact reports whether the input carries Wago compiled-artifact magic.
-func (input *Input) IsArtifact() bool { return input != nil && input.artifact }
-
-// Size reports the stable pre-read size of a regular input.
-func (input *Input) Size() (int64, bool) {
-	if input == nil || !input.regular {
-		return 0, false
+func readSource(path string, reader io.Reader, info os.FileInfo) ([]byte, error) {
+	if !info.Mode().IsRegular() {
+		return readStream(path, reader, MaxBytes)
 	}
-	return input.size, true
-}
-
-// ReadSource materializes a bounded source module with exact slice capacity.
-func (input *Input) ReadSource() ([]byte, error) {
-	if input == nil {
-		return nil, fmt.Errorf("module input is nil")
-	}
-	if input.artifact {
-		return nil, fmt.Errorf("compiled artifact must be decoded as a stream")
-	}
-	if !input.regular {
-		return readStream(input.path, input, input.limit)
+	if info.Size() > MaxBytes {
+		return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), MaxBytes)
 	}
 	// Reserve one sentinel byte so growth after Stat is detected without
 	// io.ReadAll's geometric over-allocation.
-	data := make([]byte, int(input.size+1))
-	n, err := io.ReadFull(input, data)
+	data := make([]byte, int(info.Size()+1))
+	n, err := io.ReadFull(reader, data)
 	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, err
 	}
-	if int64(n) > input.limit {
-		return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", input.path, input.limit)
+	if int64(n) > MaxBytes {
+		return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, MaxBytes)
 	}
-	if int64(n) > input.size {
-		return nil, fmt.Errorf("module %q changed size while being read", input.path)
+	if int64(n) > info.Size() {
+		return nil, fmt.Errorf("module %q changed size while being read", path)
 	}
 	return data[:n:n], nil
 }

--- a/cli/runtime/internal/modulefile/read.go
+++ b/cli/runtime/internal/modulefile/read.go
@@ -11,7 +11,7 @@ import (
 // MaxBytes is the largest module input accepted by CLI commands.
 const MaxBytes int64 = 256 << 20
 
-// Read reads path without allocating beyond MaxBytes plus one sentinel byte.
+// Read reads path without accepting more than MaxBytes.
 func Read(path string) ([]byte, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -25,22 +25,53 @@ func Read(path string) ([]byte, error) {
 	if info.Size() > MaxBytes {
 		return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), MaxBytes)
 	}
-	readLimit := MaxBytes + 1
 	if info.Mode().IsRegular() {
 		// Reserve one sentinel byte so growth after Stat is detected without
 		// io.ReadAll's geometric over-allocation.
-		readLimit = info.Size() + 1
+		readLimit := info.Size() + 1
+		data := make([]byte, int(readLimit))
+		n, err := io.ReadFull(file, data)
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, err
+		}
+		if int64(n) > MaxBytes {
+			return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, MaxBytes)
+		}
+		if int64(n) > info.Size() {
+			return nil, fmt.Errorf("module %q changed size while being read", path)
+		}
+		return data[:n:n], nil
 	}
-	data := make([]byte, int(readLimit))
-	n, err := io.ReadFull(file, data)
-	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+	return readStream(path, file)
+}
+
+// readStream spools pipes and other unknown-length inputs through a bounded
+// fixed-size buffer. This avoids reserving the entire input limit before the
+// stream has produced any bytes while still returning one exact-sized slice.
+func readStream(path string, source io.Reader) ([]byte, error) {
+	temporary, err := os.CreateTemp("", "wago-module-*")
+	if err != nil {
 		return nil, err
 	}
-	if int64(n) > MaxBytes {
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	defer temporary.Close()
+
+	buffer := make([]byte, 64<<10)
+	n, err := io.CopyBuffer(temporary, io.LimitReader(source, MaxBytes+1), buffer)
+	if err != nil {
+		return nil, err
+	}
+	if n > MaxBytes {
 		return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, MaxBytes)
 	}
-	if info.Mode().IsRegular() && int64(n) > info.Size() {
-		return nil, fmt.Errorf("module %q changed size while being read", path)
+	if _, err := temporary.Seek(0, io.SeekStart); err != nil {
+		return nil, err
 	}
-	return data[:n:n], nil
+	data := make([]byte, int(n))
+	read, err := io.ReadFull(temporary, data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:read:read], nil
 }

--- a/cli/runtime/internal/modulefile/read.go
+++ b/cli/runtime/internal/modulefile/read.go
@@ -1,0 +1,33 @@
+// Package modulefile bounds CLI reads of untrusted Wasm and artifact inputs.
+package modulefile
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// MaxBytes is the largest module input accepted by CLI commands.
+const MaxBytes int64 = 256 << 20
+
+// Read reads path without allocating beyond MaxBytes plus one sentinel byte.
+func Read(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	if info, err := file.Stat(); err != nil {
+		return nil, err
+	} else if info.Size() > MaxBytes {
+		return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), MaxBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, MaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > MaxBytes {
+		return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, MaxBytes)
+	}
+	return data, nil
+}

--- a/cli/runtime/internal/modulefile/read.go
+++ b/cli/runtime/internal/modulefile/read.go
@@ -2,6 +2,7 @@
 package modulefile
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,17 +18,29 @@ func Read(path string) ([]byte, error) {
 		return nil, err
 	}
 	defer file.Close()
-	if info, err := file.Stat(); err != nil {
-		return nil, err
-	} else if info.Size() > MaxBytes {
-		return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), MaxBytes)
-	}
-	data, err := io.ReadAll(io.LimitReader(file, MaxBytes+1))
+	info, err := file.Stat()
 	if err != nil {
 		return nil, err
 	}
-	if int64(len(data)) > MaxBytes {
+	if info.Size() > MaxBytes {
+		return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), MaxBytes)
+	}
+	readLimit := MaxBytes + 1
+	if info.Mode().IsRegular() {
+		// Reserve one sentinel byte so growth after Stat is detected without
+		// io.ReadAll's geometric over-allocation.
+		readLimit = info.Size() + 1
+	}
+	data := make([]byte, int(readLimit))
+	n, err := io.ReadFull(file, data)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, err
+	}
+	if int64(n) > MaxBytes {
 		return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, MaxBytes)
 	}
-	return data, nil
+	if info.Mode().IsRegular() && int64(n) > info.Size() {
+		return nil, fmt.Errorf("module %q changed size while being read", path)
+	}
+	return data[:n:n], nil
 }

--- a/cli/runtime/internal/modulefile/read.go
+++ b/cli/runtime/internal/modulefile/read.go
@@ -2,14 +2,20 @@
 package modulefile
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/wago-org/wago"
 )
 
 // MaxBytes is the largest module input accepted by CLI commands.
 const MaxBytes int64 = 256 << 20
+
+// MaxArtifactBytes matches the public artifact decoder plus framing overhead.
+const MaxArtifactBytes int64 = (1 << 30) + (256 << 20) + 64
 
 // Read reads path without accepting more than MaxBytes.
 func Read(path string) ([]byte, error) {
@@ -22,10 +28,19 @@ func Read(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if info.Size() > MaxBytes {
-		return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), MaxBytes)
-	}
 	if info.Mode().IsRegular() {
+		var prefix [5]byte
+		n, readErr := io.ReadFull(file, prefix[:])
+		if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+			return nil, readErr
+		}
+		limit := inputLimit(prefix[:n])
+		if info.Size() > limit {
+			return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), limit)
+		}
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
 		// Reserve one sentinel byte so growth after Stat is detected without
 		// io.ReadAll's geometric over-allocation.
 		readLimit := info.Size() + 1
@@ -34,21 +49,30 @@ func Read(path string) ([]byte, error) {
 		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 			return nil, err
 		}
-		if int64(n) > MaxBytes {
-			return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, MaxBytes)
+		if int64(n) > limit {
+			return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, limit)
 		}
 		if int64(n) > info.Size() {
 			return nil, fmt.Errorf("module %q changed size while being read", path)
 		}
 		return data[:n:n], nil
 	}
-	return readStream(path, file)
+	buffered := bufio.NewReaderSize(file, 5)
+	prefix, _ := buffered.Peek(5)
+	return readStream(path, buffered, inputLimit(prefix))
+}
+
+func inputLimit(prefix []byte) int64 {
+	if wago.IsCompiled(prefix) {
+		return MaxArtifactBytes
+	}
+	return MaxBytes
 }
 
 // readStream spools pipes and other unknown-length inputs through a bounded
 // fixed-size buffer. This avoids reserving the entire input limit before the
 // stream has produced any bytes while still returning one exact-sized slice.
-func readStream(path string, source io.Reader) ([]byte, error) {
+func readStream(path string, source io.Reader, limit int64) ([]byte, error) {
 	temporary, err := os.CreateTemp("", "wago-module-*")
 	if err != nil {
 		return nil, err
@@ -58,12 +82,12 @@ func readStream(path string, source io.Reader) ([]byte, error) {
 	defer temporary.Close()
 
 	buffer := make([]byte, 64<<10)
-	n, err := io.CopyBuffer(temporary, io.LimitReader(source, MaxBytes+1), buffer)
+	n, err := io.CopyBuffer(temporary, io.LimitReader(source, limit+1), buffer)
 	if err != nil {
 		return nil, err
 	}
-	if n > MaxBytes {
-		return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, MaxBytes)
+	if n > limit {
+		return nil, fmt.Errorf("module %q exceeds CLI limit of %d bytes", path, limit)
 	}
 	if _, err := temporary.Seek(0, io.SeekStart); err != nil {
 		return nil, err

--- a/cli/runtime/internal/modulefile/read.go
+++ b/cli/runtime/internal/modulefile/read.go
@@ -19,6 +19,16 @@ const MaxArtifactBytes int64 = (1 << 30) + (256 << 20) + 64
 
 // Read reads path without accepting more than MaxBytes.
 func Read(path string) ([]byte, error) {
+	return read(path, false)
+}
+
+// ReadSourceOrArtifact reads a run-command input, selecting the larger decoder
+// ceiling only when the input carries Wago's compiled-artifact magic.
+func ReadSourceOrArtifact(path string) ([]byte, error) {
+	return read(path, true)
+}
+
+func read(path string, allowArtifact bool) ([]byte, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -29,17 +39,20 @@ func Read(path string) ([]byte, error) {
 		return nil, err
 	}
 	if info.Mode().IsRegular() {
-		var prefix [5]byte
-		n, readErr := io.ReadFull(file, prefix[:])
-		if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
-			return nil, readErr
+		limit := MaxBytes
+		if allowArtifact {
+			var prefix [5]byte
+			n, readErr := io.ReadFull(file, prefix[:])
+			if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+				return nil, readErr
+			}
+			limit = inputLimit(prefix[:n])
+			if _, err := file.Seek(0, io.SeekStart); err != nil {
+				return nil, err
+			}
 		}
-		limit := inputLimit(prefix[:n])
 		if info.Size() > limit {
 			return nil, fmt.Errorf("module %q is %d bytes; CLI limit is %d bytes", path, info.Size(), limit)
-		}
-		if _, err := file.Seek(0, io.SeekStart); err != nil {
-			return nil, err
 		}
 		// Reserve one sentinel byte so growth after Stat is detected without
 		// io.ReadAll's geometric over-allocation.
@@ -56,6 +69,9 @@ func Read(path string) ([]byte, error) {
 			return nil, fmt.Errorf("module %q changed size while being read", path)
 		}
 		return data[:n:n], nil
+	}
+	if !allowArtifact {
+		return readStream(path, file, MaxBytes)
 	}
 	buffered := bufio.NewReaderSize(file, 5)
 	prefix, _ := buffered.Peek(5)

--- a/cli/runtime/internal/modulefile/read_test.go
+++ b/cli/runtime/internal/modulefile/read_test.go
@@ -1,0 +1,26 @@
+package modulefile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadBoundsModuleInput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large.wasm")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(MaxBytes + 1); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := Read(path); err == nil || data != nil || !strings.Contains(err.Error(), "CLI limit") {
+		t.Fatalf("oversized read = %d bytes, %v", len(data), err)
+	}
+}

--- a/cli/runtime/internal/modulefile/read_test.go
+++ b/cli/runtime/internal/modulefile/read_test.go
@@ -77,7 +77,7 @@ func TestReadUsesExactSizedResult(t *testing.T) {
 	}
 }
 
-func TestOpenSourceOrArtifactStreamsRegularArtifact(t *testing.T) {
+func TestReadSourceOrOpenArtifactStreamsRegularArtifact(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "large.wago")
 	file, err := os.Create(path)
 	if err != nil {
@@ -95,19 +95,19 @@ func TestOpenSourceOrArtifactStreamsRegularArtifact(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	input, err := OpenSourceOrArtifact(path)
+	source, artifact, artifactFile, size, err := ReadSourceOrOpenArtifact(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer input.Close()
-	if !input.IsArtifact() {
-		t.Fatal("compiled artifact was classified as source")
+	defer artifactFile.Close()
+	if source != nil || artifact == nil {
+		t.Fatalf("compiled artifact classification = source %d bytes, reader %v", len(source), artifact)
 	}
-	if size, ok := input.Size(); !ok || size != MaxBytes+1 {
-		t.Fatalf("artifact size = %d, %v; want %d, true", size, ok, MaxBytes+1)
+	if size != MaxBytes+1 {
+		t.Fatalf("artifact size = %d, want %d", size, MaxBytes+1)
 	}
 	prefix := make([]byte, 5)
-	if _, err := io.ReadFull(input, prefix); err != nil || string(prefix) != "WAGO\x01" {
+	if _, err := io.ReadFull(artifact, prefix); err != nil || string(prefix) != "WAGO\x01" {
 		t.Fatalf("streamed artifact prefix = %q, %v", prefix, err)
 	}
 }

--- a/cli/runtime/internal/modulefile/read_test.go
+++ b/cli/runtime/internal/modulefile/read_test.go
@@ -1,6 +1,7 @@
 package modulefile
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,5 +74,40 @@ func TestReadUsesExactSizedResult(t *testing.T) {
 	}
 	if cap(got) != len(got) {
 		t.Fatalf("result capacity = %d, want exact length %d", cap(got), len(got))
+	}
+}
+
+func TestOpenSourceOrArtifactStreamsRegularArtifact(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large.wago")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(MaxBytes + 1); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if _, err := file.WriteAt([]byte("WAGO\x01"), 0); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	input, err := OpenSourceOrArtifact(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input.Close()
+	if !input.IsArtifact() {
+		t.Fatal("compiled artifact was classified as source")
+	}
+	if size, ok := input.Size(); !ok || size != MaxBytes+1 {
+		t.Fatalf("artifact size = %d, %v; want %d, true", size, ok, MaxBytes+1)
+	}
+	prefix := make([]byte, 5)
+	if _, err := io.ReadFull(input, prefix); err != nil || string(prefix) != "WAGO\x01" {
+		t.Fatalf("streamed artifact prefix = %q, %v", prefix, err)
 	}
 }

--- a/cli/runtime/internal/modulefile/read_test.go
+++ b/cli/runtime/internal/modulefile/read_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/wago-org/wago"
 )
 
 func TestReadBoundsModuleInput(t *testing.T) {
@@ -25,9 +27,22 @@ func TestReadBoundsModuleInput(t *testing.T) {
 	}
 }
 
+func TestInputLimitDistinguishesSourceAndArtifact(t *testing.T) {
+	if got := inputLimit([]byte("\x00asm\x01")); got != MaxBytes {
+		t.Fatalf("Wasm input limit = %d, want %d", got, MaxBytes)
+	}
+	if got := inputLimit([]byte("WAGO\x01")); got != MaxArtifactBytes {
+		t.Fatalf("artifact input limit = %d, want %d", got, MaxArtifactBytes)
+	}
+	limits := wago.DefaultArtifactLimits()
+	if want := limits.MaxCodeBytes + limits.MaxMetadataBytes + 64; MaxArtifactBytes != want {
+		t.Fatalf("artifact input limit = %d, decoder allowance %d", MaxArtifactBytes, want)
+	}
+}
+
 func TestReadStreamReturnsExactSizedResult(t *testing.T) {
 	want := "pipe payload"
-	got, err := readStream("pipe", strings.NewReader(want))
+	got, err := readStream("pipe", strings.NewReader(want), MaxBytes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/runtime/internal/modulefile/read_test.go
+++ b/cli/runtime/internal/modulefile/read_test.go
@@ -24,3 +24,21 @@ func TestReadBoundsModuleInput(t *testing.T) {
 		t.Fatalf("oversized read = %d bytes, %v", len(data), err)
 	}
 }
+
+func TestReadUsesExactSizedResult(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "module.wasm")
+	want := []byte("wasm payload")
+	if err := os.WriteFile(path, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("Read = %q, want %q", got, want)
+	}
+	if cap(got) != len(got) {
+		t.Fatalf("result capacity = %d, want exact length %d", cap(got), len(got))
+	}
+}

--- a/cli/runtime/internal/modulefile/read_test.go
+++ b/cli/runtime/internal/modulefile/read_test.go
@@ -19,11 +19,15 @@ func TestReadBoundsModuleInput(t *testing.T) {
 		file.Close()
 		t.Fatal(err)
 	}
+	if _, err := file.WriteAt([]byte("WAGO\x01"), 0); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
 	if data, err := Read(path); err == nil || data != nil || !strings.Contains(err.Error(), "CLI limit") {
-		t.Fatalf("oversized read = %d bytes, %v", len(data), err)
+		t.Fatalf("oversized source read = %d bytes, %v", len(data), err)
 	}
 }
 

--- a/cli/runtime/internal/modulefile/read_test.go
+++ b/cli/runtime/internal/modulefile/read_test.go
@@ -25,6 +25,20 @@ func TestReadBoundsModuleInput(t *testing.T) {
 	}
 }
 
+func TestReadStreamReturnsExactSizedResult(t *testing.T) {
+	want := "pipe payload"
+	got, err := readStream("pipe", strings.NewReader(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("readStream = %q, want %q", got, want)
+	}
+	if cap(got) != len(got) {
+		t.Fatalf("result capacity = %d, want exact length %d", cap(got), len(got))
+	}
+}
+
 func TestReadUsesExactSizedResult(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "module.wasm")
 	want := []byte("wasm payload")

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -3963,14 +3963,13 @@ func (c *Compiled) ArtifactSectionSizes() (ArtifactSectionSizes, error) {
 	if err := c.validateSerializableLocked(); err != nil {
 		return ArtifactSectionSizes{}, err
 	}
-	metadata, result, err := marshalCompiledMetadataMeasured(c)
+	result, err := measureCompiledMetadata(c)
 	if err != nil {
 		return ArtifactSectionSizes{}, err
 	}
-	framing := int64(6 + 2 + compiledUvarintLen(uint64(len(c.code))) + compiledUvarintLen(uint64(len(metadata))))
+	framing := int64(6 + 2 + compiledUvarintLen(uint64(len(c.code))) + compiledUvarintLen(uint64(result.Metadata)))
 	result.Framing = framing
 	result.Code = int64(len(c.code))
-	result.Metadata = int64(len(metadata))
 	result.Total = result.Framing + result.Code + result.Metadata
 	return result, nil
 }

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -265,12 +265,24 @@ func marshalCompiledMetadata(c *Compiled) ([]byte, error) {
 }
 
 func marshalCompiledMetadataMeasured(c *Compiled) ([]byte, ArtifactSectionSizes, error) {
-	w := compiledWriter{buf: make([]byte, 0, 256)}
+	return encodeCompiledMetadataMeasured(c, false)
+}
+
+func measureCompiledMetadata(c *Compiled) (ArtifactSectionSizes, error) {
+	_, sizes, err := encodeCompiledMetadataMeasured(c, true)
+	return sizes, err
+}
+
+func encodeCompiledMetadataMeasured(c *Compiled, countOnly bool) ([]byte, ArtifactSectionSizes, error) {
+	w := compiledWriter{countOnly: countOnly}
+	if !countOnly {
+		w.buf = make([]byte, 0, 256)
+	}
 	var sizes ArtifactSectionSizes
-	start := 0
+	start := int64(0)
 	mark := func(dst *int64) {
-		*dst = int64(len(w.buf) - start)
-		start = len(w.buf)
+		*dst = w.length() - start
+		start = w.length()
 	}
 	w.intSlice(c.Entry)
 	w.internalEntrySlice(c.InternalEntry)
@@ -333,8 +345,8 @@ func marshalCompiledMetadataMeasured(c *Compiled) ([]byte, ArtifactSectionSizes,
 	w.stringIntMap(c.memoryExportMap())
 	mark(&sizes.Memories)
 	w.bool(c.dynamicImports)
-	sizes.Features = int64(len(w.buf) - start)
-	start = len(w.buf)
+	sizes.Features = w.length() - start
+	start = w.length()
 	w.tags(c)
 	mark(&sizes.Tags)
 	required := uint64(compiledStructuralRequiredFeatures(c))
@@ -363,8 +375,8 @@ func marshalCompiledMetadataMeasured(c *Compiled) ([]byte, ArtifactSectionSizes,
 		required |= compiledRegisterABIDisabled
 	}
 	w.u64(required)
-	sizes.Features += int64(len(w.buf) - start)
-	start = len(w.buf)
+	sizes.Features += w.length() - start
+	start = w.length()
 	if required&(compiledGCExecutionGenericStruct|compiledGCExecutionGenericArray) != 0 || c.hasCollectorReferenceCallBoundary() {
 		w.u32(c.nativeGCABIRequirement())
 	}
@@ -376,15 +388,44 @@ func marshalCompiledMetadataMeasured(c *Compiled) ([]byte, ArtifactSectionSizes,
 		w.gcFrameRoots(rootMap)
 	}
 	mark(&sizes.GC)
+	sizes.Metadata = w.length()
 	return w.buf, sizes, nil
 }
 
 type compiledWriter struct {
-	buf []byte
-	tmp [binary.MaxVarintLen64]byte
+	buf       []byte
+	tmp       [binary.MaxVarintLen64]byte
+	count     int64
+	countOnly bool
 }
 
-func (w *compiledWriter) u8(v byte) { w.buf = append(w.buf, v) }
+func (w *compiledWriter) length() int64 {
+	if w.countOnly {
+		return w.count
+	}
+	return int64(len(w.buf))
+}
+
+func (w *compiledWriter) appendBytes(p []byte) {
+	if w.countOnly {
+		w.count += int64(len(p))
+	} else {
+		w.buf = append(w.buf, p...)
+	}
+}
+
+func (w *compiledWriter) appendString(s string) {
+	if w.countOnly {
+		w.count += int64(len(s))
+	} else {
+		w.buf = append(w.buf, s...)
+	}
+}
+
+func (w *compiledWriter) u8(v byte) {
+	w.tmp[0] = v
+	w.appendBytes(w.tmp[:1])
+}
 func (w *compiledWriter) bool(v bool) {
 	if v {
 		w.u8(1)
@@ -394,30 +435,32 @@ func (w *compiledWriter) bool(v bool) {
 }
 func (w *compiledWriter) uvar(v uint64) {
 	n := binary.PutUvarint(w.tmp[:], v)
-	w.buf = append(w.buf, w.tmp[:n]...)
+	w.appendBytes(w.tmp[:n])
 }
 func (w *compiledWriter) ivar(v int) {
 	n := binary.PutVarint(w.tmp[:], int64(v))
-	w.buf = append(w.buf, w.tmp[:n]...)
+	w.appendBytes(w.tmp[:n])
 }
 func (w *compiledWriter) u32(v uint32) {
-	w.buf = binary.LittleEndian.AppendUint32(w.buf, v)
+	binary.LittleEndian.PutUint32(w.tmp[:4], v)
+	w.appendBytes(w.tmp[:4])
 }
 func (w *compiledWriter) u64(v uint64) {
-	w.buf = binary.LittleEndian.AppendUint64(w.buf, v)
+	binary.LittleEndian.PutUint64(w.tmp[:8], v)
+	w.appendBytes(w.tmp[:8])
 }
 func (w *compiledWriter) bytes(b []byte) {
 	w.uvar(uint64(len(b)))
-	w.buf = append(w.buf, b...)
+	w.appendBytes(b)
 }
 func (w *compiledWriter) section(id byte, payload []byte) {
 	w.u8(id)
 	w.uvar(uint64(len(payload)))
-	w.buf = append(w.buf, payload...)
+	w.appendBytes(payload)
 }
 func (w *compiledWriter) str(s string) {
 	w.uvar(uint64(len(s)))
-	w.buf = append(w.buf, s...)
+	w.appendString(s)
 }
 func (w *compiledWriter) stringSlice(v []string) {
 	w.uvar(uint64(len(v)))
@@ -710,7 +753,7 @@ func (w *compiledWriter) globals(v []GlobalDef, c *Compiled) error {
 			w.u8(0)
 			w.u64(g.Bits)
 			if g.Type == ValV128 {
-				w.buf = append(w.buf, g.V128[:]...)
+				w.appendBytes(g.V128[:])
 			}
 		}
 	}

--- a/src/wago/codec.go
+++ b/src/wago/codec.go
@@ -529,12 +529,19 @@ func (w *compiledWriter) memories(c *Compiled) {
 }
 
 func (w *compiledWriter) stringIntMap(m map[string]int) {
+	w.uvar(uint64(len(m)))
+	if w.countOnly {
+		for k, v := range m {
+			w.str(k)
+			w.ivar(v)
+		}
+		return
+	}
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	w.uvar(uint64(len(keys)))
 	for _, k := range keys {
 		w.str(k)
 		w.ivar(m[k])

--- a/src/wago/codec_hardening_test.go
+++ b/src/wago/codec_hardening_test.go
@@ -84,6 +84,23 @@ func TestArtifactSectionSizesDoesNotMaterializeMetadata(t *testing.T) {
 	}
 }
 
+func TestCountOnlyStringMapDoesNotAllocate(t *testing.T) {
+	values := make(map[string]int, 4096)
+	for i := 0; i < 4096; i++ {
+		values[fmt.Sprintf("export-%04d", i)] = i
+	}
+	w := compiledWriter{countOnly: true}
+	if allocs := testing.AllocsPerRun(10, func() {
+		w.count = 0
+		w.stringIntMap(values)
+	}); allocs != 0 {
+		t.Fatalf("count-only string map allocations = %.1f, want 0", allocs)
+	}
+	if w.count == 0 {
+		t.Fatal("count-only string map measured no bytes")
+	}
+}
+
 func TestCompiledReadFromLoadsCodeImageDirectly(t *testing.T) {
 	c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(1), benchAddOneModule())
 	if err != nil {

--- a/src/wago/codec_hardening_test.go
+++ b/src/wago/codec_hardening_test.go
@@ -62,6 +62,28 @@ func TestCompiledWriteToMatchesMarshalBinary(t *testing.T) {
 	}
 }
 
+func TestArtifactSectionSizesDoesNotMaterializeMetadata(t *testing.T) {
+	const payloadBytes = 8 << 20
+	c := &Compiled{PassiveData: []PassiveDataInit{{Bytes: make([]byte, payloadBytes)}}}
+	defer c.Close()
+	sizes, err := c.ArtifactSectionSizes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sizes.Data < payloadBytes || sizes.Metadata < payloadBytes {
+		t.Fatalf("large metadata sizes = data %d metadata %d, want at least %d", sizes.Data, sizes.Metadata, payloadBytes)
+	}
+	var measured ArtifactSectionSizes
+	if allocs := testing.AllocsPerRun(10, func() {
+		measured, err = c.ArtifactSectionSizes()
+	}); allocs != 0 {
+		t.Fatalf("ArtifactSectionSizes allocations = %.1f, want 0", allocs)
+	}
+	if err != nil || measured != sizes {
+		t.Fatalf("repeated artifact sizing = %+v, %v; want %+v", measured, err, sizes)
+	}
+}
+
 func TestCompiledReadFromLoadsCodeImageDirectly(t *testing.T) {
 	c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(1), benchAddOneModule())
 	if err != nil {


### PR DESCRIPTION
Small correctness fix: CLI commands read entire untrusted module files without a ceiling, and compiling unique inputs could grow the automatic artifact cache indefinitely.

Build, run, validate, and module inspection now share a 256 MiB limited reader. Successful cache publication prunes oldest regular `.wago` entries to a 512 MiB default total without following symlinks. Cache maintenance remains best-effort and never prevents execution.

Proof:
- `WAGO_HOME=<temporary> go test ./cli/runtime/commands/build ./cli/runtime/commands/run ./cli/runtime/commands/validate ./cli/runtime/internal/module`
- `go test ./cli/runtime/internal/modulefile ./cli/runtime/internal/artifactcache`