### PR TITLE
perf: specialize typed host callbacks

### DIFF
--- a/docs/host-caller-performance.md
+++ b/docs/host-caller-performance.md
@@ -640,3 +640,97 @@ from separate reference and candidate binaries. CPU, allocation and mutex
 profiles were collected after every meaningful production step. The public
 single-call benchmark is selected separately from loop sub-benchmark filters
 so it is never silently excluded by a slash-qualified regular expression.
+
+## Typed call-gate checkpoint (2026-09-11)
+
+The first specialized gates now sit beside, rather than replace, the managed
+callback path:
+
+- `I32ToI32HostFunc` and `I32I32ToI32HostFunc` are checked against the imported
+  Wasm signature at instantiation. Their bound dispatch calls the typed function
+  directly, without constructing a `Caller` or exposing argument/result slices.
+- `ImportModuleBuilder.I32ToI32Func` and `I32I32ToI32Func` preserve plugin
+  shutdown admission and operation reservations without granting callback
+  capabilities.
+- `PrepareI32ToI32` and `PrepareI32I32ToI32` bind local exports once and expose
+  typed scalar calls over the existing compiler-verified prepared integer entry.
+  They retain `PreparedFunction`'s ownership rule: calls must not race instance
+  closure or another call on the same instance.
+
+The callback remains ordinary Go. It may allocate, block, panic, or run another
+instance through a closure. The typed callback has no callback-scoped authority
+and cannot synchronously re-enter its calling instance; callbacks that require
+re-entry use the managed `CallerHostFunc` and `InvokeFromHost` path.
+
+For a root-instance typed scalar import with no plugin gate or GC domain, the
+runtime now selects a fixed-slot portal. The engine passes at most two raw scalar
+slots and receives one raw result without constructing argument/result slices or
+entering the managed capability path. Independent instances retain their local
+execution lease while the callback runs (the public invocation already excludes
+a second call on that instance); shared execution releases and reacquires the
+global lease. Both modes restore native context when another instance or a host
+mutation invalidates the parked context. Stack growth plus `runtime.GC`, panic,
+blocking callbacks, and callbacks that run a different instance have dedicated
+tests. Gated typed plugin callbacks conservatively retain the managed admission
+path.
+
+Five matched Apple M4 Max samples of the 1,024-callback typed loop now measure
+46.2-48.2 us, median 46.7 us, at zero allocations. The matched guest-only
+control remains 673.5 ns per public invocation, yielding about 44.9 ns per
+typed callback after subtraction. The preceding typed binding plus activation
+cache checkpoint measured 77.0 us median, so the fixed-slot direct portal saves
+about 29.6 ns per callback. The experimental 20 ns callback target is therefore
+not yet met, but the retained lane is materially faster than the 88.6 ns managed
+callback and preserves ordinary Go callback semantics.
+
+A scheduler-elided resume prototype was not retained. On an exact prepared,
+single-callback entry with a complete short/acyclic continuation proof it
+measured 227.0 ns median with the managed resume and 228.2 ns with the raw
+resume, both at zero allocations. The current profile still attributes 27.7%
+cumulative time to `resumeNative` (including 16.3% flat in its raw assembly),
+but removing the Go scheduler transition did not produce a repeatable end-to-end
+win. Loops and generic/public entries remain ineligible without a complete
+continuation proof and a carried bounded-work budget.
+
+Reproduce the retained typed-gate measurements with:
+
+```bash
+go test ./src/wago -run '^$' \
+  -bench '^BenchmarkPreparedTypedI32ToI32$' \
+  -benchmem -count=5
+go test ./src/wago -run '^$' \
+  -bench '^BenchmarkHostRoundtripLoopTyped/mem0/parallelfalse/host1/n1024$' \
+  -benchmem -count=5
+go test ./src/wago -run '^$' \
+  -bench '^BenchmarkHostRoundtripLoopTyped/mem0/parallelfalse/host1/n1024$' \
+  -benchtime=5s -cpuprofile=/tmp/wago-typed-portal.pprof
+```
+
+Initial typed-dispatch baseline on Darwin/arm64, Go, Apple M4 Max, five
+500 ms samples; median (range):
+
+| Path | ns per 1,024 callbacks | B/op | allocs/op |
+|---|---:|---:|---:|
+| Managed `CallerHostFunc` | 91,436 (90,278-93,604) | 0 | 0 |
+| Typed `I32ToI32HostFunc` | 77,015 (76,800-78,252) | 0 | 0 |
+
+The matched 1,024-iteration guest control median was 673.5 ns per public
+invocation. Subtraction gives approximately 88.6 ns per managed callback and
+74.6 ns per typed callback at this checkpoint. The typed prepared Go-to-Wasm
+entry measured 5.805 ns/op median (5.689-5.963), 0 B/op and 0 allocations, and
+therefore meets the restricted 20 ns experimental target on this machine.
+
+An attempted conditional skip of invocation-context resolution was rejected:
+its typed-loop median moved from about 78.2 to 80.6 microseconds per 1,024 calls.
+Caching the already-published instance sidecar in the activation loop was kept;
+it improved both typed and managed medians while preserving cross-instance state
+selection.
+
+The Wasm-to-Go result remains well above 20 ns. An 8-second typed-loop CPU
+profile attributes 72.76% cumulative samples to the generic engine resume loop,
+with 18.27% cumulative in `resumeNative`, 10.35% flat in `resumeNativeRaw`, and
+roughly 9.7% combined flat time in scheduler re-entry/exit. Percentages overlap
+where cumulative. This profile motivated the fixed-slot portal above rather
+than another callback adapter. Scheduler-transition elision remains disabled:
+`AnalyzeNativeSegment` still has no compiler-produced complete-continuation
+graph or cross-segment work budget.

