### PR TITLE
memory: make zero-copy view explicitly unsafe

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -481,7 +481,7 @@ same context slot.
 ## 12. Memory model
 
 Linear memory is the mmap-backed tail of JobMemory, exposed zero-copy via
-`Instance.Memory().Bytes()` — writes are visible in both directions without
+`Instance.Memory().UnsafeBytes()` — writes are visible in both directions without
 copying. Explicit mode checks the current size cached in basedata; supported
 platforms can instead use guard-page reservations. `memory.grow` raises the
 logical size within a stable pre-reserved mapping, preserving the native base.

--- a/bench/binarytrees_test.go
+++ b/bench/binarytrees_test.go
@@ -70,7 +70,7 @@ func btFreshRun(tb testing.TB, c *wago.Compiled, depth int) (lat time.Duration, 
 	}
 	checksum = uint32(res[0])
 	if m := in.Memory(); m != nil {
-		footprint = len(m.Bytes())
+		footprint = len(m.UnsafeBytes())
 	}
 	return lat, checksum, footprint
 }

--- a/bench/corpus_explicit_test.go
+++ b/bench/corpus_explicit_test.go
@@ -62,7 +62,7 @@ func testExplicitMemoryCopyForward12(t *testing.T, dynamic bool, base int32) {
 		t.Fatalf("instantiate: %v", err)
 	}
 	defer in.Close()
