### PR TITLE
runtime: preserve entry safety with narrow prepared admission

### DIFF
--- a/docs/runtime-entry-safety-audit.md
+++ b/docs/runtime-entry-safety-audit.md
@@ -13,7 +13,7 @@ The invocation gate adds 16 bytes to `instancePluginState` on amd64. The fast-en
 
 ## Narrow direct prepared entry
 
-The compiler's direct-entry metadata and isolated module shape establish that the entry cannot call a host, enter another instance, or use GC facilities. The module has no imports, collector, external global cells, or external memory. Isolated local tables require the existing compiler proof. The integer signature alone is not a safety proof. Those construction-time facts are immutable; current sharing and GC-domain exclusions are checked at each entry. GC-domain flags are published during reference-store registration, before public calls. Resource sharing revokes direct admission before publishing a shared handle.
+The compiler's direct-entry metadata and isolated module shape establish that the entry cannot call a host, enter another instance, or use GC facilities. The module has no imports, collector, external global cells, or external memory. Isolated local tables require the existing compiler proof. The integer signature alone is not a safety proof. Those construction-time facts are immutable; current sharing and GC-domain exclusions are checked at each entry. Non-private GC domains are registered during construction. A late boundary-created store is private and cannot add GC domains to a module with no collector or imports. Resource sharing revokes direct admission before publishing a shared handle.
 
 The gate state machine uses `Held`, `Fast`, `Waiters`, and permanent `Revoked` bits:
 

--- a/docs/runtime-entry-safety-audit.md
+++ b/docs/runtime-entry-safety-audit.md
@@ -1,0 +1,37 @@
+# Runtime entry safety audit
+
+Base: `788a3bfb0` (main). This report records the fixes and the limits of the investigation.
+
+## Confirmed defects
+
+* Prepared scalar and direct integer calls used ownership decisions saved at preparation. After `ExportedFunc`, these calls could omit the required native lock and context binding. Every prepared entry now takes lifetime and invocation leases. Specialized entry reserves a bit in the atomic execution flags. Ownership publication sets the shared bit, blocks new reservations, and waits for an existing reservation to finish. The wait uses the invocation gate's notification channel. Both changes use the same atomic word, so there is no check-to-entry window. Private entries take the global native lock before the reservation. Shared calls use the general guarded entry. The ARM64 call-block implementation now uses the same boundary as its other direct entries. Normal cached `Invoke` uses the reservation too.
+* Optimized typed and `HostCallFunc` callbacks kept the independent native mutex held. A closure that called `GlobalValue` or `SetGlobalValue` then deadlocked. Each optimized portal now releases the local native lease before Go code and defers reacquisition and context restoration. The saved state is a stack value. Shared execution keeps its existing global lease protocol. Public host access still takes its lock; callback activity grants no authority to another goroutine.
+* `Call(ctx)` waited on a mutex after cancellation. The new invocation gate has a context-aware wait and uses an atomic reservation for uncontended admission. It checks cancellation before and after reservation. Cancellation visible at either check wins and releases any acquired slot. Contended wait registration and release use the same atomic state word to prevent missed wakeups. Cancellation after that decision is checked again before guest entry. A canceled waiter does not modify the owner's identity or trap. The uncontended gate allocates nothing. Contenders share one notification channel for the current wait interval; there is no waiter goroutine.
+* The full race suite found a separate structural-call-identity cache race during concurrent instantiation. Writers held the code-cache mutex, but readers loaded the published cache pointer without synchronization. The pointer is now atomic. One acquire load reads a complete immutable cache. The writer lock, retention budget, lazy second-use construction, and exact identity comparisons remain in place. This changes neither object size nor allocation count.
+
+The invocation gate adds 16 bytes to `instancePluginState` on amd64. The fast-entry reservation reuses the existing atomic execution flags and gate wait state. No new per-call allocation is required for `Invoke`, prepared entry, or optimized host callbacks. `Call` retains its existing typed-value allocations.
+
+## Native code limit
+
+`WithMaxNativeCodeBytes` is an accepted final output-size limit. It is not a peak compiler memory or work limit. The API comment now states this explicitly. The final check counts the complete module image after parallel workers have joined, including alignment, adapters, literals, and shared stubs. It is not a separate allowance for each worker. Failed compilation does not publish a `Compiled` value. The existing deferred code-image cleanup remains active.
+
+The amd64 and arm64 emitters were inspected for incremental enforcement. Directly charging every reservation against this same limit would change accepted-output semantics:
+
+* Serial emission reserves a mapping tail that includes relocation and local-reference scratch space.
+* Assemblers emit through byte slices. A tail-capacity underestimate can use a detached slice and append it later.
+* Function finalization and module-wide adapter/trap-body sharing can shrink emitted code. An intermediate image can therefore exceed the final accepted size.
+* Parallel workers retain separate code and relocation arenas before final assembly. Charging each arena capacity would count temporary storage and duplicated code as final output.
+
+No incremental emission or peak-memory guarantee is claimed by this change. A safe early cutoff needs a proven lower bound on final size, or a separate temporary-emission budget enforced by both encoders and all slice growth paths. Such a budget also needs shared worker cancellation and cleanup. That work remains separate; a raw reservation cap would incorrectly reject some modules that meet the existing API contract.
+
+`TestNativeCodeLimitIsOneFinalModuleBudget` checks limits one byte above, exactly at, and below the measured final size with one and four workers. It checks that failure returns no artifact and that a subsequent exact-limit compilation executes correctly. `TestCompileByteAndNativeCodeQuotas` continues to cover the final compiler check and the decoded-artifact check. These contract tests pass on the original behavior; they do not claim an early-emission fix.
+
+## Linux job control
+
+The reported shared-foreground failure has not been reproduced. The investigation covered terminal process-group setup, the guardian's child-state loop, `waitWatchedProcess`, stop mirroring, `SIGCONT` handling, foreground restoration, interrupt forwarding/exclusion, and child cleanup. No timeout was increased and no production guarantee was removed.
+
+Runs of the existing test passed with ordinary scheduling, the race detector, and one- and two-CPU scheduling. This evidence does not establish that the CI failure was a timeout or a test defect. Its root cause remains unresolved. A production change without a confirmed failing transition would be speculative.
+
+## Validation
+
+Validation results and remaining toolchain limits are recorded in the pull request. Raw local logs are in `/tmp/wago-entry-validation` during this session.

--- a/docs/runtime-entry-safety-audit.md
+++ b/docs/runtime-entry-safety-audit.md
@@ -4,12 +4,31 @@ Base: `788a3bfb0` (main). This report records the fixes and the limits of the in
 
 ## Confirmed defects
 
-* Prepared scalar and direct integer calls used ownership decisions saved at preparation. After `ExportedFunc`, these calls could omit the required native lock and context binding. Every prepared entry now takes lifetime and invocation leases. Specialized entry reserves a bit in the atomic execution flags. Ownership publication sets the shared bit, blocks new reservations, and waits for an existing reservation to finish. The wait uses the invocation gate's notification channel. Both changes use the same atomic word, so there is no check-to-entry window. Private entries take the global native lock before the reservation. Shared calls use the general guarded entry. The ARM64 call-block implementation now uses the same boundary as its other direct entries. Normal cached `Invoke` uses the reservation too.
+* Prepared scalar and direct integer calls used ownership decisions saved at preparation. After `ExportedFunc`, these calls could omit native locking and context binding. Every prepared entry retains lifetime protection. The isolated direct integer path now reserves invocation ownership and private entry together in the existing invocation gate. Other specialized paths retain their execution-flag reservation under the general gate. Sharing revokes direct gate admission before setting the shared execution flag, then waits for older reservations. Shared calls use guarded general entry. ARM64 call-block entry uses the same boundary as its other direct entries.
 * Optimized typed and `HostCallFunc` callbacks kept the independent native mutex held. A closure that called `GlobalValue` or `SetGlobalValue` then deadlocked. Each optimized portal now releases the local native lease before Go code and defers reacquisition and context restoration. The saved state is a stack value. Shared execution keeps its existing global lease protocol. Public host access still takes its lock; callback activity grants no authority to another goroutine.
 * `Call(ctx)` waited on a mutex after cancellation. The new invocation gate has a context-aware wait and uses an atomic reservation for uncontended admission. It checks cancellation before and after reservation. Cancellation visible at either check wins and releases any acquired slot. Contended wait registration and release use the same atomic state word to prevent missed wakeups. Cancellation after that decision is checked again before guest entry. A canceled waiter does not modify the owner's identity or trap. The uncontended gate allocates nothing. Contenders share one notification channel for the current wait interval; there is no waiter goroutine.
 * The full race suite found a separate structural-call-identity cache race during concurrent instantiation. Writers held the code-cache mutex, but readers loaded the published cache pointer without synchronization. The pointer is now atomic. One acquire load reads a complete immutable cache. The writer lock, retention budget, lazy second-use construction, and exact identity comparisons remain in place. This changes neither object size nor allocation count.
 
 The invocation gate adds 16 bytes to `instancePluginState` on amd64. The fast-entry reservation reuses the existing atomic execution flags and gate wait state. No new per-call allocation is required for `Invoke`, prepared entry, or optimized host callbacks. `Call` retains its existing typed-value allocations.
+
+## Narrow direct prepared entry
+
+The compiler's direct-entry metadata and isolated module shape establish that the entry cannot call a host, enter another instance, or use GC facilities. The module has no imports, collector, external global cells, or external memory. Isolated local tables require the existing compiler proof. The integer signature alone is not a safety proof. Those construction-time facts are immutable; current sharing and GC-domain exclusions are checked at each entry. GC-domain flags are published during reference-store registration, before public calls. Resource sharing revokes direct admission before publishing a shared handle.
+
+The gate state machine uses `Held`, `Fast`, `Waiters`, and permanent `Revoked` bits:
+
+1. Acquire the existing lifetime lease. Its instance-local atomic count prevents physical teardown. Runtime-owned instances also retain runtime operation accounting.
+2. CAS an idle, unrevoked gate to `Held|Fast`. This owns the same gate as ordinary calls. Check the current execution exclusions; release and fall back if any exclusion applies.
+3. Enter native code without allocating an invocation ID, acquiring a GC domain lease, or taking a second ownership reservation.
+4. Release the gate with CAS while preserving `Revoked`. Notify registered waiters if required. Release the lifetime lease after native and result processing finish.
+
+Sharing sets `Revoked` in this same word. If it observes `Fast`, it registers for notification and waits until the call releases the gate. Thus sharing either prevents entry or waits for it; there is no load-to-native-entry gap. General admission can acquire a revoked gate, but direct entry cannot. A direct call cannot bypass a general call or its fallback. General waiters remain cancellable.
+
+The omitted invocation ID has no observer: this entry cannot execute callbacks, cross-instance calls, or callback reentry. The omitted GC helper has no domain to own: isolated module metadata excludes local GC and the current flags exclude imported, dynamic, and store-owned GC. No synchronization has been removed from ordinary host callbacks.
+
+Lifetime is independent of invocation ownership. The existing instance count and close bit order entry against physical release, including runtime shutdown. Runtime-owned instances still use the runtime mutex and operation count: plugin teardown drains these operations, not only the instance's native gate. This change does not substitute an unproven local lease for that runtime contract. The standalone hot path uses only local atomic lifetime accounting and the combined gate; it allocates nothing and adds no storage.
+
+`TestPreparedDirectDoesNotAllocateInvocationIdentity` failed before the change and passed afterward. Additional tests cover the shared general gate, revocation and fallback, each GC exclusion bit, and both instance and runtime close while a direct lease is held. Existing tests cover actual concurrent export, context rebinding, trap handling, disabled-direct mode, call-block mode, and allocation counts. The GC-bit test checks the admission predicate, without inventing missing GC topology.
 
 ## Native code limit
 
@@ -34,4 +53,4 @@ Runs of the existing test passed with ordinary scheduling, the race detector, an
 
 ## Validation
 
-Validation results and remaining toolchain limits are recorded in the pull request. Raw local logs are in `/tmp/wago-entry-validation` during this session.
+Validation results and remaining toolchain limits are recorded in the pull request. Raw local logs are in `/tmp/wago-entry-validation` and `/tmp/wago-pr617-perf` during this session.

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4404,7 +4404,7 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 		// Keep both dynamic security bits on the entry boundary and fall back to
 		// the audited rebinding and topology-lease route.
 		executionFlags := in.executionFlags.Load()
