### PR TITLE
cli: support ordered repeated --invoke calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+Notable user-facing changes to Wago are recorded here. This changelog starts
+with `v0.1.0-beta.8`; earlier prereleases remain available in the
+[GitHub Releases](https://github.com/wago-org/wago/releases) history.
+
+## [Unreleased]
+
+### Added
+
+- `wago run` accepts repeated `--invoke` flags and calls the selected exports in
+  order on one module instance. Each call consumes only the positional values
+  required by its signature, including typed values such as `7:i64` and
+  `3.5:f64`.
+
+### Changed
+
+- The README's one-shot Go installer command now runs the installer from
+  `@main`, and the redundant persistent-installer example has been removed.
+
+## [v0.1.0-beta.8] - 2026-09-10
+
+### Added
+
+- Added Beta and commit-addressed Canary release channels, with qualified
+  release artifacts and a Go-native installation route.
+- Added explicit native-artifact trust controls, runtime resource policies,
+  callback re-entry, and broader Core 3 and WebAssembly GC support.
+- Added end-to-end semantic corpus coverage and differential engine-state
+  testing.
+
+### Changed
+
+- Replaced the Make-based developer interface with Just.
+- Reduced compiler memory use, compile latency, host-call overhead, and prepared
+  invocation latency across AMD64 and ARM64.
+- Simplified release notes and installer/channel discovery behavior.
+
+### Fixed
+
+- Fixed JIT, invocation, validation, settings, TinyGo trampoline, signal,
+  reference-lifetime, and resource-limit correctness issues found by the
+  September audit.
+- Fixed AMD64 corpus miscompiles, ARM64 indexed bulk-memory bounds checks, and
+  incomplete typed-select immediate decoding.
+- Fixed Beta discovery and retracted legacy tagged Canary module versions.
+
+[Unreleased]: https://github.com/wago-org/wago/compare/v0.1.0-beta.8...HEAD
+[v0.1.0-beta.8]: https://github.com/wago-org/wago/releases/tag/v0.1.0-beta.8

--- a/cli/internal/command/command_test.go
+++ b/cli/internal/command/command_test.go
@@ -58,6 +58,20 @@ func TestParseAndHelpRecognition(t *testing.T) {
 	}
 }
 
