### PR TITLE
installer: fall back to Go before first release

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -44,6 +44,11 @@ bootstrap script only refreshes `PATH` in its own shell when requested:
 
 `wago-installer-<os>-<arch>`
 
+Before the first GitHub Release provides that executable, the `main` bootstrap
+uses `go run github.com/wago-org/wago/cli/wago-installer@main` when Go is
+available. Other channels do not fall back to source, and a machine without Go
+gets an explicit message that no published installer is available.
+
 The CLI installs and switches runtimes. Runtime files use this name format:
 
 `wago-runtime-<profile>-<build>-<os>-<arch>`

--- a/install.ps1
+++ b/install.ps1
@@ -115,9 +115,11 @@ $previousRefreshRequest = $env:WAGO_PATH_REFRESH_FILE
 $previousRefreshChoice = $env:WAGO_REFRESH_PATH
 $runsInChildShell = [Environment]::GetCommandLineArgs()[-1] -eq "-"
 $installerStatus = 1
+$installerWasRun = $false
 
 try {
     $env:WAGO_PATH_REFRESH_FILE = $refreshRequest
+    $env:WAGO_VERSION = $version
     if ($runsInChildShell) {
         $env:WAGO_REFRESH_PATH = "no"
     }
@@ -136,7 +138,13 @@ try {
         $downloaded = $false
         $downloadError = $null
 
-        foreach ($tag in @(Get-WagoDownloadTags $version)) {
+        $downloadTags = @()
+        try {
+            $downloadTags = @(Get-WagoDownloadTags $version)
+        } catch {
+            $downloadError = $_.Exception.Message
+        }
+        foreach ($tag in $downloadTags) {
             if (-not $tag) {
                 continue
             }
@@ -160,16 +168,26 @@ try {
         }
 
         if (-not $downloaded) {
-            if ($env:WAGO_INSTALLER_DEBUG -and $downloadError) {
-                throw "wago: the installer is unavailable: $downloadError"
+            $goCommandName = if ($env:WAGO_GO_COMMAND) { $env:WAGO_GO_COMMAND } else { "go" }
+            $goCommand = Get-Command -Name $goCommandName -CommandType Application -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+            if ($version -eq "main" -and $null -ne $goCommand) {
+                & $goCommand.Source run github.com/wago-org/wago/cli/wago-installer@main install @args
+                $installerStatus = $LASTEXITCODE
+                $installerWasRun = $true
+            } else {
+                if ($env:WAGO_INSTALLER_DEBUG -and $downloadError) {
+                    throw "wago: the installer is unavailable: $downloadError"
+                }
+                throw "wago: no published installer is available; install Go and try again, or wait for the next Wago release"
             }
-            throw "wago: the installer is unavailable; check your internet connection and try again"
         }
     }
 
-    $env:WAGO_VERSION = $version
-    & $installer install @args
-    $installerStatus = $LASTEXITCODE
+    if (-not $installerWasRun) {
+        & $installer install @args
+        $installerStatus = $LASTEXITCODE
+    }
     if ($installerStatus -eq 2) {
         throw "wago: this installer release predates the native install flow; wait for the channel to update and try again"
     }

--- a/install.sh
+++ b/install.sh
@@ -176,6 +176,27 @@ start_refreshed_shell() {
 	exec "$shell" -i
 }
 
+run_go_fallback() {
+	[ "$version" = main ] || return 1
+	go_command=${WAGO_GO_COMMAND:-go}
+	command -v "$go_command" >/dev/null 2>&1 || return 1
+	if WAGO_VERSION="$install_version" WAGO_PATH_REFRESH_FILE="$tmp/path-refresh" \
+		"$go_command" run github.com/wago-org/wago/cli/wago-installer@main install "$@"; then
+		start_refreshed_shell
+		exit 0
+	else
+		status=$?
+		exit "$status"
+	fi
+}
+
+unavailable() {
+	if run_go_fallback "$@"; then
+		return 0
+	fi
+	die "no published installer is available; install Go and try again, or wait for the next Wago release"
+}
+
 tmp=$(mktemp -d 2>/dev/null || mktemp -d -t wago) || die "could not create a temporary directory"
 
 if [ -n "${WAGO_INSTALLER:-}" ]; then
@@ -187,7 +208,7 @@ fi
 
 asset=$(target_name) || die "this operating system or architecture is not supported"
 if ! resolve_release; then
-	die "the installer is unavailable; check your internet connection and try again"
+	unavailable "$@"
 fi
 downloaded=""
 for tag in $tags; do
@@ -203,7 +224,7 @@ for tag in $tags; do
 	break
 done
 if [ -z "$downloaded" ]; then
-	die "the installer is unavailable; check your internet connection and try again"
+	unavailable "$@"
 fi
 chmod +x "$tmp/installer"
 run_installer "$tmp/installer" "$@"

--- a/install_powershell_portable_test.go
+++ b/install_powershell_portable_test.go
@@ -46,8 +46,8 @@ func TestPowerShellBootstrapFallsBackToGoForMainWithoutRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("source fallback: %v\n%s", err, output)
 	}
-	if got, want := strings.TrimSpace(string(output)), "source installer: main"; got != want {
-		t.Fatalf("source fallback output = %q, want %q", got, want)
+	if got, want := string(output), "source installer: main"; !strings.Contains(got, want) {
+		t.Fatalf("source fallback output = %q, want it to contain %q", got, want)
 	}
 	args, err := os.ReadFile(log)
 	if err != nil {

--- a/install_powershell_portable_test.go
+++ b/install_powershell_portable_test.go
@@ -1,0 +1,59 @@
+package wago
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPowerShellBootstrapFallsBackToGoForMainWithoutRelease(t *testing.T) {
+	if _, err := exec.LookPath("pwsh"); err != nil {
+		t.Skip("pwsh is not available")
+	}
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	log := filepath.Join(t.TempDir(), "go.log")
+	goCommand := filepath.Join(t.TempDir(), "go")
+	content := "#!/bin/sh\nprintf '%s\\n' \"$*\" >\"$WAGO_GO_LOG\"\nprintf 'source installer: %s\\n' \"$WAGO_VERSION\"\n"
+	if runtime.GOOS == "windows" {
+		goCommand += ".cmd"
+		content = "@echo off\r\necho %* > \"%WAGO_GO_LOG%\"\r\necho source installer: %WAGO_VERSION%\r\n"
+	}
+	if err := os.WriteFile(goCommand, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script, err := os.ReadFile("install.ps1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-Command", "-")
+	command.Stdin = bytes.NewReader(script)
+	command.Env = append(os.Environ(),
+		"WAGO_VERSION=main",
+		"WAGO_INSTALLER_DEBUG=1",
+		"WAGO_RELEASES_API_URL="+server.URL+"/releases",
+		"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"WAGO_GO_COMMAND="+goCommand,
+		"WAGO_GO_LOG="+log,
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("source fallback: %v\n%s", err, output)
+	}
+	if got, want := strings.TrimSpace(string(output)), "source installer: main"; got != want {
+		t.Fatalf("source fallback output = %q, want %q", got, want)
+	}
+	args, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.TrimSpace(string(args)), "run github.com/wago-org/wago/cli/wago-installer@main install"; got != want {
+		t.Fatalf("go fallback arguments = %q, want %q", got, want)
+	}
+}

--- a/install_test.go
+++ b/install_test.go
@@ -125,6 +125,7 @@ func TestShellBootstrapStopsCleanlyWhenInstallerIsUnavailable(t *testing.T) {
 	defer server.Close()
 	command := exec.Command("sh", "install.sh")
 	command.Env = append(os.Environ(),
+		"WAGO_VERSION=beta",
 		"WAGO_RELEASES_API_URL="+server.URL+"/releases",
 		"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
 	)
@@ -132,8 +133,40 @@ func TestShellBootstrapStopsCleanlyWhenInstallerIsUnavailable(t *testing.T) {
 	if err == nil {
 		t.Fatal("bootstrap unexpectedly succeeded without an installer")
 	}
-	if text := string(output); !strings.Contains(text, "installer is unavailable") || !strings.Contains(text, "internet connection") {
+	if text := string(output); !strings.Contains(text, "no published installer") || !strings.Contains(text, "install Go") {
 		t.Fatalf("unavailable output:\n%s", output)
+	}
+}
+
+func TestShellBootstrapFallsBackToGoForMainWithoutRelease(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	log := filepath.Join(t.TempDir(), "go.log")
+	goCommand := filepath.Join(t.TempDir(), "go")
+	if err := os.WriteFile(goCommand, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >\"$WAGO_GO_LOG\"\nprintf 'source installer: %s\\n' \"$WAGO_VERSION\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command("sh", "install.sh")
+	command.Env = append(os.Environ(),
+		"WAGO_VERSION=main",
+		"WAGO_RELEASES_API_URL="+server.URL+"/releases",
+		"WAGO_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"WAGO_GO_COMMAND="+goCommand,
+		"WAGO_GO_LOG="+log,
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("source fallback: %v\n%s", err, output)
+	}
+	if got, want := string(output), "source installer: main\n"; got != want {
+		t.Fatalf("source fallback output = %q, want %q", got, want)
+	}
+	args, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.TrimSpace(string(args)), "run github.com/wago-org/wago/cli/wago-installer@main install"; got != want {
+		t.Fatalf("go fallback arguments = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- fall back to `go run github.com/wago-org/wago/cli/wago-installer@main` when the rolling `main` channel has no published installer binary
- keep beta, stable, checksum-failure, and explicit-version paths strict
- give machines without Go a precise pre-release error
- cover the fallback on both shell and PowerShell

## Cause

The public bootstrap scripts download installer binaries from GitHub Releases. The repository currently has tags and retained Actions artifacts, but no published GitHub Release. Actions artifact archives require authentication, so they cannot bootstrap a clean public install.

## Proof

- original live repro: `curl -fsSL https://install.wago.sh/unix | WAGO_DRY_RUN=1 sh` fails before this change
- fixed Unix script against the real release catalog: `WAGO_DRY_RUN=1 NO_COLOR=1 sh ./install.sh`
- fixed PowerShell script against the real release catalog: `WAGO_DRY_RUN=1 NO_COLOR=1 pwsh -NoLogo -NoProfile -File ./install.ps1`
- `just docs`
- `just lint`
- `just test`

The live URL will update after merge through the existing installer-site synchronization workflow.

## Assistance

Developed with AI assistance; all changes and test results were reviewed by the author.
