### PR TITLE
ci: stop docs-only overtesting and stabilize Windows cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,13 @@ jobs:
           # Avoid a separate PR-files API call; compare the checked-out merge
           # ref with the base SHA from the pull_request event instead.
           token: ''
+          # Every change validates documentation. Code additionally requires
+          # every exclusion below to match, so documentation-only changes do
+          # not schedule the native matrix.
+          predicate-quantifier: 'every'
           filters: |
             docs:
-              - '**/*.md'
-              - 'docs/**'
-              - 'LICENSE'
+              - '**'
             code:
               - '**'
               - '!**/*.md'
@@ -58,9 +60,9 @@ jobs:
   docs:
     name: Documentation
     needs: changes
-    # Code-only changes can delete or rename a path referenced by unchanged
-    # documentation, so validate both documentation and executable changes.
-    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.code == 'true'
+    # Code changes can delete or rename a path referenced by unchanged
+    # documentation, so every change validates documentation.
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,10 @@ go test ./...
 (cd bench && go test ./...)
 ```
 
+CI validates documentation for every change. Changes limited to Markdown,
+`LICENSE`, or `docs/` paths skip the native code matrix; mixed or executable
+changes run both documentation validation and the full matrix.
+
 For CLI changes, also build and run these checks:
 
 ```bash

