### PR TITLE
railshot: model versioned residency transitions

### DIFF
--- a/RAILSHOT_R3_EXECUTION_PERFORMANCE_PLAN.md
+++ b/RAILSHOT_R3_EXECUTION_PERFORMANCE_PLAN.md
@@ -21,6 +21,13 @@ Implementation progress:
 - [x] Admit R8 as AMD64's last-choice tenth regional lease only for explicit
   bounds in the existing call-free, control-free, bulk-memory-free region;
   signals-based bounds retain R8 as fixed scratch.
+- [x] Reject additive dirty-eviction cost, post-eviction read cooldown, and
+  dirty-definition admission credit after bounded ARM64 sweeps showed either
+  noise-sized movement or writeback churn.
+- [x] Add an opt-in, codegen-neutral transition shadow that scores local
+  versions by avoided physical work and reports predicted admissions,
+  evictions, reloads, and dirty writebacks. Ordinary compilation retains the
+  cheaper aggregate shadow only.
 - [ ] Design the next active lease policy around dirty-home cost and transient
   expression pressure, then qualify it against the full corpus.
 

--- a/research/railshot_exec_v3/current_main_residency_baseline.md
+++ b/research/railshot_exec_v3/current_main_residency_baseline.md
@@ -236,3 +236,47 @@ and leasing it corrupted `blake-as.wasm.hashN`. Native AMD64 guard testing
 reproduced the same wrong result. The retained policy therefore caps the region
 at nine leases in signals mode and permits the tenth R8 lease only with explicit
 bounds; the focused speedups above measure that explicit-bounds configuration.
+
+## Physical-debt policy screening
+
+Three bounded ARM64 policy sweeps tested whether small dynamic costs could make
+the existing whole-local lease policy phase-sensitive without retaining a
+version plan. None met the retention threshold:
+
+1. Adding a cost to dirty eviction was catastrophic at large values. The only
+   plausible value (`+4`) was mixed across ten alternating samples: blake-as was
+   approximately 0.3% slower while BLAKE3 was approximately 1% faster. This is
+   below the phase threshold and does not transfer across the two ARX kernels.
+2. Suppressing the first four reads after a pressure eviction changed only two
+   BLAKE3 activations and one load. Ten alternating samples were approximately
+   flat on blake-as and 0.3% faster on BLAKE3, with eight additional native
+   bytes. The movement is noise-sized.
+3. Crediting a newly defined dirty version by even one score unit increased
+   BLAKE3 evictions from 21 to 39 and dirty writebacks from 17 to 35. Larger
+   credits regressed execution materially. Without a future-use proof, rotating
+   leases merely converts pressure misses into stores.
+
+All experimental code and environment knobs were removed. These results rule
+out scalar adjustments to the whole-local hotness score; the next active policy
+must carry bounded per-version evidence.
+
+An opt-in transition shadow now supplies that evidence without changing emitted
+code. It scores each bounded version segment by avoided loads/stores minus
+fixed-register, synchronization, and transient-pressure debt, then simulates a
+one-unit-hysteresis lease matcher. Detailed simulation runs only when codegen
+statistics are requested; ordinary compilation retains the cheaper aggregate
+shadow.
+
+On the M4 Max explicit-bounds baseline it predicts:
+
+| Workload | Admissions | Evictions | Reloads | Dirty writebacks |
+| --- | ---: | ---: | ---: | ---: |
+| blake-as | 25 | 6 | 4 | 5 |
+| BLAKE3 | 26 | 7 | 3 | 5 |
+
+Those transition counts are far below the rejected definition-credit policy's
+39 evictions and 35 writebacks on BLAKE3. They are a planning signal, not an
+execution-speed claim; no transition decision is consumed by code generation.
+Four alternating ordinary-compilation pairs showed noise-sized timing movement,
+unchanged allocations and native bytes, and only 16-28 additional retained heap
+bytes from the expanded pointer-free summary.

