### PR TITLE
Handle missing canary tags cleanly

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -142,7 +142,7 @@ jobs:
           SHA: ${{ needs.prepare.outputs.sha }}
           TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          existing=$(gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          existing=$(gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null) || existing=""
           if [ -n "$existing" ]; then
             if [ "$existing" != "$SHA" ]; then
               echo "::error::tag $TAG already targets $existing instead of $SHA"

--- a/tests/integration/cipolicy/workflows_test.go
+++ b/tests/integration/cipolicy/workflows_test.go
@@ -69,6 +69,7 @@ func TestCanaryCreatesOnlyImmutableSemVerTags(t *testing.T) {
 		`-f sha="$SHA"`,
 		`retention-days: 90`,
 		`group: publish-canary-${{ github.event.workflow_run.head_sha || github.sha }}`,
+		`2>/dev/null) || existing=""`,
 	} {
 		if !strings.Contains(contents, required) {
 			t.Errorf("canary workflow is missing immutable SemVer policy %q", required)


### PR DESCRIPTION
Treat a 404 from the Git references API as an empty result instead of mistaking its JSON error body for an existing tag target.

Validation:
- `actionlint .github/workflows/canary.yml`
- `go test ./tests/integration/cipolicy`