### PR TITLE
installer: add Go-native installation route

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -257,7 +257,9 @@ src/wago/                         public API implementation (package wago)
   import_attachments.go           imported owner attachment and root retention
 wago.go                           generated root facade (re-exports src/wago)
 internal/genfacade/               generator for wago.go (+ up-to-date test)
-cli/wago/                         CLI entry point and command implementation
+cli/wago/                         manager and runtime command entry point
+cli/wago-installer/               installer command entry point
+cli/installer/                    shared installer implementation
 src/core/compiler/wasm/           decoder + validator (front end)
 src/core/compiler/backend/railshot/  direct native codegen (Valent-Block)
   amd64/                            x86-64 selection, registers, ABI, encoding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,8 @@ go test -bench .
 | `src/wago` | Public API implementation. |
 | `internal/genfacade` | Generator for `wago.go`. |
 | `cli/wago` | Build-tagged manager and runtime entry point. |
+| `cli/wago-installer` | Installable `wago-installer` command entry point. |
+| `cli/installer` | Shared installer implementation. |
 | `cli/manager` | Manager commands. |
 | `cli/runtime` | Runtime commands. |
 | `cli/internal` | Shared CLI code. |

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ fuzz-engine-state: ## Compare Starshine state hashes in Node and Railshot (ENGIN
 
 .PHONY: install-local
 install-local: ## Run the installer from this checkout
-	@go run ./cli/installer install
+	@go run ./cli/wago-installer install
 
 .PHONY: install-local-runtime
 install-local-runtime: ## Build this checkout and atomically replace the global manager and canary standard runtime

