### PR TITLE
Fix strict input handling and ARM64 indexed bulk bounds

### DIFF
--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -445,6 +445,7 @@ type installerReleaseCatalog struct{ installer *installer }
 const (
 	installerReleasePageSize  = 20
 	installerReleasePageLimit = 50
+	installerReleaseJSONLimit = int64(4 << 20)
 )
 
 func (catalog installerReleaseCatalog) Latest() (installbootstrap.Release, error) {
@@ -481,7 +482,11 @@ func (catalog installerReleaseCatalog) Releases() ([]installbootstrap.Release, e
 }
 
 func (i *installer) getJSON(url string, value any) error {
-	response, err := i.httpClient.Get(url)
+	request, err := http.NewRequestWithContext(i.installContext(), http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	response, err := i.httpClient.Do(request)
 	if err != nil {
 		return err
 	}
@@ -489,7 +494,22 @@ func (i *installer) getJSON(url string, value any) error {
 	if response.StatusCode/100 != 2 {
 		return fmt.Errorf("%s returned %s", url, response.Status)
 	}
-	return json.NewDecoder(io.LimitReader(response.Body, 4<<20)).Decode(value)
+	limited := &io.LimitedReader{R: response.Body, N: installerReleaseJSONLimit + 1}
+	decoder := json.NewDecoder(limited)
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("release metadata contains multiple JSON values")
+		}
+		return fmt.Errorf("release metadata contains trailing data: %w", err)
+	}
+	if limited.N == 0 {
+		return fmt.Errorf("release metadata exceeds %d-byte limit", installerReleaseJSONLimit)
+	}
+	return nil
 }
 
 func (i *installer) downloadChecked(url, target string) error {

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,6 +17,12 @@ import (
 	"testing"
 	"time"
 )
+
+type installerRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn installerRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
 
 func TestInstallerMovesPayloadsAcrossFilesystems(t *testing.T) {
 	downloadRoot := t.TempDir()
@@ -92,6 +99,42 @@ func TestInstallerMovesPayloadsAcrossFilesystems(t *testing.T) {
 		if matches, err := filepath.Glob(pattern); err != nil || len(matches) != 0 {
 			t.Fatalf("temporary paths for %q = %v, %v", pattern, matches, err)
 		}
+	}
+}
+
+func TestInstallerReleaseMetadataHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	i := &installer{
+		ctx: ctx,
+		httpClient: &http.Client{Transport: installerRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return nil, request.Context().Err()
+		})},
+	}
+	var value any
+	if err := i.getJSON("https://example.invalid/releases", &value); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled release metadata request = %v, want context.Canceled", err)
+	}
+}
+
+func TestInstallerReleaseMetadataRejectsTrailingAndOversizedData(t *testing.T) {
+	for name, body := range map[string]string{
+		"trailing value":  "{}{}",
+		"over byte limit": "{}" + strings.Repeat(" ", int(installerReleaseJSONLimit)+1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			i := &installer{httpClient: &http.Client{Transport: installerRoundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Body:       io.NopCloser(strings.NewReader(body)),
+				}, nil
+			})}}
+			var value any
+			if err := i.getJSON("https://example.invalid/releases", &value); err == nil {
+				t.Fatal("invalid release metadata accepted")
+			}
+		})
 	}
 }
 

--- a/cli/internal/settings/catalog.go
+++ b/cli/internal/settings/catalog.go
@@ -182,16 +182,32 @@ func validateValues(kind boolSettingKind, values map[string]bool) error {
 		prefix = "optimizations."
 		label = "optimization"
 	}
+	seen := make(map[string]string, len(values))
 	for name, enabled := range values {
 		setting, ok := Lookup(prefix + name)
 		if !ok || setting.kind != kind {
 			return fmt.Errorf("unknown %s setting %q", label, name)
+		}
+		if err := recordCanonicalSetting(seen, setting.Key, name, label); err != nil {
+			return err
 		}
 		if enabled && !setting.Available {
 			return fmt.Errorf("%s setting %q is unavailable", label, name)
 		}
 	}
 	return nil
