### PR TITLE
perf: eliminate memarg allocations and import rescans

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -17,7 +17,21 @@ Legend: effort S/M/L · value ⬜ low · 🟦 medium · 🟩 high · ⭐ very hi
 
 ---
 
-## What's in place (updated 2026-08-29)
+## What's in place (updated 2026-08-30)
+
+**Benchmark-audit frontend wins (2026-08-30).** Indexed multi-memory memargs in
+allocation-free bytecode walks now decode directly into `InstructionImmediate`
+instead of constructing the AST pointer form. A 10,000-load mixed-width fixture
+improves **287.6→211.7 µs/op** (-26.4%), **42,183→1,915 B/op**, and
+**10,001→1 alloc/op**. Large function-import modules also avoid quadratic
+`ImportedFuncCount`/`FuncSignature` rescans: GC-boundary and synchronous-host-slot
+prepasses range the import section once, while frontend diagnostics format only
+on failure. The 10,000-import compile watchpoint improves **199.726→30.442 ms**
+(-84.8%), **6,364,072→5,486,008 B/op**, and **79,818→40,071 allocs/op**; sqlite3,
+ruby, and esbuild corpus compile medians remain flat with unchanged allocation
+counts. Stale resource-limit and survivor-policy benchmark fixtures were repaired.
+Adjacent import-name reuse and an inline mixed-memory width word were measured and
+rejected. See `docs/research/benchmark-audit-2026-08-30.md`.
 
 **Commutative self-updates and low-32 masks (2026-08-29).** AMD64 now
 accumulates every safe non-fixed `x = f(y) op x` form directly in `x` instead of

--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -24,12 +24,16 @@ allocation-free bytecode walks now decode directly into `InstructionImmediate`
 instead of constructing the AST pointer form. A 10,000-load mixed-width fixture
 improves **287.6→211.7 µs/op** (-26.4%), **42,183→1,915 B/op**, and
 **10,001→1 alloc/op**. Large function-import modules also avoid quadratic
-`ImportedFuncCount`/`FuncSignature` rescans: GC-boundary and synchronous-host-slot
-prepasses range the import section once, while frontend diagnostics format only
-on failure. The 10,000-import compile watchpoint improves **199.726→30.442 ms**
-(-84.8%), **6,364,072→5,486,008 B/op**, and **79,818→40,071 allocs/op**; sqlite3,
-ruby, and esbuild corpus compile medians remain flat with unchanged allocation
-counts. Stale resource-limit and survivor-policy benchmark fixtures were repaired.
+`ImportedFuncCount`, `FuncSignature`, and `FuncTypeIndex` rescans: GC-boundary,
+synchronous-host-slot, and imported-signature prepasses each range the import
+section once, while frontend diagnostics format only on failure. Ten-sample
+`benchstat` results improve the 10,000-import compile watchpoint
+**217.278→5.361 ms** (-97.53%), **6,364,072→5,486,008 B/op**, and
+**79,818→40,071 allocs/op**. Ten interleaved sqlite3, ruby, and esbuild corpus
+samples are statistically unchanged with a -0.43% geomean and identical
+allocation counts. The stripped manager size is unchanged; runtime-standard and
+runtime-minimal each grow 4,096 bytes. Stale resource-limit and survivor-policy
+benchmark fixtures were repaired.
 Adjacent import-name reuse and an inline mixed-memory width word were measured and
 rejected. See `docs/research/benchmark-audit-2026-08-30.md`.
 

--- a/docs/research/benchmark-audit-2026-08-30.md
+++ b/docs/research/benchmark-audit-2026-08-30.md
@@ -1,0 +1,131 @@
+# Benchmark audit — 2026-08-30
+
+Host: Linux/amd64, AMD Ryzen 7 8845HS, Go 1.24.4. Focused runs used
+`GOMAXPROCS=1` and `-cpu=1`.
+
+## Scope
+
+The tracked tree contains 451 benchmark functions across 17 package directories.
+The audit ran one-iteration scout passes over the frontend, wasm decoder and
+validator, AMD64 backend, runtime, collector, public runtime, and CLI/internal
+benchmark packages. It also ran the complete `src/core/compiler/wasm`,
+`src/core/runtime/gc`, and `src/wago` benchmark sets after the changes below.
+
+## Retained: allocation-free indexed memarg classification
+
+The bytecode classifier claimed an allocation-free interface, but indexed
+multi-memory memargs called the AST decoder. The AST `MemArg` representation uses
+an optional `*MemIdx`, so every classified indexed load allocated one small Go
+object.
+
+The classifier now decodes the align/index/offset fields directly into
+`InstructionImmediate`. The AST decoder and its public representation are
+unchanged.
+
+Command:
+
+```sh
+GOMAXPROCS=1 go test ./src/core/compiler/wasm -run '^$' \
+  -bench '^BenchmarkModuleInstructionClassifier(ManyImportsAndOps|MixedLateMemory)$' \
+  -benchmem -benchtime=200ms -count=5 -cpu=1
+```
+
+Median result for 10,000 indexed memory64 loads:
+
+| metric | before | after | change |
+|---|---:|---:|---:|
+| time | 287.6 us/op | 211.7 us/op | -26.4% |
+| Go bytes | 42,183 B/op | 1,915 B/op | -95.5% |
+| allocations | 10,001/op | 1/op | -99.99% |
+
+The remaining allocation is the mixed-memory width bitset created once per
+classifier. The immediate-free control stayed allocation-free and improved from
+about 50.6 us/op to 48.3 us/op in the final run.
+
+## Retained: linear imported-function metadata passes
+
+`BenchmarkCompileImportMetadata` exposed quadratic compile time. Two module
+prepasses iterated imported function indexes and called `FuncSignature` for every
+index. `FuncSignature` rescanned the import section from its start, while repeated
+`ImportedFuncCount` calls performed more full scans. A CPU profile attributed
+about 63% of samples to `Module.importCount` and 36% to `Module.FuncTypeIndex`.
+
+The runtime now ranges the import section once and resolves each function import
+by its actual import-section index through `Module.ImportFuncType`.
+Frontend admission also stopped formatting a diagnostic string for every valid
+function import; the exact text is now built only on an error path.
+
+Command:
+
+```sh
+GOMAXPROCS=1 go test ./src/wago -run '^$' \
+  -bench '^BenchmarkCompileImportMetadata/imports=(1000|10000)/low-level$' \
+  -benchmem -benchtime=1x -count=5 -cpu=1
+```
+
+Median results:
+
+| imports | metric | before | after | change |
+|---:|---|---:|---:|---:|
+| 1,000 | time | 2.428 ms | 0.636 ms | -73.8% |
+| 1,000 | Go bytes | 393,560 B/op | 307,608 B/op | -21.8% |
+| 1,000 | allocations | 7,798/op | 4,054/op | -48.0% |
+| 10,000 | time | 199.726 ms | 30.442 ms | -84.8% |
+| 10,000 | Go bytes | 6,364,072 B/op | 5,486,008 B/op | -13.8% |
+| 10,000 | allocations | 79,818/op | 40,071/op | -49.8% |
+
+Three one-iteration corpus compile samples were flat after the change:
+
+| corpus | before median | after median |
+|---|---:|---:|
+| sqlite3 | 77.474 ms | 77.810 ms |
+| ruby | 797.416 ms | 796.829 ms |
+| esbuild | 530.954 ms | 530.050 ms |
+
+Corpus compile bytes and allocation counts were unchanged.
+
+## Benchmark repairs
+
+The previous resource-policy change exposed three stale benchmark assumptions:
+
+- staged validation benchmarks constructed an internal validator without the
+  normalized default limits;
+- import validation generated 10,000 memories even though the executable
+  implementation ceiling is 4,096; and
+- the dirty-persistent-root collector benchmark expected first-minor promotion
+  after survivor aging became the default Throughput policy.
+
+The validation benchmarks now use explicit valid limits. The pure-memory matrix
+ends at 4,096 entries. The persistent-root benchmark disables moving survivors
+because it measures dirty-root scanning, not tenuring policy. The complete wasm
+and collector benchmark packages now pass with `-benchtime=1x`.
+
+## Measured and rejected
+
+### Adjacent import-module string reuse
+
+A one-entry adjacent-name reuse experiment halved allocations in a synthetic
+repeated-module decode and improved that microbenchmark by about 8%. Real corpus
+decode removed only 21 to 54 allocations and showed no timing win: ruby was about
+2.7% slower, sqlite3 about 1.8% slower, and esbuild was flat in five cold samples.
+The change was reverted. `BenchmarkImportNameDecode` remains as a permanent
+repeated-module, repeated-field, and all-unique watchpoint.
+
+### Inline first mixed-memory width word
+
+Keeping the first 64 mixed-memory width bits inline removed the sole allocation
+for a two-memory classifier, but construction regressed from about 13.9 ns/op to
+18.0 ns/op. The retained slice representation is faster and the experiment was
+reverted.
+
+## Verification
+
+```sh
+go test ./src/core/compiler/wasm ./src/core/compiler/frontend ./src/core/runtime/gc -count=1
+go test ./src/wago -count=1
+go test ./src/core/compiler/wasm -run '^$' -bench . -benchmem -benchtime=1x -count=1
+go test ./src/core/runtime/gc -run '^$' -bench . -benchmem -benchtime=1x -count=1
+go test ./src/wago -run '^$' -bench . -benchmem -benchtime=1x -count=1
+```
+
+All passed on the audit host.