--- a/src/core/runtime/engine.go
+++ b/src/core/runtime/engine.go
@@ -270,6 +270,22 @@ func (e *Engine) CallWithHost(code uintptr, serArgs, linMem, trap, results, ctrl
 // reserved linear-memory base may not be representable by LinearMemory's Go
 // slice. The guard handler is installed/registered by JobMemory creation.
 func (e *Engine) CallWithHostBase(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, host HostCall) error {
+	return e.callWithHostBase(code, serArgs, linMemBase, trap, results, ctrl, host, nil)
+}
+
+// ScalarHostCall is an optional fixed-slot portal for the common scalar import
+// shapes. rawSlots packs parameter slots in the low 16 bits and result slots in
+// the high 16 bits. Returning handled=false preserves the generic slice path.
+type ScalarHostCall func(ctrl uintptr, importIdx, rawSlots uint32, a0, a1 uint64) (result uint64, handled bool)
+
+// CallWithHostBaseScalar adds a fixed-slot portal without changing the generic
+// host callback contract used for unsupported signatures and cross-instance
+// frames.
+func (e *Engine) CallWithHostBaseScalar(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, host HostCall, scalar ScalarHostCall) error {
+	return e.callWithHostBase(code, serArgs, linMemBase, trap, results, ctrl, host, scalar)
+}
+
+func (e *Engine) callWithHostBase(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, host HostCall, scalar ScalarHostCall) error {
 	if linMemBase == 0 {
 		return fmt.Errorf("jit: host-call linear-memory base is zero")
 	}
@@ -285,11 +301,11 @@ func (e *Engine) CallWithHostBase(code uintptr, serArgs []byte, linMemBase uintp
 	var callErr error
 	if e.hostScratchInUse {
 		var argBuf, resBuf [maxHostArity]uint64
-		callErr = e.callWithHostLoop(code, serArgs, linMemBase, trap, results, ctrl, ctrlPtr, host, argBuf[:], resBuf[:])
+		callErr = e.callWithHostLoop(code, serArgs, linMemBase, trap, results, ctrl, ctrlPtr, host, scalar, argBuf[:], resBuf[:])
 	} else {
 		e.hostScratchInUse = true
 		defer func() { e.hostScratchInUse = false }()
-		callErr = e.callWithHostLoop(code, serArgs, linMemBase, trap, results, ctrl, ctrlPtr, host, e.hostArgs[:], e.hostResults[:])
+		callErr = e.callWithHostLoop(code, serArgs, linMemBase, trap, results, ctrl, ctrlPtr, host, scalar, e.hostArgs[:], e.hostResults[:])
 	}
 	// Native frames can retain these addresses across every host park/resume.
 	goruntime.KeepAlive(serArgs)
@@ -325,7 +341,7 @@ func hostCtrlFrame(ptr uintptr) []byte {
 	return unsafe.Slice((*byte)(offHeapPointer(ptr)), ctrlFrameSize)
 }
 
-func (e *Engine) callWithHostLoop(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, ctrlPtr uintptr, host HostCall, argBuf, resBuf []uint64) error {
+func (e *Engine) callWithHostLoop(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, ctrlPtr uintptr, host HostCall, scalar ScalarHostCall, argBuf, resBuf []uint64) error {
 	rootCtrl, rootCtrlPtr := ctrl, ctrlPtr
 	// The host-call re-entry loop is intentionally unbounded: a single guest
 	// invocation may legitimately make an arbitrary number of host calls (e.g. a
@@ -380,6 +396,19 @@ func (e *Engine) callWithHostLoop(code uintptr, serArgs []byte, linMemBase uintp
 				clear(wideResults[:nres])
 				host(ctrlPtr, imp, args[:n], wideResults[:nres])
 				continue
+			}
+			if scalar != nil && n <= 2 && nres == 1 {
+				var a0, a1 uint64
+				if n != 0 {
+					a0 = binary.LittleEndian.Uint64(ctrl[hcArgs:])
+				}
+				if n == 2 {
+					a1 = binary.LittleEndian.Uint64(ctrl[hcArgs+8:])
+				}
+				if result, handled := scalar(ctrlPtr, imp, raw, a0, a1); handled {
+					binary.LittleEndian.PutUint64(ctrl[hcResults:], result)
+					continue
+				}
 			}
 			for k := 0; k < n; k++ {
 				argBuf[k] = binary.LittleEndian.Uint64(ctrl[hcArgs+k*8:])

--- a/src/wago/footprint_test.go
+++ b/src/wago/footprint_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func TestSyncHostBindingStaysCompact(t *testing.T) {
-	// Two callback representations, one exact descriptor, and the index/flag.
+	// Four callback representations, two pointers, the index, and a
+	// classification byte.
 	// TinyGo function values are larger than standard Go function values. Keep
 	// the budget exact for this compiler instead of accepting either footprint.
-	want := unsafe.Sizeof(HostFunc(nil)) + unsafe.Sizeof(CallerHostFunc(nil)) + unsafe.Sizeof((*DefinedTypeDescriptor)(nil)) + 5
+	want := unsafe.Sizeof(HostFunc(nil)) + unsafe.Sizeof(CallerHostFunc(nil)) + unsafe.Sizeof(I32ToI32HostFunc(nil)) + unsafe.Sizeof(I32I32ToI32HostFunc(nil)) + 2*unsafe.Sizeof((*DefinedTypeDescriptor)(nil)) + 5
 	align := unsafe.Alignof(syncHostBinding{})
 	want = (want + align - 1) &^ (align - 1)
 	if got := unsafe.Sizeof(syncHostBinding{}); got != want {

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -34,8 +34,9 @@ func valTypeCode(t wasm.ValType) byte {
 }
 
 // Imports supplies a module's imports by "module.name" key, JS-style: one
-// namespace whose values may be a HostFunc or CallerHostFunc, a GlobalImport or
-// *Global, or a *Memory — mirroring the WebAssembly JS API's single imports object.
+// namespace whose function values may be a HostFunc, CallerHostFunc, or a
+// supported typed host function, alongside a GlobalImport, *Global, or *Memory.
+// This mirrors the WebAssembly JS API's single imports object.
 type Imports map[string]any
 
 // hostFuncs extracts the HostFunc entries (the import-function wiring).

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -42,9 +42,22 @@ var hostInvocationContexts sync.Map // map[uintptr]hostInvocationContext
 // binding spans this loop. Nested entries get distinct values and control
 // frames. This cache is neither execution ownership nor callback authority.
 type hostLoopActivation struct {
-	root       *Instance
-	ctrl       uintptr
-	invocation hostInvocationContext
+	root                        *Instance
+	ctrl                        uintptr
+	invocation                  hostInvocationContext
+	state                       *instancePluginState
+	parkedNativeContextReusable bool
+}
+
+func (a *hostLoopActivation) stateFor(active *Instance) *instancePluginState {
+	if active == a.root && a.state != nil {
+		return a.state
+	}
+	state := active.ensurePluginState()
+	if active == a.root {
+		a.state = state
+	}
+	return state
 }
 
 func (a *hostLoopActivation) context(active *Instance) hostInvocationContext {
@@ -201,7 +214,6 @@ func (a *hostLoopActivation) dispatch(ctrl uintptr, importIdx uint32, args, resu
 		active.hostCall(ctrl, importIdx, args, results, hostInvocationContext{})
 		return
 	}
-
 	// Run arbitrary Go host code without the non-reentrant native execution
 	// lease. The deferred reacquire covers normal return, HostExit, validation
 	// panics, and arbitrary host panics. Rebind the exact parked callee because a
@@ -242,9 +254,14 @@ func (a *hostLoopActivation) dispatch(ctrl uintptr, importIdx uint32, args, resu
 	var localMu *sync.Mutex
 	var epoch uint64
 	var localVersion uint64
+	state := a.stateFor(active)
 	if active.usesIndependentExecution() {
-		localMu = active.independentNativeExecutionMu()
-		localVersion = active.ensurePluginState().nativeContextVersion.Load()
+		if active.memoryDir != nil {
+			localMu = &active.memoryDir.nativeMu
+		} else {
+			localMu = &state.nativeExecutionMu
+		}
+		localVersion = state.nativeContextVersion.Load()
 		localMu.Unlock()
 	} else {
 		epoch = nativeExecutionEpoch
@@ -270,7 +287,7 @@ func (a *hostLoopActivation) dispatch(ctrl uintptr, importIdx uint32, args, resu
 		// local lease. All root, interruption, and resume steps remain required.
 		restore := false
 		if localMu != nil {
-			restore = !active.canReuseParkedNativeContext(localVersion)
+			restore = !active.canReuseParkedNativeContextWithState(localVersion, state)
 		} else {
 			restore = nativeExecutionEpoch != epoch
 		}
@@ -292,13 +309,90 @@ func (a *hostLoopActivation) dispatch(ctrl uintptr, importIdx uint32, args, resu
 	// Only arbitrary host code can synchronously re-enter this instance. The
 	// active marker includes the callback-scoped invocation identity, so another
 	// call chain cannot masquerade as this parked activation.
-	markNativeActiveID(active, id)
-	defer unmarkNativeActiveID(active, id)
+	markNativeActiveState(state, id)
+	defer unmarkNativeActiveState(state, id)
 	if active != root {
 		restoreInvocationContext := bindHostInvocationContext(ctrl, invocation)
 		defer restoreInvocationContext()
 	}
 	active.hostCall(ctrl, importIdx, args, results, invocation)
+}
+
+// dispatchTypedScalarPortal is the capability-free root portal. Its callback
+// type cannot inspect Caller or obtain supported re-entry authority, and non-GC
+// activations have no native roots to publish while parked. Independent
+// instances retain their already-exclusive local lease; shared execution
+// releases the global lease so another instance may run. The context version or
+// global epoch still decides whether native context must be rebound before resume.
+func (a *hostLoopActivation) dispatchTypedScalarPortal(ctrl uintptr, importIdx, rawSlots uint32, a0, a1 uint64) (uint64, bool) {
+	active := a.root
+	if active == nil || ctrl != a.ctrl ||
+		importIdx&hostFuncRefDispatchBit != 0 || int(importIdx) >= len(active.syncHosts) ||
+		active.gc != nil || active.executionFlags.Load()&(executionFlagImportedGCDomain|executionFlagDynamicGCDomain|executionFlagStoreOwnedGCCollector) != 0 {
+		return 0, false
+	}
+	binding := &active.syncHosts[importIdx]
+	if binding.gate != nil || binding.scalarKind < syncHostTypedI32 {
+		return 0, false
+	}
+	typedScalarArity := uint32(binding.scalarKind - syncHostScalar)
+	if rawSlots != typedScalarArity|1<<16 {
+		return 0, false
+	}
+
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
+		version := state.nativeContextVersion.Load()
+		var result uint64
+		if binding.scalarKind == syncHostTypedI32 {
+			result = I32(binding.typedI32(AsI32(a0)))
+		} else {
+			result = I32(binding.typedI32x2(AsI32(a0), AsI32(a1)))
+		}
+		if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+			active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+			state.nativeContextVersion.Load() != version {
+			active.restoreTypedScalarNativeContext(ctrl)
+		}
+		return result, true
+	}
+
+	epoch := nativeExecutionEpoch
+	nativeExecutionMu.Unlock()
+	defer func() {
+		nativeExecutionMu.Lock()
+		if nativeExecutionEpoch != epoch {
+			active.restoreTypedScalarNativeContext(ctrl)
+		}
+	}()
+
+	if binding.scalarKind == syncHostTypedI32 {
+		return I32(binding.typedI32(AsI32(a0))), true
+	} else {
+		return I32(binding.typedI32x2(AsI32(a0), AsI32(a1))), true
+	}
+}
+
+func (in *Instance) restoreTypedScalarNativeContext(ctrl uintptr) {
+	if err := in.bindNativeContext(); err != nil {
+		panic(invalidHostReference{err: err})
+	}
+	in.jm.SetStackFence(in.eng.StackLimit())
+	if err := in.jm.RebindTrapCell(in.trap); err != nil {
+		panic(invalidHostReference{err: err})
+	}
+	in.jm.SetCustomCtx(ctrl)
+}
+
+func (in *Instance) hasDirectTypedScalarHost() bool {
+	for i := range in.syncHosts {
+		binding := &in.syncHosts[i]
+		if binding.gate == nil && (binding.typedI32 != nil || binding.typedI32x2 != nil) {
+			return true
+		}
+	}
+	return false
 }
 
 // prepareHostReentryState gives arbitrary host code an isolated native stack,

--- a/src/wago/host_roundtrip_bench_test.go
+++ b/src/wago/host_roundtrip_bench_test.go
@@ -67,14 +67,26 @@ func hostRoundtripLoopFixture(b testing.TB, memories int, collector, imported, d
 }
 
 func BenchmarkHostRoundtripLoop(b *testing.B) {
-	benchmarkHostRoundtripLoop(b, false)
+	benchmarkHostRoundtripLoop(b, hostRoundtripLegacy)
 }
 
 func BenchmarkHostRoundtripLoopCaller(b *testing.B) {
-	benchmarkHostRoundtripLoop(b, true)
+	benchmarkHostRoundtripLoop(b, hostRoundtripCaller)
 }
 
-func benchmarkHostRoundtripLoop(b *testing.B, concrete bool) {
+func BenchmarkHostRoundtripLoopTyped(b *testing.B) {
+	benchmarkHostRoundtripLoop(b, hostRoundtripTyped)
+}
+
+type hostRoundtripCallback uint8
+
+const (
+	hostRoundtripLegacy hostRoundtripCallback = iota
+	hostRoundtripCaller
+	hostRoundtripTyped
+)
+
+func benchmarkHostRoundtripLoop(b *testing.B, callbackKind hostRoundtripCallback) {
 	for _, memories := range []int{0, 1, 4} {
 		b.Run(fmt.Sprintf("mem%d", memories), func(b *testing.B) {
 			cfg := NewRuntimeConfig()
@@ -100,8 +112,10 @@ func benchmarkHostRoundtripLoop(b *testing.B, concrete bool) {
 							instances := make([]*Instance, workers)
 							for i := range instances {
 								var callback any = HostFunc(func(_ HostModule, p, r []uint64) { r[0] = p[0] + 1 })
-								if concrete {
+								if callbackKind == hostRoundtripCaller {
 									callback = CallerHostFunc(func(_ Caller, p, r []uint64) { r[0] = p[0] + 1 })
+								} else if callbackKind == hostRoundtripTyped {
+									callback = I32ToI32HostFunc(func(v int32) int32 { return v + 1 })
 								}
 								in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.step": callback}})
 								if err != nil {

--- a/src/wago/host_scheduler_bench_test.go
+++ b/src/wago/host_scheduler_bench_test.go
@@ -42,6 +42,31 @@ func BenchmarkHostSchedulerPotential(b *testing.B) {
 	}
 }
 
+func BenchmarkPreparedTypedI32ToI32(b *testing.B) {
+	c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), benchAddOneModule())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareI32ToI32("f")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := fn.Call(41)
+		if err != nil || got != 42 {
+			b.Fatalf("invoke=%d, %v", got, err)
+		}
+	}
+}
+
 func TestHostImportsRemainOutsideBoundedSchedulerAdmission(t *testing.T) {
 	for _, fixture := range []struct {
 		name        string

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -106,6 +106,21 @@ type Caller struct {
 // Legacy asynchronous host-call logging does not support CallerHostFunc.
 type CallerHostFunc func(caller Caller, params, results []uint64)
 
+// I32ToI32HostFunc is a capability-free synchronous host import specialized
+// for the Wasm signature (i32) -> i32. Its signature is checked once when the
+// instance is created. Calls do not construct a Caller or expose slot slices.
+// The callback still runs on an ordinary Go stack and may allocate or panic.
+// It carries no supported synchronous re-entry authority; use CallerHostFunc
+// when callback-scoped re-entry is required. Directly invoking a captured
+// Instance remains subject to ordinary instance serialization and is not a
+// substitute for Caller-authorized re-entry.
+type I32ToI32HostFunc func(int32) int32
+
+// I32I32ToI32HostFunc is a capability-free synchronous host import specialized
+// for the Wasm signature (i32, i32) -> i32. It has the same execution and
+// lifetime and re-entry rules as I32ToI32HostFunc.
+type I32I32ToI32HostFunc func(int32, int32) int32
+
 // Only runtime-issued representations carry authority. The snapshot is copied,
 // never replaced with the scope's current generation, including on re-entry.
 func resolveHostCaller(module HostModule) (instanceHostModule, bool) {
@@ -1097,14 +1112,36 @@ func bindHostImport(v any, sig FuncSig) (HostFunc, error) {
 }
 
 type syncHostBinding struct {
-	fn        HostFunc
-	concrete  CallerHostFunc
-	exact     *DefinedTypeDescriptor
-	importIdx uint32
-	scalar    bool
+	fn         HostFunc
+	concrete   CallerHostFunc
+	typedI32   I32ToI32HostFunc
+	typedI32x2 I32I32ToI32HostFunc
+	gate       *pluginCallGate
+	exact      *DefinedTypeDescriptor
+	importIdx  uint32
+	scalarKind uint8
 }
 
-func (b *syncHostBinding) callable() bool { return b.fn != nil || b.concrete != nil }
+const (
+	syncHostNonScalar uint8 = iota
+	syncHostScalar
+	syncHostTypedI32
+	syncHostTypedI32x2
+)
+
+type gatedI32ToI32HostFunc struct {
+	fn   I32ToI32HostFunc
+	gate *pluginCallGate
+}
+
+type gatedI32I32ToI32HostFunc struct {
+	fn   I32I32ToI32HostFunc
+	gate *pluginCallGate
+}
+
+func (b *syncHostBinding) callable() bool {
+	return b.fn != nil || b.concrete != nil || b.typedI32 != nil || b.typedI32x2 != nil
+}
 
 func (b *syncHostBinding) call(caller instanceHostModule, args, results []uint64) {
 	if b.concrete != nil {
@@ -1115,14 +1152,51 @@ func (b *syncHostBinding) call(caller instanceHostModule, args, results []uint64
 }
 
 func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
-	if fn, ok := value.(CallerHostFunc); ok {
+	switch fn := value.(type) {
+	case CallerHostFunc:
 		if fn == nil {
 			return syncHostBinding{}, fmt.Errorf("concrete host function is nil")
 		}
 		return syncHostBinding{concrete: fn}, nil
+	case I32ToI32HostFunc:
+		return bindI32ToI32HostFunc(fn, sig)
+	case func(int32) int32:
+		return bindI32ToI32HostFunc(I32ToI32HostFunc(fn), sig)
+	case I32I32ToI32HostFunc:
+		return bindI32I32ToI32HostFunc(fn, sig)
+	case func(int32, int32) int32:
+		return bindI32I32ToI32HostFunc(I32I32ToI32HostFunc(fn), sig)
+	case gatedI32ToI32HostFunc:
+		binding, err := bindI32ToI32HostFunc(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
+	case gatedI32I32ToI32HostFunc:
+		binding, err := bindI32I32ToI32HostFunc(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
 	}
 	fn, err := bindHostImport(value, sig)
 	return syncHostBinding{fn: fn}, err
+}
+
+func bindI32ToI32HostFunc(fn I32ToI32HostFunc, sig FuncSig) (syncHostBinding, error) {
+	if fn == nil {
+		return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+	}
+	if len(sig.Params) != 1 || sig.Params[0] != ValI32 || len(sig.Results) != 1 || sig.Results[0] != ValI32 {
+		return syncHostBinding{}, fmt.Errorf("typed host function requires signature (i32) -> i32")
+	}
+	return syncHostBinding{typedI32: fn, scalarKind: syncHostTypedI32}, nil
+}
+
+func bindI32I32ToI32HostFunc(fn I32I32ToI32HostFunc, sig FuncSig) (syncHostBinding, error) {
+	if fn == nil {
+		return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+	}
+	if len(sig.Params) != 2 || sig.Params[0] != ValI32 || sig.Params[1] != ValI32 || len(sig.Results) != 1 || sig.Results[0] != ValI32 {
+		return syncHostBinding{}, fmt.Errorf("typed host function requires signature (i32, i32) -> i32")
+	}
+	return syncHostBinding{typedI32x2: fn, scalarKind: syncHostTypedI32x2}, nil
 }
 
 // buildSyncHosts resolves every function import of a sync-mode module to one
@@ -1149,17 +1223,20 @@ func (c *Compiled) buildSyncHosts(imports Imports) ([]syncHostBinding, error) {
 		if err != nil {
 			return nil, fmt.Errorf("import %q: %w", key, err)
 		}
-		binding.importIdx, binding.scalar = uint32(i), true
+		binding.importIdx = uint32(i)
+		if binding.scalarKind == syncHostNonScalar {
+			binding.scalarKind = syncHostScalar
+		}
 		for _, typ := range sig.Params {
 			if isReferenceValType(typ) {
-				binding.scalar = false
+				binding.scalarKind = syncHostNonScalar
 				break
 			}
 		}
-		if binding.scalar {
+		if binding.scalarKind != syncHostNonScalar {
 			for _, typ := range sig.Results {
 				if isReferenceValType(typ) {
-					binding.scalar = false
+					binding.scalarKind = syncHostNonScalar
 					break
 				}
 			}
@@ -1280,6 +1357,24 @@ func (in *Instance) boundHostFuncRef(dispatch uint32) (boundHostFuncRefCall, boo
 }
 
 func dispatchSyncHostScalar(in *Instance, scope *hostCallScope, binding *syncHostBinding, args, results []uint64, invocation hostInvocationContext) {
+	enteredGate := false
+	if binding.gate != nil && (invocation.reservation == nil || !invocation.reservation.allows(binding.gate)) {
+		if err := binding.gate.enter(); err != nil {
+			panic(HostTrap{Err: err})
+		}
+		enteredGate = true
+	}
+	if enteredGate {
+		defer binding.gate.release()
+	}
+	if binding.typedI32 != nil {
+		results[0] = I32(binding.typedI32(AsI32(args[0])))
+		return
+	}
+	if binding.typedI32x2 != nil {
+		results[0] = I32(binding.typedI32x2(AsI32(args[0]), AsI32(args[1])))
+		return
+	}
 	caller := scope.beginReservedWithID(in, invocation.id, invocation.reservation)
 	caller.exact = binding.exact
 	defer caller.scope.end(caller.generation, caller.parentGeneration)
@@ -1363,7 +1458,7 @@ func (in *Instance) newHostDispatch() resolvedHostCall {
 			panic(missingHostFunc{importIdx: importIdx})
 		}
 		binding := &in.syncHosts[importIdx]
-		if binding.scalar {
+		if binding.scalarKind != syncHostNonScalar {
 			dispatchSyncHostScalar(in, scope, binding, args, results, invocation)
 		} else {
 			dispatchSyncHostReference(in, scope, ctrl, importIdx, binding, in.c.importFuncSigs[importIdx], binding.exact, in.c.Types, &in.c.Types, args, results, invocation)
@@ -1632,8 +1727,17 @@ func (in *Instance) callNativeSyncWithTrapContext(entry uintptr, activeTrap []by
 	}
 	// Resolve stable root context lazily in this activation, not on the instance.
 	// Each nested native entry receives a separate snapshot and fresh callbacks.
-	activation := hostLoopActivation{root: in, ctrl: offHeapSlicePtr(in.ctrl)}
-	err = in.eng.CallWithHostBase(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch)
+	activation := hostLoopActivation{
+		root:                        in,
+		ctrl:                        offHeapSlicePtr(in.ctrl),
+		state:                       in.ensurePluginState(),
+		parkedNativeContextReusable: in.gc == nil && !in.c.threadedMemory0(),
+	}
+	if in.hasDirectTypedScalarHost() {
+		err = in.eng.CallWithHostBaseScalar(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchTypedScalarPortal)
+	} else {
+		err = in.eng.CallWithHostBase(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch)
+	}
 	goruntime.KeepAlive(in)
 	goruntime.KeepAlive(in.c)
 	return err

--- a/src/wago/hostcall_allocation_test.go
+++ b/src/wago/hostcall_allocation_test.go
@@ -28,3 +28,26 @@ func TestScalarSyncHostCallUsesOneScopedHandleAllocation(t *testing.T) {
 		t.Fatalf("scalar synchronous host-call allocations = %.1f, want at most 1", allocs)
 	}
 }
+
+func TestTypedScalarSyncHostCallAllocatesNothing(t *testing.T) {
+	compiled := MustCompile(benchReturningImportModule())
+	defer compiled.Close()
+	instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": I32ToI32HostFunc(func(v int32) int32 { return v + 1 }),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close()
+	if got, err := instance.Invoke("g", I32(1)); err != nil || len(got) != 1 || got[0] != 2 {
+		t.Fatalf("warm typed host call = %v, %v", got, err)
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		if _, err := instance.Invoke("g", I32(1)); err != nil {
+			panic(err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("typed scalar synchronous host-call allocations = %.1f, want 0", allocs)
+	}
+}

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -223,6 +223,121 @@ func TestSyncHostImportSlotForm(t *testing.T) {
 	}
 }
 
+func TestTypedI32HostImports(t *testing.T) {
+	t.Run("one parameter", func(t *testing.T) {
+		sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+		body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b} // local.get 0; call 0; end
+		c := MustCompile(returningImportModule(sig, body))
+		defer c.Close()
+		in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+			"env.f": func(v int32) int32 { return v - 1 },
+		}})
+		if err != nil {
+			t.Fatalf("instantiate: %v", err)
+		}
+		defer in.Close()
+		if got, err := in.Invoke("g", I32(-41)); err != nil || len(got) != 1 || AsI32(got[0]) != -42 {
+			t.Fatalf("g(-41) = %v, %v; want -42", got, err)
+		}
+		if got := in.ensurePluginState().hostScope.sequence.Load(); got != 0 {
+			t.Fatalf("typed callback issued %d Caller capabilities, want 0", got)
+		}
+	})
+
+	t.Run("two parameters", func(t *testing.T) {
+		sig := wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32}, []wasm.ValType{wasm.I32})
+		body := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x10, 0x00, 0x0b} // local.get 0, 1; call 0; end
+		c := MustCompile(returningImportModule(sig, body))
+		defer c.Close()
+		in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+			"env.f": I32I32ToI32HostFunc(func(a, b int32) int32 { return a + b }),
+		}})
+		if err != nil {
+			t.Fatalf("instantiate: %v", err)
+		}
+		defer in.Close()
+		if got, err := in.Invoke("g", I32(20), I32(22)); err != nil || len(got) != 1 || AsI32(got[0]) != 42 {
+			t.Fatalf("g(20, 22) = %v, %v; want 42", got, err)
+		}
+	})
+
+	t.Run("panic", func(t *testing.T) {
+		sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+		body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b}
+		c := MustCompile(returningImportModule(sig, body))
+		defer c.Close()
+		in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+			"env.f": I32ToI32HostFunc(func(int32) int32 { panic(HostExit{Code: 23}) }),
+		}})
+		if err != nil {
+			t.Fatalf("instantiate: %v", err)
+		}
+		defer in.Close()
+		_, err = in.Invoke("g", 0)
+		var exit *ExitError
+		if !errors.As(err, &exit) || exit.Code != 23 {
+			t.Fatalf("typed callback panic = %v, want ExitError(23)", err)
+		}
+	})
+}
+
+func TestTypedI32HostImportBindingRejectsInvalidFunctions(t *testing.T) {
+	oneI32 := FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}}
+	twoI32 := FuncSig{Params: []ValType{ValI32, ValI32}, Results: []ValType{ValI32}}
+	one, err := bindSyncHostImport(I32ToI32HostFunc(func(v int32) int32 { return v }), oneI32)
+	if err != nil || one.scalarKind != syncHostTypedI32 {
+		t.Fatalf("one-parameter typed binding = kind %d, %v; want kind %d", one.scalarKind, err, syncHostTypedI32)
+	}
+	two, err := bindSyncHostImport(I32I32ToI32HostFunc(func(a, b int32) int32 { return a + b }), twoI32)
+	if err != nil || two.scalarKind != syncHostTypedI32x2 {
+		t.Fatalf("two-parameter typed binding = kind %d, %v; want kind %d", two.scalarKind, err, syncHostTypedI32x2)
+	}
+
+	var nilOne I32ToI32HostFunc
+	if _, err := bindSyncHostImport(nilOne, oneI32); err == nil {
+		t.Fatal("nil typed host function was accepted")
+	}
+	if _, err := bindSyncHostImport(I32I32ToI32HostFunc(func(a, b int32) int32 { return a + b }), oneI32); err == nil {
+		t.Fatal("two-parameter typed host function accepted a one-parameter signature")
+	}
+	if _, err := bindSyncHostImport(I32ToI32HostFunc(func(v int32) int32 { return v }), twoI32); err == nil {
+		t.Fatal("one-parameter typed host function accepted a two-parameter signature")
+	}
+}
+
+func TestGatedTypedI32HostImportAdmission(t *testing.T) {
+	gate := newPluginCallGate("typed")
+	binding, err := bindSyncHostImport(gatedI32ToI32HostFunc{
+		fn:   func(v int32) int32 { return v + 1 },
+		gate: gate,
+	}, FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := []uint64{0}
+	dispatchSyncHostScalar(nil, nil, &binding, []uint64{41}, results, hostInvocationContext{})
+	if results[0] != 42 || gate.state.Load() != 0 {
+		t.Fatalf("gated typed call = %v, gate state %#x; want [42], 0", results, gate.state.Load())
+	}
+
+	reservation, err := reservePluginOperation([]*pluginCallGate{gate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gate.state.Store(pluginCallGateClosed | 1)
+	results[0] = 0
+	dispatchSyncHostScalar(nil, nil, &binding, []uint64{41}, results, hostInvocationContext{reservation: reservation})
+	if results[0] != 42 {
+		t.Fatalf("reserved typed call during close = %v, want [42]", results)
+	}
+	reservation.release()
+	select {
+	case <-gate.drained:
+	default:
+		t.Fatal("typed plugin gate did not drain after its reservation")
+	}
+}
+
 func TestSyncHostImportV128SlotForm(t *testing.T) {
 	if !hostSupportsSIMD() {
 		t.Skip("host SIMD unavailable")

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -55,7 +55,11 @@ type instanceActivations struct {
 }
 
 func markNativeActiveID(in *Instance, id invocationID) {
-	a := &in.ensurePluginState().activations
+	markNativeActiveState(in.ensurePluginState(), id)
+}
+
+func markNativeActiveState(state *instancePluginState, id invocationID) {
+	a := &state.activations
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if (a.count == 0 && a.other[id] == 0) || (a.count != 0 && a.id == id) {
@@ -76,7 +80,11 @@ func markNativeActiveID(in *Instance, id invocationID) {
 }
 
 func unmarkNativeActiveID(in *Instance, id invocationID) {
-	a := &in.ensurePluginState().activations
+	unmarkNativeActiveState(in.ensurePluginState(), id)
+}
+
+func unmarkNativeActiveState(state *instancePluginState, id invocationID) {
+	a := &state.activations
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.count != 0 && a.id == id {
@@ -227,12 +235,16 @@ func (in *Instance) invalidateNativeContext() {
 }
 
 func (in *Instance) canReuseParkedNativeContext(version uint64) bool {
+	return in.canReuseParkedNativeContextWithState(version, in.ensurePluginState())
+}
+
+func (in *Instance) canReuseParkedNativeContextWithState(version uint64, state *instancePluginState) bool {
 	// Independent admission excludes imported resources. Exporting a resource
 	// or native function revokes it. GC and threaded memory remain conservative:
 	// their shared owners can change native state outside this instance's entry.
 	return version != ^uint64(0) && in.usesIndependentExecution() &&
 		in.gc == nil && !in.c.threadedMemory0() &&
-		in.ensurePluginState().nativeContextVersion.Load() == version
+		state.nativeContextVersion.Load() == version
 }
 
 // refreshMemoryDirectory rebinds the instance-owned indexed-memory directory

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -588,7 +588,7 @@ func validateRegistration(reg *Registrar) error {
 		}
 	}
 	for _, imp := range reg.imports {
-		if imp.fn == nil && imp.concrete == nil || imp.module == "" || imp.name == "" {
+		if imp.fn == nil && imp.concrete == nil && imp.typedI32 == nil && imp.typedI32x2 == nil || imp.module == "" || imp.name == "" {
 			return fmt.Errorf("invalid host import %q", imp.key())
 		}
 	}
@@ -760,7 +760,11 @@ func (rt *Runtime) commitPluginPlan(plan []plannedPlugin) error {
 		needsInstructionABI = needsInstructionABI || len(p.reg.instructions) != 0
 		for _, imp := range p.reg.imports {
 			key := imp.key()
-			if imp.concrete != nil {
+			if imp.typedI32 != nil {
+				rt.imports[key] = gatedI32ToI32HostFunc{fn: imp.typedI32, gate: p.reg.callGate}
+			} else if imp.typedI32x2 != nil {
+				rt.imports[key] = gatedI32I32ToI32HostFunc{fn: imp.typedI32x2, gate: p.reg.callGate}
+			} else if imp.concrete != nil {
 				rt.imports[key] = p.reg.callGate.wrapCaller(imp.concrete)
 			} else {
 				rt.imports[key] = p.reg.callGate.wrap(imp.fn)

--- a/src/wago/prepared_typed.go
+++ b/src/wago/prepared_typed.go
@@ -1,0 +1,83 @@
+package wago
+
+import "fmt"
+
+// PreparedI32ToI32 is a bound local Wasm export with signature (i32) -> i32.
+// It has PreparedFunction's ownership and concurrency rules, but its hot call
+// has no name lookup, variadic arguments, slot slices, or result decoding at
+// the call site.
+type PreparedI32ToI32 struct {
+	prepared *PreparedFunction
+}
+
+// PreparedI32I32ToI32 is a bound local Wasm export with signature
+// (i32, i32) -> i32. It has the same ownership and concurrency rules as
+// PreparedI32ToI32.
+type PreparedI32I32ToI32 struct {
+	prepared *PreparedFunction
+}
+
+// PrepareI32ToI32 resolves export and verifies its exact scalar signature once.
+func (in *Instance) PrepareI32ToI32(export string) (*PreparedI32ToI32, error) {
+	prepared, err := in.PrepareFunction(export)
+	if err != nil {
+		return nil, err
+	}
+	if !prepared.hasSignature([]ValType{ValI32}, []ValType{ValI32}) {
+		return nil, fmt.Errorf("wago: prepare function %q: expected signature (i32) -> i32", export)
+	}
+	return &PreparedI32ToI32{prepared: prepared}, nil
+}
+
+// PrepareI32I32ToI32 resolves export and verifies its exact scalar signature once.
+func (in *Instance) PrepareI32I32ToI32(export string) (*PreparedI32I32ToI32, error) {
+	prepared, err := in.PrepareFunction(export)
+	if err != nil {
+		return nil, err
+	}
+	if !prepared.hasSignature([]ValType{ValI32, ValI32}, []ValType{ValI32}) {
+		return nil, fmt.Errorf("wago: prepare function %q: expected signature (i32, i32) -> i32", export)
+	}
+	return &PreparedI32I32ToI32{prepared: prepared}, nil
+}
+
+func (fn *PreparedFunction) hasSignature(params, results []ValType) bool {
+	if fn == nil || len(fn.paramTypes) != len(params) || len(fn.resultTypes) != len(results) {
+		return false
+	}
+	for i := range params {
+		if fn.paramTypes[i] != params[i] {
+			return false
+		}
+	}
+	for i := range results {
+		if fn.resultTypes[i] != results[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Call invokes the bound export.
+func (fn *PreparedI32ToI32) Call(a int32) (int32, error) {
+	if fn == nil || fn.prepared == nil {
+		return 0, fmt.Errorf("wago: invoke closed prepared function")
+	}
+	results, err := fn.prepared.Invoke1(I32(a))
+	if err != nil {
+		return 0, err
+	}
+	return AsI32(results[0]), nil
+}
+
+// Call invokes the bound export.
+func (fn *PreparedI32I32ToI32) Call(a, b int32) (int32, error) {
+	if fn == nil || fn.prepared == nil {
+		return 0, fmt.Errorf("wago: invoke closed prepared function")
+	}
+	results, err := fn.prepared.Invoke2(I32(a), I32(b))
+	if err != nil {
+		return 0, err
+	}
+	return AsI32(results[0]), nil
+}

--- a/src/wago/prepared_typed_test.go
+++ b/src/wago/prepared_typed_test.go
@@ -1,0 +1,55 @@
+package wago
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+func TestPreparedTypedI32Calls(t *testing.T) {
+	module := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.I32}, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("inc", 0, 0),
+			wasmtest.ExportEntry("add", 0, 1),
+		)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x20, 0x00, 0x41, 0x01, 0x6a, 0x0b}),
+			wasmtest.Code([]byte{0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b}),
+		)),
+	)
+	compiled := MustCompile(module)
+	defer compiled.Close()
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+
+	inc, err := in.PrepareI32ToI32("inc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := inc.Call(-2); err != nil || got != -1 {
+		t.Fatalf("inc(-2) = %d, %v; want -1", got, err)
+	}
+	add, err := in.PrepareI32I32ToI32("add")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := add.Call(20, 22); err != nil || got != 42 {
+		t.Fatalf("add(20, 22) = %d, %v; want 42", got, err)
+	}
+	if _, err := in.PrepareI32I32ToI32("inc"); err == nil || !strings.Contains(err.Error(), "expected signature") {
+		t.Fatalf("mismatched typed prepare error = %v", err)
+	}
+	if _, err := (*PreparedI32ToI32)(nil).Call(0); err == nil {
+		t.Fatal("nil typed prepared function was callable")
+	}
+}

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -160,15 +160,17 @@ func CapabilityDocs(docs string) CapabilityOption {
 
 // registeredImport is one declared host function.
 type registeredImport struct {
-	module   string
-	name     string
-	fn       HostFunc
-	concrete CallerHostFunc
-	params   []ValType
-	results  []ValType
-	cap      Capability
-	hasCap   bool
-	docs     string
+	module     string
+	name       string
+	fn         HostFunc
+	concrete   CallerHostFunc
+	typedI32   I32ToI32HostFunc
+	typedI32x2 I32I32ToI32HostFunc
+	params     []ValType
+	results    []ValType
+	cap        Capability
+	hasCap     bool
+	docs       string
 }
 
 func (i *registeredImport) key() string { return i.module + "." + i.name }
@@ -207,6 +209,32 @@ func (m *ImportModuleBuilder) CallerFunc(name string, fn CallerHostFunc) *Import
 		return &ImportFuncBuilder{}
 	}
 	imp := &registeredImport{module: m.module, name: name, concrete: fn}
+	if m.reg != nil && !m.reg.sealed {
+		m.reg.imports = append(m.reg.imports, imp)
+	}
+	return &ImportFuncBuilder{imp: imp}
+}
+
+// I32ToI32Func declares a capability-free typed synchronous import. Params and
+// Results are fixed by the callback type and need not be declared separately.
+func (m *ImportModuleBuilder) I32ToI32Func(name string, fn I32ToI32HostFunc) *ImportFuncBuilder {
+	if m == nil {
+		return &ImportFuncBuilder{}
+	}
+	imp := &registeredImport{module: m.module, name: name, typedI32: fn, params: []ValType{ValI32}, results: []ValType{ValI32}}
+	if m.reg != nil && !m.reg.sealed {
+		m.reg.imports = append(m.reg.imports, imp)
+	}
+	return &ImportFuncBuilder{imp: imp}
+}
+
+// I32I32ToI32Func declares a capability-free typed synchronous import. Params
+// and Results are fixed by the callback type and need not be declared separately.
+func (m *ImportModuleBuilder) I32I32ToI32Func(name string, fn I32I32ToI32HostFunc) *ImportFuncBuilder {
+	if m == nil {
+		return &ImportFuncBuilder{}
+	}
+	imp := &registeredImport{module: m.module, name: name, typedI32x2: fn, params: []ValType{ValI32, ValI32}, results: []ValType{ValI32}}
 	if m.reg != nil && !m.reg.sealed {
 		m.reg.imports = append(m.reg.imports, imp)
 	}

--- a/src/wago/registry_typed_test.go
+++ b/src/wago/registry_typed_test.go
@@ -1,0 +1,15 @@
+package wago
+
+import "testing"
+
+func TestImportModuleBuilderTypedFunctionsDeclareExactSignatures(t *testing.T) {
+	module := &ImportModuleBuilder{module: "env"}
+	one := module.I32ToI32Func("one", func(v int32) int32 { return v })
+	if one.imp == nil || one.imp.typedI32 == nil || len(one.imp.params) != 1 || one.imp.params[0] != ValI32 || len(one.imp.results) != 1 || one.imp.results[0] != ValI32 {
+		t.Fatalf("one-parameter typed declaration = %+v", one.imp)
+	}
+	two := module.I32I32ToI32Func("two", func(a, b int32) int32 { return a + b })
+	if two.imp == nil || two.imp.typedI32x2 == nil || len(two.imp.params) != 2 || two.imp.params[0] != ValI32 || two.imp.params[1] != ValI32 || len(two.imp.results) != 1 || two.imp.results[0] != ValI32 {
+		t.Fatalf("two-parameter typed declaration = %+v", two.imp)
+	}
+}

--- a/src/wago/typed_host_runtime_test.go
+++ b/src/wago/typed_host_runtime_test.go
@@ -1,0 +1,194 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64) && !tinygo
+
+package wago
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+func typedHostGrowStack(depth int, value int32) int32 {
+	var frame [256]byte
+	frame[0] = byte(depth)
+	if depth != 0 {
+		value = typedHostGrowStack(depth-1, value)
+	}
+	runtime.KeepAlive(&frame)
+	return value
+}
+
+func TestTypedI32HostCallbackMayGrowStackAndCollect(t *testing.T) {
+	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b}
+	compiled := MustCompile(returningImportModule(sig, body))
+	defer compiled.Close()
+	in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": I32ToI32HostFunc(func(value int32) int32 {
+			value = typedHostGrowStack(128, value)
+			runtime.GC()
+			return value + 1
+		}),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if got, err := in.Invoke("g", I32(41)); err != nil || len(got) != 1 || AsI32(got[0]) != 42 {
+		t.Fatalf("typed callback after stack growth and GC = %v, %v; want 42", got, err)
+	}
+}
+
+func TestTypedI32HostCallbackRestoresAfterOtherInstanceRuns(t *testing.T) {
+	otherCompiled := MustCompile(benchAddOneModule())
+	defer otherCompiled.Close()
+	other, err := Instantiate(otherCompiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer other.Close()
+	otherFn, err := other.PrepareI32ToI32("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compiled := MustCompile(benchReturningImportModule())
+	defer compiled.Close()
+	in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": I32ToI32HostFunc(func(value int32) int32 {
+			got, callErr := otherFn.Call(value)
+			if callErr != nil {
+				panic(callErr)
+			}
+			return got
+		}),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareI32ToI32("g")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := int32(0); i < 100; i++ {
+		got, err := fn.Call(i)
+		if err != nil || got != i+1 {
+			t.Fatalf("call %d after other instance = %d, %v; want %d", i, got, err, i+1)
+		}
+	}
+}
+
+func TestTypedI32HostCallbackRestoresAfterIndependentExecutionRevocation(t *testing.T) {
+	compiled := MustCompile(benchReturningImportModule())
+	defer compiled.Close()
+	var in *Instance
+	revoked := false
+	var err error
+	in, err = Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": I32ToI32HostFunc(func(value int32) int32 {
+			if !revoked {
+				revoked = true
+				in.markNativeControlShared()
+			}
+			return value + 1
+		}),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareI32ToI32("g")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := int32(0); i < 100; i++ {
+		got, err := fn.Call(i)
+		if err != nil || got != i+1 {
+			t.Fatalf("call %d after execution-mode revocation = %d, %v; want %d", i, got, err, i+1)
+		}
+	}
+	if in.usesIndependentExecution() {
+		t.Fatal("callback-time native-control sharing did not revoke independent execution")
+	}
+}
+
+func TestTypedI32HostCallbackMayBlockWhileOtherInstanceRuns(t *testing.T) {
+	for _, independent := range []bool{true, false} {
+		t.Run(map[bool]string{true: "independent", false: "shared"}[independent], func(t *testing.T) {
+			cfg := NewRuntimeConfig().WithIndependentInstanceExecution(independent)
+			otherCompiled, err := cfg.Compile(benchAddOneModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer otherCompiled.Close()
+			other, err := Instantiate(otherCompiled, InstantiateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer other.Close()
+			otherFn, err := other.PrepareI32ToI32("f")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			compiled, err := cfg.Compile(benchReturningImportModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer compiled.Close()
+			in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+				"env.f": I32ToI32HostFunc(func(value int32) int32 {
+					close(entered)
+					<-release
+					return value + 1
+				}),
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			fn, err := in.PrepareI32ToI32("g")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rootDone := make(chan error, 1)
+			go func() {
+				got, callErr := fn.Call(41)
+				if callErr == nil && got != 42 {
+					callErr = fmt.Errorf("root result = %d, want 42", got)
+				}
+				rootDone <- callErr
+			}()
+			<-entered
+			otherDone := make(chan error, 1)
+			go func() {
+				got, callErr := otherFn.Call(1)
+				if callErr == nil && got != 2 {
+					callErr = fmt.Errorf("other result = %d, want 2", got)
+				}
+				otherDone <- callErr
+			}()
+			select {
+			case err := <-otherDone:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(2 * time.Second):
+				close(release)
+				t.Fatal("other instance blocked behind typed callback")
+			}
+			close(release)
+			if err := <-rootDone; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/wago.go
+++ b/wago.go
@@ -99,6 +99,8 @@ type (
 	HostModule                      = impl.HostModule
 	HostTrap                        = impl.HostTrap
 	I31Ref                          = impl.I31Ref
+	I32I32ToI32HostFunc             = impl.I32I32ToI32HostFunc
+	I32ToI32HostFunc                = impl.I32ToI32HostFunc
 	ImplementationLimitError        = impl.ImplementationLimitError
 	ImportFuncBuilder               = impl.ImportFuncBuilder
 	ImportKind                      = impl.ImportKind
@@ -167,6 +169,8 @@ type (
 	Policy                          = impl.Policy
 	PreparedCompile                 = impl.PreparedCompile
 	PreparedFunction                = impl.PreparedFunction
+	PreparedI32I32ToI32             = impl.PreparedI32I32ToI32
+	PreparedI32ToI32                = impl.PreparedI32ToI32
 	ProviderCatalogDocument         = impl.ProviderCatalogDocument
 	ProviderCatalogEntry            = impl.ProviderCatalogEntry
 	RefInit                         = impl.RefInit


### PR DESCRIPTION
## Summary

- add typed `(i32) -> i32` and `(i32, i32) -> i32` host imports plus typed prepared-call and plugin registration APIs
- add a prevalidated fixed-slot scalar portal that avoids generic slice and callback dispatch work
- preserve panic, blocking, stack-growth, GC, plugin-gate, and native-context restoration behavior
- add focused allocation, runtime-safety, benchmark, footprint, and API documentation coverage

## AMD64 performance

Matched native measurements compare base `ea892d97de197a703872e364fb8f3fd230460f77` with head `5a71b2d5bbdbc7f64716546aaff272b5dd53411d` on an AMD Ryzen 7 7800X3D, Linux, Go 1.26.5, `GOMAXPROCS=1`, pinned to CPU 7. Exact case: `mem0/parallelfalse/host1/n1024`. Each sample is ns/op for 1,024 synchronous callbacks.

| Path | Base samples | Head samples | Median delta | Allocations |
| --- | --- | --- | ---: | ---: |
| `HostFunc` | 158753, 159469, 159080, 161758, 159106, 159271, 159129, 159284, 159210, 158688 | 161690, 160684, 169338, 161708, 164031, 162096, 162033, 160872, 160418, 160531 | 159169.5 → 161699, **+1.59%** | 65536 B, 1024 allocs |
| `CallerHostFunc` | 126738, 127462, 133307, 129806, 128178, 128513, 126368, 128022, 128106, 126716 | 132919, 130745, 132579, 130627, 130255, 133331, 135391, 131471, 131028, 130614 | 128064 → 131249.5, **+2.49%** | 0 B, 0 allocs |
| typed head vs base `HostFunc` | same base samples above | 62413, 62728, 63499, 62644, 62620, 64142, 62800, 62615, 62469, 62517 | 159169.5 → 62632, **−60.65%** | 0 B, 0 allocs at head |
| typed head vs base `CallerHostFunc` | same base samples above | same typed samples above | 128064 → 62632, **−51.09%** | 0 B, 0 allocs |

Base has no typed callback API, so there is no like-for-like typed main/head row. The same-API rows above are retained as regression guards rather than being folded into the typed speedup claim.

## AMD64 / ARM64 diagnosis

Matched Apple M4 Max / macOS / Go 1.26.5 measurements produced these medians for the same 1,024-callback case:

| ARM64 path | Base median | Head median | Delta |
| --- | ---: | ---: | ---: |
| `HostFunc` | 117386.5 ns/op | 118744 ns/op | **+1.16%** |
| `CallerHostFunc` | 90647.5 ns/op | 90854 ns/op | **+0.23%** |
| typed head vs base `HostFunc` | 117386.5 ns/op | 44412.5 ns/op | **−62.17%** |
| typed head vs base `CallerHostFunc` | 90647.5 ns/op | 44412.5 ns/op | **−51.00%** |

After subtracting each architecture's `host0/n1024` guest-loop control median, the committed typed callback round trip is approximately 60.56 ns/callback on AMD64 and 42.72 ns/callback on ARM64. AMD64 is therefore about 42% slower for the callback round trip itself.

CPU profiles identify `runtime.entersyscall` / `runtime.exitsyscall` around every native resume as the remaining AMD64 cost. In a matched, interleaved Go 1.26.5 diagnostic, managed samples had a 62706.5 ns/op median while removing those transitions produced 42175, 42041, 42189, 42020, 42008, 42180, 42002, 41969, 41990, 42027 ns/op (median 42023.5; zero allocations). After control subtraction, the raw prototype is approximately 40.44 ns/callback, 2.28 ns faster than managed ARM64; the scheduler-safe resume costs AMD64 approximately 20.20 ns/callback. The raw prototype was reverted: without a compiler proof that the post-callback native continuation reaches another scheduler-safe boundary within a fixed amount of work, arbitrary guest code could retain a P and delay scheduling or GC.

Rejected safe-path experiments were also reverted completely: prebinding the typed import regressed 0.70%, locking the host loop to its OS thread regressed about 1.4%, and skipping redundant context publication changed the median by only −0.13% (noise).

## Validation

- `go test ./src/... -skip "^TestStaged"` on native AMD64
- `go test ./src/core/compiler/backend/railshot/amd64 ./src/core/runtime`
- focused typed/host callback tests on native AMD64 and ARM64
- focused `go test -race ./src/wago` on native AMD64 and ARM64
- focused `checkptr=2` typed callback tests
- `go vet ./...`
- `git diff --check`
- all PR CI checks pass on Linux, macOS, and Windows across AMD64 and ARM64
