### PR TITLE
Isolate canary concurrency by source commit

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -13,7 +13,9 @@ permissions:
   contents: write
 
 concurrency:
-  group: publish-canary
+  # A workflow_run that fails the job-level guard still enters concurrency.
+  # Scope by source SHA so it cannot cancel a valid build for another commit.
+  group: publish-canary-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/tests/integration/cipolicy/workflows_test.go
+++ b/tests/integration/cipolicy/workflows_test.go
@@ -68,6 +68,7 @@ func TestCanaryCreatesOnlyImmutableSemVerTags(t *testing.T) {
 		`-f ref="refs/tags/$TAG"`,
 		`-f sha="$SHA"`,
 		`retention-days: 90`,
+		`group: publish-canary-${{ github.event.workflow_run.head_sha || github.sha }}`,
 	} {
 		if !strings.Contains(contents, required) {
 			t.Errorf("canary workflow is missing immutable SemVer policy %q", required)


### PR DESCRIPTION
Prevent skipped workflow-run events for unrelated commits from cancelling an active canary build.

Validation:
- `actionlint .github/workflows/canary.yml`
- `go test ./tests/integration/cipolicy`