### PR TITLE
fix: consume complete typed-select reference immediates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,13 @@ The retired list includes `inline-loop-callees` and `deep-fp-pins` from v1.
 Host calls convert both `HostExit` and non-nil `*HostExit` panics to `ExitError`,
 including calls through a Wasm wrapper and replayed host logs.
 
+Both native backends consume the complete result-type vector of a typed
+`select` through the shared Wasm immediate reader. Explicit reference types
+include a nullable/non-null prefix and a signed heap-type index, which can span
+multiple bytes. No heap-type byte may re-enter the instruction stream.
+`TestTypedSelectReferenceImmediates` checks reference identity and selection for
+both nullability forms and one-byte/multi-byte type indexes.
+
 Reference instructions constrain an unreachable stack value to a reference.
 The validator uses an internal heap bottom type for this value; it cannot match
 a numeric or vector operand and has no binary encoding.

--- a/src/core/compiler/backend/railshot/amd64/driver.go
+++ b/src/core/compiler/backend/railshot/amd64/driver.go
@@ -129,14 +129,8 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 	case 0x1b: // select
 		f.emitSelect()
 	case 0x1c: // select t (typed) — consume the declared result types
-		n, err := r.U32()
-		if err != nil {
+		if err := wasm.SkipInstructionImmediate(r, op); err != nil {
 			return err
-		}
-		for k := uint32(0); k < n; k++ {
-			if _, err := r.Byte(); err != nil {
-				return err
-			}
 		}
 		f.emitSelect()
 

--- a/src/core/compiler/backend/railshot/arm64/driver.go
+++ b/src/core/compiler/backend/railshot/arm64/driver.go
@@ -136,14 +136,8 @@ func (f *fn) emitPlain(r *wasm.Reader, op byte) error {
 		}
 		f.emitSelect()
 	case 0x1c: // select t (typed) — consume the declared result types
-		n, err := r.U32()
-		if err != nil {
+		if err := wasm.SkipInstructionImmediate(r, op); err != nil {
 			return err
-		}
-		for k := uint32(0); k < n; k++ {
-			if _, err := r.Byte(); err != nil {
-				return err
-			}
 		}
 		if done, err := f.trySelectLocalSet(r); done || err != nil {
 			return err

--- a/src/wago/typed_select_reference_test.go
+++ b/src/wago/typed_select_reference_test.go
@@ -1,0 +1,86 @@
+//go:build (linux && (amd64 || arm64)) || (darwin && arm64)
+
+package wago
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+// A reference result type has a prefix followed by a signed heap-type index.
+// Type index zero used to remain in the opcode stream and execute as unreachable.
+func typedSelectReferenceModule(typeIndex uint32, nullable bool, same bool) []byte {
+	types := make([][]byte, typeIndex+1)
+	for i := range types {
+		types[i] = []byte{0x5f, 0x01, 0x7f, 0x00} // struct (field i32)
+	}
+	types = append(types, wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}))
+	ref := append([]byte{0x64}, wasmtest.SLEB32(int32(typeIndex))...)
+	body := append([]byte{0x01, 0x02}, ref...)  // two non-null reference locals
+	body = append(body, 0x41, 0x0b, 0xfb, 0x00) // struct.new with field 11
+	body = append(body, wasmtest.ULEB(typeIndex)...)
+	body = append(body, 0x21, 0x01, 0x41, 0x16, 0xfb, 0x00) // local 1; struct.new with field 22
+	body = append(body, wasmtest.ULEB(typeIndex)...)
+	body = append(body, 0x21, 0x02, 0x20, 0x01, 0x20)
+	if same {
+		body = append(body, 0x01)
+	} else {
+		body = append(body, 0x02)
+	}
+	body = append(body, 0x20, 0x00, 0x1c, 0x01) // condition; select with one declared result
+	if nullable {
+		ref[0] = 0x63
+	}
+	body = append(body, ref...)
+	if same {
+		body = append(body, 0x20, 0x01, 0xd3) // ref.eq against the original
+	} else {
+		body = append(body, 0xfb, 0x02) // struct.get field 0
+		body = append(body, wasmtest.ULEB(typeIndex)...)
+		body = append(body, 0x00)
+	}
+	body = append(body, 0x0b)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(types...)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(typeIndex+1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", byte(wasm.ExternFunc), 0))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
+func TestTypedSelectReferenceImmediates(t *testing.T) {
+	for _, index := range []uint32{0, 130} {
+		for _, nullable := range []bool{false, true} {
+			for _, same := range []bool{true, false} {
+				t.Run(fmt.Sprintf("index=%d/nullable=%t/same=%t", index, nullable, same), func(t *testing.T) {
+					compiled, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), typedSelectReferenceModule(index, nullable, same))
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer compiled.Close()
+					instance, err := Instantiate(compiled, InstantiateOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer instance.Close()
+					for _, condition := range []uint32{0, 1, 0xffffffff} {
+						got, err := instance.Invoke("run", I32(int32(condition)))
+						want := uint64(11)
+						if condition == 0 {
+							want = 22
+						}
+						if same {
+							want = 1
+						}
+						if err != nil || len(got) != 1 || got[0] != want {
+							t.Fatalf("condition %#x: got %v, error %v; want [%d]", condition, got, err, want)
+						}
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
A typed `select` with an explicit reference type could trap in valid Wasm. Both native backends consumed only the type prefix; the following heap-type index remained in the instruction stream. For `(ref 0)`, the remaining zero byte became `unreachable`.

Use the shared immediate reader in amd64 and arm64. Add execution tests for nullable/non-null references, type indexes 0 and 130, both identical and distinct operands, and conditions 0, 1, and -1. Update the architecture rule.

Validation completed locally before submission:

- New regression fails before the fix and passes all 24 checks afterward.
- Runtime CLI built successfully (2.73 s). A rebuilt Dewdrop runner passes the small reproducer and the original source case at prefixes 5, 6, and 12.
- `go test ./src/wago ./src/core/compiler/backend/railshot/... ./src/core/compiler/wasm -count=1` passes with the pinned Release 3 interpreter (7.56 s).
- `go -C bench test ./...` passes (2.63 s).
- Linux/arm64 runtime tests cross-compile (6.83 s); native execution was tested on Linux/amd64.
- `go test ./...` was also run (66.62 s). Two unrelated standalone TinyGo tests fail with `duplicate symbol: tinygo_task_exit` using local TinyGo 0.42.0 / Go 1.27.1; CI pins TinyGo 0.41.1. The same tests fail in the unmodified checkout.

This affects compilation-time decoding only. It adds no runtime instructions and does not change the feature-support matrix.

AI assistance: Codex reduced the failing Dewdrop case, wrote the fix and tests, and ran the local validation.
