### PR TITLE
wago: admit wide scalar GC callers

### DIFF
--- a/src/wago/gc_frame_roots_arm64.go
+++ b/src/wago/gc_frame_roots_arm64.go
@@ -275,12 +275,14 @@ func arm64GCFrameBodySafe(m *wasm.Module, body []byte, classifier *wasm.ModuleIn
 			if !ok {
 				return false
 			}
-			if int(imm.Index) < m.ImportedFuncCount() && (collectorBoundary || wasmFuncTypeReferenceFree(ft)) {
-				if !arm64GCFrameHostCallABI(ft) {
+			if int(imm.Index) < m.ImportedFuncCount() {
+				if collectorBoundary || wasmFuncTypeReferenceFree(ft) {
+					if !arm64GCFrameHostCallABI(ft) {
+						return false
+					}
+				} else if !arm64GCFrameReferenceCallABI(m, ft) {
 					return false
 				}
-			} else if !collectorBoundary && !arm64GCFrameReferenceCallABI(m, ft) {
-				return false
 			}
 		case 0x11:
 			ft, ok := m.TypeFunc(imm.Index)

--- a/src/wago/gc_frame_roots_linux_amd64.go
+++ b/src/wago/gc_frame_roots_linux_amd64.go
@@ -162,9 +162,6 @@ functions:
 		if maximumLive > shared.GCFrameRootLimit {
 			return reject("function %d has %d simultaneously live collector locals, limit %d", function, maximumLive, shared.GCFrameRootLimit)
 		}
-		if !collectorBoundary && bodyUsesNativeCall(m.Code[function].BodyBytes, &classifier) && !gcFrameReferenceCallABI(m, ft) {
-			return reject("function %d exceeds the exact native caller ABI", function)
-		}
 		if uint64(safepointBase)+uint64(len(liveMasks)) > uint64(shared.GCSafepointIDMax) {
 			return reject("function %d exceeds the dense safepoint ID bound", function)
 		}
@@ -301,24 +298,6 @@ func bodyUsesEH(body []byte, classifier *wasm.ModuleInstructionClassifier) bool 
 			return true
 		}
 		if err := classifier.ClassifyInto(r, op, &imm); err != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func bodyUsesNativeCall(body []byte, classifier *wasm.ModuleInstructionClassifier) bool {
-	r := wasm.NewReader(body)
-	var imm wasm.InstructionImmediate
-	for r.HasNext() {
-		op, err := r.Byte()
-		if err != nil {
-			return true
-		}
-		if err := classifier.ClassifyInto(r, op, &imm); err != nil {
-			return true
-		}
-		if op == 0x10 || op == 0x12 || op == 0x14 || op == 0x15 {
 			return true
 		}
 	}

--- a/src/wago/plugin_gc_wide_boundary_test.go
+++ b/src/wago/plugin_gc_wide_boundary_test.go
@@ -138,6 +138,44 @@ func pluginGCWideScalarResultModule() []byte {
 	)
 }
 
+func pluginGCWideScalarCallerModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01} // (struct (field (mut i32)))
+	wideScalarType := wasmtest.FuncType(
+		[]wasm.ValType{wasm.I32},
+		[]wasm.ValType{wasm.I32, wasm.I32, wasm.I64, wasm.I64, wasm.I32, wasm.I64, wasm.I32, wasm.I64, wasm.I32, wasm.I32},
+	)
+	wideCallerType := []byte{
+		0x60, 0x08, 0x63, 0x00, // func, eight params, (ref null 0)
+		0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, // seven i32 params
+		0x01, 0x7f, // one i32 result
+	}
+	runType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
+	wideCallerBody := []byte{
+		0x20, 0x01, // local.get 1
+		0x10, 0x00, // call wide_scalar_results
+		0x1a, 0x1a, 0x1a, 0x1a, 0x1a, // drop ten scalar results
+		0x1a, 0x1a, 0x1a, 0x1a, 0x1a,
+		0x20, 0x00, 0xd1, 0x1a, // local.get 0; ref.is_null; drop
+		0xfb, 0x01, 0x00, 0x1a, // struct.new_default 0; drop
+		0x20, 0x07, // local.get 7
+		0x0b,
+	}
+	runBody := []byte{
+		0xfb, 0x01, 0x00, // struct.new_default 0
+		0x41, 0x01, 0x41, 0x02, 0x41, 0x03, 0x41, 0x04,
+		0x41, 0x05, 0x41, 0x06, 0x41, 0x07,
+		0x10, 0x01, // call wide_caller
+		0x0b,
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(structType, wideScalarType, wideCallerType, runType)),
+		wasmtest.Section(2, wasmtest.Vec(pluginGCImport("plugin_gc_wide", "wide_scalar_results", 1))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2), wasmtest.ULEB(3))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 2))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(wideCallerBody), wasmtest.Code(runBody))),
+	)
+}
+
 // This architecture-neutral regression runs in the mandatory native amd64 and
 // arm64 suites. The module itself has no collector-reference import boundary:
 // its wide import is scalar-only, while struct.new_default still requires exact
