### PR TITLE
release: simplify generated notes

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -15,6 +15,14 @@ SHA that already passed main CI. Both paths build, smoke-test, checksum, and
 publish the same platform asset set. Before starting a new release series,
 update `RELEASE_SERIES` in `canary.yml`.
 
+## Release notes
+
+GitHub generates the public notes for every channel. Pull requests carrying the
+`enhancement` label appear under **New features**; all other included pull
+requests appear under **Changelog**. GitHub also identifies first-time
+contributors. Qualification details and asset hashes stay in
+`release-manifest.json` instead of cluttering the public notes.
+
 ## Choose a file
 
 Start with the Wago CLI that matches your operating system and CPU architecture:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: New features
+      labels:
+        - enhancement
+    - title: Changelog
+      labels:
+        - "*"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -151,8 +151,11 @@ jobs:
         run: |
           mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
           test "${#assets[@]}" -gt 0
-          notes=$(printf 'Automated canary build of main at `%s`. All supported Normal targets are required; unsupported Tiny variants are omitted. Unstable — may break without notice.\n\n' \
-            '${{ needs.prepare.outputs.sha }}'; sed -n '1,$p' .github/release-asset-naming.md)
+          gh api --method POST \
+            "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="${{ needs.prepare.outputs.tag }}" \
+            -f target_commitish="${{ needs.prepare.outputs.sha }}" --jq .body |
+            sed 's/^## New Contributors$/## First-time contributors/' >release-notes.md
           if gh release view "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             target=$(gh api "repos/${{ github.repository }}/releases/tags/${{ needs.prepare.outputs.tag }}" --jq '.target_commitish')
             if [ "$target" != "${{ needs.prepare.outputs.sha }}" ]; then
@@ -160,7 +163,7 @@ jobs:
               exit 1
             fi
             gh release upload "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" --clobber "${assets[@]}"
-            gh release edit "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" --notes "$notes"
+            gh release edit "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" --notes-file release-notes.md
             echo "canary release already exists for ${{ needs.prepare.outputs.sha }}"
             exit 0
           fi
@@ -168,7 +171,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --target "${{ needs.prepare.outputs.sha }}" \
             --title "Canary (${{ needs.prepare.outputs.version }})" \
-            --notes "$notes" \
+            --notes-file release-notes.md \
             --prerelease \
             "${assets[@]}"
       - name: Create documentation synchronization token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,24 +348,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.prepare.outputs.version }}
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
-          CI_RUN_ID: ${{ needs.prepare.outputs.ci_run_id }}
-          CI_RUN_ATTEMPT: ${{ needs.prepare.outputs.ci_run_attempt }}
           RESUME_DRAFT: ${{ steps.release.outputs.resume_draft }}
           PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
         run: |
-          manifest_sha=$(awk '$2 == "release-manifest.json" {print $1}' release/release-manifest.json.sha256)
           generated_notes=$(gh api --method POST \
             "repos/${{ github.repository }}/releases/generate-notes" \
             -f tag_name="$VERSION" -f target_commitish="$SOURCE_SHA" --jq .body)
-          {
-            printf 'Qualified %s release from commit `%s`.\n\n' '${{ needs.prepare.outputs.channel }}' "$SOURCE_SHA"
-            printf -- '- Source commit: `%s`\n' "$SOURCE_SHA"
-            printf -- '- Complete CI qualification: `%s/actions/runs/%s` (attempt `%s`)\n' \
-              '${{ github.server_url }}/${{ github.repository }}' "$CI_RUN_ID" "$CI_RUN_ATTEMPT"
-            printf -- '- Release manifest SHA-256: `%s`\n\n' "$manifest_sha"
-            sed -n '1,$p' .github/release-asset-naming.md
-            printf '\n%s\n' "$generated_notes"
-          } >release-notes.md
+          printf '%s\n' "$generated_notes" |
+            sed 's/^## New Contributors$/## First-time contributors/' >release-notes.md
           mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
           assets+=(release/release-manifest.json release/release-manifest.json.sha256)
           if [ "$RESUME_DRAFT" = "true" ]; then


### PR DESCRIPTION
## Summary

- replace public qualification and asset-guide boilerplate with GitHub-generated notes
- group enhancement-labelled PRs under **New features** and everything else under **Changelog**
- rename GitHub’s new-contributor section to **First-time contributors**
- retain provenance and checksums in `release-manifest.json`

## Validation

- `git diff --check`
- `actionlint -ignore SC2129 .github/workflows/release.yml .github/workflows/canary.yml`
- parsed `.github/release.yml` as YAML