--- a/cli/manager/internal/self/replace/cleanup_windows_test.go
+++ b/cli/manager/internal/self/replace/cleanup_windows_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+const deferredCleanupTestTimeout = 45 * time.Second
+
 func TestTargetRemovalScriptWaitsThenRemovesTargets(t *testing.T) {
 	script := targetRemovalScript(1234, []string{`C:\Users\A'lice\.wago`, `C:\Users\A'lice\.local\bin\wago.exe`}, `C:\Users\A'lice\.local\bin\.wago-release.lock`, nil, syscall.ByHandleFileInformation{}, "test-operation", 1)
 	if strings.Index(script, "[WagoLockIdentity]::WaitForParent(") < strings.Index(script, "$lock.Lock(0, 1)") {
@@ -25,6 +27,7 @@ func TestTargetRemovalScriptWaitsThenRemovesTargets(t *testing.T) {
 		`Remove-WagoTarget 'C:\Users\A''lice\.wago'`,
 		`Remove-WagoTarget 'C:\Users\A''lice\.local\bin\wago.exe'`,
 		`Start-Sleep -Milliseconds 250`,
+		`$attempt -lt 80`,
 		`Remove-Item -LiteralPath $PSCommandPath -Force`,
 	} {
 		if !strings.Contains(script, want) {
@@ -82,7 +85,7 @@ func TestScheduleTargetRemovalDeletesContainingDirectoryAfterExit(t *testing.T) 
 	if err := lock.Close(); err != nil {
 		t.Fatal(err)
 	}
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(deferredCleanupTestTimeout)
 	for time.Now().Before(deadline) {
 		if _, err := os.Stat(root); os.IsNotExist(err) {
 			return
@@ -141,7 +144,7 @@ func TestScheduleTargetRemovalFindsRunningPayload(t *testing.T) {
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("run payload cleanup child: %v\n%s", err, output)
 	}
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(deferredCleanupTestTimeout)
 	for time.Now().Before(deadline) {
 		_, releaseErr := os.Stat(releases)
 		_, launcherErr := os.Stat(launcher)

--- a/cli/manager/internal/self/replace/replace_windows.go
+++ b/cli/manager/internal/self/replace/replace_windows.go
@@ -254,7 +254,7 @@ try {
             }
             return
         }
-        for ($attempt = 0; $attempt -lt 20 -and (Test-Path -LiteralPath $path); $attempt++) {
+        for ($attempt = 0; $attempt -lt 80 -and (Test-Path -LiteralPath $path); $attempt++) {
             Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
             if (Test-Path -LiteralPath $path) { Start-Sleep -Milliseconds 250 }
         }

--- a/internal/managedrelease/leases.go
+++ b/internal/managedrelease/leases.go
@@ -85,7 +85,7 @@ func pruneReleases(root string, record Record) error {
 		name := entry.Name()
 		path := filepath.Join(directory, name)
 		if strings.HasPrefix(name, ".retired-release-") {
-			if err := os.RemoveAll(path); err != nil {
+			if err := removeRetiredDirectory(path); err != nil {
 				return err
 			}
 			continue
@@ -132,7 +132,7 @@ func pruneReleases(root string, record Record) error {
 		}
 		// The lease name disappeared before unlock, so old waiters and fresh
 		// launchers cannot acquire a valid lease on this retired directory.
-		if err := os.RemoveAll(retired); err != nil {
+		if err := removeRetiredDirectory(retired); err != nil {
 			return err
 		}
 	}

--- a/internal/managedrelease/platform_unix.go
+++ b/internal/managedrelease/platform_unix.go
@@ -35,6 +35,7 @@ func inheritLease(lease *filelock.Lock) error {
 }
 
 func renameRetiredDirectory(path, retired string) error { return os.Rename(path, retired) }
+func removeRetiredDirectory(path string) error          { return os.RemoveAll(path) }
 
 func leaseHandoff(lease *filelock.Lock) (string, error) {
 	if lease == nil {

--- a/internal/managedrelease/platform_windows.go
+++ b/internal/managedrelease/platform_windows.go
@@ -12,6 +12,11 @@ import (
 	"github.com/wago-org/wago/internal/filelock"
 )
 
+const (
+	windowsFilesystemRetryDelay   = 10 * time.Millisecond
+	windowsFilesystemRetryTimeout = 5 * time.Second
+)
+
 // Files and selection use MOVEFILE_WRITE_THROUGH; Go does not expose a portable
 // directory fsync on Windows.
 func syncDirectory(string) error { return nil }
@@ -32,17 +37,30 @@ func inheritLease(*filelock.Lock) error { return nil }
 // A racing nonblocking lease opener closes its child handle after observing
 // retirement. Bound the wait for that Windows directory-sharing restriction.
 func renameRetiredDirectory(path, retired string) error {
-	var err error
-	for attempt := 0; attempt < 32; attempt++ {
-		err = os.Rename(path, retired)
-		if err == nil || (!errors.Is(err, syscall.ERROR_ACCESS_DENIED) && !errors.Is(err, syscall.Errno(32))) {
+	return retryWindowsFilesystemOperation(func() error { return os.Rename(path, retired) })
+}
+
+func removeRetiredDirectory(path string) error {
+	return retryWindowsFilesystemOperation(func() error { return os.RemoveAll(path) })
+}
+
+func retryWindowsFilesystemOperation(operation func() error) error {
+	deadline := time.Now().Add(windowsFilesystemRetryTimeout)
+	for {
+		err := operation()
+		if err == nil || os.IsNotExist(err) {
+			return nil
+		}
+		if !errors.Is(err, syscall.ERROR_ACCESS_DENIED) &&
+			!errors.Is(err, syscall.Errno(32)) &&
+			!errors.Is(err, syscall.Errno(33)) {
 			return err
 		}
-		if attempt != 31 {
-			time.Sleep(10 * time.Millisecond)
+		if !time.Now().Before(deadline) {
+			return err
 		}
+		time.Sleep(windowsFilesystemRetryDelay)
 	}
-	return err
 }
 
 func leaseHandoff(*filelock.Lock) (string, error) { return "", nil }

--- a/internal/managedrelease/platform_windows_test.go
+++ b/internal/managedrelease/platform_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package managedrelease
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+)
+
+func TestRetryWindowsFilesystemOperationRetriesSharingViolations(t *testing.T) {
+	attempts := 0
+	err := retryWindowsFilesystemOperation(func() error {
+		attempts++
+		if attempts < 3 {
+			return syscall.ERROR_ACCESS_DENIED
+		}
+		return nil
+	})
+	if err != nil || attempts != 3 {
+		t.Fatalf("retry result: attempts=%d, err=%v", attempts, err)
+	}
+
+	want := errors.New("permanent failure")
+	attempts = 0
+	err = retryWindowsFilesystemOperation(func() error {
+		attempts++
+		return want
+	})
+	if !errors.Is(err, want) || attempts != 1 {
+		t.Fatalf("non-retryable result: attempts=%d, err=%v", attempts, err)
+	}
+}

--- a/tests/cipolicy/workflows_test.go
+++ b/tests/cipolicy/workflows_test.go
@@ -337,12 +337,29 @@ func TestDocsChangesRunDocumentationValidation(t *testing.T) {
 	contents := string(workflow)
 	for _, required := range []string{
 		`docs: ${{ steps.derive.outputs.docs }}`,
-		`if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.code == 'true'`,
+		`if: needs.changes.outputs.docs == 'true'`,
 		`run: make docs-check`,
 		`needs: [changes, docs, lint, regression-corpus`,
 	} {
 		if !strings.Contains(contents, required) {
 			t.Errorf("CI workflow is missing docs-validation policy %q", required)
+		}
+	}
+}
+
+func TestDocsOnlyChangesSkipCodeMatrix(t *testing.T) {
+	workflow, err := os.ReadFile(filepath.Clean("../../.github/workflows/ci.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(workflow)
+	for _, required := range []string{
+		`predicate-quantifier: 'every'`,
+		"docs:\n              - '**'",
+		"code:\n              - '**'\n              - '!**/*.md'\n              - '!docs/**'\n              - '!LICENSE'",
+	} {
+		if !strings.Contains(contents, required) {
+			t.Errorf("CI workflow is missing docs-only gating policy %q", required)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- classify documentation-only changes correctly so they run documentation validation without scheduling the native code matrix
- allow cold Windows deferred-cleanup workers enough bounded startup/deletion time
- retry transient Windows access/sharing violations while removing retired releases

## Cause

`dorny/paths-filter` defaults to any-pattern matching. The positive `**` code rule therefore won even when a later negative Markdown rule matched, so every README edit ran the full matrix. Separately, the Windows cleanup integration test allowed 10 seconds even though its detached PowerShell worker dynamically compiles its lock-identity helper before cleanup; loaded hosted runners repeatedly crossed that bound. Windows can also retain an executable image lock briefly after process exit, and final retired-directory removal did not retry it.

## Proof

- red before fix: `go test ./tests/cipolicy -run TestDocsOnlyChangesSkipCodeMatrix -count=1`
- green after fix: `go test ./tests/cipolicy ./internal/managedrelease ./cli/manager/internal/self/replace -count=1`
- full suite: `go test ./... -count=1`
- documentation: `make docs-check`
- lint: `make lint` (gofmt, go vet, generated facade, JS policy tests passed; local staticcheck was unavailable)
- Windows amd64 and arm64 test binaries cross-compiled for both affected packages

## Notes

The Windows cleanup path is cold/background-only; this changes no JIT or runtime hot path and needs no benchmark. The native Windows CI jobs are the execution proof.

AI-assisted: diagnosis, focused tests, implementation, and verification were performed with Codex and reviewed against the failed run logs.