### PR TITLE
release: make canaries commit-addressed artifacts

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -2,26 +2,27 @@
 
 ## Channels and versions
 
-- `canary` resolves the newest successful main commit carrying an immutable
-  SemVer tag such as `v0.1.0-canary.g<7-character-commit-sha>`. Canaries are
-  tags only in the repository: they do not create GitHub Releases. Their
-  cross-platform binaries are retained on the matching Actions workflow run.
+- `canary` resolves the newest successful main commit with a retained host
+  artifact. Its canonical identity is `canary@<40-character-commit-sha>`.
+  Canaries create neither git tags nor GitHub Releases. Legacy
+  `vMAJOR.MINOR.PATCH-canary.g<7-character-commit-sha>` artifacts remain
+  installable while they are retained.
 - `beta` resolves the newest manually qualified beta, such as
   `v0.1.0-beta.1`.
 - `latest` resolves the newest stable `vMAJOR.MINOR.PATCH` release.
 
-The canary workflow builds and tags automatically after main CI succeeds. Its
-workflow artifacts are retained for 90 days. Manager and runtime installation
+The canary workflow builds automatically after main CI succeeds. Artifacts are
+named `canary-<40-character-commit-sha>-<os>-<arch>` and retained for 90 days.
+Manager and runtime installation
 first attempt the matching host artifact and verify its bundled SHA-256 file.
 Wago first asks an installed and authenticated GitHub CLI (`gh`) to download the
 artifact. If that is unavailable, it tries the Actions API with
 `WAGO_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`. If both transports fail, or
-the archive is expired or invalid, installation builds the exact tagged source
+the archive is expired or invalid, installation builds the exact commit source
 with the requested `go` or `tinygo` executable from `PATH`. Beta and stable
 releases are dispatched through
 `release.yml` with an exact full commit SHA that already passed main CI; those
-releases build, smoke-test, checksum, and publish the platform asset set. Before
-starting a new release series, update `RELEASE_SERIES` in `canary.yml`.
+releases build, smoke-test, checksum, and publish the platform asset set.
 
 ## Release notes
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,7 +1,7 @@
-name: Publish canary tag
+name: Publish canary artifacts
 
-# A successful CI run on main builds workflow artifacts and creates one
-# immutable SemVer canary tag. It never creates a GitHub Release.
+# A successful CI run on main builds commit-addressed workflow artifacts.
+# Canary builds intentionally create neither git tags nor GitHub Releases.
 on:
   workflow_run:
     workflows: [CI]
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   # A workflow_run that fails the job-level guard still enters concurrency.
@@ -21,7 +21,6 @@ concurrency:
 env:
   GO_VERSION: "1.22"
   TINYGO_VERSION: "0.41.1"
-  RELEASE_SERIES: "0.1.0"
 
 jobs:
   prepare:
@@ -35,19 +34,16 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.version.outputs.sha }}
-      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}
           fetch-depth: 1
-      - name: Resolve canary tag
+      - name: Resolve canary commit
         id: version
         run: |
           sha=$(git rev-parse HEAD)
-          short_sha=${sha:0:7}
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "tag=v${RELEASE_SERIES}-canary.g$short_sha" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build canary (${{ matrix.goos }}/${{ matrix.goarch }})
@@ -116,7 +112,7 @@ jobs:
       - name: Upload canary workflow artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: ${{ needs.prepare.outputs.tag }}-${{ matrix.target }}
+          name: canary-${{ needs.prepare.outputs.sha }}-${{ matrix.target }}
           path: |
             wago-${{ matrix.target }}
             wago-${{ matrix.target }}.sha256
@@ -127,8 +123,8 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-  tag:
-    name: Tag qualified canary
+  synchronize-docs:
+    name: Synchronize canary documentation
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
@@ -136,24 +132,6 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.sha }}
           fetch-depth: 1
-      - name: Create immutable canary tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SHA: ${{ needs.prepare.outputs.sha }}
-          TAG: ${{ needs.prepare.outputs.tag }}
-        run: |
-          existing=$(gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null) || existing=""
-          if [ -n "$existing" ]; then
-            if [ "$existing" != "$SHA" ]; then
-              echo "::error::tag $TAG already targets $existing instead of $SHA"
-              exit 1
-            fi
-            echo "canary tag $TAG already exists"
-            exit 0
-          fi
-          gh api --method POST "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/$TAG" \
-            -f sha="$SHA"
       - name: Create documentation synchronization token
         id: docs-sync-token
         if: vars.DOCS_SYNC_APP_ID != ''
@@ -166,4 +144,4 @@ jobs:
       - name: Synchronize canary documentation
         env:
           DOCS_SYNC_TOKEN: ${{ steps.docs-sync-token.outputs.token }}
-        run: scripts/dispatch-docs-release.sh canary "${{ needs.prepare.outputs.tag }}" "${{ needs.prepare.outputs.sha }}"
+        run: scripts/dispatch-docs-release.sh canary "canary@${{ needs.prepare.outputs.sha }}" "${{ needs.prepare.outputs.sha }}"

