### PR TITLE
plugin: allow scoped active caller re-entry

### DIFF
--- a/cli/internal/project/lock.go
+++ b/cli/internal/project/lock.go
@@ -31,6 +31,7 @@ const (
 var knownAuthorities = map[string]struct{}{
 	"host.import.define":             {},
 	"host.caller.identify":           {},
+	"host.caller.invoke":             {},
 	"host.arguments.read":            {},
 	"runtime.close.observe":          {},
 	"module.source.transform":        {},

--- a/cli/internal/project/lock_test.go
+++ b/cli/internal/project/lock_test.go
@@ -123,6 +123,25 @@ func TestModuleCloseAuthorityIsKnownAndUnscoped(t *testing.T) {
 	}
 }
 
+func TestActiveCallerInvokeAuthorityIsKnownAndUnscoped(t *testing.T) {
+	document := NewLockDocument()
+	entry := testLockEntry(true, "github.com/acme/plugin", map[string]string{})
+	entry.RequestedAuthorities = []AuthorityRequest{{
+		Name: "host.caller.invoke", Mode: AuthorityRequired, Reason: "run an active guest callback",
+	}}
+	entry.Grants = []AuthorityGrant{{Name: "host.caller.invoke"}}
+	document.Plugins["github.com/acme/plugin"] = entry
+	if err := ValidateLock(document); err != nil {
+		t.Fatalf("active caller invoke authority: %v", err)
+	}
+
+	entry.Grants[0].Scope.Modules = []string{"env"}
+	document.Plugins["github.com/acme/plugin"] = entry
+	if err := ValidateLock(document); err == nil || !strings.Contains(err.Error(), "does not accept a scope") {
+		t.Fatalf("scoped active caller invoke authority error=%v", err)
+	}
+}
+
 func TestLockContractBindingsAndCycles(t *testing.T) {
 	document := NewLockDocument()
 	consumer := testLockEntry(true, "github.com/acme/pool", map[string]string{"github.com/acme/workers": "^1.0.0"})

--- a/docs/plugin-api-plan.md
+++ b/docs/plugin-api-plan.md
@@ -90,6 +90,7 @@ display only; granting a parent or wildcard is invalid.
 |---|---|
 | `host.import.define` | Define guest host functions in the named import modules. |
 | `host.caller.identify` | Resolve the exact active instance during a synchronous host call. |
+| `host.caller.invoke` | Synchronously invoke an export on the exact guest making the active host call. |
 | `host.arguments.read` | Read the guest argument vector exposed by the host. |
 | `runtime.close.observe` | Observe logical runtime shutdown. |
 | `module.source.transform` | Replace module bytes before compilation. |

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -222,11 +222,37 @@ the same callback returns the same context. Nested re-entry receives a distinct
 context and does not shorten the outer callback's lifetime.
 
 Invocation contexts deliberately expose no parent context values. Plugins must
-pass explicit dependencies instead of using context values as an ambient data
-channel. Calls without a cancellable public parent, including raw `Invoke`,
-prepared calls, and start-time callbacks, receive a live callback-scoped context
-without a deadline. Forged, expired, cross-Runtime, and low-level callers are
-rejected with `ErrPermissionDenied`.
+pass explicit dependencies instead of using context values as ambient data.
+Calls without a cancellable public parent, including raw `Invoke`, prepared
+calls, and start-time callbacks, receive a live callback-scoped context without
+a deadline. Forged, expired, cross-Runtime, and low-level callers are rejected
+with `ErrPermissionDenied`.
+
+## Active caller re-entry
+
+A plugin granted `host.caller.invoke` may synchronously invoke an export on the
+exact guest making its active host call. This is intended for callback ABIs such
+as Emscripten trampolines; it does not grant instance discovery, retention,
+close, or invocation outside that callback:
+
+```go
+invoker, err := reg.HostCallerInvoker()
+if err != nil {
+    return err
+}
+
+module.Func("callback", func(caller wago.HostModule, params, results []uint64) {
+    nested, err := invoker.Invoke(context.Background(), caller, "host_callback", params...)
+    if err != nil {
+        panic(wago.HostTrap{Err: err})
+    }
+    copy(results, nested)
+})
+```
+
+The caller token expires when the host function returns. Re-entry uses Wago's
+isolated native stack and call buffers and remains subject to the outer
+invocation's cancellation and normal recursion limits.
 
 ## Exact authorities and scopes
 
@@ -237,6 +263,7 @@ parent, wildcard, descendant, or future authority.
 |---|---|
 | `host.import.define` | Define host functions in specifically granted import modules. |
 | `host.caller.identify` | Resolve the exact active instance and its callback-scoped invocation cancellation/deadline during a synchronous host call. |
+| `host.caller.invoke` | Synchronously invoke an export on the exact guest making the active host call. |
 | `host.arguments.read` | Read guest arguments exposed by the host. |
 | `runtime.close.observe` | Observe logical runtime close. |
 | `module.source.transform` | Replace module bytes before compilation. |

--- a/providers.schema.json
+++ b/providers.schema.json
@@ -220,6 +220,7 @@
               "name": {
                 "enum": [
                   "host.caller.identify",
+                  "host.caller.invoke",
                   "host.arguments.read",
                   "runtime.close.observe",
                   "module.source.transform",
@@ -247,6 +248,7 @@
       "enum": [
         "host.import.define",
         "host.caller.identify",
+        "host.caller.invoke",
         "host.arguments.read",
         "runtime.close.observe",
         "module.source.transform",

--- a/src/wago/access.go
+++ b/src/wago/access.go
@@ -117,6 +117,19 @@ func (r *Registrar) HostCallers() (*CallerResolver, error) {
 	return a, nil
 }
 
+// HostCallerInvoker returns a revocable handle that may synchronously re-enter
+// only the guest instance making the active host call. It cannot retain,
+// discover, close, or invoke any other instance.
+func (r *Registrar) HostCallerInvoker() (*CallerInvoker, error) {
+	if _, err := r.authorize(AuthorityHostCallerInvoke); err != nil {
+		return nil, err
+	}
+	a := &CallerInvoker{}
+	r.activate = append(r.activate, a.activate)
+	r.revoke = append(r.revoke, a.close)
+	return a, nil
+}
+
 type RuntimeCloseObserver struct{ reg *Registrar }
 
 func (r *Registrar) RuntimeCloseObserver() (*RuntimeCloseObserver, error) {

--- a/src/wago/caller_invoker_test.go
+++ b/src/wago/caller_invoker_test.go
@@ -1,0 +1,89 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/wasmtest"
+)
+
+type callerInvokerPlugin struct {
+	invoker *CallerInvoker
+}
+
+func (p *callerInvokerPlugin) Register(reg *Registrar) error {
+	var err error
+	p.invoker, err = reg.HostCallerInvoker()
+	if err != nil {
+		return err
+	}
+	imports, err := reg.HostImports()
+	if err != nil {
+		return err
+	}
+	module, err := imports.Module("env")
+	if err != nil {
+		return err
+	}
+	module.Func("outer", func(caller HostModule, params, results []uint64) {
+		nested, err := p.invoker.Invoke(context.Background(), caller, "callback", params...)
+		if err != nil {
+			panic(HostTrap{Err: err})
+		}
+		copy(results, nested)
+	}).Params(ValI32).Results(ValI32)
+	return nil
+}
+
+func TestCallerInvokerReentersOnlyActiveGuest(t *testing.T) {
+	plugin := &callerInvokerPlugin{}
+	definition := testDefinition("example.com/caller-invoker")
+	definition.Authorities = []AuthorityRequest{
+		{Name: AuthorityHostCallerInvoke, Mode: AuthorityRequired, Reason: "test active re-entry"},
+		{Name: AuthorityHostImportDefine, Mode: AuthorityRequired, Reason: "test import", Scope: AuthorityScope{Modules: []string{"env"}}},
+	}
+	provider := PluginProvider{Definition: definition, New: func() Plugin { return plugin }}
+	rt := NewRuntime()
+	defer rt.Close()
+	if err := rt.LoadPlugins(context.Background(), testSet(t, provider)); err != nil {
+		t.Fatal(err)
+	}
+	module, err := rt.Compile(callerInvokerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer module.Close()
+	instance, err := rt.Instantiate(context.Background(), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close()
+	results, err := instance.Invoke("run", 41)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || AsI32(results[0]) != 42 {
+		t.Fatalf("run(41) = %v, want 42", results)
+	}
+	if _, err := plugin.invoker.Invoke(context.Background(), nil, "callback", 1); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("retained invocation = %v, want permission denied", err)
+	}
+}
+
+func callerInvokerModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "outer", 0, 0))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("run", 0, 1),
+			wasmtest.ExportEntry("callback", 0, 2),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x20, 0x00, 0x10, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0x41, 0x01, 0x6a, 0x0b}),
+		)),
+	)
+}

