### PR TITLE
Fix instance close completion and managed entry lifecycle

### DIFF
--- a/examples/17-managed-instances/main.go
+++ b/examples/17-managed-instances/main.go
@@ -66,6 +66,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	// Close is callback-safe and starts logical close. Use WaitClosed when the
+	// caller must wait for active calls and terminal close hooks to finish.
 	defer owned.Close()
 
 	result, err := owned.Instance().Call(

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4344,15 +4344,13 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 	if state := in.pluginState.Load(); state != nil && state.guestStorageBorrow.Load() != 0 {
 		return nil, fmt.Errorf("invoke %q: guest storage is borrowed: %w", export, ErrPermissionDenied)
 	}
-	state := in.ensurePluginState()
-	state.invokeMu.Lock()
+	state := in.lockInvocation(0)
 	admittedHere := false
 	defer func() {
 		if admittedHere {
 			in.endInvocation()
 		}
-		state.invocationID = 0
-		state.invokeMu.Unlock()
+		state.unlockInvocation()
 	}()
 	privateRefStore := in.refStore == nil || in.refStore.private
 	if !alreadyAdmitted && contexts.interrupt == nil && contexts.callback == nil && privateRefStore {
@@ -4397,9 +4395,7 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 			}
 		}
 	}
-	id := newInvocationID()
-	state.invocationID = id
-	return in.invokeWithToken(export, args, contexts, id, true, alreadyAdmitted, nil)
+	return in.invokeWithToken(export, args, contexts, state.invocationID, true, alreadyAdmitted, nil)
 }
 
 //go:noinline
