### PR TITLE
Reduce safe call and dispatch latency

### DIFF
--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -1706,7 +1706,7 @@ func compileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 			fmt.Fprint(os.Stderr, ms.String())
 		}
 		keepCodeBuffer = true
-		return &amd64.CompiledModule{Code: code, CodeImage: codeBuffer, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, RequiresBMI2: requiresBMI2, RequiresAVX2: requiresAVX2, RequiresAVX512: requiresAVX512}, nil
+		return &amd64.CompiledModule{Code: code, CodeImage: codeBuffer, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, PreparedIsolatedTables: allTablesPreparedIsolated(immutableTables), RequiresBMI2: requiresBMI2, RequiresAVX2: requiresAVX2, RequiresAVX512: requiresAVX512}, nil
 	}
 
 	return compileModuleParallel(m, opts, workers, codeCap, entry, internalEntry, relocs, literalOffsets, allHints, hintSidecar, immutableTables, modGlobals, hostAdapters, inlineTargets, policy, ms, guardMode, boundsFacts, importedFuncs)
@@ -1983,7 +1983,19 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 			requiresAVX512 = requiresAVX512 || lowering.Features&plugincodegen.FeatureAVX512 != 0
 		}
 	}
-	return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, RequiresBMI2: requiresBMI2, RequiresAVX2: requiresAVX2, RequiresAVX512: requiresAVX512}, nil
+	return &amd64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, PreparedIsolatedTables: allTablesPreparedIsolated(immutableTables), RequiresBMI2: requiresBMI2, RequiresAVX2: requiresAVX2, RequiresAVX512: requiresAVX512}, nil
+}
+
+func allTablesPreparedIsolated(tables []immutableTableHint) bool {
+	if len(tables) == 0 {
+		return false
+	}
+	for i := range tables {
+		if !tables[i].local {
+			return false
+		}
+	}
+	return true
 }
 
 func countGCSharedStubRelocs(relocs [][]callReloc) int {

--- a/src/core/compiler/backend/railshot/amd64/parallel_compile_test.go
+++ b/src/core/compiler/backend/railshot/amd64/parallel_compile_test.go
@@ -223,4 +223,7 @@ func assertCompiledModuleEqual(t *testing.T, got, want *encoder.CompiledModule) 
 	if !reflect.DeepEqual(got.DirectPrepared, want.DirectPrepared) {
 		t.Fatalf("DirectPrepared differs\n got: %v\nwant: %v", got.DirectPrepared, want.DirectPrepared)
 	}
+	if got.PreparedIsolatedTables != want.PreparedIsolatedTables {
+		t.Fatalf("PreparedIsolatedTables = %v, want %v", got.PreparedIsolatedTables, want.PreparedIsolatedTables)
+	}
 }

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -1504,7 +1504,7 @@ func compileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 			fmt.Fprint(os.Stderr, ms.String())
 		}
 		keepCodeBuffer = true
-		return &a64.CompiledModule{Code: code, CodeImage: codeBuffer, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared}, nil
+		return &a64.CompiledModule{Code: code, CodeImage: codeBuffer, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, PreparedIsolatedTables: immutableTable.local}, nil
 	}
 
 	return compileModuleParallel(m, opts, workers, codeCap, entry, internalEntry, allHints, hintSidecar, immutableTable, modGlobals, hostAdapters, inlineTargets, policy, ms, guardMode, boundsFacts, importedFuncs)
@@ -1711,7 +1711,7 @@ func compileModuleParallel(m *wasm.Module, opts CompileOptions, workers, codeCap
 	if explainEnabled && ms != nil {
 		fmt.Fprint(os.Stderr, ms.String())
 	}
-	return &a64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared}, nil
+	return &a64.CompiledModule{Code: code, Entry: entry, InternalEntry: internalEntry, DirectPrepared: directPrepared, PreparedIsolatedTables: immutableTable.local}, nil
 }
 
 // finalizeOmittedInlineEntries closes the module-layout seam for standalone

--- a/src/core/compiler/backend/railshot/arm64/parallel_compile_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/parallel_compile_arm64_test.go
@@ -213,4 +213,7 @@ func assertCompiledModuleEqualArm64(t *testing.T, got, want *encoder.CompiledMod
 	if !reflect.DeepEqual(got.InternalEntry, want.InternalEntry) {
 		t.Fatalf("InternalEntry differs\n got: %v\nwant: %v", got.InternalEntry, want.InternalEntry)
 	}
+	if got.PreparedIsolatedTables != want.PreparedIsolatedTables {
+		t.Fatalf("PreparedIsolatedTables = %v, want %v", got.PreparedIsolatedTables, want.PreparedIsolatedTables)
+	}
 }