@@ -155,6 +193,37 @@ func TestPluginGCWideScalarHostImportUsesSynchronousABI(t *testing.T) {
 	admission := mod.c.GCNativeRootAdmission()
 	if !admission.Required || !admission.Exact || admission.Callsites == 0 || admission.Safepoints == 0 {
 		t.Fatalf("wide scalar host root admission = %+v", admission)
+	}
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	values, err := in.Call(context.Background(), "run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(values) != 1 || values[0].I32() != 7 {
+		t.Fatalf("run = %v; want i32(7)", values)
+	}
+}
+
+// The wide local function uses the wrapper entry ABI. Its scalar host call uses
+// the synchronous host ABI. Neither boundary needs the smaller reference-call
+// register proof merely because the module has no collector-reference import.
+func TestPluginGCWideScalarCallerUsesSynchronousABI(t *testing.T) {
+	requireCompleteCore3Backend(t)
+	rt := newPluginGCWideBoundaryRuntime(t)
+	defer rt.Close()
+
+	mod, err := rt.Compile(pluginGCWideScalarCallerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Close()
+	admission := mod.c.GCNativeRootAdmission()
+	if !admission.Required || !admission.Exact || admission.Callsites == 0 || admission.Safepoints == 0 || admission.MaximumRoots == 0 {
+		t.Fatalf("wide scalar caller root admission = %+v", admission)
 	}
 	in, err := rt.Instantiate(context.Background(), mod)
 	if err != nil {


### PR DESCRIPTION
## Summary

- remove the stale AMD64 check that requires every native-call caller to fit the small reference-call register ABI
- stop applying the ARM64 imported-call ABI check to direct local calls, which already select the register or wrapper path
- keep the per-target ABI proof for dynamic typed-reference calls
- add an AMD64 and ARM64 regression with one live GC reference across a scalar host call that returns ten values

The wide local caller uses the wrapper ABI. The scalar import uses the synchronous host ABI. Both paths already publish exact native roots.

Closes #536

## Validation

Passed:

- go test ./src/wago -run "^(TestGC|TestPluginGC)" -count=1
- go test -tags wago_guardpage ./src/wago -run "^(TestGC|TestPluginGC)" -count=1
- go test ./src/wago -run "^(TestPluginGCWideScalarCallerUsesSynchronousABI|TestGCWideDynamicCallRefRetainsRegisterABIProof)$" -count=20
- go test ./src/core/compiler/backend/railshot/amd64 ./src/core/compiler/backend/railshot/arm64 ./src/core/compiler/backend/railshot/shared -count=1
- GOOS=linux GOARCH=arm64 go test -c -o /tmp/wago-issue536-arm64.test ./src/wago

The first CI run exposed and confirmed the ARM64 direct-local variant. The follow-up limits its imported-call proof to actual imports. Native ARM64 CI executes the shared regression.

The complete local go test ./src/wago -count=1 run reached unrelated staged-suite checks and failed because the local wast2json is 1.0.36. The repository requires 1.0.41.

## Performance and footprint

AMD64 removes one extra linear function-body scan. ARM64 keeps its existing scan and narrows one branch. The change adds no runtime operations, allocations, persistent metadata, or memory.