### PR TITLE
runtime: harden TinyGo trampoline and trap handling

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -117,7 +117,7 @@ func wagoSetup(b *testing.B, wasmBytes []byte, export string) (func(n int32) int
 	entry := base + uintptr(cm.Entry[localIdx])
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	lin := jm.LinearMemory()
 	call := func(n int32) int32 {
 		binary.LittleEndian.PutUint32(serArgs, uint32(n))

--- a/src/core/compiler/backend/railshot/amd64/adapter_tails_bench_amd64_test.go
+++ b/src/core/compiler/backend/railshot/amd64/adapter_tails_bench_amd64_test.go
@@ -53,7 +53,7 @@ func BenchmarkExecSharedAdapterTailAMD64(b *testing.B) {
 				b.Fatal(err)
 			}
 			defer coreruntime.Unmap(code)
-			results, trap := arena.Alloc(16), arena.Alloc(8)
+			results, trap := arena.Alloc(16), arena.Alloc(coreruntime.TrapBufferBytes)
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/src/core/compiler/backend/railshot/amd64/brtable_bench_amd64_test.go
+++ b/src/core/compiler/backend/railshot/amd64/brtable_bench_amd64_test.go
@@ -44,7 +44,7 @@ func BenchmarkExecBrTableCompactTargetIDsAMD64(b *testing.B) {
 			}
 			defer coreruntime.Unmap(code)
 
-			args, results, trap := arena.Alloc(16), arena.Alloc(8), arena.Alloc(8)
+			args, results, trap := arena.Alloc(16), arena.Alloc(8), arena.Alloc(coreruntime.TrapBufferBytes)
 			binary.LittleEndian.PutUint64(args, 7)
 			binary.LittleEndian.PutUint64(args[8:], 1)
 			b.ResetTimer()

--- a/src/core/compiler/backend/railshot/amd64/callref_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/callref_exec_test.go
@@ -82,7 +82,7 @@ func runCallRefRaw(t *testing.T, m *wasm.Module, value uint64, descriptor bool, 
 	binary.LittleEndian.PutUint64(args, value)
 	binary.LittleEndian.PutUint64(args[8:], ref)
 	results := arena.Alloc(8)
-	trap := arena.Alloc(8)
+	trap := arena.Alloc(coreruntime.TrapBufferBytes)
 	err = eng.Call(base+uintptr(cm.Entry[0]), args, jm.LinearMemory(), trap, results)
 	return append([]byte(nil), results...), err
 }
@@ -169,7 +169,7 @@ func runReturnCallRefRaw(t *testing.T, m *wasm.Module, n uint64, sigKey uint64, 
 	args := arena.Alloc(8)
 	binary.LittleEndian.PutUint64(args, n)
 	results := arena.Alloc(8)
-	trap := arena.Alloc(8)
+	trap := arena.Alloc(coreruntime.TrapBufferBytes)
 	err = eng.Call(base+uintptr(cm.Entry[0]), args, jm.LinearMemory(), trap, results)
 	return append([]byte(nil), results...), err
 }

--- a/src/core/compiler/backend/railshot/amd64/exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/exec_test.go
@@ -123,7 +123,7 @@ func runAmd64(t *testing.T, m *wasm.Module, args ...int32) int32 {
 
 	serArgs := ar.Alloc(128)
 	results := ar.Alloc(128)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	for i, a := range args {
 		binary.LittleEndian.PutUint32(serArgs[i*8:], uint32(a))
 	}
@@ -192,7 +192,7 @@ func runMemAmd64WithOptions(t *testing.T, m *wasm.Module, opts CompileOptions, s
 	defer runtime.Unmap(mem)
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	for i, a := range args {
 		binary.LittleEndian.PutUint64(serArgs[i*8:], a)
 	}
@@ -236,7 +236,7 @@ func runCompiledAmd64u(t *testing.T, cm *encoderamd64.CompiledModule, args ...ui
 
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	for i, a := range args {
 		binary.LittleEndian.PutUint64(serArgs[i*8:], a)
 	}
@@ -853,7 +853,7 @@ func TestAmd64Phase4Calls(t *testing.T) {
 		}
 		defer runtime.Unmap(mem)
 		res := ar.Alloc(64)
-		trap := ar.Alloc(8)
+		trap := ar.Alloc(runtime.TrapBufferBytes)
 		err = eng.Call(entry+uintptr(cm.Entry[0]), ar.Alloc(64), jm.LinearMemory(), trap, res)
 		if err == nil {
 			t.Fatal("expected trap to propagate through caller, got nil")
@@ -916,7 +916,7 @@ func TestAmd64BulkAndSat(t *testing.T) {
 			defer runtime.Unmap(mem)
 			serArgs := ar.Alloc(256)
 			results := ar.Alloc(256)
-			trap := ar.Alloc(8)
+			trap := ar.Alloc(runtime.TrapBufferBytes)
 			for i, a := range args {
 				binary.LittleEndian.PutUint64(serArgs[i*8:], a)
 			}

--- a/src/core/compiler/backend/railshot/amd64/magicdiv_test.go
+++ b/src/core/compiler/backend/railshot/amd64/magicdiv_test.go
@@ -37,7 +37,7 @@ func divInvoker(t *testing.T, m *wasm.Module) (call func(uint64) uint64, done fu
 	}
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	call = func(arg uint64) uint64 {
 		binary.LittleEndian.PutUint64(serArgs, arg)
 		if err := eng.Call(entry+uintptr(cm.Entry[0]), serArgs, jm.LinearMemory(), trap, results); err != nil {

--- a/src/core/compiler/backend/railshot/amd64/simd_bench_test.go
+++ b/src/core/compiler/backend/railshot/amd64/simd_bench_test.go
@@ -48,7 +48,7 @@ func benchmarkSIMDV128Body(b *testing.B, body []byte) {
 
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	callEntry := entry + uintptr(cm.Entry[0])
 	lin := jm.LinearMemory()
 

--- a/src/core/compiler/backend/railshot/amd64/simd_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/simd_exec_test.go
@@ -158,7 +158,7 @@ func runAmd64V128(t *testing.T, m *wasm.Module, arg *[16]byte) [16]byte {
 
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	if arg != nil {
 		copy(serArgs, arg[:])
 	}
@@ -199,7 +199,7 @@ func runAmd64ResultBuffer(t *testing.T, m *wasm.Module, setup func(*runtime.JobM
 
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	if setup != nil {
 		setup(jm, serArgs, entry, cm)
 	}
@@ -241,7 +241,7 @@ func runMemAmd64V128(t *testing.T, m *wasm.Module, setup func([]byte)) ([16]byte
 	defer runtime.Unmap(mem)
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	callErr := eng.Call(entry+uintptr(cm.Entry[0]), serArgs, lin, trap, results)
 	var out [16]byte
 	copy(out[:], results[:16])
@@ -2322,7 +2322,7 @@ func TestSIMDV128FunctionABIUsesSixteenByteSlots(t *testing.T) {
 	defer runtime.Unmap(code)
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(runtime.TrapBufferBytes)
 	binary.LittleEndian.PutUint32(serArgs[0:4], 0x11111111)
 	copy(serArgs[8:24], arg[:])
 	binary.LittleEndian.PutUint32(serArgs[24:28], 0x76543210)

--- a/src/core/compiler/backend/railshot/amd64/swar_test.go
+++ b/src/core/compiler/backend/railshot/amd64/swar_test.go
@@ -356,7 +356,7 @@ func BenchmarkSWARPack4Exec(b *testing.B) {
 				b.Fatal(err)
 			}
 			defer wagoruntime.Unmap(mem)
-			args, results, trap := make([]byte, 8), make([]byte, 8), make([]byte, 8)
+			args, results, trap := make([]byte, 8), make([]byte, 8), make([]byte, wagoruntime.TrapBufferBytes)
 			b.ReportAllocs()
 			b.ReportMetric(float64(len(cm.Code)), "code-B")
 			b.ResetTimer()

--- a/src/core/compiler/backend/railshot/amd64/tailcall_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/tailcall_exec_test.go
@@ -43,7 +43,7 @@ func runTailRaw(t *testing.T, m *wasm.Module, args ...uint64) ([]byte, error) {
 	defer runtime.Unmap(code)
 	argBuf := arena.Alloc(128)
 	resultBuf := arena.Alloc(128)
-	trap := arena.Alloc(8)
+	trap := arena.Alloc(runtime.TrapBufferBytes)
 	for i, arg := range args {
 		binary.LittleEndian.PutUint64(argBuf[i*8:], arg)
 	}

--- a/src/core/compiler/backend/railshot/amd64/tailcall_indirect_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/tailcall_indirect_exec_test.go
@@ -93,7 +93,7 @@ func runIndirectTail(t *testing.T, m *wasm.Module, tableFuncs []int, args ...uin
 
 	argBuf := arena.Alloc(128)
 	resultBuf := arena.Alloc(128)
-	trap := arena.Alloc(8)
+	trap := arena.Alloc(coreruntime.TrapBufferBytes)
 	for i, arg := range args {
 		binary.LittleEndian.PutUint64(argBuf[i*8:], arg)
 	}

--- a/src/core/compiler/backend/railshot/amd64/typed_ref_control_exec_test.go
+++ b/src/core/compiler/backend/railshot/amd64/typed_ref_control_exec_test.go
@@ -59,7 +59,7 @@ func runTypedRefControl(t *testing.T, m *wasm.Module, ref uint64) (uint64, error
 	args := arena.Alloc(8)
 	binary.LittleEndian.PutUint64(args, ref)
 	results := arena.Alloc(8)
-	trap := arena.Alloc(8)
+	trap := arena.Alloc(coreruntime.TrapBufferBytes)
 	err = eng.Call(base+uintptr(cm.Entry[0]), args, jm.LinearMemory(), trap, results)
 	return binary.LittleEndian.Uint64(results), err
 }

--- a/src/core/compiler/backend/railshot/arm64/adapter_tails_bench_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/adapter_tails_bench_arm64_test.go
@@ -49,7 +49,7 @@ func BenchmarkExecSharedAdapterTailArm64(b *testing.B) {
 				b.Fatal(err)
 			}
 			defer coreruntime.Unmap(code)
-			results, trap := arena.Alloc(8), arena.Alloc(8)
+			results, trap := arena.Alloc(8), arena.Alloc(coreruntime.TrapBufferBytes)
 			b.ReportMetric(float64(len(cm.Code)), "code-B")
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/src/core/compiler/backend/railshot/arm64/boundshoist_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/boundshoist_arm64_test.go
@@ -48,7 +48,7 @@ func runArm64WrapperMem(t *testing.T, m *wasm.Module, arg uint32, init func([]by
 		t.Fatal(err)
 	}
 	defer coreruntime.Unmap(code)
-	serArgs, results, trap := ar.Alloc(16), ar.Alloc(16), ar.Alloc(8)
+	serArgs, results, trap := ar.Alloc(16), ar.Alloc(16), ar.Alloc(coreruntime.TrapBufferBytes)
 	binary.LittleEndian.PutUint32(serArgs, arg)
 	err = eng.Call(entry+uintptr(cm.Entry[0]), serArgs, jm.LinearMemory(), trap, results)
 	return binary.LittleEndian.Uint32(results), err

--- a/src/core/compiler/backend/railshot/arm64/brtable_bench_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/brtable_bench_arm64_test.go
@@ -44,7 +44,7 @@ func BenchmarkExecBrTableCompactTargetIDsArm64(b *testing.B) {
 			}
 			defer coreruntime.Unmap(code)
 
-			args, results, trap := arena.Alloc(16), arena.Alloc(8), arena.Alloc(8)
+			args, results, trap := arena.Alloc(16), arena.Alloc(8), arena.Alloc(coreruntime.TrapBufferBytes)
 			binary.LittleEndian.PutUint64(args, 7)
 			binary.LittleEndian.PutUint64(args[8:], 1)
 			b.ReportMetric(float64(len(cm.Code)), "code-B")

--- a/src/core/compiler/backend/railshot/arm64/entry_param_pairs_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/entry_param_pairs_arm64_test.go
@@ -121,7 +121,7 @@ func BenchmarkEntryParamPairsARM64(b *testing.B) {
 				b.Fatal(err)
 			}
 			defer coreruntime.Unmap(code)
-			args, results, trap := arena.Alloc(n*8), arena.Alloc(8), arena.Alloc(8)
+			args, results, trap := arena.Alloc(n*8), arena.Alloc(8), arena.Alloc(coreruntime.TrapBufferBytes)
 			for i := range n {
 				binary.LittleEndian.PutUint64(args[i*8:], uint64(i+1))
 			}

--- a/src/core/compiler/backend/railshot/arm64/entry_zero_pairs_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/entry_zero_pairs_arm64_test.go
@@ -118,7 +118,7 @@ func BenchmarkEntryZeroPairsARM64(b *testing.B) {
 				b.Fatal(err)
 			}
 			defer coreruntime.Unmap(code)
-			args, results, trap := arena.Alloc(8), arena.Alloc(8), arena.Alloc(8)
+			args, results, trap := arena.Alloc(8), arena.Alloc(8), arena.Alloc(coreruntime.TrapBufferBytes)
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {

--- a/src/core/compiler/backend/railshot/arm64/exec_helpers_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/exec_helpers_arm64_test.go
@@ -49,7 +49,7 @@ func runArm64WrapperWithOptions(t *testing.T, m *wasm.Module, opts CompileOption
 
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(coreruntime.TrapBufferBytes)
 	for i, a := range args {
 		binary.LittleEndian.PutUint64(serArgs[i*8:], a)
 	}

--- a/src/core/compiler/backend/railshot/arm64/load_pair_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/load_pair_arm64_test.go
@@ -102,7 +102,7 @@ func BenchmarkLoadPairArm64(b *testing.B) {
 				b.Fatal(err)
 			}
 			defer coreruntime.Unmap(code)
-			args, results, trap := arena.Alloc(8), arena.Alloc(8), arena.Alloc(8)
+			args, results, trap := arena.Alloc(8), arena.Alloc(8), arena.Alloc(coreruntime.TrapBufferBytes)
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/src/core/compiler/backend/railshot/arm64/simd_exec_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/simd_exec_arm64_test.go
@@ -131,7 +131,7 @@ func runArm64Result(t *testing.T, m *wasm.Module, n int) []byte {
 
 	serArgs := ar.Alloc(256)
 	results := ar.Alloc(256)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(coreruntime.TrapBufferBytes)
 	if err := eng.Call(entry+uintptr(cm.Entry[0]), serArgs, jm.LinearMemory(), trap, results); err != nil {
 		t.Fatalf("call: %v", err)
 	}

--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -4,7 +4,6 @@ package runtime
 
 import (
 	"encoding/binary"
-	"fmt"
 	"sync"
 	"unsafe"
 
@@ -248,13 +247,14 @@ func (j *JobMemory) LinMemBase() uintptr {
 // guard ([linMem - 72]).
 func (j *JobMemory) SetStackFence(v uintptr) { j.putU64(offStackFence, uint64(v)) }
 
-// BindTrapCell installs the stable trap-cell pointer used by native trap stubs
-// and establishes the zero-on-entry invariant required by Engine.CallPrepared.
-// The caller must keep trap alive and at a stable address for the JobMemory's
-// native calls (Arena-backed instance buffers satisfy this).
+// BindTrapCell installs the stable trap-buffer pointer used by native trap
+// stubs and establishes the zero-on-entry invariant required by
+// Engine.CallPrepared. Native trap stubs write through byte 23, so the caller
+// must provide TrapBufferBytes stable off-heap bytes for all native calls
+// (Arena-backed instance buffers satisfy this).
 func (j *JobMemory) BindTrapCell(trap []byte) error {
-	if len(trap) < 4 {
-		return fmt.Errorf("trap cell requires at least 4 bytes")
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
 	}
 	binary.LittleEndian.PutUint32(trap, 0)
 	j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
@@ -265,8 +265,8 @@ func (j *JobMemory) BindTrapCell(trap []byte) error {
 // nested entry changed basedata. Unlike BindTrapCell, it preserves a concurrent
 // interruption while clearing stale host-pending or ordinary trap state.
 func (j *JobMemory) RebindTrapCell(trap []byte) error {
-	if len(trap) < 4 {
-		return fmt.Errorf("trap cell requires at least 4 bytes")
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
 	}
 	clearTrapUnlessInterrupted(trap)
 	j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
@@ -277,7 +277,7 @@ func (j *JobMemory) RebindTrapCell(trap []byte) error {
 // Cross-instance entry replaces the pointer (and the fence alongside it), so
 // this one-word identity check is sufficient for the prepared-call fast path.
 func (j *JobMemory) HasTrapCell(trap []byte) bool {
-	return len(trap) >= 4 && j.getU64(abi.TrapCellPtrOffset) == uint64(slicePtr(trap))
+	return len(trap) >= TrapBufferBytes && j.getU64(abi.TrapCellPtrOffset) == uint64(slicePtr(trap))
 }
 
 // InstanceContext is the per-instance subset of basedata. It deliberately

--- a/src/core/runtime/basedata_control_test.go
+++ b/src/core/runtime/basedata_control_test.go
@@ -76,7 +76,7 @@ func TestJobMemoryHasTrapCellDetectsCrossInstanceOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer jm.Close()
-	trap := make([]byte, 8)
+	trap := make([]byte, TrapBufferBytes)
 	if jm.HasTrapCell(trap) {
 		t.Fatal("fresh job memory unexpectedly has the trap cell bound")
 	}

--- a/src/core/runtime/bench_test.go
+++ b/src/core/runtime/bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkCrossBoundaryCall(b *testing.B) {
 
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 	lin := jm.LinearMemory()
 	binary.LittleEndian.PutUint32(serArgs, 41)
 	codePtr := slicePtr(code)

--- a/src/core/runtime/engine.go
+++ b/src/core/runtime/engine.go
@@ -106,49 +106,46 @@ func (e *Engine) StackTop() uintptr {
 
 // Call enters native code at code following WARP's WasmWrapper ABI. serArgs,
 // linMem, trap and results MUST be backed by off-heap memory (Arena/JobMemory)
-// so their addresses are stable across the call. It returns a *TrapError if the
-// wrapper set a non-zero trap code.
+// so their addresses are stable across the call. trap must contain at least
+// TrapBufferBytes bytes because native trap stubs write the code and source
+// location. It returns a *TrapError if the wrapper set a non-zero trap code.
 //
 // The trap cell is zeroed and its pointer installed in basedata here, once per
 // entry, so generated code never passes or clears it: emitTrap (the only
 // consumer, cold) reads [linMem-abi.TrapCellPtrOffset], and function returns
 // carry no trap protocol at all (WARP's model).
 func (e *Engine) Call(code uintptr, serArgs, linMem, trap, results []byte) error {
-	if err := validateTrapCell(trap); err != nil {
+	if err := validateTrapBuffer(trap); err != nil {
 		return err
 	}
 	installTrapCell(linMem, trap)
 	enterNative(code, slicePtr(serArgs), slicePtr(linMem), slicePtr(trap), slicePtr(results), e.stackTop)
-	if len(trap) >= 4 {
-		if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
-			return trapErrorFromBuffer(tc, trap)
-		}
+	if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
+		return trapErrorFromBuffer(tc, trap)
 	}
 	return nil
 }
 
 // CallPrepared enters native code after JobMemory.BindTrapCell established a
-// stable trap pointer and a zero trap cell. Successful native execution never
-// writes that cell, so repeated calls avoid clearing/rebinding it. A cold trap
-// is consumed and cleared before returning, re-establishing the invariant for
-// the next call.
+// stable trap pointer and a zero trap buffer of at least TrapBufferBytes bytes.
+// Successful native execution never writes that buffer, so repeated calls avoid
+// clearing/rebinding it. A cold trap is consumed and cleared before returning,
+// re-establishing the invariant for the next call.
 func (e *Engine) CallPrepared(code uintptr, serArgs []byte, linMemBase uintptr, trap, results []byte) error {
-	if err := validateTrapCell(trap); err != nil {
+	if err := validateTrapBuffer(trap); err != nil {
 		return err
 	}
 	enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
-	if len(trap) >= 4 {
-		if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
-			storeTrap(trap, 0)
-			return trapErrorFromBuffer(tc, trap)
-		}
+	if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
+		storeTrap(trap, 0)
+		return trapErrorFromBuffer(tc, trap)
 	}
 	return nil
 }
 
-func validateTrapCell(trap []byte) error {
-	if len(trap) < 4 {
-		return fmt.Errorf("jit: trap cell has %d bytes, need at least 4", len(trap))
+func validateTrapBuffer(trap []byte) error {
+	if len(trap) < TrapBufferBytes {
+		return fmt.Errorf("jit: trap buffer has %d bytes, need %d", len(trap), TrapBufferBytes)
 	}
 	return nil
 }
@@ -204,8 +201,8 @@ func (e *Engine) CallWithHostBase(code uintptr, serArgs []byte, linMemBase uintp
 	if linMemBase == 0 {
 		return fmt.Errorf("jit: host-call linear-memory base is zero")
 	}
-	if len(trap) < TrapBufferBytes {
-		return fmt.Errorf("jit: host-call trap buffer has %d bytes, need %d", len(trap), TrapBufferBytes)
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
 	}
 	if err := InitHostCtrlFrame(ctrl); err != nil {
 		return err

--- a/src/core/runtime/engine.go
+++ b/src/core/runtime/engine.go
@@ -114,6 +114,9 @@ func (e *Engine) StackTop() uintptr {
 // consumer, cold) reads [linMem-abi.TrapCellPtrOffset], and function returns
 // carry no trap protocol at all (WARP's model).
 func (e *Engine) Call(code uintptr, serArgs, linMem, trap, results []byte) error {
+	if err := validateTrapCell(trap); err != nil {
+		return err
+	}
 	installTrapCell(linMem, trap)
 	enterNative(code, slicePtr(serArgs), slicePtr(linMem), slicePtr(trap), slicePtr(results), e.stackTop)
 	if len(trap) >= 4 {
@@ -130,12 +133,22 @@ func (e *Engine) Call(code uintptr, serArgs, linMem, trap, results []byte) error
 // is consumed and cleared before returning, re-establishing the invariant for
 // the next call.
 func (e *Engine) CallPrepared(code uintptr, serArgs []byte, linMemBase uintptr, trap, results []byte) error {
+	if err := validateTrapCell(trap); err != nil {
+		return err
+	}
 	enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
 	if len(trap) >= 4 {
 		if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
 			storeTrap(trap, 0)
 			return trapErrorFromBuffer(tc, trap)
 		}
+	}
+	return nil
+}
+
+func validateTrapCell(trap []byte) error {
+	if len(trap) < 4 {
+		return fmt.Errorf("jit: trap cell has %d bytes, need at least 4", len(trap))
 	}
 	return nil
 }

--- a/src/core/runtime/engine.go
+++ b/src/core/runtime/engine.go
@@ -43,7 +43,11 @@ func NewEngine() (*Engine, error) {
 	}
 	top := uintptr(unsafe.Pointer(&st[0])) + uintptr(len(st))
 	top &^= 15 // 16-byte align (page-aligned already, but be explicit)
-	return &Engine{stack: st, stackTop: top}, nil
+	e := &Engine{stack: st, stackTop: top}
+	if err := e.initNativeEntry(); err != nil {
+		return nil, errors.Join(err, munmap(st))
+	}
+	return e, nil
 }
 
 var engineCache struct {
@@ -143,9 +147,11 @@ func (e *Engine) CallPrepared(code uintptr, serArgs []byte, linMemBase uintptr, 
 	return nil
 }
 
+var errIncompleteTrapBuffer = errors.New("jit: trap buffer needs at least 24 bytes")
+
 func validateTrapBuffer(trap []byte) error {
 	if len(trap) < TrapBufferBytes {
-		return fmt.Errorf("jit: trap buffer has %d bytes, need %d", len(trap), TrapBufferBytes)
+		return errIncompleteTrapBuffer
 	}
 	return nil
 }
@@ -265,8 +271,9 @@ func (e *Engine) callWithHostLoop(code uintptr, serArgs []byte, linMemBase uintp
 			if TrapCode(loadTrap(trap)) == TrapInterrupted {
 				return trapErrorFromBuffer(TrapInterrupted, trap)
 			}
-			prepareHostResume(ctrl, trap, e.stackTop, e.StackLimit())
-			resumeNative(ctrlPtr, e.stackTop)
+			stackTop := e.StackTop()
+			prepareHostResume(ctrl, trap, stackTop, e.StackLimit())
+			resumeNative(ctrlPtr, stackTop)
 		}
 		switch tc := loadTrap(trap); {
 		case tc == hostCallPending:

--- a/src/core/runtime/engine_int_tinygo_amd64.go
+++ b/src/core/runtime/engine_int_tinygo_amd64.go
@@ -2,10 +2,7 @@
 
 package runtime
 
-import (
-	"encoding/binary"
-	"unsafe"
-)
+import "unsafe"
 
 // TinyGo cannot assemble engine_int_amd64.s. Its indirect-call ABI passes the
 // five explicit uintptr arguments in RDI, RSI, RDX, RCX, and R8, followed by the
@@ -45,19 +42,10 @@ var tinygoIntThunkTemplate = []byte{
 const tinygoIntThunkStackTopOff = 2
 
 func preparedIntThunkFor(e *Engine) (uintptr, error) {
-	if e.preparedInt.entry != 0 {
-		return e.preparedInt.entry, nil
-	}
-	code := make([]byte, len(tinygoIntThunkTemplate))
-	copy(code, tinygoIntThunkTemplate)
-	binary.LittleEndian.PutUint64(code[tinygoIntThunkStackTopOff:], uint64(e.stackTop))
-	mem, err := mmapExec(code)
-	if err != nil {
+	if err := e.initNativeEntry(); err != nil {
 		return 0, err
 	}
-	e.preparedInt.mem = mem
-	e.preparedInt.entry = uintptr(unsafe.Pointer(&mem[0]))
-	return e.preparedInt.entry, nil
+	return uintptr(unsafe.Pointer(&e.preparedInt.mem[0])) + tinygoPreparedIntEntryOffset, nil
 }
 
 func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) (uint64, error) {

--- a/src/core/runtime/engine_int_tinygo_arm64.go
+++ b/src/core/runtime/engine_int_tinygo_arm64.go
@@ -37,16 +37,10 @@ func tinygoARM64IntEntryCode(foreignStackTop uintptr) []byte {
 }
 
 func preparedIntThunkFor(e *Engine) (uintptr, error) {
-	if e.preparedInt.entry != 0 {
-		return e.preparedInt.entry, nil
-	}
-	mem, err := mmapExec(tinygoARM64IntEntryCode(e.stackTop))
-	if err != nil {
+	if err := e.initNativeEntry(); err != nil {
 		return 0, err
 	}
-	e.preparedInt.mem = mem
-	e.preparedInt.entry = uintptr(unsafe.Pointer(&mem[0]))
-	return e.preparedInt.entry, nil
+	return uintptr(unsafe.Pointer(&e.preparedInt.mem[0])) + tinygoARM64PreparedIntEntryOffset, nil
 }
 
 func (e *Engine) EnterPreparedInt(code, linMemBase uintptr, a0, a1, a2, a3 uint64) (uint64, error) {

--- a/src/core/runtime/engine_int_tinygo_test.go
+++ b/src/core/runtime/engine_int_tinygo_test.go
@@ -2,7 +2,23 @@
 
 package runtime
 
-import "testing"
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestTinyGoTrampolineFailurePreservesInterrupt(t *testing.T) {
+	trap := uint32(TrapInterrupted)
+	markTinyGoTrampolineFailure(uintptr(unsafe.Pointer(&trap)))
+	if got := TrapCode(trap); got != TrapInterrupted {
+		t.Fatalf("pending interrupt changed to %v", got)
+	}
+	trap = 0
+	markTinyGoTrampolineFailure(uintptr(unsafe.Pointer(&trap)))
+	if got := TrapCode(trap); got != TrapBuiltin {
+		t.Fatalf("ordinary mapping failure = %v, want builtin trap", got)
+	}
+}
 
 func TestPreparedIntThunkOwnedByEngine(t *testing.T) {
 	e := &Engine{}

--- a/src/core/runtime/engine_int_tinygo_test.go
+++ b/src/core/runtime/engine_int_tinygo_test.go
@@ -39,7 +39,7 @@ func TestPreparedIntThunkOwnedByEngine(t *testing.T) {
 	if err := e.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if e.preparedInt.entry != 0 || e.preparedInt.mem != nil {
+	if e.preparedInt.stackTop != 0 || e.preparedInt.mem != nil {
 		t.Fatal("prepared integer entry mapping retained after engine close")
 	}
 }

--- a/src/core/runtime/engine_prepared_state_tinygo.go
+++ b/src/core/runtime/engine_prepared_state_tinygo.go
@@ -3,8 +3,8 @@
 package runtime
 
 type tinygoPreparedIntState struct {
-	mem   []byte
-	entry uintptr
+	mem      []byte
+	stackTop uintptr
 }
 
 func (state *tinygoPreparedIntState) close() error {
@@ -12,6 +12,6 @@ func (state *tinygoPreparedIntState) close() error {
 		return err
 	}
 	state.mem = nil
-	state.entry = 0
+	state.stackTop = 0
 	return nil
 }

--- a/src/core/runtime/engine_trap_buffer_guardpage_test.go
+++ b/src/core/runtime/engine_trap_buffer_guardpage_test.go
@@ -1,0 +1,29 @@
+//go:build wago_guardpage
+
+package runtime
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCallGuardedRejectsIncompleteTrapBuffersBeforeNativeEntry(t *testing.T) {
+	jm, err := NewJobMemoryGuarded(0, wasmPageBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jm.Close()
+
+	engine := &Engine{}
+	for length := 0; length < TrapBufferBytes; length++ {
+		backing := bytes.Repeat([]byte{0xaa}, TrapBufferBytes)
+		err := engine.CallGuarded(0, nil, jm.LinMemBase(), backing[:length], nil, jm)
+		if err == nil || !strings.Contains(err.Error(), "trap buffer") {
+			t.Fatalf("trap length %d error = %v", length, err)
+		}
+		if want := bytes.Repeat([]byte{0xaa}, TrapBufferBytes); !bytes.Equal(backing, want) {
+			t.Fatalf("trap length %d changed backing bytes: %x", length, backing)
+		}
+	}
+}

--- a/src/core/runtime/engine_trap_buffer_test.go
+++ b/src/core/runtime/engine_trap_buffer_test.go
@@ -1,0 +1,26 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEngineRejectsShortTrapCellsBeforeNativeEntry(t *testing.T) {
+	engine := &Engine{}
+	for length := 0; length < 4; length++ {
+		backing := []byte{0xaa, 0xbb, 0xcc, 0xdd}
+		trap := backing[:length]
+		for name, call := range map[string]func() error{
+			"Call":         func() error { return engine.Call(0, nil, nil, trap, nil) },
+			"CallPrepared": func() error { return engine.CallPrepared(0, nil, 0, trap, nil) },
+		} {
+			err := call()
+			if err == nil || !strings.Contains(err.Error(), "trap cell") {
+				t.Fatalf("%s trap length %d error = %v", name, length, err)
+			}
+			if got := backing; got[0] != 0xaa || got[1] != 0xbb || got[2] != 0xcc || got[3] != 0xdd {
+				t.Fatalf("%s trap length %d changed backing bytes: %x", name, length, got)
+			}
+		}
+	}
+}

--- a/src/core/runtime/engine_trap_buffer_test.go
+++ b/src/core/runtime/engine_trap_buffer_test.go
@@ -1,25 +1,50 @@
 package runtime
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
 
-func TestEngineRejectsShortTrapCellsBeforeNativeEntry(t *testing.T) {
+func TestEngineRejectsIncompleteTrapBuffersBeforeNativeEntry(t *testing.T) {
 	engine := &Engine{}
-	for length := 0; length < 4; length++ {
-		backing := []byte{0xaa, 0xbb, 0xcc, 0xdd}
+	for length := 0; length < TrapBufferBytes; length++ {
+		backing := bytes.Repeat([]byte{0xaa}, TrapBufferBytes)
 		trap := backing[:length]
 		for name, call := range map[string]func() error{
 			"Call":         func() error { return engine.Call(0, nil, nil, trap, nil) },
 			"CallPrepared": func() error { return engine.CallPrepared(0, nil, 0, trap, nil) },
 		} {
 			err := call()
-			if err == nil || !strings.Contains(err.Error(), "trap cell") {
+			if err == nil || !strings.Contains(err.Error(), "trap buffer") {
 				t.Fatalf("%s trap length %d error = %v", name, length, err)
 			}
-			if got := backing; got[0] != 0xaa || got[1] != 0xbb || got[2] != 0xcc || got[3] != 0xdd {
-				t.Fatalf("%s trap length %d changed backing bytes: %x", name, length, got)
+			if want := bytes.Repeat([]byte{0xaa}, TrapBufferBytes); !bytes.Equal(backing, want) {
+				t.Fatalf("%s trap length %d changed backing bytes: %x", name, length, backing)
+			}
+		}
+	}
+}
+
+func TestJobMemoryRejectsIncompleteTrapBuffers(t *testing.T) {
+	jm, err := NewJobMemory(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jm.Close()
+
+	for length := 0; length < TrapBufferBytes; length++ {
+		for name, bind := range map[string]func([]byte) error{
+			"BindTrapCell":   jm.BindTrapCell,
+			"RebindTrapCell": jm.RebindTrapCell,
+		} {
+			backing := bytes.Repeat([]byte{0xaa}, TrapBufferBytes)
+			err := bind(backing[:length])
+			if err == nil || !strings.Contains(err.Error(), "trap buffer") {
+				t.Fatalf("%s trap length %d error = %v", name, length, err)
+			}
+			if want := bytes.Repeat([]byte{0xaa}, TrapBufferBytes); !bytes.Equal(backing, want) {
+				t.Fatalf("%s trap length %d changed backing bytes: %x", name, length, backing)
 			}
 		}
 	}

--- a/src/core/runtime/guardmem_darwin.go
+++ b/src/core/runtime/guardmem_darwin.go
@@ -231,15 +231,14 @@ func (e *Engine) CallGuarded(code uintptr, serArgs []byte, linMemBase uintptr, t
 	if j.reserveBase == 0 || linMemBase == 0 {
 		return fmt.Errorf("CallGuarded requires NewJobMemoryGuarded")
 	}
-	if len(trap) >= 4 {
-		clearTrapUnlessInterrupted(trap)
-		j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
 	}
+	clearTrapUnlessInterrupted(trap)
+	j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
 	enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
-	if len(trap) >= 4 {
-		if tc := TrapCode(uint32(trap[0]) | uint32(trap[1])<<8 | uint32(trap[2])<<16 | uint32(trap[3])<<24); tc != TrapNone {
-			return trapErrorFromBuffer(tc, trap)
-		}
+	if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
+		return trapErrorFromBuffer(tc, trap)
 	}
 	return nil
 }

--- a/src/core/runtime/guardmem_windows.go
+++ b/src/core/runtime/guardmem_windows.go
@@ -226,15 +226,14 @@ func (e *Engine) CallGuarded(code uintptr, serArgs []byte, linMemBase uintptr, t
 	if j.reserveBase == 0 || linMemBase == 0 {
 		return fmt.Errorf("CallGuarded requires NewJobMemoryGuarded")
 	}
-	if len(trap) >= 4 {
-		clearTrapUnlessInterrupted(trap)
-		j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
 	}
+	clearTrapUnlessInterrupted(trap)
+	j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
 	enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
-	if len(trap) >= 4 {
-		if tc := TrapCode(uint32(trap[0]) | uint32(trap[1])<<8 | uint32(trap[2])<<16 | uint32(trap[3])<<24); tc != TrapNone {
-			return trapErrorFromBuffer(tc, trap)
-		}
+	if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
+		return trapErrorFromBuffer(tc, trap)
 	}
 	return nil
 }

--- a/src/core/runtime/instance_context_test.go
+++ b/src/core/runtime/instance_context_test.go
@@ -74,7 +74,7 @@ func TestInstanceContextRoundTripLeavesMemoryAndInvocationState(t *testing.T) {
 	defer jm.Close()
 
 	jm.SetStackFence(0x1111)
-	trap := make([]byte, 8)
+	trap := make([]byte, TrapBufferBytes)
 	if err := jm.BindTrapCell(trap); err != nil {
 		t.Fatal(err)
 	}

--- a/src/core/runtime/jit_arm64_test.go
+++ b/src/core/runtime/jit_arm64_test.go
@@ -100,7 +100,7 @@ func TestAdd1(t *testing.T) {
 
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 	binary.LittleEndian.PutUint32(serArgs, 41)
 
 	if err := eng.Call(slicePtr(code), serArgs, jm.LinearMemory(), trap, results); err != nil {
@@ -121,7 +121,7 @@ func TestTrapReadback(t *testing.T) {
 
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 
 	err = eng.Call(slicePtr(code), serArgs, jm.LinearMemory(), trap, results)
 	var te *TrapError
@@ -138,7 +138,7 @@ func TestLinearMemoryZeroCopy(t *testing.T) {
 	lin := jm.LinearMemory()
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 
 	storeCode, err := mmapExec(stubMemStore())
 	if err != nil {

--- a/src/core/runtime/jit_test.go
+++ b/src/core/runtime/jit_test.go
@@ -60,7 +60,7 @@ func TestAdd1(t *testing.T) {
 
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 	binary.LittleEndian.PutUint32(serArgs, 41)
 
 	if err := eng.Call(slicePtr(code), serArgs, jm.LinearMemory(), trap, results); err != nil {
@@ -82,7 +82,7 @@ func TestTrapReadback(t *testing.T) {
 
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 
 	err = eng.Call(slicePtr(code), serArgs, jm.LinearMemory(), trap, results)
 	var te *TrapError
@@ -100,7 +100,7 @@ func TestLinearMemoryZeroCopy(t *testing.T) {
 	lin := jm.LinearMemory()
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 
 	// native -> Go: stub stores 0xCAFEBABE at linMem[64].
 	storeCode, err := mmapExec(stubMemStore)

--- a/src/core/runtime/sigtrap_linux_amd64.go
+++ b/src/core/runtime/sigtrap_linux_amd64.go
@@ -232,15 +232,14 @@ func (e *Engine) CallGuarded(code uintptr, serArgs []byte, linMemBase uintptr, t
 	if j.reserveBase == 0 || linMemBase == 0 {
 		return fmt.Errorf("CallGuarded requires NewJobMemoryGuarded")
 	}
-	if len(trap) >= 4 {
-		clearTrapUnlessInterrupted(trap)
-		j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
 	}
+	clearTrapUnlessInterrupted(trap)
+	j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
 	enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
-	if len(trap) >= 4 {
-		if tc := TrapCode(uint32(trap[0]) | uint32(trap[1])<<8 | uint32(trap[2])<<16 | uint32(trap[3])<<24); tc != TrapNone {
-			return trapErrorFromBuffer(tc, trap)
-		}
+	if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
+		return trapErrorFromBuffer(tc, trap)
 	}
 	return nil
 }

--- a/src/core/runtime/sigtrap_linux_arm64.go
+++ b/src/core/runtime/sigtrap_linux_arm64.go
@@ -193,15 +193,14 @@ func (e *Engine) CallGuarded(code uintptr, serArgs []byte, linMemBase uintptr, t
 	if j.reserveBase == 0 || linMemBase == 0 {
 		return fmt.Errorf("CallGuarded requires NewJobMemoryGuarded")
 	}
-	if len(trap) >= 4 {
-		clearTrapUnlessInterrupted(trap)
-		j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
 	}
+	clearTrapUnlessInterrupted(trap)
+	j.putU64(abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
 	enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
-	if len(trap) >= 4 {
-		if tc := TrapCode(uint32(trap[0]) | uint32(trap[1])<<8 | uint32(trap[2])<<16 | uint32(trap[3])<<24); tc != TrapNone {
-			return trapErrorFromBuffer(tc, trap)
-		}
+	if tc := TrapCode(loadTrap(trap)); tc != TrapNone {
+		return trapErrorFromBuffer(tc, trap)
 	}
 	return nil
 }

--- a/src/core/runtime/stress_test.go
+++ b/src/core/runtime/stress_test.go
@@ -48,7 +48,7 @@ func TestGCPreemptStressBounded(t *testing.T) {
 	lin := jm.LinearMemory()
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 	binary.LittleEndian.PutUint32(serArgs, 2000) // iterations per native call
 
 	var stop atomic.Bool
@@ -120,7 +120,7 @@ func TestGCStallCharacterization(t *testing.T) {
 	lin := jm.LinearMemory()
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 	binary.LittleEndian.PutUint32(serArgs, 2000000000) // ~2e9 iters: long native run
 
 	// Observer: wait until native is demonstrably running (heartbeat != 0), then

--- a/src/core/runtime/stress_tinygo_test.go
+++ b/src/core/runtime/stress_tinygo_test.go
@@ -30,7 +30,7 @@ func TestTinyGoBoundedRunStability(t *testing.T) {
 
 	serArgs := ar.Alloc(16)
 	results := ar.Alloc(16)
-	trap := ar.Alloc(8)
+	trap := ar.Alloc(TrapBufferBytes)
 	lin := jm.LinearMemory()
 
 	const iters = 50000

--- a/src/core/runtime/trampoline_asm_amd64.go
+++ b/src/core/runtime/trampoline_asm_amd64.go
@@ -10,6 +10,8 @@ package runtime
 // trampoline_tinygo_amd64.go.
 func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr)
 
+func (e *Engine) initNativeEntry() error { return nil }
+
 // resumeNative is implemented in resume_amd64.s. It resumes native code parked
 // at a returning host import (see hostcall_amd64.go): it restores the wasm
 // register state + RSP saved in the control frame and returns into wasm after

--- a/src/core/runtime/trampoline_asm_arm64.go
+++ b/src/core/runtime/trampoline_asm_arm64.go
@@ -8,6 +8,8 @@ package runtime
 // Go context.
 func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr)
 
+func (e *Engine) initNativeEntry() error { return nil }
+
 // resumeNative is implemented in resume_arm64.s. It restores the wasm state
 // parked by hostCallStub and returns to the instruction after the host CALL.
 func resumeNative(ctrl, foreignStackTop uintptr)

--- a/src/core/runtime/trampoline_failure_tinygo.go
+++ b/src/core/runtime/trampoline_failure_tinygo.go
@@ -1,0 +1,28 @@
+//go:build tinygo && ((linux && amd64) || ((linux || darwin) && arm64))
+
+package runtime
+
+import (
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/wago-org/wago/src/core/runtime/abi"
+)
+
+func markTinyGoTrampolineFailure(trap uintptr) {
+	if trap != 0 {
+		atomic.StoreUint32((*uint32)(unsafe.Pointer(trap)), uint32(TrapBuiltin))
+	}
+}
+
+func markTinyGoResumeFailure(ctrl uintptr) {
+	if ctrl == 0 {
+		return
+	}
+	linMem := tinyGoSavedLinMem(ctrl)
+	if linMem == 0 {
+		return
+	}
+	trap := *(*uintptr)(unsafe.Pointer(linMem - abi.TrapCellPtrOffset))
+	markTinyGoTrampolineFailure(trap)
+}

--- a/src/core/runtime/trampoline_failure_tinygo.go
+++ b/src/core/runtime/trampoline_failure_tinygo.go
@@ -10,8 +10,15 @@ import (
 )
 
 func markTinyGoTrampolineFailure(trap uintptr) {
-	if trap != 0 {
-		atomic.StoreUint32((*uint32)(unsafe.Pointer(trap)), uint32(TrapBuiltin))
+	if trap == 0 {
+		return
+	}
+	cell := (*uint32)(unsafe.Pointer(trap))
+	for {
+		old := atomic.LoadUint32(cell)
+		if TrapCode(old) == TrapInterrupted || atomic.CompareAndSwapUint32(cell, old, uint32(TrapBuiltin)) {
+			return
+		}
 	}
 }
 

--- a/src/core/runtime/trampoline_failure_tinygo_amd64.go
+++ b/src/core/runtime/trampoline_failure_tinygo_amd64.go
@@ -1,0 +1,9 @@
+//go:build tinygo && linux && amd64
+
+package runtime
+
+import "unsafe"
+
+func tinyGoSavedLinMem(ctrl uintptr) uintptr {
+	return *(*uintptr)(unsafe.Pointer(ctrl + hcSavedRBX))
+}

--- a/src/core/runtime/trampoline_failure_tinygo_arm64.go
+++ b/src/core/runtime/trampoline_failure_tinygo_arm64.go
@@ -1,0 +1,9 @@
+//go:build tinygo && (linux || darwin) && arm64
+
+package runtime
+
+import "unsafe"
+
+func tinyGoSavedLinMem(ctrl uintptr) uintptr {
+	return *(*uintptr)(unsafe.Pointer(ctrl + hcSavedLinMem))
+}

--- a/src/core/runtime/trampoline_tinygo_amd64.go
+++ b/src/core/runtime/trampoline_tinygo_amd64.go
@@ -188,21 +188,28 @@ var resumeThunkTemplate = []byte{
 }
 
 var (
-	resumeThunkOnce  sync.Once
+	resumeThunkMu    sync.Mutex
 	resumeThunkEntry uintptr
 )
 
 func resumeThunkPtr() uintptr {
-	resumeThunkOnce.Do(func() {
-		code := make([]byte, len(resumeThunkTemplate))
-		copy(code, resumeThunkTemplate)
-		mem, err := tinygoMmapExec(code)
-		if err != nil {
-			return
-		}
-		resumeThunkEntry = uintptr(unsafe.Pointer(&mem[0])) // retained for the process
-	})
-	return resumeThunkEntry
+	if entry := atomic.LoadUintptr(&resumeThunkEntry); entry != 0 {
+		return entry
+	}
+	resumeThunkMu.Lock()
+	defer resumeThunkMu.Unlock()
+	if entry := atomic.LoadUintptr(&resumeThunkEntry); entry != 0 {
+		return entry
+	}
+	code := make([]byte, len(resumeThunkTemplate))
+	copy(code, resumeThunkTemplate)
+	mem, err := tinygoMmapExec(code)
+	if err != nil {
+		return 0
+	}
+	entry := uintptr(unsafe.Pointer(&mem[0])) // retained for the process
+	atomic.StoreUintptr(&resumeThunkEntry, entry)
+	return entry
 }
 
 // resumeNative resumes native code parked at a host call (see hostcall_amd64.go).

--- a/src/core/runtime/trampoline_tinygo_amd64.go
+++ b/src/core/runtime/trampoline_tinygo_amd64.go
@@ -83,6 +83,10 @@ var thunkTemplate = []byte{
 
 const thunkStackTopOff = 2
 
+const maxTinyGoEntryThunks = 256
+
+var tinygoMmapExec = mmapExec
+
 // funcValue mirrors TinyGo's in-memory representation of a func value:
 // {context, fnptr}. Overlaying it lets us synthesize a callable that jumps to
 // arbitrary machine code with a chosen context word.
@@ -110,8 +114,8 @@ var (
 
 // thunkFor returns the entry point of a foreign-stack-switch trampoline
 // specialized for foreignStackTop, generating and caching it on first use. The
-// mapping is kept for the life of the process (one executable page per distinct
-// engine stack, of which there are typically very few).
+// mapping is kept for the life of the process, up to maxTinyGoEntryThunks
+// executable pages. Exhaustion fails the call through its trap cell.
 func thunkFor(foreignStackTop uintptr) uintptr {
 	if r := lastThunk.Load(); r != nil && r.top == foreignStackTop {
 		return r.entry
@@ -123,13 +127,17 @@ func thunkForSlow(foreignStackTop uintptr) uintptr {
 	thunkMu.Lock()
 	entry, ok := thunkCache[foreignStackTop]
 	if !ok {
+		if len(thunkCache) >= maxTinyGoEntryThunks {
+			thunkMu.Unlock()
+			return 0
+		}
 		code := make([]byte, len(thunkTemplate))
 		copy(code, thunkTemplate)
 		binary.LittleEndian.PutUint64(code[thunkStackTopOff:], uint64(foreignStackTop))
-		mem, err := mmapExec(code)
+		mem, err := tinygoMmapExec(code)
 		if err != nil {
 			thunkMu.Unlock()
-			panic("wago: cannot map tinygo trampoline: " + err.Error())
+			return 0
 		}
 		entry = uintptr(unsafe.Pointer(&mem[0]))
 		thunkCache[foreignStackTop] = entry
@@ -143,7 +151,12 @@ func thunkForSlow(foreignStackTop uintptr) uintptr {
 // WasmWrapper ABI, then returns to Go. See the file comment for how the
 // arguments reach the native code with no assembly and no cgo.
 func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr) {
-	fv := funcValue{context: code, fnptr: thunkFor(foreignStackTop)}
+	entry := thunkFor(foreignStackTop)
+	if entry == 0 {
+		markTinyGoTrampolineFailure(trap)
+		return
+	}
+	fv := funcValue{context: code, fnptr: entry}
 	call := *(*func(a, b, c, d uintptr))(unsafe.Pointer(&fv))
 	call(serArgs, linMem, trap, results)
 }
@@ -183,9 +196,9 @@ func resumeThunkPtr() uintptr {
 	resumeThunkOnce.Do(func() {
 		code := make([]byte, len(resumeThunkTemplate))
 		copy(code, resumeThunkTemplate)
-		mem, err := mmapExec(code)
+		mem, err := tinygoMmapExec(code)
 		if err != nil {
-			panic("wago: cannot map tinygo resume trampoline: " + err.Error())
+			return
 		}
 		resumeThunkEntry = uintptr(unsafe.Pointer(&mem[0])) // retained for the process
 	})
@@ -195,7 +208,12 @@ func resumeThunkPtr() uintptr {
 // resumeNative resumes native code parked at a host call (see hostcall_amd64.go).
 // It mirrors resume_amd64.s. The thunk ignores the func-value context word.
 func resumeNative(ctrl, foreignStackTop uintptr) {
-	fv := funcValue{context: 0, fnptr: resumeThunkPtr()}
+	entry := resumeThunkPtr()
+	if entry == 0 {
+		markTinyGoResumeFailure(ctrl)
+		return
+	}
+	fv := funcValue{context: 0, fnptr: entry}
 	call := *(*func(a, b uintptr))(unsafe.Pointer(&fv))
 	call(ctrl, foreignStackTop)
 }

--- a/src/core/runtime/trampoline_tinygo_amd64.go
+++ b/src/core/runtime/trampoline_tinygo_amd64.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"encoding/binary"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -83,9 +84,10 @@ var thunkTemplate = []byte{
 
 const thunkStackTopOff = 2
 
-const maxTinyGoEntryThunks = 256
-
-var tinygoMmapExec = mmapExec
+var (
+	tinygoPreparedIntEntryOffset = uintptr(len(thunkTemplate))
+	tinygoMmapExec               = mmapExec
+)
 
 // funcValue mirrors TinyGo's in-memory representation of a func value:
 // {context, fnptr}. Overlaying it lets us synthesize a callable that jumps to
@@ -95,63 +97,31 @@ type funcValue struct {
 	fnptr   uintptr
 }
 
-// thunkRef pairs a foreign-stack top with the entry point of the trampoline
-// specialized for it, so the two are published together atomically.
-type thunkRef struct {
-	top   uintptr
-	entry uintptr
-}
-
-var (
-	// hot path: a lock-free single-slot cache. Engines almost always share one
-	// foreign stack, so this hits on every call after the first and keeps
-	// enterNative free of locks and map hashing.
-	lastThunk atomic.Pointer[thunkRef]
-
-	thunkMu    sync.Mutex
-	thunkCache = map[uintptr]uintptr{} // foreign-stack top -> thunk entry point
-)
-
-// thunkFor returns the entry point of a foreign-stack-switch trampoline
-// specialized for foreignStackTop, generating and caching it on first use. The
-// mapping is kept for the life of the process, up to maxTinyGoEntryThunks
-// executable pages. Exhaustion fails the call through its trap cell.
-func thunkFor(foreignStackTop uintptr) uintptr {
-	if r := lastThunk.Load(); r != nil && r.top == foreignStackTop {
-		return r.entry
+// initNativeEntry creates the wrapper and prepared-integer entry thunks in one
+// Engine-owned executable mapping. Engine.Close releases the mapping with the
+// 4 MiB foreign stack, so historical stack addresses retain no executable page.
+func (e *Engine) initNativeEntry() error {
+	if e.preparedInt.mem != nil {
+		return nil
 	}
-	return thunkForSlow(foreignStackTop)
-}
-
-func thunkForSlow(foreignStackTop uintptr) uintptr {
-	thunkMu.Lock()
-	entry, ok := thunkCache[foreignStackTop]
-	if !ok {
-		if len(thunkCache) >= maxTinyGoEntryThunks {
-			thunkMu.Unlock()
-			return 0
-		}
-		code := make([]byte, len(thunkTemplate))
-		copy(code, thunkTemplate)
-		binary.LittleEndian.PutUint64(code[thunkStackTopOff:], uint64(foreignStackTop))
-		mem, err := tinygoMmapExec(code)
-		if err != nil {
-			thunkMu.Unlock()
-			return 0
-		}
-		entry = uintptr(unsafe.Pointer(&mem[0]))
-		thunkCache[foreignStackTop] = entry
+	stackTop := e.stackTop
+	code := make([]byte, len(thunkTemplate)+len(tinygoIntThunkTemplate))
+	copy(code, thunkTemplate)
+	copy(code[len(thunkTemplate):], tinygoIntThunkTemplate)
+	binary.LittleEndian.PutUint64(code[thunkStackTopOff:], uint64(stackTop))
+	binary.LittleEndian.PutUint64(code[len(thunkTemplate)+tinygoIntThunkStackTopOff:], uint64(stackTop))
+	mem, err := tinygoMmapExec(code)
+	if err != nil {
+		return fmt.Errorf("tinygo entry trampoline: %w", err)
 	}
-	thunkMu.Unlock()
-	lastThunk.Store(&thunkRef{top: foreignStackTop, entry: entry})
-	return entry
+	e.preparedInt.mem = mem
+	e.preparedInt.stackTop = stackTop
+	e.stackTop = uintptr(unsafe.Pointer(&mem[0]))
+	return nil
 }
 
-// enterNative runs WARP code at code on the engine's foreign stack following the
-// WasmWrapper ABI, then returns to Go. See the file comment for how the
-// arguments reach the native code with no assembly and no cgo.
-func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr) {
-	entry := thunkFor(foreignStackTop)
+// enterNative runs WARP code at code on the Engine-specific entry trampoline.
+func enterNative(code, serArgs, linMem, trap, results, entry uintptr) {
 	if entry == 0 {
 		markTinyGoTrampolineFailure(trap)
 		return

--- a/src/core/runtime/trampoline_tinygo_amd64_test.go
+++ b/src/core/runtime/trampoline_tinygo_amd64_test.go
@@ -4,38 +4,60 @@ package runtime
 
 import (
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"unsafe"
 )
 
-func TestTinyGoThunkFailureReturnsTrap(t *testing.T) {
-	thunkMu.Lock()
-	oldCache, oldMapper := thunkCache, tinygoMmapExec
-	thunkCache = map[uintptr]uintptr{}
+func TestTinyGoEntryMappingFailureReturnsError(t *testing.T) {
+	oldMapper := tinygoMmapExec
 	tinygoMmapExec = func([]byte) ([]byte, error) { return nil, errors.New("mapping denied") }
-	lastThunk.Store(nil)
-	thunkMu.Unlock()
-	defer func() {
-		thunkMu.Lock()
-		thunkCache, tinygoMmapExec = oldCache, oldMapper
-		lastThunk.Store(nil)
-		thunkMu.Unlock()
-	}()
+	defer func() { tinygoMmapExec = oldMapper }()
 
-	var trap uint32
-	enterNative(1, 0, 0, uintptr(unsafe.Pointer(&trap)), 0, 1)
-	if TrapCode(trap) != TrapBuiltin {
-		t.Fatalf("mapping failure trap = %v, want builtin trap", TrapCode(trap))
+	engine, err := NewEngine()
+	if engine != nil {
+		engine.Close()
+		t.Fatal("failed entry mapping returned an Engine")
 	}
+	if err == nil || !strings.Contains(err.Error(), "tinygo entry trampoline") {
+		t.Fatalf("entry mapping error = %v", err)
+	}
+}
 
-	thunkMu.Lock()
-	for i := 0; i < maxTinyGoEntryThunks; i++ {
-		thunkCache[uintptr(i+1)] = uintptr(i + 1)
+func TestTinyGoEntryMappingRetriesWithNewEngine(t *testing.T) {
+	oldMapper := tinygoMmapExec
+	calls := 0
+	tinygoMmapExec = func(code []byte) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("mapping denied")
+		}
+		return oldMapper(code)
 	}
-	thunkMu.Unlock()
-	if entry := thunkForSlow(maxTinyGoEntryThunks + 1); entry != 0 {
-		t.Fatalf("entry beyond bounded cache = %#x, want zero", entry)
+	defer func() { tinygoMmapExec = oldMapper }()
+
+	if engine, err := NewEngine(); err == nil || engine != nil {
+		if engine != nil {
+			engine.Close()
+		}
+		t.Fatalf("first NewEngine = %v, %v; want mapping failure", engine, err)
+	}
+	engine, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if engine.stackTop == 0 || len(engine.preparedInt.mem) == 0 {
+		t.Fatal("successful Engine did not own its entry mapping")
+	}
+	if calls != 2 {
+		t.Fatalf("mapping calls = %d, want 2", calls)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if engine.preparedInt.stackTop != 0 || engine.preparedInt.mem != nil {
+		t.Fatal("Engine.Close retained its entry mapping")
 	}
 }
 

--- a/src/core/runtime/trampoline_tinygo_amd64_test.go
+++ b/src/core/runtime/trampoline_tinygo_amd64_test.go
@@ -1,0 +1,39 @@
+//go:build linux && amd64 && tinygo
+
+package runtime
+
+import (
+	"errors"
+	"testing"
+	"unsafe"
+)
+
+func TestTinyGoThunkFailureReturnsTrap(t *testing.T) {
+	thunkMu.Lock()
+	oldCache, oldMapper := thunkCache, tinygoMmapExec
+	thunkCache = map[uintptr]uintptr{}
+	tinygoMmapExec = func([]byte) ([]byte, error) { return nil, errors.New("mapping denied") }
+	lastThunk.Store(nil)
+	thunkMu.Unlock()
+	defer func() {
+		thunkMu.Lock()
+		thunkCache, tinygoMmapExec = oldCache, oldMapper
+		lastThunk.Store(nil)
+		thunkMu.Unlock()
+	}()
+
+	var trap uint32
+	enterNative(1, 0, 0, uintptr(unsafe.Pointer(&trap)), 0, 1)
+	if TrapCode(trap) != TrapBuiltin {
+		t.Fatalf("mapping failure trap = %v, want builtin trap", TrapCode(trap))
+	}
+
+	thunkMu.Lock()
+	for i := 0; i < maxTinyGoEntryThunks; i++ {
+		thunkCache[uintptr(i+1)] = uintptr(i + 1)
+	}
+	thunkMu.Unlock()
+	if entry := thunkForSlow(maxTinyGoEntryThunks + 1); entry != 0 {
+		t.Fatalf("entry beyond bounded cache = %#x, want zero", entry)
+	}
+}

--- a/src/core/runtime/trampoline_tinygo_amd64_test.go
+++ b/src/core/runtime/trampoline_tinygo_amd64_test.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 	"unsafe"
 )
@@ -35,5 +36,37 @@ func TestTinyGoThunkFailureReturnsTrap(t *testing.T) {
 	thunkMu.Unlock()
 	if entry := thunkForSlow(maxTinyGoEntryThunks + 1); entry != 0 {
 		t.Fatalf("entry beyond bounded cache = %#x, want zero", entry)
+	}
+}
+
+func TestTinyGoResumeThunkRetriesMappingFailure(t *testing.T) {
+	resumeThunkMu.Lock()
+	oldEntry, oldMapper := atomic.LoadUintptr(&resumeThunkEntry), tinygoMmapExec
+	atomic.StoreUintptr(&resumeThunkEntry, 0)
+	calls := 0
+	backing := make([]byte, 1)
+	tinygoMmapExec = func([]byte) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("mapping denied")
+		}
+		return backing, nil
+	}
+	resumeThunkMu.Unlock()
+	defer func() {
+		resumeThunkMu.Lock()
+		atomic.StoreUintptr(&resumeThunkEntry, oldEntry)
+		tinygoMmapExec = oldMapper
+		resumeThunkMu.Unlock()
+	}()
+
+	if entry := resumeThunkPtr(); entry != 0 {
+		t.Fatalf("first mapping attempt = %#x, want zero", entry)
+	}
+	if entry := resumeThunkPtr(); entry != uintptr(unsafe.Pointer(&backing[0])) {
+		t.Fatalf("retry mapping = %#x, want %#x", entry, uintptr(unsafe.Pointer(&backing[0])))
+	}
+	if calls != 2 {
+		t.Fatalf("mapping calls = %d, want 2", calls)
 	}
 }

--- a/src/core/runtime/trampoline_tinygo_arm64.go
+++ b/src/core/runtime/trampoline_tinygo_arm64.go
@@ -3,6 +3,7 @@
 package runtime
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -21,20 +22,10 @@ type tinygoARM64FuncValue struct {
 	fnptr   uintptr
 }
 
-type tinygoARM64ThunkRef struct {
-	top   uintptr
-	entry uintptr
-}
-
 var (
-	tinygoARM64LastThunk atomic.Pointer[tinygoARM64ThunkRef]
-	tinygoARM64ThunkMu   sync.Mutex
-	tinygoARM64Thunks    = map[uintptr]uintptr{}
+	tinygoARM64PreparedIntEntryOffset = uintptr(len(tinygoARM64EntryCode(0)))
+	tinygoMmapExec                    = mmapExec
 )
-
-const maxTinyGoARM64EntryThunks = 256
-
-var tinygoMmapExec = mmapExec
 
 func tinygoARM64Store(a *a64.Asm, src, base a64.Reg, off uint32) {
 	if !a.Store64(src, base, off) {
@@ -74,7 +65,10 @@ func tinygoARM64RestoreGoContext(a *a64.Asm) {
 
 func tinygoARM64EntryCode(foreignStackTop uintptr) []byte {
 	var a a64.Asm
-	a.MovImm64(a64.X10, uint64(foreignStackTop))
+	a.Movz64(a64.X10, uint16(foreignStackTop), 0)
+	a.Movk64(a64.X10, uint16(foreignStackTop>>16), 1)
+	a.Movk64(a64.X10, uint16(foreignStackTop>>32), 2)
+	a.Movk64(a64.X10, uint16(foreignStackTop>>48), 3)
 	tinygoARM64SaveGoContext(&a, a64.X10)
 	a.AddImm64(a64.SP, a64.X10, 0)
 	a.MovImm64(a64.FP, 0)
@@ -90,34 +84,30 @@ func tinygoARM64EntryCode(foreignStackTop uintptr) []byte {
 	return a.B
 }
 
-// tinygoARM64ThunkFor retains at most maxTinyGoARM64EntryThunks executable
-// entry pages; exhaustion fails the call through its trap cell.
-func tinygoARM64ThunkFor(foreignStackTop uintptr) uintptr {
-	if ref := tinygoARM64LastThunk.Load(); ref != nil && ref.top == foreignStackTop {
-		return ref.entry
+// initNativeEntry creates the wrapper and prepared-integer entry thunks in one
+// Engine-owned executable mapping. Engine.Close releases the mapping with the
+// 4 MiB foreign stack, so historical stack addresses retain no executable page.
+func (e *Engine) initNativeEntry() error {
+	if e.preparedInt.mem != nil {
+		return nil
 	}
-	tinygoARM64ThunkMu.Lock()
-	entry, ok := tinygoARM64Thunks[foreignStackTop]
-	if !ok {
-		if len(tinygoARM64Thunks) >= maxTinyGoARM64EntryThunks {
-			tinygoARM64ThunkMu.Unlock()
-			return 0
-		}
-		mem, err := tinygoMmapExec(tinygoARM64EntryCode(foreignStackTop))
-		if err != nil {
-			tinygoARM64ThunkMu.Unlock()
-			return 0
-		}
-		entry = uintptr(unsafe.Pointer(&mem[0]))
-		tinygoARM64Thunks[foreignStackTop] = entry
+	stackTop := e.stackTop
+	entryCode := tinygoARM64EntryCode(stackTop)
+	intCode := tinygoARM64IntEntryCode(stackTop)
+	code := make([]byte, len(entryCode)+len(intCode))
+	copy(code, entryCode)
+	copy(code[len(entryCode):], intCode)
+	mem, err := tinygoMmapExec(code)
+	if err != nil {
+		return fmt.Errorf("tinygo entry trampoline: %w", err)
 	}
-	tinygoARM64ThunkMu.Unlock()
-	tinygoARM64LastThunk.Store(&tinygoARM64ThunkRef{top: foreignStackTop, entry: entry})
-	return entry
+	e.preparedInt.mem = mem
+	e.preparedInt.stackTop = stackTop
+	e.stackTop = uintptr(unsafe.Pointer(&mem[0]))
+	return nil
 }
 
-func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr) {
-	entry := tinygoARM64ThunkFor(foreignStackTop)
+func enterNative(code, serArgs, linMem, trap, results, entry uintptr) {
 	if entry == 0 {
 		markTinyGoTrampolineFailure(trap)
 		return

--- a/src/core/runtime/trampoline_tinygo_arm64.go
+++ b/src/core/runtime/trampoline_tinygo_arm64.go
@@ -128,7 +128,7 @@ func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr) 
 }
 
 var (
-	tinygoARM64ResumeOnce  sync.Once
+	tinygoARM64ResumeMu    sync.Mutex
 	tinygoARM64ResumeEntry uintptr
 )
 
@@ -163,14 +163,21 @@ func tinygoARM64ResumeCode() []byte {
 }
 
 func tinygoARM64ResumePtr() uintptr {
-	tinygoARM64ResumeOnce.Do(func() {
-		mem, err := tinygoMmapExec(tinygoARM64ResumeCode())
-		if err != nil {
-			return
-		}
-		tinygoARM64ResumeEntry = uintptr(unsafe.Pointer(&mem[0]))
-	})
-	return tinygoARM64ResumeEntry
+	if entry := atomic.LoadUintptr(&tinygoARM64ResumeEntry); entry != 0 {
+		return entry
+	}
+	tinygoARM64ResumeMu.Lock()
+	defer tinygoARM64ResumeMu.Unlock()
+	if entry := atomic.LoadUintptr(&tinygoARM64ResumeEntry); entry != 0 {
+		return entry
+	}
+	mem, err := tinygoMmapExec(tinygoARM64ResumeCode())
+	if err != nil {
+		return 0
+	}
+	entry := uintptr(unsafe.Pointer(&mem[0]))
+	atomic.StoreUintptr(&tinygoARM64ResumeEntry, entry)
+	return entry
 }
 
 func resumeNative(ctrl, foreignStackTop uintptr) {

--- a/src/core/runtime/trampoline_tinygo_arm64.go
+++ b/src/core/runtime/trampoline_tinygo_arm64.go
@@ -32,6 +32,10 @@ var (
 	tinygoARM64Thunks    = map[uintptr]uintptr{}
 )
 
+const maxTinyGoARM64EntryThunks = 256
+
+var tinygoMmapExec = mmapExec
+
 func tinygoARM64Store(a *a64.Asm, src, base a64.Reg, off uint32) {
 	if !a.Store64(src, base, off) {
 		panic("wago: arm64 TinyGo trampoline store is not encodable")
@@ -86,6 +90,8 @@ func tinygoARM64EntryCode(foreignStackTop uintptr) []byte {
 	return a.B
 }
 
+// tinygoARM64ThunkFor retains at most maxTinyGoARM64EntryThunks executable
+// entry pages; exhaustion fails the call through its trap cell.
 func tinygoARM64ThunkFor(foreignStackTop uintptr) uintptr {
 	if ref := tinygoARM64LastThunk.Load(); ref != nil && ref.top == foreignStackTop {
 		return ref.entry
@@ -93,10 +99,14 @@ func tinygoARM64ThunkFor(foreignStackTop uintptr) uintptr {
 	tinygoARM64ThunkMu.Lock()
 	entry, ok := tinygoARM64Thunks[foreignStackTop]
 	if !ok {
-		mem, err := mmapExec(tinygoARM64EntryCode(foreignStackTop))
+		if len(tinygoARM64Thunks) >= maxTinyGoARM64EntryThunks {
+			tinygoARM64ThunkMu.Unlock()
+			return 0
+		}
+		mem, err := tinygoMmapExec(tinygoARM64EntryCode(foreignStackTop))
 		if err != nil {
 			tinygoARM64ThunkMu.Unlock()
-			panic("wago: cannot map arm64 TinyGo trampoline: " + err.Error())
+			return 0
 		}
 		entry = uintptr(unsafe.Pointer(&mem[0]))
 		tinygoARM64Thunks[foreignStackTop] = entry
@@ -107,7 +117,12 @@ func tinygoARM64ThunkFor(foreignStackTop uintptr) uintptr {
 }
 
 func enterNative(code, serArgs, linMem, trap, results, foreignStackTop uintptr) {
-	fv := tinygoARM64FuncValue{context: code, fnptr: tinygoARM64ThunkFor(foreignStackTop)}
+	entry := tinygoARM64ThunkFor(foreignStackTop)
+	if entry == 0 {
+		markTinyGoTrampolineFailure(trap)
+		return
+	}
+	fv := tinygoARM64FuncValue{context: code, fnptr: entry}
 	call := *(*func(a, b, c, d uintptr))(unsafe.Pointer(&fv))
 	call(serArgs, linMem, trap, results)
 }
@@ -149,9 +164,9 @@ func tinygoARM64ResumeCode() []byte {
 
 func tinygoARM64ResumePtr() uintptr {
 	tinygoARM64ResumeOnce.Do(func() {
-		mem, err := mmapExec(tinygoARM64ResumeCode())
+		mem, err := tinygoMmapExec(tinygoARM64ResumeCode())
 		if err != nil {
-			panic("wago: cannot map arm64 TinyGo resume trampoline: " + err.Error())
+			return
 		}
 		tinygoARM64ResumeEntry = uintptr(unsafe.Pointer(&mem[0]))
 	})
@@ -159,7 +174,12 @@ func tinygoARM64ResumePtr() uintptr {
 }
 
 func resumeNative(ctrl, foreignStackTop uintptr) {
-	fv := tinygoARM64FuncValue{fnptr: tinygoARM64ResumePtr()}
+	entry := tinygoARM64ResumePtr()
+	if entry == 0 {
+		markTinyGoResumeFailure(ctrl)
+		return
+	}
+	fv := tinygoARM64FuncValue{fnptr: entry}
 	call := *(*func(a, b uintptr))(unsafe.Pointer(&fv))
 	call(ctrl, foreignStackTop)
 }


### PR DESCRIPTION
## Summary

Hardens native entry and trap handling at the TinyGo runtime boundary.

Before this change, TinyGo retained executable entry trampolines by historical
engine stack address, executable mapping failure could panic the process, and
native entry accepted trap buffers smaller than the 24-byte record written by
compiled trap stubs.

## Changes

- each TinyGo `Engine` now owns one combined wrapper/prepared-integer executable
  mapping in its existing fixed-size state;
- `Engine.Close` releases that mapping with the 4 MiB foreign stack;
- entry mapping failure returns from `NewEngine` as an error instead of panicking;
- resume mapping failure returns through the trap path and retries after a
  transient failure;
- a pending `TrapInterrupted` remains authoritative during resume failure;
- `Call`, `CallPrepared`, `CallGuarded`, `BindTrapCell`, and `RebindTrapCell`
  require the complete 24-byte `TrapBufferBytes` record before native entry;
- all guarded and explicit entry paths reject incomplete buffers without
  changing adjacent bytes.

This removes the process-wide trampoline map and its lifetime exhaustion state.
Executable entry mappings are now bounded by live engines, not historical stack
addresses.

## Performance and footprint

Linux/AMD64 TinyGo, five 500 ms samples, `BenchmarkCrossBoundaryCall`:

- previous median: 9.169 ns/op;
- current median: 8.187 ns/op;
- both: 0 B/op and 0 allocs/op.

The `Engine` object stays at 1,064 bytes under standard Go and 1,096 bytes under
TinyGo. Each live engine owns one entry mapping; closed engines retain none.
Paired local release builds against current `main` changed by +276 bytes for the
TinyGo minimal profile and +4,096 bytes for the Go minimal profile. Both fit the
headroom recorded by the latest `main` size gate.

## Proof

- `go test ./src/core/runtime ./src/core/compiler/backend/railshot/amd64`
- `go test -race ./src/core/runtime -run '^(TestHostCtrlFrameWideCapacityKeepsInlineLayout|TestEngineRejectsIncompleteTrapBuffersBeforeNativeEntry|TestJobMemoryRejectsIncompleteTrapBuffers)$' -count=1`
- `go test -tags wago_guardpage ./src/core/runtime`
- `go test -tags tinygo ./src/core/runtime -run '^(TestTinyGoEntryMappingFailureReturnsError|TestTinyGoEntryMappingRetriesWithNewEngine|TestTinyGoResumeThunkRetriesMappingFailure|TestTinyGoTrampolineFailurePreservesInterrupt)$' -count=1`
- `make tinygo-test`
- `(cd bench && go test ./...)`
- Linux/ARM64 and Darwin/ARM64 TinyGo-tagged runtime cross-compiles
- `git diff --check`
