### PR TITLE
version: order channels by release stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ wago-installer
 ```
 
 These commands install the Wago manager. Run `wago version install` to install
-a runtime. See [Getting started](https://docs.wago.sh/getting-started) for other
-installation methods, release channels, and source builds.
+a runtime. Its picker lists available Official, Beta, and Canary channels in
+that order; unavailable channels remain visible and disabled at the bottom. See
+[Getting started](https://docs.wago.sh/getting-started) for other installation
+methods, release channels, and source builds.
 
 ## Run a module
 

--- a/cli/internal/tui/picker.go
+++ b/cli/internal/tui/picker.go
@@ -15,6 +15,7 @@ type Item struct {
 	MetaWidth   int
 	Description string
 	Value       string
+	Disabled    bool
 	Children    []Item
 	ChildCursor int
 	AcceptTitle string
@@ -37,7 +38,7 @@ type Picker struct {
 const pickerVisibleRows = 15
 
 func NewPicker(title string, items []Item) *Picker {
-	return &Picker{pages: []pickerPage{{title: title, items: items}}}
+	return &Picker{pages: []pickerPage{{title: title, items: items, cursor: pickerCursor(items, 0)}}}
 }
 
 func (p *Picker) page() *pickerPage {
@@ -48,21 +49,30 @@ func (p *Picker) apply(key selectKey) (done, cancelled bool) {
 	page := p.page()
 	switch key {
 	case keyUp:
-		if page.cursor > 0 {
-			page.cursor--
+		for cursor := page.cursor - 1; cursor >= 0; cursor-- {
+			if !page.items[cursor].Disabled {
+				page.cursor = cursor
+				break
+			}
 		}
 	case keyDown:
-		if page.cursor < len(page.items)-1 {
-			page.cursor++
+		for cursor := page.cursor + 1; cursor < len(page.items); cursor++ {
+			if !page.items[cursor].Disabled {
+				page.cursor = cursor
+				break
+			}
 		}
 	case keyRight:
 		if len(page.items) != 0 {
 			item := page.items[page.cursor]
+			if item.Disabled {
+				return false, false
+			}
 			if len(item.Children) != 0 {
 				p.pages = append(p.pages, pickerPage{
 					title:  page.title + " › " + item.Label,
 					items:  item.Children,
-					cursor: item.ChildCursor,
+					cursor: pickerCursor(item.Children, item.ChildCursor),
 				})
 			} else {
 				return p.accept(item)
@@ -88,10 +98,14 @@ func (p *Picker) apply(key selectKey) (done, cancelled bool) {
 }
 
 func (p *Picker) accept(item Item) (done, cancelled bool) {
+	if item.Disabled {
+		return false, false
+	}
 	if len(item.AcceptItems) != 0 {
 		p.pages = append(p.pages, pickerPage{
-			title: item.AcceptTitle,
-			items: item.AcceptItems,
+			title:  item.AcceptTitle,
+			items:  item.AcceptItems,
+			cursor: pickerCursor(item.AcceptItems, 0),
 		})
 		return false, false
 	}
@@ -114,12 +128,15 @@ func (p *Picker) Selected() string {
 	if len(page.items) == 0 {
 		return ""
 	}
+	if page.items[page.cursor].Disabled {
+		return ""
+	}
 	return page.items[page.cursor].Value
 }
 
 func (p *Picker) SetCursor(cursor int) {
 	page := p.page()
-	if cursor >= 0 && cursor < len(page.items) {
+	if cursor >= 0 && cursor < len(page.items) && !page.items[cursor].Disabled {
 		page.cursor = cursor
 	}
 }
@@ -165,7 +182,9 @@ func (p *Picker) frame() string {
 	for i := start; i < end; i++ {
 		item := page.items[i]
 		cursor, mark := "  ", "○"
-		if i == page.cursor {
+		if item.Disabled {
+			mark = ui.Dim("◌")
+		} else if i == page.cursor {
 			cursor, mark = ui.Cyan("› "), ui.Cyan("◉")
 		}
 		line := fmt.Sprintf("%s%s %-*s", cursor, mark, labelW, item.Label)
@@ -181,6 +200,9 @@ func (p *Picker) frame() string {
 		}
 		if item.Description != "" {
 			line += "  " + ui.Dim(item.Description)
+		}
+		if item.Disabled {
+			line = ui.Dim(line)
 		}
 		fmt.Fprintf(&b, "%s\n", line)
 	}
@@ -203,11 +225,23 @@ func (p *Picker) Frame() string {
 
 func pickerHasChildren(items []Item) bool {
 	for _, item := range items {
-		if len(item.Children) != 0 {
+		if !item.Disabled && len(item.Children) != 0 {
 			return true
 		}
 	}
 	return false
+}
+
+func pickerCursor(items []Item, preferred int) int {
+	if preferred >= 0 && preferred < len(items) && !items[preferred].Disabled {
+		return preferred
+	}
+	for i := range items {
+		if !items[i].Disabled {
+			return i
+		}
+	}
+	return 0
 }
 
 func pickerWindow(page *pickerPage) (start, end int) {

--- a/cli/internal/tui/picker_test.go
+++ b/cli/internal/tui/picker_test.go
@@ -94,6 +94,42 @@ func TestPickerRightSelectsLeaf(t *testing.T) {
 	}
 }
 
+func TestPickerSkipsAndRejectsDisabledItems(t *testing.T) {
+	p := NewPicker("Pick", []Item{
+		{Label: "unavailable first", Value: "first", Disabled: true},
+		{Label: "available", Value: "available"},
+		{Label: "unavailable last", Value: "last", Disabled: true},
+	})
+	if got := p.Selected(); got != "available" {
+		t.Fatalf("initial selection = %q, want available", got)
+	}
+	p.apply(keyUp)
+	if got := p.Selected(); got != "available" {
+		t.Fatalf("up selected disabled item: %q", got)
+	}
+	p.apply(keyDown)
+	if got := p.Selected(); got != "available" {
+		t.Fatalf("down selected disabled item: %q", got)
+	}
+	if frame := p.frame(); strings.Count(frame, "◌") != 2 {
+		t.Fatalf("disabled rows are not rendered distinctly:\n%s", frame)
+	}
+
+	allDisabled := NewPicker("Pick", []Item{{
+		Label: "unavailable", Value: "no", Disabled: true,
+		Children: []Item{{Label: "hidden", Value: "hidden"}},
+	}})
+	if got := allDisabled.Selected(); got != "" {
+		t.Fatalf("disabled selection = %q, want empty", got)
+	}
+	if done, cancelled := allDisabled.apply(keyAccept); done || cancelled {
+		t.Fatalf("disabled accept = done %v, cancelled %v", done, cancelled)
+	}
+	if done, cancelled := allDisabled.apply(keyRight); done || cancelled || allDisabled.Depth() != 1 {
+		t.Fatalf("disabled browse = done %v, cancelled %v, depth %d", done, cancelled, allDisabled.Depth())
+	}
+}
+
 func TestPickerFramePaginatesAtWindowBoundary(t *testing.T) {
 	items := make([]Item, 25)
 	for i := range items {

--- a/cli/manager/internal/version/lifecycle_test.go
+++ b/cli/manager/internal/version/lifecycle_test.go
@@ -500,17 +500,20 @@ func TestInstallPickerHidesImmutableChannelTagsAtTopLevel(t *testing.T) {
 	commits[1].Commit.Author.Date = "2026-07-27T00:48:44Z"
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	items := versionPickerItemsWithCommits(releases, commits, now)
-	if got, want := []string{items[0].Children[0].Value, items[0].Children[1].Value, items[0].Children[2].Value}, []string{"canary", canaryCommitTarget(commits[0].SHA), canaryCommitTarget(commits[1].SHA)}; !slices.Equal(got, want) {
+	if got, want := []string{items[0].Label, items[1].Label, items[2].Label}, []string{"Official", "Beta", "Canary"}; !slices.Equal(got, want) {
+		t.Fatalf("channel order = %v, want %v", got, want)
+	}
+	if got, want := []string{items[2].Children[0].Value, items[2].Children[1].Value, items[2].Children[2].Value}, []string{"canary", canaryCommitTarget(commits[0].SHA), canaryCommitTarget(commits[1].SHA)}; !slices.Equal(got, want) {
 		t.Fatalf("canary picker children = %v, want %v", got, want)
 	}
-	if got, want := []string{items[2].Children[0].Value, items[2].Children[1].Value, items[2].Children[2].Value, items[2].Children[3].Value}, []string{"latest", "v0.2.0", "v0.1.4", "0.1.0"}; !slices.Equal(got, want) {
+	if got, want := []string{items[0].Children[0].Value, items[0].Children[1].Value, items[0].Children[2].Value, items[0].Children[3].Value}, []string{"latest", "v0.2.0", "v0.1.4", "0.1.0"}; !slices.Equal(got, want) {
 		t.Fatalf("latest picker children = %v, want %v", got, want)
 	}
 	beta := items[1].Children[1]
 	if beta.Label != "v0.1.0-beta.2" || beta.Value != "v0.1.0-beta.2@7d8c58a123456789012345678901234567890123" || beta.Description != "07/28/2026  1d ago" {
 		t.Fatalf("beta picker item = %#v", beta)
 	}
-	canary := items[0].Children[1]
+	canary := items[2].Children[1]
 	if canary.Label != "canary-cafef00" || canary.Description != "07/28/2026  1d ago" {
 		t.Fatalf("canary picker item = %#v", canary)
 	}
@@ -522,6 +525,25 @@ func TestInstallPickerHidesImmutableChannelTagsAtTopLevel(t *testing.T) {
 	}
 }
 
+func TestInstallPickerMovesUnavailableChannelsToBottom(t *testing.T) {
+	releases := []remoteRelease{{TagName: "v0.2.0", PublishedAt: "2026-07-28T08:31:22Z"}}
+	items := installPickerItemsWithCommits(releases, nil, time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC))
+	if got, want := []string{items[0].Label, items[1].Label, items[2].Label, items[3].Label}, []string{"Official", "v0.2.0", "Beta", "Canary"}; !slices.Equal(got, want) {
+		t.Fatalf("picker order = %v, want %v", got, want)
+	}
+	for _, item := range items[2:] {
+		if !item.Disabled || item.Description != "no releases available" || len(item.AcceptItems) != 0 || len(item.Children) != 0 {
+			t.Fatalf("unavailable channel is selectable: %#v", item)
+		}
+	}
+	p := tui.NewPicker("Install Wago version", items)
+	p.Apply(tui.KeyDown)
+	p.Apply(tui.KeyDown)
+	if got := p.Selected(); got != "v0.2.0" {
+		t.Fatalf("picker moved onto unavailable channel: %q", got)
+	}
+}
+
 func TestInstallPickerProfilePageReturnsToReleasePage(t *testing.T) {
 	releases := []remoteRelease{
 		{TagName: "v0.2.0", PublishedAt: "2026-07-27T08:31:22Z"},
@@ -529,6 +551,7 @@ func TestInstallPickerProfilePageReturnsToReleasePage(t *testing.T) {
 	commits := []remoteCommit{{SHA: "7d8c58a123456789012345678901234567890123"}}
 	commits[0].Commit.Author.Date = "2026-07-28T08:31:22Z"
 	p := tui.NewPicker("Install Wago version", installPickerItemsWithCommits(releases, commits, time.Now()))
+	p.Apply(tui.KeyDown)  // choose Canary
 	p.Apply(tui.KeyRight) // browse canary releases
 	p.Apply(tui.KeyDown)  // choose the immutable canary build
 	if done, cancelled := p.Apply(tui.KeyAccept); done || cancelled {
@@ -569,9 +592,9 @@ func TestPaginatedInstallPickerKeepsChannelsSelectableAndLoadActionsTerminal(t *
 		channel    string
 		loadAction string
 	}{
-		{name: "canary", item: items[0], channel: "canary", loadAction: pickerLoadMoreCommits},
+		{name: "official", item: items[0], channel: "latest", loadAction: pickerLoadMoreReleases},
 		{name: "beta", item: items[1], channel: "beta", loadAction: pickerLoadMoreReleases},
-		{name: "latest", item: items[2], channel: "latest", loadAction: pickerLoadMoreReleases},
+		{name: "canary", item: items[2], channel: "canary", loadAction: pickerLoadMoreCommits},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cli/manager/internal/version/releases.go
+++ b/cli/manager/internal/version/releases.go
@@ -339,16 +339,35 @@ func paginatedVersionPickerItems(releases []remoteRelease, commits []remoteCommi
 		betaChildren = appendLoadMorePickerItem("beta", betaChildren, loadMore)
 		latestChildren = appendLoadMorePickerItem("latest", latestChildren, loadMore)
 	}
-	items := []tui.Item{
-		{Label: "canary", Value: "canary", Children: canaryChildren},
-		{Label: "beta", Value: "beta", Children: betaChildren},
-		{Label: "latest", Value: "latest", Children: latestChildren},
+	channels := []tui.Item{
+		channelPickerItem("Official", "latest", latestChildren),
+		channelPickerItem("Beta", "beta", betaChildren),
+		channelPickerItem("Canary", "canary", canaryChildren),
+	}
+	items := make([]tui.Item, 0, len(channels)+len(stable)+1)
+	unavailable := make([]tui.Item, 0, len(channels))
+	for _, channel := range channels {
+		if channel.Disabled {
+			unavailable = append(unavailable, channel)
+		} else {
+			items = append(items, channel)
+		}
 	}
 	items = append(items, stable...)
 	if moreReleases {
 		items = append(items, loadMorePickerItem("Load older releases…", pickerLoadMoreReleases))
 	}
+	items = append(items, unavailable...)
 	return items
+}
+
+func channelPickerItem(label, value string, children []tui.Item) tui.Item {
+	item := tui.Item{Label: label, Value: value, Children: children}
+	if len(children) == 0 {
+		item.Description = "no releases available"
+		item.Disabled = true
+	}
+	return item
 }
 
 func installPickerItemsWithCommits(releases []remoteRelease, commits []remoteCommit, now time.Time) []tui.Item {
@@ -362,7 +381,7 @@ func paginatedInstallPickerItems(releases []remoteRelease, commits []remoteCommi
 func addProfileChoices(items []tui.Item) []tui.Item {
 	for i := range items {
 		items[i].Children = addProfileChoices(items[i].Children)
-		if items[i].Value == "" || isPickerLoadMore(items[i].Value) {
+		if items[i].Disabled || items[i].Value == "" || isPickerLoadMore(items[i].Value) {
 			continue
 		}
 		items[i].AcceptTitle = "Choose Wago profile"


### PR DESCRIPTION
## Summary

- list available channels as Official, Beta, then Canary
- move unavailable channels below selectable releases
- dim unavailable channels and prevent selection or drill-down
- document the picker behavior

## Proof

- `go test ./cli/... -count=1`
- `go test -tags wago_runtime ./cli/... -count=1`
- `just docs`
- `just lint`