### PR TITLE
amd64: retain measured scalar optimization wins

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -19,6 +19,26 @@ Legend: effort S/M/L · value ⬜ low · 🟦 medium · 🟩 high · ⭐ very hi
 
 ## What's in place (updated 2026-08-29)
 
+**Commutative self-updates and low-32 masks (2026-08-29).** AMD64 now
+accumulates every safe non-fixed `x = f(y) op x` form directly in `x` instead of
+spilling the old destination, including the first site in a function. The direct
+lowering avoids the generic relocation path and is default-on with
+`WAGO_AMD64_NO_COMMUTE_SELF_UPDATE=1` as the A/B oracle. A same-process seven-row
+corpus watchpoint improves **3.55% geomean**: scalar BLAKE3 improves
+**718.4→703.3 µs** (-2.1%), SIMD BLAKE3 **628.2→575.8 µs** (-8.3%), and the
+open-coded multiply-high loop **2.239→1.995 µs** (-10.9%); the worst row is
+spectral norm at +0.14%. Across the complete compile corpus, emitted code falls
+**69,708,236→69,675,415 bytes** (-32,821) and allocator spills fall
+**3,817→1,259** (-67.0%), with 2,556 retained sites. The nearby #438 mask
+experiment also generalizes `i64.and` to use a zero-extending 32-bit immediate
+for every mask through `0xffffffff`, not only the full low word. Runtime is flat
+in dependent loops, while 7,483 corpus sites remove 4,800 native bytes beyond
+the old exact-mask rule. `BenchmarkExecCommuteSelfUpdate`,
+`BenchmarkCompileCommuteSelfUpdate`, and `BenchmarkAMD64Low32MaskInstruction`
+are the permanent A/B watchpoints. Default-off float-compare fusion, vector
+sinking, loop prechecks, tee-spill reuse, call next-use, affine LEA, and BMI2
+RORX were remeasured and remain rejected or opt-in.
+
 **Scalar float mask and copysign lowering (2026-08-29).** AMD64 implicit
 abs/neg/copysign masks now use the existing RIP-relative constant pool instead of
 a GPR rebuild. Focused dependent loops improve `f64.abs` **0.571→0.447 ns/op**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -243,9 +243,10 @@ current optimization priorities. The Core 3.0 implementation ledger is
   `WAGO_EXPLAIN`, golden-disassembly harness, `WAGO_DEBUG_MODGLOBALS`, and
   `WAGO_PIN_GLOBAL_K` are implemented on amd64 and arm64.
 <!-- roadmap:P2 status=partial -->
-- 🚧 **P2 — cheap railshot wins**: the const-fold pack and same-operand integer
-  identities are landed; alias-aware pending loads, pure-tree `drop`, and
-  narrow-load mask elision remain measurement-gated.
+- 🚧 **P2 — cheap railshot wins**: the const-fold pack, same-operand integer
+  identities, direct commutative self-updates, generalized low-32 i64 masks,
+  alias-aware pending loads, and pure-tree `drop` are landed. Broader narrow-load
+  mask elision remains measurement-gated.
 <!-- roadmap:P3 status=partial -->
 - 🚧 **P3 — `stFlags` and compare fusion**: eqz-of-compare inversion and ordered
   float compare-to-branch fusion are landed; broader flags-resident consumers

