### PR TITLE
gc: remove repeated helper-boundary root scans

### DIFF
--- a/src/core/runtime/gc/native_alloc.go
+++ b/src/core/runtime/gc/native_alloc.go
@@ -219,10 +219,37 @@ func (c *Collector) discardNativeStructHandles() {
 		c.nurseryBump = rewind
 	}
 	if canceled {
-		// Remove canceled identities immediately. A failed collection can return
-		// before normal nursery compaction, and later handle reuse must not append
-		// a duplicate identity to the dense young set.
-		c.compactNurseryHandles()
+		// Reserved handles are appended as one tail batch and no Go allocation or
+		// collection can append another nursery identity before cancellation. Trim
+		// that bounded tail directly and retain only consumed live handles. Keep the
+		// full compaction as a fail-closed fallback if the invariant is not exact.
+		trimmed := false
+		if int(end) <= len(c.nurseryHandles) {
+			start := len(c.nurseryHandles) - int(end)
+			trimmed = true
+			for i := uint32(0); i < end; i++ {
+				if c.nurseryHandles[start+int(i)] != s.Handles[i] {
+					trimmed = false
+					break
+				}
+			}
+			if trimmed {
+				out := c.nurseryHandles[:start]
+				for i := uint32(0); i < end; i++ {
+					h := s.Handles[i]
+					if h != 0 && int(h) < len(c.handles) && c.handles[h].space != spaceFree {
+						out = append(out, h)
+					}
+				}
+				c.nurseryHandles = out
+			}
+		}
+		if !trimmed {
+			// A failed collection can return before normal nursery compaction, and
+			// later handle reuse must not append a duplicate identity to the dense
+			// young set.
+			c.compactNurseryHandles()
+		}
 	}
 	clear(s.Handles[:])
 	s.Cursor = 0

--- a/src/core/runtime/gc/native_alloc_test.go
+++ b/src/core/runtime/gc/native_alloc_test.go
@@ -219,6 +219,68 @@ func TestNativeStructHandleCancellationCannotDuplicateNurserySet(t *testing.T) {
 	}
 }
 
