### PR TITLE
release: use GitHub-style canary hashes

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -4,7 +4,7 @@
 
 - `canary` resolves the newest successful main build. Canary releases use an
   immutable SemVer tag such as
-  `v0.1.0-canary.g<40-character-commit-sha>`.
+  `v0.1.0-canary.g<7-character-commit-sha>`.
 - `beta` resolves the newest manually qualified beta, such as
   `v0.1.0-beta.1`.
 - `latest` resolves the newest stable `vMAJOR.MINOR.PATCH` release.

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -46,9 +46,10 @@ jobs:
         id: version
         run: |
           sha=$(git rev-parse HEAD)
+          short_sha=${sha:0:7}
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "version=v${RELEASE_SERIES}-canary.g$sha" >> "$GITHUB_OUTPUT"
-          echo "tag=v${RELEASE_SERIES}-canary.g$sha" >> "$GITHUB_OUTPUT"
+          echo "version=v${RELEASE_SERIES}-canary.g$short_sha" >> "$GITHUB_OUTPUT"
+          echo "tag=v${RELEASE_SERIES}-canary.g$short_sha" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build canary (${{ matrix.goos }}/${{ matrix.goarch }})

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -161,13 +161,13 @@ func TestInstallerDownloadsExactCanonicalRollingManager(t *testing.T) {
 		switch r.URL.Path {
 		case "/releases":
 			_, _ = fmt.Fprintf(w, `[
-  {"tag_name":"v0.1.0-canary.gdeadbee123456789012345678901234567890123","target_commitish":%q,"published_at":"2026-08-05T00:00:00Z","draft":true},
-  {"tag_name":"v0.1.0-canary.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","target_commitish":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","published_at":"2026-08-04T00:00:00Z"},
-  {"tag_name":"v0.1.0-canary.gdeadbee123456789012345678901234567890123","target_commitish":%q,"published_at":"2026-08-03T00:00:00Z"}
+  {"tag_name":"v0.1.0-canary.gdeadbee","target_commitish":%q,"published_at":"2026-08-05T00:00:00Z","draft":true},
+  {"tag_name":"v0.1.0-canary.gaaaaaaa","target_commitish":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","published_at":"2026-08-04T00:00:00Z"},
+  {"tag_name":"v0.1.0-canary.gdeadbee","target_commitish":%q,"published_at":"2026-08-03T00:00:00Z"}
 ]`, sha, sha)
-		case "/download/v0.1.0-canary.gdeadbee123456789012345678901234567890123/" + asset:
+		case "/download/v0.1.0-canary.gdeadbee/" + asset:
 			_, _ = w.Write(payload)
-		case "/download/v0.1.0-canary.gdeadbee123456789012345678901234567890123/" + asset + ".sha256":
+		case "/download/v0.1.0-canary.gdeadbee/" + asset + ".sha256":
 			_, _ = fmt.Fprintf(w, "%s  %s\n", hash, asset)
 		default:
 			http.NotFound(w, r)
@@ -192,7 +192,7 @@ func TestInstallerDownloadsExactCanonicalRollingManager(t *testing.T) {
 	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, payload) {
 		t.Fatalf("manager = %q, %v", got, err)
 	}
-	if installer.managerTag != "v0.1.0-canary.gdeadbee123456789012345678901234567890123" || !installer.managerFromRelease {
+	if installer.managerTag != "v0.1.0-canary.gdeadbee" || !installer.managerFromRelease {
 		t.Fatalf("manager resolution = %q, %v", installer.managerTag, installer.managerFromRelease)
 	}
 }
@@ -222,13 +222,13 @@ func TestInstallerCanonicalRollingManagerResolutionPaginates(t *testing.T) {
 			_, _ = fmt.Fprint(w, "]")
 			return
 		}
-		_, _ = fmt.Fprintf(w, `[{"tag_name":"v0.1.0-canary.gdeadbee123456789012345678901234567890123","target_commitish":%q,"published_at":"2026-08-03T00:00:00Z"}]`, sha)
+		_, _ = fmt.Fprintf(w, `[{"tag_name":"v0.1.0-canary.gdeadbee","target_commitish":%q,"published_at":"2026-08-03T00:00:00Z"}]`, sha)
 	}))
 	defer server.Close()
 
 	i := &installer{releaseAPI: server.URL + "/releases?scope=installer&per_page=1&page=99", httpClient: server.Client()}
 	tag, _, err := i.resolveReleaseForTest("canary@" + sha)
