### PR TITLE
Publish canaries as tags and workflow artifacts

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -2,22 +2,25 @@
 
 ## Channels and versions
 
-- `canary` resolves the newest successful main build. Canary releases use an
-  immutable SemVer tag such as
-  `v0.1.0-canary.g<7-character-commit-sha>`.
+- `canary` resolves the newest successful main commit carrying an immutable
+  SemVer tag such as `v0.1.0-canary.g<7-character-commit-sha>`. Canaries are
+  tags only in the repository: they do not create GitHub Releases. Their
+  cross-platform binaries are retained on the matching Actions workflow run.
 - `beta` resolves the newest manually qualified beta, such as
   `v0.1.0-beta.1`.
 - `latest` resolves the newest stable `vMAJOR.MINOR.PATCH` release.
 
-The canary workflow publishes automatically after main CI succeeds. Beta and
-stable releases are dispatched through `release.yml` with an exact full commit
-SHA that already passed main CI. Both paths build, smoke-test, checksum, and
-publish the same platform asset set. Before starting a new release series,
-update `RELEASE_SERIES` in `canary.yml`.
+The canary workflow builds and tags automatically after main CI succeeds. Its
+workflow artifacts are retained for 90 days, while CLI canary installation
+builds the exact tagged source with the requested `go` or `tinygo` executable
+from `PATH`. Beta and stable releases are dispatched through
+`release.yml` with an exact full commit SHA that already passed main CI; those
+releases build, smoke-test, checksum, and publish the platform asset set. Before
+starting a new release series, update `RELEASE_SERIES` in `canary.yml`.
 
 ## Release notes
 
-GitHub generates the public notes for every channel. Pull requests carrying the
+GitHub generates public notes for beta and stable releases. Pull requests carrying the
 `enhancement` label appear under **New features**; all other included pull
 requests appear under **Changelog**. GitHub also identifies first-time
 contributors. Qualification details and asset hashes stay in

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,9 +1,7 @@
-name: Publish canary
+name: Publish canary tag
 
-# A push to main publishes a canary only after that commit's CI run succeeds.
-# Manual dispatches build the current main tip. Every successful target is
-# attached to a uniquely tagged SemVer canary prerelease with the same asset
-# names as beta and stable releases.
+# A successful CI run on main builds workflow artifacts and creates one
+# immutable SemVer canary tag. It never creates a GitHub Release.
 on:
   workflow_run:
     workflows: [CI]
@@ -35,20 +33,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.version.outputs.sha }}
-      version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}
           fetch-depth: 1
-      - name: Resolve version
+      - name: Resolve canary tag
         id: version
         run: |
           sha=$(git rev-parse HEAD)
           short_sha=${sha:0:7}
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "version=v${RELEASE_SERIES}-canary.g$short_sha" >> "$GITHUB_OUTPUT"
           echo "tag=v${RELEASE_SERIES}-canary.g$short_sha" >> "$GITHUB_OUTPUT"
 
   build:
@@ -115,10 +111,10 @@ jobs:
         run: |
           scripts/build-release-assets.sh
           scripts/verify-channel-assets.sh . "${{ matrix.target }}"
-      - name: Upload release files
+      - name: Upload canary workflow artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: canary-${{ matrix.target }}
+          name: ${{ needs.prepare.outputs.tag }}-${{ matrix.target }}
           path: |
             wago-${{ matrix.target }}
             wago-${{ matrix.target }}.sha256
@@ -127,53 +123,35 @@ jobs:
             wago-runtime-*-${{ matrix.target }}
             wago-runtime-*-${{ matrix.target }}.sha256
           if-no-files-found: error
+          retention-days: 90
 
-  publish:
-    name: Publish canary release
+  tag:
+    name: Tag qualified canary
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: ${{ needs.prepare.outputs.sha }}
-      - name: Download release files
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          pattern: canary-*
-          merge-multiple: true
-          path: release
-      - name: Verify available release files
-        run: |
-          scripts/verify-channel-assets.sh release
-      - name: Publish uniquely tagged canary release
+          fetch-depth: 1
+      - name: Create immutable canary tag
         env:
           GH_TOKEN: ${{ github.token }}
