### PR TITLE
compile: use PATH toolchains and print raw results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,7 +521,7 @@ jobs:
         run: |
           out="$(./wago-tinygo run --invoke fib tests/fixtures/wasm/fib.wasm 20)"
           echo "$out"
-          test "$out" = "fib(20) = 6765"
+          test "$out" = "6765"
 
       # Debug builds alone did not expose an intermittent failure in optimized
       # startup. Exercise the shipped optimizer/GC settings in fresh processes.
@@ -534,7 +534,7 @@ jobs:
             ./wago-tinygo-release --version
             out="$(./wago-tinygo-release run --invoke fib tests/fixtures/wasm/fib.wasm 20)"
             echo "$out"
-            test "$out" = "fib(20) = 6765"
+            test "$out" = "6765"
           done
 
   # Coverage is deliberately kept off pull requests and runs after code changes

--- a/cli/internal/wasmcall/values.go
+++ b/cli/internal/wasmcall/values.go
@@ -100,18 +100,6 @@ func FormatValue(bits uint64, valueType wago.ValType) string {
 	}
 }
 
-func Format(export string, args, results []uint64, paramTypes, resultTypes []wago.ValType) string {
-	arguments := make([]string, len(args))
-	for index, value := range args {
-		arguments[index] = FormatValue(value, paramTypes[index])
-	}
-	call := fmt.Sprintf("%s(%s)", export, strings.Join(arguments, ", "))
-	if len(results) == 0 {
-		return call + " = ()"
-	}
-	return fmt.Sprintf("%s = %s", call, FormatResults(results, resultTypes))
-}
-
 // FormatResults renders raw function results without a call-expression prefix.
 func FormatResults(results []uint64, resultTypes []wago.ValType) string {
 	formatted := make([]string, len(results))

--- a/cli/manager/internal/standalone/build.go
+++ b/cli/manager/internal/standalone/build.go
@@ -64,8 +64,7 @@ type Result struct {
 }
 
 var (
-	findTool    = exec.LookPath
-	toolVersion = func(path string) ([]byte, error) { return exec.Command(path, "version").Output() }
+	findTool = exec.LookPath
 )
 
 func DefaultOutput(input string, target Target) string {
@@ -205,40 +204,16 @@ func Build(request Request) (Result, error) {
 }
 
 func requireToolchain(name string) error {
-	path, err := findTool(name)
-	if err == nil {
-		version, versionErr := toolVersion(path)
-		if versionErr == nil && (name != "go" || supportedGoVersion(string(version))) {
-			return nil
-		}
+	if _, err := findTool(name); err == nil {
+		return nil
 	}
 	label, website := "Go", "https://go.dev/dl/"
 	if name == "tinygo" {
 		label, website = "TinyGo", "https://tinygo.org/getting-started/install/"
 	}
-	problem := "was not found on PATH"
-	if err == nil {
-		problem = "is unsupported or could not report its version"
-	}
-	return fmt.Errorf(`%s is required to build this executable but %s.
+	return fmt.Errorf(`%s is required to build this executable but was not found on PATH.
 
-Install it, then run this command again:
-	local (~/.wago): download the archive from %s and add its bin directory to PATH
-	global: install it with your system package manager or from %s`, label, problem, website, website)
-}
-
-func supportedGoVersion(value string) bool {
-	value = strings.TrimSpace(value)
-	fields := strings.Fields(value)
-	if len(fields) < 3 || fields[0] != "go" {
-		return false
-	}
-	version := strings.TrimPrefix(fields[2], "go")
-	major, minor := 0, 0
-	if _, err := fmt.Sscanf(version, "%d.%d", &major, &minor); err != nil {
-		return false
-	}
-	return major > 1 || major == 1 && minor >= 22
+Install %s and ensure %q is available on PATH: %s`, label, label, name, website)
 }
 
 func mainSource(providerImports []string, selections []byte, invoke string, core int, deferredBoundsChecking bool, functionWorkers int, optimizations map[string]bool, precompiled bool) []byte {

--- a/cli/manager/internal/standalone/build_test.go
+++ b/cli/manager/internal/standalone/build_test.go
@@ -22,25 +22,26 @@ func TestParseTargetAndDefaultOutput(t *testing.T) {
 	}
 }
 
-func TestRequireToolchainExplainsLocalAndGlobalInstall(t *testing.T) {
-	originalFind, originalVersion := findTool, toolVersion
-	t.Cleanup(func() { findTool, toolVersion = originalFind, originalVersion })
+func TestRequireToolchainExplainsPathRequirement(t *testing.T) {
+	originalFind := findTool
+	t.Cleanup(func() { findTool = originalFind })
 	findTool = func(string) (string, error) { return "", exec.ErrNotFound }
-	if err := requireToolchain("go"); err == nil || !strings.Contains(err.Error(), "~/.wago") || !strings.Contains(err.Error(), "https://go.dev/dl/") {
+	if err := requireToolchain("go"); err == nil || !strings.Contains(err.Error(), `"go" is available on PATH`) || !strings.Contains(err.Error(), "https://go.dev/dl/") {
 		t.Fatalf("Go toolchain error = %v", err)
 	}
-	if err := requireToolchain("tinygo"); err == nil || !strings.Contains(err.Error(), "https://tinygo.org/getting-started/install/") {
+	if err := requireToolchain("tinygo"); err == nil || !strings.Contains(err.Error(), `"tinygo" is available on PATH`) || !strings.Contains(err.Error(), "https://tinygo.org/getting-started/install/") {
 		t.Fatalf("TinyGo toolchain error = %v", err)
 	}
 }
 
-func TestRequireToolchainRejectsUnsupportedGo(t *testing.T) {
-	originalFind, originalVersion := findTool, toolVersion
-	t.Cleanup(func() { findTool, toolVersion = originalFind, originalVersion })
-	findTool = func(string) (string, error) { return "/tools/go", nil }
-	toolVersion = func(string) ([]byte, error) { return []byte("go version go1.21.9 darwin/arm64"), nil }
-	if err := requireToolchain("go"); err == nil || !strings.Contains(err.Error(), "unsupported") {
-		t.Fatalf("unsupported Go error = %v", err)
+func TestRequireToolchainAcceptsVersionFoundOnPath(t *testing.T) {
+	originalFind := findTool
+	t.Cleanup(func() { findTool = originalFind })
+	findTool = func(name string) (string, error) { return "/tools/" + name, nil }
+	for _, name := range []string{"go", "tinygo"} {
+		if err := requireToolchain(name); err != nil {
+			t.Fatalf("requireToolchain(%q) = %v", name, err)
+		}
 	}
 }
 

--- a/cli/runtime/commands/run/command.go
+++ b/cli/runtime/commands/run/command.go
@@ -131,7 +131,9 @@ func (cmd implementation) Run(ctx *command.Ctx) {
 	if err != nil {
 		ui.Fatal("%s %s", ui.Red("trap:"), trapReason(err))
 	}
-	fmt.Println(format(export, values, result, params, results))
+	if output := format(result, results); output != "" {
+		fmt.Println(output)
+	}
 }
 
 func runStart(runtime *wago.Runtime, module *wago.Module, gc wago.GCConfig, configuredGC bool) {

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -435,11 +435,11 @@ func TestRunValueParsingAndFormatting(t *testing.T) {
 			t.Errorf("parseVal(%q, %s) accepted invalid value", tc.in, tc.typ)
 		}
 	}
-	args := mustParseArgs([]string{"7", "1.5:f32"}, []wago.ValType{wago.ValI32, wago.ValI64})
-	if got := format("f", args, []uint64{wago.I64(9)}, []wago.ValType{wago.ValI32, wago.ValF32}, []wago.ValType{wago.ValI64}); got != "f(7, 1.5) = 9" {
+	_ = mustParseArgs([]string{"7", "1.5:f32"}, []wago.ValType{wago.ValI32, wago.ValI64})
+	if got := format([]uint64{wago.I64(9)}, []wago.ValType{wago.ValI64}); got != "9" {
 		t.Fatalf("format result = %q", got)
 	}
-	if got := format("g", nil, nil, nil, nil); got != "g() = ()" {
+	if got := format(nil, nil); got != "" {
 		t.Fatalf("format void = %q", got)
 	}
 	if got := trapReason(&wago.TrapError{Code: wago.TrapDivZero}); got != "integer division by zero" {

--- a/cli/runtime/commands/run/values.go
+++ b/cli/runtime/commands/run/values.go
@@ -1,9 +1,6 @@
 package run
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/wago-org/wago"
 	"github.com/wago-org/wago/cli/internal/ui"
 	"github.com/wago-org/wago/cli/internal/wasmcall"
@@ -25,18 +22,9 @@ func fmtVal(bits uint64, valueType wago.ValType) string {
 	return wasmcall.FormatValue(bits, valueType)
 }
 
-func format(export string, args, results []uint64, paramTypes, resultTypes []wago.ValType) string {
-	arguments := make([]string, len(args))
-	for index, value := range args {
-		arguments[index] = fmtVal(value, paramTypes[index])
-	}
-	call := fmt.Sprintf("%s(%s)", export, strings.Join(arguments, ", "))
+func format(results []uint64, resultTypes []wago.ValType) string {
 	if len(results) == 0 {
-		return fmt.Sprintf("%s = %s", call, ui.Dim("()"))
+		return ""
 	}
-	formatted := make([]string, len(results))
-	for index, value := range results {
-		formatted[index] = fmtVal(value, resultTypes[index])
-	}
-	return fmt.Sprintf("%s = %s", call, ui.Cyan(strings.Join(formatted, ", ")))
+	return wasmcall.FormatResults(results, resultTypes)
 }

--- a/scripts/smoke-release-assets.sh
+++ b/scripts/smoke-release-assets.sh
@@ -60,7 +60,7 @@ for runtime in "${runtimes[@]}"; do
     exit 1
   }
   output=$("$runtime" run --invoke fib "$fixture" 20)
-  [[ "$output" == "fib(20) = 6765" ]] || {
+  [[ "$output" == "6765" ]] || {
     echo "$(basename "$runtime") raw wasm smoke output: $output" >&2
     exit 1
   }
@@ -74,7 +74,7 @@ artifact="$scratch/fib.wago"
 }
 for runtime in "${runtimes[@]}"; do
   output=$("$runtime" run --allow-native-artifact --invoke fib "$artifact" 20)
-  [[ "$output" == "fib(20) = 6765" ]] || {
+  [[ "$output" == "6765" ]] || {
     echo "$(basename "$runtime") .wago smoke output: $output" >&2
     exit 1
   }

--- a/tests/scripts/release-qualification.sh
+++ b/tests/scripts/release-qualification.sh
@@ -101,7 +101,7 @@ if [[ "\${1:-}" == "run" ]]; then
   if [[ "\$*" == *".wago"* && "\$*" != *"--allow-native-artifact"* ]]; then
     exit 1
   fi
-  printf 'fib(20) = 6765\n'
+  printf '6765\n'
   exit 0
 fi
 exit 1


### PR DESCRIPTION
## Summary

- accept whichever `go` and `tinygo` executables resolve from `PATH`, without Wago-managed version probing
- simplify missing-toolchain guidance to require the executable on `PATH`
- print invocation return values only; void functions print nothing
- update release smoke tests and CI expectations to the raw-output contract

## Root cause

Standalone preflight resolved Go from `PATH`, then rejected it through a second Wago-specific version probe.

## Validation

- `go test ./...`
- real Go standalone `fib.wasm` build and execution: `6765`
- real TinyGo standalone `fib.wasm` build and execution: `6765`
- runtime CLI execution: `6765`
- `bash tests/scripts/release-qualification.sh`
- actionlint with repository baseline ignores
- `git diff --check`