### PR TITLE
Retract legacy tagged Canary module versions

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -4,9 +4,9 @@
 
 - `canary` resolves the newest successful main commit with a retained host
   artifact. Its canonical identity is `canary@<40-character-commit-sha>`.
-  Canaries create neither git tags nor GitHub Releases. Legacy
-  `vMAJOR.MINOR.PATCH-canary.g<7-character-commit-sha>` artifacts remain
-  installable while they are retained.
+  Canaries create neither git tags nor GitHub Releases. Legacy tagged Canary
+  module versions are retracted and remain available only for builds that
+  request an exact old version.
 - `beta` resolves the newest manually qualified beta, such as
   `v0.1.0-beta.1`.
 - `latest` resolves the newest stable `vMAJOR.MINOR.PATCH` release.

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,26 @@ module github.com/wago-org/wago
 go 1.22
 
 require golang.org/x/sys v0.30.0
+
+// Legacy tagged Canary builds. Canary is now distributed only as
+// commit-addressed GitHub Actions artifacts.
+retract (
+	v0.1.0-canary.g014a2fe
+	v0.1.0-canary.g1087001
+	v0.1.0-canary.g12ccfd4
+	v0.1.0-canary.g2025c38
+	v0.1.0-canary.g215b022
+	v0.1.0-canary.g363fadf
+	v0.1.0-canary.g3c96977
+	v0.1.0-canary.g3ca7525
+	v0.1.0-canary.g4d6c627
+	v0.1.0-canary.g470442d792991f50c397d62ac6f7dfc06700a0b8
+	v0.1.0-canary.g666cd54
+	v0.1.0-canary.g709494c
+	v0.1.0-canary.g7b3efce
+	v0.1.0-canary.g81feb65
+	v0.1.0-canary.g8ae8468
+	v0.1.0-canary.gbd742cd
+	v0.1.0-canary.gdd58578
+	v0.1.0-canary.ge844da4
+)


### PR DESCRIPTION
## Summary

- retract every historical tagged Canary module version
- keep the current tagless, commit-addressed Actions-artifact Canary channel unchanged
- document that exact old versions remain available only for reproducible builds

The retractions become active after a higher version containing them is published. Stable `v0.1.0` will satisfy that requirement and take precedence for `@latest`.

## Verification

- `go test ./...`
- `just docs`
- matched the retraction list against all historical local tagged Canary versions
- matched the public Go proxy list against the retracted versions