### PR TITLE
runtime: preserve chained signal semantics

### DIFF
--- a/src/core/runtime/sigtrap_amd64.s
+++ b/src/core/runtime/sigtrap_amd64.s
@@ -6,7 +6,7 @@
 // DX=*ucontext). Pure asm, no Go calls, no g use — runs on the signal alt-stack.
 // It derives everything per-fault (no per-call shared state): scan the live
 // reservation table for one containing the fault address, confirm the faulting
-// frame's primary linMem owns that reservation, then record a wasm out-of-bounds trap
+// frame's pinned linMem owns that reservation, then record a wasm out-of-bounds trap
 // in the frame's *trap and redirect the saved RIP to the matching native trap
 // exit. Anything else chains to Go's saved handler.
 //
@@ -28,28 +28,15 @@ scan:
 	CMPQ	R8, R9
 	JCC	next                    // addr >= end
 
-	// addr is inside this reservation. First try the frameless x64 ABI: RBX is
-	// pinned to linMem and the trap cell pointer lives at [linMem-TrapCellPtrOffset].
+	// addr is inside this reservation. The x64 ABI pins linMem in RBX and keeps
+	// the trap cell pointer at [linMem-TrapCellPtrOffset]. A mismatched RBX chains
+	// without dereferencing arbitrary frame memory.
 	MOVQ	16(R10), R9             // region.linMem (fault-address base)
 	MOVQ	24(R10), R13            // region.ownerLinMem (active primary)
 	MOVQ	128(R12), AX            // AX = saved RBX (x64 primary linMem)
 	CMPQ	AX, R13
-	JE	match_x64
-
-	// Fall back to the framed amd64 ABI: [RBP-16] is linMem and [RBP-24] is trap.
-	MOVQ	120(R12), R15           // R15 = saved RBP (faulting frame)
-	MOVQ	-16(R15), CX            // CX = [RBP-16] = saved linMem
-	CMPQ	CX, R13
-	JNE	next                    // mismatch -> not this reservation's wasm fault
-	XORL	R14, R14                // mode 0 = framed amd64
-	JMP	matched
-
-match_x64:
+	JNE	next
 	MOVQ	AX, CX                  // CX = linMem
-	MOVQ	160(R12), R15           // R15 = saved RSP (frameless frame base)
-	MOVQ	$1, R14                 // mode 1 = frameless x64
-
-matched:
 	// Fault is in this reservation's wasm memory. Lazily commit a grown-but-
 	// uncommitted page (off < current logical size), else trap a genuinely
 	// out-of-range access. R9 is the faulting memory base; CX is the active
@@ -80,14 +67,6 @@ dotrap:
 	MOVL	$3, R13                 // TrapLinMemOutOfBounds
 settrap:
 	// Record the selected wasm trap and redirect RIP.
-	TESTQ	R14, R14
-	JNZ	dotrap_x64
-	MOVQ	-24(R15), CX            // CX = [RBP-24] = framed trap pointer
-	MOVL	R13, (CX)
-	MOVQ	·guardTrapExitFramedPC(SB), R9
-	MOVQ	R9, 168(R12)            // saved RIP = nativeTrapExitFramed
-	RET                             // -> restorer -> rt_sigreturn -> nativeTrapExitFramed
-dotrap_x64:
 	// The trap cell moved off the stack into basedata: [linMem-TrapCellPtrOffset]
 	// holds the trap-cell POINTER (CX is still linMem here) and the code is written
 	// through it, exactly as emitTrap does. (It was [RSP+0] under the pre-basedata
@@ -115,15 +94,6 @@ TEXT ·guardSigRestorer(SB), NOSPLIT|NOFRAME, $0-0
 	MOVQ	$15, AX
 	SYSCALL
 