-	if err != nil || tag != "v0.1.0-canary.gdeadbee123456789012345678901234567890123" {
+	if err != nil || tag != "v0.1.0-canary.gdeadbee" {
 		t.Fatalf("resolve canonical manager = %q, %v", tag, err)
 	}
 	if requests != 2 {
@@ -458,12 +458,12 @@ func TestInstallerDownloadsNewestChannelManager(t *testing.T) {
 		switch r.URL.Path {
 		case "/releases":
 			_, _ = fmt.Fprint(w, `[
-  {"tag_name":"v0.1.0-canary.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","published_at":"2026-01-01T00:00:00Z"},
-  {"tag_name":"v0.1.0-canary.gdeadbee123456789012345678901234567890123","published_at":"2026-08-03T00:00:00Z"}
+  {"tag_name":"v0.1.0-canary.gaaaaaaa","published_at":"2026-01-01T00:00:00Z"},
+  {"tag_name":"v0.1.0-canary.gdeadbee","published_at":"2026-08-03T00:00:00Z"}
 ]`)
-		case "/download/v0.1.0-canary.gdeadbee123456789012345678901234567890123/" + asset:
+		case "/download/v0.1.0-canary.gdeadbee/" + asset:
 			_, _ = w.Write(payload)
-		case "/download/v0.1.0-canary.gdeadbee123456789012345678901234567890123/" + asset + ".sha256":
+		case "/download/v0.1.0-canary.gdeadbee/" + asset + ".sha256":
 			_, _ = fmt.Fprintf(w, "%s  %s\n", hash, asset)
 		default:
 			http.NotFound(w, r)
@@ -488,7 +488,7 @@ func TestInstallerDownloadsNewestChannelManager(t *testing.T) {
 	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, payload) {
 		t.Fatalf("manager = %q, %v", got, err)
 	}
-	if installer.managerTag != "v0.1.0-canary.gdeadbee123456789012345678901234567890123" || !installer.managerFromRelease {
+	if installer.managerTag != "v0.1.0-canary.gdeadbee" || !installer.managerFromRelease {
 		t.Fatalf("manager resolution = %q, %v", installer.managerTag, installer.managerFromRelease)
 	}
 }
@@ -686,7 +686,7 @@ func assertInstallerTranscript(t *testing.T, reinstall bool) {
 	}
 	fmt.Fprintln(&output)
 	statuses := []string{
-		"Downloaded Wago manager v0.1.0-canary.gdeadbee123456789012345678901234567890123",
+		"Downloaded Wago manager v0.1.0-canary.gdeadbee",
 		"Fetched Wago source",
 	}
 	if reinstall {
@@ -712,7 +712,7 @@ func assertInstallerTranscript(t *testing.T, reinstall bool) {
 		installer.offerCompletions(installed, configFile)
 	}
 	installer.offerPathRefresh(configFile)
-	installer.finish("v0.1.0-canary.gdeadbee123456789012345678901234567890123", installed, pathReady, configFile)
+	installer.finish("v0.1.0-canary.gdeadbee", installed, pathReady, configFile)
 
 	separator := string(os.PathSeparator)
 	command := "~" + separator + ".wago" + separator + "bin" + separator + executableName("wago")
@@ -722,7 +722,7 @@ func assertInstallerTranscript(t *testing.T, reinstall bool) {
 		want += "Reinstall method: Full\n"
 	}
 	want += "\n" +
-		"✓ Downloaded Wago manager v0.1.0-canary.gdeadbee123456789012345678901234567890123\n" +
+		"✓ Downloaded Wago manager v0.1.0-canary.gdeadbee\n" +
 		"✓ Fetched Wago source\n"
 	if reinstall {
 		want += "✓ Cleaned existing Wago installation\n"
@@ -735,14 +735,14 @@ func assertInstallerTranscript(t *testing.T, reinstall bool) {
 		want += "Add Wago to PATH? Yes\n" +
 			"✓ Added Wago to PATH\n\n" +
 			"Refresh PATH now? Yes\n\n" +
-			"Sweet, Wago v0.1.0-canary.gdeadbee123456789012345678901234567890123 is ready at " + command + "\n"
+			"Sweet, Wago v0.1.0-canary.gdeadbee is ready at " + command + "\n"
 	} else {
 		want += "Add Wago to PATH in ~/.zshrc? Yes\n" +
 			"✓ Added Wago to PATH\n\n" +
 			"Enable zsh completions? Yes\n" +
 			"✓ Enabled zsh completions\n\n" +
 			"Refresh PATH now? Yes\n\n" +
-			"Sweet, Wago v0.1.0-canary.gdeadbee123456789012345678901234567890123 is ready at " + command + "\n"
+			"Sweet, Wago v0.1.0-canary.gdeadbee is ready at " + command + "\n"
 	}
 	want += "\nNow, install the Wago version you want:\n\n" +
 		"wago version install\n"
@@ -766,8 +766,8 @@ func TestInstallerWarmFinishAfterPathSetup(t *testing.T) {
 	}
 	installer.pathAdded = true
 	installed := filepath.Join(home, ".wago", "bin", "wago")
-	installer.finish("v0.1.0-canary.gdeadbee123456789012345678901234567890123", installed, true, filepath.Join(home, ".zshrc"))
-	want := "\nSweet, Wago v0.1.0-canary.gdeadbee123456789012345678901234567890123 is ready at ~/.wago/bin/wago\n\n" +
+	installer.finish("v0.1.0-canary.gdeadbee", installed, true, filepath.Join(home, ".zshrc"))
+	want := "\nSweet, Wago v0.1.0-canary.gdeadbee is ready at ~/.wago/bin/wago\n\n" +
 		"Open a new terminal or run:\n\n" +
 		"source ~/.zshrc\n\n" +
 		"Then install the Wago version you want:\n\n" +
@@ -791,9 +791,9 @@ func TestInstallerFinishWhenPathIsAlreadyReady(t *testing.T) {
 		t.Fatal(err)
 	}
 	installed := filepath.Join(binDir, executableName("wago"))
-	installer.finish("v0.1.0-canary.gdeadbee123456789012345678901234567890123", installed, true, "")
+	installer.finish("v0.1.0-canary.gdeadbee", installed, true, "")
 	separator := string(os.PathSeparator)
-	want := "\nSweet, Wago v0.1.0-canary.gdeadbee123456789012345678901234567890123 is ready at ~" + separator + ".wago" + separator + "bin" + separator + executableName("wago") + "\n\n" +
+	want := "\nSweet, Wago v0.1.0-canary.gdeadbee is ready at ~" + separator + ".wago" + separator + "bin" + separator + executableName("wago") + "\n\n" +
 		"Now, install the Wago version you want:\n\n" +
 		"wago version install\n"
 	if got := output.String(); got != want {

--- a/cli/installer/install_windows_test.go
+++ b/cli/installer/install_windows_test.go
@@ -132,8 +132,8 @@ func TestWindowsWarmFinishAfterPathSetup(t *testing.T) {
 	}
 	installer.pathAdded = true
 	installed := filepath.Join(home, ".wago", "bin", "wago.exe")
-	installer.finish("v0.1.0-canary.gdeadbee123456789012345678901234567890123", installed, true, "")
-	want := "\nSweet, Wago v0.1.0-canary.gdeadbee123456789012345678901234567890123 is ready at ~\\.wago\\bin\\wago.exe\n\n" +
+	installer.finish("v0.1.0-canary.gdeadbee", installed, true, "")
+	want := "\nSweet, Wago v0.1.0-canary.gdeadbee is ready at ~\\.wago\\bin\\wago.exe\n\n" +
 		"Open a new terminal.\n\n" +
 		"Then install the Wago version you want:\n\n" +
 		"wago version install\n"
@@ -143,8 +143,8 @@ func TestWindowsWarmFinishAfterPathSetup(t *testing.T) {
 
 	output.Reset()
 	installer.pathAdded = false
-	installer.finish("v0.1.0-canary.gdeadbee123456789012345678901234567890123", installed, true, "")
-	want = "\nSweet, Wago v0.1.0-canary.gdeadbee123456789012345678901234567890123 is ready at ~\\.wago\\bin\\wago.exe\n\n" +
+	installer.finish("v0.1.0-canary.gdeadbee", installed, true, "")
+	want = "\nSweet, Wago v0.1.0-canary.gdeadbee is ready at ~\\.wago\\bin\\wago.exe\n\n" +
 		"Now, install the Wago version you want:\n\n" +
 		"wago version install\n"
 	if got := output.String(); got != want {

--- a/cli/manager/internal/self/release_test.go
+++ b/cli/manager/internal/self/release_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestChannelPreservesReleaseTrack(t *testing.T) {
 	tests := map[string]string{
-		"canary": "canary",
-		"v0.1.0-canary.g7d8c58a000000000000000000000000000000000": "canary",
-		"canary@7d8c58a000000000000000000000000000000000":         "canary",
+		"canary":                 "canary",
+		"v0.1.0-canary.g7d8c58a": "canary",
+		"canary@7d8c58a000000000000000000000000000000000": "canary",
 		"beta":          "beta",
 		"v0.1.0-beta.2": "beta",
 		"beta@7d8c58a000000000000000000000000000000000": "beta",

--- a/cli/manager/internal/version/diagnostics_test.go
+++ b/cli/manager/internal/version/diagnostics_test.go
@@ -7,7 +7,7 @@ func TestDiagnosticChannel(t *testing.T) {
 		active, release, want string
 	}{
 		{"canary", "deadbee", "canary"},
-		{"", "v0.1.0-canary.gdeadbee123456789012345678901234567890123", "canary"},
+		{"", "v0.1.0-canary.gdeadbee", "canary"},
 		{"", "canary@deadbee123456789012345678901234567890123", "canary"},
 		{"beta", "deadbee", "beta"},
 		{"", "v0.1.0-beta.1", "beta"},

--- a/cli/manager/internal/version/helpers_test.go
+++ b/cli/manager/internal/version/helpers_test.go
@@ -13,7 +13,7 @@ func TestVersionSelectionAndOrderingHelpers(t *testing.T) {
 	if !isRollingChannel("canary") || isRollingChannel("1.2.3") || channelRelease("v0.1.0-beta.1") != "beta" || channelRelease("v1.2.3") != "" {
 		t.Fatal("release channel detection mismatch")
 	}
-	if got := strings.Join(stableReleaseNames([]string{"v1.2.3", "v0.1.0-canary.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "", "v1.2.3-beta.1"}), ","); got != "v1.2.3" {
+	if got := strings.Join(stableReleaseNames([]string{"v1.2.3", "v0.1.0-canary.gaaaaaaa", "", "v1.2.3-beta.1"}), ","); got != "v1.2.3" {
 		t.Fatalf("stable releases = %q", got)
 	}
 	for _, tc := range []struct {

--- a/cli/manager/internal/version/lifecycle_test.go
+++ b/cli/manager/internal/version/lifecycle_test.go
@@ -428,7 +428,7 @@ func TestInstalledWagoLabel(t *testing.T) {
 		build     wagopaths.Build
 		want      string
 	}{
-		{"canary", "v0.1.0-canary.g7d8c58a123456789012345678901234567890123", wagopaths.ProfileStandard, wagopaths.BuildTiny, "Wago Canary (7d8c58a/standard/tiny)"},
+		{"canary", "v0.1.0-canary.g7d8c58a", wagopaths.ProfileStandard, wagopaths.BuildTiny, "Wago Canary (7d8c58a/standard/tiny)"},
 		{"v0.1.0-beta.1", "v0.1.0-beta.1", wagopaths.ProfileMinimal, wagopaths.BuildNormal, "Wago Beta (minimal/normal)"},
 		{"v0.2.0", "v0.2.0", wagopaths.ProfileStandard, wagopaths.BuildNormal, "Wago v0.2.0 (standard/normal)"},
 	}
@@ -479,7 +479,7 @@ func TestUpdateVersionTarget(t *testing.T) {
 }
 
 func TestInstallPickerHidesImmutableChannelTagsAtTopLevel(t *testing.T) {
-	tags := []string{"v0.1.0-beta.2", "v0.1.4", "v0.1.0-canary.gcafef00123456789012345678901234567890123", "v0.1.0-beta.1", "v0.2.0", "0.1.0", "canary"}
+	tags := []string{"v0.1.0-beta.2", "v0.1.4", "v0.1.0-canary.gcafef00", "v0.1.0-beta.1", "v0.2.0", "0.1.0", "canary"}
 	if got, want := stableReleaseNames(tags), []string{"v0.2.0", "v0.1.4", "v0.1.0"}; !slices.Equal(got, want) {
 		t.Fatalf("stableReleaseNames = %v, want %v", got, want)
 	}
@@ -489,7 +489,7 @@ func TestInstallPickerHidesImmutableChannelTagsAtTopLevel(t *testing.T) {
 	releases := []remoteRelease{
 		{TagName: "v0.1.0-beta.2", TargetCommitish: "7d8c58a123456789012345678901234567890123", PublishedAt: "2026-07-28T08:31:22Z"},
 		{TagName: "v0.1.4", PublishedAt: "2026-06-30T12:00:00Z"},
-		{TagName: "v0.1.0-canary.gcafef00123456789012345678901234567890123", PublishedAt: "2026-07-28T00:48:44Z"},
+		{TagName: "v0.1.0-canary.gcafef00", PublishedAt: "2026-07-28T00:48:44Z"},
 		{TagName: "v0.1.0-beta.1", PublishedAt: "2026-07-11T08:31:22Z"},
 		{TagName: "v0.2.0", PublishedAt: "2026-07-28T08:31:22Z"},
 		{TagName: "0.1.0", PublishedAt: "2026-06-01T12:00:00Z"},

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -27,7 +27,7 @@ func TestLatestChannelRelease(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		_, _ = w.Write([]byte(`[{"tag_name":"v0.1.0-beta.2","target_commitish":"deadbee123456789012345678901234567890123"},{"tag_name":"v0.1.0-canary.gcafef00123456789012345678901234567890123","target_commitish":"cafef00123456789012345678901234567890123"}]`))
+		_, _ = w.Write([]byte(`[{"tag_name":"v0.1.0-beta.2","target_commitish":"deadbee123456789012345678901234567890123"},{"tag_name":"v0.1.0-canary.gcafef00","target_commitish":"cafef00123456789012345678901234567890123"}]`))
 	}))
 	defer srv.Close()
 	t.Setenv("WAGO_RELEASE_API", srv.URL)
@@ -285,7 +285,7 @@ func TestMainCommitBrowsingPaginatesAndResolvesTip(t *testing.T) {
 			}
 			releases := make([]remoteRelease, count)
 			for i := range releases {
-				releases[i].TagName = fmt.Sprintf("v0.1.0-canary.g%040x", i+1)
+				releases[i].TagName = fmt.Sprintf("v0.1.0-canary.g%07x", i+1)
 			}
 			_ = json.NewEncoder(w).Encode(releases)
 		default:
@@ -632,10 +632,10 @@ func TestVersionAssetsIncludeProfileAndHost(t *testing.T) {
 
 func TestCanonicalReleaseRef(t *testing.T) {
 	for input, want := range map[string]string{
-		"0.2.0":  "v0.2.0",
-		"v0.2.0": "v0.2.0",
-		"main":   "main",
-		"v0.1.0-canary.gdeadbee123456789012345678901234567890123": "v0.1.0-canary.gdeadbee123456789012345678901234567890123",
+		"0.2.0":                  "v0.2.0",
+		"v0.2.0":                 "v0.2.0",
+		"main":                   "main",
+		"v0.1.0-canary.gdeadbee": "v0.1.0-canary.gdeadbee",
 	} {
 		if got := canonicalReleaseRef(input); got != want {
 			t.Fatalf("canonicalReleaseRef(%q) = %q, want %q", input, got, want)

--- a/cli/manager/internal/version/releases.go
+++ b/cli/manager/internal/version/releases.go
@@ -51,11 +51,23 @@ func channelRelease(tag string) string {
 			return ""
 		}
 	case "canary":
-		if !strings.HasPrefix(identity, "g") || !validCommitSHA(strings.TrimPrefix(identity, "g")) {
+		if !strings.HasPrefix(identity, "g") || !validShortCommitSHA(strings.TrimPrefix(identity, "g")) {
 			return ""
 		}
 	}
 	return channel
+}
+
+func validShortCommitSHA(sha string) bool {
+	if len(sha) != 7 {
+		return false
+	}
+	for _, char := range sha {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return false
+		}
+	}
+	return true
 }
 
 func validReleaseCore(tag string) bool {

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -243,12 +243,12 @@ func TestChecksumMismatchDoesNotBuildFromSource(t *testing.T) {
 func TestCanaryResolvesLatestPublishedCanary(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`[{"tag_name":"v0.1.0-canary.g` + sha + `","target_commitish":"` + sha + `"}]`))
+		_, _ = w.Write([]byte(`[{"tag_name":"v0.1.0-canary.g` + sha[:7] + `","target_commitish":"` + sha + `"}]`))
 	}))
 	defer server.Close()
 	t.Setenv("WAGO_RELEASE_API", server.URL)
 	ref, sourceOnly, err := resolveRunnerVersion("canary", nil)
-	if err != nil || ref != "v0.1.0-canary.g"+sha+"@"+sha || sourceOnly {
+	if err != nil || ref != "v0.1.0-canary.g"+sha[:7]+"@"+sha || sourceOnly {
 		t.Fatalf("resolveRunnerVersion = %q, %v, %v", ref, sourceOnly, err)
 	}
 }

--- a/cli/manager/internal/version/update_test.go
+++ b/cli/manager/internal/version/update_test.go
@@ -18,7 +18,7 @@ func TestInstalledCommitMatchesOnlyCanonicalHashes(t *testing.T) {
 	previous := runtimeVersionOutput
 	t.Cleanup(func() { runtimeVersionOutput = previous })
 	runtimeVersionOutput = func(string) ([]byte, error) {
-		return []byte("Wago\n  release      v0.1.0-canary.gdeadbee123456789012345678901234567890123\n"), nil
+		return []byte("Wago\n  release      v0.1.0-canary.gdeadbee\n"), nil
 	}
 	if installedCommitMatches(runtime, "canary@deadbee123456789012345678901234567890123") {
 		t.Fatal("legacy abbreviated canary hash was treated as canonical")
@@ -58,7 +58,7 @@ func TestRollingCommitIdentityRequiresCanonicalSHA(t *testing.T) {
 		{"v0.1.0-beta.1@cafef00123456789012345678901234567890123", "beta", "cafef00123456789012345678901234567890123", true},
 		{" CANARY@DEADBEE123456789012345678901234567890123 ", "canary", "deadbee123456789012345678901234567890123", true},
 		{"canary@deadbee123456789012345678901234567890123@junk", "", "", false},
-		{"v0.1.0-canary.gdeadbee123456789012345678901234567890123", "", "", false},
+		{"v0.1.0-canary.gdeadbee", "", "", false},
 		{"v0.1.0-beta.1", "", "", false},
 		{"v0.2.0", "", "", false},
 	} {

--- a/cli/runtime/internal/version/report_test.go
+++ b/cli/runtime/internal/version/report_test.go
@@ -21,7 +21,7 @@ func TestVersionReportIncludesDiagnostics(t *testing.T) {
 		t.Fatal(err)
 	}
 	os.Stdout = write
-	Print("v0.1.0-canary.gdeadbee123456789012345678901234567890123", "standard", "normal", "none")
+	Print("v0.1.0-canary.gdeadbee", "standard", "normal", "none")
 	_ = write.Close()
 	output, err := io.ReadAll(read)
 	_ = read.Close()
@@ -32,7 +32,7 @@ func TestVersionReportIncludesDiagnostics(t *testing.T) {
 	for _, want := range []string{
 		"Wago",
 		"channel      canary",
-		"release      v0.1.0-canary.gdeadbee123456789012345678901234567890123",
+		"release      v0.1.0-canary.gdeadbee",
 		"profile      standard",
 		"platform",
 		"toolchain",
@@ -82,7 +82,7 @@ func TestDiagnosticChannel(t *testing.T) {
 		active, release, want string
 	}{
 		{"canary", "deadbee", "canary"},
-		{"", "v0.1.0-canary.gdeadbee123456789012345678901234567890123", "canary"},
+		{"", "v0.1.0-canary.gdeadbee", "canary"},
 		{"", "canary@deadbee123456789012345678901234567890123", "canary"},
 		{"beta", "deadbee", "beta"},
 		{"", "v0.1.0-beta.1", "beta"},

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ release_tag_from_json() {
 			sub(/^.*"published_at"[[:space:]]*:[[:space:]]*"/, "", line)
 			sub(/".*$/, "", line)
 			matches = (channel == "beta" && tag ~ /^v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$/) || \
-				(channel == "canary" && tag ~ /^v[0-9]+\.[0-9]+\.[0-9]+-canary\.g[0-9a-f]{40}$/)
+				(channel == "canary" && tag ~ /^v[0-9]+\.[0-9]+\.[0-9]+-canary\.g[0-9a-f]{7}$/)
 			if (matches && (best == "" || line > best)) {
 				best = line
 				best_tag = tag

--- a/install_test.go
+++ b/install_test.go
@@ -37,12 +37,12 @@ func TestShellBootstrapMatchesReleaseContract(t *testing.T) {
 	catalog := bootstrapContractCatalog{
 		latest: installbootstrap.Release{TagName: "v1.2.3", PublishedAt: "2026-08-04T00:00:00Z"},
 		releases: []installbootstrap.Release{
-			{TagName: "v0.1.0-canary.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", PublishedAt: "2026-08-01T00:00:00Z"},
+			{TagName: "v0.1.0-canary.gaaaaaaa", PublishedAt: "2026-08-01T00:00:00Z"},
 			{TagName: "v0.1.0-beta.1", PublishedAt: "2026-08-04T00:00:00Z"},
-			{TagName: "v0.1.0-canary.gbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", PublishedAt: "2026-08-03T00:00:00Z"},
+			{TagName: "v0.1.0-canary.gbbbbbbb", PublishedAt: "2026-08-03T00:00:00Z"},
 		},
 	}
-	for _, version := range []string{"latest", "main", "beta", "v0.1.0-canary.gcccccccccccccccccccccccccccccccccccccccc"} {
+	for _, version := range []string{"latest", "main", "beta", "v0.1.0-canary.gccccccc"} {
 		t.Run(version, func(t *testing.T) {
 			wantTag, err := installbootstrap.Resolve(version, catalog)
 			if err != nil {
@@ -56,7 +56,7 @@ func TestShellBootstrapMatchesReleaseContract(t *testing.T) {
 				case "/releases/latest":
 					_, _ = fmt.Fprintf(w, "{\n  \"tag_name\": %q,\n  \"published_at\": %q\n}\n", catalog.latest.TagName, catalog.latest.PublishedAt)
 				case "/releases":
-					_, _ = fmt.Fprint(w, "[\n  {\n    \"tag_name\": \"v0.1.0-canary.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\n    \"published_at\": \"2026-08-01T00:00:00Z\"\n  },\n  {\n    \"tag_name\": \"v0.1.0-beta.1\",\n    \"published_at\": \"2026-08-04T00:00:00Z\"\n  },\n  {\n    \"tag_name\": \"v0.1.0-canary.gbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\n    \"published_at\": \"2026-08-03T00:00:00Z\"\n  }\n]\n")
+					_, _ = fmt.Fprint(w, "[\n  {\n    \"tag_name\": \"v0.1.0-canary.gaaaaaaa\",\n    \"published_at\": \"2026-08-01T00:00:00Z\"\n  },\n  {\n    \"tag_name\": \"v0.1.0-beta.1\",\n    \"published_at\": \"2026-08-04T00:00:00Z\"\n  },\n  {\n    \"tag_name\": \"v0.1.0-canary.gbbbbbbb\",\n    \"published_at\": \"2026-08-03T00:00:00Z\"\n  }\n]\n")
 				case "/download/" + wantTag + "/" + asset:
 					_, _ = w.Write(payload)
 				case "/download/" + wantTag + "/" + asset + ".sha256":
@@ -82,7 +82,7 @@ func TestShellBootstrapMatchesReleaseContract(t *testing.T) {
 func TestShellBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 	payload := []byte("#!/bin/sh\nprintf 'native installer: %s\\n' \"$WAGO_VERSION\"\n")
 	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
-	tag := "v0.1.0-canary.gdeadbee123456789012345678901234567890123"
+	tag := "v0.1.0-canary.gdeadbee"
 	asset := "wago-installer-" + runtime.GOOS + "-" + runtime.GOARCH
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -331,7 +331,7 @@ func TestWineCmdBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 		t.Fatal(err)
 	}
 	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
-	tag := "v0.1.0-canary.gbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	tag := "v0.1.0-canary.gbbbbbbb"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/releases":
@@ -378,7 +378,7 @@ func TestWineInstallerCompletesNativeInstallFlow(t *testing.T) {
 	}
 	managerHash := fmt.Sprintf("%x", sha256.Sum256(manager))
 	sourceArchive := makeSourceArchive(t)
-	tag := "v0.1.0-canary.gcccccccccccccccccccccccccccccccccccccccc"
+	tag := "v0.1.0-canary.gccccccc"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/download/" + tag + "/wago-windows-amd64":

--- a/internal/installbootstrap/release.go
+++ b/internal/installbootstrap/release.go
@@ -135,13 +135,25 @@ func releaseChannel(tag string) string {
 			return ""
 		}
 	case "canary":
-		if !strings.HasPrefix(identity, "g") || !fullCommitSHA(strings.TrimPrefix(identity, "g")) {
+		if !strings.HasPrefix(identity, "g") || !shortCommitSHA(strings.TrimPrefix(identity, "g")) {
 			return ""
 		}
 	default:
 		return ""
 	}
 	return channel
+}
+
+func shortCommitSHA(value string) bool {
+	if len(value) != 7 {
+		return false
+	}
+	for _, char := range value {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return false
+		}
+	}
+	return true
 }
 
 func validReleaseCore(tag string) bool {

--- a/internal/installbootstrap/release_test.go
+++ b/internal/installbootstrap/release_test.go
@@ -23,15 +23,15 @@ func TestResolveReleaseContract(t *testing.T) {
 	catalog := memoryCatalog{
 		latest: Release{TagName: "v1.2.3"},
 		releases: []Release{
-			{TagName: "v0.1.0-canary.gdeadbee123456789012345678901234567890123", TargetCommitish: canarySHA, PublishedAt: "2026-08-05T00:00:00Z", Draft: true},
-			{TagName: "v0.1.0-canary.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", TargetCommitish: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", PublishedAt: "2026-08-01T00:00:00Z"},
+			{TagName: "v0.1.0-canary.gdeadbee", TargetCommitish: canarySHA, PublishedAt: "2026-08-05T00:00:00Z", Draft: true},
+			{TagName: "v0.1.0-canary.gaaaaaaa", TargetCommitish: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", PublishedAt: "2026-08-01T00:00:00Z"},
 			{TagName: "v0.1.0-beta.2", TargetCommitish: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", PublishedAt: "2026-08-04T00:00:00Z"},
-			{TagName: "v0.1.0-canary.gdeadbee123456789012345678901234567890123", TargetCommitish: canarySHA, PublishedAt: "2026-08-03T00:00:00Z"},
+			{TagName: "v0.1.0-canary.gdeadbee", TargetCommitish: canarySHA, PublishedAt: "2026-08-03T00:00:00Z"},
 		},
 	}
 	for _, test := range []struct{ version, want string }{
-		{"latest", "v1.2.3"}, {"main", "v0.1.0-canary.gdeadbee123456789012345678901234567890123"}, {"canary", "v0.1.0-canary.gdeadbee123456789012345678901234567890123"},
-		{"canary@" + canarySHA, "v0.1.0-canary.gdeadbee123456789012345678901234567890123"}, {"beta", "v0.1.0-beta.2"},
+		{"latest", "v1.2.3"}, {"main", "v0.1.0-canary.gdeadbee"}, {"canary", "v0.1.0-canary.gdeadbee"},
+		{"canary@" + canarySHA, "v0.1.0-canary.gdeadbee"}, {"beta", "v0.1.0-beta.2"},
 		{" v9.0.0 ", "v9.0.0"},
 	} {
 		got, err := Resolve(test.version, catalog)
@@ -52,11 +52,11 @@ func TestResolveReleaseContract(t *testing.T) {
 		t.Fatal("release tag accepted an appended commit identity")
 	}
 	resolved, err := ResolveRelease("canary@"+canarySHA, catalog)
-	if err != nil || resolved.Tag != "v0.1.0-canary.gdeadbee123456789012345678901234567890123" || resolved.SourceRef != canarySHA {
+	if err != nil || resolved.Tag != "v0.1.0-canary.gdeadbee" || resolved.SourceRef != canarySHA {
 		t.Fatalf("ResolveRelease canonical = %+v, %v", resolved, err)
 	}
 	resolved, err = ResolveRelease("main", catalog)
-	if err != nil || resolved.Tag != "v0.1.0-canary.gdeadbee123456789012345678901234567890123" || resolved.SourceRef != canarySHA {
+	if err != nil || resolved.Tag != "v0.1.0-canary.gdeadbee" || resolved.SourceRef != canarySHA {
 		t.Fatalf("ResolveRelease channel = %+v, %v", resolved, err)
 	}
 	resolved, err = ResolveRelease("v9.0.0", catalog)

--- a/scripts/smoke-release-assets.sh
+++ b/scripts/smoke-release-assets.sh
@@ -6,8 +6,8 @@ target="${2:?release target is required}"
 version="${3:?release version is required}"
 repository_root=$(git rev-parse --show-toplevel)
 
-[[ "$version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
-  echo "invalid stable version: $version" >&2
+[[ "$version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-beta\.(0|[1-9][0-9]*))?$ ]] || {
+  echo "invalid release version: $version" >&2
   exit 1
 }
 

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -61,7 +61,8 @@ func TestCanaryUsesImmutableSemVerTagsAndTargets(t *testing.T) {
 	contents := string(canary)
 	for _, required := range []string{
 		`RELEASE_SERIES: "0.1.0"`,
-		`echo "tag=v${RELEASE_SERIES}-canary.g$sha"`,
+		`short_sha=${sha:0:7}`,
+		`echo "tag=v${RELEASE_SERIES}-canary.g$short_sha"`,
 		`target=$(gh api "repos/${{ github.repository }}/releases/tags/`,
 		`has an invalid target commit`,
 		`if [ "$target" != "${{ needs.`,

--- a/tests/scripts/release-qualification.sh
+++ b/tests/scripts/release-qualification.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$test_root"' EXIT
 
 source_sha=0123456789abcdef0123456789abcdef01234567
 run_id=123456
-version=v1.2.3
+version=v1.2.3-beta.1
 repository=wago-org/wago
 success_needs='{"changes":{"result":"success"},"docs":{"result":"success"},"lint":{"result":"success"},"regression-corpus":{"result":"success"},"runtime-concurrency":{"result":"success"},"race":{"result":"success"},"platform-test":{"result":"success"},"core-v2":{"result":"success"},"core-v3":{"result":"success"},"tinygo":{"result":"success"},"coverage":{"result":"success"},"size":{"result":"success"}}'
 


### PR DESCRIPTION
## Summary
- shorten canary SemVer tags to GitHub-style 7-character hashes (`v0.1.0-canary.gabcdef0`)
- retain full-SHA release targets and provenance validation
- allow beta SemVer values through the qualified asset smoke test

## Validation
- `go test ./...`
- `bash tests/scripts/release-qualification.sh`
- `bash tests/scripts/dispatch-docs-release.sh`
- `actionlint` on release workflows