+}
+
+func recordCanonicalSetting(seen map[string]string, canonical, name, label string) error {
+	previous, duplicate := seen[canonical]
+	if !duplicate {
+		seen[canonical] = name
+		return nil
+	}
+	if name < previous {
+		previous, name = name, previous
+	}
+	return fmt.Errorf("duplicate %s settings %q and %q", label, previous, name)
 }
 
 func ValidateFeatureValues(values map[string]bool) error {

--- a/cli/internal/settings/store.go
+++ b/cli/internal/settings/store.go
@@ -8,11 +8,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
 	"github.com/wago-org/wago/cli/internal/project"
+	"github.com/wago-org/wago/internal/atomicfile"
+	"github.com/wago-org/wago/internal/jsonstrict"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
@@ -93,6 +94,9 @@ func LoadFile(path string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	if err := jsonstrict.ValidateTypedJSON(data, &storedConfig{}); err != nil {
+		return Config{}, fmt.Errorf("decode %s: %w", path, err)
+	}
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	var stored storedConfig
@@ -105,16 +109,21 @@ func LoadFile(path string) (Config, error) {
 	if stored.Version != Version {
 		return Config{}, fmt.Errorf("unsupported settings version %d (want %d)", stored.Version, Version)
 	}
+	featureNames := make(map[string]string, len(stored.Features))
 	for name, value := range stored.Features {
 		setting, ok := Lookup("features." + name)
 		if !ok {
 			return Config{}, fmt.Errorf("unknown feature setting %q", name)
+		}
+		if err := recordCanonicalSetting(featureNames, setting.Key, name, "feature"); err != nil {
+			return Config{}, err
 		}
 		if value && !setting.Available {
 			return Config{}, fmt.Errorf("feature setting %q is unavailable", name)
 		}
 		setting.SetValue(&config, value)
 	}
+	optimizationNames := make(map[string]string, len(stored.Optimizations))
 	for name, value := range stored.Optimizations {
 		if project.IsRetiredOptimizationName(name) {
 			continue
@@ -122,6 +131,9 @@ func LoadFile(path string) (Config, error) {
 		if setting, ok := Lookup("optimizations." + name); !ok || !setting.Available {
 			return Config{}, fmt.Errorf("unknown optimization setting %q for %s", name, filepath.Base(path))
 		} else {
+			if err := recordCanonicalSetting(optimizationNames, setting.Key, name, "optimization"); err != nil {
+				return Config{}, err
+			}
 			setting.SetValue(&config, value)
 		}
 	}
@@ -139,11 +151,10 @@ func LoadFile(path string) (Config, error) {
 
 func Save(config Config) error { return SaveFile(Path(), config) }
 
+var replaceSettingsFile = atomicfile.ReplaceFile
+
 func SaveFile(path string, config Config) error {
 	if err := Validate(config); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(config, "", "  ")
@@ -151,34 +162,10 @@ func SaveFile(path string, config Config) error {
 		return err
 	}
 	data = append(data, '\n')
-	temporary, err := os.CreateTemp(filepath.Dir(path), ".settings-*.json")
-	if err != nil {
+	return replaceSettingsFile(path, atomicfile.Options{Mode: 0o644}, func(writer io.Writer) error {
+		_, err := writer.Write(data)
 		return err
-	}
-	temporaryPath := temporary.Name()
-	defer os.Remove(temporaryPath)
-	if err := temporary.Chmod(0o644); err != nil {
-		temporary.Close()
-		return err
-	}
-	if _, err := temporary.Write(data); err != nil {
-		temporary.Close()
-		return err
-	}
-	if err := temporary.Close(); err != nil {
-		return err
-	}
-	renameErr := os.Rename(temporaryPath, path)
-	if renameErr == nil {
-		return nil
-	}
-	if runtime.GOOS != "windows" {
-		return renameErr
-	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	return os.Rename(temporaryPath, path)
+	})
 }
 
 func Validate(config Config) error {

--- a/cli/internal/settings/store_test.go
+++ b/cli/internal/settings/store_test.go
@@ -1,13 +1,16 @@
 package settings
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/wago-org/wago/cli/internal/project"
+	"github.com/wago-org/wago/internal/atomicfile"
 )
 
 func TestGlobalSettingsIgnoreRetiredV1Optimizations(t *testing.T) {
@@ -56,6 +59,33 @@ func TestSettingsRoundTripAndDefaults(t *testing.T) {
 	}
 }
 
+func TestSettingsSavePreservesExistingOnReplaceFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	original := []byte(`{"version":1}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	injected := errors.New("replace failed")
+	previous := replaceSettingsFile
+	replaceSettingsFile = func(_ string, _ atomicfile.Options, write func(io.Writer) error) error {
+		if err := write(io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		return injected
+	}
+	t.Cleanup(func() { replaceSettingsFile = previous })
+	if err := SaveFile(path, Default()); !errors.Is(err, injected) {
+		t.Fatalf("SaveFile error = %v, want %v", err, injected)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("failed save changed existing settings to %q", got)
+	}
+}
+
 func TestPartialSettingsKeepBuiltInDefaults(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(path, []byte(`{"version":1,"features":{"simd":false},"runtime":{}}`), 0o644); err != nil {
@@ -67,6 +97,25 @@ func TestPartialSettingsKeepBuiltInDefaults(t *testing.T) {
 	}
 	if config.Features["simd"] || !config.Features["multi-value"] || !config.Runtime.DeferredBoundsChecking || config.Runtime.Parallel != "1" {
 		t.Fatalf("partial config did not preserve defaults: %#v", config)
+	}
+}
+
+func TestSettingsRejectDuplicateMembers(t *testing.T) {
+	for _, data := range []string{
+		`{"version":1,"version":1}`,
+		`{"version":1,"Version":1}`,
+		`{"version":1,"features":{"simd":true,"simd":false}}`,
+		`{"version":1,"features":{"simd":false,"SIMD":false}}`,
+		`{"version":1,"features":{"tail-call":false,"tail_call":false}}`,
+		`{"version":1,"optimizations":{"inline":false,"INLINE":false}}`,
+	} {
+		path := filepath.Join(t.TempDir(), "settings.json")
+		if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadFile(path); err == nil || !strings.Contains(err.Error(), "duplicate") {
+			t.Fatalf("duplicate settings members accepted: %s: %v", data, err)
+		}
 	}
 }
 

--- a/cli/manager/commands/plugin/arguments.go
+++ b/cli/manager/commands/plugin/arguments.go
@@ -1,13 +1,13 @@
 package plugin
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/wago-org/wago/cli/internal/project"
+	"github.com/wago-org/wago/internal/jsonstrict"
 )
 
 func SplitCommaList(value string) []string {
@@ -32,7 +32,7 @@ func ParseAuthorityScopeOverrides(raw string) (AuthorityScopeOverrides, error) {
 	if len(raw) > 1<<20 {
 		return nil, fmt.Errorf("--scopes JSON exceeds 1 MiB")
 	}
-	if err := rejectDuplicateJSONKeys([]byte(raw)); err != nil {
+	if err := jsonstrict.ValidateTypedJSON([]byte(raw), AuthorityScopeOverrides{}); err != nil {
 		return nil, fmt.Errorf("--scopes: %w", err)
 	}
 	decoder := json.NewDecoder(strings.NewReader(raw))
@@ -70,73 +70,4 @@ func ParseAuthorityScopeOverrides(raw string) (AuthorityScopeOverrides, error) {
 		}
 	}
 	return overrides, nil
-}
-
-func rejectDuplicateJSONKeys(raw []byte) error {
-	decoder := json.NewDecoder(bytes.NewReader(raw))
-	var walk func() error
-	walk = func() error {
-		token, err := decoder.Token()
-		if err != nil {
-			return err
-		}
-		delim, ok := token.(json.Delim)
-		if !ok {
-			return nil
-		}
-		switch delim {
-		case '{':
-			seen := map[string]struct{}{}
-			for decoder.More() {
-				keyToken, err := decoder.Token()
-				if err != nil {
-					return err
-				}
-				key, ok := keyToken.(string)
-				if !ok {
-					return fmt.Errorf("object key is not a string")
-				}
-				if _, duplicate := seen[key]; duplicate {
-					return fmt.Errorf("duplicate JSON key %q", key)
-				}
-				seen[key] = struct{}{}
-				if err := walk(); err != nil {
-					return err
-				}
-			}
-			closing, err := decoder.Token()
-			if err != nil {
-				return err
-			}
-			if closing != json.Delim('}') {
-				return fmt.Errorf("invalid JSON object")
-			}
-		case '[':
-			for decoder.More() {
-				if err := walk(); err != nil {
-					return err
-				}
-			}
-			closing, err := decoder.Token()
-			if err != nil {
-				return err
-			}
-			if closing != json.Delim(']') {
-				return fmt.Errorf("invalid JSON array")
-			}
-		default:
-			return fmt.Errorf("unexpected JSON delimiter %q", delim)
-		}
-		return nil
-	}
-	if err := walk(); err != nil {
-		return err
-	}
-	if _, err := decoder.Token(); err != io.EOF {
-		if err == nil {
-			return fmt.Errorf("multiple JSON values")
-		}
-		return err
-	}
-	return nil
 }

--- a/cli/manager/commands/plugin/arguments_test.go
+++ b/cli/manager/commands/plugin/arguments_test.go
@@ -44,6 +44,7 @@ func TestParseAuthorityScopeOverridesRejectsAmbiguousJSON(t *testing.T) {
 		`{"github.com/acme/plugin":{"host.import.define":{"modules":["env"]}},"github.com/acme/plugin":{"instance.manage":{"maxInstances":1,"maxMemoryBytes":1}}}`,
 		`{"github.com/acme/plugin":{"host.import.define":{"modules":["env"]},"host.import.define":{"modules":["clock"]}}}`,
 		`{"github.com/acme/plugin":{"instance.manage":{"maxInstances":1,"maxInstances":2,"maxMemoryBytes":1}}}`,
+		`{"github.com/acme/plugin":{"instance.manage":{"maxInstances":1,"MaxInstances":2,"maxMemoryBytes":1}}}`,
 	}
 	for _, raw := range tests {
 		if _, err := ParseAuthorityScopeOverrides(raw); err == nil {

--- a/cli/manager/internal/plugin/catalog_test.go
+++ b/cli/manager/internal/plugin/catalog_test.go
@@ -773,7 +773,6 @@ func TestHTTPCatalogRejectsExactDuplicateConfigSchemaProperties(t *testing.T) {
 		"properties":{"mode":{"type":"string"},"mode":{"type":"number"}},
 		"additionalProperties":false
 	}`)
-	release = resignRelease(t, release)
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(response).Encode(map[string]any{
 			"plugins": []CatalogRelease{release}, "total": 1, "offset": 0, "limit": 256,

--- a/src/core/compiler/backend/railshot/arm64/memory.go
+++ b/src/core/compiler/backend/railshot/arm64/memory.go
@@ -1815,11 +1815,16 @@ func (f *fn) bulkBoundsCheck(base Reg, n int, memoryIndex uint32) {
 	} else {
 		f.leaDisp(t, base, int32(n), true)
 	}
-	if f.memSizeReg != regNone {
+	if memoryIndex == 0 && f.memSizeReg != regNone {
 		f.cmpRR(t, f.memSizeReg, true)
 	} else {
 		mb := f.allocReg(maskOf(t))
-		f.ld64(mb, linMemReg, -int32(bdCurBytes))
+		if memoryIndex == 0 {
+			f.ld64(mb, linMemReg, -int32(bdCurBytes))
+		} else {
+			f.ld64(mb, linMemReg, -int32(offMemoryDirPtr))
+			f.ld64(mb, mb, int32(memoryIndex)*abi.MemoryDirEntryBytes+abi.MemoryDirCurrentBytesOffset)
+		}
 		f.cmpRR(t, mb, true)
 		f.release(mb)
 	}

--- a/src/core/compiler/backend/railshot/arm64/multimemory_bulk_exec_arm64_test.go
+++ b/src/core/compiler/backend/railshot/arm64/multimemory_bulk_exec_arm64_test.go
@@ -1,0 +1,108 @@
+//go:build (linux || darwin) && arm64
+
+package arm64
+
+import (
+	"encoding/binary"
+	"testing"
+	"unsafe"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/src/core/runtime"
+	"github.com/wago-org/wago/src/core/runtime/abi"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+func multiMemoryFillModuleArm64(t testing.TB) *wasm.Module {
+	t.Helper()
+	body := []byte{
+		0x00,
+		0x20, 0x00, 0x20, 0x01, 0x41, 0x05, // dst, value, n=5
+		0xfc, 0x0b, 0x01, // memory.fill 1
+		0x41, 0x00, 0x0b,
+	}
+	entry := append(wasmtest.ULEB(uint32(len(body))), body...)
+	memory0 := append([]byte{0x00}, wasmtest.ULEB(uint32(1))...)
+	memory1 := append([]byte{0x00}, wasmtest.ULEB(uint32(2))...)
+	b := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(
+			[]wasm.ValType{wasm.I32, wasm.I32}, []wasm.ValType{wasm.I32},
+		))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(5, wasmtest.Vec(memory0, memory1)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(entry)),
+	)
+	m, err := wasm.DecodeModule(b)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return m
+}
+
+func TestConstBulkChecksIndexedMemorySizeArm64(t *testing.T) {
+	const (
+		dst       = 1 << 16
+		fillValue = 0x5a
+		fillLen   = 5
+	)
+	m := multiMemoryFillModuleArm64(t)
+	var stats ModuleStats
+	cm, err := CompileModuleWith(m, CompileOptions{Stats: &stats})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if cm.CodeImage != nil {
+		defer cm.CodeImage.Close()
+	}
+	if stats.Funcs[0].Peephole["memfill-unroll"] != 1 {
+		t.Fatalf("constant fill fast path did not fire: %v", stats.Funcs[0].Peephole)
+	}
+	eng, err := runtime.NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+	primary, err := runtime.NewJobMemory(1 << 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer primary.Close()
+	secondary, err := runtime.NewJobMemory(2 << 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer secondary.Close()
+	ar, err := runtime.NewArena(4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ar.Close()
+
+	dir := ar.Alloc(2 * abi.MemoryDirEntryBytes)
+	for i, jm := range []*runtime.JobMemory{primary, secondary} {
+		entry := dir[i*abi.MemoryDirEntryBytes:]
+		binary.LittleEndian.PutUint64(entry[abi.MemoryDirBaseOffset:], uint64(jm.LinMemBase()))
+		binary.LittleEndian.PutUint64(entry[abi.MemoryDirCurrentBytesOffset:], uint64(len(jm.CurrentBytes())))
+		binary.LittleEndian.PutUint32(entry[abi.MemoryDirCurrentPagesOffset:], jm.CurrentPages())
+	}
+	primary.SetMemoryDirPtr(uintptr(unsafe.Pointer(&dir[0])))
+
+	code, entry, err := runtime.MapCode(cm.Code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Unmap(code)
+	serArgs := ar.Alloc(16)
+	binary.LittleEndian.PutUint64(serArgs, dst)
+	binary.LittleEndian.PutUint64(serArgs[8:], fillValue)
+	err = eng.Call(entry+uintptr(cm.Entry[0]), serArgs, primary.LinearMemory(), ar.Alloc(runtime.TrapBufferBytes), ar.Alloc(16))
+	if err != nil {
+		t.Fatalf("in-bounds fill in memory 1 trapped against memory 0 size: %v", err)
+	}
+	for i := dst; i < dst+fillLen; i++ {
+		if got := secondary.CurrentBytes()[i]; got != fillValue {
+			t.Fatalf("memory 1 byte %d = %#x, want %#x", i, got, fillValue)
+		}
+	}
+}

--- a/src/core/compiler/wasm/validate_bytebacked_bench_fuzz_test.go
+++ b/src/core/compiler/wasm/validate_bytebacked_bench_fuzz_test.go
@@ -37,6 +37,7 @@ func FuzzDecodeValidateByteBackedDifferentialGenerated(f *testing.F) {
 		{6, 1, 0, 0},
 		{0, 8, 1, 17},
 		{0, 8, 2, 23},
+		{0, 23, 2, 222}, // nonzero memory.copy index under Core 3 grammar
 		{0, 8, 3, 5},
 		{0, 8, 4, 0},
 	} {
@@ -45,8 +46,9 @@ func FuzzDecodeValidateByteBackedDifferentialGenerated(f *testing.F) {
 	f.Fuzz(func(t *testing.T, kind, funcs, mutation uint8, arg uint32) {
 		data := generatedDifferentialModule(kind, funcs)
 		data = mutateDifferentialModule(data, mutation, arg)
-		want := decodeThenValidate(data)
-		got := byteBackedDecodeThenValidate(data)
+		features := ValidationFeatures{MultiMemory: true}
+		want := decodeThenValidateWithFeatures(data, features)
+		got := byteBackedDecodeThenValidateWithFeatures(data, features)
 		if (want == nil) != (got == nil) {
 			t.Fatalf("AST decode+ValidateModule=%v byte-backed decode+validate=%v", want, got)
 		}
@@ -57,6 +59,22 @@ func FuzzDecodeValidateByteBackedDifferentialGenerated(f *testing.F) {
 		// acceptance. Focused edge tests above pin phases where phase is part of
 		// the intended behavior.
 	})
+}
+
+func decodeThenValidateWithFeatures(data []byte, features ValidationFeatures) error {
+	m, err := decodeModuleASTWithFeaturesForTest(data, features)
+	if err != nil {
+		return err
+	}
+	return ValidateModuleWithFeatures(m, features)
+}
+
+func byteBackedDecodeThenValidateWithFeatures(data []byte, features ValidationFeatures) error {
+	dm, err := DecodeModuleByteBackedWithFeatures(data, features)
+	if err != nil {
+		return err
+	}
+	return ValidateDecodedByteBackedModuleWithFeatures(dm, features)
 }
 
 func generatedDifferentialModule(kind, funcs uint8) []byte {

--- a/src/wago/extension.go
+++ b/src/wago/extension.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/wago-org/wago/internal/jsonstrict"
 	"github.com/wago-org/wago/internal/namecheck"
 	"github.com/wago-org/wago/src/core/semver"
 )
@@ -349,6 +350,9 @@ func canonicalPluginDefinition(def PluginDefinition) (PluginDefinition, error) {
 }
 
 func canonicalJSON(raw []byte) ([]byte, error) {
+	if err := jsonstrict.ValidateUniqueJSON(raw); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
 	var value any

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/wago-org/wago/internal/jsonstrict"
 	"github.com/wago-org/wago/src/core/semver"
 )
 
@@ -224,8 +225,10 @@ func validateImmutablePlan(set PluginSet) (*immutablePlan, error) {
 		if selection.DefinitionDigest != plan.digests[selection.ID] {
 			return nil, &PluginError{Plugin: selection.ID, Phase: PluginPhaseValidate, Path: "definitionDigest", Err: fmt.Errorf("linked definition digest %q does not match reviewed digest %q", plan.digests[selection.ID], selection.DefinitionDigest)}
 		}
-		if len(selection.Config) != 0 && !json.Valid(selection.Config) {
-			return nil, &PluginError{Plugin: selection.ID, Phase: PluginPhaseConfigure, Path: "config", Err: fmt.Errorf("invalid JSON")}
+		if len(selection.Config) != 0 {
+			if err := jsonstrict.ValidateUniqueJSON(selection.Config); err != nil {
+				return nil, &PluginError{Plugin: selection.ID, Phase: PluginPhaseConfigure, Path: "config", Err: err}
+			}
 		}
 		if err := validateGrants(provider.Definition, selection.Grants); err != nil {
 			return nil, &PluginError{Plugin: selection.ID, Phase: PluginPhaseAuthorize, Err: err}

--- a/src/wago/plugin_vnext_test.go
+++ b/src/wago/plugin_vnext_test.go
@@ -77,7 +77,11 @@ func TestDefinitionDigestCanonicalAndStrict(t *testing.T) {
 	if da != db || !strings.HasPrefix(da, "sha256:") {
 		t.Fatalf("digests %q %q", da, db)
 	}
-	for _, raw := range []string{`{} garbage`, `{} {}`} {
+	for _, raw := range []string{
+		`{} garbage`,
+		`{} {}`,
+		`{"type":"object","type":"object","additionalProperties":false}`,
+	} {
 		broken := a
 		broken.ConfigSchema = []byte(raw)
 		if _, err := DefinitionDigest(broken); err == nil {
@@ -686,6 +690,13 @@ func TestConfigStrictAndRegistrarSealed(t *testing.T) {
 	if err := NewRuntime().LoadPlugins(context.Background(), set); err == nil {
 		t.Fatal("trailing config accepted")
 	}
+	for _, config := range []string{`{"limit":1,"limit":2}`, `{"limit":1,"Limit":2}`} {
+		set = testSet(t, provider)
+		set.Selections[0].Config = []byte(config)
+		if err := NewRuntime().LoadPlugins(context.Background(), set); err == nil {
+			t.Fatalf("duplicate config accepted: %s", config)
+		}
+	}
 	set = testSet(t, provider)
 	set.Selections[0].Config = []byte(`{"limit":1}`)
 	rt := NewRuntime()
@@ -694,6 +705,18 @@ func TestConfigStrictAndRegistrarSealed(t *testing.T) {
 	}
 	if err := handle.Observe(func(ModuleCompiledEvent) {}); err == nil {
 		t.Fatal("sealed handle mutated registration")
+	}
+}
+
+func TestPluginPlanRejectsDuplicateOpaqueConfig(t *testing.T) {
+	provider := PluginProvider{
+		Definition: testDefinition("example.com/config/unused"),
+		New:        func() Plugin { return pluginFunc(func(*Registrar) error { return nil }) },
+	}
+	set := testSet(t, provider)
+	set.Selections[0].Config = []byte(`{"value":1,"value":2}`)
+	if err := NewRuntime().LoadPlugins(context.Background(), set); err == nil {
+		t.Fatal("duplicate opaque config accepted")
 	}
 }
 

--- a/src/wago/provider_catalog.go
+++ b/src/wago/provider_catalog.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/wago-org/wago/internal/jsonstrict"
 )
 
 const (
@@ -90,6 +92,9 @@ func EncodeProviderCatalog(importPath string, providers []PluginProvider) ([]byt
 func DecodeProviderCatalog(encoded []byte) (ProviderCatalogDocument, error) {
 	if len(encoded) == 0 || len(encoded) > 2<<20 {
 		return ProviderCatalogDocument{}, errors.New("wago: provider catalog must contain 1 byte to 2 MiB")
+	}
+	if err := jsonstrict.ValidateTypedJSON(encoded, ProviderCatalogDocument{}); err != nil {
+		return ProviderCatalogDocument{}, fmt.Errorf("wago: decode provider catalog: %w", err)
 	}
 	decoder := json.NewDecoder(bytes.NewReader(encoded))
 	decoder.DisallowUnknownFields()

--- a/src/wago/provider_catalog_test.go
+++ b/src/wago/provider_catalog_test.go
@@ -253,10 +253,12 @@ func TestDecodeProviderCatalogRejectsNoncanonicalArtifacts(t *testing.T) {
 	}
 
 	for name, raw := range map[string][]byte{
-		"unknown document field":   bytes.Replace(encoded, []byte(`"providers":`), []byte(`"future":true,"providers":`), 1),
-		"unknown entry field":      bytes.Replace(encoded, []byte(`"importPath":`), []byte(`"future":true,"importPath":`), 1),
-		"unknown definition field": bytes.Replace(encoded, []byte(`"version": "1.2.3"`), []byte(`"version": "1.2.3", "future": true`), 1),
-		"trailing value":           append(append([]byte(nil), encoded...), []byte("{}")...),
+		"unknown document field":    bytes.Replace(encoded, []byte(`"providers":`), []byte(`"future":true,"providers":`), 1),
+		"unknown entry field":       bytes.Replace(encoded, []byte(`"importPath":`), []byte(`"future":true,"importPath":`), 1),
+		"unknown definition field":  bytes.Replace(encoded, []byte(`"version": "1.2.3"`), []byte(`"version": "1.2.3", "future": true`), 1),
+		"duplicate document field":  bytes.Replace(encoded, []byte(`"providers":`), []byte(`"$schema":"`+ProviderCatalogSchemaURI+`","providers":`), 1),
+		"case alias document field": bytes.Replace(encoded, []byte(`"providers":`), []byte(`"$Schema":"`+ProviderCatalogSchemaURI+`","providers":`), 1),
+		"trailing value":            append(append([]byte(nil), encoded...), []byte("{}")...),
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := DecodeProviderCatalog(raw); err == nil {

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/wago-org/wago/internal/jsonstrict"
 )
 
 // Registrar is the declarative builder passed to Plugin.Register. It is scoped
@@ -85,6 +87,9 @@ func (r *Registrar) Config(dst any) error {
 	b := r.config
 	if len(b) == 0 {
 		b = []byte("{}")
+	}
+	if err := jsonstrict.ValidateTypedJSON(b, dst); err != nil {
+		return &PluginError{Plugin: r.definition.ID, Phase: PluginPhaseConfigure, Path: "config", Err: err}
 	}
 	dec := json.NewDecoder(bytes.NewReader(b))
 	dec.DisallowUnknownFields()

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -651,6 +651,9 @@ func (p *PreparedCompile) Compile() (*Module, error) {
 // ownership. A failed adoption closes the artifact exactly once.
 func (p *PreparedCompile) Adopt(c *Compiled) (*Module, error) {
 	if err := p.consume(); err != nil {
+		if c != nil {
+			err = joinPrimary(err, c.Close())
+		}
 		return nil, err
 	}
 	defer p.finish()
@@ -731,7 +734,7 @@ func (rt *Runtime) Module(c *Compiled) (*Module, error) {
 func (rt *Runtime) AdoptModule(c *Compiled) (*Module, error) {
 	mod, err := rt.bindModule(c, true)
 	if err != nil && c != nil {
-		_ = c.Close()
+		err = joinPrimary(err, c.Close())
 	}
 	return mod, err
 }

--- a/src/wago/runtime_hardening_test.go
+++ b/src/wago/runtime_hardening_test.go
@@ -1,6 +1,7 @@
 package wago
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"reflect"
@@ -210,6 +211,29 @@ func TestPreparedCompileAdoptNilConsumesPreparation(t *testing.T) {
 	}
 	if _, err := prepared.Compile(); err == nil || !strings.Contains(err.Error(), "already consumed") {
 		t.Fatalf("Compile after Adopt(nil) = %v", err)
+	}
+}
+
+func TestPreparedCompileFailedAdoptClosesArtifact(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	prepared, err := rt.PrepareCompile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := prepared.Close(); err != nil {
+		t.Fatal(err)
+	}
+	compiled, err := Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepared.Adopt(compiled); err == nil || !strings.Contains(err.Error(), "already consumed") {
+		t.Fatalf("Adopt after Close = %v", err)
+	}
+	var code bytes.Buffer
+	if _, err := compiled.WriteCodeTo(&code); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("rejected compiled artifact remains open: %v", err)
 	}
 }
 


### PR DESCRIPTION
A correctness audit found several inputs and failure paths that could produce wrong or ambiguous behavior. This change rejects those inputs, preserves owned resources and settings files on failure, and fixes ARM64 indexed bulk-memory bounds checks.

## Changes

- Check the selected memory-directory entry for ARM64 constant `memory.fill` and `memory.copy` operations. A valid operation on memory 1 no longer traps against memory 0's smaller size.
- Close artifacts rejected by `PreparedCompile.Adopt`, and retain cleanup errors from `Runtime.AdoptModule`.
- Reject duplicate JSON fields and case aliases in global settings, plugin configuration, provider catalogs, config schemas, and `--scopes`. Also reject different setting spellings that normalize to the same key.
- Replace the Windows settings delete-then-rename fallback with the platform atomic-file helper, so a failed replacement keeps the prior settings file.
- Bind installer metadata requests to the install context and enforce one complete JSON value within the 4 MiB limit.
- Give both sides of the byte-backed differential fuzzer the same multi-memory feature policy.

## Validation

Passed:

- `go test -skip '^(TestWineCmdBootstrapDownloadsVerifiesAndExecutesInstaller|TestBuildTinyGoEmbedsArtifactWithoutCompiler|TestBuildTinyGoStripsByDefault|TestStaged.*)$' ./...`
- `(cd bench && go test ./...)`
- focused package tests for the installer, settings, plugin manager, JSON validator, Wasm validator, Railshot, and public runtime
- race tests for all changed portable packages
- `go vet` for all changed packages
- Linux/ARM64 Railshot and Windows/AMD64 CLI package cross-compiles
- manager/runtime builds and the documented fib, hypot, artifact, and validation smoke tests
- 15-second byte-backed differential fuzz run: about 1.67 million executions

The unfiltered `go test ./...` was also run. Its remaining failures require unavailable host tools: Wine could not download the installer, TinyGo's local cache links a duplicate `tinygo_task_exit`, and local WABT cannot parse the pinned Core 3 files without `WAGO_SPEC_INTERPRETER`.

## Performance and memory

The memory 0 hot path emits the same sequence. Each affected nonzero-memory unrolled bounds check adds one or two 4-byte ARM64 metadata loads, depending on whether the memory 0 size was cached. It adds no runtime allocation. Native ARM64 timing was not available on this x86_64 host.

## Documentation

Documentation is unchanged. These fixes enforce existing ownership, strict-input, size-limit, and multi-memory contracts; they do not change feature support or workflow.

## AI assistance

AI-assisted review was used to search for bug patterns, draft regression tests, and inspect the patch. Every changed line and reported test result was reviewed.