@@ -4413,13 +4409,8 @@ func (in *Instance) invokeWithToken(export string, args []uint64, contexts invoc
 		// Acquire the target instance gate before the shared collector lease. A
 		// parked same-domain callback must be able to reacquire the collector and
 		// finish releasing this gate while a second callback waits to enter.
-		state := in.ensurePluginState()
-		state.invokeMu.Lock()
-		state.invocationID = id
-		defer func() {
-			state.invocationID = 0
-			state.invokeMu.Unlock()
-		}()
+		state := in.lockInvocation(id)
+		defer state.unlockInvocation()
 	}
 	// Cancellation may arrive while this call waits for the instance gate.
 	ctx := contexts.interrupt

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -409,15 +409,17 @@ type instancePluginState struct {
 }
 
 type instanceCloseState struct {
-	done           chan struct{}
-	quiesced       chan struct{}
-	quiescedOnce   sync.Once
-	result         error
-	interruptStop  func()
-	hooks          *hookRegistry
-	event          *InstanceCloseEvent
-	terminalOnce   sync.Once
-	terminalResult error
+	done            chan struct{}
+	quiesced        chan struct{}
+	quiescedOnce    sync.Once
+	prepared        atomic.Bool // publishes hook data and completion of all BeforeClose work
+	result          error
+	interruptStop   func()
+	hooks           *hookRegistry
+	event           *InstanceCloseEvent
+	terminalStarted atomic.Bool
+	terminalDone    chan struct{} // publishes terminalResult, independently of quiescence
+	terminalResult  error
 }
 
 func (in *Instance) instantiateOrigin() InstantiateOrigin {

--- a/src/wago/instance.go
+++ b/src/wago/instance.go
@@ -57,8 +57,8 @@ type Instance struct {
 	closed                  bool          // logical close; retained references may defer physical release
 	finalizing              bool          // one goroutine owns quiescent finalization
 	resourcesClosed         bool
-	icNext                  uint8 // round-robin invoke-cache replacement cursor
-	physicalFinalizer       func()
+	icNext                  uint8                    // round-robin invoke-cache replacement cursor
+	finalizers              *instanceFinalizers      // optional lifecycle callbacks; lifeMu protects access
 	ownsMem                 bool                     // false when memory 0 is host-imported (don't close it)
 	memoryDir               *instanceMemoryDirectory // allocated only for indexed memory execution
 	syncMode                bool                     // true when host imports use the synchronous re-entry protocol

--- a/src/wago/instance_call.go
+++ b/src/wago/instance_call.go
@@ -26,13 +26,8 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 		return nil, fmt.Errorf("call %q: %w", export, err)
 	}
 	defer in.endInvocation()
-	state := in.ensurePluginState()
-	state.invokeMu.Lock()
-	state.invocationID = newInvocationID()
-	defer func() {
-		state.invocationID = 0
-		state.invokeMu.Unlock()
-	}()
+	state := in.lockInvocation(0)
+	defer state.unlockInvocation()
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/src/wago/instance_close_completion_test.go
+++ b/src/wago/instance_close_completion_test.go
@@ -1,0 +1,179 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+func closeCompletionInstance(t *testing.T, hooks *hookRegistry) (*Runtime, *Instance) {
+	t.Helper()
+	rt := NewRuntime()
+	rt.storeHooks(hooks)
+	mod, err := rt.Compile(wasmtest.Module())
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := rt.Instantiate(context.Background(), mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = rt.CloseContext(context.Background()); _ = mod.Close() })
+	return rt, in
+}
+
+func TestClosePreparationOrdersTerminalHooks(t *testing.T) {
+	for _, phase := range []string{"internal", "public", "panic"} {
+		t.Run(phase, func(t *testing.T) {
+			entered, release := make(chan struct{}), make(chan struct{})
+			var after atomic.Int32
+			block := func() {
+				close(entered)
+				<-release
+				if phase == "panic" {
+					panic("before")
+				}
+			}
+			hooks := &hookRegistry{afterClose: []func(InstanceCloseEvent){func(InstanceCloseEvent) { after.Add(1) }}}
+			if phase == "internal" {
+				hooks.internalBeforeClose = []func(*Instance){func(*Instance) { block() }}
+			} else {
+				hooks.beforeClose = []func(InstanceCloseEvent){func(InstanceCloseEvent) { block() }}
+			}
+			_, in := closeCompletionInstance(t, hooks)
+			if err := in.beginInvocation(); err != nil {
+				t.Fatal(err)
+			}
+			closed := make(chan error, 1)
+			go func() { closed <- in.Close() }()
+			<-entered
+			in.endInvocation()
+			gotEarly := after.Load()
+			close(release)
+			err := <-closed
+			if gotEarly != 0 {
+				t.Fatal("AfterClose ran before BeforeClose completed")
+			}
+			if errors.Is(err, ErrCallbackPanic) != (phase == "panic") {
+				t.Fatalf("Close = %v", err)
+			}
+			_ = in.closeAndWait()
+			_ = in.Close()
+			if after.Load() != 1 {
+				t.Fatalf("AfterClose calls = %d, want 1", after.Load())
+			}
+		})
+	}
+}
+
+func TestCloseTerminalWaitsForConstruction(t *testing.T) {
+	var after atomic.Int32
+	_, in := closeCompletionInstance(t, &hookRegistry{afterClose: []func(InstanceCloseEvent){func(InstanceCloseEvent) { after.Add(1) }}})
+	in.beginConstruction(nil)
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if after.Load() != 0 {
+		t.Error("AfterClose ran during construction")
+	}
+	in.endConstruction()
+	if err := in.closeAndWait(); err != nil {
+		t.Fatal(err)
+	}
+	if after.Load() != 1 {
+		t.Fatalf("AfterClose calls = %d, want 1", after.Load())
+	}
+}
+
+func TestCloseTerminalWaiters(t *testing.T) {
+	for _, waiter := range []string{"instance", "managed", "drain", "drain-logically-closed"} {
+		for _, panics := range []bool{false, true} {
+			name := waiter
+			if panics {
+				name += "/panic"
+			}
+			t.Run(name, func(t *testing.T) {
+				entered, release := make(chan struct{}), make(chan struct{})
+				rt, in := closeCompletionInstance(t, &hookRegistry{afterClose: []func(InstanceCloseEvent){func(event InstanceCloseEvent) {
+					close(entered)
+					<-release
+					// Callback reentry must not wait for its own terminal phase.
+					if err := event.Instance.value.Close(); err != nil {
+						panic(err)
+					}
+					event.Instance.value.releaseResourceRoot()
+					if panics {
+						panic("after")
+					}
+				}}})
+				manager := newPendingInstanceManager("close-test", AuthorityScope{})
+				manager.activate(rt)
+				manager.live = 1
+				owned, err := manager.adopt(in, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !in.retainResourceRoot() || !in.retainResourceRoot() {
+					t.Fatal("retain resources")
+				}
+				t.Cleanup(in.releaseResourceRoot)
+				if err := in.beginInvocation(); err != nil {
+					t.Fatal(err)
+				}
+				if err := in.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if waiter == "drain-logically-closed" {
+					if _, err := owned.closeLogical(); err != nil {
+						t.Fatal(err)
+					}
+				}
+				ended := make(chan struct{})
+				go func() { in.endInvocation(); close(ended) }()
+				<-entered
+				state := in.ensurePluginState().close.Load()
+				select {
+				case <-state.quiesced:
+				default:
+					t.Fatal("invocations did not quiesce")
+				}
+				started, done := make(chan struct{}), make(chan error, 1)
+				go func() {
+					close(started)
+					switch waiter {
+					case "instance":
+						done <- in.closeAndWait()
+					case "managed":
+						done <- owned.Close()
+					case "drain", "drain-logically-closed":
+						done <- manager.close()
+					}
+				}()
+				<-started
+				select {
+				case <-state.terminalDone:
+					t.Error("terminal completion preceded AfterClose")
+				default:
+				}
+				select {
+				case err := <-done:
+					t.Errorf("terminal waiter returned early: %v", err)
+					done <- err
+				default:
+				}
+				close(release)
+				err = <-done
+				<-ended
+				if errors.Is(err, ErrCallbackPanic) != panics {
+					t.Fatalf("terminal waiter = %v", err)
+				}
+				if !in.referenceLifetime().snapshot().PhysicalResources {
+					t.Fatal("retained resources were released")
+				}
+			})
+		}
+	}
+}

--- a/src/wago/instance_close_completion_test.go
+++ b/src/wago/instance_close_completion_test.go
@@ -115,7 +115,7 @@ func TestCloseTerminalWaiters(t *testing.T) {
 					if err := event.Instance.value.Close(); err != nil {
 						panic(err)
 					}
-					if err := owned.CloseLogical(); err != nil {
+					if err := owned.Close(); err != nil {
 						panic(err)
 					}
 					event.Instance.value.releaseResourceRoot()
@@ -142,7 +142,7 @@ func TestCloseTerminalWaiters(t *testing.T) {
 					t.Fatal(err)
 				}
 				if waiter == "drain-logically-closed" {
-					if _, err := owned.closeLogical(); err != nil {
+					if err := owned.Close(); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -161,7 +161,7 @@ func TestCloseTerminalWaiters(t *testing.T) {
 					case "instance":
 						done <- in.closeAndWait()
 					case "managed":
-						done <- owned.Close()
+						done <- owned.WaitClosed()
 					case "drain", "drain-logically-closed":
 						done <- manager.close()
 					}
@@ -192,14 +192,14 @@ func TestCloseTerminalWaiters(t *testing.T) {
 	}
 }
 
-func TestManagedCloseLogicalReentry(t *testing.T) {
+func TestManagedCloseCallbackReentry(t *testing.T) {
 	for _, phase := range []string{"before", "after"} {
 		t.Run(phase, func(t *testing.T) {
 			var owned *ManagedInstance
 			var calls atomic.Int32
 			hook := func(InstanceCloseEvent) {
 				calls.Add(1)
-				if err := owned.CloseLogical(); err != nil {
+				if err := owned.Close(); err != nil {
 					panic(err)
 				}
 			}
@@ -219,7 +219,13 @@ func TestManagedCloseLogicalReentry(t *testing.T) {
 				t.Fatal(err)
 			}
 			done := make(chan error, 1)
-			go func() { done <- owned.Close() }()
+			go func() {
+				if err := owned.Close(); err != nil {
+					done <- err
+					return
+				}
+				done <- owned.WaitClosed()
+			}()
 			if err := awaitCloseResult(t, done); err != nil {
 				t.Fatal(err)
 			}
@@ -279,7 +285,7 @@ func awaitTerminalWait(t *testing.T, done chan error) {
 			return
 		}
 		for _, stack := range strings.Split(string(buf[:n]), "\n\n") {
-			if strings.Contains(stack, "[chan receive]:") && strings.Contains(stack, "(*Instance).waitTerminalClose(") && strings.Contains(stack, "TestCloseTerminalWaiters.func") {
+			if strings.Contains(stack, "[chan receive]:") && strings.Contains(stack, "(*Instance).waitTerminalClose(") && strings.Contains(stack, strings.Split(t.Name(), "/")[0]+".func") {
 				return
 			}
 		}

--- a/src/wago/instance_close_completion_test.go
+++ b/src/wago/instance_close_completion_test.go
@@ -3,8 +3,11 @@ package wago
 import (
 	"context"
 	"errors"
+	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/tests/support/wasmtest"
 )
@@ -21,7 +24,14 @@ func closeCompletionInstance(t *testing.T, hooks *hookRegistry) (*Runtime, *Inst
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = rt.CloseContext(context.Background()); _ = mod.Close() })
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := rt.CloseContext(ctx); errors.Is(err, context.DeadlineExceeded) {
+			t.Error("runtime cleanup timed out")
+		}
+		_ = mod.Close()
+	})
 	return rt, in
 }
 
@@ -32,7 +42,7 @@ func TestClosePreparationOrdersTerminalHooks(t *testing.T) {
 			var after atomic.Int32
 			block := func() {
 				close(entered)
-				<-release
+				awaitCloseHookRelease(release)
 				if phase == "panic" {
 					panic("before")
 				}
@@ -49,11 +59,11 @@ func TestClosePreparationOrdersTerminalHooks(t *testing.T) {
 			}
 			closed := make(chan error, 1)
 			go func() { closed <- in.Close() }()
-			<-entered
+			awaitCloseSignal(t, entered)
 			in.endInvocation()
 			gotEarly := after.Load()
 			close(release)
-			err := <-closed
+			err := awaitCloseResult(t, closed)
 			if gotEarly != 0 {
 				t.Fatal("AfterClose ran before BeforeClose completed")
 			}
@@ -97,11 +107,15 @@ func TestCloseTerminalWaiters(t *testing.T) {
 			}
 			t.Run(name, func(t *testing.T) {
 				entered, release := make(chan struct{}), make(chan struct{})
+				var owned *ManagedInstance
 				rt, in := closeCompletionInstance(t, &hookRegistry{afterClose: []func(InstanceCloseEvent){func(event InstanceCloseEvent) {
 					close(entered)
-					<-release
+					awaitCloseHookRelease(release)
 					// Callback reentry must not wait for its own terminal phase.
 					if err := event.Instance.value.Close(); err != nil {
+						panic(err)
+					}
+					if err := owned.CloseLogical(); err != nil {
 						panic(err)
 					}
 					event.Instance.value.releaseResourceRoot()
@@ -112,7 +126,8 @@ func TestCloseTerminalWaiters(t *testing.T) {
 				manager := newPendingInstanceManager("close-test", AuthorityScope{})
 				manager.activate(rt)
 				manager.live = 1
-				owned, err := manager.adopt(in, 0)
+				var err error
+				owned, err = manager.adopt(in, 0)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -133,16 +148,15 @@ func TestCloseTerminalWaiters(t *testing.T) {
 				}
 				ended := make(chan struct{})
 				go func() { in.endInvocation(); close(ended) }()
-				<-entered
+				awaitCloseSignal(t, entered)
 				state := in.ensurePluginState().close.Load()
 				select {
 				case <-state.quiesced:
 				default:
 					t.Fatal("invocations did not quiesce")
 				}
-				started, done := make(chan struct{}), make(chan error, 1)
+				done := make(chan error, 1)
 				go func() {
-					close(started)
 					switch waiter {
 					case "instance":
 						done <- in.closeAndWait()
@@ -152,7 +166,7 @@ func TestCloseTerminalWaiters(t *testing.T) {
 						done <- manager.close()
 					}
 				}()
-				<-started
+				awaitTerminalWait(t, done)
 				select {
 				case <-state.terminalDone:
 					t.Error("terminal completion preceded AfterClose")
@@ -165,8 +179,8 @@ func TestCloseTerminalWaiters(t *testing.T) {
 				default:
 				}
 				close(release)
-				err = <-done
-				<-ended
+				err = awaitCloseResult(t, done)
+				awaitCloseSignal(t, ended)
 				if errors.Is(err, ErrCallbackPanic) != panics {
 					t.Fatalf("terminal waiter = %v", err)
 				}
@@ -174,6 +188,111 @@ func TestCloseTerminalWaiters(t *testing.T) {
 					t.Fatal("retained resources were released")
 				}
 			})
+		}
+	}
+}
+
+func TestManagedCloseLogicalReentry(t *testing.T) {
+	for _, phase := range []string{"before", "after"} {
+		t.Run(phase, func(t *testing.T) {
+			var owned *ManagedInstance
+			var calls atomic.Int32
+			hook := func(InstanceCloseEvent) {
+				calls.Add(1)
+				if err := owned.CloseLogical(); err != nil {
+					panic(err)
+				}
+			}
+			hooks := &hookRegistry{}
+			if phase == "before" {
+				hooks.beforeClose = []func(InstanceCloseEvent){hook}
+			} else {
+				hooks.afterClose = []func(InstanceCloseEvent){hook}
+			}
+			rt, in := closeCompletionInstance(t, hooks)
+			manager := newPendingInstanceManager("close-reentry", AuthorityScope{})
+			manager.activate(rt)
+			manager.live = 1
+			var err error
+			owned, err = manager.adopt(in, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan error, 1)
+			go func() { done <- owned.Close() }()
+			if err := awaitCloseResult(t, done); err != nil {
+				t.Fatal(err)
+			}
+			if calls.Load() != 1 || owned.Instance() != nil {
+				t.Fatal("logical callback close did not complete exactly once")
+			}
+			manager.mu.Lock()
+			remaining := len(manager.instances)
+			manager.mu.Unlock()
+			if remaining != 0 {
+				t.Fatal("terminal close retained managed ownership")
+			}
+		})
+	}
+}
+
+func awaitCloseHookRelease(release <-chan struct{}) {
+	select {
+	case <-release:
+	case <-time.After(10 * time.Second):
+		panic("close hook release timed out")
+	}
+}
+
+func awaitCloseSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(10 * time.Second):
+		t.Fatal("close signal timed out")
+	}
+}
+
+func awaitCloseResult(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(10 * time.Second):
+		return errors.New("close completion timed out")
+	}
+}
+
+// Observe the blocked receive itself, not a signal sent before entering Close.
+// This is test-only: no wait probes or allocations enter production close paths.
+func awaitTerminalWait(t *testing.T, done chan error) {
+	t.Helper()
+	deadline := time.NewTimer(10 * time.Second)
+	defer deadline.Stop()
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n == 0 {
+			// TinyGo has no goroutine stack snapshots. Its tasks scheduler
+			// runs the queued waiter until it blocks when this task yields.
+			runtime.Gosched()
+			return
+		}
+		for _, stack := range strings.Split(string(buf[:n]), "\n\n") {
+			if strings.Contains(stack, "[chan receive]:") && strings.Contains(stack, "(*Instance).waitTerminalClose(") && strings.Contains(stack, "TestCloseTerminalWaiters.func") {
+				return
+			}
+		}
+		select {
+		case err := <-done:
+			t.Errorf("terminal waiter returned before blocking: %v", err)
+			done <- err
+			return
+		case <-deadline.C:
+			t.Error("terminal waiter did not enter its channel wait")
+			return
+		default:
+			runtime.Gosched()
 		}
 	}
 }

--- a/src/wago/instance_entry.go
+++ b/src/wago/instance_entry.go
@@ -1,0 +1,87 @@
+package wago
+
+import (
+	"context"
+	"encoding/binary"
+)
+
+// lockInvocation serializes a complete public call, including parked callbacks.
+// A zero identity requests a fresh chain; host reentry supplies its existing ID.
+// Before native entry, the caller must also hold an invocation or construction
+// lifetime lease.
+func (in *Instance) lockInvocation(id invocationID) *instancePluginState {
+	state := in.ensurePluginState()
+	state.invokeMu.Lock()
+	if id == 0 {
+		id = newInvocationID()
+	}
+	state.invocationID = id
+	return state
+}
+
+func (state *instancePluginState) unlockInvocation() {
+	state.invocationID = 0
+	state.invokeMu.Unlock()
+}
+
+// invokeVoidEntry runs a table dispatcher or local start under the same native,
+// collector, callback, and cancellation machinery as ordinary invocation. The
+// caller owns serialization, identity, lifetime, and any argument slots.
+func (in *Instance) invokeVoidEntry(ctx context.Context, entry uintptr, reservation *pluginOperationReservation) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	gcLease := in.lockGCInvocation(in.currentInvocationID())
+	defer func() {
+		gcLease.unlock()
+		if in.importsFuncrefStorage() || in.table != nil {
+			in.reconcileFuncrefRoots()
+		}
+	}()
+	if reservation != nil {
+		previous := in.swapInvocationReservation(reservation)
+		defer in.swapInvocationReservation(previous)
+	}
+	if mu := in.lockThreadedInstanceState(); mu != nil {
+		defer mu.Unlock()
+	}
+	if err := in.collectGenericGCAtBoundary(); err != nil {
+		return err
+	}
+	if len(in.hostLog) > 0 {
+		binary.LittleEndian.PutUint32(in.hostLog, 0)
+	}
+	if ctx == nil || ctx.Done() == nil {
+		// Keep non-cancelable entries free of context watcher allocations.
+		if err := in.callVoidNative(entry); err != nil {
+			return err
+		}
+		return in.reconcileGCGlobalRoots()
+	}
+	stopCancel, err := in.startCancellationWatch(ctx, in.trap)
+	if err != nil {
+		return err
+	}
+	defer stopCancel()
+	if in.syncMode {
+		err = in.callNativeSyncWithTrapContext(entry, in.trap, ctx)
+	} else {
+		err = in.callVoidNative(entry)
+	}
+	if err != nil {
+		return contextInterruptError(ctx, err)
+	}
+	return in.reconcileGCGlobalRoots()
+}
+
+func (in *Instance) callVoidNative(entry uintptr) error {
+	if in.syncMode {
+		return in.callNativeSync(entry)
+	}
+	if err := in.callNativeAsync(entry, false); err != nil {
+		return err
+	}
+	return in.replayHostLog()
+}

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -73,7 +73,7 @@ func (in *Instance) beginClose() (*instanceCloseState, bool) {
 	if active := state.close.Load(); active != nil {
 		return active, false
 	}
-	candidate := &instanceCloseState{done: make(chan struct{}), quiesced: make(chan struct{})}
+	candidate := &instanceCloseState{done: make(chan struct{}), quiesced: make(chan struct{}), terminalDone: make(chan struct{})}
 	if state.close.CompareAndSwap(nil, candidate) {
 		return candidate, true
 	}
@@ -140,6 +140,7 @@ func (in *Instance) closeOnce() error {
 	in.lifeMu.Unlock()
 
 	appendStep("close reference store instance", func() { in.referenceLifetime().notifyStore(store, referenceLifetimeClosed) })
+	in.ensurePluginState().close.Load().prepared.Store(true)
 	appendStep("finalize instance resources", in.tryFinalize)
 	return errors.Join(errs...)
 }
@@ -152,14 +153,20 @@ func (in *Instance) closeAndWait() error {
 	if in == nil {
 		return nil
 	}
-	closeErr := in.Close()
+	_ = in.Close()
+	return in.waitTerminalClose()
+}
+
+// waitTerminalClose joins logical preparation and terminal hooks, but does not
+// wait for resources retained by other instances or public reference tokens.
+func (in *Instance) waitTerminalClose() error {
 	state := in.ensurePluginState().close.Load()
 	if state != nil {
 		<-state.done
-		<-state.quiesced
+		<-state.terminalDone
 		return joinPrimary(state.result, state.terminalResult)
 	}
-	return closeErr
+	return nil
 }
 
 func (in *Instance) isLogicallyClosed() bool {
@@ -271,7 +278,11 @@ func (in *Instance) tryFinalize() {
 		return
 	}
 	if closeState := in.ensurePluginState().close.Load(); closeState != nil {
-		closeState.terminalOnce.Do(func() {
+		if !closeState.prepared.Load() {
+			return
+		}
+		closeState.quiescedOnce.Do(func() { close(closeState.quiesced) })
+		if closeState.terminalStarted.CompareAndSwap(false, true) {
 			if closeState.hooks != nil && closeState.event != nil {
 				var errs []error
 				for i := len(closeState.hooks.afterClose) - 1; i >= 0; i-- {
@@ -282,8 +293,16 @@ func (in *Instance) tryFinalize() {
 				}
 				closeState.terminalResult = errors.Join(errs...)
 			}
-			closeState.quiescedOnce.Do(func() { close(closeState.quiesced) })
-		})
+			close(closeState.terminalDone)
+		} else {
+			// A hook can release a reference and reenter tryFinalize. Do not
+			// wait for that hook here, or release its resources underneath it.
+			select {
+			case <-closeState.terminalDone:
+			default:
+				return
+			}
+		}
 	}
 	in.referenceLifetime().finalize()
 }

--- a/src/wago/instance_lifecycle.go
+++ b/src/wago/instance_lifecycle.go
@@ -42,6 +42,11 @@ func (in *Instance) Close() (err error) {
 		}
 		state.result = err
 		close(state.done)
+		// Managed terminal work must not detach ownership before the logical
+		// result is available to drain and WaitClosed. Retry after publication.
+		if in.hasManagedOwner() {
+			in.tryFinalize()
+		}
 	}()
 	return in.closeOnce()
 }
@@ -253,10 +258,9 @@ func (in *Instance) endInvocation() {
 			}
 			in.tryFinalize()
 		}
-		// Keep the Runtime operation admitted through terminal instance
-		// finalization. Runtime shutdown uses this count as its barrier, so
-		// publishing it earlier could let WaitClosed return before reference
-		// tokens and store membership were released.
+		// Keep the Runtime operation admitted through invocation finalization.
+		// Managed terminal hooks can finish asynchronously; manager drain
+		// separately waits for terminalDone before provider teardown.
 		if in.rt != nil {
 			in.rt.mu.Lock()
 			if in.rt.activeOperations == 0 {
@@ -281,19 +285,25 @@ func (in *Instance) tryFinalize() {
 		if !closeState.prepared.Load() {
 			return
 		}
+		managed := in.hasManagedOwner()
+		if managed {
+			select {
+			case <-closeState.done:
+			default:
+				return
+			}
+		}
 		closeState.quiescedOnce.Do(func() { close(closeState.quiesced) })
 		if closeState.terminalStarted.CompareAndSwap(false, true) {
-			if closeState.hooks != nil && closeState.event != nil {
-				var errs []error
-				for i := len(closeState.hooks.afterClose) - 1; i >= 0; i-- {
-					fn := closeState.hooks.afterClose[i]
-					if err := callShutdownSafely("AfterClose", func() { fn(*closeState.event) }); err != nil {
-						errs = append(errs, err)
-					}
-				}
-				closeState.terminalResult = errors.Join(errs...)
+			if managed && closeState.hooks != nil && len(closeState.hooks.afterClose) != 0 {
+				// Managed Close must return without waiting for terminal hooks.
+				// One short-lived worker owns hooks, detachment, and finalization;
+				// there is no per-instance background waiter for ownership cleanup.
+				go in.finishTerminalClose(closeState)
+			} else {
+				in.finishTerminalClose(closeState)
 			}
-			close(closeState.terminalDone)
+			return
 		} else {
 			// A hook can release a reference and reenter tryFinalize. Do not
 			// wait for that hook here, or release its resources underneath it.
@@ -304,6 +314,36 @@ func (in *Instance) tryFinalize() {
 			}
 		}
 	}
+	in.referenceLifetime().finalize()
+}
+
+func (in *Instance) hasManagedOwner() bool {
+	in.lifeMu.Lock()
+	managed := in.finalizers != nil && in.finalizers.managed != nil
+	in.lifeMu.Unlock()
+	return managed
+}
+
+func (in *Instance) finishTerminalClose(state *instanceCloseState) {
+	if state.hooks != nil && state.event != nil {
+		var errs []error
+		for i := len(state.hooks.afterClose) - 1; i >= 0; i-- {
+			fn := state.hooks.afterClose[i]
+			if err := callShutdownSafely("AfterClose", func() { fn(*state.event) }); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		state.terminalResult = errors.Join(errs...)
+	}
+	in.lifeMu.Lock()
+	if in.finalizers != nil && in.finalizers.managed != nil {
+		managed := in.finalizers.managed
+		in.finalizers.managed = nil
+		managed.finishTerminalClose(state)
+	} else {
+		close(state.terminalDone)
+	}
+	in.lifeMu.Unlock()
 	in.referenceLifetime().finalize()
 }
 

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -1,6 +1,7 @@
 package wago
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -21,6 +22,7 @@ type InstantiateOptions struct {
 	Imports                  Imports
 	GC                       GCConfig
 	store                    *referenceStore
+	startContext             context.Context
 
 	ownedImports             bool // private Runtime resolution has transferred ownership
 	runtime                  *Runtime
@@ -133,6 +135,11 @@ func instantiateCoreWithModuleLease(c *Compiled, opts InstantiateOptions, module
 	}
 	b := instanceBuilder{c: c, opts: opts, imports: opts.Imports, moduleUse: moduleUse}
 	defer b.releaseModuleUse()
+	if opts.startContext != nil {
+		if err := opts.startContext.Err(); err != nil {
+			return nil, err
+		}
+	}
 	if c == nil {
 		return nil, errors.New("wago: instantiate: nil compiled module")
 	}
@@ -1664,6 +1671,11 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 
 	// Run the start function (() -> ()) now that memory, globals, table, and data
 	// are initialized. A trap here aborts instantiation.
+	if opts.startContext != nil {
+		if err := opts.startContext.Err(); err != nil {
+			return nil, err
+		}
+	}
 	if c.HasStart {
 		if c.StartIsImport {
 			// Imported start: run the imported function through the same normalized
@@ -1695,22 +1707,9 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 			// tenant's native result before public tokenization. The instance gate is
 			// acquired first, matching Invoke and prepared-call lock ordering.
 			startErr := func() error {
-				state := in.ensurePluginState()
-				state.invokeMu.Lock()
-				id := newInvocationID()
-				state.invocationID = id
-				defer func() {
-					state.invocationID = 0
-					state.invokeMu.Unlock()
-				}()
-				gcLease := in.lockGCInvocation(id)
-				defer gcLease.unlock()
-				previousReservation := in.swapInvocationReservation(in.constructionReservationSnapshot())
-				defer in.swapInvocationReservation(previousReservation)
-				if in.syncMode {
-					return in.callNativeSync(startEntry)
-				}
-				return in.callNativeAsync(startEntry, false)
+				state := in.lockInvocation(0)
+				defer state.unlockInvocation()
+				return in.invokeVoidEntry(opts.startContext, startEntry, in.constructionReservationSnapshot())
 			}()
 			if startErr != nil {
 				// Instantiation writes to imported tables are store side effects. If a

--- a/src/wago/managed_close_test.go
+++ b/src/wago/managed_close_test.go
@@ -137,14 +137,10 @@ func TestManagedCloseWaitClosed(t *testing.T) {
 }
 
 func TestManagedCloseAutomaticOwnership(t *testing.T) {
-	for _, hooks := range []bool{false, true} {
-		name := "inline"
-		if hooks {
-			name = "terminal-worker"
-		}
-		t.Run(name, func(t *testing.T) {
+	for _, mode := range []string{"inline", "terminal-worker", "retained"} {
+		t.Run(mode, func(t *testing.T) {
 			p := &disposalTestPlugin{}
-			if hooks {
+			if mode != "inline" {
 				p.afterClose = []func(*InstanceContext){func(*InstanceContext) {}}
 			}
 			_, manager, mod := managedCloseRuntime(t, p)
@@ -154,6 +150,9 @@ func TestManagedCloseAutomaticOwnership(t *testing.T) {
 					t.Fatal(err)
 				}
 				in := owned.Instance()
+				if mode == "retained" && !in.retainResourceRoot() {
+					t.Fatal("retain")
+				}
 				released := make(chan struct{})
 				in.referenceLifetime().afterPhysicalRelease(func() { close(released) })
 				if err := owned.Close(); err != nil {
@@ -163,6 +162,12 @@ func TestManagedCloseAutomaticOwnership(t *testing.T) {
 				// detachment, and physical release owns budget accounting.
 				awaitCloseSignal(t, in.ensurePluginState().close.Load().terminalDone)
 				assertManagedDetached(t, manager, owned, in)
+				if mode == "retained" {
+					if !in.referenceLifetime().snapshot().PhysicalResources {
+						t.Fatal("retained resources released during detachment")
+					}
+					in.releaseResourceRoot()
+				}
 				awaitCloseSignal(t, released)
 				assertManagedReservationsReleased(t, manager)
 			}

--- a/src/wago/managed_close_test.go
+++ b/src/wago/managed_close_test.go
@@ -1,0 +1,267 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+func managedCloseRuntime(t *testing.T, p *disposalTestPlugin) (*Runtime, *InstanceManager, *Module) {
+	t.Helper()
+	p.id = "test.managed-close"
+	p.requires = []PluginCapability{PluginInstanceHooks, PluginManagedInstances}
+	rt := NewRuntime()
+	if err := rt.Use(p, WithPluginGrants(PluginInstanceHooks, PluginManagedInstances)); err != nil {
+		t.Fatal(err)
+	}
+	p.manager.budget = AuthorityScope{MaxInstances: 1, MaxMemoryBytes: 65536}
+	mod, err := rt.Compile(wasmtest.Module(wasmtest.Section(5, wasmtest.Vec([]byte{1, 1, 1}))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := rt.CloseContext(ctx); errors.Is(err, context.DeadlineExceeded) {
+			t.Error("runtime cleanup timed out")
+		}
+		_ = mod.Close()
+	})
+	return rt, p.manager, mod
+}
+
+func assertManagedDetached(t *testing.T, manager *InstanceManager, owned *ManagedInstance, in *Instance) {
+	t.Helper()
+	manager.mu.Lock()
+	records, callers := len(manager.instances), len(manager.byInstance)
+	manager.mu.Unlock()
+	owned.mu.Lock()
+	detached := owned.manager == nil && owned.value == nil && owned.closedValue == in
+	owned.mu.Unlock()
+	if records != 0 || callers != 0 || !detached {
+		t.Fatalf("terminal ownership: records=%d callers=%d detached=%v", records, callers, detached)
+	}
+}
+
+func assertManagedReservationsReleased(t *testing.T, manager *InstanceManager) {
+	t.Helper()
+	manager.mu.Lock()
+	live, memory := manager.live, manager.memoryBytes
+	manager.mu.Unlock()
+	manager.rt.mu.Lock()
+	mappings, reservations := manager.rt.nativeMemoryMappings, len(manager.rt.instanceReservations)
+	manager.rt.mu.Unlock()
+	if live != 0 || memory != 0 || mappings != 0 || reservations != 0 {
+		t.Fatalf("reservations: live=%d memory=%d mappings=%d instances=%d", live, memory, mappings, reservations)
+	}
+}
+
+func TestManagedCloseWaitClosed(t *testing.T) {
+	for _, phase := range []string{"normal", "before-panic", "after-panic", "both-panic"} {
+		t.Run(phase, func(t *testing.T) {
+			beforePanic, afterPanic := phase == "before-panic" || phase == "both-panic", phase == "after-panic" || phase == "both-panic"
+			entered, release := make(chan struct{}), make(chan struct{})
+			p := &disposalTestPlugin{
+				beforeClose: []func(*InstanceContext){func(*InstanceContext) {
+					if beforePanic {
+						panic("before close")
+					}
+				}},
+				afterClose: []func(*InstanceContext){func(*InstanceContext) {
+					close(entered)
+					awaitCloseHookRelease(release)
+					if afterPanic {
+						panic("after close")
+					}
+				}},
+			}
+			_, manager, mod := managedCloseRuntime(t, p)
+			owned, err := manager.Instantiate(nil, mod)
+			if err != nil {
+				t.Fatal(err)
+			}
+			in := owned.Instance()
+			if !in.retainResourceRoot() {
+				t.Fatal("retain")
+			}
+			released := make(chan struct{})
+			in.referenceLifetime().afterPhysicalRelease(func() { close(released) })
+			closed := make(chan error, 1)
+			go func() { closed <- owned.Close() }()
+			awaitCloseSignal(t, entered)
+			// There are no active invocations: Close must still return while
+			// AfterClose is blocked, and must report only logical errors.
+			logicalErr := awaitCloseResult(t, closed)
+			if errors.Is(logicalErr, ErrCallbackPanic) != beforePanic || (!beforePanic && logicalErr != nil) {
+				t.Errorf("Close = %v", logicalErr)
+			}
+			manager.mu.Lock()
+			pending := len(manager.instances) == 1 && len(manager.byInstance) == 0
+			manager.mu.Unlock()
+			if !pending || owned.Instance() != nil {
+				t.Error("logical close lost pending ownership or left admission open")
+			}
+			done := make(chan error, 1)
+			go func() { done <- owned.WaitClosed() }()
+			awaitTerminalWait(t, done)
+			close(release)
+			terminalErr := awaitCloseResult(t, done)
+			if errors.Is(terminalErr, ErrCallbackPanic) != (beforePanic || afterPanic) {
+				t.Fatalf("WaitClosed = %v", terminalErr)
+			}
+			if afterPanic && !strings.Contains(terminalErr.Error(), "AfterClose") {
+				t.Fatalf("missing terminal error: %v", terminalErr)
+			}
+			for i := 0; i < 3; i++ {
+				if err := owned.WaitClosed(); err != terminalErr && (err == nil || terminalErr == nil || err.Error() != terminalErr.Error()) {
+					t.Errorf("repeated WaitClosed = %v, want %v", err, terminalErr)
+				}
+			}
+			assertManagedDetached(t, manager, owned, in)
+			manager.mu.Lock()
+			retainedBudget := manager.live == 1 && manager.memoryBytes == 65536
+			manager.mu.Unlock()
+			if !retainedBudget || !in.referenceLifetime().snapshot().PhysicalResources {
+				t.Fatal("terminal wait released retained physical resources")
+			}
+			in.releaseResourceRoot()
+			awaitCloseSignal(t, released)
+			assertManagedReservationsReleased(t, manager)
+		})
+	}
+}
+
+func TestManagedCloseAutomaticOwnership(t *testing.T) {
+	for _, hooks := range []bool{false, true} {
+		name := "inline"
+		if hooks {
+			name = "terminal-worker"
+		}
+		t.Run(name, func(t *testing.T) {
+			p := &disposalTestPlugin{}
+			if hooks {
+				p.afterClose = []func(*InstanceContext){func(*InstanceContext) {}}
+			}
+			_, manager, mod := managedCloseRuntime(t, p)
+			for i := 0; i < 20; i++ {
+				owned, err := manager.Instantiate(nil, mod)
+				if err != nil {
+					t.Fatal(err)
+				}
+				in := owned.Instance()
+				released := make(chan struct{})
+				in.referenceLifetime().afterPhysicalRelease(func() { close(released) })
+				if err := owned.Close(); err != nil {
+					t.Fatal(err)
+				}
+				// No public wait or second close: the terminal finalizer owns
+				// detachment, and physical release owns budget accounting.
+				awaitCloseSignal(t, in.ensurePluginState().close.Load().terminalDone)
+				assertManagedDetached(t, manager, owned, in)
+				awaitCloseSignal(t, released)
+				assertManagedReservationsReleased(t, manager)
+			}
+		})
+	}
+}
+
+func TestManagedCloseConcurrentShutdown(t *testing.T) {
+	var owned *ManagedInstance
+	var before, after atomic.Int32
+	entered, release := make(chan struct{}), make(chan struct{})
+	p := &disposalTestPlugin{
+		beforeClose: []func(*InstanceContext){func(*InstanceContext) { before.Add(1); _ = owned.Close() }},
+		afterClose: []func(*InstanceContext){func(*InstanceContext) {
+			after.Add(1)
+			close(entered)
+			awaitCloseHookRelease(release)
+			_ = owned.Close()
+		}},
+	}
+	rt, manager, mod := managedCloseRuntime(t, p)
+	var err error
+	owned, err = manager.Instantiate(nil, mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := owned.Instance()
+	if err := in.beginInvocation(); err != nil {
+		t.Fatal(err)
+	}
+	released := make(chan struct{})
+	in.referenceLifetime().afterPhysicalRelease(func() { close(released) })
+	start, results := make(chan struct{}), make(chan error, 18)
+	for i := 0; i < 8; i++ {
+		go func() { <-start; results <- owned.Close() }()
+		go func() { <-start; results <- owned.WaitClosed() }()
+	}
+	go func() { <-start; results <- manager.close() }()
+	go func() { <-start; results <- rt.Close() }()
+	close(start)
+	// Race the final invocation exit with logical close preparation.
+	if err := owned.Close(); err != nil {
+		t.Fatal(err)
+	}
+	in.endInvocation()
+	awaitCloseSignal(t, entered)
+	close(release)
+	for i := 0; i < 18; i++ {
+		if err := awaitCloseResult(t, results); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := rt.WaitClosed(ctx); err != nil {
+		t.Fatal(err)
+	}
+	awaitCloseSignal(t, released)
+	if before.Load() != 1 || after.Load() != 1 {
+		t.Fatalf("hook counts = %d/%d", before.Load(), after.Load())
+	}
+	assertManagedDetached(t, manager, owned, in)
+	assertManagedReservationsReleased(t, manager)
+}
+
+func TestManagedCloseBeforeAdoption(t *testing.T) {
+	p := &disposalTestPlugin{afterInst: []func(*InstantiateContext, *Instance) error{
+		func(_ *InstantiateContext, in *Instance) error { return in.Close() },
+	}}
+	_, manager, mod := managedCloseRuntime(t, p)
+	owned, err := manager.Instantiate(nil, mod)
+	if owned != nil || err == nil {
+		t.Fatalf("adopt closed child = %v, %v", owned, err)
+	}
+	manager.mu.Lock()
+	records, callers := len(manager.instances), len(manager.byInstance)
+	manager.mu.Unlock()
+	if records != 0 || callers != 0 {
+		t.Fatalf("closed child registered: %d/%d", records, callers)
+	}
+	assertManagedReservationsReleased(t, manager)
+}
+
+func TestManagedWaitClosedInitiatesClose(t *testing.T) {
+	var after atomic.Int32
+	p := &disposalTestPlugin{afterClose: []func(*InstanceContext){func(*InstanceContext) { after.Add(1) }}}
+	_, manager, mod := managedCloseRuntime(t, p)
+	owned, err := manager.Instantiate(nil, mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := owned.Instance()
+	done := make(chan error, 1)
+	go func() { done <- owned.WaitClosed() }()
+	if err := awaitCloseResult(t, done); err != nil {
+		t.Fatal(err)
+	}
+	if after.Load() != 1 {
+		t.Fatalf("AfterClose calls = %d", after.Load())
+	}
+	assertManagedDetached(t, manager, owned, in)
+}

--- a/src/wago/managed_entry_context_test.go
+++ b/src/wago/managed_entry_context_test.go
@@ -1,0 +1,319 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+// Entry 0 calls the host, entry 1 traps after that call, and entry 2 loops
+// after that call. The nested export returns a value to verify isolated scratch.
+func managedReentryModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil), wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}))),
+		wasmtest.Section(2, wasmtest.Vec(append(append(wasmtest.Name("env"), wasmtest.Name("host")...), 0, 0))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0), wasmtest.ULEB(0), wasmtest.ULEB(1))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x00, 0x03})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("nested", 0, 4))),
+		wasmtest.Section(9, wasmtest.Vec(tableTestActiveElem(0, 1, 2, 3))),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x10, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x10, 0x00, 0x00, 0x0b}),
+			wasmtest.Code([]byte{0x10, 0x00, 0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b}),
+			wasmtest.Code([]byte{0x41, 0x2a, 0x0b}),
+		)),
+	)
+}
+
+type managedReservationSnapshot struct {
+	live                                    uint32
+	memory                                  uint64
+	owned, callers, instances, reservations int
+	mappings                                uint32
+	operations, plugin                      uint64
+}
+
+func managedReservations(manager *InstanceManager, gate *pluginCallGate) managedReservationSnapshot {
+	manager.mu.Lock()
+	s := managedReservationSnapshot{live: manager.live, memory: manager.memoryBytes, owned: len(manager.instances), callers: len(manager.byInstance)}
+	manager.mu.Unlock()
+	rt := manager.rt
+	rt.mu.Lock()
+	s.instances, s.reservations = len(rt.instances), len(rt.instanceReservations)
+	s.mappings, s.operations = rt.nativeMemoryMappings, rt.activeOperations
+	rt.mu.Unlock()
+	s.plugin = gate.state.Load()
+	return s
+}
+
+func managedStartModule() []byte {
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(nil, nil), wasmtest.FuncType(nil, []wasm.ValType{wasm.I32}))),
+		wasmtest.Section(2, wasmtest.Vec(
+			append(append(wasmtest.Name("env"), wasmtest.Name("fork")...), 0, 0),
+			append(append(wasmtest.Name("env"), wasmtest.Name("start")...), 0, 1),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
+		wasmtest.Section(5, wasmtest.Vec([]byte{1, 1, 1})), // one page, bounded maximum
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 3))),
+		wasmtest.Section(8, wasmtest.ULEB(2)),
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x10, 1, 0x04, 0x40, 0x03, 0x40, 0x0c, 0, 0x0b, 0x0b, 0x0b}),
+			wasmtest.Code([]byte{0x10, 0, 0x0b}),
+		)),
+	)
+}
+
+func TestManagedForkContext(t *testing.T) {
+	for _, mode := range []string{"canceled", "before-create", "during-start", "after-start", "live", "nil", "mapping-limit"} {
+		t.Run(mode, func(t *testing.T) {
+			if mode == "during-start" && !nativeCancellationSupported() {
+				t.Skip("native cancellation requires a concurrent scheduler")
+			}
+			mappingLimit := uint32(2)
+			if mode == "mapping-limit" {
+				mappingLimit = 1
+			}
+			rt := NewRuntime(WithRuntimeConfig(NewRuntimeConfig().WithNativeMemoryMappingLimit(mappingLimit)))
+			manager := newPendingInstanceManager("fork-test", AuthorityScope{MaxInstances: 2, MaxMemoryBytes: 2 * 65536})
+			manager.activate(rt)
+			t.Cleanup(func() { _ = manager.close(); _ = rt.CloseContext(context.Background()) })
+			gate := newPluginCallGate("fork-test")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if mode == "canceled" {
+				cancel()
+			}
+			var forkCtx context.Context = ctx
+			if mode == "nil" {
+				forkCtx = nil
+			}
+			var parent, partial *Instance
+			var childClosed int
+			rt.storeHooks(&hookRegistry{
+				operationGates: []*pluginCallGate{gate},
+				beforeInstantiate: []func(InstantiationRequest) error{func(InstantiationRequest) error {
+					if parent != nil && mode == "before-create" {
+						cancel()
+					}
+					return nil
+				}},
+				afterCreate: []func(InstantiationEvent) error{func(event InstantiationEvent) error {
+					if parent != nil {
+						partial = event.Instance.value
+					}
+					return nil
+				}},
+				afterInstantiate: []func(InstantiationEvent){func(InstantiationEvent) {
+					if parent != nil && mode == "after-start" {
+						cancel()
+					}
+				}},
+				afterClose: []func(InstanceCloseEvent){func(event InstanceCloseEvent) {
+					if event.Instance.value == partial {
+						childClosed++
+					}
+				}},
+			})
+			mod, err := rt.Compile(managedStartModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer mod.Close()
+			started, release := make(chan struct{}), make(chan struct{})
+			imports := Imports{
+				"env.start": gate.wrapCaller(func(caller Caller, _, out []uint64) {
+					if parent == nil {
+						out[0] = 0
+						return
+					}
+					if caller.invocationID == 0 || !caller.reservation.allows(gate) {
+						t.Error("start lacks invocation identity or reservation")
+					}
+					if mode == "during-start" {
+						if activeHostInvocationContext(caller.in).parent != ctx {
+							t.Error("start lost its parent context")
+						}
+						close(started)
+						<-release
+						out[0] = 1
+					} else {
+						out[0] = 0
+					}
+				}),
+				"env.fork": gate.wrapCaller(func(caller Caller, _, _ []uint64) {
+					before := managedReservations(manager, gate)
+					child, err := manager.Fork(forkCtx, caller)
+					wantCanceled := mode == "canceled" || mode == "before-create" || mode == "during-start" || mode == "after-start"
+					if wantCanceled {
+						if child != nil || !errors.Is(err, context.Canceled) {
+							t.Errorf("Fork = %v, %v; want context.Canceled", child, err)
+						}
+					} else if mode == "mapping-limit" {
+						if child != nil || !errors.Is(err, ErrResourceLimit) {
+							t.Errorf("Fork = %v, %v; want mapping limit", child, err)
+						}
+					} else if err != nil || child == nil {
+						t.Errorf("Fork = %v, %v", child, err)
+					}
+					if child != nil {
+						if child.Instance().currentInvocationID() != 0 {
+							t.Error("start identity leaked")
+						}
+						if err := child.Close(); err != nil {
+							t.Error(err)
+						}
+					}
+					if after := managedReservations(manager, gate); after != before {
+						t.Errorf("reservations: before=%+v after=%+v", before, after)
+					}
+				}),
+			}
+			owned, err := manager.Instantiate(nil, mod, WithImports(imports))
+			if err != nil {
+				t.Fatal(err)
+			}
+			parent = owned.Instance()
+			if mode == "canceled" {
+				// Cancellation must win before the capacity check, even at capacity.
+				manager.budget.MaxInstances = 1
+			}
+			done := make(chan error, 1)
+			go func() { _, err := parent.Invoke("run"); done <- err }()
+			if mode == "during-start" {
+				<-started
+				cancel()
+				close(release)
+			}
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			manager.pending.Wait()
+			if partial != nil {
+				if childClosed != 1 || partial.referenceLifetime().snapshot().PhysicalResources {
+					t.Fatalf("partial child close count=%d, resources=%+v", childClosed, partial.referenceLifetime().snapshot())
+				}
+				assertManagedEntryCleanAfterClose(t, partial)
+			} else if mode == "during-start" || mode == "live" || mode == "nil" {
+				t.Fatal("child was not created")
+			}
+		})
+	}
+}
+
+func assertManagedEntryCleanAfterClose(t *testing.T, in *Instance) {
+	t.Helper()
+	if in.currentInvocationID() != 0 || in.invocationState.Load() != instanceInvocationClosed || in.constructionIsActive() {
+		t.Fatal("closed child retained invocation or construction state")
+	}
+}
+
+func assertManagedEntryClean(t *testing.T, in *Instance, caller HostModule) {
+	t.Helper()
+	state := in.ensurePluginState()
+	if state.invocationID != 0 || in.invocationState.Load() != 0 {
+		t.Fatalf("entry state leaked: identity=%d invocations=%d", state.invocationID, in.invocationState.Load())
+	}
+	if state.hostScope.active.Load() != 0 {
+		t.Fatal("callback scope remained active")
+	}
+	a := &state.activations
+	a.mu.Lock()
+	clean := a.count == 0 && len(a.other) == 0 && a.reservation == nil && len(a.reservations) == 0
+	a.mu.Unlock()
+	if !clean {
+		t.Fatal("activation or plugin reservation leaked")
+	}
+	if _, err := in.InvokeFromHost(nil, caller, "nested"); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("stale callback reentry = %v", err)
+	}
+	if _, err := in.InvokeFromHost(nil, Caller{}, "nested"); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("unrelated callback reentry = %v", err)
+	}
+}
+
+func TestManagedTableReentryCleanup(t *testing.T) {
+	rt := NewRuntime()
+	manager := newPendingInstanceManager("entry-test", AuthorityScope{})
+	manager.activate(rt)
+	t.Cleanup(func() { _ = manager.close(); _ = rt.CloseContext(context.Background()) })
+	mod, err := rt.Compile(managedReentryModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Close()
+	var in *Instance
+	var stale HostModule
+	var lastID invocationID
+	var cancel context.CancelFunc
+	var hostPanic bool
+	var callbacks int
+	owned, err := manager.Instantiate(nil, mod, WithImports(Imports{"env.host": CallerHostFunc(func(caller Caller, _, _ []uint64) {
+		callbacks++
+		if caller.invocationID == 0 || caller.invocationID == lastID {
+			t.Error("missing or reused invocation identity")
+		}
+		lastID = caller.invocationID
+		if stale != nil {
+			if _, err := in.InvokeFromHost(nil, stale, "nested"); !errors.Is(err, ErrPermissionDenied) {
+				t.Errorf("previous callback retained authority: %v", err)
+			}
+		}
+		stale = caller
+		out, err := in.InvokeFromHost(nil, caller, "nested")
+		if err != nil || len(out) != 1 || out[0] != 42 {
+			t.Errorf("nested call = %v, %v", out, err)
+		}
+		if cancel != nil {
+			cancel()
+		}
+		if hostPanic {
+			panic("host panic")
+		}
+	})}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	in = owned.Instance()
+	for i := 0; i < 2; i++ {
+		if err := owned.InvokeVoidTable(nil, 0); err != nil {
+			t.Fatal(err)
+		}
+		assertManagedEntryClean(t, in, stale)
+	}
+	if err := owned.InvokeVoidTable(nil, 1); err == nil {
+		t.Fatal("trap entry succeeded")
+	}
+	assertManagedEntryClean(t, in, stale)
+	if nativeCancellationSupported() {
+		ctx, cancelCall := context.WithCancel(context.Background())
+		cancel = cancelCall
+		if err := owned.InvokeVoidTable(ctx, 2); !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled table call = %v", err)
+		}
+		cancelCall()
+		cancel = nil
+		assertManagedEntryClean(t, in, stale)
+	}
+	hostPanic = true
+	func() {
+		defer func() {
+			if recover() != "host panic" {
+				t.Error("host panic did not propagate")
+			}
+		}()
+		_ = owned.InvokeVoidTable(nil, 0)
+	}()
+	assertManagedEntryClean(t, in, stale)
+	hostPanic = false
+	if err := owned.InvokeVoidTable(nil, 0); err != nil {
+		t.Fatalf("call after failures: %v", err)
+	}
+	assertManagedEntryClean(t, in, stale)
+	if callbacks < 5 {
+		t.Fatalf("host calls = %d", callbacks)
+	}
+}

--- a/src/wago/managed_entry_context_test.go
+++ b/src/wago/managed_entry_context_test.go
@@ -228,12 +228,18 @@ func TestManagedForkContext(t *testing.T) {
 						t.Errorf("Fork = %v, %v", child, err)
 					}
 					if child != nil {
+						released := make(chan struct{})
+						child.Instance().referenceLifetime().afterPhysicalRelease(func() { close(released) })
 						if child.Instance().currentInvocationID() != 0 {
 							t.Error("start identity leaked")
 						}
 						if err := child.Close(); err != nil {
 							t.Error(err)
 						}
+						if err := child.WaitClosed(); err != nil {
+							t.Error(err)
+						}
+						awaitCloseSignal(t, released)
 					}
 					if after := managedReservations(manager, gate); after != before {
 						t.Errorf("reservations: before=%+v after=%+v", before, after)

--- a/src/wago/managed_entry_context_test.go
+++ b/src/wago/managed_entry_context_test.go
@@ -367,6 +367,8 @@ func TestManagedTableReentryCleanup(t *testing.T) {
 	var lastID invocationID
 	var cancel context.CancelFunc
 	var hostPanic bool
+	var hostTrap bool
+	trapErr := errors.New("managed host trap")
 	var callbacks int
 	owned, err := manager.Instantiate(nil, mod, WithImports(Imports{"env.host": CallerHostFunc(func(caller Caller, _, _ []uint64) {
 		callbacks++
@@ -390,6 +392,9 @@ func TestManagedTableReentryCleanup(t *testing.T) {
 		if hostPanic {
 			panic("host panic")
 		}
+		if hostTrap {
+			panic(HostTrap{Err: trapErr})
+		}
 	})}))
 	if err != nil {
 		t.Fatal(err)
@@ -405,7 +410,9 @@ func TestManagedTableReentryCleanup(t *testing.T) {
 		t.Fatal("trap entry succeeded")
 	}
 	assertManagedEntryClean(t, in, stale)
+	wantCallbacks := 5 // Two normal entries, guest trap, host trap, final entry.
 	if nativeCancellationSupported() {
+		wantCallbacks++
 		ctx, cancelCall := context.WithCancel(context.Background())
 		cancel = cancelCall
 		if err := owned.InvokeVoidTable(ctx, 2); !errors.Is(err, context.Canceled) {
@@ -415,22 +422,36 @@ func TestManagedTableReentryCleanup(t *testing.T) {
 		cancel = nil
 		assertManagedEntryClean(t, in, stale)
 	}
-	hostPanic = true
-	func() {
-		defer func() {
-			if recover() != "host panic" {
-				t.Error("host panic did not propagate")
-			}
-		}()
-		_ = owned.InvokeVoidTable(nil, 0)
-	}()
+	hostTrap = true
+	if err := owned.InvokeVoidTable(nil, 0); !errors.Is(err, trapErr) {
+		t.Fatalf("host trap = %v", err)
+	}
 	assertManagedEntryClean(t, in, stale)
-	hostPanic = false
+	hostTrap = false
+	t.Run("host-panic", func(t *testing.T) {
+		// Match the existing nested host-panic test boundary: TinyGo
+		// cannot unwind this recovered panic when the native bridge rethrows it.
+		if !requireStandardGoTestRuntime(t) {
+			return
+		}
+		wantCallbacks++
+		hostPanic = true
+		func() {
+			defer func() {
+				if recover() != "host panic" {
+					t.Error("host panic did not propagate")
+				}
+			}()
+			_ = owned.InvokeVoidTable(nil, 0)
+		}()
+		assertManagedEntryClean(t, in, stale)
+		hostPanic = false
+	})
 	if err := owned.InvokeVoidTable(nil, 0); err != nil {
 		t.Fatalf("call after failures: %v", err)
 	}
 	assertManagedEntryClean(t, in, stale)
-	if callbacks < 5 {
-		t.Fatalf("host calls = %d", callbacks)
+	if callbacks != wantCallbacks {
+		t.Fatalf("host calls = %d, want %d", callbacks, wantCallbacks)
 	}
 }

--- a/src/wago/managed_entry_context_test.go
+++ b/src/wago/managed_entry_context_test.go
@@ -3,7 +3,9 @@ package wago
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/support/wasmtest"
@@ -55,24 +57,32 @@ func managedStartModule() []byte {
 		wasmtest.Section(2, wasmtest.Vec(
 			append(append(wasmtest.Name("env"), wasmtest.Name("fork")...), 0, 0),
 			append(append(wasmtest.Name("env"), wasmtest.Name("start")...), 0, 1),
+			append(append(wasmtest.Name("env"), wasmtest.Name("resumed")...), 0, 0),
 		)),
 		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0), wasmtest.ULEB(0))),
 		wasmtest.Section(5, wasmtest.Vec([]byte{1, 1, 1})), // one page, bounded maximum
-		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 3))),
-		wasmtest.Section(8, wasmtest.ULEB(2)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 4))),
+		wasmtest.Section(8, wasmtest.ULEB(3)),
 		wasmtest.Section(10, wasmtest.Vec(
-			wasmtest.Code([]byte{0x10, 1, 0x04, 0x40, 0x03, 0x40, 0x0c, 0, 0x0b, 0x0b, 0x0b}),
+			wasmtest.Code([]byte{0x10, 1, 0x04, 0x40, 0x10, 2, 0x03, 0x40, 0x0c, 0, 0x0b, 0x0b, 0x0b}),
 			wasmtest.Code([]byte{0x10, 0, 0x0b}),
 		)),
 	)
 }
 
 func TestManagedForkContext(t *testing.T) {
-	for _, mode := range []string{"canceled", "before-create", "during-start", "after-start", "live", "nil", "mapping-limit"} {
+	modes := []string{"canceled", "before-create", "live", "nil", "mapping-limit"}
+	if nativeCancellationSupported() {
+		modes = append(modes, "during-start", "after-resume", "deadline", "after-start", "after-start-close-panic", "live-cancelable")
+	} else {
+		// TinyGo tasks cannot run native cancellation. Do not call t.Skip:
+		// its incomplete SkipNow both marks failure and continues execution.
+		modes = append(modes, "unsupported-scheduler")
+	}
+	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
-			if mode == "during-start" && !nativeCancellationSupported() {
-				t.Skip("native cancellation requires a concurrent scheduler")
-			}
+			longStart := mode == "during-start" || mode == "after-resume" || mode == "deadline"
+			afterStart := mode == "after-start" || mode == "after-start-close-panic"
 			mappingLimit := uint32(2)
 			if mode == "mapping-limit" {
 				mappingLimit = 1
@@ -80,7 +90,18 @@ func TestManagedForkContext(t *testing.T) {
 			rt := NewRuntime(WithRuntimeConfig(NewRuntimeConfig().WithNativeMemoryMappingLimit(mappingLimit)))
 			manager := newPendingInstanceManager("fork-test", AuthorityScope{MaxInstances: 2, MaxMemoryBytes: 2 * 65536})
 			manager.activate(rt)
-			t.Cleanup(func() { _ = manager.close(); _ = rt.CloseContext(context.Background()) })
+			t.Cleanup(func() {
+				done := make(chan error, 1)
+				go func() { done <- manager.close() }()
+				if err := awaitCloseResult(t, done); err != nil {
+					t.Error(err)
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				if err := rt.CloseContext(ctx); errors.Is(err, context.DeadlineExceeded) {
+					t.Error("runtime cleanup timed out")
+				}
+			})
 			gate := newPluginCallGate("fork-test")
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -88,13 +109,29 @@ func TestManagedForkContext(t *testing.T) {
 				cancel()
 			}
 			var forkCtx context.Context = ctx
-			if mode == "nil" {
+			switch mode {
+			case "nil":
 				forkCtx = nil
+			case "live", "mapping-limit":
+				forkCtx = context.Background()
 			}
 			var parent, partial *Instance
 			var childClosed int
+			var notifications [2]int
+			observeError := func(index int) func(InstantiationErrorEvent) {
+				return func(event InstantiationErrorEvent) {
+					notifications[index]++
+					if !event.reservation.allows(gate) || gate.state.Load() == 0 {
+						t.Error("error observer lost its plugin-operation reservation")
+					}
+					if afterStart && (!errors.Is(event.Err, context.Canceled) || childClosed != 1) {
+						t.Errorf("post-start observer: error=%v close count=%d", event.Err, childClosed)
+					}
+				}
+			}
 			rt.storeHooks(&hookRegistry{
-				operationGates: []*pluginCallGate{gate},
+				operationGates:     []*pluginCallGate{gate},
+				onInstantiateError: []func(InstantiationErrorEvent){observeError(0), observeError(1)},
 				beforeInstantiate: []func(InstantiationRequest) error{func(InstantiationRequest) error {
 					if parent != nil && mode == "before-create" {
 						cancel()
@@ -108,13 +145,16 @@ func TestManagedForkContext(t *testing.T) {
 					return nil
 				}},
 				afterInstantiate: []func(InstantiationEvent){func(InstantiationEvent) {
-					if parent != nil && mode == "after-start" {
+					if parent != nil && afterStart {
 						cancel()
 					}
 				}},
 				afterClose: []func(InstanceCloseEvent){func(event InstanceCloseEvent) {
 					if event.Instance.value == partial {
 						childClosed++
+						if mode == "after-start-close-panic" {
+							panic("partial close")
+						}
 					}
 				}},
 			})
@@ -123,7 +163,8 @@ func TestManagedForkContext(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer mod.Close()
-			started, release := make(chan struct{}), make(chan struct{})
+			started, resumed, release := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			defer close(release)
 			imports := Imports{
 				"env.start": gate.wrapCaller(func(caller Caller, _, out []uint64) {
 					if parent == nil {
@@ -133,24 +174,51 @@ func TestManagedForkContext(t *testing.T) {
 					if caller.invocationID == 0 || !caller.reservation.allows(gate) {
 						t.Error("start lacks invocation identity or reservation")
 					}
-					if mode == "during-start" {
-						if activeHostInvocationContext(caller.in).parent != ctx {
+					if longStart {
+						if activeHostInvocationContext(caller.in).parent != forkCtx {
 							t.Error("start lost its parent context")
 						}
 						close(started)
-						<-release
+						select {
+						case <-release:
+						case <-forkCtx.Done():
+						case <-time.After(10 * time.Second):
+							t.Error("start callback timed out")
+							return
+						}
 						out[0] = 1
 					} else {
 						out[0] = 0
 					}
 				}),
+				"env.resumed": gate.wrapCaller(func(Caller, []uint64, []uint64) {
+					// Guest instructions ran after env.start returned, before
+					// entering this second callback and the native loop.
+					close(resumed)
+				}),
 				"env.fork": gate.wrapCaller(func(caller Caller, _, _ []uint64) {
 					before := managedReservations(manager, gate)
+					if mode == "deadline" {
+						var stop context.CancelFunc
+						forkCtx, stop = context.WithTimeout(context.Background(), 250*time.Millisecond)
+						defer stop()
+					}
 					child, err := manager.Fork(forkCtx, caller)
-					wantCanceled := mode == "canceled" || mode == "before-create" || mode == "during-start" || mode == "after-start"
+					wantCanceled := mode == "canceled" || mode == "before-create" || longStart || afterStart
 					if wantCanceled {
-						if child != nil || !errors.Is(err, context.Canceled) {
-							t.Errorf("Fork = %v, %v; want context.Canceled", child, err)
+						want := context.Canceled
+						if mode == "deadline" {
+							want = context.DeadlineExceeded
+						}
+						if child != nil || !errors.Is(err, want) {
+							t.Errorf("Fork = %v, %v; want %v", child, err, want)
+						}
+						if errors.Is(err, ErrCallbackPanic) != (mode == "after-start-close-panic") {
+							t.Errorf("Fork close error = %v", err)
+						}
+					} else if mode == "unsupported-scheduler" {
+						if child != nil || err == nil || !strings.Contains(err.Error(), "requires a concurrent scheduler") {
+							t.Errorf("Fork = %v, %v; want unsupported scheduler", child, err)
 						}
 					} else if mode == "mapping-limit" {
 						if child != nil || !errors.Is(err, ErrResourceLimit) {
@@ -183,15 +251,51 @@ func TestManagedForkContext(t *testing.T) {
 			}
 			done := make(chan error, 1)
 			go func() { _, err := parent.Invoke("run"); done <- err }()
-			if mode == "during-start" {
-				<-started
+			if longStart {
+				if !awaitManagedStart(t, started, done) {
+					cancel()
+					return
+				}
+				if mode == "during-start" {
+					cancel()
+				} else {
+					// Release the first callback without canceling startup.
+					select {
+					case release <- struct{}{}:
+					case err := <-done:
+						t.Errorf("Fork ended before startup resumed: %v", err)
+						return
+					case <-time.After(10 * time.Second):
+						t.Error("startup release timed out")
+						cancel()
+						return
+					}
+					if !awaitManagedStart(t, resumed, done) {
+						cancel()
+						return
+					}
+					if mode == "after-resume" {
+						cancel()
+					}
+				}
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Error("Fork did not finish")
 				cancel()
-				close(release)
+				return
 			}
-			if err := <-done; err != nil {
-				t.Fatal(err)
+			wantNotifications := 0
+			if mode == "before-create" || longStart || afterStart || mode == "unsupported-scheduler" {
+				wantNotifications = 1
 			}
-			manager.pending.Wait()
+			if notifications != [2]int{wantNotifications, wantNotifications} {
+				t.Errorf("error notifications = %v, want %d per observer", notifications, wantNotifications)
+			}
 			if partial != nil {
 				if childClosed != 1 || partial.referenceLifetime().snapshot().PhysicalResources {
 					t.Fatalf("partial child close count=%d, resources=%+v", childClosed, partial.referenceLifetime().snapshot())
@@ -202,6 +306,19 @@ func TestManagedForkContext(t *testing.T) {
 			}
 		})
 	}
+}
+
+func awaitManagedStart(t *testing.T, started <-chan struct{}, done <-chan error) bool {
+	t.Helper()
+	select {
+	case <-started:
+		return true
+	case err := <-done:
+		t.Errorf("Fork ended before the startup signal: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Error("startup signal timed out")
+	}
+	return false
 }
 
 func assertManagedEntryCleanAfterClose(t *testing.T, in *Instance) {

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -114,6 +114,12 @@ func (m *InstanceManager) Instantiate(ctx context.Context, mod *Module, opts ...
 	if m == nil {
 		return nil, fmt.Errorf("wago: nil instance manager")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	memoryBytes, err := managedMemoryReservation(mod)
 	if err != nil {
 		return nil, fmt.Errorf("wago: plugin %s module memory limits: %v: %w", m.owner, err, ErrPermissionDenied)
@@ -174,6 +180,12 @@ func (m *InstanceManager) adopt(in *Instance, memoryBytes uint64) (*ManagedInsta
 // safe host functions, by-value globals, GC configuration, and runtime policy.
 // Borrowed memories, tables, globals, and cross-instance exports are rejected.
 func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*ManagedInstance, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	parent, err := m.caller(caller)
 	if err != nil {
 		return nil, err
@@ -223,7 +235,7 @@ func (m *InstanceManager) Fork(ctx context.Context, caller HostModule) (*Managed
 	mod, err := buildModule(parent.c, bindings)
 	var child *Instance
 	if err == nil {
-		child, err = rt.instantiateWithHooksOrigin(mod, imports, pluginGCImports, gc, hasGC, false, InstantiateManaged, hooks, operation.reservation, nil)
+		child, err = rt.instantiateWithHooksOrigin(ctx, mod, imports, pluginGCImports, gc, hasGC, parent.syncMode, InstantiateManaged, hooks, operation.reservation)
 	}
 	if err != nil {
 		m.mu.Lock()
@@ -330,6 +342,8 @@ func (m *ManagedInstance) InvokeVoidTable(ctx context.Context, index uint32) err
 		return fmt.Errorf("wago: managed instance invocation: %w", err)
 	}
 	defer in.endInvocation()
+	state := in.lockInvocation(0)
+	defer state.unlockInvocation()
 	if err := validateVoidTableEntry(in, index); err != nil {
 		return err
 	}
@@ -344,33 +358,7 @@ func (m *ManagedInstance) InvokeVoidTable(ctx context.Context, index uint32) err
 		return fmt.Errorf("wago: managed invocation argument buffer is unavailable")
 	}
 	binary.LittleEndian.PutUint64(in.serArgs, uint64(index))
-	if len(in.hostLog) > 0 {
-		binary.LittleEndian.PutUint32(in.hostLog, 0)
-	}
-	if ctx.Done() == nil {
-		// Keep the common non-cancelable path identical to the original dispatch:
-		// Go 1.22 otherwise retains the context through the trap translation call
-		// and adds a heap allocation even though no watcher can ever fire.
-		if in.syncMode {
-			return in.callNativeSync(base)
-		}
-		if err := in.callNativeAsync(base, false); err != nil {
-			return err
-		}
-		return in.replayHostLog()
-	}
-	stopCancel, err := in.startCancellationWatch(ctx, in.trap)
-	if err != nil {
-		return err
-	}
-	defer stopCancel()
-	if in.syncMode {
-		return contextInterruptError(ctx, in.callNativeSyncWithTrapContext(base, in.trap, ctx))
-	}
-	if err := in.callNativeAsync(base, false); err != nil {
-		return contextInterruptError(ctx, err)
-	}
-	return contextInterruptError(ctx, in.replayHostLog())
+	return in.invokeVoidEntry(ctx, base, nil)
 }
 
 func (m *InstanceManager) ensureVoidDispatcher() (uintptr, error) {
@@ -431,12 +419,27 @@ func (m *ManagedInstance) Identity() InstanceIdentity {
 func (m *ManagedInstance) Close() error {
 	in, err := m.closeLogical()
 	if in != nil {
-		state := in.ensurePluginState().close.Load()
-		if state != nil {
-			<-state.quiesced
-		}
+		err = in.waitTerminalClose()
 	}
+	m.releaseOwnership()
 	return err
+}
+
+// Keep an instance in the manager's drain set until its terminal close has
+// completed, including when a concurrent ManagedInstance.Close owns the close.
+func (m *ManagedInstance) releaseOwnership() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	manager := m.manager
+	m.manager = nil
+	m.mu.Unlock()
+	if manager != nil {
+		manager.mu.Lock()
+		delete(manager.instances, m)
+		manager.mu.Unlock()
+	}
 }
 
 func (m *ManagedInstance) closeLogical() (*Instance, error) {
@@ -459,7 +462,7 @@ func (m *ManagedInstance) closeLogical() (*Instance, error) {
 	m.done = make(chan struct{})
 	in, manager, done := m.value, m.manager, m.done
 	m.closedValue = in
-	m.value, m.manager = nil, nil
+	m.value = nil
 	m.memoryBytes = 0
 	m.mu.Unlock()
 	var err error
@@ -468,7 +471,6 @@ func (m *ManagedInstance) closeLogical() (*Instance, error) {
 	}
 	if manager != nil {
 		manager.mu.Lock()
-		delete(manager.instances, m)
 		delete(manager.byInstance, in)
 		manager.mu.Unlock()
 	}
@@ -525,7 +527,7 @@ func (m *InstanceManager) drain() error {
 	list := make([]*Instance, 0, len(owned))
 	for _, managed := range owned {
 		in, err := managed.closeLogical()
-		if err != nil {
+		if err != nil && in == nil {
 			errs = append(errs, err)
 		}
 		if in != nil {
@@ -538,10 +540,12 @@ func (m *InstanceManager) drain() error {
 	m.byInstance = nil
 	m.mu.Unlock()
 	for _, in := range list {
-		state := in.ensurePluginState().close.Load()
-		if state != nil {
-			<-state.quiesced
+		if err := in.waitTerminalClose(); err != nil {
+			errs = append(errs, err)
 		}
+	}
+	for _, managed := range owned {
+		managed.releaseOwnership()
 	}
 	m.mu.Lock()
 	m.draining = nil

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -30,19 +30,19 @@ type InstanceManager struct {
 	dispatchBase uintptr
 	pending      sync.WaitGroup
 	draining     []*Instance
+	drainOnce    sync.Once
+	drainErr     error
 }
 
 // ManagedInstance is one instance whose lifetime is owned by an
-// InstanceManager. Instance exposes the normal call surface; Close releases the
-// ownership record and closes the instance exactly once.
+// InstanceManager. Close initiates logical close; WaitClosed waits for terminal
+// completion. Manager ownership ends automatically at terminal completion.
 type ManagedInstance struct {
 	mu          sync.Mutex
 	manager     *InstanceManager
 	value       *Instance
 	closed      bool
-	done        chan struct{}
 	closedValue *Instance
-	err         error
 	memoryBytes uint64
 }
 
@@ -164,15 +164,21 @@ func managedMemoryReservation(mod *Module) (uint64, error) {
 func (m *InstanceManager) adopt(in *Instance, memoryBytes uint64) (*ManagedInstance, error) {
 	owned := &ManagedInstance{manager: m, value: in, memoryBytes: memoryBytes}
 	in.referenceLifetime().afterPhysicalRelease(func() { m.releaseReservation(memoryBytes) })
+	// Registration and terminal detachment use the same lock order. A child
+	// closed during creation must not acquire an ownership record afterward.
+	in.lifeMu.Lock()
 	m.mu.Lock()
-	if m.closed {
+	if m.closed || in.isLogicallyClosed() {
 		m.mu.Unlock()
+		in.lifeMu.Unlock()
 		closeErr := in.closeAndWait()
-		return nil, joinPrimary(fmt.Errorf("wago: instance manager closed during instantiation"), closeErr)
+		return nil, joinPrimary(fmt.Errorf("wago: instance or manager closed during instantiation"), closeErr)
 	}
 	m.instances[owned] = struct{}{}
 	m.byInstance[in] = owned
+	in.finalizers.managed = owned
 	m.mu.Unlock()
+	in.lifeMu.Unlock()
 	return owned, nil
 }
 
@@ -416,49 +422,50 @@ func (m *ManagedInstance) Identity() InstanceIdentity {
 	return InstanceIdentity{value: m.Instance()}
 }
 
-// Close closes the instance and waits for all terminal close hooks. It must not
-// be called from a lifecycle callback whose completion it waits for; use
-// CloseLogical from those callbacks. Retained references may delay resource release.
+// Close initiates logical close without waiting for active invocations or
+// terminal close hooks. The first call runs BeforeClose synchronously and
+// returns its logical-close error. Repeated calls, including calls from
+// BeforeClose and AfterClose, join the same operation without waiting for it.
+// Manager ownership is removed automatically at terminal completion.
 func (m *ManagedInstance) Close() error {
-	in, err := m.closeLogical()
-	if m != nil {
-		m.mu.Lock()
-		done := m.done
-		m.mu.Unlock()
-		// A concurrent logical closer may not yet have called Instance.Close.
-		<-done
-	}
-	if in != nil {
-		err = in.waitTerminalClose()
-	}
-	m.releaseOwnership()
-	return err
-}
-
-// CloseLogical closes admission without waiting for active invocations or an
-// ongoing close callback. It is safe to call again from BeforeClose or AfterClose
-// on the same instance. The first call can run hooks synchronously. Use Close
-// outside those callbacks to wait for terminal completion and receive hook errors.
-func (m *ManagedInstance) CloseLogical() error {
 	_, err := m.closeLogical()
 	return err
 }
 
-// Keep an instance in the manager's drain set until its terminal close has
-// completed, including when a concurrent ManagedInstance.Close owns the close.
-func (m *ManagedInstance) releaseOwnership() {
-	if m == nil {
-		return
+// WaitClosed initiates close if necessary, then waits until logical close,
+// admitted invocations, and terminal close hooks are complete. It returns the
+// joined logical and terminal errors, without waiting for retained references
+// to release physical resources. Do not call it from a close callback on the
+// same instance: that callback is part of the completion condition.
+func (m *ManagedInstance) WaitClosed() error {
+	in, err := m.closeLogical()
+	if in != nil {
+		return in.waitTerminalClose()
 	}
+	return err
+}
+
+// Called exactly once by the instance's terminal finalizer, with lifeMu held.
+// Publish completion under the manager lock so drain cannot miss a record
+// whose terminal work is still in progress. No plugin hooks run under locks.
+func (m *ManagedInstance) finishTerminalClose(state *instanceCloseState) {
 	m.mu.Lock()
 	manager := m.manager
 	m.manager = nil
-	m.mu.Unlock()
+	if !m.closed {
+		m.closed, m.closedValue, m.value = true, m.value, nil
+		m.memoryBytes = 0
+	}
 	if manager != nil {
 		manager.mu.Lock()
 		delete(manager.instances, m)
+		delete(manager.byInstance, m.closedValue)
+		close(state.terminalDone)
 		manager.mu.Unlock()
+	} else {
+		close(state.terminalDone)
 	}
+	m.mu.Unlock()
 }
 
 func (m *ManagedInstance) closeLogical() (*Instance, error) {
@@ -466,32 +473,23 @@ func (m *ManagedInstance) closeLogical() (*Instance, error) {
 		return nil, nil
 	}
 	m.mu.Lock()
-	if m.closed {
-		in, err := m.closedValue, m.err
-		m.mu.Unlock()
-		return in, err
+	if !m.closed {
+		m.closed, m.closedValue, m.value = true, m.value, nil
+		m.memoryBytes = 0
 	}
-	m.closed = true
-	m.done = make(chan struct{})
-	in, manager, done := m.value, m.manager, m.done
-	m.closedValue = in
-	m.value = nil
-	m.memoryBytes = 0
+	in, manager := m.closedValue, m.manager
 	m.mu.Unlock()
-	var err error
-	if in != nil {
-		err = in.Close()
-	}
 	if manager != nil {
 		manager.mu.Lock()
 		delete(manager.byInstance, in)
 		manager.mu.Unlock()
 	}
-	m.mu.Lock()
-	m.err = err
-	close(done)
-	m.mu.Unlock()
-	return in, err
+	// Instance.Close owns preparation and its result. Calling it even when
+	// another managed caller won admission avoids a second publication barrier.
+	if in != nil {
+		return in, in.Close()
+	}
+	return nil, nil
 }
 
 func (m *InstanceManager) releaseReservation(memoryBytes uint64) {
@@ -526,6 +524,11 @@ func (m *InstanceManager) drain() error {
 	if m == nil {
 		return nil
 	}
+	m.drainOnce.Do(func() { m.drainErr = m.drainInstances() })
+	return m.drainErr
+}
+
+func (m *InstanceManager) drainInstances() error {
 	// closed was published under m.mu before this wait, so no later pending.Add
 	// can race the Wait. In-flight creators either fail or close their partial
 	// instance in adopt before signaling Done.
@@ -538,15 +541,13 @@ func (m *InstanceManager) drain() error {
 	m.mu.Unlock()
 	var errs []error
 	for _, managed := range owned {
-		_ = managed.CloseLogical()
+		_ = managed.Close()
 	}
 	m.mu.Lock()
 	list := m.draining
-	m.instances = nil
-	m.byInstance = nil
 	m.mu.Unlock()
 	for _, managed := range owned {
-		if err := managed.Close(); err != nil {
+		if err := managed.WaitClosed(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -416,12 +416,31 @@ func (m *ManagedInstance) Identity() InstanceIdentity {
 	return InstanceIdentity{value: m.Instance()}
 }
 
+// Close closes the instance and waits for all terminal close hooks. It must not
+// be called from a lifecycle callback whose completion it waits for; use
+// CloseLogical from those callbacks. Retained references may delay resource release.
 func (m *ManagedInstance) Close() error {
 	in, err := m.closeLogical()
+	if m != nil {
+		m.mu.Lock()
+		done := m.done
+		m.mu.Unlock()
+		// A concurrent logical closer may not yet have called Instance.Close.
+		<-done
+	}
 	if in != nil {
 		err = in.waitTerminalClose()
 	}
 	m.releaseOwnership()
+	return err
+}
+
+// CloseLogical closes admission without waiting for active invocations or an
+// ongoing close callback. It is safe to call again from BeforeClose or AfterClose
+// on the same instance. The first call can run hooks synchronously. Use Close
+// outside those callbacks to wait for terminal completion and receive hook errors.
+func (m *ManagedInstance) CloseLogical() error {
+	_, err := m.closeLogical()
 	return err
 }
 
@@ -448,12 +467,6 @@ func (m *ManagedInstance) closeLogical() (*Instance, error) {
 	}
 	m.mu.Lock()
 	if m.closed {
-		done := m.done
-		m.mu.Unlock()
-		if done != nil {
-			<-done
-		}
-		m.mu.Lock()
 		in, err := m.closedValue, m.err
 		m.mu.Unlock()
 		return in, err
@@ -524,28 +537,23 @@ func (m *InstanceManager) drain() error {
 	}
 	m.mu.Unlock()
 	var errs []error
-	list := make([]*Instance, 0, len(owned))
 	for _, managed := range owned {
-		in, err := managed.closeLogical()
-		if err != nil && in == nil {
-			errs = append(errs, err)
-		}
-		if in != nil {
-			list = append(list, in)
-		}
+		_ = managed.CloseLogical()
 	}
 	m.mu.Lock()
-	list = append(list, m.draining...)
+	list := m.draining
 	m.instances = nil
 	m.byInstance = nil
 	m.mu.Unlock()
+	for _, managed := range owned {
+		if err := managed.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	for _, in := range list {
 		if err := in.waitTerminalClose(); err != nil {
 			errs = append(errs, err)
 		}
-	}
-	for _, managed := range owned {
-		managed.releaseOwnership()
 	}
 	m.mu.Lock()
 	m.draining = nil

--- a/src/wago/reference_lifetime.go
+++ b/src/wago/reference_lifetime.go
@@ -2,6 +2,13 @@ package wago
 
 import "sync"
 
+// Only instances with managed ownership or physical-release callbacks need
+// this state. Terminal detachment and physical release remain separate phases.
+type instanceFinalizers struct {
+	managed  *ManagedInstance
+	physical func()
+}
+
 // referenceLifetimeEvent is the complete interface between instance lifecycle
 // and reference-store accounting. Events are idempotent and may arrive in any
 // order; the store releases tokens only after the required state converges.
@@ -56,14 +63,14 @@ func (lifetime referenceLifetime) finalize() {
 		return
 	}
 	in.resourcesClosed = true
-	finalizer := in.physicalFinalizer
-	in.physicalFinalizer = nil
+	finalizers := in.finalizers
+	in.finalizers = nil
 	in.lifeMu.Unlock()
 
 	lifetime.notifyStore(store, referenceLifetimeResourcesReleased)
 	in.releaseResources()
-	if finalizer != nil {
-		finalizer()
+	if finalizers != nil && finalizers.physical != nil {
+		finalizers.physical()
 	}
 }
 
@@ -78,11 +85,14 @@ func (lifetime referenceLifetime) afterPhysicalRelease(fn func()) {
 		fn()
 		return
 	}
-	if in.physicalFinalizer == nil {
-		in.physicalFinalizer = fn
+	if in.finalizers == nil {
+		in.finalizers = &instanceFinalizers{}
+	}
+	if in.finalizers.physical == nil {
+		in.finalizers.physical = fn
 	} else {
-		previous := in.physicalFinalizer
-		in.physicalFinalizer = func() {
+		previous := in.finalizers.physical
+		in.finalizers.physical = func() {
 			previous()
 			fn()
 		}

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -1124,6 +1124,7 @@ func (rt *Runtime) instantiateWithHooksOrigin(ctx context.Context, mod *Module, 
 	if err == nil && ctx.Err() != nil {
 		err = joinPrimary(ctx.Err(), in.closeAndWait())
 		in = nil
+		err = emitInstantiationError(hooks, InstantiationRequest{Module: moduleView(mod), Origin: origin, reservation: reservation}, err)
 	}
 	return in, err
 }
@@ -1136,16 +1137,7 @@ func (rt *Runtime) instantiateWithHooksOrigin(ctx context.Context, mod *Module, 
 func instantiateWithLifecycleHooks(mod *Module, iopts InstantiateOptions, origin InstantiateOrigin, hooks *hookRegistry, reservation *pluginOperationReservation) (*Instance, error) {
 	request := InstantiationRequest{Module: moduleView(mod), Origin: origin, reservation: reservation}
 	emitError := func(original error) error {
-		var hookErrs []error
-		for _, fn := range hooks.onInstantiateError {
-			observer := fn
-			if panicErr := callHookSafely("OnInstantiateError", func() {
-				observer(InstantiationErrorEvent{Module: request.Module, Origin: origin, Err: original, reservation: reservation})
-			}); panicErr != nil {
-				hookErrs = append(hookErrs, panicErr)
-			}
-		}
-		return joinPrimary(original, hookErrs...)
+		return emitInstantiationError(hooks, request, original)
 	}
 
 	for _, fn := range hooks.beforeInstantiate {
@@ -1181,6 +1173,21 @@ func instantiateWithLifecycleHooks(mod *Module, iopts InstantiateOptions, origin
 		}
 	}
 	return inst, nil
+}
+
+// The caller retains the plugin-operation reservation through every observer,
+// including when cancellation is first detected after AfterInstantiate.
+func emitInstantiationError(hooks *hookRegistry, request InstantiationRequest, original error) error {
+	var hookErrs []error
+	for _, fn := range hooks.onInstantiateError {
+		observer := fn
+		if panicErr := callHookSafely("OnInstantiateError", func() {
+			observer(InstantiationErrorEvent{Module: request.Module, Origin: request.Origin, Err: original, reservation: request.reservation})
+		}); panicErr != nil {
+			hookErrs = append(hookErrs, panicErr)
+		}
+	}
+	return joinPrimary(original, hookErrs...)
 }
 
 func instantiateCoreWithModuleUse(mod *Module, opts InstantiateOptions) (*Instance, error) {

--- a/src/wago/runtime.go
+++ b/src/wago/runtime.go
@@ -923,16 +923,6 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	if err := applyPolicy(mod, cfg.policy); err != nil {
 		return nil, err
 	}
-	reservation, err := rt.reserveRuntimeInstance(mod, origin)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if reservation != nil && !reservation.registered.Load() {
-			reservation.release()
-		}
-	}()
-
 	imports, pluginGCImports, err := rt.resolveInstanceImports(mod.imports, mod.importIdentities, cfg.imports, cfg.exactImports, cfg.extraImports...)
 	if err != nil {
 		return nil, err
@@ -946,7 +936,7 @@ func (rt *Runtime) instantiateOrigin(ctx context.Context, mod *Module, origin In
 	// retained code ownership before start-time host callbacks.
 	mod.endUse()
 	usingModule = false
-	in, err := rt.instantiateWithHooksOrigin(mod, imports, pluginGCImports, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks, operation.reservation, reservation)
+	in, err := rt.instantiateWithHooksOrigin(ctx, mod, imports, pluginGCImports, cfg.gc, cfg.hasGC, cfg.forceSyncHost, origin, hooks, operation.reservation)
 	if err == nil && rt.isClosed() {
 		err = joinPrimary(fmt.Errorf("wago: runtime closed during instantiation"), in.Close())
 		in = nil
@@ -1085,8 +1075,28 @@ func applyInstantiateOptions(opts []InstantiateOption) instantiateConfig {
 
 // instantiateWithHooksOrigin runs the Runtime-aware instantiation path and emits
 // plugin lifecycle callbacks around the low-level instantiator.
-func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, pluginGCImports map[uint32]struct{}, gc GCConfig, hasGC, forceSyncHost bool, origin InstantiateOrigin, hooks *hookRegistry, reservation *pluginOperationReservation, runtimeReservation *runtimeInstanceReservation) (*Instance, error) {
+func (rt *Runtime) instantiateWithHooksOrigin(ctx context.Context, mod *Module, imports Imports, pluginGCImports map[uint32]struct{}, gc GCConfig, hasGC, forceSyncHost bool, origin InstantiateOrigin, hooks *hookRegistry, reservation *pluginOperationReservation) (*Instance, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !mod.beginUse() {
+		return nil, fmt.Errorf("wago: Instantiate: module is closed")
+	}
+	runtimeReservation, err := rt.reserveRuntimeInstance(mod, origin)
+	mod.endUse()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if runtimeReservation != nil && !runtimeReservation.registered.Load() {
+			runtimeReservation.release()
+		}
+	}()
 	iopts := InstantiateOptions{
+		startContext:             ctx,
 		MaxCompiledMetadataBytes: rt.cfg.maxCompiledMetadataBytes,
 		Imports:                  imports, ownedImports: true, store: rt.refStore, runtime: rt, origin: origin, pluginGCImports: pluginGCImports,
 		forceSyncHost:            forceSyncHost || rt.callerResolverActive.Load(),
@@ -1105,10 +1115,17 @@ func (rt *Runtime) instantiateWithHooksOrigin(mod *Module, imports Imports, plug
 	}
 
 	// Keep the no-lifecycle-hook path allocation-free.
+	var in *Instance
 	if len(hooks.beforeInstantiate) == 0 && len(hooks.afterCreate) == 0 && len(hooks.afterInstantiate) == 0 && len(hooks.onInstantiateError) == 0 {
-		return instantiateCoreWithModuleUse(mod, iopts)
+		in, err = instantiateCoreWithModuleUse(mod, iopts)
+	} else {
+		in, err = instantiateWithLifecycleHooks(mod, iopts, origin, hooks, reservation)
 	}
-	return instantiateWithLifecycleHooks(mod, iopts, origin, hooks, reservation)
+	if err == nil && ctx.Err() != nil {
+		err = joinPrimary(ctx.Err(), in.closeAndWait())
+		in = nil
+	}
+	return in, err
 }
 
 // instantiateWithLifecycleHooks is kept separate from the ordinary no-hook
@@ -1437,13 +1454,8 @@ func (rt *Runtime) finishClose(ctx context.Context, state *runtimeCloseState, ho
 	}
 	rt.mu.Unlock()
 	for i := len(instances) - 1; i >= 0; i-- {
-		closeState := instances[i].ensurePluginState().close.Load()
-		if closeState != nil {
-			<-closeState.done
-			<-closeState.quiesced
-			if err := joinPrimary(closeState.result, closeState.terminalResult); err != nil {
-				errs = append(errs, err)
-			}
+		if err := instances[i].waitTerminalClose(); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	for i := len(internalClose) - 1; i >= 0; i-- {


### PR DESCRIPTION
Close could run or skip terminal hooks before preparation finished, and shutdown waiters could return before hook results were available. Managed table calls also lacked the invocation state required for host re-entry, while Fork discarded its context during child startup.

This single PR fixes all four issues with shared lifecycle, entry, and creation helpers. It preserves prompt logical Instance.Close and allows retained references to delay physical release.

| Issue | Root cause and fix |
| --- | --- |
| #609 | Terminal finalization had no preparation barrier. Publish completion of all internal and public BeforeClose hooks before terminal hooks can claim execution. Retry finalization after publication. |
| #610 | Invocation quiescence also served as terminal completion. Add a separate terminal signal, store terminalResult first, and share terminal waiting across instance, manager, and Runtime shutdown. |
| #611 | InvokeVoidTable bypassed public invocation serialization and identity setup. Share that setup with Invoke, Call, and local start; retain GC, native execution, context, reservation, and deferred cleanup rules. |
| #612 | Fork bypassed context-aware startup and Runtime native-memory reservations. Pass its context through the shared instantiation path and use the existing native cancellation watcher. Reject already-canceled contexts before manager capacity is reserved. |

The same review found that manager drain could miss an instance already removed by a concurrent managed close. Keep that instance in the manager's ownership set until terminal completion. Terminal finalization uses a nonblocking claim so an AfterClose hook can release a retained reference without waiting on itself.

Managed close now has one public close operation and an explicit terminal wait:

- `ManagedInstance.Close()` performs logical close. It runs initial BeforeClose preparation synchronously, returns its logical error, and never waits for active invocations or AfterClose. Repeated calls from BeforeClose and AfterClose are safe.
- `ManagedInstance.WaitClosed()` initiates close if needed and waits for logical preparation, admitted invocations, and terminal hooks. It returns the joined logical and terminal errors. It must not be called from a close callback on the same instance.
- There is no public `CloseLogical()` method. Terminal completion automatically removes both manager indexes and clears wrapper ownership, without requiring another call or waiting for retained physical resources. The closed handle retains its result for repeated waits.
- Existing terminal finalization performs ownership cleanup. Only managed instances with terminal hooks need a short-lived terminal worker, so Close does not block on those hooks; there is no permanent per-instance cleanup goroutine. Concurrent drains share one completion result. Physical-release accounting remains separate, and instance/plugin-state size checks remain unchanged.

Files changed:

- Lifecycle and terminal waiters: `instance_lifecycle.go`, `hostcall.go`, `managed_instances.go`, `runtime.go`, `instance.go`, `reference_lifetime.go`.
- Shared entry and startup: `instance_entry.go`, `api.go`, `instance_call.go`, `instantiate.go`.
- Regression tests: `instance_close_completion_test.go`, `managed_entry_context_test.go`, `managed_close_test.go`.
- API guidance: `examples/17-managed-instances/main.go`.

Regression coverage uses channels, with no sleeps for ordering:

- Internal/public close preparation, unpublished hook data, BeforeClose panic, construction, exactly-once terminal hooks, callback re-entry, retained resources, and AfterClose panic.
- Instance and managed terminal waiters, including manager drain after logical managed close.
- Callback-safe managed Close; external WaitClosed; joined/repeated error results; retained references; automatic ownership removal without WaitClosed across repeated MaxInstances=1 cycles; concurrent managed/manager/Runtime shutdown; rejection of adoption after creation hooks close the instance.
- Managed table -> CallerHostFunc -> InvokeFromHost -> nested export; expired and unrelated callers; fresh identities; normal, trap, cancellation, and host-panic cleanup.
- Fork with canceled, live, and nil contexts; cancellation before creation, during local start, and after startup; native mapping limits; exact manager, memory, Runtime, and plugin reservation counts.

Review follow-up:

- Select Fork test modes before running subtests. TinyGo 0.41.1's incomplete `SkipNow` both marks a failure and continues execution, so adding a return alone is not enough. Tasks runs nil/background, already-canceled, before-create, mapping-limit, and explicit unsupported-scheduler coverage. Native cancellation cases run only on supported schedulers.
- Share error notification with post-start cancellation. Close the partial instance first, preserve the context error and close errors, and keep the operation reservation through every observer. Two observers each receive exactly one notification, including when partial close panics; earlier failures are not notified twice.
- Use callback-safe `ManagedInstance.Close` and explicit `ManagedInstance.WaitClosed`. Manager drain uses the same terminal waiting path. No hook-running shortcut changes external wait semantics.
- Bound startup signals, worker completion, hook waits, and test cleanup. Add cancellation after guest startup resumes and a deadline-expiry case. Standard Go tests observe the blocked terminal receive through goroutine snapshots; TinyGo tasks uses its cooperative scheduler. No test probes or allocations were added to production waiting or invocation paths.
- Full TinyGo validation exposed the existing panic-rethrow limit in the new table test. A stack trace showed the runtime stuck rethrowing a recovered host panic. Only that phase now uses the same standard-Go boundary as `TestNestedHostPanicDoesNotCorruptRuntime`; normal re-entry, guest traps, handled host traps, stale-token rejection, and exact cleanup remain tested on TinyGo. Production panic behavior is unchanged.

Validation of the review changes:

- `go test ./src/wago`: pass (7.439 seconds).
- `go test -race ./src/wago`: pass (256.368 seconds), with no race reports on final source `ce87a5744`.
- Focused regression tests: 50 normal runs (14.152 seconds) and 10 race runs (5.401 seconds) passed. Automatic ownership tests, including retained resources without WaitClosed, also passed 50 race runs. Close/terminal tests passed another 10 race runs each with `-cpu=1,2,8` (3.576 seconds).
- `go test -tags wago_guardpage ./src/wago`: pass (3.230 seconds).
- `go test ./...`: all packages passed with Go 1.22.12 and CI's TinyGo 0.41.1, including the standalone TinyGo tests. The earlier duplicate-symbol failures with local TinyGo 0.42 do not occur with the CI version.
- TinyGo 0.41.1 tasks full runtime/API tests passed locally on final source (0.037 seconds / 2.555 seconds). Earlier review validation also passed focused lifecycle/Fork/table tests, CLI build, CLI smoke, and ten optimized-release smoke runs.
- All jobs in final-source [CI run 34651433558](https://github.com/wago-org/wago/actions/runs/34651433558) passed on `ce87a5744`. This includes TinyGo Linux amd64/arm64 and Darwin amd64/arm64, runtime/API tests on supported TinyGo targets, CLI/release smoke tests, Go amd64/arm64 platform gates, the race detector, concurrency, conformance, lint, and size checks. No checks remain pending.
- Existing background InvokeVoidTable allocation test remains at zero steady-state allocations.

Conformance tests use the repository's verified WABT 1.0.41 and pinned Release 3 interpreter. Temporary TinyGo builds use `GOFLAGS=-buildvcs=false` because this environment otherwise fails VCS stamping.

The startup-context work on `codex/pr522-update` was inspected. This change uses the cancellation support already on main; #522's broader work on cancelable lock waits remains separate. It does not force cancellation of arbitrary Go host callbacks. Terminal wait methods must not be called from the callbacks they wait for; Instance.Close and ManagedInstance.Close are the reentrant paths.

Fixes #609
Fixes #610
Fixes #611
Fixes #612
