### PR TITLE
ci: disable coverage jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,58 +537,6 @@ jobs:
             test "$out" = "6765"
           done
 
-  # Coverage is deliberately kept off pull requests and runs after code changes
-  # land on main. The size job remains a separate pull-request and main gate.
-  coverage:
-    name: Coverage
-    needs: changes
-    if: github.event_name == 'push' && needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          # No go.sum (stdlib-only module) -> nothing to cache; avoids a warning.
-          cache: false
-
-      - name: Initialize Release 3 suite
-        run: git submodule update --init --depth=1 tests/spec-v3
-
-      # Coverage executes the same Core 3 tests as the native matrix, including
-      # source forms that require the official interpreter fallback.
-      - name: Install Release 3 interpreter toolchain
-        run: sudo apt-get update && sudo apt-get install -y ocaml-nox ocaml-dune menhir
-
-      - name: Bootstrap pinned Core 3 tools
-        run: |
-          scripts/bootstrap-wabt.sh --verify
-          echo "$(dirname "$(scripts/bootstrap-wabt.sh --print-path)")" >> "$GITHUB_PATH"
-          interpreter="$(scripts/bootstrap-spec-interpreter.sh --print-path)"
-          scripts/bootstrap-spec-interpreter.sh --verify
-          echo "WAGO_SPEC_INTERPRETER=$interpreter" >> "$GITHUB_ENV"
-          echo "WAGO_SPEC_INTERPRETER_REVISION=$(scripts/bootstrap-spec-interpreter.sh --print-revision)" >> "$GITHUB_ENV"
-
-      # Coverage merges normal, focused wago_gcstats collector, guard-page,
-      # spec1, spec2, and SIMD gates after the change reaches main.
-      # The spec card still renders its own per-version accounting afterward.
-      - name: Produce card fragments
-        run: make card-fragments
-
-      - name: Upload card fragments
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: card-fragments
-          path: ci-card
-          if-no-files-found: error
-
-      - name: Upload coverage profile
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: coverage
-          path: coverage.out
-          if-no-files-found: error
-
   size:
     name: Build size
     needs: changes
@@ -633,7 +581,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [changes, docs, lint, regression-corpus, runtime-concurrency, race, platform-test, core-v2, core-v3, tinygo, coverage, size]
+    needs: [changes, docs, lint, regression-corpus, runtime-concurrency, race, platform-test, core-v2, core-v3, tinygo, size]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -109,6 +109,17 @@ func TestAggregateCIRequiresEveryWorkflowJob(t *testing.T) {
 	}
 }
 
+func TestCIDoesNotScheduleCoverage(t *testing.T) {
+	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobs := workflowJobBlocks(string(workflow))
+	if _, ok := jobs["coverage"]; ok {
+		t.Fatal("CI must not schedule the coverage job for pull requests or main")
+	}
+}
+
 func workflowJobBlocks(workflow string) map[string]string {
 	lines := strings.Split(workflow, "\n")
 	jobLine := regexp.MustCompile(`^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$`)

--- a/tests/scripts/release-qualification.sh
+++ b/tests/scripts/release-qualification.sh
@@ -9,7 +9,7 @@ source_sha=0123456789abcdef0123456789abcdef01234567
 run_id=123456
 version=v1.2.3-beta.1
 repository=wago-org/wago
-success_needs='{"changes":{"result":"success"},"docs":{"result":"success"},"lint":{"result":"success"},"regression-corpus":{"result":"success"},"runtime-concurrency":{"result":"success"},"race":{"result":"success"},"platform-test":{"result":"success"},"core-v2":{"result":"success"},"core-v3":{"result":"success"},"tinygo":{"result":"success"},"coverage":{"result":"success"},"size":{"result":"success"}}'
+success_needs='{"changes":{"result":"success"},"docs":{"result":"success"},"lint":{"result":"success"},"regression-corpus":{"result":"success"},"runtime-concurrency":{"result":"success"},"race":{"result":"success"},"platform-test":{"result":"success"},"core-v2":{"result":"success"},"core-v3":{"result":"success"},"tinygo":{"result":"success"},"size":{"result":"success"}}'
 
 CI_NEEDS="$success_needs" \
 CI_REPOSITORY="$repository" \

--- a/tests/tools/release-qualification/main.go
+++ b/tests/tools/release-qualification/main.go
@@ -27,7 +27,7 @@ var (
 
 var requiredJobs = []string{
 	"changes", "docs", "lint", "regression-corpus", "runtime-concurrency",
-	"race", "platform-test", "core-v2", "core-v3", "tinygo", "coverage", "size",
+	"race", "platform-test", "core-v2", "core-v3", "tinygo", "size",
 }
 
 type qualificationJob struct {


### PR DESCRIPTION
## Summary

- remove the CI coverage job for pull requests and `main`
- remove coverage from the aggregate CI and release qualification contract
- retain local coverage tooling (`make cover`) for explicit use
- add a policy test preventing the CI coverage job from returning

## Validation

- `go test ./tests/cipolicy ./tests/tools/release-qualification -count=1`
- `bash tests/scripts/release-qualification.sh`
- actionlint with repository baseline ignores
- `git diff --check`