### PR TITLE
bench: publish host call latency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ WAZERO_BENCH_RE ?= [Ww]azero
 BENCH_RE_all      := .
 BENCH_RE_pipeline := ^Benchmark(Decode|Validate|Compile|CompileFull|Instantiate)$$
 BENCH_RE_compile  := ^Benchmark(Decode|Validate|Compile|CompileFull)$$
-BENCH_RE_exec     := ^Benchmark(Exec|CommandExec)$$
+BENCH_RE_exec     := ^Benchmark(Exec|CommandExec)$$|^BenchmarkExec(CallOverhead|HostRoundtrip)_
 BENCH_RE          := $(or $(BENCH_RE_$(BENCH)),$(BENCH))
 # Where `make cover` writes the coverage profile, and where `make card` collects
 # section fragments / writes the assembled PR card.

--- a/bench/cmd/benchpub/main.go
+++ b/bench/cmd/benchpub/main.go
@@ -27,7 +27,7 @@ import (
 // suiteRegex selects the wago stage suite plus the cross-engine wazero
 // benchmarks (compare_test.go). The fixed wago-vs-wazero set in bench_test.go is
 // excluded — these fan out over the same corpus as the wago stages.
-const suiteRegex = `^(BenchmarkDecode|BenchmarkValidate|BenchmarkCompile|BenchmarkCompileFull|BenchmarkInstantiate|BenchmarkExec|BenchmarkCommandExec|BenchmarkWazeroCompile|BenchmarkWazeroInstantiate|BenchmarkWazeroExec|BenchmarkWazeroCommandExec)$`
+const suiteRegex = `^(BenchmarkDecode|BenchmarkValidate|BenchmarkCompile|BenchmarkCompileFull|BenchmarkInstantiate|BenchmarkExec|BenchmarkCommandExec|BenchmarkWazeroCompile|BenchmarkWazeroInstantiate|BenchmarkWazeroExec|BenchmarkWazeroCommandExec|BenchmarkExecCallOverhead_(wago|wazero)|BenchmarkExecHostRoundtrip_(wago|wazero))$`
 
 // stampPath (bench-relative — benchpub runs with cwd=bench/) records the commit
 // the last published/charted numbers reflect and the wall-clock time benchpub

--- a/bench/cmd/benchpub/main_test.go
+++ b/bench/cmd/benchpub/main_test.go
@@ -1,6 +1,26 @@
 package main
 
-import "testing"
+import (
+	"regexp"
+	"testing"
+)
+
+func TestSuiteRegexIncludesPublishedBoundaryBenchmarks(t *testing.T) {
+	re := regexp.MustCompile(suiteRegex)
+	for _, name := range []string{
+		"BenchmarkExecCallOverhead_wago",
+		"BenchmarkExecCallOverhead_wazero",
+		"BenchmarkExecHostRoundtrip_wago",
+		"BenchmarkExecHostRoundtrip_wazero",
+	} {
+		if !re.MatchString(name) {
+			t.Errorf("suiteRegex does not match %s", name)
+		}
+	}
+	if re.MatchString("BenchmarkExecGlobalGet_wago") {
+		t.Fatal("suiteRegex unexpectedly includes an unpublished microbenchmark")
+	}
+}
 
 func TestParseRunAcceptsOptionalProcessorSuffix(t *testing.T) {
 	const input = `goos: linux

--- a/scripts/update-website-bench.mjs
+++ b/scripts/update-website-bench.mjs
@@ -280,11 +280,22 @@ function buildGeneralSummary(metrics, raw, modules) {
       ENGINES.map(({ id }) => [id, Number(compileTime[id] ?? 0) + Number(instantiate[id] ?? 0)]),
     )],
   ].map(([label, sub, kind, values]) => ({ label, sub, kind, values }));
+  const boundary = [
+    generalPairedMetric(metrics, "Host → Wasm call", "public entry", "ExecCallOverhead_wago", "ExecCallOverhead_wazero"),
+    generalPairedMetric(metrics, "Wasm → host → Wasm", "import call and return", "ExecHostRoundtrip_wago", "ExecHostRoundtrip_wazero"),
+  ].filter(Boolean);
   const breakdowns = [
     generalCorpusMetric(metrics, "Application commands", "fresh instance + fixed workload", "CommandExec/", "WazeroCommandExec/", [...applicationModules]),
     generalCorpusMetric(metrics, "SIMD execution", "AssemblyScript SIMD", "Exec/", "WazeroExec/", ["json-as-simd.serializeN", "json-as-simd.deserializeN", "blake-as-simd.hashN", "utf-as-simd.convertN"]),
   ].filter(Boolean);
-  return [...summary, ...breakdowns];
+  return [...summary, ...boundary, ...breakdowns];
+}
+
+function generalPairedMetric(metrics, label, sub, railshotKey, wazeroKey) {
+  const railshot = Number(metrics.get(railshotKey)?.ns ?? 0);
+  const wazero = Number(metrics.get(wazeroKey)?.ns ?? 0);
+  if (!(railshot > 0) || !(wazero > 0)) return null;
+  return { label, sub, kind: "ns", values: { railshot, wazero } };
 }
 
 function generalCorpusMetric(metrics, label, sub, railshotPrefix, wazeroPrefix, keys, kind = "ns") {

--- a/scripts/update-website-bench.test.mjs
+++ b/scripts/update-website-bench.test.mjs
@@ -39,6 +39,8 @@ test("benchmark regeneration only replaces the benchmark widget", async () => {
       "Instantiate/many_funcs": { ns: 6 }, "WazeroInstantiate/many_funcs": { ns: 9 },
       "Instantiate/json-as": { ns: 7 }, "WazeroInstantiate/json-as": { ns: 14 },
       "Exec/tiny.add": { ns: 3 }, "DraglineExec/tiny.add": { ns: 2 }, "WazeroExec/tiny.add": { ns: 4 },
+      "ExecCallOverhead_wago": { ns: 11 }, "ExecCallOverhead_wazero": { ns: 22 },
+      "ExecHostRoundtrip_wago": { ns: 33 }, "ExecHostRoundtrip_wazero": { ns: 66 },
       "Exec/nbody.step": { ns: 20 }, "WazeroExec/nbody.step": { ns: 30 },
       "Exec/json-as.deserializeN": { ns: 25 }, "WazeroExec/json-as.deserializeN": { ns: 50 },
       "Exec/json-as-simd.deserializeN": { ns: 18 }, "WazeroExec/json-as-simd.deserializeN": { ns: 36 },
@@ -189,10 +191,12 @@ function assertDOMContract(html) {
     const generalStart = html.indexOf(`id="perf-${arch}-panel-general"`);
     const generalEnd = html.indexOf(`id="perf-${arch}-panel-compile"`, generalStart);
     const general = html.slice(generalStart, generalEnd);
-    assert.equal(matches(general, /data-engine-row/g), 8);
-    for (const label of ["Machine code", "Application commands", "SIMD execution"]) {
+    assert.equal(matches(general, /data-engine-row/g), 10);
+    for (const label of ["Machine code", "Host → Wasm call", "Wasm → host → Wasm", "Application commands", "SIMD execution"]) {
       assert.equal(matches(general, new RegExp(`<span class="vs__label">${label}</span>`, "g")), 1);
     }
+    assert.ok(general.includes('<span class="vs__sub">public entry</span>'));
+    assert.ok(general.includes('<span class="vs__sub">import call and return</span>'));
 	const machineCodeStart = general.indexOf('<span class="vs__label">Machine code</span>');
 	const machineCodeEnd = general.indexOf('<div class="vs__row" data-engine-row>', machineCodeStart);
 	const machineCode = general.slice(machineCodeStart, machineCodeEnd);


### PR DESCRIPTION
## Summary
- include host-to-Wasm and Wasm-to-host-to-Wasm microbenchmarks in publication captures
- add both paired average-latency rows to the website General tab
- test the capture selector and generated DOM contract

## Proof
- `make lint` (staticcheck unavailable and skipped by the Makefile)
- `make test`
- `node --test scripts/update-website-bench.test.mjs`
- `(cd bench && go test ./cmd/benchpub)`
- `make test-corpus-all`
- exact-source ARM64 full capture: PASS, 62 corpus modules
- exact-source native AMD64 correctness: PASS, 62 corpus modules; timed publication capture in progress

Docs unchanged: this extends existing benchmark output without changing the documented workflow.