--- a/docs/research/benchmark-audit-2026-08-30.md
+++ b/docs/research/benchmark-audit-2026-08-30.md
@@ -44,45 +44,64 @@ about 50.6 us/op to 48.3 us/op in the final run.
 
 ## Retained: linear imported-function metadata passes
 
-`BenchmarkCompileImportMetadata` exposed quadratic compile time. Two module
-prepasses iterated imported function indexes and called `FuncSignature` for every
-index. `FuncSignature` rescanned the import section from its start, while repeated
-`ImportedFuncCount` calls performed more full scans. A CPU profile attributed
-about 63% of samples to `Module.importCount` and 36% to `Module.FuncTypeIndex`.
+`BenchmarkCompileImportMetadata` exposed quadratic compile time. GC-boundary,
+synchronous-host-slot, and imported-signature prepasses iterated function indexes
+while `FuncSignature` or `FuncTypeIndex` rescanned the import section from its
+start. Repeated `ImportedFuncCount` calls performed more full scans. The initial
+CPU profile attributed about 63% of samples to `Module.importCount` and 36% to
+`Module.FuncTypeIndex`. After the first two prepasses became linear, an adversarial
+follow-up profile found the imported-signature loop still spent 86.7% of samples
+in `FuncTypeIndex`.
 
-The runtime now ranges the import section once and resolves each function import
-by its actual import-section index through `Module.ImportFuncType`.
-Frontend admission also stopped formatting a diagnostic string for every valid
-function import; the exact text is now built only on an error path.
+All three runtime prepasses now range the import section once. Direct
+import-section lookups use `Module.ImportFuncType` where the stored signature is
+sufficient; imported-signature conversion keeps the exact function namespace
+while resolving types directly from each function import. Frontend admission also
+stopped formatting a diagnostic string for every valid function import; the exact
+text is now built only on an error path.
 
 Command:
 
 ```sh
 GOMAXPROCS=1 go test ./src/wago -run '^$' \
   -bench '^BenchmarkCompileImportMetadata/imports=(1000|10000)/low-level$' \
-  -benchmem -benchtime=1x -count=5 -cpu=1
+  -benchmem -benchtime=1x -count=10 -cpu=1
+benchstat main.txt head.txt
 ```
 
-Median results:
+Ten-sample `benchstat` results:
 
 | imports | metric | before | after | change |
 |---:|---|---:|---:|---:|
-| 1,000 | time | 2.428 ms | 0.636 ms | -73.8% |
-| 1,000 | Go bytes | 393,560 B/op | 307,608 B/op | -21.8% |
-| 1,000 | allocations | 7,798/op | 4,054/op | -48.0% |
-| 10,000 | time | 199.726 ms | 30.442 ms | -84.8% |
-| 10,000 | Go bytes | 6,364,072 B/op | 5,486,008 B/op | -13.8% |
-| 10,000 | allocations | 79,818/op | 40,071/op | -49.8% |
+| 1,000 | time | 2.452 ms | 0.394 ms | -83.94% |
+| 1,000 | Go bytes | 393,560 B/op | 307,608 B/op | -21.84% |
+| 1,000 | allocations | 7,798/op | 4,054/op | -48.01% |
+| 10,000 | time | 217.278 ms | 5.361 ms | -97.53% |
+| 10,000 | Go bytes | 6,364,072 B/op | 5,486,008 B/op | -13.80% |
+| 10,000 | allocations | 79,818/op | 40,071/op | -49.80% |
 
-Three one-iteration corpus compile samples were flat after the change:
+Ten interleaved one-iteration corpus samples found no significant compile-time
+change. The geomean moved -0.43%:
 
-| corpus | before median | after median |
-|---|---:|---:|
-| sqlite3 | 77.474 ms | 77.810 ms |
-| ruby | 797.416 ms | 796.829 ms |
-| esbuild | 530.954 ms | 530.050 ms |
+| corpus | before median | after median | p value |
+|---|---:|---:|---:|
+| sqlite3 | 83.36 ms | 83.76 ms | 0.436 |
+| ruby | 847.5 ms | 844.8 ms | 0.796 |
+| esbuild | 571.1 ms | 562.9 ms | 0.143 |
 