--- a/src/core/compiler/backend/railshot/amd64/compile.go
+++ b/src/core/compiler/backend/railshot/amd64/compile.go
@@ -1418,7 +1418,7 @@ func compileModuleWith(m *wasm.Module, opts CompileOptions) (*amd64.CompiledModu
 	if opts.Stats != nil || explainEnabled {
 		hintStart = time.Now()
 	}
-	allHints, hintSidecar, globalScores, err := computeModuleHintsWithPolicy(m, nGlobals, importedFuncs, opts.Codegen.Module.GCTypeLayouts, opts.GCStructHelpers, policy)
+	allHints, hintSidecar, globalScores, err := computeModuleHintsWithPolicy(m, nGlobals, importedFuncs, opts.Codegen.Module.GCTypeLayouts, opts.GCStructHelpers, policy, opts.Stats != nil || explainEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("amd64: %w", err)
 	}
@@ -2204,10 +2204,10 @@ var moduleGlobalRegs = []Reg{R14, R13, R12}
 // avoids both a second body pass and a functions-by-globals retained matrix. The
 // standalone computeModuleGlobalScores is retained as the parity oracle in tests.
 func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int, gcTypeLayouts []codegen.GCTypeLayout, gcStructHelpers bool) ([]funcHints, funcHintSidecar, []int64, error) {
-	return computeModuleHintsWithPolicy(m, nGlobals, importedFuncs, gcTypeLayouts, gcStructHelpers, currentCodegenPolicy())
+	return computeModuleHintsWithPolicy(m, nGlobals, importedFuncs, gcTypeLayouts, gcStructHelpers, currentCodegenPolicy(), false)
 }
 