--- a/src/wago/extension.go
+++ b/src/wago/extension.go
@@ -51,6 +51,7 @@ type Authority string
 const (
 	AuthorityHostImportDefine             Authority = "host.import.define"
 	AuthorityHostCallerIdentify           Authority = "host.caller.identify"
+	AuthorityHostCallerInvoke             Authority = "host.caller.invoke"
 	AuthorityHostArgumentsRead            Authority = "host.arguments.read"
 	AuthorityRuntimeCloseObserve          Authority = "runtime.close.observe"
 	AuthorityModuleSourceTransform        Authority = "module.source.transform"
@@ -71,7 +72,7 @@ const (
 
 func validAuthority(a Authority) bool {
 	switch a {
-	case AuthorityHostImportDefine, AuthorityHostCallerIdentify, AuthorityHostArgumentsRead,
+	case AuthorityHostImportDefine, AuthorityHostCallerIdentify, AuthorityHostCallerInvoke, AuthorityHostArgumentsRead,
 		AuthorityRuntimeCloseObserve, AuthorityModuleSourceTransform, AuthorityModuleCompileObserve,
 		AuthorityModuleCloseObserve,
 		AuthorityInstanceInstantiateIntercept, AuthorityInstanceInstantiateObserve,

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -99,6 +99,44 @@ type CallerResolver struct {
 	rt atomic.Pointer[Runtime]
 }
 
+// CallerInvoker is a revocable synchronous re-entry handle for the exact guest
+// making an active host call. The HostModule token supplies both instance
+// identity and callback lifetime; forged, retained, and cross-runtime tokens
+// fail closed.
+type CallerInvoker struct {
+	rt atomic.Pointer[Runtime]
+}
+
+func (r *CallerInvoker) activate(rt *Runtime) {
+	if r == nil || rt == nil {
+		return
+	}
+	r.rt.Store(rt)
+	rt.callerResolverActive.Store(true)
+}
+
+func (r *CallerInvoker) close() error {
+	if r != nil {
+		r.rt.Store(nil)
+	}
+	return nil
+}
+
+// Invoke synchronously invokes an export on the active calling guest. Nested
+// execution uses Wago's isolated re-entry stack and inherits cancellation from
+// ctx. The authority expires when the outer host callback returns.
+func (r *CallerInvoker) Invoke(ctx context.Context, caller HostModule, export string, args ...uint64) ([]uint64, error) {
+	if r == nil {
+		return nil, fmt.Errorf("wago: nil caller invoker: %w", ErrPermissionDenied)
+	}
+	rt := r.rt.Load()
+	h, ok := caller.(instanceHostModule)
+	if rt == nil || !ok || !h.valid() || h.in == nil || h.in.rt != rt {
+		return nil, fmt.Errorf("wago: caller invocation requires an active host call from the owning runtime: %w", ErrPermissionDenied)
+	}
+	return h.in.InvokeFromHost(ctx, caller, export, args...)
+}
+
 func (r *CallerResolver) activate(rt *Runtime) {
 	if r == nil || rt == nil {
 		return

--- a/wago.go
+++ b/wago.go
@@ -21,6 +21,7 @@ type (
 	AuthorityScope                  = impl.AuthorityScope
 	Bits                            = impl.Bits
 	BoundsCheckMode                 = impl.BoundsCheckMode
+	CallerInvoker                   = impl.CallerInvoker
 	CallerResolver                  = impl.CallerResolver
 	Capability                      = impl.Capability
 	CapabilityOption                = impl.CapabilityOption
@@ -217,6 +218,7 @@ const (
 	AuthorityCoreModuleCompile                 = impl.AuthorityCoreModuleCompile
 	AuthorityHostArgumentsRead                 = impl.AuthorityHostArgumentsRead
 	AuthorityHostCallerIdentify                = impl.AuthorityHostCallerIdentify
+	AuthorityHostCallerInvoke                  = impl.AuthorityHostCallerInvoke
 	AuthorityHostImportDefine                  = impl.AuthorityHostImportDefine
 	AuthorityInstanceCloseObserve              = impl.AuthorityInstanceCloseObserve
 	AuthorityInstanceInstantiateIntercept      = impl.AuthorityInstanceInstantiateIntercept


### PR DESCRIPTION
## Summary

- add a separately granted `host.caller.invoke` authority
- expose a revocable `CallerInvoker` limited to the exact guest in the active synchronous host call
- reject retained, forged, and cross-runtime caller tokens
- document callback-ABI usage

This is the narrow runtime seam used by the standalone Emscripten/Go js-wasm compatibility plugin for Lua and Go callback trampolines.

## Proof

- `go test ./src/wago`
- `go test ./...`
- `go vet ./...`