-Corpus compile bytes and allocation counts were unchanged.
+Corpus compile bytes and allocation counts were unchanged in every sample.
+
+### Release binary size
+
+The retained changes do not change the stripped manager profile. On Linux/amd64,
+the stripped `runtime-standard` and `runtime-minimal` profiles each grow by one
+4 KiB file-alignment page:
+
+| profile | before | after | change |
+|---|---:|---:|---:|
+| manager | 8,601,784 B | 8,601,784 B | 0 B |
+| runtime-standard | 8,466,616 B | 8,470,712 B | +4,096 B |
+| runtime-minimal | 8,159,416 B | 8,163,512 B | +4,096 B |
 
 ## Benchmark repairs
 
@@ -95,10 +114,12 @@ The previous resource-policy change exposed three stale benchmark assumptions:
 - the dirty-persistent-root collector benchmark expected first-minor promotion
   after survivor aging became the default Throughput policy.
 
-The validation benchmarks now use explicit valid limits. The pure-memory matrix
-ends at 4,096 entries. The persistent-root benchmark disables moving survivors
-because it measures dirty-root scanning, not tenuring policy. The complete wasm
-and collector benchmark packages now pass with `-benchtime=1x`.
+The validation benchmarks now use explicit valid limits. The pure-memory
+validation matrix ends at 4,096 entries, while decode and metadata-iteration
+watchpoints retain their 10,000-import scale. The persistent-root benchmark
+disables moving survivors because it measures dirty-root scanning, not tenuring
+policy. The complete wasm and collector benchmark packages now pass with
+`-benchtime=1x`.
 
 ## Measured and rejected
 

--- a/docs/research/runtime-limit-refactor-2026-08-30.md
+++ b/docs/research/runtime-limit-refactor-2026-08-30.md
@@ -84,3 +84,33 @@ paired geometric-mean change. The remaining 112-byte allocation is the immutable
 callback-scoped `HostModule` value; removing it from the existing API would need
 a non-reusable stale-safe token representation or a separate module-free fast
 host API.
+
+## CI qualification follow-up
+
+The post-merge qualification run exposed four fixture and policy gaps rather
+than runtime failures:
+
+- the cold single-memory quota test converted a captured native `uintptr` back
+  to a Go pointer, which `go vet` correctly rejected; it now proves separate
+  per-instance policy directories through non-aliasing pointers and observable
+  low/high `memory.grow` quotas without dereferencing native state;
+- the multi-memory execution test now uses the existing complete-Core-3 backend
+  guard, matching the memory64 test on Darwin/AMD64;
+- `syncHostBinding` remains 24 bytes under standard Go, while TinyGo may align
+  the same pointer-bearing shape to 32 bytes on some targets; both bounded shapes
+  are accepted; and
+- release-size budgets now describe the measured resource-policy product rather
+  than the pre-refactor binaries.
+
+The final Linux/AMD64 stripped sizes and updated ceilings are:
+
+| profile | measured bytes | budget bytes | headroom |
+|---|---:|---:|---:|
+| manager | 8,601,784 | 9,000,000 | 398,216 |
+| runtime-standard | 8,470,712 | 8,870,000 | 399,288 |
+| runtime-minimal | 8,163,512 | 8,560,000 | 396,488 |
+
+The performance-audit follow-up accounts for one 4 KiB alignment page in each
+runtime profile. The remaining increase belongs to the resource-policy change.
+The new ceilings restore about 389 KiB of explicit headroom per standard-Go
+runtime profile instead of hiding the measured product behind stale budgets.

--- a/docs/research/runtime-limit-refactor-2026-08-30.md
+++ b/docs/research/runtime-limit-refactor-2026-08-30.md
@@ -87,7 +87,7 @@ host API.
 
 ## CI qualification follow-up
 
-The post-merge qualification run exposed four fixture and policy gaps rather
+The post-merge qualification run exposed five fixture and policy gaps rather
 than runtime failures:
 
 - the cold single-memory quota test converted a captured native `uintptr` back
@@ -98,7 +98,9 @@ than runtime failures:
   guard, matching the memory64 test on Darwin/AMD64;
 - `syncHostBinding` remains 24 bytes under standard Go, while TinyGo may align
   the same pointer-bearing shape to 32 bytes on some targets; both bounded shapes
-  are accepted; and
+  are accepted;
+- the late-instantiation mapping leak test now warms one-time engine and arena
+  mappings before counting repeated failures; and
 - release-size budgets now describe the measured resource-policy product rather
   than the pre-refactor binaries.
 
@@ -109,8 +111,11 @@ The final Linux/AMD64 stripped sizes and updated ceilings are:
 | manager | 8,601,784 | 9,000,000 | 398,216 |
 | runtime-standard | 8,470,712 | 8,870,000 | 399,288 |
 | runtime-minimal | 8,163,512 | 8,560,000 | 396,488 |
+| runtime-minimal-tiny | 2,314,776 | 2,317,000 | 2,224 |
 
 The performance-audit follow-up accounts for one 4 KiB alignment page in each
-runtime profile. The remaining increase belongs to the resource-policy change.
-The new ceilings restore about 389 KiB of explicit headroom per standard-Go
-runtime profile instead of hiding the measured product behind stale budgets.
+standard-Go runtime profile. The remaining increase belongs to the
+resource-policy change. The new ceilings restore about 389 KiB of explicit
+headroom per standard-Go runtime profile instead of hiding the measured product
+behind stale budgets. TinyGo keeps a deliberately tight 2,224-byte ceiling under
+the CI Go 1.22.12 and TinyGo 0.41.1 toolchain.

--- a/scripts/release-size-budgets.tsv
+++ b/scripts/release-size-budgets.tsv
@@ -2,4 +2,4 @@
 manager	9000000
 runtime-standard	8870000
 runtime-minimal	8560000
-runtime-minimal-tiny	2312000
+runtime-minimal-tiny	2317000

--- a/scripts/release-size-budgets.tsv
+++ b/scripts/release-size-budgets.tsv
@@ -1,5 +1,5 @@
 # profile	max_linux_amd64_bytes
 manager	9000000
-runtime-standard	8100000
-runtime-minimal	7770000
+runtime-standard	8870000
+runtime-minimal	8560000
 runtime-minimal-tiny	2312000

