### PR TITLE
Prefer canary workflow artifacts for installs

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -11,9 +11,14 @@
 - `latest` resolves the newest stable `vMAJOR.MINOR.PATCH` release.
 
 The canary workflow builds and tags automatically after main CI succeeds. Its
-workflow artifacts are retained for 90 days, while CLI canary installation
-builds the exact tagged source with the requested `go` or `tinygo` executable
-from `PATH`. Beta and stable releases are dispatched through
+workflow artifacts are retained for 90 days. Manager and runtime installation
+first attempt the matching host artifact and verify its bundled SHA-256 file.
+Wago first asks an installed and authenticated GitHub CLI (`gh`) to download the
+artifact. If that is unavailable, it tries the Actions API with
+`WAGO_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`. If both transports fail, or
+the archive is expired or invalid, installation builds the exact tagged source
+with the requested `go` or `tinygo` executable from `PATH`. Beta and stable
+releases are dispatched through
 `release.yml` with an exact full commit SHA that already passed main CI; those
 releases build, smoke-test, checksum, and publish the platform asset set. Before
 starting a new release series, update `RELEASE_SERIES` in `canary.yml`.

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wago-org/wago/internal/actionartifact"
 	"github.com/wago-org/wago/internal/installbootstrap"
 	"github.com/wago-org/wago/internal/sourcearchive"
 )