-		const directBlocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector
+		const directBlocked = preparedFastBlocked
 		if ic.directIntFast && executionFlags&directBlocked == 0 && in.lockPreparedFastState() {
 			defer in.unlockPreparedFastState()
 			if len(args) != ic.paramSlots {

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4405,7 +4405,8 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 		// the audited rebinding and topology-lease route.
 		executionFlags := in.executionFlags.Load()
 		const directBlocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector
-		if ic.directIntFast && executionFlags&directBlocked == 0 {
+		if ic.directIntFast && executionFlags&directBlocked == 0 && in.lockPreparedFastState() {
+			defer in.unlockPreparedFastState()
 			if len(args) != ic.paramSlots {
 				return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", export, ic.paramSlots, len(args))
 			}

--- a/src/wago/api.go
+++ b/src/wago/api.go
@@ -4301,6 +4301,13 @@ type invocationContextSet struct {
 	callback  context.Context
 }
 
+func (contexts invocationContextSet) admissionContext() context.Context {
+	if contexts.interrupt != nil {
+		return contexts.interrupt
+	}
+	return contexts.callback
+}
+
 func invocationContextSetFor(ctx context.Context) (contexts invocationContextSet) {
 	if ctx == nil || ctx.Done() == nil {
 		return contexts
@@ -4363,7 +4370,10 @@ func (in *Instance) invokeEntry(export string, args []uint64, contexts invocatio
 	if state := in.pluginState.Load(); state != nil && state.guestStorageBorrow.Load() != 0 {
 		return nil, fmt.Errorf("invoke %q: guest storage is borrowed: %w", export, ErrPermissionDenied)
 	}
-	state := in.lockInvocation(0)
+	state, err := in.lockInvocationContext(contexts.admissionContext(), 0)
+	if err != nil {
+		return nil, err
+	}
 	admittedHere := false
 	defer func() {
 		if admittedHere {
@@ -4462,19 +4472,19 @@ func nilInstanceInvokeError() error {
 }
 
 func (in *Instance) invokeWithToken(export string, args []uint64, contexts invocationContextSet, id invocationID, gateHeld, alreadyAdmitted bool, reservation *pluginOperationReservation) ([]uint64, error) {
+	ctx := contexts.admissionContext()
 	reentry := !gateHeld && isNativeActive(in, id)
 	if !reentry && !gateHeld {
 		// Acquire the target instance gate before the shared collector lease. A
 		// parked same-domain callback must be able to reacquire the collector and
 		// finish releasing this gate while a second callback waits to enter.
-		state := in.lockInvocation(id)
+		state, err := in.lockInvocationContext(ctx, id)
+		if err != nil {
+			return nil, err
+		}
 		defer state.unlockInvocation()
 	}
 	// Cancellation may arrive while this call waits for the instance gate.
-	ctx := contexts.interrupt
-	if ctx == nil {
-		ctx = contexts.callback
-	}
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/src/wago/code_mapping.go
+++ b/src/wago/code_mapping.go
@@ -658,7 +658,7 @@ func (c *Compiled) releaseCode() {
 	}
 	if cc.refs == 0 && cc.closed {
 		if c.validateMemo != nil {
-			c.validateMemo.structuralCallIdentities = nil
+			c.validateMemo.structuralCallIdentities.Store(nil)
 		}
 	}
 }
@@ -713,7 +713,7 @@ func (c *Compiled) Close() error {
 		return nil
 	}
 	if c.validateMemo != nil {
-		c.validateMemo.structuralCallIdentities = nil
+		c.validateMemo.structuralCallIdentities.Store(nil)
 	}
 	if cc.mem == nil {
 		// Preserve compiler-produced metadata so a later Instantiate reaches the

--- a/src/wago/config.go
+++ b/src/wago/config.go
@@ -506,7 +506,10 @@ func (c *RuntimeConfig) WithMaxModuleBytes(bytes uint64) *RuntimeConfig {
 	return &n
 }
 
-// WithMaxNativeCodeBytes caps generated native code bytes for one module. Zero
+// WithMaxNativeCodeBytes caps the accepted final native code image for one module.
+// The limit is checked after code generation and final compaction. It does not
+// bound peak compiler memory, temporary code, or compilation work. Function
+// workers share this one final module limit; it is not a per-worker allowance. Zero
 // is unbounded. Runtime.Module rechecks decoded artifacts against this quota.
 func (c *RuntimeConfig) WithMaxNativeCodeBytes(bytes uint64) *RuntimeConfig {
 	n := *c

--- a/src/wago/gc_array_reference_amd64_test.go
+++ b/src/wago/gc_array_reference_amd64_test.go
@@ -374,7 +374,8 @@ func TestStagedGCArrayReferenceFootprint(t *testing.T) {
 	} {
 		// The plugin sidecar includes instance-local counted activations and
 		// reservations, plus monotonic callback/context versions (72 bytes).
-		want := map[string]uintptr{"gcArrayElementInit": 40, "gcArrayElementState": 112, "compiledMemoryDirectory": 136, "instancePluginState": 208}[name]
+		// Cancellable admission adds 16 bytes.
+		want := map[string]uintptr{"gcArrayElementInit": 40, "gcArrayElementState": 112, "compiledMemoryDirectory": 136, "instancePluginState": 224}[name]
 		if got != want {
 			t.Fatalf("%s size = %d, want %d", name, got, want)
 		}

--- a/src/wago/globals.go
+++ b/src/wago/globals.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 
 	railshot "github.com/wago-org/wago/src/core/compiler/backend/railshot"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
@@ -1170,7 +1171,7 @@ type validateMemo struct {
 	once                     sync.Once
 	err                      error
 	gcFrameRoots             *compiledGCFrameRoots // immutable compiled/codec native safepoint and callsite map
-	structuralCallIdentities *structuralCallIdentityCache
+	structuralCallIdentities atomic.Pointer[structuralCallIdentityCache]
 	// importModuleEnds stores one plus the module-name byte length for each
 	// non-global import, grouped as functions, tables, memories, then tags. A
 	// zero entry retains the legacy first-dot interpretation for hand-built

--- a/src/wago/host_callback_access_test.go
+++ b/src/wago/host_callback_access_test.go
@@ -1,0 +1,170 @@
+//go:build (linux || darwin || windows) && (amd64 || arm64) && !tinygo
+
+package wago
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	wruntime "github.com/wago-org/wago/src/core/runtime"
+	"os"
+	"os/exec"
+	goruntime "runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+)
+
+func TestHostCallbackGlobalAccess(t *testing.T) {
+	if mode := os.Getenv("WAGO_TEST_CALLBACK_ACCESS"); mode != "" {
+		testHostCallbackGlobalAccess(t, mode)
+		return
+	}
+	for _, family := range []string{"typed", "expanded", "hostcall", "generic"} {
+		for _, outcome := range []string{"return", "cancel", "host-error", "panic", "trap"} {
+			mode := family + "/" + outcome
+			t.Run(mode, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestHostCallbackGlobalAccess$", "-test.count=1")
+				cmd.Env = append(os.Environ(), "WAGO_TEST_CALLBACK_ACCESS="+mode)
+				output, err := cmd.CombinedOutput()
+				if ctx.Err() != nil {
+					t.Fatalf("callback state access did not finish: %s", output)
+				}
+				if err != nil {
+					t.Fatalf("callback subprocess: %v\n%s", err, output)
+				}
+			})
+		}
+	}
+}
+
+func testHostCallbackGlobalAccess(t *testing.T, mode string) {
+	mode, outcome, _ := strings.Cut(mode, "/")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sentinel := errors.New("callback sentinel")
+	body := []byte{0x20, 0, 0x10, 0}
+	if outcome == "trap" {
+		body = append(body, 0x00)
+	}
+	body = append(body, 0x0b)
+	typ := wasm.I32
+	if mode == "expanded" {
+		typ = wasm.I64
+	}
+	source := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{typ}, []wasm.ValType{typ}))),
+		wasmtest.Section(2, wasmtest.Vec(importEntry("env", "f", 0, 0))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(6, wasmtest.Vec([]byte{0x7f, 1, 0x41, 7, 0x0b})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("g", 0, 1), wasmtest.ExportEntry("value", 3, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code(body))),
+	)
+	c := MustCompile(source)
+	defer c.Close()
+	var in *Instance
+	access := func(v int32) int32 {
+		value, err := in.GlobalValue("value")
+		if err != nil || value.I32() != 7 {
+			panic(fmt.Errorf("callback global read = %v, %v", value, err))
+		}
+		if err := in.SetGlobalValue("value", ValueI32(40)); err != nil {
+			panic(err)
+		}
+		// An unrelated goroutine must use the same lock, even during a callback.
+		done := make(chan error, 1)
+		started := make(chan struct{})
+		unlock := in.lockInstanceNativeStateForHostAccess()
+		go func() { close(started); done <- in.SetGlobalValue("value", ValueI32(41)) }()
+		<-started
+		select {
+		case err := <-done:
+			unlock()
+			panic(fmt.Errorf("unrelated host access bypassed native mutex: %v", err))
+		case <-time.After(10 * time.Millisecond):
+		}
+		unlock()
+		if err := <-done; err != nil {
+			panic(err)
+		}
+
+		switch outcome {
+		case "cancel":
+			cancel()
+			// Keep the callback parked until the watcher has delivered cancellation.
+			// Immediate return can legitimately win the race with the watcher.
+			for atomic.LoadUint32((*uint32)(unsafe.Pointer(&in.trap[0]))) != uint32(wruntime.TrapInterrupted) {
+				goruntime.Gosched()
+			}
+		case "host-error":
+			panic(HostTrap{Err: sentinel})
+		case "panic":
+			panic(sentinel)
+		}
+		return v + 1
+	}
+	var host any
+	switch mode {
+	case "typed":
+		host = func(v int32) int32 { return access(v) }
+	case "expanded":
+		host = func(v int64) int64 { return int64(access(int32(v))) }
+	case "hostcall":
+		host = HostCallFunc(func(c HostCall) { c.SetI32(0, access(c.I32(0))) })
+	case "generic":
+		host = HostFunc(func(_ HostModule, a, r []uint64) { r[0] = I32(access(AsI32(a[0]))) })
+	}
+	var err error
+	in, err = Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": host}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	if !in.usesIndependentExecution() {
+		t.Fatal("fixture requires independent execution")
+	}
+	var out []uint64
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		out, err = in.InvokeContext(ctx, "g", 41)
+	}()
+	switch outcome {
+	case "return":
+		if recovered != nil || err != nil || len(out) != 1 || out[0] != 42 {
+			t.Fatalf("call = %v, %v, panic %v", out, err, recovered)
+		}
+	case "cancel":
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled callback = %v", err)
+		}
+	case "host-error":
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("host error = %v", err)
+		}
+	case "panic":
+		if recovered != sentinel {
+			t.Fatalf("panic = %v", recovered)
+		}
+	case "trap":
+		var trap *wruntime.TrapError
+		if !errors.As(err, &trap) || trap.Code != wruntime.TrapUnreachable {
+			t.Fatalf("guest trap = %v", err)
+		}
+	}
+	if outcome != "panic" && recovered != nil {
+		t.Fatalf("unexpected panic: %v", recovered)
+	}
+
+	value, err := in.GlobalValue("value")
+	if err != nil || value.I32() != 41 {
+		t.Fatalf("global after callback = %v, %v", value, err)
+	}
+}

--- a/src/wago/host_execution.go
+++ b/src/wago/host_execution.go
@@ -318,11 +318,36 @@ func (a *hostLoopActivation) dispatch(ctrl uintptr, importIdx uint32, args, resu
 	active.hostCall(ctrl, importIdx, args, results, invocation)
 }
 
+// parkIndependentHostCallback gives closure-based public host access the same
+// lease contract as the generic dispatcher. Reacquisition is deferred by the
+// caller, so errors and panics restore ownership too. No other goroutine gains
+// callback authority; public state access still acquires the native mutex.
+type parkedIndependentHostLease struct {
+	root     *Instance
+	state    *instancePluginState
+	reusable bool
+	mu       *sync.Mutex
+	version  uint64
+	ctrl     uintptr
+}
+
+func (a *hostLoopActivation) parkIndependentHostCallback(ctrl uintptr) parkedIndependentHostLease {
+	lease := parkedIndependentHostLease{root: a.root, state: a.state, reusable: a.parkedNativeContextReusable, mu: a.root.independentNativeExecutionMu(), version: a.state.nativeContextVersion.Load(), ctrl: ctrl}
+	lease.mu.Unlock()
+	return lease
+}
+
+func (l parkedIndependentHostLease) resume() {
+	l.mu.Lock()
+	if !l.reusable || !l.root.canReuseParkedNativeContextWithState(l.version, l.state) {
+		l.root.restoreTypedScalarNativeContext(l.ctrl)
+	}
+}
+
 // dispatchTypedScalarPortal is the capability-free root portal. Its callback
 // type cannot inspect Caller or obtain supported re-entry authority, and non-GC
 // activations have no native roots to publish while parked. Independent
-// instances retain their already-exclusive local lease; shared execution
-// releases the global lease so another instance may run. The context version or
+// and shared instances release their native lease while arbitrary Go runs. The context version or
 // global epoch still decides whether native context must be rebound before resume.
 func (a *hostLoopActivation) dispatchTypedScalarExpandedPortal(ctrl uintptr, importIdx, rawSlots uint32, a0, a1 uint64) (uint64, bool) {
 	active := a.root
@@ -347,10 +372,10 @@ func (a *hostLoopActivation) dispatchTypedScalarExpandedPortal(ctrl uintptr, imp
 		return 0, false
 	}
 
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
-		version := state.nativeContextVersion.Load()
+		resume := a.parkIndependentHostCallback(ctrl)
+		defer resume.resume()
 		var result uint64
 		if binding.scalarKind == syncHostTypedI32 {
 			result = I32(binding.typedI32(AsI32(a0)))
@@ -358,11 +383,6 @@ func (a *hostLoopActivation) dispatchTypedScalarExpandedPortal(ctrl uintptr, imp
 			result = I32(binding.typedI32x2(AsI32(a0), AsI32(a1)))
 		} else {
 			result = binding.callTypedScalar(a0, a1)
-		}
-		if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-			active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-			state.nativeContextVersion.Load() != version {
-			active.restoreTypedScalarNativeContext(ctrl)
 		}
 		return result, true
 	}
@@ -404,20 +424,15 @@ func (a *hostLoopActivation) dispatchTypedScalarPortal(ctrl uintptr, importIdx, 
 		return 0, false
 	}
 
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
-		version := state.nativeContextVersion.Load()
+		resume := a.parkIndependentHostCallback(ctrl)
+		defer resume.resume()
 		var result uint64
 		if binding.scalarKind == syncHostTypedI32 {
 			result = I32(binding.typedI32(AsI32(a0)))
 		} else {
 			result = I32(binding.typedI32x2(AsI32(a0), AsI32(a1)))
-		}
-		if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-			active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-			state.nativeContextVersion.Load() != version {
-			active.restoreTypedScalarNativeContext(ctrl)
 		}
 		return result, true
 	}
@@ -453,22 +468,17 @@ func (a *hostLoopActivation) dispatchSingleTypedScalarPortal(ctrl uintptr, impor
 		return 0, false
 	}
 
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchTypedScalarPortal(ctrl, importIdx, rawSlots, a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(ctrl)
+	defer resume.resume()
 	var result uint64
 	if binding.scalarKind == syncHostTypedI32 {
 		result = I32(binding.typedI32(AsI32(a0)))
 	} else {
 		result = I32(binding.typedI32x2(AsI32(a0), AsI32(a1)))
-	}
-	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-		state.nativeContextVersion.Load() != version {
-		active.restoreTypedScalarNativeContext(ctrl)
 	}
 	return result, true
 }
@@ -483,18 +493,13 @@ func (a *hostLoopActivation) dispatchSingleTypedScalarExpandedPortal(ctrl uintpt
 		return 0, false
 	}
 
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchTypedScalarExpandedPortal(ctrl, importIdx, rawSlots, a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(ctrl)
+	defer resume.resume()
 	result := binding.callTypedScalar(a0, a1)
-	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-		state.nativeContextVersion.Load() != version {
-		active.restoreTypedScalarNativeContext(ctrl)
-	}
 	return result, true
 }
 
@@ -516,16 +521,11 @@ func (a *hostLoopActivation) dispatchSingleHostCall(ctrl uintptr, importIdx uint
 		})
 	}
 
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
-		version := state.nativeContextVersion.Load()
+		resume := a.parkIndependentHostCallback(ctrl)
+		defer resume.resume()
 		call()
-		if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-			active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-			state.nativeContextVersion.Load() != version {
-			active.restoreTypedScalarNativeContext(ctrl)
-		}
 		return
 	}
 
@@ -558,16 +558,11 @@ func (a *hostLoopActivation) dispatchSingleHostCallView(ctrl uintptr, importIdx 
 		})
 	}
 
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
-		version := state.nativeContextVersion.Load()
+		resume := a.parkIndependentHostCallback(ctrl)
+		defer resume.resume()
 		call()
