### PR TITLE
test: repair helper import after test layout merge

### DIFF
--- a/src/wago/global_trap_test.go
+++ b/src/wago/global_trap_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	wruntime "github.com/wago-org/wago/src/core/runtime"
-	"github.com/wago-org/wago/tests/wasmtest"
+	"github.com/wago-org/wago/tests/support/wasmtest"
 )
 
 func TestGlobalWritesSurviveTrap(t *testing.T) {


### PR DESCRIPTION
## Why

PR #581 added the global trap regression test using the then-current tests/wasmtest helper path. PR #573 subsequently moved shared helpers under tests/support, so the integrated main revision referenced a package that no longer exists. Package loading then failed across lint, ordinary tests, cross-platform jobs, and standalone consumer tests.

## What

Update global_trap_test.go to import tests/support/wasmtest, matching the unified test layout. A repository-wide scan found no other legacy helper imports.

## Proof

- go test ./src/wago -run TestGlobalWritesSurviveTrap -count=1
- go test ./cli/manager/internal/standalone -run TestBuildEmbedsArtifactWithoutCompiler -count=1
- make test
- make lint
- make docs-check

## Docs

Not needed; this corrects an internal test-helper import after a directory move.