### PR TITLE
wago: add portable host callbacks and optimize wide host calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,20 @@ The example compiles a module, creates an instance, and calls an exported
 function. See [Embed Wago in Go](https://docs.wago.sh/guides/embed-wago) for the
 complete guide.
 
-Capability-free synchronous imports have direct typed lanes for `() -> ()`,
-`(i32) -> ()`, `(i32) -> i32`, `(i32, i32) -> ()`, `(i32, i32) -> i32`,
-`(i32) -> (i32, i32)`, and `(i32, i32) -> (i32, i32)`. Their public Go types
-follow the signature, such as `I32HostFunc` and `I32I32ToI32I32HostFunc`.
+Register synchronous imports with ordinary Go functions. Wago infers supported
+hot signatures once and dispatches them without reflection or allocation:
+
+```go
+module.Func("add", func(a, b int32) int32 { return a + b })
+module.Func("hypot", func(a, b float64) float64 { return math.Hypot(a, b) })
+```
+
+For arbitrary arity, mixed types, `v128`, or references, use the same `Func`
+method with `func(wago.HostCall)`. The call is a borrowed logical view and
+supports every core Wasm value category under both Go and TinyGo. Eligible wide
+scalar signatures use the parked argument/result slots directly.
+High-arity adapters can process the borrowed raw ABI slices directly with
+`ParamSlots()` and `ResultSlots()`; `v128` occupies two consecutive slots.
 
 For high-frequency one-way `(i32) -> ()` imports, `wago.I32HostEvent` avoids a
 Go stack transition for every call. Events are delivered in order after the

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ go run github.com/wago-org/wago/examples/02-runtime-typed@latest
 ```
 
 The example compiles a module, creates an instance, and invokes an exported
-function with `wago.I32`, `wago.I64`, `wago.F32`, and `wago.F64` slot encodings;
-`wago.V128` represents vector values and occupies two slots. See
+function with `wago.I32`, `wago.I64`, `wago.F32`, and `wago.F64` slot encodings.
+See
 [Embed Wago in Go](https://docs.wago.sh/guides/embed-wago) for the complete guide.
 
 Register synchronous imports with ordinary Go functions. Wago infers supported
@@ -121,12 +121,12 @@ module.Func("add", func(a, b int32) int32 { return a + b })
 module.Func("hypot", func(a, b float64) float64 { return math.Hypot(a, b) })
 ```
 
-For arbitrary arity, mixed types, `v128`, or references, use the same `Func`
-method with `func(wago.HostCall)`. The call is a borrowed logical view and
-supports every core Wasm value category under both Go and TinyGo. Eligible wide
-scalar signatures use the parked argument/result slots directly.
-High-arity adapters can process the borrowed raw ABI slices directly with
-`ParamSlots()` and `ResultSlots()`; `v128` occupies two consecutive slots.
+For arbitrary arity, mixed scalar types, or references, use the same `Func`
+method with `func(wago.HostCall)`. The call is a borrowed logical view supported
+under both Go and TinyGo. Eligible wide scalar signatures use the parked
+argument/result slots directly. High-arity adapters can process the borrowed raw
+ABI slices directly with `ParamSlots()` and `ResultSlots()`. V128 values are
+intentionally unsupported at host callback boundaries for now.
 
 For high-frequency one-way `(i32) -> ()` imports, `wago.I32HostEvent` avoids a
 Go stack transition for every call. Events are delivered in order after the

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ The example compiles a module, creates an instance, and calls an exported
 function. See [Embed Wago in Go](https://docs.wago.sh/guides/embed-wago) for the
 complete guide.
 
+For high-frequency one-way `(i32) -> ()` imports, `wago.I32HostEvent` avoids a
+Go stack transition for every call. Events are delivered in order after the
+native invocation returns. This is an explicit deferred contract; use a normal
+host function when Wasm must observe the callback's effects immediately.
+
 ## Performance
 
 [**View the benchmarks →**](https://wago.sh/#performance)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ The example compiles a module, creates an instance, and calls an exported
 function. See [Embed Wago in Go](https://docs.wago.sh/guides/embed-wago) for the
 complete guide.
 
+Capability-free synchronous imports have direct typed lanes for `() -> ()`,
+`(i32) -> ()`, `(i32) -> i32`, `(i32, i32) -> ()`, `(i32, i32) -> i32`,
+`(i32) -> (i32, i32)`, and `(i32, i32) -> (i32, i32)`. Their public Go types
+follow the signature, such as `I32HostFunc` and `I32I32ToI32I32HostFunc`.
+
 For high-frequency one-way `(i32) -> ()` imports, `wago.I32HostEvent` avoids a
 Go stack transition for every call. Events are delivered in order after the
 native invocation returns. This is an explicit deferred contract; use a normal

--- a/README.md
+++ b/README.md
@@ -102,15 +102,16 @@ Add Wago to your module:
 go get github.com/wago-org/wago
 ```
 
-Run the typed API example:
+Run the Go API example:
 
 ```sh
 go run github.com/wago-org/wago/examples/02-runtime-typed@latest
 ```
 
-The example compiles a module, creates an instance, and calls an exported
-function. See [Embed Wago in Go](https://docs.wago.sh/guides/embed-wago) for the
-complete guide.
+The example compiles a module, creates an instance, and invokes an exported
+function with `wago.I32`, `wago.I64`, `wago.F32`, `wago.F64`, and `wago.V128`
+value encodings. See [Embed Wago in Go](https://docs.wago.sh/guides/embed-wago)
+for the complete guide.
 
 Register synchronous imports with ordinary Go functions. Wago infers supported
 hot signatures once and dispatches them without reflection or allocation:

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ go run github.com/wago-org/wago/examples/02-runtime-typed@latest
 ```
 
 The example compiles a module, creates an instance, and invokes an exported
-function with `wago.I32`, `wago.I64`, `wago.F32`, `wago.F64`, and `wago.V128`
-value encodings. See [Embed Wago in Go](https://docs.wago.sh/guides/embed-wago)
-for the complete guide.
+function with `wago.I32`, `wago.I64`, `wago.F32`, and `wago.F64` slot encodings;
+`wago.V128` represents vector values and occupies two slots. See
+[Embed Wago in Go](https://docs.wago.sh/guides/embed-wago) for the complete guide.
 
 Register synchronous imports with ordinary Go functions. Wago infers supported
 hot signatures once and dispatches them without reflection or allocation:

--- a/bench/cmd/benchpub/main.go
+++ b/bench/cmd/benchpub/main.go
@@ -27,7 +27,7 @@ import (
 // suiteRegex selects the wago stage suite plus the cross-engine wazero
 // benchmarks (compare_test.go). The fixed wago-vs-wazero set in bench_test.go is
 // excluded — these fan out over the same corpus as the wago stages.
-const suiteRegex = `^(BenchmarkDecode|BenchmarkValidate|BenchmarkCompile|BenchmarkCompileFull|BenchmarkInstantiate|BenchmarkExec|BenchmarkCommandExec|BenchmarkWazeroCompile|BenchmarkWazeroInstantiate|BenchmarkWazeroExec|BenchmarkWazeroCommandExec|BenchmarkExecCallOverhead_(wago|wazero)|BenchmarkExecHostCallback_wago|BenchmarkExecHostRoundtrip_(wago|wazero))$`
+const suiteRegex = `^(BenchmarkDecode|BenchmarkValidate|BenchmarkCompile|BenchmarkCompileFull|BenchmarkInstantiate|BenchmarkExec|BenchmarkCommandExec|BenchmarkWazeroCompile|BenchmarkWazeroInstantiate|BenchmarkWazeroExec|BenchmarkWazeroCommandExec|BenchmarkExecCallOverhead_(wago|wazero)|BenchmarkExecTypedCall_wago|BenchmarkExecHostCallback_wago|BenchmarkExecHostRoundtrip_(wago|wazero))$`
 
 // stampPath (bench-relative — benchpub runs with cwd=bench/) records the commit
 // the last published/charted numbers reflect and the wall-clock time benchpub

--- a/bench/cmd/benchpub/main_test.go
+++ b/bench/cmd/benchpub/main_test.go
@@ -10,6 +10,7 @@ func TestSuiteRegexIncludesPublishedBoundaryBenchmarks(t *testing.T) {
 	for _, name := range []string{
 		"BenchmarkExecCallOverhead_wago",
 		"BenchmarkExecCallOverhead_wazero",
+		"BenchmarkExecTypedCall_wago",
 		"BenchmarkExecHostCallback_wago",
 		"BenchmarkExecHostRoundtrip_wago",
 		"BenchmarkExecHostRoundtrip_wazero",

--- a/bench/suite/bench_test.go
+++ b/bench/suite/bench_test.go
@@ -234,6 +234,42 @@ func BenchmarkExecCallOverhead_wazero(b *testing.B) {
 	}
 }
 
+// BenchmarkExecTypedCall_wago measures the public specialized (i32) -> i32
+// entry path. Setup resolves the export and verifies its signature once; the
+// timed loop uses PreparedI32ToI32 rather than the arbitrary-slot Invoke API.
+func BenchmarkExecTypedCall_wago(b *testing.B) {
+	c, err := wago.Compile(nil, fibWasm)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer c.Close()
+	in, err := wago.Instantiate(c, wago.InstantiateOptions{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareI32ToI32("fib")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if got, err := fn.Call(1); err != nil || got != 1 {
+		b.Fatalf("fib(1) = %d, %v; want 1", got, err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var got int32
+	for i := 0; i < b.N; i++ {
+		got, err = fn.Call(1)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	if got != 1 {
+		b.Fatalf("fib(1) = %d, want 1", got)
+	}
+}
+
 // BenchmarkExecHostRoundtrip measures one full wasm -> host -> wasm roundtrip:
 // the guest calls a value-returning host import (env.host) once and returns its
 // result. wago routes this through its synchronous host-call trampoline (the

--- a/docs/host-caller-performance.md
+++ b/docs/host-caller-performance.md
@@ -654,8 +654,9 @@ Wago classifies ordinary functions with a concrete type switch and validates the
 inferred signature once. It does not use `reflect`, `reflect.Value.Call`, or a
 callback-time adapter allocation. The direct catalog includes the established
 zero-to-two-`i32` matrix plus unary and binary same-type `i64`, `f32`, and `f64`
-results. Unary `V128`, `FuncRef`, `ExternRef`, `ExnRef`, `GCRef`, and `I31Ref`
-forms are also accepted without signature names.
+results. Unary `FuncRef`, `ExternRef`, `ExnRef`, `GCRef`, and `I31Ref` forms are
+also accepted without signature names. V128 host callbacks are intentionally
+unsupported for now.
 
 No finite portable Go type switch can recognize arbitrary function arity. TinyGo
 0.41.1 also does not implement `reflect.Type.NumIn`, so complete coverage uses a
@@ -663,24 +664,21 @@ single explicit borrowed view:
 
 ```go
 module.Func("transform", func(call wago.HostCall) {
-    vector := call.V128(0)
-    object := call.ExternRef(1)
-    count := call.I64(2)
+    object := call.ExternRef(0)
+    count := call.I64(1)
 
-    call.SetV128(0, vector)
-    call.SetExternRef(1, object)
-    call.SetI64(2, count+1)
+    call.SetExternRef(0, object)
+    call.SetI64(1, count+1)
 }).
-    Params(wago.ValV128, wago.ValExternRef, wago.ValI64).
-    Results(wago.ValV128, wago.ValExternRef, wago.ValI64)
+    Params(wago.ValExternRef, wago.ValI64).
+    Results(wago.ValExternRef, wago.ValI64)
 ```
 
-`HostCall` indexes logical Wasm values, so `v128` is one index despite occupying
-two native slots. It exposes exact `ValueTypeDescriptor` metadata, typed accessors
-for every current core value category, and raw low/high access for future value
-types. High-arity codecs and adapters can use `ParamSlots()` and `ResultSlots()`
-to process the borrowed raw ABI buffers linearly; `v128` occupies two adjacent
-slots in that view. Its storage is valid only during the callback. The implementation passes
+`HostCall` indexes logical Wasm values. It exposes exact `ValueTypeDescriptor`
+metadata, typed scalar/reference accessors, and raw access for future value types.
+High-arity codecs and adapters can use `ParamSlots()` and `ResultSlots()` to
+process the borrowed raw ABI buffers linearly. Its storage is valid only during
+the callback. The implementation passes
 the view by value over the existing parked argument/result buffers; the tested
 dispatch path allocates zero bytes under both Go and TinyGo.
 Non-null exception references remain intentionally unable to cross the host

--- a/docs/host-caller-performance.md
+++ b/docs/host-caller-performance.md
@@ -734,3 +734,34 @@ where cumulative. This profile motivated the fixed-slot portal above rather
 than another callback adapter. Scheduler-transition elision remains disabled:
 `AnalyzeNativeSegment` still has no compiler-produced complete-continuation
 graph or cross-segment work budget.
+
+## Expanded typed signature matrix (2026-09-11)
+
+The fixed-slot portal now covers every zero-to-two-`i32` parameter/result shape
+requested for the public host API. The matrix runs 1,024 calls inside one Wasm
+invocation and reports elapsed time divided by 1,024. Generic and typed rows use
+the same compiled fixture. Five samples used Go 1.26.5, one logical CPU, an
+Apple M4 Max on Darwin/arm64 and a Ryzen 7 7800X3D on Linux/amd64.
+
+| Signature | Go type | ARM64 generic / typed ns | AMD64 generic / typed ns |
+|---|---|---:|---:|
+| `[] -> []` | `NoArgsHostFunc` | 87.50 / 44.85 | 120.8 / 60.94 |
+| `[i32] -> []` | `I32HostFunc` | 86.93 / 43.87 | 121.6 / 61.82 |
+| `[i32] -> [i32]` | `I32ToI32HostFunc` | 88.78 / 44.70 | 125.2 / 62.63 |
+| `[i32, i32] -> []` | `I32I32HostFunc` | 89.53 / 46.15 | 126.4 / 63.22 |
+| `[i32, i32] -> [i32]` | `I32I32ToI32HostFunc` | 88.82 / 44.66 | 129.1 / 63.71 |
+| `[i32] -> [i32, i32]` | `I32ToI32I32HostFunc` | 89.37 / 46.09 | 127.7 / 65.24 |
+| `[i32, i32] -> [i32, i32]` | `I32I32ToI32I32HostFunc` | 89.91 / 47.41 | 128.7 / 63.02 |
+
+Every row reports 0 B/op and 0 allocs/op. Typed dispatch is 1.90-1.99x faster
+than generic dispatch on ARM64 and 1.96-2.04x faster on AMD64. The explicitly
+deferred `[i32] -> []` `I32HostEvent` path measures 7.297 ns/event on ARM64 and
+9.013 ns/event on AMD64, but delivery occurs only after the outer Wasm
+invocation returns and is not a synchronous-latency replacement.
+
+The expanded zero/two-result engine loop is separate from the original
+one-result loop. Eight alternating one-second measurements of the established
+`[i32] -> [i32]` benchmark gave 44,878 ns/1,024 calls for its parent and
+44,905.5 ns/1,024 calls for this change (+0.06%, noise), preserving the old
+portal's register allocation and binding-field layout. The corresponding
+AMD64 exact-main/head medians were 63,476.5 and 63,460.5 ns (-0.03%, noise).

--- a/docs/host-caller-performance.md
+++ b/docs/host-caller-performance.md
@@ -38,9 +38,10 @@ imports := wago.Imports{
 }
 ```
 
-`ImportModuleBuilder.CallerFunc` is the plugin equivalent of `Func`. It uses
-the existing plugin call gate, admission reservation and exact GC signature
-rules. The legacy `HostFunc` and owned `HostFuncRef` APIs are unchanged.
+`ImportModuleBuilder.Func` accepts both this concrete callback and ordinary Go
+functions. It uses the existing plugin call gate, admission reservation and
+exact GC signature rules. `HostFunc` and owned `HostFuncRef` remain available as
+low-level slot adapters.
 `Caller` implements the existing optional host-module interfaces, including
 guest storage, externrefs and GC result construction. Resolver, invoker,
 invocation-context and manager methods accept the concrete value through their
@@ -54,9 +55,9 @@ TinyGo represents each function value with 16 bytes, so its binding grows from
 32 to 48 bytes. The footprint test computes the exact compact layout from the
 two function-value sizes, descriptor pointer and index/flag; it does not accept
 an enlarged standard-Go layout just because TinyGo needs more space.
-The updated footprint assertion passes with Go. Local TinyGo linking stops at
-the checkout's existing duplicate `tinygo_task_exit` symbol, before tests run;
-the native CI TinyGo jobs are used to verify the 48-byte layout.
+The updated footprint assertion passes with Go. At this historical checkpoint,
+local TinyGo linking stopped at the checkout's duplicate `tinygo_task_exit`
+symbol before tests ran; native CI TinyGo jobs verified the 48-byte layout.
 Reference dispatch keeps argument translation, exact result validation and
 temporary root/token cleanup. Imported starts and re-exports also dispatch the
 concrete value directly. Raw callbacks do not gain plugin GC import authority.
@@ -641,17 +642,78 @@ profiles were collected after every meaningful production step. The public
 single-call benchmark is selected separately from loop sub-benchmark filters
 so it is never silently excluded by a slash-qualified regular expression.
 
-## Typed call-gate checkpoint (2026-09-11)
+## Portable host-function interface (2026-09-11)
+
+The plugin interface is now one method:
+
+```go
+module.Func("add", func(a, b int32) int32 { return a + b })
+```
+
+Wago classifies ordinary functions with a concrete type switch and validates the
+inferred signature once. It does not use `reflect`, `reflect.Value.Call`, or a
+callback-time adapter allocation. The direct catalog includes the established
+zero-to-two-`i32` matrix plus unary and binary same-type `i64`, `f32`, and `f64`
+results. Unary `V128`, `FuncRef`, `ExternRef`, `ExnRef`, `GCRef`, and `I31Ref`
+forms are also accepted without signature names.
+
+No finite portable Go type switch can recognize arbitrary function arity. TinyGo
+0.41.1 also does not implement `reflect.Type.NumIn`, so complete coverage uses a
+single explicit borrowed view:
+
+```go
+module.Func("transform", func(call wago.HostCall) {
+    vector := call.V128(0)
+    object := call.ExternRef(1)
+    count := call.I64(2)
+
+    call.SetV128(0, vector)
+    call.SetExternRef(1, object)
+    call.SetI64(2, count+1)
+}).
+    Params(wago.ValV128, wago.ValExternRef, wago.ValI64).
+    Results(wago.ValV128, wago.ValExternRef, wago.ValI64)
+```
+
+`HostCall` indexes logical Wasm values, so `v128` is one index despite occupying
+two native slots. It exposes exact `ValueTypeDescriptor` metadata, typed accessors
+for every current core value category, and raw low/high access for future value
+types. High-arity codecs and adapters can use `ParamSlots()` and `ResultSlots()`
+to process the borrowed raw ABI buffers linearly; `v128` occupies two adjacent
+slots in that view. Its storage is valid only during the callback. The implementation passes
+the view by value over the existing parked argument/result buffers; the tested
+dispatch path allocates zero bytes under both Go and TinyGo.
+Non-null exception references remain intentionally unable to cross the host
+boundary; `ExnRef` represents and validates the null value until rooted
+exception-token transfer is implemented.
+
+The full `just test tinygo` suite passes with this interface, including the
+portable `HostCall` coverage and the compact binding-footprint assertion.
+
+Callbacks that need caller authority use an explicit leading value without
+making every capability-free call copy it:
+
+```go
+module.Func("read", func(caller wago.Caller, call wago.HostCall) {
+    memory := caller.Memory()
+    call.SetI32(0, int32(memory[call.I32(0)]))
+}).Params(wago.ValI32).Results(wago.ValI32)
+```
+
+The previous signature-named builder methods were removed. The signature-named
+function types remain accepted as migration aliases, but new code should pass an
+ordinary function or `func(wago.HostCall)` directly.
+
+## Ordinary-function call-gate checkpoint (2026-09-11)
 
 The first specialized gates now sit beside, rather than replace, the managed
 callback path:
 
-- `I32ToI32HostFunc` and `I32I32ToI32HostFunc` are checked against the imported
-  Wasm signature at instantiation. Their bound dispatch calls the typed function
+- Ordinary `func(int32) int32` and `func(int32, int32) int32` values are checked
+  against the imported Wasm signature at instantiation. Their bound dispatch calls the function
   directly, without constructing a `Caller` or exposing argument/result slices.
-- `ImportModuleBuilder.I32ToI32Func` and `I32I32ToI32Func` preserve plugin
-  shutdown admission and operation reservations without granting callback
-  capabilities.
+- The single `ImportModuleBuilder.Func` method preserves plugin shutdown
+  admission and operation reservations without granting callback capabilities.
 - `PrepareI32ToI32` and `PrepareI32I32ToI32` bind local exports once and expose
   typed scalar calls over the existing compiler-verified prepared integer entry.
   They retain `PreparedFunction`'s ownership rule: calls must not race instance
@@ -712,7 +774,7 @@ Initial typed-dispatch baseline on Darwin/arm64, Go, Apple M4 Max, five
 | Path | ns per 1,024 callbacks | B/op | allocs/op |
 |---|---:|---:|---:|
 | Managed `CallerHostFunc` | 91,436 (90,278-93,604) | 0 | 0 |
-| Typed `I32ToI32HostFunc` | 77,015 (76,800-78,252) | 0 | 0 |
+| Ordinary `func(int32) int32` | 77,015 (76,800-78,252) | 0 | 0 |
 
 The matched 1,024-iteration guest control median was 673.5 ns per public
 invocation. Subtraction gives approximately 88.6 ns per managed callback and
@@ -745,13 +807,13 @@ Apple M4 Max on Darwin/arm64 and a Ryzen 7 7800X3D on Linux/amd64.
 
 | Signature | Go type | ARM64 generic / typed ns | AMD64 generic / typed ns |
 |---|---|---:|---:|
-| `[] -> []` | `NoArgsHostFunc` | 87.50 / 44.85 | 120.8 / 60.94 |
-| `[i32] -> []` | `I32HostFunc` | 86.93 / 43.87 | 121.6 / 61.82 |
-| `[i32] -> [i32]` | `I32ToI32HostFunc` | 88.78 / 44.70 | 125.2 / 62.63 |
-| `[i32, i32] -> []` | `I32I32HostFunc` | 89.53 / 46.15 | 126.4 / 63.22 |
-| `[i32, i32] -> [i32]` | `I32I32ToI32HostFunc` | 88.82 / 44.66 | 129.1 / 63.71 |
-| `[i32] -> [i32, i32]` | `I32ToI32I32HostFunc` | 89.37 / 46.09 | 127.7 / 65.24 |
-| `[i32, i32] -> [i32, i32]` | `I32I32ToI32I32HostFunc` | 89.91 / 47.41 | 128.7 / 63.02 |
+| `[] -> []` | `func()` | 87.50 / 44.85 | 120.8 / 60.94 |
+| `[i32] -> []` | `func(int32)` | 86.93 / 43.87 | 121.6 / 61.82 |
+| `[i32] -> [i32]` | `func(int32) int32` | 88.78 / 44.70 | 125.2 / 62.63 |
+| `[i32, i32] -> []` | `func(int32, int32)` | 89.53 / 46.15 | 126.4 / 63.22 |
+| `[i32, i32] -> [i32]` | `func(int32, int32) int32` | 88.82 / 44.66 | 129.1 / 63.71 |
+| `[i32] -> [i32, i32]` | `func(int32) (int32, int32)` | 89.37 / 46.09 | 127.7 / 65.24 |
+| `[i32, i32] -> [i32, i32]` | `func(int32, int32) (int32, int32)` | 89.91 / 47.41 | 128.7 / 63.02 |
 
 Every row reports 0 B/op and 0 allocs/op. Typed dispatch is 1.90-1.99x faster
 than generic dispatch on ARM64 and 1.96-2.04x faster on AMD64. The explicitly
@@ -765,3 +827,110 @@ one-result loop. Eight alternating one-second measurements of the established
 44,905.5 ns/1,024 calls for this change (+0.06%, noise), preserving the old
 portal's register allocation and binding-field layout. The corresponding
 AMD64 exact-main/head medians were 63,476.5 and 63,460.5 ns (-0.03%, noise).
+
+## Capability-free `HostCall` portal checkpoint (2026-09-11)
+
+Reference-free `HostCallFunc` imports now receive the same capability-free
+activation treatment as ordinary typed functions. For an instance with one
+ungated import and no collector domain, dispatch is selected once at native
+entry and skips callback-scoped authority, GC-root publication, import-kind
+checks, and generic interface dispatch. The callback still runs on the normal
+Go stack and may allocate, grow that stack, trigger Go GC, panic, or block. A
+cross-instance control frame or internal helper dispatch falls back to the full
+checked path. Reference parameters/results, plugin gates, `CallerHostCallFunc`,
+and collector-backed instances also retain the full path.
+
+Seven matched samples used Linux/amd64, Go 1.22.2, a Ryzen 7 7800X3D, one
+logical CPU (`taskset -c 7`, `GOMAXPROCS=1`), and 1,024 synchronous callbacks
+per public invocation:
+
+| Path | Before median (range), ns/1,024 | After median (range), ns/1,024 | Delta |
+|---|---:|---:|---:|
+| `func(HostCall)`, `[i32] -> [i32]` | 163595 (163335-164269) | 81953 (81908-82253) | -49.91% |
+| `func(int32) int32` | 69797 (69399-70106) | 68972 (68899-69043) | -1.18% |
+
+Both paths remain at 0 B/op and 0 allocs/op. The universal row is 80.03 raw
+ns/callback; the ordinary typed row is 67.36 raw ns/callback. These are
+unsubtracted round-trip costs. On an Apple M4 Max with the same one-CPU setup,
+the retained universal path measures 51,115 ns/1,024 (50,840-51,261), or 49.92
+raw ns/callback, also with zero allocations. No matched pre-portal ARM64
+snapshot was available for a delta.
+
+The AMD64 host and Apple M4 Max measured the universal view across the requested
+`i32` signature matrix (five samples, median):
+
+| Signature | ARM64 `func(HostCall)` ns/call | AMD64 `func(HostCall)` ns/call |
+|---|---:|---:|
+| `[] -> []` | 46.72 | 69.99 |
+| `[i32] -> []` | 45.47 | 69.88 |
+| `[i32] -> [i32]` | 52.05 | 79.07 |
+| `[i32, i32] -> []` | 47.36 | 71.65 |
+| `[i32, i32] -> [i32]` | 50.67 | 82.45 |
+| `[i32] -> [i32, i32]` | 56.93 | 91.04 |
+| `[i32, i32] -> [i32, i32]` | 55.12 | 90.99 |
+
+Every row reports zero allocations. A 15-second profile moved the generic
+`hostLoopActivation.dispatch` out of the hot path; the retained specialized
+dispatcher accounts for 22.06% cumulative CPU, while the engine park/resume
+loop remains 67.68% cumulative. That profile motivated a direct control-frame
+prototype for wide signatures; the retained form is described below.
+
+The arbitrary-arity benchmark invokes one imported function per public call,
+so these numbers include public `Invoke` overhead rather than reporting an
+inner-loop callback rate. All parameters and results are `i64`; the callback
+fills the borrowed `ResultSlots()` view:
+
+| Raw signature | AMD64 ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `[] -> []` | 278.0 | 0 | 0 |
+| `[1 x i64] -> []` | 285.0 | 0 | 0 |
+| `[1 x i64] -> [1 x i64]` | 288.8 | 0 | 0 |
+| `[4 x i64] -> [1 x i64]` | 297.7 | 0 | 0 |
+| `[8 x i64] -> [4 x i64]` | 319.2 | 0 | 0 |
+| `[16 x i64] -> [8 x i64]` | 353.9 | 0 | 0 |
+| `[64 x i64] -> [64 x i64]` | 699.4 | 0 | 0 |
+
+For wide inline calls, copying parked slots through the engine's scratch arrays
+became the dominant scalable cost. Wago now preclassifies a single eligible
+`HostCallFunc` at instantiation and, at 96 or more total parameter/result slots,
+passes borrowed slices over the parked control frame directly. Smaller calls
+retain the compact copied loop; calls exceeding the 64-slot inline capacity
+already use the control-frame extension directly. Keeping the wide loop in a
+separate compilation unit is performance-critical: placing it beside the
+compact loop regressed the 1,024-call `[i32] -> [i32]` control by about 3.4%.
+
+Five final interleaved 500 ms samples on the same pinned Ryzen core measured:
+
+| Raw signature | Copied median (range) ns/op | Direct median (range) ns/op | Delta |
+|---|---:|---:|---:|
+| `[48 x i64] -> [48 x i64]` | 583.7 (579.0-591.6) | 464.5 (459.0-465.7) | -20.42% |
+| `[64 x i64] -> [64 x i64]` | 681.3 (679.6-687.7) | 525.7 (525.2-528.0) | -22.84% |
+
+On the Apple M4 Max, five 500 ms samples show the same crossover: 48-to-48
+moves from a 401.6 ns median to 338.1 ns (-15.81%), and 64-to-64 moves from
+470.5 to 385.7 ns (-18.02%). The one-to-one control changes from 213.8 to
+214.3 ns (+0.23%, noise). All ARM64 rows also remain allocation-free.
+
+Both rows remain at 0 B/op and 0 allocs/op. The copied `[1 x i64] -> [1 x
+i64]` control moved from 291.8 ns/op (288.8-294.2) to 291.7 ns/op
+(289.9-292.9), -0.03%. The 1,024-call `[i32] -> [i32]` control moved from
+83,388 ns (83,131-83,651) to 83,709 ns (82,772-84,859), +0.38% with overlapping
+ranges, confirming that the established per-callback loop was not materially
+deoptimized.
+
+Matched five-second CPU profiles explain the gain. At 64-to-64, the copied
+engine loop accounts for 22.92% flat CPU; the direct-view loop accounts for
+1.99% flat CPU. The profiled benchmark moved from 691.3 to 531.9 ns/op, with
+zero allocations in both builds.
+
+The view remains valid only until the callback returns. Its backing storage is
+off-heap and stable while the callback allocates, grows the Go stack, triggers
+GC, blocks, or panics. Cross-instance frames return `handled=false` and use the
+existing checked dispatcher; references, gates, caller-capable callbacks, and
+GC domains never select this path.
+
+Using a typed logical setter for every wide result remains valid, but repeatedly
+mapping logical indexes around possible `v128` slots measured 1,990 ns for the
+64-to-64 case. A precomputed mapping prototype improved that case but regressed
+the common one-result callback by 3.7-7%, so it was reverted. The explicit bulk
+view keeps the common ABI compact and makes wide scalar processing linear.

--- a/examples/02-runtime-typed/main.go
+++ b/examples/02-runtime-typed/main.go
@@ -1,8 +1,7 @@
-// Example 02: runtime + typed Call.
+// Example 02: runtime invocation.
 //
-// The high-level Runtime wraps compile/instantiate and gives you a typed,
-// context-aware Call where arguments and results are checked against the export's
-// signature. Run:
+// The high-level Runtime wraps compile/instantiate. InvokeContext accepts Wasm
+// values encoded with wago.I32, wago.I64, wago.F32, and wago.F64. Run:
 //
 //	go run ./examples/02-runtime-typed
 package main
@@ -32,13 +31,12 @@ func main() {
 	}
 	defer inst.Close()
 
-	// Call takes typed Values and returns typed Values — no manual slot encoding.
 	// The context is honored for cancellation.
-	out, err := inst.Call(ctx, "add", wago.ValueI32(2), wago.ValueI32(3))
+	out, err := inst.InvokeContext(ctx, "add", wago.I32(2), wago.I32(3))
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("add(2, 3) = %d (type %s)\n", out[0].I32(), out[0].Type())
+	fmt.Printf("add(2, 3) = %d\n", wago.AsI32(out[0]))
 
 	// Inspect the module.
 	fmt.Println("exports:", mod.Exports())

--- a/examples/03-host-import/main.go
+++ b/examples/03-host-import/main.go
@@ -1,8 +1,7 @@
 // Example 03: host imports.
 //
-// A guest can call back into the host. Host functions use the single, portable
-// stack form wago.HostFunc — it reads params and writes results as raw slots and
-// binds identically on standard Go and TinyGo (no reflection). Run:
+// A guest can call back into the host. Ordinary Go functions bind directly and
+// identically on standard Go and TinyGo (no reflection). Run:
 //
 //	go run ./examples/03-host-import
 package main
@@ -21,14 +20,9 @@ func main() {
 		panic(err)
 	}
 
-	// A HostFunc reads its wasm params from params[] and writes results into
-	// results[]. Here: mul(a, b) = a * b.
-	mul := wago.HostFunc(func(_ wago.HostModule, params, results []uint64) {
-		a, b := wago.AsI32(params[0]), wago.AsI32(params[1])
-		results[0] = wago.I32(a * b)
-	})
-
-	inst, err := wago.Instantiate(compiled, wago.InstantiateOptions{Imports: wago.Imports{"host.mul": mul}})
+	inst, err := wago.Instantiate(compiled, wago.InstantiateOptions{Imports: wago.Imports{
+		"host.mul": func(a, b int32) int32 { return a * b },
+	}})
 	if err != nil {
 		panic(err)
 	}

--- a/examples/05-globals/main.go
+++ b/examples/05-globals/main.go
@@ -32,8 +32,8 @@ func main() {
 
 	// Each inc() bumps the global.
 	for i := 0; i < 3; i++ {
-		out, _ := inst.Call(ctx, "inc")
-		fmt.Printf("inc() = %d\n", out[0].I32())
+		out, _ := inst.InvokeContext(ctx, "inc")
+		fmt.Printf("inc() = %d\n", wago.AsI32(out[0]))
 	}
 
 	// Read the global directly, typed.
@@ -41,7 +41,7 @@ func main() {
 	fmt.Printf("count global = %d\n", v.I32())
 
 	// Set it from the host, then observe the guest continue from there.
-	_ = inst.SetGlobalValue("count", wago.ValueI32(100))
-	out, _ := inst.Call(ctx, "inc")
-	fmt.Printf("after set to 100, inc() = %d\n", out[0].I32())
+	_ = inst.SetGlobal("count", wago.I32(100))
+	out, _ := inst.InvokeContext(ctx, "inc")
+	fmt.Printf("after set to 100, inc() = %d\n", wago.AsI32(out[0]))
 }

--- a/examples/06-runtime-service/main.go
+++ b/examples/06-runtime-service/main.go
@@ -39,11 +39,11 @@ func (s *service) add(ctx context.Context, a, b int32) (int32, error) {
 	}
 	defer instance.Close()
 
-	result, err := instance.Call(ctx, "add", wago.ValueI32(a), wago.ValueI32(b))
+	result, err := instance.InvokeContext(ctx, "add", wago.I32(a), wago.I32(b))
 	if err != nil {
 		return 0, err
 	}
-	return result[0].I32(), nil
+	return wago.AsI32(result[0]), nil
 }
 
 func (s *service) close(ctx context.Context) error {

--- a/examples/08-custom-plugin/main.go
+++ b/examples/08-custom-plugin/main.go
@@ -89,7 +89,7 @@ func main() {
 	defer inst.Close()
 
 	for i := 0; i < 3; i++ {
-		out, _ := inst.Call(ctx, "roll")
-		fmt.Printf("roll() = %d\n", uint64(out[0].I64()))
+		out, _ := inst.InvokeContext(ctx, "roll")
+		fmt.Printf("roll() = %d\n", uint64(wago.AsI64(out[0])))
 	}
 }

--- a/examples/10-hooks/main.go
+++ b/examples/10-hooks/main.go
@@ -154,7 +154,7 @@ func main() {
 		panic(err)
 	}
 
-	if _, err := inst.Call(ctx, "add", wago.ValueI32(20), wago.ValueI32(22)); err != nil {
+	if _, err := inst.InvokeContext(ctx, "add", wago.I32(20), wago.I32(22)); err != nil {
 		panic(err)
 	}
 	if err := inst.Close(); err != nil {

--- a/examples/12-caller-context/main.go
+++ b/examples/12-caller-context/main.go
@@ -99,9 +99,9 @@ func main() {
 	}
 	defer instance.Close()
 
-	result, err := instance.Call(context.Background(), "run", wago.ValueI32(41))
+	result, err := instance.Invoke("run", wago.I32(41))
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("guest callback returned", result[0].I32())
+	fmt.Println("guest callback returned", wago.AsI32(result[0]))
 }

--- a/examples/15-config/main.go
+++ b/examples/15-config/main.go
@@ -41,6 +41,6 @@ func main() {
 	inst, _ := rt.Instantiate(ctx, mod)
 	defer inst.Close()
 
-	out, _ := inst.Call(ctx, "add", wago.ValueI32(1), wago.ValueI32(2))
-	fmt.Printf("add(1, 2) = %d\n", out[0].I32())
+	out, _ := inst.InvokeContext(ctx, "add", wago.I32(1), wago.I32(2))
+	fmt.Printf("add(1, 2) = %d\n", wago.AsI32(out[0]))
 }

--- a/examples/17-managed-instances/main.go
+++ b/examples/17-managed-instances/main.go
@@ -70,14 +70,14 @@ func main() {
 	// caller must wait for active calls and terminal close hooks to finish.
 	defer owned.Close()
 
-	result, err := owned.Instance().Call(
+	result, err := owned.Instance().InvokeContext(
 		context.Background(),
 		"add",
-		wago.ValueI32(20),
-		wago.ValueI32(22),
+		wago.I32(20),
+		wago.I32(22),
 	)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("managed worker returned", result[0].I32())
+	fmt.Println("managed worker returned", wago.AsI32(result[0]))
 }

--- a/examples/18-custom-instruction/main.go
+++ b/examples/18-custom-instruction/main.go
@@ -77,9 +77,9 @@ func main() {
 	}
 	defer instance.Close()
 
-	result, err := instance.Call(context.Background(), "add", wago.ValueI32(15), wago.ValueI32(3))
+	result, err := instance.Invoke("add", wago.I32(15), wago.I32(3))
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("i4.add(15, 3) =", result[0].I32())
+	fmt.Println("i4.add(15, 3) =", wago.AsI32(result[0]))
 }

--- a/examples/19-custom-type/main.go
+++ b/examples/19-custom-type/main.go
@@ -99,7 +99,7 @@ func main() {
 		panic(err)
 	}
 	defer instance.Close()
-	if _, err := instance.Call(context.Background(), "run"); err != nil {
+	if _, err := instance.Invoke("run"); err != nil {
 		panic(err)
 	}
 	fmt.Println("created and consumed one v256 value")

--- a/examples/20-core-handles/main.go
+++ b/examples/20-core-handles/main.go
@@ -90,9 +90,9 @@ func (p *corePlugin) start(ctx context.Context) error {
 	if instantiateErr != nil {
 		return errors.Join(instantiateErr, module.Close())
 	}
-	values, callErr := owned.Instance().Call(ctx, "add", wago.ValueI32(20), wago.ValueI32(22))
+	values, callErr := owned.Instance().InvokeContext(ctx, "add", wago.I32(20), wago.I32(22))
 	if callErr == nil {
-		fmt.Println("startup worker returned", values[0].I32())
+		fmt.Println("startup worker returned", wago.AsI32(values[0]))
 	}
 	return errors.Join(callErr, owned.Close(), module.Close())
 }

--- a/examples/21-guest-storage/main.go
+++ b/examples/21-guest-storage/main.go
@@ -100,9 +100,9 @@ func main() {
 		panic(err)
 	}
 	defer instance.Close()
-	result, err := instance.Call(context.Background(), "run")
+	result, err := instance.Invoke("run")
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("guest read %q from memory\n", byte(result[0].I32()))
+	fmt.Printf("guest read %q from memory\n", byte(wago.AsI32(result[0])))
 }

--- a/examples/22-language-guests/main.go
+++ b/examples/22-language-guests/main.go
@@ -79,15 +79,15 @@ func run(rt *wago.Runtime, source []byte, initialize bool) int32 {
 	}
 	defer instance.Close()
 	if initialize {
-		if _, err := instance.Call(context.Background(), "_initialize"); err != nil {
+		if _, err := instance.Invoke("_initialize"); err != nil {
 			panic(err)
 		}
 	}
-	result, err := instance.Call(context.Background(), "run")
+	result, err := instance.Invoke("run")
 	if err != nil {
 		panic(err)
 	}
-	return result[0].I32()
+	return wago.AsI32(result[0])
 }
 
 func main() {

--- a/scripts/update-website-bench.mjs
+++ b/scripts/update-website-bench.mjs
@@ -278,7 +278,7 @@ function buildGeneralSummary(metrics, raw, modules) {
     )],
   ].map(([label, sub, kind, values]) => ({ label, sub, kind, values }));
   const boundary = [
-    generalPairedMetric(metrics, "Host → Wasm", "public entry", "ExecCallOverhead_wago", "ExecCallOverhead_wazero"),
+    generalPairedMetric(metrics, "Host → Wasm", "prepared (i32) → i32", "ExecTypedCall_wago", "ExecCallOverhead_wazero"),
     generalPairedMetric(metrics, "Wasm → host", "typed import callback", "ExecHostCallback_wago", "ExecHostRoundtrip_wazero"),
   ].filter(Boolean);
   return [...summary, ...boundary];

--- a/scripts/update-website-bench.test.mjs
+++ b/scripts/update-website-bench.test.mjs
@@ -40,6 +40,7 @@ test("benchmark regeneration only replaces the benchmark widget", async () => {
       "Instantiate/json-as": { ns: 7 }, "WazeroInstantiate/json-as": { ns: 14 },
       "Exec/tiny.add": { ns: 3 }, "DraglineExec/tiny.add": { ns: 2 }, "WazeroExec/tiny.add": { ns: 4 },
       "ExecCallOverhead_wago": { ns: 100 }, "ExecCallOverhead_wazero": { ns: 104 },
+	  "ExecTypedCall_wago": { ns: 104 },
       "ExecHostCallback_wago": { ns: 33 }, "ExecHostRoundtrip_wago": { ns: 99 }, "ExecHostRoundtrip_wazero": { ns: 66 },
       "Exec/nbody.step": { ns: 20 }, "WazeroExec/nbody.step": { ns: 30 },
       "Exec/json-as.deserializeN": { ns: 25 }, "WazeroExec/json-as.deserializeN": { ns: 50 },
@@ -196,7 +197,7 @@ function assertDOMContract(html) {
       assert.equal(matches(general, new RegExp(`<span class="vs__label">${label}</span>`, "g")), 1);
     }
     assert.doesNotMatch(general, /Application commands|SIMD execution/);
-    assert.ok(general.includes('<span class="vs__sub">public entry</span>'));
+    assert.ok(general.includes('<span class="vs__sub">prepared (i32) → i32</span>'));
     assert.ok(general.includes('<span class="vs__sub">typed import callback</span>'));
 	const callStart = general.indexOf('<span class="vs__label">Host → Wasm</span>');
 	const callEnd = general.indexOf('<div class="vs__row" data-engine-row>', callStart);

--- a/src/core/compiler/backend/railshot/amd64/call.go
+++ b/src/core/compiler/backend/railshot/amd64/call.go
@@ -1211,12 +1211,11 @@ func (f *fn) callHostSync(importIdx int, ft *wasm.CompType) error {
 	return nil
 }
 
-// HostIndirectThunk returns standalone machine code that logs a host call for
-// importIdx and returns — for a legacy HostFunc reached through call_indirect
-// (placed in a table as a funcref). It is entered with the wrapper ABI (RSI =
+// HostIndirectThunk returns standalone machine code that logs a deferred host
+// event for importIdx and returns. It is entered with the wrapper ABI (RSI =
 // linMem, RDI = args buffer), appends (importIdx, first-arg-i32) to the host-call
 // log at [linMem-offCustomCtx] exactly like callHost, and returns void, so the
-// normal post-invoke replay runs the host function. Emitted per host funcref into
+// normal post-invoke replay delivers the event. Emitted per host funcref into
 // a per-instance mapping; the same code is instance-independent (it reads the log
 // pointer from RSI at run time).
 func HostIndirectThunk(importIdx uint32) []byte {
@@ -1224,11 +1223,18 @@ func HostIndirectThunk(importIdx uint32) []byte {
 	a.Load32(RAX, RDI, 0)            // RAX = first arg (i32; a harmless slot read for 0-param funcs)
 	a.Load64(R8, RSI, -offCustomCtx) // R8 = host-call log (RSI = linMem in the wrapper ABI)
 	a.Load32(RCX, R8, 0)             // count
-	a.LeaScaled(RDX, R8, RCX, 3, 8)  // entry = log + count*8 + 8
+	a.AluRI(cmpDigit, RCX, runtime.HostCallLogEntries, false)
+	full := a.JccPlaceholder(condAE)
+	a.LeaScaled(RDX, R8, RCX, 3, 8) // entry = log + count*8 + 8
 	a.StoreImm32Mem(RDX, 0, int32(importIdx))
 	a.Store32(RDX, 4, RAX)    // arg
 	a.AluRI(0, RCX, 1, false) // count++
 	a.Store32(R8, 0, RCX)
+	a.Ret()
+	a.PatchRel32(full, a.Len())
+	a.Load64(R8, RSI, -offTrapCellPtr)
+	a.StoreImm32Mem(R8, 0, int32(runtime.TrapHostEventOverflow))
+	a.Load64(RSP, RSI, -offTrapStackReentry)
 	a.Ret()
 	return a.B
 }

--- a/src/core/compiler/backend/railshot/arm64/call.go
+++ b/src/core/compiler/backend/railshot/arm64/call.go
@@ -1384,12 +1384,11 @@ func (f *fn) callHostSync(importIdx int, ft *wasm.CompType) error {
 	return nil
 }
 
-// HostIndirectThunk returns standalone machine code that logs a host call for
-// importIdx and returns — for a legacy HostFunc reached through call_indirect
-// (placed in a table as a funcref). It is entered with the wrapper ABI (X1 =
+// HostIndirectThunk returns standalone machine code that logs a deferred host
+// event for importIdx and returns. It is entered with the wrapper ABI (X1 =
 // linMem, X0 = args buffer), appends (importIdx, first-arg-i32) to the host-call
 // log at [linMem-offCustomCtx] exactly like callHost, and returns void, so the
-// normal post-invoke replay runs the host function. Emitted per host funcref into
+// normal post-invoke replay delivers the event. Emitted per host funcref into
 // a per-instance mapping; the same code is instance-independent (it reads the log
 // pointer from X1 at run time).
 func HostIndirectThunk(importIdx uint32) []byte {
@@ -1399,7 +1398,9 @@ func HostIndirectThunk(importIdx uint32) []byte {
 	a.Load32(X9, X0, 0)               // X9 = first arg (i32; a harmless slot read for 0-param funcs)
 	a.SubImm64(X10, X1, offCustomCtx) // X10 = &host-call log (X1 = linMem in the wrapper ABI)
 	a.Load64(X10, X10, 0)
-	a.Load32(X11, X10, 0)                 // count
+	a.Load32(X11, X10, 0) // count
+	a.CmpImm32LSL12(X11, runtime.HostCallLogEntries)
+	full := a.Bcond(condAE)
 	a.AddShifted(X12, X10, X11, 3, false) // entry = log + count*8
 	a.AddImm64(X12, X12, 8)               // + 8 header
 	a.MovImm64(X16, uint64(uint32(importIdx)))
@@ -1407,6 +1408,17 @@ func HostIndirectThunk(importIdx uint32) []byte {
 	a.Store32(X9, X12, 4)   // arg
 	a.AddImm32(X11, X11, 1) // count++
 	a.Store32(X11, X10, 0)
+	a.Ret()
+	a.PatchBranch19(full, a.Len())
+	a.SubImm64(X10, X1, offTrapCellPtr)
+	a.Load64(X10, X10, 0)
+	a.MovImm64(X16, uint64(runtime.TrapHostEventOverflow))
+	a.Store32(X16, X10, 0)
+	a.SubImm64(X10, X1, offTrapStackReentry)
+	a.Load64(X10, X10, 0)
+	a.SubImm64(X11, X1, offTrapHandlerPtr)
+	a.Load64(LR, X11, 0)
+	a.AddImm64(SP, X10, 0)
 	a.Ret()
 	return a.B
 }

--- a/src/core/runtime/basedata_control_test.go
+++ b/src/core/runtime/basedata_control_test.go
@@ -143,8 +143,8 @@ func TestJobMemoryRebindTrapCellPreservesInterruption(t *testing.T) {
 }
 
 func TestTrapMessagesStayCompactAndComplete(t *testing.T) {
-	if got := unsafe.Sizeof(trapMessages); got != 352 {
-		t.Fatalf("trap message storage = %d bytes, want 352", got)
+	if got := unsafe.Sizeof(trapMessages); got != 368 {
+		t.Fatalf("trap message storage = %d bytes, want 368", got)
 	}
 	for code, message := range trapMessages {
 		if message == "" {

--- a/src/core/runtime/engine.go
+++ b/src/core/runtime/engine.go
@@ -285,6 +285,39 @@ func (e *Engine) CallWithHostBaseScalar(code uintptr, serArgs []byte, linMemBase
 	return e.callWithHostBase(code, serArgs, linMemBase, trap, results, ctrl, host, scalar)
 }
 
+// CallWithHostBaseScalarExpanded enables the fixed-slot portal for zero, one,
+// or two results. The separate entry keeps the established one-result loop's
+// register allocation and code layout unchanged.
+func (e *Engine) CallWithHostBaseScalarExpanded(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, host HostCall, scalar ScalarHostCall) error {
+	if linMemBase == 0 {
+		return fmt.Errorf("jit: host-call linear-memory base is zero")
+	}
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
+	}
+	if err := InitHostCtrlFrame(ctrl); err != nil {
+		return err
+	}
+	clearTrapUnlessInterrupted(trap)
+	storeOffHeapU64(linMemBase-abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	ctrlPtr := slicePtr(ctrl)
+	var callErr error
+	if e.hostScratchInUse {
+		var argBuf, resBuf [maxHostArity]uint64
+		callErr = e.callWithHostLoopExpanded(code, serArgs, linMemBase, trap, results, ctrl, ctrlPtr, host, scalar, argBuf[:], resBuf[:])
+	} else {
+		e.hostScratchInUse = true
+		defer func() { e.hostScratchInUse = false }()
+		callErr = e.callWithHostLoopExpanded(code, serArgs, linMemBase, trap, results, ctrl, ctrlPtr, host, scalar, e.hostArgs[:], e.hostResults[:])
+	}
+	goruntime.KeepAlive(serArgs)
+	goruntime.KeepAlive(trap)
+	goruntime.KeepAlive(results)
+	goruntime.KeepAlive(ctrl)
+	goruntime.KeepAlive(e)
+	return callErr
+}
+
 func (e *Engine) callWithHostBase(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, host HostCall, scalar ScalarHostCall) error {
 	if linMemBase == 0 {
 		return fmt.Errorf("jit: host-call linear-memory base is zero")
@@ -342,6 +375,77 @@ func hostCtrlFrame(ptr uintptr) []byte {
 }
 
 func (e *Engine) callWithHostLoop(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, ctrlPtr uintptr, host HostCall, scalar ScalarHostCall, argBuf, resBuf []uint64) error {
+	rootCtrl, rootCtrlPtr := ctrl, ctrlPtr
+	for first := true; ; first = false {
+		if first {
+			enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
+		} else {
+			clearTrapUnlessInterrupted(trap)
+			if TrapCode(loadTrap(trap)) == TrapInterrupted {
+				return trapErrorFromBuffer(TrapInterrupted, trap)
+			}
+			stackTop := e.StackTop()
+			prepareHostResume(ctrl, trap, stackTop, e.StackLimit())
+			resumeNative(ctrlPtr, stackTop)
+		}
+		switch tc := loadTrap(trap); {
+		case tc == hostCallPending:
+			ctrlPtr = uintptr(binary.LittleEndian.Uint64(trap[8:]))
+			if ctrlPtr == 0 {
+				return fmt.Errorf("jit: host call did not publish an active control frame")
+			}
+			if ctrlPtr == rootCtrlPtr {
+				ctrl = rootCtrl
+			} else {
+				ctrl = hostCtrlFrame(ctrlPtr)
+			}
+			imp := binary.LittleEndian.Uint32(ctrl[hcImportIdx:])
+			raw := binary.LittleEndian.Uint32(ctrl[hcNArgs:])
+			n := int(raw & 0xffff)
+			nres := int(raw >> 16)
+			if n > maxHostArity || nres > maxHostArity {
+				argsArea, resultsArea, capacity, err := hostCtrlWideCallAreas(ctrl, n, nres)
+				if err != nil {
+					return err
+				}
+				args := unsafe.Slice((*uint64)(unsafe.Pointer(&argsArea[0])), capacity)
+				wideResults := unsafe.Slice((*uint64)(unsafe.Pointer(&resultsArea[0])), capacity)
+				clear(wideResults[:nres])
+				host(ctrlPtr, imp, args[:n], wideResults[:nres])
+				continue
+			}
+			if scalar != nil && n <= 2 && nres == 1 {
+				var a0, a1 uint64
+				if n != 0 {
+					a0 = binary.LittleEndian.Uint64(ctrl[hcArgs:])
+				}
+				if n == 2 {
+					a1 = binary.LittleEndian.Uint64(ctrl[hcArgs+8:])
+				}
+				if result, handled := scalar(ctrlPtr, imp, raw, a0, a1); handled {
+					binary.LittleEndian.PutUint64(ctrl[hcResults:], result)
+					continue
+				}
+			}
+			for k := 0; k < n; k++ {
+				argBuf[k] = binary.LittleEndian.Uint64(ctrl[hcArgs+k*8:])
+			}
+			for k := 0; k < nres; k++ {
+				resBuf[k] = 0
+			}
+			host(ctrlPtr, imp, argBuf[:n], resBuf[:nres])
+			for k := 0; k < nres; k++ {
+				binary.LittleEndian.PutUint64(ctrl[hcResults+k*8:], resBuf[k])
+			}
+		case tc != 0:
+			return trapErrorFromBuffer(TrapCode(tc), trap)
+		default:
+			return nil
+		}
+	}
+}
+
+func (e *Engine) callWithHostLoopExpanded(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, ctrlPtr uintptr, host HostCall, scalar ScalarHostCall, argBuf, resBuf []uint64) error {
 	rootCtrl, rootCtrlPtr := ctrl, ctrlPtr
 	// The host-call re-entry loop is intentionally unbounded: a single guest
 	// invocation may legitimately make an arbitrary number of host calls (e.g. a
@@ -407,6 +511,22 @@ func (e *Engine) callWithHostLoop(code uintptr, serArgs []byte, linMemBase uintp
 				}
 				if result, handled := scalar(ctrlPtr, imp, raw, a0, a1); handled {
 					binary.LittleEndian.PutUint64(ctrl[hcResults:], result)
+					continue
+				}
+			}
+			if scalar != nil && n <= 2 && (nres == 0 || nres == 2) {
+				var a0, a1 uint64
+				if n != 0 {
+					a0 = binary.LittleEndian.Uint64(ctrl[hcArgs:])
+				}
+				if n == 2 {
+					a1 = binary.LittleEndian.Uint64(ctrl[hcArgs+8:])
+				}
+				if result, handled := scalar(ctrlPtr, imp, raw, a0, a1); handled {
+					if nres == 2 {
+						binary.LittleEndian.PutUint64(ctrl[hcResults:], result&0xffffffff)
+						binary.LittleEndian.PutUint64(ctrl[hcResults+8:], result>>32)
+					}
 					continue
 				}
 			}

--- a/src/core/runtime/engine.go
+++ b/src/core/runtime/engine.go
@@ -278,6 +278,11 @@ func (e *Engine) CallWithHostBase(code uintptr, serArgs []byte, linMemBase uintp
 // the high 16 bits. Returning handled=false preserves the generic slice path.
 type ScalarHostCall func(ctrl uintptr, importIdx, rawSlots uint32, a0, a1 uint64) (result uint64, handled bool)
 
+// FixedScalarHostCall is the preselected portal for a root instance with one
+// capability-free scalar import. The engine validates the fixed slot shape once
+// at entry and uses the generic callbacks for any cross-instance control frame.
+type FixedScalarHostCall func(a0, a1 uint64) (result uint64)
+
 // CallWithHostBaseScalar adds a fixed-slot portal without changing the generic
 // host callback contract used for unsupported signatures and cross-instance
 // frames.

--- a/src/core/runtime/engine_hostview.go
+++ b/src/core/runtime/engine_hostview.go
@@ -1,0 +1,125 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64)
+
+package runtime
+
+import (
+	"encoding/binary"
+	"fmt"
+	goruntime "runtime"
+	"unsafe"
+
+	"github.com/wago-org/wago/src/core/runtime/abi"
+)
+
+// HostCallView is an optional zero-copy portal over the parked native control
+// frame. args and results are borrowed for the duration of the call; returning
+// handled=false falls back to HostCall, including for cross-instance frames.
+type HostCallView func(ctrl uintptr, importIdx uint32, args, results []uint64) (handled bool)
+
+// CallWithHostBaseView exposes the parked argument and result areas directly to
+// an eligible host callback. It lives outside engine.go so adding this uncommon
+// wide-signature loop cannot perturb the generic and typed scalar loop layout.
+func (e *Engine) CallWithHostBaseView(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, host HostCall, view HostCallView) error {
+	if linMemBase == 0 {
+		return fmt.Errorf("jit: host-call linear-memory base is zero")
+	}
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
+	}
+	if err := InitHostCtrlFrame(ctrl); err != nil {
+		return err
+	}
+	clearTrapUnlessInterrupted(trap)
+	storeOffHeapU64(linMemBase-abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	callErr := e.callWithHostLoopView(code, serArgs, linMemBase, trap, results, ctrl, slicePtr(ctrl), host, view)
+	goruntime.KeepAlive(serArgs)
+	goruntime.KeepAlive(trap)
+	goruntime.KeepAlive(results)
+	goruntime.KeepAlive(ctrl)
+	goruntime.KeepAlive(e)
+	return callErr
+}
+
+func (e *Engine) callWithHostLoopView(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, ctrlPtr uintptr, host HostCall, view HostCallView) error {
+	rootCtrl, rootCtrlPtr := ctrl, ctrlPtr
+	for first := true; ; first = false {
+		if first {
+			enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
+		} else {
+			clearTrapUnlessInterrupted(trap)
+			if TrapCode(loadTrap(trap)) == TrapInterrupted {
+				return trapErrorFromBuffer(TrapInterrupted, trap)
+			}
+			stackTop := e.StackTop()
+			prepareHostResume(ctrl, trap, stackTop, e.StackLimit())
+			resumeNative(ctrlPtr, stackTop)
+		}
+		switch tc := loadTrap(trap); {
+		case tc == hostCallPending:
+			ctrlPtr = uintptr(binary.LittleEndian.Uint64(trap[8:]))
+			if ctrlPtr == 0 {
+				return fmt.Errorf("jit: host call did not publish an active control frame")
+			}
+			if ctrlPtr == rootCtrlPtr {
+				ctrl = rootCtrl
+			} else {
+				ctrl = hostCtrlFrame(ctrlPtr)
+			}
+			imp := binary.LittleEndian.Uint32(ctrl[hcImportIdx:])
+			raw := binary.LittleEndian.Uint32(ctrl[hcNArgs:])
+			n := int(raw & 0xffff)
+			nres := int(raw >> 16)
+			if n > maxHostArity || nres > maxHostArity {
+				argsArea, resultsArea, capacity, err := hostCtrlWideCallAreas(ctrl, n, nres)
+				if err != nil {
+					return err
+				}
+				args := unsafe.Slice((*uint64)(unsafe.Pointer(&argsArea[0])), capacity)[:n]
+				wideResults := unsafe.Slice((*uint64)(unsafe.Pointer(&resultsArea[0])), capacity)[:nres]
+				clear(wideResults)
+				if view(ctrlPtr, imp, args, wideResults) {
+					continue
+				}
+				host(ctrlPtr, imp, args, wideResults)
+				continue
+			}
+			args := unsafe.Slice((*uint64)(unsafe.Pointer(&ctrl[hcArgs])), n)
+			directResults := unsafe.Slice((*uint64)(unsafe.Pointer(&ctrl[hcResults])), nres)
+			clear(directResults)
+			if view(ctrlPtr, imp, args, directResults) {
+				continue
+			}
+			e.callHostCopied(ctrl, ctrlPtr, imp, n, nres, host)
+		case tc != 0:
+			return trapErrorFromBuffer(TrapCode(tc), trap)
+		default:
+			return nil
+		}
+	}
+}
+
+// callHostCopied preserves the generic inline-buffer boundary when the direct
+// portal declines a foreign control frame. This is cold for the single-import
+// view, so keeping it out of callWithHostLoopView also keeps the wide hot loop
+// compact.
+func (e *Engine) callHostCopied(ctrl []byte, ctrlPtr uintptr, imp uint32, n, nres int, host HostCall) {
+	if e.hostScratchInUse {
+		var args, results [maxHostArity]uint64
+		callHostCopiedWith(ctrl, ctrlPtr, imp, n, nres, host, args[:], results[:])
+		return
+	}
+	e.hostScratchInUse = true
+	defer func() { e.hostScratchInUse = false }()
+	callHostCopiedWith(ctrl, ctrlPtr, imp, n, nres, host, e.hostArgs[:], e.hostResults[:])
+}
+
+func callHostCopiedWith(ctrl []byte, ctrlPtr uintptr, imp uint32, n, nres int, host HostCall, args, results []uint64) {
+	for i := 0; i < n; i++ {
+		args[i] = binary.LittleEndian.Uint64(ctrl[hcArgs+i*8:])
+	}
+	clear(results[:nres])
+	host(ctrlPtr, imp, args[:n], results[:nres])
+	for i := 0; i < nres; i++ {
+		binary.LittleEndian.PutUint64(ctrl[hcResults+i*8:], results[i])
+	}
+}

--- a/src/core/runtime/hostthunk/amd64.go
+++ b/src/core/runtime/hostthunk/amd64.go
@@ -8,12 +8,16 @@ package hostthunk
 import "github.com/wago-org/wago/src/core/encoder/amd64"
 
 const (
-	offCustomCtx = 40
-	hcTrampoline = 56
-	hcImportIdx  = 64
-	hcNArgs      = 68
-	hcArgs       = 72
-	hcResults    = 584
+	offTrapStackReentry = 24
+	offCustomCtx        = 40
+	offTrapCellPtr      = 104
+	hostCallLogEntries  = 1 << 13
+	trapHostEventFull   = 22
+	hcTrampoline        = 56
+	hcImportIdx         = 64
+	hcNArgs             = 68
+	hcArgs              = 72
+	hcResults           = 584
 )
 
 func Indirect(importIdx uint32) []byte {
@@ -21,11 +25,18 @@ func Indirect(importIdx uint32) []byte {
 	a.Load32(amd64.RAX, amd64.RDI, 0)
 	a.Load64(amd64.R8, amd64.RSI, -offCustomCtx)
 	a.Load32(amd64.RCX, amd64.R8, 0)
+	a.AluRI(7, amd64.RCX, hostCallLogEntries, false)
+	full := a.JccPlaceholder(amd64.CondAE)
 	a.LeaScaled(amd64.RDX, amd64.R8, amd64.RCX, 3, 8)
 	a.StoreImm32Mem(amd64.RDX, 0, int32(importIdx))
 	a.Store32(amd64.RDX, 4, amd64.RAX)
 	a.AluRI(0, amd64.RCX, 1, false)
 	a.Store32(amd64.R8, 0, amd64.RCX)
+	a.Ret()
+	a.PatchRel32(full, a.Len())
+	a.Load64(amd64.R8, amd64.RSI, -offTrapCellPtr)
+	a.StoreImm32Mem(amd64.R8, 0, trapHostEventFull)
+	a.Load64(amd64.RSP, amd64.RSI, -offTrapStackReentry)
 	a.Ret()
 	return a.B
 }

--- a/src/core/runtime/hostthunk/arm64.go
+++ b/src/core/runtime/hostthunk/arm64.go
@@ -5,12 +5,17 @@ package hostthunk
 import a64 "github.com/wago-org/wago/src/core/encoder/arm64"
 
 const (
-	offCustomCtx = 40
-	hcTrampoline = 176
-	hcImportIdx  = 184
-	hcNArgs      = 188
-	hcArgs       = 192
-	hcResults    = 704
+	offTrapHandlerPtr   = 32
+	offTrapStackReentry = 24
+	offCustomCtx        = 40
+	offTrapCellPtr      = 104
+	hostCallLogEntries  = 1 << 13
+	trapHostEventFull   = 22
+	hcTrampoline        = 176
+	hcImportIdx         = 184
+	hcNArgs             = 188
+	hcArgs              = 192
+	hcResults           = 704
 )
 
 func Indirect(importIdx uint32) []byte {
@@ -19,6 +24,8 @@ func Indirect(importIdx uint32) []byte {
 	a.SubImm64(a64.X10, a64.X1, offCustomCtx)
 	a.Load64(a64.X10, a64.X10, 0)
 	a.Load32(a64.X11, a64.X10, 0)
+	a.CmpImm32LSL12(a64.X11, hostCallLogEntries)
+	full := a.Bcond(a64.CondCS)
 	a.AddShifted(a64.X12, a64.X10, a64.X11, 3, false)
 	a.AddImm64(a64.X12, a64.X12, 8)
 	a.MovImm64(a64.X16, uint64(importIdx))
@@ -26,6 +33,17 @@ func Indirect(importIdx uint32) []byte {
 	a.Store32(a64.X9, a64.X12, 4)
 	a.AddImm32(a64.X11, a64.X11, 1)
 	a.Store32(a64.X11, a64.X10, 0)
+	a.Ret()
+	a.PatchBranch19(full, a.Len())
+	a.SubImm64(a64.X10, a64.X1, offTrapCellPtr)
+	a.Load64(a64.X10, a64.X10, 0)
+	a.MovImm64(a64.X16, trapHostEventFull)
+	a.Store32(a64.X16, a64.X10, 0)
+	a.SubImm64(a64.X10, a64.X1, offTrapStackReentry)
+	a.Load64(a64.X10, a64.X10, 0)
+	a.SubImm64(a64.X11, a64.X1, offTrapHandlerPtr)
+	a.Load64(a64.LR, a64.X11, 0)
+	a.AddImm64(a64.SP, a64.X10, 0)
 	a.Ret()
 	return a.B
 }

--- a/src/core/runtime/limits.go
+++ b/src/core/runtime/limits.go
@@ -11,7 +11,12 @@ import (
 // at their exact size and are unmapped instead of entering the one-entry cache.
 const InstantiateArenaCacheBytes = 1 << 20
 
-const HostCallLogBytes = 8 + ((1<<16)/8)*8
+const (
+	// HostCallLogEntries is the maximum number of deferred host events recorded
+	// by one native invocation before it traps without replaying a partial log.
+	HostCallLogEntries = 1 << 13
+	HostCallLogBytes   = 8 + HostCallLogEntries*8
+)
 
 // TrapBufferBytes reserves the 4-byte trap code, an 8-byte parked-host
 // control-frame pointer at offset 8, and an 8-byte packed Wasm source location

--- a/src/core/runtime/trap.go
+++ b/src/core/runtime/trap.go
@@ -34,6 +34,7 @@ const (
 	TrapTableOutOfBounds     TrapCode = 19
 	TrapAtomicUnaligned      TrapCode = 20
 	TrapExpectedSharedMemory TrapCode = 21
+	TrapHostEventOverflow    TrapCode = 22
 )
 
 var trapMessages = [...]string{
@@ -59,6 +60,7 @@ var trapMessages = [...]string{
 	TrapTableOutOfBounds:     "table access out of bounds",
 	TrapAtomicUnaligned:      "unaligned atomic memory access",
 	TrapExpectedSharedMemory: "expected shared memory",
+	TrapHostEventOverflow:    "deferred host event log capacity exceeded",
 }
 
 func (c TrapCode) String() string {

--- a/src/core/runtime/zz_engine_hostfixed.go
+++ b/src/core/runtime/zz_engine_hostfixed.go
@@ -1,0 +1,144 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64)
+
+package runtime
+
+import (
+	"encoding/binary"
+	"fmt"
+	goruntime "runtime"
+	"unsafe"
+
+	"github.com/wago-org/wago/src/core/runtime/abi"
+)
+
+// CallWithHostBaseScalarFixed removes per-callback import and signature
+// decoding for the single-import scalar shape selected by the caller. Foreign
+// control frames still take the complete checked dispatch path.
+func (e *Engine) CallWithHostBaseScalarFixed(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, rawSlots uint32, host HostCall, scalar ScalarHostCall, fixed FixedScalarHostCall) error {
+	if linMemBase == 0 {
+		return fmt.Errorf("jit: host-call linear-memory base is zero")
+	}
+	if fixed == nil {
+		return fmt.Errorf("jit: fixed scalar host portal is nil")
+	}
+	n, nres := int(rawSlots&0xffff), int(rawSlots>>16)
+	if n > 2 || nres > 2 {
+		return fmt.Errorf("jit: fixed scalar host shape has %d parameter slots and %d result slots", n, nres)
+	}
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
+	}
+	if err := InitHostCtrlFrame(ctrl); err != nil {
+		return err
+	}
+	clearTrapUnlessInterrupted(trap)
+	storeOffHeapU64(linMemBase-abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	ctrlPtr := slicePtr(ctrl)
+	var callErr error
+	if e.hostScratchInUse {
+		var argBuf, resBuf [maxHostArity]uint64
+		callErr = e.callWithHostLoopFixed(code, serArgs, linMemBase, trap, results, ctrl, ctrlPtr, rawSlots, host, scalar, fixed, argBuf[:], resBuf[:])
+	} else {
+		e.hostScratchInUse = true
+		defer func() { e.hostScratchInUse = false }()
+		callErr = e.callWithHostLoopFixed(code, serArgs, linMemBase, trap, results, ctrl, ctrlPtr, rawSlots, host, scalar, fixed, e.hostArgs[:], e.hostResults[:])
+	}
+	goruntime.KeepAlive(serArgs)
+	goruntime.KeepAlive(trap)
+	goruntime.KeepAlive(results)
+	goruntime.KeepAlive(ctrl)
+	goruntime.KeepAlive(e)
+	return callErr
+}
+
+func (e *Engine) callWithHostLoopFixed(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, ctrlPtr uintptr, rawSlots uint32, host HostCall, scalar ScalarHostCall, fixed FixedScalarHostCall, argBuf, resBuf []uint64) error {
+	rootCtrl, rootCtrlPtr := ctrl, ctrlPtr
+	n, nres := int(rawSlots&0xffff), int(rawSlots>>16)
+	for first := true; ; first = false {
+		if first {
+			enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
+		} else {
+			clearTrapUnlessInterrupted(trap)
+			if TrapCode(loadTrap(trap)) == TrapInterrupted {
+				return trapErrorFromBuffer(TrapInterrupted, trap)
+			}
+			stackTop := e.StackTop()
+			prepareHostResume(ctrl, trap, stackTop, e.StackLimit())
+			resumeNative(ctrlPtr, stackTop)
+		}
+		switch tc := loadTrap(trap); {
+		case tc == hostCallPending:
+			ctrlPtr = uintptr(binary.LittleEndian.Uint64(trap[8:]))
+			if ctrlPtr == 0 {
+				return fmt.Errorf("jit: host call did not publish an active control frame")
+			}
+			if ctrlPtr == rootCtrlPtr {
+				ctrl = rootCtrl
+				var a0, a1 uint64
+				if n != 0 {
+					a0 = binary.LittleEndian.Uint64(ctrl[hcArgs:])
+				}
+				if n == 2 {
+					a1 = binary.LittleEndian.Uint64(ctrl[hcArgs+8:])
+				}
+				result := fixed(a0, a1)
+				if nres == 1 {
+					binary.LittleEndian.PutUint64(ctrl[hcResults:], result)
+				} else if nres == 2 {
+					binary.LittleEndian.PutUint64(ctrl[hcResults:], result&0xffffffff)
+					binary.LittleEndian.PutUint64(ctrl[hcResults+8:], result>>32)
+				}
+				continue
+			}
+
+			ctrl = hostCtrlFrame(ctrlPtr)
+			imp := binary.LittleEndian.Uint32(ctrl[hcImportIdx:])
+			raw := binary.LittleEndian.Uint32(ctrl[hcNArgs:])
+			foreignN := int(raw & 0xffff)
+			foreignNres := int(raw >> 16)
+			if foreignN > maxHostArity || foreignNres > maxHostArity {
+				argsArea, resultsArea, capacity, err := hostCtrlWideCallAreas(ctrl, foreignN, foreignNres)
+				if err != nil {
+					return err
+				}
+				args := unsafe.Slice((*uint64)(unsafe.Pointer(&argsArea[0])), capacity)
+				wideResults := unsafe.Slice((*uint64)(unsafe.Pointer(&resultsArea[0])), capacity)
+				clear(wideResults[:foreignNres])
+				host(ctrlPtr, imp, args[:foreignN], wideResults[:foreignNres])
+				continue
+			}
+			if scalar != nil && foreignN <= 2 && foreignNres <= 2 {
+				var a0, a1 uint64
+				if foreignN != 0 {
+					a0 = binary.LittleEndian.Uint64(ctrl[hcArgs:])
+				}
+				if foreignN == 2 {
+					a1 = binary.LittleEndian.Uint64(ctrl[hcArgs+8:])
+				}
+				if result, handled := scalar(ctrlPtr, imp, raw, a0, a1); handled {
+					if foreignNres == 1 {
+						binary.LittleEndian.PutUint64(ctrl[hcResults:], result)
+					} else if foreignNres == 2 {
+						binary.LittleEndian.PutUint64(ctrl[hcResults:], result&0xffffffff)
+						binary.LittleEndian.PutUint64(ctrl[hcResults+8:], result>>32)
+					}
+					continue
+				}
+			}
+			for k := 0; k < foreignN; k++ {
+				argBuf[k] = binary.LittleEndian.Uint64(ctrl[hcArgs+k*8:])
+			}
+			for k := 0; k < foreignNres; k++ {
+				resBuf[k] = 0
+			}
+			host(ctrlPtr, imp, argBuf[:foreignN], resBuf[:foreignNres])
+			for k := 0; k < foreignNres; k++ {
+				binary.LittleEndian.PutUint64(ctrl[hcResults+k*8:], resBuf[k])
+			}
+		case tc != 0:
+			return trapErrorFromBuffer(TrapCode(tc), trap)
+		default:
+			return nil
+		}
+	}
+}

--- a/src/core/runtime/zz_engine_hostfixed.go
+++ b/src/core/runtime/zz_engine_hostfixed.go
@@ -76,17 +76,17 @@ func (e *Engine) callWithHostLoopFixed(code uintptr, serArgs []byte, linMemBase 
 				ctrl = rootCtrl
 				var a0, a1 uint64
 				if n != 0 {
-					a0 = binary.LittleEndian.Uint64(ctrl[hcArgs:])
+					a0 = *(*uint64)(unsafe.Pointer(&ctrl[hcArgs]))
 				}
 				if n == 2 {
-					a1 = binary.LittleEndian.Uint64(ctrl[hcArgs+8:])
+					a1 = *(*uint64)(unsafe.Pointer(&ctrl[hcArgs+8]))
 				}
 				result := fixed(a0, a1)
 				if nres == 1 {
-					binary.LittleEndian.PutUint64(ctrl[hcResults:], result)
+					*(*uint64)(unsafe.Pointer(&ctrl[hcResults])) = result
 				} else if nres == 2 {
-					binary.LittleEndian.PutUint64(ctrl[hcResults:], result&0xffffffff)
-					binary.LittleEndian.PutUint64(ctrl[hcResults+8:], result>>32)
+					*(*uint64)(unsafe.Pointer(&ctrl[hcResults])) = result & 0xffffffff
+					*(*uint64)(unsafe.Pointer(&ctrl[hcResults+8])) = result >> 32
 				}
 				continue
 			}

--- a/src/core/runtime/zz_engine_hostfixedview.go
+++ b/src/core/runtime/zz_engine_hostfixedview.go
@@ -1,0 +1,97 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64)
+
+package runtime
+
+import (
+	"encoding/binary"
+	"fmt"
+	goruntime "runtime"
+	"unsafe"
+
+	"github.com/wago-org/wago/src/core/runtime/abi"
+)
+
+// FixedHostCallView is a preselected zero-copy portal over the root control
+// frame for one scalar host import with a fixed signature.
+type FixedHostCallView func(args, results []uint64)
+
+func (e *Engine) CallWithHostBaseFixedView(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, ctrl []byte, rawSlots uint32, host HostCall, fixed FixedHostCallView) error {
+	if linMemBase == 0 {
+		return fmt.Errorf("jit: host-call linear-memory base is zero")
+	}
+	if fixed == nil {
+		return fmt.Errorf("jit: fixed host-call view is nil")
+	}
+	n, nres := int(rawSlots&0xffff), int(rawSlots>>16)
+	if n > maxHostArity || nres > maxHostArity {
+		return fmt.Errorf("jit: fixed host-call view has %d parameter slots and %d result slots", n, nres)
+	}
+	if err := validateTrapBuffer(trap); err != nil {
+		return err
+	}
+	if err := InitHostCtrlFrame(ctrl); err != nil {
+		return err
+	}
+	clearTrapUnlessInterrupted(trap)
+	storeOffHeapU64(linMemBase-abi.TrapCellPtrOffset, uint64(slicePtr(trap)))
+	rootArgs := unsafe.Slice((*uint64)(unsafe.Pointer(&ctrl[hcArgs])), n)
+	rootResults := unsafe.Slice((*uint64)(unsafe.Pointer(&ctrl[hcResults])), nres)
+	callErr := e.callWithHostLoopFixedView(code, serArgs, linMemBase, trap, results, ctrl, slicePtr(ctrl), host, fixed, rootArgs, rootResults)
+	goruntime.KeepAlive(serArgs)
+	goruntime.KeepAlive(trap)
+	goruntime.KeepAlive(results)
+	goruntime.KeepAlive(ctrl)
+	goruntime.KeepAlive(e)
+	return callErr
+}
+
+func (e *Engine) callWithHostLoopFixedView(code uintptr, serArgs []byte, linMemBase uintptr, trap, results, rootCtrl []byte, rootCtrlPtr uintptr, host HostCall, fixed FixedHostCallView, rootArgs, rootResults []uint64) error {
+	ctrl, ctrlPtr := rootCtrl, rootCtrlPtr
+	for first := true; ; first = false {
+		if first {
+			enterNative(code, slicePtr(serArgs), linMemBase, slicePtr(trap), slicePtr(results), e.stackTop)
+		} else {
+			clearTrapUnlessInterrupted(trap)
+			if TrapCode(loadTrap(trap)) == TrapInterrupted {
+				return trapErrorFromBuffer(TrapInterrupted, trap)
+			}
+			stackTop := e.StackTop()
+			prepareHostResume(ctrl, trap, stackTop, e.StackLimit())
+			resumeNative(ctrlPtr, stackTop)
+		}
+		switch tc := loadTrap(trap); {
+		case tc == hostCallPending:
+			ctrlPtr = uintptr(binary.LittleEndian.Uint64(trap[8:]))
+			if ctrlPtr == 0 {
+				return fmt.Errorf("jit: host call did not publish an active control frame")
+			}
+			if ctrlPtr == rootCtrlPtr {
+				ctrl = rootCtrl
+				clear(rootResults)
+				fixed(rootArgs, rootResults)
+				continue
+			}
+
+			ctrl = hostCtrlFrame(ctrlPtr)
+			imp := binary.LittleEndian.Uint32(ctrl[hcImportIdx:])
+			raw := binary.LittleEndian.Uint32(ctrl[hcNArgs:])
+			n, nres := int(raw&0xffff), int(raw>>16)
+			if n > maxHostArity || nres > maxHostArity {
+				argsArea, resultsArea, capacity, err := hostCtrlWideCallAreas(ctrl, n, nres)
+				if err != nil {
+					return err
+				}
+				args := unsafe.Slice((*uint64)(unsafe.Pointer(&argsArea[0])), capacity)[:n]
+				wideResults := unsafe.Slice((*uint64)(unsafe.Pointer(&resultsArea[0])), capacity)[:nres]
+				clear(wideResults)
+				host(ctrlPtr, imp, args, wideResults)
+				continue
+			}
+			e.callHostCopied(ctrl, ctrlPtr, imp, n, nres, host)
+		case tc != 0:
+			return trapErrorFromBuffer(TrapCode(tc), trap)
+		default:
+			return nil
+		}
+	}
+}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -2377,6 +2377,12 @@ func (c *Compiled) importsRequireSync(imports Imports, force bool) bool {
 		return true
 	}
 	for _, key := range c.Imports {
+		if _, ok := imports[key].(I32HostEvent); ok {
+			continue
+		}
+		if _, ok := imports[key].(gatedI32HostEvent); ok {
+			continue
+		}
 		if export, cross := imports[key].(*InstanceExport); cross {
 			// A cross-instance-only consumer needs the parked-host loop only when
 			// its target can itself park. syncMode is immutable after the producer
@@ -2386,10 +2392,9 @@ func (c *Compiled) importsRequireSync(imports Imports, force bool) bool {
 			}
 			continue
 		}
-		// Every actual host binding remains synchronous. In particular, a legacy
-		// replayable HostFunc may later be reached through an InstanceExport, where
-		// logging into the callee's private buffer would be invisible to the public
-		// root. Only host-free cross-instance links take the fast native path.
+		// Only the explicit I32HostEvent contract may use deferred replay. Every
+		// ordinary host binding remains synchronous; otherwise a callback could be
+		// delayed despite expecting immediate side effects or a Caller capability.
 		return true
 	}
 	// An imported funcref table can be mutated to contain a host or
@@ -4764,9 +4769,8 @@ func (in *Instance) startCancellationWatch(cancel context.Context, activeTrap []
 	}, nil
 }
 
-// replayHostLog runs the void host imports the last native call logged. Each
-// logged entry carries the single i32 argument the codegen captured; it is passed
-// to the stack-form HostFunc as params[0], with no results.
+// replayHostLog delivers the deferred events the last native call logged. Each
+// entry carries its import index and one i32 payload.
 func (in *Instance) replayHostLog() (err error) {
 	if len(in.hostLog) == 0 {
 		return nil
@@ -4807,19 +4811,25 @@ func (in *Instance) replayHostLog() (err error) {
 		}
 	}()
 	n := binary.LittleEndian.Uint32(in.hostLog)
-	var params [1]uint64
 	for i := uint32(0); i < n; i++ {
 		off := 8 + i*8
 		imp := binary.LittleEndian.Uint32(in.hostLog[off:])
 		arg := int32(binary.LittleEndian.Uint32(in.hostLog[off+4:]))
-		if int(imp) < len(in.c.Imports) {
-			if fn := in.hosts[in.c.Imports[imp]]; fn != nil {
-				params[0] = uint64(uint32(arg))
-				caller := in.beginHostCallScope()
-				func() {
-					defer caller.scope.end(caller.generation, caller.parentGeneration)
-					fn(caller, params[:], nil)
-				}()
+		if in.hostEvents != nil && int(imp) < len(in.hostEvents.byImport) {
+			binding := &in.hostEvents.byImport[imp]
+			if binding.eventI32 != nil {
+				if binding.gate != nil {
+					if err := binding.gate.enter(); err != nil {
+						panic(HostTrap{Err: err})
+					}
+					func() {
+						defer binding.gate.release()
+						binding.eventI32(arg)
+					}()
+				} else {
+					binding.eventI32(arg)
+				}
+				continue
 			}
 		}
 	}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -2453,6 +2453,20 @@ func (c *Compiled) validateImportBindingsWithPluginGC(imports Imports, store *re
 					if sigTransfersCollectorObjects && c.genericGCFrameRoots() == nil {
 						return fmt.Errorf("Runtime plugin host import %q cannot transfer collector references: exact native root maps are unavailable", key)
 					}
+				case HostCallFunc:
+					if owner == nil || !pluginImport || store == nil {
+						return fmt.Errorf("host import %q cannot transfer collector references; use a Runtime plugin import", key)
+					}
+					if sigTransfersCollectorObjects && c.genericGCFrameRoots() == nil {
+						return fmt.Errorf("Runtime plugin host import %q cannot transfer collector references: exact native root maps are unavailable", key)
+					}
+				case gatedHostCallFunc, gatedOrdinaryHostFunc:
+					if !pluginImport || store == nil {
+						return fmt.Errorf("host import %q cannot transfer collector references; use a Runtime plugin import", key)
+					}
+					if sigTransfersCollectorObjects && c.genericGCFrameRoots() == nil {
+						return fmt.Errorf("Runtime plugin host import %q cannot transfer collector references: exact native root maps are unavailable", key)
+					}
 				default:
 					return fmt.Errorf("host import %q cannot transfer collector references; use Runtime.NewGCHostFuncRef, a Runtime plugin import, or a same-Runtime InstanceExport", key)
 				}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4413,8 +4413,47 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 				return in.invokeDirectIntEntry(directEntry, ic.paramSlots, ic.resultSlots, ic.scalarWideMask, ic.scalarResultWide, true, ic.directIntLight, ic.directIntBounded, args[0], args[1], args[2], args[3])
 			}
 		}
+		if invokePrivateEntryEnabled && ic.entryMode != preparedEntryGeneral && executionFlags&directBlocked == 0 {
+			return in.invokeCachedNumericEntry(export, ic, args)
+		}
 	}
 	return in.invokeWithToken(export, args, contexts, state.invocationID, true, alreadyAdmitted, nil)
+}
+
+func (in *Instance) invokeCachedNumericEntry(export string, ic *invokeCache, args []uint64) ([]uint64, error) {
+	if len(args) != ic.paramSlots {
+		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
+	}
+	if len(args) > len(in.serArgs)/8 {
+		return nil, fmt.Errorf("%s requires %d arg slot(s), instance buffer has %d", export, len(args), len(in.serArgs)/8)
+	}
+	if ic.resultSlots > len(in.results)/8 {
+		return nil, fmt.Errorf("%s requires %d result slot(s), instance buffer has %d", export, ic.resultSlots, len(in.results)/8)
+	}
+	marshalPublicScalarSlotsByWidth(nativeUint64Slots(in.serArgs), args, ic.slotWide[:ic.paramSlots])
+	if len(in.hostLog) > 0 {
+		binary.LittleEndian.PutUint32(in.hostLog, 0)
+	}
+	entry := in.base + uintptr(in.c.Entry[ic.li])
+	var err error
+	if ic.entryMode == preparedEntryIsolated && preparedIsolatedEntryEnabled {
+		err = in.callPreparedIsolated(entry, in.trap)
+	} else {
+		err = in.callPreparedPrivate(entry, in.trap)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(in.hostLog) != 0 {
+		if err := in.replayHostLog(); err != nil {
+			return nil, err
+		}
+	}
+	goruntime.KeepAlive(in)
+	goruntime.KeepAlive(in.c)
+	out := in.resultVals[:ic.resultSlots]
+	decodePublicScalarSlots(out, nativeUint64Slots(in.results), ic.slotWide[ic.paramSlots:])
+	return out, nil
 }
 
 //go:noinline
@@ -4565,7 +4604,7 @@ func (in *Instance) invokeWithToken(export string, args []uint64, contexts invoc
 	goruntime.KeepAlive(in)
 	goruntime.KeepAlive(in.c)
 	out := in.resultVals[:ic.resultSlots]
-	for i, wide := range ic.resultWide {
+	for i, wide := range ic.slotWide[ic.paramSlots:] {
 		off := i * 8
 		if off+8 > len(in.results) {
 			return nil, fmt.Errorf("%s result slot %d exceeds instance result buffer", export, i)
@@ -4945,7 +4984,7 @@ func (in *Instance) fillInvokeCache(export string) (*invokeCache, error) {
 		}
 		slot := &in.ic[int(in.icNext)%len(in.ic)]
 		in.icNext++
-		*slot = invokeCache{export: export, valid: true, li: -1 - gfi, resultWide: slot.resultWide[:0]}
+		*slot = invokeCache{export: export, valid: true, li: -1 - gfi, slotWide: slot.slotWide[:0]}
 		return slot, nil
 	}
 	li := gfi - in.c.NumImports
@@ -4963,33 +5002,29 @@ func (in *Instance) fillInvokeCache(export string) (*invokeCache, error) {
 	}
 	slot := &in.ic[int(in.icNext)%len(in.ic)]
 	in.icNext++
-	rw := slot.resultWide[:0]
-	if cap(rw) < resultSlots {
-		rw = make([]bool, 0, resultSlots)
+	widths := slot.slotWide[:0]
+	if cap(widths) < paramSlots+resultSlots {
+		widths = make([]bool, 0, paramSlots+resultSlots)
 	}
-	for _, r := range sig.Results {
-		if r == ValV128 {
-			rw = append(rw, true, true)
-		} else {
-			rw = append(rw, isWideValType(r))
-		}
-	}
+	widths = appendValTypeSlotWidths(widths, sig.Params)
+	widths = appendValTypeSlotWidths(widths, sig.Results)
 	entryMode := preparedEntryGeneral
 	directEntryMode := preparedEntryGeneral
 	var scalarWideMask uint8
-	if !hasReferenceValType(sig.Params) && !hasReferenceValType(sig.Results) &&
-		paramSlots <= 4 && resultSlots <= 1 {
+	if !hasReferenceValType(sig.Params) && !hasReferenceValType(sig.Results) {
 		entryMode = in.preparedEntryMode()
 		directEntryMode = entryMode
 		if directEntryMode == preparedEntryGeneral && in.c.boundsMode == BoundsChecksSignalsBased && in.c.directPreparedAt(li) {
 			directEntryMode = in.preparedMemoryFreeEntryMode()
 		}
-		paramSlot := 0
-		for _, typ := range sig.Params {
-			if isWideValType(typ) {
-				scalarWideMask |= 1 << paramSlot
+		if paramSlots <= 4 {
+			paramSlot := 0
+			for _, typ := range sig.Params {
+				if isWideValType(typ) {
+					scalarWideMask |= 1 << paramSlot
+				}
+				paramSlot++
 			}
-			paramSlot++
 		}
 	}
 	directIntFast := preparedCallEnabled && invokePrivateEntryEnabled && preparedIsolatedEntryEnabled &&
@@ -5002,13 +5037,13 @@ func (in *Instance) fillInvokeCache(export string) (*invokeCache, error) {
 		directIntLight:    directIntFast && in.c.directPreparedLightAt(li),
 		directIntBounded:  directIntFast && in.c.directPreparedBoundedAt(li),
 		scalarWideMask:    scalarWideMask,
-		scalarResultWide:  resultSlots == 1 && rw[0],
+		scalarResultWide:  resultSlots == 1 && widths[paramSlots],
 		li:                li,
 		paramSlots:        paramSlots,
 		resultSlots:       resultSlots,
 		hasFuncRefParams:  hasReferenceValType(sig.Params),
 		hasFuncRefResults: hasReferenceValType(sig.Results),
-		resultWide:        rw,
+		slotWide:          widths,
 		entryMode:         entryMode,
 	}
 	return slot, nil
@@ -5030,6 +5065,36 @@ func marshalPublicScalarArgs(dst []byte, values []uint64, types []ValType) {
 		binary.LittleEndian.PutUint64(dst[slot*8:], bits)
 		slot++
 	}
+}
+
+func marshalPublicScalarSlotsByWidth(dst, values []uint64, wide []bool) {
+	for i, bits := range values {
+		if !wide[i] {
+			bits = uint64(uint32(bits))
+		}
+		dst[i] = bits
+	}
+}
+
+func decodePublicScalarSlots(dst, values []uint64, wide []bool) {
+	for i := range dst {
+		bits := values[i]
+		if !wide[i] {
+			bits = uint64(uint32(bits))
+		}
+		dst[i] = bits
+	}
+}
+
+func appendValTypeSlotWidths(dst []bool, types []ValType) []bool {
+	for _, typ := range types {
+		if typ == ValV128 {
+			dst = append(dst, true, true)
+		} else {
+			dst = append(dst, isWideValType(typ))
+		}
+	}
+	return dst
 }
 
 func hasValType(types []ValType, want ValType) bool {

--- a/src/wago/caller_arity_bench_test.go
+++ b/src/wago/caller_arity_bench_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func BenchmarkCallerArity(b *testing.B) {
-	for _, arity := range [][2]int{{0, 0}, {1, 0}, {1, 1}, {4, 1}, {8, 4}, {16, 8}, {64, 64}} {
+	for _, arity := range [][2]int{{0, 0}, {1, 0}, {1, 1}, {4, 1}, {8, 4}, {16, 8}, {24, 12}, {32, 16}, {32, 32}, {48, 24}, {48, 48}, {64, 64}} {
 		b.Run(fmt.Sprintf("%d-%d", arity[0], arity[1]), func(b *testing.B) {
 			params, results := make([]wasm.ValType, arity[0]), make([]wasm.ValType, arity[1])
 			body := []byte{}
@@ -33,20 +33,30 @@ func BenchmarkCallerArity(b *testing.B) {
 			)
 			c := benchMustCompile(b, data)
 			defer c.Close()
-			for _, concrete := range []bool{false, true} {
-				b.Run(fmt.Sprintf("concrete%t", concrete), func(b *testing.B) {
-					var fn any = HostFunc(func(_ HostModule, _, r []uint64) {
-						for i := range r {
-							r[i] = uint64(i + 1)
-						}
-					})
-					if concrete {
-						fn = CallerHostFunc(func(_ Caller, _, r []uint64) {
-							for i := range r {
-								r[i] = uint64(i + 1)
-							}
-						})
+			paths := []struct {
+				name string
+				fn   any
+			}{
+				{name: "legacy", fn: HostFunc(func(_ HostModule, _, r []uint64) {
+					for i := range r {
+						r[i] = uint64(i + 1)
 					}
+				})},
+				{name: "caller", fn: CallerHostFunc(func(_ Caller, _, r []uint64) {
+					for i := range r {
+						r[i] = uint64(i + 1)
+					}
+				})},
+				{name: "call", fn: HostCallFunc(func(call HostCall) {
+					results := call.ResultSlots()
+					for i := range results {
+						results[i] = uint64(i + 1)
+					}
+				})},
+			}
+			for _, path := range paths {
+				b.Run(path.name, func(b *testing.B) {
+					fn := path.fn
 					in, err := Instantiate(c, Imports{"env.f": fn})
 					if err != nil {
 						b.Fatal(err)

--- a/src/wago/caller_test.go
+++ b/src/wago/caller_test.go
@@ -19,10 +19,10 @@ func callerTestCallback(concrete bool, fn HostFunc) any {
 func callerTestDeclare(module *ImportModuleBuilder, concrete bool) func(string, HostFunc) *ImportFuncBuilder {
 	if concrete {
 		return func(name string, fn HostFunc) *ImportFuncBuilder {
-			return module.CallerFunc(name, func(c Caller, p, r []uint64) { fn(c, p, r) })
+			return module.Func(name, CallerHostFunc(func(c Caller, p, r []uint64) { fn(c, p, r) }))
 		}
 	}
-	return module.Func
+	return func(name string, fn HostFunc) *ImportFuncBuilder { return module.Func(name, fn) }
 }
 
 func BenchmarkInvokeCallerHostFuncDirect(b *testing.B) {

--- a/src/wago/cross_instance.go
+++ b/src/wago/cross_instance.go
@@ -27,6 +27,14 @@ type InstanceExport struct {
 	results  []ValType
 }
 
+func deferredHostEventCalleeError() error {
+	return fmt.Errorf("instance with deferred host events cannot be used as a cross-instance native callee")
+}
+
+func valTypeMayCarryFuncref(typ ValType) bool {
+	return typ == ValFuncRef || typ == ValAnyRef
+}
+
 // ExportedFunc returns a handle to this instance's exported function `name`,
 // suitable as a cross-instance import value in another module's Imports. A
 // re-exported InstanceExport resolves to the original producer handle, preserving
@@ -41,7 +49,7 @@ func (in *Instance) ExportedFunc(name string) (*InstanceExport, error) {
 	}
 	defer in.endInvocation()
 	if in.hostEvents != nil {
-		return nil, fmt.Errorf("instance with deferred host events cannot be used as a cross-instance native callee")
+		return nil, deferredHostEventCalleeError()
 	}
 	gfi, ok := in.c.Exports[name]
 	if !ok {
@@ -969,6 +977,10 @@ func (in *Instance) ExportedTable(name string) (*Table, error) {
 			return nil, fmt.Errorf("no exported table %q", name)
 		}
 	}
+	elementType := in.c.tableElementType(tableIndex)
+	if in.hostEvents != nil && valTypeMayCarryFuncref(elementType) {
+		return nil, deferredHostEventCalleeError()
+	}
 	if importDef, imported := in.c.tableImportAt(tableIndex); imported {
 		table, ok := in.imports.table(importDef.Key)
 		if !ok || len(table.desc) < 8 {
@@ -980,7 +992,6 @@ func (in *Instance) ExportedTable(name string) (*Table, error) {
 	if len(desc) < 8 {
 		return nil, fmt.Errorf("exported table %q index %d descriptor is invalid", name, tableIndex)
 	}
-	elementType := in.c.tableElementType(tableIndex)
 	store := in.refStore
 	if (elementType == ValExternRef || isGCRefValType(elementType)) && store == nil {
 		var err error
@@ -1077,6 +1088,9 @@ func (in *Instance) ExportedGlobalObject(name string) (*Global, error) {
 		return nil, fmt.Errorf("exported global %q index %d out of range", name, idx)
 	}
 	g := in.globalCells[idx]
+	if in.hostEvents != nil && valTypeMayCarryFuncref(g.Type) {
+		return nil, deferredHostEventCalleeError()
+	}
 	if idx < len(in.c.GlobalImports) {
 		return g, nil
 	}

--- a/src/wago/cross_instance.go
+++ b/src/wago/cross_instance.go
@@ -40,6 +40,9 @@ func (in *Instance) ExportedFunc(name string) (*InstanceExport, error) {
 		return nil, err
 	}
 	defer in.endInvocation()
+	if in.hostEvents != nil {
+		return nil, fmt.Errorf("instance with deferred host events cannot be used as a cross-instance native callee")
+	}
 	gfi, ok := in.c.Exports[name]
 	if !ok {
 		return nil, fmt.Errorf("no exported function %q", name)

--- a/src/wago/custom_type_test.go
+++ b/src/wago/custom_type_test.go
@@ -70,6 +70,12 @@ func TestCustomTypeCarriersCompileAndExecuteAsErasedValues(t *testing.T) {
 				t.Fatal(err)
 			}
 			in, err := rt.Instantiate(context.Background(), mod)
+			if carrier == 0x7b {
+				if err == nil || !strings.Contains(err.Error(), "v128 host callbacks are not supported") {
+					t.Fatalf("instantiate error = %v, want unsupported v128 host callback", err)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/wago/footprint_test.go
+++ b/src/wago/footprint_test.go
@@ -10,11 +10,15 @@ import (
 )
 
 func TestSyncHostBindingStaysCompact(t *testing.T) {
-	// Four callback representations, two pointers, the index, and a
+	// Nine callback representations, two pointers, the index, and a
 	// classification byte.
 	// TinyGo function values are larger than standard Go function values. Keep
 	// the budget exact for this compiler instead of accepting either footprint.
-	want := unsafe.Sizeof(HostFunc(nil)) + unsafe.Sizeof(CallerHostFunc(nil)) + unsafe.Sizeof(I32ToI32HostFunc(nil)) + unsafe.Sizeof(I32I32ToI32HostFunc(nil)) + 2*unsafe.Sizeof((*DefinedTypeDescriptor)(nil)) + 5
+	want := unsafe.Sizeof(HostFunc(nil)) + unsafe.Sizeof(CallerHostFunc(nil)) +
+		unsafe.Sizeof(NoArgsHostFunc(nil)) + unsafe.Sizeof(I32HostFunc(nil)) +
+		unsafe.Sizeof(I32ToI32HostFunc(nil)) + unsafe.Sizeof(I32I32HostFunc(nil)) +
+		unsafe.Sizeof(I32I32ToI32HostFunc(nil)) + unsafe.Sizeof(I32ToI32I32HostFunc(nil)) +
+		unsafe.Sizeof(I32I32ToI32I32HostFunc(nil)) + 2*unsafe.Sizeof((*DefinedTypeDescriptor)(nil)) + 5
 	align := unsafe.Alignof(syncHostBinding{})
 	want = (want + align - 1) &^ (align - 1)
 	if got := unsafe.Sizeof(syncHostBinding{}); got != want {

--- a/src/wago/footprint_test.go
+++ b/src/wago/footprint_test.go
@@ -10,15 +10,15 @@ import (
 )
 
 func TestSyncHostBindingStaysCompact(t *testing.T) {
-	// Nine callback representations, two pointers, the index, and a
+	// One tagged callback, seven dedicated hot representations, three pointers,
+	// the index, and a
 	// classification byte.
 	// TinyGo function values are larger than standard Go function values. Keep
 	// the budget exact for this compiler instead of accepting either footprint.
-	want := unsafe.Sizeof(HostFunc(nil)) + unsafe.Sizeof(CallerHostFunc(nil)) +
-		unsafe.Sizeof(NoArgsHostFunc(nil)) + unsafe.Sizeof(I32HostFunc(nil)) +
+	want := unsafe.Sizeof(any(nil)) + unsafe.Sizeof(NoArgsHostFunc(nil)) + unsafe.Sizeof(I32HostFunc(nil)) +
 		unsafe.Sizeof(I32ToI32HostFunc(nil)) + unsafe.Sizeof(I32I32HostFunc(nil)) +
 		unsafe.Sizeof(I32I32ToI32HostFunc(nil)) + unsafe.Sizeof(I32ToI32I32HostFunc(nil)) +
-		unsafe.Sizeof(I32I32ToI32I32HostFunc(nil)) + 2*unsafe.Sizeof((*DefinedTypeDescriptor)(nil)) + 5
+		unsafe.Sizeof(I32I32ToI32I32HostFunc(nil)) + 3*unsafe.Sizeof((*DefinedTypeDescriptor)(nil)) + 5
 	align := unsafe.Alignof(syncHostBinding{})
 	want = (want + align - 1) &^ (align - 1)
 	if got := unsafe.Sizeof(syncHostBinding{}); got != want {

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -34,8 +34,8 @@ func valTypeCode(t wasm.ValType) byte {
 }
 
 // Imports supplies a module's imports by "module.name" key, JS-style: one
-// namespace whose function values may be a HostFunc, CallerHostFunc, a supported
-// typed host function, or an I32HostEvent, alongside a GlobalImport, *Global, or
+// namespace whose function values may be an ordinary supported Go function,
+// HostCallFunc, HostFunc, CallerHostFunc, or I32HostEvent, alongside a GlobalImport, *Global, or
 // *Memory.
 // This mirrors the WebAssembly JS API's single imports object.
 type Imports map[string]any

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -34,35 +34,11 @@ func valTypeCode(t wasm.ValType) byte {
 }
 
 // Imports supplies a module's imports by "module.name" key, JS-style: one
-// namespace whose function values may be a HostFunc, CallerHostFunc, or a
-// supported typed host function, alongside a GlobalImport, *Global, or *Memory.
+// namespace whose function values may be a HostFunc, CallerHostFunc, a supported
+// typed host function, or an I32HostEvent, alongside a GlobalImport, *Global, or
+// *Memory.
 // This mirrors the WebAssembly JS API's single imports object.
 type Imports map[string]any
-
-// hostFuncs extracts the HostFunc entries (the import-function wiring).
-func (im Imports) hostFuncs() map[string]HostFunc {
-	var m map[string]HostFunc
-	for k, v := range im {
-		var fn HostFunc
-		switch value := v.(type) {
-		case HostFunc:
-			fn = value
-		case *HostFuncRef:
-			if value != nil {
-				value.mu.Lock()
-				fn = value.fn
-				value.mu.Unlock()
-			}
-		}
-		if fn != nil {
-			if m == nil {
-				m = make(map[string]HostFunc, len(im))
-			}
-			m[k] = fn
-		}
-	}
-	return m
-}
 
 // global returns the imported global for key, accepting either a GlobalImport
 // value or a *Global object.

--- a/src/wago/host_call_api_test.go
+++ b/src/wago/host_call_api_test.go
@@ -1,0 +1,301 @@
+package wago
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+func TestHostCallSupportsEveryABIValueType(t *testing.T) {
+	types := []ValType{
+		ValI32, ValI64, ValF32, ValF64, ValV128,
+		ValFuncRef, ValExternRef, ValExnRef, ValAnyRef, ValI31Ref,
+	}
+	vec := V128{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	lo, hi := binary.LittleEndian.Uint64(vec[:8]), binary.LittleEndian.Uint64(vec[8:])
+	args := []uint64{
+		I32(-7), I64(-9), F32(1.25), F64(-2.5), lo, hi,
+		11, 12, 0, 13, uint64(NewI31Ref(-3).bits),
+	}
+	results := make([]uint64, len(args))
+	called := false
+	binding, err := bindSyncHostImport(func(call HostCall) {
+		called = true
+		if call.ParamCount() != len(types) || call.ResultCount() != len(types) {
+			t.Fatalf("counts = %d/%d", call.ParamCount(), call.ResultCount())
+		}
+		if call.I32(0) != -7 || call.I64(1) != -9 || call.F32(2) != 1.25 || call.F64(3) != -2.5 {
+			t.Fatal("numeric parameter mismatch")
+		}
+		if call.V128(4) != vec || call.FuncRef(5).token != 11 || call.ExternRef(6).token != 12 ||
+			!call.ExnRef(7).IsNull() || call.GCRef(8).token != 13 || call.I31Ref(9).Signed() != -3 {
+			t.Fatal("vector/reference parameter mismatch")
+		}
+		call.SetI32(0, -7)
+		call.SetI64(1, -9)
+		call.SetF32(2, 1.25)
+		call.SetF64(3, -2.5)
+		call.SetV128(4, vec)
+		call.SetFuncRef(5, FuncRef{token: 11})
+		call.SetExternRef(6, ExternRef{token: 12})
+		call.SetExnRef(7, ExnRef{})
+		call.SetGCRef(8, GCRef{token: 13})
+		call.SetI31Ref(9, NewI31Ref(-3))
+	}, FuncSig{Params: types, Results: types})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding.call(instanceHostModule{}, args, results)
+	if !called {
+		t.Fatal("callback was not called")
+	}
+	for i := range args {
+		if results[i] != args[i] {
+			t.Fatalf("result slot %d = %#x, want %#x", i, results[i], args[i])
+		}
+	}
+}
+
+func TestHostCallMixedSignatureRuntime(t *testing.T) {
+	if !hostSupportsSIMD() {
+		t.Skip("host SIMD unavailable")
+	}
+	vec := V128{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	sig := wasmtest.FuncType(
+		[]wasm.ValType{wasm.I32, wasm.V128, wasm.I64},
+		[]wasm.ValType{wasm.V128, wasm.I32},
+	)
+	body := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0x10, 0x00, 0x0b}
+	compiled := MustCompile(returningImportModule(sig, body))
+	defer compiled.Close()
+	instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": func(call HostCall) {
+			if call.I32(0) != 7 || call.V128(1) != vec || call.I64(2) != 9 {
+				t.Fatal("mixed HostCall parameters were decoded incorrectly")
+			}
+			call.SetV128(0, vec)
+			call.SetI32(1, 42)
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close()
+	lo, hi := hostV128Slots(vec)
+	results, err := instance.Invoke("g", I32(7), lo, hi, I64(9))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hostV128FromSlots(results[0], results[1]); got != vec || AsI32(results[2]) != 42 {
+		t.Fatalf("mixed HostCall results = %x/%d", got, AsI32(results[2]))
+	}
+}
+
+func TestOrdinaryNumericFunctionsRuntime(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  wasm.ValType
+		fn   any
+		arg  uint64
+		want uint64
+	}{
+		{"i64", wasm.I64, func(v int64) int64 { return v + 1 }, I64(41), I64(42)},
+		{"f32", wasm.F32, func(v float32) float32 { return v + 1 }, F32(1.5), F32(2.5)},
+		{"f64", wasm.F64, func(v float64) float64 { return v + 1 }, F64(1.5), F64(2.5)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sig := wasmtest.FuncType([]wasm.ValType{test.typ}, []wasm.ValType{test.typ})
+			body := []byte{0x00, 0x20, 0x00, 0x10, 0x00, 0x0b}
+			compiled := MustCompile(returningImportModule(sig, body))
+			defer compiled.Close()
+			instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{"env.f": test.fn}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer instance.Close()
+			results, err := instance.Invoke("g", test.arg)
+			if err != nil || len(results) != 1 || results[0] != test.want {
+				t.Fatalf("result = %#v, %v; want %#x", results, err, test.want)
+			}
+		})
+	}
+}
+
+func TestHostCallUsesLogicalV128Indexes(t *testing.T) {
+	sig := FuncSig{
+		Params:  []ValType{ValI32, ValV128, ValI64},
+		Results: []ValType{ValI32, ValV128, ValI64},
+	}
+	call := HostCall{
+		params:  []uint64{1, 2, 3, 4},
+		results: make([]uint64, 4),
+		sig:     &sig,
+	}
+	if lo, hi := call.RawParam(1); lo != 2 || hi != 3 {
+		t.Fatalf("v128 slots = %#x/%#x", lo, hi)
+	}
+	if got := call.ParamSlots(); len(got) != 4 || got[0] != 1 || got[3] != 4 {
+		t.Fatalf("parameter slots = %#v", got)
+	}
+	if got := call.I64(2); got != 4 {
+		t.Fatalf("post-v128 i64 = %d", got)
+	}
+	call.ResultSlots()[0] = 7
+	call.SetRawResult(1, 8, 9)
+	call.SetI64(2, 10)
+	if call.results[0] != 7 || call.results[1] != 8 || call.results[2] != 9 || call.results[3] != 10 {
+		t.Fatalf("results = %#v", call.results)
+	}
+}
+
+func TestHostCallExposesExactReferenceType(t *testing.T) {
+	exact := ValueTypeDescriptor{Kind: ValueTypeReference, Ref: ReferenceTypeDescriptor{
+		Nullable: false,
+		Heap:     HeapTypeDescriptor{Defined: true, TypeIndex: 3},
+	}}
+	sig := FuncSig{Params: []ValType{ValFuncRef}, Results: []ValType{ValFuncRef}}
+	call := HostCall{
+		params: []uint64{0}, results: []uint64{0}, sig: &sig,
+		exact: &DefinedTypeDescriptor{Params: []ValueTypeDescriptor{exact}, Results: []ValueTypeDescriptor{exact}},
+	}
+	if got := call.ParamType(0); got != exact {
+		t.Fatalf("exact parameter type = %+v, want %+v", got, exact)
+	}
+	if got := call.ResultType(0); got != exact {
+		t.Fatalf("exact result type = %+v, want %+v", got, exact)
+	}
+}
+
+func TestHostCallDispatchAllocations(t *testing.T) {
+	binding, err := bindSyncHostImport(func(call HostCall) {
+		call.SetI32(0, call.I32(0)+1)
+	}, FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args, results := []uint64{I32(1)}, []uint64{0}
+	if got := testing.AllocsPerRun(1000, func() { binding.call(instanceHostModule{}, args, results) }); got != 0 {
+		t.Fatalf("HostCall dispatch allocations = %v", got)
+	}
+}
+
+func TestHostCallPluginGateBinding(t *testing.T) {
+	gate := newPluginCallGate("host-call")
+	value, err := gateHostImport(func(call HostCall) {
+		call.SetI32(0, call.I32(0)+1)
+	}, gate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := bindSyncHostImport(value, FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.gate != gate {
+		t.Fatal("HostCall plugin gate was not retained")
+	}
+	results := []uint64{0}
+	sig := FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}}
+	dispatchSyncHostReference(nil, nil, 0, 0, &binding, sig, nil, nil, nil, []uint64{41}, results, hostInvocationContext{})
+	if results[0] != 42 {
+		t.Fatalf("gated HostCall binding = %v", results)
+	}
+	if state := gate.state.Load(); state != 0 {
+		t.Fatalf("HostCall plugin gate leaked admission: %#x", state)
+	}
+	gate.deactivate()
+	func() {
+		defer func() {
+			if _, ok := recover().(HostTrap); !ok {
+				t.Fatal("inactive HostCall plugin gate did not fail closed")
+			}
+		}()
+		dispatchSyncHostReference(nil, nil, 0, 0, &binding, sig, nil, nil, nil, []uint64{41}, results, hostInvocationContext{})
+	}()
+}
+
+func TestCallerHostCallBinding(t *testing.T) {
+	binding, err := bindSyncHostImport(func(caller Caller, call HostCall) {
+		if caller.Memory() != nil {
+			t.Fatal("zero test caller unexpectedly has memory")
+		}
+		call.SetI32(0, call.I32(0)+1)
+	}, FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := []uint64{0}
+	binding.call(instanceHostModule{}, []uint64{41}, results)
+	if results[0] != 42 {
+		t.Fatalf("caller HostCall result = %v", results)
+	}
+}
+
+func TestOrdinaryNumericFunctionsInferAndBind(t *testing.T) {
+	tests := []struct {
+		fn   any
+		typ  ValType
+		args int
+	}{
+		{func(v int64) int64 { return v }, ValI64, 1},
+		{func(a, b int64) int64 { return a + b }, ValI64, 2},
+		{func(v float32) float32 { return v }, ValF32, 1},
+		{func(a, b float32) float32 { return a + b }, ValF32, 2},
+		{func(v float64) float64 { return v }, ValF64, 1},
+		{func(a, b float64) float64 { return a + b }, ValF64, 2},
+	}
+	for _, test := range tests {
+		params, results, ok := inferredHostFuncSignature(test.fn)
+		if !ok || len(params) != test.args || len(results) != 1 || results[0] != test.typ {
+			t.Fatalf("signature for %T = %v -> %v, %v", test.fn, params, results, ok)
+		}
+		if _, err := bindSyncHostImport(test.fn, FuncSig{Params: params, Results: results}); err != nil {
+			t.Fatalf("bind %T: %v", test.fn, err)
+		}
+	}
+}
+
+func TestSingleTypedScalarPortalSelection(t *testing.T) {
+	in := &Instance{syncHosts: []syncHostBinding{{
+		typedI32:   func(int32) int32 { return 0 },
+		scalarKind: syncHostTypedI32,
+	}}}
+	if !in.hasSingleDirectTypedScalarHost() || in.hasSingleExpandedTypedScalarHost() {
+		t.Fatal("single direct scalar import selected the wrong portal")
+	}
+
+	in.syncHosts[0] = syncHostBinding{typedNone: func() {}, scalarKind: syncHostTypedNone}
+	if in.hasSingleDirectTypedScalarHost() || !in.hasSingleExpandedTypedScalarHost() {
+		t.Fatal("single expanded scalar import selected the wrong portal")
+	}
+
+	in.syncHosts[0].gate = newPluginCallGate("gated")
+	if in.hasSingleExpandedTypedScalarHost() {
+		t.Fatal("gated import selected the single-import portal")
+	}
+	in.syncHosts[0].gate = nil
+	in.syncHosts = append(in.syncHosts, syncHostBinding{typedNone: func() {}, scalarKind: syncHostTypedNone})
+	if in.hasSingleExpandedTypedScalarHost() {
+		t.Fatal("multi-import instance selected the single-import portal")
+	}
+
+	sig := FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}}
+	in.syncHosts = []syncHostBinding{{
+		fn: HostCallFunc(func(HostCall) {}), sig: &sig, hostCall: true, scalarKind: syncHostScalar,
+	}}
+	if !in.hasSingleHostCallPortal() {
+		t.Fatal("single capability-free HostCallFunc did not select its portal")
+	}
+	in.syncHosts[0].gate = newPluginCallGate("gated")
+	if in.hasSingleHostCallPortal() {
+		t.Fatal("gated HostCallFunc selected the single-import portal")
+	}
+	in.syncHosts[0].gate = nil
+	in.syncHosts[0].scalarKind = syncHostNonScalar
+	if in.hasSingleHostCallPortal() {
+		t.Fatal("reference HostCallFunc selected the scalar portal")
+	}
+}

--- a/src/wago/host_call_api_test.go
+++ b/src/wago/host_call_api_test.go
@@ -1,22 +1,20 @@
 package wago
 
 import (
-	"encoding/binary"
+	"strings"
 	"testing"
 
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/support/wasmtest"
 )
 
-func TestHostCallSupportsEveryABIValueType(t *testing.T) {
+func TestHostCallSupportsScalarAndReferenceValueTypes(t *testing.T) {
 	types := []ValType{
-		ValI32, ValI64, ValF32, ValF64, ValV128,
+		ValI32, ValI64, ValF32, ValF64,
 		ValFuncRef, ValExternRef, ValExnRef, ValAnyRef, ValI31Ref,
 	}
-	vec := V128{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	lo, hi := binary.LittleEndian.Uint64(vec[:8]), binary.LittleEndian.Uint64(vec[8:])
 	args := []uint64{
-		I32(-7), I64(-9), F32(1.25), F64(-2.5), lo, hi,
+		I32(-7), I64(-9), F32(1.25), F64(-2.5),
 		11, 12, 0, 13, uint64(NewI31Ref(-3).bits),
 	}
 	results := make([]uint64, len(args))
@@ -29,20 +27,19 @@ func TestHostCallSupportsEveryABIValueType(t *testing.T) {
 		if call.I32(0) != -7 || call.I64(1) != -9 || call.F32(2) != 1.25 || call.F64(3) != -2.5 {
 			t.Fatal("numeric parameter mismatch")
 		}
-		if call.V128(4) != vec || call.FuncRef(5).token != 11 || call.ExternRef(6).token != 12 ||
-			!call.ExnRef(7).IsNull() || call.GCRef(8).token != 13 || call.I31Ref(9).Signed() != -3 {
-			t.Fatal("vector/reference parameter mismatch")
+		if call.FuncRef(4).token != 11 || call.ExternRef(5).token != 12 ||
+			!call.ExnRef(6).IsNull() || call.GCRef(7).token != 13 || call.I31Ref(8).Signed() != -3 {
+			t.Fatal("reference parameter mismatch")
 		}
 		call.SetI32(0, -7)
 		call.SetI64(1, -9)
 		call.SetF32(2, 1.25)
 		call.SetF64(3, -2.5)
-		call.SetV128(4, vec)
-		call.SetFuncRef(5, FuncRef{token: 11})
-		call.SetExternRef(6, ExternRef{token: 12})
-		call.SetExnRef(7, ExnRef{})
-		call.SetGCRef(8, GCRef{token: 13})
-		call.SetI31Ref(9, NewI31Ref(-3))
+		call.SetFuncRef(4, FuncRef{token: 11})
+		call.SetExternRef(5, ExternRef{token: 12})
+		call.SetExnRef(6, ExnRef{})
+		call.SetGCRef(7, GCRef{token: 13})
+		call.SetI31Ref(8, NewI31Ref(-3))
 	}, FuncSig{Params: types, Results: types})
 	if err != nil {
 		t.Fatal(err)
@@ -58,11 +55,7 @@ func TestHostCallSupportsEveryABIValueType(t *testing.T) {
 	}
 }
 
-func TestHostCallMixedSignatureRuntime(t *testing.T) {
-	if !hostSupportsSIMD() {
-		t.Skip("host SIMD unavailable")
-	}
-	vec := V128{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+func TestHostCallRejectsV128Signature(t *testing.T) {
 	sig := wasmtest.FuncType(
 		[]wasm.ValType{wasm.I32, wasm.V128, wasm.I64},
 		[]wasm.ValType{wasm.V128, wasm.I32},
@@ -70,26 +63,11 @@ func TestHostCallMixedSignatureRuntime(t *testing.T) {
 	body := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0x10, 0x00, 0x0b}
 	compiled := MustCompile(returningImportModule(sig, body))
 	defer compiled.Close()
-	instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
-		"env.f": func(call HostCall) {
-			if call.I32(0) != 7 || call.V128(1) != vec || call.I64(2) != 9 {
-				t.Fatal("mixed HostCall parameters were decoded incorrectly")
-			}
-			call.SetV128(0, vec)
-			call.SetI32(1, 42)
-		},
+	_, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": func(HostCall) {},
 	}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer instance.Close()
-	lo, hi := hostV128Slots(vec)
-	results, err := instance.Invoke("g", I32(7), lo, hi, I64(9))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := hostV128FromSlots(results[0], results[1]); got != vec || AsI32(results[2]) != 42 {
-		t.Fatalf("mixed HostCall results = %x/%d", got, AsI32(results[2]))
+	if err == nil || !strings.Contains(err.Error(), "v128 host callbacks are not supported") {
+		t.Fatalf("Instantiate error = %v, want unsupported v128 host callback", err)
 	}
 }
 
@@ -121,33 +99,6 @@ func TestOrdinaryNumericFunctionsRuntime(t *testing.T) {
 				t.Fatalf("result = %#v, %v; want %#x", results, err, test.want)
 			}
 		})
-	}
-}
-
-func TestHostCallUsesLogicalV128Indexes(t *testing.T) {
-	sig := FuncSig{
-		Params:  []ValType{ValI32, ValV128, ValI64},
-		Results: []ValType{ValI32, ValV128, ValI64},
-	}
-	call := HostCall{
-		params:  []uint64{1, 2, 3, 4},
-		results: make([]uint64, 4),
-		sig:     &sig,
-	}
-	if lo, hi := call.RawParam(1); lo != 2 || hi != 3 {
-		t.Fatalf("v128 slots = %#x/%#x", lo, hi)
-	}
-	if got := call.ParamSlots(); len(got) != 4 || got[0] != 1 || got[3] != 4 {
-		t.Fatalf("parameter slots = %#v", got)
-	}
-	if got := call.I64(2); got != 4 {
-		t.Fatalf("post-v128 i64 = %d", got)
-	}
-	call.ResultSlots()[0] = 7
-	call.SetRawResult(1, 8, 9)
-	call.SetI64(2, 10)
-	if call.results[0] != 7 || call.results[1] != 8 || call.results[2] != 9 || call.results[3] != 10 {
-		t.Fatalf("results = %#v", call.results)
 	}
 }
 
@@ -255,6 +206,19 @@ func TestOrdinaryNumericFunctionsInferAndBind(t *testing.T) {
 		if _, err := bindSyncHostImport(test.fn, FuncSig{Params: params, Results: results}); err != nil {
 			t.Fatalf("bind %T: %v", test.fn, err)
 		}
+	}
+}
+
+func TestOrdinaryV128HostFunctionIsUnsupported(t *testing.T) {
+	fn := func(v V128) V128 { return v }
+	if isHostCallback(fn) {
+		t.Fatal("ordinary v128 function was recognized as a host callback")
+	}
+	if _, _, ok := inferredHostFuncSignature(fn); ok {
+		t.Fatal("ordinary v128 function signature was inferred")
+	}
+	if _, err := bindSyncHostImport(fn, FuncSig{Params: []ValType{ValV128}, Results: []ValType{ValV128}}); err == nil || !strings.Contains(err.Error(), "v128 host callbacks are not supported") {
+		t.Fatalf("bind error = %v, want unsupported v128 host callback", err)
 	}
 }
 

--- a/src/wago/host_event_test.go
+++ b/src/wago/host_event_test.go
@@ -3,6 +3,7 @@
 package wago
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -152,6 +153,106 @@ func TestI32HostEventInstanceRejectsCrossInstanceExport(t *testing.T) {
 	if export, err := in.ExportedFunc("run"); err == nil || export != nil || !strings.Contains(err.Error(), "deferred host events") {
 		t.Fatalf("ExportedFunc = %v, %v; want deferred-event boundary error", export, err)
 	}
+}
+
+func TestI32HostEventInstanceRejectsFuncrefTransferRoutes(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	module, err := rt.Compile(hostEventFuncrefTransferModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := rt.Instantiate(context.Background(), module, WithImports(Imports{
+		"env.event": I32HostEvent(func(int32) {}),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+
+	if got, err := in.Invoke("get"); err == nil || got != nil || !strings.Contains(err.Error(), "deferred host events") {
+		t.Fatalf("returned funcref = %v, %v; want deferred-event boundary error", got, err)
+	}
+	if table, err := in.ExportedTable("table"); err == nil || table != nil || !strings.Contains(err.Error(), "deferred host events") {
+		t.Fatalf("ExportedTable = %v, %v; want deferred-event boundary error", table, err)
+	}
+	if global, err := in.ExportedGlobalObject("global"); err == nil || global != nil || !strings.Contains(err.Error(), "deferred host events") {
+		t.Fatalf("ExportedGlobalObject = %v, %v; want deferred-event boundary error", global, err)
+	}
+}
+
+func TestI32HostEventInstanceRejectsImportedFuncrefStorage(t *testing.T) {
+	t.Run("table", func(t *testing.T) {
+		table, err := NewTable(1, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer table.Close()
+		compiled := MustCompile(watToWasm(t, `(module
+			(import "env" "event" (func $event (param i32)))
+			(import "env" "shared" (table 1 funcref))
+			(func $target (i32.const 1) (call $event))
+			(elem (i32.const 0) func $target))`))
+		defer compiled.Close()
+		in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+			"env.event":  I32HostEvent(func(int32) {}),
+			"env.shared": table,
+		}})
+		if err == nil || in != nil || !strings.Contains(err.Error(), "deferred host event cannot be used by a module that requires synchronous host control") {
+			t.Fatalf("Instantiate = %v, %v; want shared-table synchronous-mode rejection", in, err)
+		}
+	})
+
+	t.Run("global", func(t *testing.T) {
+		rt := NewRuntime()
+		defer rt.Close()
+		global, err := rt.NewFuncRefGlobal(NullFuncRef(), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer global.Close()
+		module, err := rt.Compile(watToWasm(t, `(module
+			(import "env" "event" (func $event (param i32)))
+			(import "env" "shared" (global $shared (mut funcref)))
+			(func $target (i32.const 1) (call $event))
+			(elem declare func $target)
+			(func (export "seed") (ref.func $target) (global.set $shared)))`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		in, err := rt.Instantiate(context.Background(), module, WithImports(Imports{
+			"env.event":  I32HostEvent(func(int32) {}),
+			"env.shared": global,
+		}))
+		if err == nil || in != nil || !strings.Contains(err.Error(), "cannot import a funcref global") {
+			t.Fatalf("Instantiate = %v, %v; want deferred funcref-global rejection", in, err)
+		}
+	})
+}
+
+func hostEventFuncrefTransferModule() []byte {
+	typeEvent := wasmtest.FuncType([]wasm.ValType{wasm.I32}, nil)
+	typeTarget := wasmtest.FuncType(nil, nil)
+	typeGet := wasmtest.FuncType(nil, []wasm.ValType{wasm.FuncRef})
+	importEvent := append(wasmtest.Name("env"), wasmtest.Name("event")...)
+	importEvent = append(importEvent, 0x00, 0x00) // function import, type 0
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(typeEvent, typeTarget, typeGet)),
+		wasmtest.Section(2, wasmtest.Vec(importEvent)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1), wasmtest.ULEB(2))),
+		wasmtest.Section(4, wasmtest.Vec([]byte{0x70, 0x00, 0x01})), // funcref table min=1
+		wasmtest.Section(6, wasmtest.Vec(wasmtest.GlobalEntry(wasm.FuncRef, false, []byte{0xd2, 0x01, 0x0b}))),
+		wasmtest.Section(7, wasmtest.Vec(
+			wasmtest.ExportEntry("get", 0, 2),
+			wasmtest.ExportEntry("table", 1, 0),
+			wasmtest.ExportEntry("global", 3, 0),
+		)),
+		wasmtest.Section(9, wasmtest.Vec([]byte{0x00, 0x41, 0x00, 0x0b, 0x01, 0x01})), // elem (i32.const 0) [func 1]
+		wasmtest.Section(10, wasmtest.Vec(
+			wasmtest.Code([]byte{0x41, 0x01, 0x10, 0x00, 0x0b}), // target calls event(1)
+			wasmtest.Code([]byte{0xd2, 0x01, 0x0b}),             // get returns ref.func target
+		)),
+	)
 }
 
 func BenchmarkHostEventLoopManaged(b *testing.B) {

--- a/src/wago/host_event_test.go
+++ b/src/wago/host_event_test.go
@@ -1,0 +1,197 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64) && !tinygo
+
+package wago
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	wruntime "github.com/wago-org/wago/src/core/runtime"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+func hostEventLoopModule() []byte {
+	typeEvent := wasmtest.FuncType([]wasm.ValType{wasm.I32}, nil)
+	importEvent := append(wasmtest.Name("env"), wasmtest.Name("event")...)
+	importEvent = append(importEvent, 0x00)
+	importEvent = append(importEvent, wasmtest.ULEB(0)...)
+	body := []byte{
+		0x02, 0x40, 0x03, 0x40, // block done; loop next
+		0x20, 0x00, 0x45, 0x0d, 0x01, // count == 0: branch done
+		0x20, 0x00, 0x10, 0x00, // event(count)
+		0x20, 0x00, 0x41, 0x01, 0x6b, 0x21, 0x00, // count--
+		0x0c, 0x00, 0x0b, 0x0b, // branch next; end loop/block
+		0x0b,
+	}
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(typeEvent)),
+		wasmtest.Section(2, wasmtest.Vec(importEvent)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+}
+
+func mixedHostEventModule() []byte {
+	typeEvent := wasmtest.FuncType([]wasm.ValType{wasm.I32}, nil)
+	typeQuery := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	typeRun := wasmtest.FuncType(nil, nil)
+	event := append(wasmtest.Name("env"), wasmtest.Name("event")...)
+	event = append(event, 0x00)
+	event = append(event, wasmtest.ULEB(0)...)
+	query := append(wasmtest.Name("env"), wasmtest.Name("query")...)
+	query = append(query, 0x00)
+	query = append(query, wasmtest.ULEB(1)...)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(typeEvent, typeQuery, typeRun)),
+		wasmtest.Section(2, wasmtest.Vec(event, query)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(2))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 2))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x0b}))),
+	)
+}
+
+func TestI32HostEventDefersOrderedDelivery(t *testing.T) {
+	c := MustCompile(hostEventLoopModule())
+	defer c.Close()
+
+	var got []int32
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+		"env.event": I32HostEvent(func(value int32) { got = append(got, value) }),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if in.syncMode {
+		t.Fatal("deferred host event selected synchronous host control")
+	}
+
+	if results, err := in.Invoke("run", I32(5)); err != nil || len(results) != 0 {
+		t.Fatalf("run = %v, %v; want no results", results, err)
+	}
+	if want := []int32{5, 4, 3, 2, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+}
+
+func TestI32HostEventRequiresExactSignature(t *testing.T) {
+	c := MustCompile(hostRoundtripLoopModule(t, 0))
+	defer c.Close()
+	if in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+		"env.step": I32HostEvent(func(int32) {}),
+	}}); err == nil || in != nil {
+		t.Fatalf("Instantiate = %v, %v; want signature error", in, err)
+	}
+}
+
+func TestI32HostEventRejectsMixedSynchronousModule(t *testing.T) {
+	c := MustCompile(mixedHostEventModule())
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+		"env.event": I32HostEvent(func(int32) {}),
+		"env.query": I32ToI32HostFunc(func(value int32) int32 { return value }),
+	}})
+	if err == nil || in != nil || !strings.Contains(err.Error(), "cannot be used by a module that requires synchronous host control") {
+		t.Fatalf("Instantiate = %v, %v; want mixed-mode rejection", in, err)
+	}
+}
+
+func TestI32HostEventOverflowTrapsWithoutPartialReplay(t *testing.T) {
+	c := MustCompile(hostEventLoopModule())
+	defer c.Close()
+
+	delivered := 0
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+		"env.event": I32HostEvent(func(int32) { delivered++ }),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+
+	_, err = in.Invoke("run", I32(MaxDeferredHostEventsPerInvocation+1))
+	var trap *wruntime.TrapError
+	if !errors.As(err, &trap) || trap.Code != wruntime.TrapHostEventOverflow {
+		t.Fatalf("overflow error = %v; want %v", err, wruntime.TrapHostEventOverflow)
+	}
+	if delivered != 0 {
+		t.Fatalf("overflow delivered %d partial events; want transactional discard", delivered)
+	}
+}
+
+func TestI32HostEventPanicUsesHostTrapSemantics(t *testing.T) {
+	c := MustCompile(hostEventLoopModule())
+	defer c.Close()
+
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+		"env.event": I32HostEvent(func(int32) { panic(HostTrap{Err: errors.New("event failed")}) }),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if _, err := in.Invoke("run", I32(1)); err == nil || !strings.Contains(err.Error(), "event failed") {
+		t.Fatalf("event panic = %v; want host trap", err)
+	}
+}
+
+func TestI32HostEventInstanceRejectsCrossInstanceExport(t *testing.T) {
+	c := MustCompile(hostEventLoopModule())
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+		"env.event": I32HostEvent(func(int32) {}),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if export, err := in.ExportedFunc("run"); err == nil || export != nil || !strings.Contains(err.Error(), "deferred host events") {
+		t.Fatalf("ExportedFunc = %v, %v; want deferred-event boundary error", export, err)
+	}
+}
+
+func BenchmarkHostEventLoopManaged(b *testing.B) {
+	benchmarkHostEventLoop(b, false)
+}
+
+func BenchmarkHostEventLoopDeferred(b *testing.B) {
+	benchmarkHostEventLoop(b, true)
+}
+
+func benchmarkHostEventLoop(b *testing.B, deferred bool) {
+	c := MustCompile(hostEventLoopModule())
+	defer c.Close()
+	var sum int64
+	var callback any = HostFunc(func(_ HostModule, params, _ []uint64) {
+		sum += int64(AsI32(params[0]))
+	})
+	if deferred {
+		callback = I32HostEvent(func(value int32) { sum += int64(value) })
+	}
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{
+		"env.event": callback,
+	}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer in.Close()
+	if _, err := in.Invoke("run", I32(1024)); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := in.Invoke("run", I32(1024)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	if sum == 0 {
+		b.Fatal("events were not delivered")
+	}
+}

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -697,6 +697,16 @@ func (in *Instance) hasSingleHostCallPortal() bool {
 	return binding.hostCall && !binding.hostCallView && binding.gate == nil && binding.scalarKind != syncHostNonScalar
 }
 
+func (in *Instance) hasSingleHostCallFixedViewPortal() bool {
+	if !in.singleTypedScalarHostEligible() {
+		return false
+	}
+	binding := &in.syncHosts[0]
+	return binding.hostCall && binding.gate == nil && binding.scalarKind != syncHostNonScalar &&
+		len(binding.sig.Params) <= coreruntime.MaxHostArity && len(binding.sig.Results) <= coreruntime.MaxHostArity &&
+		len(binding.sig.Params)+len(binding.sig.Results) < directHostCallViewSlots
+}
+
 // The compact copy loop remains faster below this crossover on native AMD64.
 // Calls exceeding the inline capacity already receive a direct extension view
 // from the generic loop, so this portal is only marked for wide inline shapes.

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -437,6 +437,152 @@ func (a *hostLoopActivation) dispatchTypedScalarPortal(ctrl uintptr, importIdx, 
 	return I32(binding.typedI32x2(AsI32(a0), AsI32(a1))), true
 }
 
+// dispatchSingleTypedScalarPortal specializes the common instance shape with
+// one capability-free scalar import. Selection validates the binding and
+// immutable GC-domain constraints once at native entry; the portal retains the
+// control-frame, import, slot, and execution-version checks that can vary while
+// the activation is live.
+func (a *hostLoopActivation) dispatchSingleTypedScalarPortal(ctrl uintptr, importIdx, rawSlots uint32, a0, a1 uint64) (uint64, bool) {
+	if ctrl != a.ctrl || importIdx != 0 {
+		return 0, false
+	}
+	active := a.root
+	binding := &active.syncHosts[0]
+	typedScalarArity := uint32(binding.scalarKind - syncHostScalar)
+	if rawSlots != typedScalarArity|1<<16 {
+		return 0, false
+	}
+
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchTypedScalarPortal(ctrl, importIdx, rawSlots, a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	var result uint64
+	if binding.scalarKind == syncHostTypedI32 {
+		result = I32(binding.typedI32(AsI32(a0)))
+	} else {
+		result = I32(binding.typedI32x2(AsI32(a0), AsI32(a1)))
+	}
+	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+		state.nativeContextVersion.Load() != version {
+		active.restoreTypedScalarNativeContext(ctrl)
+	}
+	return result, true
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedScalarExpandedPortal(ctrl uintptr, importIdx, rawSlots uint32, a0, a1 uint64) (uint64, bool) {
+	if ctrl != a.ctrl || importIdx != 0 {
+		return 0, false
+	}
+	active := a.root
+	binding := &active.syncHosts[0]
+	if !binding.matchesTypedScalarSlots(rawSlots) {
+		return 0, false
+	}
+
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchTypedScalarExpandedPortal(ctrl, importIdx, rawSlots, a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	result := binding.callTypedScalar(a0, a1)
+	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+		state.nativeContextVersion.Load() != version {
+		active.restoreTypedScalarNativeContext(ctrl)
+	}
+	return result, true
+}
+
+// dispatchSingleHostCall is selected once for an instance whose only import is
+// an ungated, capability-free HostCallFunc with no reference values. Such a
+// callback cannot obtain supported re-entry authority and needs no GC root
+// translation, so it can share the typed portal's compact park/resume protocol
+// while retaining the generic slice ABI for arbitrary scalar arity.
+func (a *hostLoopActivation) dispatchSingleHostCall(ctrl uintptr, importIdx uint32, args, results []uint64) {
+	if ctrl != a.ctrl || importIdx != 0 {
+		a.dispatch(ctrl, importIdx, args, results)
+		return
+	}
+	active := a.root
+	binding := &active.syncHosts[0]
+	call := func() {
+		binding.fn.(HostCallFunc)(HostCall{
+			params: args, results: results, sig: binding.sig, exact: binding.exact,
+		})
+	}
+
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
+		version := state.nativeContextVersion.Load()
+		call()
+		if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+			active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+			state.nativeContextVersion.Load() != version {
+			active.restoreTypedScalarNativeContext(ctrl)
+		}
+		return
+	}
+
+	epoch := nativeExecutionEpoch
+	nativeExecutionMu.Unlock()
+	defer func() {
+		nativeExecutionMu.Lock()
+		if nativeExecutionEpoch != epoch {
+			active.restoreTypedScalarNativeContext(ctrl)
+		}
+	}()
+	call()
+}
+
+// dispatchSingleHostCallView is selected for wide instances whose only import is
+// an ungated, capability-free HostCallFunc with no reference values. Such a
+// callback cannot obtain supported re-entry authority and needs no GC root
+// translation, so it can share the typed portal's compact park/resume protocol
+// while operating directly on the parked argument and result areas. A foreign
+// control frame falls back to the activation's generic dispatcher.
+func (a *hostLoopActivation) dispatchSingleHostCallView(ctrl uintptr, importIdx uint32, args, results []uint64) bool {
+	if ctrl != a.ctrl || importIdx != 0 {
+		return false
+	}
+	active := a.root
+	binding := &active.syncHosts[0]
+	call := func() {
+		binding.fn.(HostCallFunc)(HostCall{
+			params: args, results: results, sig: binding.sig, exact: binding.exact,
+		})
+	}
+
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
+		version := state.nativeContextVersion.Load()
+		call()
+		if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+			active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+			state.nativeContextVersion.Load() != version {
+			active.restoreTypedScalarNativeContext(ctrl)
+		}
+		return true
+	}
+
+	epoch := nativeExecutionEpoch
+	nativeExecutionMu.Unlock()
+	defer func() {
+		nativeExecutionMu.Lock()
+		if nativeExecutionEpoch != epoch {
+			active.restoreTypedScalarNativeContext(ctrl)
+		}
+	}()
+	call()
+	return true
+}
+
 func (b *syncHostBinding) matchesTypedScalarSlots(raw uint32) bool {
 	switch b.scalarKind {
 	case syncHostTypedNone:
@@ -453,6 +599,10 @@ func (b *syncHostBinding) matchesTypedScalarSlots(raw uint32) bool {
 		return raw == 1|2<<16
 	case syncHostTypedI32x2R2:
 		return raw == 2|2<<16
+	case syncHostTypedI64, syncHostTypedF32, syncHostTypedF64:
+		return raw == 1|1<<16
+	case syncHostTypedI64x2, syncHostTypedF32x2, syncHostTypedF64x2:
+		return raw == 2|1<<16
 	default:
 		return false
 	}
@@ -476,6 +626,18 @@ func (b *syncHostBinding) callTypedScalar(a0, a1 uint64) uint64 {
 	case syncHostTypedI32x2R2:
 		a, c := b.typedI32x2R2(AsI32(a0), AsI32(a1))
 		return uint64(uint32(a)) | uint64(uint32(c))<<32
+	case syncHostTypedI64:
+		return I64(b.fn.(func(int64) int64)(AsI64(a0)))
+	case syncHostTypedI64x2:
+		return I64(b.fn.(func(int64, int64) int64)(AsI64(a0), AsI64(a1)))
+	case syncHostTypedF32:
+		return F32(b.fn.(func(float32) float32)(AsF32(a0)))
+	case syncHostTypedF32x2:
+		return F32(b.fn.(func(float32, float32) float32)(AsF32(a0), AsF32(a1)))
+	case syncHostTypedF64:
+		return F64(b.fn.(func(float64) float64)(AsF64(a0)))
+	case syncHostTypedF64x2:
+		return F64(b.fn.(func(float64, float64) float64)(AsF64(a0), AsF64(a1)))
 	}
 	return 0
 }
@@ -499,6 +661,48 @@ func (in *Instance) hasDirectTypedScalarHost() bool {
 		}
 	}
 	return false
+}
+
+func (in *Instance) hasSingleDirectTypedScalarHost() bool {
+	if !in.singleTypedScalarHostEligible() {
+		return false
+	}
+	binding := &in.syncHosts[0]
+	return binding.gate == nil && (binding.scalarKind == syncHostTypedI32 || binding.scalarKind == syncHostTypedI32x2)
+}
+
+func (in *Instance) hasSingleExpandedTypedScalarHost() bool {
+	if !in.singleTypedScalarHostEligible() {
+		return false
+	}
+	binding := &in.syncHosts[0]
+	return binding.gate == nil && binding.scalarKind >= syncHostTypedNone
+}
+
+func (in *Instance) singleTypedScalarHostEligible() bool {
+	return len(in.syncHosts) == 1 && in.gc == nil &&
+		in.executionFlags.Load()&(executionFlagImportedGCDomain|executionFlagDynamicGCDomain|executionFlagStoreOwnedGCCollector) == 0
+}
+
+func (in *Instance) hasSingleHostCallPortal() bool {
+	if !in.singleTypedScalarHostEligible() {
+		return false
+	}
+	binding := &in.syncHosts[0]
+	return binding.hostCall && !binding.hostCallView && binding.gate == nil && binding.scalarKind != syncHostNonScalar
+}
+
+// The compact copy loop remains faster below this crossover on native AMD64.
+// Calls exceeding the inline capacity already receive a direct extension view
+// from the generic loop, so this portal is only marked for wide inline shapes.
+const directHostCallViewSlots = 96
+
+func (in *Instance) hasSingleHostCallViewPortal() bool {
+	if !in.singleTypedScalarHostEligible() {
+		return false
+	}
+	binding := &in.syncHosts[0]
+	return binding.hostCallView && binding.gate == nil && binding.scalarKind != syncHostNonScalar
 }
 
 func (in *Instance) hasExpandedTypedScalarHost() bool {

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -324,6 +324,70 @@ func (a *hostLoopActivation) dispatch(ctrl uintptr, importIdx uint32, args, resu
 // instances retain their already-exclusive local lease; shared execution
 // releases the global lease so another instance may run. The context version or
 // global epoch still decides whether native context must be rebound before resume.
+func (a *hostLoopActivation) dispatchTypedScalarExpandedPortal(ctrl uintptr, importIdx, rawSlots uint32, a0, a1 uint64) (uint64, bool) {
+	active := a.root
+	if active == nil || ctrl != a.ctrl ||
+		importIdx&hostFuncRefDispatchBit != 0 || int(importIdx) >= len(active.syncHosts) ||
+		active.gc != nil || active.executionFlags.Load()&(executionFlagImportedGCDomain|executionFlagDynamicGCDomain|executionFlagStoreOwnedGCCollector) != 0 {
+		return 0, false
+	}
+	binding := &active.syncHosts[importIdx]
+	if binding.gate != nil || binding.scalarKind < syncHostTypedI32 {
+		return 0, false
+	}
+	if binding.scalarKind == syncHostTypedI32 {
+		if rawSlots != 1|1<<16 {
+			return 0, false
+		}
+	} else if binding.scalarKind == syncHostTypedI32x2 {
+		if rawSlots != 2|1<<16 {
+			return 0, false
+		}
+	} else if !binding.matchesTypedScalarSlots(rawSlots) {
+		return 0, false
+	}
+
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
+		version := state.nativeContextVersion.Load()
+		var result uint64
+		if binding.scalarKind == syncHostTypedI32 {
+			result = I32(binding.typedI32(AsI32(a0)))
+		} else if binding.scalarKind == syncHostTypedI32x2 {
+			result = I32(binding.typedI32x2(AsI32(a0), AsI32(a1)))
+		} else {
+			result = binding.callTypedScalar(a0, a1)
+		}
+		if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+			active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+			state.nativeContextVersion.Load() != version {
+			active.restoreTypedScalarNativeContext(ctrl)
+		}
+		return result, true
+	}
+
+	epoch := nativeExecutionEpoch
+	nativeExecutionMu.Unlock()
+	defer func() {
+		nativeExecutionMu.Lock()
+		if nativeExecutionEpoch != epoch {
+			active.restoreTypedScalarNativeContext(ctrl)
+		}
+	}()
+
+	if binding.scalarKind == syncHostTypedI32 {
+		return I32(binding.typedI32(AsI32(a0))), true
+	}
+	if binding.scalarKind == syncHostTypedI32x2 {
+		return I32(binding.typedI32x2(AsI32(a0), AsI32(a1))), true
+	}
+	return binding.callTypedScalar(a0, a1), true
+}
+
+// dispatchTypedScalarPortal preserves the compact one-result ABI and hot path
+// for the original typed scalar imports. Expanded signatures use the separate
+// portal above so adding them cannot perturb this path's register allocation.
 func (a *hostLoopActivation) dispatchTypedScalarPortal(ctrl uintptr, importIdx, rawSlots uint32, a0, a1 uint64) (uint64, bool) {
 	active := a.root
 	if active == nil || ctrl != a.ctrl ||
@@ -369,9 +433,51 @@ func (a *hostLoopActivation) dispatchTypedScalarPortal(ctrl uintptr, importIdx, 
 
 	if binding.scalarKind == syncHostTypedI32 {
 		return I32(binding.typedI32(AsI32(a0))), true
-	} else {
-		return I32(binding.typedI32x2(AsI32(a0), AsI32(a1))), true
 	}
+	return I32(binding.typedI32x2(AsI32(a0), AsI32(a1))), true
+}
+
+func (b *syncHostBinding) matchesTypedScalarSlots(raw uint32) bool {
+	switch b.scalarKind {
+	case syncHostTypedNone:
+		return raw == 0
+	case syncHostTypedI32V:
+		return raw == 1
+	case syncHostTypedI32:
+		return raw == 1|1<<16
+	case syncHostTypedI32x2V:
+		return raw == 2
+	case syncHostTypedI32x2:
+		return raw == 2|1<<16
+	case syncHostTypedI32R2:
+		return raw == 1|2<<16
+	case syncHostTypedI32x2R2:
+		return raw == 2|2<<16
+	default:
+		return false
+	}
+}
+
+func (b *syncHostBinding) callTypedScalar(a0, a1 uint64) uint64 {
+	switch b.scalarKind {
+	case syncHostTypedNone:
+		b.typedNone()
+	case syncHostTypedI32V:
+		b.typedI32V(AsI32(a0))
+	case syncHostTypedI32:
+		return I32(b.typedI32(AsI32(a0)))
+	case syncHostTypedI32x2V:
+		b.typedI32x2V(AsI32(a0), AsI32(a1))
+	case syncHostTypedI32x2:
+		return I32(b.typedI32x2(AsI32(a0), AsI32(a1)))
+	case syncHostTypedI32R2:
+		a, c := b.typedI32R2(AsI32(a0))
+		return uint64(uint32(a)) | uint64(uint32(c))<<32
+	case syncHostTypedI32x2R2:
+		a, c := b.typedI32x2R2(AsI32(a0), AsI32(a1))
+		return uint64(uint32(a)) | uint64(uint32(c))<<32
+	}
+	return 0
 }
 
 func (in *Instance) restoreTypedScalarNativeContext(ctrl uintptr) {
@@ -388,7 +494,17 @@ func (in *Instance) restoreTypedScalarNativeContext(ctrl uintptr) {
 func (in *Instance) hasDirectTypedScalarHost() bool {
 	for i := range in.syncHosts {
 		binding := &in.syncHosts[i]
-		if binding.gate == nil && (binding.typedI32 != nil || binding.typedI32x2 != nil) {
+		if binding.gate == nil && (binding.scalarKind == syncHostTypedI32 || binding.scalarKind == syncHostTypedI32x2) {
+			return true
+		}
+	}
+	return false
+}
+
+func (in *Instance) hasExpandedTypedScalarHost() bool {
+	for i := range in.syncHosts {
+		binding := &in.syncHosts[i]
+		if binding.gate == nil && binding.scalarKind >= syncHostTypedNone {
 			return true
 		}
 	}

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -584,27 +584,32 @@ func (a *hostLoopActivation) dispatchSingleHostCallView(ctrl uintptr, importIdx 
 }
 
 func (b *syncHostBinding) matchesTypedScalarSlots(raw uint32) bool {
+	want, ok := b.typedScalarSlots()
+	return ok && raw == want
+}
+
+func (b *syncHostBinding) typedScalarSlots() (uint32, bool) {
 	switch b.scalarKind {
 	case syncHostTypedNone:
-		return raw == 0
+		return 0, true
 	case syncHostTypedI32V:
-		return raw == 1
+		return 1, true
 	case syncHostTypedI32:
-		return raw == 1|1<<16
+		return 1 | 1<<16, true
 	case syncHostTypedI32x2V:
-		return raw == 2
+		return 2, true
 	case syncHostTypedI32x2:
-		return raw == 2|1<<16
+		return 2 | 1<<16, true
 	case syncHostTypedI32R2:
-		return raw == 1|2<<16
+		return 1 | 2<<16, true
 	case syncHostTypedI32x2R2:
-		return raw == 2|2<<16
+		return 2 | 2<<16, true
 	case syncHostTypedI64, syncHostTypedF32, syncHostTypedF64:
-		return raw == 1|1<<16
+		return 1 | 1<<16, true
 	case syncHostTypedI64x2, syncHostTypedF32x2, syncHostTypedF64x2:
-		return raw == 2|1<<16
+		return 2 | 1<<16, true
 	default:
-		return false
+		return 0, false
 	}
 }
 

--- a/src/wago/host_roundtrip_bench_test.go
+++ b/src/wago/host_roundtrip_bench_test.go
@@ -78,12 +78,17 @@ func BenchmarkHostRoundtripLoopTyped(b *testing.B) {
 	benchmarkHostRoundtripLoop(b, hostRoundtripTyped)
 }
 
+func BenchmarkHostRoundtripLoopCall(b *testing.B) {
+	benchmarkHostRoundtripLoop(b, hostRoundtripCall)
+}
+
 type hostRoundtripCallback uint8
 
 const (
 	hostRoundtripLegacy hostRoundtripCallback = iota
 	hostRoundtripCaller
 	hostRoundtripTyped
+	hostRoundtripCall
 )
 
 func benchmarkHostRoundtripLoop(b *testing.B, callbackKind hostRoundtripCallback) {
@@ -115,7 +120,9 @@ func benchmarkHostRoundtripLoop(b *testing.B, callbackKind hostRoundtripCallback
 								if callbackKind == hostRoundtripCaller {
 									callback = CallerHostFunc(func(_ Caller, p, r []uint64) { r[0] = p[0] + 1 })
 								} else if callbackKind == hostRoundtripTyped {
-									callback = I32ToI32HostFunc(func(v int32) int32 { return v + 1 })
+									callback = func(v int32) int32 { return v + 1 }
+								} else if callbackKind == hostRoundtripCall {
+									callback = func(call HostCall) { call.SetI32(0, call.I32(0)+1) }
 								}
 								in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.step": callback}})
 								if err != nil {

--- a/src/wago/host_signature_matrix_bench_test.go
+++ b/src/wago/host_signature_matrix_bench_test.go
@@ -1,0 +1,189 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64) && !tinygo
+
+package wago
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+type hostSignatureCase struct {
+	name            string
+	params, results int
+	typed           any
+}
+
+func hostSignatureCases() []hostSignatureCase {
+	return []hostSignatureCase{
+		{name: "empty_to_empty", typed: NoArgsHostFunc(func() {})},
+		{name: "i32_to_empty", params: 1, typed: I32HostFunc(func(int32) {})},
+		{name: "i32_to_i32", params: 1, results: 1, typed: I32ToI32HostFunc(func(int32) int32 { return 7 })},
+		{name: "i32_i32_to_empty", params: 2, typed: I32I32HostFunc(func(int32, int32) {})},
+		{name: "i32_i32_to_i32", params: 2, results: 1, typed: I32I32ToI32HostFunc(func(int32, int32) int32 { return 7 })},
+		{name: "i32_to_i32_i32", params: 1, results: 2, typed: I32ToI32I32HostFunc(func(int32) (int32, int32) { return 7, 9 })},
+		{name: "i32_i32_to_i32_i32", params: 2, results: 2, typed: I32I32ToI32I32HostFunc(func(int32, int32) (int32, int32) { return 7, 9 })},
+	}
+}
+
+func hostSignatureLoopModule(params, results int) []byte {
+	importParams := make([]wasm.ValType, params)
+	importResults := make([]wasm.ValType, results)
+	for i := range importParams {
+		importParams[i] = wasm.I32
+	}
+	for i := range importResults {
+		importResults[i] = wasm.I32
+	}
+	body := []byte{
+		1, 1, 0x7f, // local accumulator: i32
+		0x02, 0x40, 0x03, 0x40, // block done; loop next
+		0x20, 0, 0x45, 0x0d, 1, // count == 0: branch done
+	}
+	for i := 0; i < params; i++ {
+		body = append(body, 0x41, byte(i+1)) // i32.const
+	}
+	body = append(body, 0x10, 0) // call import 0
+	for i := 0; i < results; i++ {
+		body = append(body, 0x21, 1) // consume result into accumulator
+	}
+	body = append(body,
+		0x20, 0, 0x41, 1, 0x6b, 0x21, 0, // count--
+		0x0c, 0, 0x0b, 0x0b, // branch next; end loop/block
+		0x20, 1, 0x0b, // return accumulator
+	)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(
+			wasmtest.FuncType(importParams, importResults),
+			wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}),
+		)),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "f", 0, 0))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(1))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 1))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+}
+
+func TestTypedHostSignatureMatrix(t *testing.T) {
+	for _, tc := range hostSignatureCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			compiled, err := Compile(NewRuntimeConfig(), hostSignatureLoopModule(tc.params, tc.results))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer compiled.Close()
+			in, err := Instantiate(compiled, Imports{"env.f": tc.typed})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			got, err := in.Invoke("run", I32(1))
+			want := uint64(0)
+			if tc.results != 0 {
+				want = 7
+			}
+			if err != nil || len(got) != 1 || got[0] != want {
+				t.Fatalf("run = %v, %v; want %d", got, err, want)
+			}
+		})
+	}
+}
+
+func TestMixedOriginalAndExpandedTypedHostSignatures(t *testing.T) {
+	i32ToI32 := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	i32ToVoid := wasmtest.FuncType([]wasm.ValType{wasm.I32}, nil)
+	body := []byte{0, 0x20, 0, 0x10, 0, 0x20, 0, 0x10, 1, 0x0b}
+	data := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(i32ToI32, i32ToVoid)),
+		wasmtest.Section(2, wasmtest.Vec(
+			importEntry("env", "transform", 0, 0),
+			importEntry("env", "event", 0, 1),
+		)),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("run", 0, 2))),
+		wasmtest.Section(10, wasmtest.Vec(append(wasmtest.ULEB(uint32(len(body))), body...))),
+	)
+	compiled, err := Compile(NewRuntimeConfig(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	seen := int32(0)
+	in, err := Instantiate(compiled, Imports{
+		"env.transform": I32ToI32HostFunc(func(v int32) int32 { return v + 1 }),
+		"env.event":     I32HostFunc(func(v int32) { seen = v }),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	got, err := in.Invoke("run", I32(41))
+	if err != nil || len(got) != 1 || got[0] != 42 || seen != 41 {
+		t.Fatalf("run = %v, %v; event %d; want [42], nil, 41", got, err, seen)
+	}
+}
+
+func BenchmarkHostSignatureMatrix(b *testing.B) {
+	const calls = int32(1024)
+	for _, tc := range hostSignatureCases() {
+		b.Run(tc.name, func(b *testing.B) {
+			compiled, err := Compile(NewRuntimeConfig(), hostSignatureLoopModule(tc.params, tc.results))
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer compiled.Close()
+			paths := []struct {
+				name string
+				fn   any
+			}{
+				{name: "generic", fn: CallerHostFunc(func(_ Caller, _ []uint64, results []uint64) {
+					for i := range results {
+						results[i] = uint64(7 + 2*i)
+					}
+				})},
+				{name: "typed", fn: tc.typed},
+			}
+			if tc.params == 1 && tc.results == 0 {
+				paths = append(paths, struct {
+					name string
+					fn   any
+				}{name: "deferred", fn: I32HostEvent(func(int32) {})})
+			}
+			for _, path := range paths {
+				b.Run(path.name, func(b *testing.B) {
+					in, err := Instantiate(compiled, Imports{"env.f": path.fn})
+					if err != nil {
+						b.Fatal(err)
+					}
+					defer in.Close()
+					if _, err := in.Invoke("run", I32(calls)); err != nil {
+						b.Fatal(err)
+					}
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if _, err := in.Invoke("run", I32(calls)); err != nil {
+							b.Fatal(err)
+						}
+					}
+					b.StopTimer()
+					b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(int64(b.N)*int64(calls)), "ns/call")
+				})
+			}
+		})
+	}
+}
+
+func ExampleNoArgsHostFunc_signatureMatrix() {
+	_ = NoArgsHostFunc(func() {})
+	_ = I32HostFunc(func(int32) {})
+	_ = I32ToI32HostFunc(func(v int32) int32 { return v })
+	_ = I32I32HostFunc(func(int32, int32) {})
+	_ = I32I32ToI32HostFunc(func(a, b int32) int32 { return a + b })
+	_ = I32ToI32I32HostFunc(func(v int32) (int32, int32) { return v, v })
+	_ = I32I32ToI32I32HostFunc(func(a, b int32) (int32, int32) { return a, b })
+	fmt.Println("typed host signature matrix")
+	// Output: typed host signature matrix
+}

--- a/src/wago/host_signature_matrix_bench_test.go
+++ b/src/wago/host_signature_matrix_bench_test.go
@@ -13,6 +13,7 @@ import (
 type hostSignatureCase struct {
 	name            string
 	params, results int
+	valueType       wasm.ValType
 	typed           any
 }
 
@@ -25,17 +26,27 @@ func hostSignatureCases() []hostSignatureCase {
 		{name: "i32_i32_to_i32", params: 2, results: 1, typed: func(int32, int32) int32 { return 7 }},
 		{name: "i32_to_i32_i32", params: 1, results: 2, typed: func(int32) (int32, int32) { return 7, 9 }},
 		{name: "i32_i32_to_i32_i32", params: 2, results: 2, typed: func(int32, int32) (int32, int32) { return 7, 9 }},
+		{name: "i64_to_i64", params: 1, results: 1, valueType: wasm.I64, typed: func(int64) int64 { return 7 }},
+		{name: "i64_i64_to_i64", params: 2, results: 1, valueType: wasm.I64, typed: func(int64, int64) int64 { return 7 }},
+		{name: "f32_to_f32", params: 1, results: 1, valueType: wasm.F32, typed: func(float32) float32 { return 7 }},
+		{name: "f32_f32_to_f32", params: 2, results: 1, valueType: wasm.F32, typed: func(float32, float32) float32 { return 7 }},
+		{name: "f64_to_f64", params: 1, results: 1, valueType: wasm.F64, typed: func(float64) float64 { return 7 }},
+		{name: "f64_f64_to_f64", params: 2, results: 1, valueType: wasm.F64, typed: func(float64, float64) float64 { return 7 }},
 	}
 }
 
-func hostSignatureLoopModule(params, results int) []byte {
+func hostSignatureLoopModule(params, results int, types ...wasm.ValType) []byte {
+	valueType := wasm.I32
+	if len(types) != 0 && types[0] != (wasm.ValType{}) {
+		valueType = types[0]
+	}
 	importParams := make([]wasm.ValType, params)
 	importResults := make([]wasm.ValType, results)
 	for i := range importParams {
-		importParams[i] = wasm.I32
+		importParams[i] = valueType
 	}
 	for i := range importResults {
-		importResults[i] = wasm.I32
+		importResults[i] = valueType
 	}
 	body := []byte{
 		1, 1, 0x7f, // local accumulator: i32
@@ -43,10 +54,27 @@ func hostSignatureLoopModule(params, results int) []byte {
 		0x20, 0, 0x45, 0x0d, 1, // count == 0: branch done
 	}
 	for i := 0; i < params; i++ {
-		body = append(body, 0x41, byte(i+1)) // i32.const
+		switch valueType {
+		case wasm.I32:
+			body = append(body, 0x41, byte(i+1))
+		case wasm.I64:
+			body = append(body, 0x42, byte(i+1))
+		case wasm.F32:
+			body = append(body, 0x43, 0, 0, 0, 0)
+		case wasm.F64:
+			body = append(body, 0x44, 0, 0, 0, 0, 0, 0, 0, 0)
+		}
 	}
 	body = append(body, 0x10, 0) // call import 0
 	for i := 0; i < results; i++ {
+		switch valueType {
+		case wasm.I64:
+			body = append(body, 0xa7) // i32.wrap_i64
+		case wasm.F32:
+			body = append(body, 0xa8) // i32.trunc_f32_s
+		case wasm.F64:
+			body = append(body, 0xaa) // i32.trunc_f64_s
+		}
 		body = append(body, 0x21, 1) // consume result into accumulator
 	}
 	body = append(body,
@@ -69,7 +97,7 @@ func hostSignatureLoopModule(params, results int) []byte {
 func TestTypedHostSignatureMatrix(t *testing.T) {
 	for _, tc := range hostSignatureCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			compiled, err := Compile(NewRuntimeConfig(), hostSignatureLoopModule(tc.params, tc.results))
+			compiled, err := Compile(NewRuntimeConfig(), hostSignatureLoopModule(tc.params, tc.results, tc.valueType))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -129,7 +157,7 @@ func BenchmarkHostSignatureMatrix(b *testing.B) {
 	const calls = int32(1024)
 	for _, tc := range hostSignatureCases() {
 		b.Run(tc.name, func(b *testing.B) {
-			compiled, err := Compile(NewRuntimeConfig(), hostSignatureLoopModule(tc.params, tc.results))
+			compiled, err := Compile(NewRuntimeConfig(), hostSignatureLoopModule(tc.params, tc.results, tc.valueType))
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -145,7 +173,16 @@ func BenchmarkHostSignatureMatrix(b *testing.B) {
 				})},
 				{name: "call", fn: HostCallFunc(func(call HostCall) {
 					for i := 0; i < call.ResultCount(); i++ {
-						call.SetI32(i, int32(7+2*i))
+						switch tc.valueType {
+						case wasm.I64:
+							call.SetI64(i, int64(7+2*i))
+						case wasm.F32:
+							call.SetF32(i, float32(7+2*i))
+						case wasm.F64:
+							call.SetF64(i, float64(7+2*i))
+						default:
+							call.SetI32(i, int32(7+2*i))
+						}
 					}
 				})},
 				{name: "typed", fn: tc.typed},
@@ -190,7 +227,13 @@ func ExampleHostCallFunc_signatureMatrix() {
 		func(a, b int32) int32 { return a + b },
 		func(v int32) (int32, int32) { return v, v },
 		func(a, b int32) (int32, int32) { return a, b },
+		func(v int64) int64 { return v },
+		func(a, b int64) int64 { return a + b },
+		func(v float32) float32 { return v },
+		func(a, b float32) float32 { return a + b },
+		func(v float64) float64 { return v },
+		func(a, b float64) float64 { return a + b },
 	}
 	fmt.Println(len(callbacks), "ordinary host signatures")
-	// Output: 7 ordinary host signatures
+	// Output: 13 ordinary host signatures
 }

--- a/src/wago/host_signature_matrix_bench_test.go
+++ b/src/wago/host_signature_matrix_bench_test.go
@@ -18,13 +18,13 @@ type hostSignatureCase struct {
 
 func hostSignatureCases() []hostSignatureCase {
 	return []hostSignatureCase{
-		{name: "empty_to_empty", typed: NoArgsHostFunc(func() {})},
-		{name: "i32_to_empty", params: 1, typed: I32HostFunc(func(int32) {})},
-		{name: "i32_to_i32", params: 1, results: 1, typed: I32ToI32HostFunc(func(int32) int32 { return 7 })},
-		{name: "i32_i32_to_empty", params: 2, typed: I32I32HostFunc(func(int32, int32) {})},
-		{name: "i32_i32_to_i32", params: 2, results: 1, typed: I32I32ToI32HostFunc(func(int32, int32) int32 { return 7 })},
-		{name: "i32_to_i32_i32", params: 1, results: 2, typed: I32ToI32I32HostFunc(func(int32) (int32, int32) { return 7, 9 })},
-		{name: "i32_i32_to_i32_i32", params: 2, results: 2, typed: I32I32ToI32I32HostFunc(func(int32, int32) (int32, int32) { return 7, 9 })},
+		{name: "empty_to_empty", typed: func() {}},
+		{name: "i32_to_empty", params: 1, typed: func(int32) {}},
+		{name: "i32_to_i32", params: 1, results: 1, typed: func(int32) int32 { return 7 }},
+		{name: "i32_i32_to_empty", params: 2, typed: func(int32, int32) {}},
+		{name: "i32_i32_to_i32", params: 2, results: 1, typed: func(int32, int32) int32 { return 7 }},
+		{name: "i32_to_i32_i32", params: 1, results: 2, typed: func(int32) (int32, int32) { return 7, 9 }},
+		{name: "i32_i32_to_i32_i32", params: 2, results: 2, typed: func(int32, int32) (int32, int32) { return 7, 9 }},
 	}
 }
 
@@ -112,8 +112,8 @@ func TestMixedOriginalAndExpandedTypedHostSignatures(t *testing.T) {
 	defer compiled.Close()
 	seen := int32(0)
 	in, err := Instantiate(compiled, Imports{
-		"env.transform": I32ToI32HostFunc(func(v int32) int32 { return v + 1 }),
-		"env.event":     I32HostFunc(func(v int32) { seen = v }),
+		"env.transform": func(v int32) int32 { return v + 1 },
+		"env.event":     func(v int32) { seen = v },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -141,6 +141,11 @@ func BenchmarkHostSignatureMatrix(b *testing.B) {
 				{name: "generic", fn: CallerHostFunc(func(_ Caller, _ []uint64, results []uint64) {
 					for i := range results {
 						results[i] = uint64(7 + 2*i)
+					}
+				})},
+				{name: "call", fn: HostCallFunc(func(call HostCall) {
+					for i := 0; i < call.ResultCount(); i++ {
+						call.SetI32(i, int32(7+2*i))
 					}
 				})},
 				{name: "typed", fn: tc.typed},
@@ -176,14 +181,16 @@ func BenchmarkHostSignatureMatrix(b *testing.B) {
 	}
 }
 
-func ExampleNoArgsHostFunc_signatureMatrix() {
-	_ = NoArgsHostFunc(func() {})
-	_ = I32HostFunc(func(int32) {})
-	_ = I32ToI32HostFunc(func(v int32) int32 { return v })
-	_ = I32I32HostFunc(func(int32, int32) {})
-	_ = I32I32ToI32HostFunc(func(a, b int32) int32 { return a + b })
-	_ = I32ToI32I32HostFunc(func(v int32) (int32, int32) { return v, v })
-	_ = I32I32ToI32I32HostFunc(func(a, b int32) (int32, int32) { return a, b })
-	fmt.Println("typed host signature matrix")
-	// Output: typed host signature matrix
+func ExampleHostCallFunc_signatureMatrix() {
+	callbacks := []any{
+		func() {},
+		func(int32) {},
+		func(v int32) int32 { return v },
+		func(int32, int32) {},
+		func(a, b int32) int32 { return a + b },
+		func(v int32) (int32, int32) { return v, v },
+		func(a, b int32) (int32, int32) { return a, b },
+	}
+	fmt.Println(len(callbacks), "ordinary host signatures")
+	// Output: 7 ordinary host signatures
 }

--- a/src/wago/host_to_wasm_signature_bench_test.go
+++ b/src/wago/host_to_wasm_signature_bench_test.go
@@ -1,0 +1,80 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64) && !tinygo
+
+package wago
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkHostToWasmSignatureMatrix measures public host-to-Wasm entry without
+// hiding multi-value signatures behind the single-result specialized API.
+func BenchmarkHostToWasmSignatureMatrix(b *testing.B) {
+	for _, shape := range [][2]int{
+		{0, 0},
+		{1, 0},
+		{1, 1},
+		{2, 1},
+		{2, 2},
+		{4, 1},
+		{4, 4},
+		{8, 1},
+		{8, 8},
+		{16, 16},
+		{24, 24},
+		{32, 32},
+		{48, 48},
+		{64, 64},
+	} {
+		params, results := shape[0], shape[1]
+		b.Run(fmt.Sprintf("i32x%d-i32x%d", params, results), func(b *testing.B) {
+			compiled := benchMustCompile(b, hostToWasmI32SignatureModule(params, results))
+			defer compiled.Close()
+			in, err := Instantiate(compiled, InstantiateOptions{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer in.Close()
+			prepared, err := in.PrepareFunction("f")
+			if err != nil {
+				b.Fatal(err)
+			}
+			args := make([]uint64, params)
+			for i := range args {
+				args[i] = I32(int32(i + 1))
+			}
+			check := func(got []uint64, err error) {
+				b.Helper()
+				if err != nil || len(got) != results {
+					b.Fatalf("result = %v, %v", got, err)
+				}
+				for i := range got {
+					if got[i] != uint64(i+1) {
+						b.Fatalf("result[%d] = %d, want %d", i, got[i], i+1)
+					}
+				}
+			}
+			check(in.Invoke("f", args...))
+			check(prepared.Invoke(args...))
+
+			b.Run("invoke", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					benchResultSink, err = in.Invoke("f", args...)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			b.Run("prepared", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					benchResultSink, err = prepared.Invoke(args...)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -121,6 +121,22 @@ type I32ToI32HostFunc func(int32) int32
 // lifetime and re-entry rules as I32ToI32HostFunc.
 type I32I32ToI32HostFunc func(int32, int32) int32
 
+// MaxDeferredHostEventsPerInvocation bounds an instance's deferred event log.
+// Exceeding it traps the invocation and discards the whole event transaction.
+const MaxDeferredHostEventsPerInvocation = runtime.HostCallLogEntries
+
+// I32HostEvent is a deferred, capability-free host import specialized for the
+// Wasm signature (i32) -> (). Native code appends each value to the instance's
+// event log and continues without crossing onto the Go stack. Wago delivers the
+// events in call order after the native invocation returns.
+//
+// The callback therefore cannot affect the currently running Wasm invocation.
+// It runs on an ordinary Go stack and may allocate, block, or panic. Use a
+// synchronous host function when the guest must observe the callback before its
+// next instruction. At most MaxDeferredHostEventsPerInvocation events may be
+// emitted by one invocation; overflow traps and delivers none of them.
+type I32HostEvent func(int32)
+
 // Only runtime-issued representations carry authority. The snapshot is copied,
 // never replaced with the scope's current generation, including on re-entry.
 func resolveHostCaller(module HostModule) (instanceHostModule, bool) {
@@ -1141,6 +1157,57 @@ type gatedI32I32ToI32HostFunc struct {
 	gate *pluginCallGate
 }
 
+type gatedI32HostEvent struct {
+	fn   I32HostEvent
+	gate *pluginCallGate
+}
+
+type asyncHostBinding struct {
+	eventI32 I32HostEvent
+	gate     *pluginCallGate
+}
+
+type hostEventBindings struct {
+	byImport []asyncHostBinding
+}
+
+func bindI32HostEvent(value any, sig FuncSig) (asyncHostBinding, error) {
+	var binding asyncHostBinding
+	switch fn := value.(type) {
+	case I32HostEvent:
+		binding.eventI32 = fn
+	case gatedI32HostEvent:
+		binding.eventI32, binding.gate = fn.fn, fn.gate
+	default:
+		return binding, fmt.Errorf("deferred host event must be a wago.I32HostEvent; got %T", value)
+	}
+	if binding.eventI32 == nil {
+		return asyncHostBinding{}, fmt.Errorf("deferred host event is nil")
+	}
+	if len(sig.Params) != 1 || sig.Params[0] != ValI32 || len(sig.Results) != 0 {
+		return asyncHostBinding{}, fmt.Errorf("deferred host event requires signature (i32) -> ()")
+	}
+	return binding, nil
+}
+
+func (c *Compiled) buildHostEvents(imports Imports) (*hostEventBindings, error) {
+	events := &hostEventBindings{byImport: make([]asyncHostBinding, len(c.Imports))}
+	for i, key := range c.Imports {
+		if _, cross := imports[key].(*InstanceExport); cross {
+			continue
+		}
+		if i >= len(c.importFuncSigs) {
+			return nil, fmt.Errorf("import %q: missing signature", key)
+		}
+		binding, err := bindI32HostEvent(imports[key], c.importFuncSigs[i])
+		if err != nil {
+			return nil, fmt.Errorf("import %q: %w", key, err)
+		}
+		events.byImport[i] = binding
+	}
+	return events, nil
+}
+
 func (b *syncHostBinding) callable() bool {
 	return b.fn != nil || b.concrete != nil || b.typedI32 != nil || b.typedI32x2 != nil
 }
@@ -1155,6 +1222,8 @@ func (b *syncHostBinding) call(caller instanceHostModule, args, results []uint64
 
 func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
 	switch fn := value.(type) {
+	case I32HostEvent, gatedI32HostEvent:
+		return syncHostBinding{}, fmt.Errorf("deferred host event cannot be used by a module that requires synchronous host control")
 	case CallerHostFunc:
 		if fn == nil {
 			return syncHostBinding{}, fmt.Errorf("concrete host function is nil")

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -2561,18 +2561,38 @@ func (in *Instance) callNativeSyncWithTrapContext(entry uintptr, activeTrap []by
 		}
 		fixed := runtime.FixedScalarHostCall(activation.dispatchSingleTypedScalarFixedPortal)
 		switch in.syncHosts[0].scalarKind {
+		case syncHostTypedNone:
+			fixed = activation.dispatchSingleTypedNoneFixedPortal
+		case syncHostTypedI32V:
+			fixed = activation.dispatchSingleTypedI32VoidFixedPortal
 		case syncHostTypedI32x2V:
 			fixed = activation.dispatchSingleTypedI32x2VoidFixedPortal
 		case syncHostTypedI32R2:
 			fixed = activation.dispatchSingleTypedI32PairFixedPortal
 		case syncHostTypedI32x2R2:
 			fixed = activation.dispatchSingleTypedI32x2PairFixedPortal
+		case syncHostTypedI64:
+			fixed = activation.dispatchSingleTypedI64FixedPortal
+		case syncHostTypedI64x2:
+			fixed = activation.dispatchSingleTypedI64x2FixedPortal
+		case syncHostTypedF32:
+			fixed = activation.dispatchSingleTypedF32FixedPortal
+		case syncHostTypedF32x2:
+			fixed = activation.dispatchSingleTypedF32x2FixedPortal
+		case syncHostTypedF64:
+			fixed = activation.dispatchSingleTypedF64FixedPortal
+		case syncHostTypedF64x2:
+			fixed = activation.dispatchSingleTypedF64x2FixedPortal
 		}
 		err = in.eng.CallWithHostBaseScalarFixed(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, rawSlots, activation.dispatch, activation.dispatchTypedScalarExpandedPortal, fixed)
 	} else if in.hasExpandedTypedScalarHost() {
 		err = in.eng.CallWithHostBaseScalarExpanded(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchTypedScalarExpandedPortal)
 	} else if in.hasDirectTypedScalarHost() {
 		err = in.eng.CallWithHostBaseScalar(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchTypedScalarPortal)
+	} else if in.hasSingleHostCallFixedViewPortal() {
+		binding := &in.syncHosts[0]
+		rawSlots := uint32(len(binding.sig.Params)) | uint32(len(binding.sig.Results))<<16
+		err = in.eng.CallWithHostBaseFixedView(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, rawSlots, activation.dispatch, activation.dispatchSingleHostCallFixedView)
 	} else if in.hasSingleHostCallPortal() {
 		err = in.eng.CallWithHostBase(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatchSingleHostCall)
 	} else if in.hasSingleHostCallViewPortal() {

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -106,6 +106,15 @@ type Caller struct {
 // Legacy asynchronous host-call logging does not support CallerHostFunc.
 type CallerHostFunc func(caller Caller, params, results []uint64)
 
+// NoArgsHostFunc is a capability-free synchronous host import specialized for
+// the Wasm signature () -> ().
+type NoArgsHostFunc func()
+
+// I32HostFunc is a capability-free synchronous host import specialized for the
+// Wasm signature (i32) -> (). Unlike I32HostEvent, it runs before the guest's
+// next instruction.
+type I32HostFunc func(int32)
+
 // I32ToI32HostFunc is a capability-free synchronous host import specialized
 // for the Wasm signature (i32) -> i32. Its signature is checked once when the
 // instance is created. Calls do not construct a Caller or expose slot slices.
@@ -120,6 +129,18 @@ type I32ToI32HostFunc func(int32) int32
 // for the Wasm signature (i32, i32) -> i32. It has the same execution and
 // lifetime and re-entry rules as I32ToI32HostFunc.
 type I32I32ToI32HostFunc func(int32, int32) int32
+
+// I32I32HostFunc is a capability-free synchronous host import specialized for
+// the Wasm signature (i32, i32) -> ().
+type I32I32HostFunc func(int32, int32)
+
+// I32ToI32I32HostFunc is a capability-free synchronous host import specialized
+// for the Wasm signature (i32) -> (i32, i32).
+type I32ToI32I32HostFunc func(int32) (int32, int32)
+
+// I32I32ToI32I32HostFunc is a capability-free synchronous host import
+// specialized for the Wasm signature (i32, i32) -> (i32, i32).
+type I32I32ToI32I32HostFunc func(int32, int32) (int32, int32)
 
 // MaxDeferredHostEventsPerInvocation bounds an instance's deferred event log.
 // Exceeding it traps the invocation and discards the whole event transaction.
@@ -1130,14 +1151,19 @@ func bindHostImport(v any, sig FuncSig) (HostFunc, error) {
 }
 
 type syncHostBinding struct {
-	fn         HostFunc
-	concrete   CallerHostFunc
-	typedI32   I32ToI32HostFunc
-	typedI32x2 I32I32ToI32HostFunc
-	gate       *pluginCallGate
-	exact      *DefinedTypeDescriptor
-	importIdx  uint32
-	scalarKind uint8
+	fn           HostFunc
+	concrete     CallerHostFunc
+	typedI32     I32ToI32HostFunc
+	typedI32x2   I32I32ToI32HostFunc
+	gate         *pluginCallGate
+	exact        *DefinedTypeDescriptor
+	importIdx    uint32
+	scalarKind   uint8
+	typedNone    NoArgsHostFunc
+	typedI32V    I32HostFunc
+	typedI32x2V  I32I32HostFunc
+	typedI32R2   I32ToI32I32HostFunc
+	typedI32x2R2 I32I32ToI32I32HostFunc
 }
 
 const (
@@ -1145,10 +1171,40 @@ const (
 	syncHostScalar
 	syncHostTypedI32
 	syncHostTypedI32x2
+	syncHostTypedNone
+	syncHostTypedI32V
+	syncHostTypedI32x2V
+	syncHostTypedI32R2
+	syncHostTypedI32x2R2
 )
 
 type gatedI32ToI32HostFunc struct {
 	fn   I32ToI32HostFunc
+	gate *pluginCallGate
+}
+
+type gatedNoArgsHostFunc struct {
+	fn   NoArgsHostFunc
+	gate *pluginCallGate
+}
+
+type gatedI32HostFunc struct {
+	fn   I32HostFunc
+	gate *pluginCallGate
+}
+
+type gatedI32I32HostFunc struct {
+	fn   I32I32HostFunc
+	gate *pluginCallGate
+}
+
+type gatedI32ToI32I32HostFunc struct {
+	fn   I32ToI32I32HostFunc
+	gate *pluginCallGate
+}
+
+type gatedI32I32ToI32I32HostFunc struct {
+	fn   I32I32ToI32I32HostFunc
 	gate *pluginCallGate
 }
 
@@ -1209,7 +1265,7 @@ func (c *Compiled) buildHostEvents(imports Imports) (*hostEventBindings, error) 
 }
 
 func (b *syncHostBinding) callable() bool {
-	return b.fn != nil || b.concrete != nil || b.typedI32 != nil || b.typedI32x2 != nil
+	return b.fn != nil || b.concrete != nil || b.scalarKind >= syncHostTypedI32
 }
 
 func (b *syncHostBinding) call(caller instanceHostModule, args, results []uint64) {
@@ -1229,6 +1285,14 @@ func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
 			return syncHostBinding{}, fmt.Errorf("concrete host function is nil")
 		}
 		return syncHostBinding{concrete: fn}, nil
+	case NoArgsHostFunc:
+		return bindNoArgsHostFunc(fn, sig)
+	case func():
+		return bindNoArgsHostFunc(NoArgsHostFunc(fn), sig)
+	case I32HostFunc:
+		return bindI32HostFunc(fn, sig)
+	case func(int32):
+		return bindI32HostFunc(I32HostFunc(fn), sig)
 	case I32ToI32HostFunc:
 		return bindI32ToI32HostFunc(fn, sig)
 	case func(int32) int32:
@@ -1237,8 +1301,40 @@ func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
 		return bindI32I32ToI32HostFunc(fn, sig)
 	case func(int32, int32) int32:
 		return bindI32I32ToI32HostFunc(I32I32ToI32HostFunc(fn), sig)
+	case I32I32HostFunc:
+		return bindI32I32HostFunc(fn, sig)
+	case func(int32, int32):
+		return bindI32I32HostFunc(I32I32HostFunc(fn), sig)
+	case I32ToI32I32HostFunc:
+		return bindI32ToI32I32HostFunc(fn, sig)
+	case func(int32) (int32, int32):
+		return bindI32ToI32I32HostFunc(I32ToI32I32HostFunc(fn), sig)
+	case I32I32ToI32I32HostFunc:
+		return bindI32I32ToI32I32HostFunc(fn, sig)
+	case func(int32, int32) (int32, int32):
+		return bindI32I32ToI32I32HostFunc(I32I32ToI32I32HostFunc(fn), sig)
 	case gatedI32ToI32HostFunc:
 		binding, err := bindI32ToI32HostFunc(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
+	case gatedNoArgsHostFunc:
+		binding, err := bindNoArgsHostFunc(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
+	case gatedI32HostFunc:
+		binding, err := bindI32HostFunc(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
+	case gatedI32I32HostFunc:
+		binding, err := bindI32I32HostFunc(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
+	case gatedI32ToI32I32HostFunc:
+		binding, err := bindI32ToI32I32HostFunc(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
+	case gatedI32I32ToI32I32HostFunc:
+		binding, err := bindI32I32ToI32I32HostFunc(fn.fn, sig)
 		binding.gate = fn.gate
 		return binding, err
 	case gatedI32I32ToI32HostFunc:
@@ -1248,6 +1344,26 @@ func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
 	}
 	fn, err := bindHostImport(value, sig)
 	return syncHostBinding{fn: fn}, err
+}
+
+func bindNoArgsHostFunc(fn NoArgsHostFunc, sig FuncSig) (syncHostBinding, error) {
+	if fn == nil {
+		return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+	}
+	if len(sig.Params) != 0 || len(sig.Results) != 0 {
+		return syncHostBinding{}, fmt.Errorf("typed host function requires signature () -> ()")
+	}
+	return syncHostBinding{typedNone: fn, scalarKind: syncHostTypedNone}, nil
+}
+
+func bindI32HostFunc(fn I32HostFunc, sig FuncSig) (syncHostBinding, error) {
+	if fn == nil {
+		return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+	}
+	if len(sig.Params) != 1 || sig.Params[0] != ValI32 || len(sig.Results) != 0 {
+		return syncHostBinding{}, fmt.Errorf("typed host function requires signature (i32) -> ()")
+	}
+	return syncHostBinding{typedI32V: fn, scalarKind: syncHostTypedI32V}, nil
 }
 
 func bindI32ToI32HostFunc(fn I32ToI32HostFunc, sig FuncSig) (syncHostBinding, error) {
@@ -1268,6 +1384,36 @@ func bindI32I32ToI32HostFunc(fn I32I32ToI32HostFunc, sig FuncSig) (syncHostBindi
 		return syncHostBinding{}, fmt.Errorf("typed host function requires signature (i32, i32) -> i32")
 	}
 	return syncHostBinding{typedI32x2: fn, scalarKind: syncHostTypedI32x2}, nil
+}
+
+func bindI32I32HostFunc(fn I32I32HostFunc, sig FuncSig) (syncHostBinding, error) {
+	if fn == nil {
+		return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+	}
+	if len(sig.Params) != 2 || sig.Params[0] != ValI32 || sig.Params[1] != ValI32 || len(sig.Results) != 0 {
+		return syncHostBinding{}, fmt.Errorf("typed host function requires signature (i32, i32) -> ()")
+	}
+	return syncHostBinding{typedI32x2V: fn, scalarKind: syncHostTypedI32x2V}, nil
+}
+
+func bindI32ToI32I32HostFunc(fn I32ToI32I32HostFunc, sig FuncSig) (syncHostBinding, error) {
+	if fn == nil {
+		return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+	}
+	if len(sig.Params) != 1 || sig.Params[0] != ValI32 || len(sig.Results) != 2 || sig.Results[0] != ValI32 || sig.Results[1] != ValI32 {
+		return syncHostBinding{}, fmt.Errorf("typed host function requires signature (i32) -> (i32, i32)")
+	}
+	return syncHostBinding{typedI32R2: fn, scalarKind: syncHostTypedI32R2}, nil
+}
+
+func bindI32I32ToI32I32HostFunc(fn I32I32ToI32I32HostFunc, sig FuncSig) (syncHostBinding, error) {
+	if fn == nil {
+		return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+	}
+	if len(sig.Params) != 2 || sig.Params[0] != ValI32 || sig.Params[1] != ValI32 || len(sig.Results) != 2 || sig.Results[0] != ValI32 || sig.Results[1] != ValI32 {
+		return syncHostBinding{}, fmt.Errorf("typed host function requires signature (i32, i32) -> (i32, i32)")
+	}
+	return syncHostBinding{typedI32x2R2: fn, scalarKind: syncHostTypedI32x2R2}, nil
 }
 
 // buildSyncHosts resolves every function import of a sync-mode module to one
@@ -1440,6 +1586,28 @@ func dispatchSyncHostScalar(in *Instance, scope *hostCallScope, binding *syncHos
 	}
 	if binding.typedI32 != nil {
 		results[0] = I32(binding.typedI32(AsI32(args[0])))
+		return
+	}
+	if binding.typedNone != nil {
+		binding.typedNone()
+		return
+	}
+	if binding.typedI32V != nil {
+		binding.typedI32V(AsI32(args[0]))
+		return
+	}
+	if binding.typedI32x2V != nil {
+		binding.typedI32x2V(AsI32(args[0]), AsI32(args[1]))
+		return
+	}
+	if binding.typedI32R2 != nil {
+		r0, r1 := binding.typedI32R2(AsI32(args[0]))
+		results[0], results[1] = I32(r0), I32(r1)
+		return
+	}
+	if binding.typedI32x2R2 != nil {
+		r0, r1 := binding.typedI32x2R2(AsI32(args[0]), AsI32(args[1]))
+		results[0], results[1] = I32(r0), I32(r1)
 		return
 	}
 	if binding.typedI32x2 != nil {
@@ -1804,7 +1972,9 @@ func (in *Instance) callNativeSyncWithTrapContext(entry uintptr, activeTrap []by
 		state:                       in.ensurePluginState(),
 		parkedNativeContextReusable: in.gc == nil && !in.c.threadedMemory0(),
 	}
-	if in.hasDirectTypedScalarHost() {
+	if in.hasExpandedTypedScalarHost() {
+		err = in.eng.CallWithHostBaseScalarExpanded(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchTypedScalarExpandedPortal)
+	} else if in.hasDirectTypedScalarHost() {
 		err = in.eng.CallWithHostBaseScalar(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchTypedScalarPortal)
 	} else {
 		err = in.eng.CallWithHostBase(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch)

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -2,7 +2,6 @@ package wago
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	goruntime "runtime"
@@ -94,7 +93,7 @@ type HostFunc func(m HostModule, params, results []uint64)
 
 // HostCall is a borrowed, logical view of one synchronous Wasm-to-Go call.
 // Values are indexed by WebAssembly parameter/result position, not raw ABI
-// slot: a v128 therefore occupies one index even though it uses two slots.
+// slot.
 // HostCall and values obtained from it are valid only until the callback
 // returns and must not be retained.
 type HostCall struct {
@@ -104,10 +103,11 @@ type HostCall struct {
 	exact   *DefinedTypeDescriptor
 }
 
-// HostCallFunc is the universal portable host callback. It supports arbitrary
-// parameter and result arity and every WebAssembly value type without
-// reflection or callback-time allocation. Ordinary Go functions recognized by
-// Func and Imports use more specialized direct lanes when available.
+// HostCallFunc is the universal portable host callback for scalar and reference
+// values. It supports arbitrary parameter and result arity without reflection
+// or callback-time allocation. V128 host boundaries are intentionally
+// unsupported. Ordinary Go functions recognized by Func and Imports use more
+// specialized direct lanes when available.
 type HostCallFunc func(HostCall)
 
 // CallerHostCallFunc is the universal form when a callback also needs memory,
@@ -128,14 +128,12 @@ func (c HostCall) ResultCount() int {
 	return len(c.sig.Results)
 }
 
-// ParamSlots returns the borrowed raw ABI slots for this call. Scalar values
-// occupy one slot and v128 occupies two consecutive little-endian slots. The
-// slice is valid only until the callback returns and must not be retained.
+// ParamSlots returns the borrowed raw ABI slots for this call. The slice is
+// valid only until the callback returns and must not be retained.
 func (c HostCall) ParamSlots() []uint64 { return c.params }
 
-// ResultSlots returns the borrowed writable raw ABI slots for this call. Scalar
-// values occupy one slot and v128 occupies two consecutive little-endian slots.
-// The slice is valid only until the callback returns and must not be retained.
+// ResultSlots returns the borrowed writable raw ABI slots for this call. The
+// slice is valid only until the callback returns and must not be retained.
 func (c HostCall) ResultSlots() []uint64 { return c.results }
 
 func (c HostCall) ParamType(i int) ValueTypeDescriptor {
@@ -166,14 +164,6 @@ func (c HostCall) ExnRef(i int) ExnRef { return ExnRef{token: c.paramSlot(i, Val
 func (c HostCall) GCRef(i int) GCRef   { return GCRef{token: c.paramSlot(i, ValAnyRef)} }
 func (c HostCall) I31Ref(i int) I31Ref { return I31Ref{bits: uint32(c.paramSlot(i, ValI31Ref))} }
 
-func (c HostCall) V128(i int) V128 {
-	slot := c.paramSlotIndex(i, ValV128)
-	var value V128
-	binary.LittleEndian.PutUint64(value[:8], c.params[slot])
-	binary.LittleEndian.PutUint64(value[8:], c.params[slot+1])
-	return value
-}
-
 func (c HostCall) SetI32(i int, v int32)       { c.setResultSlot(i, ValI32, I32(v)) }
 func (c HostCall) SetI64(i int, v int64)       { c.setResultSlot(i, ValI64, I64(v)) }
 func (c HostCall) SetF32(i int, v float32)     { c.setResultSlot(i, ValF32, F32(v)) }
@@ -186,14 +176,8 @@ func (c HostCall) SetExnRef(i int, v ExnRef) { c.setResultSlot(i, ValExnRef, v.t
 func (c HostCall) SetGCRef(i int, v GCRef)   { c.setResultSlot(i, ValAnyRef, v.token) }
 func (c HostCall) SetI31Ref(i int, v I31Ref) { c.setResultSlot(i, ValI31Ref, uint64(v.bits)) }
 
-func (c HostCall) SetV128(i int, v V128) {
-	slot := c.resultSlotIndex(i, ValV128)
-	c.results[slot] = binary.LittleEndian.Uint64(v[:8])
-	c.results[slot+1] = binary.LittleEndian.Uint64(v[8:])
-}
-
 // RawParam and SetRawResult are the complete, future-proof escape hatch for
-// value types added after this release. hi is non-zero-width only for v128.
+// value types added after this release.
 func (c HostCall) RawParam(i int) (lo, hi uint64) {
 	typ := c.paramType(i)
 	slot := hostCallSlot(c.sig.Params, i)
@@ -1444,7 +1428,7 @@ func isHostCallback(value any) bool {
 		func(int64) int64, func(int64, int64) int64,
 		func(float32) float32, func(float32, float32) float32,
 		func(float64) float64, func(float64, float64) float64,
-		func(V128) V128, func(FuncRef) FuncRef, func(ExternRef) ExternRef,
+		func(FuncRef) FuncRef, func(ExternRef) ExternRef,
 		func(ExnRef) ExnRef, func(GCRef) GCRef, func(I31Ref) I31Ref,
 		gatedNoArgsHostFunc, gatedI32HostFunc, gatedI32ToI32HostFunc,
 		gatedI32I32HostFunc, gatedI32I32ToI32HostFunc,
@@ -1484,8 +1468,6 @@ func inferredHostFuncSignature(value any) (params, results []ValType, ok bool) {
 		return []ValType{ValF64}, []ValType{ValF64}, true
 	case func(float64, float64) float64:
 		return []ValType{ValF64, ValF64}, []ValType{ValF64}, true
-	case func(V128) V128:
-		return []ValType{ValV128}, []ValType{ValV128}, true
 	case func(FuncRef) FuncRef:
 		return []ValType{ValFuncRef}, []ValType{ValFuncRef}, true
 	case func(ExternRef) ExternRef:
@@ -1574,7 +1556,7 @@ func gateHostImport(value any, gate *pluginCallGate) (any, error) {
 	case func(int64) int64, func(int64, int64) int64,
 		func(float32) float32, func(float32, float32) float32,
 		func(float64) float64, func(float64, float64) float64,
-		func(V128) V128, func(FuncRef) FuncRef, func(ExternRef) ExternRef,
+		func(FuncRef) FuncRef, func(ExternRef) ExternRef,
 		func(ExnRef) ExnRef, func(GCRef) GCRef, func(I31Ref) I31Ref:
 		return gatedOrdinaryHostFunc{fn: value, gate: gate}, nil
 	default:
@@ -1656,12 +1638,6 @@ func (b *syncHostBinding) call(caller instanceHostModule, args, results []uint64
 		results[0] = F64(fn(AsF64(args[0])))
 	case func(float64, float64) float64:
 		results[0] = F64(fn(AsF64(args[0]), AsF64(args[1])))
-	case func(V128) V128:
-		var value V128
-		binary.LittleEndian.PutUint64(value[:8], args[0])
-		binary.LittleEndian.PutUint64(value[8:], args[1])
-		value = fn(value)
-		results[0], results[1] = binary.LittleEndian.Uint64(value[:8]), binary.LittleEndian.Uint64(value[8:])
 	case func(FuncRef) FuncRef:
 		results[0] = fn(FuncRef{token: args[0]}).token
 	case func(ExternRef) ExternRef:
@@ -1680,6 +1656,9 @@ func (b *syncHostBinding) call(caller instanceHostModule, args, results []uint64
 }
 
 func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
+	if hasValType(sig.Params, ValV128) || hasValType(sig.Results, ValV128) {
+		return syncHostBinding{}, fmt.Errorf("v128 host callbacks are not supported")
+	}
 	switch fn := value.(type) {
 	case I32HostEvent, gatedI32HostEvent:
 		return syncHostBinding{}, fmt.Errorf("deferred host event cannot be used by a module that requires synchronous host control")
@@ -1771,11 +1750,6 @@ func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
 			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
 		}
 		return bindSimpleTypedHostFunc(sig, ValF64, 2, syncHostBinding{fn: fn, scalarKind: syncHostTypedF64x2})
-	case func(V128) V128:
-		if fn == nil {
-			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
-		}
-		return bindSimpleTypedHostFunc(sig, ValV128, 1, syncHostBinding{fn: fn})
 	case func(FuncRef) FuncRef:
 		if fn == nil {
 			return syncHostBinding{}, fmt.Errorf("typed host function is nil")

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -1614,7 +1614,48 @@ func (b *syncHostBinding) callable() bool {
 	return b.fn != nil || b.scalarKind >= syncHostTypedI32
 }
 
+// call is the common Go-level entry for a bound synchronous host function. It
+// owns plugin admission unless the caller carries an operation reservation for
+// this exact gate. Native guest dispatch uses representation-specific unchecked
+// helpers after performing the same admission around argument/result translation.
 func (b *syncHostBinding) call(caller instanceHostModule, args, results []uint64) {
+	if b.gate != nil && (caller.reservation == nil || !caller.reservation.allows(b.gate)) {
+		if err := b.gate.enter(); err != nil {
+			panic(HostTrap{Err: err})
+		}
+		defer b.gate.release()
+	}
+	b.callUnchecked(caller, args, results)
+}
+
+func (b *syncHostBinding) callUnchecked(caller instanceHostModule, args, results []uint64) {
+	if b.fn != nil {
+		b.callBoundUnchecked(caller, args, results)
+		return
+	}
+	switch b.scalarKind {
+	case syncHostTypedI32:
+		results[0] = I32(b.typedI32(AsI32(args[0])))
+	case syncHostTypedI32x2:
+		results[0] = I32(b.typedI32x2(AsI32(args[0]), AsI32(args[1])))
+	case syncHostTypedNone:
+		b.typedNone()
+	case syncHostTypedI32V:
+		b.typedI32V(AsI32(args[0]))
+	case syncHostTypedI32x2V:
+		b.typedI32x2V(AsI32(args[0]), AsI32(args[1]))
+	case syncHostTypedI32R2:
+		r0, r1 := b.typedI32R2(AsI32(args[0]))
+		results[0], results[1] = I32(r0), I32(r1)
+	case syncHostTypedI32x2R2:
+		r0, r1 := b.typedI32x2R2(AsI32(args[0]), AsI32(args[1]))
+		results[0], results[1] = I32(r0), I32(r1)
+	default:
+		panic(fmt.Sprintf("wago: invalid bound host function %T", b.fn))
+	}
+}
+
+func (b *syncHostBinding) callBoundUnchecked(caller instanceHostModule, args, results []uint64) {
 	switch fn := b.fn.(type) {
 	case CallerHostFunc:
 		fn(Caller{instanceHostModule: caller}, args, results)
@@ -2115,7 +2156,7 @@ func dispatchSyncHostScalar(in *Instance, scope *hostCallScope, binding *syncHos
 	caller := scope.beginReservedWithID(in, invocation.id, invocation.reservation)
 	caller.exact = binding.exact
 	defer caller.scope.end(caller.generation, caller.parentGeneration)
-	binding.call(caller, args, results)
+	binding.callBoundUnchecked(caller, args, results)
 }
 
 func dispatchSyncHostReference(in *Instance, scope *hostCallScope, ctrl uintptr, importIdx uint32, binding *syncHostBinding, sig FuncSig, exact *DefinedTypeDescriptor, exactTypes []DefinedTypeDescriptor, exactTypesPtr *[]DefinedTypeDescriptor, args, results []uint64, invocation hostInvocationContext) {
@@ -2124,7 +2165,7 @@ func dispatchSyncHostReference(in *Instance, scope *hostCallScope, ctrl uintptr,
 		return
 	}
 	if _, ok := binding.fn.(HostCallFunc); ok && !hasReferenceValType(sig.Params) && !hasReferenceValType(sig.Results) {
-		binding.call(instanceHostModule{}, args, results)
+		binding.callBoundUnchecked(instanceHostModule{}, args, results)
 		return
 	}
 	var exactParams, exactResults []ValueTypeDescriptor
@@ -2144,7 +2185,7 @@ func dispatchSyncHostReference(in *Instance, scope *hostCallScope, ctrl uintptr,
 	caller.ephemeralGCResults = &gcResultTemps
 	defer gcResultTemps.release(in)
 	defer caller.scope.end(caller.generation, caller.parentGeneration)
-	binding.call(caller, args, results)
+	binding.callBoundUnchecked(caller, args, results)
 	if err := in.translateHostReferenceResults(ctrl, results, sig.Results, exactResults, exactTypes); err != nil {
 		panic(invalidHostReference{err: fmt.Errorf("host import %d: %w", importIdx, err)})
 	}

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -2,6 +2,7 @@ package wago
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	goruntime "runtime"
@@ -91,6 +92,192 @@ type GCHostModule interface {
 // under standard Go and TinyGo — with no reflection anywhere on the path.
 type HostFunc func(m HostModule, params, results []uint64)
 
+// HostCall is a borrowed, logical view of one synchronous Wasm-to-Go call.
+// Values are indexed by WebAssembly parameter/result position, not raw ABI
+// slot: a v128 therefore occupies one index even though it uses two slots.
+// HostCall and values obtained from it are valid only until the callback
+// returns and must not be retained.
+type HostCall struct {
+	params  []uint64
+	results []uint64
+	sig     *FuncSig
+	exact   *DefinedTypeDescriptor
+}
+
+// HostCallFunc is the universal portable host callback. It supports arbitrary
+// parameter and result arity and every WebAssembly value type without
+// reflection or callback-time allocation. Ordinary Go functions recognized by
+// Func and Imports use more specialized direct lanes when available.
+type HostCallFunc func(HostCall)
+
+// CallerHostCallFunc is the universal form when a callback also needs memory,
+// reference-store access, invocation context, or synchronous re-entry authority.
+type CallerHostCallFunc func(Caller, HostCall)
+
+func (c HostCall) ParamCount() int {
+	if c.sig == nil {
+		return 0
+	}
+	return len(c.sig.Params)
+}
+
+func (c HostCall) ResultCount() int {
+	if c.sig == nil {
+		return 0
+	}
+	return len(c.sig.Results)
+}
+
+// ParamSlots returns the borrowed raw ABI slots for this call. Scalar values
+// occupy one slot and v128 occupies two consecutive little-endian slots. The
+// slice is valid only until the callback returns and must not be retained.
+func (c HostCall) ParamSlots() []uint64 { return c.params }
+
+// ResultSlots returns the borrowed writable raw ABI slots for this call. Scalar
+// values occupy one slot and v128 occupies two consecutive little-endian slots.
+// The slice is valid only until the callback returns and must not be retained.
+func (c HostCall) ResultSlots() []uint64 { return c.results }
+
+func (c HostCall) ParamType(i int) ValueTypeDescriptor {
+	if c.exact != nil && uint(i) < uint(len(c.exact.Params)) {
+		return c.exact.Params[i]
+	}
+	t, _ := valueTypeDescriptorFromValType(c.paramType(i))
+	return t
+}
+
+func (c HostCall) ResultType(i int) ValueTypeDescriptor {
+	if c.exact != nil && uint(i) < uint(len(c.exact.Results)) {
+		return c.exact.Results[i]
+	}
+	t, _ := valueTypeDescriptorFromValType(c.resultType(i))
+	return t
+}
+
+func (c HostCall) I32(i int) int32       { return AsI32(c.paramSlot(i, ValI32)) }
+func (c HostCall) I64(i int) int64       { return AsI64(c.paramSlot(i, ValI64)) }
+func (c HostCall) F32(i int) float32     { return AsF32(c.paramSlot(i, ValF32)) }
+func (c HostCall) F64(i int) float64     { return AsF64(c.paramSlot(i, ValF64)) }
+func (c HostCall) FuncRef(i int) FuncRef { return FuncRef{token: c.paramSlot(i, ValFuncRef)} }
+func (c HostCall) ExternRef(i int) ExternRef {
+	return ExternRef{token: c.paramSlot(i, ValExternRef)}
+}
+func (c HostCall) ExnRef(i int) ExnRef { return ExnRef{token: c.paramSlot(i, ValExnRef)} }
+func (c HostCall) GCRef(i int) GCRef   { return GCRef{token: c.paramSlot(i, ValAnyRef)} }
+func (c HostCall) I31Ref(i int) I31Ref { return I31Ref{bits: uint32(c.paramSlot(i, ValI31Ref))} }
+
+func (c HostCall) V128(i int) V128 {
+	slot := c.paramSlotIndex(i, ValV128)
+	var value V128
+	binary.LittleEndian.PutUint64(value[:8], c.params[slot])
+	binary.LittleEndian.PutUint64(value[8:], c.params[slot+1])
+	return value
+}
+
+func (c HostCall) SetI32(i int, v int32)       { c.setResultSlot(i, ValI32, I32(v)) }
+func (c HostCall) SetI64(i int, v int64)       { c.setResultSlot(i, ValI64, I64(v)) }
+func (c HostCall) SetF32(i int, v float32)     { c.setResultSlot(i, ValF32, F32(v)) }
+func (c HostCall) SetF64(i int, v float64)     { c.setResultSlot(i, ValF64, F64(v)) }
+func (c HostCall) SetFuncRef(i int, v FuncRef) { c.setResultSlot(i, ValFuncRef, v.token) }
+func (c HostCall) SetExternRef(i int, v ExternRef) {
+	c.setResultSlot(i, ValExternRef, v.token)
+}
+func (c HostCall) SetExnRef(i int, v ExnRef) { c.setResultSlot(i, ValExnRef, v.token) }
+func (c HostCall) SetGCRef(i int, v GCRef)   { c.setResultSlot(i, ValAnyRef, v.token) }
+func (c HostCall) SetI31Ref(i int, v I31Ref) { c.setResultSlot(i, ValI31Ref, uint64(v.bits)) }
+
+func (c HostCall) SetV128(i int, v V128) {
+	slot := c.resultSlotIndex(i, ValV128)
+	c.results[slot] = binary.LittleEndian.Uint64(v[:8])
+	c.results[slot+1] = binary.LittleEndian.Uint64(v[8:])
+}
+
+// RawParam and SetRawResult are the complete, future-proof escape hatch for
+// value types added after this release. hi is non-zero-width only for v128.
+func (c HostCall) RawParam(i int) (lo, hi uint64) {
+	typ := c.paramType(i)
+	slot := hostCallSlot(c.sig.Params, i)
+	lo = c.params[slot]
+	if typ == ValV128 {
+		hi = c.params[slot+1]
+	}
+	return
+}
+
+func (c HostCall) SetRawResult(i int, lo, hi uint64) {
+	typ := c.resultType(i)
+	slot := hostCallSlot(c.sig.Results, i)
+	c.results[slot] = lo
+	if typ == ValV128 {
+		c.results[slot+1] = hi
+	}
+}
+
+func (c HostCall) paramType(i int) ValType {
+	if c.sig == nil || uint(i) >= uint(len(c.sig.Params)) {
+		panic(fmt.Sprintf("wago: host parameter index %d out of range", i))
+	}
+	return c.sig.Params[i]
+}
+
+func (c HostCall) resultType(i int) ValType {
+	if c.sig == nil || uint(i) >= uint(len(c.sig.Results)) {
+		panic(fmt.Sprintf("wago: host result index %d out of range", i))
+	}
+	return c.sig.Results[i]
+}
+
+func hostCallSlot(types []ValType, index int) int {
+	if uint(index) >= uint(len(types)) {
+		panic(fmt.Sprintf("wago: host value index %d out of range", index))
+	}
+	slot := index
+	for i := 0; i < index; i++ {
+		if types[i] == ValV128 {
+			slot++
+		}
+	}
+	return slot
+}
+
+func (c HostCall) paramSlotIndex(i int, want ValType) int {
+	if i == 0 && c.sig != nil && len(c.sig.Params) != 0 {
+		got := c.sig.Params[0]
+		if got != want {
+			panic(fmt.Sprintf("wago: host parameter %d is %s, not %s", i, got, want))
+		}
+		return 0
+	}
+	got := c.paramType(i)
+	if got != want {
+		panic(fmt.Sprintf("wago: host parameter %d is %s, not %s", i, got, want))
+	}
+	return hostCallSlot(c.sig.Params, i)
+}
+
+func (c HostCall) resultSlotIndex(i int, want ValType) int {
+	if i == 0 && c.sig != nil && len(c.sig.Results) != 0 {
+		got := c.sig.Results[0]
+		if got != want {
+			panic(fmt.Sprintf("wago: host result %d is %s, not %s", i, got, want))
+		}
+		return 0
+	}
+	got := c.resultType(i)
+	if got != want {
+		panic(fmt.Sprintf("wago: host result %d is %s, not %s", i, got, want))
+	}
+	return hostCallSlot(c.sig.Results, i)
+}
+
+func (c HostCall) paramSlot(i int, want ValType) uint64 {
+	return c.params[c.paramSlotIndex(i, want)]
+}
+
+func (c HostCall) setResultSlot(i int, want ValType, value uint64) {
+	c.results[c.resultSlotIndex(i, want)] = value
+}
+
 // Caller is an immutable, callback-scoped capability for a synchronous host
 // import. Its zero value has no authority. Copying or retaining a Caller does
 // not extend its lifetime. Its methods have the same checks as HostModule.
@@ -108,11 +295,13 @@ type CallerHostFunc func(caller Caller, params, results []uint64)
 
 // NoArgsHostFunc is a capability-free synchronous host import specialized for
 // the Wasm signature () -> ().
+// Deprecated: pass func() directly to Func or Imports.
 type NoArgsHostFunc func()
 
 // I32HostFunc is a capability-free synchronous host import specialized for the
 // Wasm signature (i32) -> (). Unlike I32HostEvent, it runs before the guest's
 // next instruction.
+// Deprecated: pass func(int32) directly to Func or Imports.
 type I32HostFunc func(int32)
 
 // I32ToI32HostFunc is a capability-free synchronous host import specialized
@@ -123,23 +312,28 @@ type I32HostFunc func(int32)
 // when callback-scoped re-entry is required. Directly invoking a captured
 // Instance remains subject to ordinary instance serialization and is not a
 // substitute for Caller-authorized re-entry.
+// Deprecated: pass func(int32) int32 directly to Func or Imports.
 type I32ToI32HostFunc func(int32) int32
 
 // I32I32ToI32HostFunc is a capability-free synchronous host import specialized
 // for the Wasm signature (i32, i32) -> i32. It has the same execution and
 // lifetime and re-entry rules as I32ToI32HostFunc.
+// Deprecated: pass func(int32, int32) int32 directly to Func or Imports.
 type I32I32ToI32HostFunc func(int32, int32) int32
 
 // I32I32HostFunc is a capability-free synchronous host import specialized for
 // the Wasm signature (i32, i32) -> ().
+// Deprecated: pass func(int32, int32) directly to Func or Imports.
 type I32I32HostFunc func(int32, int32)
 
 // I32ToI32I32HostFunc is a capability-free synchronous host import specialized
 // for the Wasm signature (i32) -> (i32, i32).
+// Deprecated: pass func(int32) (int32, int32) directly to Func or Imports.
 type I32ToI32I32HostFunc func(int32) (int32, int32)
 
 // I32I32ToI32I32HostFunc is a capability-free synchronous host import
 // specialized for the Wasm signature (i32, i32) -> (i32, i32).
+// Deprecated: pass func(int32, int32) (int32, int32) directly to Func or Imports.
 type I32I32ToI32I32HostFunc func(int32, int32) (int32, int32)
 
 // MaxDeferredHostEventsPerInvocation bounds an instance's deferred event log.
@@ -1151,19 +1345,21 @@ func bindHostImport(v any, sig FuncSig) (HostFunc, error) {
 }
 
 type syncHostBinding struct {
-	fn           HostFunc
-	concrete     CallerHostFunc
+	fn           any
 	typedI32     I32ToI32HostFunc
 	typedI32x2   I32I32ToI32HostFunc
 	gate         *pluginCallGate
 	exact        *DefinedTypeDescriptor
 	importIdx    uint32
 	scalarKind   uint8
+	hostCall     bool
+	hostCallView bool
 	typedNone    NoArgsHostFunc
 	typedI32V    I32HostFunc
 	typedI32x2V  I32I32HostFunc
 	typedI32R2   I32ToI32I32HostFunc
 	typedI32x2R2 I32I32ToI32I32HostFunc
+	sig          *FuncSig
 }
 
 const (
@@ -1176,6 +1372,12 @@ const (
 	syncHostTypedI32x2V
 	syncHostTypedI32R2
 	syncHostTypedI32x2R2
+	syncHostTypedI64
+	syncHostTypedI64x2
+	syncHostTypedF32
+	syncHostTypedF32x2
+	syncHostTypedF64
+	syncHostTypedF64x2
 )
 
 type gatedI32ToI32HostFunc struct {
@@ -1216,6 +1418,168 @@ type gatedI32I32ToI32HostFunc struct {
 type gatedI32HostEvent struct {
 	fn   I32HostEvent
 	gate *pluginCallGate
+}
+
+type gatedHostCallFunc struct {
+	fn   any
+	gate *pluginCallGate
+}
+
+type gatedOrdinaryHostFunc struct {
+	fn   any
+	gate *pluginCallGate
+}
+
+func isHostCallback(value any) bool {
+	switch value.(type) {
+	case HostFunc, func(HostModule, []uint64, []uint64),
+		CallerHostFunc, func(Caller, []uint64, []uint64),
+		HostCallFunc, func(HostCall), CallerHostCallFunc, func(Caller, HostCall), gatedHostCallFunc,
+		NoArgsHostFunc, func(), I32HostFunc, func(int32),
+		I32ToI32HostFunc, func(int32) int32,
+		I32I32HostFunc, func(int32, int32),
+		I32I32ToI32HostFunc, func(int32, int32) int32,
+		I32ToI32I32HostFunc, func(int32) (int32, int32),
+		I32I32ToI32I32HostFunc, func(int32, int32) (int32, int32),
+		func(int64) int64, func(int64, int64) int64,
+		func(float32) float32, func(float32, float32) float32,
+		func(float64) float64, func(float64, float64) float64,
+		func(V128) V128, func(FuncRef) FuncRef, func(ExternRef) ExternRef,
+		func(ExnRef) ExnRef, func(GCRef) GCRef, func(I31Ref) I31Ref,
+		gatedNoArgsHostFunc, gatedI32HostFunc, gatedI32ToI32HostFunc,
+		gatedI32I32HostFunc, gatedI32I32ToI32HostFunc,
+		gatedI32ToI32I32HostFunc, gatedI32I32ToI32I32HostFunc,
+		gatedOrdinaryHostFunc, I32HostEvent, gatedI32HostEvent, *HostFuncRef:
+		return true
+	default:
+		return false
+	}
+}
+
+func inferredHostFuncSignature(value any) (params, results []ValType, ok bool) {
+	switch value.(type) {
+	case NoArgsHostFunc, func():
+		return nil, nil, true
+	case I32HostFunc, func(int32):
+		return []ValType{ValI32}, nil, true
+	case I32ToI32HostFunc, func(int32) int32:
+		return []ValType{ValI32}, []ValType{ValI32}, true
+	case I32I32HostFunc, func(int32, int32):
+		return []ValType{ValI32, ValI32}, nil, true
+	case I32I32ToI32HostFunc, func(int32, int32) int32:
+		return []ValType{ValI32, ValI32}, []ValType{ValI32}, true
+	case I32ToI32I32HostFunc, func(int32) (int32, int32):
+		return []ValType{ValI32}, []ValType{ValI32, ValI32}, true
+	case I32I32ToI32I32HostFunc, func(int32, int32) (int32, int32):
+		return []ValType{ValI32, ValI32}, []ValType{ValI32, ValI32}, true
+	case func(int64) int64:
+		return []ValType{ValI64}, []ValType{ValI64}, true
+	case func(int64, int64) int64:
+		return []ValType{ValI64, ValI64}, []ValType{ValI64}, true
+	case func(float32) float32:
+		return []ValType{ValF32}, []ValType{ValF32}, true
+	case func(float32, float32) float32:
+		return []ValType{ValF32, ValF32}, []ValType{ValF32}, true
+	case func(float64) float64:
+		return []ValType{ValF64}, []ValType{ValF64}, true
+	case func(float64, float64) float64:
+		return []ValType{ValF64, ValF64}, []ValType{ValF64}, true
+	case func(V128) V128:
+		return []ValType{ValV128}, []ValType{ValV128}, true
+	case func(FuncRef) FuncRef:
+		return []ValType{ValFuncRef}, []ValType{ValFuncRef}, true
+	case func(ExternRef) ExternRef:
+		return []ValType{ValExternRef}, []ValType{ValExternRef}, true
+	case func(ExnRef) ExnRef:
+		return []ValType{ValExnRef}, []ValType{ValExnRef}, true
+	case func(GCRef) GCRef:
+		return []ValType{ValAnyRef}, []ValType{ValAnyRef}, true
+	case func(I31Ref) I31Ref:
+		return []ValType{ValI31Ref}, []ValType{ValI31Ref}, true
+	default:
+		return nil, nil, false
+	}
+}
+
+func gateHostImport(value any, gate *pluginCallGate) (any, error) {
+	switch fn := value.(type) {
+	case HostFunc:
+		if fn == nil {
+			return nil, fmt.Errorf("host function is nil")
+		}
+		return gate.wrap(fn), nil
+	case func(HostModule, []uint64, []uint64):
+		if fn == nil {
+			return nil, fmt.Errorf("host function is nil")
+		}
+		return gate.wrap(HostFunc(fn)), nil
+	case CallerHostFunc:
+		if fn == nil {
+			return nil, fmt.Errorf("caller host function is nil")
+		}
+		return gate.wrapCaller(fn), nil
+	case func(Caller, []uint64, []uint64):
+		if fn == nil {
+			return nil, fmt.Errorf("caller host function is nil")
+		}
+		return gate.wrapCaller(CallerHostFunc(fn)), nil
+	case HostCallFunc:
+		if fn == nil {
+			return nil, fmt.Errorf("host call function is nil")
+		}
+		return gatedHostCallFunc{fn: fn, gate: gate}, nil
+	case func(HostCall):
+		if fn == nil {
+			return nil, fmt.Errorf("host call function is nil")
+		}
+		return gatedHostCallFunc{fn: HostCallFunc(fn), gate: gate}, nil
+	case CallerHostCallFunc:
+		if fn == nil {
+			return nil, fmt.Errorf("caller host call function is nil")
+		}
+		return gatedHostCallFunc{fn: fn, gate: gate}, nil
+	case func(Caller, HostCall):
+		if fn == nil {
+			return nil, fmt.Errorf("caller host call function is nil")
+		}
+		return gatedHostCallFunc{fn: CallerHostCallFunc(fn), gate: gate}, nil
+	case NoArgsHostFunc:
+		return gatedNoArgsHostFunc{fn: fn, gate: gate}, nil
+	case func():
+		return gatedNoArgsHostFunc{fn: NoArgsHostFunc(fn), gate: gate}, nil
+	case I32HostFunc:
+		return gatedI32HostFunc{fn: fn, gate: gate}, nil
+	case func(int32):
+		return gatedI32HostFunc{fn: I32HostFunc(fn), gate: gate}, nil
+	case I32ToI32HostFunc:
+		return gatedI32ToI32HostFunc{fn: fn, gate: gate}, nil
+	case func(int32) int32:
+		return gatedI32ToI32HostFunc{fn: I32ToI32HostFunc(fn), gate: gate}, nil
+	case I32I32HostFunc:
+		return gatedI32I32HostFunc{fn: fn, gate: gate}, nil
+	case func(int32, int32):
+		return gatedI32I32HostFunc{fn: I32I32HostFunc(fn), gate: gate}, nil
+	case I32I32ToI32HostFunc:
+		return gatedI32I32ToI32HostFunc{fn: fn, gate: gate}, nil
+	case func(int32, int32) int32:
+		return gatedI32I32ToI32HostFunc{fn: I32I32ToI32HostFunc(fn), gate: gate}, nil
+	case I32ToI32I32HostFunc:
+		return gatedI32ToI32I32HostFunc{fn: fn, gate: gate}, nil
+	case func(int32) (int32, int32):
+		return gatedI32ToI32I32HostFunc{fn: I32ToI32I32HostFunc(fn), gate: gate}, nil
+	case I32I32ToI32I32HostFunc:
+		return gatedI32I32ToI32I32HostFunc{fn: fn, gate: gate}, nil
+	case func(int32, int32) (int32, int32):
+		return gatedI32I32ToI32I32HostFunc{fn: I32I32ToI32I32HostFunc(fn), gate: gate}, nil
+	case func(int64) int64, func(int64, int64) int64,
+		func(float32) float32, func(float32, float32) float32,
+		func(float64) float64, func(float64, float64) float64,
+		func(V128) V128, func(FuncRef) FuncRef, func(ExternRef) ExternRef,
+		func(ExnRef) ExnRef, func(GCRef) GCRef, func(I31Ref) I31Ref:
+		return gatedOrdinaryHostFunc{fn: value, gate: gate}, nil
+	default:
+		return nil, fmt.Errorf("unsupported host function %T; use an ordinary supported function or func(wago.HostCall)", value)
+	}
 }
 
 type asyncHostBinding struct {
@@ -1265,14 +1629,53 @@ func (c *Compiled) buildHostEvents(imports Imports) (*hostEventBindings, error) 
 }
 
 func (b *syncHostBinding) callable() bool {
-	return b.fn != nil || b.concrete != nil || b.scalarKind >= syncHostTypedI32
+	return b.fn != nil || b.scalarKind >= syncHostTypedI32
 }
 
 func (b *syncHostBinding) call(caller instanceHostModule, args, results []uint64) {
-	if b.concrete != nil {
-		b.concrete(Caller{instanceHostModule: caller}, args, results)
-	} else {
-		b.fn(caller, args, results)
+	switch fn := b.fn.(type) {
+	case CallerHostFunc:
+		fn(Caller{instanceHostModule: caller}, args, results)
+	case HostCallFunc:
+		fn(HostCall{
+			params: args, results: results, sig: b.sig, exact: b.exact,
+		})
+	case CallerHostCallFunc:
+		fn(Caller{instanceHostModule: caller}, HostCall{
+			params: args, results: results, sig: b.sig, exact: b.exact,
+		})
+	case func(int64) int64:
+		results[0] = I64(fn(AsI64(args[0])))
+	case func(int64, int64) int64:
+		results[0] = I64(fn(AsI64(args[0]), AsI64(args[1])))
+	case func(float32) float32:
+		results[0] = F32(fn(AsF32(args[0])))
+	case func(float32, float32) float32:
+		results[0] = F32(fn(AsF32(args[0]), AsF32(args[1])))
+	case func(float64) float64:
+		results[0] = F64(fn(AsF64(args[0])))
+	case func(float64, float64) float64:
+		results[0] = F64(fn(AsF64(args[0]), AsF64(args[1])))
+	case func(V128) V128:
+		var value V128
+		binary.LittleEndian.PutUint64(value[:8], args[0])
+		binary.LittleEndian.PutUint64(value[8:], args[1])
+		value = fn(value)
+		results[0], results[1] = binary.LittleEndian.Uint64(value[:8]), binary.LittleEndian.Uint64(value[8:])
+	case func(FuncRef) FuncRef:
+		results[0] = fn(FuncRef{token: args[0]}).token
+	case func(ExternRef) ExternRef:
+		results[0] = fn(ExternRef{token: args[0]}).token
+	case func(ExnRef) ExnRef:
+		results[0] = fn(ExnRef{token: args[0]}).token
+	case func(GCRef) GCRef:
+		results[0] = fn(GCRef{token: args[0]}).token
+	case func(I31Ref) I31Ref:
+		results[0] = uint64(fn(I31Ref{bits: uint32(args[0])}).bits)
+	case HostFunc:
+		fn(caller, args, results)
+	default:
+		panic(fmt.Sprintf("wago: invalid bound host function %T", b.fn))
 	}
 }
 
@@ -1284,7 +1687,32 @@ func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
 		if fn == nil {
 			return syncHostBinding{}, fmt.Errorf("concrete host function is nil")
 		}
-		return syncHostBinding{concrete: fn}, nil
+		return syncHostBinding{fn: fn, sig: &sig}, nil
+	case func(Caller, []uint64, []uint64):
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("concrete host function is nil")
+		}
+		return syncHostBinding{fn: CallerHostFunc(fn)}, nil
+	case HostCallFunc:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("host call function is nil")
+		}
+		return syncHostBinding{fn: fn, sig: &sig, hostCall: true}, nil
+	case func(HostCall):
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("host call function is nil")
+		}
+		return syncHostBinding{fn: HostCallFunc(fn), sig: &sig, hostCall: true}, nil
+	case CallerHostCallFunc:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("caller host call function is nil")
+		}
+		return syncHostBinding{fn: fn, sig: &sig}, nil
+	case func(Caller, HostCall):
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("caller host call function is nil")
+		}
+		return syncHostBinding{fn: CallerHostCallFunc(fn), sig: &sig}, nil
 	case NoArgsHostFunc:
 		return bindNoArgsHostFunc(fn, sig)
 	case func():
@@ -1313,6 +1741,66 @@ func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
 		return bindI32I32ToI32I32HostFunc(fn, sig)
 	case func(int32, int32) (int32, int32):
 		return bindI32I32ToI32I32HostFunc(I32I32ToI32I32HostFunc(fn), sig)
+	case func(int64) int64:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValI64, 1, syncHostBinding{fn: fn, scalarKind: syncHostTypedI64})
+	case func(int64, int64) int64:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValI64, 2, syncHostBinding{fn: fn, scalarKind: syncHostTypedI64x2})
+	case func(float32) float32:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValF32, 1, syncHostBinding{fn: fn, scalarKind: syncHostTypedF32})
+	case func(float32, float32) float32:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValF32, 2, syncHostBinding{fn: fn, scalarKind: syncHostTypedF32x2})
+	case func(float64) float64:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValF64, 1, syncHostBinding{fn: fn, scalarKind: syncHostTypedF64})
+	case func(float64, float64) float64:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValF64, 2, syncHostBinding{fn: fn, scalarKind: syncHostTypedF64x2})
+	case func(V128) V128:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValV128, 1, syncHostBinding{fn: fn})
+	case func(FuncRef) FuncRef:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValFuncRef, 1, syncHostBinding{fn: fn})
+	case func(ExternRef) ExternRef:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValExternRef, 1, syncHostBinding{fn: fn})
+	case func(ExnRef) ExnRef:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValExnRef, 1, syncHostBinding{fn: fn})
+	case func(GCRef) GCRef:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValAnyRef, 1, syncHostBinding{fn: fn})
+	case func(I31Ref) I31Ref:
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("typed host function is nil")
+		}
+		return bindSimpleTypedHostFunc(sig, ValI31Ref, 1, syncHostBinding{fn: fn})
 	case gatedI32ToI32HostFunc:
 		binding, err := bindI32ToI32HostFunc(fn.fn, sig)
 		binding.gate = fn.gate
@@ -1341,9 +1829,34 @@ func bindSyncHostImport(value any, sig FuncSig) (syncHostBinding, error) {
 		binding, err := bindI32I32ToI32HostFunc(fn.fn, sig)
 		binding.gate = fn.gate
 		return binding, err
+	case gatedHostCallFunc:
+		binding, err := bindSyncHostImport(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
+	case gatedOrdinaryHostFunc:
+		binding, err := bindSyncHostImport(fn.fn, sig)
+		binding.gate = fn.gate
+		return binding, err
+	case func(HostModule, []uint64, []uint64):
+		if fn == nil {
+			return syncHostBinding{}, fmt.Errorf("host function is nil")
+		}
+		return syncHostBinding{fn: HostFunc(fn)}, nil
 	}
 	fn, err := bindHostImport(value, sig)
 	return syncHostBinding{fn: fn}, err
+}
+
+func bindSimpleTypedHostFunc(sig FuncSig, typ ValType, params int, binding syncHostBinding) (syncHostBinding, error) {
+	if len(sig.Params) != params || len(sig.Results) != 1 || sig.Results[0] != typ {
+		return syncHostBinding{}, fmt.Errorf("typed host function requires %d %s parameter(s) and one %s result", params, typ, typ)
+	}
+	for _, param := range sig.Params {
+		if param != typ {
+			return syncHostBinding{}, fmt.Errorf("typed host function requires %d %s parameter(s) and one %s result", params, typ, typ)
+		}
+	}
+	return binding, nil
 }
 
 func bindNoArgsHostFunc(fn NoArgsHostFunc, sig FuncSig) (syncHostBinding, error) {
@@ -1430,10 +1943,12 @@ func (c *Compiled) buildSyncHosts(imports Imports) ([]syncHostBinding, error) {
 			continue
 		}
 		sig := c.importFuncSigs[i]
-		if _, err := valTypesSlots(sig.Params); err != nil {
+		paramSlots, err := valTypesSlots(sig.Params)
+		if err != nil {
 			return nil, fmt.Errorf("import %q params: %w", key, err)
 		}
-		if _, err := valTypesSlots(sig.Results); err != nil {
+		resultSlots, err := valTypesSlots(sig.Results)
+		if err != nil {
 			return nil, fmt.Errorf("import %q results: %w", key, err)
 		}
 		binding, err := bindSyncHostImport(imports[key], sig)
@@ -1441,6 +1956,9 @@ func (c *Compiled) buildSyncHosts(imports Imports) ([]syncHostBinding, error) {
 			return nil, fmt.Errorf("import %q: %w", key, err)
 		}
 		binding.importIdx = uint32(i)
+		binding.sig = &c.importFuncSigs[i]
+		binding.hostCallView = binding.hostCall && paramSlots <= runtime.MaxHostArity &&
+			resultSlots <= runtime.MaxHostArity && paramSlots+resultSlots >= directHostCallViewSlots
 		if binding.scalarKind == syncHostNonScalar {
 			binding.scalarKind = syncHostScalar
 		}
@@ -1614,6 +2132,12 @@ func dispatchSyncHostScalar(in *Instance, scope *hostCallScope, binding *syncHos
 		results[0] = I32(binding.typedI32x2(AsI32(args[0]), AsI32(args[1])))
 		return
 	}
+	if binding.hostCall {
+		binding.fn.(HostCallFunc)(HostCall{
+			params: args, results: results, sig: binding.sig, exact: binding.exact,
+		})
+		return
+	}
 	caller := scope.beginReservedWithID(in, invocation.id, invocation.reservation)
 	caller.exact = binding.exact
 	defer caller.scope.end(caller.generation, caller.parentGeneration)
@@ -1621,6 +2145,14 @@ func dispatchSyncHostScalar(in *Instance, scope *hostCallScope, binding *syncHos
 }
 
 func dispatchSyncHostReference(in *Instance, scope *hostCallScope, ctrl uintptr, importIdx uint32, binding *syncHostBinding, sig FuncSig, exact *DefinedTypeDescriptor, exactTypes []DefinedTypeDescriptor, exactTypesPtr *[]DefinedTypeDescriptor, args, results []uint64, invocation hostInvocationContext) {
+	if binding.gate != nil && (invocation.reservation == nil || !invocation.reservation.allows(binding.gate)) {
+		dispatchSyncHostReferenceGated(in, scope, ctrl, importIdx, binding, sig, exact, exactTypes, exactTypesPtr, args, results, invocation)
+		return
+	}
+	if _, ok := binding.fn.(HostCallFunc); ok && !hasReferenceValType(sig.Params) && !hasReferenceValType(sig.Results) {
+		binding.call(instanceHostModule{}, args, results)
+		return
+	}
 	var exactParams, exactResults []ValueTypeDescriptor
 	if exact != nil {
 		exactParams, exactResults = exact.Params, exact.Results
@@ -1644,6 +2176,16 @@ func dispatchSyncHostReference(in *Instance, scope *hostCallScope, ctrl uintptr,
 	}
 }
 
+func dispatchSyncHostReferenceGated(in *Instance, scope *hostCallScope, ctrl uintptr, importIdx uint32, binding *syncHostBinding, sig FuncSig, exact *DefinedTypeDescriptor, exactTypes []DefinedTypeDescriptor, exactTypesPtr *[]DefinedTypeDescriptor, args, results []uint64, invocation hostInvocationContext) {
+	if err := binding.gate.enter(); err != nil {
+		panic(HostTrap{Err: err})
+	}
+	defer binding.gate.release()
+	ungated := *binding
+	ungated.gate = nil
+	dispatchSyncHostReference(in, scope, ctrl, importIdx, &ungated, sig, exact, exactTypes, exactTypesPtr, args, results, invocation)
+}
+
 // newHostDispatch builds the runtime callback the CallWithHost loop invokes: it
 // maps the wasm import index to the bound HostFunc and runs it with a HostModule
 // bound to this instance. It is constructed once at instantiation so hot Invoke
@@ -1653,7 +2195,7 @@ func (in *Instance) newHostDispatch() resolvedHostCall {
 	// only its address, not authority: each callback still gets a fresh atomic
 	// generation and the runtime-resolved invocation identity passed below.
 	scope := &in.ensurePluginState().hostScope
-	return func(ctrl uintptr, importIdx uint32, args, results []uint64, invocation hostInvocationContext) {
+	dispatch := func(ctrl uintptr, importIdx uint32, args, results []uint64, invocation hostInvocationContext) {
 		if importIdx&shared.AtomicWaitDispatchBit != 0 {
 			if importIdx&(gcStructDispatchBit|hostFuncRefDispatchBit) != 0 {
 				panic(atomicWaitHelperError{err: fmt.Errorf("invalid overlapping atomic helper dispatch index %#x", importIdx)})
@@ -1703,6 +2245,21 @@ func (in *Instance) newHostDispatch() resolvedHostCall {
 			dispatchSyncHostReference(in, scope, ctrl, importIdx, binding, in.c.importFuncSigs[importIdx], binding.exact, in.c.Types, &in.c.Types, args, results, invocation)
 		}
 	}
+	if len(in.syncHosts) == 1 {
+		binding := &in.syncHosts[0]
+		if binding.hostCall && binding.gate == nil && binding.scalarKind != syncHostNonScalar {
+			fn := binding.fn.(HostCallFunc)
+			sig, exact := binding.sig, binding.exact
+			return func(ctrl uintptr, importIdx uint32, args, results []uint64, invocation hostInvocationContext) {
+				if importIdx == 0 {
+					fn(HostCall{params: args, results: results, sig: sig, exact: exact})
+					return
+				}
+				dispatch(ctrl, importIdx, args, results, invocation)
+			}
+		}
+	}
+	return dispatch
 }
 
 func (in *Instance) translateHostReferenceArgs(values []uint64, types []ValType, exact []ValueTypeDescriptor, exactTypes []DefinedTypeDescriptor, gcTemps *gcHostTempTokens) error {
@@ -1746,6 +2303,10 @@ func (in *Instance) translateHostReferenceArgs(values []uint64, types []ValType,
 		case ValExternRef:
 			if values[slot] != 0 && !in.validExternrefToken(values[slot]) {
 				return fmt.Errorf("invalid externref token for argument %d", i)
+			}
+		case ValExnRef:
+			if values[slot] != 0 {
+				return fmt.Errorf("non-null exception reference argument %d cannot cross the host boundary", i)
 			}
 		case ValAnyRef, ValI31Ref:
 			required, ok := exactReferenceType(exact, i, typ)
@@ -1821,6 +2382,10 @@ func (in *Instance) translateHostReferenceResults(ctrl uintptr, values []uint64,
 		case ValExternRef:
 			if values[slot] != 0 && !in.validExternrefToken(values[slot]) {
 				return fmt.Errorf("invalid externref token for result %d", i)
+			}
+		case ValExnRef:
+			if values[slot] != 0 {
+				return fmt.Errorf("non-null exception reference result %d cannot cross the host boundary", i)
 			}
 		case ValAnyRef, ValI31Ref:
 			required, ok := exactReferenceType(exact, i, typ)
@@ -1972,10 +2537,18 @@ func (in *Instance) callNativeSyncWithTrapContext(entry uintptr, activeTrap []by
 		state:                       in.ensurePluginState(),
 		parkedNativeContextReusable: in.gc == nil && !in.c.threadedMemory0(),
 	}
-	if in.hasExpandedTypedScalarHost() {
+	if in.hasSingleDirectTypedScalarHost() {
+		err = in.eng.CallWithHostBaseScalar(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchSingleTypedScalarPortal)
+	} else if in.hasSingleExpandedTypedScalarHost() {
+		err = in.eng.CallWithHostBaseScalarExpanded(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchSingleTypedScalarExpandedPortal)
+	} else if in.hasExpandedTypedScalarHost() {
 		err = in.eng.CallWithHostBaseScalarExpanded(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchTypedScalarExpandedPortal)
 	} else if in.hasDirectTypedScalarHost() {
 		err = in.eng.CallWithHostBaseScalar(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchTypedScalarPortal)
+	} else if in.hasSingleHostCallPortal() {
+		err = in.eng.CallWithHostBase(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatchSingleHostCall)
+	} else if in.hasSingleHostCallViewPortal() {
+		err = in.eng.CallWithHostBaseView(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchSingleHostCallView)
 	} else {
 		err = in.eng.CallWithHostBase(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch)
 	}

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -2555,7 +2555,20 @@ func (in *Instance) callNativeSyncWithTrapContext(entry uintptr, activeTrap []by
 	if in.hasSingleDirectTypedScalarHost() {
 		err = in.eng.CallWithHostBaseScalar(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchSingleTypedScalarPortal)
 	} else if in.hasSingleExpandedTypedScalarHost() {
-		err = in.eng.CallWithHostBaseScalarExpanded(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchSingleTypedScalarExpandedPortal)
+		rawSlots, ok := in.syncHosts[0].typedScalarSlots()
+		if !ok {
+			panic("wago: invalid fixed scalar host signature")
+		}
+		fixed := runtime.FixedScalarHostCall(activation.dispatchSingleTypedScalarFixedPortal)
+		switch in.syncHosts[0].scalarKind {
+		case syncHostTypedI32x2V:
+			fixed = activation.dispatchSingleTypedI32x2VoidFixedPortal
+		case syncHostTypedI32R2:
+			fixed = activation.dispatchSingleTypedI32PairFixedPortal
+		case syncHostTypedI32x2R2:
+			fixed = activation.dispatchSingleTypedI32x2PairFixedPortal
+		}
+		err = in.eng.CallWithHostBaseScalarFixed(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, rawSlots, activation.dispatch, activation.dispatchTypedScalarExpandedPortal, fixed)
 	} else if in.hasExpandedTypedScalarHost() {
 		err = in.eng.CallWithHostBaseScalarExpanded(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results, in.ctrl, activation.dispatch, activation.dispatchTypedScalarExpandedPortal)
 	} else if in.hasDirectTypedScalarHost() {

--- a/src/wago/hostcall_allocation_test.go
+++ b/src/wago/hostcall_allocation_test.go
@@ -33,7 +33,7 @@ func TestTypedScalarSyncHostCallAllocatesNothing(t *testing.T) {
 	compiled := MustCompile(benchReturningImportModule())
 	defer compiled.Close()
 	instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
-		"env.f": I32ToI32HostFunc(func(v int32) int32 { return v + 1 }),
+		"env.f": func(v int32) int32 { return v + 1 },
 	}})
 	if err != nil {
 		t.Fatal(err)

--- a/src/wago/hostcall_hardening_test.go
+++ b/src/wago/hostcall_hardening_test.go
@@ -267,34 +267,12 @@ func TestLegacyHostFuncInTableStillRunsIndirectly(t *testing.T) {
 	}
 }
 
-func TestSyncHostImportV128InTableRunsIndirectly(t *testing.T) {
-	if !hostSupportsSIMD() {
-		t.Skip("host SIMD unavailable")
-	}
-	inVec := V128{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	outVec := V128{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+func TestSyncHostImportV128InTableRejected(t *testing.T) {
 	sig := wasmtest.FuncType([]wasm.ValType{wasm.V128}, []wasm.ValType{wasm.V128})
 	body := []byte{0x20, 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x0b} // local.get 0; i32.const 0; call_indirect type 0 table 0; end
 	c := MustCompile(tableHostImportModule(sig, body))
-	calls := 0
-	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
-		calls++
-		if got := hostV128FromSlots(p[0], p[1]); got != inVec {
-			t.Fatalf("v128 param = % x, want % x", got, inVec)
-		}
-		r[0], r[1] = hostV128Slots(outVec)
-	})}})
-	if err != nil {
-		t.Fatalf("instantiate: %v", err)
-	}
-	defer in.Close()
-	lo, hi := hostV128Slots(inVec)
-	res, err := in.Invoke("g", lo, hi)
-	if err != nil {
-		t.Fatalf("invoke: %v", err)
-	}
-	if got := hostV128FromSlots(res[0], res[1]); got != outVec || calls != 1 {
-		t.Fatalf("g/calls = % x/%d, want % x/1", got, calls, outVec)
+	if _, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(HostModule, []uint64, []uint64) {})}}); err == nil || !strings.Contains(err.Error(), "v128 host callbacks are not supported") {
+		t.Fatalf("instantiate error = %v, want unsupported v128 host callback", err)
 	}
 }
 

--- a/src/wago/hostcall_hardening_test.go
+++ b/src/wago/hostcall_hardening_test.go
@@ -131,6 +131,21 @@ func TestImportedStartHostFuncRuns(t *testing.T) {
 	}
 }
 
+func TestImportedStartNoArgsHostFuncRuns(t *testing.T) {
+	c := MustCompile(importedStartModule())
+	calls := 0
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.start": func() {
+		calls++
+	}}})
+	if err != nil {
+		t.Fatalf("instantiate: %v", err)
+	}
+	defer in.Close()
+	if calls != 1 {
+		t.Fatalf("start called %d times, want 1", calls)
+	}
+}
+
 func TestImportedStartBadSignatureErrors(t *testing.T) {
 	c := MustCompile(importedStartModule())
 	// Bare functions matching a typed fast lane are accepted without reflection,

--- a/src/wago/hostcall_hardening_test.go
+++ b/src/wago/hostcall_hardening_test.go
@@ -133,10 +133,10 @@ func TestImportedStartHostFuncRuns(t *testing.T) {
 
 func TestImportedStartBadSignatureErrors(t *testing.T) {
 	c := MustCompile(importedStartModule())
-	// A bare native func is not a HostFunc; binding it is rejected identically on
-	// standard Go and TinyGo (no reflection anywhere).
+	// Bare functions matching a typed fast lane are accepted without reflection,
+	// but their exact Wasm signature is still enforced.
 	_, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.start": func(int32) {}}})
-	want := "must be a wago.HostFunc"
+	want := "requires signature (i32) -> ()"
 	if err == nil || !strings.Contains(err.Error(), "env.start") || !strings.Contains(err.Error(), want) {
 		t.Fatalf("want clear start binding error containing %q, got %v", want, err)
 	}

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -305,6 +305,29 @@ func TestTypedI32HostImportBindingRejectsInvalidFunctions(t *testing.T) {
 	}
 }
 
+func TestTypedHostSignatureMatrixRejectsMismatches(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   any
+		bad  FuncSig
+	}{
+		{name: "empty_to_empty", fn: NoArgsHostFunc(func() {}), bad: FuncSig{Params: []ValType{ValI32}}},
+		{name: "i32_to_empty", fn: I32HostFunc(func(int32) {}), bad: FuncSig{}},
+		{name: "i32_to_i32", fn: I32ToI32HostFunc(func(v int32) int32 { return v }), bad: FuncSig{Params: []ValType{ValI32}}},
+		{name: "i32_i32_to_empty", fn: I32I32HostFunc(func(int32, int32) {}), bad: FuncSig{Params: []ValType{ValI32}}},
+		{name: "i32_i32_to_i32", fn: I32I32ToI32HostFunc(func(a, b int32) int32 { return a + b }), bad: FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}}},
+		{name: "i32_to_i32_i32", fn: I32ToI32I32HostFunc(func(v int32) (int32, int32) { return v, v }), bad: FuncSig{Params: []ValType{ValI32}, Results: []ValType{ValI32}}},
+		{name: "i32_i32_to_i32_i32", fn: I32I32ToI32I32HostFunc(func(a, b int32) (int32, int32) { return a, b }), bad: FuncSig{Params: []ValType{ValI32, ValI32}, Results: []ValType{ValI32}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := bindSyncHostImport(tc.fn, tc.bad); err == nil {
+				t.Fatal("mismatched typed host signature was accepted")
+			}
+		})
+	}
+}
+
 func TestGatedTypedI32HostImportAdmission(t *testing.T) {
 	gate := newPluginCallGate("typed")
 	binding, err := bindSyncHostImport(gatedI32ToI32HostFunc{

--- a/src/wago/hostcall_test.go
+++ b/src/wago/hostcall_test.go
@@ -3,6 +3,7 @@ package wago
 import (
 	"encoding/binary"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -361,58 +362,16 @@ func TestGatedTypedI32HostImportAdmission(t *testing.T) {
 	}
 }
 
-func TestSyncHostImportV128SlotForm(t *testing.T) {
-	if !hostSupportsSIMD() {
-		t.Skip("host SIMD unavailable")
-	}
-	inVec := V128{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	outVec := V128{0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5, 0x96, 0x87, 0x78, 0x69, 0x5a, 0x4b, 0x3c, 0x2d, 0x1e, 0x0f}
+func TestSyncHostImportV128SlotFormRejected(t *testing.T) {
 	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32, wasm.V128, wasm.I64}, []wasm.ValType{wasm.V128, wasm.I32})
 	body := []byte{0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0x10, 0x00, 0x0b} // local.get 0,1,2; call 0; end
 	c := MustCompile(returningImportModule(sig, body))
-	if !c.dynamicImports || len(c.code) == 0 {
-		t.Fatal("v128 host import should compile through dynamic dispatch")
-	}
-	calls := 0
-	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
-		calls++
-		if len(p) != 4 { // i32 + two v128 slots + i64
-			t.Fatalf("params len = %d, want 4", len(p))
-		}
-		if AsI32(p[0]) != 7 || p[3] != 0x1122334455667788 {
-			t.Fatalf("scalar params = (%d,%#x), want (7,0x1122334455667788)", AsI32(p[0]), p[3])
-		}
-		if got := hostV128FromSlots(p[1], p[2]); got != inVec {
-			t.Fatalf("v128 param = % x, want % x", got, inVec)
-		}
-		r[0], r[1] = hostV128Slots(outVec)
-		r[2] = I32(99)
-	})}})
-	if err != nil {
-		t.Fatalf("instantiate: %v", err)
-	}
-	defer in.Close()
-	lo, hi := hostV128Slots(inVec)
-	res, err := in.Invoke("g", I32(7), lo, hi, I64(0x1122334455667788))
-	if err != nil {
-		t.Fatalf("invoke: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("host called %d times, want 1", calls)
-	}
-	if got := hostV128FromSlots(res[0], res[1]); got != outVec {
-		t.Fatalf("v128 result = % x, want % x", got, outVec)
-	}
-	if AsI32(res[2]) != 99 {
-		t.Fatalf("i32 result = %d, want 99", AsI32(res[2]))
+	if _, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(HostModule, []uint64, []uint64) {})}}); err == nil || !strings.Contains(err.Error(), "v128 host callbacks are not supported") {
+		t.Fatalf("instantiate error = %v, want unsupported v128 host callback", err)
 	}
 }
 
-func TestSyncHostImportVoidV128UsesSyncPath(t *testing.T) {
-	if !hostSupportsSIMD() {
-		t.Skip("host SIMD unavailable")
-	}
-	vec := V128{0xaa, 0xbb, 0xcc, 0xdd, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+func TestSyncHostImportVoidV128Rejected(t *testing.T) {
 	imp := append(append(wasmtest.Name("env"), wasmtest.Name("f")...), 0x00, 0x00) // func, type 0
 	mod := wasmtest.Module(
 		wasmtest.Section(1, wasmtest.Vec(
@@ -425,30 +384,8 @@ func TestSyncHostImportVoidV128UsesSyncPath(t *testing.T) {
 		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0x00, 0x10, 0x00, 0x41, 0x07, 0x0b}))), // local.get 0; call 0; i32.const 7; end
 	)
 	c := MustCompile(mod)
-	if !c.dynamicImports || len(c.code) == 0 {
-		t.Fatal("void v128 host import should compile through dynamic dispatch")
-	}
-	called := false
-	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(_ HostModule, p, r []uint64) {
-		called = true
-		if got := hostV128FromSlots(p[0], p[1]); got != vec {
-			t.Fatalf("v128 param = % x, want % x", got, vec)
-		}
-	})}})
-	if err != nil {
-		t.Fatalf("instantiate: %v", err)
-	}
-	defer in.Close()
-	lo, hi := hostV128Slots(vec)
-	res, err := in.Invoke("g", lo, hi)
-	if err != nil {
-		t.Fatalf("invoke: %v", err)
-	}
-	if !called {
-		t.Fatal("host function was not called")
-	}
-	if AsI32(res[0]) != 7 {
-		t.Fatalf("g returned %d, want 7", AsI32(res[0]))
+	if _, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": HostFunc(func(HostModule, []uint64, []uint64) {})}}); err == nil || !strings.Contains(err.Error(), "v128 host callbacks are not supported") {
+		t.Fatalf("instantiate error = %v, want unsupported v128 host callback", err)
 	}
 }
 

--- a/src/wago/instance.go
+++ b/src/wago/instance.go
@@ -27,8 +27,8 @@ type Instance struct {
 	memory                  *Memory // the memory object (owned or host-imported)
 	ar                      *runtime.Arena
 	base                    uintptr
-	hosts                   map[string]HostFunc
-	imports                 Imports // the imports as provided to Instantiate
+	hostEvents              *hostEventBindings // nil outside deferred event mode
+	imports                 Imports            // the imports as provided to Instantiate
 	hostLog                 []byte
 	ctrl                    []byte                              // sync host-call control frame (nil in async mode)
 	syncHosts               []syncHostBinding                   // immutable per-import sync host bindings

--- a/src/wago/instance.go
+++ b/src/wago/instance.go
@@ -78,6 +78,15 @@ type Instance struct {
 	moduleIdentity ModuleIdentity
 }
 
+// nativeUint64Slots views an arena-backed, 8-byte-aligned byte buffer as native
+// value slots. Instance argument and result buffers satisfy both invariants.
+func nativeUint64Slots(bytes []byte) []uint64 {
+	if len(bytes) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*uint64)(unsafe.Pointer(&bytes[0])), len(bytes)/8)
+}
+
 // instanceMemoryDirectory is allocated only after indexed memory execution is
 // admitted. Memory 0 stays in Instance.memory/ownsMem so ordinary single-memory
 // instances carry only this nil sidecar pointer.
@@ -107,5 +116,5 @@ type invokeCache struct {
 	resultSlots       int
 	hasFuncRefParams  bool
 	hasFuncRefResults bool
-	resultWide        []bool // one entry per returned uint64 slot; false means read low 32 bits
+	slotWide          []bool // parameter slots followed by result slots; false means a 32-bit scalar
 }

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -723,6 +723,11 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 			// the ~64 KiB buffer needs no instantiate-time zero-fill.
 			hostLog = ar.AllocNoZero(runtime.HostCallLogBytes)
 			jm.SetCustomCtx(uintptr(unsafe.Pointer(&hostLog[0])))
+			for _, global := range c.GlobalImports {
+				if valTypeMayCarryFuncref(global.Type) {
+					return nil, fmt.Errorf("deferred host-event instance cannot import a funcref global: %w", ErrPermissionDenied)
+				}
+			}
 		}
 	}
 	jm.SetStackFence(eng.StackLimit()) // trap runaway recursion instead of faulting

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -678,6 +678,7 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 	// while this reference keeps its native mapping live.
 	b.releaseModuleUse()
 	var hostLog, ctrl []byte
+	var hostEvents *hostEventBindings
 	var syncHosts []syncHostBinding
 	if syncMode {
 		// Synchronous host-call path: install the control frame (not the async
@@ -703,19 +704,23 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 			}
 			hasHostImport = true
 			if imports[key] == nil {
-				return nil, fmt.Errorf("import %q: legacy async host calls require wago.HostFunc or *wago.HostFuncRef", key)
+				return nil, fmt.Errorf("import %q: deferred host event is missing", key)
 			}
 			if i >= len(c.importFuncSigs) {
 				return nil, fmt.Errorf("import %q: missing signature", key)
 			}
-			if _, err := bindHostImport(imports[key], c.importFuncSigs[i]); err != nil {
-				return nil, fmt.Errorf("import %q: legacy async host call: %w", key, err)
+			if _, err := bindI32HostEvent(imports[key], c.importFuncSigs[i]); err != nil {
+				return nil, err
 			}
 		}
 		if hasHostImport {
+			hostEvents, err = c.buildHostEvents(imports)
+			if err != nil {
+				return nil, fmt.Errorf("instantiate: %w", err)
+			}
 			// The log's count header is reset at the start of every Invoke and its
-			// body is written by native code before the host reads it, so the ~64 KiB
-			// buffer needs no instantiate-time zero-fill.
+			// body is written by native code before deferred callbacks read it, so
+			// the ~64 KiB buffer needs no instantiate-time zero-fill.
 			hostLog = ar.AllocNoZero(runtime.HostCallLogBytes)
 			jm.SetCustomCtx(uintptr(unsafe.Pointer(&hostLog[0])))
 		}
@@ -1509,7 +1514,7 @@ func (b *instanceBuilder) instantiate() (result *Instance, err error) {
 		binary.LittleEndian.PutUint64(nativeContext[runtime.InstanceContextGCNativeViewOffset:], uint64(uintptr(unsafe.Pointer(gcNativeView))))
 	}
 	in := &Instance{
-		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, hosts: imports.hostFuncs(), imports: imports, hostLog: hostLog, syncMode: syncMode, ctrl: ctrl, syncHosts: syncHosts, globals: globals, globalCells: globalCells, tableDescPtr: tableDescPtr, tableDescLen: len(tableDesc), funcRefDescs: funcRefDescs, passiveDataDesc: passiveDataDesc, thunkMem: thunkMem, gc: b.collector, gcTypeMap: b.gcTypeMap, gcNativeView: gcNativeView,
+		c: c, eng: eng, jm: jm, memory: memObj, ownsMem: ownsMem, ar: ar, base: base, hostEvents: hostEvents, imports: imports, hostLog: hostLog, syncMode: syncMode, ctrl: ctrl, syncHosts: syncHosts, globals: globals, globalCells: globalCells, tableDescPtr: tableDescPtr, tableDescLen: len(tableDesc), funcRefDescs: funcRefDescs, passiveDataDesc: passiveDataDesc, thunkMem: thunkMem, gc: b.collector, gcTypeMap: b.gcTypeMap, gcNativeView: gcNativeView,
 		serArgs: serArgs, results: results, trap: trap, rt: opts.runtime,
 		nativeContext:   nativeContextPtr,
 		moduleIdentity:  opts.moduleIdentity,
@@ -1881,12 +1886,12 @@ func buildHostFuncThunks(c *Compiled, imports Imports, syncMode bool) (map[uint3
 			continue
 		}
 		switch imports[key].(type) {
-		case HostFunc, CallerHostFunc, *HostFuncRef:
+		case HostFunc, CallerHostFunc, *HostFuncRef, I32HostEvent, gatedI32HostEvent:
 			offs[uint32(fidx)] = len(blob)
 			blob = append(blob, railshotHostIndirectThunk(uint32(fidx))...)
 		default:
 			if imports[key] != nil {
-				return nil, nil, fmt.Errorf("import %q is %T; async host wrappers support wago.HostFunc or *wago.HostFuncRef bindings", key, imports[key])
+				return nil, nil, fmt.Errorf("import %q is %T; async host wrappers require wago.I32HostEvent", key, imports[key])
 			}
 		}
 	}

--- a/src/wago/instantiate.go
+++ b/src/wago/instantiate.go
@@ -1885,11 +1885,10 @@ func buildHostFuncThunks(c *Compiled, imports Imports, syncMode bool) (map[uint3
 			}
 			continue
 		}
-		switch imports[key].(type) {
-		case HostFunc, CallerHostFunc, *HostFuncRef, I32HostEvent, gatedI32HostEvent:
+		if isHostCallback(imports[key]) {
 			offs[uint32(fidx)] = len(blob)
 			blob = append(blob, railshotHostIndirectThunk(uint32(fidx))...)
-		default:
+		} else {
 			if imports[key] != nil {
 				return nil, nil, fmt.Errorf("import %q is %T; async host wrappers require wago.I32HostEvent", key, imports[key])
 			}

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -261,7 +261,7 @@ func managedForkImports(parent *Instance) (Imports, error) {
 			return fmt.Errorf("managed fork import %q is missing", key)
 		}
 		switch x := v.(type) {
-		case HostFunc, CallerHostFunc:
+		case HostFunc, CallerHostFunc, I32HostEvent, gatedI32HostEvent:
 			imports[key] = x
 		case GlobalImport:
 			if x.Global != nil {

--- a/src/wago/managed_instances.go
+++ b/src/wago/managed_instances.go
@@ -260,9 +260,12 @@ func managedForkImports(parent *Instance) (Imports, error) {
 		if !ok {
 			return fmt.Errorf("managed fork import %q is missing", key)
 		}
+		_, ownedHostRef := v.(*HostFuncRef)
+		if !ownedHostRef && isHostCallback(v) {
+			imports[key] = v
+			return nil
+		}
 		switch x := v.(type) {
-		case HostFunc, CallerHostFunc, I32HostEvent, gatedI32HostEvent:
-			imports[key] = x
 		case GlobalImport:
 			if x.Global != nil {
 				return fmt.Errorf("managed fork import %q borrows a global: %w", key, ErrManagedImportLifetime)

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -588,7 +588,7 @@ func validateRegistration(reg *Registrar) error {
 		}
 	}
 	for _, imp := range reg.imports {
-		if imp.fn == nil && imp.concrete == nil && imp.typedI32 == nil && imp.typedI32x2 == nil && imp.eventI32 == nil || imp.module == "" || imp.name == "" {
+		if imp.fn == nil && imp.concrete == nil && imp.typedNone == nil && imp.typedI32V == nil && imp.typedI32 == nil && imp.typedI32x2V == nil && imp.typedI32x2 == nil && imp.typedI32R2 == nil && imp.typedI32x2R2 == nil && imp.eventI32 == nil || imp.module == "" || imp.name == "" {
 			return fmt.Errorf("invalid host import %q", imp.key())
 		}
 	}
@@ -762,10 +762,20 @@ func (rt *Runtime) commitPluginPlan(plan []plannedPlugin) error {
 			key := imp.key()
 			if imp.eventI32 != nil {
 				rt.imports[key] = gatedI32HostEvent{fn: imp.eventI32, gate: p.reg.callGate}
+			} else if imp.typedNone != nil {
+				rt.imports[key] = gatedNoArgsHostFunc{fn: imp.typedNone, gate: p.reg.callGate}
+			} else if imp.typedI32V != nil {
+				rt.imports[key] = gatedI32HostFunc{fn: imp.typedI32V, gate: p.reg.callGate}
 			} else if imp.typedI32 != nil {
 				rt.imports[key] = gatedI32ToI32HostFunc{fn: imp.typedI32, gate: p.reg.callGate}
+			} else if imp.typedI32x2V != nil {
+				rt.imports[key] = gatedI32I32HostFunc{fn: imp.typedI32x2V, gate: p.reg.callGate}
 			} else if imp.typedI32x2 != nil {
 				rt.imports[key] = gatedI32I32ToI32HostFunc{fn: imp.typedI32x2, gate: p.reg.callGate}
+			} else if imp.typedI32R2 != nil {
+				rt.imports[key] = gatedI32ToI32I32HostFunc{fn: imp.typedI32R2, gate: p.reg.callGate}
+			} else if imp.typedI32x2R2 != nil {
+				rt.imports[key] = gatedI32I32ToI32I32HostFunc{fn: imp.typedI32x2R2, gate: p.reg.callGate}
 			} else if imp.concrete != nil {
 				rt.imports[key] = p.reg.callGate.wrapCaller(imp.concrete)
 			} else {

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -588,7 +588,7 @@ func validateRegistration(reg *Registrar) error {
 		}
 	}
 	for _, imp := range reg.imports {
-		if imp.fn == nil && imp.concrete == nil && imp.typedI32 == nil && imp.typedI32x2 == nil || imp.module == "" || imp.name == "" {
+		if imp.fn == nil && imp.concrete == nil && imp.typedI32 == nil && imp.typedI32x2 == nil && imp.eventI32 == nil || imp.module == "" || imp.name == "" {
 			return fmt.Errorf("invalid host import %q", imp.key())
 		}
 	}
@@ -760,7 +760,9 @@ func (rt *Runtime) commitPluginPlan(plan []plannedPlugin) error {
 		needsInstructionABI = needsInstructionABI || len(p.reg.instructions) != 0
 		for _, imp := range p.reg.imports {
 			key := imp.key()
-			if imp.typedI32 != nil {
+			if imp.eventI32 != nil {
+				rt.imports[key] = gatedI32HostEvent{fn: imp.eventI32, gate: p.reg.callGate}
+			} else if imp.typedI32 != nil {
 				rt.imports[key] = gatedI32ToI32HostFunc{fn: imp.typedI32, gate: p.reg.callGate}
 			} else if imp.typedI32x2 != nil {
 				rt.imports[key] = gatedI32I32ToI32HostFunc{fn: imp.typedI32x2, gate: p.reg.callGate}

--- a/src/wago/plugin_plan.go
+++ b/src/wago/plugin_plan.go
@@ -588,8 +588,13 @@ func validateRegistration(reg *Registrar) error {
 		}
 	}
 	for _, imp := range reg.imports {
-		if imp.fn == nil && imp.concrete == nil && imp.typedNone == nil && imp.typedI32V == nil && imp.typedI32 == nil && imp.typedI32x2V == nil && imp.typedI32x2 == nil && imp.typedI32R2 == nil && imp.typedI32x2R2 == nil && imp.eventI32 == nil || imp.module == "" || imp.name == "" {
+		if imp.fn == nil && imp.eventI32 == nil || imp.module == "" || imp.name == "" {
 			return fmt.Errorf("invalid host import %q", imp.key())
+		}
+		if imp.fn != nil {
+			if _, err := gateHostImport(imp.fn, reg.callGate); err != nil {
+				return fmt.Errorf("invalid host import %q: %w", imp.key(), err)
+			}
 		}
 	}
 	if len(reg.imports) != 0 {
@@ -762,24 +767,12 @@ func (rt *Runtime) commitPluginPlan(plan []plannedPlugin) error {
 			key := imp.key()
 			if imp.eventI32 != nil {
 				rt.imports[key] = gatedI32HostEvent{fn: imp.eventI32, gate: p.reg.callGate}
-			} else if imp.typedNone != nil {
-				rt.imports[key] = gatedNoArgsHostFunc{fn: imp.typedNone, gate: p.reg.callGate}
-			} else if imp.typedI32V != nil {
-				rt.imports[key] = gatedI32HostFunc{fn: imp.typedI32V, gate: p.reg.callGate}
-			} else if imp.typedI32 != nil {
-				rt.imports[key] = gatedI32ToI32HostFunc{fn: imp.typedI32, gate: p.reg.callGate}
-			} else if imp.typedI32x2V != nil {
-				rt.imports[key] = gatedI32I32HostFunc{fn: imp.typedI32x2V, gate: p.reg.callGate}
-			} else if imp.typedI32x2 != nil {
-				rt.imports[key] = gatedI32I32ToI32HostFunc{fn: imp.typedI32x2, gate: p.reg.callGate}
-			} else if imp.typedI32R2 != nil {
-				rt.imports[key] = gatedI32ToI32I32HostFunc{fn: imp.typedI32R2, gate: p.reg.callGate}
-			} else if imp.typedI32x2R2 != nil {
-				rt.imports[key] = gatedI32I32ToI32I32HostFunc{fn: imp.typedI32x2R2, gate: p.reg.callGate}
-			} else if imp.concrete != nil {
-				rt.imports[key] = p.reg.callGate.wrapCaller(imp.concrete)
 			} else {
-				rt.imports[key] = p.reg.callGate.wrap(imp.fn)
+				gated, err := gateHostImport(imp.fn, p.reg.callGate)
+				if err != nil {
+					return fmt.Errorf("plugin %q host import %q: %w", id, key, err)
+				}
+				rt.imports[key] = gated
 			}
 			rt.importMeta[key] = cloneRegisteredImport(imp)
 			rt.importOwner[key] = id

--- a/src/wago/prepared_function.go
+++ b/src/wago/prepared_function.go
@@ -25,6 +25,7 @@ type PreparedFunction struct {
 	resultTypes         []ValType
 	paramExact          []ValueTypeDescriptor
 	resultExact         []ValueTypeDescriptor
+	paramWide           []bool
 	hasReferenceParams  bool
 	hasReferenceResults bool
 	scalarWideMask      uint8
@@ -106,14 +107,13 @@ func (in *Instance) PrepareFunction(export string) (*PreparedFunction, error) {
 	if err != nil {
 		return nil, fmt.Errorf("wago: prepare function %q exact signature: %w", export, err)
 	}
-	wide := append([]bool(nil), ic.resultWide...)
+	paramWide := append([]bool(nil), ic.slotWide[:ic.paramSlots]...)
+	resultWide := append([]bool(nil), ic.slotWide[ic.paramSlots:]...)
 	scalarFast := preparedScalarFastEnabled &&
 		!hasReferenceValType(sig.Params) &&
-		!hasReferenceValType(sig.Results) &&
-		ic.paramSlots <= 4 &&
-		ic.resultSlots <= 1
+		!hasReferenceValType(sig.Results)
 	var scalarWideMask uint8
-	if scalarFast {
+	if scalarFast && ic.paramSlots <= 4 {
 		slot := 0
 		for _, typ := range sig.Params {
 			if typ == ValV128 {
@@ -135,14 +135,15 @@ func (in *Instance) PrepareFunction(export string) (*PreparedFunction, error) {
 		resultSlots:         ic.resultSlots,
 		scalarWideMask:      scalarWideMask,
 		scalarFast:          scalarFast,
-		scalarResultWide:    ic.resultSlots == 1 && wide[0],
+		scalarResultWide:    ic.resultSlots == 1 && resultWide[0],
 		paramTypes:          append([]ValType(nil), sig.Params...),
 		resultTypes:         append([]ValType(nil), sig.Results...),
 		paramExact:          append([]ValueTypeDescriptor(nil), params...),
 		resultExact:         append([]ValueTypeDescriptor(nil), results...),
+		paramWide:           paramWide,
 		hasReferenceParams:  hasReferenceValType(sig.Params),
 		hasReferenceResults: hasReferenceValType(sig.Results),
-		resultWide:          wide,
+		resultWide:          resultWide,
 	}
 	if scalarFast && preparedCallEnabled && preparedPrivateEntryEnabled {
 		entryMode := in.preparedEntryMode()
@@ -350,25 +351,29 @@ func (fn *PreparedFunction) invokeScalar(args []uint64) ([]uint64, error) {
 		preparedLease := in.lockPreparedInvocation()
 		defer preparedLease.unlock()
 	}
-	put := func(slot int) {
-		bits := args[slot]
-		if fn.scalarWideMask&(1<<slot) == 0 {
-			bits = uint64(uint32(bits))
+	if len(args) <= 4 {
+		put := func(slot int) {
+			bits := args[slot]
+			if fn.scalarWideMask&(1<<slot) == 0 {
+				bits = uint64(uint32(bits))
+			}
+			binary.LittleEndian.PutUint64(in.serArgs[slot*8:], bits)
 		}
-		binary.LittleEndian.PutUint64(in.serArgs[slot*8:], bits)
-	}
-	switch len(args) {
-	case 4:
-		put(3)
-		fallthrough
-	case 3:
-		put(2)
-		fallthrough
-	case 2:
-		put(1)
-		fallthrough
-	case 1:
-		put(0)
+		switch len(args) {
+		case 4:
+			put(3)
+			fallthrough
+		case 3:
+			put(2)
+			fallthrough
+		case 2:
+			put(1)
+			fallthrough
+		case 1:
+			put(0)
+		}
+	} else {
+		marshalPublicScalarSlotsByWidth(nativeUint64Slots(in.serArgs), args, fn.paramWide)
 	}
 	if len(in.hostLog) > 0 {
 		binary.LittleEndian.PutUint32(in.hostLog, 0)
@@ -399,12 +404,6 @@ func (fn *PreparedFunction) invokeScalar(args []uint64) ([]uint64, error) {
 	goruntime.KeepAlive(in)
 	goruntime.KeepAlive(in.c)
 	out := in.resultVals[:fn.resultSlots]
-	if fn.resultSlots == 1 {
-		if fn.scalarResultWide {
-			out[0] = binary.LittleEndian.Uint64(in.results)
-		} else {
-			out[0] = uint64(binary.LittleEndian.Uint32(in.results))
-		}
-	}
+	decodePublicScalarSlots(out, nativeUint64Slots(in.results), fn.resultWide)
 	return out, nil
 }

--- a/src/wago/prepared_function_test.go
+++ b/src/wago/prepared_function_test.go
@@ -27,7 +27,7 @@ func TestPreparedFunctionInvokeAndCacheIndependence(t *testing.T) {
 	// Replace every tiny Instance cache slot; the prepared signature must own its
 	// result-width metadata rather than aliasing a round-robin cache slot.
 	for i := range in.ic {
-		in.ic[i] = invokeCache{export: "other", valid: true, resultWide: []bool{true, true}}
+		in.ic[i] = invokeCache{export: "other", valid: true, slotWide: []bool{true, true}}
 	}
 	got, err := fn.Invoke(I32(41))
 	if err != nil {
@@ -361,6 +361,148 @@ func TestInvokeScalarUsesIsolatedEntry(t *testing.T) {
 	if got.err != nil || len(got.values) != 1 || AsI32(got.values[0]) != 43 {
 		t.Fatalf("shared-control invoke = %v, %v", got.values, got.err)
 	}
+}
+
+func TestNumericMultiResultFastPaths(t *testing.T) {
+	savedPrepared := preparedPrivateEntryEnabled
+	savedScalar := preparedScalarFastEnabled
+	savedInvoke := invokePrivateEntryEnabled
+	preparedPrivateEntryEnabled = true
+	preparedScalarFastEnabled = true
+	invokePrivateEntryEnabled = true
+	defer func() {
+		preparedPrivateEntryEnabled = savedPrepared
+		preparedScalarFastEnabled = savedScalar
+		invokePrivateEntryEnabled = savedInvoke
+	}()
+
+	compiled, err := Compile(
+		NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit),
+		hostToWasmI32SignatureModule(2, 2),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	prepared, err := in.PrepareFunction("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !prepared.scalarFast || !prepared.privateFast {
+		t.Fatalf("numeric multi-result prepared path not selected: scalar=%v private=%v", prepared.scalarFast, prepared.privateFast)
+	}
+	check := func(name string, got []uint64, err error) {
+		t.Helper()
+		if err != nil || len(got) != 2 || AsI32(got[0]) != 7 || AsI32(got[1]) != 11 {
+			t.Fatalf("%s = %v, %v; want [7 11]", name, got, err)
+		}
+	}
+	values, callErr := in.Invoke("f", I32(7), I32(11))
+	check("Invoke", values, callErr)
+	values, callErr = prepared.Invoke(I32(7), I32(11))
+	check("PreparedFunction.Invoke", values, callErr)
+
+	ic := in.findInvokeCache("f")
+	if ic == nil || ic.entryMode == preparedEntryGeneral {
+		t.Fatalf("numeric multi-result Invoke cache mode = %v", ic)
+	}
+	// Native control may become shared after the cache is populated. The public
+	// Invoke fast path must honor that dynamic exclusion and take the serialized
+	// fallback rather than using its cached isolated entry.
+	in.markNativeControlShared()
+	type result struct {
+		values []uint64
+		err    error
+	}
+	done := make(chan result, 1)
+	nativeExecutionMu.Lock()
+	go func() {
+		values, err := in.Invoke("f", I32(7), I32(11))
+		done <- result{values: values, err: err}
+	}()
+	select {
+	case got := <-done:
+		nativeExecutionMu.Unlock()
+		t.Fatalf("shared-control multi-result invoke bypassed execution lease: %v, %v", got.values, got.err)
+	case <-time.After(20 * time.Millisecond):
+		nativeExecutionMu.Unlock()
+	}
+	got := <-done
+	check("shared-control Invoke", got.values, got.err)
+}
+
+func TestNumericFastPathsPreserveScalarWidths(t *testing.T) {
+	types := []wasm.ValType{wasm.I32, wasm.I64, wasm.F32, wasm.F64}
+	body := make([]byte, 0, len(types)*2+1)
+	for i := range types {
+		body = append(body, 0x20, byte(i))
+	}
+	body = append(body, 0x0b)
+	module := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(types, types))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+	compiled, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compiled.Close()
+	in, err := Instantiate(compiled, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	prepared, err := in.PrepareFunction("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []uint64{I32(-7), I64(-9), F32(1.25), F64(-3.5)}
+	check := func(name string, got []uint64, err error) {
+		t.Helper()
+		if err != nil || len(got) != len(args) {
+			t.Fatalf("%s = %v, %v", name, got, err)
+		}
+		for i := range got {
+			if got[i] != args[i] {
+				t.Fatalf("%s result[%d] = %#x, want %#x", name, i, got[i], args[i])
+			}
+		}
+	}
+	values, callErr := in.Invoke("f", args...)
+	check("Invoke", values, callErr)
+	values, callErr = prepared.Invoke(args...)
+	check("PreparedFunction.Invoke", values, callErr)
+}
+
+func hostToWasmI32SignatureModule(params, results int) []byte {
+	paramTypes := make([]wasm.ValType, params)
+	for i := range paramTypes {
+		paramTypes[i] = wasm.I32
+	}
+	resultTypes := make([]wasm.ValType, results)
+	body := make([]byte, 0, results*2+1)
+	for i := range resultTypes {
+		resultTypes[i] = wasm.I32
+		if i < params {
+			body = append(body, 0x20, byte(i)) // local.get i
+		} else {
+			body = append(body, 0x41, byte(i+1)) // i32.const i+1
+		}
+	}
+	body = append(body, 0x0b)
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(paramTypes, resultTypes))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
 }
 
 func BenchmarkPreparedInvokeAddOne(b *testing.B) {

--- a/src/wago/reexport_test.go
+++ b/src/wago/reexport_test.go
@@ -2,6 +2,7 @@ package wago
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,152 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/support/wasmtest"
 )
+
+func TestDirectHostReexportSupportsTypedSignatureMatrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  []wasm.ValType
+		results []wasm.ValType
+		fn      any
+		args    []uint64
+		want    []uint64
+	}{
+		{name: "empty_to_empty", fn: func() {}},
+		{name: "i32_to_empty", params: []wasm.ValType{wasm.I32}, fn: func(int32) {}, args: []uint64{I32(7)}},
+		{name: "i32_to_i32", params: []wasm.ValType{wasm.I32}, results: []wasm.ValType{wasm.I32}, fn: func(v int32) int32 { return v + 1 }, args: []uint64{I32(7)}, want: []uint64{I32(8)}},
+		{name: "i32_i32_to_empty", params: []wasm.ValType{wasm.I32, wasm.I32}, fn: func(int32, int32) {}, args: []uint64{I32(7), I32(9)}},
+		{name: "i32_i32_to_i32", params: []wasm.ValType{wasm.I32, wasm.I32}, results: []wasm.ValType{wasm.I32}, fn: func(a, b int32) int32 { return a + b }, args: []uint64{I32(7), I32(9)}, want: []uint64{I32(16)}},
+		{name: "i32_to_i32_i32", params: []wasm.ValType{wasm.I32}, results: []wasm.ValType{wasm.I32, wasm.I32}, fn: func(v int32) (int32, int32) { return v, v + 1 }, args: []uint64{I32(7)}, want: []uint64{I32(7), I32(8)}},
+		{name: "i32_i32_to_i32_i32", params: []wasm.ValType{wasm.I32, wasm.I32}, results: []wasm.ValType{wasm.I32, wasm.I32}, fn: func(a, b int32) (int32, int32) { return a, b }, args: []uint64{I32(7), I32(9)}, want: []uint64{I32(7), I32(9)}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			compiled := MustCompile(directHostReexportModule(test.params, test.results))
+			defer compiled.Close()
+			instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{"env.f": test.fn}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer instance.Close()
+			got, err := instance.Invoke("f", test.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != len(test.want) {
+				t.Fatalf("results = %v, want %v", got, test.want)
+			}
+			for i := range got {
+				if got[i] != test.want[i] {
+					t.Fatalf("result %d = %#x, want %#x", i, got[i], test.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDirectHostReexportEnforcesPluginGate(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   any
+	}{
+		{name: "ordinary", fn: func(v int32) int32 { return v + 1 }},
+		{name: "host_call", fn: HostCallFunc(func(call HostCall) { call.SetI32(0, call.I32(0)+1) })},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gate := newPluginCallGate(test.name)
+			gated, err := gateHostImport(test.fn, gate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			compiled := MustCompile(directHostReexportModule([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}))
+			defer compiled.Close()
+			instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{"env.f": gated}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer instance.Close()
+			gate.deactivate()
+			got, err := instance.Invoke("f", I32(41))
+			if got != nil || !errors.Is(err, ErrPermissionDenied) {
+				t.Fatalf("inactive gated re-export = %v, %v; want ErrPermissionDenied", got, err)
+			}
+		})
+	}
+}
+
+func TestDirectHostReexportPluginGateDrainsActiveCallback(t *testing.T) {
+	gate := newPluginCallGate("drain")
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	gated, err := gateHostImport(func(v int32) int32 {
+		close(entered)
+		<-release
+		return v + 1
+	}, gate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled := MustCompile(directHostReexportModule([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}))
+	defer compiled.Close()
+	instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{"env.f": gated}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close()
+
+	invokeDone := make(chan error, 1)
+	go func() {
+		_, err := instance.Invoke("f", I32(41))
+		invokeDone <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("callback did not enter")
+	}
+	gate.deactivate()
+	drainDone := make(chan error, 1)
+	go func() { drainDone <- gate.closeAndWait() }()
+	select {
+	case err := <-drainDone:
+		t.Fatalf("gate drained before active callback returned: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	if err := <-invokeDone; err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if err := <-drainDone; err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+}
+
+func TestDirectHostReexportHonorsPluginOperationReservation(t *testing.T) {
+	gate := newPluginCallGate("reserved")
+	gated, err := gateHostImport(func(v int32) int32 { return v + 1 }, gate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled := MustCompile(directHostReexportModule([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}))
+	defer compiled.Close()
+	instance, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{"env.f": gated}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close()
+	reservation, err := reservePluginOperation([]*pluginCallGate{gate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reservation.release()
+	instance.ensurePluginState().invocationID = newInvocationID()
+	gate.deactivate()
+	got, err := instance.invokeAdmitted("f", []uint64{I32(41)}, invocationContextSet{}, reservation)
+	if err != nil || len(got) != 1 || got[0] != I32(42) {
+		t.Fatalf("reserved gated re-export = %v, %v; want [42]", got, err)
+	}
+}
 
 func TestCompiledSignatureReportsImportedFunctionReexport(t *testing.T) {
 	c, err := Compile(nil, importedFunctionReexportModule())
@@ -367,6 +514,16 @@ func importedFunctionReexportModule() []byte {
 		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}))),
 		wasmtest.Section(2, wasmtest.Vec(imp)),
 		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("forward", 0, 0))),
+	)
+}
+
+func directHostReexportModule(params, results []wasm.ValType) []byte {
+	imp := append(wasmtest.Name("env"), wasmtest.Name("f")...)
+	imp = append(imp, 0x00, 0x00) // function import, type 0
+	return wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType(params, results))),
+		wasmtest.Section(2, wasmtest.Vec(imp)),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0))),
 	)
 }
 

--- a/src/wago/reference_store.go
+++ b/src/wago/reference_store.go
@@ -1941,6 +1941,9 @@ func (s *referenceStore) issueMode(source *Instance, descriptor uint64, attached
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if entry := s.byIdentity[funcrefIdentity{descriptor: descriptor}]; entry != nil {
+		if entry.owner != nil && entry.owner.hostEvents != nil {
+			return 0, deferredHostEventCalleeError()
+		}
 		return entry.token, nil
 	}
 	if source == nil {
@@ -1950,13 +1953,22 @@ func (s *referenceStore) issueMode(source *Instance, descriptor uint64, attached
 	if !ok {
 		return 0, fmt.Errorf("invalid funcref result descriptor")
 	}
+	if owner.hostEvents != nil {
+		return 0, deferredHostEventCalleeError()
+	}
 	identity, hasIdentity := source.funcrefFunctionIdentity(descriptor)
 	if hasIdentity {
 		if entry := s.byIdentity[identity]; entry != nil {
+			if entry.owner != nil && entry.owner.hostEvents != nil {
+				return 0, deferredHostEventCalleeError()
+			}
 			return entry.token, nil
 		}
 	}
 	if entry := s.byIdentity[funcrefIdentity{descriptor: canonical}]; entry != nil {
+		if entry.owner != nil && entry.owner.hostEvents != nil {
+			return 0, deferredHostEventCalleeError()
+		}
 		return entry.token, nil
 	}
 	var retained bool

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -160,18 +160,23 @@ func CapabilityDocs(docs string) CapabilityOption {
 
 // registeredImport is one declared host function.
 type registeredImport struct {
-	module     string
-	name       string
-	fn         HostFunc
-	concrete   CallerHostFunc
-	typedI32   I32ToI32HostFunc
-	typedI32x2 I32I32ToI32HostFunc
-	eventI32   I32HostEvent
-	params     []ValType
-	results    []ValType
-	cap        Capability
-	hasCap     bool
-	docs       string
+	module       string
+	name         string
+	fn           HostFunc
+	concrete     CallerHostFunc
+	typedNone    NoArgsHostFunc
+	typedI32V    I32HostFunc
+	typedI32     I32ToI32HostFunc
+	typedI32x2V  I32I32HostFunc
+	typedI32x2   I32I32ToI32HostFunc
+	typedI32R2   I32ToI32I32HostFunc
+	typedI32x2R2 I32I32ToI32I32HostFunc
+	eventI32     I32HostEvent
+	params       []ValType
+	results      []ValType
+	cap          Capability
+	hasCap       bool
+	docs         string
 }
 
 func (i *registeredImport) key() string { return i.module + "." + i.name }
@@ -216,6 +221,30 @@ func (m *ImportModuleBuilder) CallerFunc(name string, fn CallerHostFunc) *Import
 	return &ImportFuncBuilder{imp: imp}
 }
 
+// NoArgsFunc declares a capability-free typed synchronous () -> () import.
+func (m *ImportModuleBuilder) NoArgsFunc(name string, fn NoArgsHostFunc) *ImportFuncBuilder {
+	if m == nil {
+		return &ImportFuncBuilder{}
+	}
+	imp := &registeredImport{module: m.module, name: name, typedNone: fn}
+	if m.reg != nil && !m.reg.sealed {
+		m.reg.imports = append(m.reg.imports, imp)
+	}
+	return &ImportFuncBuilder{imp: imp}
+}
+
+// I32Func declares a capability-free typed synchronous (i32) -> () import.
+func (m *ImportModuleBuilder) I32Func(name string, fn I32HostFunc) *ImportFuncBuilder {
+	if m == nil {
+		return &ImportFuncBuilder{}
+	}
+	imp := &registeredImport{module: m.module, name: name, typedI32V: fn, params: []ValType{ValI32}}
+	if m.reg != nil && !m.reg.sealed {
+		m.reg.imports = append(m.reg.imports, imp)
+	}
+	return &ImportFuncBuilder{imp: imp}
+}
+
 // I32ToI32Func declares a capability-free typed synchronous import. Params and
 // Results are fixed by the callback type and need not be declared separately.
 func (m *ImportModuleBuilder) I32ToI32Func(name string, fn I32ToI32HostFunc) *ImportFuncBuilder {
@@ -236,6 +265,45 @@ func (m *ImportModuleBuilder) I32I32ToI32Func(name string, fn I32I32ToI32HostFun
 		return &ImportFuncBuilder{}
 	}
 	imp := &registeredImport{module: m.module, name: name, typedI32x2: fn, params: []ValType{ValI32, ValI32}, results: []ValType{ValI32}}
+	if m.reg != nil && !m.reg.sealed {
+		m.reg.imports = append(m.reg.imports, imp)
+	}
+	return &ImportFuncBuilder{imp: imp}
+}
+
+// I32I32Func declares a capability-free typed synchronous
+// (i32, i32) -> () import.
+func (m *ImportModuleBuilder) I32I32Func(name string, fn I32I32HostFunc) *ImportFuncBuilder {
+	if m == nil {
+		return &ImportFuncBuilder{}
+	}
+	imp := &registeredImport{module: m.module, name: name, typedI32x2V: fn, params: []ValType{ValI32, ValI32}}
+	if m.reg != nil && !m.reg.sealed {
+		m.reg.imports = append(m.reg.imports, imp)
+	}
+	return &ImportFuncBuilder{imp: imp}
+}
+
+// I32ToI32I32Func declares a capability-free typed synchronous
+// (i32) -> (i32, i32) import.
+func (m *ImportModuleBuilder) I32ToI32I32Func(name string, fn I32ToI32I32HostFunc) *ImportFuncBuilder {
+	if m == nil {
+		return &ImportFuncBuilder{}
+	}
+	imp := &registeredImport{module: m.module, name: name, typedI32R2: fn, params: []ValType{ValI32}, results: []ValType{ValI32, ValI32}}
+	if m.reg != nil && !m.reg.sealed {
+		m.reg.imports = append(m.reg.imports, imp)
+	}
+	return &ImportFuncBuilder{imp: imp}
+}
+
+// I32I32ToI32I32Func declares a capability-free typed synchronous
+// (i32, i32) -> (i32, i32) import.
+func (m *ImportModuleBuilder) I32I32ToI32I32Func(name string, fn I32I32ToI32I32HostFunc) *ImportFuncBuilder {
+	if m == nil {
+		return &ImportFuncBuilder{}
+	}
+	imp := &registeredImport{module: m.module, name: name, typedI32x2R2: fn, params: []ValType{ValI32, ValI32}, results: []ValType{ValI32, ValI32}}
 	if m.reg != nil && !m.reg.sealed {
 		m.reg.imports = append(m.reg.imports, imp)
 	}

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -166,6 +166,7 @@ type registeredImport struct {
 	concrete   CallerHostFunc
 	typedI32   I32ToI32HostFunc
 	typedI32x2 I32I32ToI32HostFunc
+	eventI32   I32HostEvent
 	params     []ValType
 	results    []ValType
 	cap        Capability
@@ -235,6 +236,19 @@ func (m *ImportModuleBuilder) I32I32ToI32Func(name string, fn I32I32ToI32HostFun
 		return &ImportFuncBuilder{}
 	}
 	imp := &registeredImport{module: m.module, name: name, typedI32x2: fn, params: []ValType{ValI32, ValI32}, results: []ValType{ValI32}}
+	if m.reg != nil && !m.reg.sealed {
+		m.reg.imports = append(m.reg.imports, imp)
+	}
+	return &ImportFuncBuilder{imp: imp}
+}
+
+// I32Event declares a deferred capability-free (i32) -> () import. Calls are
+// delivered in order after the native invocation returns.
+func (m *ImportModuleBuilder) I32Event(name string, fn I32HostEvent) *ImportFuncBuilder {
+	if m == nil {
+		return &ImportFuncBuilder{}
+	}
+	imp := &registeredImport{module: m.module, name: name, eventI32: fn, params: []ValType{ValI32}}
 	if m.reg != nil && !m.reg.sealed {
 		m.reg.imports = append(m.reg.imports, imp)
 	}

--- a/src/wago/registry.go
+++ b/src/wago/registry.go
@@ -160,23 +160,15 @@ func CapabilityDocs(docs string) CapabilityOption {
 
 // registeredImport is one declared host function.
 type registeredImport struct {
-	module       string
-	name         string
-	fn           HostFunc
-	concrete     CallerHostFunc
-	typedNone    NoArgsHostFunc
-	typedI32V    I32HostFunc
-	typedI32     I32ToI32HostFunc
-	typedI32x2V  I32I32HostFunc
-	typedI32x2   I32I32ToI32HostFunc
-	typedI32R2   I32ToI32I32HostFunc
-	typedI32x2R2 I32I32ToI32I32HostFunc
-	eventI32     I32HostEvent
-	params       []ValType
-	results      []ValType
-	cap          Capability
-	hasCap       bool
-	docs         string
+	module   string
+	name     string
+	fn       any
+	eventI32 I32HostEvent
+	params   []ValType
+	results  []ValType
+	cap      Capability
+	hasCap   bool
+	docs     string
 }
 
 func (i *registeredImport) key() string { return i.module + "." + i.name }
@@ -197,113 +189,16 @@ type ImportModuleBuilder struct {
 	module string
 }
 
-func (m *ImportModuleBuilder) Func(name string, fn HostFunc) *ImportFuncBuilder {
+// Func declares a synchronous host import. Ordinary Go functions use a
+// reflection-free specialized lane when their shape is recognized. HostCallFunc
+// (or func(HostCall)) is the universal form for arbitrary arity and every Wasm
+// value type; declare its signature with Params and Results.
+func (m *ImportModuleBuilder) Func(name string, fn any) *ImportFuncBuilder {
 	if m == nil {
 		return &ImportFuncBuilder{}
 	}
 	imp := &registeredImport{module: m.module, name: name, fn: fn}
-	if m.reg != nil && !m.reg.sealed {
-		m.reg.imports = append(m.reg.imports, imp)
-	}
-	return &ImportFuncBuilder{imp: imp}
-}
-
-// CallerFunc declares a concrete synchronous import with the same signature,
-// authority and plugin lifetime rules as Func.
-func (m *ImportModuleBuilder) CallerFunc(name string, fn CallerHostFunc) *ImportFuncBuilder {
-	if m == nil {
-		return &ImportFuncBuilder{}
-	}
-	imp := &registeredImport{module: m.module, name: name, concrete: fn}
-	if m.reg != nil && !m.reg.sealed {
-		m.reg.imports = append(m.reg.imports, imp)
-	}
-	return &ImportFuncBuilder{imp: imp}
-}
-
-// NoArgsFunc declares a capability-free typed synchronous () -> () import.
-func (m *ImportModuleBuilder) NoArgsFunc(name string, fn NoArgsHostFunc) *ImportFuncBuilder {
-	if m == nil {
-		return &ImportFuncBuilder{}
-	}
-	imp := &registeredImport{module: m.module, name: name, typedNone: fn}
-	if m.reg != nil && !m.reg.sealed {
-		m.reg.imports = append(m.reg.imports, imp)
-	}
-	return &ImportFuncBuilder{imp: imp}
-}
-
-// I32Func declares a capability-free typed synchronous (i32) -> () import.
-func (m *ImportModuleBuilder) I32Func(name string, fn I32HostFunc) *ImportFuncBuilder {
-	if m == nil {
-		return &ImportFuncBuilder{}
-	}
-	imp := &registeredImport{module: m.module, name: name, typedI32V: fn, params: []ValType{ValI32}}
-	if m.reg != nil && !m.reg.sealed {
-		m.reg.imports = append(m.reg.imports, imp)
-	}
-	return &ImportFuncBuilder{imp: imp}
-}
-
-// I32ToI32Func declares a capability-free typed synchronous import. Params and
-// Results are fixed by the callback type and need not be declared separately.
-func (m *ImportModuleBuilder) I32ToI32Func(name string, fn I32ToI32HostFunc) *ImportFuncBuilder {
-	if m == nil {
-		return &ImportFuncBuilder{}
-	}
-	imp := &registeredImport{module: m.module, name: name, typedI32: fn, params: []ValType{ValI32}, results: []ValType{ValI32}}
-	if m.reg != nil && !m.reg.sealed {
-		m.reg.imports = append(m.reg.imports, imp)
-	}
-	return &ImportFuncBuilder{imp: imp}
-}
-
-// I32I32ToI32Func declares a capability-free typed synchronous import. Params
-// and Results are fixed by the callback type and need not be declared separately.
-func (m *ImportModuleBuilder) I32I32ToI32Func(name string, fn I32I32ToI32HostFunc) *ImportFuncBuilder {
-	if m == nil {
-		return &ImportFuncBuilder{}
-	}
-	imp := &registeredImport{module: m.module, name: name, typedI32x2: fn, params: []ValType{ValI32, ValI32}, results: []ValType{ValI32}}
-	if m.reg != nil && !m.reg.sealed {
-		m.reg.imports = append(m.reg.imports, imp)
-	}
-	return &ImportFuncBuilder{imp: imp}
-}
-
-// I32I32Func declares a capability-free typed synchronous
-// (i32, i32) -> () import.
-func (m *ImportModuleBuilder) I32I32Func(name string, fn I32I32HostFunc) *ImportFuncBuilder {
-	if m == nil {
-		return &ImportFuncBuilder{}
-	}
-	imp := &registeredImport{module: m.module, name: name, typedI32x2V: fn, params: []ValType{ValI32, ValI32}}
-	if m.reg != nil && !m.reg.sealed {
-		m.reg.imports = append(m.reg.imports, imp)
-	}
-	return &ImportFuncBuilder{imp: imp}
-}
-
-// I32ToI32I32Func declares a capability-free typed synchronous
-// (i32) -> (i32, i32) import.
-func (m *ImportModuleBuilder) I32ToI32I32Func(name string, fn I32ToI32I32HostFunc) *ImportFuncBuilder {
-	if m == nil {
-		return &ImportFuncBuilder{}
-	}
-	imp := &registeredImport{module: m.module, name: name, typedI32R2: fn, params: []ValType{ValI32}, results: []ValType{ValI32, ValI32}}
-	if m.reg != nil && !m.reg.sealed {
-		m.reg.imports = append(m.reg.imports, imp)
-	}
-	return &ImportFuncBuilder{imp: imp}
-}
-
-// I32I32ToI32I32Func declares a capability-free typed synchronous
-// (i32, i32) -> (i32, i32) import.
-func (m *ImportModuleBuilder) I32I32ToI32I32Func(name string, fn I32I32ToI32I32HostFunc) *ImportFuncBuilder {
-	if m == nil {
-		return &ImportFuncBuilder{}
-	}
-	imp := &registeredImport{module: m.module, name: name, typedI32x2R2: fn, params: []ValType{ValI32, ValI32}, results: []ValType{ValI32, ValI32}}
+	imp.params, imp.results, _ = inferredHostFuncSignature(fn)
 	if m.reg != nil && !m.reg.sealed {
 		m.reg.imports = append(m.reg.imports, imp)
 	}

--- a/src/wago/registry_typed_test.go
+++ b/src/wago/registry_typed_test.go
@@ -12,4 +12,8 @@ func TestImportModuleBuilderTypedFunctionsDeclareExactSignatures(t *testing.T) {
 	if two.imp == nil || two.imp.typedI32x2 == nil || len(two.imp.params) != 2 || two.imp.params[0] != ValI32 || two.imp.params[1] != ValI32 || len(two.imp.results) != 1 || two.imp.results[0] != ValI32 {
 		t.Fatalf("two-parameter typed declaration = %+v", two.imp)
 	}
+	event := module.I32Event("event", func(int32) {})
+	if event.imp == nil || event.imp.eventI32 == nil || len(event.imp.params) != 1 || event.imp.params[0] != ValI32 || len(event.imp.results) != 0 {
+		t.Fatalf("deferred event declaration = %+v", event.imp)
+	}
 }

--- a/src/wago/registry_typed_test.go
+++ b/src/wago/registry_typed_test.go
@@ -4,6 +4,14 @@ import "testing"
 
 func TestImportModuleBuilderTypedFunctionsDeclareExactSignatures(t *testing.T) {
 	module := &ImportModuleBuilder{module: "env"}
+	none := module.NoArgsFunc("none", func() {})
+	if none.imp == nil || none.imp.typedNone == nil || len(none.imp.params) != 0 || len(none.imp.results) != 0 {
+		t.Fatalf("no-parameter typed declaration = %+v", none.imp)
+	}
+	sink := module.I32Func("sink", func(int32) {})
+	if sink.imp == nil || sink.imp.typedI32V == nil || len(sink.imp.params) != 1 || sink.imp.params[0] != ValI32 || len(sink.imp.results) != 0 {
+		t.Fatalf("one-parameter void typed declaration = %+v", sink.imp)
+	}
 	one := module.I32ToI32Func("one", func(v int32) int32 { return v })
 	if one.imp == nil || one.imp.typedI32 == nil || len(one.imp.params) != 1 || one.imp.params[0] != ValI32 || len(one.imp.results) != 1 || one.imp.results[0] != ValI32 {
 		t.Fatalf("one-parameter typed declaration = %+v", one.imp)
@@ -11,6 +19,18 @@ func TestImportModuleBuilderTypedFunctionsDeclareExactSignatures(t *testing.T) {
 	two := module.I32I32ToI32Func("two", func(a, b int32) int32 { return a + b })
 	if two.imp == nil || two.imp.typedI32x2 == nil || len(two.imp.params) != 2 || two.imp.params[0] != ValI32 || two.imp.params[1] != ValI32 || len(two.imp.results) != 1 || two.imp.results[0] != ValI32 {
 		t.Fatalf("two-parameter typed declaration = %+v", two.imp)
+	}
+	twoSink := module.I32I32Func("two-sink", func(int32, int32) {})
+	if twoSink.imp == nil || twoSink.imp.typedI32x2V == nil || len(twoSink.imp.params) != 2 || len(twoSink.imp.results) != 0 {
+		t.Fatalf("two-parameter void typed declaration = %+v", twoSink.imp)
+	}
+	pair := module.I32ToI32I32Func("pair", func(v int32) (int32, int32) { return v, v })
+	if pair.imp == nil || pair.imp.typedI32R2 == nil || len(pair.imp.params) != 1 || len(pair.imp.results) != 2 || pair.imp.results[0] != ValI32 || pair.imp.results[1] != ValI32 {
+		t.Fatalf("one-parameter pair typed declaration = %+v", pair.imp)
+	}
+	twoPair := module.I32I32ToI32I32Func("two-pair", func(a, b int32) (int32, int32) { return a, b })
+	if twoPair.imp == nil || twoPair.imp.typedI32x2R2 == nil || len(twoPair.imp.params) != 2 || len(twoPair.imp.results) != 2 {
+		t.Fatalf("two-parameter pair typed declaration = %+v", twoPair.imp)
 	}
 	event := module.I32Event("event", func(int32) {})
 	if event.imp == nil || event.imp.eventI32 == nil || len(event.imp.params) != 1 || event.imp.params[0] != ValI32 || len(event.imp.results) != 0 {

--- a/src/wago/registry_typed_test.go
+++ b/src/wago/registry_typed_test.go
@@ -4,32 +4,32 @@ import "testing"
 
 func TestImportModuleBuilderTypedFunctionsDeclareExactSignatures(t *testing.T) {
 	module := &ImportModuleBuilder{module: "env"}
-	none := module.NoArgsFunc("none", func() {})
-	if none.imp == nil || none.imp.typedNone == nil || len(none.imp.params) != 0 || len(none.imp.results) != 0 {
+	none := module.Func("none", func() {})
+	if none.imp == nil || none.imp.fn == nil || len(none.imp.params) != 0 || len(none.imp.results) != 0 {
 		t.Fatalf("no-parameter typed declaration = %+v", none.imp)
 	}
-	sink := module.I32Func("sink", func(int32) {})
-	if sink.imp == nil || sink.imp.typedI32V == nil || len(sink.imp.params) != 1 || sink.imp.params[0] != ValI32 || len(sink.imp.results) != 0 {
+	sink := module.Func("sink", func(int32) {})
+	if sink.imp == nil || sink.imp.fn == nil || len(sink.imp.params) != 1 || sink.imp.params[0] != ValI32 || len(sink.imp.results) != 0 {
 		t.Fatalf("one-parameter void typed declaration = %+v", sink.imp)
 	}
-	one := module.I32ToI32Func("one", func(v int32) int32 { return v })
-	if one.imp == nil || one.imp.typedI32 == nil || len(one.imp.params) != 1 || one.imp.params[0] != ValI32 || len(one.imp.results) != 1 || one.imp.results[0] != ValI32 {
+	one := module.Func("one", func(v int32) int32 { return v })
+	if one.imp == nil || one.imp.fn == nil || len(one.imp.params) != 1 || one.imp.params[0] != ValI32 || len(one.imp.results) != 1 || one.imp.results[0] != ValI32 {
 		t.Fatalf("one-parameter typed declaration = %+v", one.imp)
 	}
-	two := module.I32I32ToI32Func("two", func(a, b int32) int32 { return a + b })
-	if two.imp == nil || two.imp.typedI32x2 == nil || len(two.imp.params) != 2 || two.imp.params[0] != ValI32 || two.imp.params[1] != ValI32 || len(two.imp.results) != 1 || two.imp.results[0] != ValI32 {
+	two := module.Func("two", func(a, b int32) int32 { return a + b })
+	if two.imp == nil || two.imp.fn == nil || len(two.imp.params) != 2 || two.imp.params[0] != ValI32 || two.imp.params[1] != ValI32 || len(two.imp.results) != 1 || two.imp.results[0] != ValI32 {
 		t.Fatalf("two-parameter typed declaration = %+v", two.imp)
 	}
-	twoSink := module.I32I32Func("two-sink", func(int32, int32) {})
-	if twoSink.imp == nil || twoSink.imp.typedI32x2V == nil || len(twoSink.imp.params) != 2 || len(twoSink.imp.results) != 0 {
+	twoSink := module.Func("two-sink", func(int32, int32) {})
+	if twoSink.imp == nil || twoSink.imp.fn == nil || len(twoSink.imp.params) != 2 || len(twoSink.imp.results) != 0 {
 		t.Fatalf("two-parameter void typed declaration = %+v", twoSink.imp)
 	}
-	pair := module.I32ToI32I32Func("pair", func(v int32) (int32, int32) { return v, v })
-	if pair.imp == nil || pair.imp.typedI32R2 == nil || len(pair.imp.params) != 1 || len(pair.imp.results) != 2 || pair.imp.results[0] != ValI32 || pair.imp.results[1] != ValI32 {
+	pair := module.Func("pair", func(v int32) (int32, int32) { return v, v })
+	if pair.imp == nil || pair.imp.fn == nil || len(pair.imp.params) != 1 || len(pair.imp.results) != 2 || pair.imp.results[0] != ValI32 || pair.imp.results[1] != ValI32 {
 		t.Fatalf("one-parameter pair typed declaration = %+v", pair.imp)
 	}
-	twoPair := module.I32I32ToI32I32Func("two-pair", func(a, b int32) (int32, int32) { return a, b })
-	if twoPair.imp == nil || twoPair.imp.typedI32x2R2 == nil || len(twoPair.imp.params) != 2 || len(twoPair.imp.results) != 2 {
+	twoPair := module.Func("two-pair", func(a, b int32) (int32, int32) { return a, b })
+	if twoPair.imp == nil || twoPair.imp.fn == nil || len(twoPair.imp.params) != 2 || len(twoPair.imp.results) != 2 {
 		t.Fatalf("two-parameter pair typed declaration = %+v", twoPair.imp)
 	}
 	event := module.I32Event("event", func(int32) {})

--- a/src/wago/regression_workload_test.go
+++ b/src/wago/regression_workload_test.go
@@ -45,9 +45,9 @@ func TestRuntimeRegressionPortRustFannkuchExecution(t *testing.T) {
 		{n: 9, want: 8629},
 	} {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		got, err := in.Call(ctx, "run_fannkuch", wago.ValueI32(tc.n))
+		got, err := in.InvokeContext(ctx, "run_fannkuch", wago.I32(tc.n))
 		cancel()
-		if err != nil || len(got) != 1 || got[0].Type() != wago.ValI32 || got[0].I32() != tc.want {
+		if err != nil || len(got) != 1 || wago.AsI32(got[0]) != tc.want {
 			t.Fatalf("run_fannkuch(%d) = %v, %v; want %d", tc.n, got, err, tc.want)
 		}
 	}
@@ -232,14 +232,14 @@ func runRegressionEmbenchen(t *testing.T, name string) (int32, []byte) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	got, err := in.Call(ctx, "_main", wago.ValueI32(2), wago.ValueI32(int32(argv)))
+	got, err := in.InvokeContext(ctx, "_main", wago.I32(2), wago.I32(int32(argv)))
 	if err != nil {
 		t.Fatalf("_main: %v", err)
 	}
-	if len(got) != 1 || got[0].Type() != wago.ValI32 {
+	if len(got) != 1 {
 		t.Fatalf("_main result = %v, want one i32", got)
 	}
-	return got[0].I32(), output
+	return wago.AsI32(got[0]), output
 }
 
 func regressionEmbenchenSlice(memory []byte, offset, length uint32, what string) []byte {

--- a/src/wago/typed_host_runtime_test.go
+++ b/src/wago/typed_host_runtime_test.go
@@ -32,6 +32,9 @@ func TestHostCallPortalMayGrowStackCollectAndRecoverFromTrap(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer in.Close()
+	if !in.hasSingleHostCallFixedViewPortal() {
+		t.Fatal("HostCall did not select the fixed control-frame view")
+	}
 	if _, err := in.Invoke("g", I32(41)); err == nil || err.Error() != "expected portal trap" {
 		t.Fatalf("first portal call error = %v", err)
 	}
@@ -179,6 +182,36 @@ func TestTypedI32HostCallbackMayGrowStackAndCollect(t *testing.T) {
 	defer in.Close()
 	if got, err := in.Invoke("g", I32(41)); err != nil || len(got) != 1 || AsI32(got[0]) != 42 {
 		t.Fatalf("typed callback after stack growth and GC = %v, %v; want 42", got, err)
+	}
+}
+
+func TestTypedExpandedHostCallbackMayGrowStackCollectAndRecoverFromTrap(t *testing.T) {
+	compiled := MustCompile(hostSignatureLoopModule(1, 1, wasm.F64))
+	defer compiled.Close()
+	calls := 0
+	in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": func(value float64) float64 {
+			calls++
+			_ = typedHostGrowStack(128, int32(value))
+			runtime.GC()
+			if calls == 1 {
+				panic(HostTrap{Err: errors.New("expected expanded typed trap")})
+			}
+			return 7
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if !in.hasSingleExpandedTypedScalarHost() {
+		t.Fatal("expanded typed callback did not select the fixed scalar portal")
+	}
+	if _, err := in.Invoke("run", I32(1)); err == nil || err.Error() != "expected expanded typed trap" {
+		t.Fatalf("first expanded typed call error = %v", err)
+	}
+	if got, err := in.Invoke("run", I32(1)); err != nil || len(got) != 1 || AsI32(got[0]) != 7 {
+		t.Fatalf("expanded typed callback after stack growth, GC, and trap = %v, %v; want 7", got, err)
 	}
 }
 

--- a/src/wago/typed_host_runtime_test.go
+++ b/src/wago/typed_host_runtime_test.go
@@ -3,6 +3,7 @@
 package wago
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"testing"
@@ -11,6 +12,144 @@ import (
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/support/wasmtest"
 )
+
+func TestHostCallPortalMayGrowStackCollectAndRecoverFromTrap(t *testing.T) {
+	compiled := MustCompile(benchReturningImportModule())
+	defer compiled.Close()
+	calls := 0
+	in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": HostCallFunc(func(call HostCall) {
+			calls++
+			value := typedHostGrowStack(128, call.I32(0))
+			runtime.GC()
+			if calls == 1 {
+				panic(HostTrap{Err: errors.New("expected portal trap")})
+			}
+			call.SetI32(0, value+1)
+		}),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if _, err := in.Invoke("g", I32(41)); err == nil || err.Error() != "expected portal trap" {
+		t.Fatalf("first portal call error = %v", err)
+	}
+	if got, err := in.Invoke("g", I32(41)); err != nil || len(got) != 1 || AsI32(got[0]) != 42 {
+		t.Fatalf("portal after stack growth, GC, and trap = %v, %v; want 42", got, err)
+	}
+}
+
+func TestWideHostCallViewMayGrowStackCollectAndRecoverFromTrap(t *testing.T) {
+	compiled := MustCompile(hostSignatureLoopModule(48, 48))
+	defer compiled.Close()
+	calls := 0
+	in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+		"env.f": HostCallFunc(func(call HostCall) {
+			calls++
+			if len(call.ParamSlots()) != 48 || len(call.ResultSlots()) != 48 {
+				t.Fatalf("wide slot counts = %d/%d", len(call.ParamSlots()), len(call.ResultSlots()))
+			}
+			for i, result := range call.ResultSlots() {
+				if result != 0 {
+					t.Fatalf("wide result slot %d was not cleared: %#x", i, result)
+				}
+			}
+			_ = typedHostGrowStack(128, int32(call.ParamSlots()[0]))
+			runtime.GC()
+			if calls == 1 {
+				panic(HostTrap{Err: errors.New("expected wide-view trap")})
+			}
+			for i := range call.ResultSlots() {
+				call.ResultSlots()[i] = 7
+			}
+		}),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if !in.syncHosts[0].hostCallView || !in.hasSingleHostCallViewPortal() || in.hasSingleHostCallPortal() {
+		t.Fatal("wide HostCall did not select the direct control-frame view")
+	}
+	if _, err := in.Invoke("run", I32(1)); err == nil || err.Error() != "expected wide-view trap" {
+		t.Fatalf("first wide-view call error = %v", err)
+	}
+	if got, err := in.Invoke("run", I32(1)); err != nil || len(got) != 1 || AsI32(got[0]) != 7 {
+		t.Fatalf("wide view after stack growth, GC, and trap = %v, %v; want 7", got, err)
+	}
+}
+
+func TestHostCallPortalMayBlockWhileOtherInstanceRuns(t *testing.T) {
+	for _, independent := range []bool{true, false} {
+		t.Run(map[bool]string{true: "independent", false: "shared"}[independent], func(t *testing.T) {
+			cfg := NewRuntimeConfig().WithIndependentInstanceExecution(independent)
+			otherCompiled, err := cfg.Compile(benchAddOneModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer otherCompiled.Close()
+			other, err := Instantiate(otherCompiled, InstantiateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer other.Close()
+			otherFn, err := other.PrepareI32ToI32("f")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			entered, release := make(chan struct{}), make(chan struct{})
+			compiled, err := cfg.Compile(benchReturningImportModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer compiled.Close()
+			in, err := Instantiate(compiled, InstantiateOptions{Imports: Imports{
+				"env.f": HostCallFunc(func(call HostCall) {
+					close(entered)
+					<-release
+					call.SetI32(0, call.I32(0)+1)
+				}),
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+
+			rootDone := make(chan error, 1)
+			go func() {
+				got, callErr := in.Invoke("g", I32(41))
+				if callErr == nil && (len(got) != 1 || AsI32(got[0]) != 42) {
+					callErr = fmt.Errorf("root result = %v, want 42", got)
+				}
+				rootDone <- callErr
+			}()
+			<-entered
+			otherDone := make(chan error, 1)
+			go func() {
+				got, callErr := otherFn.Call(1)
+				if callErr == nil && got != 2 {
+					callErr = fmt.Errorf("other result = %d, want 2", got)
+				}
+				otherDone <- callErr
+			}()
+			select {
+			case err := <-otherDone:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(2 * time.Second):
+				close(release)
+				t.Fatal("other instance blocked behind HostCall portal")
+			}
+			close(release)
+			if err := <-rootDone; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
 
 func typedHostGrowStack(depth int, value int32) int32 {
 	var frame [256]byte

--- a/src/wago/valtype.go
+++ b/src/wago/valtype.go
@@ -26,6 +26,7 @@ type V128 [16]byte
 // Signed/Unsigned accessors expose its 31-bit payload.
 type FuncRef struct{ token uint64 }
 type ExternRef struct{ token uint64 }
+type ExnRef struct{ token uint64 }
 type GCRef struct{ token uint64 }
 type I31Ref struct{ bits uint32 }
 
@@ -42,9 +43,10 @@ const (
 	ValI31Ref // exact i31 immediate category; never an opaque GCRef token
 )
 
-// NullFuncRef, NullExternRef, NullGCRef, and NullI31Ref return null reference values.
+// NullFuncRef, NullExternRef, NullExnRef, NullGCRef, and NullI31Ref return null reference values.
 func NullFuncRef() FuncRef     { return FuncRef{} }
 func NullExternRef() ExternRef { return ExternRef{} }
+func NullExnRef() ExnRef       { return ExnRef{} }
 func NullGCRef() GCRef         { return GCRef{} }
 func NullI31Ref() I31Ref       { return I31Ref{} }
 
@@ -54,6 +56,7 @@ func NewI31Ref(v int32) I31Ref { return I31Ref{bits: uint32(v)<<1 | 1} }
 // IsNull reports whether a reference is null.
 func (r FuncRef) IsNull() bool   { return r.token == 0 }
 func (r ExternRef) IsNull() bool { return r.token == 0 }
+func (r ExnRef) IsNull() bool    { return r.token == 0 }
 func (r GCRef) IsNull() bool     { return r.token == 0 }
 func (r I31Ref) IsNull() bool    { return r.bits == 0 }
 

--- a/src/wago/zz_host_execution_fixed.go
+++ b/src/wago/zz_host_execution_fixed.go
@@ -1,5 +1,141 @@
 package wago
 
+func (a *hostLoopActivation) singleTypedScalarNativeContextChanged(active *Instance, state *instancePluginState, version uint64) bool {
+	return version == ^uint64(0) || !a.parkedNativeContextReusable ||
+		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+		state.nativeContextVersion.Load() != version
+}
+
+func (a *hostLoopActivation) finishSingleTypedScalarFixedPortal(active *Instance, state *instancePluginState, version uint64) {
+	if a.singleTypedScalarNativeContextChanged(active, state, version) {
+		active.restoreTypedScalarNativeContext(a.ctrl)
+	}
+}
+
+func (a *hostLoopActivation) dispatchSingleHostCallFixedView(args, results []uint64) {
+	active := a.root
+	binding := &active.syncHosts[0]
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
+		version := state.nativeContextVersion.Load()
+		binding.fn.(HostCallFunc)(HostCall{params: args, results: results, sig: binding.sig, exact: binding.exact})
+		a.finishSingleTypedScalarFixedPortal(active, state, version)
+		return
+	}
+
+	epoch := nativeExecutionEpoch
+	nativeExecutionMu.Unlock()
+	defer func() {
+		nativeExecutionMu.Lock()
+		if nativeExecutionEpoch != epoch {
+			active.restoreTypedScalarNativeContext(a.ctrl)
+		}
+	}()
+	binding.fn.(HostCallFunc)(HostCall{params: args, results: results, sig: binding.sig, exact: binding.exact})
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedNoneFixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	active.syncHosts[0].typedNone()
+	if a.singleTypedScalarNativeContextChanged(active, state, version) {
+		active.restoreTypedScalarNativeContext(a.ctrl)
+	}
+	return 0
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedI32VoidFixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	active.syncHosts[0].typedI32V(AsI32(a0))
+	a.finishSingleTypedScalarFixedPortal(active, state, version)
+	return 0
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedI64FixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	result := I64(active.syncHosts[0].fn.(func(int64) int64)(AsI64(a0)))
+	a.finishSingleTypedScalarFixedPortal(active, state, version)
+	return result
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedI64x2FixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	result := I64(active.syncHosts[0].fn.(func(int64, int64) int64)(AsI64(a0), AsI64(a1)))
+	a.finishSingleTypedScalarFixedPortal(active, state, version)
+	return result
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedF32FixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	result := F32(active.syncHosts[0].fn.(func(float32) float32)(AsF32(a0)))
+	if a.singleTypedScalarNativeContextChanged(active, state, version) {
+		active.restoreTypedScalarNativeContext(a.ctrl)
+	}
+	return result
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedF32x2FixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	result := F32(active.syncHosts[0].fn.(func(float32, float32) float32)(AsF32(a0), AsF32(a1)))
+	a.finishSingleTypedScalarFixedPortal(active, state, version)
+	return result
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedF64FixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	result := F64(active.syncHosts[0].fn.(func(float64) float64)(AsF64(a0)))
+	if a.singleTypedScalarNativeContextChanged(active, state, version) {
+		active.restoreTypedScalarNativeContext(a.ctrl)
+	}
+	return result
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedF64x2FixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	state := a.state
+	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
+	}
+	version := state.nativeContextVersion.Load()
+	result := F64(active.syncHosts[0].fn.(func(float64, float64) float64)(AsF64(a0), AsF64(a1)))
+	a.finishSingleTypedScalarFixedPortal(active, state, version)
+	return result
+}
+
 func (a *hostLoopActivation) dispatchSingleTypedScalarFixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
 	binding := &active.syncHosts[0]

--- a/src/wago/zz_host_execution_fixed.go
+++ b/src/wago/zz_host_execution_fixed.go
@@ -1,0 +1,107 @@
+package wago
+
+func (a *hostLoopActivation) dispatchSingleTypedScalarFixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	binding := &active.syncHosts[0]
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		rawSlots, ok := binding.typedScalarSlots()
+		if !ok {
+			panic("wago: fixed scalar host portal lost its bound signature")
+		}
+		result, handled := a.dispatchTypedScalarExpandedPortal(a.ctrl, 0, rawSlots, a0, a1)
+		if !handled {
+			panic("wago: fixed scalar host portal rejected its bound signature")
+		}
+		return result
+	}
+	version := state.nativeContextVersion.Load()
+	result := binding.callTypedScalar(a0, a1)
+	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+		state.nativeContextVersion.Load() != version {
+		active.restoreTypedScalarNativeContext(a.ctrl)
+	}
+	return result
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedI32x2VoidFixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	binding := &active.syncHosts[0]
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		rawSlots, ok := binding.typedScalarSlots()
+		if !ok {
+			panic("wago: fixed i32/i32 void host portal lost its bound signature")
+		}
+		result, handled := a.dispatchTypedScalarExpandedPortal(a.ctrl, 0, rawSlots, a0, a1)
+		if !handled {
+			panic("wago: fixed i32/i32 void host portal rejected its bound signature")
+		}
+		return result
+	}
+	version := state.nativeContextVersion.Load()
+	binding.typedI32x2V(AsI32(a0), AsI32(a1))
+	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+		state.nativeContextVersion.Load() != version {
+		active.restoreTypedScalarNativeContext(a.ctrl)
+	}
+	return 0
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedI32PairFixedPortal(a0, _ uint64) uint64 {
+	active := a.root
+	binding := &active.syncHosts[0]
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		rawSlots, ok := binding.typedScalarSlots()
+		if !ok {
+			panic("wago: fixed i32 pair-result host portal lost its bound signature")
+		}
+		result, handled := a.dispatchTypedScalarExpandedPortal(a.ctrl, 0, rawSlots, a0, 0)
+		if !handled {
+			panic("wago: fixed i32 pair-result host portal rejected its bound signature")
+		}
+		return result
+	}
+	version := state.nativeContextVersion.Load()
+	first, second := binding.typedI32R2(AsI32(a0))
+	result := uint64(uint32(first)) | uint64(uint32(second))<<32
+	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+		state.nativeContextVersion.Load() != version {
+		active.restoreTypedScalarNativeContext(a.ctrl)
+	}
+	return result
+}
+
+func (a *hostLoopActivation) dispatchSingleTypedI32x2PairFixedPortal(a0, a1 uint64) uint64 {
+	active := a.root
+	binding := &active.syncHosts[0]
+	state := a.state
+	flags := active.executionFlags.Load()
+	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
+		rawSlots, ok := binding.typedScalarSlots()
+		if !ok {
+			panic("wago: fixed i32/i32 pair-result host portal lost its bound signature")
+		}
+		result, handled := a.dispatchTypedScalarExpandedPortal(a.ctrl, 0, rawSlots, a0, a1)
+		if !handled {
+			panic("wago: fixed i32/i32 pair-result host portal rejected its bound signature")
+		}
+		return result
+	}
+	version := state.nativeContextVersion.Load()
+	first, second := binding.typedI32x2R2(AsI32(a0), AsI32(a1))
+	result := uint64(uint32(first)) | uint64(uint32(second))<<32
+	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
+		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
+		state.nativeContextVersion.Load() != version {
+		active.restoreTypedScalarNativeContext(a.ctrl)
+	}
+	return result
+}

--- a/wago.go
+++ b/wago.go
@@ -22,6 +22,7 @@ type (
 	Bits                            = impl.Bits
 	BoundsCheckMode                 = impl.BoundsCheckMode
 	Caller                          = impl.Caller
+	CallerHostCallFunc              = impl.CallerHostCallFunc
 	CallerHostFunc                  = impl.CallerHostFunc
 	CallerInvoker                   = impl.CallerInvoker
 	CallerResolver                  = impl.CallerResolver
@@ -51,6 +52,7 @@ type (
 	ElemInit                        = impl.ElemInit
 	ElemMode                        = impl.ElemMode
 	ExitError                       = impl.ExitError
+	ExnRef                          = impl.ExnRef
 	ExternRef                       = impl.ExternRef
 	ExternRefHostModule             = impl.ExternRefHostModule
 	FeatureInfo                     = impl.FeatureInfo
@@ -92,6 +94,8 @@ type (
 	Handle                          = impl.Handle
 	HandleTable                     = impl.HandleTable
 	HeapTypeDescriptor              = impl.HeapTypeDescriptor
+	HostCall                        = impl.HostCall
+	HostCallFunc                    = impl.HostCallFunc
 	HostExit                        = impl.HostExit
 	HostFunc                        = impl.HostFunc
 	HostFuncRef                     = impl.HostFuncRef
@@ -508,6 +512,8 @@ func NewTable(minSize uint32, maxSize uint32) (*Table, error) { return impl.NewT
 func NewTable64(minSize uint32, maxSize uint32) (*Table, error) {
 	return impl.NewTable64(minSize, maxSize)
 }
+
+func NullExnRef() ExnRef { return impl.NullExnRef() }
 
 func NullExternRef() ExternRef { return impl.NullExternRef() }
 

--- a/wago.go
+++ b/wago.go
@@ -99,8 +99,13 @@ type (
 	HostModule                      = impl.HostModule
 	HostTrap                        = impl.HostTrap
 	I31Ref                          = impl.I31Ref
+	I32HostEvent                    = impl.I32HostEvent
+	I32HostFunc                     = impl.I32HostFunc
+	I32I32HostFunc                  = impl.I32I32HostFunc
 	I32I32ToI32HostFunc             = impl.I32I32ToI32HostFunc
+	I32I32ToI32I32HostFunc          = impl.I32I32ToI32I32HostFunc
 	I32ToI32HostFunc                = impl.I32ToI32HostFunc
+	I32ToI32I32HostFunc             = impl.I32ToI32I32HostFunc
 	ImplementationLimitError        = impl.ImplementationLimitError
 	ImportFuncBuilder               = impl.ImportFuncBuilder
 	ImportKind                      = impl.ImportKind
@@ -149,6 +154,7 @@ type (
 	ModuleSourceTransformer         = impl.ModuleSourceTransformer
 	ModuleView                      = impl.ModuleView
 	NativeMemoryStats               = impl.NativeMemoryStats
+	NoArgsHostFunc                  = impl.NoArgsHostFunc
 	OffsetInit                      = impl.OffsetInit
 	OperationIdentity               = impl.OperationIdentity
 	OptKnobInfo                     = impl.OptKnobInfo
@@ -321,6 +327,7 @@ const (
 	ImportTag                                  = impl.ImportTag
 	InstantiateDirect                          = impl.InstantiateDirect
 	InstantiateManaged                         = impl.InstantiateManaged
+	MaxDeferredHostEventsPerInvocation         = impl.MaxDeferredHostEventsPerInvocation
 	MaxFunctionLocalsLimit                     = impl.MaxFunctionLocalsLimit
 	MaxMemoriesPerModuleLimit                  = impl.MaxMemoriesPerModuleLimit
 	MaxNativeStackBytes                        = impl.MaxNativeStackBytes


### PR DESCRIPTION
## Summary

- replace signature-named registration methods with `Func(name, fn any)`, accepting ordinary Go functions and a universal `HostCallFunc`
- support arbitrary scalar/reference arity without reflection, while remaining portable across standard Go and TinyGo
- retain specialized zero-allocation scalar portals and add a direct parked-frame view for profitable wide callbacks
- expand API, runtime, allocation, signature-matrix, and safety coverage; document the measured latency and tradeoffs

## Performance

### Wasm → host

These tables use the optimized ordinary-function route on pushed head `02065bc9`, not the arbitrary-signature `HostCallFunc` route. The baseline is current main `36ba5c89`. Each invocation performs 1,024 synchronous callbacks; values are medians of five per-signature, revision-interleaved 500 ms samples and allocations remain zero.

The comparison measures migration from main's general `CallerHostFunc` API to the unified optimized ordinary-function API. Main also has legacy dedicated fast types for `[i32] -> [i32]` and `[i32, i32] -> [i32]`; these tables do not claim a 2x improvement over those two types. An ABBA control of the unchanged legacy scalar portal was flat (-0.36% ARM64, +0.04% AMD64).

Native Linux/AMD64, Ryzen 7 7800X3D, Go 1.26.5, `GOMAXPROCS=1`, pinned to CPU 7:

| Signature | Main route | Main median | Head route | Head median | Delta | Allocations |
|---|---|---:|---|---:|---:|---:|
| `[] -> []` | `CallerHostFunc` | 117.80 ns | `func()` | 58.47 ns | -50.37% | 0 |
| `[i32] -> []` | `CallerHostFunc` | 119.10 ns | `func(int32)` | 57.66 ns | -51.59% | 0 |
| `[i32] -> [i32]` | `CallerHostFunc` | 119.30 ns | `func(int32) int32` | 58.65 ns | -50.84% | 0 |
| `[i32, i32] -> []` | `CallerHostFunc` | 122.70 ns | `func(int32, int32)` | 57.28 ns | -53.32% | 0 |
| `[i32, i32] -> [i32]` | `CallerHostFunc` | 123.60 ns | `func(int32, int32) int32` | 59.78 ns | -51.63% | 0 |
| `[i32] -> [i32, i32]` | `CallerHostFunc` | 123.00 ns | `func(int32) (int32, int32)` | 58.82 ns | -52.18% | 0 |
| `[i32, i32] -> [i32, i32]` | `CallerHostFunc` | 124.20 ns | `func(int32, int32) (int32, int32)` | 57.57 ns | -53.65% | 0 |
| `[i64] -> [i64]` | `CallerHostFunc` | 121.20 ns | `func(int64) int64` | 56.71 ns | -53.21% | 0 |
| `[i64, i64] -> [i64]` | `CallerHostFunc` | 124.30 ns | `func(int64, int64) int64` | 59.82 ns | -51.87% | 0 |
| `[f32] -> [f32]` | `CallerHostFunc` | 120.50 ns | `func(float32) float32` | 58.91 ns | -51.11% | 0 |
| `[f32, f32] -> [f32]` | `CallerHostFunc` | 124.80 ns | `func(float32, float32) float32` | 59.52 ns | -52.31% | 0 |
| `[f64] -> [f64]` | `CallerHostFunc` | 120.00 ns | `func(float64) float64` | 58.47 ns | -51.28% | 0 |
| `[f64, f64] -> [f64]` | `CallerHostFunc` | 124.10 ns | `func(float64, float64) float64` | 59.72 ns | -51.88% | 0 |

Native Darwin/ARM64, Apple M4 Max, Go 1.26.5, `GOMAXPROCS=1`:

| Signature | Main route | Main median | Head route | Head median | Delta | Allocations |
|---|---|---:|---|---:|---:|---:|
| `[] -> []` | `CallerHostFunc` | 85.30 ns | `func()` | 40.76 ns | -52.22% | 0 |
| `[i32] -> []` | `CallerHostFunc` | 86.50 ns | `func(int32)` | 41.08 ns | -52.51% | 0 |
| `[i32] -> [i32]` | `CallerHostFunc` | 88.59 ns | `func(int32) int32` | 41.99 ns | -52.60% | 0 |
| `[i32, i32] -> []` | `CallerHostFunc` | 87.35 ns | `func(int32, int32)` | 41.56 ns | -52.42% | 0 |
| `[i32, i32] -> [i32]` | `CallerHostFunc` | 89.21 ns | `func(int32, int32) int32` | 42.77 ns | -52.06% | 0 |
| `[i32] -> [i32, i32]` | `CallerHostFunc` | 88.88 ns | `func(int32) (int32, int32)` | 41.06 ns | -53.80% | 0 |
| `[i32, i32] -> [i32, i32]` | `CallerHostFunc` | 89.15 ns | `func(int32, int32) (int32, int32)` | 42.15 ns | -52.72% | 0 |
| `[i64] -> [i64]` | `CallerHostFunc` | 88.00 ns | `func(int64) int64` | 41.18 ns | -53.20% | 0 |
| `[i64, i64] -> [i64]` | `CallerHostFunc` | 88.75 ns | `func(int64, int64) int64` | 41.95 ns | -52.73% | 0 |
| `[f32] -> [f32]` | `CallerHostFunc` | 87.90 ns | `func(float32) float32` | 41.30 ns | -53.01% | 0 |
| `[f32, f32] -> [f32]` | `CallerHostFunc` | 89.27 ns | `func(float32, float32) float32` | 43.36 ns | -51.43% | 0 |
| `[f64] -> [f64]` | `CallerHostFunc` | 88.27 ns | `func(float64) float64` | 41.24 ns | -53.28% | 0 |
| `[f64, f64] -> [f64]` | `CallerHostFunc` | 88.09 ns | `func(float64, float64) float64` | 42.15 ns | -52.15% | 0 |

Against main's general callback route, the unified optimized API is 51.43-53.80% faster across all 13 ARM64 signatures and 50.37-53.65% faster across all 13 AMD64 signatures. A longer order-balanced 15-pair AMD64 control for the narrowest `[] -> []` case measured 117.60 ns on main versus 57.92 ns on head (-50.75%), confirming the smallest margin. Allocations remain zero throughout.

The fixed-shape loop removes per-callback import/signature matching. Exact scalar portals remove the remaining typed dispatch switch; aligned root-frame access removes byte-wise scalar loads/stores; and the three narrowest portals inline the native-context validity predicate so callback results are not spilled around an out-of-line helper. Separately, the new fixed `HostCallFunc` parked-frame view improved the seven common scalar signatures by 2.77-7.89% on ARM64 and 2.91-6.52% on AMD64 versus the previous PR head, also at zero allocations.

### Host → Wasm

These tables use the optimized numeric entry route. They are matched fast-path-on versus feature-disabled medians from five 300 ms samples with `GOMAXPROCS=1`.

Native Linux/AMD64, Ryzen 7 7800X3D, Go 1.22.2, pinned to CPU 7:

| Signature | API | Before median | After median | Delta | Allocations |
|---|---|---:|---:|---:|---:|
| `[16xi32] -> [16xi32]` | `Invoke` | 153.3 ns | 69.13 ns | -54.9% | 0 |
| `[16xi32] -> [16xi32]` | `PreparedFunction` | 152.3 ns | 56.31 ns | -63.0% | 0 |
| `[64xi32] -> [64xi32]` | `Invoke` | 292.5 ns | 137.9 ns | -52.9% | 0 |
| `[64xi32] -> [64xi32]` | `PreparedFunction` | 296.4 ns | 123.9 ns | -58.2% | 0 |

Native Darwin/ARM64, Apple M4 Max, Go 1.26.5:

| Signature | API | Before median | After median | Delta | Allocations |
|---|---|---:|---:|---:|---:|
| `[16xi32] -> [16xi32]` | `Invoke` | 148.6 ns | 78.40 ns | -47.2% | 0 |
| `[16xi32] -> [16xi32]` | `PreparedFunction` | 128.9 ns | 62.23 ns | -51.7% | 0 |
| `[64xi32] -> [64xi32]` | `Invoke` | 257.5 ns | 130.9 ns | -49.2% | 0 |
| `[64xi32] -> [64xi32]` | `PreparedFunction` | 234.1 ns | 119.6 ns | -48.9% | 0 |

After merging current `main`, a second five-sample 64/64 run remained below 150 ns: ARM64 medians were 131.3 ns for `Invoke` and 118.2 ns prepared; AMD64 medians were 144.5 ns for `Invoke` and 124.2 ns prepared.

## Breaking changes

- signature-named builder methods are removed in favor of `Func`
- ordinary functions are classified once during registration/instantiation
- legacy signature-specific callback types remain accepted during migration

## Validation

Passed on current head:

- focused API, signature, lifecycle, panic, reentry, GC, direct re-export, imported-start, and deferred-event tests
- focused race tests
- `go test ./src/wago`
- `go test ./src/core/runtime`
- native Linux/AMD64 `go test ./src/core/compiler/backend/railshot/amd64`
- focused `-d=checkptr=2` callback tests
- focused Go 1.22.12 compatibility tests
- `just lint all`
- `just test tinygo`
- `go test ./... -count=1`

Current pushed head `02065bc9` passes the complete GitHub CI matrix across Linux, Darwin, Windows, AMD64, ARM64, race, conformance, fuzzing, TinyGo, lint, and documentation, along with the local suites above.