@@ -31,6 +32,8 @@ type installer struct {
 	releaseAPI          string
 	tagAPI              string
 	commitAPI           string
+	actionsArtifactAPI  string
+	actionsArtifactRepo string
 	releaseDownloadBase string
 	binDir              string
 	srcDir              string
@@ -85,6 +88,8 @@ var installerSourceArchiveURL = func(repo, ref string) string {
 	return "https://api.github.com/repos/" + repo + "/zipball/" + ref
 }
 
+var downloadInstallerActionArtifact = actionartifact.DownloadExecutable
+
 func newInstaller(out io.Writer) (*installer, error) {
 	home, err := os.UserHomeDir()
 	if value := firstEnv("HOME", "USERPROFILE"); value != "" {
@@ -115,6 +120,8 @@ func newInstaller(out io.Writer) (*installer, error) {
 		releaseAPI:          envOr("WAGO_RELEASES_API_URL", "https://api.github.com/repos/"+releaseRepo+"/releases"),
 		tagAPI:              envOr("WAGO_TAGS_API_URL", "https://api.github.com/repos/"+releaseRepo+"/tags"),
 		commitAPI:           envOr("WAGO_COMMITS_API_URL", "https://api.github.com/repos/"+releaseRepo+"/commits"),
+		actionsArtifactAPI:  envOr("WAGO_ACTIONS_ARTIFACT_API", "https://api.github.com/repos/"+releaseRepo+"/actions/artifacts"),
+		actionsArtifactRepo: releaseRepo,
 		releaseDownloadBase: envOr("WAGO_RELEASE_DOWNLOAD_BASE", "https://github.com/"+releaseRepo+"/releases"),
 		binDir:              filepath.Clean(binDir),
 		srcDir:              filepath.Clean(envOr("WAGO_SRC_DIR", filepath.Join(home, ".wago", "src"))),
@@ -409,16 +416,21 @@ func (i *installer) downloadManager(target string) error {
 	if channel, sha, canonical := installerRollingCommit(i.version); canonical && channel == "canary" {
 		i.managerTag = i.version
 		i.managerSourceRef = sha
-		return errors.New("canary tags do not contain release assets")
+		tag, err := i.canaryTagForCommit(sha)
+		if err != nil {
+			return fmt.Errorf("resolve canary workflow artifact: %w", err)
+		}
+		return i.downloadCanaryManager(tag, sha, target)
 	}
 	if i.version == "main" || i.version == "canary" {
 		tag, sha, err := i.latestCanaryTag()
 		if err != nil {
 			return err
 		}
-		i.managerTag = tag
-		i.managerSourceRef = sha
-		return errors.New("canary tags do not contain release assets")
+		return i.downloadCanaryManager(tag, sha, target)
+	}
+	if installerCanaryTag(i.version) {
+		return i.downloadCanaryManager(i.version, "", target)
 	}
 	resolved := installbootstrap.ResolvedRelease{Tag: i.version, SourceRef: installerSourceRef(i.version)}
 	base := ""
@@ -450,6 +462,31 @@ func (i *installer) downloadManager(target string) error {
 	return nil
 }
 
+func (i *installer) downloadCanaryManager(tag, sha, target string) error {
+	i.managerTag = tag
+	i.managerSourceRef = sha
+	if i.managerSourceRef == "" {
+		i.managerSourceRef = tag
+	}
+	asset, err := installbootstrap.Asset("wago", runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+	i.begin("Downloading Wago manager " + tag + " workflow artifact")
+	err = downloadInstallerActionArtifact(i.installContext(), actionartifact.Config{
+		CatalogURL: i.actionsArtifactAPI,
+		Repository: i.actionsArtifactRepo,
+		Token:      actionartifact.TokenFromEnvironment(),
+		HTTPClient: i.httpClient,
+	}, tag, sha, runtime.GOOS+"-"+runtime.GOARCH, asset, target)
+	if err != nil {
+		return fmt.Errorf("download canary workflow artifact: %w", err)
+	}
+	i.managerFromRelease = true
+	i.done("Downloaded and verified Wago manager " + tag)
+	return nil
+}
+
 type installerTag struct {
 	Name   string `json:"name"`
 	Commit struct {
@@ -457,21 +494,21 @@ type installerTag struct {
 	} `json:"commit"`
 }
 
-func (i *installer) latestCanaryTag() (string, string, error) {
+func (i *installer) canaryTagsByCommit() (map[string]string, error) {
 	var tags []installerTag
 	address, err := url.Parse(i.tagAPI)
 	if err != nil {
-		return "", "", fmt.Errorf("parse tag catalog URL: %w", err)
+		return nil, fmt.Errorf("parse tag catalog URL: %w", err)
 	}
 	query := address.Query()
 	query.Set("per_page", "100")
 	query.Set("page", "1")
 	address.RawQuery = query.Encode()
 	if err := i.getJSON(address.String(), &tags); err != nil {
-		return "", "", err
+		return nil, err
 	}
 	if len(tags) > 100 {
-		return "", "", errors.New("tag catalog returned too many tags")
+		return nil, errors.New("tag catalog returned too many tags")
 	}
 	byCommit := make(map[string]string, len(tags))
 	for _, tag := range tags {
@@ -484,9 +521,28 @@ func (i *installer) latestCanaryTag() (string, string, error) {
 		short := name[index+len(marker):]
 		sha := strings.ToLower(strings.TrimSpace(tag.Commit.SHA))
 		if len(short) != 7 || !fullInstallerCommitSHA(sha) || !strings.HasPrefix(sha, short) {
-			return "", "", fmt.Errorf("canary tag %q has an invalid target commit", tag.Name)
+			return nil, fmt.Errorf("canary tag %q has an invalid target commit", tag.Name)
 		}
 		byCommit[sha] = tag.Name
+	}
+	return byCommit, nil
+}
+
+func (i *installer) canaryTagForCommit(sha string) (string, error) {
+	byCommit, err := i.canaryTagsByCommit()
+	if err != nil {
+		return "", err
+	}
+	if tag := byCommit[strings.ToLower(strings.TrimSpace(sha))]; tag != "" {
+		return tag, nil
+	}
+	return "", errors.New("no canary tag found")
+}
+
+func (i *installer) latestCanaryTag() (string, string, error) {
+	byCommit, err := i.canaryTagsByCommit()
+	if err != nil {
+		return "", "", err
 	}
 	type commit struct {
 		SHA string `json:"sha"`
@@ -496,7 +552,7 @@ func (i *installer) latestCanaryTag() (string, string, error) {
 	if err != nil {
 		return "", "", fmt.Errorf("parse commit catalog URL: %w", err)
 	}
-	query = commitsAddress.Query()
+	query := commitsAddress.Query()
 	query.Set("sha", "main")
 	query.Set("per_page", "100")
 	query.Set("page", "1")

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -15,6 +15,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/wago-org/wago/internal/actionartifact"
+	"github.com/wago-org/wago/internal/installbootstrap"
 )
 
 type installerRoundTripFunc func(*http.Request) (*http.Response, error)
@@ -196,8 +199,18 @@ func TestInstallerDryRunPresentation(t *testing.T) {
 
 func TestInstallerBuildsExactCanonicalCanaryFromSource(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
+	const tag = "v0.1.0-canary.gdeadbee"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/tags" {
+			http.NotFound(writer, request)
+			return
+		}
+		_, _ = fmt.Fprintf(writer, `[{"name":%q,"commit":{"sha":%q}}]`, tag, sha)
+	}))
+	defer server.Close()
 	t.Setenv("NO_COLOR", "1")
 	t.Setenv("WAGO_VERSION", "canary@"+sha)
+	t.Setenv("WAGO_TAGS_API_URL", server.URL+"/tags")
 	var output bytes.Buffer
 	installer, err := newInstaller(&output)
 	if err != nil {
@@ -205,10 +218,18 @@ func TestInstallerBuildsExactCanonicalCanaryFromSource(t *testing.T) {
 	}
 	installer.tmpDir = t.TempDir()
 	target := filepath.Join(installer.tmpDir, executableName("wago"))
-	if err := installer.downloadManager(target); err == nil || !strings.Contains(err.Error(), "do not contain release assets") {
+	previousDownload := downloadInstallerActionArtifact
+	downloadInstallerActionArtifact = func(_ context.Context, _ actionartifact.Config, gotTag, commit, _, _, _ string) error {
+		if gotTag != tag || commit != sha {
+			t.Fatalf("artifact identity = %q@%s", gotTag, commit)
+		}
+		return errors.New("artifact unavailable")
+	}
+	t.Cleanup(func() { downloadInstallerActionArtifact = previousDownload })
+	if err := installer.downloadManager(target); err == nil || !strings.Contains(err.Error(), "artifact unavailable") {
 		t.Fatalf("downloadManager error = %v", err)
 	}
-	if installer.managerTag != "canary@"+sha || installer.managerSourceRef != sha || installer.managerFromRelease {
+	if installer.managerTag != tag || installer.managerSourceRef != sha || installer.managerFromRelease {
 		t.Fatalf("manager resolution = %q, %q, %v", installer.managerTag, installer.managerSourceRef, installer.managerFromRelease)
 	}
 }
@@ -494,11 +515,53 @@ func TestInstallerResolvesNewestCanaryTagForSourceBuild(t *testing.T) {
 	}
 	installer.tmpDir = t.TempDir()
 	target := filepath.Join(installer.tmpDir, executableName("wago"))
-	if err := installer.downloadManager(target); err == nil || !strings.Contains(err.Error(), "do not contain release assets") {
+	previousDownload := downloadInstallerActionArtifact
+	downloadInstallerActionArtifact = func(context.Context, actionartifact.Config, string, string, string, string, string) error {
+		return errors.New("artifact unavailable")
+	}
+	t.Cleanup(func() { downloadInstallerActionArtifact = previousDownload })
+	if err := installer.downloadManager(target); err == nil || !strings.Contains(err.Error(), "artifact unavailable") {
 		t.Fatalf("downloadManager error = %v", err)
 	}
 	if installer.managerTag != "v0.1.0-canary.gdeadbee" || installer.managerSourceRef != sha || installer.managerFromRelease {
 		t.Fatalf("manager resolution = %q, %q, %v", installer.managerTag, installer.managerSourceRef, installer.managerFromRelease)
+	}
+}
+
+func TestInstallerDownloadsCanaryManagerWorkflowArtifact(t *testing.T) {
+	const tag = "v0.1.0-canary.gdeadbee"
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("WAGO_VERSION", tag)
+	var output bytes.Buffer
+	installer, err := newInstaller(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installer.tmpDir = t.TempDir()
+	target := filepath.Join(installer.tmpDir, executableName("wago"))
+	previousDownload := downloadInstallerActionArtifact
+	downloadInstallerActionArtifact = func(_ context.Context, config actionartifact.Config, gotTag, commit, platform, asset, destination string) error {
+		if config.CatalogURL != installer.actionsArtifactAPI || gotTag != tag || commit != "" || platform != runtime.GOOS+"-"+runtime.GOARCH {
+			t.Fatalf("artifact request = %#v, %q, %q, %q", config, gotTag, commit, platform)
+		}
+		wantAsset, assetErr := installbootstrap.Asset("wago", runtime.GOOS, runtime.GOARCH)
+		if assetErr != nil {
+			t.Fatal(assetErr)
+		}
+		if asset != wantAsset || destination != target {
+			t.Fatalf("artifact target = %q, %q; want %q, %q", asset, destination, wantAsset, target)
+		}
+		return os.WriteFile(destination, []byte("artifact manager"), 0o755)
+	}
+	t.Cleanup(func() { downloadInstallerActionArtifact = previousDownload })
+	if err := installer.downloadManager(target); err != nil {
+		t.Fatal(err)
+	}
+	if installer.managerTag != tag || installer.managerSourceRef != tag || !installer.managerFromRelease {
+		t.Fatalf("manager resolution = %q, %q, %v", installer.managerTag, installer.managerSourceRef, installer.managerFromRelease)
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != "artifact manager" {
+		t.Fatalf("manager = %q, %v", got, readErr)
 	}
 }
 

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -392,6 +392,26 @@ func resolveRunnerVersion(ver string, progress *managerprogress.Progress) (resol
 func resolveRunnerVersionContext(ctx context.Context, ver string, progress *managerprogress.Progress) (resolved string, sourceOnly bool, err error) {
 	if channel, sha, canonical := rollingCommitSHA(ver); canonical {
 		if channel == "canary" {
+			if progress != nil {
+				progress.Begin("resolving canary workflow artifact")
+			}
+			tag, tagErr := canaryTagForCommitContext(ctx, sha)
+			if tagErr == nil {
+				resolved = tag + "@" + sha
+				if progress != nil {
+					progress.Done("resolved " + releasePickerLabel(resolved))
+				}
+				return resolved, true, nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				if progress != nil {
+					progress.Fail("could not resolve canary workflow artifact")
+				}
+				return "", false, ctxErr
+			}
+			if progress != nil {
+				progress.Done("no workflow artifact tag; using " + releasePickerLabel(ver) + " source")
+			}
 			return ver, true, nil
 		}
 		if progress != nil {
@@ -477,6 +497,16 @@ func installRunnerPayload(ref string, profile wagopaths.Profile, build wagopaths
 }
 
 func installRunnerPayloadContext(ctx context.Context, ref string, profile wagopaths.Profile, build wagopaths.Build, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
+	if _, _, canaryArtifact := canaryArtifactReference(ref); canaryArtifact {
+		err := downloadCanaryArtifactContext(ctx, ref, versionAsset(profile, build), dest, progress)
+		if err == nil {
+			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return buildRunnerSource(ctx, ref, profile, build, dest, progress)
+	}
 	if !sourceOnly {
 		err := downloadBinaryWithProgressContext(ctx, releaseBase(), releaseAssetVersion(ref), profile, build, dest, progress)
 		if err == nil {
@@ -531,6 +561,16 @@ func installManagerPayload(resolved, dest string, sourceOnly bool, progress *man
 }
 
 func installManagerPayloadContext(ctx context.Context, resolved, dest string, sourceOnly bool, progress *managerprogress.Progress) error {
+	if _, _, canaryArtifact := canaryArtifactReference(resolved); canaryArtifact {
+		err := downloadCanaryArtifactContext(ctx, resolved, managerAsset(), dest, progress)
+		if err == nil {
+			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return buildManagerSource(ctx, resolved, dest, progress)
+	}
 	if !sourceOnly {
 		err := downloadReleaseAssetWithProgressContext(
 			ctx,
@@ -601,24 +641,21 @@ func latestChannelRelease(channel string) (string, error) {
 
 const canaryTagDiscoveryPageSize = 100
 
-// latestCanaryTagContext resolves the newest qualified canary tag by
-// intersecting repository tags with main's newest-first commit history. The
-// repository tags endpoint does not guarantee commit-date ordering.
-func latestCanaryTagContext(ctx context.Context) (string, error) {
+func canaryTagsByCommitContext(ctx context.Context) (map[string]string, error) {
 	address := fmt.Sprintf("%s/repos/wago-org/wago/tags?per_page=%d&page=1", releaseAPI(), canaryTagDiscoveryPageSize)
 	response, err := getReleaseBytes(ctx, "canary tag discovery", address, releaseMetadataMaximum)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if response.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub returned %s", response.Status)
+		return nil, fmt.Errorf("GitHub returned %s", response.Status)
 	}
 	var tags []remoteTag
 	if err := json.Unmarshal(response.Body, &tags); err != nil {
-		return "", err
+		return nil, err
 	}
 	if len(tags) > canaryTagDiscoveryPageSize {
-		return "", errors.New("GitHub returned too many tags")
+		return nil, errors.New("GitHub returned too many tags")
 	}
 	byCommit := make(map[string]string, len(tags))
 	for _, tag := range tags {
@@ -627,13 +664,35 @@ func latestCanaryTagContext(ctx context.Context) (string, error) {
 		}
 		sha := strings.ToLower(strings.TrimSpace(tag.Commit.SHA))
 		if !validCommitSHA(sha) {
-			return "", fmt.Errorf("GitHub tag %q has an invalid target commit", tag.Name)
+			return nil, fmt.Errorf("GitHub tag %q has an invalid target commit", tag.Name)
 		}
 		_, identity, _ := strings.Cut(strings.ToLower(tag.Name), "-canary.g")
 		if !strings.HasPrefix(sha, identity) {
-			return "", fmt.Errorf("GitHub tag %q does not match target commit %s", tag.Name, sha)
+			return nil, fmt.Errorf("GitHub tag %q does not match target commit %s", tag.Name, sha)
 		}
 		byCommit[sha] = tag.Name
+	}
+	return byCommit, nil
+}
+
+func canaryTagForCommitContext(ctx context.Context, sha string) (string, error) {
+	byCommit, err := canaryTagsByCommitContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	if tag := byCommit[strings.ToLower(strings.TrimSpace(sha))]; tag != "" {
+		return tag, nil
+	}
+	return "", fmt.Errorf("%w: canary tag", errNoPublishedRelease)
+}
+
+// latestCanaryTagContext resolves the newest qualified canary tag by
+// intersecting repository tags with main's newest-first commit history. The
+// repository tags endpoint does not guarantee commit-date ordering.
+func latestCanaryTagContext(ctx context.Context) (string, error) {
+	byCommit, err := canaryTagsByCommitContext(ctx)
+	if err != nil {
+		return "", err
 	}
 	commitsAddress := fmt.Sprintf("%s/repos/wago-org/wago/commits?sha=main&per_page=%d&page=1", releaseAPI(), canaryTagDiscoveryPageSize)
 	commitsResponse, err := getReleaseBytes(ctx, "canary commit discovery", commitsAddress, releaseMetadataMaximum)

--- a/cli/manager/internal/version/download.go
+++ b/cli/manager/internal/version/download.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
+	"github.com/wago-org/wago/internal/actionartifact"
 	"github.com/wago-org/wago/internal/atomicfile"
 	"github.com/wago-org/wago/internal/httpclient"
 	"github.com/wago-org/wago/internal/wagopaths"
@@ -25,8 +26,9 @@ import (
 const releaseAssetLimit int64 = 512 << 20
 
 var (
-	releaseAssetMaximum = releaseAssetLimit
-	errChecksumFormat   = errors.New("invalid release checksum format")
+	releaseAssetMaximum       = releaseAssetLimit
+	errChecksumFormat         = errors.New("invalid release checksum format")
+	downloadActionsExecutable = actionartifact.DownloadExecutable
 )
 
 type httpStatusError struct {
@@ -238,6 +240,47 @@ func managerAsset() string {
 	return "wago-" + runtime.GOOS + "-" + runtime.GOARCH
 }
 
+func canaryArtifactReference(ref string) (tag, commit string, ok bool) {
+	tag = releaseAssetVersion(ref)
+	if channelRelease(tag) != "canary" {
+		return "", "", false
+	}
+	if _, sha, canonical := rollingCommitSHA(ref); canonical {
+		commit = sha
+	}
+	return tag, commit, true
+}
+
+func downloadCanaryArtifactContext(ctx context.Context, ref, asset, dest string, progress *managerprogress.Progress) error {
+	tag, commit, ok := canaryArtifactReference(ref)
+	if !ok {
+		return errors.New("version does not identify a canary workflow artifact")
+	}
+	if progress != nil {
+		progress.Begin("downloading canary workflow artifact")
+	}
+	err := downloadActionsExecutable(ctx, actionartifact.Config{
+		CatalogURL: actionsArtifactCatalog(),
+		Repository: "wago-org/wago",
+		Token:      actionartifact.TokenFromEnvironment(),
+	}, tag, commit, runtime.GOOS+"-"+runtime.GOARCH, asset, dest)
+	if err != nil {
+		if progress != nil {
+			if ctx.Err() != nil {
+				progress.Fail("artifact download canceled")
+			} else {
+				progress.Done("workflow artifact unavailable; using source")
+			}
+		}
+		return err
+	}
+	if progress != nil {
+		progress.Done("downloaded and verified " + asset)
+		progress.Done("installed executable")
+	}
+	return nil
+}
+
 // httpGetBytesProgress remains for small metadata tests/callers only. Release
 // executables use the dedicated streaming path above.
 func httpGetBytesProgress(url string, progress func(current, total int64)) ([]byte, error) {
@@ -268,4 +311,11 @@ func releaseAPI() string {
 		return v
 	}
 	return "https://api.github.com"
+}
+
+func actionsArtifactCatalog() string {
+	if value := os.Getenv("WAGO_ACTIONS_ARTIFACT_API"); value != "" {
+		return value
+	}
+	return strings.TrimRight(releaseAPI(), "/") + "/repos/wago-org/wago/actions/artifacts"
 }

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -10,12 +10,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
+	"github.com/wago-org/wago/internal/actionartifact"
 	"github.com/wago-org/wago/internal/atomicfile"
 	"github.com/wago-org/wago/internal/httpclient"
 	"github.com/wago-org/wago/internal/wagopaths"
@@ -212,6 +214,79 @@ func TestMissingManagerAssetFallsBackToSource(t *testing.T) {
 	}
 }
 
+func TestCanaryWorkflowArtifactPreferredForRuntimeAndManager(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	ref := "v0.1.0-canary.gdeadbee@" + sha
+	previousDownload := downloadActionsExecutable
+	previousRunner, previousManager := buildRunnerSource, buildManagerSource
+	var assets []string
+	downloadActionsExecutable = func(_ context.Context, config actionartifact.Config, tag, commit, platform, asset, destination string) error {
+		if config.CatalogURL != actionsArtifactCatalog() || tag != "v0.1.0-canary.gdeadbee" || commit != sha || platform != runtime.GOOS+"-"+runtime.GOARCH {
+			t.Fatalf("artifact request = %#v, %q, %q, %q", config, tag, commit, platform)
+		}
+		assets = append(assets, asset)
+		return os.WriteFile(destination, []byte("artifact "+asset), 0o755)
+	}
+	buildRunnerSource = func(context.Context, string, wagopaths.Profile, wagopaths.Build, string, *managerprogress.Progress) error {
+		t.Fatal("runtime source build called after artifact download")
+		return nil
+	}
+	buildManagerSource = func(context.Context, string, string, *managerprogress.Progress) error {
+		t.Fatal("manager source build called after artifact download")
+		return nil
+	}
+	t.Cleanup(func() {
+		downloadActionsExecutable = previousDownload
+		buildRunnerSource, buildManagerSource = previousRunner, previousManager
+	})
+
+	runner := filepath.Join(t.TempDir(), "runner")
+	manager := filepath.Join(t.TempDir(), "manager")
+	if err := installRunnerPayload(ref, wagopaths.ProfileMinimal, wagopaths.BuildTiny, runner, true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := installManagerPayload(ref, manager, true, nil); err != nil {
+		t.Fatal(err)
+	}
+	wantAssets := []string{versionAsset(wagopaths.ProfileMinimal, wagopaths.BuildTiny), managerAsset()}
+	if fmt.Sprint(assets) != fmt.Sprint(wantAssets) {
+		t.Fatalf("downloaded assets = %v, want %v", assets, wantAssets)
+	}
+}
+
+func TestCanaryWorkflowArtifactFailureBuildsExactSource(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	ref := "v0.1.0-canary.gdeadbee@" + sha
+	previousDownload := downloadActionsExecutable
+	previousRunner, previousManager := buildRunnerSource, buildManagerSource
+	var runnerRef, managerRef string
+	downloadActionsExecutable = func(context.Context, actionartifact.Config, string, string, string, string, string) error {
+		return errors.New("GitHub returned 401")
+	}
+	buildRunnerSource = func(_ context.Context, ref string, _ wagopaths.Profile, _ wagopaths.Build, destination string, _ *managerprogress.Progress) error {
+		runnerRef = ref
+		return os.WriteFile(destination, []byte("source runner"), 0o755)
+	}
+	buildManagerSource = func(_ context.Context, ref, destination string, _ *managerprogress.Progress) error {
+		managerRef = ref
+		return os.WriteFile(destination, []byte("source manager"), 0o755)
+	}
+	t.Cleanup(func() {
+		downloadActionsExecutable = previousDownload
+		buildRunnerSource, buildManagerSource = previousRunner, previousManager
+	})
+
+	if err := installRunnerPayload(ref, wagopaths.ProfileStandard, wagopaths.BuildNormal, filepath.Join(t.TempDir(), "runner"), true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := installManagerPayload(ref, filepath.Join(t.TempDir(), "manager"), true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if runnerRef != ref || managerRef != ref {
+		t.Fatalf("source fallback refs = runtime %q, manager %q; want %q", runnerRef, managerRef, ref)
+	}
+}
+
 func TestChecksumMismatchDoesNotBuildFromSource(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ".sha256") {
@@ -254,6 +329,40 @@ func TestCanaryResolvesLatestTagAsSource(t *testing.T) {
 	ref, sourceOnly, err := resolveRunnerVersion("canary", nil)
 	if err != nil || ref != "v0.1.0-canary.g"+sha[:7]+"@"+sha || !sourceOnly {
 		t.Fatalf("resolveRunnerVersion = %q, %v, %v", ref, sourceOnly, err)
+	}
+}
+
+func TestCanonicalCanaryCommitResolvesWorkflowArtifactTag(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.HasSuffix(request.URL.Path, "/tags") {
+			_, _ = fmt.Fprintf(writer, `[{"name":"v0.1.0-canary.gdeadbee","commit":{"sha":%q}}]`, sha)
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_RELEASE_API", server.URL)
+	resolved, sourceOnly, err := resolveRunnerVersion("canary@"+sha, nil)
+	if err != nil || resolved != "v0.1.0-canary.gdeadbee@"+sha || !sourceOnly {
+		t.Fatalf("canonical canary resolution = %q, %v, %v", resolved, sourceOnly, err)
+	}
+}
+
+func TestCanonicalCanaryCommitWithoutTagRemainsExactSource(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.HasSuffix(request.URL.Path, "/tags") {
+			_, _ = writer.Write([]byte(`[]`))
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+	t.Setenv("WAGO_RELEASE_API", server.URL)
+	resolved, sourceOnly, err := resolveRunnerVersion("canary@"+sha, nil)
+	if err != nil || resolved != "canary@"+sha || !sourceOnly {
+		t.Fatalf("untagged canary resolution = %q, %v, %v", resolved, sourceOnly, err)
 	}
 }
 

--- a/install_test.go
+++ b/install_test.go
@@ -400,14 +400,20 @@ func TestWineInstallerCompletesNativeInstallFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	managerHash := fmt.Sprintf("%x", sha256.Sum256(manager))
+	managerArtifact := makeArtifactArchive(t, map[string][]byte{
+		"wago-windows-amd64":        manager,
+		"wago-windows-amd64.sha256": []byte(managerHash + "  wago-windows-amd64\n"),
+	})
 	sourceArchive := makeSourceArchive(t)
 	tag := "v0.1.0-canary.gccccccc"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/download/" + tag + "/wago-windows-amd64":
-			_, _ = w.Write(manager)
-		case "/download/" + tag + "/wago-windows-amd64.sha256":
-			_, _ = fmt.Fprintf(w, "%s  wago-windows-amd64\n", managerHash)
+		case "/artifacts":
+			_, _ = fmt.Fprintf(w, `{"artifacts":[{"id":1,"name":%q,"expired":false,"created_at":"2026-09-10T00:00:00Z","archive_download_url":%q,"workflow_run":{"head_sha":"cccccccccccccccccccccccccccccccccccccccc"}}]}`,
+				tag+"-windows-amd64", server.URL+"/artifact.zip")
+		case "/artifact.zip":
+			_, _ = w.Write(managerArtifact)
 		case "/source.zip":
 			_, _ = w.Write(sourceArchive)
 		default:
@@ -427,7 +433,7 @@ func TestWineInstallerCompletesNativeInstallFlow(t *testing.T) {
 		"WAGO_VERSION="+tag,
 		"WAGO_BIN_DIR="+windowsPath(binDir),
 		"WAGO_SRC_DIR="+windowsPath(srcDir),
-		"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"WAGO_ACTIONS_ARTIFACT_API="+server.URL+"/artifacts",
 		"WAGO_ARCHIVE_URL="+server.URL+"/source.zip",
 		"WAGO_REPO_URL=Z:\\does-not-exist",
 	)
@@ -437,7 +443,7 @@ func TestWineInstallerCompletesNativeInstallFlow(t *testing.T) {
 	}
 	text := strings.ReplaceAll(string(output), "\r", "")
 	for _, fragment := range []string{
-		"Downloaded Wago manager " + tag,
+		"Downloaded and verified Wago manager " + tag,
 		"Fetched Wago source",
 		"Verified installation",
 		"Sweet, Wago " + tag + " is ready",
@@ -466,6 +472,25 @@ func TestWineInstallerCompletesNativeInstallFlow(t *testing.T) {
 			t.Fatalf("Wine install did not create %s: %v", path, err)
 		}
 	}
+}
+
+func makeArtifactArchive(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	for name, data := range files {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return archive.Bytes()
 }
 
 func buildInstaller(t *testing.T, target, goos, goarch string) {

--- a/internal/actionartifact/artifact.go
+++ b/internal/actionartifact/artifact.go
@@ -1,0 +1,423 @@
+// Package actionartifact downloads checksum-verified executables from GitHub
+// Actions artifacts. Callers retain an exact-source fallback because GitHub
+// requires authentication for artifact archives and expires them over time.
+package actionartifact
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wago-org/wago/internal/atomicfile"
+	"github.com/wago-org/wago/internal/httpclient"
+)
+
+const (
+	metadataLimit int64 = 4 << 20
+	archiveLimit  int64 = 512 << 20
+	checksumLimit int64 = 4 << 10
+)
+
+// Config identifies one repository's Actions artifact catalog. HTTPClient is
+// optional and primarily supports deterministic tests.
+type Config struct {
+	CatalogURL string
+	Repository string
+	Token      string
+	HTTPClient *http.Client
+}
+
+type catalog struct {
+	Artifacts []artifact `json:"artifacts"`
+}
+
+type artifact struct {
+	ID                 int64     `json:"id"`
+	Name               string    `json:"name"`
+	Expired            bool      `json:"expired"`
+	CreatedAt          time.Time `json:"created_at"`
+	ArchiveDownloadURL string    `json:"archive_download_url"`
+	WorkflowRun        struct {
+		ID      int64  `json:"id"`
+		HeadSHA string `json:"head_sha"`
+	} `json:"workflow_run"`
+}
+
+var downloadWithGitHubCLI = githubCLIDownload
+
+// TokenFromEnvironment returns the conventional GitHub API token, when one is
+// available. GitHub Actions archive downloads return 401 without one even for
+// public repositories; an empty token is still useful because callers must
+// attempt the public endpoint before falling back to source.
+func TokenFromEnvironment() string {
+	for _, name := range []string{"WAGO_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// DownloadExecutable downloads the newest non-expired host artifact for tag,
+// verifies that its workflow commit matches commit (or tag's short SHA), then
+// extracts and checksum-verifies asset into destination atomically.
+func DownloadExecutable(ctx context.Context, config Config, tag, commit, target, asset, destination string) error {
+	if ctx == nil {
+		return errors.New("nil Actions artifact context")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(config.CatalogURL) == "" {
+		return errors.New("Actions artifact catalog URL is empty")
+	}
+	short, err := canaryShortSHA(tag)
+	if err != nil {
+		return err
+	}
+	commit = strings.ToLower(strings.TrimSpace(commit))
+	if commit != "" && (!fullCommitSHA(commit) || !strings.HasPrefix(commit, short)) {
+		return fmt.Errorf("canary artifact commit %q does not match tag %s", commit, tag)
+	}
+	artifactName := tag + "-" + target
+	selected, err := find(ctx, config, artifactName, commit, short)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(config.Repository) != "" {
+		directory, tempErr := os.MkdirTemp("", ".wago-gh-artifact-*")
+		if tempErr == nil {
+			defer os.RemoveAll(directory)
+			if ghErr := downloadWithGitHubCLI(ctx, config.Repository, selected.WorkflowRun.ID, selected.Name, directory); ghErr == nil {
+				if installErr := installDirectoryExecutable(directory, asset, destination); installErr == nil {
+					return nil
+				}
+			} else if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+		}
+	}
+	return download(ctx, config, selected, asset, destination)
+}
+
+func githubCLIDownload(ctx context.Context, repository string, runID int64, name, directory string) error {
+	if runID <= 0 {
+		return errors.New("Actions artifact does not identify its workflow run")
+	}
+	gh, err := exec.LookPath("gh")
+	if err != nil {
+		return err
+	}
+	command := exec.CommandContext(ctx, gh,
+		"run", "download", strconv.FormatInt(runID, 10),
+		"--repo", repository,
+		"--name", name,
+		"--dir", directory,
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		return fmt.Errorf("gh run download: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func find(ctx context.Context, config Config, name, commit, short string) (artifact, error) {
+	address, err := url.Parse(config.CatalogURL)
+	if err != nil {
+		return artifact{}, fmt.Errorf("parse Actions artifact catalog URL: %w", err)
+	}
+	query := address.Query()
+	query.Set("name", name)
+	query.Set("per_page", "100")
+	address.RawQuery = query.Encode()
+	request, err := request(ctx, address.String(), config.Token)
+	if err != nil {
+		return artifact{}, err
+	}
+	client := httpclient.New(httpclient.Config{HTTPClient: config.HTTPClient, Timeout: 30 * time.Second})
+	response, err := client.Bytes(ctx, request, metadataLimit)
+	if err != nil {
+		return artifact{}, fmt.Errorf("fetch Actions artifact catalog: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return artifact{}, fmt.Errorf("fetch Actions artifact catalog: GET %s: %s", address, response.Status)
+	}
+	var items catalog
+	if err := json.Unmarshal(response.Body, &items); err != nil {
+		return artifact{}, fmt.Errorf("decode Actions artifact catalog: %w", err)
+	}
+	if len(items.Artifacts) > 100 {
+		return artifact{}, errors.New("Actions artifact catalog returned too many artifacts")
+	}
+	sort.SliceStable(items.Artifacts, func(i, j int) bool {
+		if items.Artifacts[i].CreatedAt.Equal(items.Artifacts[j].CreatedAt) {
+			return items.Artifacts[i].ID > items.Artifacts[j].ID
+		}
+		return items.Artifacts[i].CreatedAt.After(items.Artifacts[j].CreatedAt)
+	})
+	for _, item := range items.Artifacts {
+		head := strings.ToLower(strings.TrimSpace(item.WorkflowRun.HeadSHA))
+		if item.ID <= 0 || item.Name != name || item.Expired || item.ArchiveDownloadURL == "" || !fullCommitSHA(head) {
+			continue
+		}
+		if commit != "" && head != commit {
+			continue
+		}
+		if commit == "" && !strings.HasPrefix(head, short) {
+			continue
+		}
+		return item, nil
+	}
+	return artifact{}, fmt.Errorf("no usable Actions artifact named %s", name)
+}
+
+func download(ctx context.Context, config Config, item artifact, asset, destination string) error {
+	request, err := request(ctx, item.ArchiveDownloadURL, config.Token)
+	if err != nil {
+		return err
+	}
+	client := httpclient.New(httpclient.Config{
+		HTTPClient:            config.HTTPClient,
+		Timeout:               30 * time.Minute,
+		ResponseHeaderTimeout: 30 * time.Second,
+	})
+	response, err := client.Open(ctx, request)
+	if err != nil {
+		return fmt.Errorf("download Actions artifact: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("download Actions artifact: GET %s: %s", item.ArchiveDownloadURL, response.Status)
+	}
+	if response.ContentLength > archiveLimit {
+		return &httpclient.BodyTooLargeError{URL: item.ArchiveDownloadURL, Limit: archiveLimit, ContentLength: response.ContentLength}
+	}
+	archive, err := os.CreateTemp("", ".wago-actions-artifact-*.zip")
+	if err != nil {
+		return err
+	}
+	archivePath := archive.Name()
+	defer os.Remove(archivePath)
+	written, copyErr := io.Copy(archive, io.LimitReader(response.Body, archiveLimit+1))
+	closeErr := archive.Close()
+	if copyErr != nil {
+		return fmt.Errorf("download Actions artifact: %w", copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close Actions artifact: %w", closeErr)
+	}
+	if written > archiveLimit {
+		return &httpclient.BodyTooLargeError{URL: item.ArchiveDownloadURL, Limit: archiveLimit, ContentLength: -1}
+	}
+	if response.ContentLength >= 0 && written != response.ContentLength {
+		return fmt.Errorf("download Actions artifact: %w", io.ErrUnexpectedEOF)
+	}
+	return extractExecutable(archivePath, asset, destination)
+}
+
+func extractExecutable(archivePath, asset, destination string) error {
+	archive, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("open Actions artifact: %w", err)
+	}
+	defer archive.Close()
+	var payload, checksum *zip.File
+	for _, file := range archive.File {
+		switch file.Name {
+		case asset:
+			if payload != nil {
+				return fmt.Errorf("Actions artifact contains duplicate %s", asset)
+			}
+			payload = file
+		case asset + ".sha256":
+			if checksum != nil {
+				return fmt.Errorf("Actions artifact contains duplicate %s.sha256", asset)
+			}
+			checksum = file
+		}
+	}
+	if payload == nil || checksum == nil {
+		return fmt.Errorf("Actions artifact does not contain %s and its checksum", asset)
+	}
+	if payload.UncompressedSize64 > uint64(archiveLimit) {
+		return &httpclient.BodyTooLargeError{URL: filepath.Base(archivePath) + ":" + asset, Limit: archiveLimit, ContentLength: int64(payload.UncompressedSize64)}
+	}
+	want, err := readChecksum(checksum, asset)
+	if err != nil {
+		return err
+	}
+	input, err := payload.Open()
+	if err != nil {
+		return fmt.Errorf("open %s in Actions artifact: %w", asset, err)
+	}
+	defer input.Close()
+	err = atomicfile.ReplaceFile(destination, atomicfile.Options{Mode: 0o755, Sync: true}, func(writer io.Writer) error {
+		hash := sha256.New()
+		written, err := io.Copy(io.MultiWriter(writer, hash), io.LimitReader(input, archiveLimit+1))
+		if err != nil {
+			return err
+		}
+		if written > archiveLimit {
+			return &httpclient.BodyTooLargeError{URL: asset, Limit: archiveLimit, ContentLength: -1}
+		}
+		if uint64(written) != payload.UncompressedSize64 {
+			return io.ErrUnexpectedEOF
+		}
+		if subtle.ConstantTimeCompare(hash.Sum(nil), want[:]) != 1 {
+			return fmt.Errorf("checksum mismatch for %s", asset)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("extract %s from Actions artifact: %w", asset, err)
+	}
+	return nil
+}
+
+func installDirectoryExecutable(directory, asset, destination string) error {
+	payloadPath := filepath.Join(directory, asset)
+	checksumPath := filepath.Join(directory, asset+".sha256")
+	payloadInfo, err := os.Lstat(payloadPath)
+	if err != nil || !payloadInfo.Mode().IsRegular() || payloadInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("gh artifact does not contain regular file %s", asset)
+	}
+	if payloadInfo.Size() > archiveLimit {
+		return &httpclient.BodyTooLargeError{URL: payloadPath, Limit: archiveLimit, ContentLength: payloadInfo.Size()}
+	}
+	checksumInfo, err := os.Lstat(checksumPath)
+	if err != nil || !checksumInfo.Mode().IsRegular() || checksumInfo.Mode()&os.ModeSymlink != 0 || checksumInfo.Size() > checksumLimit {
+		return fmt.Errorf("gh artifact does not contain valid checksum %s.sha256", asset)
+	}
+	checksum, err := os.ReadFile(checksumPath)
+	if err != nil {
+		return err
+	}
+	want, err := parseChecksum(checksum, asset)
+	if err != nil {
+		return err
+	}
+	input, err := os.Open(payloadPath)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	err = atomicfile.ReplaceFile(destination, atomicfile.Options{Mode: 0o755, Sync: true}, func(writer io.Writer) error {
+		hash := sha256.New()
+		written, err := io.Copy(io.MultiWriter(writer, hash), io.LimitReader(input, archiveLimit+1))
+		if err != nil {
+			return err
+		}
+		if written > archiveLimit {
+			return &httpclient.BodyTooLargeError{URL: payloadPath, Limit: archiveLimit, ContentLength: -1}
+		}
+		if written != payloadInfo.Size() {
+			return io.ErrUnexpectedEOF
+		}
+		if subtle.ConstantTimeCompare(hash.Sum(nil), want[:]) != 1 {
+			return fmt.Errorf("checksum mismatch for %s", asset)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("install %s from gh artifact: %w", asset, err)
+	}
+	return nil
+}
+
+func readChecksum(file *zip.File, asset string) ([sha256.Size]byte, error) {
+	var digest [sha256.Size]byte
+	if file.UncompressedSize64 > uint64(checksumLimit) {
+		return digest, errors.New("Actions artifact checksum exceeds size limit")
+	}
+	reader, err := file.Open()
+	if err != nil {
+		return digest, fmt.Errorf("open Actions artifact checksum: %w", err)
+	}
+	defer reader.Close()
+	data, err := httpclient.ReadBounded(reader, int64(file.UncompressedSize64), checksumLimit, asset+".sha256")
+	if err != nil {
+		return digest, err
+	}
+	return parseChecksum(data, asset)
+}
+
+func parseChecksum(data []byte, asset string) ([sha256.Size]byte, error) {
+	var digest [sha256.Size]byte
+	line := strings.TrimSuffix(strings.TrimSuffix(string(data), "\n"), "\r")
+	if line == "" || strings.ContainsAny(line, "\r\n") {
+		return digest, errors.New("Actions artifact checksum is malformed")
+	}
+	separator := strings.IndexAny(line, " \t")
+	if separator != 64 {
+		return digest, errors.New("Actions artifact checksum is malformed")
+	}
+	name := strings.TrimLeft(line[separator:], " \t")
+	name = strings.TrimPrefix(name, "*")
+	if name != asset && name != "./"+asset {
+		return digest, errors.New("Actions artifact checksum names the wrong file")
+	}
+	decoded, err := hex.DecodeString(line[:separator])
+	if err != nil || len(decoded) != sha256.Size {
+		return digest, errors.New("Actions artifact checksum is malformed")
+	}
+	copy(digest[:], decoded)
+	return digest, nil
+}
+
+func request(ctx context.Context, address, token string) (*http.Request, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	request.Header.Set("User-Agent", "wago-cli")
+	if token = strings.TrimSpace(token); token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	return request, nil
+}
+
+func canaryShortSHA(tag string) (string, error) {
+	marker := "-canary.g"
+	index := strings.LastIndex(strings.ToLower(strings.TrimSpace(tag)), marker)
+	if index < 0 {
+		return "", fmt.Errorf("%q is not a canary tag", tag)
+	}
+	short := strings.ToLower(strings.TrimSpace(tag))[index+len(marker):]
+	if len(short) != 7 {
+		return "", fmt.Errorf("%q is not a canary tag", tag)
+	}
+	for _, char := range short {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return "", fmt.Errorf("%q is not a canary tag", tag)
+		}
+	}
+	return short, nil
+}
+
+func fullCommitSHA(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, char := range value {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/actionartifact/artifact_test.go
+++ b/internal/actionartifact/artifact_test.go
@@ -1,0 +1,233 @@
+package actionartifact
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const testCommit = "deadbee123456789012345678901234567890123"
+
+func TestDownloadExecutable(t *testing.T) {
+	const (
+		tag    = "v0.1.0-canary.gdeadbee"
+		target = "linux-amd64"
+		asset  = "wago-linux-amd64"
+	)
+	payload := []byte("manager")
+	archive := artifactZip(t, asset, payload, "")
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Bearer secret" {
+			t.Errorf("authorization = %q", request.Header.Get("Authorization"))
+		}
+		switch request.URL.Path {
+		case "/artifacts":
+			if got := request.URL.Query().Get("name"); got != tag+"-"+target {
+				t.Errorf("artifact name = %q", got)
+			}
+			fmt.Fprintf(writer, `{"artifacts":[{"id":7,"name":%q,"expired":false,"created_at":"2026-09-10T00:00:00Z","archive_download_url":%q,"workflow_run":{"head_sha":%q}}]}`,
+				tag+"-"+target, server.URL+"/archive", testCommit)
+		case "/archive":
+			writer.Header().Set("Content-Length", fmt.Sprint(len(archive)))
+			_, _ = writer.Write(archive)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "wago")
+	if err := os.WriteFile(destination, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := DownloadExecutable(context.Background(), Config{CatalogURL: server.URL + "/artifacts", Token: "secret", HTTPClient: server.Client()}, tag, testCommit, target, asset, destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded payload = %q, %v", got, err)
+	}
+	if info, err := os.Stat(destination); err != nil {
+		t.Fatal(err)
+	} else if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
+		t.Fatalf("downloaded mode = %v", info.Mode().Perm())
+	}
+}
+
+func TestDownloadExecutablePrefersGitHubCLI(t *testing.T) {
+	const (
+		tag        = "v0.1.0-canary.gdeadbee"
+		target     = "linux-amd64"
+		asset      = "wago-linux-amd64"
+		repository = "wago-org/wago"
+	)
+	payload := []byte("manager from gh")
+	archiveRequested := false
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/artifacts":
+			fmt.Fprintf(writer, `{"artifacts":[{"id":7,"name":%q,"expired":false,"created_at":"2026-09-10T00:00:00Z","archive_download_url":%q,"workflow_run":{"id":42,"head_sha":%q}}]}`,
+				tag+"-"+target, server.URL+"/archive", testCommit)
+		case "/archive":
+			archiveRequested = true
+			http.Error(writer, "direct API must not be used", http.StatusInternalServerError)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	original := downloadWithGitHubCLI
+	downloadWithGitHubCLI = func(_ context.Context, gotRepository string, runID int64, name, directory string) error {
+		if gotRepository != repository || runID != 42 || name != tag+"-"+target {
+			t.Fatalf("gh download = repository %q, run %d, artifact %q", gotRepository, runID, name)
+		}
+		if err := os.WriteFile(filepath.Join(directory, asset), payload, 0o644); err != nil {
+			return err
+		}
+		sum := sha256.Sum256(payload)
+		return os.WriteFile(filepath.Join(directory, asset+".sha256"), []byte(fmt.Sprintf("%x  %s\n", sum, asset)), 0o644)
+	}
+	t.Cleanup(func() { downloadWithGitHubCLI = original })
+
+	destination := filepath.Join(t.TempDir(), "wago")
+	err := DownloadExecutable(context.Background(), Config{
+		CatalogURL: server.URL + "/artifacts",
+		Repository: repository,
+		HTTPClient: server.Client(),
+	}, tag, testCommit, target, asset, destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archiveRequested {
+		t.Fatal("direct Actions API archive was requested after successful gh download")
+	}
+	if got, readErr := os.ReadFile(destination); readErr != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded payload = %q, %v", got, readErr)
+	}
+}
+
+func TestDownloadExecutableFallsBackFromGitHubCLIToAPI(t *testing.T) {
+	const (
+		tag    = "v0.1.0-canary.gdeadbee"
+		target = "linux-amd64"
+		asset  = "wago-linux-amd64"
+	)
+	payload := []byte("manager from API")
+	archive := artifactZip(t, asset, payload, "")
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/artifacts":
+			fmt.Fprintf(writer, `{"artifacts":[{"id":7,"name":%q,"expired":false,"created_at":"2026-09-10T00:00:00Z","archive_download_url":%q,"workflow_run":{"id":42,"head_sha":%q}}]}`,
+				tag+"-"+target, server.URL+"/archive", testCommit)
+		case "/archive":
+			_, _ = writer.Write(archive)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	original := downloadWithGitHubCLI
+	downloadWithGitHubCLI = func(context.Context, string, int64, string, string) error {
+		return errors.New("gh is unavailable")
+	}
+	t.Cleanup(func() { downloadWithGitHubCLI = original })
+
+	destination := filepath.Join(t.TempDir(), "wago")
+	err := DownloadExecutable(context.Background(), Config{
+		CatalogURL: server.URL + "/artifacts",
+		Repository: "wago-org/wago",
+		HTTPClient: server.Client(),
+	}, tag, testCommit, target, asset, destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, readErr := os.ReadFile(destination); readErr != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded payload = %q, %v", got, readErr)
+	}
+}
+
+func TestDownloadExecutableRejectsUnusableArtifactWithoutChangingDestination(t *testing.T) {
+	const tag = "v0.1.0-canary.gdeadbee"
+	for _, test := range []struct {
+		name       string
+		catalogSHA string
+		status     int
+		checksum   string
+	}{
+		{name: "wrong commit", catalogSHA: "cafef00123456789012345678901234567890123", status: http.StatusOK},
+		{name: "unauthorized archive", catalogSHA: testCommit, status: http.StatusUnauthorized},
+		{name: "bad checksum", catalogSHA: testCommit, status: http.StatusOK, checksum: strings.Repeat("0", 64) + "  wago-linux-amd64\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			archive := artifactZip(t, "wago-linux-amd64", []byte("new"), test.checksum)
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				switch request.URL.Path {
+				case "/artifacts":
+					fmt.Fprintf(writer, `{"artifacts":[{"id":7,"name":%q,"expired":false,"created_at":"2026-09-10T00:00:00Z","archive_download_url":%q,"workflow_run":{"head_sha":%q}}]}`,
+						tag+"-linux-amd64", server.URL+"/archive", test.catalogSHA)
+				case "/archive":
+					if test.status != http.StatusOK {
+						writer.WriteHeader(test.status)
+						return
+					}
+					_, _ = writer.Write(archive)
+				default:
+					http.NotFound(writer, request)
+				}
+			}))
+			defer server.Close()
+
+			destination := filepath.Join(t.TempDir(), "wago")
+			if err := os.WriteFile(destination, []byte("old"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			err := DownloadExecutable(context.Background(), Config{CatalogURL: server.URL + "/artifacts", HTTPClient: server.Client()}, tag, testCommit, "linux-amd64", "wago-linux-amd64", destination)
+			if err == nil {
+				t.Fatal("unusable artifact was accepted")
+			}
+			if got, readErr := os.ReadFile(destination); readErr != nil || string(got) != "old" {
+				t.Fatalf("destination = %q, %v after %v", got, readErr, err)
+			}
+		})
+	}
+}
+
+func artifactZip(t *testing.T, asset string, payload []byte, checksum string) []byte {
+	t.Helper()
+	if checksum == "" {
+		sum := sha256.Sum256(payload)
+		checksum = fmt.Sprintf("%x  %s\n", sum, asset)
+	}
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for name, data := range map[string][]byte{asset: payload, asset + ".sha256": []byte(checksum)} {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}


### PR DESCRIPTION
Canary manager and runtime installation now attempt the matching host-specific GitHub Actions artifact first, validate its workflow commit and bundled SHA-256 checksum, and atomically install the executable.

The download order is authenticated `gh run download`, the Actions archive API with `WAGO_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`, then an exact tagged source build with the Go/TinyGo executable on `PATH`. Unavailable, expired, unauthenticated, or invalid artifacts safely fall through.

This covers the bootstrap installer manager path, manager self-updates, runtime installs, exact tagged canaries, and tagged canary commit selections.

Verification:
- `go test ./...`
- Wine bootstrap installer integration test
- live manager and minimal/normal runtime artifact installs at `v0.1.0-canary.g014a2fe`
- live install with token environment variables removed, using stored GitHub CLI authentication
- live manager and runtime exact-source fallbacks