--- a/src/core/compiler/frontend/frontend.go
+++ b/src/core/compiler/frontend/frontend.go
@@ -627,33 +627,34 @@ func compTypeName(k wasm.CompTypeKind) string {
 
 func (p supportPass) imports() error {
 	for i, im := range p.m.Imports {
-		ctx := fmt.Sprintf("import %d %q.%q", i, im.Module, im.Name)
 		switch im.Type.Kind {
 		case wasm.ExternFunc:
 			ft, ok := p.funcType(im.Type.FuncType())
 			if !ok {
-				return p.unsupported("import", "function with unknown type", ctx)
+				return p.unsupported("import", "function with unknown type", fmt.Sprintf("import %d %q.%q", i, im.Module, im.Name))
 			}
 			// Reflection-free host imports admit externref handles and opaque funcref
 			// tokens. Instantiation still requires explicit ownership before a host
 			// descriptor itself may cross a public funcref boundary.
 			for _, pt := range ft.Params {
 				if !p.supportedValType(pt) {
-					return p.valType(pt, ctx+" function signature")
+					return p.valType(pt, fmt.Sprintf("import %d %q.%q function signature", i, im.Module, im.Name))
 				}
 			}
 			for _, rt := range ft.Results {
 				if !p.supportedValType(rt) {
-					return p.valType(rt, ctx+" function result")
+					return p.valType(rt, fmt.Sprintf("import %d %q.%q function result", i, im.Module, im.Name))
 				}
 			}
 		case wasm.ExternGlobal:
+			ctx := fmt.Sprintf("import %d %q.%q", i, im.Module, im.Name)
 			// Imported reference globals are admitted structurally here; instantiation
 			// requires an exact typed, mutable, compatible-store Global owner.
 			if err := p.globalType(im.Type.GlobalType().Type, ctx); err != nil {
 				return err
 			}
 		case wasm.ExternTable:
+			ctx := fmt.Sprintf("import %d %q.%q", i, im.Module, im.Name)
 			// Imported tables carry their exact reference type into the shared
 			// runtime handle. Externref imports additionally require reference types
 			// and a compatible store-bound owner at instantiation.
@@ -676,15 +677,16 @@ func (p supportPass) imports() error {
 				}
 			}
 		case wasm.ExternMem:
+			ctx := fmt.Sprintf("import %d %q.%q", i, im.Module, im.Name)
 			if err := p.checkMemType(im.Type.MemType(), ctx); err != nil {
 				return err
 			}
 		case wasm.ExternTag:
 			if !p.feat.ExceptionHandling {
-				return p.unsupported("import", "tag (exception-handling disabled)", ctx)
+				return p.unsupported("import", "tag (exception-handling disabled)", fmt.Sprintf("import %d %q.%q", i, im.Module, im.Name))
 			}
 		default:
-			return p.unsupported("import", "unknown external kind", ctx)
+			return p.unsupported("import", "unknown external kind", fmt.Sprintf("import %d %q.%q", i, im.Module, im.Name))
 		}
 	}
 	return nil

--- a/src/core/compiler/wasm/bytecode_skip.go
+++ b/src/core/compiler/wasm/bytecode_skip.go
@@ -225,13 +225,31 @@ func skipRefHeapTypeBytes(r *reader) error {
 }
 
 func classifyMemArgBytes(r *reader, imm *InstructionImmediate, widths memargWidths) error {
-	ma, err := decodeMemArgWithWidths(r, widths)
-	imm.MemAlign = ma.Align
-	imm.MemOffset = ma.Offset
-	if ma.Mem != nil {
-		imm.HasMemIndex = true
-		imm.MemIndex = uint32(*ma.Mem)
+	n, err := r.u32()
+	if err != nil {
+		return err
 	}
+	memoryIndex := uint32(0)
+	switch {
+	case n < 64:
+		imm.MemAlign = n
+	case n < 128:
+		imm.MemAlign = n - 64
+		memoryIndex, err = r.u32()
+		if err != nil {
+			return err
+		}
+		imm.HasMemIndex = true
+		imm.MemIndex = memoryIndex
+	default:
+		return &DecodeError{Code: ErrInvalidInstruction, Offset: r.off()}
+	}
+	if widths.offset64(memoryIndex) {
+		imm.MemOffset, err = r.u64()
+		return err
+	}
+	offset, err := r.u32()
+	imm.MemOffset = uint64(offset)
 	return err
 }
 

--- a/src/core/compiler/wasm/import_rep_bench_test.go
+++ b/src/core/compiler/wasm/import_rep_bench_test.go
@@ -71,12 +71,56 @@ func syntheticImportModuleBytes(kindName string, imports int) []byte {
 
 func benchmarkImportShapes(b *testing.B, fn func(*testing.B, []byte)) {
 	for _, kind := range []string{"functions", "globals", "tables", "memories", "tags", "mixed"} {
-		for _, imports := range []int{10, 100, 1000, 10000} {
+		counts := []int{10, 100, 1000, 10000}
+		if kind == "memories" {
+			counts = []int{10, 100, 1000, int(MaximumMemoriesPerModule)}
+		}
+		for _, imports := range counts {
 			data := syntheticImportModuleBytes(kind, imports)
 			b.Run(fmt.Sprintf("kind=%s/imports=%d", kind, imports), func(b *testing.B) {
 				fn(b, data)
 			})
 		}
+	}
+}
+
+func syntheticNamedFunctionImports(imports int, moduleName, fieldName func(int) string) []byte {
+	typePayload := []byte{1, 0x60, 0, 0}
+	module := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, secType}
+	module = appendTypeRepU32(module, uint32(len(typePayload)))
+	module = append(module, typePayload...)
+	payload := appendTypeRepU32(nil, uint32(imports))
+	for i := 0; i < imports; i++ {
+		payload = appendImportRepName(payload, moduleName(i))
+		payload = appendImportRepName(payload, fieldName(i))
+		payload = append(payload, byte(ExternFunc), 0)
+	}
+	module = append(module, secImport)
+	module = appendTypeRepU32(module, uint32(len(payload)))
+	return append(module, payload...)
+}
+
+func BenchmarkImportNameDecode(b *testing.B) {
+	const imports = 1000
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"repeated-module", syntheticNamedFunctionImports(imports, func(int) string { return "env" }, func(i int) string { return fmt.Sprintf("field-%04d", i) })},
+		{"repeated-field", syntheticNamedFunctionImports(imports, func(i int) string { return fmt.Sprintf("module-%04d", i) }, func(int) string { return "field" })},
+		{"all-unique", syntheticNamedFunctionImports(imports, func(i int) string { return fmt.Sprintf("module-%04d", i) }, func(i int) string { return fmt.Sprintf("field-%04d", i) })},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				m, err := DecodeModule(tc.data)
+				if err != nil {
+					b.Fatal(err)
+				}
+				typeRepModuleSink = m
+			}
+		})
 	}
 }
 
@@ -100,10 +144,11 @@ func BenchmarkImportMetadataValidate(b *testing.B) {
 			b.Fatal(err)
 		}
 		features := ValidationFeatures{MultiMemory: true}
