### PR TITLE
wago: admit wide scalar GC host imports

### DIFF
--- a/src/wago/gc_frame_roots.go
+++ b/src/wago/gc_frame_roots.go
@@ -101,6 +101,23 @@ func wasmFuncTypeTransfersCollectorRefs(m *wasm.Module, ft *wasm.CompType) bool 
 	return false
 }
 
+func wasmFuncTypeReferenceFree(ft *wasm.CompType) bool {
+	if ft == nil {
+		return false
+	}
+	for _, typ := range ft.Params {
+		if typ.Kind() == wasm.ValRef {
+			return false
+		}
+	}
+	for _, typ := range ft.Results {
+		if typ.Kind() == wasm.ValRef {
+			return false
+		}
+	}
+	return true
+}
+
 func moduleHasCollectorReferenceCallBoundary(m *wasm.Module) bool {
 	if m == nil {
 		return false

--- a/src/wago/gc_frame_roots_arm64.go
+++ b/src/wago/gc_frame_roots_arm64.go
@@ -45,7 +45,11 @@ func newGCFrameRootPlan(m *wasm.Module, exactRoots bool) *shared.GCModuleFrameRo
 			if !ok {
 				return reject("function import %d has no validated signature", funcImport-1)
 			}
-			if collectorBoundary {
+			// Reference-free imports use the parked synchronous wrapper and need
+			// not also fit the internal register ABI. Preserve the existing
+			// collector-boundary path so reference ownership and root handling
+			// remain coupled to that module-level proof.
+			if collectorBoundary || wasmFuncTypeReferenceFree(ft) {
 				if !arm64GCFrameHostCallABI(ft) {
 					return reject("function import %d exceeds the synchronous host-call ABI", funcImport-1)
 				}
@@ -261,7 +265,7 @@ func arm64GCFrameBodySafe(m *wasm.Module, body []byte, classifier *wasm.ModuleIn
 			if !ok {
 				return false
 			}
-			if int(imm.Index) < m.ImportedFuncCount() && collectorBoundary {
+			if int(imm.Index) < m.ImportedFuncCount() && (collectorBoundary || wasmFuncTypeReferenceFree(ft)) {
 				if !arm64GCFrameHostCallABI(ft) {
 					return false
 				}

--- a/src/wago/gc_frame_roots_linux_amd64.go
+++ b/src/wago/gc_frame_roots_linux_amd64.go
@@ -44,7 +44,11 @@ func newGCFrameRootPlan(m *wasm.Module, exactRoots bool) *shared.GCModuleFrameRo
 			if !ok {
 				return reject("function import %d has no validated signature", funcImport-1)
 			}
-			if collectorBoundary {
+			// Reference-free imports use the parked synchronous wrapper and need
+			// not also fit the internal register ABI. Preserve the existing
+			// collector-boundary path so reference ownership and root handling
+			// remain coupled to that module-level proof.
+			if collectorBoundary || wasmFuncTypeReferenceFree(ft) {
 				if !gcFrameHostCallABI(ft) {
 					return reject("function import %d exceeds the synchronous host-call ABI", funcImport-1)
 				}

--- a/src/wago/gc_type_domain.go
+++ b/src/wago/gc_type_domain.go
@@ -176,18 +176,6 @@ func gcModuleFitsDomain(c *Compiled, domain *gcStoreDomain) bool {
 	return true
 }
 
-func (c *Compiled) functionImportRequiresGCDomain(key string) bool {
-	if c == nil {
-		return false
-	}
-	for i, candidate := range c.Imports {
-		if candidate == key && i < len(c.importFuncSigs) && funcSigHasGCRefs(c.importFuncSigs[i]) {
-			return true
-		}
-	}
-	return false
-}
-
 func preferredGCCollectorFromImports(c *Compiled, imports Imports, store *referenceStore) (*gc.Collector, error) {
 	var collector *gc.Collector
 	consider := func(candidate *Instance) error {
@@ -203,17 +191,26 @@ func preferredGCCollectorFromImports(c *Compiled, imports Imports, store *refere
 		collector = candidate.gc
 		return nil
 	}
-	for key, value := range imports {
-		switch v := value.(type) {
-		case *InstanceExport:
-			// A scalar-only native call transfers no collector ownership. Its
-			// caller and producer may therefore keep independent domains and GC
-			// policies even though the function is linked cross-instance.
-			if v != nil && c.functionImportRequiresGCDomain(key) {
+	// Function imports are index-aligned with their signatures. Walk them once
+	// so large import sets remain linear instead of rescanning the complete key
+	// list for every InstanceExport in the imports map.
+	if c != nil {
+		for i, key := range c.Imports {
+			if i >= len(c.importFuncSigs) || !funcSigHasGCRefs(c.importFuncSigs[i]) {
+				continue
+			}
+			v, ok := imports[key].(*InstanceExport)
+			if ok && v != nil {
 				if err := consider(v.inst); err != nil {
 					return nil, err
 				}
 			}
+		}
+	}
+	for _, value := range imports {
+		switch v := value.(type) {
+		case *InstanceExport:
+			// Function owners were handled by the index-aligned pass above.
 		case *Global:
 			if v != nil && v.owner != nil {
 				if err := consider(v.owner.instance); err != nil {

--- a/src/wago/gc_type_domain.go
+++ b/src/wago/gc_type_domain.go
@@ -176,7 +176,19 @@ func gcModuleFitsDomain(c *Compiled, domain *gcStoreDomain) bool {
 	return true
 }
 
-func preferredGCCollectorFromImports(imports Imports, store *referenceStore) (*gc.Collector, error) {
+func (c *Compiled) functionImportRequiresGCDomain(key string) bool {
+	if c == nil {
+		return false
+	}
+	for i, candidate := range c.Imports {
+		if candidate == key && i < len(c.importFuncSigs) && funcSigHasGCRefs(c.importFuncSigs[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func preferredGCCollectorFromImports(c *Compiled, imports Imports, store *referenceStore) (*gc.Collector, error) {
 	var collector *gc.Collector
 	consider := func(candidate *Instance) error {
 		if candidate == nil || candidate.gc == nil {
@@ -191,10 +203,13 @@ func preferredGCCollectorFromImports(imports Imports, store *referenceStore) (*g
 		collector = candidate.gc
 		return nil
 	}
-	for _, value := range imports {
+	for key, value := range imports {
 		switch v := value.(type) {
 		case *InstanceExport:
-			if v != nil {
+			// A scalar-only native call transfers no collector ownership. Its
+			// caller and producer may therefore keep independent domains and GC
+			// policies even though the function is linked cross-instance.
+			if v != nil && c.functionImportRequiresGCDomain(key) {
 				if err := consider(v.inst); err != nil {
 					return nil, err
 				}

--- a/src/wago/gc_type_domain_test.go
+++ b/src/wago/gc_type_domain_test.go
@@ -33,9 +33,10 @@ func TestGCTypeMappingRejectsConflictingCanonicalTypes(t *testing.T) {
 
 func TestPreferredGCCollectorIgnoresReferenceFreeFunctionImports(t *testing.T) {
 	store := &referenceStore{}
-	collector := new(gc.Collector)
-	producer := &Instance{gc: collector, refStore: store}
-	imports := Imports{"env.call": &InstanceExport{inst: producer}}
+	foreignStore := &referenceStore{}
+	scalarCollector := new(gc.Collector)
+	scalarProvider := &Instance{gc: scalarCollector, refStore: foreignStore}
+	imports := Imports{"env.call": &InstanceExport{inst: scalarProvider}}
 
 	scalar := &Compiled{
 		Imports:        []string{"env.call"},
@@ -49,15 +50,21 @@ func TestPreferredGCCollectorIgnoresReferenceFreeFunctionImports(t *testing.T) {
 		t.Fatalf("scalar-only import selected collector %p; want an independent domain", got)
 	}
 
+	referenceCollector := new(gc.Collector)
+	referenceProvider := &Instance{gc: referenceCollector, refStore: store}
+	imports["env.reference"] = &InstanceExport{inst: referenceProvider}
 	reference := &Compiled{
-		Imports:        []string{"env.call"},
-		importFuncSigs: []FuncSig{{Results: []ValType{ValAnyRef}}},
+		Imports: []string{"env.call", "env.reference"},
+		importFuncSigs: []FuncSig{
+			{Results: []ValType{ValI64, ValI64, ValF32, ValF32, ValV128, ValI32}},
+			{Results: []ValType{ValAnyRef}},
+		},
 	}
 	got, err = preferredGCCollectorFromImports(reference, imports, store)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != collector {
-		t.Fatalf("collector-reference import selected collector %p; want %p", got, collector)
+	if got != referenceCollector {
+		t.Fatalf("collector-reference import selected collector %p; want %p", got, referenceCollector)
 	}
 }

--- a/src/wago/gc_type_domain_test.go
+++ b/src/wago/gc_type_domain_test.go
@@ -30,3 +30,34 @@ func TestGCTypeMappingRejectsConflictingCanonicalTypes(t *testing.T) {
 		t.Fatal("conflicting canonical representatives succeeded")
 	}
 }
+
+func TestPreferredGCCollectorIgnoresReferenceFreeFunctionImports(t *testing.T) {
+	store := &referenceStore{}
+	collector := new(gc.Collector)
+	producer := &Instance{gc: collector, refStore: store}
+	imports := Imports{"env.call": &InstanceExport{inst: producer}}
+
+	scalar := &Compiled{
+		Imports:        []string{"env.call"},
+		importFuncSigs: []FuncSig{{Results: []ValType{ValI64, ValI64, ValF32, ValF32, ValV128, ValI32}}},
+	}
+	got, err := preferredGCCollectorFromImports(scalar, imports, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("scalar-only import selected collector %p; want an independent domain", got)
+	}
+
+	reference := &Compiled{
+		Imports:        []string{"env.call"},
+		importFuncSigs: []FuncSig{{Results: []ValType{ValAnyRef}}},
+	}
+	got, err = preferredGCCollectorFromImports(reference, imports, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != collector {
+		t.Fatalf("collector-reference import selected collector %p; want %p", got, collector)
+	}
+}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -206,7 +206,7 @@ func (b *instanceBuilder) prepareCollector() error {
 	// modules in private collector domains so a same-memory notifier never waits
 	// behind the parked invocation's Runtime-wide collector lease.
 	if b.opts.store != nil && !b.opts.store.private && needsRuntimeDomain && b.c.sharedGCPersistentDomainSafe() && !b.c.usesAtomicWaitHelpers() {
-		preferred, err := preferredGCCollectorFromImports(b.imports, b.opts.store)
+		preferred, err := preferredGCCollectorFromImports(b.c, b.imports, b.opts.store)
 		if err != nil {
 			return err
 		}

--- a/src/wago/plugin_gc_wide_boundary_test.go
+++ b/src/wago/plugin_gc_wide_boundary_test.go
@@ -4,6 +4,7 @@ package wago
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -166,6 +167,40 @@ func TestPluginGCWideScalarHostImportUsesSynchronousABI(t *testing.T) {
 	}
 	if len(values) != 1 || values[0].I32() != 7 {
 		t.Fatalf("run = %v; want i32(7)", values)
+	}
+}
+
+func TestGCWideDynamicCallRefRetainsRegisterABIProof(t *testing.T) {
+	requireCompleteCore3Backend(t)
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	wideType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32, wasm.I32, wasm.I32})
+	runType := wasmtest.FuncType(nil, nil)
+	module := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, wideType, runType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("target", 0, 0), // declares target for ref.func
+			wasmtest.ExportEntry("run", 0, 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x01, 0x41, 0x02, 0x41, 0x03, 0x0b}),
+			wasmtest.Code([]byte{
+				0xd2, 0x00, // ref.func 0
+				0x14, 0x01, // call_ref type 1
+				0x1a, 0x1a, 0x1a,
+				0xfb, 0x01, 0x00, 0x1a, // collecting allocation remains present
+				0x0b,
+			}),
+		)),
+	)
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	admission := compiled.GCNativeRootAdmission()
+	if !admission.Required || admission.Exact || !strings.Contains(admission.Reason, "unsupported native call or frame shape") {
+		t.Fatalf("wide dynamic call_ref root admission = %+v", admission)
 	}
 }
 

--- a/src/wago/plugin_gc_wide_boundary_test.go
+++ b/src/wago/plugin_gc_wide_boundary_test.go
@@ -50,6 +50,11 @@ func (pluginGCWideBoundaryTestPlugin) Register(reg *Registrar) error {
 		params[i] = ValI32
 	}
 	module.Func("scalar_11", func(HostModule, []uint64, []uint64) {}).Params(params...)
+	module.Func("wide_scalar_results", func(_ HostModule, params, results []uint64) {
+		for i := range results {
+			results[i] = uint64(i) + params[0]
+		}
+	}).Params(ValI32).Results(ValI32, ValI32, ValI64, ValI64, ValI32, ValI64, ValI32, ValI64, ValI32, ValI32)
 	return nil
 }
 
@@ -105,6 +110,63 @@ func pluginGCFourResultCallerModule() []byte {
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
 	)
+}
+
+func pluginGCWideScalarResultModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01} // (struct (field (mut i32)))
+	wideScalarType := wasmtest.FuncType(
+		[]wasm.ValType{wasm.I32},
+		[]wasm.ValType{wasm.I32, wasm.I32, wasm.I64, wasm.I64, wasm.I32, wasm.I64, wasm.I32, wasm.I64, wasm.I32, wasm.I32},
+	)
+	runType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	body := []byte{
+		0x41, 0x00, // i32.const 0
+		0x10, 0x00, // call wide_scalar_results
+		0x1a, 0x1a, 0x1a, 0x1a, 0x1a, // drop ten scalar results
+		0x1a, 0x1a, 0x1a, 0x1a, 0x1a,
+		0xfb, 0x01, 0x00, 0x1a, // struct.new_default 0; drop
+		0x41, 0x07, // i32.const 7
+		0x0b,
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, wideScalarType, runType)),
+		wasmtest.Section(2, wasmtest.Vec(pluginGCImport("plugin_gc_wide", "wide_scalar_results", 1))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+}
+
+// This architecture-neutral regression runs in the mandatory native amd64 and
+// arm64 suites. The module itself has no collector-reference import boundary:
+// its wide import is scalar-only, while struct.new_default still requires exact
+// roots for collection in the calling native frame.
+func TestPluginGCWideScalarHostImportUsesSynchronousABI(t *testing.T) {
+	requireCompleteCore3Backend(t)
+	rt := newPluginGCWideBoundaryRuntime(t)
+	defer rt.Close()
+
+	mod, err := rt.Compile(pluginGCWideScalarResultModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Close()
+	admission := mod.c.GCNativeRootAdmission()
+	if !admission.Required || !admission.Exact || admission.Callsites == 0 || admission.Safepoints == 0 {
+		t.Fatalf("wide scalar host root admission = %+v", admission)
+	}
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	values, err := in.Call(context.Background(), "run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(values) != 1 || values[0].I32() != 7 {
+		t.Fatalf("run = %v; want i32(7)", values)
+	}
 }
 
 func TestPluginGCHostBoundaryWideWrapperABI(t *testing.T) {


### PR DESCRIPTION
## Summary

- classify reference-free function imports through the checked synchronous host ABI on AMD64 and ARM64
- keep collector-reference ownership/root handling tied to the existing collector-boundary proof
- keep dynamic `call_ref` on the smaller register-ABI proof
- avoid forcing reference-free cross-instance calls to join the provider collector domain
- add the reported ten-result scalar import regression and an explicit three-result dynamic-call counter-test

## Why

Exact native GC-root admission previously selected the internal reference-call ABI for every function import whenever the module had no collector-reference import boundary. That rejected a reference-free synchronous import after two results even though the actual parked host ABI accepts up to 64 slots in each direction.

The newly admitted Wasmtime `gc/issue-13152` consumer also exposed a downstream ownership bug: preferred-domain selection treated every `InstanceExport` as a collector edge. Its reference-free imported function therefore tried to join a collection-disabled provider to a collection-enabled consumer. Reference-free calls transfer no collector ownership, so the instances may safely retain independent domains and GC policies.

This change classifies only reference-free imports through the synchronous capacity and ignores those imports during preferred collector selection. Reference-bearing functions plus imported GC globals/tables retain existing domain ownership, while dynamic typed-reference calls remain bounded by the register ABI.

## Verification

- `go test ./src/core/... -count=1`
- `go test ./src/wago -run "^TestWasmtimeCore3Corpus$" -count=1` — 215 modules and 690 assertions, zero skips
- direct `gc/issue-13152` fixture replay — 2 modules and 1 assertion, zero skips
- `go test ./src/wago -run "^(TestGC|TestPluginGC)" -count=1`
- focused explicit and `wago_guardpage` ABI tests
- focused race-detector tests
- `GOOS=linux GOARCH=arm64 go test -c -o /tmp/wago-issue536-arm64.test ./src/wago`

A full `go test ./src/wago -count=1` was also attempted locally. Its pinned official-spec cases stop before execution because the host has WABT 1.0.36 while the repository requires 1.0.41; the checked-in Wasmtime Core 3 corpus and all non-WABT suites above pass.

## Performance and footprint

No generated hot path, runtime layout, ABI capacity, or persistent metadata changes. Both changes are bounded compile/instantiation classification with no new allocations, so no benchmark or memory delta is expected.

## Docs

Unchanged: these internal correctness fixes do not alter developer workflow, public configuration, or supported ABI limits.

Fixes #536