+func TestParsePreservesRepeatedStringFlagsInOrder(t *testing.T) {
+	cmd := &Cmd{Flags: []Flag{{Name: "invoke", Short: "e", Arg: "<name>"}}}
+	ctx, err := cmd.Parse("wago run", []string{"--invoke=setup", "-e", "add"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(ctx.Strings("invoke"), ","); got != "setup,add" {
+		t.Fatalf("invoke values = %q", got)
+	}
+	if got := ctx.Str("invoke"); got != "add" {
+		t.Fatalf("last invoke = %q", got)
+	}
+}
+
 func TestPassThroughRecognizesInterspersedCommandFlags(t *testing.T) {
 	cmd := &Cmd{
 		Name:        "run",

--- a/cli/internal/command/context.go
+++ b/cli/internal/command/context.go
@@ -12,7 +12,7 @@ type Ctx struct {
 	Path  string
 	Args  []string
 	input []string
-	strs  map[string]string
+	strs  map[string][]string
 	bools map[string]bool
 }
 
@@ -24,11 +24,25 @@ func NewContext(args []string, strs map[string]string, bools map[string]bool) *C
 	if bools == nil {
 		bools = map[string]bool{}
 	}
-	return &Ctx{Args: args, strs: strs, bools: bools}
+	values := make(map[string][]string, len(strs))
+	for name, value := range strs {
+		values[name] = []string{value}
+	}
+	return &Ctx{Args: args, strs: values, bools: bools}
 }
 
-func (c *Ctx) Str(name string) string { return c.strs[name] }
-func (c *Ctx) Bool(name string) bool  { return c.bools[name] }
+func (c *Ctx) Str(name string) string {
+	values := c.strs[name]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[len(values)-1]
+}
+
+// Strings returns every value supplied for a string flag, in command-line order.
+func (c *Ctx) Strings(name string) []string { return append([]string(nil), c.strs[name]...) }
+
+func (c *Ctx) Bool(name string) bool { return c.bools[name] }
 
 // Invocation returns the normalized arguments that produced this context.
 func (c *Ctx) Invocation() []string { return append([]string(nil), c.input...) }

--- a/cli/internal/command/parse.go
+++ b/cli/internal/command/parse.go
@@ -32,7 +32,7 @@ func WantsHelp(args []string, _ bool, flags []Flag) bool {
 // first positional; unknown flags there belong to the guest. Use -- when a
 // guest argument intentionally collides with a command flag.
 func (c *Cmd) Parse(path string, args []string) (*Ctx, error) {
-	ctx := &Ctx{Cmd: c, Path: path, input: append([]string(nil), args...), strs: map[string]string{}, bools: map[string]bool{}}
+	ctx := &Ctx{Cmd: c, Path: path, input: append([]string(nil), args...), strs: map[string][]string{}, bools: map[string]bool{}}
 	lookup := flagLookup(c.AllFlags())
 	raw, positional := false, false
 	for index := 0; index < len(args); index++ {
@@ -67,9 +67,9 @@ func (c *Cmd) Parse(path string, args []string) (*Ctx, error) {
 		}
 		switch {
 		case inline:
-			ctx.strs[flag.Name] = inlineValue
+			ctx.strs[flag.Name] = append(ctx.strs[flag.Name], inlineValue)
 		case index+1 < len(args):
-			ctx.strs[flag.Name] = args[index+1]
+			ctx.strs[flag.Name] = append(ctx.strs[flag.Name], args[index+1])
 			index++
 		default:
 			return nil, fmt.Errorf("flag --%s needs a value", flag.Name)

--- a/cli/internal/handoff/runtime_commands.go
+++ b/cli/internal/handoff/runtime_commands.go
@@ -17,7 +17,7 @@ func RuntimeCommands() []*command.Cmd {
 	profileFlags := runtimeProfileFlags()
 	knobs := runtimeCompilationKnobs()
 	runFlags := []command.Flag{
-		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
+		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call; repeat to call multiple exports in order"},
 		{Name: "allow-native-artifact", Bool: true, Help: "execute a trusted .wago native-code artifact"},
 	}
 	runFlags = append(runFlags, runtimeWatchFlags()...)

--- a/cli/runtime/commands/run/command.go
+++ b/cli/runtime/commands/run/command.go
@@ -26,7 +26,7 @@ type Environment interface {
 
 func Command(environment Environment) *command.Cmd {
 	flags := []command.Flag{
-		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call"},
+		{Name: "invoke", Short: "e", Arg: "<name>", Help: "exported function to call; repeat to call multiple exports in order"},
 		{Name: "allow-native-artifact", Bool: true, Help: "execute a trusted .wago native-code artifact"},
 	}
 	flags = append(flags, watchFlags()...)
@@ -49,6 +49,8 @@ func Command(environment Environment) *command.Cmd {
 		Long: "<file> is raw .wasm. Trusted precompiled .wago native code requires --allow-native-artifact.\n" +
 			"Never enable that flag for an untrusted artifact. Args after the file are typed by the\n" +
 			"signature; override per-arg with a suffix:  42   7:i64   3.5:f64\n" +
+			"Repeated --invoke flags share one instance and consume positional values by function arity;\n" +
+			"remaining values are not passed as function parameters.\n" +
 			"Wago flags may appear before or after <file>; use -- before colliding guest flags.\n" +
 			"Selected Core 3 features default on where supported; use --core 2 for strict Release 2\n" +
 			"or --core 3 for the complete release. Use -p for\n" +
@@ -108,47 +110,62 @@ func (cmd implementation) Run(ctx *command.Ctx) {
 	defer runtime.Close()
 	module := mustLoadModule(positionals[0], config, runtime, cmd.environment.ArtifactCache(), ctx.Bool("allow-native-artifact"))
 	compiled := module.Compiled()
-	export := mustResolveExport(compiled, ctx.Str("invoke"))
-
-	if export == "_start" {
-		runStart(runtime, module, gc, configuredGC)
-		return
-	}
-	params, results, err := compiled.Signature(export)
-	if err != nil {
-		ui.Fatal("run: %v", err)
-	}
-	if err := wasmcall.ValidateSignature(params, results); err != nil {
-		ui.Fatal("run: %v", err)
-	}
-	values := mustParseArgs(positionals[1:], params)
-	instance, err := instantiate(runtime, module, gc, configuredGC)
-	if err != nil {
-		ui.Fatal("%v", friendlyInstantiationError(err))
-	}
-	defer instance.Close()
-	result, err := instance.Invoke(export, values...)
-	if err != nil {
-		ui.Fatal("%s %s", ui.Red("trap:"), trapReason(err))
-	}
-	if output := format(result, results); output != "" {
-		fmt.Println(output)
-	}
-}
-
-func runStart(runtime *wago.Runtime, module *wago.Module, gc wago.GCConfig, configuredGC bool) {
-	instance, err := instantiate(runtime, module, gc, configuredGC)
-	if err != nil {
-		ui.Fatal("%v", friendlyInstantiationError(err))
-	}
-	defer instance.Close()
-	if _, err := instance.Invoke("_start"); err != nil {
-		var exit *wago.ExitError
-		if errors.As(err, &exit) {
-			instance.Close()
-			os.Exit(int(exit.Code))
+	exports := ctx.Strings("invoke")
+	if len(exports) == 0 {
+		exports = []string{mustResolveExport(compiled, "")}
+	} else {
+		for index, export := range exports {
+			exports[index] = mustResolveExport(compiled, export)
 		}
-		ui.Fatal("%s %s", ui.Red("trap:"), trapReason(err))
+	}
+	type invocation struct {
+		export  string
+		values  []uint64
+		results []wago.ValType
+	}
+	invocations := make([]invocation, 0, len(exports))
+	arguments := positionals[1:]
+	for _, export := range exports {
+		if export == "_start" {
+			invocations = append(invocations, invocation{export: export})
+			continue
+		}
+		params, results, err := compiled.Signature(export)
+		if err != nil {
+			ui.Fatal("run: %v", err)
+		}
+		if err := wasmcall.ValidateSignature(params, results); err != nil {
+			ui.Fatal("run: %s: %v", export, err)
+		}
+		count := len(params)
+		if len(arguments) < count {
+			ui.Fatal("run: %s: expected %d arg(s), got %d", export, count, len(arguments))
+		}
+		invocations = append(invocations, invocation{
+			export: export, values: mustParseArgs(arguments[:count], params), results: results,
+		})
+		arguments = arguments[count:]
+	}
+	instance, err := instantiate(runtime, module, gc, configuredGC)
+	if err != nil {
+		ui.Fatal("%v", friendlyInstantiationError(err))
+	}
+	defer instance.Close()
+	for _, invocation := range invocations {
+		result, err := instance.Invoke(invocation.export, invocation.values...)
+		if err != nil {
+			if invocation.export == "_start" {
+				var exit *wago.ExitError
+				if errors.As(err, &exit) {
+					instance.Close()
+					os.Exit(int(exit.Code))
+				}
+			}
+			ui.Fatal("%s %s", ui.Red("trap:"), trapReason(err))
+		}
+		if output := format(result, invocation.results); output != "" {
+			fmt.Println(output)
+		}
 	}
 }
 

--- a/cli/runtime/commands/run/command_test.go
+++ b/cli/runtime/commands/run/command_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -365,6 +366,70 @@ func TestRunExecValueMode(t *testing.T) {
 	implementation{environment: testEnvironment{}}.Run(command.NewContext([]string{path}, nil, map[string]bool{"no-deferred-bounds-checking": true}))
 }
 
+func TestRunExecInvokesReactorInitializerInOrder(t *testing.T) {
+	const helper = "WAGO_TEST_RUN_REACTOR_SEQUENCE"
+	if os.Getenv(helper) != "" {
+		cmd := Command(testEnvironment{})
+		args, err := cmd.Normalize([]string{
+			os.Getenv(helper), "--invoke", "_initialize", "--invoke", "value",
+		})
+		if err != nil {
+			panic(err)
+		}
+		ctx, err := cmd.Parse("wago run", args)
+		if err != nil {
+			panic(err)
+		}
+		implementation{environment: testEnvironment{}}.Run(ctx)
+		os.Exit(0)
+	}
+	path := filepath.Join(t.TempDir(), "reactor.wasm")
+	if err := os.WriteFile(path, reactorModule(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunExecInvokesReactorInitializerInOrder$", "-test.count=1")
+	cmd.Env = append(os.Environ(), helper+"="+path, "WAGO_BARE=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("reactor invocation sequence: %v\n%s", err, output)
+	}
+	if got := string(output); got != "42\n" {
+		t.Fatalf("output = %q, want 42", got)
+	}
+}
+
+func TestRunExecMultipleInvokesConsumeArgumentsByArity(t *testing.T) {
+	const helper = "WAGO_TEST_RUN_INVOKE_SEQUENCE"
+	if os.Getenv(helper) != "" {
+		cmd := Command(testEnvironment{})
+		args, err := cmd.Normalize([]string{
+			os.Getenv(helper), "--invoke", "set", "7:i32", "--invoke", "add", "35", "subcommand",
+		})
+		if err != nil {
+			panic(err)
+		}
+		ctx, err := cmd.Parse("wago run", args)
+		if err != nil {
+			panic(err)
+		}
+		implementation{environment: testEnvironment{}}.Run(ctx)
+		os.Exit(0)
+	}
+	path := filepath.Join(t.TempDir(), "sequence.wasm")
+	if err := os.WriteFile(path, invokeSequenceModule(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunExecMultipleInvokesConsumeArgumentsByArity$", "-test.count=1")
+	cmd.Env = append(os.Environ(), helper+"="+path, "WAGO_BARE=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ordered invocation: %v\n%s", err, output)
+	}
+	if got := string(output); got != "42\n" {
+		t.Fatalf("output = %q, want 42", got)
+	}
+}
+
 func TestRunExecGCHeapOverride(t *testing.T) {
 	if wago.CoreFeaturesV3&^wago.SupportedFeatures() != 0 {
 		t.Skip("complete Core 3 execution is unavailable on this platform")
@@ -447,5 +512,39 @@ func TestRunValueParsingAndFormatting(t *testing.T) {
 	}
 	if got := trapReason(errors.New("plain error")); got != "plain error" {
 		t.Fatalf("plain trap reason = %q", got)
+	}
+}
+
+func reactorModule() []byte {
+	// (module
+	//   (global $initialized (mut i32) (i32.const 0))
+	//   (func (export "_initialize") (global.set $initialized (i32.const 1)))
+	//   (func (export "value") (result i32)
+	//     (if (result i32) (global.get $initialized)
+	//       (then (i32.const 42)) (else unreachable))))
+	return []byte{
+		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x60,
+		0x00, 0x00, 0x60, 0x00, 0x01, 0x7f, 0x03, 0x03, 0x02, 0x00, 0x01, 0x06,
+		0x06, 0x01, 0x7f, 0x01, 0x41, 0x00, 0x0b, 0x07, 0x17, 0x02, 0x0b, 0x5f,
+		0x69, 0x6e, 0x69, 0x74, 0x69, 0x61, 0x6c, 0x69, 0x7a, 0x65, 0x00, 0x00,
+		0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x00, 0x01, 0x0a, 0x14, 0x02, 0x06,
+		0x00, 0x41, 0x01, 0x24, 0x00, 0x0b, 0x0b, 0x00, 0x23, 0x00, 0x04, 0x7f,
+		0x41, 0x2a, 0x05, 0x00, 0x0b, 0x0b,
+	}
+}
+
+func invokeSequenceModule() []byte {
+	// (module
+	//   (global $value (mut i32) (i32.const 0))
+	//   (func (export "set") (param i32) (global.set $value (local.get 0)))
+	//   (func (export "add") (param i32) (result i32)
+	//     (i32.add (global.get $value) (local.get 0))))
+	return []byte{
+		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0a, 0x02, 0x60,
+		0x01, 0x7f, 0x00, 0x60, 0x01, 0x7f, 0x01, 0x7f, 0x03, 0x03, 0x02, 0x00,
+		0x01, 0x06, 0x06, 0x01, 0x7f, 0x01, 0x41, 0x00, 0x0b, 0x07, 0x0d, 0x02,
+		0x03, 0x73, 0x65, 0x74, 0x00, 0x00, 0x03, 0x61, 0x64, 0x64, 0x00, 0x01,
+		0x0a, 0x10, 0x02, 0x06, 0x00, 0x20, 0x00, 0x24, 0x00, 0x0b, 0x07, 0x00,
+		0x23, 0x00, 0x20, 0x00, 0x6a, 0x0b,
 	}
 }


### PR DESCRIPTION
## Summary

- preserve repeated string flag values in command-line order
- run repeated `--invoke` exports sequentially on one module instance
- consume only each export signature's arity while retaining typed argument annotations
- document repeatable invocation behavior in runtime and handoff help
- start the repository changelog at `v0.1.0-beta.8`, with current work under Unreleased

## Diagnosis

TinyGo `wasm-unknown` callable wrappers trap until the exported `_initialize` reactor hook runs. Wago previously retained only the last `--invoke`, so users could not explicitly run initialization and then call another export on the same instance.

The working invocation is now:

```console
wago run --invoke _initialize --invoke add add.wasm 20 22
42
```

Extra positional values after all selected function parameters are not passed as direct function arguments, leaving them available for guest subcommands or other guest-side interpretation.

## Validation

- `go test -count=1 ./...`
- `go test -count=1 -tags wago_runtime ./cli/...`
- `go vet ./...`
- `go vet -tags wago_runtime ./cli/...`
- `go build ./...`
- `go build -tags wago_runtime ./cli/...`
- `just docs` (27 Markdown files)
- exact TinyGo 0.41.1 repro returns `42`
- ordered `set(7:i32)`, `add(35)` probe returns `42` while leaving a trailing positional unconsumed