-	mem := in.Memory().Bytes()
+	mem := in.Memory().UnsafeBytes()
 	dst := int(base)
 	src := int(base + 48)
 	for i := 0; i < 12; i++ {

--- a/bench/sqli_rule_test.go
+++ b/bench/sqli_rule_test.go
@@ -50,7 +50,7 @@ func newASString(tb testing.TB, in *wago.Instance, s string) uint64 {
 		tb.Fatalf("__new: %v", err)
 	}
 	ptr := r[0]
-	mem := in.Memory().Bytes()
+	mem := in.Memory().UnsafeBytes()
 	for i := 0; i < len(s); i++ {
 		mem[ptr+uint64(2*i)] = s[i]
 		mem[ptr+uint64(2*i)+1] = 0

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -195,7 +195,7 @@ In guard-page mode, `memory.grow` raises the logical size before newly in-bounds
 pages are necessarily committed; native loads/stores commit them lazily through
 the fault handler. Host access uses `JobMemory.HostBytesChecked`, which mprotects
 and extends the stable-base Go view through the current logical size first. This
-is required for `Memory.Bytes`, typed host reads/writes, snapshot restore, and
+is required for `Memory.UnsafeBytes`, typed host reads/writes, snapshot restore, and
 active data initialization against an imported memory that grew before the new
 instance was created. `CurrentBytes` remains limited to the original committed
 Go slice and must not be used for that case.

--- a/docs/tinygo.md
+++ b/docs/tinygo.md
@@ -196,7 +196,7 @@ toolchains. The func-value-cast entry does the same `RSP` switch + `call` as the
 assembly trampoline, so the boundary cost matches.
 
 The `LinearMemoryAccess` row is the one apparent gap, but it is not the trampoline
-and not even linear memory itself — `Instance.Memory().Bytes()` hands back the raw,
+and not even linear memory itself — `Instance.Memory().UnsafeBytes()` hands back the raw,
 zero-copy mmap `[]byte`, which is optimal. That benchmark measures the *host's*
 access idiom, `binary.LittleEndian.{Put,}Uint32`, whose per-byte assembly + bounds
 checks LLVM optimizes less aggressively than `gc`.
@@ -207,7 +207,7 @@ idiom under TinyGo** — 0.73 ns/op vs 1.57 ns/op (and faster than `encoding/bin
 on the standard toolchain too). Use them for hot host loops:
 
 ```go
-v, ok := in.ReadUint32Le(off)   // not binary.LittleEndian.Uint32(in.Memory().Bytes()[off:])
+v, ok := in.ReadUint32Le(off)   // not binary.LittleEndian.Uint32(in.Memory().UnsafeBytes()[off:])
 in.WriteUint32Le(off, v)
 ```
 

--- a/src/core/runtime/basedata.go
+++ b/src/core/runtime/basedata.go
@@ -193,7 +193,7 @@ func (j *JobMemory) CurrentPages() uint32 { return j.getU32(offLinMemWasmSize) }
 func (j *JobMemory) MaxPages() uint32     { return j.getU32(offMaxLinMemPages) }
 
 // CurrentBytes returns the host-facing view of linear memory at its current
-// (possibly grown) logical size — what Memory.Bytes exposes.
+// (possibly grown) logical size — what Memory.UnsafeBytes exposes.
 func (j *JobMemory) CurrentBytes() []byte {
 	n := j.curBytes()
 	return j.mem[j.linOff : j.linOff+n : j.linOff+n]

--- a/src/wago/bench_test.go
+++ b/src/wago/bench_test.go
@@ -2409,8 +2409,8 @@ func BenchmarkBulkMemoryARM64(b *testing.B) {
 				b.Fatal(err)
 			}
 			defer in.Close()
-			for i := range in.Memory().Bytes() {
-				in.Memory().Bytes()[i] = byte(i)
+			for i := range in.Memory().UnsafeBytes() {
+				in.Memory().UnsafeBytes()[i] = byte(i)
 			}
 			for _, n := range []uint64{64, 256, 4096} {
 				b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {

--- a/src/wago/bulk_memory_test.go
+++ b/src/wago/bulk_memory_test.go
@@ -31,13 +31,13 @@ func TestPassiveDataMemoryInitAndDrop(t *testing.T) {
 	if _, err := in.Invoke("init", I32(10), I32(1), I32(3)); err != nil {
 		t.Fatalf("memory.init: %v", err)
 	}
-	if got := string(in.Memory().Bytes()[10:13]); got != "ell" {
+	if got := string(in.Memory().UnsafeBytes()[10:13]); got != "ell" {
 		t.Fatalf("memory.init copied %q, want ell", got)
 	}
 	if _, err := in.Invoke("init", I32(20), I32(0), I32(5)); err != nil {
 		t.Fatalf("second memory.init before drop: %v", err)
 	}
-	if got := string(in.Memory().Bytes()[20:25]); got != "hello" {
+	if got := string(in.Memory().UnsafeBytes()[20:25]); got != "hello" {
 		t.Fatalf("second memory.init copied %q, want hello", got)
 	}
 	if _, err := in.Invoke("drop"); err != nil {

--- a/src/wago/cross_instance_test.go
+++ b/src/wago/cross_instance_test.go
@@ -53,7 +53,7 @@ func TestHostMediatedCrossInstanceCallRestoresCallerMemoryContext(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	calleeMemory.Bytes()[1000+6159], calleeMemory.Bytes()[10000+6159] = 9, 8
+	calleeMemory.UnsafeBytes()[1000+6159], calleeMemory.UnsafeBytes()[10000+6159] = 9, 8
 
 	caller, err = rt.Instantiate(ctx, mustCompileWat(rt, t, `(module
 		(import "env" "ping" (func $ping))
@@ -94,8 +94,8 @@ func TestHostMediatedCrossInstanceCallRestoresCallerMemoryContext(t *testing.T) 
 	if len(got) != 1 || AsI32(got[0]) != 0 {
 		t.Fatalf("run = %v, want caller memory byte 0", got)
 	}
-	if calleeMemory.Bytes()[10000+6159] != 8 {
-		t.Fatalf("callee memory was modified after returning to caller: byte = %d", calleeMemory.Bytes()[10000+6159])
+	if calleeMemory.UnsafeBytes()[10000+6159] != 8 {
+		t.Fatalf("callee memory was modified after returning to caller: byte = %d", calleeMemory.UnsafeBytes()[10000+6159])
 	}
 }
 
@@ -161,7 +161,7 @@ func TestCrossInstanceImportedTablePreservesFourArguments(t *testing.T) {
 		t.Fatalf("result = %v, want 33", got)
 	}
 	for i, want := range []uint32{11, 22, 33, 44} {
-		if got := binary.LittleEndian.Uint32(mem.Bytes()[i*4:]); got != want {
+		if got := binary.LittleEndian.Uint32(mem.UnsafeBytes()[i*4:]); got != want {
 			t.Fatalf("argument %d = %d, want %d", i, got, want)
 		}
 	}

--- a/src/wago/export_acquisition_race_test.go
+++ b/src/wago/export_acquisition_race_test.go
@@ -50,7 +50,7 @@ func TestExportAcquisitionCloseLinearization(t *testing.T) {
 		rt, in, _ := newExportAcquisitionFixture(t)
 		defer rt.Close()
 		memory := in.Memory()
-		if memory == nil || len(memory.Bytes()) != 1<<16 {
+		if memory == nil || len(memory.UnsafeBytes()) != 1<<16 {
 			t.Fatal("Instance.Memory acquisition was not usable")
 		}
 		memoryImporter := mustCompileWat(rt, t, `(module (import "env" "memory" (memory 1 1)))`)
@@ -69,14 +69,14 @@ func TestExportAcquisitionCloseLinearization(t *testing.T) {
 		closeDone := make(chan error, 1)
 		go func() { closeDone <- in.Close() }()
 		<-gatePublished
-		if got := memory.Bytes(); got != nil {
+		if got := memory.UnsafeBytes(); got != nil {
 			t.Fatalf("Instance.Memory Bytes after close gate length = %d, want nil", len(got))
 		}
 		close(releaseClose)
 		if err := <-closeDone; err != nil {
 			t.Fatalf("Close: %v", err)
 		}
-		if got := memory.Bytes(); got != nil {
+		if got := memory.UnsafeBytes(); got != nil {
 			t.Fatalf("Instance.Memory Bytes after physical close length = %d, want nil", len(got))
 		}
 	})
@@ -106,7 +106,7 @@ func TestExportAcquisitionCloseLinearization(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ExportedMemory: %v", err)
 		}
-		if table.Size() != 1 || global.Get() != 42 || len(memory.Bytes()) != 1<<16 {
+		if table.Size() != 1 || global.Get() != 42 || len(memory.UnsafeBytes()) != 1<<16 {
 			t.Fatal("acquired exports were not usable before close")
 		}
 
@@ -127,7 +127,7 @@ func TestExportAcquisitionCloseLinearization(t *testing.T) {
 		if got := global.Get(); got != 0 {
 			t.Fatalf("global Get after close gate = %d, want fail-closed zero", got)
 		}
-		if got := memory.Bytes(); got != nil {
+		if got := memory.UnsafeBytes(); got != nil {
 			t.Fatalf("memory Bytes after close gate length = %d, want nil", len(got))
 		}
 		if _, err := rt.Instantiate(context.Background(), consumerCode, WithImports(Imports{"env.f": fn})); err == nil || !strings.Contains(err.Error(), "closed") {
@@ -148,7 +148,7 @@ func TestExportAcquisitionCloseLinearization(t *testing.T) {
 		if err := global.Set(9); err == nil || !strings.Contains(err.Error(), "closed") {
 			t.Fatalf("global Set after physical close error = %v, want closed", err)
 		}
-		if got := memory.Bytes(); got != nil {
+		if got := memory.UnsafeBytes(); got != nil {
 			t.Fatalf("memory Bytes after physical close length = %d, want nil", len(got))
 		}
 		if got := in.Memory(); got != nil {

--- a/src/wago/extended_offset_memory64_amd64_test.go
+++ b/src/wago/extended_offset_memory64_amd64_test.go
@@ -43,7 +43,7 @@ func TestMemory64ActiveOffsetUsesLocalImmutableI64Global(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer in.Close()
-	if got := in.Memory().Bytes()[4]; got != 'x' {
+	if got := in.Memory().UnsafeBytes()[4]; got != 'x' {
 		t.Fatalf("memory[4] = %d, want %d", got, 'x')
 	}
 }

--- a/src/wago/fuzz_regression_test.go
+++ b/src/wago/fuzz_regression_test.go
@@ -176,7 +176,7 @@ func TestFuzzRegressionCorpus(t *testing.T) {
 				_ = c.Close()
 				t.Fatalf("instantiate %d: %v", i, err)
 			}
-			memories = append(memories, append([]byte(nil), in.Memory().Bytes()...))
+			memories = append(memories, append([]byte(nil), in.Memory().UnsafeBytes()...))
 			_ = in.Close()
 			_ = c.Close()
 		}
@@ -552,7 +552,7 @@ func assertFuzzMemorySHA(t *testing.T, in *Instance, wantLen int, want string) {
 	if in.Memory() == nil {
 		t.Fatal("module has no memory")
 	}
-	b := in.Memory().Bytes()
+	b := in.Memory().UnsafeBytes()
 	if len(b) != wantLen {
 		t.Fatalf("memory length = %d, want %d", len(b), wantLen)
 	}

--- a/src/wago/global_test.go
+++ b/src/wago/global_test.go
@@ -683,7 +683,7 @@ func TestDataOffsetI32ConstUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer in.Close()
-	if got := string(in.Memory().Bytes()[4:6]); got != "OK" {
+	if got := string(in.Memory().UnsafeBytes()[4:6]); got != "OK" {
 		t.Fatalf("data at i32.const offset = %q, want OK", got)
 	}
 }
@@ -865,7 +865,7 @@ func TestDataOffsetCanUseImportedImmutableGlobal(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer in.Close()
-	if got := string(in.Memory().Bytes()[9:11]); got != "OK" {
+	if got := string(in.Memory().UnsafeBytes()[9:11]); got != "OK" {
 		t.Fatalf("data at imported-global offset = %q, want OK", got)
 	}
 }

--- a/src/wago/guest_storage.go
+++ b/src/wago/guest_storage.go
@@ -198,7 +198,7 @@ func (v *guestStorageView) MemoryInfo(index uint32) (GuestMemoryInfo, error) {
 	if err != nil {
 		return GuestMemoryInfo{}, err
 	}
-	bytes := memory.Bytes()
+	bytes := memory.UnsafeBytes()
 	if bytes == nil && memory.jobMemory() == nil {
 		return GuestMemoryInfo{}, fmt.Errorf("wago: memory index %d is closed", index)
 	}
@@ -218,7 +218,7 @@ func (v *guestStorageView) MemoryRange(index uint32, offset, length uint64, acce
 	if err != nil {
 		return nil, err
 	}
-	bytes := memory.Bytes()
+	bytes := memory.UnsafeBytes()
 	if bytes == nil && memory.jobMemory() == nil {
 		return nil, fmt.Errorf("wago: memory index %d is closed", index)
 	}

--- a/src/wago/guest_storage_memory_amd64_test.go
+++ b/src/wago/guest_storage_memory_amd64_test.go
@@ -95,7 +95,7 @@ func TestHostGuestStorageMemory64MetadataAndRange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := binary.LittleEndian.Uint64(memory.Bytes()[64:72]); got != 0x0102030405060708 {
+	if got := binary.LittleEndian.Uint64(memory.UnsafeBytes()[64:72]); got != 0x0102030405060708 {
 		t.Fatalf("memory64 host write = %#x", got)
 	}
 }

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -406,8 +406,9 @@ func (in *Instance) releaseResources() {
 }
 
 // Memory returns the instance's linear-memory object (instance-owned or the
-// host-imported one). Use Memory().Bytes() for the zero-copy byte view. A close
-// that wins the acquisition race returns nil instead of a dangling object.
+// host-imported one). Use Memory().UnsafeBytes() for an explicitly unsafe
+// zero-copy byte view. A close that wins the acquisition race returns nil
+// instead of a dangling object.
 func (in *Instance) Memory() *Memory {
 	if in == nil || in.c == nil || in.c.memoryCount() == 0 || in.memory == nil || in.beginInvocation() != nil {
 		return nil

--- a/src/wago/memory.go
+++ b/src/wago/memory.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Memory is a linear-memory object the host can create and import into a module,
-// mirroring JS WebAssembly.Memory. The host owns it: read and write Bytes(), and
+// mirroring JS WebAssembly.Memory. The host owns it: access UnsafeBytes(), and
 // Close() it when no instance importing it is still in use.
 //
 // The handle stays two pointers wide. Ordinary instance-owned memories keep the
@@ -133,13 +133,19 @@ func newMemory(minPages, maxPages uint32, shared bool) (*Memory, error) {
 	return m, nil
 }
 
-// Bytes returns the zero-copy linear-memory view shared with wasm, at the
-// current (possibly grown) size. It uses the host-facing accessor so it stays
-// valid after a memory.grow in guard-page mode — where the Go-side j.mem slice is
-// capped at the initial commit while the grown pages live in the reservation.
-// CurrentBytes would panic there (slice bounds beyond the initial commit); this
-// mirrors what Instance.Read/Write already use via mem().
-func (m *Memory) Bytes() []byte {
+// UnsafeBytes returns the zero-copy linear-memory view shared with wasm, at the
+// current (possibly grown) size. The returned slice is valid only while the
+// Memory and its owner instance remain open, and Close must not race any access.
+// Retaining or using it after Close is unsafe because the off-heap mapping may
+// be recycled for another instance. Prefer Instance.Read and Instance.Write
+// when a retained or close-safe view is required.
+//
+// It uses the host-facing accessor so it stays valid after a memory.grow in
+// guard-page mode — where the Go-side j.mem slice is capped at the initial commit
+// while the grown pages live in the reservation. CurrentBytes would panic there
+// (slice bounds beyond the initial commit); this mirrors what Instance.Read/Write
+// already use via mem().
+func (m *Memory) UnsafeBytes() []byte {
 	if m == nil {
 		return nil
 	}

--- a/src/wago/memory64_exec_amd64_test.go
+++ b/src/wago/memory64_exec_amd64_test.go
@@ -553,7 +553,7 @@ func TestStagedMemory64ActiveDataLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := memory.Bytes()[65532:65536]; !bytes.Equal(got, []byte{1, 2, 3, 4}) {
+	if got := memory.UnsafeBytes()[65532:65536]; !bytes.Equal(got, []byte{1, 2, 3, 4}) {
 		t.Fatalf("memory64 active data bytes = %v, want [1 2 3 4]", got)
 	}
 
@@ -602,7 +602,7 @@ func TestStagedMemory64PassiveDataLifecycle(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			mem := memory.Bytes()
+			mem := memory.UnsafeBytes()
 			if _, err := in.Invoke("init", 16, I32(1), I32(3)); err != nil {
 				t.Fatalf("memory64.init: %v", err)
 			}
@@ -663,7 +663,7 @@ func TestStagedMemory64IntegerScalarFamily(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mem := memory.Bytes()
+	mem := memory.UnsafeBytes()
 	const addr = 64
 	loadCases := map[string]struct {
 		bits uint64
@@ -736,7 +736,7 @@ func TestStagedMemory64FloatScalarFamily(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mem := memory.Bytes()
+	mem := memory.UnsafeBytes()
 	const addr = 96
 	f32bits := uint32(0x7fa00001)
 	f64bits := uint64(0x7ff4000000000001)
@@ -814,10 +814,10 @@ func TestStagedMemory64SIMDMemoryFamily(t *testing.T) {
 		if got := invokeV128(t, in, "run", 3, lo, hi); got != want {
 			t.Fatalf("memory64 v128 round trip = % x, want % x", got, want)
 		}
-		if got := V128(memory.Bytes()[8:24]); got != want {
+		if got := V128(memory.UnsafeBytes()[8:24]); got != want {
 			t.Fatalf("memory64 v128 bytes = % x, want % x", got, want)
 		}
-		if _, err := in.Invoke("run", uint64(len(memory.Bytes())-20), lo, hi); err == nil || !strings.Contains(err.Error(), "out of bounds") {
+		if _, err := in.Invoke("run", uint64(len(memory.UnsafeBytes())-20), lo, hi); err == nil || !strings.Contains(err.Error(), "out of bounds") {
 			t.Fatalf("memory64 v128 end trap = %v", err)
 		}
 
@@ -854,11 +854,11 @@ func TestStagedMemory64SIMDMemoryFamily(t *testing.T) {
 			body := append([]byte{0x20, 0x00}, memory64SIMDMemOp(tc.sub, tc.align, 5)...)
 			body = append(body, 0x0b)
 			_, in, memory := compile(t, []wasm.ValType{wasm.I64}, []wasm.ValType{wasm.V128}, body)
-			copy(memory.Bytes()[8:], tc.input[:tc.size])
+			copy(memory.UnsafeBytes()[8:], tc.input[:tc.size])
 			if got := invokeV128(t, in, "run", 3); got != tc.want {
 				t.Fatalf("%s = % x, want % x", tc.name, got, tc.want)
 			}
-			if _, err := in.Invoke("run", uint64(len(memory.Bytes())-5-tc.size+1)); err == nil || !strings.Contains(err.Error(), "out of bounds") {
+			if _, err := in.Invoke("run", uint64(len(memory.UnsafeBytes())-5-tc.size+1)); err == nil || !strings.Contains(err.Error(), "out of bounds") {
 				t.Fatalf("%s exact-width end trap = %v", tc.name, err)
 			}
 		})
@@ -877,10 +877,10 @@ func TestStagedMemory64SIMDMemoryFamily(t *testing.T) {
 			loadBody = append(loadBody, 0x0b)
 			_, loadIn, loadMemory := compile(t, []wasm.ValType{wasm.I64, wasm.V128}, []wasm.ValType{wasm.V128}, loadBody)
 			for i := byte(0); i < tc.size; i++ {
-				loadMemory.Bytes()[8+int(i)] = 0xa0 + i
+				loadMemory.UnsafeBytes()[8+int(i)] = 0xa0 + i
 			}
 			want := initial
-			copy(want[int(tc.lane)*int(tc.size):], loadMemory.Bytes()[8:8+int(tc.size)])
+			copy(want[int(tc.lane)*int(tc.size):], loadMemory.UnsafeBytes()[8:8+int(tc.size)])
 			if got := invokeV128(t, loadIn, "run", 3, lo, hi); got != want {
 				t.Fatalf("load lane = % x, want % x", got, want)
 			}
@@ -892,14 +892,14 @@ func TestStagedMemory64SIMDMemoryFamily(t *testing.T) {
 				t.Fatal(err)
 			}
 			laneStart := int(tc.lane) * int(tc.size)
-			if got, wantBytes := storeMemory.Bytes()[8:8+int(tc.size)], initial[laneStart:laneStart+int(tc.size)]; !bytes.Equal(got, wantBytes) {
+			if got, wantBytes := storeMemory.UnsafeBytes()[8:8+int(tc.size)], initial[laneStart:laneStart+int(tc.size)]; !bytes.Equal(got, wantBytes) {
 				t.Fatalf("stored lane = % x, want % x", got, wantBytes)
 			}
-			before := append([]byte(nil), storeMemory.Bytes()[8:8+int(tc.size)]...)
-			if _, err := storeIn.Invoke("run", uint64(len(storeMemory.Bytes())-5-int(tc.size)+1), lo, hi); err == nil || !strings.Contains(err.Error(), "out of bounds") {
+			before := append([]byte(nil), storeMemory.UnsafeBytes()[8:8+int(tc.size)]...)
+			if _, err := storeIn.Invoke("run", uint64(len(storeMemory.UnsafeBytes())-5-int(tc.size)+1), lo, hi); err == nil || !strings.Contains(err.Error(), "out of bounds") {
 				t.Fatalf("store lane end trap = %v", err)
 			}
-			if got := storeMemory.Bytes()[8 : 8+int(tc.size)]; !bytes.Equal(got, before) {
+			if got := storeMemory.UnsafeBytes()[8 : 8+int(tc.size)]; !bytes.Equal(got, before) {
 				t.Fatalf("trapping lane store changed memory: % x", got)
 			}
 		})
@@ -943,7 +943,7 @@ func TestStagedMemory64BulkCopyFill(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mem := memory.Bytes()
+	mem := memory.UnsafeBytes()
 	for i := 0; i < 64; i++ {
 		mem[i] = byte(i)
 	}
@@ -1489,7 +1489,7 @@ func BenchmarkStagedMemory64FloatLoad(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	binary.LittleEndian.PutUint64(memory.Bytes()[64:], 0x7ff4000000000001)
+	binary.LittleEndian.PutUint64(memory.UnsafeBytes()[64:], 0x7ff4000000000001)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/src/wago/memory_access.go
+++ b/src/wago/memory_access.go
@@ -8,7 +8,8 @@ import (
 // Typed little-endian accessors over an instance's linear memory.
 //
 // They read/write through a single aligned machine load/store after one bounds
-// check, which is faster than reaching for encoding/binary on Memory().Bytes() —
+// check, which is faster than reaching for encoding/binary on
+// Memory().UnsafeBytes() —
 // and it closes the host-side gap under TinyGo, whose LLVM backend optimizes
 // encoding/binary's per-byte assembly less aggressively (see docs/tinygo.md;
 // ~0.43 ns/op vs ~1.6 ns/op for the binary idiom, at parity with the standard
@@ -236,7 +237,8 @@ func (in *Instance) WriteFloat64Le(offset uint32, v float64) bool {
 }
 
 // Read returns a copy of length bytes starting at offset, or ok=false if the
-// range falls outside linear memory. For zero-copy access use Memory().Bytes().
+// range falls outside linear memory. For explicitly unsafe zero-copy access use
+// Memory().UnsafeBytes().
 func (in *Instance) Read(offset, length uint32) ([]byte, bool) {
 	if in == nil || in.beginInvocation() != nil {
 		return nil, false

--- a/src/wago/memory_access_test.go
+++ b/src/wago/memory_access_test.go
@@ -20,7 +20,7 @@ func TestMemoryAccessors(t *testing.T) {
 		t.Fatalf("Instantiate: %v", err)
 	}
 	defer in.Close()
-	lin := in.Memory().Bytes()
+	lin := in.Memory().UnsafeBytes()
 	if len(lin) < 64 {
 		t.Fatalf("linear memory too small: %d", len(lin))
 	}

--- a/src/wago/memory_copy_overlap_amd64_test.go
+++ b/src/wago/memory_copy_overlap_amd64_test.go
@@ -42,7 +42,7 @@ func TestMemoryCopyBackwardVectorTiers(t *testing.T) {
 			}
 			defer instance.Close()
 
-			memory := instance.Memory().Bytes()
+			memory := instance.Memory().UnsafeBytes()
 			for i := 0; i <= n; i++ {
 				memory[i] = byte(i*31 + 7)
 			}

--- a/src/wago/memory_grow_guardpage_test.go
+++ b/src/wago/memory_grow_guardpage_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 )
 
-// TestMemoryBytesAfterGrowGuardPage is a regression for Memory.Bytes() using the
+// TestMemoryBytesAfterGrowGuardPage is a regression for Memory.UnsafeBytes() using the
 // grow-safe host accessor. Under guard-page bounds the Go-side j.mem slice stays
 // capped at the initial commit while memory.grow commits pages in the reservation;
-// Memory.Bytes() must reflect the grown logical size (previously it called
+// Memory.UnsafeBytes() must reflect the grown logical size (previously it called
 // CurrentBytes and panicked with "slice bounds out of range" after growth).
 func TestMemoryBytesAfterGrowGuardPage(t *testing.T) {
 	const page = 65536
@@ -25,7 +25,7 @@ func TestMemoryBytesAfterGrowGuardPage(t *testing.T) {
 	}
 	defer in.Close()
 
-	if got := len(in.Memory().Bytes()); got != page {
+	if got := len(in.Memory().UnsafeBytes()); got != page {
 		t.Fatalf("initial Bytes() len = %d, want %d", got, page)
 	}
 
@@ -39,7 +39,7 @@ func TestMemoryBytesAfterGrowGuardPage(t *testing.T) {
 	}
 
 	// The whole point: Bytes() reflects the grown size and does not panic.
-	if got := len(in.Memory().Bytes()); got != 5*page {
+	if got := len(in.Memory().UnsafeBytes()); got != 5*page {
 		t.Fatalf("after grow, Bytes() len = %d, want %d", got, 5*page)
 	}
 
@@ -48,7 +48,7 @@ func TestMemoryBytesAfterGrowGuardPage(t *testing.T) {
 	if _, err := in.Invoke("store", I32(int32(off)), I32(0xABCD)); err != nil {
 		t.Fatalf("store into grown page: %v", err)
 	}
-	if got := binary.LittleEndian.Uint32(in.Memory().Bytes()[off:]); got != 0xABCD {
+	if got := binary.LittleEndian.Uint32(in.Memory().UnsafeBytes()[off:]); got != 0xABCD {
 		t.Fatalf("grown page via Bytes() = %#x, want 0xABCD", got)
 	}
 }

--- a/src/wago/memory_guardpage_test.go
+++ b/src/wago/memory_guardpage_test.go
@@ -39,7 +39,7 @@ func TestGuardedImportedGrownMemoryAcceptsActiveData(t *testing.T) {
 		t.Fatalf("instantiate consumer after grow: %v", err)
 	}
 	defer consumer.Close()
-	if got := memory.Bytes()[4*65536]; got != 'x' {
+	if got := memory.UnsafeBytes()[4*65536]; got != 'x' {
 		t.Fatalf("active data byte = %q, want x", got)
 	}
 }
@@ -75,11 +75,11 @@ func TestImportedMemoryGuardPage(t *testing.T) {
 	if _, err := in.Invoke("store", I32(8), I32(0xCAFE)); err != nil {
 		t.Fatal(err)
 	}
-	if got := binary.LittleEndian.Uint32(mem.Bytes()[8:]); got != 0xCAFE {
+	if got := binary.LittleEndian.Uint32(mem.UnsafeBytes()[8:]); got != 0xCAFE {
 		t.Fatalf("host sees mem[8] = %#x, want 0xCAFE", got)
 	}
 	// host write -> wasm observes.
-	binary.LittleEndian.PutUint32(mem.Bytes()[16:], 0x1234)
+	binary.LittleEndian.PutUint32(mem.UnsafeBytes()[16:], 0x1234)
 	if r, err := in.Invoke("load", I32(16)); err != nil || AsI32(r[0]) != 0x1234 {
 		t.Fatalf("wasm load = %#x err=%v, want 0x1234", AsI32(r[0]), err)
 	}

--- a/src/wago/memory_limit_regression_test.go
+++ b/src/wago/memory_limit_regression_test.go
@@ -126,7 +126,7 @@ func TestNewMemoryRejectsOversizedAndPreservesFourGiBLimit(t *testing.T) {
 	if got := memory.jobMemory().MaxPages(); got != 65536 {
 		t.Fatalf("maximum pages = %d, want 65536", got)
 	}
-	if got := len(memory.Bytes()); uint64(got) != uint64(65536)*65536 {
+	if got := len(memory.UnsafeBytes()); uint64(got) != uint64(65536)*65536 {
 		t.Fatalf("byte length = %d, want 4294967296", got)
 	}
 }

--- a/src/wago/memory_test.go
+++ b/src/wago/memory_test.go
@@ -173,11 +173,11 @@ func TestImportedMemoryShared(t *testing.T) {
 	if _, err := in.Invoke("store", I32(8), I32(0xCAFE)); err != nil {
 		t.Fatal(err)
 	}
-	if got := binary.LittleEndian.Uint32(mem.Bytes()[8:]); got != 0xCAFE {
+	if got := binary.LittleEndian.Uint32(mem.UnsafeBytes()[8:]); got != 0xCAFE {
 		t.Fatalf("host sees mem[8] = %#x, want 0xCAFE", got)
 	}
 	// host writes -> wasm observes.
-	binary.LittleEndian.PutUint32(mem.Bytes()[16:], 0x1234)
+	binary.LittleEndian.PutUint32(mem.UnsafeBytes()[16:], 0x1234)
 	r, err := in.Invoke("load", I32(16))
 	if err != nil {
 		t.Fatal(err)
@@ -210,7 +210,7 @@ func TestMemoryGrowExported(t *testing.T) {
 	if prev := AsI32(r[0]); prev != 1 {
 		t.Fatalf("memory.grow returned %d, want previous count 1", prev)
 	}
-	if got := len(in.Memory().Bytes()); got != 5*65536 {
+	if got := len(in.Memory().UnsafeBytes()); got != 5*65536 {
 		t.Fatalf("after grow, Bytes() len = %d, want %d", got, 5*65536)
 	}
 }
@@ -408,7 +408,7 @@ func TestImportedMemorySurvivesMarshalLoad(t *testing.T) {
 	if _, err := in.Invoke("store", I32(4), I32(0x55AA)); err != nil {
 		t.Fatal(err)
 	}
-	if got := binary.LittleEndian.Uint32(mem.Bytes()[4:]); got != 0x55AA {
+	if got := binary.LittleEndian.Uint32(mem.UnsafeBytes()[4:]); got != 0x55AA {
 		t.Fatalf("host sees mem[4] = %#x, want 0x55AA", got)
 	}
 }

--- a/src/wago/memory_wait_test.go
+++ b/src/wago/memory_wait_test.go
@@ -15,7 +15,7 @@ func TestMemoryWaitMismatchAndZeroTimeoutDoNotRetainState(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer m.Close()
-	atomic.StoreUint32((*uint32)(unsafe.Pointer(&m.Bytes()[0])), 7)
+	atomic.StoreUint32((*uint32)(unsafe.Pointer(&m.UnsafeBytes()[0])), 7)
 	if got, err := m.wait32(context.Background(), 0, 8, -1); err != nil || got != memoryWaitNotEqual {
 		t.Fatalf("mismatch = %d, %v", got, err)
 	}

--- a/src/wago/multi_memory_bench_amd64_test.go
+++ b/src/wago/multi_memory_bench_amd64_test.go
@@ -199,7 +199,7 @@ func BenchmarkStagedMultiMemorySIMDLoad(b *testing.B) {
 	if err != nil {
 		b.Fatalf("export memory 1: %v", err)
 	}
-	copy(m1.Bytes()[32:], []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
+	copy(m1.UnsafeBytes()[32:], []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/src/wago/multi_memory_bulk_amd64_test.go
+++ b/src/wago/multi_memory_bulk_amd64_test.go
@@ -79,46 +79,46 @@ func exerciseIndexedBulkMemory(t *testing.T, in *Instance) {
 	if err != nil {
 		t.Fatalf("export m1: %v", err)
 	}
-	if got := string(m1.Bytes()[4:6]); got != "A1" {
+	if got := string(m1.UnsafeBytes()[4:6]); got != "A1" {
 		t.Fatalf("active memory-1 data = %q, want A1", got)
 	}
 	if _, err := in.Invoke("init1", I32(10), I32(1), I32(3)); err != nil {
 		t.Fatalf("memory.init 1: %v", err)
 	}
-	if got := string(m1.Bytes()[10:13]); got != "ell" {
+	if got := string(m1.UnsafeBytes()[10:13]); got != "ell" {
 		t.Fatalf("memory.init bytes = %q, want ell", got)
 	}
-	copy(m0.Bytes()[20:24], "zero")
+	copy(m0.UnsafeBytes()[20:24], "zero")
 	if _, err := in.Invoke("copy10", I32(30), I32(20), I32(4)); err != nil {
 		t.Fatalf("memory.copy 0->1: %v", err)
 	}
-	if got := string(m1.Bytes()[30:34]); got != "zero" {
+	if got := string(m1.UnsafeBytes()[30:34]); got != "zero" {
 		t.Fatalf("memory.copy 0->1 bytes = %q", got)
 	}
 	if _, err := in.Invoke("copy01", I32(40), I32(30), I32(4)); err != nil {
 		t.Fatalf("memory.copy 1->0: %v", err)
 	}
-	if got := string(m0.Bytes()[40:44]); got != "zero" {
+	if got := string(m0.UnsafeBytes()[40:44]); got != "zero" {
 		t.Fatalf("memory.copy 1->0 bytes = %q", got)
 	}
-	copy(m1.Bytes()[50:56], "abcdef")
+	copy(m1.UnsafeBytes()[50:56], "abcdef")
 	if _, err := in.Invoke("copy11", I32(52), I32(50), I32(6)); err != nil {
 		t.Fatalf("overlap memory.copy 1->1: %v", err)
 	}
-	if got := string(m1.Bytes()[50:58]); got != "ababcdef" {
+	if got := string(m1.UnsafeBytes()[50:58]); got != "ababcdef" {
 		t.Fatalf("overlap memory.copy bytes = %q, want ababcdef", got)
 	}
 	if _, err := in.Invoke("fill1", I32(70), I32('x'), I32(5)); err != nil {
 		t.Fatalf("memory.fill 1: %v", err)
 	}
-	if got := string(m1.Bytes()[70:75]); got != "xxxxx" {
+	if got := string(m1.UnsafeBytes()[70:75]); got != "xxxxx" {
 		t.Fatalf("memory.fill bytes = %q", got)
 	}
-	before := append([]byte(nil), m1.Bytes()[80:84]...)
+	before := append([]byte(nil), m1.UnsafeBytes()[80:84]...)
 	if _, err := in.Invoke("copy10", I32(65534), I32(20), I32(4)); err == nil {
 		t.Fatal("out-of-bounds cross-memory copy unexpectedly succeeded")
 	}
-	if !bytes.Equal(m1.Bytes()[80:84], before) {
+	if !bytes.Equal(m1.UnsafeBytes()[80:84], before) {
 		t.Fatal("trapping cross-memory copy changed unrelated destination bytes")
 	}
 	if _, err := in.Invoke("drop"); err != nil {

--- a/src/wago/multi_memory_exec_amd64_test.go
+++ b/src/wago/multi_memory_exec_amd64_test.go
@@ -226,11 +226,11 @@ func TestIndexedMemory64FloatUsesSelectedBaseAndFullWidthBounds(t *testing.T) {
 			}
 			var m0Bits, m1Bits uint64
 			if width == 4 {
-				m0Bits = uint64(binary.LittleEndian.Uint32(m0.Bytes()[17:]))
-				m1Bits = uint64(binary.LittleEndian.Uint32(m1.Bytes()[17:]))
+				m0Bits = uint64(binary.LittleEndian.Uint32(m0.UnsafeBytes()[17:]))
+				m1Bits = uint64(binary.LittleEndian.Uint32(m1.UnsafeBytes()[17:]))
 			} else {
-				m0Bits = binary.LittleEndian.Uint64(m0.Bytes()[17:])
-				m1Bits = binary.LittleEndian.Uint64(m1.Bytes()[17:])
+				m0Bits = binary.LittleEndian.Uint64(m0.UnsafeBytes()[17:])
+				m1Bits = binary.LittleEndian.Uint64(m1.UnsafeBytes()[17:])
 			}
 			if m0Bits != 0 || m1Bits != tc.bits {
 				t.Fatalf("selected base bits m0=%#x m1=%#x, want 0/%#x", m0Bits, m1Bits, tc.bits)
@@ -318,11 +318,11 @@ func TestStagedMultiMemoryScalarWidthsAndGrow(t *testing.T) {
 		if got := tableTestCallI32(t, in, "size1"); got != 2 {
 			t.Fatalf("grown memory.size 1 = %d, want 2", got)
 		}
-		if len(m1.Bytes()) != 2*65536 || len(alias.Bytes()) != 2*65536 {
-			t.Fatalf("exported alias lengths = %d,%d, want %d", len(m1.Bytes()), len(alias.Bytes()), 2*65536)
+		if len(m1.UnsafeBytes()) != 2*65536 || len(alias.UnsafeBytes()) != 2*65536 {
+			t.Fatalf("exported alias lengths = %d,%d, want %d", len(m1.UnsafeBytes()), len(alias.UnsafeBytes()), 2*65536)
 		}
-		if m1.Bytes()[65536] != 0 {
-			t.Fatalf("grown page first byte = %d, want zero", m1.Bytes()[65536])
+		if m1.UnsafeBytes()[65536] != 0 {
+			t.Fatalf("grown page first byte = %d, want zero", m1.UnsafeBytes()[65536])
 		}
 		if _, err := in.Invoke("store1", I32(65536), I32(0x55aa)); err != nil {
 			t.Fatalf("store in grown page: %v", err)
@@ -334,7 +334,7 @@ func TestStagedMultiMemoryScalarWidthsAndGrow(t *testing.T) {
 			if got := tableTestCallI32(t, in, "size1"); got != 2 {
 				t.Fatalf("size after failed grow = %d, want 2", got)
 			}
-			if len(m1.Bytes()) != 2*65536 || binary.LittleEndian.Uint32(m1.Bytes()[65536:]) != 0x55aa {
+			if len(m1.UnsafeBytes()) != 2*65536 || binary.LittleEndian.Uint32(m1.UnsafeBytes()[65536:]) != 0x55aa {
 				t.Fatalf("failed grow changed exported memory state")
 			}
 		}
@@ -369,8 +369,8 @@ func TestStagedMultiMemoryScalarWidthsAndGrow(t *testing.T) {
 		if err := in.Close(); err != nil {
 			t.Fatalf("close: %v", err)
 		}
-		if len(m1.Bytes()) != 2*65536 {
-			t.Fatalf("host import length after close = %d, want %d", len(m1.Bytes()), 2*65536)
+		if len(m1.UnsafeBytes()) != 2*65536 {
+			t.Fatalf("host import length after close = %d, want %d", len(m1.UnsafeBytes()), 2*65536)
 		}
 	})
 
@@ -416,7 +416,7 @@ func TestStagedMultiMemoryLocalAndImportedExecution(t *testing.T) {
 		if err != nil {
 			t.Fatalf("export memory 1: %v", err)
 		}
-		if got := binary.LittleEndian.Uint32(m1.Bytes()[32:]); got != 0x12345678 {
+		if got := binary.LittleEndian.Uint32(m1.UnsafeBytes()[32:]); got != 0x12345678 {
 			t.Fatalf("exported memory-1 bytes = %#x", got)
 		}
 	})
@@ -441,7 +441,7 @@ func TestStagedMultiMemoryLocalAndImportedExecution(t *testing.T) {
 		if err := in.Close(); err != nil {
 			t.Fatalf("close imported-memory instance: %v", err)
 		}
-		if got := binary.LittleEndian.Uint32(m1.Bytes()[32:]); got != 0x12345678 {
+		if got := binary.LittleEndian.Uint32(m1.UnsafeBytes()[32:]); got != 0x12345678 {
 			t.Fatalf("imported memory-1 bytes = %#x", got)
 		}
 	})

--- a/src/wago/multi_memory_guardpage_test.go
+++ b/src/wago/multi_memory_guardpage_test.go
@@ -50,7 +50,7 @@ func TestSignalIndexedMemoryGrowCommitsWholeWasmPageThroughPrimaryOwner(t *testi
 	if err != nil {
 		t.Fatalf("export memory1: %v", err)
 	}
-	if got := len(memory1.Bytes()); got != 2*65536 {
+	if got := len(memory1.UnsafeBytes()); got != 2*65536 {
 		t.Fatalf("grown indexed guarded memory length = %d, want %d", got, 2*65536)
 	}
 }

--- a/src/wago/multi_memory_linking_official_amd64_test.go
+++ b/src/wago/multi_memory_linking_official_amd64_test.go
@@ -239,7 +239,7 @@ func TestStagedOfficialMultiMemoryLinkingStoreSemantics(t *testing.T) {
 			t.Fatalf("trapping data segment wrote partial bytes: load(327670) = %d", got)
 		}
 
-		mem1.Bytes()[0] = 0
+		mem1.UnsafeBytes()[0] = 0
 		unsafeContextCompiled := stagedMultiMemoryCompile(t, modules[3])
 		if _, err := instantiateCore(unsafeContextCompiled, InstantiateOptions{Imports: Imports{"Mm.mem1": mem1}}); err == nil || !strings.Contains(err.Error(), "active element segment 0 out of bounds") {
 			unsafeContextCompiled.Close()

--- a/src/wago/multi_memory_simd_amd64_test.go
+++ b/src/wago/multi_memory_simd_amd64_test.go
@@ -84,16 +84,16 @@ func TestStagedMultiMemorySIMDLoadsAndStores(t *testing.T) {
 		if got := invokeV128(t, in, "run", I32(3), lo, hi); got != want {
 			t.Fatalf("indexed v128 round trip = % x, want % x", got, want)
 		}
-		if got := V128(m1.Bytes()[8:24]); got != want {
+		if got := V128(m1.UnsafeBytes()[8:24]); got != want {
 			t.Fatalf("memory 1 bytes = % x, want % x", got, want)
 		}
 		m0, err := in.ExportedMemory("m0")
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, b := range m0.Bytes()[8:24] {
+		for _, b := range m0.UnsafeBytes()[8:24] {
 			if b != 0 {
-				t.Fatalf("memory 0 changed through indexed SIMD store: % x", m0.Bytes()[8:24])
+				t.Fatalf("memory 0 changed through indexed SIMD store: % x", m0.UnsafeBytes()[8:24])
 			}
 		}
 		if _, err := in.Invoke("run", I32(65516), lo, hi); err == nil {
@@ -127,7 +127,7 @@ func TestStagedMultiMemorySIMDLoadsAndStores(t *testing.T) {
 			body := append([]byte{0x20, 0x00}, indexedSIMDMemOp(tc.sub, tc.align, 5)...)
 			body = append(body, 0x0b)
 			_, in, m1 := stagedSIMDInstance(t, indexedSIMDModule([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.V128}, body))
-			copy(m1.Bytes()[8:], tc.input[:tc.size])
+			copy(m1.UnsafeBytes()[8:], tc.input[:tc.size])
 			if got := invokeV128(t, in, "run", I32(3)); got != tc.want {
 				t.Fatalf("%s = % x, want % x", tc.name, got, tc.want)
 			}
@@ -167,11 +167,11 @@ func TestStagedMultiMemorySIMDLanes(t *testing.T) {
 			loadBody = append(loadBody, 0x0b)
 			_, loadIn, loadMem := stagedSIMDInstance(t, indexedSIMDModule([]wasm.ValType{wasm.I32, wasm.V128}, []wasm.ValType{wasm.V128}, loadBody))
 			for i := byte(0); i < tc.size; i++ {
-				loadMem.Bytes()[8+int(i)] = 0xa0 + i
+				loadMem.UnsafeBytes()[8+int(i)] = 0xa0 + i
 			}
 			initial := V128{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 			want := initial
-			copy(want[int(tc.lane)*int(tc.size):], loadMem.Bytes()[8:8+int(tc.size)])
+			copy(want[int(tc.lane)*int(tc.size):], loadMem.UnsafeBytes()[8:8+int(tc.size)])
 			lo, hi := v128RawSlots(initial)
 			if got := invokeV128(t, loadIn, "run", I32(3), lo, hi); got != want {
 				t.Fatalf("load lane = % x, want % x", got, want)
@@ -187,14 +187,14 @@ func TestStagedMultiMemorySIMDLanes(t *testing.T) {
 				t.Fatalf("store lane: %v", err)
 			}
 			laneStart := int(tc.lane) * int(tc.size)
-			if got, wantBytes := storeMem.Bytes()[8:8+int(tc.size)], initial[laneStart:laneStart+int(tc.size)]; string(got) != string(wantBytes) {
+			if got, wantBytes := storeMem.UnsafeBytes()[8:8+int(tc.size)], initial[laneStart:laneStart+int(tc.size)]; string(got) != string(wantBytes) {
 				t.Fatalf("stored lane bytes = % x, want % x", got, wantBytes)
 			}
-			before := append([]byte(nil), storeMem.Bytes()[8:8+int(tc.size)]...)
+			before := append([]byte(nil), storeMem.UnsafeBytes()[8:8+int(tc.size)]...)
 			if _, err := storeIn.Invoke("run", I32(int32(65536-5-int(tc.size)+1)), lo, hi); err == nil {
 				t.Fatal("cross-boundary indexed SIMD lane store unexpectedly succeeded")
 			}
-			if got := storeMem.Bytes()[8 : 8+int(tc.size)]; string(got) != string(before) {
+			if got := storeMem.UnsafeBytes()[8 : 8+int(tc.size)]; string(got) != string(before) {
 				t.Fatalf("trapping lane store changed memory: % x", got)
 			}
 		})

--- a/src/wago/regression_remaining_test.go
+++ b/src/wago/regression_remaining_test.go
@@ -36,7 +36,7 @@ func TestRuntimeRegressionPortReusedMemoryIsZeroed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	memory := first.Memory().Bytes()
+	memory := first.Memory().UnsafeBytes()
 	for i := range memory {
 		memory[i] = 0xfe
 	}
@@ -53,7 +53,7 @@ func TestRuntimeRegressionPortReusedMemoryIsZeroed(t *testing.T) {
 	if second.jm != reused {
 		t.Fatalf("JobMemory cache did not reuse the dirtied mapping: first=%p second=%p", reused, second.jm)
 	}
-	for i, b := range second.Memory().Bytes() {
+	for i, b := range second.Memory().UnsafeBytes() {
 		if b != 0 {
 			t.Fatalf("reused memory byte %d = %#x, want zero", i, b)
 		}
@@ -136,7 +136,7 @@ func TestRuntimeRegressionPortFailedInstantiationMemoryDoesNotLeak(t *testing.T)
 	if after.jm != reused {
 		t.Fatalf("failed instantiation did not return the primed mapping: prime=%p after=%p", reused, after.jm)
 	}
-	for i, b := range after.Memory().Bytes() {
+	for i, b := range after.Memory().UnsafeBytes() {
 		if b != 0 {
 			t.Fatalf("memory byte %d after failed instantiation = %#x, want zero", i, b)
 		}

--- a/src/wago/regression_workload_test.go
+++ b/src/wago/regression_workload_test.go
@@ -139,7 +139,7 @@ func runRegressionEmbenchen(t *testing.T, name string) (int32, []byte) {
 	if stackTop >= stackMax {
 		t.Fatalf("Emscripten fixture static data leaves no test stack: top=%d max=%d", stackTop, stackMax)
 	}
-	binary.LittleEndian.PutUint32(memory.Bytes()[dynamicTopPtr:], stackMax)
+	binary.LittleEndian.PutUint32(memory.UnsafeBytes()[dynamicTopPtr:], stackMax)
 
 	imports := wago.Imports{
 		"env.DYNAMICTOP_PTR": wago.GlobalImport{Type: wago.ValI32, Bits: uint64(dynamicTopPtr)},
@@ -225,10 +225,10 @@ func runRegressionEmbenchen(t *testing.T, name string) (int32, []byte) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = in.Close() })
-	binary.LittleEndian.PutUint32(memory.Bytes()[argv:], prog)
-	binary.LittleEndian.PutUint32(memory.Bytes()[argv+4:], arg)
-	copy(memory.Bytes()[prog:], "bench\x00")
-	copy(memory.Bytes()[arg:], "1\x00")
+	binary.LittleEndian.PutUint32(memory.UnsafeBytes()[argv:], prog)
+	binary.LittleEndian.PutUint32(memory.UnsafeBytes()[argv+4:], arg)
+	copy(memory.UnsafeBytes()[prog:], "bench\x00")
+	copy(memory.UnsafeBytes()[arg:], "1\x00")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/src/wago/runtime_adversarial_test.go
+++ b/src/wago/runtime_adversarial_test.go
@@ -156,7 +156,7 @@ func TestMemoryGrowThroughHostReentry(t *testing.T) {
 	if nestedErr != nil || calls != 1 {
 		t.Fatalf("nested grow = calls %d err %v, want one successful call", calls, nestedErr)
 	}
-	if got := len(in.Memory().Bytes()); got != 2*65536 {
+	if got := len(in.Memory().UnsafeBytes()); got != 2*65536 {
 		t.Fatalf("memory length after nested grow = %d, want %d", got, 2*65536)
 	}
 }
@@ -185,7 +185,7 @@ func TestMemoryViewRemainsCoherentAcrossGrow(t *testing.T) {
 	)
 	in := mustInstantiateAdversarial(t, mod, nil)
 	defer in.Close()
-	old := in.Memory().Bytes()
+	old := in.Memory().UnsafeBytes()
 	if _, err := in.Invoke("store", I32(0x11223344)); err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestMemoryViewRemainsCoherentAcrossGrow(t *testing.T) {
 	if got, err := in.Invoke("grow", I32(1)); err != nil || len(got) != 1 || AsI32(got[0]) != 1 {
 		t.Fatalf("grow = %v, %v; want old size 1", got, err)
 	}
-	if got := len(in.Memory().Bytes()); got != 2*65536 {
+	if got := len(in.Memory().UnsafeBytes()); got != 2*65536 {
 		t.Fatalf("grown memory length = %d", got)
 	}
 	old[0] = 9

--- a/src/wago/runtime_regression_test.go
+++ b/src/wago/runtime_regression_test.go
@@ -156,7 +156,7 @@ func TestCompiledModuleInstantiationIsolation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("instantiate %d: %v", i, err)
 		}
-		if got := binary.LittleEndian.Uint64(in.Memory().Bytes()[1:]); got != 0 {
+		if got := binary.LittleEndian.Uint64(in.Memory().UnsafeBytes()[1:]); got != 0 {
 			_ = in.Close()
 			t.Fatalf("instance %d inherited memory value %d", i, got)
 		}
@@ -164,7 +164,7 @@ func TestCompiledModuleInstantiationIsolation(t *testing.T) {
 			_ = in.Close()
 			t.Fatalf("instance %d store: %v", i, err)
 		}
-		if got := binary.LittleEndian.Uint64(in.Memory().Bytes()[1:]); got != 1000 {
+		if got := binary.LittleEndian.Uint64(in.Memory().UnsafeBytes()[1:]); got != 1000 {
 			_ = in.Close()
 			t.Fatalf("instance %d memory value = %d, want 1000", i, got)
 		}
@@ -213,7 +213,7 @@ func TestHostFunctionSeesCallerMemory(t *testing.T) {
 		t.Fatalf("store_int result = %v, err %v", got, err)
 	}
 	want := []byte{0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0}
-	if mem := in.Memory().Bytes()[:10]; string(mem) != string(want) {
+	if mem := in.Memory().UnsafeBytes()[:10]; string(mem) != string(want) {
 		t.Fatalf("memory prefix = %x, want %x", mem, want)
 	}
 }
@@ -411,7 +411,7 @@ func TestARM64UremRegalloc(t *testing.T) {
 		t.Fatalf("instantiate: %v", err)
 	}
 	defer in.Close()
-	self := in.Memory().Bytes()[0x100000:]
+	self := in.Memory().UnsafeBytes()[0x100000:]
 	binary.LittleEndian.PutUint32(self[8:], 8)
 	binary.LittleEndian.PutUint32(self[12:], 2)
 	binary.LittleEndian.PutUint32(self[16:], 1)

--- a/src/wago/segment_state_test.go
+++ b/src/wago/segment_state_test.go
@@ -92,7 +92,7 @@ func TestActiveDataSegmentStartsDroppedForBulkInstructions(t *testing.T) {
 			}
 			defer inst.Close()
 
-			if got := inst.Memory().Bytes()[0]; got != 'x' {
+			if got := inst.Memory().UnsafeBytes()[0]; got != 'x' {
 				t.Fatalf("active data byte = %#x, want %#x", got, byte('x'))
 			}
 			if _, err := inst.Invoke("init", I32(0)); err != nil {

--- a/src/wago/shared_memory_basedata_test.go
+++ b/src/wago/shared_memory_basedata_test.go
@@ -46,7 +46,7 @@ func TestSharedMemoryImporterRebindsBasedataState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initializer-only shared-memory importer: %v", err)
 	}
-	if got := memImport.Bytes()[0]; got != 'a' {
+	if got := memImport.UnsafeBytes()[0]; got != 'a' {
 		t.Fatalf("active data byte = %q, want a", got)
 	}
 	if err := initializer.Close(); err != nil {
@@ -181,7 +181,7 @@ func TestHostReentryRefreshesMemorySizeAfterNestedGrow(t *testing.T) {
 			if len(grown) != 1 {
 				panic(HostTrap{Err: fmt.Errorf("nested memory.grow = %v, want one result", grown)})
 			}
-			if got := len(instance.Memory().Bytes()); got < 2*65536 || got > 3*65536 {
+			if got := len(instance.Memory().UnsafeBytes()); got < 2*65536 || got > 3*65536 {
 				panic(HostTrap{Err: fmt.Errorf("memory after nested grow = %d bytes", got)})
 			}
 			if got := len(caller.Memory()); got < 2*65536 || got > 3*65536 {

--- a/src/wago/store_forward_arm64_test.go
+++ b/src/wago/store_forward_arm64_test.go
@@ -62,7 +62,7 @@ func TestArm64LinearStoreLoadForwardingSemantics(t *testing.T) {
 	}
 
 	const untouched = uint64(0x8877665544332211)
-	binary.LittleEndian.PutUint64(in.Memory().Bytes()[16:24], untouched)
+	binary.LittleEndian.PutUint64(in.Memory().UnsafeBytes()[16:24], untouched)
 	got, err = in.Invoke("changedAddress", I32(0), I32(16), stored)
 	if err != nil {
 		t.Fatalf("changedAddress: %v", err)

--- a/src/wago/threads_atomic_corpus_test.go
+++ b/src/wago/threads_atomic_corpus_test.go
@@ -72,7 +72,7 @@ func TestThreadsOfficialAtomicCoreExecutesWithinImportedMemoryBoundary(t *testin
 			if len(args) != 1 {
 				t.Fatalf("line %d init arity = %d", command.Line, len(args))
 			}
-			binary.LittleEndian.PutUint64(memory.Bytes()[:8], args[0])
+			binary.LittleEndian.PutUint64(memory.UnsafeBytes()[:8], args[0])
 			actions++
 			continue
 		}
@@ -136,7 +136,7 @@ func TestThreadsOfficialAtomicWaitNotifyExecutesWithinImportedMemoryBoundary(t *
 		t.Fatal(err)
 	}
 	defer instance.Close()
-	binary.LittleEndian.PutUint64(memory.Bytes()[:8], 0xffffffffffff)
+	binary.LittleEndian.PutUint64(memory.UnsafeBytes()[:8], 0xffffffffffff)
 
 	for _, tc := range []struct {
 		name string

--- a/src/wago/threads_atomic_stress_test.go
+++ b/src/wago/threads_atomic_stress_test.go
@@ -58,7 +58,7 @@ func TestThreadsAtomicRMWContentionReturnsExactCounter(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if got := atomic.LoadUint32((*uint32)(unsafe.Pointer(&memory.Bytes()[0]))); got != goroutines*increments {
+	if got := atomic.LoadUint32((*uint32)(unsafe.Pointer(&memory.UnsafeBytes()[0]))); got != goroutines*increments {
 		t.Fatalf("contended RMW counter = %d, want %d", got, goroutines*increments)
 	}
 }
@@ -73,7 +73,7 @@ func TestThreadsAtomicCmpxchgContentionReturnsExactCounter(t *testing.T) {
 	defer compiled.Close()
 	memory, _ := NewSharedMemory(1, 1)
 	defer memory.Close()
-	cell := (*uint32)(unsafe.Pointer(&memory.Bytes()[0]))
+	cell := (*uint32)(unsafe.Pointer(&memory.UnsafeBytes()[0]))
 	instances := make([]*Instance, goroutines)
 	for i := range instances {
 		instances[i], err = Instantiate(compiled, Imports{"env.memory": memory})
@@ -131,7 +131,7 @@ func TestThreadsAtomicWaitNotifyBarrier(t *testing.T) {
 	defer waitCode.Close()
 	memory, _ := NewSharedMemory(1, 1)
 	defer memory.Close()
-	phase := (*uint32)(unsafe.Pointer(&memory.Bytes()[4]))
+	phase := (*uint32)(unsafe.Pointer(&memory.UnsafeBytes()[4]))
 	type pair struct{ add, wait *Instance }
 	instances := make([]pair, participants)
 	for i := range instances {

--- a/src/wago/threads_atomic_test.go
+++ b/src/wago/threads_atomic_test.go
@@ -278,7 +278,7 @@ func TestThreadsAtomicRMWAddExecutesOnSharedMemory(t *testing.T) {
 	if old := AsI32(result[0]); old != 0 {
 		t.Fatalf("atomic add old value = %d, want 0", old)
 	}
-	if got := binary.LittleEndian.Uint32(memory.Bytes()[:4]); got != 7 {
+	if got := binary.LittleEndian.Uint32(memory.UnsafeBytes()[:4]); got != 7 {
 		t.Fatalf("shared memory value = %d, want 7", got)
 	}
 }
@@ -362,8 +362,8 @@ func TestThreadsHostGlobalAccessSerializesWithInvoke(t *testing.T) {
 			err   error
 		}{value, err}
 	}()
-	signal := (*uint32)(unsafe.Pointer(&memory.Bytes()[0]))
-	release := (*uint32)(unsafe.Pointer(&memory.Bytes()[4]))
+	signal := (*uint32)(unsafe.Pointer(&memory.UnsafeBytes()[0]))
+	release := (*uint32)(unsafe.Pointer(&memory.UnsafeBytes()[4]))
 	defer atomic.StoreUint32(release, 1)
 	deadline := time.Now().Add(5 * time.Second)
 	for atomic.LoadUint32(signal) == 0 && time.Now().Before(deadline) {
@@ -481,7 +481,7 @@ func TestThreadsAtomicLoadStoreAndFenceExecute(t *testing.T) {
 	if _, err := instance.Invoke("store", I32(-559038737)); err != nil { // 0xdeadbeef
 		t.Fatal(err)
 	}
-	if got := binary.LittleEndian.Uint32(memory.Bytes()[:4]); got != 0xdeadbeef {
+	if got := binary.LittleEndian.Uint32(memory.UnsafeBytes()[:4]); got != 0xdeadbeef {
 		t.Fatalf("host memory = %#x", got)
 	}
 	result, err := instance.Invoke("load")
@@ -522,7 +522,7 @@ func TestThreadsAtomicLoadStoreWidthAndExtensionMatrix(t *testing.T) {
 			defer memory.Close()
 			const initial = uint64(0xaabbccddeeff0011)
 			const value = uint64(0x1122334455667788)
-			binary.LittleEndian.PutUint64(memory.Bytes()[:8], initial)
+			binary.LittleEndian.PutUint64(memory.UnsafeBytes()[:8], initial)
 			instance, err := Instantiate(compiled, Imports{"env.memory": memory})
 			if err != nil {
 				t.Fatal(err)
@@ -532,7 +532,7 @@ func TestThreadsAtomicLoadStoreWidthAndExtensionMatrix(t *testing.T) {
 				t.Fatal(err)
 			}
 			wantMemory := initial&^tc.mask | value&tc.mask
-			if got := binary.LittleEndian.Uint64(memory.Bytes()[:8]); got != wantMemory {
+			if got := binary.LittleEndian.Uint64(memory.UnsafeBytes()[:8]); got != wantMemory {
 				t.Fatalf("memory = %#x, want %#x", got, wantMemory)
 			}
 			result, err := instance.Invoke("load")
@@ -571,7 +571,7 @@ func TestThreadsAtomicRMWOperationAndWidthMatrix(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer memory.Close()
-			binary.LittleEndian.PutUint64(memory.Bytes()[:8], tc.old)
+			binary.LittleEndian.PutUint64(memory.UnsafeBytes()[:8], tc.old)
 			instance, err := Instantiate(compiled, Imports{"env.memory": memory})
 			if err != nil {
 				t.Fatal(err)
@@ -584,7 +584,7 @@ func TestThreadsAtomicRMWOperationAndWidthMatrix(t *testing.T) {
 			if got := result[0]; got != tc.old&tc.memMask {
 				t.Fatalf("old = %#x, want %#x", got, tc.old&tc.memMask)
 			}
-			if got := binary.LittleEndian.Uint64(memory.Bytes()[:8]) & tc.memMask; got != tc.want {
+			if got := binary.LittleEndian.Uint64(memory.UnsafeBytes()[:8]) & tc.memMask; got != tc.want {
 				t.Fatalf("memory = %#x, want %#x", got, tc.want)
 			}
 		})
@@ -616,7 +616,7 @@ func TestThreadsAtomicCmpxchgSuccessFailureAndWidths(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer memory.Close()
-			binary.LittleEndian.PutUint64(memory.Bytes()[:8], tc.old)
+			binary.LittleEndian.PutUint64(memory.UnsafeBytes()[:8], tc.old)
 			instance, err := Instantiate(compiled, Imports{"env.memory": memory})
 			if err != nil {
 				t.Fatal(err)
@@ -626,14 +626,14 @@ func TestThreadsAtomicCmpxchgSuccessFailureAndWidths(t *testing.T) {
 			if err != nil || result[0] != tc.old&tc.mask {
 				t.Fatalf("failed cmpxchg old = %v, %v", result, err)
 			}
-			if got := binary.LittleEndian.Uint64(memory.Bytes()[:8]) & tc.mask; got != tc.old&tc.mask {
+			if got := binary.LittleEndian.Uint64(memory.UnsafeBytes()[:8]) & tc.mask; got != tc.old&tc.mask {
 				t.Fatalf("failed cmpxchg changed memory to %#x", got)
 			}
 			result, err = instance.Invoke("cmpxchg", tc.old, 0x12345678)
 			if err != nil || result[0] != tc.old&tc.mask {
 				t.Fatalf("successful cmpxchg old = %v, %v", result, err)
 			}
-			if got := binary.LittleEndian.Uint64(memory.Bytes()[:8]) & tc.mask; got != 0x12345678&tc.mask {
+			if got := binary.LittleEndian.Uint64(memory.UnsafeBytes()[:8]) & tc.mask; got != 0x12345678&tc.mask {
 				t.Fatalf("successful cmpxchg memory = %#x", got)
 			}
 		})
@@ -662,7 +662,7 @@ func TestThreadsAtomicRMWRejectsUnalignedAddressBeforeWrite(t *testing.T) {
 	if !errors.As(err, &trap) || trap.Code != TrapAtomicUnaligned {
 		t.Fatalf("unaligned add error = %v, want atomic alignment trap", err)
 	}
-	if got := binary.LittleEndian.Uint32(memory.Bytes()[:4]); got != 0 {
+	if got := binary.LittleEndian.Uint32(memory.UnsafeBytes()[:4]); got != 0 {
 		t.Fatalf("memory changed on alignment trap: %d", got)
 	}
 }
@@ -715,10 +715,10 @@ func TestThreadsAtomicWriteMatrixTrapsBeforeMutation(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer memory.Close()
-			for i := range memory.Bytes() {
-				memory.Bytes()[i] = byte(i*131 + 17)
+			for i := range memory.UnsafeBytes() {
+				memory.UnsafeBytes()[i] = byte(i*131 + 17)
 			}
-			want := append([]byte(nil), memory.Bytes()...)
+			want := append([]byte(nil), memory.UnsafeBytes()...)
 			instance, err := Instantiate(compiled, Imports{"env.memory": memory})
 			if err != nil {
 				t.Fatal(err)
@@ -735,7 +735,7 @@ func TestThreadsAtomicWriteMatrixTrapsBeforeMutation(t *testing.T) {
 				if !errors.As(err, &trap) || (trap.Code != TrapLinMemOutOfBounds && trap.Code != TrapLinkedMemOutOfBounds) {
 					t.Fatalf("address %#x error = %v, want memory bounds trap", address, err)
 				}
-				if !bytes.Equal(memory.Bytes(), want) {
+				if !bytes.Equal(memory.UnsafeBytes(), want) {
 					t.Fatalf("address %#x mutated memory before trapping", address)
 				}
 			}
@@ -786,10 +786,10 @@ func TestThreadsDistinctInstancesOverlapInNativeExecution(t *testing.T) {
 			t.Fatalf("concurrent native call: %v", err)
 		}
 	}
-	if arrivals := binary.LittleEndian.Uint32(memory.Bytes()[0:4]); arrivals != 2 {
+	if arrivals := binary.LittleEndian.Uint32(memory.UnsafeBytes()[0:4]); arrivals != 2 {
 		t.Fatalf("arrivals = %d, want 2", arrivals)
 	}
-	if completions := binary.LittleEndian.Uint32(memory.Bytes()[4:8]); completions != 2 {
+	if completions := binary.LittleEndian.Uint32(memory.UnsafeBytes()[4:8]); completions != 2 {
 		t.Fatalf("completions = %d, want 2", completions)
 	}
 }
@@ -849,14 +849,14 @@ func TestThreadsAtomicWaitNotifyExecutesAcrossInstances(t *testing.T) {
 		t.Fatal("notified Wasm wait did not resume")
 	}
 
-	binary.LittleEndian.PutUint32(memory.Bytes()[:4], 7)
+	binary.LittleEndian.PutUint32(memory.UnsafeBytes()[:4], 7)
 	if out, err = waiter.Invoke("wait32", I32(0), I32(8), I64(-1)); err != nil || AsI32(out[0]) != int32(memoryWaitNotEqual) {
 		t.Fatalf("mismatched wait32 = %v, %v", out, err)
 	}
 	if out, err = waiter.Invoke("wait32", I32(0), I32(7), I64(0)); err != nil || AsI32(out[0]) != int32(memoryWaitTimedOut) {
 		t.Fatalf("zero-timeout wait32 = %v, %v", out, err)
 	}
-	binary.LittleEndian.PutUint64(memory.Bytes()[8:16], 0x1122334455667788)
+	binary.LittleEndian.PutUint64(memory.UnsafeBytes()[8:16], 0x1122334455667788)
 	if out, err = waiter.Invoke("wait64", I32(8), I64(0x1122334455667788), I64(0)); err != nil || AsI32(out[0]) != int32(memoryWaitTimedOut) {
 		t.Fatalf("zero-timeout wait64 = %v, %v", out, err)
 	}

--- a/tests/runtimeconcurrency/harness_test.go
+++ b/tests/runtimeconcurrency/harness_test.go
@@ -74,7 +74,7 @@ func TestRuntimeConcurrencyGCAtomicWaitNotify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	marker := (*uint32)(unsafe.Pointer(&memory.Bytes()[4]))
+	marker := (*uint32)(unsafe.Pointer(&memory.UnsafeBytes()[4]))
 	atomic.StoreUint32(marker, 0)
 	waitDone := make(chan invokeResult, 1)
 	go func() {
@@ -723,11 +723,11 @@ func (h *concurrencyHarness) testThreads(t *testing.T) {
 	if t.Failed() {
 		return
 	}
-	if got := binary.LittleEndian.Uint32(memory.Bytes()[:4]); got != want {
+	if got := binary.LittleEndian.Uint32(memory.UnsafeBytes()[:4]); got != want {
 		t.Fatalf("shared atomic total = %d, want %d", got, want)
 	}
 
-	marker := (*uint32)(unsafe.Pointer(&memory.Bytes()[4]))
+	marker := (*uint32)(unsafe.Pointer(&memory.UnsafeBytes()[4]))
 	atomic.StoreUint32(marker, 0)
 	ctx, cancel := h.deadlineContext()
 	defer cancel()
@@ -799,7 +799,7 @@ func (h *concurrencyHarness) testThreads(t *testing.T) {
 	if err := memory.Close(); err != nil {
 		t.Fatalf("close shared memory after consumers: %v", err)
 	}
-	if memory.Bytes() != nil {
+	if memory.UnsafeBytes() != nil {
 		t.Fatal("closed shared memory retained a host-visible byte view")
 	}
 	h.record("threads complete close-order=%v", order)


### PR DESCRIPTION
Small correctness fix: a retained raw memory slice can outlive instance close and alias a recycled off-heap mapping.

The zero-copy accessor is now explicitly named `UnsafeBytes` and documents that the slice must not be retained or raced with close. Close-safe code is directed to the invocation-leased `Instance.Read` and `Instance.Write` APIs. The implementation remains zero-copy and allocation-free; copying an entire memory was intentionally avoided because memory32 can be 4 GiB.

Tests:
- `env WAGO_HOME=/tmp/wago-audit-home go test ./... -run "^$"`
- `go test ./src/wago -run "^(TestMemoryAccessors|TestMemoryGrowExported|TestMemoryViewRemainsCoherentAcrossGrow|TestRuntimeRegressionPortReusedMemoryIsZeroed|TestClosedInstanceMemoryAccessCannotReachReusedJobMemory)$"`
- `go test -race ./src/wago -run "^(TestMemoryAccessors|TestMemoryGrowExported|TestMemoryViewRemainsCoherentAcrossGrow|TestRuntimeRegressionPortReusedMemoryIsZeroed|TestClosedInstanceMemoryAccessCannotReachReusedJobMemory)$"`