### PR TITLE
compiler: reuse function result type scratch

### DIFF
--- a/docs/research/compiler-arena-reuse-2026-09-01.md
+++ b/docs/research/compiler-arena-reuse-2026-09-01.md
@@ -145,6 +145,33 @@ change:
 The change therefore gives a clear compile-memory win for utf-as SWAR, leaves
 json-as compile memory neutral, and does not alter execution speed.
 
+## Function result-type scratch follow-up
+
+A later bounded slice removed the per-function `typesOfVals(ft.Results)` heap
+slice from the standard Go backends. Each serial compiler or parallel worker now
+owns 64 bytes of function-result type scratch. Signatures above 64 results use a
+function-local fallback allocation and do not enlarge retained scratch. TinyGo
+keeps the prior allocation path and a zero-capacity arena to protect the minimal
+release profile.
+
+Ten interleaved base/head samples ran on CPU 2 with `GOMAXPROCS=1`. Allocation
+counts were stable; timing was noisy, so this slice claims the allocation result
+only.
+
+| workload | base allocs/op | candidate allocs/op | change | base B/op | candidate B/op |
+|---|---:|---:|---:|---:|---:|
+| 301-function scale module | 337 | 36 | **-89.32%** | 171,068 | 170,762 |
+| json-as | 1,353 | 1,329 | **-1.77%** | 280,488 | 280,440 |
+| utf-as | 147 | 144 | **-2.04%** | 224,334 | 224,326 |
+| Ruby 3.3 interpreter | 276,784 | 262,364 | **-5.21%** | 25,259,400 | 25,238,304 |
+| esbuild | 76,383 | 72,240 | **-5.42%** | 23,759,552 | 23,754,544 |
+
+The allocation reductions match result-bearing local functions, plus retrying
+functions that previously converted the same signature again. Base and candidate
+native code SHA-256 hashes were identical for all five workloads. The local
+TinyGo 0.41.1 minimal binary changed by 96 bytes; the merged baseline CI report
+had 3,968 bytes of budget headroom, and PR CI remains the release-size authority.
+
 ## Verification
 
 Passed:
@@ -162,7 +189,6 @@ host.
 ## Next work
 
 - Add retry cost counters and a bounded pressure hint before changing pin policy.