-func computeModuleHintsWithPolicy(m *wasm.Module, nGlobals, importedFuncs int, gcTypeLayouts []codegen.GCTypeLayout, gcStructHelpers bool, policy CodegenPolicy) ([]funcHints, funcHintSidecar, []int64, error) {
+func computeModuleHintsWithPolicy(m *wasm.Module, nGlobals, importedFuncs int, gcTypeLayouts []codegen.GCTypeLayout, gcStructHelpers bool, policy CodegenPolicy, detailedResidency bool) ([]funcHints, funcHintSidecar, []int64, error) {
 	n := len(m.Code)
 	allHints := make([]funcHints, n)
 	totalScores := 0
@@ -2298,10 +2298,13 @@ func computeModuleHintsWithPolicy(m *wasm.Module, nGlobals, importedFuncs int, g
 			localEventMeta[intervalEventAt] = h.localStart
 			localEventMeta[intervalEventAt+1] = h.localEventMeta
 			intervalEventAt += 2
-			residencyShadow = append(residencyShadow, shared.ResidencyShadowEntry{
-				LocalStart: h.localStart,
-				Summary:    shared.PlanResidencyShadow(localEvents.Events, nLocals, maxIntervalRegionRegs, localEvents.Overflow),
-			})
+			var summary shared.ResidencyShadowSummary
+			if detailedResidency {
+				summary = shared.PlanResidencyTransitionShadow(localEvents.Events, nLocals, maxIntervalRegionRegs, localEvents.Overflow)
+			} else {
+				summary = shared.PlanResidencyShadow(localEvents.Events, nLocals, maxIntervalRegionRegs, localEvents.Overflow)
+			}
+			residencyShadow = append(residencyShadow, shared.ResidencyShadowEntry{LocalStart: h.localStart, Summary: summary})
 		}
 		h.inlineCallSites = allHints[i].inlineCallSites
 		h.flags.assign(hintIntervalRegionStorage, intervalStorage)

--- a/src/core/compiler/backend/railshot/amd64/stats.go
+++ b/src/core/compiler/backend/railshot/amd64/stats.go
@@ -617,9 +617,10 @@ func (s *CodegenStats) report() string {
 			r.Events, r.EventOverflows, r.Candidates, r.Activations, r.ActivationLoads, r.PressureMisses,
 			r.Evictions, r.DirtyWritebacks, r.FinalTransfers, r.MaxActive)
 		if p := r.Shadow; p.Active() {
-			fmt.Fprintf(&b, "    residency-shadow: candidates=%d versions=%d segments=%d profitable=%d reads=%d defines=%d loads-avoided=%d sync-debt=%d pressure-debt=%d max-live=%d fail-soft=%d\n",
+			fmt.Fprintf(&b, "    residency-shadow: candidates=%d versions=%d segments=%d profitable=%d reads=%d defines=%d loads-avoided=%d sync-debt=%d pressure-debt=%d max-live=%d admissions=%d evictions=%d reloads=%d writebacks=%d fail-soft=%d\n",
 				p.Candidates, p.Versions, p.Segments, p.Profitable, p.Reads, p.Defines,
-				p.LoadsAvoided, p.SyncDebt, p.PressureDebt, p.MaxLive, p.FailSoft)
+				p.LoadsAvoided, p.SyncDebt, p.PressureDebt, p.MaxLive, p.Admissions,
+				p.Evictions, p.Reloads, p.Writebacks, p.FailSoft)
 		}
 	}
 	if s.InlineSiteBytes != 0 {

--- a/src/core/compiler/backend/railshot/arm64/compile.go
+++ b/src/core/compiler/backend/railshot/arm64/compile.go
@@ -1286,7 +1286,7 @@ func compileModuleWith(m *wasm.Module, opts CompileOptions) (*a64.CompiledModule
 	if opts.Stats != nil || explainEnabled {
 		hintStart = time.Now()
 	}
-	allHints, hintSidecar, globalScores, err := computeModuleHintsWithPolicy(m, nGlobals, importedFuncs, policy)
+	allHints, hintSidecar, globalScores, err := computeModuleHintsWithPolicy(m, nGlobals, importedFuncs, policy, opts.Stats != nil || explainEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("arm64: %w", err)
 	}
@@ -1886,10 +1886,10 @@ var moduleGlobalRegs = []Reg{X25, X24, X23}
 // avoids both a second body pass and a functions-by-globals retained matrix. The
 // standalone computeModuleGlobalScores is retained as the parity oracle in tests.
 func computeModuleHints(m *wasm.Module, nGlobals, importedFuncs int) ([]funcHints, funcHintSidecar, []int64, error) {
-	return computeModuleHintsWithPolicy(m, nGlobals, importedFuncs, currentCodegenPolicy())
+	return computeModuleHintsWithPolicy(m, nGlobals, importedFuncs, currentCodegenPolicy(), false)
 }
 
-func computeModuleHintsWithPolicy(m *wasm.Module, nGlobals, importedFuncs int, policy CodegenPolicy) ([]funcHints, funcHintSidecar, []int64, error) {
+func computeModuleHintsWithPolicy(m *wasm.Module, nGlobals, importedFuncs int, policy CodegenPolicy, detailedResidency bool) ([]funcHints, funcHintSidecar, []int64, error) {
 	n := len(m.Code)
 	allHints := make([]funcHints, n)
 	totalScores := 0
@@ -1997,10 +1997,13 @@ func computeModuleHintsWithPolicy(m *wasm.Module, nGlobals, importedFuncs int, p
 			localEventMeta[intervalEventAt] = h.localStart
 			localEventMeta[intervalEventAt+1] = h.localEventMeta
 			intervalEventAt += 2
-			residencyShadow = append(residencyShadow, shared.ResidencyShadowEntry{
-				LocalStart: h.localStart,
-				Summary:    shared.PlanResidencyShadow(localEvents.Events, nLocals, maxIntervalRegionRegs, localEvents.Overflow),
-			})
+			var summary shared.ResidencyShadowSummary
+			if detailedResidency {
+				summary = shared.PlanResidencyTransitionShadow(localEvents.Events, nLocals, maxIntervalRegionRegs, localEvents.Overflow)
+			} else {
+				summary = shared.PlanResidencyShadow(localEvents.Events, nLocals, maxIntervalRegionRegs, localEvents.Overflow)
+			}
+			residencyShadow = append(residencyShadow, shared.ResidencyShadowEntry{LocalStart: h.localStart, Summary: summary})
 		}
 		h.inlineCallSites = allHints[i].inlineCallSites
 		h.directCallRefs = allHints[i].directCallRefs

--- a/src/core/compiler/backend/railshot/arm64/stats.go
+++ b/src/core/compiler/backend/railshot/arm64/stats.go
@@ -559,9 +559,10 @@ func (s *CodegenStats) report() string {
 			r.Events, r.EventOverflows, r.Candidates, r.Activations, r.ActivationLoads, r.PressureMisses,
 			r.Evictions, r.DirtyWritebacks, r.FinalTransfers, r.MaxActive)
 		if p := r.Shadow; p.Active() {
-			fmt.Fprintf(&b, "    residency-shadow: candidates=%d versions=%d segments=%d profitable=%d reads=%d defines=%d loads-avoided=%d sync-debt=%d pressure-debt=%d max-live=%d fail-soft=%d\n",
+			fmt.Fprintf(&b, "    residency-shadow: candidates=%d versions=%d segments=%d profitable=%d reads=%d defines=%d loads-avoided=%d sync-debt=%d pressure-debt=%d max-live=%d admissions=%d evictions=%d reloads=%d writebacks=%d fail-soft=%d\n",
 				p.Candidates, p.Versions, p.Segments, p.Profitable, p.Reads, p.Defines,
-				p.LoadsAvoided, p.SyncDebt, p.PressureDebt, p.MaxLive, p.FailSoft)
+				p.LoadsAvoided, p.SyncDebt, p.PressureDebt, p.MaxLive, p.Admissions,
+				p.Evictions, p.Reloads, p.Writebacks, p.FailSoft)
 		}
 	}
 	if s.InlineSiteBytes != 0 {

--- a/src/core/compiler/backend/railshot/shared/residency_shadow.go
+++ b/src/core/compiler/backend/railshot/shared/residency_shadow.go
@@ -19,12 +19,17 @@ type ResidencyShadowSummary struct {
 	SyncDebt     uint16
 	MaxLive      uint16
 	PressureDebt uint16
+	Admissions   uint16
+	Evictions    uint16
+	Reloads      uint16
+	Writebacks   uint16
 	FailSoft     uint16
 }
 
 func (s ResidencyShadowSummary) Active() bool {
 	return s.Candidates|s.Versions|s.Segments|s.Profitable|s.Reads|s.Defines|
-		s.LoadsAvoided|s.SyncDebt|s.MaxLive|s.PressureDebt|s.FailSoft != 0
+		s.LoadsAvoided|s.SyncDebt|s.MaxLive|s.PressureDebt|s.Admissions|
+		s.Evictions|s.Reloads|s.Writebacks|s.FailSoft != 0
 }
 
 // ResidencyShadowEntry associates a summary with the already-retained local
@@ -45,6 +50,15 @@ type shadowLocal struct {
 	pressure uint16
 	dirty    bool
 	active   bool
+	segment  int16
+}
+
+type shadowSegment struct {
+	local   uint16
+	start   uint16
+	end     uint16
+	benefit int16
+	dirty   bool
 }
 
 // PlanResidencyShadow forms local-version segments at definitions and hard
@@ -52,8 +66,19 @@ type shadowLocal struct {
 // and transient-pressure debt. Fixed arrays and hard caps keep the plan
 // deterministic and allocation-free.
 func PlanResidencyShadow(events []LocalEvent, nLocals, regBudget int, overflow bool) ResidencyShadowSummary {
+	return planResidencyShadow(events, nLocals, regBudget, overflow, false)
+}
+
+// PlanResidencyTransitionShadow adds the more expensive version-transition
+// simulation used by opt-in explain output. Keeping it out of ordinary hint
+// construction makes the diagnostic model free in production compilation.
+func PlanResidencyTransitionShadow(events []LocalEvent, nLocals, regBudget int, overflow bool) ResidencyShadowSummary {
+	return planResidencyShadow(events, nLocals, regBudget, overflow, true)
+}
+
+func planResidencyShadow(events []LocalEvent, nLocals, regBudget int, overflow, transitions bool) ResidencyShadowSummary {
 	var out ResidencyShadowSummary
-	if overflow || nLocals < 0 || nLocals > ResidencyShadowMaxLocals {
+	if overflow || len(events) > LocalEventLimit || nLocals < 0 || nLocals > ResidencyShadowMaxLocals {
 		out.FailSoft = 1
 		return out
 	}
@@ -105,17 +130,13 @@ func PlanResidencyShadow(events []LocalEvent, nLocals, regBudget int, overflow b
 		selected[candidate.local] = true
 	}
 	var state [ResidencyShadowMaxLocals]shadowLocal
+	var segments [ResidencyShadowMaxSegments]shadowSegment
 	live := 0
-	closeOne := func(local uint16, sync uint16) bool {
+	closeOne := func(local uint16, sync uint16, end int) bool {
 		s := &state[local]
 		if !s.active {
 			return true
 		}
-		if out.Segments == ResidencyShadowMaxSegments {
-			out.FailSoft = 1
-			return false
-		}
-		out.Segments++
 		avoided := uint16(0)
 		if s.reads > 1 {
 			avoided = s.reads - 1
@@ -131,22 +152,39 @@ func PlanResidencyShadow(events []LocalEvent, nLocals, regBudget int, overflow b
 		if avoided > debt {
 			out.Profitable++
 		}
+		benefit := int(avoided) - int(debt)
+		if benefit < -32768 {
+			benefit = -32768
+		} else if benefit > 32767 {
+			benefit = 32767
+		}
+		segment := &segments[s.segment]
+		segment.end = uint16(end)
+		segment.benefit = int16(benefit)
+		segment.dirty = s.dirty
 		*s = shadowLocal{}
 		live--
 		return true
 	}
-	closeAll := func(sync uint16) bool {
+	closeAll := func(sync uint16, end int) bool {
 		for _, candidate := range ranked[:rankedN] {
-			if !closeOne(candidate.local, sync) {
+			if !closeOne(candidate.local, sync, end) {
 				return false
 			}
 		}
 		return true
 	}
-	open := func(local uint16) *shadowLocal {
+	open := func(local uint16, at int) *shadowLocal {
 		s := &state[local]
 		if !s.active {
+			if out.Segments == ResidencyShadowMaxSegments {
+				out.FailSoft = 1
+				return nil
+			}
 			s.active = true
+			s.segment = int16(out.Segments)
+			segments[out.Segments] = shadowSegment{local: local, start: uint16(at)}
+			out.Segments++
 			out.Versions = saturatingInc16(out.Versions)
 			live++
 			if live > int(out.MaxLive) {
@@ -156,18 +194,24 @@ func PlanResidencyShadow(events []LocalEvent, nLocals, regBudget int, overflow b
 		return s
 	}
 
-	for _, event := range events {
+	for at, event := range events {
 		if event.Local != NoLocal && int(event.Local) < nLocals && selected[event.Local] {
 			switch event.Kind {
 			case LocalEventRead:
-				s := open(event.Local)
+				s := open(event.Local, at)
+				if s == nil {
+					return out
+				}
 				s.reads = saturatingInc16(s.reads)
 				out.Reads = saturatingInc16(out.Reads)
 			case LocalEventDefine:
-				if !closeOne(event.Local, 0) {
+				if !closeOne(event.Local, 0, at) {
 					return out
 				}
-				s := open(event.Local)
+				s := open(event.Local, at)
+				if s == nil {
+					return out
+				}
 				s.dirty = true
 				out.Defines = saturatingInc16(out.Defines)
 			}
@@ -186,12 +230,12 @@ func PlanResidencyShadow(events []LocalEvent, nLocals, regBudget int, overflow b
 				}
 			}
 		case LocalEventCall, LocalEventCollection:
-			if !closeAll(2) {
+			if !closeAll(2, at) {
 				return out
 			}
 		case LocalEventBlock, LocalEventLoop, LocalEventIf, LocalEventElse,
 			LocalEventEnd, LocalEventBranch, LocalEventInvalidate:
-			if !closeAll(0) {
+			if !closeAll(0, at) {
 				return out
 			}
 		}
@@ -200,8 +244,115 @@ func PlanResidencyShadow(events []LocalEvent, nLocals, regBudget int, overflow b
 			out.PressureDebt = saturatingAdd16(out.PressureDebt, excess)
 		}
 	}
-	closeAll(0)
+	if !closeAll(0, len(events)) {
+		return out
+	}
+	if transitions {
+		planShadowTransitions(events, segments[:out.Segments], ranked[:rankedN], regBudget, &out)
+	}
 	return out
+}
+
+// planShadowTransitions simulates a bounded, hysteretic lease policy over the
+// already-scored version segments. It is deliberately telemetry-only: the
+// compiler does not consume these decisions. The counters reveal whether a
+// future active policy would trade pressure misses for excessive reload/store
+// churn before that policy is allowed to affect machine code.
+func planShadowTransitions(events []LocalEvent, segments []shadowSegment, candidates []shadowCandidate, regBudget int, out *ResidencyShadowSummary) {
+	if regBudget <= 0 || len(segments) == 0 {
+		return
+	}
+	if regBudget > len(candidates) {
+		regBudget = len(candidates)
+	}
+	var current [ResidencyShadowMaxLocals]int16
+	var resident, dirty [ResidencyShadowMaxLocals]bool
+	var remaining [ResidencyShadowMaxSegments]int16
+	for i := range current {
+		current[i] = -1
+	}
+	active, next := 0, 0
+	for at := 0; at <= len(events); at++ {
+		for next < len(segments) && int(segments[next].start) == at {
+			seg := &segments[next]
+			local := seg.local
+			wasResident := resident[local]
+			current[local] = int16(next)
+			remaining[next] = seg.benefit
+			if wasResident && seg.benefit <= 0 {
+				resident[local] = false
+				dirty[local] = false // a same-event definition supersedes the old value.
+				active--
+				wasResident = false
+			}
+			if wasResident {
+				dirty[local] = dirty[local] || seg.dirty
+			} else if seg.benefit > 0 {
+				victim := uint16(NoLocal)
+				victimCost := int(^uint(0) >> 1)
+				if active >= regBudget {
+					for _, candidate := range candidates {
+						x := candidate.local
+						if !resident[x] || current[x] < 0 {
+							continue
+						}
+						cost := int(remaining[current[x]])
+						if dirty[x] {
+							cost++
+						}
+						if cost < victimCost || cost == victimCost && x < victim {
+							victim, victimCost = x, cost
+						}
+					}
+				}
+				// One unit of hysteresis pays for changing physical ownership.
+				if active < regBudget || victim != NoLocal && int(seg.benefit) > victimCost+1 {
+					if victim != NoLocal {
+						resident[victim] = false
+						active--
+						out.Evictions = saturatingInc16(out.Evictions)
+						if dirty[victim] {
+							out.Writebacks = saturatingInc16(out.Writebacks)
+						}
+					}
+					resident[local] = true
+					dirty[local] = seg.dirty
+					active++
+					out.Admissions = saturatingInc16(out.Admissions)
+					if at < len(events) && events[at].Kind == LocalEventRead {
+						out.Reloads = saturatingInc16(out.Reloads)
+					}
+				}
+			}
+			next++
+		}
+
+		for _, candidate := range candidates {
+			local := candidate.local
+			idx := current[local]
+			if resident[local] && idx >= 0 && int(segments[idx].end) <= at {
+				resident[local] = false
+				dirty[local] = false
+				active--
+			}
+		}
+		if at == len(events) {
+			break
+		}
+		event := events[at]
+		if event.Local == NoLocal || int(event.Local) >= len(current) || current[event.Local] < 0 || !resident[event.Local] {
+			continue
+		}
+		idx := current[event.Local]
+		switch event.Kind {
+		case LocalEventRead:
+			if remaining[idx] > 0 {
+				remaining[idx]--
+			}
+		case LocalEventDefine:
+			dirty[event.Local] = true
+		}
+	}
 }
 
 func FindResidencyShadow(entries []ResidencyShadowEntry, key uint32) ResidencyShadowSummary {

--- a/src/core/compiler/backend/railshot/shared/residency_shadow_test.go
+++ b/src/core/compiler/backend/railshot/shared/residency_shadow_test.go
@@ -21,6 +21,25 @@ func TestPlanResidencyShadowVersionsAndBoundaries(t *testing.T) {
 	if got.LoadsAvoided != 3 || got.SyncDebt != 2 {
 		t.Fatalf("physical estimate = %+v", got)
 	}
+	if got.Admissions|got.Evictions|got.Reloads|got.Writebacks != 0 {
+		t.Fatalf("ordinary shadow unexpectedly ran transition simulation: %+v", got)
+	}
+}
+
+func TestPlanResidencyTransitionShadowModelsHystereticDirtyReplacement(t *testing.T) {
+	events := []LocalEvent{
+		{Local: 0, Kind: LocalEventDefine},
+		{Local: 0, Kind: LocalEventRead},
+		{Local: 0, Kind: LocalEventRead},
+		{Local: 1, Kind: LocalEventDefine},
+		{Local: 1, Kind: LocalEventRead},
+		{Local: 1, Kind: LocalEventRead},
+		{Local: 1, Kind: LocalEventRead},
+	}
+	got := PlanResidencyTransitionShadow(events, 2, 1, false)
+	if got.Admissions != 2 || got.Evictions != 1 || got.Reloads != 0 || got.Writebacks != 1 {
+		t.Fatalf("transition shadow = %+v", got)
+	}
 }
 
 func TestPlanResidencyShadowFailsSoft(t *testing.T) {
@@ -52,6 +71,7 @@ func TestPlanResidencyShadowNeverPanics(t *testing.T) {
 			events[i] = LocalEvent{Local: uint16(raw[i*3]), Depth: raw[i*3+1], Kind: LocalEventKind(raw[i*3+2])}
 		}
 		_ = PlanResidencyShadow(events, ResidencyShadowMaxLocals, 18, false)
+		_ = PlanResidencyTransitionShadow(events, ResidencyShadowMaxLocals, 18, false)
 		return true
 	}
 	if err := quick.Check(f, nil); err != nil {


### PR DESCRIPTION
## Summary

- add an allocation-free transition simulation over bounded local-version segments
- score avoided physical work against sync, fixed-register, and pressure debt
- report predicted admissions, evictions, reloads, and dirty writebacks only when codegen stats are requested
- record and remove three rejected active-policy experiments

This is a codegen-neutral dependent slice stacked on #568. It does not consume the simulated decisions or change emitted native code.

## Findings

On ARM64 explicit bounds, the transition shadow predicts:

| Workload | Admissions | Evictions | Reloads | Dirty writebacks |
| --- | ---: | ---: | ---: | ---: |
| blake-as | 25 | 6 | 4 | 5 |
| BLAKE3 | 26 | 7 | 3 | 5 |

A dirty-definition credit was rejected: even a one-unit credit increased BLAKE3 evictions from 21 to 39 and writebacks from 17 to 35. Dirty-eviction penalties and read cooldowns were also removed after mixed/noise-sized results.

## Proof

- `go test ./...`
- `go test ./src/core/compiler/backend/railshot/...`
- `make test-guard`
- `GOOS=linux GOARCH=amd64 go test -c ./src/core/compiler/backend/railshot/amd64`
- four alternating ordinary compilation pairs: native bytes and allocations unchanged; latency movement noise-sized

## Budgets

- emitted native code: unchanged
- ordinary compile allocations: unchanged
- retained heap: +16 to +28 bytes on the two measured modules
- operation lowering allocations: unchanged

Depends on #568.