-		if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-			active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-			state.nativeContextVersion.Load() != version {
-			active.restoreTypedScalarNativeContext(ctrl)
-		}
 		return true
 	}
 

--- a/src/wago/hostcall.go
+++ b/src/wago/hostcall.go
@@ -607,8 +607,8 @@ type instancePluginState struct {
 	hostScope            hostCallScope
 	activations          instanceActivations
 	nativeContextVersion atomic.Uint64
-	invokeMu             sync.Mutex // serializes unrelated public calls across parked host callbacks
-	nativeExecutionMu    sync.Mutex // serializes native entry for an independent instance
+	invokeMu             invocationGate // serializes unrelated public calls across parked host callbacks
+	nativeExecutionMu    sync.Mutex     // serializes native entry for an independent instance
 	invocationID         invocationID
 	close                atomic.Pointer[instanceCloseState]
 	gcConfig             *GCConfig

--- a/src/wago/instance_call.go
+++ b/src/wago/instance_call.go
@@ -26,7 +26,10 @@ func (in *Instance) Call(ctx context.Context, export string, args ...Value) ([]V
 		return nil, fmt.Errorf("call %q: %w", export, err)
 	}
 	defer in.endInvocation()
-	state := in.lockInvocation(0)
+	state, err := in.lockInvocationContext(ctx, 0)
+	if err != nil {
+		return nil, err
+	}
 	defer state.unlockInvocation()
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {

--- a/src/wago/instance_entry.go
+++ b/src/wago/instance_entry.go
@@ -3,7 +3,79 @@ package wago
 import (
 	"context"
 	"encoding/binary"
+	"sync"
 )
+
+// invocationGate has a zero-value, allocation-free uncontended path. Waiters
+// share a notification channel, not an invocation slot. Cancellation never
+// changes the owner or interrupts the active invocation.
+type invocationGate struct {
+	mu      sync.Mutex
+	held    bool
+	changed chan struct{}
+}
+
+func (g *invocationGate) Lock() { _ = g.lockContext(nil) }
+
+func (g *invocationGate) lockContext(ctx context.Context) error {
+	g.mu.Lock()
+	for {
+		// Cancellation wins if it is visible at the admission decision, including
+		// when both the notification and Done channels became ready.
+		if ctx != nil {
+			if err := ctx.Err(); err != nil {
+				g.mu.Unlock()
+				return err
+			}
+		}
+		if !g.held {
+			g.held = true
+			g.mu.Unlock()
+			return nil
+		}
+		if g.changed == nil {
+			g.changed = make(chan struct{})
+		}
+		changed := g.changed
+		g.mu.Unlock()
+		if ctx == nil {
+			<-changed
+		} else {
+			select {
+			case <-changed:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		g.mu.Lock()
+	}
+}
+
+func (g *invocationGate) Unlock() {
+	g.mu.Lock()
+	if !g.held {
+		g.mu.Unlock()
+		panic("unlock of unlocked invocation gate")
+	}
+	g.held = false
+	if g.changed != nil {
+		close(g.changed)
+		g.changed = nil
+	}
+	g.mu.Unlock()
+}
+
+func (in *Instance) lockInvocationContext(ctx context.Context, id invocationID) (*instancePluginState, error) {
+	state := in.ensurePluginState()
+	if err := state.invokeMu.lockContext(ctx); err != nil {
+		return nil, err
+	}
+	if id == 0 {
+		id = newInvocationID()
+	}
+	state.invocationID = id
+	return state, nil
+}
 
 // lockInvocation serializes a complete public call, including parked callbacks.
 // A zero identity requests a fresh chain; host reentry supplies its existing ID.

--- a/src/wago/instance_entry.go
+++ b/src/wago/instance_entry.go
@@ -19,6 +19,8 @@ type invocationGate struct {
 const (
 	invocationGateHeld    = uint32(1)
 	invocationGateWaiters = uint32(2)
+	invocationGateFast    = uint32(4)
+	invocationGateRevoked = uint32(8)
 )
 
 func (g *invocationGate) Lock() { _ = g.lockContext(nil) }
@@ -30,7 +32,7 @@ func (g *invocationGate) lockContext(ctx context.Context) error {
 				return err
 			}
 		}
-		if g.state.CompareAndSwap(0, invocationGateHeld) {
+		if g.state.CompareAndSwap(0, invocationGateHeld) || g.state.CompareAndSwap(invocationGateRevoked, invocationGateRevoked|invocationGateHeld) {
 			// Cancellation observed after acquisition wins; return the slot before
 			// the caller publishes an identity or arms an interrupt watcher.
 			if ctx != nil {
@@ -45,7 +47,7 @@ func (g *invocationGate) lockContext(ctx context.Context) error {
 		registered := false
 		for {
 			state := g.state.Load()
-			if state == 0 {
+			if state&invocationGateHeld == 0 {
 				break
 			}
 			// Registration and release use the same atomic word. If release wins,
@@ -76,18 +78,58 @@ func (g *invocationGate) lockContext(ctx context.Context) error {
 	}
 }
 
+// Unlock preserves revocation and releases either kind of owner with one CAS.
+// Sharing and waiter registration can force a retry and notification.
 func (g *invocationGate) Unlock() {
-	previous := g.state.Swap(0)
-	if previous&invocationGateHeld == 0 {
-		panic("unlock of unlocked invocation gate")
-	}
-	if previous&invocationGateWaiters != 0 {
-		g.mu.Lock()
-		if g.changed != nil {
-			close(g.changed)
-			g.changed = nil
+	for {
+		previous := g.state.Load()
+		if previous&invocationGateHeld == 0 {
+			panic("unlock of unlocked invocation gate")
 		}
+		if !g.state.CompareAndSwap(previous, previous&invocationGateRevoked) {
+			continue
+		}
+		if previous&invocationGateWaiters != 0 {
+			g.notify()
+		}
+		return
+	}
+}
+
+func (g *invocationGate) notify() {
+	g.mu.Lock()
+	if g.changed != nil {
+		close(g.changed)
+		g.changed = nil
+	}
+	g.mu.Unlock()
+}
+
+// revokeFast orders resource publication against direct entry on the same word
+// that owns ordinary invocation admission. Revocation is permanent. Ordinary
+// invocations may still acquire the gate and use their native/context guards.
+func (g *invocationGate) revokeFast() {
+	g.mu.Lock()
+	for {
+		state := g.state.Load()
+		next := state | invocationGateRevoked
+		if state&invocationGateFast != 0 {
+			next |= invocationGateWaiters
+		}
+		if !g.state.CompareAndSwap(state, next) {
+			continue
+		}
+		if state&invocationGateFast == 0 {
+			g.mu.Unlock()
+			return
+		}
+		if g.changed == nil {
+			g.changed = make(chan struct{})
+		}
+		changed := g.changed
 		g.mu.Unlock()
+		<-changed
+		g.mu.Lock()
 	}
 }
 

--- a/src/wago/instance_entry.go
+++ b/src/wago/instance_entry.go
@@ -4,34 +4,60 @@ import (
 	"context"
 	"encoding/binary"
 	"sync"
+	"sync/atomic"
 )
 
 // invocationGate has a zero-value, allocation-free uncontended path. Waiters
 // share a notification channel, not an invocation slot. Cancellation never
 // changes the owner or interrupts the active invocation.
 type invocationGate struct {
+	state   atomic.Uint32
 	mu      sync.Mutex
-	held    bool
 	changed chan struct{}
 }
+
+const (
+	invocationGateHeld    = uint32(1)
+	invocationGateWaiters = uint32(2)
+)
 
 func (g *invocationGate) Lock() { _ = g.lockContext(nil) }
 
 func (g *invocationGate) lockContext(ctx context.Context) error {
-	g.mu.Lock()
 	for {
-		// Cancellation wins if it is visible at the admission decision, including
-		// when both the notification and Done channels became ready.
 		if ctx != nil {
 			if err := ctx.Err(); err != nil {
-				g.mu.Unlock()
 				return err
 			}
 		}
-		if !g.held {
-			g.held = true
-			g.mu.Unlock()
+		if g.state.CompareAndSwap(0, invocationGateHeld) {
+			// Cancellation observed after acquisition wins; return the slot before
+			// the caller publishes an identity or arms an interrupt watcher.
+			if ctx != nil {
+				if err := ctx.Err(); err != nil {
+					g.Unlock()
+					return err
+				}
+			}
 			return nil
+		}
+		g.mu.Lock()
+		registered := false
+		for {
+			state := g.state.Load()
+			if state == 0 {
+				break
+			}
+			// Registration and release use the same atomic word. If release wins,
+			// retry admission; otherwise Unlock must take mu and notify this waiter.
+			if g.state.CompareAndSwap(state, state|invocationGateWaiters) {
+				registered = true
+				break
+			}
+		}
+		if !registered {
+			g.mu.Unlock()
+			continue
 		}
 		if g.changed == nil {
 			g.changed = make(chan struct{})
@@ -47,22 +73,22 @@ func (g *invocationGate) lockContext(ctx context.Context) error {
 				return ctx.Err()
 			}
 		}
-		g.mu.Lock()
 	}
 }
 
 func (g *invocationGate) Unlock() {
-	g.mu.Lock()
-	if !g.held {
-		g.mu.Unlock()
+	previous := g.state.Swap(0)
+	if previous&invocationGateHeld == 0 {
 		panic("unlock of unlocked invocation gate")
 	}
-	g.held = false
-	if g.changed != nil {
-		close(g.changed)
-		g.changed = nil
+	if previous&invocationGateWaiters != 0 {
+		g.mu.Lock()
+		if g.changed != nil {
+			close(g.changed)
+			g.changed = nil
+		}
+		g.mu.Unlock()
 	}
-	g.mu.Unlock()
 }
 
 func (in *Instance) lockInvocationContext(ctx context.Context, id invocationID) (*instancePluginState, error) {

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -456,8 +456,9 @@ func (in *Instance) preparedIsolatedEligible() bool {
 
 // Shared control requires native locking/rebinding. Imported, dynamic, and
 // store-owned GC domains require general GC admission, even for numeric exports.
-// Registration fixes the GC bits before public entry. Resource sharing revokes
-// direct gate admission before setting the shared bit.
+// Non-private domains are registered before public entry. Late boundary stores
+// are private; an isolated module has no collector or imports to attach there.
+// Resource sharing revokes direct gate admission before setting the shared bit.
 const preparedFastBlocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector
 
 func (in *Instance) preparedFastStateValid() bool {
@@ -533,8 +534,9 @@ func (in *Instance) callPreparedIsolated(entry uintptr, activeTrap []byte) error
 // caller holds a lifetime lease and has the compiler's direct-entry proof plus
 // the immutable isolated module shape: no imports/host calls, collector, global
 // cells, external memory, or externally reachable function context. A scalar
-// signature alone is not sufficient. GC-domain flags are set at registration;
-// resource export revokes this gate before publishing shared ownership. Direct
+// signature alone is not sufficient. Non-private GC domains are registered
+// during construction; late private stores cannot add GC to this module shape.
+// Resource export revokes this gate before publishing shared ownership. Direct
 // memory-free code uses its own engine and cannot need native context rebinding.
 func (in *Instance) tryPreparedDirect() bool {
 	gate := &in.ensurePluginState().invokeMu

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -306,6 +306,7 @@ func (in *Instance) usesIndependentExecution() bool {
 }
 
 func (in *Instance) markNativeControlShared() {
+	in.ensurePluginState().invokeMu.revokeFast()
 	for {
 		flags := in.executionFlags.Load()
 		if flags&executionFlagNativeControlShared != 0 ||
@@ -453,10 +454,14 @@ func (in *Instance) preparedIsolatedEligible() bool {
 	return in.preparedEntryMode() == preparedEntryIsolated
 }
 
-// The cached entry shape is immutable; these ownership exclusions are not.
+// Shared control requires native locking/rebinding. Imported, dynamic, and
+// store-owned GC domains require general GC admission, even for numeric exports.
+// Registration fixes the GC bits before public entry. Resource sharing revokes
+// direct gate admission before setting the shared bit.
+const preparedFastBlocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector
+
 func (in *Instance) preparedFastStateValid() bool {
-	const blocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector
-	return in.executionFlags.Load()&blocked == 0
+	return in.executionFlags.Load()&preparedFastBlocked == 0
 }
 
 // Reservation and ownership revocation use the same atomic word. Thus a
@@ -464,7 +469,7 @@ func (in *Instance) preparedFastStateValid() bool {
 // invocation gate permits only one fast activation per instance. Private paths
 // acquire the global lease first, since a revoker can already own that lease.
 func (in *Instance) lockPreparedFastState() bool {
-	const blocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector | executionFlagPreparedActive
+	const blocked = preparedFastBlocked | executionFlagPreparedActive
 	for {
 		flags := in.executionFlags.Load()
 		if flags&blocked != 0 {
@@ -522,4 +527,23 @@ func (in *Instance) callPreparedIsolated(entry uintptr, activeTrap []byte) error
 		return err
 	}
 	return in.decorateTrap(in.eng.CallPrepared(entry, in.serArgs, in.jm.LinMemBase(), activeTrap, in.results))
+}
+
+// tryPreparedDirect reserves both invocation ownership and private entry. The
+// caller holds a lifetime lease and has the compiler's direct-entry proof plus
+// the immutable isolated module shape: no imports/host calls, collector, global
+// cells, external memory, or externally reachable function context. A scalar
+// signature alone is not sufficient. GC-domain flags are set at registration;
+// resource export revokes this gate before publishing shared ownership. Direct
+// memory-free code uses its own engine and cannot need native context rebinding.
+func (in *Instance) tryPreparedDirect() bool {
+	gate := &in.ensurePluginState().invokeMu
+	if !gate.state.CompareAndSwap(0, invocationGateHeld|invocationGateFast) {
+		return false
+	}
+	if !in.preparedFastStateValid() {
+		gate.Unlock()
+		return false
+	}
+	return true
 }

--- a/src/wago/instance_native_context.go
+++ b/src/wago/instance_native_context.go
@@ -27,6 +27,7 @@ const (
 	executionFlagImportedGCDomain
 	executionFlagDynamicGCDomain
 	executionFlagStoreOwnedGCCollector
+	executionFlagPreparedActive
 )
 
 type invocationID uint64
@@ -309,8 +310,25 @@ func (in *Instance) markNativeControlShared() {
 		flags := in.executionFlags.Load()
 		if flags&executionFlagNativeControlShared != 0 ||
 			in.executionFlags.CompareAndSwap(flags, flags|executionFlagNativeControlShared) {
-			return
+			break
 		}
+	}
+	// Publishing the shared bit prevents new specialized entries. Do not return
+	// a shareable resource until the previous fast activation has left native
+	// code. The gate notification closes the check/wait race without spinning.
+	if in.executionFlags.Load()&executionFlagPreparedActive != 0 {
+		gate := &in.ensurePluginState().invokeMu
+		gate.mu.Lock()
+		for in.executionFlags.Load()&executionFlagPreparedActive != 0 {
+			if gate.changed == nil {
+				gate.changed = make(chan struct{})
+			}
+			changed := gate.changed
+			gate.mu.Unlock()
+			<-changed
+			gate.mu.Lock()
+		}
+		gate.mu.Unlock()
 	}
 }
 
@@ -435,8 +453,55 @@ func (in *Instance) preparedIsolatedEligible() bool {
 	return in.preparedEntryMode() == preparedEntryIsolated
 }
 
+// The cached entry shape is immutable; these ownership exclusions are not.
+func (in *Instance) preparedFastStateValid() bool {
+	const blocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector
+	return in.executionFlags.Load()&blocked == 0
+}
+
+// Reservation and ownership revocation use the same atomic word. Thus a
+// revoker either prevents entry or waits for its reservation to finish. The
+// invocation gate permits only one fast activation per instance. Private paths
+// acquire the global lease first, since a revoker can already own that lease.
+func (in *Instance) lockPreparedFastState() bool {
+	const blocked = executionFlagNativeControlShared | executionFlagImportedGCDomain | executionFlagDynamicGCDomain | executionFlagStoreOwnedGCCollector | executionFlagPreparedActive
+	for {
+		flags := in.executionFlags.Load()
+		if flags&blocked != 0 {
+			return false
+		}
+		if in.executionFlags.CompareAndSwap(flags, flags|executionFlagPreparedActive) {
+			return true
+		}
+	}
+}
+
+func (in *Instance) unlockPreparedFastState() {
+	for {
+		flags := in.executionFlags.Load()
+		if !in.executionFlags.CompareAndSwap(flags, flags&^executionFlagPreparedActive) {
+			continue
+		}
+		if flags&executionFlagNativeControlShared != 0 {
+			gate := &in.ensurePluginState().invokeMu
+			gate.mu.Lock()
+			if gate.changed != nil {
+				close(gate.changed)
+				gate.changed = nil
+			}
+			gate.mu.Unlock()
+		}
+		return
+	}
+}
+
 func (in *Instance) callPreparedPrivate(entry uintptr, activeTrap []byte) error {
 	nativeExecutionMu.Lock()
+	if !in.lockPreparedFastState() {
+		nativeExecutionMu.Unlock()
+		return in.callNativeAsyncWithTrap(entry, true, activeTrap)
+	}
+	defer in.unlockPreparedFastState()
 	nativeExecutionEpoch++
 	defer nativeExecutionMu.Unlock()
 	if err := validateNativeGCEntry(in); err != nil {
@@ -449,6 +514,10 @@ func (in *Instance) callPreparedPrivate(entry uintptr, activeTrap []byte) error 
 }
 
 func (in *Instance) callPreparedIsolated(entry uintptr, activeTrap []byte) error {
+	if !in.lockPreparedFastState() {
+		return in.callNativeAsyncWithTrap(entry, true, activeTrap)
+	}
+	defer in.unlockPreparedFastState()
 	if err := refreshNativeControl(true, in.eng, in.jm, activeTrap); err != nil {
 		return err
 	}

--- a/src/wago/invocation_admission_test.go
+++ b/src/wago/invocation_admission_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"github.com/wago-org/wago/src/core/compiler/wasm"
 	"github.com/wago-org/wago/tests/support/wasmtest"
+	goruntime "runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -222,5 +224,35 @@ func TestContextEntryCancellationWhileWaiting(t *testing.T) {
 				t.Fatal("canceled context entry waited for admission")
 			}
 		})
+	}
+}
+
+func TestInvocationGateConcurrentOwners(t *testing.T) {
+	var gate invocationGate
+	var owners atomic.Int32
+	var workers sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for j := 0; j < 100; j++ {
+				gate.Lock()
+				if owners.Add(1) != 1 {
+					t.Error("multiple invocation owners")
+				}
+				goruntime.Gosched()
+				if owners.Add(-1) != 0 {
+					t.Error("invocation ownership changed")
+				}
+				gate.Unlock()
+			}
+		}()
+	}
+	done := make(chan struct{})
+	go func() { workers.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("invocation owner lost its wakeup")
 	}
 }

--- a/src/wago/invocation_admission_test.go
+++ b/src/wago/invocation_admission_test.go
@@ -1,0 +1,226 @@
+package wago
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCallCancellationWhileWaitingForAdmission(t *testing.T) {
+	c := MustCompile(benchAddOneModule())
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	state := in.lockInvocation(0)
+	released := false
+	defer func() {
+		if !released {
+			state.unlockInvocation()
+		}
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { _, err := in.Call(ctx, "f", ValueI32(41)); done <- err }()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Call = %v, want canceled", err)
+		}
+	case <-time.After(time.Second):
+		state.unlockInvocation()
+		released = true
+		<-done
+		t.Fatal("canceled Call remained blocked on invocation admission")
+	}
+	state.unlockInvocation()
+	released = true
+	out, err := in.Call(context.Background(), "f", ValueI32(41))
+	if err != nil || len(out) != 1 || out[0].I32() != 42 {
+		t.Fatalf("next Call = %v, %v", out, err)
+	}
+}
+
+// admissionContext reports when a waiter reaches the cancellable wait.
+type admissionContext struct {
+	context.Context
+	waiting chan struct{}
+	once    sync.Once
+}
+
+func (c *admissionContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.waiting) })
+	return c.Context.Done()
+}
+
+func TestInvocationGateCanceledWaiters(t *testing.T) {
+	for _, count := range []int{1, 64} {
+		var gate invocationGate
+		gate.Lock()
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, count)
+		for i := 0; i < count; i++ {
+			waiter := &admissionContext{Context: ctx, waiting: make(chan struct{})}
+			go func() { done <- gate.lockContext(waiter) }()
+			<-waiter.waiting
+		}
+		cancel()
+		for i := 0; i < count; i++ {
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("waiter = %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("waiter did not return")
+			}
+		}
+		gate.Unlock()
+		gate.Lock()
+		gate.Unlock()
+	}
+}
+
+func TestInvocationGateCancellationAtAdmission(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		var gate invocationGate
+		gate.Lock()
+		base, cancel := context.WithCancel(context.Background())
+		ctx := &admissionContext{Context: base, waiting: make(chan struct{})}
+		done := make(chan error, 1)
+		go func() { done <- gate.lockContext(ctx) }()
+		<-ctx.waiting
+		cancel()
+		gate.Unlock()
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("admission = %v", err)
+		}
+		gate.Lock()
+		gate.Unlock()
+	}
+}
+
+func TestCallDeadlineWhileCallbackOwnsAdmission(t *testing.T) {
+	sig := wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32})
+	c := MustCompile(returningImportModule(sig, []byte{0, 0x20, 0, 0x10, 0, 0x0b}))
+	defer c.Close()
+	entered, release := make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": func(v int32) int32 {
+		once.Do(func() { close(entered); <-release })
+		return v + 1
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	done := make(chan error, 1)
+	go func() {
+		out, err := in.Call(context.Background(), "g", ValueI32(41))
+		if err == nil && (len(out) != 1 || out[0].I32() != 42) {
+			err = fmt.Errorf("first call = %v", out)
+		}
+		done <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("callback did not start")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	waiter := make(chan error, 1)
+	go func() { _, err := in.Call(ctx, "g", ValueI32(9)); waiter <- err }()
+	select {
+	case err := <-waiter:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("waiter = %v", err)
+		}
+	case <-time.After(time.Second):
+		close(release)
+		<-done
+		<-waiter
+		t.Fatal("deadline did not cancel admission")
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	out, err := in.Call(context.Background(), "g", ValueI32(41))
+	if err != nil || len(out) != 1 || out[0].I32() != 42 {
+		t.Fatalf("next call = %v, %v", out, err)
+	}
+}
+
+func BenchmarkCallAdmission(b *testing.B) {
+	c := MustCompile(benchAddOneModule())
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer in.Close()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := in.Call(context.Background(), "f", ValueI32(41)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestInvocationGateUncontendedAllocations(t *testing.T) {
+	var gate invocationGate
+	allocations := testing.AllocsPerRun(100, func() {
+		if err := gate.lockContext(context.Background()); err != nil {
+			panic(err)
+		}
+		gate.Unlock()
+	})
+	if allocations != 0 {
+		t.Fatalf("uncontended gate allocations = %v, want 0", allocations)
+	}
+}
+
+func TestContextEntryCancellationWhileWaiting(t *testing.T) {
+	for _, entry := range []string{"invoke", "host-token"} {
+		t.Run(entry, func(t *testing.T) {
+			in := &Instance{}
+			state := in.lockInvocation(0)
+			ctx, cancel := context.WithCancel(context.Background())
+			contexts := invocationContextSetFor(ctx)
+			cancel()
+			done := make(chan error, 1)
+			go func() {
+				var err error
+				if entry == "invoke" {
+					_, err = in.invokeEntry("unused", nil, contexts, false)
+				} else {
+					_, err = in.invokeWithToken("unused", nil, contexts, newInvocationID(), false, false, nil)
+				}
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				state.unlockInvocation()
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("entry = %v", err)
+				}
+			case <-time.After(time.Second):
+				state.unlockInvocation()
+				<-done
+				t.Fatal("canceled context entry waited for admission")
+			}
+		})
+	}
+}

--- a/src/wago/native_code_limit_contract_test.go
+++ b/src/wago/native_code_limit_contract_test.go
@@ -1,0 +1,57 @@
+package wago
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNativeCodeLimitIsOneFinalModuleBudget(t *testing.T) {
+	source := benchImportedModule(64, 8)
+	for _, workers := range []int{1, 4} {
+		t.Run(fmt.Sprint(workers), func(t *testing.T) {
+			cfg := NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit).WithFunctionWorkers(workers)
+			baseline, err := Compile(cfg, source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			size := uint64(baseline.CodeSize())
+			baseline.Close()
+			for _, limit := range []uint64{size + 1, size, size - 1, size / 2} {
+				c, err := Compile(cfg.WithMaxNativeCodeBytes(limit), source)
+				if limit >= size {
+					if err != nil {
+						t.Fatalf("limit %d: %v", limit, err)
+					}
+					if uint64(c.CodeSize()) != size {
+						t.Fatalf("code size changed: %d", c.CodeSize())
+					}
+					c.Close()
+				} else {
+					if c != nil {
+						c.Close()
+						t.Fatal("failed compile published an artifact")
+					}
+					if !errors.Is(err, ErrResourceLimit) {
+						t.Fatalf("limit %d: %v", limit, err)
+					}
+				}
+			}
+			// Failure cannot poison the compiler or transfer a partial native image.
+			c, err := Compile(cfg.WithMaxNativeCodeBytes(size), source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			in, err := Instantiate(c, InstantiateOptions{Imports: Imports{"env.f": func(v int32) int32 { return v }}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			out, err := in.Invoke("f0", 34)
+			if err != nil || len(out) != 1 || out[0] != 42 {
+				t.Fatalf("compile after failure = %v, %v", out, err)
+			}
+		})
+	}
+}

--- a/src/wago/prepared_direct_amd64.go
+++ b/src/wago/prepared_direct_amd64.go
@@ -50,9 +50,12 @@ func (fn *PreparedFunction) invokeDirectInt(args []uint64) ([]uint64, error) {
 
 func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint64, error) {
 	in := fn.in
-	if in.isLogicallyClosed() {
-		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
+	if err := in.beginInvocation(); err != nil {
+		return nil, fmt.Errorf("wago: invoke prepared function: %w", err)
 	}
+	defer in.endInvocation()
+	preparedLease := in.lockPreparedInvocation()
+	defer preparedLease.unlock()
 	switch fn.paramSlots {
 	case 4:
 		if fn.scalarWideMask&8 == 0 {
@@ -74,6 +77,11 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 			a0 = uint64(uint32(a0))
 		}
 	}
+	if !in.lockPreparedFastState() {
+		args := [4]uint64{a0, a1, a2, a3}
+		return fn.invokeGeneralAdmitted(args[:fn.paramSlots])
+	}
+	defer in.unlockPreparedFastState()
 	var result uint64
 	var err error
 	wruntime.PreparePreparedIntTrap(in.trap)

--- a/src/wago/prepared_direct_amd64.go
+++ b/src/wago/prepared_direct_amd64.go
@@ -54,8 +54,13 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 		return nil, fmt.Errorf("wago: invoke prepared function: %w", err)
 	}
 	defer in.endInvocation()
-	preparedLease := in.lockPreparedInvocation()
-	defer preparedLease.unlock()
+	if !fn.directIsolated || !in.tryPreparedDirect() {
+		lease := in.lockPreparedInvocation()
+		defer lease.unlock()
+		args := [4]uint64{a0, a1, a2, a3}
+		return fn.invokeGeneralAdmitted(args[:fn.paramSlots])
+	}
+	defer in.ensurePluginState().invokeMu.Unlock()
 	switch fn.paramSlots {
 	case 4:
 		if fn.scalarWideMask&8 == 0 {
@@ -77,11 +82,6 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 			a0 = uint64(uint32(a0))
 		}
 	}
-	if !in.lockPreparedFastState() {
-		args := [4]uint64{a0, a1, a2, a3}
-		return fn.invokeGeneralAdmitted(args[:fn.paramSlots])
-	}
-	defer in.unlockPreparedFastState()
 	var result uint64
 	var err error
 	wruntime.PreparePreparedIntTrap(in.trap)

--- a/src/wago/prepared_direct_arm64.go
+++ b/src/wago/prepared_direct_arm64.go
@@ -44,8 +44,13 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 		return nil, fmt.Errorf("wago: invoke prepared function: %w", err)
 	}
 	defer in.endInvocation()
-	preparedLease := in.lockPreparedInvocation()
-	defer preparedLease.unlock()
+	narrow := fn.directIsolated && in.tryPreparedDirect()
+	if narrow {
+		defer in.ensurePluginState().invokeMu.Unlock()
+	} else {
+		preparedLease := in.lockPreparedInvocation()
+		defer preparedLease.unlock()
+	}
 	switch fn.paramSlots {
 	case 4:
 		if fn.scalarWideMask&8 == 0 {
@@ -72,14 +77,16 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 		nativeExecutionMu.Lock()
 		nativeExecutionEpoch++
 	}
-	if !in.lockPreparedFastState() {
+	if !narrow && !in.lockPreparedFastState() {
 		if locked {
 			nativeExecutionMu.Unlock()
 		}
 		args := [4]uint64{a0, a1, a2, a3}
 		return fn.invokeGeneralAdmitted(args[:fn.paramSlots])
 	}
-	defer in.unlockPreparedFastState()
+	if !narrow {
+		defer in.unlockPreparedFastState()
+	}
 	var result uint64
 	var err error
 	wruntime.PreparePreparedIntTrap(in.trap)

--- a/src/wago/prepared_direct_arm64.go
+++ b/src/wago/prepared_direct_arm64.go
@@ -39,13 +39,13 @@ func (fn *PreparedFunction) invokeDirectInt(args []uint64) ([]uint64, error) {
 }
 
 func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint64, error) {
-	if fn.directIntMode == preparedIntCallBlock {
-		return fn.invokeDirectIntCallFixed(a0, a1, a2, a3)
-	}
 	in := fn.in
-	if in.isLogicallyClosed() {
-		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
+	if err := in.beginInvocation(); err != nil {
+		return nil, fmt.Errorf("wago: invoke prepared function: %w", err)
 	}
+	defer in.endInvocation()
+	preparedLease := in.lockPreparedInvocation()
+	defer preparedLease.unlock()
 	switch fn.paramSlots {
 	case 4:
 		if fn.scalarWideMask&8 == 0 {
@@ -72,10 +72,20 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 		nativeExecutionMu.Lock()
 		nativeExecutionEpoch++
 	}
+	if !in.lockPreparedFastState() {
+		if locked {
+			nativeExecutionMu.Unlock()
+		}
+		args := [4]uint64{a0, a1, a2, a3}
+		return fn.invokeGeneralAdmitted(args[:fn.paramSlots])
+	}
+	defer in.unlockPreparedFastState()
 	var result uint64
 	var err error
 	wruntime.PreparePreparedIntTrap(in.trap)
-	if fn.directIntBounded {
+	if fn.directIntMode == preparedIntCallBlock {
+		result = in.eng.EnterPreparedIntCallBounded(&fn.directIntCall, a0, a1, a2, a3)
+	} else if fn.directIntBounded {
 		if fn.directIntLight {
 			result, err = in.eng.EnterPreparedIntLightBounded(fn.directEntry, fn.directLinMem, a0, a1, a2, a3)
 		} else {
@@ -112,51 +122,6 @@ func (fn *PreparedFunction) invokeDirectIntFixed(a0, a1, a2, a3 uint64) ([]uint6
 	}
 	if locked {
 		nativeExecutionMu.Unlock()
-	}
-	return out, nil
-}
-
-func (fn *PreparedFunction) invokeDirectIntCallFixed(a0, a1, a2, a3 uint64) ([]uint64, error) {
-	in := fn.in
-	if in.isLogicallyClosed() {
-		return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
-	}
-	switch fn.paramSlots {
-	case 4:
-		if fn.scalarWideMask&8 == 0 {
-			a3 = uint64(uint32(a3))
-		}
-		fallthrough
-	case 3:
-		if fn.scalarWideMask&4 == 0 {
-			a2 = uint64(uint32(a2))
-		}
-		fallthrough
-	case 2:
-		if fn.scalarWideMask&2 == 0 {
-			a1 = uint64(uint32(a1))
-		}
-		fallthrough
-	case 1:
-		if fn.scalarWideMask&1 == 0 {
-			a0 = uint64(uint32(a0))
-		}
-	}
-	wruntime.PreparePreparedIntTrap(in.trap)
-	result := in.eng.EnterPreparedIntCallBounded(&fn.directIntCall, a0, a1, a2, a3)
-	if wruntime.PreparedIntTrapCode(in.trap) != wruntime.TrapNone {
-		return nil, in.decorateTrap(wruntime.ConsumePreparedIntTrap(in.trap))
-	}
-	goruntime.KeepAlive(fn)
-	goruntime.KeepAlive(in)
-	goruntime.KeepAlive(in.c)
-	out := in.resultVals[:fn.resultSlots]
-	if fn.resultSlots == 1 {
-		if fn.scalarResultWide {
-			out[0] = result
-		} else {
-			out[0] = uint64(uint32(result))
-		}
 	}
 	return out, nil
 }

--- a/src/wago/prepared_entry_bench_test.go
+++ b/src/wago/prepared_entry_bench_test.go
@@ -1,0 +1,55 @@
+package wago
+
+import (
+	"context"
+	"testing"
+)
+
+func BenchmarkPreparedEntryModes(b *testing.B) {
+	for _, mode := range []string{"direct", "scalar", "general", "shared", "runtime"} {
+		b.Run(mode, func(b *testing.B) {
+			c := benchMustCompile(b, benchAddOneModule())
+			var in *Instance
+			var err error
+			if mode == "runtime" {
+				rt := NewRuntime()
+				defer rt.Close()
+				mod, e := rt.Module(c)
+				if e != nil {
+					b.Fatal(e)
+				}
+				defer mod.Close()
+				in, err = rt.Instantiate(context.Background(), mod)
+			} else {
+				in, err = Instantiate(c, InstantiateOptions{})
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer in.Close()
+			fn, err := in.PrepareFunction("f")
+			if err != nil {
+				b.Fatal(err)
+			}
+			if mode == "scalar" || mode == "general" {
+				fn.directIntFast = false
+			}
+			if mode == "general" {
+				fn.scalarFast = false
+			}
+			if mode == "shared" {
+				if _, err := in.ExportedFunc("f"); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := fn.Invoke1(41)
+				if err != nil || len(out) != 1 || out[0] != 42 {
+					b.Fatalf("call = %v, %v", out, err)
+				}
+			}
+		})
+	}
+}

--- a/src/wago/prepared_function.go
+++ b/src/wago/prepared_function.go
@@ -275,6 +275,11 @@ func (fn *PreparedFunction) invokeGeneral(args []uint64) ([]uint64, error) {
 	// reference-result tokenization.
 	preparedLease := in.lockPreparedInvocation()
 	defer preparedLease.unlock()
+	return fn.invokeGeneralAdmitted(args)
+}
+
+func (fn *PreparedFunction) invokeGeneralAdmitted(args []uint64) ([]uint64, error) {
+	in := fn.in
 	if len(args) != fn.paramSlots {
 		return nil, fmt.Errorf("%s expects %d arg slot(s), got %d", fn.export, fn.paramSlots, len(args))
 	}
@@ -339,17 +344,14 @@ func (fn *PreparedFunction) invokeGeneral(args []uint64) ([]uint64, error) {
 
 func (fn *PreparedFunction) invokeScalar(args []uint64) ([]uint64, error) {
 	in := fn.in
-	if fn.privateFast {
-		if in.isLogicallyClosed() {
-			return nil, fmt.Errorf("wago: invoke prepared function: instance is closed")
-		}
-	} else {
-		if err := in.beginInvocation(); err != nil {
-			return nil, fmt.Errorf("wago: invoke prepared function: %w", err)
-		}
-		defer in.endInvocation()
-		preparedLease := in.lockPreparedInvocation()
-		defer preparedLease.unlock()
+	if err := in.beginInvocation(); err != nil {
+		return nil, fmt.Errorf("wago: invoke prepared function: %w", err)
+	}
+	defer in.endInvocation()
+	preparedLease := in.lockPreparedInvocation()
+	defer preparedLease.unlock()
+	if !in.preparedFastStateValid() {
+		return fn.invokeGeneralAdmitted(args)
 	}
 	if len(args) <= 4 {
 		put := func(slot int) {

--- a/src/wago/prepared_narrow_gc_test.go
+++ b/src/wago/prepared_narrow_gc_test.go
@@ -1,0 +1,62 @@
+//go:build linux && (amd64 || arm64) && !tinygo
+
+package wago
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestPreparedNumericGCEntryKeepsDomainLease(t *testing.T) {
+	c, err := Compile(NewRuntimeConfig().WithCoreFeatures(CoreFeaturesV3), gcAllocatingScalarProducerModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	for _, sharedStore := range []bool{false, true} {
+		t.Run(fmt.Sprint(sharedStore), func(t *testing.T) {
+			store := newReferenceStore(!sharedStore)
+			defer store.closeRuntime()
+			in, err := instantiateCore(c, InstantiateOptions{store: store, GC: GCConfig{CollectEveryAlloc: true, StressNurseryBytes: 64, ForceMajorEveryMinor: true, VerifyAfterCollect: true}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			fn, err := in.PrepareFunction("allocate")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !fn.scalarFast || fn.directIntFast || in.gc == nil {
+				t.Fatal("numeric GC fixture selected invalid entry metadata")
+			}
+			if in.gcInvocationDomains().len() == 0 {
+				t.Fatal("fixture has no registered collector domain")
+			}
+			lease := in.lockGCInvocation(newInvocationID())
+			done := make(chan error, 1)
+			go func() {
+				out, err := fn.Invoke0()
+				if err == nil && (len(out) != 1 || out[0] != 7) {
+					err = fmt.Errorf("result = %v", out)
+				}
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				lease.unlock()
+				t.Fatalf("prepared GC call bypassed collector lease: %v", err)
+			case <-time.After(20 * time.Millisecond):
+			}
+			lease.unlock()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("prepared GC call did not resume")
+			}
+		})
+	}
+}

--- a/src/wago/prepared_narrow_test.go
+++ b/src/wago/prepared_narrow_test.go
@@ -1,0 +1,208 @@
+package wago
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPreparedDirectDoesNotAllocateInvocationIdentity(t *testing.T) {
+	c := MustCompile(benchAddOneModule())
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareFunction("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preparedDirectIntEnabled && (!fn.directIntFast || !fn.directIsolated) {
+		t.Fatal("fixture must select isolated direct entry")
+	}
+	before := nextInvocationID.Load()
+	out, err := fn.Invoke1(41)
+	if err != nil || len(out) != 1 || out[0] != 42 {
+		t.Fatalf("call = %v, %v", out, err)
+	}
+	after := nextInvocationID.Load()
+	if fn.directIntFast {
+		if after != before {
+			t.Fatalf("isolated direct entry consumed invocation identity: %d -> %d", before, after)
+		}
+	} else if after == before {
+		t.Fatal("disabled direct mode omitted general invocation identity")
+	}
+}
+
+func narrowPreparedFixture(t *testing.T) (*Instance, *PreparedFunction) {
+	t.Helper()
+	c := MustCompile(benchAddOneModule())
+	t.Cleanup(func() { c.Close() })
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { in.Close() })
+	fn, err := in.PrepareFunction("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return in, fn
+}
+
+func TestPreparedDirectSharesInvocationGate(t *testing.T) {
+	in, fn := narrowPreparedFixture(t)
+	if err := in.beginInvocation(); err != nil {
+		t.Fatal(err)
+	}
+	defer in.endInvocation()
+	if !in.tryPreparedDirect() {
+		t.Fatal("private reservation rejected")
+	}
+	gate := &in.ensurePluginState().invokeMu
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := gate.lockContext(ctx); err != context.DeadlineExceeded {
+		t.Fatalf("general admission during direct entry: %v", err)
+	}
+	gate.Unlock()
+	gate.Lock()
+	if in.tryPreparedDirect() {
+		gate.Unlock()
+		t.Fatal("direct entry bypassed general owner")
+	}
+	gate.Unlock()
+	out, err := fn.Invoke1(41)
+	if err != nil || len(out) != 1 || out[0] != 42 {
+		t.Fatalf("call after conflict = %v, %v", out, err)
+	}
+}
+
+func TestPreparedDirectRevocation(t *testing.T) {
+	in, fn := narrowPreparedFixture(t)
+	if err := in.beginInvocation(); err != nil {
+		t.Fatal(err)
+	}
+	if !in.tryPreparedDirect() {
+		t.Fatal("private reservation rejected")
+	}
+	done := make(chan struct{})
+	go func() { in.markNativeControlShared(); close(done) }()
+	select {
+	case <-done:
+		t.Fatal("sharing completed during direct reservation")
+	case <-time.After(20 * time.Millisecond):
+	}
+	in.ensurePluginState().invokeMu.Unlock()
+	in.endInvocation()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sharing did not complete")
+	}
+	if in.tryPreparedDirect() {
+		in.ensurePluginState().invokeMu.Unlock()
+		t.Fatal("revoked instance admitted direct entry")
+	}
+	before := nextInvocationID.Load()
+	out, err := fn.Invoke1(41)
+	if err != nil || len(out) != 1 || out[0] != 42 {
+		t.Fatalf("fallback = %v, %v", out, err)
+	}
+	if nextInvocationID.Load() == before {
+		t.Fatal("fallback omitted general identity")
+	}
+}
+
+func TestPreparedDirectRejectsGCModes(t *testing.T) {
+	for _, flag := range []uint32{executionFlagImportedGCDomain, executionFlagDynamicGCDomain, executionFlagStoreOwnedGCCollector} {
+		t.Run(fmt.Sprint(flag), func(t *testing.T) {
+			in, _ := narrowPreparedFixture(t)
+			// Registration publishes these bits before public entry. Exercise each
+			// exclusion independently; a numeric signature does not override it.
+			in.executionFlags.Store(in.executionFlags.Load() | flag)
+			if in.tryPreparedDirect() {
+				in.ensurePluginState().invokeMu.Unlock()
+				t.Fatal("GC ownership admitted direct entry")
+			}
+			if in.ensurePluginState().invokeMu.state.Load()&invocationGateHeld != 0 {
+				t.Fatal("rejected entry retained gate")
+			}
+		})
+	}
+}
+
+func TestPreparedDirectLifetimeDuringClose(t *testing.T) {
+	for _, owned := range []bool{false, true} {
+		t.Run(fmt.Sprint(owned), func(t *testing.T) {
+			var in *Instance
+			var rt *Runtime
+			if owned {
+				rt = NewRuntime()
+				t.Cleanup(func() { rt.Close() })
+				mod, err := rt.Compile(benchAddOneModule())
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer mod.Close()
+				in, err = rt.Instantiate(context.Background(), mod)
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				in, _ = narrowPreparedFixture(t)
+			}
+			fn, err := in.PrepareFunction("f")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := in.beginInvocation(); err != nil {
+				t.Fatal(err)
+			}
+			if !in.tryPreparedDirect() {
+				t.Fatal("private reservation rejected")
+			}
+			var once sync.Once
+			release := func() { once.Do(func() { in.ensurePluginState().invokeMu.Unlock(); in.endInvocation() }) }
+			defer release()
+			done := make(chan error, 1)
+			go func() {
+				if rt != nil {
+					done <- rt.Close()
+				} else {
+					done <- in.Close()
+				}
+			}()
+			// Close publishes its lifetime bit before it can release native storage.
+			deadline := time.Now().Add(time.Second)
+			for in.invocationState.Load()&instanceInvocationClosed == 0 {
+				if time.Now().After(deadline) {
+					t.Fatal("close did not publish")
+				}
+				time.Sleep(time.Millisecond)
+			}
+			in.lifeMu.Lock()
+			released := in.resourcesClosed
+			in.lifeMu.Unlock()
+			if released || in.eng == nil || in.base == 0 {
+				t.Fatal("close released an active direct lease")
+			}
+			release()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("close did not finish")
+			}
+			if _, err := fn.Invoke1(41); err == nil {
+				t.Fatal("closed instance accepted prepared call")
+			}
+		})
+	}
+}

--- a/src/wago/prepared_sharing_test.go
+++ b/src/wago/prepared_sharing_test.go
@@ -1,0 +1,198 @@
+package wago
+
+import (
+	"fmt"
+	"github.com/wago-org/wago/src/core/compiler/wasm"
+	"github.com/wago-org/wago/tests/support/wasmtest"
+	"testing"
+	"time"
+)
+
+func TestPreparedFunctionRechecksSharedControl(t *testing.T) {
+	for _, family := range []string{"variadic", "fixed", "scalar", "general"} {
+		t.Run(family, func(t *testing.T) {
+			c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), benchAddOneModule())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			in, err := Instantiate(c, InstantiateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer in.Close()
+			fn, err := in.PrepareFunction("f")
+			if err != nil {
+				t.Fatal(err)
+			}
+			call := func() ([]uint64, error) {
+				switch family {
+				case "fixed":
+					return fn.Invoke1(41)
+				case "scalar":
+					return fn.invokeScalar([]uint64{41})
+				case "general":
+					return fn.invokeGeneral([]uint64{41})
+				default:
+					return fn.Invoke(41)
+				}
+			}
+			if out, err := call(); err != nil || len(out) != 1 || out[0] != 42 {
+				t.Fatalf("private call = %v, %v", out, err)
+			}
+			if _, err := in.ExportedFunc("f"); err != nil {
+				t.Fatal(err)
+			}
+			if !in.nativeControlIsShared() {
+				t.Fatal("export did not revoke private execution")
+			}
+			done := make(chan error, 1)
+			nativeExecutionMu.Lock()
+			go func() {
+				out, err := call()
+				if err == nil && (len(out) != 1 || out[0] != 42) {
+					err = fmt.Errorf("result = %v", out)
+				}
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				nativeExecutionMu.Unlock()
+				t.Fatalf("shared prepared call bypassed native lease: %v", err)
+			case <-time.After(20 * time.Millisecond):
+				nativeExecutionMu.Unlock()
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("shared prepared call did not finish")
+			}
+		})
+	}
+}
+
+func TestPreparedOwnershipRevocationWaitsForFastEntry(t *testing.T) {
+	in := &Instance{}
+	if !in.lockPreparedFastState() {
+		t.Fatal("private entry rejected")
+	}
+	started, done := make(chan struct{}), make(chan struct{})
+	go func() { close(started); in.markNativeControlShared(); close(done) }()
+	<-started
+	select {
+	case <-done:
+		in.unlockPreparedFastState()
+		t.Fatal("ownership published during a fast entry")
+	case <-time.After(20 * time.Millisecond):
+	}
+	in.unlockPreparedFastState()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ownership publication did not finish")
+	}
+	if in.lockPreparedFastState() {
+		in.unlockPreparedFastState()
+		t.Fatal("shared instance admitted a fast entry")
+	}
+}
+
+func TestPreparedEntryAddsNoCallAllocations(t *testing.T) {
+	c := MustCompile(benchAddOneModule())
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareFunction("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, shared := range []bool{false, true} {
+		if shared {
+			if _, err := in.ExportedFunc("f"); err != nil {
+				t.Fatal(err)
+			}
+		}
+		allocations := testing.AllocsPerRun(100, func() {
+			out, err := fn.Invoke1(41)
+			if err != nil || len(out) != 1 || out[0] != 42 {
+				panic("invalid prepared result")
+			}
+		})
+		if allocations != 0 {
+			t.Fatalf("shared=%v: allocations = %v, want 0", shared, allocations)
+		}
+	}
+}
+
+func TestPreparedPrivateGlobalRebindsAfterExport(t *testing.T) {
+	source := wasmtest.Module(
+		wasmtest.Section(1, wasmtest.Vec(wasmtest.FuncType([]wasm.ValType{wasm.I32}, []wasm.ValType{wasm.I32}))),
+		wasmtest.Section(3, wasmtest.Vec(wasmtest.ULEB(0))),
+		wasmtest.Section(6, wasmtest.Vec([]byte{0x7f, 1, 0x41, 1, 0x0b})),
+		wasmtest.Section(7, wasmtest.Vec(wasmtest.ExportEntry("f", 0, 0), wasmtest.ExportEntry("value", 3, 0))),
+		wasmtest.Section(10, wasmtest.Vec(wasmtest.Code([]byte{0x20, 0, 0x23, 0, 0x6a, 0x0b}))),
+	)
+	c, err := Compile(NewRuntimeConfig().WithBoundsChecks(BoundsChecksExplicit), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareFunction("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preparedPrivateEntryEnabled && preparedScalarFastEnabled && (!fn.privateFast || fn.isolatedFast) {
+		t.Fatal("fixture did not select private scalar entry")
+	}
+	if out, err := fn.Invoke1(41); err != nil || len(out) != 1 || out[0] != 42 {
+		t.Fatalf("private call = %v, %v", out, err)
+	}
+	if _, err := in.ExportedFunc("f"); err != nil {
+		t.Fatal(err)
+	}
+	version := in.ensurePluginState().nativeContextVersion.Load()
+	out, err := fn.Invoke1(41)
+	if err != nil || len(out) != 1 || out[0] != 42 {
+		t.Fatalf("shared call = %v, %v", out, err)
+	}
+	if in.ensurePluginState().nativeContextVersion.Load() <= version {
+		t.Fatal("shared prepared entry did not bind native context")
+	}
+}
+
+func TestPreparedConcurrentExportTransition(t *testing.T) {
+	c := MustCompile(benchAddOneModule())
+	defer c.Close()
+	in, err := Instantiate(c, InstantiateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer in.Close()
+	fn, err := in.PrepareFunction("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	start, done := make(chan struct{}), make(chan error, 1)
+	go func() { <-start; _, err := in.ExportedFunc("f"); done <- err }()
+	close(start)
+	for i := 0; i < 100; i++ {
+		out, err := fn.Invoke1(41)
+		if err != nil || len(out) != 1 || out[0] != 42 {
+			t.Fatalf("call during export = %v, %v", out, err)
+		}
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/src/wago/structural_call_identity.go
+++ b/src/wago/structural_call_identity.go
@@ -30,18 +30,19 @@ func (c *Compiled) prepareStructuralCallIdentities() error {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
 	memo := c.validateMemo
-	if memo.structuralCallIdentities != nil && memo.structuralCallIdentities != structuralCallIdentitySeenSentinel {
+	published := memo.structuralCallIdentities.Load()
+	if published != nil && published != structuralCallIdentitySeenSentinel {
 		return nil
 	}
-	if memo.structuralCallIdentities == nil {
-		memo.structuralCallIdentities = structuralCallIdentitySeenSentinel
+	if published == nil {
+		memo.structuralCallIdentities.Store(structuralCallIdentitySeenSentinel)
 		return nil
 	}
 	spanBytes := uint64(len(c.Types)) * structuralCallIdentitySpanBytes
 	if spanBytes > maxStructuralCallIdentityCacheBytes-structuralCallIdentityCacheHeaderBytes {
 		// A non-nil empty cache records that this module exceeded the bounded
 		// retention budget. Registrations keep reconstructing identities exactly.
-		memo.structuralCallIdentities = &structuralCallIdentityCache{}
+		memo.structuralCallIdentities.Store(&structuralCallIdentityCache{})
 		return nil
 	}
 	identityBudget := maxStructuralCallIdentityCacheBytes - structuralCallIdentityCacheHeaderBytes - int(spanBytes)
@@ -72,15 +73,19 @@ func (c *Compiled) prepareStructuralCallIdentities() error {
 		end := len(cache.identities)
 		cache.spans[sig.TypeIndex] = structuralCallIdentitySpan{start: uint32(start), end: uint32(end)}
 	}
-	memo.structuralCallIdentities = cache
+	memo.structuralCallIdentities.Store(cache)
 	return nil
 }
 
 func (c *Compiled) cachedStructuralCallIdentity(functionIndex int) ([]byte, bool) {
-	if c.validateMemo == nil || c.validateMemo.structuralCallIdentities == nil || c.validateMemo.structuralCallIdentities == structuralCallIdentitySeenSentinel {
+	if c.validateMemo == nil {
 		return nil, false
 	}
-	cache := c.validateMemo.structuralCallIdentities
+	// A single acquire load observes one fully constructed immutable cache.
+	cache := c.validateMemo.structuralCallIdentities.Load()
+	if cache == nil || cache == structuralCallIdentitySeenSentinel {
+		return nil, false
+	}
 	sig, ok := compiledFunctionSignature(c, functionIndex)
 	if !ok || !sig.HasTypeIndex || int(sig.TypeIndex) >= len(cache.spans) {
 		return nil, false

--- a/src/wago/structural_identity_publication_test.go
+++ b/src/wago/structural_identity_publication_test.go
@@ -1,0 +1,42 @@
+package wago
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+func TestStructuralCallIdentityConcurrentPublication(t *testing.T) {
+	c := MustCompile(benchAddOneModule())
+	defer c.Close()
+	want, err := compiledStructuralCallIdentity(c, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.prepareStructuralCallIdentities(); err != nil {
+		t.Fatal(err)
+	}
+	start := make(chan struct{})
+	var readers sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			<-start
+			for j := 0; j < 1000; j++ {
+				if got, ok := c.cachedStructuralCallIdentity(0); ok && !bytes.Equal(got, want) {
+					t.Error("partially published structural identity")
+				}
+			}
+		}()
+	}
+	close(start)
+	if err := c.prepareStructuralCallIdentities(); err != nil {
+		t.Fatal(err)
+	}
+	readers.Wait()
+	got, ok := c.cachedStructuralCallIdentity(0)
+	if !ok || !bytes.Equal(got, want) {
+		t.Fatalf("published identity = %x, %v; want %x", got, ok, want)
+	}
+}

--- a/src/wago/structural_type_store_test.go
+++ b/src/wago/structural_type_store_test.go
@@ -22,7 +22,7 @@ func TestCompiledStructuralCallIdentityCacheLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if compiled.validateMemo.structuralCallIdentities != nil {
+	if compiled.validateMemo.structuralCallIdentities.Load() != nil {
 		t.Fatal("structural identity cache built before instantiation")
 	}
 
@@ -30,7 +30,7 @@ func TestCompiledStructuralCallIdentityCacheLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if compiled.validateMemo.structuralCallIdentities != structuralCallIdentitySeenSentinel {
+	if compiled.validateMemo.structuralCallIdentities.Load() != structuralCallIdentitySeenSentinel {
 		t.Fatal("structural identity cache built for one-shot instantiation")
 	}
 	if err := in.Close(); err != nil {
@@ -44,7 +44,7 @@ func TestCompiledStructuralCallIdentityCacheLifecycle(t *testing.T) {
 	if !ok || !bytes.Equal(got, want) {
 		t.Fatalf("cached identity = %x, %v; want %x", got, ok, want)
 	}
-	cache := compiled.validateMemo.structuralCallIdentities
+	cache := compiled.validateMemo.structuralCallIdentities.Load()
 	retained := structuralCallIdentityCacheHeaderBytes + cap(cache.spans)*structuralCallIdentitySpanBytes + cap(cache.identities)
 	if retained > maxStructuralCallIdentityCacheBytes {
 		t.Fatalf("identity cache retains %d bytes; budget %d", retained, maxStructuralCallIdentityCacheBytes)
@@ -52,13 +52,13 @@ func TestCompiledStructuralCallIdentityCacheLifecycle(t *testing.T) {
 	if err := compiled.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if compiled.validateMemo.structuralCallIdentities == nil {
+	if compiled.validateMemo.structuralCallIdentities.Load() == nil {
 		t.Fatal("Close released identity cache while an instance was live")
 	}
 	if err := in.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if compiled.validateMemo.structuralCallIdentities != nil {
+	if compiled.validateMemo.structuralCallIdentities.Load() != nil {
 		t.Fatal("identity cache retained after compiled module and final instance closed")
 	}
 }
@@ -79,7 +79,7 @@ func TestCompiledStructuralCallIdentityCacheBudget(t *testing.T) {
 	if err := compiled.prepareStructuralCallIdentities(); err != nil {
 		t.Fatal(err)
 	}
-	cache := compiled.validateMemo.structuralCallIdentities
+	cache := compiled.validateMemo.structuralCallIdentities.Load()
 	if cache == nil {
 		t.Fatal("oversized module did not record disabled identity cache")
 	}

--- a/src/wago/zz_host_execution_fixed.go
+++ b/src/wago/zz_host_execution_fixed.go
@@ -1,25 +1,12 @@
 package wago
 
-func (a *hostLoopActivation) singleTypedScalarNativeContextChanged(active *Instance, state *instancePluginState, version uint64) bool {
-	return version == ^uint64(0) || !a.parkedNativeContextReusable ||
-		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-		state.nativeContextVersion.Load() != version
-}
-
-func (a *hostLoopActivation) finishSingleTypedScalarFixedPortal(active *Instance, state *instancePluginState, version uint64) {
-	if a.singleTypedScalarNativeContextChanged(active, state, version) {
-		active.restoreTypedScalarNativeContext(a.ctrl)
-	}
-}
-
 func (a *hostLoopActivation) dispatchSingleHostCallFixedView(args, results []uint64) {
 	active := a.root
 	binding := &active.syncHosts[0]
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) == executionFlagIndependent {
-		version := state.nativeContextVersion.Load()
+		resume := a.parkIndependentHostCallback(a.ctrl)
+		defer resume.resume()
 		binding.fn.(HostCallFunc)(HostCall{params: args, results: results, sig: binding.sig, exact: binding.exact})
-		a.finishSingleTypedScalarFixedPortal(active, state, version)
 		return
 	}
 
@@ -36,110 +23,95 @@ func (a *hostLoopActivation) dispatchSingleHostCallFixedView(args, results []uin
 
 func (a *hostLoopActivation) dispatchSingleTypedNoneFixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	active.syncHosts[0].typedNone()
-	if a.singleTypedScalarNativeContextChanged(active, state, version) {
-		active.restoreTypedScalarNativeContext(a.ctrl)
-	}
 	return 0
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedI32VoidFixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	active.syncHosts[0].typedI32V(AsI32(a0))
-	a.finishSingleTypedScalarFixedPortal(active, state, version)
 	return 0
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedI64FixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	result := I64(active.syncHosts[0].fn.(func(int64) int64)(AsI64(a0)))
-	a.finishSingleTypedScalarFixedPortal(active, state, version)
 	return result
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedI64x2FixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	result := I64(active.syncHosts[0].fn.(func(int64, int64) int64)(AsI64(a0), AsI64(a1)))
-	a.finishSingleTypedScalarFixedPortal(active, state, version)
 	return result
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedF32FixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	result := F32(active.syncHosts[0].fn.(func(float32) float32)(AsF32(a0)))
-	if a.singleTypedScalarNativeContextChanged(active, state, version) {
-		active.restoreTypedScalarNativeContext(a.ctrl)
-	}
 	return result
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedF32x2FixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	result := F32(active.syncHosts[0].fn.(func(float32, float32) float32)(AsF32(a0), AsF32(a1)))
-	a.finishSingleTypedScalarFixedPortal(active, state, version)
 	return result
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedF64FixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	result := F64(active.syncHosts[0].fn.(func(float64) float64)(AsF64(a0)))
-	if a.singleTypedScalarNativeContextChanged(active, state, version) {
-		active.restoreTypedScalarNativeContext(a.ctrl)
-	}
 	return result
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedF64x2FixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
-	state := a.state
 	if active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		return a.dispatchSingleTypedScalarFixedPortal(a0, a1)
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	result := F64(active.syncHosts[0].fn.(func(float64, float64) float64)(AsF64(a0), AsF64(a1)))
-	a.finishSingleTypedScalarFixedPortal(active, state, version)
 	return result
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedScalarFixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
 	binding := &active.syncHosts[0]
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		rawSlots, ok := binding.typedScalarSlots()
@@ -152,20 +124,15 @@ func (a *hostLoopActivation) dispatchSingleTypedScalarFixedPortal(a0, a1 uint64)
 		}
 		return result
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	result := binding.callTypedScalar(a0, a1)
-	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-		state.nativeContextVersion.Load() != version {
-		active.restoreTypedScalarNativeContext(a.ctrl)
-	}
 	return result
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedI32x2VoidFixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
 	binding := &active.syncHosts[0]
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		rawSlots, ok := binding.typedScalarSlots()
@@ -178,20 +145,15 @@ func (a *hostLoopActivation) dispatchSingleTypedI32x2VoidFixedPortal(a0, a1 uint
 		}
 		return result
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	binding.typedI32x2V(AsI32(a0), AsI32(a1))
-	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-		state.nativeContextVersion.Load() != version {
-		active.restoreTypedScalarNativeContext(a.ctrl)
-	}
 	return 0
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedI32PairFixedPortal(a0, _ uint64) uint64 {
 	active := a.root
 	binding := &active.syncHosts[0]
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		rawSlots, ok := binding.typedScalarSlots()
@@ -204,21 +166,16 @@ func (a *hostLoopActivation) dispatchSingleTypedI32PairFixedPortal(a0, _ uint64)
 		}
 		return result
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	first, second := binding.typedI32R2(AsI32(a0))
 	result := uint64(uint32(first)) | uint64(uint32(second))<<32
-	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-		state.nativeContextVersion.Load() != version {
-		active.restoreTypedScalarNativeContext(a.ctrl)
-	}
 	return result
 }
 
 func (a *hostLoopActivation) dispatchSingleTypedI32x2PairFixedPortal(a0, a1 uint64) uint64 {
 	active := a.root
 	binding := &active.syncHosts[0]
-	state := a.state
 	flags := active.executionFlags.Load()
 	if flags&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent {
 		rawSlots, ok := binding.typedScalarSlots()
@@ -231,13 +188,9 @@ func (a *hostLoopActivation) dispatchSingleTypedI32x2PairFixedPortal(a0, a1 uint
 		}
 		return result
 	}
-	version := state.nativeContextVersion.Load()
+	resume := a.parkIndependentHostCallback(a.ctrl)
+	defer resume.resume()
 	first, second := binding.typedI32x2R2(AsI32(a0), AsI32(a1))
 	result := uint64(uint32(first)) | uint64(uint32(second))<<32
-	if version == ^uint64(0) || !a.parkedNativeContextReusable ||
-		active.executionFlags.Load()&(executionFlagIndependent|executionFlagNativeControlShared) != executionFlagIndependent ||
-		state.nativeContextVersion.Load() != version {
-		active.restoreTypedScalarNativeContext(a.ctrl)
-	}
 	return result
 }


### PR DESCRIPTION
This PR fixes unsafe runtime entry behavior: prepared functions could keep private-entry assumptions after resource export, optimized callbacks could deadlock on public global access, and canceled calls could wait for invocation admission. It also fixes a structural-call-identity cache publication race.

The isolated direct prepared path now combines invocation ownership and sharing exclusion in one gate reservation. It retains lifetime protection, but omits invocation IDs, the GC lease helper, and a second ownership reservation. PreparedInvokeAddOne measures 19.19 ns/op, versus 40.88 ns/op for Invoke and about 53.6 ns/op in the earlier draft. It remains slower than main's unsafe 6.90 ns/op path.

**Ready for review:** all current CI checks pass on `0a26a1af6`. All 11 commits have verified signatures. The branch contains current main. An approving review from another eligible reviewer is still required. Scalar prepared entry and callback-heavy paths still have substantial costs relative to main; no claim is made that those costs are unavoidable.

## Entry state and safety proof

- The existing instance lifetime count and close bit prevent physical release during native execution. Runtime-owned instances retain runtime operation accounting and its mutex; plugin shutdown relies on that accounting.
- The existing invocation gate has Held, Fast, Waiters, and permanent Revoked bits. An isolated direct call reserves idle state with CAS to Held|Fast, checks current execution exclusions, enters native code, and releases the gate while preserving Revoked.
- Sharing sets Revoked in that same gate before publishing shared native control. It waits if Fast is active. Sharing therefore either prevents direct entry or waits for its exit. Ordinary admission uses the same Held bit and cannot bypass direct entry; canceled waiters do not affect the owner.
- Immutable compiler direct-entry metadata and isolated module shape exclude host calls, imports, external instance entry, and local GC use. Current flags exclude shared control and imported, dynamic, or store-owned GC domains. A numeric signature alone is not used as proof.
- No invocation ID is allocated on that narrow path: it cannot participate in host or callback reentry. No GC lease helper is called because metadata and current flags exclude all relevant domains. Rejected reservations use guarded fallback. Other prepared entry families retain their existing guards.
- Optimized callbacks continue to release the native lease before arbitrary Go code, then reacquire and validate or restore context after return, error, panic, trap, or cancellation. No new public callback API is introduced.
- The structural identity cache remains immutable after atomic publication. Native code quota semantics remain accepted final output size, including compaction; no raw reservation budget is added.

## Regression tests

The invocation-ID test failed before the refactor and passed after it. New tests cover a direct reservation conflicting with general admission, ownership revocation and guarded fallback, each GC exclusion flag, and instance/runtime close while a direct lease is held. A numeric prepared GC function is also tested against real private and shared reference-store domain leases. Its numeric signature must not bypass collector ownership.

The existing regression tests continue to cover prepare/call/export/call, actual concurrent export, native-context rebinding, allocation counts, callback global reads/writes and unrelated access, callback errors/panics/traps/cancellation, canceled admission and waiter wakeups, structural identity publication, and final code-size limits.

## Validation

- GitHub CI is green on the exact head, including Linux, Windows, Darwin, race, conformance, GC hardening, TinyGo, and pinned lint checks. [CI run](https://github.com/wago-org/wago/actions/runs/34717405953).
- The first Windows/amd64 attempt reported 19 clone allocations against the existing limit of 17. One diagnostic retry passed without source changes. Focused tests passed on branch and main with Go 1.22.12 on Linux and Windows under Wine; the preceding-test sequence and full Windows runtime package also passed under Wine. The cause is unconfirmed. No threshold or assertion was changed.
- Current main independently fails the known Linux shared-foreground job-control test ([main run](https://github.com/wago-org/wago/actions/runs/34705814982/job/103585554743)). This PR's Linux job passed. The cause remains unresolved; no speculative production change or timeout increase is included.

- `go test ./...` and `go test -race ./...` ran with pinned WABT and spec-interpreter tools. The known TinyGo standalone build tests fail on VCS stamping; disabling stamping reproduces duplicate `tinygo_task_exit` on unchanged main. These failures are reported separately from runtime validation. No races were reported; the final src/wago runs passed in 6.634 seconds normally and 276.931 seconds under the race detector.
- `go vet ./...` and runtime-tag CLI vet passed. Runtime-tag CLI tests encounter the same TinyGo failures.
- Focused prepared and callback safety tests passed under the race detector. Focused disabled-direct and call-block safety tests passed. Guard-page prepared tests passed. Broad disabled-direct tests contain existing assertions that specifically require direct/prebound mode; those assertions remain intact.
- ARM64 cross-build and focused prepared safety tests under QEMU passed, including GC lease coverage. No native ARM64 performance measurement is claimed.
- Both compiled-codec fuzz targets passed five-second runs with two workers (36,967 and 44,974 executions). Generation, script tests, formatting, and diff checks passed.
- Current staticcheck still reports repository ST1005/U1000 and test SA findings. Runtime-tag CLI staticcheck passed. An older installed staticcheck could not read the current Go export format and was replaced for this check.

## Fresh performance comparison

Main is `788a3bfb0`, fetched again for this run. Both sides ran on the same AMD Ryzen 7 8845HS, Linux/amd64, Go 1.27.1, GOMAXPROCS=16. Each of the 26 cases has six 200 ms samples. Entry and callback groups ran separately, with main and branch measurements made sequentially while other checks were stopped. The benchmark fixtures for new entry modes and CallAdmission were copied unchanged into the main worktree.

All cases retained their allocation counts: 0 B/op and 0 allocs/op, except CallAdmission at 32 B/op and 3 allocs/op on both sides. The refactor adds no instance storage. The earlier PR's invocation gate still adds 16 bytes per instance plugin state relative to main. Contention can allocate a shared wait channel; the separate-instance parallel benchmarks do not measure same-instance contention.

The shared prepared baseline below uses main's stale private decision and is unsafe. It is shown for transparency, not as a performance target. `PreparedEntryModes/runtime` retains required runtime lifetime accounting in this draft.

```text
goos: linux
goarch: amd64
pkg: github.com/wago-org/wago/src/wago
cpu: AMD Ryzen 7 8845HS w/ Radeon 780M Graphics     
                                                         │ /tmp/wago-pr617-perf/bench-main.txt │ /tmp/wago-pr617-perf/bench-branch.txt │
                                                         │               sec/op                │    sec/op     vs base                 │
HostRoundtripLoopTyped/mem0/parallelfalse/host1/n1-16                             242.9n ±  1%    267.9n ± 1%    +10.29% (p=0.002 n=6)
HostRoundtripLoopTyped/mem0/parallelfalse/host1/n1024-16                          59.90µ ±  1%    73.42µ ± 1%    +22.57% (p=0.002 n=6)
HostRoundtripLoopTyped/mem0/paralleltrue/host1/n1-16                              32.04n ±  2%    35.50n ± 2%    +10.78% (p=0.002 n=6)
HostRoundtripLoopTyped/mem0/paralleltrue/host1/n1024-16                           6.915µ ±  2%    8.718µ ± 1%    +26.08% (p=0.002 n=6)
HostRoundtripLoopTyped/mem4/parallelfalse/host1/n1-16                             269.4n ± 51%    292.7n ± 2%          ~ (p=0.058 n=6)
HostRoundtripLoopTyped/mem4/parallelfalse/host1/n1024-16                          60.37µ ±  2%    74.08µ ± 1%    +22.72% (p=0.002 n=6)
HostRoundtripLoopTyped/mem4/paralleltrue/host1/n1-16                              36.30n ±  2%    38.59n ± 2%     +6.32% (p=0.002 n=6)
HostRoundtripLoopTyped/mem4/paralleltrue/host1/n1024-16                           6.949µ ±  2%    8.642µ ± 2%    +24.37% (p=0.002 n=6)
HostRoundtripLoopCall/mem0/parallelfalse/host1/n1-16                              268.5n ±  2%    293.7n ± 1%     +9.39% (p=0.002 n=6)
HostRoundtripLoopCall/mem0/parallelfalse/host1/n1024-16                           66.51µ ±  2%    82.56µ ± 2%    +24.12% (p=0.002 n=6)
HostRoundtripLoopCall/mem0/paralleltrue/host1/n1-16                               34.09n ±  3%    38.12n ± 6%    +11.84% (p=0.002 n=6)
HostRoundtripLoopCall/mem0/paralleltrue/host1/n1024-16                            7.843µ ±  1%    9.876µ ± 3%    +25.93% (p=0.002 n=6)
HostRoundtripLoopCall/mem4/parallelfalse/host1/n1-16                              290.6n ±  2%    315.2n ± 1%     +8.47% (p=0.002 n=6)
HostRoundtripLoopCall/mem4/parallelfalse/host1/n1024-16                           66.44µ ±  1%    83.63µ ± 2%    +25.88% (p=0.002 n=6)
HostRoundtripLoopCall/mem4/paralleltrue/host1/n1-16                               39.54n ±  7%    42.03n ± 8%     +6.28% (p=0.015 n=6)
HostRoundtripLoopCall/mem4/paralleltrue/host1/n1024-16                            8.152µ ±  4%    9.994µ ± 5%    +22.60% (p=0.002 n=6)
CallAdmission-16                                                                  153.7n ±  2%    168.9n ± 3%     +9.93% (p=0.002 n=6)
InvokeAddOne-16                                                                   22.23n ±  3%    40.88n ± 2%    +83.91% (p=0.002 n=6)
PreparedEntryModes/direct-16                                                      6.852n ±  3%   19.215n ± 1%   +180.43% (p=0.002 n=6)
PreparedEntryModes/scalar-16                                                      27.76n ± 11%    72.17n ± 1%   +160.03% (p=0.002 n=6)
PreparedEntryModes/general-16                                                     90.37n ±  3%    82.72n ± 1%     -8.47% (p=0.002 n=6)
PreparedEntryModes/shared-16                                                      7.017n ±  4%   87.565n ± 1%  +1147.90% (p=0.002 n=6)
PreparedEntryModes/runtime-16                                                     6.923n ±  3%   25.580n ± 1%   +269.47% (p=0.002 n=6)
PreparedInvokeAddOne-16                                                           6.895n ±  1%   19.185n ± 1%   +178.27% (p=0.002 n=6)
PreparedInvokeAddOneCallBlock/off-16                                              7.109n ±  2%   19.390n ± 2%   +172.77% (p=0.002 n=6)
PreparedInvokeAddOneCallBlock/on-16                                               6.936n ±  2%   19.635n ± 2%   +183.09% (p=0.002 n=6)
geomean                                                                           255.2n          403.8n         +58.21%
```

The combined typed/HostCall callback CPU profile attributes 9.62% inclusive time to parking the independent lease and 4.93% to resuming it. Native transitions and dispatch also account for material cost. This update does not remove callback locking or version validation to recover speed; it does not establish that all remaining overhead is unavoidable.

## Deferred work

- Further scalar prepared and callback performance work, while preserving their default safety contract.
- Any larger attempt to replace runtime operation accounting with a local lease.
- Incremental emission limits: raw assembler reservations cannot be charged against a final compacted output quota without changing semantics. A separate budget or proven lower bound is follow-up work.
- The Linux shared-foreground CI failure remains unresolved; no speculative signal change or timeout increase is included.

See `docs/runtime-entry-safety-audit.md` for the detailed invariant and investigation limits.