-- Reuse function result-type conversion storage.
 - Measure large real modules and forced parallel builds before changing worker
   arena growth.
 - Rerun the matrix on Go 1.26 when that toolchain is available.

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -673,8 +673,9 @@ type scratch struct {
 	gcArrayAllocStubSites   []gcArrayAllocStubSite
 	trapSites               [trapMax + 1][]trapSite
 	ctrl                    []ctrlFrame // control-frame stack backing; reused across functions
-	pinnedLocals            []int       // pinned-local index backing; reused across functions
-	brTableStubAt           []int       // duplicate-heavy jump-table target positions by control depth
+	functionResultTypeArena [maxScratchFunctionResults]machineType
+	pinnedLocals            []int // pinned-local index backing; reused across functions
+	brTableStubAt           []int // duplicate-heavy jump-table target positions by control depth
 	jumpTableFragments      []jumpTableFragment
 	localRefs               amd64.LocalRefRecorder
 	offsetMap               shared.WideOffsetMap
@@ -703,6 +704,11 @@ func newScratch() *scratch {
 func newScratchWithStackCap(stackCap int) *scratch {
 	return &scratch{stack: newStackWithCap(stackCap), asm: &amd64.Asm{}}
 }
+
+// maxScratchFunctionResults bounds owner-local signature lowering storage.
+// Standard Go keeps 64 entries; TinyGo keeps none to protect release size.
+// Signatures above the active bound allocate for that function only.
+const maxScratchFunctionResults = shared.FunctionResultScratchCapacity
 
 // maxInitialStackArenaCap bounds speculative operand-node storage retained by
 // one serial compiler scratch. Larger functions still grow through stable
@@ -2817,11 +2823,12 @@ func (f *fn) finalizeStats(codeLen int) {
 // runBody opens the function control frame, lowers the body, and patches every
 // return/br-to-function site to the (current) epilogue position.
 func (f *fn) runBody(c *wasm.Func) error {
-	resultTypes := typesOfVals(f.ft.Results)
+	sc := f.scratchState()
+	resultTypes := lowerFunctionResultTypes(sc, f.ft.Results)
 	// Seed the control-frame stack from scratch's retained backing so its
 	// (large-struct) array is reused across functions rather than regrown to peak
 	// nesting depth for every one; sc.ctrl is written back below to keep the cap.
-	f.ctrl = append(f.sc.ctrl[:0], ctrlFrame{kind: cfFunc, resultN: len(resultTypes), branchN: len(resultTypes), resultTypes: resultTypes})
+	f.ctrl = append(sc.ctrl[:0], ctrlFrame{kind: cfFunc, resultN: len(resultTypes), branchN: len(resultTypes), resultTypes: resultTypes})
 	if err := f.body(c.BodyBytes); err != nil {
 		return err
 	}

--- a/src/core/compiler/backend/railshot/amd64/compile_test.go
+++ b/src/core/compiler/backend/railshot/amd64/compile_test.go
@@ -146,6 +146,36 @@ func TestModuleStackArenaCapIsDeterministicAcrossFunctionOrder(t *testing.T) {
 	}
 }
 
+func TestFunctionResultTypesUseBoundedScratch(t *testing.T) {
+	var sc scratch
+	got := lowerFunctionResultTypes(&sc, []wasm.ValType{wasm.I32, wasm.F64})
+	if len(got) != 2 || got[0] != mtI32 || got[1] != mtF64 {
+		t.Fatalf("lowered result types = %v, want [i32 f64]", got)
+	}
+	if &got[0] != &sc.functionResultTypeArena[0] {
+		t.Fatal("common function results did not use scratch backing")
+	}
+	one := []wasm.ValType{wasm.I32}
+	var sink machineType
+	if allocs := testing.AllocsPerRun(100, func() {
+		sink = lowerFunctionResultTypes(&sc, one)[0]
+	}); allocs != 0 {
+		t.Fatalf("common result lowering allocations = %v, want 0", allocs)
+	}
+	_ = sink
+
+	wide := make([]wasm.ValType, maxScratchFunctionResults+1)
+	overflow := lowerFunctionResultTypes(&sc, wide)
+	if &overflow[0] == &sc.functionResultTypeArena[0] {
+		t.Fatal("oversized function results unexpectedly used bounded scratch")
+	}
+
+	again := lowerFunctionResultTypes(&sc, []wasm.ValType{wasm.I64})
+	if &again[0] != &sc.functionResultTypeArena[0] || again[0] != mtI64 {
+		t.Fatalf("reused result scratch = %v, want [i64]", again)
+	}
+}
+
 func TestHintSizedScratchRemovesFixedArenaBacking(t *testing.T) {
 	saved := uintptr(defaultStackArenaCap-minStackArenaCap) * unsafe.Sizeof(elem{})
 	if want := uintptr(24 << 10); saved < want {

--- a/src/core/compiler/backend/railshot/amd64/function_result_types_go.go
+++ b/src/core/compiler/backend/railshot/amd64/function_result_types_go.go
@@ -1,0 +1,18 @@
+//go:build !tinygo
+
+package amd64
+
+import "github.com/wago-org/wago/src/core/compiler/wasm"
+
+func lowerFunctionResultTypes(sc *scratch, vals []wasm.ValType) []machineType {
+	var types []machineType
+	if len(vals) <= len(sc.functionResultTypeArena) {
+		types = sc.functionResultTypeArena[:len(vals)]
+	} else {
+		types = make([]machineType, len(vals))
+	}
+	for i, val := range vals {
+		types[i] = mtOf(val)
+	}
+	return types
+}

--- a/src/core/compiler/backend/railshot/amd64/function_result_types_go.go
+++ b/src/core/compiler/backend/railshot/amd64/function_result_types_go.go
@@ -1,4 +1,4 @@
-//go:build !tinygo
+//go:build amd64 && !tinygo
 
 package amd64
 

--- a/src/core/compiler/backend/railshot/amd64/function_result_types_tinygo.go
+++ b/src/core/compiler/backend/railshot/amd64/function_result_types_tinygo.go
@@ -1,0 +1,9 @@
+//go:build tinygo
+
+package amd64
+
+import "github.com/wago-org/wago/src/core/compiler/wasm"
+
+func lowerFunctionResultTypes(_ *scratch, vals []wasm.ValType) []machineType {
+	return typesOfVals(vals)
+}

--- a/src/core/compiler/backend/railshot/amd64/function_result_types_tinygo.go
+++ b/src/core/compiler/backend/railshot/amd64/function_result_types_tinygo.go
@@ -1,4 +1,4 @@
-//go:build tinygo
+//go:build amd64 && tinygo
 
 package amd64
 

--- a/src/core/compiler/backend/railshot/arm64/allocation_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/allocation_arm64_test.go
@@ -137,6 +137,36 @@ func TestExpandedLoweringKeepsLegacyStackArenaCapArm64(t *testing.T) {
 	}
 }
 
+func TestFunctionResultTypesUseBoundedScratchArm64(t *testing.T) {
+	var sc scratch
+	got := lowerFunctionResultTypes(&sc, []wasm.ValType{wasm.I32, wasm.F64})
+	if len(got) != 2 || got[0] != mtI32 || got[1] != mtF64 {
+		t.Fatalf("lowered result types = %v, want [i32 f64]", got)
+	}
+	if &got[0] != &sc.functionResultTypeArena[0] {
+		t.Fatal("common function results did not use scratch backing")
+	}
+	one := []wasm.ValType{wasm.I32}
+	var sink machineType
+	if allocs := testing.AllocsPerRun(100, func() {
+		sink = lowerFunctionResultTypes(&sc, one)[0]
+	}); allocs != 0 {
+		t.Fatalf("common result lowering allocations = %v, want 0", allocs)
+	}
+	_ = sink
+
+	wide := make([]wasm.ValType, maxScratchFunctionResults+1)
+	overflow := lowerFunctionResultTypes(&sc, wide)
+	if &overflow[0] == &sc.functionResultTypeArena[0] {
+		t.Fatal("oversized function results unexpectedly used bounded scratch")
+	}
+
+	again := lowerFunctionResultTypes(&sc, []wasm.ValType{wasm.I64})
+	if &again[0] != &sc.functionResultTypeArena[0] || again[0] != mtI64 {
+		t.Fatalf("reused result scratch = %v, want [i64]", again)
+	}
+}
+
 func TestHintSizedModuleStackArenaExecArm64(t *testing.T) {
 	m := mod1(t, nil, []wasm.ValType{wasm.I32}, []byte{0x00, 0x41, 0x2a, 0x0b})
 	if got := runArm64(t, m); got != 42 {

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -517,20 +517,21 @@ type scratch struct {
 	classifier     wasm.ModuleInstructionClassifier
 	directPrepared bool
 
-	retSites         []int
-	ctrl             []ctrlFrame
-	trapSites        [trapAtomicUnaligned + 1][]trapSite
-	branchTargets    map[int]bool
-	brTableStubAt    []int // duplicate-heavy jump-table target positions by control depth
-	finalFragments   []finalizerFragment
-	deadHoleSites    [maxFinalizerDeletions]int
-	branchNextSites  [maxFinalizerDeletions]int
-	singleBitTests   [maxFinalizerDeletions]singleBitTestSite
-	deadHoleN        uint8
-	branchNextN      uint8
-	singleBitTestN   uint8
-	deadHoleOverflow bool
-	offsetMap        shared.OffsetMap
+	retSites                []int
+	ctrl                    []ctrlFrame
+	functionResultTypeArena [maxScratchFunctionResults]machineType
+	trapSites               [trapAtomicUnaligned + 1][]trapSite
+	branchTargets           map[int]bool
+	brTableStubAt           []int // duplicate-heavy jump-table target positions by control depth
+	finalFragments          []finalizerFragment
+	deadHoleSites           [maxFinalizerDeletions]int
+	branchNextSites         [maxFinalizerDeletions]int
+	singleBitTests          [maxFinalizerDeletions]singleBitTestSite
+	deadHoleN               uint8
+	branchNextN             uint8
+	singleBitTestN          uint8
+	deadHoleOverflow        bool
+	offsetMap               shared.OffsetMap
 	transient
 }
 
@@ -556,6 +557,11 @@ func newScratch() *scratch {
 func newScratchWithStackCap(stackCap int) *scratch {
 	return &scratch{stack: newStackWithCap(stackCap), asm: &a64.Asm{}}
 }
+
+// maxScratchFunctionResults bounds owner-local signature lowering storage.
+// Standard Go keeps 64 entries; TinyGo keeps none to protect release size.
+// Signatures above the active bound allocate for that function only.
+const maxScratchFunctionResults = shared.FunctionResultScratchCapacity
 
 // maxInitialStackArenaCap bounds speculative operand-node storage retained by
 // one serial compiler scratch. Larger functions still grow through stable
@@ -2278,8 +2284,8 @@ func (f *fn) finalizeStats(codeLen int) {
 // runBody opens the function control frame, lowers the body, and patches every
 // return/br-to-function site to the current epilogue position.
 func (f *fn) runBody(c *wasm.Func) error {
-	resultTypes := typesOfVals(f.ft.Results)
 	sc := f.scratchState()
+	resultTypes := lowerFunctionResultTypes(sc, f.ft.Results)
 	f.ctrl = append(sc.ctrl[:0], ctrlFrame{kind: cfFunc, resultN: len(resultTypes), branchN: len(resultTypes), resultTypes: resultTypes})
 	if err := f.body(c.BodyBytes); err != nil {
 		return err

--- a/src/core/compiler/backend/railshot/arm64/function_result_types_go.go
+++ b/src/core/compiler/backend/railshot/arm64/function_result_types_go.go
@@ -1,4 +1,4 @@
-//go:build !tinygo
+//go:build arm64 && !tinygo
 
 package arm64
 

--- a/src/core/compiler/backend/railshot/arm64/function_result_types_go.go
+++ b/src/core/compiler/backend/railshot/arm64/function_result_types_go.go
@@ -1,0 +1,18 @@
+//go:build !tinygo
+
+package arm64
+
+import "github.com/wago-org/wago/src/core/compiler/wasm"
+
+func lowerFunctionResultTypes(sc *scratch, vals []wasm.ValType) []machineType {
+	var types []machineType
+	if len(vals) <= len(sc.functionResultTypeArena) {
+		types = sc.functionResultTypeArena[:len(vals)]
+	} else {
+		types = make([]machineType, len(vals))
+	}
+	for i, val := range vals {
+		types[i] = mtOf(val)
+	}
+	return types
+}

--- a/src/core/compiler/backend/railshot/arm64/function_result_types_tinygo.go
+++ b/src/core/compiler/backend/railshot/arm64/function_result_types_tinygo.go
@@ -1,0 +1,9 @@
+//go:build tinygo
+
+package arm64
+
+import "github.com/wago-org/wago/src/core/compiler/wasm"
+
+func lowerFunctionResultTypes(_ *scratch, vals []wasm.ValType) []machineType {
+	return typesOfVals(vals)
+}

--- a/src/core/compiler/backend/railshot/arm64/function_result_types_tinygo.go
+++ b/src/core/compiler/backend/railshot/arm64/function_result_types_tinygo.go
@@ -1,4 +1,4 @@
-//go:build tinygo
+//go:build arm64 && tinygo
 
 package arm64
 

--- a/src/core/compiler/backend/railshot/shared/result_type_scratch_go.go
+++ b/src/core/compiler/backend/railshot/shared/result_type_scratch_go.go
@@ -1,0 +1,6 @@
+//go:build !tinygo
+
+package shared
+
+// FunctionResultScratchCapacity bounds owner-local signature lowering storage.
+const FunctionResultScratchCapacity = 64

--- a/src/core/compiler/backend/railshot/shared/result_type_scratch_tinygo.go
+++ b/src/core/compiler/backend/railshot/shared/result_type_scratch_tinygo.go
@@ -1,0 +1,6 @@
+//go:build tinygo
+
+package shared
+
+// FunctionResultScratchCapacity is zero because TinyGo profiles prefer code size.
+const FunctionResultScratchCapacity = 0


### PR DESCRIPTION
## Summary

- reuse 64 bytes of owner-local function result-type conversion storage per standard Go compiler scratch
- keep signatures above 64 results on a function-local fallback allocation
- keep TinyGo on its previous conversion path with zero retained result scratch
- apply the same bounded policy to AMD64 and ARM64

This is a second bounded allocation-reduction slice for #316.

## Measurements

Ten interleaved base/head samples ran on CPU 2 with `GOMAXPROCS=1`. Allocation counts were stable. Timing was noisy, so this PR claims the allocation result only.

| workload | base allocs/op | candidate allocs/op | change | base B/op | candidate B/op |
|---|---:|---:|---:|---:|---:|
| 301-function scale module | 337 | 36 | -89.32% | 171,068 | 170,762 |
| json-as | 1,353 | 1,329 | -1.77% | 280,488 | 280,440 |
| utf-as | 147 | 144 | -2.04% | 224,334 | 224,326 |
| Ruby 3.3 interpreter | 276,784 | 262,364 | -5.21% | 25,259,400 | 25,238,304 |
| esbuild | 76,383 | 72,240 | -5.42% | 23,759,552 | 23,754,544 |

Base and candidate native-code SHA-256 hashes were identical for all five modules.

The local TinyGo 0.41.1 minimal binary changed by 96 bytes. The current main CI size report has 3,968 bytes of budget headroom; PR CI remains authoritative.

## Verification

```sh
go test ./src/core/compiler/backend/railshot/shared \
  ./src/core/compiler/backend/railshot/amd64

GOOS=linux GOARCH=arm64 go test -c \
  ./src/core/compiler/backend/railshot/arm64

GOMAXPROCS=1 go test ./bench -run '^$' \
  -bench '^BenchmarkCompile$/^many_funcs$' -benchmem
```

The ARM64 command cross-compiled the test binary but did not execute it on this AMD64 host.

## Documentation

- `docs/research/compiler-arena-reuse-2026-09-01.md`
