### PR TITLE
installer: publish removed bootstrap files

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -49,6 +49,10 @@ uses `go run github.com/wago-org/wago/cli/wago-installer@main` when Go is
 available. Other channels do not fall back to source, and a machine without Go
 gets an explicit message that no published installer is available.
 
+The `Publish installers` workflow copies these bootstrap scripts to the
+installer site. It stages the full site checkout so that removed bootstrap
+files are also removed from the published site.
+
 The CLI installs and switches runtimes. Runtime files use this name format:
 
 `wago-runtime-<profile>-<build>-<os>-<arch>`

--- a/.github/workflows/sync-install.yml
+++ b/.github/workflows/sync-install.yml
@@ -49,6 +49,6 @@ jobs:
           fi
           git config user.name "wago-bot"
           git config user.email "wago-bot@users.noreply.github.com"
-          git add --all -- install.sh install.cmd install.ps1
+          git add --all -- .
           git commit -m "sync: update installer bootstraps"
           git push origin HEAD:main

--- a/tests/integration/cipolicy/workflows_test.go
+++ b/tests/integration/cipolicy/workflows_test.go
@@ -100,6 +100,20 @@ func TestCanaryPublishesCommitAddressedArtifactsWithoutTags(t *testing.T) {
 	}
 }
 
+func TestInstallerPublishStagesRemovedBootstraps(t *testing.T) {
+	workflow, err := os.ReadFile(filepath.Clean("../../../.github/workflows/sync-install.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(workflow)
+	if !strings.Contains(contents, "git add --all -- .") {
+		t.Error("installer publish workflow must stage removed bootstrap files")
+	}
+	if strings.Contains(contents, "git add --all -- install.sh install.cmd install.ps1") {
+		t.Error("installer publish workflow names the removed install.cmd path")
+	}
+}
+
 func TestAggregateCIRequiresEveryWorkflowJob(t *testing.T) {
 	workflow, err := os.ReadFile(filepath.Clean("../../../.github/workflows/ci.yml"))
 	if err != nil {


### PR DESCRIPTION
## Summary

- fix the installer-site sync after `install.cmd` was removed
- stage the full published checkout so file removals are included
- add a CI policy regression test and document the sync rule

## Cause

The publish job named the removed `install.cmd` path in `git add`, so Git stopped before the updated source fallback reached `install.wago.sh`.

## Proof

- `go test ./tests/integration/cipolicy -count=1`
- `go test . -run 'Test(ShellBootstrapFallsBackToGoForMainWithoutRelease|PowerShellBootstrapFallsBackToGoForMainWithoutRelease)$' -count=1`\n- `just docs`\n- local `WAGO_DRY_RUN=1 NO_COLOR=1 sh ./install.sh` succeeds