### PR TITLE
gc: configure heap sizing and preserve wide arguments

### DIFF
--- a/cli/internal/handoff/runtime_commands.go
+++ b/cli/internal/handoff/runtime_commands.go
@@ -23,6 +23,8 @@ func RuntimeCommands() []*command.Cmd {
 	runFlags = append(runFlags, runtimeWatchFlags()...)
 	runFlags = append(runFlags,
 		command.Flag{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 | 3 (default: best supported)"},
+		command.Flag{Name: "gc-heap", Arg: "<size>", Help: "throughput GC heap capacity in bytes or KiB, MiB, GiB"},
+		command.Flag{Name: "gc-nursery", Arg: "<size>", Help: "throughput GC nursery capacity in bytes or KiB, MiB, GiB"},
 		parallel,
 	)
 	runFlags = append(runFlags, profileFlags...)

--- a/cli/manager/internal/plugin/environment_test.go
+++ b/cli/manager/internal/plugin/environment_test.go
@@ -169,6 +169,12 @@ func TestRunPluginScopeOverrides(t *testing.T) {
 	}
 
 	t.Setenv("WAGO_GLOBAL", "")
+	applyTestPluginScope(t, []string{"run", "--gc-heap", "2GiB", "--gc-nursery=64MiB", "--global", "module.wasm"})
+	if !projectconfig.Truthy("WAGO_GLOBAL") {
+		t.Fatal("GC sizing flag value hid --global")
+	}
+
+	t.Setenv("WAGO_GLOBAL", "")
 	t.Setenv("WAGO_LOCAL", "")
 	t.Setenv("WAGO_BARE", "")
 	applyTestPluginScope(t, []string{"run", "--local", "module.wasm"})

--- a/cli/manager/internal/plugin/invoke.go
+++ b/cli/manager/internal/plugin/invoke.go
@@ -89,7 +89,7 @@ func applyRunScope(args []string, environment Environment) error {
 			local = true
 		case "--bare":
 			bare = true
-		case "--invoke", "-e", "--core", "--watch-interval":
+		case "--invoke", "-e", "--core", "--watch-interval", "--gc-heap", "--gc-nursery":
 			if !inline && index+1 < len(args) {
 				index++
 			}

--- a/cli/runtime/commands/run/command.go
+++ b/cli/runtime/commands/run/command.go
@@ -2,7 +2,6 @@
 package run
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -32,8 +31,9 @@ func Command(environment Environment) *command.Cmd {
 	flags = append(flags, watchFlags()...)
 	flags = append(flags,
 		command.Flag{Name: "core", Arg: "<version>", Help: "WebAssembly core feature set: 2 | 3 (default: best supported)"},
-		ParallelFlag(),
 	)
+	flags = append(flags, gcFlags()...)
+	flags = append(flags, ParallelFlag())
 	flags = append(flags, environment.ProfileFlags()...)
 	knobs := append(DeferredBoundsCheckingFlags(), OptimizationFlags()...)
 	parserFlags := append(append([]command.Flag(nil), flags...), knobs...)
@@ -51,7 +51,8 @@ func Command(environment Environment) *command.Cmd {
 			"Selected Core 3 features default on where supported; use --core 2 for strict Release 2\n" +
 			"or --core 3 for the complete release. Use -p for\n" +
 			"adaptive validation/compile parallelism, or -p8 / -p 8 / --parallel=8 to force a\n" +
-			"worker maximum. Advanced compiler controls are listed in `wago run --help-optimizations`.",
+			"worker maximum. " + gcLongHelp() +
+			"Advanced compiler controls are listed in `wago run --help-optimizations`.",
 		Run: implementation.Run,
 	}
 }
@@ -86,6 +87,10 @@ func (cmd implementation) Run(ctx *command.Ctx) {
 		}
 		ui.Usage("run: %v", err)
 	}
+	gc, configuredGC, err := gcConfiguration(ctx)
+	if err != nil {
+		ui.Usage("run: %v", err)
+	}
 	config := selection.RuntimeConfig()
 	runtime := cmd.environment.LoadRuntime(config, positionals)
 	defer runtime.Close()
@@ -94,12 +99,12 @@ func (cmd implementation) Run(ctx *command.Ctx) {
 	export := mustResolveExport(compiled, ctx.Str("invoke"))
 
 	if export == "_start" {
-		runStart(runtime, module)
+		runStart(runtime, module, gc, configuredGC)
 		return
 	}
 	params, results, _ := compiled.Signature(export)
 	values := mustParseArgs(positionals[1:], params)
-	instance, err := runtime.Instantiate(context.Background(), module)
+	instance, err := instantiate(runtime, module, gc, configuredGC)
 	if err != nil {
 		ui.Fatal("%v", friendlyInstantiationError(err))
 	}
@@ -111,8 +116,8 @@ func (cmd implementation) Run(ctx *command.Ctx) {
 	fmt.Println(format(export, values, result, params, results))
 }
 
-func runStart(runtime *wago.Runtime, module *wago.Module) {
-	instance, err := runtime.Instantiate(context.Background(), module)
+func runStart(runtime *wago.Runtime, module *wago.Module, gc wago.GCConfig, configuredGC bool) {
+	instance, err := instantiate(runtime, module, gc, configuredGC)
 	if err != nil {
 		ui.Fatal("%v", friendlyInstantiationError(err))
 	}

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -77,6 +77,8 @@ func TestHelpCollapsesBooleanPairs(t *testing.T) {
 		t.Fatalf("run help did not collapse advanced optimization help:\n%s", text)
 	}
 	if !strings.Contains(text, "--parallel, -p [workers]") ||
+		!strings.Contains(text, "--gc-heap <size>") ||
+		!strings.Contains(text, "--gc-nursery <size>") ||
 		!strings.Contains(text, "-p8 / -p 8 / --parallel=8") ||
 		!strings.Contains(text, "use -- before colliding guest flags") {
 		t.Fatalf("run help did not document function parallelism:\n%s", text)
@@ -115,6 +117,38 @@ func TestRunRecognizesFlagsAfterModulePath(t *testing.T) {
 	}
 	if !ctx.Bool("global") || len(ctx.Args) != 1 || ctx.Args[0] != "module.wasm" {
 		t.Fatalf("file --global parsed as global=%v args=%v", ctx.Bool("global"), ctx.Args)
+	}
+}
+
+func TestRunGCHeapFlags(t *testing.T) {
+	cmd := Command(testEnvironment{})
+	normalized, err := cmd.Normalize([]string{"module.wasm", "--gc-heap", "2GiB", "--gc-nursery=64MiB"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, err := cmd.Parse("wago run", normalized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, configured, err := gcConfiguration(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !configured || cfg.ThroughputHeapBytes != 2<<30 || cfg.NurseryBytes != 64<<20 {
+		t.Fatalf("GC config = %+v, configured=%v", cfg, configured)
+	}
+	if len(ctx.Args) != 1 || ctx.Args[0] != "module.wasm" {
+		t.Fatalf("GC flags consumed guest arguments: %v", ctx.Args)
+	}
+
+	for _, value := range []string{"0", "4GiB", "1GB", "many"} {
+		ctx := command.NewContext(nil, map[string]string{"gc-heap": value}, nil)
+		if _, _, err := gcConfiguration(ctx); err == nil {
+			t.Errorf("gc heap %q was accepted", value)
+		}
+	}
+	if _, configured, err := gcConfiguration(command.NewContext(nil, nil, nil)); err != nil || configured {
+		t.Fatalf("default GC config = configured %v, error %v", configured, err)
 	}
 }
 
@@ -293,6 +327,30 @@ func TestRunExecValueMode(t *testing.T) {
 	}
 	implementation{environment: testEnvironment{}}.Run(command.NewContext([]string{path}, nil, nil))
 	implementation{environment: testEnvironment{}}.Run(command.NewContext([]string{path}, nil, map[string]bool{"no-deferred-bounds-checking": true}))
+}
+
+func TestRunExecGCHeapOverride(t *testing.T) {
+	if wago.CoreFeaturesV3&^wago.SupportedFeatures() != 0 {
+		t.Skip("complete Core 3 execution is unavailable on this platform")
+	}
+	t.Setenv("WAGO_BARE", "1")
+	// (module (type (array (mut i8))) (func (export "_start")
+	//   i32.const 20971520 array.new_default 0 drop))
+	wasm := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+		0x01, 0x07, 0x02, 0x5e, 0x78, 0x01, 0x60, 0x00,
+		0x00, 0x03, 0x02, 0x01, 0x01, 0x07, 0x0a, 0x01,
+		0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00,
+		0x00, 0x0a, 0x0d, 0x01, 0x0b, 0x00, 0x41, 0x80,
+		0x80, 0x80, 0x0a, 0xfb, 0x07, 0x00, 0x1a, 0x0b}
+	path := filepath.Join(t.TempDir(), "large-array.wasm")
+	if err := os.WriteFile(path, wasm, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	implementation{environment: testEnvironment{}}.Run(command.NewContext(
+		[]string{path},
+		map[string]string{"core": "3", "gc-heap": "32MiB"},
+		nil,
+	))
 }
 
 func TestRunExecProgramMode(t *testing.T) {

--- a/cli/runtime/commands/run/gc_heap.go
+++ b/cli/runtime/commands/run/gc_heap.go
@@ -1,0 +1,87 @@
+//go:build !wago_lean
+
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/wago-org/wago"
+	"github.com/wago-org/wago/cli/internal/command"
+)
+
+func gcFlags() []command.Flag {
+	return []command.Flag{
+		{Name: "gc-heap", Arg: "<size>", Help: "throughput GC heap capacity in bytes or KiB, MiB, GiB"},
+		{Name: "gc-nursery", Arg: "<size>", Help: "throughput GC nursery capacity in bytes or KiB, MiB, GiB"},
+	}
+}
+
+func gcLongHelp() string {
+	return "Large WasmGC workloads can set --gc-heap and --gc-nursery with binary sizes such as 2GiB and 64MiB. "
+}
+
+func instantiate(runtime *wago.Runtime, module *wago.Module, gc wago.GCConfig, configured bool) (*wago.Instance, error) {
+	if configured {
+		return runtime.Instantiate(context.Background(), module, wago.WithGC(gc))
+	}
+	return runtime.Instantiate(context.Background(), module)
+}
+
+func gcConfiguration(ctx *command.Ctx) (wago.GCConfig, bool, error) {
+	var cfg wago.GCConfig
+	heap := ctx.Str("gc-heap")
+	if heap != "" {
+		value, err := parseGCBytes(heap)
+		if err != nil {
+			return cfg, false, fmt.Errorf("--gc-heap: %w", err)
+		}
+		cfg.ThroughputHeapBytes = value
+	}
+	nursery := ctx.Str("gc-nursery")
+	if nursery != "" {
+		value, err := parseGCBytes(nursery)
+		if err != nil {
+			return cfg, false, fmt.Errorf("--gc-nursery: %w", err)
+		}
+		cfg.NurseryBytes = value
+	}
+	return cfg, heap != "" || nursery != "", nil
+}
+
+func parseGCBytes(raw string) (uint32, error) {
+	value := raw
+	multiplier := uint64(1)
+	switch {
+	case strings.HasSuffix(value, "GiB"):
+		value, multiplier = value[:len(value)-3], 1<<30
+	case strings.HasSuffix(value, "MiB"):
+		value, multiplier = value[:len(value)-3], 1<<20
+	case strings.HasSuffix(value, "KiB"):
+		value, multiplier = value[:len(value)-3], 1<<10
+	case strings.HasSuffix(value, "B"):
+		value = value[:len(value)-1]
+	}
+	if value == "" {
+		return 0, errors.New("size is empty")
+	}
+	limit := uint64(^uint32(0)) / multiplier
+	count := uint64(0)
+	for i := 0; i < len(value); i++ {
+		digit := value[i]
+		if digit < '0' || digit > '9' {
+			return 0, fmt.Errorf("invalid size %q", raw)
+		}
+		digit -= '0'
+		if uint64(digit) > limit || count > (limit-uint64(digit))/10 {
+			return 0, fmt.Errorf("size %q exceeds the 4 GiB collector address space", raw)
+		}
+		count = count*10 + uint64(digit)
+	}
+	if count == 0 {
+		return 0, errors.New("size must be positive")
+	}
+	return uint32(count * multiplier), nil
+}

--- a/cli/runtime/commands/run/gc_heap_lean.go
+++ b/cli/runtime/commands/run/gc_heap_lean.go
@@ -1,0 +1,21 @@
+//go:build wago_lean
+
+package run
+
+import (
+	"context"
+
+	"github.com/wago-org/wago"
+	"github.com/wago-org/wago/cli/internal/command"
+)
+
+func gcFlags() []command.Flag { return nil }
+func gcLongHelp() string      { return "" }
+
+func gcConfiguration(*command.Ctx) (wago.GCConfig, bool, error) {
+	return wago.GCConfig{}, false, nil
+}
+
+func instantiate(runtime *wago.Runtime, module *wago.Module, _ wago.GCConfig, _ bool) (*wago.Instance, error) {
+	return runtime.Instantiate(context.Background(), module)
+}

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -11,6 +11,21 @@ The decision-grade collector measurement contract, canonical
 [benchmark review protocol](gc-benchmarks.md#benchmark-review-protocol), and
 roadmap-aligned matrix are documented in [gc-benchmarks.md](gc-benchmarks.md).
 
+## CLI heap sizing
+
+`wago run` uses the bounded Throughput collector defaults unless the invocation
+sets explicit capacities. Large compiler and build workloads can select the
+root instance's old/large-object heap and Eden nursery directly:
+
+```sh
+wago run --gc-heap 2GiB --gc-nursery 64MiB compiler.wasm
+```
+
+Both flags accept a positive byte count or a binary `KiB`, `MiB`, or `GiB`
+suffix. Values must fit the collector's 32-bit address space. Omitting the flags
+preserves the existing defaults. Collection remains enabled; heap sizing is not
+a substitute for exact native root admission.
+
 ## Current generated-payload boundary
 
 The mandatory pinned Core 3 corpus is complete, but that result is narrower than

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -388,7 +388,10 @@ suspended direct-host activations (including sync-thunk records), and same-domai
 foreign instances. Mutable local GC globals synchronize checked collector slots,
 one private collector-reference table is scanned directly, and indirect/reference
 calls, function subtype checks, proper tails, and fixed EH payload records publish
-exact maps. Wrapper calls stage any operand stack whose later spilled source sits
+exact maps. AMD64 compact finalization does not apply `local-slot-order` to a
+function with exact GC frame-root metadata. The final local homes therefore stay
+identical to the offsets recorded by every safepoint and caller map. Wrapper calls
+stage any operand stack whose later spilled source sits
 below its canonical destination. This preserves leading arguments for wide
 reference signatures even below the 64-slot wide-stack threshold. It also stages
 before materialization when GP pressure would consume the scratch-register

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -388,7 +388,15 @@ suspended direct-host activations (including sync-thunk records), and same-domai
 foreign instances. Mutable local GC globals synchronize checked collector slots,
 one private collector-reference table is scanned directly, and indirect/reference
 calls, function subtype checks, proper tails, and fixed EH payload records publish
-exact maps. Dynamic host and same-domain foreign direct tails discard the current
+exact maps. Wrapper calls stage any operand stack whose later spilled source sits
+below its canonical destination. This preserves leading arguments for wide
+reference signatures even below the 64-slot wide-stack threshold. It also stages
+before materialization when GP pressure would consume the scratch-register
+reserve or XMM pressure would exhaust the vector register file, so a deferred
+argument cannot create a new overlapping spill. The Dewdrop
+reproducer used one nullable reference followed by 17 non-null references and
+previously propagated the leading null through the first five non-null argument
+slots. Dynamic host and same-domain foreign direct tails discard the current
 frame, so no dead caller roots are retained. A direct immutable-root visitor keeps
 warmed Throughput/Tiny recursive collection allocation-free. ARM64 polymorphic
 local `call_indirect` and same-domain foreign `call_ref` publish every possible

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -1377,7 +1377,7 @@ func (f *fn) emitCrossInstanceCall(b ImportBinding, ft *wasm.CompType) error {
 	resultSlot := slotTop
 	resultSlots := funcTypeSlots(ft.Results)
 
-	f.flush()
+	f.flushWrapper()
 	f.storePinnedGlobals(false) // value-pinned globals → cells (reloaded after; callee can't touch B's cells)
 
 	if need := resultSlot + resultSlots; need > f.maxSpill {
@@ -2829,7 +2829,7 @@ func (f *fn) emitIndirectCallHomeAware(ft *wasm.CompType, homeReg, targetContext
 	if scratchEnd > f.spillFloor {
 		f.spillFloor = scratchEnd
 	}
-	f.flush() // args → canonical slot-width slots
+	f.flushWrapper() // args → canonical slot-width slots
 	f.spillFloor = oldSpillFloor
 	f.storePinnedGlobals(false)      // value-pinned globals → cells
 	f.storeModuleGlobals(RAX)        // same-instance callee's offset-0 prologue reloads from cells
@@ -2933,7 +2933,7 @@ func (f *fn) emitWrapperCall(ft *wasm.CompType, emitCall func()) {
 		resultSlots += mtOf(rt).stackSlots()
 	}
 
-	f.flush()                   // all operands to canonical slots; args start at slotOf[d-p]
+	f.flushWrapper()            // all operands to canonical slots; args start at slotOf[d-p]
 	f.storePinnedGlobals(false) // spill value-pinned globals to their cells before the call
 	f.storeModuleGlobals(RAX)   // wrapper callee's offset-0 prologue reloads from the cells
 

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -2669,7 +2669,7 @@ func symbolicLocalSlotPackingPolicy(policy CodegenPolicy) bool {
 // expand, so every changed site is a monotonic disp32 -> disp8/disp0 shrink.
 func (f *fn) packLocalSlots(siteBudget int) int {
 	r := f.a.LocalRefs
-	if r == nil || r.Overflow || r.Pending || siteBudget <= 0 || int(r.Locals) != f.nLocals {
+	if f.gcFrameRoots != nil || r == nil || r.Overflow || r.Pending || siteBudget <= 0 || int(r.Locals) != f.nLocals {
 		return 0
 	}
 

--- a/src/core/compiler/backend/railshot/amd64/control.go
+++ b/src/core/compiler/backend/railshot/amd64/control.go
@@ -295,6 +295,16 @@ func (f *fn) frameDepthTypes(base, suffix []machineType) []machineType {
 // deferred nodes, then rebuilds the stack model as canonical slot entries with
 // all registers freed. v128 values occupy two adjacent 8-byte slots.
 func (f *fn) flush() {
+	f.flushWithPressure(false)
+}
+
+// flushWrapper reserves register headroom before canonicalizing the operand
+// image consumed by an ordinary wrapper-ABI call.
+func (f *fn) flushWrapper() {
+	f.flushWithPressure(true)
+}
+
+func (f *fn) flushWithPressure(stageRegisterPressure bool) {
 	f.stats.addFlush()
 	f.invalidateGlobalsCache() // the cached cell ptr must not span a call/control boundary
 	f.invalidateBoundsCert()   // bounds facts are valid only within a straight-line region
@@ -307,7 +317,7 @@ func (f *fn) flush() {
 	}
 	f.tmpGCRoots = gcRoots
 	f.tmpGCFacts = gcFacts
-	if f.flushWideStack(roots, gcRoots, gcFacts) {
+	if f.flushWideStack(roots, gcRoots, gcFacts, stageRegisterPressure) {
 		return
 	}
 	types := f.tmpTypes[:0]
@@ -354,25 +364,59 @@ func (f *fn) flush() {
 	f.setDepthTypesWithGCInfo(types, gcRoots, gcFacts)
 }
 
-// flushWideStack stages unusually wide operand stacks in a disjoint frame range
-// before copying them to canonical slots. The normal one-pass flush is faster,
-// but with more live values than the register files can hold, earlier allocation
-// spills can occupy low slots that the one-pass walk overwrites before reloading
-// their owners. Wide multi-value signatures are cold ABI stress shapes, so a
-// bounded extra copy is preferable to making every ordinary flush pay for a
-// parallel-move algorithm.
-func (f *fn) flushWideStack(roots []*elem, gcRoots []bool, gcFacts []shared.GCRefFact) bool {
+// flushWideStack stages unusually wide or overlapping operand stacks in a
+// disjoint frame range before copying them to canonical slots. The normal
+// one-pass flush is faster, but a value already spilled below its destination
+// may be overwritten by an earlier canonical store before it is reloaded. This
+// occurs below the historical 64-slot width threshold when register pressure
+// spills a later wrapper argument into an earlier argument's destination.
+func (f *fn) flushWideStack(roots []*elem, gcRoots []bool, gcFacts []shared.GCRefFact, stageRegisterPressure bool) bool {
 	const wideFlushSlots = 64
 
 	types := f.tmpFlushTypes[:0]
-	total := 0
+	total, gpValues, fpValues := 0, 0, 0
+	needsStage := false
 	for _, root := range roots {
 		typ := rootMachineType(root)
 		types = append(types, typ)
+		if root.kind == ekValue && root.st.kind == stSlot && root.st.slot < total {
+			needsStage = true
+		}
+		if typ.isFloat() || typ.isV128() {
+			fpValues++
+		} else {
+			gpValues++
+		}
 		total += typ.stackSlots()
 	}
+	if stageRegisterPressure {
+		// Keep the scratch-register reserve available while materializing deferred
+		// wrapper arguments. Otherwise a flush that begins with no spilled roots
+		// can create a later low-slot spill, then overwrite it before that operand
+		// is visited.
+		gpBlocked := f.pinnedLocalMask.union(f.reserved)
+		gpBudget := 0
+		for _, reg := range gpAlloc {
+			if !gpBlocked.has(reg) {
+				gpBudget++
+			}
+		}
+		if gpValues > max(0, gpBudget-numScratchGP) {
+			needsStage = true
+		}
+		fpBlocked := f.fpinnedLocalMask.union(f.fconstMask()).union(f.v128ConstMask())
+		fpBudget := 0
+		for reg := Reg(0); reg < 16; reg++ {
+			if !fpBlocked.has(reg) {
+				fpBudget++
+			}
+		}
+		if fpValues > fpBudget {
+			needsStage = true
+		}
+	}
 	f.tmpFlushTypes = types
-	if total <= wideFlushSlots {
+	if total <= wideFlushSlots && !needsStage {
 		return false
 	}
 

--- a/src/core/compiler/backend/railshot/amd64/local_slot_order_test.go
+++ b/src/core/compiler/backend/railshot/amd64/local_slot_order_test.go
@@ -5,6 +5,7 @@ package amd64
 import (
 	"testing"
 
+	"github.com/wago-org/wago/src/core/compiler/backend/railshot/shared"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	encamd64 "github.com/wago-org/wago/src/core/encoder/amd64"
 )
@@ -87,6 +88,30 @@ func TestLocalSlotOrderDoesNotGrowMixedCompactFrame(t *testing.T) {
 	}
 	if on.Peephole["local-slot-order"] != 0 {
 		t.Fatalf("local-slot-order hits = %d, want rollback", on.Peephole["local-slot-order"])
+	}
+}
+
+func TestLocalSlotOrderSkipsGCFrameRootFunctions(t *testing.T) {
+	refs := encamd64.LocalRefRecorder{
+		Sites:  []encamd64.LocalRefSite{{Local: 1}},
+		Limit:  1,
+		Locals: 2,
+	}
+	plan := &shared.GCFrameRootPlan{Candidate: true, LocalIndexes: []uint32{1}, LocalOffsets: []uint32{128}}
+	f := fn{
+		a:                  &encamd64.Asm{LocalRefs: &refs},
+		nLocals:            2,
+		localType:          []machineType{mtI64, mtI64},
+		localSlot:          []int{0, int(uint64(1)<<32 | 128)},
+		compactFrameHeader: true,
+		gcFrameRoots:       plan,
+		stats:              &CodegenStats{},
+	}
+	if got := f.packLocalSlots(1); got != 0 {
+		t.Fatalf("GC frame-root local slot swaps = %d, want 0", got)
+	}
+	if got := f.localOff(1); got != 128 || plan.LocalOffsets[0] != 128 {
+		t.Fatalf("GC frame-root local home changed: frame=%d metadata=%d", got, plan.LocalOffsets[0])
 	}
 }
 

--- a/src/wago/gc_wide_wrapper_args_amd64_test.go
+++ b/src/wago/gc_wide_wrapper_args_amd64_test.go
@@ -1,0 +1,196 @@
+//go:build linux && amd64 && !tinygo && !wago_guardpage
+
+package wago
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+func gcWideWrapperReferenceArgumentsModule() []byte {
+	structType := []byte{0x5f, 0x01, 0x7f, 0x01} // (struct (field (mut i32)))
+	calleeType := append([]byte{0x60}, wasmtest.ULEB(18)...)
+	calleeType = append(calleeType, 0x63, 0x00) // (ref null 0)
+	for range 17 {
+		calleeType = append(calleeType, 0x64, 0x00) // (ref 0)
+	}
+	calleeType = append(calleeType, 0x01, 0x7f)                // (result i32)
+	callee := []byte{0x20, 0x01, 0xfb, 0x02, 0x00, 0x00, 0x0b} // local.get 1; struct.get 0 0
+	caller := []byte{0xd0, 0x00}                               // ref.null 0
+	for range 17 {
+		caller = append(caller, 0x23, 0x00) // global.get 0
+	}
+	caller = append(caller, 0x10, 0x00, 0x0b)                                     // call 0
+	initializer := append([]byte{0x64, 0x00, 0x00, 0x41}, wasmtest.SLEB32(73)...) // (ref 0), immutable, i32.const 73
+	initializer = append(initializer, 0xfb, 0x00, 0x00, 0x0b)                     // struct.new 0; end
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			structType,
+			calleeType,
+			[]byte{0x60, 0x00, 0x01, 0x7f},
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(2))),
+		wasmtest.Section(6, wasmtest.Vec(initializer)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(callee), wasmtest.Code(caller))),
+	)
+}
+
+func wideWrapperDeferredMemoryArgumentsModule() []byte {
+	params := make([]byte, 14)
+	for i := range params {
+		params[i] = 0x7f
+	}
+	calleeType := append([]byte{0x60}, wasmtest.ULEB(uint32(len(params)))...)
+	calleeType = append(calleeType, params...)
+	calleeType = append(calleeType, 0x01, 0x7f)
+	callee := []byte{0x20, 0x01, 0x0b} // local.get 1
+	caller := append([]byte{0x41}, wasmtest.SLEB32(42)...)
+	for range 13 {
+		caller = append(caller, 0x3f, 0x00) // memory.size 0
+	}
+	caller = append(caller, 0x10, 0x00, 0x0b)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(calleeType, []byte{0x60, 0x00, 0x01, 0x7f})),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(callee), wasmtest.Code(caller))),
+	)
+}
+
+func crossInstanceWideWrapperModules() (provider, consumer []byte) {
+	calleeType := []byte{0x60, 0x0e}
+	for range 14 {
+		calleeType = append(calleeType, 0x7f)
+	}
+	calleeType = append(calleeType, 0x01, 0x7f)
+	callee := []byte{0x20, 0x01, 0x0b}
+	caller := append([]byte{0x41}, wasmtest.SLEB32(42)...)
+	for range 13 {
+		caller = append(caller, 0x3f, 0x00)
+	}
+	caller = append(caller, 0x10, 0x00, 0x0b)
+	provider = wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(calleeType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(callee))),
+	)
+	importEntry := append(wasmtest.Name("env"), wasmtest.Name("f")...)
+	importEntry = append(importEntry, 0x00, 0x00) // function import, type 0
+	consumer = wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(calleeType, []byte{0x60, 0x00, 0x01, 0x7f})),
+		wasmtest.Section(2, wasmtest.Vec(importEntry)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(5, wasmtest.Vec([]byte{0x00, 0x01})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(caller))),
+	)
+	return provider, consumer
+}
+
+func TestCrossInstanceWideWrapperStagesSpillsCreatedDuringFlush(t *testing.T) {
+	providerData, consumerData := crossInstanceWideWrapperModules()
+	providerCode, err := Compile(NewRuntimeConfig(), providerData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer providerCode.Close()
+	provider, err := instantiateCore(providerCode, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer provider.Close()
+	exported, err := provider.ExportedFunc("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumerCode, err := Compile(NewRuntimeConfig(), consumerData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumerCode.Close()
+	consumer, err := instantiateCore(consumerCode, InstantiateOptions{Imports: Imports{"env.f": exported}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+	got, callErr := consumer.Invoke("run")
+	if callErr != nil || !reflect.DeepEqual(got, []uint64{1}) {
+		t.Fatalf("run = %v, %v; want [1]", got, callErr)
+	}
+}
+
+func TestWideWrapperStagesSpillsCreatedDuringFlush(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig(), wideWrapperDeferredMemoryArgumentsModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	got, callErr := in.Invoke("run")
+	if callErr != nil || !reflect.DeepEqual(got, []uint64{1}) {
+		t.Fatalf("run = %v, %v; want [1]", got, callErr)
+	}
+}
+
+func wideWrapperDeferredFloatArgumentsModule() []byte {
+	calleeType := []byte{0x60, 0x11}
+	for range 17 {
+		calleeType = append(calleeType, 0x7c) // f64
+	}
+	calleeType = append(calleeType, 0x01, 0x7c)
+	callee := []byte{0x20, 0x01, 0x0b}                                     // local.get 1
+	caller := []byte{0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x45, 0x40} // f64.const 42
+	for range 16 {
+		caller = append(caller, 0x41, 0x01, 0xb7) // i32.const 1; f64.convert_i32_s
+	}
+	caller = append(caller, 0x10, 0x00, 0x0b)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(calleeType, []byte{0x60, 0x00, 0x01, 0x7c})),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(callee), wasmtest.Code(caller))),
+	)
+}
+
+func TestWideWrapperStagesXMMSpillsCreatedDuringFlush(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig(), wideWrapperDeferredFloatArgumentsModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	got, callErr := in.Invoke("run")
+	if callErr != nil || len(got) != 1 || got[0] != F64(1) {
+		t.Fatalf("run = %v, %v; want f64(1)", got, callErr)
+	}
+}
+
+func TestGCWideWrapperReferenceArgumentsPreserveLeadingValues(t *testing.T) {
+	compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), gcWideWrapperReferenceArgumentsModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	got, callErr := in.Invoke("run")
+	if callErr != nil || !reflect.DeepEqual(got, []uint64{73}) {
+		t.Fatalf("run = %v, %v; want [73]", got, callErr)
+	}
+}


### PR DESCRIPTION
## Summary

Fix the two remaining Wago-side blockers found by the Dewdrop self-host compiler:

1. `wago run` can now select bounded Throughput heap and nursery capacities.
2. AMD64 wrapper calls no longer overwrite later spilled arguments while canonicalizing an overlapping operand stack.

The investigation also found and fixes a second exact-root defect: compact local-slot finalization changed local homes after GC safepoint/caller offsets were recorded.

## Configurable heap sizing

`wago run` accepts:

```text
--gc-heap <size>
--gc-nursery <size>
```

Sizes accept positive byte counts or `KiB`, `MiB`, and `GiB` suffixes and must fit the collector's 32-bit address space.

The flags flow through runtime command parsing, manager handoff metadata, plugin-scope routing, and root-module instantiation. Omitting both flags preserves the existing collector defaults.

A 20 MiB WasmGC array deterministically exhausts the default 16 MiB heap. The same module completes with:

```text
wago run --core 3 --gc-heap 32MiB module.wasm
```

## Proven wrapper-argument bug

The Dewdrop failure was not a guest null. The failing callee was validated with this shape:

```text
(param (ref null 325) (ref 259) ... seventeen non-null refs total ...)
```

Its only caller passed one explicit null followed by the same non-null immutable global 17 times. Native disassembly showed the wrapper flush writing the leading null to slot 0, then copying slot 0 to slot 1, slot 1 to slot 2, and so on. This overwrote the first five non-null arguments before the call. The callee then trapped at its first `struct.get 259 0` with a zero reference.

The exact standalone regression, `TestGCWideWrapperReferenceArgumentsPreserveLeadingValues`, fails before the fix with:

```text
wasm trap: null reference
    at func[0] (func[0], wasm pc 0x3)
```

After the fix it returns `73`.

The flush now uses its existing disjoint staging range whenever a later spilled source sits below its canonical destination, or when GP/XMM pressure can create a new spill during argument materialization. Direct, cross-instance, and home-aware indirect wrapper paths use this pressure-aware flush.

## Exact root-map finalization

`local-slot-order` can swap equal-width local homes during compact finalization. Safepoint and caller offsets were recorded before that permutation and would become stale.

Compact finalization now skips `local-slot-order` for functions carrying exact GC frame-root metadata. `TestLocalSlotOrderSkipsGCFrameRootFunctions` verifies that the frame home and every recorded root offset remain identical.

## Dewdrop proof

Artifact:

```text
648dd7abf8b4a4fabbbbd8a941cb1a20c6bf65f9be64b592af37a5e680f31  facet-self-host-a-profile.wasm
a2acdeacccd2be3b4cd8fd9c881455ae58d60c71259f62cb24682af211be0d43  facet-request-new.bin
```

Before the wrapper fix:

```text
GC HELPER TRAP 2 0 16 3
GC HELPER ARG 0 0
GC HELPER ARG 1 259
GC HELPER ARG 2 0
ERR *runtime.TrapError wasm trap: null reference
```

After both AMD64 fixes, the same collection-enabled 2 GiB heap / 64 MiB nursery run passes the former null site and reaches the next independent Dewdrop gate:

```text
self-host smoke: Starshine rejected the linked self-host output module
ERR *wago.ExitError exit status 1
```

This proves the Wago null-reference blocker is removed. The remaining Starshine rejection is output validation in Dewdrop, not the former runtime argument corruption.

## Tests

```text
make lint
GIT_CONFIG_COUNT=2 \
GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false \
GIT_CONFIG_KEY_1=tag.forceSignAnnotated GIT_CONFIG_VALUE_1=false \
make test
```

Focused repeat runs:

```text
go test ./src/wago -run '^(TestCrossInstanceWideWrapperStagesSpillsCreatedDuringFlush|TestWideWrapperStagesSpillsCreatedDuringFlush|TestWideWrapperStagesXMMSpillsCreatedDuringFlush|TestGCWideWrapperReferenceArgumentsPreserveLeadingValues|TestSyncSQLiteQuery)$' -count=100
go test ./src/core/compiler/backend/railshot/amd64 -run '^TestLocalSlotOrderSkipsGCFrameRootFunctions$' -count=20
go test ./cli/runtime/commands/run -run '^(TestRunGCHeapFlags|TestRunExecGCHeapOverride)$' -count=10
```

All pass.