### PR TITLE
GC: admit wide functions by live native roots

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -37,6 +37,10 @@ and starts the 3,225,249-byte MoonBit Starshine CLI smoke payload (SHA-256
 Linux/amd64 generated code publishes exact roots across the admitted local,
 indirect, reference, host-re-entry, EH, and same-Runtime cross-instance boundaries;
 Throughput and Tiny collectors may collect while those native frames are active.
+Root admission now compacts locals dead at every collecting site, so the 1,024-root
+bound applies per site rather than to all declared reference locals. Function
+parameters plus declared locals default to a configurable 4,096 ceiling and may be
+raised through 65,535 without weakening the independent native stack-fence check.
 Codec version 1 reloads and strictly validates the root metadata. Exact
 same-Runtime cross-instance calls canonicalize recursive structural identities across
 reordered or additional module-local types, transfer compact references through one
@@ -75,7 +79,9 @@ remain fail-closed. Explicit `target.CloneGCRefFrom(source, ref)` instead perfor
 bounded transactional graph clone across distinct Runtime stores, preserving cycles
 and internal sharing while assigning new target identity and rejecting non-null
 opaque store-owned payloads.
-See [docs/wasm3.md](docs/wasm3.md) for the implementation ledger.
+See [docs/wasm3.md](docs/wasm3.md) for the implementation ledger and
+[docs/function-local-limits.md](docs/function-local-limits.md) for the local and
+root-map bounds.
 
 ## WebAssembly 1.0 (MVP)
 
@@ -152,4 +158,3 @@ can allocate an exact caller-selected numeric or `v128` GC-array result.
 Direct views cannot outlive the host callback. Wago serializes collector/native
 mutation while a view is active and rejects Wasm re-entry during the borrow.
 See [`docs/host-guest-storage.md`](docs/host-guest-storage.md).
-

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,8 +117,9 @@ current optimization priorities. The Core 3.0 implementation ledger is
   direct/indirect/reference calls, recursion, bounded host re-entry,
   mutable/shared GC globals, local/shared collector-reference tables, EH payload
   records, local starts, and same-Runtime cross-instance calls. One-/two-word and
-  bounded flat masks cover up to 1,024 roots; codec version 1 validates the native
-  maps and the required native-GC ABI version.
+  bounded flat masks cover up to 1,024 simultaneously live roots per site; locals
+  dead at every collecting site are compacted from the plan. Codec version 1
+  validates the native maps and the required native-GC ABI version.
 - [x] Add snapshot version 1 stable-ID heap graphs for objects reachable from owned
   local GC globals and one or more heterogeneous local collector-reference tables,
   preserving cycles, sharing, growth state, strict structural subtype validation,
@@ -539,6 +540,12 @@ snapshot roots, then completes signal-backed and broader native-platform parity.
   share repeated immutable offset maps, and expose fail-closed diagnostics. The
   one-root 16K-instruction compile benchmark improves 3.2% while temporary bytes
   fall 18.6%; dense safepoint lookup remains about 1.66 ns, zero allocation.
+- [x] Base large-frame admission on per-site liveness: track the configured local
+  population, compact locals dead at every collection point, and keep the 1,024
+  bound on simultaneous roots. Function parameters plus declared locals default
+  to 4,096, are configurable through 65,535, and remain independently bounded by
+  the native 256 KiB stack fence. See
+  [`docs/function-local-limits.md`](docs/function-local-limits.md).
 - [x] Add bounded Throughput survivor aging: Eden feeds two bump-copy semispaces,
   handle-owned age bits retain the 20-byte native entry, medium-lived objects
   tenure after measured survival, and large young objects age in place. Exact

--- a/cli/runtime/internal/artifactcache/cache.go
+++ b/cli/runtime/internal/artifactcache/cache.go
@@ -29,7 +29,7 @@ type Cache struct {
 	ReportError func(error)
 }
 
-const cacheKeyFormat = 2
+const cacheKeyFormat = 3
 
 var defaultIdentity = sync.OnceValues(func() ([sha256.Size]byte, bool) {
 	info, ok := debug.ReadBuildInfo()
@@ -117,6 +117,7 @@ func (cache Cache) path(source []byte, config *wago.RuntimeConfig) (string, bool
 		encoded[len(encoded)-1] = 1
 	}
 	encoded = binary.LittleEndian.AppendUint32(encoded, config.MemoryLimitPages())
+	encoded = binary.LittleEndian.AppendUint32(encoded, config.MaxFunctionLocals())
 	knobs := config.OptimizationInfos()
 	encoded = binary.LittleEndian.AppendUint32(encoded, uint32(len(knobs)))
 	for base := 0; base < len(knobs); base += 8 {

--- a/cli/runtime/internal/artifactcache/cache_test.go
+++ b/cli/runtime/internal/artifactcache/cache_test.go
@@ -351,8 +351,8 @@ func TestLoadOrCompileBypassesArtifactsForCompileOnlyTelemetry(t *testing.T) {
 }
 
 func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
-	if cacheKeyFormat != 2 {
-		t.Fatalf("cache key format = %d, want objective-free version 2", cacheKeyFormat)
+	if cacheKeyFormat != 3 {
+		t.Fatalf("cache key format = %d, want local-limit-aware version 3", cacheKeyFormat)
 	}
 	source := constantModule()
 	dir := t.TempDir()
@@ -364,6 +364,7 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	bounds := base.WithBoundsChecks(wago.BoundsChecksSignalsBased)
 	deferredOff := base.WithDeferBoundsChecks(false)
 	memoryLimit := base.WithMemoryLimitPages(base.MemoryLimitPages() - 1)
+	localLimit := base.WithMaxFunctionLocals(base.MaxFunctionLocals() - 1)
 
 	basePath, ok := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, base)
 	if !ok {
@@ -375,6 +376,7 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	boundsPath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, bounds)
 	deferredPath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, deferredOff)
 	memoryPath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, memoryLimit)
+	localPath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(source, localLimit)
 	runtimePath, _ := (Cache{Dir: dir, Identity: []byte("runtime-b")}).path(source, base)
 	sourcePath, _ := (Cache{Dir: dir, Identity: []byte("runtime-a")}).path(append(source, 0), base)
 	if basePath == featurePath {
@@ -397,6 +399,9 @@ func TestCacheKeyIncludesRuntimeAndCompilerConfiguration(t *testing.T) {
 	}
 	if basePath == memoryPath {
 		t.Fatal("memory limit did not change artifact key")
+	}
+	if basePath == localPath {
+		t.Fatal("function local limit did not change artifact key")
 	}
 	if basePath == sourcePath {
 		t.Fatal("source bytes did not change artifact key")

--- a/docs/function-local-limits.md
+++ b/docs/function-local-limits.md
@@ -28,14 +28,15 @@ limited to 1,024 exact roots. A function may consequently declare more than
 with 1,025 live collector locals fails closed with an actionable admission
 diagnostic.
 
-The liveness bitmap is compile-only. Its main arena is capped at 512 MiB for an
-adversarial combination of body size and configured locals, while serialized
-metadata contains only final site offset vectors of at most 1,024 entries. The
-common path through 64 roots retains one-word masks.
+The liveness bitmap is compile-only. Its main arena is capped at 64 MiB for an
+adversarial combination of body size and configured locals. The CFG omits
+instructions that cannot affect local liveness or control flow before sizing
+that arena, and serialized metadata contains only final site offset vectors of
+at most 1,024 entries. The common path through 64 roots retains one-word masks.
 
 On the Ryzen 7 8845HS development host, the permanent 1,138-declared/one-live
-analysis benchmark measured a warmed median of 17.9 us, 29,728 B/op, and 13
-allocations. The existing dense 1,024-root benchmark measured 290.7-293.2 us,
-445,268-445,269 B/op, and 11 allocations. These are compile-time costs; runtime
+analysis benchmark measured a warmed median of 17.2 us, 29,408 B/op, and 13
+allocations. The existing dense 1,024-root benchmark measured 160.8-164.2 us,
+224,082-224,084 B/op, and 10 allocations. These are compile-time costs; runtime
 safepoint lookup and the final one-root metadata vector do not retain the
 declaration-wide bitmap.

--- a/docs/function-local-limits.md
+++ b/docs/function-local-limits.md
@@ -1,0 +1,41 @@
+# Function local limits
+
+`RuntimeConfig.WithMaxFunctionLocals` bounds the combined number of parameters
+and declared locals in one Wasm function. `NewRuntimeConfig` defaults to 4,096;
+callers may select any value from 1 through 65,535. Zero and values above the
+unsigned 16-bit maximum are configuration errors.
+
+This is an early validation and compiler-bookkeeping ceiling, not a native
+stack-size promise. AMD64 and ARM64 lowering independently reject a function
+whose actual frame, including width-dependent local slots, headers, inlining,
+and operand spills, exceeds the 256 KiB stack-fence headroom. Raising the local
+ceiling never weakens that fail-closed frame check. For example, a configured
+65,535-local ceiling admits validation of the declaration but a function with
+65,535 `v128` locals still fails native compilation because its frame is too
+large.
+
+The limit is part of the automatic artifact-cache key. A cached artifact built
+under a larger ceiling therefore cannot bypass a smaller caller policy.
+
+## WasmGC root admission
+
+Collector-reference locals use the same declaration ceiling, but the separate
+native root-map limit applies to values simultaneously live at a collecting
+site. Liveness first covers the configured population, then removes locals dead
+at every allocation or native call. Each emitted safepoint and callsite remains
+limited to 1,024 exact roots. A function may consequently declare more than
+1,024 reference locals when its live site maps stay within that bound; a site
+with 1,025 live collector locals fails closed with an actionable admission
+diagnostic.
+
+The liveness bitmap is compile-only. Its main arena is capped at 512 MiB for an
+adversarial combination of body size and configured locals, while serialized
+metadata contains only final site offset vectors of at most 1,024 entries. The
+common path through 64 roots retains one-word masks.
+
+On the Ryzen 7 8845HS development host, the permanent 1,138-declared/one-live
+analysis benchmark measured a warmed median of 17.9 us, 29,728 B/op, and 13
+allocations. The existing dense 1,024-root benchmark measured 290.7-293.2 us,
+445,268-445,269 B/op, and 11 allocations. These are compile-time costs; runtime
+safepoint lookup and the final one-root metadata vector do not retain the
+declaration-wide bitmap.

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -1633,10 +1633,11 @@ func (f *fn) prepareGCFrameCallsite(paramCount int) ([]uint32, bool) {
 	}
 	f.materializeGCFrameLocalsAt(siteIndex, true)
 	offsets := make([]uint32, 0, min(len(plan.LocalOffsets), shared.GCFrameRootLimit))
-	for i, off := range plan.LocalOffsets {
-		if plan.CallLocalLiveAt(siteIndex, i) {
-			offsets = append(offsets, off)
-		}
+	if !plan.VisitLiveLocals(siteIndex, true, func(root int) {
+		offsets = append(offsets, plan.LocalOffsets[root])
+	}) {
+		plan.Exact = false
+		return nil, false
 	}
 	hidden := len(roots) - paramCount
 	slot := 0

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -1632,7 +1632,7 @@ func (f *fn) prepareGCFrameCallsite(paramCount int) ([]uint32, bool) {
 		return nil, false
 	}
 	f.materializeGCFrameLocalsAt(siteIndex, true)
-	offsets := make([]uint32, 0, len(plan.LocalOffsets))
+	offsets := make([]uint32, 0, min(len(plan.LocalOffsets), shared.GCFrameRootLimit))
 	for i, off := range plan.LocalOffsets {
 		if plan.CallLocalLiveAt(siteIndex, i) {
 			offsets = append(offsets, off)

--- a/src/core/compiler/backend/railshot/amd64/gc_struct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_struct.go
@@ -881,10 +881,11 @@ func (f *fn) recordGCFrameSafepoint(paramCount int) uint32 {
 		return id
 	}
 	offsets := make([]uint32, 0, min(len(plan.LocalOffsets), shared.GCFrameRootLimit))
-	for i, off := range plan.LocalOffsets {
-		if plan.LocalLiveAt(siteIndex, i) {
-			offsets = append(offsets, off)
-		}
+	if !plan.VisitLiveLocals(siteIndex, false, func(root int) {
+		offsets = append(offsets, plan.LocalOffsets[root])
+	}) {
+		plan.Exact = false
+		return id
 	}
 	hidden := len(roots) - paramCount
 	slot := 0

--- a/src/core/compiler/backend/railshot/amd64/gc_struct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_struct.go
@@ -944,15 +944,10 @@ func gcFrameRefType(m *wasm.Module, t wasm.ValType) bool {
 }
 
 func (f *fn) gcFrameLocal(index int) bool {
-	if f.gcFrameRoots == nil || !f.gcFrameRoots.Candidate {
+	if index < 0 || f.gcFrameRoots == nil {
 		return false
 	}
-	for _, candidate := range f.gcFrameRoots.LocalIndexes {
-		if int(candidate) == index {
-			return true
-		}
-	}
-	return false
+	return f.gcFrameRoots.TracksLocal(uint32(index))
 }
 
 func gcHelperMayAllocate(helper uint32) bool {

--- a/src/core/compiler/backend/railshot/amd64/gc_struct.go
+++ b/src/core/compiler/backend/railshot/amd64/gc_struct.go
@@ -880,7 +880,7 @@ func (f *fn) recordGCFrameSafepoint(paramCount int) uint32 {
 		plan.Exact = false
 		return id
 	}
-	offsets := make([]uint32, 0, len(plan.LocalOffsets))
+	offsets := make([]uint32, 0, min(len(plan.LocalOffsets), shared.GCFrameRootLimit))
 	for i, off := range plan.LocalOffsets {
 		if plan.LocalLiveAt(siteIndex, i) {
 			offsets = append(offsets, off)

--- a/src/core/compiler/backend/railshot/amd64/localstate.go
+++ b/src/core/compiler/backend/railshot/amd64/localstate.go
@@ -192,14 +192,10 @@ func (f *fn) materializeGCFrameLocalsAt(site int, call bool) {
 	if f.gcFrameRoots == nil || !f.lazyZero {
 		return
 	}
-	for i, index := range f.gcFrameRoots.LocalIndexes {
-		live := f.gcFrameRoots.LocalLiveAt(site, i)
-		if call {
-			live = f.gcFrameRoots.CallLocalLiveAt(site, i)
-		}
-		if live {
-			f.materializeGCFrameLocal(index)
-		}
+	if !f.gcFrameRoots.VisitLiveLocals(site, call, func(root int) {
+		f.materializeGCFrameLocal(f.gcFrameRoots.LocalIndexes[root])
+	}) {
+		f.gcFrameRoots.Exact = false
 	}
 }
 

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -1611,10 +1611,11 @@ func (f *fn) prepareGCFrameCallsite(paramCount int) ([]uint32, bool) {
 	}
 	f.materializeGCFrameLocalsAt(siteIndex, true)
 	offsets := make([]uint32, 0, min(len(plan.LocalOffsets), shared.GCFrameRootLimit))
-	for i, off := range plan.LocalOffsets {
-		if plan.CallLocalLiveAt(siteIndex, i) {
-			offsets = append(offsets, off)
-		}
+	if !plan.VisitLiveLocals(siteIndex, true, func(root int) {
+		offsets = append(offsets, plan.LocalOffsets[root])
+	}) {
+		plan.Exact = false
+		return nil, false
 	}
 	hidden := len(roots) - paramCount
 	slot := 0

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -1610,7 +1610,7 @@ func (f *fn) prepareGCFrameCallsite(paramCount int) ([]uint32, bool) {
 		return nil, false
 	}
 	f.materializeGCFrameLocalsAt(siteIndex, true)
-	offsets := make([]uint32, 0, len(plan.LocalOffsets))
+	offsets := make([]uint32, 0, min(len(plan.LocalOffsets), shared.GCFrameRootLimit))
 	for i, off := range plan.LocalOffsets {
 		if plan.CallLocalLiveAt(siteIndex, i) {
 			offsets = append(offsets, off)

--- a/src/core/compiler/backend/railshot/arm64/gc.go
+++ b/src/core/compiler/backend/railshot/arm64/gc.go
@@ -923,15 +923,10 @@ func (f *fn) tracksGCFrameRoots() bool {
 }
 
 func (f *fn) gcFrameLocal(index int) bool {
-	if !f.tracksGCFrameRoots() {
+	if index < 0 || f.gcFrameRoots == nil {
 		return false
 	}
-	for _, candidate := range f.gcFrameRoots.LocalIndexes {
-		if int(candidate) == index {
-			return true
-		}
-	}
-	return false
+	return f.gcFrameRoots.TracksLocal(uint32(index))
 }
 
 func arm64GCHelperMayAllocate(helper uint32) bool {

--- a/src/core/compiler/backend/railshot/arm64/gc.go
+++ b/src/core/compiler/backend/railshot/arm64/gc.go
@@ -855,7 +855,7 @@ func (f *fn) recordGCFrameSafepoint(paramCount int) uint32 {
 		return id
 	}
 	f.materializeGCFrameLocalsAt(siteIndex, false)
-	offsets := make([]uint32, 0, len(plan.LocalOffsets))
+	offsets := make([]uint32, 0, min(len(plan.LocalOffsets), shared.GCFrameRootLimit))
 	for i, off := range plan.LocalOffsets {
 		if plan.LocalLiveAt(siteIndex, i) {
 			offsets = append(offsets, off)

--- a/src/core/compiler/backend/railshot/arm64/gc.go
+++ b/src/core/compiler/backend/railshot/arm64/gc.go
@@ -856,10 +856,11 @@ func (f *fn) recordGCFrameSafepoint(paramCount int) uint32 {
 	}
 	f.materializeGCFrameLocalsAt(siteIndex, false)
 	offsets := make([]uint32, 0, min(len(plan.LocalOffsets), shared.GCFrameRootLimit))
-	for i, off := range plan.LocalOffsets {
-		if plan.LocalLiveAt(siteIndex, i) {
-			offsets = append(offsets, off)
-		}
+	if !plan.VisitLiveLocals(siteIndex, false, func(root int) {
+		offsets = append(offsets, plan.LocalOffsets[root])
+	}) {
+		plan.Exact = false
+		return id
 	}
 	hidden := len(roots) - paramCount
 	slot := 0

--- a/src/core/compiler/backend/railshot/arm64/localstate.go
+++ b/src/core/compiler/backend/railshot/arm64/localstate.go
@@ -164,22 +164,18 @@ func (f *fn) materializeGCFrameLocalsAt(site int, call bool) {
 	if f.gcFrameRoots == nil || !f.lazyZero {
 		return
 	}
-	for i, index := range f.gcFrameRoots.LocalIndexes {
-		live := f.gcFrameRoots.LocalLiveAt(site, i)
-		if call {
-			live = f.gcFrameRoots.CallLocalLiveAt(site, i)
-		}
-		if !live {
-			continue
-		}
+	if !f.gcFrameRoots.VisitLiveLocals(site, call, func(root int) {
+		index := f.gcFrameRoots.LocalIndexes[root]
 		x := int(index)
 		if x < 0 || x >= f.nLocals {
 			f.gcFrameRoots.Exact = false
-			continue
+			return
 		}
 		if f.locals[x].state == lsConstZero {
 			f.materializeZeroLocal(x, true)
 		}
+	}) {
+		f.gcFrameRoots.Exact = false
 	}
 }
 

--- a/src/core/compiler/backend/railshot/shared/gc_frame_roots.go
+++ b/src/core/compiler/backend/railshot/shared/gc_frame_roots.go
@@ -23,10 +23,15 @@ const (
 	GCSafepointIDShift = GCHelperIDBits
 	GCSafepointIDMax   = uint32(1<<(30-GCSafepointIDShift)) - 1
 
-	// GCFrameRootLimit bounds exact roots in one native frame. The compiler keeps
+	// GCFrameRootLimit bounds simultaneously live exact roots in one native frame. The compiler keeps
 	// a one-word fast path through 64 roots, a two-word path through 128 roots,
 	// and uses one flat word arena for larger masks up to this limit.
 	GCFrameRootLimit = 1024
+
+	// GCFrameTrackedLocalLimit is the maximum configured parameter-plus-local
+	// population whose liveness may be tracked. Site maps remain bounded by
+	// GCFrameRootLimit after dead-at-all-sites locals are removed.
+	GCFrameTrackedLocalLimit = 1<<16 - 1
 )
 
 func EncodeGCDispatch(helper, safepoint uint32) (uint32, bool) {
@@ -97,7 +102,7 @@ func (p *GCFrameRootPlan) rootMaskExtraWordsPerSite() int {
 // ValidLiveMasks reports whether the flat extra-word arena matches both
 // low-word streams and the function's bounded collector-local count.
 func (p *GCFrameRootPlan) ValidLiveMasks() bool {
-	if p == nil || len(p.LocalOffsets) > GCFrameRootLimit {
+	if p == nil || len(p.LocalOffsets) > GCFrameTrackedLocalLimit {
 		return false
 	}
 	extra := p.rootMaskExtraWordsPerSite()

--- a/src/core/compiler/backend/railshot/shared/gc_frame_roots.go
+++ b/src/core/compiler/backend/railshot/shared/gc_frame_roots.go
@@ -1,6 +1,9 @@
 package shared
 
-import "sort"
+import (
+	"math/bits"
+	"sort"
+)
 
 // AMD64FrameHeaderBytes and ARM64FrameHeaderBytes are the stable local-slot
 // bases used by the railshot native frames. Root-map producers and consumers
@@ -150,6 +153,50 @@ func (p *GCFrameRootPlan) CallLocalLiveAt(site, root int) bool {
 		return false
 	}
 	return rootMaskContains(p.LiveCallLocalMasks, p.LiveMaskExtraWords[start:], extra, site, root)
+}
+
+// VisitLiveLocals calls visit with each retained-slice index live at one
+// allocation or call site. It iterates set mask bits, so sparse sites do work
+// proportional to their live population instead of all retained locals.
+func (p *GCFrameRootPlan) VisitLiveLocals(site int, call bool, visit func(root int)) bool {
+	if p == nil || visit == nil || len(p.LocalIndexes) != len(p.LocalOffsets) {
+		return false
+	}
+	masks := p.LiveLocalMasks
+	extraPerSite := p.rootMaskExtraWordsPerSite()
+	extraStart := 0
+	if call {
+		masks = p.LiveCallLocalMasks
+		extraStart = len(p.LiveLocalMasks) * extraPerSite
+	}
+	if site < 0 || site >= len(masks) {
+		return false
+	}
+	visitWord := func(word int, value uint64) bool {
+		for value != 0 {
+			bit := bits.TrailingZeros64(value)
+			value &= value - 1
+			root := word*64 + bit
+			if root >= len(p.LocalOffsets) {
+				return false
+			}
+			visit(root)
+		}
+		return true
+	}
+	if !visitWord(0, masks[site]) {
+		return false
+	}
+	base := extraStart + site*extraPerSite
+	if base < 0 || base+extraPerSite > len(p.LiveMaskExtraWords) {
+		return false
+	}
+	for word := 1; word <= extraPerSite; word++ {
+		if !visitWord(word, p.LiveMaskExtraWords[base+word-1]) {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *GCModuleFrameRootPlan) Function(index int) *GCFrameRootPlan {

--- a/src/core/compiler/backend/railshot/shared/gc_frame_roots.go
+++ b/src/core/compiler/backend/railshot/shared/gc_frame_roots.go
@@ -1,5 +1,7 @@
 package shared
 
+import "sort"
+
 // AMD64FrameHeaderBytes and ARM64FrameHeaderBytes are the stable local-slot
 // bases used by the railshot native frames. Root-map producers and consumers
 // must use the matching architecture value.
@@ -83,6 +85,17 @@ type GCFrameRootPlan struct {
 	// point beyond the function-owned bytes into a module-level adapter island.
 	AdapterReturnOffset uint32
 	SafepointBase       uint32
+}
+
+// TracksLocal reports whether index belongs to the sorted collector-local
+// population retained by the frontend. Binary search keeps backend local
+// instruction handling bounded when disjoint safepoints retain a wide union.
+func (p *GCFrameRootPlan) TracksLocal(index uint32) bool {
+	if p == nil || !p.Candidate {
+		return false
+	}
+	i := sort.Search(len(p.LocalIndexes), func(i int) bool { return p.LocalIndexes[i] >= index })
+	return i < len(p.LocalIndexes) && p.LocalIndexes[i] == index
 }
 
 // GCModuleFrameRootPlan owns one independent function plan per local function.

--- a/src/core/compiler/backend/railshot/shared/gc_frame_roots_test.go
+++ b/src/core/compiler/backend/railshot/shared/gc_frame_roots_test.go
@@ -39,19 +39,19 @@ func TestGCFrameRootPlanWideMaskWords(t *testing.T) {
 	}
 }
 
-func TestGCFrameRootPlanBoundedVectorMask(t *testing.T) {
-	const roots = GCFrameRootLimit
-	extraWords := roots/64 - 1
+func TestGCFrameRootPlanTrackedVectorMask(t *testing.T) {
+	const roots = GCFrameRootLimit + 1
+	extraWords := (roots+63)/64 - 1
 	plan := &GCFrameRootPlan{
 		LocalOffsets:       make([]uint32, roots),
 		LiveLocalMasks:     []uint64{0},
 		LiveMaskExtraWords: make([]uint64, extraWords),
 	}
-	plan.LiveMaskExtraWords[extraWords-1] = uint64(1) << 63
+	plan.LiveMaskExtraWords[extraWords-1] = 1
 	if !plan.ValidLiveMasks() || !plan.LocalLiveAt(0, roots-1) {
 		t.Fatal("bounded vector mask lost its highest root")
 	}
-	plan.LocalOffsets = append(plan.LocalOffsets, 0)
+	plan.LocalOffsets = make([]uint32, GCFrameTrackedLocalLimit+1)
 	if plan.ValidLiveMasks() {
 		t.Fatal("over-limit vector mask accepted")
 	}

--- a/src/core/compiler/backend/railshot/shared/gc_frame_roots_test.go
+++ b/src/core/compiler/backend/railshot/shared/gc_frame_roots_test.go
@@ -56,3 +56,27 @@ func TestGCFrameRootPlanTrackedVectorMask(t *testing.T) {
 		t.Fatal("over-limit vector mask accepted")
 	}
 }
+
+func TestGCFrameRootPlanTracksWideLocalPopulation(t *testing.T) {
+	// Even indexes retain a wide population while leaving in-range misses to
+	// exercise both outcomes across the configured uint16 local-index space.
+	indexes := make([]uint32, (GCFrameTrackedLocalLimit+1)/2)
+	for i := range indexes {
+		indexes[i] = uint32(i * 2)
+	}
+	plan := &GCFrameRootPlan{Candidate: true, LocalIndexes: indexes}
+	for _, index := range []uint32{0, 2, GCFrameTrackedLocalLimit - 1} {
+		if !plan.TracksLocal(index) {
+			t.Fatalf("retained local %d not found", index)
+		}
+	}
+	for _, index := range []uint32{1, 3, GCFrameTrackedLocalLimit - 2} {
+		if plan.TracksLocal(index) {
+			t.Fatalf("unretained local %d found", index)
+		}
+	}
+	plan.Candidate = false
+	if plan.TracksLocal(0) {
+		t.Fatal("non-candidate plan reported a retained local")
+	}
+}

--- a/src/core/compiler/backend/railshot/shared/gc_frame_roots_test.go
+++ b/src/core/compiler/backend/railshot/shared/gc_frame_roots_test.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"slices"
 	"testing"
 	"unsafe"
 )
@@ -19,6 +20,7 @@ func TestGCFrameRootPlanFootprint(t *testing.T) {
 
 func TestGCFrameRootPlanWideMaskWords(t *testing.T) {
 	plan := &GCFrameRootPlan{
+		LocalIndexes:       make([]uint32, 65),
 		LocalOffsets:       make([]uint32, 65),
 		LiveLocalMasks:     []uint64{1},
 		LiveCallLocalMasks: []uint64{2},
@@ -33,9 +35,20 @@ func TestGCFrameRootPlanWideMaskWords(t *testing.T) {
 	if !plan.CallLocalLiveAt(0, 1) || !plan.CallLocalLiveAt(0, 64) || plan.CallLocalLiveAt(0, 0) {
 		t.Fatal("call mask lookup returned the wrong roots")
 	}
+	var allocations, calls []int
+	if !plan.VisitLiveLocals(0, false, func(root int) { allocations = append(allocations, root) }) ||
+		!plan.VisitLiveLocals(0, true, func(root int) { calls = append(calls, root) }) {
+		t.Fatal("valid live-mask iteration rejected")
+	}
+	if !slices.Equal(allocations, []int{0, 64}) || !slices.Equal(calls, []int{1, 64}) {
+		t.Fatalf("live-mask iteration = allocations %v, calls %v", allocations, calls)
+	}
 	plan.LiveMaskExtraWords = plan.LiveMaskExtraWords[:1]
 	if plan.ValidLiveMasks() {
 		t.Fatal("truncated two-word allocation arena accepted")
+	}
+	if plan.VisitLiveLocals(0, true, func(int) {}) {
+		t.Fatal("truncated call-mask arena accepted by iteration")
 	}
 }
 
@@ -78,5 +91,44 @@ func TestGCFrameRootPlanTracksWideLocalPopulation(t *testing.T) {
 	plan.Candidate = false
 	if plan.TracksLocal(0) {
 		t.Fatal("non-candidate plan reported a retained local")
+	}
+}
+
+var gcFrameVisitSink int
+
+func BenchmarkGCFrameRootPlanVisitsDisjointWideSites(b *testing.B) {
+	const roots = 10_000
+	extraPerSite := (roots+63)/64 - 1
+	plan := GCFrameRootPlan{
+		Candidate:          true,
+		LocalIndexes:       make([]uint32, roots),
+		LocalOffsets:       make([]uint32, roots),
+		LiveLocalMasks:     make([]uint64, roots),
+		LiveCallLocalMasks: make([]uint64, roots),
+		LiveMaskExtraWords: make([]uint64, roots*extraPerSite*2),
+	}
+	for root := 0; root < roots; root++ {
+		plan.LocalIndexes[root], plan.LocalOffsets[root] = uint32(root), uint32(root*8)
+		if root < 64 {
+			plan.LiveLocalMasks[root] = uint64(1) << uint(root)
+			plan.LiveCallLocalMasks[root] = uint64(1) << uint(root)
+		} else {
+			word := root/64 - 1
+			plan.LiveMaskExtraWords[root*extraPerSite+word] = uint64(1) << uint(root%64)
+			plan.LiveMaskExtraWords[(roots+root)*extraPerSite+word] = uint64(1) << uint(root%64)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(roots*2, "sites/op")
+	for i := 0; i < b.N; i++ {
+		sum := 0
+		visit := func(root int) { sum += root }
+		for site := 0; site < roots; site++ {
+			if !plan.VisitLiveLocals(site, false, visit) || !plan.VisitLiveLocals(site, true, visit) {
+				b.Fatal("valid sparse site rejected")
+			}
+		}
+		gcFrameVisitSink = sum
 	}
 }

--- a/src/core/compiler/wasm/validate.go
+++ b/src/core/compiler/wasm/validate.go
@@ -16,13 +16,29 @@ type ValidationFeatures struct {
 	GCConstExpr          bool // internal staged admission for GC allocation/conversion constant expressions
 }
 
+// ValidationLimits bounds implementation resources consumed by one module.
+// MaxFunctionLocals counts function parameters and declared locals together;
+// zero selects DefaultMaxFunctionLocals.
+type ValidationLimits struct {
+	MaxFunctionLocals uint32
+}
+
+// DefaultMaxFunctionLocals is the ordinary validation ceiling for the total
+// parameter-plus-local count of one function.
+const DefaultMaxFunctionLocals uint32 = 4096
+
+// MaximumFunctionLocals is the largest configurable validation ceiling.
+const MaximumFunctionLocals uint32 = 1<<16 - 1
+
+var defaultValidationLimits = ValidationLimits{MaxFunctionLocals: DefaultMaxFunctionLocals}
+
 // ValidateModule validates module-level indexes and typechecks function bodies.
 // The default path consumes raw BodyBytes produced by DecodeModule instead of a
 // structured function-body instruction tree. Programmatically constructed tests
 // may still supply Func.Body instructions when BodyBytes is empty. The default
 // preserves the WebAssembly 2.0 single-memory validation boundary.
 func ValidateModule(m *Module) error {
-	return validateModuleWithWorkersAndFeatures(m, nil, 1, ValidationFeatures{})
+	return validateModuleWithWorkersFeaturesAndLimits(m, nil, 1, ValidationFeatures{}, defaultValidationLimits)
 }
 
 // ValidateModuleWithWorkers is ValidateModule with bounded function-body
@@ -32,27 +48,39 @@ func ValidateModule(m *Module) error {
 // function count. If multiple functions are invalid, the lowest function index
 // wins regardless of completion order.
 func ValidateModuleWithWorkers(m *Module, workers int) error {
-	return validateModuleWithWorkersAndFeatures(m, nil, workers, ValidationFeatures{})
+	return validateModuleWithWorkersFeaturesAndLimits(m, nil, workers, ValidationFeatures{}, defaultValidationLimits)
 }
 
 // ValidateModuleWithFeatures validates a module under explicitly staged release
 // features. Unsupported execution remains the frontend's responsibility.
 func ValidateModuleWithFeatures(m *Module, features ValidationFeatures) error {
-	return validateModuleWithWorkersAndFeatures(m, nil, 1, features)
+	return validateModuleWithWorkersFeaturesAndLimits(m, nil, 1, features, defaultValidationLimits)
 }
 
 // ValidateModuleWithFeaturesAndWorkers combines explicitly staged validation
 // features with bounded function-body parallelism.
 func ValidateModuleWithFeaturesAndWorkers(m *Module, features ValidationFeatures, workers int) error {
-	return validateModuleWithWorkersAndFeatures(m, nil, workers, features)
+	return validateModuleWithWorkersFeaturesAndLimits(m, nil, workers, features, defaultValidationLimits)
 }
 
-func validateModuleWithWorkersAndFeatures(m *Module, direct *directValidationEnv, workers int, features ValidationFeatures) error {
+// ValidateModuleWithConfig validates a module with explicit feature, worker,
+// and resource-limit policy.
+func ValidateModuleWithConfig(m *Module, features ValidationFeatures, workers int, limits ValidationLimits) error {
+	return validateModuleWithWorkersFeaturesAndLimits(m, nil, workers, features, limits)
+}
+
+func validateModuleWithWorkersFeaturesAndLimits(m *Module, direct *directValidationEnv, workers int, features ValidationFeatures, limits ValidationLimits) error {
+	if limits.MaxFunctionLocals == 0 {
+		limits = defaultValidationLimits
+	}
+	if limits.MaxFunctionLocals > MaximumFunctionLocals {
+		return &ValidationError{Code: ErrInvalidLimitRange, Func: -1, Detail: "configured function local limit exceeds 65535"}
+	}
 	// Keep the serial validation owner in this frame. TinyGo's conservative
 	// collector can otherwise lose a short-lived heap validator while nested
 	// decoding allocates, leaving its inline operand/control stacks reclaimed
 	// during validation.
-	v := moduleValidator{m: m, funcIndex: -1, direct: direct, features: features}
+	v := moduleValidator{m: m, funcIndex: -1, direct: direct, features: features, limits: limits}
 	if err := v.validateModule(); err != nil {
 		runtime.KeepAlive(m)
 		runtime.KeepAlive(direct)
@@ -170,6 +198,7 @@ type moduleValidator struct {
 	funcIndex int
 	direct    *directValidationEnv
 	features  ValidationFeatures
+	limits    ValidationLimits
 
 	// declaredFuncBits is the module validation context's declared function-
 	// reference set. The inline word keeps the common <=64-function module from
@@ -207,12 +236,6 @@ const (
 	maxTable32Limit  = uint64(1<<32 - 1)
 	maxMemory32Pages = uint64(1 << 16)
 	maxMemory64Pages = uint64(1 << 48)
-	// A generated prologue may reserve its frame before checking the next stack
-	// fence, whose guaranteed headroom is 256 KiB. At the worst-case 16 bytes per
-	// v128 local, 2^13 locals consume 128 KiB and leave the other half for frame
-	// headers and operand spills, instead of letting locals alone overrun the
-	// pre-check region.
-	maxFunctionLocals = uint64(1 << 13)
 )
 
 func (v *moduleValidator) err(c ValidationErrorCode, d string) error {
@@ -969,8 +992,8 @@ func (v *funcValidator) validateFunc(fn Func, ft *CompType) error {
 	if overflow {
 		return v.verr(ErrInvalidLimitRange, "local count overflow")
 	}
-	if v.localCount > maxFunctionLocals {
-		return v.verr(ErrInvalidLimitRange, "local count exceeds implementation limit")
+	if v.localCount > uint64(v.limits.MaxFunctionLocals) {
+		return v.verr(ErrInvalidLimitRange, "parameter and local count exceeds configured limit")
 	}
 	for _, run := range fn.Locals.Runs {
 		if err := v.validateValType(run.Type); err != nil {

--- a/src/core/compiler/wasm/validate_bytebacked.go
+++ b/src/core/compiler/wasm/validate_bytebacked.go
@@ -57,27 +57,33 @@ type DecodedByteBackedModule struct {
 // path. It is a convenience for benchmarks and internal tests that need a
 // single call around explicit decode then validate phases.
 func ValidateByteBackedModule(data []byte) error {
-	return validateByteBackedModule(data, 1, ValidationFeatures{})
+	return validateByteBackedModule(data, 1, ValidationFeatures{}, defaultValidationLimits)
 }
 
 // ValidateByteBackedModuleWithWorkers is ValidateByteBackedModule with bounded
 // parallel function-body validation. workers <= 1 retains serial behavior.
 func ValidateByteBackedModuleWithWorkers(data []byte, workers int) error {
-	return validateByteBackedModule(data, workers, ValidationFeatures{})
+	return validateByteBackedModule(data, workers, ValidationFeatures{}, defaultValidationLimits)
 }
 
 // ValidateByteBackedModuleWithFeatures is the explicit-feature variant of
 // ValidateByteBackedModule.
 func ValidateByteBackedModuleWithFeatures(data []byte, features ValidationFeatures) error {
-	return validateByteBackedModule(data, 1, features)
+	return validateByteBackedModule(data, 1, features, defaultValidationLimits)
 }
 
-func validateByteBackedModule(data []byte, workers int, features ValidationFeatures) error {
+// ValidateByteBackedModuleWithConfig is the explicit feature, worker, and
+// resource-limit variant of ValidateByteBackedModule.
+func ValidateByteBackedModuleWithConfig(data []byte, features ValidationFeatures, workers int, limits ValidationLimits) error {
+	return validateByteBackedModule(data, workers, features, limits)
+}
+
+func validateByteBackedModule(data []byte, workers int, features ValidationFeatures, limits ValidationLimits) error {
 	dm, err := DecodeModuleByteBacked(data)
 	if err != nil {
 		return err
 	}
-	return validateDecodedByteBackedModule(dm, workers, features)
+	return validateDecodedByteBackedModule(dm, workers, features, limits)
 }
 
 // DecodeModuleByteBacked decodes data without materializing the structured
@@ -100,27 +106,33 @@ func DecodeModuleByteBacked(data []byte) (*DecodedByteBackedModule, error) {
 // DecodeModuleByteBacked without requiring a structured function-body
 // instruction tree.
 func ValidateDecodedByteBackedModule(dm *DecodedByteBackedModule) error {
-	return validateDecodedByteBackedModule(dm, 1, ValidationFeatures{})
+	return validateDecodedByteBackedModule(dm, 1, ValidationFeatures{}, defaultValidationLimits)
 }
 
 // ValidateDecodedByteBackedModuleWithWorkers is
 // ValidateDecodedByteBackedModule with bounded parallel function-body
 // validation. Errors remain ordered by function index.
 func ValidateDecodedByteBackedModuleWithWorkers(dm *DecodedByteBackedModule, workers int) error {
-	return validateDecodedByteBackedModule(dm, workers, ValidationFeatures{})
+	return validateDecodedByteBackedModule(dm, workers, ValidationFeatures{}, defaultValidationLimits)
 }
 
 // ValidateDecodedByteBackedModuleWithFeatures validates a decoded compact module
 // under explicitly staged release features.
 func ValidateDecodedByteBackedModuleWithFeatures(dm *DecodedByteBackedModule, features ValidationFeatures) error {
-	return validateDecodedByteBackedModule(dm, 1, features)
+	return validateDecodedByteBackedModule(dm, 1, features, defaultValidationLimits)
 }
 
-func validateDecodedByteBackedModule(dm *DecodedByteBackedModule, workers int, features ValidationFeatures) error {
+// ValidateDecodedByteBackedModuleWithConfig validates decoded byte-backed
+// metadata with explicit feature, worker, and resource-limit policy.
+func ValidateDecodedByteBackedModuleWithConfig(dm *DecodedByteBackedModule, features ValidationFeatures, workers int, limits ValidationLimits) error {
+	return validateDecodedByteBackedModule(dm, workers, features, limits)
+}
+
+func validateDecodedByteBackedModule(dm *DecodedByteBackedModule, workers int, features ValidationFeatures, limits ValidationLimits) error {
 	if dm == nil || dm.Module == nil {
 		return &ValidationError{Code: ErrTypeMismatch, Func: -1, Detail: "nil byte-backed module"}
 	}
-	return validateModuleWithWorkersAndFeatures(dm.Module, &dm.direct, workers, features)
+	return validateModuleWithWorkersFeaturesAndLimits(dm.Module, &dm.direct, workers, features, limits)
 }
 
 func (dm *directModule) populateCodeBodies() {
@@ -878,8 +890,8 @@ func (v *funcValidator) validateFuncDirect(body directCodeBody, ft *CompType, wi
 	if overflow {
 		return v.verr(ErrInvalidLimitRange, "local count overflow")
 	}
-	if v.localCount > maxFunctionLocals {
-		return v.verr(ErrInvalidLimitRange, "local count exceeds implementation limit")
+	if v.localCount > uint64(v.limits.MaxFunctionLocals) {
+		return v.verr(ErrInvalidLimitRange, "parameter and local count exceeds configured limit")
 	}
 	for _, run := range body.locals.Runs {
 		if err := v.validateValType(run.Type); err != nil {

--- a/src/core/compiler/wasm/validate_internal_test.go
+++ b/src/core/compiler/wasm/validate_internal_test.go
@@ -63,12 +63,12 @@ func TestValidatorCoverageCoreOpcodeFamilies(t *testing.T) {
 	}
 }
 
-func TestValidateRejectsFunctionLocalCountAboveNativeFrameLimit(t *testing.T) {
+func TestValidateFunctionLocalCountDefaultAndCustomLimits(t *testing.T) {
 	m := modWithFunc(nil, nil)
-	m.Code[0].Locals = Locals{Runs: []LocalRun{{Count: uint32(maxFunctionLocals + 1), Type: V128}}}
+	m.Code[0].Locals = Locals{Runs: []LocalRun{{Count: DefaultMaxFunctionLocals + 1, Type: V128}}}
 	expectValidateErr(t, m, ErrInvalidLimitRange)
 
-	localRun := append(u32(uint32(maxFunctionLocals+1)), byte(0x7f))
+	localRun := append(u32(DefaultMaxFunctionLocals+1), byte(0x7f))
 	body := append([]byte{0x01}, localRun...)
 	body = append(body, 0x0b)
 	code := append(u32(uint32(len(body))), body...)
@@ -79,6 +79,30 @@ func TestValidateRejectsFunctionLocalCountAboveNativeFrameLimit(t *testing.T) {
 	)
 	err := ValidateByteBackedModule(data)
 	expectValidationCode(t, err, ErrInvalidLimitRange)
+
+	for _, count := range []uint32{DefaultMaxFunctionLocals, MaximumFunctionLocals} {
+		limits := ValidationLimits{MaxFunctionLocals: count}
+		ast := modWithFunc(nil, nil)
+		ast.Code[0].Locals = Locals{Runs: []LocalRun{{Count: count, Type: I32}}}
+		if err := ValidateModuleWithConfig(ast, ValidationFeatures{}, 1, limits); err != nil {
+			t.Fatalf("AST local boundary %d: %v", count, err)
+		}
+		localRun := append(u32(count), byte(0x7f))
+		body := append([]byte{0x01}, localRun...)
+		body = append(body, 0x0b)
+		code := append(u32(uint32(len(body))), body...)
+		encoded := module(
+			section(secType, 0x01, 0x60, 0x00, 0x00),
+			section(secFunction, 0x01, 0x00),
+			section(secCode, append([]byte{0x01}, code...)...),
+		)
+		if err := ValidateByteBackedModuleWithConfig(encoded, ValidationFeatures{}, 1, limits); err != nil {
+			t.Fatalf("byte-backed local boundary %d: %v", count, err)
+		}
+	}
+	if err := ValidateModuleWithConfig(modWithFunc(nil, nil), ValidationFeatures{}, 1, ValidationLimits{MaxFunctionLocals: MaximumFunctionLocals + 1}); err == nil {
+		t.Fatal("validation accepted a configured local limit above uint16")
+	}
 }
 
 func TestValidatorCoverageSIMDOpcodeFamilies(t *testing.T) {

--- a/src/core/compiler/wasm/validate_parallel_test.go
+++ b/src/core/compiler/wasm/validate_parallel_test.go
@@ -153,7 +153,7 @@ func TestValidateModuleWithWorkersTableInitElementExprRace(t *testing.T) {
 
 	t.Run("function phase does not revalidate initializers", func(t *testing.T) {
 		m := tableInitExprModule(AbsRef(HeapFunc), false)
-		v := &moduleValidator{m: m, funcIndex: -1}
+		v := &moduleValidator{m: m, funcIndex: -1, limits: defaultValidationLimits}
 		if err := v.validateModule(); err != nil {
 			t.Fatalf("module validation: %v", err)
 		}
@@ -167,7 +167,7 @@ func TestValidateModuleWithWorkersTableInitElementExprRace(t *testing.T) {
 
 	t.Run("defensive metadata errors", func(t *testing.T) {
 		m := tableInitExprModule(AbsRef(HeapFunc), false)
-		fv := funcValidator{moduleValidator: &moduleValidator{m: m}, funcIndex: 7}
+		fv := funcValidator{moduleValidator: &moduleValidator{m: m, limits: defaultValidationLimits}, funcIndex: 7}
 		if _, err := fv.elemRefType(uint32(len(m.Elements))); !isValidationCode(err, ErrUnknownTable) {
 			t.Fatalf("out-of-range element error = %v", err)
 		}
@@ -223,7 +223,7 @@ func TestValidateDecodedByteBackedModuleWithWorkersTableInitElementExprRace(t *t
 		if err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		v := &moduleValidator{m: dm.Module, funcIndex: -1, direct: &dm.direct}
+		v := &moduleValidator{m: dm.Module, funcIndex: -1, direct: &dm.direct, limits: defaultValidationLimits}
 		if err := v.validateModule(); err != nil {
 			t.Fatalf("module validation: %v", err)
 		}
@@ -237,7 +237,7 @@ func TestValidateDecodedByteBackedModuleWithWorkersTableInitElementExprRace(t *t
 
 	t.Run("defensive metadata errors", func(t *testing.T) {
 		direct := &directValidationEnv{elements: []directElem{{kind: ElemKindKind(0xff)}}}
-		fv := funcValidator{moduleValidator: &moduleValidator{m: &Module{}, direct: direct}, funcIndex: 7}
+		fv := funcValidator{moduleValidator: &moduleValidator{m: &Module{}, direct: direct, limits: defaultValidationLimits}, funcIndex: 7}
 		if _, err := fv.directElemRefType(1); !isValidationCode(err, ErrUnknownTable) {
 			t.Fatalf("out-of-range direct element error = %v", err)
 		}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1129,7 +1129,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 		ExtendedConstGlobals: features.ExtendedConstGlobals,
 		GCConstExpr:          features.GCStructProducts || features.GCArrayProducts || features.GCI31Products,
 	}
-	if err := wasm.ValidateModuleWithFeaturesAndWorkers(m, validationFeatures, workers); err != nil {
+	if err := wasm.ValidateModuleWithConfig(m, validationFeatures, workers, wasm.ValidationLimits{MaxFunctionLocals: cfg.maxFunctionLocals}); err != nil {
 		// Proposal-aware decoding can expose a structurally unsupported module to
 		// validation before the validator has complete proposal subtyping rules.
 		// Compile must still fail clearly as unsupported rather than mislabeling a

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -123,7 +123,7 @@ func (c *Compiled) setGCRootAdmissionFailure(diagnostic string) {
 		code = 5
 	case strings.Contains(diagnostic, "unsupported native call or frame"):
 		code = 6
-	case strings.Contains(diagnostic, "exceeds 1024 collector roots"):
+	case strings.Contains(diagnostic, "simultaneously live collector locals"):
 		code = 7
 	case strings.Contains(diagnostic, "local liveness"):
 		code = 8
@@ -153,7 +153,7 @@ func (c *Compiled) gcRootAdmissionFailure() string {
 	case 6:
 		return "a collecting function contains an unsupported native call or frame shape"
 	case 7:
-		return "a collecting function exceeds 1024 collector roots or the frame-offset bound"
+		return "a collecting function exceeds 1024 simultaneously live collector roots"
 	case 8:
 		return "exact structured-CFG local liveness could not be constructed"
 	case 9:

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/wago-org/wago/src/core/compiler/frontend"
 	"github.com/wago-org/wago/src/core/compiler/optimization"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
 )
 
 // CoreFeatures is a bit set of WebAssembly Core specification features. A
@@ -237,6 +238,7 @@ type RuntimeConfig struct {
 	optimizationDeltas   map[string]bool
 	trustedOptimizations bool
 	maxMemoryPages       uint32
+	maxFunctionLocals    uint32 // total function parameters plus declared locals
 	boundsChecks         BoundsCheckMode
 	noDeferBounds        bool // disable skipping of provably-redundant bounds checks (default: enabled)
 	functionWorkers      int  // function validation/codegen: 0 adaptive; 1 serial; >1 forced maximum
@@ -251,6 +253,14 @@ type runtimeInstanceLimits struct {
 }
 
 const defaultMaxMemoryPages = 1 << 16 // 4 GiB worth of 64 KiB wasm pages
+
+// DefaultMaxFunctionLocals is the default ceiling for one function's combined
+// parameter and declared-local count. MaxFunctionLocalsLimit is the largest
+// configurable ceiling; native frame-size safety remains independently checked.
+const (
+	DefaultMaxFunctionLocals = wasm.DefaultMaxFunctionLocals
+	MaxFunctionLocalsLimit   = wasm.MaximumFunctionLocals
+)
 
 var defaultOptimizationCache struct {
 	sync.Mutex
@@ -323,6 +333,7 @@ func NewRuntimeConfig() *RuntimeConfig {
 		optimizationDeltas:   optimizationDeltas,
 		trustedOptimizations: true,
 		maxMemoryPages:       defaultMaxMemoryPages,
+		maxFunctionLocals:    DefaultMaxFunctionLocals,
 		boundsChecks:         bounds,
 		functionWorkers:      1,
 		independentInstances: true,
@@ -418,6 +429,16 @@ func (c *RuntimeConfig) WithOptimizations(values map[string]bool) *RuntimeConfig
 func (c *RuntimeConfig) WithMemoryLimitPages(pages uint32) *RuntimeConfig {
 	n := *c
 	n.maxMemoryPages = pages
+	return &n
+}
+
+// WithMaxFunctionLocals sets the maximum combined parameter and declared-local
+// count for one function. Valid values are 1 through 65,535. This bounds
+// validation/compiler bookkeeping; native frame-size checks may reject a lower
+// count when its slots and spills exceed the stack fence.
+func (c *RuntimeConfig) WithMaxFunctionLocals(locals uint32) *RuntimeConfig {
+	n := *c
+	n.maxFunctionLocals = locals
 	return &n
 }
 
@@ -519,6 +540,10 @@ func (c *RuntimeConfig) DeferBoundsChecks() bool { return !c.noDeferBounds }
 // MemoryLimitPages reports the configured maximum linear-memory size in pages.
 func (c *RuntimeConfig) MemoryLimitPages() uint32 { return c.maxMemoryPages }
 
+// MaxFunctionLocals reports the configured combined parameter and declared-
+// local ceiling for one function.
+func (c *RuntimeConfig) MaxFunctionLocals() uint32 { return c.maxFunctionLocals }
+
 // GCCodeTelemetry reports whether fresh compilation should retain code-neutral
 // WasmGC native-byte attribution. Serialized artifacts do not contain it.
 func (c *RuntimeConfig) GCCodeTelemetry() bool { return c.gcCodeTelemetry }
@@ -555,8 +580,8 @@ func (c *RuntimeConfig) MustCompile(wasmBytes []byte) *Compiled {
 }
 
 func (c *RuntimeConfig) String() string {
-	return fmt.Sprintf("RuntimeConfig{features: %s, optimizations: %d, bounds: %s, maxMemoryPages: %d, functionWorkers: %d, independentInstances: %t}",
-		c.features, len(c.optimizations), c.boundsChecks, c.maxMemoryPages, c.functionWorkers, c.independentInstances)
+	return fmt.Sprintf("RuntimeConfig{features: %s, optimizations: %d, bounds: %s, maxMemoryPages: %d, maxFunctionLocals: %d, functionWorkers: %d, independentInstances: %t}",
+		c.features, len(c.optimizations), c.boundsChecks, c.maxMemoryPages, c.maxFunctionLocals, c.functionWorkers, c.independentInstances)
 }
 
 // SupportedFeatures reports the WebAssembly feature set this wago build can
@@ -689,6 +714,9 @@ func (c *RuntimeConfig) frontendFeatures() frontend.Features {
 // surfacing a bad config early (e.g. at startup). A feature flag is never a
 // silent no-op.
 func (c *RuntimeConfig) Validate() error {
+	if c.maxFunctionLocals == 0 || c.maxFunctionLocals > MaxFunctionLocalsLimit {
+		return fmt.Errorf("wago: max function locals must be between 1 and %d, got %d", MaxFunctionLocalsLimit, c.maxFunctionLocals)
+	}
 	if c.functionWorkers < 0 {
 		return fmt.Errorf("wago: function workers must be non-negative, got %d", c.functionWorkers)
 	}

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -434,6 +434,19 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	if err := NewRuntimeConfig().WithFunctionWorkers(-1).Validate(); err == nil || !strings.Contains(err.Error(), "non-negative") {
 		t.Fatalf("negative function workers should fail validation, got %v", err)
 	}
+	if got := NewRuntimeConfig().MaxFunctionLocals(); got != 4096 {
+		t.Fatalf("default max function locals = %d, want 4096", got)
+	}
+	if err := NewRuntimeConfig().WithMaxFunctionLocals(0).Validate(); err == nil || !strings.Contains(err.Error(), "between 1 and 65535") {
+		t.Fatalf("zero max function locals should fail validation, got %v", err)
+	}
+	if err := NewRuntimeConfig().WithMaxFunctionLocals(MaxFunctionLocalsLimit + 1).Validate(); err == nil || !strings.Contains(err.Error(), "between 1 and 65535") {
+		t.Fatalf("oversized max function locals should fail validation, got %v", err)
+	}
+	maximumLocals := NewRuntimeConfig().WithMaxFunctionLocals(MaxFunctionLocalsLimit)
+	if maximumLocals.MaxFunctionLocals() != 65535 || NewRuntimeConfig().MaxFunctionLocals() != DefaultMaxFunctionLocals {
+		t.Fatal("WithMaxFunctionLocals must be immutable and accept the uint16 maximum")
+	}
 	workers := NewRuntimeConfig().WithFunctionWorkers(4)
 	if workers.FunctionWorkers() != 4 || NewRuntimeConfig().FunctionWorkers() != 1 {
 		t.Fatal("WithFunctionWorkers must be immutable and observable; default must remain serial")
@@ -472,8 +485,40 @@ func TestConfigValidateAndIntrospection(t *testing.T) {
 	}
 	// String is non-empty / informative. The default bounds mode depends on the
 	// build tag (explicit normally, signals-based under wago_guardpage).
-	if s := NewRuntimeConfig().String(); (!strings.Contains(s, "explicit") && !strings.Contains(s, "signals-based")) || !strings.Contains(s, "functionWorkers: 1") {
+	if s := NewRuntimeConfig().String(); (!strings.Contains(s, "explicit") && !strings.Contains(s, "signals-based")) || !strings.Contains(s, "functionWorkers: 1") || !strings.Contains(s, "maxFunctionLocals: 4096") {
 		t.Fatalf("config String missing bounds mode or serial default policy: %q", s)
+	}
+}
+
+func functionLocalLimitModule(params, locals uint32, typ wasm.ValType) []byte {
+	paramTypes := make([]wasm.ValType, params)
+	for i := range paramTypes {
+		paramTypes[i] = typ
+	}
+	body := []byte{0x01}
+	body = append(body, wasmtest.ULEB(locals)...)
+	body = append(body, wasm.MustEncodeValType(typ), 0x0b)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(paramTypes, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
+func TestMaxFunctionLocalsCountsParametersAndPreservesStackFence(t *testing.T) {
+	module := functionLocalLimitModule(1, 1, wasm.I32)
+	if _, err := Compile(NewRuntimeConfig().WithMaxFunctionLocals(1), module); err == nil || !strings.Contains(err.Error(), "parameter and local count exceeds configured limit") {
+		t.Fatalf("combined parameter/local limit error = %v", err)
+	}
+	if compiled, err := Compile(NewRuntimeConfig().WithMaxFunctionLocals(2), module); err != nil {
+		t.Fatalf("combined parameter/local boundary: %v", err)
+	} else {
+		compiled.Close()
+	}
+
+	_, err := Compile(NewRuntimeConfig().WithMaxFunctionLocals(MaxFunctionLocalsLimit), functionLocalLimitModule(0, MaxFunctionLocalsLimit, wasm.V128))
+	if err == nil || !strings.Contains(err.Error(), "exceeds stack-fence headroom") {
+		t.Fatalf("uint16 maximum must retain native stack-fence rejection, got %v", err)
 	}
 }
 

--- a/src/wago/gc_exec_arm64_test.go
+++ b/src/wago/gc_exec_arm64_test.go
@@ -26,6 +26,40 @@ func arm64GCStructModule() []byte {
 	)
 }
 
+func arm64GCSparseLiveFrameRootModule(count uint32) []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	locals := append([]byte{0x01}, wasmtest.ULEB(count)...)
+	locals = append(locals, 0x63, 0x00)
+	body := append(locals, 0xfb, 0x01, 0x00, 0x1a, 0x20, 0x00, 0x1a, 0x0b)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
+func TestGCArm64NativeRootAdmissionCompactsDeadDeclaredLocals(t *testing.T) {
+	const declaredRoots = 1138
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), arm64GCSparseLiveFrameRootModule(declaredRoots))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	status := compiled.GCNativeRootAdmission()
+	if !status.Exact || status.Safepoints != 1 || status.MaximumRoots != 1 {
+		t.Fatalf("%d-declared-root arm64 admission = %+v", declaredRoots, status)
+	}
+	in, err := Instantiate(compiled, InstantiateOptions{GC: GCConfig{Profile: GCProfileTiny, TinyHeapBytes: 32, TinyBlockBytes: 32, TinyCollectEveryAlloc: true, VerifyAfterCollect: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if _, err := in.Invoke("run"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestARM64GCNativeABIArtifactAndInstantiationPreflight(t *testing.T) {
 	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), arm64GCStructModule())
 	if err != nil {

--- a/src/wago/gc_frame_liveness.go
+++ b/src/wago/gc_frame_liveness.go
@@ -2,6 +2,7 @@ package wago
 
 import (
 	"fmt"
+	"math/bits"
 
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -20,6 +21,8 @@ const (
 )
 
 const noGCLiveIndex = ^uint32(0)
+
+const maxGCFrameLivenessArenaBytes = 512 << 20
 
 type gcLiveNode struct {
 	use, def   uint32 // tracked-root indexes, or noGCLiveIndex
@@ -52,20 +55,112 @@ type gcFrameLivenessExtra struct {
 	words []uint64 // allocation-site words followed by native-call words
 }
 
+// gcFrameCompactLiveLocals removes collector locals that are dead at every
+// collecting site and returns the maximum population live at any one site.
+// Masks remain site-major and exact; the returned local slices preserve their
+// original frame order.
+func gcFrameCompactLiveLocals(indexes, offsets []uint32, allocations, calls []uint64, extra *gcFrameLivenessExtra) ([]uint32, []uint32, []uint64, []uint64, int, error) {
+	if len(indexes) != len(offsets) {
+		return nil, nil, nil, nil, 0, fmt.Errorf("GC local liveness index/offset count mismatch")
+	}
+	wordCount := (len(indexes) + 63) / 64
+	if wordCount == 0 {
+		wordCount = 1
+	}
+	extraPerSite := wordCount - 1
+	totalSites := len(allocations) + len(calls)
+	extraWords := []uint64(nil)
+	if extra != nil {
+		extraWords = extra.words
+	}
+	if len(extraWords) != totalSites*extraPerSite {
+		return nil, nil, nil, nil, 0, fmt.Errorf("GC local liveness extra-word arena has %d words, want %d", len(extraWords), totalSites*extraPerSite)
+	}
+	lowAt := func(site int) uint64 {
+		if site < len(allocations) {
+			return allocations[site]
+		}
+		return calls[site-len(allocations)]
+	}
+	union := make([]uint64, wordCount)
+	maximum := 0
+	for site := 0; site < totalSites; site++ {
+		low := lowAt(site)
+		union[0] |= low
+		live := bits.OnesCount64(low)
+		for word := 1; word < wordCount; word++ {
+			value := extraWords[site*extraPerSite+word-1]
+			union[word] |= value
+			live += bits.OnesCount64(value)
+		}
+		if live > maximum {
+			maximum = live
+		}
+	}
+	kept := make([]int, 0, len(indexes))
+	for root := range indexes {
+		if union[root/64]&(uint64(1)<<uint(root%64)) != 0 {
+			kept = append(kept, root)
+		}
+	}
+	compactedIndexes := make([]uint32, len(kept))
+	compactedOffsets := make([]uint32, len(kept))
+	for i, root := range kept {
+		compactedIndexes[i] = indexes[root]
+		compactedOffsets[i] = offsets[root]
+	}
+	newWordCount := (len(kept) + 63) / 64
+	if newWordCount == 0 {
+		newWordCount = 1
+	}
+	newExtraPerSite := newWordCount - 1
+	newExtra := make([]uint64, totalSites*newExtraPerSite)
+	for site := 0; site < totalSites; site++ {
+		oldLow := lowAt(site)
+		var newLow uint64
+		for root, oldRoot := range kept {
+			word, bit := oldRoot/64, uint(oldRoot%64)
+			value := oldLow
+			if word != 0 {
+				value = extraWords[site*extraPerSite+word-1]
+			}
+			if value&(uint64(1)<<bit) == 0 {
+				continue
+			}
+			if root < 64 {
+				newLow |= uint64(1) << uint(root)
+			} else {
+				newExtra[site*newExtraPerSite+root/64-1] |= uint64(1) << uint(root%64)
+			}
+		}
+		if site < len(allocations) {
+			allocations[site] = newLow
+		} else {
+			calls[site-len(allocations)] = newLow
+		}
+	}
+	if extra != nil {
+		extra.words = newExtra
+	}
+	return compactedIndexes, compactedOffsets, allocations, calls, maximum, nil
+}
+
 // gcFrameLocalLiveness computes architecture-independent exact backwards local
 // liveness over the validated structured Wasm CFG. The low word for each site is
 // returned directly. For functions wider than 64 collector locals, remaining
 // words are appended to one flat site-major arena in extra.
 // Small functions retain the one-word dataflow path; larger functions use one
-// bounded nodes-by-words arena rather than per-node heap bitsets.
+// bounded nodes-by-words arena rather than per-node heap bitsets. The tracked
+// population may exceed the final per-site root limit; compaction and admission
+// apply that limit after this exact analysis.
 func gcFrameLocalLiveness(body []byte, indexes []uint32, callMasks *[]uint64, extra *gcFrameLivenessExtra) ([]uint64, error) {
 	classifier := wasm.NewModuleInstructionClassifier(nil, true)
 	return gcFrameLocalLivenessWithClassifier(body, indexes, callMasks, extra, &classifier)
 }
 
 func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks *[]uint64, extra *gcFrameLivenessExtra, classifier *wasm.ModuleInstructionClassifier) ([]uint64, error) {
-	if len(indexes) > shared.GCFrameRootLimit {
-		return nil, fmt.Errorf("GC local liveness tracks %d roots, limit %d", len(indexes), shared.GCFrameRootLimit)
+	if len(indexes) > shared.GCFrameTrackedLocalLimit {
+		return nil, fmt.Errorf("GC local liveness tracks %d locals, limit %d", len(indexes), shared.GCFrameTrackedLocalLimit)
 	}
 	bits := make(map[uint32]uint32, len(indexes))
 	for i, index := range indexes {
@@ -283,6 +378,9 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 	if wordCount == 0 {
 		wordCount = 1
 	}
+	if len(nodes) != 0 && wordCount > maxGCFrameLivenessArenaBytes/8/len(nodes) {
+		return nil, fmt.Errorf("GC local liveness arena exceeds %d-byte implementation limit", maxGCFrameLivenessArenaBytes)
+	}
 	liveIn := make([]uint64, len(nodes)*wordCount)
 	changed := true
 	for changed {
@@ -411,8 +509,8 @@ func gcFrameAllLiveMasks(body []byte, localRoots int, extra *gcFrameLivenessExtr
 }
 
 func gcFrameAllLiveMasksWithClassifier(body []byte, localRoots int, extra *gcFrameLivenessExtra, classifier *wasm.ModuleInstructionClassifier) (allocations, calls []uint64, err error) {
-	if localRoots < 0 || localRoots > shared.GCFrameRootLimit {
-		return nil, nil, fmt.Errorf("GC conservative liveness tracks %d roots, limit %d", localRoots, shared.GCFrameRootLimit)
+	if localRoots < 0 || localRoots > shared.GCFrameTrackedLocalLimit {
+		return nil, nil, fmt.Errorf("GC conservative liveness tracks %d locals, limit %d", localRoots, shared.GCFrameTrackedLocalLimit)
 	}
 	wordCount := (localRoots + 63) / 64
 	if wordCount == 0 {

--- a/src/wago/gc_frame_liveness.go
+++ b/src/wago/gc_frame_liveness.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"fmt"
 	"math/bits"
+	"slices"
 
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -24,8 +25,18 @@ const noGCLiveIndex = ^uint32(0)
 
 const maxGCFrameLivenessArenaBytes = 64 << 20
 
+const maxGCFrameBranchTargets = maxGCFrameLivenessArenaBytes / 4
+
+const maxGCFrameLivenessWorkWords = maxGCFrameLivenessArenaBytes / 8
+
 func gcFrameLivenessArenaFits(nodes, words int) bool {
 	return nodes >= 0 && words > 0 && (nodes == 0 || words <= maxGCFrameLivenessArenaBytes/8/nodes)
+}
+
+func gcFrameLivenessWorkFits(nodes, branchEdges, words int) bool {
+	units := nodes + branchEdges
+	return nodes >= 0 && branchEdges >= 0 && units >= nodes && words > 0 &&
+		(units == 0 || words <= maxGCFrameLivenessWorkWords/units)
 }
 
 type gcLiveNode struct {
@@ -210,6 +221,9 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 			if count > uint64(^uint32(0)) || uint64(len(branchTargets))+count > uint64(^uint32(0)) {
 				return nil, fmt.Errorf("GC liveness br_table target count exceeds implementation limit")
 			}
+			if count > uint64(maxGCFrameBranchTargets) || uint64(len(branchTargets))+count > uint64(maxGCFrameBranchTargets) {
+				return nil, fmt.Errorf("GC liveness br_table target arena exceeds %d-byte implementation limit", maxGCFrameLivenessArenaBytes)
+			}
 			node.flow = gcLiveBrTable
 			node.index = uint32(len(branchTargets))
 			node.indexN = uint32(count)
@@ -330,6 +344,7 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 		}
 		return target, target < len(nodes), nil
 	}
+	branchEdgeN := 0
 	for i := range nodes {
 		next := i + 1
 		addNext := func() {
@@ -387,9 +402,26 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 					succN++
 				}
 			}
-			nodes[i].indexN = uint32(succN)
+			// The liveness equation unions successors, so duplicate destinations
+			// carry no information. Compact them once before bitmap dataflow to
+			// keep repeated br_table labels from multiplying work by local width.
+			targets = targets[:succN]
+			slices.Sort(targets)
+			targets = slices.Compact(targets)
+			nodes[i].indexN = uint32(len(targets))
+			branchEdgeN += len(targets)
 		case gcLiveStop:
 		}
+	}
+	wordCount := (len(indexes) + 63) / 64
+	if wordCount == 0 {
+		wordCount = 1
+	}
+	if !gcFrameLivenessArenaFits(len(nodes), wordCount) {
+		return nil, fmt.Errorf("GC local liveness arena exceeds %d-byte implementation limit", maxGCFrameLivenessArenaBytes)
+	}
+	if !gcFrameLivenessWorkFits(len(nodes), branchEdgeN, wordCount) {
+		return nil, fmt.Errorf("GC local liveness graph exceeds %d bitmap-word implementation limit", maxGCFrameLivenessWorkWords)
 	}
 
 	work := []int{0}
@@ -409,13 +441,6 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 				work = append(work, int(succ))
 			}
 		}
-	}
-	wordCount := (len(indexes) + 63) / 64
-	if wordCount == 0 {
-		wordCount = 1
-	}
-	if !gcFrameLivenessArenaFits(len(nodes), wordCount) {
-		return nil, fmt.Errorf("GC local liveness arena exceeds %d-byte implementation limit", maxGCFrameLivenessArenaBytes)
 	}
 	liveIn := make([]uint64, len(nodes)*wordCount)
 	changed := true

--- a/src/wago/gc_frame_liveness.go
+++ b/src/wago/gc_frame_liveness.go
@@ -100,20 +100,32 @@ func gcFrameCompactLiveLocals(indexes, offsets []uint32, allocations, calls []ui
 		if live > maximum {
 			maximum = live
 		}
-	}
-	kept := make([]int, 0, len(indexes))
-	for root := range indexes {
-		if union[root/64]&(uint64(1)<<uint(root%64)) != 0 {
-			kept = append(kept, root)
+		if live > shared.GCFrameRootLimit {
+			return nil, nil, nil, nil, maximum, fmt.Errorf("GC local liveness has %d simultaneously live collector locals, limit %d", live, shared.GCFrameRootLimit)
 		}
 	}
-	compactedIndexes := make([]uint32, len(kept))
-	compactedOffsets := make([]uint32, len(kept))
-	for i, root := range kept {
-		compactedIndexes[i] = indexes[root]
-		compactedOffsets[i] = offsets[root]
+	// Every set bit in a site belongs to the union. Retain a direct old-to-new
+	// mapping so reconstruction visits arena words and live bits rather than
+	// rescanning the complete retained union at every site.
+	remap := make([]uint32, len(indexes))
+	kept := 0
+	for root := range indexes {
+		if union[root/64]&(uint64(1)<<uint(root%64)) != 0 {
+			remap[root] = uint32(kept)
+			kept++
+		}
 	}
-	newWordCount := (len(kept) + 63) / 64
+	compactedIndexes := make([]uint32, kept)
+	compactedOffsets := make([]uint32, kept)
+	compacted := 0
+	for root := range indexes {
+		if union[root/64]&(uint64(1)<<uint(root%64)) != 0 {
+			compactedIndexes[compacted] = indexes[root]
+			compactedOffsets[compacted] = offsets[root]
+			compacted++
+		}
+	}
+	newWordCount := (kept + 63) / 64
 	if newWordCount == 0 {
 		newWordCount = 1
 	}
@@ -122,19 +134,24 @@ func gcFrameCompactLiveLocals(indexes, offsets []uint32, allocations, calls []ui
 	for site := 0; site < totalSites; site++ {
 		oldLow := lowAt(site)
 		var newLow uint64
-		for root, oldRoot := range kept {
-			word, bit := oldRoot/64, uint(oldRoot%64)
+		for word := 0; word < wordCount; word++ {
 			value := oldLow
 			if word != 0 {
 				value = extraWords[site*extraPerSite+word-1]
 			}
-			if value&(uint64(1)<<bit) == 0 {
-				continue
-			}
-			if root < 64 {
-				newLow |= uint64(1) << uint(root)
-			} else {
-				newExtra[site*newExtraPerSite+root/64-1] |= uint64(1) << uint(root%64)
+			for value != 0 {
+				bit := bits.TrailingZeros64(value)
+				value &= value - 1
+				oldRoot := word*64 + bit
+				if oldRoot >= len(remap) { // Ignore unused padding bits in the final word.
+					continue
+				}
+				root := int(remap[oldRoot])
+				if root < 64 {
+					newLow |= uint64(1) << uint(root)
+				} else {
+					newExtra[site*newExtraPerSite+root/64-1] |= uint64(1) << uint(root%64)
+				}
 			}
 		}
 		if site < len(allocations) {

--- a/src/wago/gc_frame_liveness.go
+++ b/src/wago/gc_frame_liveness.go
@@ -528,8 +528,8 @@ func gcFrameAllLiveMasks(body []byte, localRoots int, extra *gcFrameLivenessExtr
 }
 
 func gcFrameAllLiveMasksWithClassifier(body []byte, localRoots int, extra *gcFrameLivenessExtra, classifier *wasm.ModuleInstructionClassifier) (allocations, calls []uint64, err error) {
-	if localRoots < 0 || localRoots > shared.GCFrameTrackedLocalLimit {
-		return nil, nil, fmt.Errorf("GC conservative liveness tracks %d locals, limit %d", localRoots, shared.GCFrameTrackedLocalLimit)
+	if localRoots < 0 || localRoots > shared.GCFrameRootLimit {
+		return nil, nil, fmt.Errorf("GC conservative liveness tracks %d locals, limit %d", localRoots, shared.GCFrameRootLimit)
 	}
 	wordCount := (localRoots + 63) / 64
 	if wordCount == 0 {

--- a/src/wago/gc_frame_liveness.go
+++ b/src/wago/gc_frame_liveness.go
@@ -22,7 +22,11 @@ const (
 
 const noGCLiveIndex = ^uint32(0)
 
-const maxGCFrameLivenessArenaBytes = 512 << 20
+const maxGCFrameLivenessArenaBytes = 64 << 20
+
+func gcFrameLivenessArenaFits(nodes, words int) bool {
+	return nodes >= 0 && words > 0 && (nodes == 0 || words <= maxGCFrameLivenessArenaBytes/8/nodes)
+}
 
 type gcLiveNode struct {
 	use, def   uint32 // tracked-root indexes, or noGCLiveIndex
@@ -219,20 +223,19 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 			}
 		}
 		node.nativeCall = imm.Kind == wasm.InstrCall || imm.Kind == wasm.InstrCallIndirect || imm.Kind == wasm.InstrCallRef
-		if node.nativeCall {
-			nativeCallN++
-		}
+		keep := node.use != noGCLiveIndex || node.def != noGCLiveIndex || node.nativeCall || node.flow == gcLiveBrTable
 		if op == 0xfb {
 			switch imm.Subopcode {
 			case 0, 1, 6, 7, 8, 9, 10: // struct.new*, array.new*
 				node.allocation = true
-				allocationN++
+				keep = true
 			}
 		}
 
 		nodeIndex := len(nodes)
 		switch op {
 		case 0x02, 0x03, 0x04: // block, loop, if
+			keep = true
 			frames = append(frames, gcLiveFrame{loop: op == 0x03, header: nodeIndex, elseNode: -1, endNode: -1})
 			node.index = uint32(len(frames) - 1)
 			stack = append(stack, int(node.index))
@@ -240,6 +243,7 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 				node.flow = gcLiveIf
 			}
 		case 0x05: // else
+			keep = true
 			if len(stack) <= 1 {
 				return nil, fmt.Errorf("GC liveness else without if")
 			}
@@ -247,6 +251,7 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 			frames[top].elseNode = nodeIndex
 			node.index, node.flow = uint32(top), gcLiveElse
 		case 0x0b: // end
+			keep = true
 			if len(stack) == 0 {
 				return nil, fmt.Errorf("GC liveness end without frame")
 			}
@@ -254,29 +259,43 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 			frames[top].endNode = nodeIndex
 			stack = stack[:len(stack)-1]
 		case 0x0c: // br
+			keep = true
 			target, ok := gcLiveBranchFrame(stack, imm.Index)
 			if !ok {
 				return nil, fmt.Errorf("GC liveness br depth %d is out of range", imm.Index)
 			}
 			node.flow, node.index = gcLiveBr, uint32(target)
 		case 0x0d: // br_if
+			keep = true
 			target, ok := gcLiveBranchFrame(stack, imm.Index)
 			if !ok {
 				return nil, fmt.Errorf("GC liveness br_if depth %d is out of range", imm.Index)
 			}
 			node.flow, node.index = gcLiveBrIf, uint32(target)
 		case 0x00, 0x0f: // unreachable, return
+			keep = true
 			node.flow = gcLiveStop
 		}
 		switch imm.Kind {
 		case wasm.InstrBrOnNull, wasm.InstrBrOnNonNull, wasm.InstrBrOnCast, wasm.InstrBrOnCastFail:
+			keep = true
 			target, ok := gcLiveBranchFrame(stack, imm.Index)
 			if !ok {
 				return nil, fmt.Errorf("GC liveness reference branch depth %d is out of range", imm.Index)
 			}
 			node.flow, node.index = gcLiveBrIf, uint32(target)
 		case wasm.InstrThrow, wasm.InstrThrowRef, wasm.InstrReturnCall, wasm.InstrReturnCallIndirect, wasm.InstrReturnCallRef:
+			keep = true
 			node.flow = gcLiveStop
+		}
+		if !keep {
+			continue
+		}
+		if node.nativeCall {
+			nativeCallN++
+		}
+		if node.allocation {
+			allocationN++
 		}
 		nodes = append(nodes, node)
 	}
@@ -378,7 +397,7 @@ func gcFrameLocalLivenessWithClassifier(body []byte, indexes []uint32, callMasks
 	if wordCount == 0 {
 		wordCount = 1
 	}
-	if len(nodes) != 0 && wordCount > maxGCFrameLivenessArenaBytes/8/len(nodes) {
+	if !gcFrameLivenessArenaFits(len(nodes), wordCount) {
 		return nil, fmt.Errorf("GC local liveness arena exceeds %d-byte implementation limit", maxGCFrameLivenessArenaBytes)
 	}
 	liveIn := make([]uint64, len(nodes)*wordCount)

--- a/src/wago/gc_frame_liveness_test.go
+++ b/src/wago/gc_frame_liveness_test.go
@@ -188,6 +188,43 @@ func TestGCFrameLocalLivenessCompactsDeadDeclaredRoots(t *testing.T) {
 	}
 }
 
+func TestGCFrameLocalLivenessCompactsDisjointWideRoots(t *testing.T) {
+	const roots = 4096
+	indexes, offsets, allocations, extra := gcFrameDisjointRootMasks(roots)
+	indexes, offsets, allocations, _, maximum, err := gcFrameCompactLiveLocals(indexes, offsets, allocations, nil, &extra)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(indexes) != roots || len(offsets) != roots || maximum != 1 {
+		t.Fatalf("compacted disjoint roots: indexes=%d offsets=%d maximum=%d", len(indexes), len(offsets), maximum)
+	}
+	plan := shared.GCFrameRootPlan{LocalOffsets: offsets, LiveLocalMasks: allocations, LiveMaskExtraWords: extra.words}
+	for _, root := range []int{0, 63, 64, roots - 1} {
+		if !plan.LocalLiveAt(root, root) {
+			t.Fatalf("site %d lost its only live root", root)
+		}
+	}
+}
+
+func TestGCFrameLocalLivenessCompactionRejectsTooManyLiveRootsBeforeRebuild(t *testing.T) {
+	const roots = shared.GCFrameRootLimit + 1
+	indexes := make([]uint32, roots)
+	offsets := make([]uint32, roots)
+	allocations := []uint64{^uint64(0)}
+	extra := gcFrameLivenessExtra{words: make([]uint64, (roots+63)/64-1)}
+	for i := range indexes {
+		indexes[i], offsets[i] = uint32(i), uint32(i*8)
+	}
+	for i := range extra.words {
+		extra.words[i] = ^uint64(0)
+	}
+	extra.words[len(extra.words)-1] = 1
+	_, _, _, _, _, err := gcFrameCompactLiveLocals(indexes, offsets, allocations, nil, &extra)
+	if err == nil || !strings.Contains(err.Error(), "1025 simultaneously live collector locals, limit 1024") {
+		t.Fatalf("wide simultaneous-root compaction error = %v", err)
+	}
+}
+
 func TestGCFrameLocalLivenessConsumesMixedWidthMemarg(t *testing.T) {
 	m := &wasm.Module{Memories: []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1, Addr64: true}}}}
 	classifier := wasm.NewModuleInstructionClassifier(m, true)
@@ -291,6 +328,38 @@ func BenchmarkGCFrameLocalLivenessSparseDeclaredRoots(b *testing.B) {
 			b.Fatalf("sparse compaction offsets=%d maximum=%d err=%v", len(compacted), maximum, err)
 		}
 	}
+}
+
+func BenchmarkGCFrameCompactDisjointWideRoots(b *testing.B) {
+	const roots = 10_000
+	indexes, offsets, allocations, extra := gcFrameDisjointRootMasks(roots)
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(extra.words)*8), "input-arena-bytes")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var err error
+		indexes, offsets, allocations, _, _, err = gcFrameCompactLiveLocals(indexes, offsets, allocations, nil, &extra)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func gcFrameDisjointRootMasks(roots int) (indexes, offsets []uint32, allocations []uint64, extra gcFrameLivenessExtra) {
+	indexes = make([]uint32, roots)
+	offsets = make([]uint32, roots)
+	allocations = make([]uint64, roots)
+	extraPerSite := (roots+63)/64 - 1
+	extra.words = make([]uint64, roots*extraPerSite)
+	for root := 0; root < roots; root++ {
+		indexes[root], offsets[root] = uint32(root), uint32(16+root*8)
+		if root < 64 {
+			allocations[root] = uint64(1) << uint(root)
+		} else {
+			extra.words[root*extraPerSite+root/64-1] = uint64(1) << uint(root%64)
+		}
+	}
+	return
 }
 
 func BenchmarkGCFrameLocalLiveness(b *testing.B) {

--- a/src/wago/gc_frame_liveness_test.go
+++ b/src/wago/gc_frame_liveness_test.go
@@ -242,6 +242,13 @@ func TestGCFrameLocalLivenessArenaBudget(t *testing.T) {
 	}
 }
 
+func TestGCFrameConservativeLivenessRejectsWideRootsBeforeSiteAllocation(t *testing.T) {
+	_, _, err := gcFrameAllLiveMasks([]byte{0x0b}, shared.GCFrameRootLimit+1, nil)
+	if err == nil || !strings.Contains(err.Error(), "conservative liveness tracks 1025") {
+		t.Fatalf("wide conservative root error = %v", err)
+	}
+}
+
 func BenchmarkGCFrameLocalLivenessRootCounts(b *testing.B) {
 	for _, roots := range []int{64, 65, 128, 256, 1024} {
 		b.Run(fmt.Sprintf("roots=%d", roots), func(b *testing.B) {

--- a/src/wago/gc_frame_liveness_test.go
+++ b/src/wago/gc_frame_liveness_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
 )
 
 func gcFrameLivenessBenchmarkBody(n int) []byte {
@@ -249,6 +250,29 @@ func TestGCFrameLocalLivenessRejectsUnrepresentableBrTable(t *testing.T) {
 	}
 }
 
+func TestGCFrameLocalLivenessDeduplicatesRepeatedWideBranchTable(t *testing.T) {
+	const roots, targets = 30_000, 100_000
+	indexes := make([]uint32, roots)
+	for i := range indexes {
+		indexes[i] = uint32(i)
+	}
+	if _, err := gcFrameLocalLiveness(gcFrameRepeatedBranchTableBody(targets), indexes, nil, nil); err != nil {
+		t.Fatalf("repeated-target br_table liveness: %v", err)
+	}
+}
+
+func TestGCFrameLocalLivenessBudgetsDistinctWideBranchTableEdges(t *testing.T) {
+	const roots, targets = 8192, 30_000
+	indexes := make([]uint32, roots)
+	for i := range indexes {
+		indexes[i] = uint32(i)
+	}
+	_, err := gcFrameLocalLiveness(gcFrameDistinctBranchTableBody(targets), indexes, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "graph exceeds 8388608 bitmap-word implementation limit") {
+		t.Fatalf("distinct-target br_table liveness error = %v", err)
+	}
+}
+
 func TestGCFrameLocalLivenessAllocationBudget(t *testing.T) {
 	if got := unsafe.Sizeof(gcLiveNode{}); got != 32 {
 		t.Fatalf("gcLiveNode size = %d, want 32 bytes", got)
@@ -276,6 +300,12 @@ func TestGCFrameLocalLivenessArenaBudget(t *testing.T) {
 	}
 	if gcFrameLivenessArenaFits(boundary+1, words) {
 		t.Fatal("liveness arena accepted a byte above its 64 MiB boundary")
+	}
+	if !gcFrameLivenessWorkFits(1, boundary-1, words) {
+		t.Fatal("liveness work rejected its exact 64 MiB-equivalent boundary")
+	}
+	if gcFrameLivenessWorkFits(1, boundary, words) {
+		t.Fatal("liveness work accepted one unit above its 64 MiB-equivalent boundary")
 	}
 }
 
@@ -376,4 +406,47 @@ func BenchmarkGCFrameLocalLiveness(b *testing.B) {
 			b.Fatalf("mask counts = %d allocations, %d calls; want 1024, 0", len(masks), len(callMasks))
 		}
 	}
+}
+
+func BenchmarkGCFrameLocalLivenessRepeatedWideBranchTable(b *testing.B) {
+	const roots, targets = 30_000, 250_000
+	indexes := make([]uint32, roots)
+	for i := range indexes {
+		indexes[i] = uint32(i)
+	}
+	body := gcFrameRepeatedBranchTableBody(targets)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(targets, "raw-edges/op")
+	for i := 0; i < b.N; i++ {
+		if _, err := gcFrameLocalLiveness(body, indexes, nil, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func gcFrameRepeatedBranchTableBody(targets int) []byte {
+	body := make([]byte, 0, targets+16)
+	body = append(body, 0x02, 0x40, 0x41, 0x00, 0x0e) // block; i32.const 0; br_table
+	body = append(body, wasmtest.ULEB(uint32(targets-1))...)
+	for i := 0; i < targets; i++ { // vector targets plus the default target
+		body = append(body, 0x00)
+	}
+	return append(body, 0x0b, 0x0b)
+}
+
+func gcFrameDistinctBranchTableBody(targets int) []byte {
+	body := make([]byte, 0, targets*6)
+	for i := 0; i < targets; i++ {
+		body = append(body, 0x02, 0x40) // block
+	}
+	body = append(body, 0x41, 0x00, 0x0e) // i32.const 0; br_table
+	body = append(body, wasmtest.ULEB(uint32(targets-1))...)
+	for depth := 0; depth < targets; depth++ { // vector targets plus default
+		body = append(body, wasmtest.ULEB(uint32(depth))...)
+	}
+	for i := 0; i < targets; i++ {
+		body = append(body, 0x0b)
+	}
+	return append(body, 0x0b)
 }

--- a/src/wago/gc_frame_liveness_test.go
+++ b/src/wago/gc_frame_liveness_test.go
@@ -161,6 +161,33 @@ func TestGCFrameLocalLivenessWideMasks(t *testing.T) {
 	}
 }
 
+func TestGCFrameLocalLivenessCompactsDeadDeclaredRoots(t *testing.T) {
+	const roots = 1138
+	indexes := make([]uint32, roots)
+	offsets := make([]uint32, roots)
+	for i := range indexes {
+		indexes[i], offsets[i] = uint32(i), uint32(16+i*8)
+	}
+	body := []byte{0xfb, 0x01, 0x00, 0x1a, 0x20, 0x00, 0x1a, 0x0b}
+	var calls []uint64
+	var extra gcFrameLivenessExtra
+	allocations, err := gcFrameLocalLiveness(body, indexes, &calls, &extra)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexes, offsets, allocations, calls, maximum, err := gcFrameCompactLiveLocals(indexes, offsets, allocations, calls, &extra)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if maximum != 1 || len(indexes) != 1 || indexes[0] != 0 || len(offsets) != 1 || len(extra.words) != 0 {
+		t.Fatalf("compacted roots: maximum=%d indexes=%v offsets=%v extra=%d", maximum, indexes, offsets, len(extra.words))
+	}
+	plan := shared.GCFrameRootPlan{LocalOffsets: offsets, LiveLocalMasks: allocations, LiveCallLocalMasks: calls, LiveMaskExtraWords: extra.words}
+	if !plan.ValidLiveMasks() || !plan.LocalLiveAt(0, 0) {
+		t.Fatalf("compacted plan = %+v", plan)
+	}
+}
+
 func TestGCFrameLocalLivenessConsumesMixedWidthMemarg(t *testing.T) {
 	m := &wasm.Module{Memories: []wasm.MemType{{Limits: wasm.Limits{Min: 1}}, {Limits: wasm.Limits{Min: 1, Addr64: true}}}}
 	classifier := wasm.NewModuleInstructionClassifier(m, true)
@@ -222,6 +249,29 @@ func BenchmarkGCFrameLocalLivenessRootCounts(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func BenchmarkGCFrameLocalLivenessSparseDeclaredRoots(b *testing.B) {
+	const roots = 1138
+	indexes := make([]uint32, roots)
+	offsets := make([]uint32, roots)
+	for i := range indexes {
+		indexes[i], offsets[i] = uint32(i), uint32(16+i*8)
+	}
+	body := []byte{0xfb, 0x01, 0x00, 0x1a, 0x20, 0x00, 0x1a, 0x0b}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var calls []uint64
+		var extra gcFrameLivenessExtra
+		allocations, err := gcFrameLocalLiveness(body, indexes, &calls, &extra)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, compacted, _, _, maximum, err := gcFrameCompactLiveLocals(indexes, offsets, allocations, calls, &extra)
+		if err != nil || len(compacted) != 1 || maximum != 1 {
+			b.Fatalf("sparse compaction offsets=%d maximum=%d err=%v", len(compacted), maximum, err)
+		}
 	}
 }
 

--- a/src/wago/gc_frame_liveness_test.go
+++ b/src/wago/gc_frame_liveness_test.go
@@ -231,6 +231,17 @@ func TestGCFrameLocalLivenessAllocationBudget(t *testing.T) {
 	}
 }
 
+func TestGCFrameLocalLivenessArenaBudget(t *testing.T) {
+	const words = (1138 + 63) / 64
+	boundary := maxGCFrameLivenessArenaBytes / 8 / words
+	if !gcFrameLivenessArenaFits(boundary, words) {
+		t.Fatal("liveness arena rejected its exact 64 MiB boundary")
+	}
+	if gcFrameLivenessArenaFits(boundary+1, words) {
+		t.Fatal("liveness arena accepted a byte above its 64 MiB boundary")
+	}
+}
+
 func BenchmarkGCFrameLocalLivenessRootCounts(b *testing.B) {
 	for _, roots := range []int{64, 65, 128, 256, 1024} {
 		b.Run(fmt.Sprintf("roots=%d", roots), func(b *testing.B) {

--- a/src/wago/gc_frame_roots.go
+++ b/src/wago/gc_frame_roots.go
@@ -206,7 +206,7 @@ func validGCModuleFrameRootPlan(module *shared.GCModuleFrameRootPlan) bool {
 		if plan == nil {
 			continue // proven non-collecting function; no active-frame map is needed
 		}
-		if !plan.Candidate || !plan.Exact || !plan.ValidLiveMasks() || len(plan.LiveLocalMasks) != len(plan.Safepoints) || len(plan.LocalIndexes) != len(plan.LocalOffsets) || len(plan.LocalOffsets) > gcNativeFrameRootLimit {
+		if !plan.Candidate || !plan.Exact || !plan.ValidLiveMasks() || len(plan.LiveLocalMasks) != len(plan.Safepoints) || len(plan.LocalIndexes) != len(plan.LocalOffsets) || len(plan.LocalOffsets) > shared.GCFrameTrackedLocalLimit {
 			return false
 		}
 		active := len(plan.Safepoints) != 0 || len(plan.Callsites) != 0

--- a/src/wago/gc_frame_roots_amd64_test.go
+++ b/src/wago/gc_frame_roots_amd64_test.go
@@ -758,6 +758,45 @@ func gcFrameRootLimitModule(count uint32) []byte {
 	)
 }
 
+func gcSparseLiveFrameRootModule(count uint32) []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	locals := append([]byte{0x01}, wasmtest.ULEB(count)...)
+	locals = append(locals, 0x63, 0x00)
+	body := append(locals,
+		0xfb, 0x01, 0x00, 0x1a, // struct.new_default; drop
+		0x20, 0x00, 0x1a, // local.get 0; drop: only this local crosses collection
+		0x0b,
+	)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
+func gcDisjointLiveFrameRootModule(count uint32) []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01}
+	locals := append([]byte{0x01}, wasmtest.ULEB(count)...)
+	locals = append(locals, 0x63, 0x00)
+	body := locals
+	for i := uint32(0); i < count; i++ {
+		body = append(body, 0xfb, 0x01, 0x00, 0x21) // new default; local.set i
+		body = append(body, wasmtest.ULEB(i)...)
+		body = append(body, 0xfb, 0x01, 0x00, 0x1a) // collect while only i is live
+		body = append(body, 0x20)
+		body = append(body, wasmtest.ULEB(i)...)
+		body = append(body, 0x1a) // local.get i; drop
+	}
+	body = append(body, 0x0b)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
 func gcRepeatedFrameRootModule(count uint32) []byte {
 	structType := []byte{0x5f, 0x01, 0x7b, 0x01}
 	locals := append([]byte{0x01}, wasmtest.ULEB(count)...)
@@ -1022,11 +1061,49 @@ func TestGCNativeRootAdmissionDiagnostic(t *testing.T) {
 	}
 	defer compiled.Close()
 	status := compiled.GCNativeRootAdmission()
-	if !status.Required || status.Exact || !strings.Contains(status.Reason, "exceeds 1024 collector roots") {
+	if !status.Required || status.Exact || !strings.Contains(status.Reason, "exceeds 1024 simultaneously live collector roots") {
 		t.Fatalf("oversized root admission = %+v", status)
 	}
 	if compiled.genericGCFrameRoots() != nil {
 		t.Fatal("oversized root module retained exact root maps")
+	}
+}
+
+func TestGCNativeRootAdmissionCompactsDeadDeclaredLocals(t *testing.T) {
+	const declaredRoots = 1138
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), gcSparseLiveFrameRootModule(declaredRoots))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	status := compiled.GCNativeRootAdmission()
+	if !status.Exact || status.Safepoints != 1 || status.MaximumRoots != 1 {
+		t.Fatalf("%d-declared-root admission = %+v", declaredRoots, status)
+	}
+	plan := compiled.genericGCFrameRoots()
+	if plan == nil || len(plan.safepoints) != 1 || len(plan.safepoints[0].offsets) != 1 {
+		t.Fatalf("compacted native root plan = %+v", plan)
+	}
+	in, err := Instantiate(compiled, InstantiateOptions{GC: GCConfig{Profile: GCProfileTiny, TinyHeapBytes: 32, TinyBlockBytes: 32, TinyCollectEveryAlloc: true, VerifyAfterCollect: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if _, err := in.Invoke("run"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGCNativeRootAdmissionAllowsWideDisjointLiveUnion(t *testing.T) {
+	const declaredRoots = shared.GCFrameRootLimit + 1
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), gcDisjointLiveFrameRootModule(declaredRoots))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	status := compiled.GCNativeRootAdmission()
+	if !status.Exact || status.Safepoints != 2*declaredRoots || status.MaximumRoots != 1 {
+		t.Fatalf("%d-root disjoint-union admission = %+v", declaredRoots, status)
 	}
 }
 

--- a/src/wago/gc_frame_roots_arm64.go
+++ b/src/wago/gc_frame_roots_arm64.go
@@ -4,7 +4,6 @@ package wago
 
 import (
 	"fmt"
-	"math"
 
 	railarm64 "github.com/wago-org/wago/src/core/compiler/backend/railshot/arm64"
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
@@ -97,7 +96,7 @@ functions:
 		slot, local := 0, uint32(0)
 		add := func(t wasm.ValType) bool {
 			if collectorFrameRefType(m, t) {
-				if len(plan.LocalOffsets) == shared.GCFrameRootLimit || slot > (math.MaxUint32-shared.ARM64FrameHeaderBytes)/8 {
+				if len(plan.LocalOffsets) == shared.GCFrameTrackedLocalLimit {
 					return false
 				}
 				plan.LocalIndexes = append(plan.LocalIndexes, local)
@@ -116,7 +115,7 @@ functions:
 				if !mayCollect {
 					continue functions
 				}
-				return reject("function %d exceeds %d collector roots or the frame-offset bound", function, shared.GCFrameRootLimit)
+				return reject("function %d exceeds %d tracked collector locals", function, shared.GCFrameTrackedLocalLimit)
 			}
 		}
 		for _, run := range m.Code[function].Locals.Runs {
@@ -125,7 +124,7 @@ functions:
 					if !mayCollect {
 						continue functions
 					}
-					return reject("function %d exceeds %d collector roots or the frame-offset bound", function, shared.GCFrameRootLimit)
+					return reject("function %d exceeds %d tracked collector locals", function, shared.GCFrameTrackedLocalLimit)
 				}
 			}
 		}
@@ -141,6 +140,14 @@ functions:
 		}
 		if err != nil {
 			return reject("function %d exact local liveness: %v", function, err)
+		}
+		var maximumLive int
+		plan.LocalIndexes, plan.LocalOffsets, liveMasks, callMasks, maximumLive, err = gcFrameCompactLiveLocals(plan.LocalIndexes, plan.LocalOffsets, liveMasks, callMasks, &maskExtra)
+		if err != nil {
+			return reject("function %d exact local liveness: %v", function, err)
+		}
+		if maximumLive > shared.GCFrameRootLimit {
+			return reject("function %d has %d simultaneously live collector locals, limit %d", function, maximumLive, shared.GCFrameRootLimit)
 		}
 		if uint64(safepointBase)+uint64(len(liveMasks)) > uint64(shared.GCSafepointIDMax) {
 			return reject("function %d exceeds the dense safepoint ID bound", function)

--- a/src/wago/gc_frame_roots_arm64.go
+++ b/src/wago/gc_frame_roots_arm64.go
@@ -134,6 +134,9 @@ functions:
 		var liveMasks, callMasks []uint64
 		var maskExtra gcFrameLivenessExtra
 		if arm64BodyUsesEH(m.Code[function].BodyBytes, &classifier) {
+			if len(plan.LocalIndexes) > shared.GCFrameRootLimit {
+				return reject("function %d has %d simultaneously live collector locals, limit %d", function, len(plan.LocalIndexes), shared.GCFrameRootLimit)
+			}
 			liveMasks, callMasks, err = arm64GCFrameConservativeMasks(m.Code[function].BodyBytes, len(plan.LocalIndexes), &maskExtra, &classifier)
 		} else {
 			liveMasks, err = gcFrameLocalLivenessWithClassifier(m.Code[function].BodyBytes, plan.LocalIndexes, &callMasks, &maskExtra, &classifier)

--- a/src/wago/gc_frame_roots_linux_amd64.go
+++ b/src/wago/gc_frame_roots_linux_amd64.go
@@ -140,6 +140,9 @@ functions:
 		var maskExtra gcFrameLivenessExtra
 		var err error
 		if bodyUsesEH(m.Code[function].BodyBytes, &classifier) {
+			if len(plan.LocalIndexes) > shared.GCFrameRootLimit {
+				return reject("function %d has %d simultaneously live collector locals, limit %d", function, len(plan.LocalIndexes), shared.GCFrameRootLimit)
+			}
 			liveMasks, callMasks, err = gcFrameConservativeMasks(m.Code[function].BodyBytes, len(plan.LocalIndexes), &maskExtra, &classifier)
 		} else {
 			liveMasks, err = gcFrameLocalLivenessWithClassifier(m.Code[function].BodyBytes, plan.LocalIndexes, &callMasks, &maskExtra, &classifier)

--- a/src/wago/gc_frame_roots_linux_amd64.go
+++ b/src/wago/gc_frame_roots_linux_amd64.go
@@ -4,7 +4,6 @@ package wago
 
 import (
 	"fmt"
-	"math"
 
 	railamd64 "github.com/wago-org/wago/src/core/compiler/backend/railshot/amd64"
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
@@ -15,9 +14,10 @@ import (
 // newGCFrameRootPlan admits bounded exact native-root call graphs. Direct local
 // and synchronous host calls may use the wrapper ABI, while dynamic typed-
 // reference calls retain their smaller register-ABI proof. Functions retain a
-// one-word path through 64 collector roots and use compact flat word arenas up
-// to shared.GCFrameRootLimit. Each function gets independent compile state so
-// railshot workers may populate maps in parallel.
+// one-word path through 64 tracked collector locals and use compact flat word
+// arenas for larger configured populations. Dead-at-all-sites locals are
+// removed before the per-site shared.GCFrameRootLimit is enforced. Each
+// function gets independent compile state so workers may populate maps in parallel.
 func newGCFrameRootPlan(m *wasm.Module, exactRoots bool) *shared.GCModuleFrameRootPlan {
 	if !exactRoots {
 		return nil
@@ -104,7 +104,7 @@ functions:
 		slot, local := 0, uint32(0)
 		add := func(t wasm.ValType) bool {
 			if collectorFrameRefType(m, t) {
-				if len(plan.LocalOffsets) == shared.GCFrameRootLimit || slot > (math.MaxUint32-shared.AMD64FrameHeaderBytes)/8 {
+				if len(plan.LocalOffsets) == shared.GCFrameTrackedLocalLimit {
 					return false
 				}
 				plan.LocalIndexes = append(plan.LocalIndexes, local)
@@ -123,7 +123,7 @@ functions:
 				if !mayCollect {
 					continue functions
 				}
-				return reject("function %d exceeds %d collector roots or the frame-offset bound", function, shared.GCFrameRootLimit)
+				return reject("function %d exceeds %d tracked collector locals", function, shared.GCFrameTrackedLocalLimit)
 			}
 		}
 		for _, run := range m.Code[function].Locals.Runs {
@@ -132,7 +132,7 @@ functions:
 					if !mayCollect {
 						continue functions
 					}
-					return reject("function %d exceeds %d collector roots or the frame-offset bound", function, shared.GCFrameRootLimit)
+					return reject("function %d exceeds %d tracked collector locals", function, shared.GCFrameTrackedLocalLimit)
 				}
 			}
 		}
@@ -146,6 +146,14 @@ functions:
 		}
 		if err != nil {
 			return reject("function %d exact local liveness: %v", function, err)
+		}
+		var maximumLive int
+		plan.LocalIndexes, plan.LocalOffsets, liveMasks, callMasks, maximumLive, err = gcFrameCompactLiveLocals(plan.LocalIndexes, plan.LocalOffsets, liveMasks, callMasks, &maskExtra)
+		if err != nil {
+			return reject("function %d exact local liveness: %v", function, err)
+		}
+		if maximumLive > shared.GCFrameRootLimit {
+			return reject("function %d has %d simultaneously live collector locals, limit %d", function, maximumLive, shared.GCFrameRootLimit)
 		}
 		if !collectorBoundary && bodyUsesNativeCall(m.Code[function].BodyBytes, &classifier) && !gcFrameReferenceCallABI(m, ft) {
 			return reject("function %d exceeds the exact native caller ABI", function)

--- a/wago.go
+++ b/wago.go
@@ -263,6 +263,7 @@ const (
 	CoreFeaturesV1                             = impl.CoreFeaturesV1
 	CoreFeaturesV2                             = impl.CoreFeaturesV2
 	CoreFeaturesV3                             = impl.CoreFeaturesV3
+	DefaultMaxFunctionLocals                   = impl.DefaultMaxFunctionLocals
 	Deprecated                                 = impl.Deprecated
 	ElemModeActive                             = impl.ElemModeActive
 	ElemModeDeclarative                        = impl.ElemModeDeclarative
@@ -303,6 +304,7 @@ const (
 	ImportTag                                  = impl.ImportTag
 	InstantiateDirect                          = impl.InstantiateDirect
 	InstantiateManaged                         = impl.InstantiateManaged
+	MaxFunctionLocalsLimit                     = impl.MaxFunctionLocalsLimit
 	NoPluginOverrides                          = impl.NoPluginOverrides
 	PackedTypeI16                              = impl.PackedTypeI16
 	PackedTypeI8                               = impl.PackedTypeI8


### PR DESCRIPTION
## Summary

- base native GC-root admission on the roots simultaneously live at each collecting site instead of all declared reference locals
- compact locals that are dead at every allocation/call while allowing disjoint live-root unions above 1,024
- add `RuntimeConfig.WithMaxFunctionLocals`, defaulting total parameters plus declared locals to 4,096 and accepting configured ceilings from 1 through 65,535
- keep the independent 256 KiB native stack-fence authoritative and include the new admission policy in artifact-cache keys

## Safety and bounds

The configurable local count is an early validation/compiler-bookkeeping ceiling, not a promise that every admitted declaration fits a native frame. AMD64 and ARM64 still reject the actual width- and spill-dependent frame when it exceeds stack-fence headroom. A regression configures 65,535 `v128` locals and verifies that it reaches this backend rejection rather than weakening the fence.

Exact GC liveness can track the configured population, but each emitted safepoint/callsite remains capped at 1,024 roots. Instructions that cannot affect local liveness or control flow are omitted from the analysis CFG before allocating bitmaps. The main compile-time bitmap arena is capped at 64 MiB, and serialized metadata contains only final bounded offset vectors. The uint16-range setting is therefore a declaration ceiling, not a promise that every locals-by-CFG product is admitted.

## Tests

- `go test ./src/core/compiler/wasm ./src/core/compiler/backend/railshot/shared ./src/core/compiler/backend/railshot/amd64 ./cli/runtime/internal/artifactcache -count=1`
- `go test ./src/wago -run '^(TestConfigValidateAndIntrospection|TestMaxFunctionLocalsCountsParametersAndPreservesStackFence|TestGCFrameLocalLiveness.*|TestGCNativeRootAdmission.*)$' -count=1`
- `GOOS=linux GOARCH=arm64 go test ./src/core/compiler/backend/railshot/arm64 -run '^$' -exec=/bin/true`
- `GOOS=linux GOARCH=arm64 go test ./src/wago -run '^TestGCArm64NativeRootAdmissionCompactsDeadDeclaredLocals$' -exec=/bin/true`
- `go test ./... -run '^$'`
- `go test ./tests/tools/docs-check ./tests/cipolicy -count=1`
- `go test ./internal/genfacade -run '^TestFacadeUpToDate$' -count=1`
- `make lint`

A complete `go test ./src/wago` ran all self-contained tests successfully but could not run the staged official-suite accounting cases because this worktree does not contain the optional `tests/spec-v3/test/core` checkout.

## Measurements

On AMD Ryzen 7 8845HS after compacting the liveness CFG:

- 1,138 declared roots / one live root: warmed median 17.2 us, 29,408 B/op, 13 allocs/op
- dense 1,024-root control: 160.8-164.2 us, 224,082-224,084 B/op, 10 allocs/op

These are compile-time liveness costs. The 1,138-local regression emits one root in its final safepoint metadata.

Fixes #537