### PR TITLE
Fix beta release discovery in the CLI

### DIFF
--- a/.github/release-asset-naming.md
+++ b/.github/release-asset-naming.md
@@ -8,7 +8,8 @@
   `vMAJOR.MINOR.PATCH-canary.g<7-character-commit-sha>` artifacts remain
   installable while they are retained.
 - `beta` resolves the newest manually qualified beta, such as
-  `v0.1.0-beta.1`.
+  `v0.1.0-beta.1`. The immutable tag is the published identity; GitHub can
+  report its release `target_commitish` as `main` when the tag already exists.
 - `latest` resolves the newest stable `vMAJOR.MINOR.PATCH` release.
 
 The canary workflow builds automatically after main CI succeeds. Artifacts are

--- a/cli/manager/internal/version/discovery.go
+++ b/cli/manager/internal/version/discovery.go
@@ -376,7 +376,7 @@ func installedCommitMatches(path, resolved string) bool {
 func sameRelease(installed, resolved string) bool {
 	lowerInstalled := strings.ToLower(strings.TrimSpace(installed))
 	rollingStamp := strings.HasPrefix(lowerInstalled, "canary@") || strings.HasPrefix(lowerInstalled, "beta@")
-	if installed != "" && installed == resolved && channelRelease(installed) == "" && !isRollingChannel(installed) && !rollingStamp {
+	if installed != "" && installed == resolved && !isRollingChannel(installed) && !rollingStamp {
 		return true
 	}
 	installedChannel, installedCommit, installedCanonical := rollingCommitSHA(installed)
@@ -629,18 +629,44 @@ func latestChannelRelease(channel string) (string, error) {
 
 func latestChannelReleaseContext(ctx context.Context, channel string) (string, error) {
 	var resolved string
-	var resolveErr error
 	err := forEachReleasePage(ctx, "release channel discovery", func(releases []remoteRelease) bool {
 		for _, release := range releases {
 			if release.Draft || channelRelease(release.TagName) != channel {
 				continue
 			}
-			sha := strings.ToLower(strings.TrimSpace(release.TargetCommitish))
-			if !validCommitSHA(sha) {
-				resolveErr = fmt.Errorf("GitHub release %q has an invalid target commit", release.TagName)
-				return false
+			resolved = release.TagName
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return "", err
+	}
+	if resolved == "" {
+		return "", fmt.Errorf("%w: %s", errNoPublishedRelease, channel)
+	}
+	return resolved, nil
+}
+
+func channelCommitReleaseContext(ctx context.Context, channel, sha string) (string, error) {
+	var resolved string
+	var resolveErr error
+	err := forEachReleasePage(ctx, "release commit discovery", func(releases []remoteRelease) bool {
+		for _, release := range releases {
+			if release.Draft || channelRelease(release.TagName) != channel {
+				continue
 			}
-			resolved = release.TagName + "@" + sha
+			target := strings.ToLower(strings.TrimSpace(release.TargetCommitish))
+			if !validCommitSHA(target) {
+				target, resolveErr = releaseTagCommitContext(ctx, release.TagName)
+				if resolveErr != nil {
+					return false
+				}
+			}
+			if !strings.EqualFold(target, sha) {
+				continue
+			}
+			resolved = release.TagName
 			return false
 		}
 		return true
@@ -652,30 +678,34 @@ func latestChannelReleaseContext(ctx context.Context, channel string) (string, e
 		return "", resolveErr
 	}
 	if resolved == "" {
-		return "", fmt.Errorf("%w: %s", errNoPublishedRelease, channel)
+		return "", fmt.Errorf("%w: %s commit %s", errNoPublishedRelease, channel, sha)
 	}
 	return resolved, nil
 }
 
-func channelCommitReleaseContext(ctx context.Context, channel, sha string) (string, error) {
-	var resolved string
-	err := forEachReleasePage(ctx, "release commit discovery", func(releases []remoteRelease) bool {
-		for _, release := range releases {
-			if release.Draft || channelRelease(release.TagName) != channel || !strings.EqualFold(release.TargetCommitish, sha) {
-				continue
-			}
-			resolved = release.TagName + "@" + strings.ToLower(sha)
-			return false
-		}
-		return true
-	})
+func releaseTagCommitContext(ctx context.Context, tag string) (string, error) {
+	address := releaseAPI() + "/repos/wago-org/wago/git/ref/tags/" + url.PathEscape(tag)
+	response, err := getReleaseBytes(ctx, "release tag discovery", address, releaseMetadataMaximum)
 	if err != nil {
 		return "", err
 	}
-	if resolved == "" {
-		return "", fmt.Errorf("%w: %s commit %s", errNoPublishedRelease, channel, sha)
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub returned %s for release tag %s", response.Status, tag)
 	}
-	return resolved, nil
+	var ref struct {
+		Object struct {
+			Type string `json:"type"`
+			SHA  string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(response.Body, &ref); err != nil {
+		return "", err
+	}
+	sha := strings.ToLower(strings.TrimSpace(ref.Object.SHA))
+	if ref.Object.Type != "commit" || !validCommitSHA(sha) {
+		return "", fmt.Errorf("GitHub returned an invalid commit for release tag %s", tag)
+	}
+	return sha, nil
 }
 
 var errNoPublishedRelease = errors.New("no published release")

--- a/cli/manager/internal/version/lifecycle_test.go
+++ b/cli/manager/internal/version/lifecycle_test.go
@@ -510,7 +510,7 @@ func TestInstallPickerHidesImmutableChannelTagsAtTopLevel(t *testing.T) {
 		t.Fatalf("latest picker children = %v, want %v", got, want)
 	}
 	beta := items[1].Children[1]
-	if beta.Label != "v0.1.0-beta.2" || beta.Value != "v0.1.0-beta.2@7d8c58a123456789012345678901234567890123" || beta.Description != "07/28/2026  1d ago" {
+	if beta.Label != "v0.1.0-beta.2" || beta.Value != "v0.1.0-beta.2" || beta.Description != "07/28/2026  1d ago" {
 		t.Fatalf("beta picker item = %#v", beta)
 	}
 	canary := items[2].Children[1]
@@ -542,6 +542,31 @@ func TestInstallPickerMovesUnavailableChannelsToBottom(t *testing.T) {
 	if got := p.Selected(); got != "v0.2.0" {
 		t.Fatalf("picker moved onto unavailable channel: %q", got)
 	}
+}
+
+func TestInstallPickerIncludesBetaReleasesWithBranchTargets(t *testing.T) {
+	releases := []remoteRelease{
+		{TagName: "v0.1.0-beta.6", TargetCommitish: "main", PublishedAt: "2026-09-10T22:36:40Z"},
+		{TagName: "v0.1.0-beta.5", TargetCommitish: "main", PublishedAt: "2026-09-10T21:58:04Z"},
+	}
+	items := versionPickerItemsWithCommits(releases, nil, time.Date(2026, 9, 10, 23, 0, 0, 0, time.UTC))
+	for _, item := range items {
+		if item.Value != "beta" {
+			continue
+		}
+		if item.Disabled {
+			t.Fatal("Beta channel is disabled")
+		}
+		got := make([]string, len(item.Children))
+		for index := range item.Children {
+			got[index] = item.Children[index].Label
+		}
+		if want := []string{"latest", "v0.1.0-beta.6", "v0.1.0-beta.5"}; !slices.Equal(got, want) {
+			t.Fatalf("Beta releases = %v, want %v", got, want)
+		}
+		return
+	}
+	t.Fatal("Beta channel is missing")
 }
 
 func TestInstallPickerProfilePageReturnsToReleasePage(t *testing.T) {

--- a/cli/manager/internal/version/network_test.go
+++ b/cli/manager/internal/version/network_test.go
@@ -33,7 +33,7 @@ func TestLatestChannelRelease(t *testing.T) {
 	t.Setenv("WAGO_RELEASE_API", srv.URL)
 
 	got, err := latestChannelRelease("beta")
-	if err != nil || got != "v0.1.0-beta.2@deadbee123456789012345678901234567890123" {
+	if err != nil || got != "v0.1.0-beta.2" {
 		t.Fatalf("latestChannelRelease(beta) = %q, %v", got, err)
 	}
 }
@@ -60,7 +60,7 @@ func TestLatestChannelReleasePaginates(t *testing.T) {
 	t.Setenv("WAGO_RELEASE_API", srv.URL)
 
 	got, err := latestChannelReleaseContext(context.Background(), "beta")
-	if err != nil || got != "v0.1.0-beta.2@deadbee123456789012345678901234567890123" {
+	if err != nil || got != "v0.1.0-beta.2" {
 		t.Fatalf("latestChannelReleaseContext = %q, %v", got, err)
 	}
 	if requests != 2 {
@@ -133,7 +133,7 @@ func TestLatestChannelReleaseUsesLinkPaginationAndSkipsDrafts(t *testing.T) {
 	t.Setenv("WAGO_RELEASE_API", srv.URL)
 
 	got, err := latestChannelReleaseContext(context.Background(), "beta")
-	if err != nil || got != "v0.1.0-beta.2@deadbee123456789012345678901234567890123" {
+	if err != nil || got != "v0.1.0-beta.2" {
 		t.Fatalf("latestChannelReleaseContext = %q, %v", got, err)
 	}
 	if requests != 2 {
@@ -183,15 +183,55 @@ func TestLatestChannelReleaseRejectsPaginationLoop(t *testing.T) {
 	}
 }
 
-func TestLatestChannelReleaseRejectsInvalidTargetCommit(t *testing.T) {
+func TestLatestChannelReleaseAcceptsBranchTarget(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "v0.1.0-beta.2", TargetCommitish: "main"}})
 	}))
 	defer srv.Close()
 	t.Setenv("WAGO_RELEASE_API", srv.URL)
 
-	if _, err := latestChannelReleaseContext(context.Background(), "beta"); err == nil || !strings.Contains(err.Error(), "invalid target commit") {
-		t.Fatalf("invalid channel target error = %v", err)
+	if got, err := latestChannelReleaseContext(context.Background(), "beta"); err != nil || got != "v0.1.0-beta.2" {
+		t.Fatalf("latestChannelReleaseContext = %q, %v", got, err)
+	}
+}
+
+func TestChannelCommitReleaseResolvesBranchTargetTag(t *testing.T) {
+	const sha = "deadbee123456789012345678901234567890123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/wago-org/wago/releases":
+			_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "v0.1.0-beta.6", TargetCommitish: "main"}})
+		case "/repos/wago-org/wago/git/ref/tags/v0.1.0-beta.6":
+			_, _ = w.Write([]byte(`{"object":{"type":"commit","sha":"` + sha + `"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	got, err := channelCommitReleaseContext(context.Background(), "beta", sha)
+	if err != nil || got != "v0.1.0-beta.6" {
+		t.Fatalf("channelCommitReleaseContext = %q, %v", got, err)
+	}
+}
+
+func TestChannelCommitReleaseRejectsInvalidTagRef(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/wago-org/wago/releases":
+			_ = json.NewEncoder(w).Encode([]remoteRelease{{TagName: "v0.1.0-beta.6", TargetCommitish: "main"}})
+		case "/repos/wago-org/wago/git/ref/tags/v0.1.0-beta.6":
+			_, _ = w.Write([]byte(`{"object":{"type":"tag","sha":"deadbee123456789012345678901234567890123"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("WAGO_RELEASE_API", srv.URL)
+
+	if _, err := channelCommitReleaseContext(context.Background(), "beta", "deadbee123456789012345678901234567890123"); err == nil || !strings.Contains(err.Error(), "invalid commit") {
+		t.Fatalf("invalid tag ref error = %v", err)
 	}
 }
 

--- a/cli/manager/internal/version/releases.go
+++ b/cli/manager/internal/version/releases.go
@@ -201,11 +201,9 @@ func canonicalRollingRelease(release remoteRelease) (string, bool) {
 	if release.Draft || channelRelease(release.TagName) == "" {
 		return "", false
 	}
-	sha := strings.ToLower(strings.TrimSpace(release.TargetCommitish))
-	if !validCommitSHA(sha) {
-		return "", false
-	}
-	return release.TagName + "@" + sha, true
+	// GitHub reports target_commitish as the branch name when the immutable tag
+	// existed before its Release. The tag is the exact published identity.
+	return release.TagName, true
 }
 
 func validCommitSHA(sha string) bool {

--- a/cli/manager/internal/version/update_test.go
+++ b/cli/manager/internal/version/update_test.go
@@ -47,6 +47,9 @@ func TestSameReleaseRejectsMalformedRollingIdentityEvenWhenTextMatches(t *testin
 	if !sameRelease("v1.2.3", "v1.2.3") {
 		t.Fatal("equal stable releases did not match")
 	}
+	if !sameRelease("v0.1.0-beta.6", "v0.1.0-beta.6") {
+		t.Fatal("equal immutable beta releases did not match")
+	}
 }
 
 func TestRollingCommitIdentityRequiresCanonicalSHA(t *testing.T) {


### PR DESCRIPTION
## Summary

- show beta releases when GitHub reports `target_commitish` as `main`
- use the immutable release tag as the normal published identity
- resolve the tag ref only when matching a source commit to a published beta
- treat matching immutable beta tags as up to date

GitHub currently returns `target_commitish: "main"` for both `v0.1.0-beta.5` and `v0.1.0-beta.6`. The prior full-SHA requirement dropped both records and disabled the Beta picker row.

## Verification

- live picker showed `v0.1.0-beta.6` and `v0.1.0-beta.5`
- `go test ./cli/...`
- `just docs`