--- a/bench/optimization_amd64_test.go
+++ b/bench/optimization_amd64_test.go
@@ -1,0 +1,109 @@
+//go:build amd64
+
+package wagobench
+
+import (
+	"testing"
+
+	wago "github.com/wago-org/wago"
+)
+
+// BenchmarkExecCommuteSelfUpdate keeps the real corpus rows that exercise the
+// AMD64 commutative self-update lowering in one explicit A/B watchpoint.
+func BenchmarkCompileCommuteSelfUpdate(b *testing.B) {
+	wanted := map[string]bool{
+		"blake-as": true, "blake-as-simd": true,
+		"sqlite3": true, "esbuild": true,
+	}
+	for _, m := range loadCorpus(b) {
+		if !wanted[m.name()] || !m.supports("CompileFull") {
+			continue
+		}
+		for _, enabled := range []bool{false, true} {
+			mode := "off"
+			if enabled {
+				mode = "on"
+			}
+			cfg := wago.NewRuntimeConfig().WithOptimization("commute-self-update", enabled)
+			b.Run(m.name()+"/"+mode, func(b *testing.B) {
+				b.ReportAllocs()
+				var compiled *wago.Compiled
+				for i := 0; i < b.N; i++ {
+					var err error
+					compiled, err = cfg.Compile(m.bytes)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				if compiled != nil {
+					b.ReportMetric(float64(compiled.CodeSize()), "code-B")
+					compiled.Close()
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkExecCommuteSelfUpdate(b *testing.B) {
+	wanted := map[string]map[string]bool{
+		"spectralnorm":  {"run": true},
+		"quicksort":     {"sortN": true},
+		"json-as":       {"serializeN": true, "deserializeN": true},
+		"blake-as":      {"hashN": true},
+		"xjb-mulhi":     {"runN": true},
+		"blake-as-simd": {"hashN": true},
+	}
+	for _, m := range loadCorpus(b) {
+		exports := wanted[m.name()]
+		if len(exports) == 0 || !m.supports("Exec") {
+			continue
+		}
+		for _, enabled := range []bool{false, true} {
+			mode := "off"
+			if enabled {
+				mode = "on"
+			}
+			cfg := wago.NewRuntimeConfig().WithOptimization("commute-self-update", enabled)
+			compiled, err := cfg.Compile(m.bytes)
+			if err != nil {
+				b.Fatalf("%s/%s compile: %v", m.name(), mode, err)
+			}
+			instance, err := wago.Instantiate(compiled, wago.InstantiateOptions{Imports: hostStubs(compiled)})
+			if err != nil {
+				b.Fatalf("%s/%s instantiate: %v", m.name(), mode, err)
+			}
+			if m.Init != "" {
+				if _, err := instance.Invoke(m.Init); err != nil {
+					b.Fatalf("%s/%s init: %v", m.name(), mode, err)
+				}
+			}
+			for _, entry := range m.Exec {
+				if !exports[entry.Export] {
+					continue
+				}
+				args := make([]uint64, len(entry.Args))
+				for i, arg := range entry.Args {
+					args[i] = wago.I32(arg)
+				}
+				fn, err := instance.PrepareFunction(entry.Export)
+				if err != nil {
+					b.Fatalf("%s/%s prepare %s: %v", m.name(), mode, entry.Export, err)
+				}
+				b.Run(m.name()+"."+entry.Export+"/"+mode, func(b *testing.B) {
+					if _, err := fn.Invoke(args...); err != nil {
+						b.Fatal(err)
+					}
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if _, err := fn.Invoke(args...); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+			instance.Close()
+			compiled.Close()
+		}
+	}
+}

--- a/docs/codegen-benchmarks.md
+++ b/docs/codegen-benchmarks.md
@@ -122,6 +122,27 @@ go test ./src/wago -run '^$' \
 Use the explicit GPR-mask float rows and baseline rotate rows as controls. Do not
 compare separate host sessions when a same-process control is available.
 
+The commutative self-update watchpoints keep the retained optimization and its
+compile/code-size cost in the same process. The low-32 mask matrix compares the
+ordinary i64 immediate/register path with the zero-extending 32-bit form:
+
+```sh
+cd bench
+GOMAXPROCS=1 go test -run '^$' \
+  -bench '^Benchmark(Exec|Compile)CommuteSelfUpdate$' \
+  -benchmem -benchtime=200ms -count=5
+
+cd ..
+go test ./src/wago -run '^$' \
+  -bench '^BenchmarkAMD64Low32MaskInstruction$' \
+  -benchmem -benchtime=300ms -count=5 -cpu=1
+```
+
+`BenchmarkExecCommuteSelfUpdate` is the execution authority because its `off`
+and `on` products share one process and the same real corpus payloads. Report
+`BenchmarkCompileCommuteSelfUpdate` time, `B/op`, `allocs/op`, and `code-B`
+together; do not trade Wago's compile advantage for a micro-only execution win.
+
 ## Targeted profiles
 
 Backend railshot compile profiles:

--- a/docs/optimization-toggle-matrix-2026-08-22.md
+++ b/docs/optimization-toggle-matrix-2026-08-22.md
@@ -9,7 +9,8 @@
 - The strongest broadly visible execution wins are ARM64 `reg-abi` (+20.42% disabled penalty), AMD64 `v128-const-cache` (+6.09%), branch folding (+2.30% ARM64 / +3.39% AMD64), AMD64 `inline` (+2.27%), and vector pins (+2.56% ARM64 / +1.84% AMD64).
 - The clearest cost/benefit review target is `loop-precheck`: disabling it cuts full-compile allocation bytes by 6.38% on ARM64 and 6.09% on AMD64 and improves compile time by 5.36% / 3.05%, while broad execution changes only +0.21% / +0.11%; focused rows still lose as much as 3.72% / 2.88%, so this is a default/removal investigation, not an immediate deletion.
 - The cleanest low-consequence implementation candidates are ARM64 `v128-const-cache`, shared `v128-sink`, AMD64 `affine-lea`, AMD64 `call-next-use`, and the default-off experimental `inline-loop-callees`. Each needs focused code-size and hit-count evidence before removal.
-- Follow-up implemented: `loop-precheck` and `v128-sink` now default off on both architectures; ARM64 also defaults `deep-fp-pins` off; AMD64 also defaults `call-next-use`, `affine-lea`, `tee-spill-elide`, and `commute-self-update` off. The already-off `inline-loop-callees` override and its unreachable backend paths were removed.
+- Follow-up implemented: `loop-precheck` and `v128-sink` now default off on both architectures; ARM64 also defaults `deep-fp-pins` off; AMD64 also defaults `call-next-use`, `affine-lea`, `tee-spill-elide`, and, at this historical checkpoint, `commute-self-update` off. The already-off `inline-loop-callees` override and its unreachable backend paths were removed.
+- Requalification on 2026-08-29 changed `commute-self-update` to handle the first eligible site through a direct lowering instead of the generic relocation path. The new same-process real-corpus A/B improves execution 3.55% geomean, removes 67.0% of measured backend spills, and leaves compile allocation unchanged, so AMD64 now defaults it on. The original table below remains the record of the older implementation and must not be read as current default policy.
 - Follow-up catalog audit: 14 formerly environment-only families are now public flags. Paired screening keeps the high-value SIMD/SWAR and focused register/code-selection wins on, defaults `fcmp-fuse` off on both architectures, and defaults AMD64 `gc-ref-facts` off while retaining it as a GC-workload opt-in.
 - In an exact original-commit versus current-commit rerun, the complete branch changed execution by **-0.10% ARM64 / +0.14% AMD64**, while improving compile time by **5.22% / 4.04%**, compile allocation bytes by **6.38% / 9.69%**, and compile allocation counts by **2.93% / 15.51%**.
 - Percentages below are **disabled versus enabled**. Positive execution time means disabling made execution slower (the optimization helped); negative means disabling made execution faster.
@@ -24,7 +25,7 @@ through the existing runtime/project optimization map.
 | Architecture | Newly default-off options | Removed surface |
 |---|---|---|
 | ARM64 | `deep-fp-pins`, `fcmp-fuse`, `loop-precheck` | `inline-loop-callees`, `v128-const-cache`, `v128-sink` |
-| AMD64 | `affine-lea`, `call-next-use`, `commute-self-update`, `fcmp-fuse`, `gc-ref-facts`, `loop-precheck`, `tee-spill-elide`, `v128-sink` | `inline-loop-callees` |
+| AMD64 | `affine-lea`, `call-next-use`, `fcmp-fuse`, `gc-ref-facts`, `loop-precheck`, `tee-spill-elide`, `v128-sink` | `inline-loop-callees` |
 
 The final bundle was measured using two separately compiled benchmark binaries:
 one at original commit `ef129fdbb820`, and one at current commit `20936e8621bc`.

--- a/docs/research/amd64-optimization-issue-sweep-2026-08-29.md
+++ b/docs/research/amd64-optimization-issue-sweep-2026-08-29.md
@@ -1,0 +1,172 @@
+# AMD64 optimization issue sweep
+
+Date: 2026-08-29
+
+Host: Linux/amd64, AMD Ryzen 7 8845HS, `GOMAXPROCS=1`. Final execution
+watchpoints were pinned to CPU 2. Timed guest rows remain at 0 B/op and 0
+allocations/op.
+
+## Scope
+
+The repository had 45 open issues, 34 of them labeled `performance` or
+`area/performance`. This pass reviewed every one before changing code.
+
+Most open performance issues are not collections of independent peepholes. They
+are product or architecture projects that must remain separate PRs:
+
+- runtime/footprint and artifact work: #305, #320, #329, #330, #331, #335;
+- GC architecture: #308, #309, #313, #317, #321;
+- compiler architecture and tooling: #316, #326, #327, #333, #399, #501, #503,
+  #504, #506, #507, #508, #509, #511, #513;
+- Component Model experiments: #434 and #435; and
+- standards/proposals: #338, #339, #340, and #359.
+
+Those issues need new representations, ABI work, proposal support, or profile
+infrastructure before an execution A/B exists. Combining them into one PR would
+violate the repository's atomicity and measurement rules.
+
+The bounded candidates that can be switched or extended on current Railshot were
+measured here. They cover the concrete #297 gaps and the local selection ideas in
+#438, #501, #504, and #508.
+
+## Baseline refresh for #297
+
+The original issue recorded 22-23x backward-copy gaps, a 1.91x scalar BLAKE gap,
+a 1.75x branch gap, and a 1.63x tiny-call gap. Current `main` had already removed
+most of those gaps. The final retained branch measured:
+
+| Workload | Wago median | wazero median | Wago/wazero |
+|---|---:|---:|---:|
+| tiny add | 8.599 ns | 26.050 ns | 0.330x |
+| branch classifier | 8.586 ns | 24.550 ns | 0.350x |
+| backward copy, 256 B | 1.142 us | 1.219 us | 0.937x |
+| backward copy, 4 KiB | 11.170 us | 10.639 us | 1.050x |
+| scalar BLAKE3 | 706.824 us | 475.709 us | 1.486x |
+| SIMD BLAKE3 | 565.633 us | 530.466 us | 1.066x |
+
+No listed row retains the severe gap recorded by the issue. Scalar BLAKE remains
+the largest selector/allocator target, but it is now below 1.5x rather than 1.91x.
+
+Command:
+
+```sh
+cd bench
+GOMAXPROCS=1 go test -run '^$' \
+  -bench '^(BenchmarkExec|BenchmarkWazeroExec)/(tiny\.add|branches\.classify|blake-as\.hashN|blake-as-simd\.hashN|isa_bulk_mem\.copy_back_256|isa_bulk_mem\.copy_back_4096)$' \
+  -wago.bench.isa -benchmem -benchtime=300ms -count=5
+```
+
+## Retained: direct commutative self-updates
+
+The existing default-off rule recognized:
+
+```text
+x = f(y) op x
+```
+
+for commutative `op`, but skipped the first site and implemented later sites by
+swapping operands into the generic two-address path. The older August 22 broad
+screen found that form neutral to negative and correctly defaulted it off.
+
+The retained form changes two details:
+
+1. admit the first safe site; and
+2. pin the non-fixed destination, condense `f(y)` once, and consume it directly
+   into that destination instead of entering generic RHS relocation and LHS
+   sinking.
+
+`RAX`, `RDX`, and `RCX` remain excluded because nested division, remainder, or
+variable shifts can claim them. Non-commutative operations retain Wasm order.
+
+### Execution
+
+`BenchmarkExecCommuteSelfUpdate` compiles both products in one process against
+real corpus payloads:
+
+| Workload | Off median | On median | Change |
+|---|---:|---:|---:|
+| spectral norm | 685.189 us | 686.153 us | +0.14% |
+| quicksort | 59.983 us | 59.413 us | -0.95% |
+| JSON serialize | 24.732 us | 24.479 us | -1.02% |
+| JSON deserialize | 44.592 us | 44.104 us | -1.09% |
+| scalar BLAKE3 | 718.376 us | 703.297 us | -2.10% |
+| open-coded multiply-high loop | 2.239 us | 1.995 us | -10.90% |
+| SIMD BLAKE3 | 628.170 us | 575.795 us | -8.34% |
+
+The seven-row geomean improves **3.55%**. Spectral norm's +0.14% is the worst
+row and is noise-sized.
+
+### Compile cost and native bytes
+
+`BenchmarkCompileCommuteSelfUpdate` reports unchanged allocation counts and
+bytes in all four retained compile rows:
+
+| Module | Off | On | Time | Code bytes |
+|---|---:|---:|---:|---:|
+| scalar BLAKE3 | 571.087 us | 569.330 us | -0.31% | 11,469 -> 11,197 |
+| SIMD BLAKE3 | 1.796 ms | 1.776 ms | -1.14% | 40,722 -> 40,482 |
+| SQLite | 118.870 ms | 118.798 ms | -0.06% | 3,638,809 -> 3,630,329 |
+| esbuild | 887.045 ms | 900.393 ms | +1.50% | 26,620,912 -> 26,619,504 |
+
+The esbuild row is one-iteration and host-noisy; its allocation metrics are exact
+and unchanged. Across the complete compile corpus, explain output records 2,556
+retained self-update sites. Combined with the low-32 mask extension below:
+
+- native bytes: **69,708,236 -> 69,675,415** (-32,821, -0.047%);
+- allocator spills: **3,817 -> 1,259** (-2,558, -67.0%); and
+- compile allocation traffic remains unchanged in the permanent watchpoints.
+
+The rule now defaults on. `WAGO_AMD64_NO_COMMUTE_SELF_UPDATE=1` is the process
+A/B and `WithOptimization("commute-self-update", false)` is the per-runtime A/B.
+
+## Retained: all low-32 i64 masks
+
+The existing #438-style clean-bit rule only selected a 32-bit `AND` for the
+exact constant `0xffffffff`. The same proof applies to every constant in
+`0..0xffffffff`:
+
+```text
+i64.and x, mask  =>  and r32, imm32
+```
+
+The destination write clears the upper 32 bits. For masks below `0x80000000`,
+this removes `REX.W`; for masks with bit 31 set, it also avoids the temporary
+register required by x86-64's sign-extended 64-bit immediate form. ZF, PF, CF,
+and OF remain exact. SF can differ for bit-31 masks, but current ALU-result
+consumers do not read SF; signed relations emit a separate compare.
+
+`BenchmarkAMD64Low32MaskInstruction` is runtime-neutral within noise at about
+0.45 ns/instruction and remains allocation-free. Focused module sizes are equal
+or smaller; the full `0xffffffff` fixture falls 103 -> 99 bytes. The compile
+corpus increases `i64-mask32` hits from 2,911 to 7,483 and removes another 4,800
+native bytes beyond the old exact-mask implementation.
+
+`WAGO_AMD64_NO_I64_MASK32=1` remains the rollback oracle.
+
+## Measured candidates not retained
+
+The following existing switches were measured against representative rows. None
+cleared the default-on gate:
+
+| Candidate | Focused result | Decision |
+|---|---|---|
+| float compare fusion | +1.41% geomean; raytrace +5.41% | keep off |
+| vector local sinking | +2.04% geomean across SIMD JSON/BLAKE/UTF | keep off |
+| call next-use + affine LEA | -0.52% geomean, but UTF +2.70% and mixed rows | keep off |
+| loop precheck | -0.18% geomean; memory tree +1.64% | keep off |
+| tee spill reuse | quicksort improved, but SHA/BLAKE rows regressed | keep off |
+| BMI2 RORX | runtime tied while adding two bytes | keep experimental/off |
+
+These results reinforce #501/#504's rule: fewer instructions or spills are not
+sufficient. The same-process execution A/B remains the final gate.
+
+## Issue disposition
+
+- #297 can close: every named severe gap was remeasured and reduced to parity,
+  a Wago win, or a sub-1.5x remaining scalar BLAKE gap.
+- #438, #501, #504, and #508 receive measured progress, but remain open because
+  their requested fact, selector, combiner, and regional-allocation scopes are
+  broader than these two bounded rules.
+- The other performance issues remain separate projects. No proposal, ABI,
+  collector, artifact, component, or multi-pass compiler work was hidden inside
+  this PR.

--- a/src/core/compiler/backend/railshot/amd64/commute_self_update_test.go
+++ b/src/core/compiler/backend/railshot/amd64/commute_self_update_test.go
@@ -54,8 +54,8 @@ func TestCommuteSelfUpdate(t *testing.T) {
 	if got := runAmd64(t, m, 0x55, 10, 20); got != 0x55 {
 		t.Fatalf("enabled result = %#x, want 0x55", got)
 	}
-	if got := on.Peephole["commute-self-update"]; got != 1 {
-		t.Fatalf("commute-self-update = %d, want 1 (all: %v)", got, on.Peephole)
+	if got := on.Peephole["commute-self-update"]; got != 2 {
+		t.Fatalf("commute-self-update = %d, want 2 (all: %v)", got, on.Peephole)
 	}
 	if on.Spills >= off.Spills {
 		t.Fatalf("enabled spills = %d, disabled = %d", on.Spills, off.Spills)

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -287,7 +287,6 @@ type fn struct {
 	// Number of commutative self-update spill opportunities seen in this function.
 	// The first keeps the conservative form; repeated pressure selects the denser
 	// register form without perturbing one-off sites in otherwise cold functions.
-	commuteSelfUpdates uint16
 
 	// Bounded straight-line local intervals. A non-regNone intervalReg entry marks
 	// an eligible local; locals[x].reg is populated only while its cached value is

--- a/src/core/compiler/backend/railshot/amd64/emit.go
+++ b/src/core/compiler/backend/railshot/amd64/emit.go
@@ -236,16 +236,28 @@ func (f *fn) condenseBinary(node *elem, dest Reg) Reg {
 		(right.st.kind == stReg || right.st.kind == stLocalReg || right.st.kind == stGlobReg) &&
 		right.st.reg == dest
 	if commuteSelfUpdate {
-		f.commuteSelfUpdates++
-		if f.stats != nil {
-			f.stats.peep("commute-self-update-candidate")
-		}
+		f.stats.peep("commute-self-update-candidate")
 	}
-	if f.opt(optCommuteSelfUpdate) && commuteSelfUpdate && f.commuteSelfUpdates > 1 {
-		left, right = right, left
-		if f.stats != nil {
-			f.stats.peep("commute-self-update")
+	if f.opt(optCommuteSelfUpdate) && commuteSelfUpdate {
+		// Preserve the old destination while evaluating the original left operand,
+		// then consume that value directly into the destination. This is the same
+		// native order as swapping the operands, but it avoids routing the common
+		// self-update case through the generic RHS relocation and LHS sink logic.
+		f.pinned = f.pinned.add(dest)
+		if left.isDeferred() {
+			f.condense(left, regNone)
 		}
+		if node.op == opMul {
+			f.applyMul(dest, left, w)
+		} else {
+			f.applyALU(aluTable[node.op], dest, left, w)
+		}
+		f.pinned = f.pinned.remove(dest)
+		f.stats.peep("commute-self-update")
+		f.consumeBlockBelow(node)
+		f.occupy(node, dest)
+		node.op = opNone
+		return dest
 	}
 
 	// Materialize the RHS into a safe, foldable operand BEFORE the LHS overwrites
@@ -1068,15 +1080,14 @@ func (f *fn) condenseInto(e *elem, dest Reg) {
 func (f *fn) applyALU(enc aluEnc, dest Reg, right *elem, w bool) {
 	switch right.st.kind {
 	case stConst:
-		// `i64.and x, 0xffffffff` is exactly a zero-extension of x's low
-		// 32 bits. `and r32, -1` performs that operation directly on x86-64 and
-		// preserves the zero/parity/carry/overflow flags relevant to current
-		// consumers; unlike the 64-bit masked result, it may set the sign flag.
-		// The 64-bit form cannot encode
-		// this positive mask because its imm32 is sign-extended and would therefore
-		// need a temporary register. Select this only at final emission so tree
-		// scheduling, associative covering, and higher-level SWAR recognition retain
-		// their original shapes.
+		// `i64.and x, mask` for any mask confined to the low 32 bits is exactly
+		// `and r32, imm32`: the 32-bit destination write clears the upper half. This
+		// saves REX.W for small masks and avoids a temporary register for masks with
+		// bit 31 set, which the 64-bit sign-extended immediate form cannot encode.
+		// ZF/PF/CF/OF remain exact. SF can reflect bit 31 instead of bit 63, but no
+		// current ALU-result consumer reads SF; signed relations emit their own CMP.
+		// Select this only at final emission so tree scheduling, associative covering,
+		// and higher-level SWAR recognition retain their original shapes.
 		if incDecEnabled && f.policy.CompactNative &&
 			(enc == aluTable[opAdd] || enc == aluTable[opSub]) && (right.st.cval == 1 || right.st.cval == -1) {
 			increment := enc == aluTable[opAdd] && right.st.cval == 1 || enc == aluTable[opSub] && right.st.cval == -1
@@ -1086,8 +1097,8 @@ func (f *fn) applyALU(enc aluEnc, dest Reg, right *elem, w bool) {
 				f.a.Dec(dest, w)
 			}
 			f.stats.peep("inc-dec")
-		} else if f.opt(optI64Mask32) && w && enc == aluTable[opAnd] && isI64Mask32(right) {
-			f.a.AluRI(enc.digit, dest, -1, false)
+		} else if f.opt(optI64Mask32) && w && enc == aluTable[opAnd] && isI64Low32Mask(right) {
+			f.a.AluRI(enc.digit, dest, int32(uint32(right.st.cval)), false)
 			f.stats.peep("i64-mask32")
 		} else if fitsImm32(right.st.cval) {
 			f.a.AluRI(enc.digit, dest, int32(right.st.cval), w)
@@ -1119,9 +1130,9 @@ func (f *fn) applyALU(enc aluEnc, dest Reg, right *elem, w bool) {
 	}
 }
 
-func isI64Mask32(e *elem) bool {
+func isI64Low32Mask(e *elem) bool {
 	return e != nil && e.kind == ekValue && e.st.kind == stConst &&
-		e.st.typ == mtI64 && uint64(e.st.cval) == 0xffffffff
+		e.st.typ == mtI64 && uint64(e.st.cval) <= 0xffffffff
 }
 
 // applyMul emits `dest = dest * right` (imul), folding the right operand.

--- a/src/core/compiler/backend/railshot/amd64/i64_mask32_test.go
+++ b/src/core/compiler/backend/railshot/amd64/i64_mask32_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/wago-org/wago/tests/wasmtest"
 )
 
-func i64Mask32Module(t *testing.T, maskFirst, tee bool) *wasm.Module {
+func i64Mask32Module(t *testing.T, mask uint64, maskFirst, tee bool) *wasm.Module {
 	t.Helper()
 	body := []byte{0x00}
-	mask := append([]byte{0x42}, wasmtest.SLEB64(0xffffffff)...)
+	maskConst := append([]byte{0x42}, wasmtest.SLEB64(int64(mask))...)
 	value := []byte{0x20, 0x00}
 	if maskFirst {
-		body = append(body, mask...)
+		body = append(body, maskConst...)
 		body = append(body, value...)
 	} else {
 		body = append(body, value...)
-		body = append(body, mask...)
+		body = append(body, maskConst...)
 	}
 	body = append(body, 0x83) // i64.and
 	if tee {
@@ -52,15 +52,19 @@ func TestI64Mask32Lowering(t *testing.T) {
 
 	for _, tc := range []struct {
 		name      string
+		mask      uint64
 		maskFirst bool
 		tee       bool
 	}{
-		{name: "constant-right"},
-		{name: "constant-left", maskFirst: true},
-		{name: "local-tee", tee: true},
+		{name: "low-31", mask: 0x7fffffff},
+		{name: "high-bit", mask: 0x80000000},
+		{name: "mixed", mask: 0x00ff00ff},
+		{name: "full-low-32", mask: 0xffffffff},
+		{name: "constant-left", mask: 0x80000000, maskFirst: true},
+		{name: "local-tee", mask: 0x00ff00ff, tee: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			m := i64Mask32Module(t, tc.maskFirst, tc.tee)
+			m := i64Mask32Module(t, tc.mask, tc.maskFirst, tc.tee)
 			setI64Mask32(t, true)
 			on := compileWithStats(t, m, false).Funcs[0]
 			if got := on.Peephole["i64-mask32"]; got != 1 {
@@ -72,7 +76,7 @@ func TestI64Mask32Lowering(t *testing.T) {
 			if got := off.Peephole["i64-mask32"]; got != 0 {
 				t.Fatalf("disabled i64-mask32 = %d, want 0", got)
 			}
-			if on.CodeBytes >= off.CodeBytes {
+			if !tc.tee && on.CodeBytes >= off.CodeBytes {
 				t.Fatalf("enabled code = %d bytes, disabled = %d; want smaller", on.CodeBytes, off.CodeBytes)
 			}
 
@@ -80,7 +84,7 @@ func TestI64Mask32Lowering(t *testing.T) {
 				0, 1, 0x7fffffff, 0x80000000, 0xffffffff,
 				0x1_0000_0000, 0xdead_beef_cafe_babe, 0xffffffffffffffff,
 			} {
-				want := uint64(uint32(x))
+				want := x & tc.mask
 				setI64Mask32(t, true)
 				if got := runAmd64u(t, m, x); got != want {
 					t.Fatalf("enabled f(%#x) = %#x, want %#x", x, got, want)

--- a/src/core/compiler/backend/railshot/amd64/stats.go
+++ b/src/core/compiler/backend/railshot/amd64/stats.go
@@ -83,10 +83,10 @@ var (
 	// default-off; WAGO_TEE_SPILL_ELIDE=1 opts in.
 	teeSpillElideEnabled = envDefaultOff(os.Getenv("WAGO_TEE_SPILL_ELIDE"))
 	// commuteSelfUpdateEnabled makes a non-fixed destination the accumulator for
-	// commutative x=f(y) op x expressions instead of spilling x first. It is
-	// default-off; WAGO_COMMUTE_SELF_UPDATE=1 opts in.
-	commuteSelfUpdateEnabled = envDefaultOff(os.Getenv("WAGO_COMMUTE_SELF_UPDATE"))
-	// i64Mask32Enabled lowers i64.and with the low-32 mask to a 32-bit AND whose
+	// commutative x=f(y) op x expressions instead of spilling x first.
+	// WAGO_AMD64_NO_COMMUTE_SELF_UPDATE=1 is the A/B oracle.
+	commuteSelfUpdateEnabled = os.Getenv("WAGO_AMD64_NO_COMMUTE_SELF_UPDATE") != "1"
+	// i64Mask32Enabled lowers i64.and with any low-32-bit mask to a 32-bit AND whose
 	// destination write implicitly zero-extends. WAGO_AMD64_NO_I64_MASK32=1 is the
 	// A/B oracle.
 	i64Mask32Enabled = os.Getenv("WAGO_AMD64_NO_I64_MASK32") != "1"

--- a/src/core/compiler/optimization/catalog.go
+++ b/src/core/compiler/optimization/catalog.go
@@ -406,7 +406,7 @@ var catalog = []Definition{
 	amd64("compact-i32-frame", "Compact i32 frames", "pack i32 locals in straight-line call-free functions"),
 	amd64("local-slot-order", "Symbolic local slot packing", "move exact referenced local homes into zero-reference compact slots"),
 	amd64Off("tee-spill-elide", "Reuse tee spill homes", "reuse a local.tee frame slot when spilling its still-live scalar result"),
-	amd64Off("commute-self-update", "Commute self-updates", "make non-fixed destinations accumulate commutative self-update expressions in place"),
+	amd64("commute-self-update", "Commute self-updates", "make non-fixed destinations accumulate commutative self-update expressions in place"),
 	amd64("i64-mask32", "Low-32 mask lowering", "lower i64 low-32 masks to zero-extending 32-bit ANDs"),
 	amd64("accumulator-immediate", "Accumulator immediates", "use ModRM-free RAX/EAX imm32 encodings in size objectives"),
 	arm64("frame-elide-reghomed", "Register-homed frames", "omit frames when locals remain in registers"),

--- a/src/core/compiler/optimization/catalog_test.go
+++ b/src/core/compiler/optimization/catalog_test.go
@@ -31,12 +31,11 @@ func TestCatalogRegistrationIsUniqueAndArchitectureScoped(t *testing.T) {
 func TestMeasuredLowValueOptimizationsDefaultOff(t *testing.T) {
 	wantOff := map[string]map[string]bool{
 		"amd64": {
-			"affine-lea":          true,
-			"call-next-use":       true,
-			"commute-self-update": true,
-			"loop-precheck":       true,
-			"tee-spill-elide":     true,
-			"v128-sink":           true,
+			"affine-lea":      true,
+			"call-next-use":   true,
+			"loop-precheck":   true,
+			"tee-spill-elide": true,
+			"v128-sink":       true,
 		},
 		"arm64": {
 			"loop-precheck": true,

--- a/src/wago/amd64_scalar_instruction_bench_test.go
+++ b/src/wago/amd64_scalar_instruction_bench_test.go
@@ -242,3 +242,91 @@ func BenchmarkAMD64IntegerShiftInstruction(b *testing.B) {
 		})
 	}
 }
+
+type amd64Low32MaskBenchmarkCase struct {
+	name   string
+	mask   uint64
+	narrow bool
+}
+
+func amd64Low32MaskBenchmarkModule(mask uint64) []byte {
+	body := []byte{
+		0x01, 0x01, 0x7f, // local 2: i32 counter
+		0x02, 0x40, // block
+		0x03, 0x40, // loop
+		0x20, 0x02, 0x20, 0x00, 0x4f, 0x0d, 0x01, // if counter >= iterations, break
+		0x20, 0x01, // accumulator
+		0x42,
+	}
+	body = append(body, wasmtest.SLEB64(int64(amd64DivBenchmarkAdd))...)
+	body = append(body, 0x7c, 0x42) // i64.add; i64.const mask
+	body = append(body, wasmtest.SLEB64(int64(mask))...)
+	body = append(body,
+		0x83, 0x21, 0x01, // i64.and; local.set accumulator
+		0x20, 0x02, 0x41, 0x01, 0x6a, 0x21, 0x02, // counter++
+		0x0c, 0x00, // continue
+		0x0b, 0x0b,
+		0x20, 0x01,
+		0x0b,
+	)
+	funcType := wasmtest.FuncType(
+		[]wasm.ValType{wasm.I32, wasm.I64},
+		[]wasm.ValType{wasm.I64},
+	)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(funcType)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
+// BenchmarkAMD64Low32MaskInstruction compares the general i64 immediate/register
+// path with a zero-extending 32-bit AND for constants confined to the low half.
+// One public invocation executes b.N dependent guest operations.
+func BenchmarkAMD64Low32MaskInstruction(b *testing.B) {
+	cases := []amd64Low32MaskBenchmarkCase{
+		{name: "low-31/baseline", mask: 0x7fffffff},
+		{name: "low-31/narrow", mask: 0x7fffffff, narrow: true},
+		{name: "high-bit/baseline", mask: 0x80000000},
+		{name: "high-bit/narrow", mask: 0x80000000, narrow: true},
+		{name: "mixed/baseline", mask: 0x00ff00ff},
+		{name: "mixed/narrow", mask: 0x00ff00ff, narrow: true},
+		{name: "full/baseline", mask: 0xffffffff},
+		{name: "full/narrow", mask: 0xffffffff, narrow: true},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			cfg := NewRuntimeConfig().WithOptimization("i64-mask32", tc.narrow)
+			compiled, err := Compile(cfg, amd64Low32MaskBenchmarkModule(tc.mask))
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer compiled.Close()
+			instance, err := Instantiate(compiled, InstantiateOptions{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer instance.Close()
+
+			want := (amd64DivBenchmarkSeed + amd64DivBenchmarkAdd) & tc.mask
+			got, err := instance.Invoke("run", 1, amd64DivBenchmarkSeed)
+			if err != nil || len(got) != 1 || got[0] != want {
+				b.Fatalf("warm run = %v, %v; want [%d]", got, err, want)
+			}
+			if uint64(b.N) > uint64(^uint32(0)) {
+				b.Fatalf("iteration count %d exceeds the i32 guest-loop limit", b.N)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			got, err = instance.Invoke("run", uint64(uint32(b.N)), amd64DivBenchmarkSeed)
+			b.StopTimer()
+			if err != nil || len(got) != 1 {
+				b.Fatalf("run(%d) = %v, %v", b.N, got, err)
+			}
+			benchUintSink = got[0]
+			b.ReportMetric(float64(compiled.CodeSize()), "code-B")
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N), "ns/instruction")
+		})
+	}
+}

--- a/src/wago/config_test.go
+++ b/src/wago/config_test.go
@@ -600,7 +600,7 @@ func TestMeasuredLowValueOptimizationsAreDisabledByDefault(t *testing.T) {
 	}
 	switch runtime.GOARCH {
 	case "amd64":
-		for _, name := range []string{"affine-lea", "call-next-use", "commute-self-update", "tee-spill-elide", "v128-sink"} {
+		for _, name := range []string{"affine-lea", "call-next-use", "tee-spill-elide", "v128-sink"} {
 			wantOff[name] = true
 		}
 	}


### PR DESCRIPTION
## Summary

- review every open issue labeled `performance` or `area/performance` and separate bounded Railshot candidates from ABI, GC, artifact, proposal, and multi-pass projects
- accumulate safe AMD64 `x = f(y) op x` forms directly in the existing destination, including the first site in a function, and enable the qualified rule by default
- generalize zero-extending `i64.and` lowering from the exact `0xffffffff` mask to every low-32-bit constant
- add permanent same-process execution and compile/code-size A/B benchmarks
- document retained and rejected experiments and refresh the severe-gap baseline

## Measured results

Linux/amd64, Ryzen 7 8845HS, `GOMAXPROCS=1`, execution watchpoints pinned to CPU 2. All execution rows remain at 0 B/op and 0 allocs/op.

### Commutative self-updates

Same-process `BenchmarkExecCommuteSelfUpdate` medians:

| Workload | Off | On | Change |
|---|---:|---:|---:|
| spectral norm | 685.189 us | 686.153 us | +0.14% |
| quicksort | 59.983 us | 59.413 us | -0.95% |
| JSON serialize | 24.732 us | 24.479 us | -1.02% |
| JSON deserialize | 44.592 us | 44.104 us | -1.09% |
| scalar BLAKE3 | 718.376 us | 703.297 us | -2.10% |
| open-coded multiply-high loop | 2.239 us | 1.995 us | -10.90% |
| SIMD BLAKE3 | 628.170 us | 575.795 us | -8.34% |

The seven-row geomean improves **3.55%**.

Across the complete compile corpus, the combined retained changes reduce:

- native bytes: **69,708,236 -> 69,675,415** (-32,821)
- allocator spills: **3,817 -> 1,259** (-67.0%)
- compile allocation bytes/counts: unchanged in the permanent watchpoints

`BenchmarkCompileCommuteSelfUpdate` is neutral on scalar BLAKE3, SIMD BLAKE3, and SQLite. The one-iteration esbuild median is +1.50% with unchanged B/op and allocs/op.

### Low-32 masks

The generalized `and r32, imm32` form is runtime-neutral at about 0.45 ns/instruction. It expands corpus hits from 2,911 to 7,483 and removes 4,800 native bytes beyond the prior exact-mask rule.

### #297 refresh

| Workload | Wago/wazero |
|---|---:|
| tiny add | 0.330x |
| branch classifier | 0.350x |
| backward copy, 256 B | 0.937x |
| backward copy, 4 KiB | 1.050x |
| scalar BLAKE3 | 1.486x |
| SIMD BLAKE3 | 1.066x |

The severe gaps recorded by #297 are gone. Scalar BLAKE remains a follow-up selector/allocator target, but is below the original 1.91x gap.

## Rejected/default-off experiments

Focused reruns keep these off:

- float compare fusion: +1.41% geomean; raytrace +5.41%
- vector local sinking: +2.04% geomean
- call next-use + affine LEA: mixed, including UTF +2.70%
- loop prechecks: mixed, including memory tree +1.64%
- tee spill reuse: mixed SHA/BLAKE regressions
- BMI2 RORX: runtime tied while adding two bytes

## Validation

- `go test ./src/core/compiler/backend/railshot/amd64 ./src/core/compiler/optimization ./src/wago -count=1`
- `cd bench && go test ./... -count=1`
- `go test -tags wago_guardpage ./src/core/compiler/backend/railshot/amd64 ./src/wago -count=1`
- `go vet ./src/core/compiler/backend/railshot/amd64 ./src/core/compiler/optimization ./src/wago`
- `cd bench && go vet ./...`
- Linux/ARM64 and Windows/AMD64 test cross-builds
- `go test ./... -count=1` passed all packages except `cli/manager/internal/registry` under the host's global signed-tag configuration; `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false go test ./cli/manager/internal/registry -count=1` passes
- `git diff --check`

## Issue scope

Closes #297.

Measured progress for #438, #501, #504, and #508. Those broader fact/selector/combiner/allocator projects remain open.
