### PR TITLE
runtime: restore TinyGo size headroom

### DIFF
--- a/src/wago/gc_frame_liveness.go
+++ b/src/wago/gc_frame_liveness.go
@@ -74,6 +74,10 @@ type gcFrameLivenessExtra struct {
 // collecting site and returns the maximum population live at any one site.
 // Masks remain site-major and exact; the returned local slices preserve their
 // original frame order.
+// Keep this large compile-time helper out of newGCFrameRootPlan. TinyGo's size
+// optimizer otherwise inlines it and grows the minimal runtime substantially.
+//
+//go:noinline
 func gcFrameCompactLiveLocals(indexes, offsets []uint32, allocations, calls []uint64, extra *gcFrameLivenessExtra) ([]uint32, []uint32, []uint64, []uint64, int, error) {
 	if len(indexes) != len(offsets) {
 		return nil, nil, nil, nil, 0, fmt.Errorf("GC local liveness index/offset count mismatch")


### PR DESCRIPTION
TinyGo 0.41.1 was inlining the large, cold GC liveness compactor into module planning. After the parallel GC fixes landed, that made the integrated minimal runtime exceed its fixed release budget even though each PR had checked against an older main snapshot.

This small code-layout fix keeps the compactor out of line. It does not change wasm validation, liveness results, runtime behavior, or generated JIT code.

Proof:
- focused GC liveness and native-root admission tests pass 10×
- all four release profiles remain within budget
- `runtime-minimal-tiny`: 2,301,124 → 2,299,780 bytes (-1,344; 220 bytes headroom)

Docs unchanged: internal compile-time code-layout fix with no workflow impact.