### PR TITLE
runtime: expose callback invocation context

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -194,6 +194,40 @@ See [Host guest-storage access](host-guest-storage.md) for exact type inspection
 array allocation, and zero-copy numeric array access. Wago intentionally exposes
 no raw GC pointer API.
 
+## Callback invocation context
+
+A plugin granted `host.caller.identify` may obtain the active guest invocation's
+cancellation and deadline inside one of its synchronous host callbacks:
+
+```go
+callers, err := reg.HostCallers()
+if err != nil {
+    return err
+}
+
+module.Func("fetch", func(caller wago.HostModule, _, _ []uint64) {
+    ctx, err := callers.InvocationContext(caller)
+    if err != nil {
+        panic(wago.HostTrap{Err: err})
+    }
+    // Use ctx only for work owned by this callback.
+})
+```
+
+The returned context is callback-scoped. Its `Done` channel closes when the
+parent invocation is canceled, its deadline expires, or the host callback
+returns. Retaining it is safe only for observing that terminal cancellation;
+it must not be used to extend callback-owned work. Repeated resolution during
+the same callback returns the same context. Nested re-entry receives a distinct
+context and does not shorten the outer callback's lifetime.
+
+Invocation contexts deliberately expose no parent context values. Plugins must
+pass explicit dependencies instead of using context values as an ambient data
+channel. Calls without a cancellable public parent, including raw `Invoke`,
+prepared calls, and start-time callbacks, receive a live callback-scoped context
+without a deadline. Forged, expired, cross-Runtime, and low-level callers are
+rejected with `ErrPermissionDenied`.
+
 ## Exact authorities and scopes
 
 Authority names are exact. Dots are for display grouping and do not grant a
@@ -202,7 +236,7 @@ parent, wildcard, descendant, or future authority.
 | Authority | Allows |
 |---|---|
 | `host.import.define` | Define host functions in specifically granted import modules. |
-| `host.caller.identify` | Resolve the exact active instance during a synchronous host call. |
+| `host.caller.identify` | Resolve the exact active instance and its callback-scoped invocation cancellation/deadline during a synchronous host call. |
 | `host.arguments.read` | Read guest arguments exposed by the host. |
 | `runtime.close.observe` | Observe logical runtime close. |
 | `module.source.transform` | Replace module bytes before compilation. |
