### PR TITLE
runtime: make native artifact trust explicit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -313,10 +313,12 @@ read-only diagnostic stream; callers never receive a mutable alias:
 
 `Compiled` serializes to a compact versioned **`.wago` blob** through either the
 slice APIs (`MarshalBinary`/`UnmarshalBinary`) or bounded streaming APIs
-(`WriteTo`/`ReadFromWithLimits`). `Load` accepts
-either a precompiled blob (fast reload, no recompile) or raw wasm (compiled on
-load); `IsCompiled` distinguishes them. `validate()` hardens every blob against
-malformed metadata before any memory is mapped. The codec persists the
+(`WriteTo`/`ReadFromWithLimits`). `Load` accepts untrusted raw Wasm and compiles
+it; `LoadTrustedArtifact` performs the fast native-code reload only for
+authenticated or locally produced `.wago` bytes. `IsCompiled` distinguishes the
+formats, but callers must choose the trust boundary explicitly. `validate()`
+hardens artifact metadata before mapping, but cannot sandbox hostile native code.
+The codec persists the
 binding-independent imported-call shape, so modules with function imports can be
 serialized before host or instance targets are known; live addresses and store
 identity are installed only during instantiation. See the codec-version comment

--- a/cli/internal/handoff/runtime_commands.go
+++ b/cli/internal/handoff/runtime_commands.go
@@ -18,6 +18,7 @@ func RuntimeCommands() []*command.Cmd {
 	knobs := runtimeCompilationKnobs()
 	runFlags := []command.Flag{
 		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
+		{Name: "allow-native-artifact", Bool: true, Help: "execute a trusted .wago native-code artifact"},
 	}
 	runFlags = append(runFlags, runtimeWatchFlags()...)
 	runFlags = append(runFlags,

--- a/cli/manager/internal/standalone/build_linux_test.go
+++ b/cli/manager/internal/standalone/build_linux_test.go
@@ -100,7 +100,7 @@ import (
 var artifact []byte
 
 func main() {
-	compiled, err := wago.Load(artifact)
+	compiled, err := wago.LoadTrustedArtifact(artifact)
 	if err != nil {
 		panic(err)
 	}

--- a/cli/runtime/commands/build/command_test.go
+++ b/cli/runtime/commands/build/command_test.go
@@ -66,7 +66,7 @@ func TestCommandWritesRunnableArtifact(t *testing.T) {
 	if !wago.IsCompiled(artifact) {
 		t.Fatalf("build output is not a .wago artifact: %x", artifact)
 	}
-	if _, err := wago.Load(artifact); err != nil {
+	if _, err := wago.LoadTrustedArtifact(artifact); err != nil {
 		t.Fatalf("load build output: %v", err)
 	}
 }

--- a/cli/runtime/commands/run/command.go
+++ b/cli/runtime/commands/run/command.go
@@ -27,7 +27,7 @@ type Environment interface {
 func Command(environment Environment) *command.Cmd {
 	flags := []command.Flag{
 		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
-		{Name: "allow-native-artifact", Help: "execute a trusted .wago native-code artifact"},
+		{Name: "allow-native-artifact", Bool: true, Help: "execute a trusted .wago native-code artifact"},
 	}
 	flags = append(flags, watchFlags()...)
 	flags = append(flags,

--- a/cli/runtime/commands/run/command.go
+++ b/cli/runtime/commands/run/command.go
@@ -25,7 +25,10 @@ type Environment interface {
 }
 
 func Command(environment Environment) *command.Cmd {
-	flags := []command.Flag{{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"}}
+	flags := []command.Flag{
+		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
+		{Name: "allow-native-artifact", Help: "execute a trusted .wago native-code artifact"},
+	}
 	flags = append(flags, watchFlags()...)
 	flags = append(flags,
 		command.Flag{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 | 3 (default: best supported)"},
@@ -41,7 +44,8 @@ func Command(environment Environment) *command.Cmd {
 		Normalize: func(args []string) ([]string, error) {
 			return NormalizeParallelArgs(args, parserFlags, false)
 		},
-		Long: "<file> is raw .wasm or a precompiled .wago. Args after the file are typed by the\n" +
+		Long: "<file> is raw .wasm. Trusted precompiled .wago native code requires --allow-native-artifact.\n" +
+			"Never enable that flag for an untrusted artifact. Args after the file are typed by the\n" +
 			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64\n" +
 			"Wago flags may appear before or after <file>; use -- before colliding guest flags.\n" +
 			"Selected Core 3 features default on where supported; use --core 2 for strict Release 2\n" +
@@ -85,7 +89,7 @@ func (cmd implementation) Run(ctx *command.Ctx) {
 	config := selection.RuntimeConfig()
 	runtime := cmd.environment.LoadRuntime(config, positionals)
 	defer runtime.Close()
-	module := mustLoadModule(positionals[0], config, runtime, cmd.environment.ArtifactCache())
+	module := mustLoadModule(positionals[0], config, runtime, cmd.environment.ArtifactCache(), ctx.Bool("allow-native-artifact"))
 	compiled := module.Compiled()
 	export := mustResolveExport(compiled, ctx.Str("invoke"))
 

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -164,7 +164,7 @@ func TestLoadModuleAndResolveExport(t *testing.T) {
 	rt := wago.NewRuntime()
 	defer rt.Close()
 	config := wago.NewRuntimeConfig()
-	mod := mustLoadModule(path, config, rt, artifactcache.Cache{})
+	mod := mustLoadModule(path, config, rt, artifactcache.Cache{}, false)
 	if got := mustResolveExport(mod.Compiled(), ""); got != "f" {
 		t.Fatalf("default export = %q", got)
 	}
@@ -179,7 +179,10 @@ func TestLoadModuleAndResolveExport(t *testing.T) {
 	if err := os.WriteFile(compiledPath, encoded, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got := mustResolveExport(mustLoadModule(compiledPath, config, rt, artifactcache.Cache{}).Compiled(), "f"); got != "f" {
+	if mod, err := loadModule(compiledPath, config, rt, artifactcache.Cache{}, false); err == nil || mod != nil || !strings.Contains(err.Error(), "--allow-native-artifact") {
+		t.Fatalf("untrusted artifact load = %v, %v; want explicit opt-in", mod, err)
+	}
+	if got := mustResolveExport(mustLoadModule(compiledPath, config, rt, artifactcache.Cache{}, true).Compiled(), "f"); got != "f" {
 		t.Fatalf("loaded export = %q", got)
 	}
 }

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -118,6 +118,26 @@ func TestRunRecognizesFlagsAfterModulePath(t *testing.T) {
 	}
 }
 
+func TestRunParsesNativeArtifactOptInAsBoolean(t *testing.T) {
+	cmd := Command(testEnvironment{})
+	for _, args := range [][]string{
+		{"--allow-native-artifact", "module.wago"},
+		{"module.wago", "--allow-native-artifact"},
+	} {
+		normalized, err := cmd.Normalize(args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, err := cmd.Parse("wago run", normalized)
+		if err != nil {
+			t.Fatalf("parse %v: %v", args, err)
+		}
+		if !ctx.Bool("allow-native-artifact") || len(ctx.Args) != 1 || ctx.Args[0] != "module.wago" {
+			t.Fatalf("parse %v = opt-in %v, args %v", args, ctx.Bool("allow-native-artifact"), ctx.Args)
+		}
+	}
+}
+
 func TestFriendlyInstantiationErrorIsProviderNeutral(t *testing.T) {
 	for _, importName := range []string{"wasi_snapshot_preview1.fd_write", "acme_host.render"} {
 		err := fmt.Errorf(`module imports %q, but nothing provides it: %w`, importName, wago.ErrMissingImport)

--- a/cli/runtime/commands/run/module.go
+++ b/cli/runtime/commands/run/module.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"fmt"
+
 	"os"
 
 	"github.com/wago-org/wago"
@@ -9,27 +11,39 @@ import (
 	"github.com/wago-org/wago/cli/runtime/internal/artifactcache"
 )
 
-func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runtime, cache artifactcache.Cache) *wago.Module {
-	source, err := os.ReadFile(file)
-	if err != nil {
-		ui.Fatal("%v", err)
-	}
-	if wago.IsCompiled(source) {
-		compiled, err := wago.Load(source)
-		if err != nil {
-			ui.Fatal("%v", err)
-		}
-		module, err := runtime.Module(compiled)
-		if err != nil {
-			ui.Fatal("%v", err)
-		}
-		return module
-	}
-	module, err := cache.LoadOrCompile(source, config, runtime)
+func mustLoadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runtime, cache artifactcache.Cache, allowNativeArtifact bool) *wago.Module {
+	module, err := loadModule(file, config, runtime, cache, allowNativeArtifact)
 	if err != nil {
 		ui.Fatal("%v", err)
 	}
 	return module
+}
+
+func loadModule(file string, config *wago.RuntimeConfig, runtime *wago.Runtime, cache artifactcache.Cache, allowNativeArtifact bool) (*wago.Module, error) {
+	source, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	if wago.IsCompiled(source) {
+		if !allowNativeArtifact {
+			return nil, fmt.Errorf("refusing native-code artifact %q; pass --allow-native-artifact only for a trusted .wago file", file)
+		}
+		compiled, err := wago.LoadTrustedArtifact(source)
+		if err != nil {
+			return nil, err
+		}
+		module, err := runtime.Module(compiled)
+		if err != nil {
+			_ = compiled.Close()
+			return nil, err
+		}
+		return module, nil
+	}
+	module, err := cache.LoadOrCompile(source, config, runtime)
+	if err != nil {
+		return nil, err
+	}
+	return module, nil
 }
 
 func mustResolveExport(compiled *wago.Compiled, requested string) string {

--- a/cli/standalone/standalone.go
+++ b/cli/standalone/standalone.go
@@ -49,7 +49,7 @@ func executeArtifact(artifact []byte, plugins wago.PluginSet, options Options, a
 		return err
 	}
 	defer runtime.Close()
-	compiled, err := wago.Load(artifact)
+	compiled, err := wago.LoadTrustedArtifact(artifact)
 	if err != nil {
 		return err
 	}

--- a/examples/16-serialize/main.go
+++ b/examples/16-serialize/main.go
@@ -29,7 +29,7 @@ func main() {
 	fmt.Printf("precompiled blob: %d bytes, is-wago-blob=%v\n", len(blob), wago.IsCompiled(blob))
 
 	// Later, in a fresh process: Load accepts a blob or raw wasm transparently.
-	loaded, err := wago.Load(blob)
+	loaded, err := wago.LoadTrustedArtifact(blob)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/16-serialize/main.go
+++ b/examples/16-serialize/main.go
@@ -28,7 +28,9 @@ func main() {
 	}
 	fmt.Printf("precompiled blob: %d bytes, is-wago-blob=%v\n", len(blob), wago.IsCompiled(blob))
 
-	// Later, in a fresh process: Load accepts a blob or raw wasm transparently.
+	// Later, in a fresh process: artifacts contain host-native code, so use the
+	// trusted loader only for authenticated or locally produced bytes. Load is
+	// intentionally reserved for untrusted raw Wasm.
 	loaded, err := wago.LoadTrustedArtifact(blob)
 	if err != nil {
 		panic(err)

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -3991,9 +3991,9 @@ func (c *Compiled) validateSerializableLocked() error {
 	return c.validateCodecMetadata()
 }
 
-// ReadFrom streams one sectioned ".wago" artifact using bounded default
-// allocations. Native code is read directly into its RW image and sealed in
-// place on first instantiation.
+// ReadFrom streams one trusted sectioned ".wago" artifact using bounded default
+// allocations. Artifacts contain unsandboxed host-native code. Native code is
+// read directly into its RW image and sealed in place on first instantiation.
 func (c *Compiled) ReadFrom(r io.Reader) (int64, error) {
 	return c.ReadFromWithLimits(r, DefaultArtifactLimits())
 }
@@ -4028,9 +4028,10 @@ func (c *Compiled) ReadFromWithLimits(r io.Reader, limits ArtifactLimits) (int64
 	return n, nil
 }
 
-// UnmarshalBinary loads a ".wago" blob produced by MarshalBinary. It may
-// replace receiver state before instantiation; replacement is rejected while
-// instances of the receiver are live.
+// UnmarshalBinary loads a trusted ".wago" blob produced by MarshalBinary. The
+// artifact contains executable native code and is not a sandboxed Wasm input.
+// It may replace receiver state before instantiation; replacement is rejected
+// while instances of the receiver are live.
 func (c *Compiled) UnmarshalBinary(data []byte) error {
 	if !IsCompiled(data) {
 		return fmt.Errorf("not a wago module")
@@ -4078,14 +4079,24 @@ func finishDecodedCompiled(decoded *Compiled) error {
 // IsCompiled reports whether b is a precompiled wago module (vs raw wasm).
 func IsCompiled(b []byte) bool { return len(b) >= 5 && string(b[:4]) == wagoMagic }
 
-// Load returns a *Compiled from either a precompiled ".wago" blob or raw wasm
-// (which it compiles).
+// Load compiles raw Wasm. It rejects native-code .wago artifacts so format
+// autodetection cannot silently cross the Wasm trust boundary.
 func Load(b []byte) (*Compiled, error) {
 	if IsCompiled(b) {
-		c := &Compiled{}
-		return c, c.UnmarshalBinary(b)
+		return nil, fmt.Errorf("wago: Load refuses native-code artifacts; use LoadTrustedArtifact only for authenticated or locally produced bytes")
 	}
 	return Compile(nil, b)
+}
+
+// LoadTrustedArtifact decodes a precompiled .wago artifact. Artifacts contain
+// raw host-native executable code and MUST be authenticated or produced in the
+// same trusted environment; validation cannot make hostile native code safe.
+func LoadTrustedArtifact(b []byte) (*Compiled, error) {
+	if !IsCompiled(b) {
+		return nil, fmt.Errorf("wago: trusted artifact input is not a .wago module")
+	}
+	c := &Compiled{}
+	return c, c.UnmarshalBinary(b)
 }
 
 // Invoke marshals slot-based arguments/results around one native WasmWrapper

--- a/src/wago/bulk_memory_test.go
+++ b/src/wago/bulk_memory_test.go
@@ -17,7 +17,7 @@ func TestPassiveDataMemoryInitAndDrop(t *testing.T) {
 		if err != nil {
 			t.Fatalf("MarshalBinary: %v", err)
 		}
-		c, err = Load(blob)
+		c, err = LoadTrustedArtifact(blob)
 		if err != nil {
 			t.Fatalf("Load compiled blob: %v", err)
 		}

--- a/src/wago/codec_reference_test.go
+++ b/src/wago/codec_reference_test.go
@@ -242,7 +242,7 @@ func TestCompiledCodecLoadedReferenceExecution(t *testing.T) {
 			if err != nil {
 				t.Fatalf("MarshalBinary: %v", err)
 			}
-			loaded, err := Load(blob)
+			loaded, err := LoadTrustedArtifact(blob)
 			if err != nil {
 				t.Fatalf("Load: %v", err)
 			}

--- a/src/wago/extended_const_corpus_test.go
+++ b/src/wago/extended_const_corpus_test.go
@@ -78,7 +78,7 @@ func TestExtendedConstCodecExecution(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			loaded, err := wago.Load(blob)
+			loaded, err := wago.LoadTrustedArtifact(blob)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/wago/extended_offset_test.go
+++ b/src/wago/extended_offset_test.go
@@ -84,7 +84,7 @@ func TestActiveOffsetsUseLocalImmutableGlobals(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			compiled, err = Load(blob)
+			compiled, err = LoadTrustedArtifact(blob)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/wago/fuzz_regression_test.go
+++ b/src/wago/fuzz_regression_test.go
@@ -614,7 +614,7 @@ func testExtendedConstElementFixture(t *testing.T, id string) {
 	if err != nil {
 		t.Fatalf("marshal extended-const fixture %s: %v", id, err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("load extended-const fixture %s: %v", id, err)
 	}

--- a/src/wago/global_test.go
+++ b/src/wago/global_test.go
@@ -263,7 +263,7 @@ func TestExtendedConstExpressionsExecuteAndRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalBinary extended const module: %v", err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("Load extended const module: %v", err)
 	}

--- a/src/wago/memory_test.go
+++ b/src/wago/memory_test.go
@@ -388,7 +388,7 @@ func TestImportedMemorySurvivesMarshalLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/wago/multivalue_test.go
+++ b/src/wago/multivalue_test.go
@@ -124,7 +124,7 @@ func TestMultiValueDefaultConfigControlCallsAndCodec(t *testing.T) {
 		if err != nil {
 			t.Fatalf("MarshalBinary: %v", err)
 		}
-		c, err = Load(blob)
+		c, err = LoadTrustedArtifact(blob)
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
@@ -199,7 +199,7 @@ func TestMultiValueBranchPayloadsAndTypedCall(t *testing.T) {
 		if err != nil {
 			t.Fatalf("MarshalBinary: %v", err)
 		}
-		c, err = Load(blob)
+		c, err = LoadTrustedArtifact(blob)
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}

--- a/src/wago/proper_tail_reference_result_arm64_test.go
+++ b/src/wago/proper_tail_reference_result_arm64_test.go
@@ -132,7 +132,7 @@ func TestARM64OrdinaryDynamicCallsUseFuncrefResultRegisterABI(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		loaded, err := Load(blob)
+		loaded, err := LoadTrustedArtifact(blob)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/wago/segment_state_test.go
+++ b/src/wago/segment_state_test.go
@@ -70,7 +70,7 @@ func segmentStateCompiledVariants(t *testing.T, mod []byte) []*Compiled {
 		if err != nil {
 			t.Fatalf("MarshalBinary: %v", err)
 		}
-		loaded, err := Load(blob)
+		loaded, err := LoadTrustedArtifact(blob)
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}

--- a/src/wago/table_ops_test.go
+++ b/src/wago/table_ops_test.go
@@ -366,7 +366,7 @@ func TestFuncrefTableInitializerExpressionSurvivesCompiledCodec(t *testing.T) {
 		}
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -1224,7 +1224,7 @@ func TestTableGrowCapacitySurvivesCompiledCodec(t *testing.T) {
 		}
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -2000,7 +2000,7 @@ func TestCompiledCodecPreservesTableImport(t *testing.T) {
 		}
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -2336,7 +2336,7 @@ func TestCompiledCodecPreservesMinOnlyTableImportAndAcceptsLargerHostTable(t *te
 		}
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -3395,7 +3395,7 @@ func TestCompiledCodecPreservesPassiveNullElementPayloads(t *testing.T) {
 		}
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -3480,7 +3480,7 @@ func TestCompiledCodecMinOnlyTableImportRejectsBelowMinAfterLoad(t *testing.T) {
 		}
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}

--- a/src/wago/typed_cross_instance_amd64_test.go
+++ b/src/wago/typed_cross_instance_amd64_test.go
@@ -358,7 +358,7 @@ func TestStagedTypedCodecRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("marshal typed module: %v", err)
 			}
-			if _, err := Load(blob); err == nil || !strings.Contains(err.Error(), "required feature") {
+			if _, err := LoadTrustedArtifact(blob); err == nil || !strings.Contains(err.Error(), "required feature") {
 				t.Fatalf("public load of staged typed artifact = %v, want fail-closed required-feature error", err)
 			}
 			var loaded Compiled

--- a/src/wago/wago_test.go
+++ b/src/wago/wago_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -397,7 +398,10 @@ func TestCompiledRoundtrip(t *testing.T) {
 	if !IsCompiled(blob) {
 		t.Fatal("blob not recognized as compiled")
 	}
-	c2, err := Load(blob) // load precompiled, no recompile
+	if loaded, err := Load(blob); err == nil || loaded != nil || !strings.Contains(err.Error(), "refuses native-code artifacts") {
+		t.Fatalf("ambiguous Load artifact = %v, %v; want trust-boundary rejection", loaded, err)
+	}
+	c2, err := LoadTrustedArtifact(blob) // load precompiled, no recompile
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,6 +416,17 @@ func TestCompiledRoundtrip(t *testing.T) {
 	}
 	if AsI32(res[0]) != 832040 {
 		t.Fatalf("fib(30) from blob = %d, want 832040", AsI32(res[0]))
+	}
+}
+
+func TestLoadCompilesRawWasm(t *testing.T) {
+	compiled, err := Load(fibWasm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	if len(compiled.Entry) == 0 {
+		t.Fatal("raw Wasm was not compiled")
 	}
 }
 
@@ -472,7 +487,7 @@ func TestCompiledRoundtripPreservesDebugNames(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalBinary: %v", err)
 	}
-	loaded, err := Load(blob)
+	loaded, err := LoadTrustedArtifact(blob)
 	if err != nil {
 		t.Fatalf("Load compiled: %v", err)
 	}
@@ -490,7 +505,7 @@ func TestCompiledRoundtripPreservesDebugNames(t *testing.T) {
 func TestCompiledUnsupportedVersionsRejected(t *testing.T) {
 	for _, version := range []byte{0, wagoVersion + 1} {
 		blob := []byte{'W', 'A', 'G', 'O', version}
-		if _, err := Load(blob); err == nil {
+		if _, err := LoadTrustedArtifact(blob); err == nil {
 			t.Fatalf("Load compiled version %d succeeded, want error", version)
 		}
 	}

--- a/wago.go
+++ b/wago.go
@@ -435,6 +435,8 @@ func IsGuardPageUnavailable(err error) bool { return impl.IsGuardPageUnavailable
 
 func Load(b []byte) (*Compiled, error) { return impl.Load(b) }
 
+func LoadTrustedArtifact(b []byte) (*Compiled, error) { return impl.LoadTrustedArtifact(b) }
+
 func MustCompile(wasmBytes []byte) *Compiled { return impl.MustCompile(wasmBytes) }
 
 func NewBits(width int32, littleEndian []byte) (Bits, error) {

--- a/wago_facade_test.go
+++ b/wago_facade_test.go
@@ -38,7 +38,7 @@ func TestFacadeForwards(t *testing.T) {
 	if !IsCompiled(encoded) {
 		t.Fatal("IsCompiled false for encoded module")
 	}
-	if _, err := Load(encoded); err != nil {
+	if _, err := LoadTrustedArtifact(encoded); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	for _, g := range []*Global{


### PR DESCRIPTION
Small correctness fix: raw Wasm and precompiled native-code artifacts should not share an implicit trust path.

`Load` now accepts only raw Wasm, while authenticated or locally produced `.wago` artifacts require `LoadTrustedArtifact`. The CLI likewise requires `--allow-native-artifact`, with an explicit warning in help and tests covering rejection plus trusted opt-in.

Tests:
- `go test ./src/wago -run "^(TestCompiledRoundtrip|TestLoadCompilesRawWasm|TestCompiledUnsupportedVersionsRejected)$"`
- `go test ./src/wago -run "^$"`
- `go test . -run "^TestFacade"`
- `go test ./cli/runtime/commands/run ./cli/runtime/commands/build`
- `go test ./cli/standalone`
- `go test ./cli/manager/internal/standalone -run "^$"`