+func TestNativeStructHandleCancellationPreservesDenseNurseryPrefix(t *testing.T) {
+	desc, err := NewStructDesc(0, []StorageKind{StorageI32})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewCollector(Config{}, []TypeDesc{desc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	const prefixCount = 4096
+	prefix := make([]uint32, 0, prefixCount)
+	for range prefixCount {
+		h := c.newHandle(handleEntry{size: 16, allocSize: 16, space: spaceNursery})
+		c.nurseryHandles = append(c.nurseryHandles, h)
+		prefix = append(prefix, h)
+	}
+	if !c.PrepareNativeStructHandles() {
+		t.Fatal("native handle batch was not prepared")
+	}
+	s := &c.nativeStructAlloc
+	consumed := s.Handles[0]
+	c.handles[consumed] = handleEntry{size: 16, allocSize: 16, space: spaceNursery}
+	s.Cursor = 1
+	c.CancelNativeAllocationBatch()
+	if len(c.nurseryHandles) != prefixCount+1 {
+		t.Fatalf("nursery handles = %d, want %d", len(c.nurseryHandles), prefixCount+1)
+	}
+	for i, want := range prefix {
+		if got := c.nurseryHandles[i]; got != want {
+			t.Fatalf("nursery prefix %d = %d, want %d", i, got, want)
+		}
+	}
+	if got := c.nurseryHandles[prefixCount]; got != consumed {
+		t.Fatalf("consumed native handle = %d, want %d", got, consumed)
+	}
+}
+
+func BenchmarkNativeAllocationBatchCancelDenseNursery(b *testing.B) {
+	desc, err := NewStructDesc(0, []StorageKind{StorageI32})
+	if err != nil {
+		b.Fatal(err)
+	}
+	c, err := NewCollector(Config{}, []TypeDesc{desc})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer c.Close()
+	for range 1 << 16 {
+		h := c.newHandle(handleEntry{size: 16, allocSize: 16, space: spaceNursery})
+		c.nurseryHandles = append(c.nurseryHandles, h)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if !c.PrepareNativeStructHandles() {
+			b.Fatal("native handle batch was not prepared")
+		}
+		c.CancelNativeAllocationBatch()
+	}
+}
+
 func TestNativeStructHandleBatchRejectedProfiles(t *testing.T) {
 	desc, err := NewStructDesc(0, []StorageKind{StorageI32})
 	if err != nil {

--- a/src/core/runtime/gc/roots.go
+++ b/src/core/runtime/gc/roots.go
@@ -632,6 +632,13 @@ func (c *Collector) SetGlobalSlot(i uint32, r Ref) error {
 	if !slotIndexOK(i, len(c.globalSlots)) {
 		return errRange
 	}
+	// Module-global synchronization commonly republishes unchanged roots at
+	// allocation safepoints. The stored value was already validated and its
+	// existing card remains conservative, so avoid repeating validation and the
+	// write barrier when no publication occurs.
+	if c.globalSlots[i] == r {
+		return nil
+	}
 	if err := c.validateStoredRef(r, true); err != nil {
 		return err
 	}
@@ -693,6 +700,9 @@ func (c *Collector) SetTableSlot(i uint32, r Ref) error {
 	}
 	if !slotIndexOK(i, len(c.tableSlots)) {
 		return errRange
+	}
+	if c.tableSlots[i] == r {
+		return nil
 	}
 	if err := c.validateStoredRef(r, true); err != nil {
 		return err

--- a/src/wago/gc_array_helper.go
+++ b/src/wago/gc_array_helper.go
@@ -80,9 +80,6 @@ func (in *Instance) dispatchGCArrayHelperParked(ctrl uintptr, helper, safepoint 
 		state = in.publicGCState()
 		state.mu.Lock()
 		defer state.mu.Unlock()
-		if err := in.syncGenericGCGlobalRootsLocked(state); err != nil {
-			panic(gcStructHelperError{err: err})
-		}
 		frameRoots = in.gcHelperRoots(ctrl, state, safepoint)
 	}
 

--- a/src/wago/gc_frame_roots_runtime_arm64.go
+++ b/src/wago/gc_frame_roots_runtime_arm64.go
@@ -53,8 +53,8 @@ func (in *Instance) gcHelperRoots(ctrl uintptr, state *gcPublicState, safepointI
 	state.frameRoots.base = base
 	state.frameRoots.offsets = offsets
 	state.frameRoots.frameBytes = frameBytes
-	state.frameRoots.frameLayout = gcNativeFrameLayoutARM64 // saved LR follows saved FP above the frame reserve
-	state.frameRoots.allowExternalReturn = true             // non-register public entries return directly to enterNative
+	state.frameRoots.frameLayout = gcNativeFrameLayoutARM64 | gcNativeFrameSyncGlobalRoots // saved LR follows saved FP above the frame reserve
+	state.frameRoots.allowExternalReturn = true                                            // non-register public entries return directly to enterNative
 	state.frameRoots.codeBase = in.base
 	state.frameRoots.codeBytes = uintptr(len(in.c.code))
 	state.frameRoots.adapterReturnOffsets = plan.adapterReturnOffsets

--- a/src/wago/gc_frame_roots_runtime_linux_amd64.go
+++ b/src/wago/gc_frame_roots_runtime_linux_amd64.go
@@ -57,7 +57,7 @@ func (in *Instance) gcHelperRoots(ctrl uintptr, state *gcPublicState, safepointI
 	state.frameRoots.base = base
 	state.frameRoots.offsets = offsets
 	state.frameRoots.frameBytes = frameBytes
-	state.frameRoots.frameLayout = gcNativeFrameLayoutAMD64
+	state.frameRoots.frameLayout = gcNativeFrameLayoutAMD64 | gcNativeFrameSyncGlobalRoots
 	state.frameRoots.codeBase = in.base
 	state.frameRoots.codeBytes = uintptr(len(in.c.code))
 	state.frameRoots.adapterReturnOffsets = plan.adapterReturnOffsets

--- a/src/wago/gc_struct_helper.go
+++ b/src/wago/gc_struct_helper.go
@@ -96,9 +96,6 @@ func (in *Instance) dispatchGCStructHelperParked(ctrl uintptr, helper, safepoint
 		state = in.publicGCState()
 		state.mu.Lock()
 		defer state.mu.Unlock()
-		if err := in.syncGenericGCGlobalRootsLocked(state); err != nil {
-			panic(gcStructHelperError{err: err})
-		}
 		frameRoots = in.gcHelperRoots(ctrl, state, safepoint)
 	}
 	structFieldKind := func(typeID, fieldID uint32) gc.StorageKind {

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -382,6 +382,8 @@ type gcRefTokenEntry struct {
 const (
 	gcNativeFrameLayoutAMD64 uint8 = iota
 	gcNativeFrameLayoutARM64
+	gcNativeFrameLayoutMask      = 0x7f
+	gcNativeFrameSyncGlobalRoots = 0x80
 )
 
 type gcNativeFrameRoots struct {
@@ -416,6 +418,19 @@ func (r *gcNativeFrameRoots) RangeRootRefs(sink gc.RootRefSink) bool {
 	return r.walk(nil, sink)
 }
 
+func (r *gcNativeFrameRoots) syncGlobalsBeforeCollection() {
+	if r == nil || r.frameLayout&gcNativeFrameSyncGlobalRoots == 0 || r.owner == nil || r.suspended == nil {
+		return
+	}
+	if err := r.owner.syncGenericGCGlobalRootsLocked(r.suspended); err != nil {
+		panic(gcStructHelperError{err: err})
+	}
+	// Native execution remains parked for the complete allocation attempt. One
+	// synchronization therefore covers a minor collection, root rewrites, and a
+	// possible full-collection retry. The next helper republishes this flag.
+	r.frameLayout &^= gcNativeFrameSyncGlobalRoots
+}
+
 // RangeClassifiedRootRefs preserves exact runtime ownership for opt-in
 // collector telemetry without allocating composite RootSet values on helper
 // paths.
@@ -423,6 +438,7 @@ func (r *gcNativeFrameRoots) RangeClassifiedRootRefs(sink gc.ClassifiedRootRefSi
 	if r == nil || sink == nil {
 		return true
 	}
+	r.syncGlobalsBeforeCollection()
 	if !r.rangeChain(nil, classifiedRootSink{sink: sink, class: gc.RootNativeFrame}) {
 		return false
 	}
@@ -473,6 +489,7 @@ func (s classifiedRootSink) VisitRootRef(r gc.Ref) bool {
 }
 
 func (r *gcNativeFrameRoots) walk(fn func(gc.RootSlot) bool, sink gc.RootRefSink) bool {
+	r.syncGlobalsBeforeCollection()
 	if !r.rangeChain(fn, sink) {
 		return false
 	}
@@ -633,7 +650,7 @@ func (r *gcNativeFrameRoots) rangeChain(fn func(gc.RootSlot) bool, sink gc.RootR
 			return true
 		}
 		returnPCBias, callerFrameBias := uintptr(0), uintptr(abi.AMD64CallReturnAddressBytes)
-		if r.frameLayout == gcNativeFrameLayoutARM64 {
+		if r.frameLayout&gcNativeFrameLayoutMask == gcNativeFrameLayoutARM64 {
 			returnPCBias = uintptr(shared.ARM64SavedLROffset)
 			callerFrameBias = uintptr(shared.ARM64FrameRecordBytes)
 		}


### PR DESCRIPTION
## Summary

Remove two O(heap/global-count) costs from ordinary WasmGC allocation helper boundaries.

The Dewdrop self-host compiler has about 2,991 reference globals and a large live nursery set. Before this change, a 90-second CPU profile spent 78% of samples synchronizing every global root at every allocating helper. After the first optimization, native-batch cancellation exposed a second full nursery compaction that consumed about half of samples.

## Changes

- Skip validation and write barriers when a persistent root slot already contains the requested reference.
- Defer module-global root synchronization until a collection actually enumerates the parked frame root set.
- Use one spare bit in the existing frame-layout byte, preserving `gcPublicState` size.
- Trim the exact 32-handle native reservation tail during cancellation.
- Retain full nursery compaction as a fail-closed fallback when the tail invariant does not match.
- Add dense-prefix correctness and benchmark coverage.

## Measurements

```text
BenchmarkGCPersistentRootBarrier
before: about 8.3 ns/op
 after: about 1.8 ns/op
```

```text
BenchmarkNativeAllocationBatchCancelDenseNursery
before: about 116 us/op
 after: about 250 ns/op
```

On the 2.3 MiB Dewdrop compiler artifact:

- before: `syncGenericGCGlobalRootsLocked` consumed 78% of a 90-second profile;
- after unchanged-slot fast path: native-batch compaction consumed about 50%;
- after both commits and lazy synchronization: neither path appears in the top profile entries, and external generated code becomes the largest sample.

The workload still has a separate late null-reference failure in Dewdrop module emission. This PR is limited to the measured runtime costs and does not claim that the full bootstrap now completes.

## Proof

```text
go test ./src/core/runtime/gc
ok github.com/wago-org/wago/src/core/runtime/gc

go test ./src/wago
ok github.com/wago-org/wago/src/wago

go test ./src/core/compiler/backend/railshot/amd64
ok github.com/wago-org/wago/src/core/compiler/backend/railshot/amd64
```

Docs are unchanged. This is an internal collector/runtime performance fix with no workflow change.
