### PR TITLE
gc: preserve mixed native allocation extents

### DIFF
--- a/src/core/runtime/gc/collect.go
+++ b/src/core/runtime/gc/collect.go
@@ -819,23 +819,21 @@ func (c *Collector) compactNurseryHandles() {
 	out := c.nurseryHandles[:0]
 	var edenMax uint32
 	if c.survivorBump == 0 {
-		// Eden is bump allocated and nurseryHandles preserves allocation order.
-		// Compact membership once, then find the last live Eden allocation from
-		// the tail instead of recomputing a maximum across every survivor.
+		// Native array chunks and direct native structs share one reserved handle
+		// batch. Their handle publication order can differ from their physical
+		// Eden order, so derive the bump from every live extent instead of trusting
+		// the last retained handle.
 		for _, h := range c.nurseryHandles {
 			if h == 0 || int(h) >= len(c.handles) {
 				continue
 			}
-			sp := c.handles[h].space
+			e := c.handles[h]
+			sp := e.space
 			if sp == spaceNursery || (sp == spaceLarge && c.handles[h].young()) {
 				out = append(out, h)
 			}
-		}
-		for i := len(out) - 1; i >= 0; i-- {
-			e := c.handles[out[i]]
-			if e.space == spaceNursery && e.off < c.edenBytes() {
+			if sp == spaceNursery && e.off < c.edenBytes() && e.off+e.size > edenMax {
 				edenMax = e.off + e.size
-				break
 			}
 		}
 		clear(c.nurseryHandles[len(out):])

--- a/src/wago/gc_native_mixed_alloc_amd64_test.go
+++ b/src/wago/gc_native_mixed_alloc_amd64_test.go
@@ -1,0 +1,68 @@
+//go:build linux && amd64 && !tinygo && !wago_guardpage
+
+package wago
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func gcNativeMixedReservationCastModule() []byte {
+	packedArrayType := []byte{0x5e, 0x78, 0x01} // type 0: (array (mut i8))
+	structType := []byte{0x5f}
+	structType = append(structType, wasmtest.Vec([]byte{0x7f, 0x00})...) // type 1: (struct (field i32))
+	nativeArrayType := []byte{0x5e, 0x7f, 0x01}                          // type 2: (array (mut i32))
+	funcType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	body := []byte{
+		0x03,
+		0x01, 0x63, 0x02, // local 0: (ref null type 2)
+		0x01, 0x63, 0x01, // local 1: (ref null type 1)
+		0x01, 0x63, 0x00, // local 2: (ref null type 0)
+	}
+	for range 9 {
+		body = append(body, 0x41, 0x01, 0xfb, 0x07, 0x02, 0x21, 0x00)
+	}
+	body = append(body,
+		0x41, 0x07, 0xfb, 0x00, 0x01, 0x21, 0x01, // native struct above the array chunk
+		0x41, 0x01, 0xfb, 0x07, 0x02, 0x21, 0x00, // native array inside the chunk
+		0x41,
+	)
+	body = append(body, wasmtest.SLEB32(5000)...)
+	body = append(body,
+		0xfb, 0x07, 0x00, 0x21, 0x02, // helper-only packed array cancels the native batch
+		0x20, 0x01, 0xfb, 0x16, 0x01, 0xd1, 0x0b, // live struct must still cast as type 1
+	)
+	code := append(wasmtest.ULEB(uint32(len(body))), body...)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(packedArrayType, structType, nativeArrayType, funcType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(3))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(code)),
+	)
+}
+
+func TestGCNativeMixedReservationPreservesStructAcrossFallbackCollection(t *testing.T) {
+	for _, native := range []bool{false, true} {
+		t.Run(map[bool]string{false: "helper", true: "native"}[native], func(t *testing.T) {
+			compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3).WithOptimization("gc-native-alloc", native), gcNativeMixedReservationCastModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer compiled.Close()
+			in, err := Instantiate(compiled, InstantiateOptions{GC: GCConfig{StressNurseryBytes: 8192, VerifyAfterCollect: true}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			if got, err := in.Invoke("run"); err != nil || !reflect.DeepEqual(got, []uint64{0}) {
+				t.Fatalf("run = %v, %v; want [0]", got, err)
+			}
+			if native && in.gc.Stats().MinorCollections == 0 {
+				t.Fatal("native fallback did not collect after preserving the high live extent")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #538

## Summary

- add a minimized native-allocation enabled/disabled regression for the reported ref.cast failure
- preserve the highest live Eden extent when compacting nursery handles
- retain collector layout, native allocation fast paths, and zero-allocation cleanup

## Root cause

Native arrays reserve 4 KiB chunks while native structs allocate directly from the same reservation batch. Their handle publication order can therefore differ from physical Eden address order. Collection assumed the final retained handle was the highest live object and could rewind nurseryBump below a live struct; a later helper fallback then overwrote the object and ref.cast trapped.

The fix computes the maximum live Eden extent during the handle-compaction scan that already visits every nursery handle.

## Validation

- go test ./src/wago -run TestGCNativeMixedReservationPreservesStructAcrossFallbackCollection -count=20
- go test -race ./src/wago -run TestGCNativeMixedReservationPreservesStructAcrossFallbackCollection -count=1
- go test ./src/core/runtime/gc -run TestNative\|Test.*Nursery\|Test.*Collection -count=1
- full src/wago package execution was attempted; self-contained tests passed, but staged official tests require the absent optional tests/spec-v3 checkout

## Performance and footprint

BenchmarkMinorCollectionCleanupScaling/old=0/survivors=0-of-64, five 500 ms samples: median 544.0 ns/op before and 541.0 ns/op after; 0 B/op and 0 allocs/op in both. No runtime-state layout or allocation hot-path change.

## Docs

No workflow or public API change.