-// nativeTrapExitFramed is the old framed-backend `leave; ret` landing pad. It
-// unwinds exactly one wasm frame and relies on the framed amd64 backend's
-// post-call trap propagation.
-TEXT ·nativeTrapExitFramed(SB), NOSPLIT|NOFRAME, $0-0
-	MOVQ	BP, SP                  // leave: rsp = rbp
-	MOVQ	0(SP), BP               // leave: pop rbp (restore caller frame ptr)
-	ADDQ	$8, SP
-	RET                             // return one frame up (to caller's post-call check)
-
 // nativeTrapExitHandlerJump is the x64/WARP landing pad. RBX is still the
 // faulting frame's linMem after sigreturn; [RBX-24] is the trampoline-recorded
 // re-entry SP. Restoring it and RETing jumps straight back to enterNative.
@@ -138,11 +108,6 @@ TEXT ·addrGuardSigHandler(SB), NOSPLIT, $0-8
 
 TEXT ·addrGuardSigRestorer(SB), NOSPLIT, $0-8
 	LEAQ	·guardSigRestorer(SB), AX
-	MOVQ	AX, ret+0(FP)
-	RET
-
-TEXT ·addrNativeTrapExitFramed(SB), NOSPLIT, $0-8
-	LEAQ	·nativeTrapExitFramed(SB), AX
 	MOVQ	AX, ret+0(FP)
 	RET
 