@@ -471,4 +505,3 @@ view.
 See [Host guest-storage access](host-guest-storage.md) for the complete API,
 lifetime rules, and examples. [Facet](https://github.com/jtenner/facet-spec) is
 one motivating consumer, but these interfaces are general Wago host APIs.
-

--- a/src/wago/access.go
+++ b/src/wago/access.go
@@ -104,8 +104,9 @@ func (a *GuestArgumentsAccess) close() error {
 	return nil
 }
 
-// HostCallers returns an identity-only, revocable resolver for synchronous host
-// calls. It cannot create, invoke, or close instances.
+// HostCallers returns a read-only, revocable resolver for synchronous host
+// caller identity and invocation cancellation/deadline context. It cannot
+// create, invoke, or close instances.
 func (r *Registrar) HostCallers() (*CallerResolver, error) {
 	if _, err := r.authorize(AuthorityHostCallerIdentify); err != nil {
 		return nil, err

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4273,7 +4273,7 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 			// nor strands an invocation initiated through the relay.
 			return ex.inst.invokeAttachedLocalContext(ex.localIdx, args, cancel, in.trap, true)
 		}
-		return in.invokeReexportedHost(export, importIdx, args, id)
+		return in.invokeReexportedHost(export, importIdx, args, id, cancel)
 	}
 	if len(args) != ic.paramSlots {
 		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
@@ -4604,7 +4604,7 @@ func (in *Instance) replayHostLog() (err error) {
 	return nil
 }
 
-func (in *Instance) invokeReexportedHost(export string, importIdx int, args []uint64, id invocationID) (results []uint64, err error) {
+func (in *Instance) invokeReexportedHost(export string, importIdx int, args []uint64, id invocationID, parent context.Context) (results []uint64, err error) {
 	if importIdx < 0 || importIdx >= len(in.syncHosts) || in.syncHosts[importIdx] == nil || importIdx >= len(in.c.importFuncSigs) {
 		return nil, fmt.Errorf("export %q is an imported function without a callable host owner", export)
 	}
@@ -4670,6 +4670,8 @@ func (in *Instance) invokeReexportedHost(export string, importIdx int, args []ui
 	// the public invocation boundary.
 	resumeGCInvocation := in.suspendGCInvocation(id)
 	defer resumeGCInvocation()
+	restoreInvocationContext := bindHostInvocationParent(in, parent)
+	defer restoreInvocationContext()
 	fn := in.syncHosts[importIdx]
 	caller := in.beginHostCallScope()
 	defer caller.scope.end(caller.generation, caller.parentGeneration)

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4142,7 +4142,26 @@ func LoadTrustedArtifact(b []byte) (*Compiled, error) {
 // use InvokeFromHost with the HostModule value it received. Direct invocation
 // fails with ErrPermissionDenied while callback-scoped guest storage is borrowed.
 func (in *Instance) Invoke(export string, args ...uint64) ([]uint64, error) {
-	return in.invoke(export, args, nil)
+	return in.invoke(export, args, invocationContextSet{})
+}
+
+// invocationContextSet keeps callback-visible cancellation independent from
+// native interruption. Targets without native cancellation still propagate the
+// public invocation's cancellation and deadline to synchronous host callbacks.
+type invocationContextSet struct {
+	interrupt context.Context
+	callback  context.Context
+}
+
+func invocationContextSetFor(ctx context.Context) (contexts invocationContextSet) {
+	if ctx == nil || ctx.Done() == nil {
+		return contexts
+	}
+	contexts.callback = ctx
+	if nativeCancellationSupported() {
+		contexts.interrupt = ctx
+	}
+	return contexts
 }
 
 // InvokeContext is like Invoke but honors context cancellation. If ctx is
@@ -4166,26 +4185,22 @@ func (in *Instance) InvokeContext(ctx context.Context, export string, args ...ui
 		}
 	}
 
-	var cancel context.Context
-	if nativeCancellationSupported() && ctx != nil && ctx.Done() != nil {
-		cancel = ctx
-	}
-
-	out, err := in.invoke(export, args, cancel)
+	contexts := invocationContextSetFor(ctx)
+	out, err := in.invoke(export, args, contexts)
 
 	return out, contextInterruptError(ctx, err)
 }
 
-func (in *Instance) invoke(export string, args []uint64, cancel context.Context) ([]uint64, error) {
-	return in.invokeEntry(export, args, cancel, false)
+func (in *Instance) invoke(export string, args []uint64, contexts invocationContextSet) ([]uint64, error) {
+	return in.invokeEntry(export, args, contexts, false)
 }
 
-func (in *Instance) invokeAdmitted(export string, args []uint64, cancel context.Context, reservation *pluginOperationReservation) ([]uint64, error) {
+func (in *Instance) invokeAdmitted(export string, args []uint64, contexts invocationContextSet, reservation *pluginOperationReservation) ([]uint64, error) {
 	state := in.ensurePluginState()
-	return in.invokeWithToken(export, args, cancel, state.invocationID, true, true, reservation)
+	return in.invokeWithToken(export, args, contexts, state.invocationID, true, true, reservation)
 }
 
-func (in *Instance) invokeEntry(export string, args []uint64, cancel context.Context, alreadyAdmitted bool) ([]uint64, error) {
+func (in *Instance) invokeEntry(export string, args []uint64, contexts invocationContextSet, alreadyAdmitted bool) ([]uint64, error) {
 	// Close hooks run after the invocation gate is published and may probe that
 	// later calls fail closed. Check the gate before waiting for the per-instance
 	// serialization lock so such a probe cannot deadlock behind the activation
@@ -4205,10 +4220,10 @@ func (in *Instance) invokeEntry(export string, args []uint64, cancel context.Con
 		state.invocationID = 0
 		state.invokeMu.Unlock()
 	}()
-	return in.invokeWithToken(export, args, cancel, id, true, alreadyAdmitted, nil)
+	return in.invokeWithToken(export, args, contexts, id, true, alreadyAdmitted, nil)
 }
 
-func (in *Instance) invokeWithToken(export string, args []uint64, cancel context.Context, id invocationID, gateHeld, alreadyAdmitted bool, reservation *pluginOperationReservation) ([]uint64, error) {
+func (in *Instance) invokeWithToken(export string, args []uint64, contexts invocationContextSet, id invocationID, gateHeld, alreadyAdmitted bool, reservation *pluginOperationReservation) ([]uint64, error) {
 	reentry := !gateHeld && isNativeActive(in, id)
 	if !reentry && !gateHeld {
 		// Acquire the target instance gate before the shared collector lease. A
@@ -4271,9 +4286,9 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 			// trap cell; the import attachment retains the producer's physical resources.
 			// Keep this Go-level re-export path identical so producer Close neither owns
 			// nor strands an invocation initiated through the relay.
-			return ex.inst.invokeAttachedLocalContext(ex.localIdx, args, cancel, in.trap, true)
+			return ex.inst.invokeAttachedLocalContext(ex.localIdx, args, contexts, in.trap, true)
 		}
-		return in.invokeReexportedHost(export, importIdx, args, id, cancel)
+		return in.invokeReexportedHost(export, importIdx, args, id, contexts.callback)
 	}
 	if len(args) != ic.paramSlots {
 		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
@@ -4303,16 +4318,16 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 		binary.LittleEndian.PutUint32(in.hostLog, 0) // reset host-call log
 	}
 	entry := in.base + uintptr(in.c.Entry[li])
-	if cancel != nil {
-		stopCancel := in.startCancellationWatch(cancel, in.trap)
+	if contexts.interrupt != nil {
+		stopCancel := in.startCancellationWatch(contexts.interrupt, in.trap)
 		defer stopCancel()
 	}
 	if in.syncMode {
-		if err := in.callNativeSyncWithTrapContext(entry, in.trap, cancel); err != nil {
+		if err := in.callNativeSyncWithTrapContext(entry, in.trap, contexts.callback); err != nil {
 			return nil, err
 		}
 	} else {
-		privateScalar := invokePrivateEntryEnabled && cancel == nil && !in.nativeControlIsShared() &&
+		privateScalar := invokePrivateEntryEnabled && contexts.interrupt == nil && !in.nativeControlIsShared() &&
 			ic.entryMode != preparedEntryGeneral
 		entryMode := preparedEntryGeneral
 		if privateScalar {
@@ -4369,10 +4384,10 @@ func (in *Instance) invokeWithToken(export string, args []uint64, cancel context
 // executing in the producer. It shares the instance's call buffers, so the
 // returned slice is valid only until the next call on this Instance.
 func (in *Instance) invokeLocal(li int, args []uint64) ([]uint64, error) {
-	return in.invokeLocalContext(li, args, nil, in.trap)
+	return in.invokeLocalContext(li, args, invocationContextSet{}, in.trap)
 }
 
-func (in *Instance) invokeLocalContext(li int, args []uint64, cancel context.Context, activeTrap []byte) ([]uint64, error) {
+func (in *Instance) invokeLocalContext(li int, args []uint64, contexts invocationContextSet, activeTrap []byte) ([]uint64, error) {
 	if err := in.beginInvocation(); err != nil {
 		return nil, fmt.Errorf("invoke function %d: %w", li, err)
 	}
@@ -4384,14 +4399,14 @@ func (in *Instance) invokeLocalContext(li int, args []uint64, cancel context.Con
 			in.reconcileFuncrefRoots()
 		}
 	}()
-	return in.invokeAttachedLocalContext(li, args, cancel, activeTrap, false)
+	return in.invokeAttachedLocalContext(li, args, contexts, activeTrap, false)
 }
 
 // invokeAttachedLocalContext enters a producer retained by the caller's function
 // import attachment. The caller owns the invocation lease and active trap cell,
 // exactly as for a native dynamic import call. attachedResult permits first-time
 // funcref tokenization to transfer the attachment's finalization lifetime.
-func (in *Instance) invokeAttachedLocalContext(li int, args []uint64, cancel context.Context, activeTrap []byte, attachedResult bool) ([]uint64, error) {
+func (in *Instance) invokeAttachedLocalContext(li int, args []uint64, contexts invocationContextSet, activeTrap []byte, attachedResult bool) ([]uint64, error) {
 	if li < 0 || li >= len(in.c.Funcs) || li >= len(in.c.Entry) {
 		return nil, fmt.Errorf("invalid function index %d", li)
 	}
@@ -4436,12 +4451,12 @@ func (in *Instance) invokeAttachedLocalContext(li int, args []uint64, cancel con
 		activeTrap = in.trap
 	}
 	stopCancel := noOpCancellationWatch
-	if cancel != nil {
-		stopCancel = in.startCancellationWatch(cancel, activeTrap)
+	if contexts.interrupt != nil {
+		stopCancel = in.startCancellationWatch(contexts.interrupt, activeTrap)
 	}
 	defer stopCancel()
 	if in.syncMode {
-		if err := in.callNativeSyncWithTrapContext(entry, activeTrap, cancel); err != nil {
+		if err := in.callNativeSyncWithTrapContext(entry, activeTrap, contexts.callback); err != nil {
 			return nil, err
 		}
 	} else {

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -1,6 +1,7 @@
 package wago
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"sync"
@@ -23,6 +24,11 @@ var hostControlInstances sync.Map // map[uintptr]*Instance
 type hostInvocationContext struct {
 	id          invocationID
 	reservation *pluginOperationReservation
+	parent      context.Context
+}
+
+func (c hostInvocationContext) empty() bool {
+	return c.id == 0 && c.reservation == nil && c.parent == nil
 }
 
 var hostInvocationContexts sync.Map // map[uintptr]hostInvocationContext
@@ -47,7 +53,7 @@ func activeHostInvocationContext(in *Instance) hostInvocationContext {
 }
 
 func bindHostInvocationContext(ctrl uintptr, next hostInvocationContext) func() {
-	if ctrl == 0 || next.id == 0 {
+	if ctrl == 0 || next.empty() {
 		return func() {}
 	}
 	previous, loaded := hostInvocationContexts.Load(ctrl)
@@ -59,6 +65,20 @@ func bindHostInvocationContext(ctrl uintptr, next hostInvocationContext) func() 
 			hostInvocationContexts.Delete(ctrl)
 		}
 	}
+}
+
+func bindHostInvocationParent(in *Instance, parent context.Context) func() {
+	if in == nil {
+		return func() {}
+	}
+	ctrl := offHeapSlicePtr(in.ctrl)
+	_, inherited := hostInvocationContexts.Load(ctrl)
+	if parent == nil && !inherited {
+		return func() {}
+	}
+	invocation := currentHostInvocationContext(ctrl, in)
+	invocation.parent = parent
+	return bindHostInvocationContext(ctrl, invocation)
 }
 
 func registerHostControl(in *Instance) error {
@@ -160,7 +180,7 @@ func (root *Instance) dispatchSynchronousHostCall(ctrl uintptr, importIdx uint32
 	// owns the invocation identity and collector lease. Carry that identity into
 	// the producer's HostModule instead of reading its zero local invocation ID.
 	invocation := activeHostInvocationContext(root)
-	if invocation.id == 0 {
+	if invocation.empty() {
 		invocation = activeHostInvocationContext(active)
 	}
 	id := invocation.id

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -52,11 +52,8 @@ func (in *Instance) InvokeFromHost(ctx context.Context, caller HostModule, expor
 			return nil, err
 		}
 	}
-	var cancel context.Context
-	if nativeCancellationSupported() && ctx != nil && ctx.Done() != nil {
-		cancel = ctx
-	}
-	results, err = in.invokeWithToken(export, args, cancel, id, false, false, reservation)
+	contexts := invocationContextSetFor(ctx)
+	results, err = in.invokeWithToken(export, args, contexts, id, false, false, reservation)
 	return results, contextInterruptError(ctx, err)
 }
 

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -7,6 +7,7 @@ import (
 	goruntime "runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
@@ -91,9 +92,9 @@ type GCHostModule interface {
 // under standard Go and TinyGo — with no reflection anywhere on the path.
 type HostFunc func(m HostModule, params, results []uint64)
 
-// CallerResolver resolves the exact Runtime-owned instance making an active
-// synchronous host call. Its authority is identity-only: it cannot create,
-// invoke, close, manage, pool, or otherwise control instances.
+// CallerResolver resolves information about the exact Runtime-owned invocation
+// making an active synchronous host call. Its authority is read-only: it cannot
+// create, invoke, close, manage, pool, or otherwise control instances.
 //
 // Resolve succeeds only while the HostFunc callback is active. Retaining the
 // HostModule and resolving it after the callback returns fails closed.
@@ -131,15 +132,167 @@ func (r *CallerResolver) Resolve(caller HostModule) (InstanceIdentity, error) {
 	return InstanceIdentity{value: h.in}, nil
 }
 
+// InvocationContext returns a cancellation- and deadline-only context for
+// caller's active synchronous host callback. The returned context is canceled
+// when its parent invocation is canceled or when the callback returns. It never
+// exposes values from the parent context. Repeated calls during one callback
+// return the same context.
+//
+// Forged, expired, cross-runtime, and low-level HostModule values are rejected.
+func (r *CallerResolver) InvocationContext(caller HostModule) (context.Context, error) {
+	if r == nil {
+		return nil, fmt.Errorf("wago: nil caller resolver: %w", ErrPermissionDenied)
+	}
+	rt := r.rt.Load()
+	h, ok := caller.(instanceHostModule)
+	if rt == nil || !ok || !h.valid() || h.in == nil || h.in.rt != rt || h.scope == nil {
+		return nil, fmt.Errorf("wago: invocation context requires an active host call from the owning runtime: %w", ErrPermissionDenied)
+	}
+	ctx, ok := h.scope.invocationContext(h.generation, activeHostInvocationContext(h.in).parent)
+	if !ok {
+		return nil, fmt.Errorf("wago: invocation context requires an active host call from the owning runtime: %w", ErrPermissionDenied)
+	}
+	return ctx, nil
+}
+
 // hostCallScope authorizes one synchronous use of an instanceHostModule.
 type hostCallScope struct {
 	active atomic.Uint64
-	waiter atomic.Pointer[hostCallWaiter]
+	state  atomic.Pointer[hostCallState]
 }
 
 type hostCallWaiter struct {
 	generation uint64
 	wake       chan struct{}
+}
+
+// hostCallState is allocated only after a plugin asks to watch a caller or
+// resolve an invocation context. The context list is bounded by the already-
+// bounded synchronous re-entry depth, and its lock does not protect waiter so
+// the two optional facilities cannot replace or block each other.
+type hostCallState struct {
+	waiter atomic.Pointer[hostCallWaiter]
+	mu     sync.Mutex
+	head   *callbackInvocationContext
+}
+
+type callbackInvocationContext struct {
+	generation  uint64
+	next        *callbackInvocationContext
+	done        chan struct{}
+	deadline    time.Time
+	hasDeadline bool
+
+	mu         sync.Mutex
+	err        error
+	stopParent func() bool
+}
+
+func newCallbackInvocationContext(generation uint64, parent context.Context) *callbackInvocationContext {
+	c := &callbackInvocationContext{generation: generation, done: make(chan struct{})}
+	if parent == nil {
+		return c
+	}
+	c.deadline, c.hasDeadline = parent.Deadline()
+	if err := parent.Err(); err != nil {
+		c.finish(err)
+		return c
+	}
+	if parent.Done() == nil {
+		return c
+	}
+	stop := context.AfterFunc(parent, func() { c.finish(parent.Err()) })
+	c.mu.Lock()
+	if c.err == nil {
+		c.stopParent = stop
+		c.mu.Unlock()
+	} else {
+		c.mu.Unlock()
+		stop()
+	}
+	return c
+}
+
+func (c *callbackInvocationContext) Deadline() (time.Time, bool) {
+	return c.deadline, c.hasDeadline
+}
+
+func (c *callbackInvocationContext) Done() <-chan struct{} { return c.done }
+
+func (c *callbackInvocationContext) Err() error {
+	c.mu.Lock()
+	err := c.err
+	c.mu.Unlock()
+	return err
+}
+
+func (*callbackInvocationContext) Value(any) any { return nil }
+
+func (c *callbackInvocationContext) finish(err error) {
+	if err == nil {
+		err = context.Canceled
+	}
+	c.mu.Lock()
+	if c.err != nil {
+		c.mu.Unlock()
+		return
+	}
+	c.err = err
+	stop := c.stopParent
+	c.stopParent = nil
+	close(c.done)
+	c.mu.Unlock()
+	if stop != nil {
+		stop()
+	}
+}
+
+func (s *hostCallScope) ensureState() *hostCallState {
+	state := s.state.Load()
+	if state == nil {
+		candidate := &hostCallState{}
+		if s.state.CompareAndSwap(nil, candidate) {
+			state = candidate
+		} else {
+			state = s.state.Load()
+		}
+	}
+	return state
+}
+
+func (s *hostCallScope) invocationContext(generation uint64, parent context.Context) (context.Context, bool) {
+	state := s.ensureState()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if generation == 0 || s.active.Load() != generation {
+		return nil, false
+	}
+	for current := state.head; current != nil; current = current.next {
+		if current.generation == generation {
+			return current, true
+		}
+	}
+	current := newCallbackInvocationContext(generation, parent)
+	current.next = state.head
+	state.head = current
+	return current, true
+}
+
+func (s *hostCallScope) expireInvocationContext(state *hostCallState, generation uint64) {
+	state.mu.Lock()
+	var expired *callbackInvocationContext
+	for link := &state.head; *link != nil; link = &(*link).next {
+		if (*link).generation == generation {
+			expired = *link
+			*link = expired.next
+			expired.next = nil
+			break
+		}
+	}
+	state.mu.Unlock()
+	if expired != nil {
+		expired.finish(context.Canceled)
+	}
 }
 
 type instancePluginState struct {
@@ -195,13 +348,20 @@ func (s *hostCallScope) beginReservedWithID(in *Instance, id invocationID, reser
 }
 
 func (s *hostCallScope) end(generation, parent uint64) {
-	if !s.active.CompareAndSwap(generation, parent) {
+	active := s.active.CompareAndSwap(generation, parent)
+	state := s.state.Load()
+	if state != nil {
+		s.expireInvocationContext(state, generation)
+	}
+	if !active {
 		return
 	}
-	if waiter := s.waiter.Load(); waiter != nil && waiter.generation == generation {
-		select {
-		case waiter.wake <- struct{}{}:
-		default:
+	if state != nil {
+		if waiter := state.waiter.Load(); waiter != nil && waiter.generation == generation {
+			select {
+			case waiter.wake <- struct{}{}:
+			default:
+			}
 		}
 	}
 }
@@ -760,9 +920,10 @@ func (h instanceHostModule) registerWait(waiter *hostCallWaiter) bool {
 		return false
 	}
 	waiter.generation = h.generation
-	h.scope.waiter.Store(waiter)
+	state := h.scope.ensureState()
+	state.waiter.Store(waiter)
 	if !h.valid() {
-		h.scope.waiter.CompareAndSwap(waiter, nil)
+		state.waiter.CompareAndSwap(waiter, nil)
 		return false
 	}
 	return true
@@ -770,7 +931,9 @@ func (h instanceHostModule) registerWait(waiter *hostCallWaiter) bool {
 
 func (h instanceHostModule) unregisterWait(waiter *hostCallWaiter) {
 	if h.scope != nil {
-		h.scope.waiter.CompareAndSwap(waiter, nil)
+		if state := h.scope.state.Load(); state != nil {
+			state.waiter.CompareAndSwap(waiter, nil)
+		}
 	}
 }
 
@@ -1233,6 +1396,8 @@ func (in *Instance) callNativeSyncWithTrapContext(entry uintptr, activeTrap []by
 		return err
 	}
 	defer locked.unlockExecution()
+	restoreInvocationContext := bindHostInvocationParent(in, waitParent)
+	defer restoreInvocationContext()
 	stopWaitContext := in.publishAtomicWaitContext(waitParent)
 	defer stopWaitContext()
 	defer func() { err = in.decorateTrap(err) }()

--- a/src/wago/instance_call.go
+++ b/src/wago/instance_call.go
@@ -59,20 +59,17 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 			return nil, fmt.Errorf("%s result %d is v128; use Invoke for v128 values", export, i)
 		}
 	}
-	var cancel context.Context
-	if nativeCancellationSupported() && ctx != nil && ctx.Done() != nil {
-		cancel = ctx
-	}
+	contexts := invocationContextSetFor(ctx)
 
 	// Fast path: no runtime or no invoke hooks — invoke directly under the one
 	// already-admitted invocation lease, with no plugin reservation allocation.
 	if in.rt == nil {
-		out, err := in.callInnerAdmitted(export, slots, results, cancel, nil)
+		out, err := in.callInnerAdmitted(export, slots, results, contexts, nil)
 		return out, contextInterruptError(ctx, err)
 	}
 	hooks := in.rt.loadHooks()
 	if len(hooks.beforeInvoke) == 0 && len(hooks.afterInvoke) == 0 {
-		out, err := in.callInnerAdmitted(export, slots, results, cancel, nil)
+		out, err := in.callInnerAdmitted(export, slots, results, contexts, nil)
 		return out, contextInterruptError(ctx, err)
 	}
 	reservation, err := reservePluginOperation(hooks.operationGates)
@@ -106,7 +103,7 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 			return nil, joinPrimary(err, emitAfter(InvocationEvent{Operation: request.Operation, Instance: request.Instance, Export: export, Err: err, Start: request.Start, reservation: reservation}))
 		}
 	}
-	out, err := in.callInnerAdmitted(export, slots, results, cancel, reservation)
+	out, err := in.callInnerAdmitted(export, slots, results, contexts, reservation)
 	err = contextInterruptError(ctx, err)
 	err = joinPrimary(err, emitAfter(InvocationEvent{Operation: request.Operation, Instance: request.Instance, Export: export, Results: out, Err: err, Start: request.Start, reservation: reservation}))
 	return out, err
@@ -130,8 +127,8 @@ func contextInterruptError(ctx context.Context, err error) error {
 
 // callInnerAdmitted performs the actual invocation and result decoding under
 // the invocation lease already held by Call.
-func (in *Instance) callInnerAdmitted(export string, slots []uint64, results []ValType, cancel context.Context, reservation *pluginOperationReservation) ([]Value, error) {
-	raw, err := in.invokeAdmitted(export, slots, cancel, reservation)
+func (in *Instance) callInnerAdmitted(export string, slots []uint64, results []ValType, contexts invocationContextSet, reservation *pluginOperationReservation) ([]Value, error) {
+	raw, err := in.invokeAdmitted(export, slots, contexts, reservation)
 	if err != nil {
 		return nil, err
 	}

--- a/src/wago/invocation_context_test.go
+++ b/src/wago/invocation_context_test.go
@@ -1,0 +1,626 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+type invocationContextTestState struct {
+	resolver *CallerResolver
+	manager  *InstanceManager
+	outer    HostFunc
+	inner    HostFunc
+}
+
+type invocationContextTestPlugin struct{ state *invocationContextTestState }
+
+func invocationContextTestProvider(state *invocationContextTestState) PluginProvider {
+	definition := testDefinition("example.com/invocation-context")
+	definition.Authorities = []AuthorityRequest{
+		{Name: AuthorityHostImportDefine, Mode: AuthorityRequired, Reason: "define context test imports", Scope: AuthorityScope{Modules: []string{"env"}}},
+		{Name: AuthorityHostCallerIdentify, Mode: AuthorityRequired, Reason: "resolve callback invocation context"},
+		{Name: AuthorityInstanceManage, Mode: AuthorityRequired, Reason: "exercise managed invocation context", Scope: AuthorityScope{MaxInstances: 4, MaxMemoryBytes: 4 << 16}},
+	}
+	return PluginProvider{
+		Definition: definition,
+		New: func() Plugin {
+			return invocationContextTestPlugin{state: state}
+		},
+	}
+}
+
+func (p invocationContextTestPlugin) Register(reg *Registrar) error {
+	resolver, err := reg.HostCallers()
+	if err != nil {
+		return err
+	}
+	manager, err := reg.ManagedInstances()
+	if err != nil {
+		return err
+	}
+	imports, err := reg.HostImports()
+	if err != nil {
+		return err
+	}
+	module, err := imports.Module("env")
+	if err != nil {
+		return err
+	}
+	p.state.resolver = resolver
+	p.state.manager = manager
+	module.Func("outer", func(m HostModule, params, results []uint64) {
+		if p.state.outer != nil {
+			p.state.outer(m, params, results)
+		}
+	})
+	module.Func("inner", func(m HostModule, params, results []uint64) {
+		if p.state.inner != nil {
+			p.state.inner(m, params, results)
+		}
+	})
+	return nil
+}
+
+func newInvocationContextTestRuntime(t testing.TB, state *invocationContextTestState) *Runtime {
+	t.Helper()
+	rt := NewRuntime()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, invocationContextTestProvider(state))); err != nil {
+		rt.Close()
+		t.Fatal(err)
+	}
+	return rt
+}
+
+func invocationContextImportModule(name string) []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", name, 0, 0))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+	)
+}
+
+func invocationContextReexportModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "outer", 0, 0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", 0, 0))),
+	)
+}
+
+func invocationContextImportedStartModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "outer", 0, 0))),
+		wasmtest.Section(8, wasmtest.ULEB(0)),
+	)
+}
+
+func invocationContextNestedModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(
+			importEntry("env", "outer", 0, 0),
+			importEntry("env", "inner", 0, 0),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("call", 0, 2),
+			wasmtest.ExportEntry("nested", 0, 3),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x10, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x10, 0x01, 0x0b}),
+		)),
+	)
+}
+
+func invocationContextManagedTableModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "outer", 0, 0))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x00, 0x01})),
+		wasmtest.Section(9, wasmtest.Vec([]byte{0x00, 0x41, 0x00, 0x0b, 0x01, 0x01})),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x10, 0x00, 0x0b}))),
+	)
+}
+
+func TestCallerResolverInvocationContextContract(t *testing.T) {
+	state := new(invocationContextTestState)
+	rt := newInvocationContextTestRuntime(t, state)
+	defer rt.Close()
+
+	type contextKey struct{}
+	deadline := time.Now().Add(time.Hour)
+	parent, cancel := context.WithDeadline(context.WithValue(context.Background(), contextKey{}, "private"), deadline)
+	defer cancel()
+	var retained context.Context
+	var retainedCaller HostModule
+	var callbackErr error
+	var same, hidValue, deadlineMatches bool
+	state.outer = func(caller HostModule, _, _ []uint64) {
+		retainedCaller = caller
+		first, err := state.resolver.InvocationContext(caller)
+		if err != nil {
+			callbackErr = err
+			return
+		}
+		second, err := state.resolver.InvocationContext(caller)
+		if err != nil {
+			callbackErr = err
+			return
+		}
+		retained = first
+		same = first == second
+		hidValue = first.Value(contextKey{}) == nil
+		gotDeadline, ok := first.Deadline()
+		deadlineMatches = ok && gotDeadline.Equal(deadline)
+		callbackErr = first.Err()
+	}
+	module, err := rt.Compile(invocationContextImportModule("outer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := rt.Instantiate(context.Background(), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if _, err := in.Call(parent, "call"); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if callbackErr != nil || retained == nil || !same || !hidValue || !deadlineMatches {
+		t.Fatalf("callback context = err %v retained %v same %v hidden-value %v deadline %v", callbackErr, retained != nil, same, hidValue, deadlineMatches)
+	}
+	select {
+	case <-retained.Done():
+	default:
+		t.Fatal("retained invocation context remained live after callback return")
+	}
+	if retained.Err() != context.Canceled {
+		t.Fatalf("retained context error = %v, want context.Canceled", retained.Err())
+	}
+	if _, err := state.resolver.InvocationContext(retainedCaller); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("expired invocation context lookup = %v, want permission denied", err)
+	}
+	if _, err := state.resolver.InvocationContext(forgedHostModule{}); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("forged invocation context lookup = %v, want permission denied", err)
+	}
+	var nilResolver *CallerResolver
+	if _, err := nilResolver.InvocationContext(retainedCaller); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("nil resolver invocation context lookup = %v, want permission denied", err)
+	}
+
+	crossState := new(invocationContextTestState)
+	crossRuntime := newInvocationContextTestRuntime(t, crossState)
+	defer crossRuntime.Close()
+	var crossErr error
+	crossState.outer = func(caller HostModule, _, _ []uint64) {
+		_, crossErr = state.resolver.InvocationContext(caller)
+	}
+	crossModule, err := crossRuntime.Compile(invocationContextImportModule("outer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	crossInstance, err := crossRuntime.Instantiate(context.Background(), crossModule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer crossInstance.Close()
+	if _, err := crossInstance.Invoke("call"); err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(crossErr, ErrPermissionDenied) {
+		t.Fatalf("cross-runtime invocation context lookup = %v, want permission denied", crossErr)
+	}
+
+	var lowLevelErr error
+	state.outer = func(caller HostModule, _, _ []uint64) {
+		_, lowLevelErr = state.resolver.InvocationContext(caller)
+	}
+	lowLevel, err := Instantiate(module.Compiled(), InstantiateOptions{Imports: rt.HostImports()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lowLevel.Close()
+	if _, err := lowLevel.Invoke("call"); err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(lowLevelErr, ErrPermissionDenied) {
+		t.Fatalf("low-level invocation context lookup = %v, want permission denied", lowLevelErr)
+	}
+}
+
+func TestCallerResolverInvocationContextParentCancellationAndTrap(t *testing.T) {
+	t.Run("parent cancellation", func(t *testing.T) {
+		state := new(invocationContextTestState)
+		rt := newInvocationContextTestRuntime(t, state)
+		defer rt.Close()
+		entered := make(chan struct{})
+		var callbackErr error
+		state.outer = func(caller HostModule, _, _ []uint64) {
+			ctx, err := state.resolver.InvocationContext(caller)
+			if err != nil {
+				callbackErr = err
+				close(entered)
+				return
+			}
+			close(entered)
+			<-ctx.Done()
+			callbackErr = ctx.Err()
+		}
+		module, err := rt.Compile(invocationContextImportModule("outer"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		in, err := rt.Instantiate(context.Background(), module)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer in.Close()
+		parent, cancel := context.WithCancel(context.Background())
+		callDone := make(chan error, 1)
+		go func() {
+			_, err := in.Call(parent, "call")
+			callDone <- err
+		}()
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("host callback did not enter")
+		}
+		cancel()
+		select {
+		case err := <-callDone:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("Call error = %v, want nil or context.Canceled", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("parent cancellation did not release host callback")
+		}
+		if callbackErr != context.Canceled {
+			t.Fatalf("callback context error = %v, want context.Canceled", callbackErr)
+		}
+	})
+
+	t.Run("host trap", func(t *testing.T) {
+		state := new(invocationContextTestState)
+		rt := newInvocationContextTestRuntime(t, state)
+		defer rt.Close()
+		trapErr := errors.New("context trap")
+		var retained context.Context
+		state.outer = func(caller HostModule, _, _ []uint64) {
+			retained, _ = state.resolver.InvocationContext(caller)
+			panic(HostTrap{Err: trapErr})
+		}
+		module, err := rt.Compile(invocationContextImportModule("outer"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		in, err := rt.Instantiate(context.Background(), module)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer in.Close()
+		if _, err := in.Invoke("call"); !errors.Is(err, trapErr) {
+			t.Fatalf("Invoke error = %v, want host trap", err)
+		}
+		if retained == nil || retained.Err() != context.Canceled {
+			t.Fatalf("trapped callback context = %v/%v, want canceled", retained, retained.Err())
+		}
+	})
+}
+
+func TestCallerResolverInvocationContextBackgroundEntries(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T, *Runtime)
+	}{
+		{"raw invoke", func(t *testing.T, rt *Runtime) {
+			module, err := rt.Compile(invocationContextImportModule("outer"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			in, err := rt.Instantiate(context.Background(), module)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			if _, err := in.Invoke("call"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"prepared invoke", func(t *testing.T, rt *Runtime) {
+			module, err := rt.Compile(invocationContextImportModule("outer"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			in, err := rt.Instantiate(context.Background(), module)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			prepared, err := in.PrepareFunction("call")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := prepared.Invoke0(); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"imported start", func(t *testing.T, rt *Runtime) {
+			module, err := rt.Compile(invocationContextImportedStartModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			in, err := rt.Instantiate(context.Background(), module)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := new(invocationContextTestState)
+			rt := newInvocationContextTestRuntime(t, state)
+			defer rt.Close()
+			var callbackContext context.Context
+			var callbackErr error
+			var live, withoutDeadline bool
+			state.outer = func(caller HostModule, _, _ []uint64) {
+				callbackContext, callbackErr = state.resolver.InvocationContext(caller)
+				if callbackErr == nil {
+					live = callbackContext.Err() == nil
+					_, hasDeadline := callbackContext.Deadline()
+					withoutDeadline = !hasDeadline
+				}
+			}
+			test.run(t, rt)
+			if callbackErr != nil || callbackContext == nil || !live || !withoutDeadline {
+				t.Fatalf("background callback context = %v, %v, live %v, without deadline %v", callbackContext, callbackErr, live, withoutDeadline)
+			}
+			if callbackContext.Err() != context.Canceled {
+				t.Fatalf("background callback context after return = %v, want context.Canceled", callbackContext.Err())
+			}
+		})
+	}
+}
+
+func TestCallbackInvocationContextPreservesDeadlineError(t *testing.T) {
+	parent, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	ctx := newCallbackInvocationContext(1, parent)
+	if ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("context error = %v, want context.DeadlineExceeded", ctx.Err())
+	}
+}
+
+func TestCallerResolverInvocationContextReentryLifetimes(t *testing.T) {
+	state := new(invocationContextTestState)
+	rt := newInvocationContextTestRuntime(t, state)
+	defer rt.Close()
+	module, err := rt.Compile(invocationContextNestedModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := rt.Instantiate(context.Background(), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	outerDeadline := time.Now().Add(2 * time.Hour)
+	nestedDeadline := time.Now().Add(time.Hour)
+	outerParent, outerCancel := context.WithDeadline(context.Background(), outerDeadline)
+	defer outerCancel()
+	nestedParent, nestedCancel := context.WithDeadline(context.Background(), nestedDeadline)
+	defer nestedCancel()
+	var outerContext, nestedContext context.Context
+	var nestedCallErr error
+	var outerLiveAfterNested, nestedExpired, outerDeadlineOK, nestedDeadlineOK bool
+	state.inner = func(caller HostModule, _, _ []uint64) {
+		nestedContext, nestedCallErr = state.resolver.InvocationContext(caller)
+		if nestedCallErr == nil {
+			got, ok := nestedContext.Deadline()
+			nestedDeadlineOK = ok && got.Equal(nestedDeadline)
+		}
+	}
+	state.outer = func(caller HostModule, _, _ []uint64) {
+		outerContext, nestedCallErr = state.resolver.InvocationContext(caller)
+		if nestedCallErr != nil {
+			return
+		}
+		got, ok := outerContext.Deadline()
+		outerDeadlineOK = ok && got.Equal(outerDeadline)
+		_, nestedCallErr = in.InvokeFromHost(nestedParent, caller, "nested")
+		outerLiveAfterNested = outerContext.Err() == nil
+		nestedExpired = nestedContext != nil && nestedContext.Err() == context.Canceled
+	}
+	if _, err := in.Call(outerParent, "call"); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if nestedCallErr != nil || !outerLiveAfterNested || !nestedExpired || !outerDeadlineOK || !nestedDeadlineOK {
+		t.Fatalf("reentry contexts = err %v outer-live %v nested-expired %v deadlines %v/%v", nestedCallErr, outerLiveAfterNested, nestedExpired, outerDeadlineOK, nestedDeadlineOK)
+	}
+	if outerContext.Err() != context.Canceled {
+		t.Fatalf("outer context after return = %v, want context.Canceled", outerContext.Err())
+	}
+}
+
+func TestCallerResolverInvocationContextEntryPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T, *Runtime, *invocationContextTestState, context.Context)
+	}{
+		{"direct host reexport", func(t *testing.T, rt *Runtime, _ *invocationContextTestState, parent context.Context) {
+			module, err := rt.Compile(invocationContextReexportModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			in, err := rt.Instantiate(context.Background(), module)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			if _, err := in.InvokeContext(parent, "call"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"cross instance", func(t *testing.T, rt *Runtime, _ *invocationContextTestState, parent context.Context) {
+			producerModule, err := rt.Compile(invocationContextImportModule("outer"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			producer, err := rt.Instantiate(context.Background(), producerModule)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer producer.Close()
+			target, err := producer.ExportedFunc("call")
+			if err != nil {
+				t.Fatal(err)
+			}
+			consumerModule, err := rt.Compile(invocationContextImportModule("next"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			consumer, err := rt.Instantiate(context.Background(), consumerModule, WithImports(Imports{"env.next": target}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer consumer.Close()
+			if _, err := consumer.Call(parent, "call"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"managed table", func(t *testing.T, rt *Runtime, state *invocationContextTestState, parent context.Context) {
+			module, err := rt.Compile(invocationContextManagedTableModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			managed, err := state.manager.Instantiate(context.Background(), module)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer managed.Close()
+			if err := managed.InvokeVoidTable(parent, 0); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := new(invocationContextTestState)
+			rt := newInvocationContextTestRuntime(t, state)
+			defer rt.Close()
+			deadline := time.Now().Add(time.Hour)
+			parent, cancel := context.WithDeadline(context.Background(), deadline)
+			defer cancel()
+			var callbackContext context.Context
+			var callbackErr error
+			var deadlineOK bool
+			state.outer = func(caller HostModule, _, _ []uint64) {
+				callbackContext, callbackErr = state.resolver.InvocationContext(caller)
+				if callbackErr == nil {
+					got, ok := callbackContext.Deadline()
+					deadlineOK = ok && got.Equal(deadline)
+				}
+			}
+			test.run(t, rt, state, parent)
+			if callbackErr != nil || callbackContext == nil || !deadlineOK {
+				t.Fatalf("callback context = %v, %v, deadline %v", callbackContext, callbackErr, deadlineOK)
+			}
+			if callbackContext.Err() != context.Canceled {
+				t.Fatalf("callback context after entry return = %v, want context.Canceled", callbackContext.Err())
+			}
+		})
+	}
+}
+
+func TestCallerResolverInvocationContextDoesNotReplaceCallerWatcher(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	resolver := &CallerResolver{}
+	resolver.activate(rt)
+	defer resolver.close()
+	manager := newPendingInstanceManager("test.invocation-context", AuthorityScope{})
+	manager.activate(rt)
+	in := &Instance{rt: rt}
+	managed := &ManagedInstance{manager: manager, value: in}
+	manager.byInstance[in] = managed
+	caller := in.beginHostCallScope()
+	wake, stop, err := manager.WatchCaller(caller)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop()
+	ctx, err := resolver.InvocationContext(caller)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caller.scope.end(caller.generation, caller.parentGeneration)
+	select {
+	case <-wake:
+	default:
+		t.Fatal("caller watcher was not signaled")
+	}
+	if ctx.Err() != context.Canceled {
+		t.Fatalf("invocation context error = %v, want context.Canceled", ctx.Err())
+	}
+}
+
+func TestCallerResolverInvocationContextExitRace(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	resolver := &CallerResolver{}
+	resolver.activate(rt)
+	defer resolver.close()
+	in := &Instance{rt: rt}
+	for i := 0; i < 1000; i++ {
+		caller := in.beginHostCallScope()
+		result := make(chan context.Context, 1)
+		go func() {
+			ctx, _ := resolver.InvocationContext(caller)
+			result <- ctx
+		}()
+		caller.scope.end(caller.generation, caller.parentGeneration)
+		if ctx := <-result; ctx != nil {
+			select {
+			case <-ctx.Done():
+			default:
+				t.Fatal("context acquired during callback exit remained live")
+			}
+		}
+	}
+}
+
+var invocationContextBenchmarkSink context.Context
+
+func BenchmarkCallerResolverInvocationContext(b *testing.B) {
+	rt := NewRuntime()
+	defer rt.Close()
+	resolver := &CallerResolver{}
+	resolver.activate(rt)
+	defer resolver.close()
+	in := &Instance{rt: rt}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		caller := in.beginHostCallScope()
+		ctx, err := resolver.InvocationContext(caller)
+		if err != nil {
+			b.Fatal(err)
+		}
+		invocationContextBenchmarkSink = ctx
+		caller.scope.end(caller.generation, caller.parentGeneration)
+	}
+	b.ReportMetric(float64(unsafe.Sizeof(hostCallScope{})), "scope-B")
+	b.ReportMetric(float64(unsafe.Sizeof(instancePluginState{})), "plugin-state-B")
+}

--- a/src/wago/invocation_context_test.go
+++ b/src/wago/invocation_context_test.go
@@ -318,6 +318,62 @@ func TestCallerResolverInvocationContextParentCancellationAndTrap(t *testing.T) 
 	})
 }
 
+func TestCallerResolverInvocationContextWithoutNativeInterruption(t *testing.T) {
+	state := new(invocationContextTestState)
+	rt := newInvocationContextTestRuntime(t, state)
+	defer rt.Close()
+	module, err := rt.Compile(invocationContextImportModule("outer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := rt.Instantiate(context.Background(), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+
+	deadline := time.Now().Add(time.Hour)
+	parent, cancel := context.WithDeadline(context.Background(), deadline)
+	entered := make(chan struct{})
+	var callbackErr error
+	var deadlineOK bool
+	state.outer = func(caller HostModule, _, _ []uint64) {
+		ctx, err := state.resolver.InvocationContext(caller)
+		if err != nil {
+			callbackErr = err
+			close(entered)
+			return
+		}
+		got, ok := ctx.Deadline()
+		deadlineOK = ok && got.Equal(deadline)
+		close(entered)
+		<-ctx.Done()
+		callbackErr = ctx.Err()
+	}
+	callDone := make(chan error, 1)
+	go func() {
+		_, err := in.invokeEntry("call", nil, invocationContextSet{callback: parent}, false)
+		callDone <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("host callback did not enter")
+	}
+	cancel()
+	select {
+	case err := <-callDone:
+		if err != nil {
+			t.Fatalf("invoke without native interruption: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("callback context did not observe cancellation")
+	}
+	if callbackErr != context.Canceled || !deadlineOK {
+		t.Fatalf("callback context = %v, deadline %v; want canceled with parent deadline", callbackErr, deadlineOK)
+	}
+}
+
 func TestCallerResolverInvocationContextBackgroundEntries(t *testing.T) {
 	tests := []struct {
 		name string

--- a/src/wago/plugin_gc_host_import_test.go
+++ b/src/wago/plugin_gc_host_import_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/wasmtest"
@@ -15,6 +16,8 @@ type pluginGCHostImportTestPlugin struct{ state *pluginGCHostImportTestState }
 
 type pluginGCHostImportTestState struct {
 	mu                sync.Mutex
+	resolver          *CallerResolver
+	invocationContext context.Context
 	retainedStorage   GuestStorage
 	retainedRef       GuestGCRef
 	otherViewRejected bool
@@ -22,12 +25,19 @@ type pluginGCHostImportTestState struct {
 
 func pluginGCHostImportTestProvider(state *pluginGCHostImportTestState) PluginProvider {
 	def := testDefinition("example.com/plugin-gc-host-import")
-	def.Authorities = []AuthorityRequest{{
-		Name:   AuthorityHostImportDefine,
-		Mode:   AuthorityRequired,
-		Reason: "define GC-reference host imports",
-		Scope:  AuthorityScope{Modules: []string{"plugin_gc"}},
-	}}
+	def.Authorities = []AuthorityRequest{
+		{
+			Name:   AuthorityHostImportDefine,
+			Mode:   AuthorityRequired,
+			Reason: "define GC-reference host imports",
+			Scope:  AuthorityScope{Modules: []string{"plugin_gc"}},
+		},
+		{
+			Name:   AuthorityHostCallerIdentify,
+			Mode:   AuthorityRequired,
+			Reason: "test GC host invocation context",
+		},
+	}
 	return PluginProvider{
 		Definition: def,
 		New: func() Plugin {
@@ -64,10 +74,15 @@ func requirePluginGCArrayType(storage GuestStorage, result bool, index int) (Def
 }
 
 func (p pluginGCHostImportTestPlugin) Register(reg *Registrar) error {
+	resolver, err := reg.HostCallers()
+	if err != nil {
+		return err
+	}
 	imports, err := reg.HostImports()
 	if err != nil {
 		return err
 	}
+	p.state.resolver = resolver
 	module, err := imports.Module("plugin_gc")
 	if err != nil {
 		return err
@@ -193,6 +208,17 @@ func (p pluginGCHostImportTestPlugin) Register(reg *Registrar) error {
 	module.Func("scalar", func(_ HostModule, _, results []uint64) {
 		results[0] = 11
 	}).Results(ValI32)
+	module.Func("context", func(m HostModule, params, results []uint64) {
+		if params[0] != 0 {
+			panic(HostTrap{Err: fmt.Errorf("context parameter arrived as %#x, want null", params[0])})
+		}
+		ctx, err := p.state.resolver.InvocationContext(m)
+		pluginGCHostTrap(err)
+		p.state.mu.Lock()
+		p.state.invocationContext = ctx
+		p.state.mu.Unlock()
+		results[0] = 1
+	}).Params(ValAnyRef).Results(ValI32)
 	return nil
 }
 
@@ -225,13 +251,17 @@ func pluginGCNullResultModule(name string, nullable bool) []byte {
 }
 
 func pluginGCNullParamModule() []byte {
+	return pluginGCNullParamModuleNamed("null_param")
+}
+
+func pluginGCNullParamModuleNamed(name string) []byte {
 	arrayType := []byte{0x5e, 0x78, 0x01}
 	importType := []byte{0x60, 0x01, 0x63, 0x00, 0x01, 0x7f}
 	callerType := wasmtest.FuncType(nil, []wasm.ValType{wasm.I32})
 	body := []byte{0xd0, 0x00, 0x10, 0x00, 0x0b} // ref.null 0; call 0; end
 	return wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(arrayType, importType, callerType)),
-		wasmtest.Section(2, wasmtest.Vec(pluginGCImport("plugin_gc", "null_param", 1))),
+		wasmtest.Section(2, wasmtest.Vec(pluginGCImport("plugin_gc", name, 1))),
 		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2))),
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("call", 0, 1))),
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
@@ -368,6 +398,44 @@ func TestPluginGCHostImportsBoundaryOnlyNulls(t *testing.T) {
 				t.Fatalf("call = %v, %v; want i32(1)", values, err)
 			}
 		})
+	}
+}
+
+func TestPluginGCHostImportInvocationContext(t *testing.T) {
+	requireCompleteCore3Backend(t)
+	rt, state := newPluginGCTestRuntime(t)
+	defer rt.Close()
+	module, err := rt.Compile(pluginGCNullParamModuleNamed("context"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := rt.Instantiate(context.Background(), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	deadline := time.Now().Add(time.Hour)
+	parent, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	result, err := in.Call(parent, "call")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 1 || result[0].I32() != 1 {
+		t.Fatalf("call result = %v, want i32(1)", result)
+	}
+	state.mu.Lock()
+	ctx := state.invocationContext
+	state.mu.Unlock()
+	if ctx == nil {
+		t.Fatal("GC host import did not receive an invocation context")
+	}
+	gotDeadline, ok := ctx.Deadline()
+	if !ok || !gotDeadline.Equal(deadline) {
+		t.Fatalf("GC host deadline = %v, %v; want %v, true", gotDeadline, ok, deadline)
+	}
+	if ctx.Err() != context.Canceled {
+		t.Fatalf("GC host context after callback = %v, want context.Canceled", ctx.Err())
 	}
 }
 

--- a/src/wago/reference_value_test.go
+++ b/src/wago/reference_value_test.go
@@ -268,7 +268,7 @@ func TestHostCallWaitRegistrationLifecycle(t *testing.T) {
 		t.Fatal("scope end did not wake registered waiter")
 	}
 	h.unregisterWait(w)
-	if got := scope.waiter.Load(); got != nil {
+	if got := scope.state.Load().waiter.Load(); got != nil {
 		t.Fatalf("unregister retained waiter %p", got)
 	}
 	if h.registerWait(&hostCallWaiter{wake: make(chan struct{}, 1)}) {


### PR DESCRIPTION
## Summary

- expose `CallerResolver.InvocationContext` to synchronous host callbacks
- propagate invocation cancellation and deadlines across native, managed, reentrant, re-exported, cross-instance, GC-bearing, and portable non-native-interruption paths
- keep callback-visible context separate from native interruption so low-end architectures retain cooperative host cancellation
- keep the context callback-scoped and hide caller values to preserve the existing capability boundary
- document the API and lifecycle contract

Closes #499.

## Verification

- `go test ./src/wago -count=1`
- focused invocation-context race detector suite
- `make tinygo-test` with TinyGo 0.41.1 and Go 1.26.1
- `make spec3`: 2,226 modules and 58,238 assertions passed with zero failures, skips, or gaps
- repository-wide `go test ./...` passed with only `TestWineCmdBootstrapDownloadsVerifiesAndExecutesInstaller` excluded because this host Wine installation lacks `curl.exe`; all other Wine tests ran

## Performance and footprint

- ordinary host-call baseline remains 736 B/op and 3 allocs/op
- opt-in invocation-context resolution measures 170–172 ns/op, 208 B/op, and 2 allocs/op
- existing host-call scope and plugin state sizes remain unchanged