--- a/README.md
+++ b/README.md
@@ -53,9 +53,22 @@ On Windows, in PowerShell:
 irm https://install.wago.sh/ps | iex
 ```
 
-These commands install the Wago manager and then install a runtime. See
-[Getting started](https://docs.wago.sh/getting-started) for other installation
-methods, release channels, and source builds.
+Or run the installer with Go:
+
+```sh
+go run github.com/wago-org/wago/cli/wago-installer@latest
+```
+
+To keep the installer command:
+
+```sh
+go install github.com/wago-org/wago/cli/wago-installer@latest
+wago-installer
+```
+
+These commands install the Wago manager. Run `wago version install` to install
+a runtime. See [Getting started](https://docs.wago.sh/getting-started) for other
+installation methods, release channels, and source builds.
 
 ## Run a module
 

--- a/cli/installer/console_unix.go
+++ b/cli/installer/console_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package main
+package installer
 
 import (
 	"bufio"

--- a/cli/installer/console_windows.go
+++ b/cli/installer/console_windows.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"fmt"

--- a/cli/installer/cross_device_unix.go
+++ b/cli/installer/cross_device_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package main
+package installer
 
 import (
 	"errors"

--- a/cli/installer/cross_device_windows.go
+++ b/cli/installer/cross_device_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package main
+package installer
 
 import (
 	"errors"

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"context"

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"archive/zip"

--- a/cli/installer/install_unix.go
+++ b/cli/installer/install_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package main
+package installer
 
 import (
 	"bufio"

--- a/cli/installer/install_windows.go
+++ b/cli/installer/install_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package main
+package installer
 
 import (
 	"errors"

--- a/cli/installer/install_windows_test.go
+++ b/cli/installer/install_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package main
+package installer
 
 import (
 	"bytes"

--- a/cli/installer/launcher_unix_test.go
+++ b/cli/installer/launcher_unix_test.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package main
+package installer
 
 import (
 	"os"
@@ -14,7 +14,7 @@ import (
 func TestInstalledLauncherAliasDispatches(t *testing.T) {
 	if os.Getenv("WAGO_TEST_LAUNCHER_ALIAS") == "1" {
 		os.Args = append(os.Args[:1], "manager-probe")
-		main()
+		Main(version)
 		t.Fatal("launcher returned without dispatch")
 	}
 	root := t.TempDir()

--- a/cli/installer/main.go
+++ b/cli/installer/main.go
@@ -1,4 +1,5 @@
-package main
+// Package installer implements the Wago installation program.
+package installer
 
 import (
 	"context"
@@ -37,7 +38,11 @@ type radioItem struct {
 
 var version = "dev"
 
-func main() {
+// Main runs the installer with the supplied release identity.
+func Main(embeddedVersion string) {
+	if embeddedVersion != "" {
+		version = embeddedVersion
+	}
 	executable, err := managedrelease.ExecutablePath()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cli/installer/main_test.go
+++ b/cli/installer/main_test.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"os"

--- a/cli/installer/move.go
+++ b/cli/installer/move.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"fmt"

--- a/cli/installer/release_cleanup.go
+++ b/cli/installer/release_cleanup.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"fmt"

--- a/cli/installer/release_cleanup_bench_test.go
+++ b/cli/installer/release_cleanup_bench_test.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"fmt"

--- a/cli/installer/release_cleanup_snapshot_test.go
+++ b/cli/installer/release_cleanup_snapshot_test.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"os"

--- a/cli/installer/release_cleanup_test.go
+++ b/cli/installer/release_cleanup_test.go
@@ -1,4 +1,4 @@
-package main
+package installer
 
 import (
 	"os"

--- a/cli/manager/internal/self/cleanup.go
+++ b/cli/manager/internal/self/cleanup.go
@@ -293,15 +293,29 @@ func isInstallerPathCommand(line string) bool {
 }
 
 func pathContains(parent, child string) bool {
+	parent = resolvedCleanupPath(parent)
+	child = resolvedCleanupPath(child)
 	relative, err := filepath.Rel(parent, child)
 	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func safeManagedPath(path string) bool {
-	clean := filepath.Clean(path)
+	clean := resolvedCleanupPath(path)
 	home, _ := os.UserHomeDir()
+	home = resolvedCleanupPath(home)
 	return clean != "" &&
 		clean != "." &&
 		clean != filepath.VolumeName(clean)+string(filepath.Separator) &&
 		(home == "" || clean != filepath.Clean(home))
+}
+
+func resolvedCleanupPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	clean := filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
+		return resolved
+	}
+	return clean
 }

--- a/cli/wago-installer/main.go
+++ b/cli/wago-installer/main.go
@@ -1,0 +1,26 @@
+// Command wago-installer installs the Wago manager and a Runtime Installation.
+package main
+
+import (
+	"runtime/debug"
+
+	"github.com/wago-org/wago/cli/installer"
+)
+
+// version is stamped at build time via -ldflags "-X main.version=<tag>".
+var version string
+
+func main() {
+	info, _ := debug.ReadBuildInfo()
+	installer.Main(resolveInstallerVersion(version, info))
+}
+
+func resolveInstallerVersion(stamped string, info *debug.BuildInfo) string {
+	if stamped != "" {
+		return stamped
+	}
+	if info != nil && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return ""
+}

--- a/cli/wago-installer/main_test.go
+++ b/cli/wago-installer/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveInstallerVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		stamped string
+		info    *debug.BuildInfo
+		want    string
+	}{
+		{name: "release build", stamped: "v1.2.3", info: &debug.BuildInfo{Main: debug.Module{Version: "v1.2.2"}}, want: "v1.2.3"},
+		{name: "go install", info: &debug.BuildInfo{Main: debug.Module{Version: "v1.2.3"}}, want: "v1.2.3"},
+		{name: "local build", info: &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}}},
+		{name: "no build info"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolveInstallerVersion(test.stamped, test.info); got != test.want {
+				t.Fatalf("resolveInstallerVersion(%q) = %q, want %q", test.stamped, got, test.want)
+			}
+		})
+	}
+}

--- a/cli/wago/self_uninstall_test.go
+++ b/cli/wago/self_uninstall_test.go
@@ -1,0 +1,39 @@
+//go:build !wago_runtime && !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestSelfUninstallThroughAliasedWagoHome(t *testing.T) {
+	root := t.TempDir()
+	physicalParent := filepath.Join(root, "physical")
+	aliasParent := filepath.Join(root, "alias")
+	physicalHome := filepath.Join(physicalParent, "managed")
+	aliasHome := filepath.Join(aliasParent, "managed")
+	if err := os.MkdirAll(filepath.Join(physicalHome, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physicalParent, aliasParent); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := filepath.Join(physicalHome, "bin", "wago")
+	build := exec.Command("go", "build", "-o", manager, ".")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build manager: %v\n%s", err, output)
+	}
+
+	command := exec.Command(manager, "--no-input", "self", "uninstall", "--yes")
+	command.Env = append(os.Environ(), "HOME="+root, "WAGO_HOME="+aliasHome)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("self uninstall through WAGO_HOME alias: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(physicalHome); !os.IsNotExist(err) {
+		t.Fatalf("managed Wago home survived uninstall: %v", err)
+	}
+}

--- a/install_test.go
+++ b/install_test.go
@@ -495,7 +495,22 @@ func makeArtifactArchive(t *testing.T, files map[string][]byte) []byte {
 
 func buildInstaller(t *testing.T, target, goos, goarch string) {
 	t.Helper()
-	buildTarget(t, target, goos, goarch, "./cli/installer")
+	buildTarget(t, target, goos, goarch, "./cli/wago-installer")
+}
+
+func TestGoInstallBuildsNamedInstallerCommand(t *testing.T) {
+	bin := t.TempDir()
+	command := exec.Command("go", "install", "./cli/wago-installer")
+	command.Env = append(os.Environ(), "GOBIN="+bin)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("go install wago-installer: %v\n%s", err, output)
+	}
+
+	executable := filepath.Join(bin, "wago-installer")
+	output, err := exec.Command(executable, "--version").CombinedOutput()
+	if err != nil || strings.TrimSpace(string(output)) != "dev" {
+		t.Fatalf("installed wago-installer version = %q, %v; want dev", output, err)
+	}
 }
 
 func buildTarget(t *testing.T, target, goos, goarch, pkg string) {

--- a/install_windows_test.go
+++ b/install_windows_test.go
@@ -33,7 +33,7 @@ func TestCmdBootstrapExecutesNativeInstaller(t *testing.T) {
 	}
 	tmp := t.TempDir()
 	installer := filepath.Join(tmp, "wago-installer.exe")
-	command := exec.Command("go", "build", "-o", installer, "./cli/installer")
+	command := exec.Command("go", "build", "-o", installer, "./cli/wago-installer")
 	command.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("build installer: %v\n%s", err, output)

--- a/scripts/build-release-assets.sh
+++ b/scripts/build-release-assets.sh
@@ -28,7 +28,7 @@ standard_tiny="${release_out}/wago-runtime-standard-tiny-${release_target}"
 minimal_tiny="${release_out}/wago-runtime-minimal-tiny-${release_target}"
 
 go_build "" "$manager" ./cli/wago
-go_build "" "$installer" ./cli/installer
+go_build "" "$installer" ./cli/wago-installer
 go_build wago_runtime "$standard_normal" ./cli/wago
 go_build wago_runtime,wago_minimal "$minimal_normal" ./cli/wago
 


### PR DESCRIPTION
## Summary

- add `github.com/wago-org/wago/cli/wago-installer` for `go run` and `go install`
- keep the installer implementation shared with release assets and bootstrap scripts
- fix full self-uninstall when `WAGO_HOME` and the executable use aliases for the same path
- preserve the separately Go-installed `wago-installer` when managed Wago is removed

After the next tag, users can run:

```sh
go run github.com/wago-org/wago/cli/wago-installer@latest
```

or:

```sh
go install github.com/wago-org/wago/cli/wago-installer@latest
wago-installer
```

## Proof

- `go test ./cli/... -count=1`
- `go test . -count=1`
- `go test ./cli/manager/internal/self -count=1`
- `make docs-check`
- installer cross-builds for linux, macOS, and Windows on amd64 and arm64
- Darwin/arm64 release asset build, including stamped `wago-installer`
- end-to-end Go-installed installer -> managed Wago -> `wago self uninstall --yes`; managed files were removed and the Go-owned installer was preserved

This changes installer and cleanup cold paths only. It does not affect runtime performance.

## Review

Standards review: no findings.

Spec review: no findings. The `@latest` package becomes available when a tag containing this change is published.

## AI assistance

Codex helped reproduce the installation and uninstall flows, draft tests and documentation, and review the final diff. Every changed line and the listed tests were checked.