--- a/src/core/runtime/sigtrap_linux_amd64.go
+++ b/src/core/runtime/sigtrap_linux_amd64.go
@@ -34,17 +34,14 @@ const (
 //   - The fault address is classified against a registry of live reservations
 //     (guardRegions). A fault outside every reservation chains to Go's saved
 //     handler, so genuine Go faults still crash/panic.
-//   - For a fault inside a reservation, the handler recognizes either wasm ABI:
-//     amd64 frameless frames keep linMem in RBX and the trap pointer at [RSP+0];
-//     framed amd64 frames keep linMem at [RBP-16] and trap at [RBP-24]. It only
-//     acts if the frame's linMem matches that reservation's linMem base, which
-//     rejects the astronomically-unlikely case of a wild non-wasm pointer landing
-//     inside a live reservation.
+//   - For a fault inside a reservation, the handler requires the x64/WARP ABI's
+//     pinned RBX linMem to match the reservation owner before dereferencing
+//     basedata. A non-Wasm fault that happens to land inside a reservation chains
+//     without treating an arbitrary RBP as a legacy frame pointer.
 //   - It then writes TrapLinMemOutOfBounds, or TrapLinMemCouldNotExtend when a
 //     lazy page commit fails, to the frame's *trap and rewrites only the saved RIP
 //     to the ABI-specific trap exit: amd64 restores the trampoline's
-//     handler-jump re-entry SP and returns straight to enterNative; framed amd64
-//     performs the old one-frame `leave; ret` unwind.
+//     handler-jump re-entry SP and returns straight to enterNative.
 //
 // This mirrors WARP's memorySignalHandler (addr/state check + ucontext rewrite)
 // in a Go asm stub installed via raw rt_sigaction.
@@ -64,7 +61,6 @@ const maxGuardRegions = 256
 var (
 	guardRegions               [maxGuardRegions]guardRegion // scanned locklessly by the handler
 	guardRegionMu              sync.Mutex                   // serialises registry mutation only
-	guardTrapExitFramedPC      uintptr                      // entry of nativeTrapExitFramed
 	guardTrapExitHandlerJumpPC uintptr                      // entry of nativeTrapExitHandlerJump
 	guardOldSEGVHandler        uintptr                      // previous SIGSEGV handler
 	guardOldBUSHandler         uintptr                      // previous SIGBUS handler
@@ -122,15 +118,12 @@ func init() {
 	guardOwnerHook = setGuardRegionOwner
 }
 
-// nativeTrapExitFramed and nativeTrapExitHandlerJump are signal-rewrite landing
-// pads. Never called from Go.
-func nativeTrapExitFramed()
+// nativeTrapExitHandlerJump is a signal-rewrite landing pad. Never called from Go.
 func nativeTrapExitHandlerJump()
 
 // asm symbol-address getters (raw ABI0 entry points for the kernel/sigaction).
 func addrGuardSigHandler() uintptr
 func addrGuardSigRestorer() uintptr
-func addrNativeTrapExitFramed() uintptr
 func addrNativeTrapExitHandlerJump() uintptr
 
 // guardSigHandler / guardSigRestorer are implemented in sigtrap_amd64.s and are
@@ -148,9 +141,12 @@ type kernelSigaction struct {
 }
 
 const (
-	_SA_SIGINFO  = 0x00000004
-	_SA_RESTORER = 0x04000000
-	_SA_ONSTACK  = 0x08000000
+	_SA_SIGINFO   = 0x00000004
+	_SA_RESTORER  = 0x04000000
+	_SA_ONSTACK   = 0x08000000
+	_SA_RESTART   = 0x10000000
+	_SA_NODEFER   = 0x40000000
+	_SA_RESETHAND = 0x80000000
 )
 
 func rtSigaction(sig uintptr, act, old *kernelSigaction) error {
@@ -177,16 +173,24 @@ func installLinuxSignalHandlers(act *kernelSigaction, call func(uintptr, *kernel
 	if oldBUS.handler <= 1 {
 		return fmt.Errorf("install SIGBUS handler: previous disposition %#x is not chainable", oldBUS.handler)
 	}
+	if oldSEGV.flags&_SA_RESETHAND != 0 || oldBUS.flags&_SA_RESETHAND != 0 {
+		return fmt.Errorf("install signal handlers: one-shot prior disposition is not chainable")
+	}
+	segvAct, busAct := *act, *act
+	segvAct.mask = oldSEGV.mask
+	busAct.mask = oldBUS.mask
+	segvAct.flags |= oldSEGV.flags & (_SA_RESTART | _SA_NODEFER)
+	busAct.flags |= oldBUS.flags & (_SA_RESTART | _SA_NODEFER)
 
 	// Publish both predecessors before either replacement can receive a fault.
 	guardOldSEGVHandler = oldSEGV.handler
 	guardOldBUSHandler = oldBUS.handler
-	if err := call(uintptr(syscall.SIGSEGV), act, nil); err != nil {
+	if err := call(uintptr(syscall.SIGSEGV), &segvAct, nil); err != nil {
 		guardOldSEGVHandler = 0
 		guardOldBUSHandler = 0
 		return fmt.Errorf("install SIGSEGV handler: %w", err)
 	}
-	if err := call(uintptr(syscall.SIGBUS), act, nil); err != nil {
+	if err := call(uintptr(syscall.SIGBUS), &busAct, nil); err != nil {
 		rollback := call(uintptr(syscall.SIGSEGV), &oldSEGV, nil)
 		guardOldSEGVHandler = 0
 		guardOldBUSHandler = 0
@@ -206,7 +210,6 @@ func InstallGuardTrapHandler() error {
 	if guardInstalled {
 		return nil
 	}
-	guardTrapExitFramedPC = addrNativeTrapExitFramed()
 	guardTrapExitHandlerJumpPC = addrNativeTrapExitHandlerJump()
 	act := kernelSigaction{
 		handler:  addrGuardSigHandler(),

--- a/src/core/runtime/sigtrap_linux_amd64.go
+++ b/src/core/runtime/sigtrap_linux_amd64.go
@@ -141,12 +141,13 @@ type kernelSigaction struct {
 }
 
 const (
-	_SA_SIGINFO   = 0x00000004
-	_SA_RESTORER  = 0x04000000
-	_SA_ONSTACK   = 0x08000000
-	_SA_RESTART   = 0x10000000
-	_SA_NODEFER   = 0x40000000
-	_SA_RESETHAND = 0x80000000
+	_SA_SIGINFO        = 0x00000004
+	_SA_EXPOSE_TAGBITS = 0x00000800
+	_SA_RESTORER       = 0x04000000
+	_SA_ONSTACK        = 0x08000000
+	_SA_RESTART        = 0x10000000
+	_SA_NODEFER        = 0x40000000
+	_SA_RESETHAND      = 0x80000000
 )
 
 func rtSigaction(sig uintptr, act, old *kernelSigaction) error {
@@ -179,8 +180,8 @@ func installLinuxSignalHandlers(act *kernelSigaction, call func(uintptr, *kernel
 	segvAct, busAct := *act, *act
 	segvAct.mask = oldSEGV.mask
 	busAct.mask = oldBUS.mask
-	segvAct.flags |= oldSEGV.flags & (_SA_RESTART | _SA_NODEFER)
-	busAct.flags |= oldBUS.flags & (_SA_RESTART | _SA_NODEFER)
+	segvAct.flags |= oldSEGV.flags & (_SA_EXPOSE_TAGBITS | _SA_RESTART | _SA_NODEFER)
+	busAct.flags |= oldBUS.flags & (_SA_EXPOSE_TAGBITS | _SA_RESTART | _SA_NODEFER)
 
 	// Publish both predecessors before either replacement can receive a fault.
 	guardOldSEGVHandler = oldSEGV.handler

--- a/src/core/runtime/sigtrap_linux_arm64.go
+++ b/src/core/runtime/sigtrap_linux_arm64.go
@@ -111,8 +111,11 @@ type kernelSigaction struct {
 }
 
 const (
-	_SA_SIGINFO = 0x00000004
-	_SA_ONSTACK = 0x08000000
+	_SA_SIGINFO   = 0x00000004
+	_SA_ONSTACK   = 0x08000000
+	_SA_RESTART   = 0x10000000
+	_SA_NODEFER   = 0x40000000
+	_SA_RESETHAND = 0x80000000
 )
 
 func rtSigaction(sig uintptr, act, old *kernelSigaction) error {
@@ -139,15 +142,23 @@ func installLinuxSignalHandlers(act *kernelSigaction, call func(uintptr, *kernel
 	if oldBUS.handler <= 1 {
 		return fmt.Errorf("install SIGBUS handler: previous disposition %#x is not chainable", oldBUS.handler)
 	}
+	if oldSEGV.flags&_SA_RESETHAND != 0 || oldBUS.flags&_SA_RESETHAND != 0 {
+		return fmt.Errorf("install signal handlers: one-shot prior disposition is not chainable")
+	}
+	segvAct, busAct := *act, *act
+	segvAct.mask = oldSEGV.mask
+	busAct.mask = oldBUS.mask
+	segvAct.flags |= oldSEGV.flags & (_SA_RESTART | _SA_NODEFER)
+	busAct.flags |= oldBUS.flags & (_SA_RESTART | _SA_NODEFER)
 
 	guardOldSEGVHandler = oldSEGV.handler
 	guardOldBUSHandler = oldBUS.handler
-	if err := call(uintptr(syscall.SIGSEGV), act, nil); err != nil {
+	if err := call(uintptr(syscall.SIGSEGV), &segvAct, nil); err != nil {
 		guardOldSEGVHandler = 0
 		guardOldBUSHandler = 0
 		return fmt.Errorf("install SIGSEGV handler: %w", err)
 	}
-	if err := call(uintptr(syscall.SIGBUS), act, nil); err != nil {
+	if err := call(uintptr(syscall.SIGBUS), &busAct, nil); err != nil {
 		rollback := call(uintptr(syscall.SIGSEGV), &oldSEGV, nil)
 		guardOldSEGVHandler = 0
 		guardOldBUSHandler = 0

--- a/src/core/runtime/sigtrap_linux_arm64.go
+++ b/src/core/runtime/sigtrap_linux_arm64.go
@@ -111,11 +111,12 @@ type kernelSigaction struct {
 }
 
 const (
-	_SA_SIGINFO   = 0x00000004
-	_SA_ONSTACK   = 0x08000000
-	_SA_RESTART   = 0x10000000
-	_SA_NODEFER   = 0x40000000
-	_SA_RESETHAND = 0x80000000
+	_SA_SIGINFO        = 0x00000004
+	_SA_EXPOSE_TAGBITS = 0x00000800
+	_SA_ONSTACK        = 0x08000000
+	_SA_RESTART        = 0x10000000
+	_SA_NODEFER        = 0x40000000
+	_SA_RESETHAND      = 0x80000000
 )
 
 func rtSigaction(sig uintptr, act, old *kernelSigaction) error {
@@ -148,8 +149,8 @@ func installLinuxSignalHandlers(act *kernelSigaction, call func(uintptr, *kernel
 	segvAct, busAct := *act, *act
 	segvAct.mask = oldSEGV.mask
 	busAct.mask = oldBUS.mask
-	segvAct.flags |= oldSEGV.flags & (_SA_RESTART | _SA_NODEFER)
-	busAct.flags |= oldBUS.flags & (_SA_RESTART | _SA_NODEFER)
+	segvAct.flags |= oldSEGV.flags & (_SA_EXPOSE_TAGBITS | _SA_RESTART | _SA_NODEFER)
+	busAct.flags |= oldBUS.flags & (_SA_EXPOSE_TAGBITS | _SA_RESTART | _SA_NODEFER)
 
 	guardOldSEGVHandler = oldSEGV.handler
 	guardOldBUSHandler = oldBUS.handler

--- a/src/core/runtime/sigtrap_linux_install_test.go
+++ b/src/core/runtime/sigtrap_linux_install_test.go
@@ -22,14 +22,14 @@ func TestInstallLinuxSignalHandlersPublishesDistinctChainTargets(t *testing.T) {
 			}
 			old.handler = 0x1111
 			old.mask = 0x11
-			old.flags = _SA_RESTART
+			old.flags = _SA_RESTART | _SA_EXPOSE_TAGBITS
 		case 2:
 			if sig != uintptr(syscall.SIGBUS) || installed != nil || old == nil {
 				t.Fatalf("read SIGBUS call = sig %d act %p old %p", sig, installed, old)
 			}
 			old.handler = 0x2222
 			old.mask = 0x22
-			old.flags = _SA_NODEFER
+			old.flags = _SA_NODEFER | _SA_EXPOSE_TAGBITS
 		case 3, 4:
 			if installed == nil || old != nil || installed == &act || installed.handler != act.handler {
 				t.Fatalf("install call %d = act %p old %p", calls, installed, old)
@@ -38,7 +38,7 @@ func TestInstallLinuxSignalHandlersPublishesDistinctChainTargets(t *testing.T) {
 			if calls == 4 {
 				wantMask, wantFlag = 0x22, _SA_NODEFER
 			}
-			if installed.mask != wantMask || installed.flags&wantFlag == 0 {
+			if installed.mask != wantMask || installed.flags&wantFlag == 0 || installed.flags&_SA_EXPOSE_TAGBITS == 0 {
 				t.Fatalf("install call %d lost prior mask/flags: %+v", calls, installed)
 			}
 			if guardOldSEGVHandler != 0x1111 || guardOldBUSHandler != 0x2222 {

--- a/src/core/runtime/sigtrap_linux_install_test.go
+++ b/src/core/runtime/sigtrap_linux_install_test.go
@@ -21,14 +21,25 @@ func TestInstallLinuxSignalHandlersPublishesDistinctChainTargets(t *testing.T) {
 				t.Fatalf("read SIGSEGV call = sig %d act %p old %p", sig, installed, old)
 			}
 			old.handler = 0x1111
+			old.mask = 0x11
+			old.flags = _SA_RESTART
 		case 2:
 			if sig != uintptr(syscall.SIGBUS) || installed != nil || old == nil {
 				t.Fatalf("read SIGBUS call = sig %d act %p old %p", sig, installed, old)
 			}
 			old.handler = 0x2222
+			old.mask = 0x22
+			old.flags = _SA_NODEFER
 		case 3, 4:
-			if installed != &act || old != nil {
+			if installed == nil || old != nil || installed == &act || installed.handler != act.handler {
 				t.Fatalf("install call %d = act %p old %p", calls, installed, old)
+			}
+			wantMask, wantFlag := uint64(0x11), uint64(_SA_RESTART)
+			if calls == 4 {
+				wantMask, wantFlag = 0x22, _SA_NODEFER
+			}
+			if installed.mask != wantMask || installed.flags&wantFlag == 0 {
+				t.Fatalf("install call %d lost prior mask/flags: %+v", calls, installed)
 			}
 			if guardOldSEGVHandler != 0x1111 || guardOldBUSHandler != 0x2222 {
 				t.Fatalf("chain targets were not published before install: %#x/%#x", guardOldSEGVHandler, guardOldBUSHandler)
@@ -62,11 +73,11 @@ func TestInstallLinuxSignalHandlersRollsBackSIGSEGV(t *testing.T) {
 			old.handler = 0x2222
 			old.flags = 0x34
 		case 3:
-			if sig != uintptr(syscall.SIGSEGV) || installed != &act {
+			if sig != uintptr(syscall.SIGSEGV) || installed == nil || installed.handler != act.handler {
 				t.Fatalf("SIGSEGV install = sig %d act %p", sig, installed)
 			}
 		case 4:
-			if sig != uintptr(syscall.SIGBUS) || installed != &act {
+			if sig != uintptr(syscall.SIGBUS) || installed == nil || installed.handler != act.handler {
 				t.Fatalf("SIGBUS install = sig %d act %p", sig, installed)
 			}
 			return busErr
@@ -84,6 +95,20 @@ func TestInstallLinuxSignalHandlersRollsBackSIGSEGV(t *testing.T) {
 	}
 	if calls != 5 || guardOldSEGVHandler != 0 || guardOldBUSHandler != 0 {
 		t.Fatalf("rollback calls/targets = %d %#x/%#x", calls, guardOldSEGVHandler, guardOldBUSHandler)
+	}
+}
+
+func TestInstallLinuxSignalHandlersRejectsOneShotPredecessor(t *testing.T) {
+	act := kernelSigaction{handler: 0x9000}
+	err := installLinuxSignalHandlers(&act, func(sig uintptr, _ *kernelSigaction, old *kernelSigaction) error {
+		old.handler = 0x1111
+		if sig == uintptr(syscall.SIGSEGV) {
+			old.flags = _SA_RESETHAND
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("one-shot predecessor was accepted")
 	}
 }
 


### PR DESCRIPTION
Small correctness fix: installing the Linux guard-page handler replaced the predecessor’s signal mask and restart/defer behavior. On amd64, a non-Wasm fault inside a live reservation could also reach an obsolete framed fallback that dereferenced arbitrary RBP-relative memory.

The installer now creates distinct SIGSEGV/SIGBUS actions preserving each predecessor mask plus `SA_RESTART`/`SA_NODEFER`, and rejects one-shot predecessors that cannot be safely chained. The handler now recognizes only the current x64/WARP ABI and requires an exact pinned-RBX owner match before dereferencing basedata.

Proof:
- `go test -tags wago_guardpage ./src/core/runtime`
- `go test -tags wago_guardpage ./src/wago -run '^(TestMemoryBytesAfterGrowGuardPage|TestGuard|TestRuntime)'`\n- `GOOS=linux GOARCH=arm64 go test -c -tags wago_guardpage ./src/core/runtime`