+		limits := ValidationLimits{MaxMemoriesPerModule: MaximumMemoriesPerModule}
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if err := ValidateModuleWithFeatures(m, features); err != nil {
+			if err := ValidateModuleWithConfig(m, features, 1, limits); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/src/core/compiler/wasm/import_rep_bench_test.go
+++ b/src/core/compiler/wasm/import_rep_bench_test.go
@@ -69,11 +69,11 @@ func syntheticImportModuleBytes(kindName string, imports int) []byte {
 	return append(module, payload...)
 }
 
-func benchmarkImportShapes(b *testing.B, fn func(*testing.B, []byte)) {
+func benchmarkImportShapes(b *testing.B, maximumMemoryImports int, fn func(*testing.B, []byte)) {
 	for _, kind := range []string{"functions", "globals", "tables", "memories", "tags", "mixed"} {
 		counts := []int{10, 100, 1000, 10000}
-		if kind == "memories" {
-			counts = []int{10, 100, 1000, int(MaximumMemoriesPerModule)}
+		if kind == "memories" && maximumMemoryImports < counts[len(counts)-1] {
+			counts[len(counts)-1] = maximumMemoryImports
 		}
 		for _, imports := range counts {
 			data := syntheticImportModuleBytes(kind, imports)
@@ -125,7 +125,7 @@ func BenchmarkImportNameDecode(b *testing.B) {
 }
 
 func BenchmarkImportMetadataDecode(b *testing.B) {
-	benchmarkImportShapes(b, func(b *testing.B, data []byte) {
+	benchmarkImportShapes(b, 10000, func(b *testing.B, data []byte) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			m, err := DecodeModule(data)
@@ -138,7 +138,7 @@ func BenchmarkImportMetadataDecode(b *testing.B) {
 }
 
 func BenchmarkImportMetadataValidate(b *testing.B) {
-	benchmarkImportShapes(b, func(b *testing.B, data []byte) {
+	benchmarkImportShapes(b, int(MaximumMemoriesPerModule), func(b *testing.B, data []byte) {
 		m, err := DecodeModule(data)
 		if err != nil {
 			b.Fatal(err)
@@ -156,7 +156,7 @@ func BenchmarkImportMetadataValidate(b *testing.B) {
 }
 
 func BenchmarkImportMetadataIterate(b *testing.B) {
-	benchmarkImportShapes(b, func(b *testing.B, data []byte) {
+	benchmarkImportShapes(b, 10000, func(b *testing.B, data []byte) {
 		m, err := DecodeModule(data)
 		if err != nil {
 			b.Fatal(err)

--- a/src/core/compiler/wasm/memory_offset_decode_test.go
+++ b/src/core/compiler/wasm/memory_offset_decode_test.go
@@ -61,6 +61,25 @@ func BenchmarkModuleInstructionClassifierManyImportsAndOps(b *testing.B) {
 	}
 }
 
+func TestModuleInstructionClassifierIndexedMemargDoesNotAllocate(t *testing.T) {
+	m := &Module{Memories: []MemType{{Limits: Limits{Min: 1}}, {Limits: Limits{Min: 1, Addr64: true}}}}
+	classifier := NewModuleInstructionClassifier(m, true)
+	encoded := []byte{0x40, 0x01, 0x00} // align=0, memory 1, offset=0
+	var classifyErr error
+	if allocs := testing.AllocsPerRun(1000, func() {
+		var imm InstructionImmediate
+		classifyErr = classifier.ClassifyInto(NewReader(encoded), 0x28, &imm)
+		if classifyErr == nil && (!imm.HasMemIndex || imm.MemIndex != 1 || imm.MemOffset != 0) {
+			panic("indexed memarg classification changed")
+		}
+	}); allocs != 0 {
+		t.Fatalf("indexed memarg classification allocs = %v, want 0", allocs)
+	}
+	if classifyErr != nil {
+		t.Fatal(classifyErr)
+	}
+}
+
 func BenchmarkModuleInstructionClassifierMixedLateMemory(b *testing.B) {
 	const count = 10000
 	m := &Module{Imports: make([]Import, count)}

--- a/src/core/compiler/wasm/module_helpers.go
+++ b/src/core/compiler/wasm/module_helpers.go
@@ -175,6 +175,16 @@ func (m *Module) FuncSignature(idx uint32) (*CompType, bool) {
 	return m.typeFunc(typeIdx)
 }
 
+// ImportFuncType returns the stored signature for one import-section entry.
+// importIndex is the index in Imports, not the function index space. The
+// returned pointer aliases immutable module type storage.
+func (m *Module) ImportFuncType(importIndex int) (*CompType, bool) {
+	if importIndex < 0 || importIndex >= len(m.Imports) || m.Imports[importIndex].Type.Kind != ExternFunc {
+		return nil, false
+	}
+	return m.typeFunc(m.Imports[importIndex].Type.FuncType())
+}
+
 // LocalFuncType returns the stored function signature for a local
 // (non-imported) function index. The returned pointer aliases module storage and
 // may contain recursive-local TypeIdx values for signatures decoded inside

--- a/src/core/compiler/wasm/module_helpers_test.go
+++ b/src/core/compiler/wasm/module_helpers_test.go
@@ -108,6 +108,18 @@ func TestModuleMetadataHelpers(t *testing.T) {
 			t.Fatalf("function signature %d = %#v, %v", idx, ft, ok)
 		}
 	}
+	if imported, ok := m.ImportFuncType(0); !ok || imported.Kind != CompFunc || len(imported.Params) != 1 || imported.Params[0] != I32 {
+		t.Fatalf("imported function type = %#v, %v", imported, ok)
+	}
+	if _, ok := m.ImportFuncType(-1); ok {
+		t.Fatal("negative import index resolved as a function type")
+	}
+	if _, ok := m.ImportFuncType(1); ok {
+		t.Fatal("non-function import resolved as a function type")
+	}
+	if _, ok := m.ImportFuncType(len(m.Imports)); ok {
+		t.Fatal("out-of-range import resolved as a function type")
+	}
 	if _, ok := m.FuncSignature(2); ok || m.CanonicalTypeID(2) != 0 || m.StructuralTypeID(2) == 0 || m.StructuralTypeID(2) == m.StructuralTypeID(0) {
 		t.Fatal("function signature IDs changed")
 	}

--- a/src/core/compiler/wasm/stage_attribution_test.go
+++ b/src/core/compiler/wasm/stage_attribution_test.go
@@ -69,7 +69,7 @@ func BenchmarkCore3ValidationStages(b *testing.B) {
 						b.Fatal(err)
 					}
 					reportValidationStageShape(b, m)
-					v := &moduleValidator{m: m, funcIndex: -1}
+					v := &moduleValidator{m: m, funcIndex: -1, limits: defaultValidationLimits}
 					b.StartTimer()
 					if err := v.validateModule(); err != nil {
 						b.Fatal(err)
@@ -85,7 +85,7 @@ func BenchmarkCore3ValidationStages(b *testing.B) {
 						b.Fatal(err)
 					}
 					reportValidationStageShape(b, m)
-					v := &moduleValidator{m: m, funcIndex: -1}
+					v := &moduleValidator{m: m, funcIndex: -1, limits: defaultValidationLimits}
 					if err := v.validateModule(); err != nil {
 						b.Fatal(err)
 					}

--- a/src/core/runtime/gc/matrix_bench_test.go
+++ b/src/core/runtime/gc/matrix_bench_test.go
@@ -520,7 +520,10 @@ func BenchmarkGCDirtyPersistentRoots(b *testing.B) {
 	}
 	for _, slots := range []int{1, 64, 4096} {
 		b.Run(fmt.Sprintf("global-slots=%d", slots), func(b *testing.B) {
-			cfg := Config{NurseryBytes: 1 << 20}
+			// This benchmark isolates dirty persistent-root scanning. Keep the
+			// survivor policy out of the fixture so one minor deterministically
+			// promotes the retained child before the cleanup full collection.
+			cfg := Config{NurseryBytes: 1 << 20, DisableMovingNursery: true}
 			if collectorTelemetryEnabled {
 				cfg.Telemetry = new(Telemetry)
 			}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1518,29 +1518,32 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	}
 	if importedFuncs > 0 {
 		c.importFuncSigs = make([]FuncSig, importedFuncs)
-		for i := 0; i < importedFuncs; i++ {
-			typeIdx, ok := m.FuncTypeIndex(uint32(i))
-			if !ok {
+		functionIndex := 0
+		for importIndex := range m.Imports {
+			if m.Imports[importIndex].Type.Kind != wasm.ExternFunc {
 				continue
 			}
+			typeIdx := m.Imports[importIndex].Type.FuncType()
 			var ft wasm.CompType
 			if !m.ResolveTypeFunc(typeIdx.Index, &ft) {
+				functionIndex++
 				continue
 			}
 			params, err := typeConverter.abiTypes(ft.Params, c.Types)
 			if err != nil {
-				return nil, fmt.Errorf("imported function %d params: %w", i, err)
+				return nil, fmt.Errorf("imported function %d params: %w", functionIndex, err)
 			}
 			results, err := typeConverter.abiTypes(ft.Results, c.Types)
 			if err != nil {
-				return nil, fmt.Errorf("imported function %d results: %w", i, err)
+				return nil, fmt.Errorf("imported function %d results: %w", functionIndex, err)
 			}
 			unsafeCrossTail := false
-			word := i >> 6
+			word := functionIndex >> 6
 			if word < len(unsafeDirectTailImports) {
-				unsafeCrossTail = unsafeDirectTailImports[word]&(uint64(1)<<uint(i&63)) != 0
+				unsafeCrossTail = unsafeDirectTailImports[word]&(uint64(1)<<uint(functionIndex&63)) != 0
 			}
-			c.importFuncSigs[i] = FuncSig{Params: params, Results: results, TypeIndex: typeIdx.Index, HasTypeIndex: true, unsafeCrossTail: unsafeCrossTail}
+			c.importFuncSigs[functionIndex] = FuncSig{Params: params, Results: results, TypeIndex: typeIdx.Index, HasTypeIndex: true, unsafeCrossTail: unsafeCrossTail}
+			functionIndex++
 		}
 	}
 	importedTables := m.ImportedTableCount()

--- a/src/wago/footprint_test.go
+++ b/src/wago/footprint_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 func TestSyncHostBindingStaysCompact(t *testing.T) {
-	if got := unsafe.Sizeof(syncHostBinding{}); got != 24 {
-		t.Fatalf("syncHostBinding size = %d, want 24", got)
+	// Standard Go packs the trailing scalar flag into 24 bytes. TinyGo may align
+	// the same pointer-bearing shape to 32 bytes on some targets.
+	if got := unsafe.Sizeof(syncHostBinding{}); got != 24 && got != 32 {
+		t.Fatalf("syncHostBinding size = %d, want 24 or 32", got)
 	}
 }
 

--- a/src/wago/gc_frame_roots.go
+++ b/src/wago/gc_frame_roots.go
@@ -120,8 +120,11 @@ func moduleHasCollectorReferenceCallBoundary(m *wasm.Module) bool {
 	if m == nil {
 		return false
 	}
-	for i := 0; i < m.ImportedFuncCount(); i++ {
-		ft, ok := m.FuncSignature(uint32(i))
+	for i := range m.Imports {
+		if m.Imports[i].Type.Kind != wasm.ExternFunc {
+			continue
+		}
+		ft, ok := m.ImportFuncType(i)
 		if !ok || wasmFuncTypeTransfersCollectorRefs(m, ft) {
 			return true
 		}

--- a/src/wago/global_test.go
+++ b/src/wago/global_test.go
@@ -475,20 +475,25 @@ func TestInstantiateInitializesGlobalSlots(t *testing.T) {
 }
 
 func TestInstantiateLateGlobalErrorCleansResources(t *testing.T) {
-	before := procSelfMapsCount(t)
 	c := newHandBuiltCompiled([]byte{0xc3}, Compiled{ // ret; code is mapped before global initialization reaches this malformed reference.
 		Globals: []GlobalDef{
 			{Type: ValI32, Bits: 1},
 			{Type: ValI32, HasInitGlobal: true, InitGlobal: 2},
 		},
 	})
-	for i := 0; i < 5; i++ {
+	instantiate := func() {
+		t.Helper()
 		if in, err := Instantiate(c, InstantiateOptions{}); err == nil {
 			in.Close()
 			t.Fatal("Instantiate malformed global initializer succeeded, want error")
 		} else if !bytes.Contains([]byte(err.Error()), []byte("initializer references unavailable global")) {
 			t.Fatalf("Instantiate error = %v, want unavailable global", err)
 		}
+	}
+	instantiate() // Exclude one-time engine and arena initialization from leak accounting.
+	before := procSelfMapsCount(t)
+	for i := 0; i < 5; i++ {
+		instantiate()
 	}
 	after := procSelfMapsCount(t)
 	if after > before+2 {

--- a/src/wago/hostcall_capacity.go
+++ b/src/wago/hostcall_capacity.go
@@ -43,10 +43,14 @@ func moduleSyncHostSlotCapacity(m *wasm.Module) (int, error) {
 	if m == nil {
 		return maxSlots, nil
 	}
-	for i := 0; i < m.ImportedFuncCount(); i++ {
-		ft, ok := m.FuncSignature(uint32(i))
+	functionIndex := 0
+	for importIndex := range m.Imports {
+		if m.Imports[importIndex].Type.Kind != wasm.ExternFunc {
+			continue
+		}
+		ft, ok := m.ImportFuncType(importIndex)
 		if !ok {
-			return 0, fmt.Errorf("imported function %d signature is unavailable", i)
+			return 0, fmt.Errorf("imported function %d signature is unavailable", functionIndex)
 		}
 		for _, values := range [][]wasm.ValType{ft.Params, ft.Results} {
 			slots := 0
@@ -58,7 +62,7 @@ func moduleSyncHostSlotCapacity(m *wasm.Module) (int, error) {
 				if slots > coreruntime.MaxSyncHostSlots {
 					return 0, &coreruntime.ImplementationLimitError{
 						Feature: "synchronous host-call signature",
-						Shape:   fmt.Sprintf("imported function %d requires more than %d ABI slots", i, coreruntime.MaxSyncHostSlots),
+						Shape:   fmt.Sprintf("imported function %d requires more than %d ABI slots", functionIndex, coreruntime.MaxSyncHostSlots),
 						Limit:   coreruntime.MaxSyncHostSlots,
 					}
 				}
@@ -67,6 +71,7 @@ func moduleSyncHostSlotCapacity(m *wasm.Module) (int, error) {
 				maxSlots = slots
 			}
 		}
+		functionIndex++
 	}
 	return maxSlots, nil
 }

--- a/src/wago/hostcall_capacity_test.go
+++ b/src/wago/hostcall_capacity_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	coreruntime "github.com/wago-org/wago/src/core/runtime"
 	"github.com/wago-org/wago/src/core/runtime/gc"
+	"github.com/wago-org/wago/tests/wasmtest"
 )
 
 func TestGCSyncHostSlotCapacityRejectsU16Overflow(t *testing.T) {
@@ -15,5 +18,65 @@ func TestGCSyncHostSlotCapacityRejectsU16Overflow(t *testing.T) {
 	_, err := gcSyncHostSlotCapacity([]gc.TypeDesc{{Kind: gc.KindStruct, Fields: fields}})
 	if err == nil || !strings.Contains(err.Error(), "uint16") {
 		t.Fatalf("u16 overflow error = %v", err)
+	}
+}
+
+func TestModuleImportPrepassesKeepFunctionNamespace(t *testing.T) {
+	wideParams := make([]wasm.ValType, coreruntime.MaxHostArity+1)
+	for i := range wideParams {
+		wideParams[i] = wasm.I32
+	}
+	m := &wasm.Module{
+		Types: []wasm.RecType{
+			{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompFunc}}}},
+			{SubTypes: []wasm.SubType{{Comp: wasm.CompType{Kind: wasm.CompFunc, Params: wideParams, Results: []wasm.ValType{wasm.AnyRef}}}}},
+		},
+		Imports: []wasm.Import{
+			{Type: wasm.NewGlobalExternType(wasm.GlobalType{Type: wasm.I32})},
+			{Type: wasm.NewFuncExternType(wasm.TypeIdx{Index: 0})},
+			{Type: wasm.NewMemExternType(wasm.MemType{Limits: wasm.Limits{Min: 1}})},
+			{Type: wasm.NewFuncExternType(wasm.TypeIdx{Index: 1})},
+			{Type: wasm.NewTableExternType(wasm.TableType{Ref: wasm.FuncRef.Ref()})},
+		},
+	}
+	if got, err := moduleSyncHostSlotCapacity(m); err != nil || got != coreruntime.MaxHostArity+1 {
+		t.Fatalf("interleaved import slot capacity = %d, %v", got, err)
+	}
+	if !moduleHasCollectorReferenceCallBoundary(m) {
+		t.Fatal("interleaved collector-reference function import was not found")
+	}
+
+	m.Imports[3].Type = wasm.NewFuncExternType(wasm.TypeIdx{Index: 99})
+	if _, err := moduleSyncHostSlotCapacity(m); err == nil || !strings.Contains(err.Error(), "imported function 1") {
+		t.Fatalf("interleaved invalid function error = %v", err)
+	}
+}
+
+func TestCompileImportSignaturesKeepInterleavedOrder(t *testing.T) {
+	globalImport := append(append(wasmtest.Name("env"), wasmtest.Name("g")...), byte(wasm.ExternGlobal), byte(wasm.NumI32), byte(wasm.Const))
+	firstFunc := append(append(wasmtest.Name("env"), wasmtest.Name("first")...), byte(wasm.ExternFunc), 0)
+	memoryImport := append(append(wasmtest.Name("env"), wasmtest.Name("memory")...), byte(wasm.ExternMem), 0, 1)
+	secondFunc := append(append(wasmtest.Name("env"), wasmtest.Name("second")...), byte(wasm.ExternFunc), 1)
+	data := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, nil),
+			wasmtest.FuncType([]wasm.ValType{wasm.I64}, []wasm.ValType{wasm.F64}),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(globalImport, firstFunc, memoryImport, secondFunc)),
+	)
+	compiled, err := Compile(nil, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	if len(compiled.importFuncSigs) != 2 {
+		t.Fatalf("import signatures = %d, want 2", len(compiled.importFuncSigs))
+	}
+	first, second := compiled.importFuncSigs[0], compiled.importFuncSigs[1]
+	if len(first.Params) != 1 || first.Params[0] != ValI32 || len(first.Results) != 0 || !first.HasTypeIndex || first.TypeIndex != 0 {
+		t.Fatalf("first import signature = %#v", first)
+	}
+	if len(second.Params) != 1 || second.Params[0] != ValI64 || len(second.Results) != 1 || second.Results[0] != ValF64 || !second.HasTypeIndex || second.TypeIndex != 1 {
+		t.Fatalf("second import signature = %#v", second)
 	}
 }

--- a/src/wago/runtime_resource_limits_test.go
+++ b/src/wago/runtime_resource_limits_test.go
@@ -4,10 +4,8 @@ package wago
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"testing"
-	"unsafe"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/src/core/runtime/abi"
@@ -208,7 +206,7 @@ func TestMemoryPageQuotaImportedMemoryUsesColdPerInstanceDirectory(t *testing.T)
 		}
 		return compiled
 	}
-	policy := func(instance *Instance) (uintptr, uint32) {
+	policyPtr := func(instance *Instance) uintptr {
 		t.Helper()
 		if instance.memoryDir != nil {
 			t.Fatal("single-memory quota installed indexed-memory hot-path state")
@@ -217,44 +215,61 @@ func TestMemoryPageQuotaImportedMemoryUsesColdPerInstanceDirectory(t *testing.T)
 		if ptr == 0 {
 			t.Fatal("single-memory quota has no native policy directory")
 		}
-		entry := unsafe.Slice((*byte)(unsafe.Pointer(ptr)), abi.MemoryDirEntryBytes)
-		return ptr, binary.LittleEndian.Uint32(entry[abi.MemoryDirPolicyMaxPagesOffset:])
+		return ptr
 	}
 
-	memory, err := NewMemory(1, 4)
+	lowMemory, err := NewMemory(1, 4)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer memory.Close()
-	imports := Imports{"env.memory": memory}
+	defer lowMemory.Close()
+	highMemory, err := NewMemory(1, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer highMemory.Close()
 	low := compile(2)
-	lowInstance, err := Instantiate(low, InstantiateOptions{Imports: imports})
+	defer low.Close()
+	lowInstance, err := Instantiate(low, InstantiateOptions{Imports: Imports{"env.memory": lowMemory}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, lowLimit := policy(lowInstance)
-	if lowLimit != 2 {
-		t.Fatalf("low policy = %d, want 2", lowLimit)
-	}
-	if err := lowInstance.Close(); err != nil {
-		t.Fatal(err)
-	}
-	low.Close()
+	defer lowInstance.Close()
+	lowPtr := policyPtr(lowInstance)
 
 	high := compile(4)
 	defer high.Close()
-	highInstance, err := Instantiate(high, InstantiateOptions{Imports: imports})
+	highInstance, err := Instantiate(high, InstantiateOptions{Imports: Imports{"env.memory": highMemory}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer highInstance.Close()
-	_, highLimit := policy(highInstance)
-	if highLimit != 4 {
-		t.Fatalf("high policy = %d, want 4", highLimit)
+	highPtr := policyPtr(highInstance)
+	if lowPtr == highPtr {
+		t.Fatalf("per-instance native policy directories alias at %#x", lowPtr)
+	}
+	if got := invokeOne(t, lowInstance, "grow", I32(1)); got != 1 {
+		t.Fatalf("low policy growth = %d, want 1", got)
+	}
+	if got := invokeOne(t, lowInstance, "grow", I32(1)); uint32(got) != ^uint32(0) {
+		t.Fatalf("low policy growth past quota = %#x", got)
+	}
+	if got := invokeOne(t, highInstance, "grow", I32(1)); got != 1 {
+		t.Fatalf("high policy first growth = %d, want 1", got)
+	}
+	if got := invokeOne(t, highInstance, "grow", I32(1)); got != 2 {
+		t.Fatalf("high policy second growth = %d, want 2", got)
+	}
+	if got := invokeOne(t, highInstance, "grow", I32(1)); got != 3 {
+		t.Fatalf("high policy third growth = %d, want 3", got)
+	}
+	if got := invokeOne(t, highInstance, "grow", I32(1)); uint32(got) != ^uint32(0) {
+		t.Fatalf("high policy growth past quota = %#x", got)
 	}
 }
 
 func TestMemoryPageQuotaMultiMemory(t *testing.T) {
+	requireCompleteCore3Backend(t)
 	cfg := NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3).WithBoundsChecks(BoundsChecksExplicit).WithMemoryLimitPages(2)
 	compiled, err := Compile(cfg, quotaMultiMemoryModule())
 	if err != nil {


### PR DESCRIPTION
## Summary

- decode indexed multi-memory memargs directly into `InstructionImmediate`, removing one allocation per classified instruction
- replace all three quadratic imported-function metadata scans with linear import-section passes
- defer valid function-import diagnostic formatting to error paths
- add mixed-import function-namespace and signature-order regression tests
- repair stale resource-limit and survivor-policy benchmark fixtures without reducing 10,000-memory decode and iteration coverage
- add import-name shape watchpoints and document retained and rejected audit experiments

## Measured results

Linux/amd64, AMD Ryzen 7 8845HS, Go 1.24.4. Focused runs used `GOMAXPROCS=1` and `-cpu=1`.

### Indexed memarg classification

10,000 indexed memory64 loads:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Time | 287.6 us/op | 211.7 us/op | -26.4% |
| Go bytes | 42,183 B/op | 1,915 B/op | -95.5% |
| Allocations | 10,001/op | 1/op | -99.99% |

The immediate-free control remains allocation-free.

### Import-heavy compilation

Ten-sample `benchstat` comparison against `main`:

| Imports | Metric | Before | After | Change |
|---:|---|---:|---:|---:|
| 1,000 | Time | 2.452 ms | 0.394 ms | -83.94% |
| 1,000 | Go bytes | 393,560 B/op | 307,608 B/op | -21.84% |
| 1,000 | Allocations | 7,798/op | 4,054/op | -48.01% |
| 10,000 | Time | 217.278 ms | 5.361 ms | -97.53% |
| 10,000 | Go bytes | 6,364,072 B/op | 5,486,008 B/op | -13.80% |
| 10,000 | Allocations | 79,818/op | 40,071/op | -49.80% |

An adversarial follow-up profile found the first revision still spent 86.7% of samples in a remaining `FuncTypeIndex` rescan. The final revision removes that loop as well.

### Corpus compile guard

Ten interleaved one-iteration samples found no significant compile-time change. Allocation bytes and counts were identical in every sample.

| Corpus | Before | After | p value |
|---|---:|---:|---:|
| SQLite | 83.36 ms | 83.76 ms | 0.436 |
| Ruby | 847.5 ms | 844.8 ms | 0.796 |
| esbuild | 571.1 ms | 562.9 ms | 0.143 |

The compile-time geomean moved -0.43%.

### Release size

Linux/amd64 stripped release profiles:

| Profile | Before | After | Change |
|---|---:|---:|---:|
| manager | 8,601,784 B | 8,601,784 B | 0 B |
| runtime-standard | 8,466,616 B | 8,470,712 B | +4,096 B |
| runtime-minimal | 8,159,416 B | 8,163,512 B | +4,096 B |

## Measured and rejected

- adjacent import-module string reuse improved a synthetic repeated-name case, but regressed real SQLite and Ruby decode samples; reverted
- an inline mixed-memory width word removed one small allocation, but slowed construction from about 13.9 to 18.0 ns/op; reverted

## Validation

- `go test ./src/core/compiler/wasm ./src/core/compiler/frontend ./src/core/runtime/gc ./src/wago -count=1`
- complete `src/core/compiler/wasm`, `src/core/runtime/gc`, and `src/wago` benchmark sets with `-benchtime=1x`
- 10-sample import `benchstat` comparison
- 10 interleaved main/head corpus compile samples with `benchstat`
- `make lint`
- TinyGo `TestSyncHostBindingStaysCompact`
- Darwin/AMD64 `src/wago` test cross-build
- `go run ./tests/tools/docs-check`
- `git diff --check origin/main..HEAD`

The follow-up also repairs the resource-policy CI failures inherited from `main`: the quota fixture no longer converts a native `uintptr` back to a Go pointer, unsupported Darwin/AMD64 multi-memory execution skips through the existing Core 3 guard, TinyGo accepts its bounded 32-byte host-binding alignment, and release-size ceilings now track the measured products with about 389 KiB of standard-Go runtime headroom.

Full measurements and audit notes are in `docs/research/benchmark-audit-2026-08-30.md`.