--- a/src/core/encoder/amd64/module.go
+++ b/src/core/encoder/amd64/module.go
@@ -25,6 +25,12 @@ type CompiledModule struct {
 	// The optional bitset uses one bit per local function.
 	DirectPrepared []uint64
 
+	// PreparedIsolatedTables reports that every table is local, unexported,
+	// never mutated, and contains only local function descriptors. Runtime entry
+	// selection may then treat the table descriptor arena as instance-private,
+	// read-only state.
+	PreparedIsolatedTables bool
+
 	// RequiresBMI2 reports that Code contains a BMI2 instruction.
 	RequiresBMI2 bool
 

--- a/src/core/encoder/arm64/module.go
+++ b/src/core/encoder/arm64/module.go
@@ -13,7 +13,12 @@ type CompiledModule struct {
 	Entry          []int           // Entry[localFuncIdx] = byte offset in Code
 	InternalEntry  []int           // register-ABI internal entry offset (== Entry[i] when none)
 	DirectPrepared []uint64        // reserved for parity with AMD64 prepared-entry metadata
-	RequiresBMI2   bool            // always false on arm64; keeps backend result metadata uniform
-	RequiresAVX2   bool            // always false on arm64; keeps backend result metadata uniform
-	RequiresAVX512 bool            // always false on arm64; keeps backend result metadata uniform
+	// PreparedIsolatedTables reports that every table is local, unexported,
+	// never mutated, and contains only local function descriptors. Runtime entry
+	// selection may then treat the table descriptor arena as instance-private,
+	// read-only state.
+	PreparedIsolatedTables bool
+	RequiresBMI2           bool // always false on arm64; keeps backend result metadata uniform
+	RequiresAVX2           bool // always false on arm64; keeps backend result metadata uniform
+	RequiresAVX512         bool // always false on arm64; keeps backend result metadata uniform
 }

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4321,7 +4321,8 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 		state.invocationID = 0
 		state.invokeMu.Unlock()
 	}()
-	if !alreadyAdmitted && contexts.interrupt == nil && contexts.callback == nil {
+	privateRefStore := in.refStore == nil || in.refStore.private
+	if !alreadyAdmitted && contexts.interrupt == nil && contexts.callback == nil && privateRefStore {
 		// Admit before reading cached or compiled entry metadata. Close publishes
 		// its gate without taking invokeMu, so the invocation count is what keeps
 		// those resources live through this fast-path probe and native entry.

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4313,7 +4313,11 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 	}
 	state := in.ensurePluginState()
 	state.invokeMu.Lock()
+	admittedHere := false
 	defer func() {
+		if admittedHere {
+			in.endInvocation()
+		}
 		state.invocationID = 0
 		state.invokeMu.Unlock()
 	}()
@@ -4324,7 +4328,7 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 		if err := in.beginInvocation(); err != nil {
 			return nil, fmt.Errorf("invoke %q: %w", export, err)
 		}
-		defer in.endInvocation()
+		admittedHere = true
 		alreadyAdmitted = true
 		ic := in.findInvokeCache(export)
 		if ic == nil {
@@ -4341,16 +4345,19 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 			if len(args) != ic.paramSlots {
 				return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
 			}
-			fn := PreparedFunction{
-				in:               in,
-				directEntry:      in.base + uintptr(internalEntryOffset(in.c.InternalEntry[ic.li])),
-				paramSlots:       ic.paramSlots,
-				resultSlots:      ic.resultSlots,
-				scalarWideMask:   ic.scalarWideMask,
-				scalarResultWide: ic.scalarResultWide,
-				isolatedFast:     true,
+			directEntry := in.base + uintptr(internalEntryOffset(in.c.InternalEntry[ic.li]))
+			switch len(args) {
+			case 0:
+				return in.invokeDirectIntEntry(directEntry, ic.paramSlots, ic.resultSlots, ic.scalarWideMask, ic.scalarResultWide, true, 0, 0, 0, 0)
+			case 1:
+				return in.invokeDirectIntEntry(directEntry, ic.paramSlots, ic.resultSlots, ic.scalarWideMask, ic.scalarResultWide, true, args[0], 0, 0, 0)
+			case 2:
+				return in.invokeDirectIntEntry(directEntry, ic.paramSlots, ic.resultSlots, ic.scalarWideMask, ic.scalarResultWide, true, args[0], args[1], 0, 0)
+			case 3:
+				return in.invokeDirectIntEntry(directEntry, ic.paramSlots, ic.resultSlots, ic.scalarWideMask, ic.scalarResultWide, true, args[0], args[1], args[2], 0)
+			case 4:
+				return in.invokeDirectIntEntry(directEntry, ic.paramSlots, ic.resultSlots, ic.scalarWideMask, ic.scalarResultWide, true, args[0], args[1], args[2], args[3])
 			}
-			return fn.invokeDirectInt(args)
 		}
 	}
 	id := newInvocationID()

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4338,10 +4338,13 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 				return nil, err
 			}
 		}