+          SHA: ${{ needs.prepare.outputs.sha }}
+          TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          mapfile -t assets < <(find release -maxdepth 1 -type f -name 'wago-*' -print | sort)
-          test "${#assets[@]}" -gt 0
-          gh api --method POST \
-            "repos/${{ github.repository }}/releases/generate-notes" \
-            -f tag_name="${{ needs.prepare.outputs.tag }}" \
-            -f target_commitish="${{ needs.prepare.outputs.sha }}" --jq .body |
-            sed 's/^## New Contributors$/## First-time contributors/' >release-notes.md
-          if gh release view "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            target=$(gh api "repos/${{ github.repository }}/releases/tags/${{ needs.prepare.outputs.tag }}" --jq '.target_commitish')
-            if [ "$target" != "${{ needs.prepare.outputs.sha }}" ]; then
-              echo "GitHub release ${{ needs.prepare.outputs.tag }} has an invalid target commit: $target" >&2
+          existing=$(gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            if [ "$existing" != "$SHA" ]; then
+              echo "::error::tag $TAG already targets $existing instead of $SHA"
               exit 1
             fi
-            gh release upload "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" --clobber "${assets[@]}"
-            gh release edit "${{ needs.prepare.outputs.tag }}" --repo "${{ github.repository }}" --notes-file release-notes.md
-            echo "canary release already exists for ${{ needs.prepare.outputs.sha }}"
+            echo "canary tag $TAG already exists"
             exit 0
           fi
-          gh release create "${{ needs.prepare.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --target "${{ needs.prepare.outputs.sha }}" \
-            --title "Canary (${{ needs.prepare.outputs.version }})" \
-            --notes-file release-notes.md \
-            --prerelease \
-            "${assets[@]}"
+          gh api --method POST "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$SHA"
       - name: Create documentation synchronization token
         id: docs-sync-token
         if: vars.DOCS_SYNC_APP_ID != ''

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -29,6 +29,8 @@ type installer struct {
 	repoURL             string
 	archiveURL          string
 	releaseAPI          string
+	tagAPI              string
+	commitAPI           string
 	releaseDownloadBase string
 	binDir              string
 	srcDir              string
@@ -111,6 +113,8 @@ func newInstaller(out io.Writer) (*installer, error) {
 		repoURL:             envOr("WAGO_REPO_URL", "https://github.com/wago-org/wago.git"),
 		archiveURL:          envOr("WAGO_ARCHIVE_URL", installerSourceArchiveURL(releaseRepo, archiveRef)),
 		releaseAPI:          envOr("WAGO_RELEASES_API_URL", "https://api.github.com/repos/"+releaseRepo+"/releases"),
+		tagAPI:              envOr("WAGO_TAGS_API_URL", "https://api.github.com/repos/"+releaseRepo+"/tags"),
+		commitAPI:           envOr("WAGO_COMMITS_API_URL", "https://api.github.com/repos/"+releaseRepo+"/commits"),
 		releaseDownloadBase: envOr("WAGO_RELEASE_DOWNLOAD_BASE", "https://github.com/"+releaseRepo+"/releases"),
 		binDir:              filepath.Clean(binDir),
 		srcDir:              filepath.Clean(envOr("WAGO_SRC_DIR", filepath.Join(home, ".wago", "src"))),
@@ -402,6 +406,20 @@ func reinstallLabel(mode string) string {
 }
 
 func (i *installer) downloadManager(target string) error {
+	if channel, sha, canonical := installerRollingCommit(i.version); canonical && channel == "canary" {
+		i.managerTag = i.version
+		i.managerSourceRef = sha
+		return errors.New("canary tags do not contain release assets")
+	}
+	if i.version == "main" || i.version == "canary" {
+		tag, sha, err := i.latestCanaryTag()
+		if err != nil {
+			return err
+		}
+		i.managerTag = tag
+		i.managerSourceRef = sha
+		return errors.New("canary tags do not contain release assets")
+	}
 	resolved := installbootstrap.ResolvedRelease{Tag: i.version, SourceRef: installerSourceRef(i.version)}
 	base := ""
 	if os.Getenv("WAGO_MANAGER_URL") == "" {
@@ -430,6 +448,99 @@ func (i *installer) downloadManager(target string) error {
 	i.managerTag, i.managerSourceRef, i.managerFromRelease = tag, resolved.SourceRef, true
 	i.done("Downloaded Wago manager " + tag)
 	return nil
+}
+
+type installerTag struct {
+	Name   string `json:"name"`
+	Commit struct {
+		SHA string `json:"sha"`
+	} `json:"commit"`
+}
+
+func (i *installer) latestCanaryTag() (string, string, error) {
+	var tags []installerTag
+	address, err := url.Parse(i.tagAPI)
+	if err != nil {
+		return "", "", fmt.Errorf("parse tag catalog URL: %w", err)
+	}
+	query := address.Query()
+	query.Set("per_page", "100")
+	query.Set("page", "1")
+	address.RawQuery = query.Encode()
+	if err := i.getJSON(address.String(), &tags); err != nil {
+		return "", "", err
+	}
+	if len(tags) > 100 {
+		return "", "", errors.New("tag catalog returned too many tags")
+	}
+	byCommit := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		name := strings.ToLower(strings.TrimSpace(tag.Name))
+		marker := "-canary.g"
+		index := strings.Index(name, marker)
+		if index < 0 || !installerCanaryTag(name) {
+			continue
+		}
+		short := name[index+len(marker):]
+		sha := strings.ToLower(strings.TrimSpace(tag.Commit.SHA))
+		if len(short) != 7 || !fullInstallerCommitSHA(sha) || !strings.HasPrefix(sha, short) {
+			return "", "", fmt.Errorf("canary tag %q has an invalid target commit", tag.Name)
+		}
+		byCommit[sha] = tag.Name
+	}
+	type commit struct {
+		SHA string `json:"sha"`
+	}
+	var commits []commit
+	commitsAddress, err := url.Parse(i.commitAPI)
+	if err != nil {
+		return "", "", fmt.Errorf("parse commit catalog URL: %w", err)
+	}
+	query = commitsAddress.Query()
+	query.Set("sha", "main")
+	query.Set("per_page", "100")
+	query.Set("page", "1")
+	commitsAddress.RawQuery = query.Encode()
+	if err := i.getJSON(commitsAddress.String(), &commits); err != nil {
+		return "", "", err
+	}
+	if len(commits) > 100 {
+		return "", "", errors.New("commit catalog returned too many commits")
+	}
+	for _, commit := range commits {
+		sha := strings.ToLower(strings.TrimSpace(commit.SHA))
+		if tag := byCommit[sha]; tag != "" {
+			return tag, sha, nil
+		}
+	}
+	return "", "", errors.New("no canary tag found")
+}
+
+func installerCanaryTag(tag string) bool {
+	core, short, found := strings.Cut(strings.TrimSpace(tag), "-canary.g")
+	if !found || len(short) != 7 || !strings.HasPrefix(core, "v") {
+		return false
+	}
+	parts := strings.Split(strings.TrimPrefix(core, "v"), ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || (len(part) > 1 && part[0] == '0') {
+			return false
+		}
+		for _, char := range part {
+			if char < '0' || char > '9' {
+				return false
+			}
+		}
+	}
+	for _, char := range short {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return false
+		}
+	}
+	return true
 }
 
 func (i *installer) resolveRelease() (installbootstrap.ResolvedRelease, string, error) {
@@ -573,7 +684,7 @@ var runInstallerGit = func(args ...string) ([]byte, error) {
 func (i *installer) fetchSource() (string, error) {
 	target := filepath.Join(i.tmpDir, "src")
 	sourceVersion := installerSourceRef(i.version)
-	if i.managerFromRelease && i.managerSourceRef != "" {
+	if i.managerSourceRef != "" {
 		sourceVersion = i.managerSourceRef
 	}
 	archiveURL := i.archiveURL
@@ -664,7 +775,13 @@ func installerRollingCommit(version string) (channel, sha string, canonical bool
 
 func (i *installer) buildManager(sourceDir, target string) error {
 	i.begin("Building Wago")
-	command := exec.Command("go", "build", "-trimpath", "-ldflags", "-s -w -X main.version="+i.version, "-o", target, "./cli/wago")
+	stamp := i.version
+	if fullInstallerCommitSHA(i.managerSourceRef) && (i.version == "main" || i.version == "canary") {
+		stamp = "canary@" + i.managerSourceRef
+	} else if channel, sha, canonical := installerRollingCommit(i.version); canonical && channel == "canary" {
+		stamp = channel + "@" + sha
+	}
+	command := exec.Command("go", "build", "-trimpath", "-ldflags", "-s -w -X main.version="+stamp, "-o", target, "./cli/wago")
 	command.Dir = sourceDir
 	command.Env = append(os.Environ(), "CGO_ENABLED=0")
 	output, err := command.CombinedOutput()

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -195,33 +194,10 @@ func TestInstallerDryRunPresentation(t *testing.T) {
 	}
 }
 
-func TestInstallerDownloadsExactCanonicalRollingManager(t *testing.T) {
+func TestInstallerBuildsExactCanonicalCanaryFromSource(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
-	payload := []byte("exact released manager")
-	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
-	asset := "wago-" + runtime.GOOS + "-" + runtime.GOARCH
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/releases":
-			_, _ = fmt.Fprintf(w, `[
-  {"tag_name":"v0.1.0-canary.gdeadbee","target_commitish":%q,"published_at":"2026-08-05T00:00:00Z","draft":true},
-  {"tag_name":"v0.1.0-canary.gaaaaaaa","target_commitish":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","published_at":"2026-08-04T00:00:00Z"},
-  {"tag_name":"v0.1.0-canary.gdeadbee","target_commitish":%q,"published_at":"2026-08-03T00:00:00Z"}
-]`, sha, sha)
-		case "/download/v0.1.0-canary.gdeadbee/" + asset:
-			_, _ = w.Write(payload)
-		case "/download/v0.1.0-canary.gdeadbee/" + asset + ".sha256":
-			_, _ = fmt.Fprintf(w, "%s  %s\n", hash, asset)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
 	t.Setenv("NO_COLOR", "1")
 	t.Setenv("WAGO_VERSION", "canary@"+sha)
-	t.Setenv("WAGO_RELEASES_API_URL", server.URL+"/releases")
-	t.Setenv("WAGO_RELEASE_DOWNLOAD_BASE", server.URL)
 	var output bytes.Buffer
 	installer, err := newInstaller(&output)
 	if err != nil {
@@ -229,14 +205,11 @@ func TestInstallerDownloadsExactCanonicalRollingManager(t *testing.T) {
 	}
 	installer.tmpDir = t.TempDir()
 	target := filepath.Join(installer.tmpDir, executableName("wago"))
-	if err := installer.downloadManager(target); err != nil {
-		t.Fatal(err)
+	if err := installer.downloadManager(target); err == nil || !strings.Contains(err.Error(), "do not contain release assets") {
+		t.Fatalf("downloadManager error = %v", err)
 	}
-	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, payload) {
-		t.Fatalf("manager = %q, %v", got, err)
-	}
-	if installer.managerTag != "v0.1.0-canary.gdeadbee" || !installer.managerFromRelease {
-		t.Fatalf("manager resolution = %q, %v", installer.managerTag, installer.managerFromRelease)
+	if installer.managerTag != "canary@"+sha || installer.managerSourceRef != sha || installer.managerFromRelease {
+		t.Fatalf("manager resolution = %q, %q, %v", installer.managerTag, installer.managerSourceRef, installer.managerFromRelease)
 	}
 }
 
@@ -493,21 +466,17 @@ func (ctx *cancelWhenStagingExists) Err() error {
 	return ctx.Context.Err()
 }
 
-func TestInstallerDownloadsNewestChannelManager(t *testing.T) {
-	payload := []byte("released manager")
-	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
-	asset := "wago-" + runtime.GOOS + "-" + runtime.GOARCH
+func TestInstallerResolvesNewestCanaryTagForSourceBuild(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/releases":
+		case "/tags":
 			_, _ = fmt.Fprint(w, `[
-  {"tag_name":"v0.1.0-canary.gaaaaaaa","published_at":"2026-01-01T00:00:00Z"},
-  {"tag_name":"v0.1.0-canary.gdeadbee","published_at":"2026-08-03T00:00:00Z"}
+  {"name":"v0.1.0-beta.2","commit":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
+  {"name":"v0.1.0-canary.gdeadbee","commit":{"sha":"deadbee123456789012345678901234567890123"}}
 ]`)
-		case "/download/v0.1.0-canary.gdeadbee/" + asset:
-			_, _ = w.Write(payload)
-		case "/download/v0.1.0-canary.gdeadbee/" + asset + ".sha256":
-			_, _ = fmt.Fprintf(w, "%s  %s\n", hash, asset)
+		case "/commits":
+			_, _ = fmt.Fprintf(w, `[{"sha":%q},{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]`, sha)
 		default:
 			http.NotFound(w, r)
 		}
@@ -516,8 +485,8 @@ func TestInstallerDownloadsNewestChannelManager(t *testing.T) {
 
 	t.Setenv("NO_COLOR", "1")
 	t.Setenv("WAGO_VERSION", "canary")
-	t.Setenv("WAGO_RELEASES_API_URL", server.URL+"/releases")
-	t.Setenv("WAGO_RELEASE_DOWNLOAD_BASE", server.URL)
+	t.Setenv("WAGO_TAGS_API_URL", server.URL+"/tags")
+	t.Setenv("WAGO_COMMITS_API_URL", server.URL+"/commits")
 	var output bytes.Buffer
 	installer, err := newInstaller(&output)
 	if err != nil {
@@ -525,14 +494,11 @@ func TestInstallerDownloadsNewestChannelManager(t *testing.T) {
 	}
 	installer.tmpDir = t.TempDir()
 	target := filepath.Join(installer.tmpDir, executableName("wago"))
-	if err := installer.downloadManager(target); err != nil {
-		t.Fatal(err)
+	if err := installer.downloadManager(target); err == nil || !strings.Contains(err.Error(), "do not contain release assets") {
+		t.Fatalf("downloadManager error = %v", err)
 	}
-	if got, err := os.ReadFile(target); err != nil || !bytes.Equal(got, payload) {
-		t.Fatalf("manager = %q, %v", got, err)
-	}
-	if installer.managerTag != "v0.1.0-canary.gdeadbee" || !installer.managerFromRelease {
-		t.Fatalf("manager resolution = %q, %v", installer.managerTag, installer.managerFromRelease)
+	if installer.managerTag != "v0.1.0-canary.gdeadbee" || installer.managerSourceRef != sha || installer.managerFromRelease {
+		t.Fatalf("manager resolution = %q, %q, %v", installer.managerTag, installer.managerSourceRef, installer.managerFromRelease)
 	}
 }
 

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -391,6 +391,9 @@ func resolveRunnerVersion(ver string, progress *managerprogress.Progress) (resol
 
 func resolveRunnerVersionContext(ctx context.Context, ver string, progress *managerprogress.Progress) (resolved string, sourceOnly bool, err error) {
 	if channel, sha, canonical := rollingCommitSHA(ver); canonical {
+		if channel == "canary" {
+			return ver, true, nil
+		}
 		if progress != nil {
 			progress.Begin("resolving release")
 		}
@@ -417,6 +420,19 @@ func resolveRunnerVersionContext(ctx context.Context, ver string, progress *mana
 	}
 	if progress != nil {
 		progress.Begin("resolving release")
+	}
+	if ver == "canary" {
+		resolved, err = latestCanaryTagContext(ctx)
+		if err == nil {
+			if progress != nil {
+				progress.Done("resolved " + releasePickerLabel(resolved))
+			}
+			return resolved, true, nil
+		}
+		if progress != nil {
+			progress.Fail("could not resolve canary tag")
+		}
+		return "", false, err
 	}
 	resolved, err = latestChannelReleaseContext(ctx, ver)
 	if err == nil {
@@ -581,6 +597,66 @@ func fetchMainCommitsContext(ctx context.Context) ([]remoteCommit, error) {
 
 func latestChannelRelease(channel string) (string, error) {
 	return latestChannelReleaseContext(context.Background(), channel)
+}
+
+const canaryTagDiscoveryPageSize = 100
+
+// latestCanaryTagContext resolves the newest qualified canary tag by
+// intersecting repository tags with main's newest-first commit history. The
+// repository tags endpoint does not guarantee commit-date ordering.
+func latestCanaryTagContext(ctx context.Context) (string, error) {
+	address := fmt.Sprintf("%s/repos/wago-org/wago/tags?per_page=%d&page=1", releaseAPI(), canaryTagDiscoveryPageSize)
+	response, err := getReleaseBytes(ctx, "canary tag discovery", address, releaseMetadataMaximum)
+	if err != nil {
+		return "", err
+	}
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub returned %s", response.Status)
+	}
+	var tags []remoteTag
+	if err := json.Unmarshal(response.Body, &tags); err != nil {
+		return "", err
+	}
+	if len(tags) > canaryTagDiscoveryPageSize {
+		return "", errors.New("GitHub returned too many tags")
+	}
+	byCommit := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		if channelRelease(tag.Name) != "canary" {
+			continue
+		}
+		sha := strings.ToLower(strings.TrimSpace(tag.Commit.SHA))
+		if !validCommitSHA(sha) {
+			return "", fmt.Errorf("GitHub tag %q has an invalid target commit", tag.Name)
+		}
+		_, identity, _ := strings.Cut(strings.ToLower(tag.Name), "-canary.g")
+		if !strings.HasPrefix(sha, identity) {
+			return "", fmt.Errorf("GitHub tag %q does not match target commit %s", tag.Name, sha)
+		}
+		byCommit[sha] = tag.Name
+	}
+	commitsAddress := fmt.Sprintf("%s/repos/wago-org/wago/commits?sha=main&per_page=%d&page=1", releaseAPI(), canaryTagDiscoveryPageSize)
+	commitsResponse, err := getReleaseBytes(ctx, "canary commit discovery", commitsAddress, releaseMetadataMaximum)
+	if err != nil {
+		return "", err
+	}
+	if commitsResponse.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub returned %s", commitsResponse.Status)
+	}
+	var commits []remoteCommit
+	if err := json.Unmarshal(commitsResponse.Body, &commits); err != nil {
+		return "", err
+	}
+	if len(commits) > canaryTagDiscoveryPageSize {
+		return "", errors.New("GitHub returned too many commits")
+	}
+	for _, commit := range commits {
+		sha := strings.ToLower(strings.TrimSpace(commit.SHA))
+		if tag := byCommit[sha]; tag != "" {
+			return tag + "@" + sha, nil
+		}
+	}
+	return "", fmt.Errorf("%w: canary tag", errNoPublishedRelease)
 }
 
 func latestChannelReleaseContext(ctx context.Context, channel string) (string, error) {

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -38,6 +38,48 @@ func TestLatestChannelRelease(t *testing.T) {
 	}
 }
 
+func TestLatestCanaryTag(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	const olderCommitSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/wago-org/wago/tags":
+			if r.URL.Query().Get("per_page") != "100" {
+				http.Error(w, "wrong page size", http.StatusBadRequest)
+				return
+			}
+			older := remoteTag{Name: "v0.1.0-canary.gaaaaaaa"}
+			older.Commit.SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			newest := remoteTag{Name: "v0.1.0-canary.gdeadbee"}
+			newest.Commit.SHA = sha
+			_ = json.NewEncoder(w).Encode([]remoteTag{older, newest})
+		case "/repos/wago-org/wago/commits":
+			_ = json.NewEncoder(w).Encode([]remoteCommit{{SHA: sha}, {SHA: olderCommitSHA}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	got, err := latestCanaryTagContext(context.Background())
+	if err != nil || got != "v0.1.0-canary.gdeadbee@"+sha {
+		t.Fatalf("latestCanaryTagContext = %q, %v", got, err)
+	}
+}
+
+func TestLatestCanaryTagRejectsMismatchedHash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"name":"v0.1.0-canary.gdeadbee","commit":{"sha":"cafef00123456789012345678901234567890123"}}]`))
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	if _, err := latestCanaryTagContext(context.Background()); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("latestCanaryTagContext mismatch error = %v", err)
+	}
+}
+
 func TestLatestChannelReleasePaginates(t *testing.T) {
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/manager/internal/version/releases.go
+++ b/cli/manager/internal/version/releases.go
@@ -29,13 +29,19 @@ type remoteCommit struct {
 	} `json:"commit"`
 }
 
+type remoteTag struct {
+	Name   string `json:"name"`
+	Commit struct {
+		SHA string `json:"sha"`
+	} `json:"commit"`
+}
+
 // isRollingChannel reports whether ver names a rolling release channel rather
 // than a pinned, immutable version.
 func isRollingChannel(ver string) bool { return rollingChannels[ver] }
 
-// channelRelease returns the moving channel represented by an immutable
-// prerelease tag, if any. Release APIs return newest-first, so callers keep the
-// first tag seen for each channel.
+// channelRelease returns the moving channel represented by an immutable SemVer
+// tag, if any.
 func channelRelease(tag string) string {
 	version, prerelease, found := strings.Cut(strings.ToLower(strings.TrimSpace(tag)), "-")
 	if !found || !validReleaseCore(version) {

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -240,15 +240,19 @@ func TestChecksumMismatchDoesNotBuildFromSource(t *testing.T) {
 	}
 }
 
-func TestCanaryResolvesLatestPublishedCanary(t *testing.T) {
+func TestCanaryResolvesLatestTagAsSource(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`[{"tag_name":"v0.1.0-canary.g` + sha[:7] + `","target_commitish":"` + sha + `"}]`))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/tags") {
+			_, _ = w.Write([]byte(`[{"name":"v0.1.0-canary.g` + sha[:7] + `","commit":{"sha":"` + sha + `"}}]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"sha":"` + sha + `"}]`))
 	}))
 	defer server.Close()
 	t.Setenv("WAGO_RELEASE_API", server.URL)
 	ref, sourceOnly, err := resolveRunnerVersion("canary", nil)
-	if err != nil || ref != "v0.1.0-canary.g"+sha[:7]+"@"+sha || sourceOnly {
+	if err != nil || ref != "v0.1.0-canary.g"+sha[:7]+"@"+sha || !sourceOnly {
 		t.Fatalf("resolveRunnerVersion = %q, %v, %v", ref, sourceOnly, err)
 	}
 }

--- a/install.cmd
+++ b/install.cmd
@@ -33,10 +33,15 @@ if defined WAGO_INSTALLER (
 
 set "version=main"
 if defined WAGO_VERSION set "version=%WAGO_VERSION%"
+set "install_version=!version!"
 set "release_repo=wago-org/wago"
 if defined WAGO_RELEASE_REPO set "release_repo=%WAGO_RELEASE_REPO%"
 set "release_api=https://api.github.com/repos/!release_repo!/releases"
 if defined WAGO_RELEASES_API_URL set "release_api=%WAGO_RELEASES_API_URL%"
+set "tags_api=https://api.github.com/repos/!release_repo!/tags"
+if defined WAGO_TAGS_API_URL set "tags_api=%WAGO_TAGS_API_URL%"
+set "commits_api=https://api.github.com/repos/!release_repo!/commits"
+if defined WAGO_COMMITS_API_URL set "commits_api=%WAGO_COMMITS_API_URL%"
 set "release_download_base=https://github.com/!release_repo!/releases"
 if defined WAGO_RELEASE_DOWNLOAD_BASE set "release_download_base=%WAGO_RELEASE_DOWNLOAD_BASE%"
 
@@ -74,6 +79,7 @@ if errorlevel 1 (
   exit /b 1
 )
 
+set "WAGO_VERSION=!install_version!"
 "!tmp_dir!\installer.exe" install %*
 set "installer_status=!ERRORLEVEL!"
 call :cleanup
@@ -116,10 +122,53 @@ if /i "!version!"=="latest" (
   if not defined tag exit /b 1
   exit /b 0
 )
-if /i "!version:~0,1!"=="v" set "tag=!version!"
+if /i "!version:~0,1!"=="v" (
+  if /i "!version:-canary.g=!"=="!version!" (
+    set "tag=!version!"
+  ) else (
+    set "channel=beta"
+  )
+)
 if defined tag exit /b 0
-set "channel=canary"
-if /i "!version!"=="beta" set "channel=beta"
+if not defined channel (
+  if /i "!version!"=="beta" (
+    set "channel=beta"
+  ) else (
+    curl.exe -fsSL "!tags_api!?per_page=100&page=1" -o "!tmp_dir!\tags.json" >nul 2>&1
+    if errorlevel 1 exit /b 1
+	curl.exe -fsSL "!commits_api!?sha=main&per_page=100&page=1" -o "!tmp_dir!\commits.json" >nul 2>&1
+	if errorlevel 1 exit /b 1
+    set "install_version="
+	set "canary_pending_tag="
+    for /f "usebackq tokens=1,* delims=:" %%A in ("!tmp_dir!\tags.json") do (
+      set "tag_key=%%A"
+      set "tag_key=!tag_key: =!"
+      set "tag_key=!tag_key:"=!"
+      if /i "!tag_key!"=="name" (
+        call :clean_release_candidate "%%B"
+		set "canary_pending_tag="
+		if /i not "!release_candidate:-canary.g=!"=="!release_candidate!" set "canary_pending_tag=!release_candidate!"
+      )
+	  if /i "!tag_key!"=="sha" if defined canary_pending_tag (
+		call :clean_release_candidate "%%B"
+		set "canary_!release_candidate!=!canary_pending_tag!"
+		set "canary_pending_tag="
+	  )
+    )
+	for /f "usebackq tokens=1,* delims=:" %%A in ("!tmp_dir!\commits.json") do if not defined install_version (
+	  set "commit_key=%%A"
+	  set "commit_key=!commit_key: =!"
+	  set "commit_key=!commit_key:"=!"
+	  if /i "!commit_key!"=="sha" (
+		call :clean_release_candidate "%%B"
+		call set "install_version=%%canary_!release_candidate!%%"
+		if "!install_version:~0,1!"=="%%" set "install_version="
+	  )
+	)
+    if not defined install_version exit /b 1
+    set "channel=beta"
+  )
+)
 curl.exe -fsSL "!release_api!?per_page=100" -o "!tmp_dir!\releases.json" >nul 2>&1
 if errorlevel 1 exit /b 1
 set "release_pending_tag="

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,11 @@ set -eu
 
 release_repo="${WAGO_RELEASE_REPO:-wago-org/wago}"
 release_api="${WAGO_RELEASES_API_URL:-https://api.github.com/repos/$release_repo/releases}"
+tags_api="${WAGO_TAGS_API_URL:-https://api.github.com/repos/$release_repo/tags}"
+commits_api="${WAGO_COMMITS_API_URL:-https://api.github.com/repos/$release_repo/commits}"
 release_download_base="${WAGO_RELEASE_DOWNLOAD_BASE:-https://github.com/$release_repo/releases}"
 version="${WAGO_VERSION:-main}"
+install_version=$version
 tmp=""
 
 die() {
@@ -59,15 +62,61 @@ release_tag_from_json() {
 	' "$2"
 }
 
+canary_tag_from_json() {
+	awk '
+		FNR == NR && /"name"[[:space:]]*:/ {
+			line = $0
+			sub(/^.*"name"[[:space:]]*:[[:space:]]*"/, "", line)
+			sub(/".*$/, "", line)
+			pending = line
+			next
+		}
+		FNR == NR && pending != "" && /"sha"[[:space:]]*:/ {
+			line = $0
+			sub(/^.*"sha"[[:space:]]*:[[:space:]]*"/, "", line)
+			sub(/".*$/, "", line)
+			if (pending ~ /^v[0-9]+\.[0-9]+\.[0-9]+-canary\.g[0-9a-f]{7}$/) tags[line] = pending
+			pending = ""
+			next
+		}
+		/"name"[[:space:]]*:/ {
+			next
+		}
+		/"sha"[[:space:]]*:/ {
+			line = $0
+			sub(/^.*"sha"[[:space:]]*:[[:space:]]*"/, "", line)
+			sub(/".*$/, "", line)
+			if (tags[line] != "") {
+				print tags[line]
+				exit
+			}
+		}
+	' "$1" "$2"
+}
+
 resolve_release() {
 	case "$version" in
 		latest)
 			download "$release_api/latest" "$tmp/release.json" || return 1
 			tag=$(sed -n 's/^[[:space:]]*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tmp/release.json" | head -1)
 			;;
+		v*-canary.g???????)
+			install_version=$version
+			download "$release_api?per_page=100" "$tmp/releases.json" || return 1
+			tag=$(release_tag_from_json beta "$tmp/releases.json")
+			;;
 		v*) tag=$version ;;
 		*)
-			case "$version" in beta) channel=beta ;; *) channel=canary ;; esac
+			case "$version" in
+				beta) channel=beta ;;
+				*)
+					download "$tags_api?per_page=100&page=1" "$tmp/tags.json" || return 1
+					download "$commits_api?sha=main&per_page=100&page=1" "$tmp/commits.json" || return 1
+					install_version=$(canary_tag_from_json "$tmp/tags.json" "$tmp/commits.json")
+					[ -n "$install_version" ] || return 1
+					channel=beta
+					;;
+			esac
 			download "$release_api?per_page=100" "$tmp/releases.json" || return 1
 			tag=$(release_tag_from_json "$channel" "$tmp/releases.json")
 			;;
@@ -110,7 +159,7 @@ verify_checksum() {
 run_installer() {
 	installer=$1
 	shift
-	if WAGO_PATH_REFRESH_FILE="$tmp/path-refresh" "$installer" install "$@"; then
+	if WAGO_VERSION="$install_version" WAGO_PATH_REFRESH_FILE="$tmp/path-refresh" "$installer" install "$@"; then
 		return 0
 	else
 		status=$?

--- a/install_test.go
+++ b/install_test.go
@@ -48,11 +48,18 @@ func TestShellBootstrapMatchesReleaseContract(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if version == "main" || strings.Contains(version, "-canary.g") {
+				wantTag = "v0.1.0-beta.1"
+			}
 			payload := []byte("#!/bin/sh\nexit 0\n")
 			hash := fmt.Sprintf("%x", sha256.Sum256(payload))
 			asset := "wago-installer-" + runtime.GOOS + "-" + runtime.GOARCH
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
+				case "/tags":
+					_, _ = fmt.Fprint(w, "[\n  {\n    \"name\": \"v0.1.0-canary.gbbbbbbb\",\n    \"commit\": {\n      \"sha\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n    }\n  }\n]\n")
+				case "/commits":
+					_, _ = fmt.Fprint(w, "[\n  {\n    \"sha\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n  }\n]\n")
 				case "/releases/latest":
 					_, _ = fmt.Fprintf(w, "{\n  \"tag_name\": %q,\n  \"published_at\": %q\n}\n", catalog.latest.TagName, catalog.latest.PublishedAt)
 				case "/releases":
@@ -70,6 +77,8 @@ func TestShellBootstrapMatchesReleaseContract(t *testing.T) {
 			command.Env = append(os.Environ(),
 				"WAGO_VERSION="+version,
 				"WAGO_RELEASES_API_URL="+server.URL+"/releases",
+				"WAGO_TAGS_API_URL="+server.URL+"/tags",
+				"WAGO_COMMITS_API_URL="+server.URL+"/commits",
 				"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
 			)
 			if output, err := command.CombinedOutput(); err != nil {
@@ -82,15 +91,20 @@ func TestShellBootstrapMatchesReleaseContract(t *testing.T) {
 func TestShellBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 	payload := []byte("#!/bin/sh\nprintf 'native installer: %s\\n' \"$WAGO_VERSION\"\n")
 	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
-	tag := "v0.1.0-canary.gdeadbee"
+	canaryTag := "v0.1.0-canary.gdeadbee"
+	carrierTag := "v0.1.0-beta.2"
 	asset := "wago-installer-" + runtime.GOOS + "-" + runtime.GOARCH
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/tags":
+			_, _ = fmt.Fprintf(w, "[\n  {\n    \"name\": %q,\n    \"commit\": {\n      \"sha\": \"deadbee123456789012345678901234567890123\"\n    }\n  }\n]\n", canaryTag)
+		case "/commits":
+			_, _ = fmt.Fprint(w, "[\n  {\n    \"sha\": \"deadbee123456789012345678901234567890123\"\n  }\n]\n")
 		case "/releases":
-			_, _ = fmt.Fprintf(w, `[{"tag_name":%q,"published_at":"2026-08-03T00:00:00Z"}]`, tag)
-		case "/download/" + tag + "/" + asset:
+			_, _ = fmt.Fprintf(w, "[\n  {\n    \"tag_name\": %q,\n    \"published_at\": \"2026-08-03T00:00:00Z\"\n  }\n]\n", carrierTag)
+		case "/download/" + carrierTag + "/" + asset:
 			_, _ = w.Write(payload)
-		case "/download/" + tag + "/" + asset + ".sha256":
+		case "/download/" + carrierTag + "/" + asset + ".sha256":
 			_, _ = fmt.Fprintf(w, "%s  %s\n", hash, asset)
 		default:
 			http.NotFound(w, r)
@@ -102,13 +116,15 @@ func TestShellBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 	command.Env = append(os.Environ(),
 		"WAGO_VERSION=main",
 		"WAGO_RELEASES_API_URL="+server.URL+"/releases",
+		"WAGO_TAGS_API_URL="+server.URL+"/tags",
+		"WAGO_COMMITS_API_URL="+server.URL+"/commits",
 		"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
 	)
 	output, err := command.CombinedOutput()
 	if err != nil {
 		t.Fatalf("run shell bootstrap: %v\n%s", err, output)
 	}
-	if got, want := string(output), "native installer: main\n"; got != want {
+	if got, want := string(output), "native installer: "+canaryTag+"\n"; got != want {
 		t.Fatalf("bootstrap output = %q, want %q", got, want)
 	}
 }
@@ -331,14 +347,19 @@ func TestWineCmdBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 		t.Fatal(err)
 	}
 	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
-	tag := "v0.1.0-canary.gbbbbbbb"
+	canaryTag := "v0.1.0-canary.gbbbbbbb"
+	carrierTag := "v0.1.0-beta.2"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/tags":
+			_, _ = fmt.Fprintf(w, "[\n  {\n    \"name\": %q,\n    \"commit\": {\n      \"sha\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n    }\n  }\n]\n", canaryTag)
+		case "/commits":
+			_, _ = fmt.Fprint(w, "[\n  {\n    \"sha\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n  }\n]\n")
 		case "/releases":
-			_, _ = fmt.Fprintf(w, "[\n  {\n    \"tag_name\": %q,\n    \"published_at\": \"2026-08-03T00:00:00Z\"\n  }\n]\n", tag)
-		case "/download/" + tag + "/wago-installer-windows-amd64":
+			_, _ = fmt.Fprintf(w, "[\n  {\n    \"tag_name\": %q,\n    \"published_at\": \"2026-08-03T00:00:00Z\"\n  }\n]\n", carrierTag)
+		case "/download/" + carrierTag + "/wago-installer-windows-amd64":
 			_, _ = w.Write(payload)
-		case "/download/" + tag + "/wago-installer-windows-amd64.sha256":
+		case "/download/" + carrierTag + "/wago-installer-windows-amd64.sha256":
 			_, _ = fmt.Fprintf(w, "%s  wago-installer-windows-amd64\n", hash)
 		default:
 			http.NotFound(w, r)
@@ -351,6 +372,8 @@ func TestWineCmdBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 		"WINEDEBUG=-all", "NO_COLOR=1", "WAGO_VERSION=canary", "WAGO_DRY_RUN=1",
 		"WAGO_BIN_DIR=ROOT\\bin", "WAGO_SRC_DIR=ROOT\\src",
 		"WAGO_RELEASES_API_URL="+server.URL+"/releases",
+		"WAGO_TAGS_API_URL="+server.URL+"/tags",
+		"WAGO_COMMITS_API_URL="+server.URL+"/commits",
 		"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
 	)
 	output, err := command.CombinedOutput()

--- a/tests/integration/cipolicy/workflows_test.go
+++ b/tests/integration/cipolicy/workflows_test.go
@@ -53,7 +53,7 @@ func TestWorkflowActionsUseImmutableCommits(t *testing.T) {
 	}
 }
 
-func TestCanaryUsesImmutableSemVerTagsAndTargets(t *testing.T) {
+func TestCanaryCreatesOnlyImmutableSemVerTags(t *testing.T) {
 	canary, err := os.ReadFile(filepath.Clean("../../../.github/workflows/canary.yml"))
 	if err != nil {
 		t.Fatal(err)
@@ -63,12 +63,19 @@ func TestCanaryUsesImmutableSemVerTagsAndTargets(t *testing.T) {
 		`RELEASE_SERIES: "0.1.0"`,
 		`short_sha=${sha:0:7}`,
 		`echo "tag=v${RELEASE_SERIES}-canary.g$short_sha"`,
-		`target=$(gh api "repos/${{ github.repository }}/releases/tags/`,
-		`has an invalid target commit`,
-		`if [ "$target" != "${{ needs.`,
+		`git/ref/tags/$TAG`,
+		`tag $TAG already targets $existing instead of $SHA`,
+		`-f ref="refs/tags/$TAG"`,
+		`-f sha="$SHA"`,
+		`retention-days: 90`,
 	} {
 		if !strings.Contains(contents, required) {
 			t.Errorf("canary workflow is missing immutable SemVer policy %q", required)
+		}
+	}
+	for _, forbidden := range []string{"gh release", "/releases", "--prerelease", "download-artifact"} {
+		if strings.Contains(contents, forbidden) {
+			t.Errorf("canary workflow must create tags only, found %q", forbidden)
 		}
 	}
 }


### PR DESCRIPTION
Canaries now create immutable SemVer tags and retain binaries only as GitHub Actions artifacts. They no longer create GitHub prereleases or release assets.

The CLI and bootstraps resolve the newest qualified canary tag and source-build that exact commit, while beta and stable continue using release assets.

Validation:
- `go test ./...`
- `actionlint .github/workflows/canary.yml`