--- a/cli/installer/install.go
+++ b/cli/installer/install.go
@@ -30,8 +30,6 @@ type installer struct {
 	repoURL             string
 	archiveURL          string
 	releaseAPI          string
-	tagAPI              string
-	commitAPI           string
 	actionsArtifactAPI  string
 	actionsArtifactRepo string
 	releaseDownloadBase string
@@ -89,6 +87,8 @@ var installerSourceArchiveURL = func(repo, ref string) string {
 }
 
 var downloadInstallerActionArtifact = actionartifact.DownloadExecutable
+var downloadInstallerCanaryArtifact = actionartifact.DownloadCanaryExecutable
+var latestInstallerCanaryCommit = actionartifact.LatestCanaryCommit
 
 func newInstaller(out io.Writer) (*installer, error) {
 	home, err := os.UserHomeDir()
@@ -118,8 +118,6 @@ func newInstaller(out io.Writer) (*installer, error) {
 		repoURL:             envOr("WAGO_REPO_URL", "https://github.com/wago-org/wago.git"),
 		archiveURL:          envOr("WAGO_ARCHIVE_URL", installerSourceArchiveURL(releaseRepo, archiveRef)),
 		releaseAPI:          envOr("WAGO_RELEASES_API_URL", "https://api.github.com/repos/"+releaseRepo+"/releases"),
-		tagAPI:              envOr("WAGO_TAGS_API_URL", "https://api.github.com/repos/"+releaseRepo+"/tags"),
-		commitAPI:           envOr("WAGO_COMMITS_API_URL", "https://api.github.com/repos/"+releaseRepo+"/commits"),
 		actionsArtifactAPI:  envOr("WAGO_ACTIONS_ARTIFACT_API", "https://api.github.com/repos/"+releaseRepo+"/actions/artifacts"),
 		actionsArtifactRepo: releaseRepo,
 		releaseDownloadBase: envOr("WAGO_RELEASE_DOWNLOAD_BASE", "https://github.com/"+releaseRepo+"/releases"),
@@ -414,20 +412,14 @@ func reinstallLabel(mode string) string {
 
 func (i *installer) downloadManager(target string) error {
 	if channel, sha, canonical := installerRollingCommit(i.version); canonical && channel == "canary" {
-		i.managerTag = i.version
-		i.managerSourceRef = sha
-		tag, err := i.canaryTagForCommit(sha)
-		if err != nil {
-			return fmt.Errorf("resolve canary workflow artifact: %w", err)
-		}
-		return i.downloadCanaryManager(tag, sha, target)
+		return i.downloadCanaryCommitManager(sha, target)
 	}
 	if i.version == "canary" {
-		tag, sha, err := i.latestCanaryTag()
+		sha, err := i.latestCanaryCommit(runtime.GOOS + "-" + runtime.GOARCH)
 		if err != nil {
 			return err
 		}
-		return i.downloadCanaryManager(tag, sha, target)
+		return i.downloadCanaryCommitManager(sha, target)
 	}
 	if installerCanaryTag(i.version) {
 		return i.downloadCanaryManager(i.version, "", target)
@@ -469,13 +461,45 @@ func (i *installer) downloadManager(target string) error {
 		return nil
 	}
 	if i.version == "main" {
-		tag, sha, err := i.latestCanaryTag()
+		sha, err := i.latestCanaryCommit(runtime.GOOS + "-" + runtime.GOARCH)
 		if err != nil {
 			return errors.Join(downloadErr, err)
 		}
-		return i.downloadCanaryManager(tag, sha, target)
+		return i.downloadCanaryCommitManager(sha, target)
 	}
 	return downloadErr
+}
+
+func (i *installer) latestCanaryCommit(target string) (string, error) {
+	return latestInstallerCanaryCommit(i.installContext(), actionartifact.Config{
+		CatalogURL: i.actionsArtifactAPI,
+		Repository: i.actionsArtifactRepo,
+		Token:      actionartifact.TokenFromEnvironment(),
+		HTTPClient: i.httpClient,
+	}, target)
+}
+
+func (i *installer) downloadCanaryCommitManager(sha, target string) error {
+	identity := "canary@" + strings.ToLower(strings.TrimSpace(sha))
+	i.managerTag = identity
+	i.managerSourceRef = sha
+	asset, err := installbootstrap.Asset("wago", runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+	i.begin("Downloading Wago manager " + identity + " workflow artifact")
+	err = downloadInstallerCanaryArtifact(i.installContext(), actionartifact.Config{
+		CatalogURL: i.actionsArtifactAPI,
+		Repository: i.actionsArtifactRepo,
+		Token:      actionartifact.TokenFromEnvironment(),
+		HTTPClient: i.httpClient,
+	}, sha, runtime.GOOS+"-"+runtime.GOARCH, asset, target)
+	if err != nil {
+		return fmt.Errorf("download canary workflow artifact: %w", err)
+	}
+	i.managerFromRelease = true
+	i.done("Downloaded and verified Wago manager " + identity)
+	return nil
 }
 
 func (i *installer) downloadCanaryManager(tag, sha, target string) error {
@@ -501,91 +525,6 @@ func (i *installer) downloadCanaryManager(tag, sha, target string) error {
 	i.managerFromRelease = true
 	i.done("Downloaded and verified Wago manager " + tag)
 	return nil
-}
-
-type installerTag struct {
-	Name   string `json:"name"`
-	Commit struct {
-		SHA string `json:"sha"`
-	} `json:"commit"`
-}
-
-func (i *installer) canaryTagsByCommit() (map[string]string, error) {
-	var tags []installerTag
-	address, err := url.Parse(i.tagAPI)
-	if err != nil {
-		return nil, fmt.Errorf("parse tag catalog URL: %w", err)
-	}
-	query := address.Query()
-	query.Set("per_page", "100")
-	query.Set("page", "1")
-	address.RawQuery = query.Encode()
-	if err := i.getJSON(address.String(), &tags); err != nil {
-		return nil, err
-	}
-	if len(tags) > 100 {
-		return nil, errors.New("tag catalog returned too many tags")
-	}
-	byCommit := make(map[string]string, len(tags))
-	for _, tag := range tags {
-		name := strings.ToLower(strings.TrimSpace(tag.Name))
-		marker := "-canary.g"
-		index := strings.Index(name, marker)
-		if index < 0 || !installerCanaryTag(name) {
-			continue
-		}
-		short := name[index+len(marker):]
-		sha := strings.ToLower(strings.TrimSpace(tag.Commit.SHA))
-		if len(short) != 7 || !fullInstallerCommitSHA(sha) || !strings.HasPrefix(sha, short) {
-			return nil, fmt.Errorf("canary tag %q has an invalid target commit", tag.Name)
-		}
-		byCommit[sha] = tag.Name
-	}
-	return byCommit, nil
-}
-
-func (i *installer) canaryTagForCommit(sha string) (string, error) {
-	byCommit, err := i.canaryTagsByCommit()
-	if err != nil {
-		return "", err
-	}
-	if tag := byCommit[strings.ToLower(strings.TrimSpace(sha))]; tag != "" {
-		return tag, nil
-	}
-	return "", errors.New("no canary tag found")
-}
-
-func (i *installer) latestCanaryTag() (string, string, error) {
-	byCommit, err := i.canaryTagsByCommit()
-	if err != nil {
-		return "", "", err
-	}
-	type commit struct {
-		SHA string `json:"sha"`
-	}
-	var commits []commit
-	commitsAddress, err := url.Parse(i.commitAPI)
-	if err != nil {
-		return "", "", fmt.Errorf("parse commit catalog URL: %w", err)
-	}
-	query := commitsAddress.Query()
-	query.Set("sha", "main")
-	query.Set("per_page", "100")
-	query.Set("page", "1")
-	commitsAddress.RawQuery = query.Encode()
-	if err := i.getJSON(commitsAddress.String(), &commits); err != nil {
-		return "", "", err
-	}
-	if len(commits) > 100 {
-		return "", "", errors.New("commit catalog returned too many commits")
-	}
-	for _, commit := range commits {
-		sha := strings.ToLower(strings.TrimSpace(commit.SHA))
-		if tag := byCommit[sha]; tag != "" {
-			return tag, sha, nil
-		}
-	}
-	return "", "", errors.New("no canary tag found")
 }
 
 func installerCanaryTag(tag string) bool {

--- a/cli/installer/install_test.go
+++ b/cli/installer/install_test.go
@@ -201,18 +201,8 @@ func TestInstallerDryRunPresentation(t *testing.T) {
 
 func TestInstallerBuildsExactCanonicalCanaryFromSource(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
-	const tag = "v0.1.0-canary.gdeadbee"
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/tags" {
-			http.NotFound(writer, request)
-			return
-		}
-		_, _ = fmt.Fprintf(writer, `[{"name":%q,"commit":{"sha":%q}}]`, tag, sha)
-	}))
-	defer server.Close()
 	t.Setenv("NO_COLOR", "1")
 	t.Setenv("WAGO_VERSION", "canary@"+sha)
-	t.Setenv("WAGO_TAGS_API_URL", server.URL+"/tags")
 	var output bytes.Buffer
 	installer, err := newInstaller(&output)
 	if err != nil {
@@ -220,18 +210,18 @@ func TestInstallerBuildsExactCanonicalCanaryFromSource(t *testing.T) {
 	}
 	installer.tmpDir = t.TempDir()
 	target := filepath.Join(installer.tmpDir, executableName("wago"))
-	previousDownload := downloadInstallerActionArtifact
-	downloadInstallerActionArtifact = func(_ context.Context, _ actionartifact.Config, gotTag, commit, _, _, _ string) error {
-		if gotTag != tag || commit != sha {
-			t.Fatalf("artifact identity = %q@%s", gotTag, commit)
+	previousDownload := downloadInstallerCanaryArtifact
+	downloadInstallerCanaryArtifact = func(_ context.Context, _ actionartifact.Config, commit, _, _, _ string) error {
+		if commit != sha {
+			t.Fatalf("artifact commit = %q", commit)
 		}
 		return errors.New("artifact unavailable")
 	}
-	t.Cleanup(func() { downloadInstallerActionArtifact = previousDownload })
+	t.Cleanup(func() { downloadInstallerCanaryArtifact = previousDownload })
 	if err := installer.downloadManager(target); err == nil || !strings.Contains(err.Error(), "artifact unavailable") {
 		t.Fatalf("downloadManager error = %v", err)
 	}
-	if installer.managerTag != tag || installer.managerSourceRef != sha || installer.managerFromRelease {
+	if installer.managerTag != "canary@"+sha || installer.managerSourceRef != sha || installer.managerFromRelease {
 		t.Fatalf("manager resolution = %q, %q, %v", installer.managerTag, installer.managerSourceRef, installer.managerFromRelease)
 	}
 }
@@ -489,27 +479,10 @@ func (ctx *cancelWhenStagingExists) Err() error {
 	return ctx.Context.Err()
 }
 
-func TestInstallerResolvesNewestCanaryTagForSourceBuild(t *testing.T) {
+func TestInstallerResolvesNewestCanaryArtifactForSourceBuild(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/tags":
-			_, _ = fmt.Fprint(w, `[
-  {"name":"v0.1.0-beta.2","commit":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
-  {"name":"v0.1.0-canary.gdeadbee","commit":{"sha":"deadbee123456789012345678901234567890123"}}
-]`)
-		case "/commits":
-			_, _ = fmt.Fprintf(w, `[{"sha":%q},{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]`, sha)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
 	t.Setenv("NO_COLOR", "1")
 	t.Setenv("WAGO_VERSION", "canary")
-	t.Setenv("WAGO_TAGS_API_URL", server.URL+"/tags")
-	t.Setenv("WAGO_COMMITS_API_URL", server.URL+"/commits")
 	var output bytes.Buffer
 	installer, err := newInstaller(&output)
 	if err != nil {
@@ -517,15 +490,18 @@ func TestInstallerResolvesNewestCanaryTagForSourceBuild(t *testing.T) {
 	}
 	installer.tmpDir = t.TempDir()
 	target := filepath.Join(installer.tmpDir, executableName("wago"))
-	previousDownload := downloadInstallerActionArtifact
-	downloadInstallerActionArtifact = func(context.Context, actionartifact.Config, string, string, string, string, string) error {
+	previousLatest := latestInstallerCanaryCommit
+	latestInstallerCanaryCommit = func(context.Context, actionartifact.Config, string) (string, error) { return sha, nil }
+	t.Cleanup(func() { latestInstallerCanaryCommit = previousLatest })
+	previousDownload := downloadInstallerCanaryArtifact
+	downloadInstallerCanaryArtifact = func(context.Context, actionartifact.Config, string, string, string, string) error {
 		return errors.New("artifact unavailable")
 	}
-	t.Cleanup(func() { downloadInstallerActionArtifact = previousDownload })
+	t.Cleanup(func() { downloadInstallerCanaryArtifact = previousDownload })
 	if err := installer.downloadManager(target); err == nil || !strings.Contains(err.Error(), "artifact unavailable") {
 		t.Fatalf("downloadManager error = %v", err)
 	}
-	if installer.managerTag != "v0.1.0-canary.gdeadbee" || installer.managerSourceRef != sha || installer.managerFromRelease {
+	if installer.managerTag != "canary@"+sha || installer.managerSourceRef != sha || installer.managerFromRelease {
 		t.Fatalf("manager resolution = %q, %q, %v", installer.managerTag, installer.managerSourceRef, installer.managerFromRelease)
 	}
 }
@@ -613,9 +589,8 @@ func TestInstallerManagerDownloadFallsBackFromOfficialToBeta(t *testing.T) {
 	}
 }
 
-func TestInstallerManagerDownloadFallsBackFromBetaToCanaryTagArtifact(t *testing.T) {
+func TestInstallerManagerDownloadFallsBackFromBetaToCanaryArtifact(t *testing.T) {
 	const (
-		canaryTag = "v1.2.0-canary.gdeadbee"
 		canarySHA = "deadbee123456789012345678901234567890123"
 	)
 	asset := "wago-" + runtime.GOOS + "-" + runtime.GOARCH
@@ -627,10 +602,6 @@ func TestInstallerManagerDownloadFallsBackFromBetaToCanaryTagArtifact(t *testing
 			_, _ = fmt.Fprint(w, `{"tag_name":"v1.0.0","published_at":"2026-08-01T00:00:00Z"}`)
 		case "/releases":
 			_, _ = fmt.Fprint(w, `[{"tag_name":"v1.1.0-beta.1","published_at":"2026-08-02T00:00:00Z"}]`)
-		case "/tags":
-			_, _ = fmt.Fprintf(w, `[{"name":%q,"commit":{"sha":%q}}]`, canaryTag, canarySHA)
-		case "/commits":
-			_, _ = fmt.Fprintf(w, `[{"sha":%q}]`, canarySHA)
 		default:
 			http.NotFound(w, r)
 		}
@@ -648,26 +619,27 @@ func TestInstallerManagerDownloadFallsBackFromBetaToCanaryTagArtifact(t *testing
 	}
 	installer.tmpDir = t.TempDir()
 	target := filepath.Join(installer.tmpDir, executableName("wago"))
-	previousDownload := downloadInstallerActionArtifact
-	downloadInstallerActionArtifact = func(_ context.Context, _ actionartifact.Config, tag, sha, platform, gotAsset, destination string) error {
-		if tag != canaryTag || sha != canarySHA || platform != runtime.GOOS+"-"+runtime.GOARCH || gotAsset != asset || destination != target {
-			t.Fatalf("artifact request = %q, %q, %q, %q, %q", tag, sha, platform, gotAsset, destination)
+	previousLatest := latestInstallerCanaryCommit
+	latestInstallerCanaryCommit = func(context.Context, actionartifact.Config, string) (string, error) { return canarySHA, nil }
+	t.Cleanup(func() { latestInstallerCanaryCommit = previousLatest })
+	previousDownload := downloadInstallerCanaryArtifact
+	downloadInstallerCanaryArtifact = func(_ context.Context, _ actionartifact.Config, sha, platform, gotAsset, destination string) error {
+		if sha != canarySHA || platform != runtime.GOOS+"-"+runtime.GOARCH || gotAsset != asset || destination != target {
+			t.Fatalf("artifact request = %q, %q, %q, %q", sha, platform, gotAsset, destination)
 		}
 		return os.WriteFile(destination, []byte("canary manager"), 0o755)
 	}
-	t.Cleanup(func() { downloadInstallerActionArtifact = previousDownload })
+	t.Cleanup(func() { downloadInstallerCanaryArtifact = previousDownload })
 
 	if err := installer.downloadManager(target); err != nil {
 		t.Fatal(err)
 	}
-	if installer.managerTag != canaryTag || installer.managerSourceRef != canarySHA {
+	if installer.managerTag != "canary@"+canarySHA || installer.managerSourceRef != canarySHA {
 		t.Fatalf("manager resolution = %q, %q", installer.managerTag, installer.managerSourceRef)
 	}
 	wantRequests := []string{
 		"/download/v1.0.0/" + asset,
 		"/download/v1.1.0-beta.1/" + asset,
-		"/tags",
-		"/commits",
 	}
 	for _, want := range wantRequests {
 		if !slices.Contains(requests, want) {

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -9,11 +9,13 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	managerprogress "github.com/wago-org/wago/cli/manager/internal/progress"
+	"github.com/wago-org/wago/internal/actionartifact"
 	"github.com/wago-org/wago/internal/wagopaths"
 )
 
@@ -392,26 +394,6 @@ func resolveRunnerVersion(ver string, progress *managerprogress.Progress) (resol
 func resolveRunnerVersionContext(ctx context.Context, ver string, progress *managerprogress.Progress) (resolved string, sourceOnly bool, err error) {
 	if channel, sha, canonical := rollingCommitSHA(ver); canonical {
 		if channel == "canary" {
-			if progress != nil {
-				progress.Begin("resolving canary workflow artifact")
-			}
-			tag, tagErr := canaryTagForCommitContext(ctx, sha)
-			if tagErr == nil {
-				resolved = tag + "@" + sha
-				if progress != nil {
-					progress.Done("resolved " + releasePickerLabel(resolved))
-				}
-				return resolved, true, nil
-			}
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				if progress != nil {
-					progress.Fail("could not resolve canary workflow artifact")
-				}
-				return "", false, ctxErr
-			}
-			if progress != nil {
-				progress.Done("no workflow artifact tag; using " + releasePickerLabel(ver) + " source")
-			}
 			return ver, true, nil
 		}
 		if progress != nil {
@@ -442,15 +424,21 @@ func resolveRunnerVersionContext(ctx context.Context, ver string, progress *mana
 		progress.Begin("resolving release")
 	}
 	if ver == "canary" {
-		resolved, err = latestCanaryTagContext(ctx)
+		sha, canaryErr := latestCanaryCommit(ctx, actionartifact.Config{
+			CatalogURL: actionsArtifactCatalog(),
+			Repository: "wago-org/wago",
+			Token:      actionartifact.TokenFromEnvironment(),
+		}, runtime.GOOS+"-"+runtime.GOARCH)
+		err = canaryErr
 		if err == nil {
+			resolved = "canary@" + sha
 			if progress != nil {
 				progress.Done("resolved " + releasePickerLabel(resolved))
 			}
 			return resolved, true, nil
 		}
 		if progress != nil {
-			progress.Fail("could not resolve canary tag")
+			progress.Fail("could not resolve canary artifact")
 		}
 		return "", false, err
 	}
@@ -637,85 +625,6 @@ func fetchMainCommitsContext(ctx context.Context) ([]remoteCommit, error) {
 
 func latestChannelRelease(channel string) (string, error) {
 	return latestChannelReleaseContext(context.Background(), channel)
-}
-
-const canaryTagDiscoveryPageSize = 100
-
-func canaryTagsByCommitContext(ctx context.Context) (map[string]string, error) {
-	address := fmt.Sprintf("%s/repos/wago-org/wago/tags?per_page=%d&page=1", releaseAPI(), canaryTagDiscoveryPageSize)
-	response, err := getReleaseBytes(ctx, "canary tag discovery", address, releaseMetadataMaximum)
-	if err != nil {
-		return nil, err
-	}
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub returned %s", response.Status)
-	}
-	var tags []remoteTag
-	if err := json.Unmarshal(response.Body, &tags); err != nil {
-		return nil, err
-	}
-	if len(tags) > canaryTagDiscoveryPageSize {
-		return nil, errors.New("GitHub returned too many tags")
-	}
-	byCommit := make(map[string]string, len(tags))
-	for _, tag := range tags {
-		if channelRelease(tag.Name) != "canary" {
-			continue
-		}
-		sha := strings.ToLower(strings.TrimSpace(tag.Commit.SHA))
-		if !validCommitSHA(sha) {
-			return nil, fmt.Errorf("GitHub tag %q has an invalid target commit", tag.Name)
-		}
-		_, identity, _ := strings.Cut(strings.ToLower(tag.Name), "-canary.g")
-		if !strings.HasPrefix(sha, identity) {
-			return nil, fmt.Errorf("GitHub tag %q does not match target commit %s", tag.Name, sha)
-		}
-		byCommit[sha] = tag.Name
-	}
-	return byCommit, nil
-}
-
-func canaryTagForCommitContext(ctx context.Context, sha string) (string, error) {
-	byCommit, err := canaryTagsByCommitContext(ctx)
-	if err != nil {
-		return "", err
-	}
-	if tag := byCommit[strings.ToLower(strings.TrimSpace(sha))]; tag != "" {
-		return tag, nil
-	}
-	return "", fmt.Errorf("%w: canary tag", errNoPublishedRelease)
-}
-
-// latestCanaryTagContext resolves the newest qualified canary tag by
-// intersecting repository tags with main's newest-first commit history. The
-// repository tags endpoint does not guarantee commit-date ordering.
-func latestCanaryTagContext(ctx context.Context) (string, error) {
-	byCommit, err := canaryTagsByCommitContext(ctx)
-	if err != nil {
-		return "", err
-	}
-	commitsAddress := fmt.Sprintf("%s/repos/wago-org/wago/commits?sha=main&per_page=%d&page=1", releaseAPI(), canaryTagDiscoveryPageSize)
-	commitsResponse, err := getReleaseBytes(ctx, "canary commit discovery", commitsAddress, releaseMetadataMaximum)
-	if err != nil {
-		return "", err
-	}
-	if commitsResponse.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub returned %s", commitsResponse.Status)
-	}
-	var commits []remoteCommit
-	if err := json.Unmarshal(commitsResponse.Body, &commits); err != nil {
-		return "", err
-	}
-	if len(commits) > canaryTagDiscoveryPageSize {
-		return "", errors.New("GitHub returned too many commits")
-	}
-	for _, commit := range commits {
-		sha := strings.ToLower(strings.TrimSpace(commit.SHA))
-		if tag := byCommit[sha]; tag != "" {
-			return tag + "@" + sha, nil
-		}
-	}
-	return "", fmt.Errorf("%w: canary tag", errNoPublishedRelease)
 }
 
 func latestChannelReleaseContext(ctx context.Context, channel string) (string, error) {

--- a/cli/manager/internal/version/download.go
+++ b/cli/manager/internal/version/download.go
@@ -29,6 +29,8 @@ var (
 	releaseAssetMaximum       = releaseAssetLimit
 	errChecksumFormat         = errors.New("invalid release checksum format")
 	downloadActionsExecutable = actionartifact.DownloadExecutable
+	downloadCanaryExecutable  = actionartifact.DownloadCanaryExecutable
+	latestCanaryCommit        = actionartifact.LatestCanaryCommit
 )
 
 type httpStatusError struct {
@@ -241,14 +243,16 @@ func managerAsset() string {
 }
 
 func canaryArtifactReference(ref string) (tag, commit string, ok bool) {
+	if channel, sha, canonical := rollingCommitSHA(ref); canonical && channel == "canary" {
+		normalized := strings.ToLower(strings.TrimSpace(ref))
+		prefix, _, _ := strings.Cut(normalized, "@")
+		if channelRelease(prefix) == "canary" {
+			return prefix, sha, true
+		}
+		return "", sha, true
+	}
 	tag = releaseAssetVersion(ref)
-	if channelRelease(tag) != "canary" {
-		return "", "", false
-	}
-	if _, sha, canonical := rollingCommitSHA(ref); canonical {
-		commit = sha
-	}
-	return tag, commit, true
+	return tag, "", channelRelease(tag) == "canary"
 }
 
 func downloadCanaryArtifactContext(ctx context.Context, ref, asset, dest string, progress *managerprogress.Progress) error {
@@ -259,11 +263,17 @@ func downloadCanaryArtifactContext(ctx context.Context, ref, asset, dest string,
 	if progress != nil {
 		progress.Begin("downloading canary workflow artifact")
 	}
-	err := downloadActionsExecutable(ctx, actionartifact.Config{
+	config := actionartifact.Config{
 		CatalogURL: actionsArtifactCatalog(),
 		Repository: "wago-org/wago",
 		Token:      actionartifact.TokenFromEnvironment(),
-	}, tag, commit, runtime.GOOS+"-"+runtime.GOARCH, asset, dest)
+	}
+	var err error
+	if tag == "" {
+		err = downloadCanaryExecutable(ctx, config, commit, runtime.GOOS+"-"+runtime.GOARCH, asset, dest)
+	} else {
+		err = downloadActionsExecutable(ctx, config, tag, commit, runtime.GOOS+"-"+runtime.GOARCH, asset, dest)
+	}
 	if err != nil {
 		if progress != nil {
 			if ctx.Err() != nil {

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -38,48 +38,6 @@ func TestLatestChannelRelease(t *testing.T) {
 	}
 }
 
-func TestLatestCanaryTag(t *testing.T) {
-	const sha = "deadbee123456789012345678901234567890123"
-	const olderCommitSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/wago-org/wago/tags":
-			if r.URL.Query().Get("per_page") != "100" {
-				http.Error(w, "wrong page size", http.StatusBadRequest)
-				return
-			}
-			older := remoteTag{Name: "v0.1.0-canary.gaaaaaaa"}
-			older.Commit.SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-			newest := remoteTag{Name: "v0.1.0-canary.gdeadbee"}
-			newest.Commit.SHA = sha
-			_ = json.NewEncoder(w).Encode([]remoteTag{older, newest})
-		case "/repos/wago-org/wago/commits":
-			_ = json.NewEncoder(w).Encode([]remoteCommit{{SHA: sha}, {SHA: olderCommitSHA}})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
-	t.Setenv("WAGO_RELEASE_API", srv.URL)
-
-	got, err := latestCanaryTagContext(context.Background())
-	if err != nil || got != "v0.1.0-canary.gdeadbee@"+sha {
-		t.Fatalf("latestCanaryTagContext = %q, %v", got, err)
-	}
-}
-
-func TestLatestCanaryTagRejectsMismatchedHash(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`[{"name":"v0.1.0-canary.gdeadbee","commit":{"sha":"cafef00123456789012345678901234567890123"}}]`))
-	}))
-	defer srv.Close()
-	t.Setenv("WAGO_RELEASE_API", srv.URL)
-
-	if _, err := latestCanaryTagContext(context.Background()); err == nil || !strings.Contains(err.Error(), "does not match") {
-		t.Fatalf("latestCanaryTagContext mismatch error = %v", err)
-	}
-}
-
 func TestLatestChannelReleasePaginates(t *testing.T) {
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/manager/internal/version/releases.go
+++ b/cli/manager/internal/version/releases.go
@@ -29,13 +29,6 @@ type remoteCommit struct {
 	} `json:"commit"`
 }
 
-type remoteTag struct {
-	Name   string `json:"name"`
-	Commit struct {
-		SHA string `json:"sha"`
-	} `json:"commit"`
-}
-
 // isRollingChannel reports whether ver names a rolling release channel rather
 // than a pinned, immutable version.
 func isRollingChannel(ver string) bool { return rollingChannels[ver] }

--- a/cli/manager/internal/version/source_test.go
+++ b/cli/manager/internal/version/source_test.go
@@ -216,13 +216,13 @@ func TestMissingManagerAssetFallsBackToSource(t *testing.T) {
 
 func TestCanaryWorkflowArtifactPreferredForRuntimeAndManager(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
-	ref := "v0.1.0-canary.gdeadbee@" + sha
-	previousDownload := downloadActionsExecutable
+	ref := "canary@" + sha
+	previousDownload := downloadCanaryExecutable
 	previousRunner, previousManager := buildRunnerSource, buildManagerSource
 	var assets []string
-	downloadActionsExecutable = func(_ context.Context, config actionartifact.Config, tag, commit, platform, asset, destination string) error {
-		if config.CatalogURL != actionsArtifactCatalog() || tag != "v0.1.0-canary.gdeadbee" || commit != sha || platform != runtime.GOOS+"-"+runtime.GOARCH {
-			t.Fatalf("artifact request = %#v, %q, %q, %q", config, tag, commit, platform)
+	downloadCanaryExecutable = func(_ context.Context, config actionartifact.Config, commit, platform, asset, destination string) error {
+		if config.CatalogURL != actionsArtifactCatalog() || commit != sha || platform != runtime.GOOS+"-"+runtime.GOARCH {
+			t.Fatalf("artifact request = %#v, %q, %q", config, commit, platform)
 		}
 		assets = append(assets, asset)
 		return os.WriteFile(destination, []byte("artifact "+asset), 0o755)
@@ -236,7 +236,7 @@ func TestCanaryWorkflowArtifactPreferredForRuntimeAndManager(t *testing.T) {
 		return nil
 	}
 	t.Cleanup(func() {
-		downloadActionsExecutable = previousDownload
+		downloadCanaryExecutable = previousDownload
 		buildRunnerSource, buildManagerSource = previousRunner, previousManager
 	})
 
@@ -256,11 +256,11 @@ func TestCanaryWorkflowArtifactPreferredForRuntimeAndManager(t *testing.T) {
 
 func TestCanaryWorkflowArtifactFailureBuildsExactSource(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
-	ref := "v0.1.0-canary.gdeadbee@" + sha
-	previousDownload := downloadActionsExecutable
+	ref := "canary@" + sha
+	previousDownload := downloadCanaryExecutable
 	previousRunner, previousManager := buildRunnerSource, buildManagerSource
 	var runnerRef, managerRef string
-	downloadActionsExecutable = func(context.Context, actionartifact.Config, string, string, string, string, string) error {
+	downloadCanaryExecutable = func(context.Context, actionartifact.Config, string, string, string, string) error {
 		return errors.New("GitHub returned 401")
 	}
 	buildRunnerSource = func(_ context.Context, ref string, _ wagopaths.Profile, _ wagopaths.Build, destination string, _ *managerprogress.Progress) error {
@@ -272,7 +272,7 @@ func TestCanaryWorkflowArtifactFailureBuildsExactSource(t *testing.T) {
 		return os.WriteFile(destination, []byte("source manager"), 0o755)
 	}
 	t.Cleanup(func() {
-		downloadActionsExecutable = previousDownload
+		downloadCanaryExecutable = previousDownload
 		buildRunnerSource, buildManagerSource = previousRunner, previousManager
 	})
 
@@ -315,36 +315,21 @@ func TestChecksumMismatchDoesNotBuildFromSource(t *testing.T) {
 	}
 }
 
-func TestCanaryResolvesLatestTagAsSource(t *testing.T) {
+func TestCanaryResolvesLatestArtifactAsSource(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/tags") {
-			_, _ = w.Write([]byte(`[{"name":"v0.1.0-canary.g` + sha[:7] + `","commit":{"sha":"` + sha + `"}}]`))
-			return
-		}
-		_, _ = w.Write([]byte(`[{"sha":"` + sha + `"}]`))
-	}))
-	defer server.Close()
-	t.Setenv("WAGO_RELEASE_API", server.URL)
+	previousLatest := latestCanaryCommit
+	latestCanaryCommit = func(context.Context, actionartifact.Config, string) (string, error) { return sha, nil }
+	t.Cleanup(func() { latestCanaryCommit = previousLatest })
 	ref, sourceOnly, err := resolveRunnerVersion("canary", nil)
-	if err != nil || ref != "v0.1.0-canary.g"+sha[:7]+"@"+sha || !sourceOnly {
+	if err != nil || ref != "canary@"+sha || !sourceOnly {
 		t.Fatalf("resolveRunnerVersion = %q, %v, %v", ref, sourceOnly, err)
 	}
 }
 
-func TestCanonicalCanaryCommitResolvesWorkflowArtifactTag(t *testing.T) {
+func TestCanonicalCanaryCommitRemainsCommitAddressed(t *testing.T) {
 	const sha = "deadbee123456789012345678901234567890123"
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if strings.HasSuffix(request.URL.Path, "/tags") {
-			_, _ = fmt.Fprintf(writer, `[{"name":"v0.1.0-canary.gdeadbee","commit":{"sha":%q}}]`, sha)
-			return
-		}
-		http.NotFound(writer, request)
-	}))
-	defer server.Close()
-	t.Setenv("WAGO_RELEASE_API", server.URL)
 	resolved, sourceOnly, err := resolveRunnerVersion("canary@"+sha, nil)
-	if err != nil || resolved != "v0.1.0-canary.gdeadbee@"+sha || !sourceOnly {
+	if err != nil || resolved != "canary@"+sha || !sourceOnly {
 		t.Fatalf("canonical canary resolution = %q, %v, %v", resolved, sourceOnly, err)
 	}
 }

--- a/cli/wago-installer/main.go
+++ b/cli/wago-installer/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"runtime/debug"
+	"strings"
 
 	"github.com/wago-org/wago/cli/installer"
 )
@@ -19,8 +20,41 @@ func resolveInstallerVersion(stamped string, info *debug.BuildInfo) string {
 	if stamped != "" {
 		return stamped
 	}
-	if info != nil && info.Main.Version != "" && info.Main.Version != "(devel)" {
+	if info != nil && info.Main.Version != "" && info.Main.Version != "(devel)" && !pseudoVersion(info.Main.Version) {
 		return info.Main.Version
 	}
 	return ""
+}
+
+func pseudoVersion(version string) bool {
+	version, _, _ = strings.Cut(version, "+")
+	dash := strings.LastIndexByte(version, '-')
+	if dash < 0 || len(version)-dash-1 != 12 || !hexString(version[dash+1:]) {
+		return false
+	}
+	prefix := version[:dash]
+	if len(prefix) < 15 {
+		return false
+	}
+	timestamp := prefix[len(prefix)-14:]
+	separator := prefix[len(prefix)-15]
+	return (separator == '.' || separator == '-') && decimalString(timestamp)
+}
+
+func hexString(value string) bool {
+	for _, char := range value {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return false
+		}
+	}
+	return true
+}
+
+func decimalString(value string) bool {
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/cli/wago-installer/main_test.go
+++ b/cli/wago-installer/main_test.go
@@ -14,6 +14,8 @@ func TestResolveInstallerVersion(t *testing.T) {
 	}{
 		{name: "release build", stamped: "v1.2.3", info: &debug.BuildInfo{Main: debug.Module{Version: "v1.2.2"}}, want: "v1.2.3"},
 		{name: "go install", info: &debug.BuildInfo{Main: debug.Module{Version: "v1.2.3"}}, want: "v1.2.3"},
+		{name: "main pseudo-version", info: &debug.BuildInfo{Main: debug.Module{Version: "v0.0.0-20260910181111-332716a90f86"}}},
+		{name: "tag-derived pseudo-version", info: &debug.BuildInfo{Main: debug.Module{Version: "v0.1.0-canary.ge844da4.0.20260910181111-332716a90f86+dirty"}}},
 		{name: "local build", info: &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}}},
 		{name: "no build info"},
 	}

--- a/install.cmd
+++ b/install.cmd
@@ -38,10 +38,6 @@ set "release_repo=wago-org/wago"
 if defined WAGO_RELEASE_REPO set "release_repo=%WAGO_RELEASE_REPO%"
 set "release_api=https://api.github.com/repos/!release_repo!/releases"
 if defined WAGO_RELEASES_API_URL set "release_api=%WAGO_RELEASES_API_URL%"
-set "tags_api=https://api.github.com/repos/!release_repo!/tags"
-if defined WAGO_TAGS_API_URL set "tags_api=%WAGO_TAGS_API_URL%"
-set "commits_api=https://api.github.com/repos/!release_repo!/commits"
-if defined WAGO_COMMITS_API_URL set "commits_api=%WAGO_COMMITS_API_URL%"
 set "release_download_base=https://github.com/!release_repo!/releases"
 if defined WAGO_RELEASE_DOWNLOAD_BASE set "release_download_base=%WAGO_RELEASE_DOWNLOAD_BASE%"
 
@@ -145,39 +141,8 @@ if /i "!version!"=="beta" (
   set "tag_1=!resolved_beta_tag!"
   exit /b 0
 )
-if /i not "!version!"=="canary" exit /b 1
-curl.exe -fsSL "!tags_api!?per_page=100&page=1" -o "!tmp_dir!\tags.json" >nul 2>&1
-if errorlevel 1 exit /b 1
-curl.exe -fsSL "!commits_api!?sha=main&per_page=100&page=1" -o "!tmp_dir!\commits.json" >nul 2>&1
-if errorlevel 1 exit /b 1
-set "install_version="
-set "canary_pending_tag="
-for /f "usebackq tokens=1,* delims=:" %%A in ("!tmp_dir!\tags.json") do (
-  set "tag_key=%%A"
-  set "tag_key=!tag_key: =!"
-  set "tag_key=!tag_key:"=!"
-  if /i "!tag_key!"=="name" (
-    call :clean_release_candidate "%%B"
-    set "canary_pending_tag="
-    if /i not "!release_candidate:-canary.g=!"=="!release_candidate!" set "canary_pending_tag=!release_candidate!"
-  )
-  if /i "!tag_key!"=="sha" if defined canary_pending_tag (
-    call :clean_release_candidate "%%B"
-    set "canary_!release_candidate!=!canary_pending_tag!"
-    set "canary_pending_tag="
-  )
-)
-for /f "usebackq tokens=1,* delims=:" %%A in ("!tmp_dir!\commits.json") do if not defined install_version (
-  set "commit_key=%%A"
-  set "commit_key=!commit_key: =!"
-  set "commit_key=!commit_key:"=!"
-  if /i "!commit_key!"=="sha" (
-    call :clean_release_candidate "%%B"
-    call set "install_version=%%canary_!release_candidate!%%"
-    if "!install_version:~0,1!"=="%%" set "install_version="
-  )
-)
-if not defined install_version exit /b 1
+if /i not "!version!"=="canary" if /i not "!version:~0,7!"=="canary@" exit /b 1
+set "install_version=!version!"
 call :resolve_beta
 if not defined resolved_beta_tag exit /b 1
 set "tag_1=!resolved_beta_tag!"

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,6 @@ set -eu
 
 release_repo="${WAGO_RELEASE_REPO:-wago-org/wago}"
 release_api="${WAGO_RELEASES_API_URL:-https://api.github.com/repos/$release_repo/releases}"
-tags_api="${WAGO_TAGS_API_URL:-https://api.github.com/repos/$release_repo/tags}"
-commits_api="${WAGO_COMMITS_API_URL:-https://api.github.com/repos/$release_repo/commits}"
 release_download_base="${WAGO_RELEASE_DOWNLOAD_BASE:-https://github.com/$release_repo/releases}"
 version="${WAGO_VERSION:-main}"
 install_version=$version
@@ -86,38 +84,6 @@ release_tag_from_pages() {
 	return 1
 }
 
-canary_tag_from_json() {
-	awk '
-		FNR == NR && /"name"[[:space:]]*:/ {
-			line = $0
-			sub(/^.*"name"[[:space:]]*:[[:space:]]*"/, "", line)
-			sub(/".*$/, "", line)
-			pending = line
-			next
-		}
-		FNR == NR && pending != "" && /"sha"[[:space:]]*:/ {
-			line = $0
-			sub(/^.*"sha"[[:space:]]*:[[:space:]]*"/, "", line)
-			sub(/".*$/, "", line)
-			if (pending ~ /^v[0-9]+\.[0-9]+\.[0-9]+-canary\.g[0-9a-f]{7}$/) tags[line] = pending
-			pending = ""
-			next
-		}
-		/"name"[[:space:]]*:/ {
-			next
-		}
-		/"sha"[[:space:]]*:/ {
-			line = $0
-			sub(/^.*"sha"[[:space:]]*:[[:space:]]*"/, "", line)
-			sub(/".*$/, "", line)
-			if (tags[line] != "") {
-				print tags[line]
-				exit
-			}
-		}
-	' "$1" "$2"
-}
-
 resolve_release() {
 	tags=""
 	case "$version" in
@@ -136,11 +102,8 @@ resolve_release() {
 				beta)
 					tags=$(release_tag_from_pages beta) || return 1
 					;;
-				canary)
-					download "$tags_api?per_page=100&page=1" "$tmp/tags.json" || return 1
-					download "$commits_api?sha=main&per_page=100&page=1" "$tmp/commits.json" || return 1
-					install_version=$(canary_tag_from_json "$tmp/tags.json" "$tmp/commits.json")
-					[ -n "$install_version" ] || return 1
+				canary|canary@*)
+					install_version=$version
 					tags=$(release_tag_from_pages beta) || return 1
 					;;
 				main)

--- a/install_test.go
+++ b/install_test.go
@@ -92,15 +92,10 @@ func TestShellBootstrapMatchesReleaseContract(t *testing.T) {
 func TestShellBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 	payload := []byte("#!/bin/sh\nprintf 'native installer: %s\\n' \"$WAGO_VERSION\"\n")
 	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
-	canaryTag := "v0.1.0-canary.gdeadbee"
 	carrierTag := "v0.1.0-beta.2"
 	asset := "wago-installer-" + runtime.GOOS + "-" + runtime.GOARCH
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/tags":
-			_, _ = fmt.Fprintf(w, "[\n  {\n    \"name\": %q,\n    \"commit\": {\n      \"sha\": \"deadbee123456789012345678901234567890123\"\n    }\n  }\n]\n", canaryTag)
-		case "/commits":
-			_, _ = fmt.Fprint(w, "[\n  {\n    \"sha\": \"deadbee123456789012345678901234567890123\"\n  }\n]\n")
 		case "/releases":
 			_, _ = fmt.Fprintf(w, "[\n  {\n    \"tag_name\": %q,\n    \"published_at\": \"2026-08-03T00:00:00Z\"\n  }\n]\n", carrierTag)
 		case "/download/" + carrierTag + "/" + asset:
@@ -117,15 +112,13 @@ func TestShellBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 	command.Env = append(os.Environ(),
 		"WAGO_VERSION=canary",
 		"WAGO_RELEASES_API_URL="+server.URL+"/releases",
-		"WAGO_TAGS_API_URL="+server.URL+"/tags",
-		"WAGO_COMMITS_API_URL="+server.URL+"/commits",
 		"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
 	)
 	output, err := command.CombinedOutput()
 	if err != nil {
 		t.Fatalf("run shell bootstrap: %v\n%s", err, output)
 	}
-	if got, want := string(output), "native installer: "+canaryTag+"\n"; got != want {
+	if got, want := string(output), "native installer: canary\n"; got != want {
 		t.Fatalf("bootstrap output = %q, want %q", got, want)
 	}
 }
@@ -389,15 +382,10 @@ func TestWineCmdBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 	}
 	hash := fmt.Sprintf("%x", sha256.Sum256(payload))
 	var requests []string
-	canaryTag := "v0.1.0-canary.gbbbbbbb"
 	carrierTag := "v0.1.0-beta.2"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests = append(requests, r.URL.RequestURI())
 		switch r.URL.Path {
-		case "/tags":
-			_, _ = fmt.Fprintf(w, "[\n  {\n    \"name\": %q,\n    \"commit\": {\n      \"sha\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n    }\n  }\n]\n", canaryTag)
-		case "/commits":
-			_, _ = fmt.Fprint(w, "[\n  {\n    \"sha\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n  }\n]\n")
 		case "/releases":
 			_, _ = fmt.Fprintf(w, "[\n  {\n    \"tag_name\": %q,\n    \"published_at\": \"2026-08-03T00:00:00Z\"\n  }\n]\n", carrierTag)
 		case "/download/" + carrierTag + "/wago-installer-windows-amd64":
@@ -415,8 +403,6 @@ func TestWineCmdBootstrapDownloadsVerifiesAndExecutesInstaller(t *testing.T) {
 		"WINEDEBUG=-all", "NO_COLOR=1", "WAGO_VERSION=canary", "WAGO_DRY_RUN=1",
 		"WAGO_BIN_DIR=ROOT\\bin", "WAGO_SRC_DIR=ROOT\\src",
 		"WAGO_RELEASES_API_URL="+server.URL+"/releases",
-		"WAGO_TAGS_API_URL="+server.URL+"/tags",
-		"WAGO_COMMITS_API_URL="+server.URL+"/commits",
 		"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
 	)
 	output, err := command.CombinedOutput()

--- a/internal/actionartifact/artifact.go
+++ b/internal/actionartifact/artifact.go
@@ -99,6 +99,49 @@ func DownloadExecutable(ctx context.Context, config Config, tag, commit, target,
 	if err != nil {
 		return err
 	}
+	return downloadSelected(ctx, config, selected, asset, destination)
+}
+
+// DownloadCanaryExecutable downloads a canary artifact addressed by its full
+// source commit. New canaries do not require or create a git tag.
+func DownloadCanaryExecutable(ctx context.Context, config Config, commit, target, asset, destination string) error {
+	commit = strings.ToLower(strings.TrimSpace(commit))
+	if !fullCommitSHA(commit) {
+		return fmt.Errorf("%q is not a full commit SHA", commit)
+	}
+	name := canaryArtifactName(commit, target)
+	selected, err := find(ctx, config, name, commit, "")
+	if err != nil {
+		return err
+	}
+	return downloadSelected(ctx, config, selected, asset, destination)
+}
+
+// LatestCanaryCommit returns the newest non-expired commit-addressed canary
+// artifact available for target.
+func LatestCanaryCommit(ctx context.Context, config Config, target string) (string, error) {
+	items, err := list(ctx, config, "")
+	if err != nil {
+		return "", err
+	}
+	prefix, suffix := "canary-", "-"+target
+	for _, item := range items {
+		head := strings.ToLower(strings.TrimSpace(item.WorkflowRun.HeadSHA))
+		if item.ID <= 0 || item.Expired || item.ArchiveDownloadURL == "" || !fullCommitSHA(head) {
+			continue
+		}
+		if item.Name == prefix+head+suffix {
+			return head, nil
+		}
+	}
+	return "", fmt.Errorf("no usable canary Actions artifact for %s", target)
+}
+
+func canaryArtifactName(commit, target string) string {
+	return "canary-" + commit + "-" + target
+}
+
+func downloadSelected(ctx context.Context, config Config, selected artifact, asset, destination string) error {
 	if strings.TrimSpace(config.Repository) != "" {
 		directory, tempErr := os.MkdirTemp("", ".wago-gh-artifact-*")
 		if tempErr == nil {
@@ -136,40 +179,11 @@ func githubCLIDownload(ctx context.Context, repository string, runID int64, name
 }
 
 func find(ctx context.Context, config Config, name, commit, short string) (artifact, error) {
-	address, err := url.Parse(config.CatalogURL)
-	if err != nil {
-		return artifact{}, fmt.Errorf("parse Actions artifact catalog URL: %w", err)
-	}
-	query := address.Query()
-	query.Set("name", name)
-	query.Set("per_page", "100")
-	address.RawQuery = query.Encode()
-	request, err := request(ctx, address.String(), config.Token)
+	items, err := list(ctx, config, name)
 	if err != nil {
 		return artifact{}, err
 	}
-	client := httpclient.New(httpclient.Config{HTTPClient: config.HTTPClient, Timeout: 30 * time.Second})
-	response, err := client.Bytes(ctx, request, metadataLimit)
-	if err != nil {
-		return artifact{}, fmt.Errorf("fetch Actions artifact catalog: %w", err)
-	}
-	if response.StatusCode != http.StatusOK {
-		return artifact{}, fmt.Errorf("fetch Actions artifact catalog: GET %s: %s", address, response.Status)
-	}
-	var items catalog
-	if err := json.Unmarshal(response.Body, &items); err != nil {
-		return artifact{}, fmt.Errorf("decode Actions artifact catalog: %w", err)
-	}
-	if len(items.Artifacts) > 100 {
-		return artifact{}, errors.New("Actions artifact catalog returned too many artifacts")
-	}
-	sort.SliceStable(items.Artifacts, func(i, j int) bool {
-		if items.Artifacts[i].CreatedAt.Equal(items.Artifacts[j].CreatedAt) {
-			return items.Artifacts[i].ID > items.Artifacts[j].ID
-		}
-		return items.Artifacts[i].CreatedAt.After(items.Artifacts[j].CreatedAt)
-	})
-	for _, item := range items.Artifacts {
+	for _, item := range items {
 		head := strings.ToLower(strings.TrimSpace(item.WorkflowRun.HeadSHA))
 		if item.ID <= 0 || item.Name != name || item.Expired || item.ArchiveDownloadURL == "" || !fullCommitSHA(head) {
 			continue
@@ -177,12 +191,60 @@ func find(ctx context.Context, config Config, name, commit, short string) (artif
 		if commit != "" && head != commit {
 			continue
 		}
-		if commit == "" && !strings.HasPrefix(head, short) {
+		if commit == "" && short != "" && !strings.HasPrefix(head, short) {
 			continue
 		}
 		return item, nil
 	}
 	return artifact{}, fmt.Errorf("no usable Actions artifact named %s", name)
+}
+
+func list(ctx context.Context, config Config, name string) ([]artifact, error) {
+	if ctx == nil {
+		return nil, errors.New("nil Actions artifact context")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(config.CatalogURL) == "" {
+		return nil, errors.New("Actions artifact catalog URL is empty")
+	}
+	address, err := url.Parse(config.CatalogURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse Actions artifact catalog URL: %w", err)
+	}
+	query := address.Query()
+	if name != "" {
+		query.Set("name", name)
+	}
+	query.Set("per_page", "100")
+	address.RawQuery = query.Encode()
+	request, err := request(ctx, address.String(), config.Token)
+	if err != nil {
+		return nil, err
+	}
+	client := httpclient.New(httpclient.Config{HTTPClient: config.HTTPClient, Timeout: 30 * time.Second})
+	response, err := client.Bytes(ctx, request, metadataLimit)
+	if err != nil {
+		return nil, fmt.Errorf("fetch Actions artifact catalog: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch Actions artifact catalog: GET %s: %s", address, response.Status)
+	}
+	var items catalog
+	if err := json.Unmarshal(response.Body, &items); err != nil {
+		return nil, fmt.Errorf("decode Actions artifact catalog: %w", err)
+	}
+	if len(items.Artifacts) > 100 {
+		return nil, errors.New("Actions artifact catalog returned too many artifacts")
+	}
+	sort.SliceStable(items.Artifacts, func(i, j int) bool {
+		if items.Artifacts[i].CreatedAt.Equal(items.Artifacts[j].CreatedAt) {
+			return items.Artifacts[i].ID > items.Artifacts[j].ID
+		}
+		return items.Artifacts[i].CreatedAt.After(items.Artifacts[j].CreatedAt)
+	})
+	return items.Artifacts, nil
 }
 
 func download(ctx context.Context, config Config, item artifact, asset, destination string) error {

--- a/internal/actionartifact/artifact_test.go
+++ b/internal/actionartifact/artifact_test.go
@@ -66,6 +66,57 @@ func TestDownloadExecutable(t *testing.T) {
 	}
 }
 
+func TestDownloadCanaryExecutableByCommit(t *testing.T) {
+	const target = "linux-amd64"
+	const asset = "wago-linux-amd64"
+	payload := []byte("tagless canary")
+	archive := artifactZip(t, asset, payload, "")
+	name := canaryArtifactName(testCommit, target)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/artifacts":
+			if got := request.URL.Query().Get("name"); got != name {
+				t.Errorf("artifact name = %q", got)
+			}
+			fmt.Fprintf(writer, `{"artifacts":[{"id":8,"name":%q,"expired":false,"created_at":"2026-09-10T00:00:00Z","archive_download_url":%q,"workflow_run":{"head_sha":%q}}]}`, name, server.URL+"/archive", testCommit)
+		case "/archive":
+			_, _ = writer.Write(archive)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "wago")
+	if err := DownloadCanaryExecutable(context.Background(), Config{CatalogURL: server.URL + "/artifacts", HTTPClient: server.Client()}, testCommit, target, asset, destination); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(destination); err != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded payload = %q, %v", got, err)
+	}
+}
+
+func TestLatestCanaryCommitUsesNewestUsableTargetArtifact(t *testing.T) {
+	newest := "cafef00123456789012345678901234567890123"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if got := request.URL.Query().Get("name"); got != "" {
+			t.Errorf("artifact name filter = %q", got)
+		}
+		fmt.Fprintf(writer, `{"artifacts":[
+			{"id":3,"name":%q,"expired":false,"created_at":"2026-09-10T03:00:00Z","archive_download_url":"archive","workflow_run":{"head_sha":%q}},
+			{"id":2,"name":%q,"expired":false,"created_at":"2026-09-10T02:00:00Z","archive_download_url":"archive","workflow_run":{"head_sha":%q}},
+			{"id":1,"name":%q,"expired":false,"created_at":"2026-09-10T01:00:00Z","archive_download_url":"archive","workflow_run":{"head_sha":%q}}
+		]}`, canaryArtifactName(newest, "darwin-arm64"), newest, canaryArtifactName(newest, "linux-amd64"), newest, canaryArtifactName(testCommit, "linux-amd64"), testCommit)
+	}))
+	defer server.Close()
+
+	got, err := LatestCanaryCommit(context.Background(), Config{CatalogURL: server.URL, HTTPClient: server.Client()}, "linux-amd64")
+	if err != nil || got != newest {
+		t.Fatalf("LatestCanaryCommit = %q, %v", got, err)
+	}
+}
+
 func TestDownloadExecutablePrefersGitHubCLI(t *testing.T) {
 	const (
 		tag        = "v0.1.0-canary.gdeadbee"

--- a/tests/integration/cipolicy/workflows_test.go
+++ b/tests/integration/cipolicy/workflows_test.go
@@ -53,31 +53,26 @@ func TestWorkflowActionsUseImmutableCommits(t *testing.T) {
 	}
 }
 
-func TestCanaryCreatesOnlyImmutableSemVerTags(t *testing.T) {
+func TestCanaryPublishesCommitAddressedArtifactsWithoutTags(t *testing.T) {
 	canary, err := os.ReadFile(filepath.Clean("../../../.github/workflows/canary.yml"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	contents := string(canary)
 	for _, required := range []string{
-		`RELEASE_SERIES: "0.1.0"`,
-		`short_sha=${sha:0:7}`,
-		`echo "tag=v${RELEASE_SERIES}-canary.g$short_sha"`,
-		`git/ref/tags/$TAG`,
-		`tag $TAG already targets $existing instead of $SHA`,
-		`-f ref="refs/tags/$TAG"`,
-		`-f sha="$SHA"`,
+		`name: Publish canary artifacts`,
+		`name: canary-${{ needs.prepare.outputs.sha }}-${{ matrix.target }}`,
+		`WAGO_VERSION: canary@${{ needs.prepare.outputs.sha }}`,
 		`retention-days: 90`,
 		`group: publish-canary-${{ github.event.workflow_run.head_sha || github.sha }}`,
-		`2>/dev/null) || existing=""`,
 	} {
 		if !strings.Contains(contents, required) {
-			t.Errorf("canary workflow is missing immutable SemVer policy %q", required)
+			t.Errorf("canary workflow is missing commit-addressed artifact policy %q", required)
 		}
 	}
-	for _, forbidden := range []string{"gh release", "/releases", "--prerelease", "download-artifact"} {
+	for _, forbidden := range []string{"gh release", "/releases", "--prerelease", "git/ref/tags", "refs/tags/", "RELEASE_SERIES", "contents: write"} {
 		if strings.Contains(contents, forbidden) {
-			t.Errorf("canary workflow must create tags only, found %q", forbidden)
+			t.Errorf("canary workflow must not publish tags or releases, found %q", forbidden)
 		}
 	}
 }


### PR DESCRIPTION
Canaries should identify qualified main commits without participating in Go module version selection.

- publish full-SHA Actions artifacts without git tags or GitHub Releases
- resolve `canary` from the newest retained host artifact and install `canary@<SHA>` directly
- keep legacy canary-tag artifact installs compatible
- use beta releases as the bootstrap carrier for canary installs
- ignore VCS pseudo-versions for local installer builds

Verification:
- `go test ./...`
- `go vet ./cli/installer ./cli/manager/internal/version ./internal/actionartifact ./tests/integration/cipolicy`
- `shellcheck install.sh`
- `git diff --check`