-		// Cross-instance attachment can make native control shared after the
-		// immutable export metadata was cached. Keep that dynamic security bit on
-		// the entry boundary and fall back to the audited rebinding route.
-		if ic.directIntFast && !in.nativeControlIsShared() {
+		// Cross-instance attachment can make native control shared or publish an
+		// imported GC invocation domain after immutable export metadata was cached.
+		// Keep both dynamic security bits on the entry boundary and fall back to
+		// the audited rebinding and topology-lease route.
+		executionFlags := in.executionFlags.Load()
+		const directBlocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector
+		if ic.directIntFast && executionFlags&directBlocked == 0 {
 			if len(args) != ic.paramSlots {
 				return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
 			}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -1459,7 +1459,7 @@ func compileWithFrontendFeaturesAndInstructions(cfg *RuntimeConfig, wasmBytes []
 	if exactNativeGCRoots || gcStructProduct.requiresHelpers() || gcArrayProduct.requiresHelpers() || gcStructProduct.requiresArrayHelpers() {
 		nativeGCABIVersion = gc.NativeABIVersion
 	}
-	c := newCompilerCompiled(Compiled{code: code, Entry: entry, InternalEntry: internalEntry, registerABIDisabled: !cfg.optimizations["reg-abi"], NumImports: importedFuncs, Types: types, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, boundsMode: boundsMode, stagedTable64: features.Table64 && usesTable64, independentInstances: cfg.independentInstances, GCTypeDescs: gcDescs, requiredFeatures: requiredByModule, dynamicImports: importedFuncs > 0, dynamicFuncrefEscape: moduleDynamicFuncrefEscape(m), customInstructions: customInstructions, requiresBMI2: cm.RequiresBMI2, requiresAVX2: cm.RequiresAVX2, requiresAVX512: cm.RequiresAVX512, syncHostSlots: uint16(syncHostSlots), hasGCCodeTelemetry: cfg.gcCodeTelemetry})
+	c := newCompilerCompiled(Compiled{code: code, Entry: entry, InternalEntry: internalEntry, registerABIDisabled: !cfg.optimizations["reg-abi"], NumImports: importedFuncs, Types: types, Exports: map[string]int{}, Names: m.NameSec, GlobalExports: map[string]int{}, hasTableExportMetadata: true, boundsMode: boundsMode, stagedTable64: features.Table64 && usesTable64, independentInstances: cfg.independentInstances, preparedIsolatedTables: cm.PreparedIsolatedTables, GCTypeDescs: gcDescs, requiredFeatures: requiredByModule, dynamicImports: importedFuncs > 0, dynamicFuncrefEscape: moduleDynamicFuncrefEscape(m), customInstructions: customInstructions, requiresBMI2: cm.RequiresBMI2, requiresAVX2: cm.RequiresAVX2, requiresAVX512: cm.RequiresAVX512, syncHostSlots: uint16(syncHostSlots), hasGCCodeTelemetry: cfg.gcCodeTelemetry})
 	c.codeCache.setNativeStackBytes(cfg.nativeStackBytes)
 	if c.validateMemo != nil {
 		c.validateMemo.memoryLimitPages = cfg.maxMemoryPages
@@ -4313,12 +4313,48 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 	}
 	state := in.ensurePluginState()
 	state.invokeMu.Lock()
-	id := newInvocationID()
-	state.invocationID = id
 	defer func() {
 		state.invocationID = 0
 		state.invokeMu.Unlock()
 	}()
+	if !alreadyAdmitted && contexts.interrupt == nil && contexts.callback == nil {
+		// Admit before reading cached or compiled entry metadata. Close publishes
+		// its gate without taking invokeMu, so the invocation count is what keeps
+		// those resources live through this fast-path probe and native entry.
+		if err := in.beginInvocation(); err != nil {
+			return nil, fmt.Errorf("invoke %q: %w", export, err)
+		}
+		defer in.endInvocation()
+		alreadyAdmitted = true
+		ic := in.findInvokeCache(export)
+		if ic == nil {
+			var err error
+			ic, err = in.fillInvokeCache(export)
+			if err != nil {
+				return nil, err
+			}
+		}
+		// Cross-instance attachment can make native control shared after the
+		// immutable export metadata was cached. Keep that dynamic security bit on
+		// the entry boundary and fall back to the audited rebinding route.
+		if ic.directIntFast && !in.nativeControlIsShared() {
+			if len(args) != ic.paramSlots {
+				return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
+			}
+			fn := PreparedFunction{
+				in:               in,
+				directEntry:      in.base + uintptr(internalEntryOffset(in.c.InternalEntry[ic.li])),
+				paramSlots:       ic.paramSlots,
+				resultSlots:      ic.resultSlots,
+				scalarWideMask:   ic.scalarWideMask,
+				scalarResultWide: ic.scalarResultWide,
+				isolatedFast:     true,
+			}
+			return fn.invokeDirectInt(args)
+		}
+	}
+	id := newInvocationID()
+	state.invocationID = id
 	return in.invokeWithToken(export, args, contexts, id, true, alreadyAdmitted, nil)
 }
 
@@ -4365,8 +4401,12 @@ func (in *Instance) invokeWithToken(export string, args []uint64, contexts invoc
 		}
 		defer restore()
 	}
-	previousReservation := in.swapInvocationReservation(reservation)
-	defer in.swapInvocationReservation(previousReservation)
+	// Ordinary Invoke and hook-free Call entries carry no reservation and start
+	// with a fresh activation, so there is no map state to clear or restore.
+	if reservation != nil {
+		previousReservation := in.swapInvocationReservation(reservation)
+		defer in.swapInvocationReservation(previousReservation)
+	}
 	if threadedMu := in.lockThreadedInstanceState(); threadedMu != nil {
 		defer threadedMu.Unlock()
 	}
@@ -4862,13 +4902,27 @@ func (in *Instance) fillInvokeCache(export string) (*invokeCache, error) {
 		}
 	}
 	entryMode := preparedEntryGeneral
