### PR TITLE
release: trust freshly built smoke artifacts

### DIFF
--- a/scripts/smoke-release-assets.sh
+++ b/scripts/smoke-release-assets.sh
@@ -73,7 +73,7 @@ artifact="$scratch/fib.wago"
   exit 1
 }
 for runtime in "${runtimes[@]}"; do
-  output=$("$runtime" run --invoke fib "$artifact" 20)
+  output=$("$runtime" run --allow-native-artifact --invoke fib "$artifact" 20)
   [[ "$output" == "fib(20) = 6765" ]] || {
     echo "$(basename "$runtime") .wago smoke output: $output" >&2
     exit 1

--- a/tests/scripts/release-qualification.sh
+++ b/tests/scripts/release-qualification.sh
@@ -98,6 +98,9 @@ if [[ "\${1:-}" == "build" ]]; then
   exit 1
 fi
 if [[ "\${1:-}" == "run" ]]; then
+  if [[ "\$*" == *".wago"* && "\$*" != *"--allow-native-artifact"* ]]; then
+    exit 1
+  fi
   printf 'fib(20) = 6765\n'
   exit 0
 fi


### PR DESCRIPTION
Pass the required native-artifact opt-in when release qualification executes the `.wago` file it just built, and make the shell fixture enforce that flag.

Validation:
- `bash tests/scripts/release-qualification.sh`
- `go test ./tests/cipolicy ./cli/runtime/commands/run`