+	var scalarWideMask uint8
 	if !hasReferenceValType(sig.Params) && !hasReferenceValType(sig.Results) &&
 		paramSlots <= 4 && resultSlots <= 1 {
 		entryMode = in.preparedEntryMode()
+		paramSlot := 0
+		for _, typ := range sig.Params {
+			if isWideValType(typ) {
+				scalarWideMask |= 1 << paramSlot
+			}
+			paramSlot++
+		}
 	}
+	directIntFast := preparedCallEnabled && invokePrivateEntryEnabled && preparedIsolatedEntryEnabled &&
+		preparedDirectIntSupported && preparedDirectIntEnabled && entryMode == preparedEntryIsolated &&
+		preparedDirectIntSignature(sig) && in.c.directPreparedAt(li)
 	*slot = invokeCache{
 		export:            export,
 		valid:             true,
+		directIntFast:     directIntFast,
+		scalarWideMask:    scalarWideMask,
+		scalarResultWide:  resultSlots == 1 && rw[0],
 		li:                li,
 		paramSlots:        paramSlots,
 		resultSlots:       resultSlots,

--- a/src/wago/api_compat_test.go
+++ b/src/wago/api_compat_test.go
@@ -80,6 +80,16 @@ func TestInvokeCacheSelectsIsolatedDirectIntegerEntry(t *testing.T) {
 	if ic == nil || ic.directIntFast != wantDirect {
 		t.Fatalf("direct integer cache selection = %+v; want %v", ic, wantDirect)
 	}
+	if _, err := in.Invoke("f"); err == nil {
+		t.Fatal("wrong-arity cached direct invocation succeeded")
+	}
+	if got := in.invocationState.Load() & instanceInvocationCount; got != 0 {
+		t.Fatalf("invocation count after direct error = %d, want 0", got)
+	}
+	got, err = in.Invoke("f", I32(9))
+	if err != nil || len(got) != 1 || AsI32(got[0]) != 10 {
+		t.Fatalf("invoke after direct error = %v, %v; want [10], nil", got, err)
+	}
 }
 
 func BenchmarkInvokeAlternatingExports(b *testing.B) {

--- a/src/wago/api_compat_test.go
+++ b/src/wago/api_compat_test.go
@@ -62,6 +62,26 @@ func TestInvokeCacheKeepsAlternatingExports(t *testing.T) {
 	}
 }
 
+func TestInvokeCacheSelectsIsolatedDirectIntegerEntry(t *testing.T) {
+	in, err := Instantiate(MustCompile(alternatingExportsModule()))
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+
+	got, err := in.Invoke("f", I32(41))
+	if err != nil || len(got) != 1 || AsI32(got[0]) != 42 {
+		t.Fatalf("invoke = %v, %v; want [42], nil", got, err)
+	}
+	ic := in.findInvokeCache("f")
+	wantDirect := preparedCallEnabled && invokePrivateEntryEnabled && preparedIsolatedEntryEnabled &&
+		preparedDirectIntSupported && preparedDirectIntEnabled && in.preparedIsolatedEligible() &&
+		in.c.directPreparedAt(0)
+	if ic == nil || ic.directIntFast != wantDirect {
+		t.Fatalf("direct integer cache selection = %+v; want %v", ic, wantDirect)
+	}
+}
+
 func BenchmarkInvokeAlternatingExports(b *testing.B) {
 	c := MustCompile(alternatingExportsModule())
 	in, err := Instantiate(c)

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -1146,6 +1146,10 @@ type Compiled struct {
 	// to use instance-local native execution leases. It is intentionally not
 	// serialized because it is runtime policy rather than a module property.
 	independentInstances bool
+	// preparedIsolatedTables is a fresh-compilation proof that every table is
+	// local, unexported, immutable, and limited to local function descriptors.
+	// Like direct-prepared entry selection, codecs conservatively discard it.
+	preparedIsolatedTables bool
 }
 
 // The sign bit of a fresh compilation's internal-entry offset carries the

--- a/src/wago/instance.go
+++ b/src/wago/instance.go
@@ -96,6 +96,9 @@ type invokeCache struct {
 	export            string
 	valid             bool
 	entryMode         preparedEntryMode
+	directIntFast     bool
+	scalarWideMask    uint8
+	scalarResultWide  bool
 	li                int // local index, or -1-import index for an InstanceExport re-export
 	paramSlots        int
 	resultSlots       int

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -185,18 +185,19 @@ func (in *Instance) beginInvocation() error {
 	if in.guestStorageBorrowed() {
 		return fmt.Errorf("instance access is unavailable while guest storage is borrowed: %w", ErrPermissionDenied)
 	}
-	if in.rt != nil {
-		in.rt.mu.Lock()
-		if in.rt.state == runtimeClosed || in.rt.state == runtimeClosing && in.instantiateOrigin() != InstantiateManaged {
-			in.rt.mu.Unlock()
-			return fmt.Errorf("instance runtime is closed")
-		}
-		in.rt.activeOperations++
-		in.rt.mu.Unlock()
+	if in.rt == nil {
+		return in.beginInstanceInvocation()
 	}
+	in.rt.mu.Lock()
+	if in.rt.state == runtimeClosed || in.rt.state == runtimeClosing && in.instantiateOrigin() != InstantiateManaged {
+		in.rt.mu.Unlock()
+		return fmt.Errorf("instance runtime is closed")
+	}
+	in.rt.activeOperations++
+	in.rt.mu.Unlock()
 	admitted := false
 	defer func() {
-		if admitted || in.rt == nil {
+		if admitted {
 			return
 		}
 		in.rt.mu.Lock()
@@ -204,6 +205,14 @@ func (in *Instance) beginInvocation() error {
 		in.rt.stateCond.Broadcast()
 		in.rt.mu.Unlock()
 	}()
+	if err := in.beginInstanceInvocation(); err != nil {
+		return err
+	}
+	admitted = true
+	return nil
+}
+
+func (in *Instance) beginInstanceInvocation() error {
 	for {
 		state := in.invocationState.Load()
 		if state&instanceInvocationClosed != 0 {
@@ -213,7 +222,6 @@ func (in *Instance) beginInvocation() error {
 			return fmt.Errorf("instance has too many active invocations")
 		}
 		if in.invocationState.CompareAndSwap(state, state+1) {
-			admitted = true
 			return nil
 		}
 	}

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -306,8 +306,10 @@ func (in *Instance) preparedEntryMode() preparedEntryMode {
 			return preparedEntryGeneral
 		}
 	}
-	if len(in.globalCells) == 0 && in.tableDescPtr == 0 && in.gc == nil &&
-		in.c.NumImports == 0 && !in.c.needsFuncRefContext() {
+	isolatedTables := in.tableDescPtr != 0 && in.c.preparedIsolatedTables &&
+		!in.c.needsFuncRefContextHeader
+	if len(in.globalCells) == 0 && (in.tableDescPtr == 0 || isolatedTables) && in.gc == nil &&
+		in.c.NumImports == 0 && (!in.c.needsFuncRefContext() || isolatedTables) {
 		return preparedEntryIsolated
 	}
 	return preparedEntryPrivate

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -306,7 +306,8 @@ func (in *Instance) preparedEntryMode() preparedEntryMode {
 			return preparedEntryGeneral
 		}
 	}
-	isolatedTables := in.tableDescPtr != 0 && in.c.preparedIsolatedTables &&
+	privateRefStore := in.refStore == nil || in.refStore.private
+	isolatedTables := privateRefStore && in.tableDescPtr != 0 && in.c.preparedIsolatedTables &&
 		!in.c.needsFuncRefContextHeader
 	if len(in.globalCells) == 0 && (in.tableDescPtr == 0 || isolatedTables) && in.gc == nil &&
 		in.c.NumImports == 0 && (!in.c.needsFuncRefContext() || isolatedTables) {

--- a/src/wago/monomorphic_call_indirect_test.go
+++ b/src/wago/monomorphic_call_indirect_test.go
@@ -156,3 +156,17 @@ func TestImmutableLocalTablePreparedEntryIsIsolated(t *testing.T) {
 		t.Fatal("serialized module unexpectedly retained compile-only table isolation proof")
 	}
 }
+
+func TestImmutableLocalTableRuntimeStoreKeepsGuardedEntry(t *testing.T) {
+	c := MustCompile(callIndirectModule(2, 1, 2))
+	rt := NewRuntime()
+	defer rt.Close()
+	in, err := instantiateCore(c, InstantiateOptions{store: rt.refStore})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	if in.preparedIsolatedEligible() {
+		t.Fatal("runtime-store table instance must retain the guarded entry")
+	}
+}

--- a/src/wago/monomorphic_call_indirect_test.go
+++ b/src/wago/monomorphic_call_indirect_test.go
@@ -119,3 +119,40 @@ func TestImmutableMultiTargetCallIndirectExec(t *testing.T) {
 		t.Fatalf("caller(1,10,3) via sub = %v, %v; want 7", got, err)
 	}
 }
+
+func TestImmutableLocalTablePreparedEntryIsIsolated(t *testing.T) {
+	c := MustCompile(callIndirectModule(2, 1, 2))
+	if !c.preparedIsolatedTables {
+		t.Fatal("fresh immutable local-table compilation did not retain its isolation proof")
+	}
+	if c.needsFuncRefContextHeader {
+		t.Fatal("immutable call_indirect module unexpectedly requires mutable call_ref context")
+	}
+
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	if c.boundsMode == BoundsChecksSignalsBased {
+		if in.preparedIsolatedEligible() {
+			t.Fatal("signals-based immutable-table instance must use the guarded entry")
+		}
+		return
+	}
+	if !in.preparedIsolatedEligible() {
+		t.Fatal("immutable, unexported local-table instance should use the isolated entry")
+	}
+
+	blob, err := c.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded Compiled
+	if err := decoded.UnmarshalBinary(blob); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.preparedIsolatedTables {
+		t.Fatal("serialized module unexpectedly retained compile-only table isolation proof")
+	}
+}

--- a/src/wago/prepared_direct_amd64.go
+++ b/src/wago/prepared_direct_amd64.go
@@ -35,17 +35,26 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 	if in.isLogicallyClosed() {
 		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
 	}
-	if fn.scalarWideMask&1 == 0 {
-		a0 = uint64(uint32(a0))
-	}
-	if fn.scalarWideMask&2 == 0 {
-		a1 = uint64(uint32(a1))
-	}
-	if fn.scalarWideMask&4 == 0 {
-		a2 = uint64(uint32(a2))
-	}
-	if fn.scalarWideMask&8 == 0 {
-		a3 = uint64(uint32(a3))
+	switch fn.paramSlots {
+	case 4:
+		if fn.scalarWideMask&8 == 0 {
+			a3 = uint64(uint32(a3))
+		}
+		fallthrough
+	case 3:
+		if fn.scalarWideMask&4 == 0 {
+			a2 = uint64(uint32(a2))
+		}
+		fallthrough
+	case 2:
+		if fn.scalarWideMask&2 == 0 {
+			a1 = uint64(uint32(a1))
+		}
+		fallthrough
+	case 1:
+		if fn.scalarWideMask&1 == 0 {
+			a0 = uint64(uint32(a0))
+		}
 	}
 	result, err := in.eng.EnterPreparedInt(fn.directEntry, in.jm.LinMemBase(), a0, a1, a2, a3)
 	if err != nil {

--- a/src/wago/prepared_direct_amd64.go
+++ b/src/wago/prepared_direct_amd64.go
@@ -75,3 +75,48 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 	}
 	return out, nil
 }
+
+func (in *Instance) invokeDirectIntEntry(directEntry uintptr, paramSlots, resultSlots int, scalarWideMask uint8, scalarResultWide, _ bool, a0, a1, a2, a3 uint64) ([]uint64, error) {
+	if in.isLogicallyClosed() {
+		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
+	}
+	switch paramSlots {
+	case 4:
+		if scalarWideMask&8 == 0 {
+			a3 = uint64(uint32(a3))
+		}
+		fallthrough
+	case 3:
+		if scalarWideMask&4 == 0 {
+			a2 = uint64(uint32(a2))
+		}
+		fallthrough
+	case 2:
+		if scalarWideMask&2 == 0 {
+			a1 = uint64(uint32(a1))
+		}
+		fallthrough
+	case 1:
+		if scalarWideMask&1 == 0 {
+			a0 = uint64(uint32(a0))
+		}
+	}
+	result, err := in.eng.EnterPreparedInt(directEntry, in.jm.LinMemBase(), a0, a1, a2, a3)
+	if err != nil {
+		return nil, fmt.Errorf("wago: map prepared integer entry: %w", err)
+	}
+	if wruntime.PreparedIntTrapCode(in.trap) != wruntime.TrapNone {
+		return nil, in.decorateTrap(wruntime.ConsumePreparedIntTrap(in.trap))
+	}
+	goruntime.KeepAlive(in)
+	goruntime.KeepAlive(in.c)
+	out := in.resultVals[:resultSlots]
+	if resultSlots == 1 {
+		if scalarResultWide {
+			out[0] = result
+		} else {
+			out[0] = uint64(uint32(result))
+		}
+	}
+	return out, nil
+}

--- a/src/wago/prepared_direct_arm64.go
+++ b/src/wago/prepared_direct_arm64.go
@@ -35,17 +35,26 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 	if in.isLogicallyClosed() {
 		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
 	}
-	if fn.scalarWideMask&1 == 0 {
-		a0 = uint64(uint32(a0))
-	}
-	if fn.scalarWideMask&2 == 0 {
-		a1 = uint64(uint32(a1))
-	}
-	if fn.scalarWideMask&4 == 0 {
-		a2 = uint64(uint32(a2))
-	}
-	if fn.scalarWideMask&8 == 0 {
-		a3 = uint64(uint32(a3))
+	switch fn.paramSlots {
+	case 4:
+		if fn.scalarWideMask&8 == 0 {
+			a3 = uint64(uint32(a3))
+		}
+		fallthrough
+	case 3:
+		if fn.scalarWideMask&4 == 0 {
+			a2 = uint64(uint32(a2))
+		}
+		fallthrough
+	case 2:
+		if fn.scalarWideMask&2 == 0 {
+			a1 = uint64(uint32(a1))
+		}
+		fallthrough
+	case 1:
+		if fn.scalarWideMask&1 == 0 {
+			a0 = uint64(uint32(a0))
+		}
 	}
 	if !fn.isolatedFast {
 		nativeExecutionMu.Lock()

--- a/src/wago/prepared_direct_arm64.go
+++ b/src/wago/prepared_direct_arm64.go
@@ -80,3 +80,53 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 	}
 	return out, nil
 }
+
+func (in *Instance) invokeDirectIntEntry(directEntry uintptr, paramSlots, resultSlots int, scalarWideMask uint8, scalarResultWide, isolatedFast bool, a0, a1, a2, a3 uint64) ([]uint64, error) {
+	if in.isLogicallyClosed() {
+		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
+	}
+	switch paramSlots {
+	case 4:
+		if scalarWideMask&8 == 0 {
+			a3 = uint64(uint32(a3))
+		}
+		fallthrough
+	case 3:
+		if scalarWideMask&4 == 0 {
+			a2 = uint64(uint32(a2))
+		}
+		fallthrough
+	case 2:
+		if scalarWideMask&2 == 0 {
+			a1 = uint64(uint32(a1))
+		}
+		fallthrough
+	case 1:
+		if scalarWideMask&1 == 0 {
+			a0 = uint64(uint32(a0))
+		}
+	}
+	if !isolatedFast {
+		nativeExecutionMu.Lock()
+		nativeExecutionEpoch++
+		defer nativeExecutionMu.Unlock()
+	}
+	result, err := in.eng.EnterPreparedInt(directEntry, in.jm.LinMemBase(), a0, a1, a2, a3)
+	if err != nil {
+		return nil, fmt.Errorf("wago: map prepared integer entry: %w", err)
+	}
+	if wruntime.PreparedIntTrapCode(in.trap) != wruntime.TrapNone {
+		return nil, in.decorateTrap(wruntime.ConsumePreparedIntTrap(in.trap))
+	}
+	goruntime.KeepAlive(in)
+	goruntime.KeepAlive(in.c)
+	out := in.resultVals[:resultSlots]
+	if resultSlots == 1 {
+		if scalarResultWide {
+			out[0] = result
+		} else {
+			out[0] = uint64(uint32(result))
+		}
+	}
+	return out, nil
+}

--- a/src/wago/prepared_direct_arm64_test.go
+++ b/src/wago/prepared_direct_arm64_test.go
@@ -76,8 +76,8 @@ func TestPreparedDirectARM64CallIndirectAndTrapRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare: %v", err)
 	}
-	if !fn.directIntFast || fn.isolatedFast {
-		t.Fatalf("direct/private selection = %v/%v, want true/false", fn.directIntFast, fn.isolatedFast)
+	if !fn.directIntFast || !fn.isolatedFast {
+		t.Fatalf("direct/isolated selection = %v/%v, want true/true", fn.directIntFast, fn.isolatedFast)
 	}
 	for _, tc := range []struct {
 		idx, want uint64

--- a/src/wago/prepared_direct_other.go
+++ b/src/wago/prepared_direct_other.go
@@ -14,3 +14,7 @@ func (fn *PreparedFunction) invokeDirectInt([]uint64) ([]uint64, error) {
 func (fn *PreparedFunction) invokeDirectIntFixed(uint64, uint64, uint64, uint64) ([]uint64, error) {
 	return nil, fmt.Errorf("wago: direct prepared integer entry is unavailable on this architecture")
 }
+
+func (in *Instance) invokeDirectIntEntry(uintptr, int, int, uint8, bool, bool, uint64, uint64, uint64, uint64) ([]uint64, error) {
+	return nil, fmt.Errorf("wago: direct prepared integer entry is unavailable on this architecture")
+}

--- a/src/wago/prepared_function.go
+++ b/src/wago/prepared_function.go
@@ -136,7 +136,18 @@ func (in *Instance) PrepareFunction(export string) (*PreparedFunction, error) {
 func (fn *PreparedFunction) Invoke(args ...uint64) ([]uint64, error) {
 	if fn != nil && fn.in != nil && len(args) == fn.paramSlots {
 		if fn.directIntFast {
-			return fn.invokeDirectInt(args)
+			switch len(args) {
+			case 0:
+				return fn.invokeDirectIntFixed(0, 0, 0, 0)
+			case 1:
+				return fn.invokeDirectIntFixed(args[0], 0, 0, 0)
+			case 2:
+				return fn.invokeDirectIntFixed(args[0], args[1], 0, 0)
+			case 3:
+				return fn.invokeDirectIntFixed(args[0], args[1], args[2], 0)
+			case 4:
+				return fn.invokeDirectIntFixed(args[0], args[1], args[2], args[3])
+			}
 		}
 		if fn.scalarFast {
 			return fn.invokeScalar(args)


### PR DESCRIPTION
## Summary

- cache direct integer-entry metadata for ordinary `Instance.Invoke`
- specialize fixed-arity public and prepared calls without allocating
- propagate a compile-time proof for isolated immutable tables so safe `call_indirect` dispatch avoids global serialization
- skip empty reservation-map work and collapse duplicate lifecycle defer machinery
- retain the `entersyscall` / `exitsyscall` GC and scheduler boundary added by #562

## Performance

Apple M4 Max, Darwin/arm64, Go 1.26.5, `GOMAXPROCS=1`, `-cpu=1`, 12 alternating 500 ms samples, median, zero allocations:

| Benchmark | main | this PR | delta |
|---|---:|---:|---:|
| `BenchmarkExecCallOverhead_wago` | 30.80 ns | 30.96 ns | flat |
| `BenchmarkExec/tiny.add` | 34.01 ns | 30.04 ns | -11.7% |
| `BenchmarkExec/dispatch.apply` | 37.07 ns | 31.20 ns | -15.8% |
| `BenchmarkInvokeAddOne` | 115.40 ns | 42.71 ns | -63.0% |
| `BenchmarkPreparedInvokeAddOne` | 28.95 ns | 28.71 ns | flat |
| wazero raw-call reference | 23.47 ns | 23.56 ns | flat |

The low-level native boundary is intentionally unchanged. The gains remove Go-side dispatch, lifecycle, cache, and serialization overhead around it.

## Safety boundaries

- Native calls still pass through the scheduler handoff from #562.
- Direct public entry requires an isolated-entry proof, a private reference store, and no shared-native-control or dynamic/imported/store-owned GC domain.
- Runtime-owned reference stores retain the established admission and topology-lease path.
- Immutable-table isolation is compiler-proven; serialized/decoded modules conservatively discard the proof.
- Wrong-arity direct-call coverage verifies that invocation admission is released and the instance remains reusable.
- Trap handling, object `KeepAlive`s, close checks, argument narrowing, and result normalization remain on the direct path.

## Validation

- `go test ./... -count=1`
- `make test-guard`
- `make lint` (`staticcheck` unavailable locally; remaining lint gates passed)
- `(cd bench && go test . -count=1)`
- focused direct-entry and lifecycle suite with `-race`
- Linux/arm64, Linux/amd64, and Windows/amd64 `src/wago` test binaries cross-compiled

Docs unchanged: this is an internal hot-path optimization with no developer workflow change.
